### PR TITLE
Address open issues: PORT support (#7), VRAM startup-check FAQ (#4), VRAM column (#1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,15 +12,20 @@
 # `export` them in your shell or prefix the command:
 #
 #   MODEL_DIR=/scratch/models bash scripts/setup.sh qwen3.6-27b
+#
+# ⚠ Variable names below are CASE-SENSITIVE. Check carefully:
+#     MODEL_DIR    — singular, NOT MODELS_DIR (plural) — that name is silently ignored
+#     PORT         — host port for the OpenAI API
+#     HF_TOKEN     — HuggingFace token
 
 
 # -----------------------------------------------------------------------------
 # Model storage
 # -----------------------------------------------------------------------------
 
-# Where weights live. Default is <repo>/models-cache. Override if you keep
-# weights on a separate disk (e.g. /mnt/models). Path is resolved as-is —
-# absolute paths recommended.
+# Where weights live (SINGULAR — `MODEL_DIR`, not `MODELS_DIR`).
+# Default is <repo>/models-cache. Override if you keep weights on a separate
+# disk (e.g. /mnt/models). Path is resolved as-is — absolute paths recommended.
 # MODEL_DIR=/mnt/models
 
 # HuggingFace token. Only needed for gated/private repos. The Lorbus
@@ -74,11 +79,33 @@
 
 
 # -----------------------------------------------------------------------------
+# Host port mapping (PORT)
+# -----------------------------------------------------------------------------
+
+# Host port the OpenAI-compatible API listens on. Each compose binds this
+# host port to the container's port 8000 (vLLM) or 8080 (llama.cpp).
+#
+# Defaults per variant (used when PORT is not set):
+#   vllm/default, long-vision, long-text, tools-text, minimal: 8020
+#   vllm/dual:                                                  8010
+#   vllm/dual-turbo:                                            8011
+#   vllm/dual-dflash:                                           8012
+#   vllm/dual-dflash-noviz:                                     8013
+#   llamacpp/default, llamacpp/concurrent:                      8020
+#
+# Setting PORT here overrides the default for whichever variant you boot.
+# Useful if 8020 is taken by something else, or you want all variants on
+# one well-known port.
+# PORT=9876
+
+
+# -----------------------------------------------------------------------------
 # verify-full.sh / verify-stress.sh
 # -----------------------------------------------------------------------------
 
-# Endpoint to test against. Default localhost:8020 matches every shipped
-# compose's host port.
+# Endpoint to test against. Defaults to http://localhost:${PORT:-8020} for
+# whichever variant you booted. Override only if your reverse-proxy /
+# tunnel sits in between.
 # URL=http://localhost:8020
 
 # Number of warmup + measured runs in the bench script. Defaults are

--- a/docs/DUAL_CARD.md
+++ b/docs/DUAL_CARD.md
@@ -6,12 +6,14 @@ You have **2× RTX 3090s, PCIe-only (no NVLink)**. This page is the front door f
 
 ## TL;DR — pick by workload
 
-| What you're doing | Compose | Max ctx | Narr / Code TPS | Why |
-|---|---|---|---|---|
-| General-purpose default (vision + tools + long ctx) | [`dual.yml`](../models/qwen3.6-27b/vllm/compose/docker-compose.dual.yml) ⭐ | **262K** (237K single-prompt verified) | **69 / 89** | fp8 KV, 2 streams, full feature set |
-| Multi-tenant (4 concurrent agents at full ctx) | [`dual-turbo.yml`](../models/qwen3.6-27b/vllm/compose/docker-compose.dual-turbo.yml) | **262K** | **54 / 73** per-stream (≈ 212/292 aggregate) | TQ3 KV (3 bits/token) frees room for 4 streams |
-| Peak code TPS with vision | [`dual-dflash.yml`](../models/qwen3.6-27b/vllm/compose/docker-compose.dual-dflash.yml) | **185K** | **82 / 125** | DFlash N=5, AL ~4.4 (vs MTP's 3.4) |
-| Peak code TPS, no vision | [`dual-dflash-noviz.yml`](../models/qwen3.6-27b/vllm/compose/docker-compose.dual-dflash-noviz.yml) | **200K** | **78 / 127** | DFlash + no vision, +15K ctx vs dual-dflash |
+| What you're doing | Compose | Max ctx | Narr / Code TPS | VRAM per card | Why |
+|---|---|---|---|---|---|
+| General-purpose default (vision + tools + long ctx) | [`dual.yml`](../models/qwen3.6-27b/vllm/compose/docker-compose.dual.yml) ⭐ | **262K** (237K single-prompt verified) | **69 / 89** | ~23.6 / 24 GB | fp8 KV, 2 streams, full feature set |
+| Multi-tenant (4 concurrent agents at full ctx) | [`dual-turbo.yml`](../models/qwen3.6-27b/vllm/compose/docker-compose.dual-turbo.yml) | **262K** | **54 / 73** per-stream (≈ 212/292 aggregate) | ~24 / 24 GB | TQ3 KV (3 bits/token) frees room for 4 streams |
+| Peak code TPS with vision | [`dual-dflash.yml`](../models/qwen3.6-27b/vllm/compose/docker-compose.dual-dflash.yml) | **185K** | **82 / 125** | ~23.6 / 24 GB | DFlash N=5 + 1.75 GB draft per card, AL ~4.4 (vs MTP's 3.4) |
+| Peak code TPS, no vision | [`dual-dflash-noviz.yml`](../models/qwen3.6-27b/vllm/compose/docker-compose.dual-dflash-noviz.yml) | **200K** | **78 / 127** | ~23.8 / 24 GB | DFlash + no vision, +15K ctx vs dual-dflash |
+
+> **VRAM column is per-card** under TP=2 (each card holds half the weights + half the KV; both cards' totals are nearly identical). For a 2× 20 GB rig (e.g. 2× 3080-20GB / 40 GB combined), `dual.yml` and `dual-turbo` should fit; `dual-dflash*` won't (FP16 KV + DFlash draft pushes per-card past 20 GB). Component breakdown in [`tools/charts/gen-vram.py`](../tools/charts/gen-vram.py).
 
 Run any of these via `bash scripts/launch.sh` (interactive) or `bash scripts/switch.sh <variant>`.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -103,9 +103,26 @@ A Genesis patch (`GENESIS_ENABLE_PN8_MTP_DRAFT_ONLINE_QUANT=1`) added in v7.62.x
 
 `CUDA_VISIBLE_DEVICES=2 bash scripts/launch.sh --variant vllm/default` (substitute your card index). For dual-card, pass two: `CUDA_VISIBLE_DEVICES=2,3`. The compose files inherit env from your shell.
 
+### Container fails to start: "Free memory ... is less than desired GPU memory utilization"
+
+Looks like:
+
+```
+ValueError: Free memory on device cuda:0 (22.76/24.0 GiB) on startup
+is less than desired GPU memory utilization (0.97, 23.28 GiB).
+```
+
+vLLM's startup check reserves `mem-util × total VRAM` of *currently-free* VRAM before booting. If something else on the GPU is holding memory (X11 / Wayland compositor, leftover container, Python process, browser GPU acceleration), the check fails. Most common on `tools-text.yml` (0.97) and the long-* variants (0.98 / 0.985).
+
+Two fixes:
+1. **Free the VRAM** (preferred). `nvidia-smi` shows what's holding it. Common: log out of GUI, stop a leftover container (`docker rm -f $(docker ps -aq --filter "name=vllm-")`), or kill orphaned `python` processes.
+2. **Lower mem-util** in the compose. e.g. on `tools-text.yml`: drop `--gpu-memory-utilization 0.97` to `0.94` and reduce `--max-model-len` proportionally (75K → ~70K). Loses ~6K context but works on any rig.
+
+The 0.97 / 0.98 / 0.985 defaults assume a headless rig with ≥23.3 GiB consistently free. If you're running a desktop session on the same card, `0.92`–`0.94` is the safer ceiling.
+
 ### Can I run multiple variants at once on the same machine?
 
-You'd need different ports per variant. Edit `ports:` in the second compose (default is `8020:8000` → change to `8021:8000`). Watch VRAM — two configs simultaneously typically don't fit on 24 GB.
+You'd need different ports per variant. Set `PORT=9876` in `.env` (or pass inline: `PORT=9876 bash scripts/switch.sh vllm/default`) — every shipped compose now reads `${PORT}` for the host-side port mapping. Watch VRAM — two configs simultaneously typically don't fit on 24 GB.
 
 ### Will this work behind Open WebUI?
 

--- a/docs/SINGLE_CARD.md
+++ b/docs/SINGLE_CARD.md
@@ -8,11 +8,11 @@ You have **one RTX 3090 (24 GB VRAM)**. This page is the front door for picking 
 
 Three recommended options:
 
-| What you're doing | Compose | Max ctx | Narr / Code TPS |
-|---|---|---|---|
-| **Long ctx + vision** (chat, agents, image input) | [`long-vision.yml`](../models/qwen3.6-27b/vllm/compose/docker-compose.long-vision.yml) | **198K** | 51 / 68 |
-| **Long ctx, text-only** (RAG, codebase, books) | [`long-text.yml`](../models/qwen3.6-27b/vllm/compose/docker-compose.long-text.yml) | **218K** | 50 / 66 |
-| **Bulletproof, no cliffs** (production service, unpredictable inputs) | [`llamacpp/default`](../models/qwen3.6-27b/llama-cpp/compose/docker-compose.yml) | **262K** | 21 / 21 |
+| What you're doing | Compose | Max ctx | Narr / Code TPS | VRAM (24 GB / card) |
+|---|---|---|---|---|
+| **Long ctx + vision** (chat, agents, image input) | [`long-vision.yml`](../models/qwen3.6-27b/vllm/compose/docker-compose.long-vision.yml) | **198K** | 51 / 68 | ~22.3 GB (mem-util 0.98) |
+| **Long ctx, text-only** (RAG, codebase, books) | [`long-text.yml`](../models/qwen3.6-27b/vllm/compose/docker-compose.long-text.yml) | **218K** | 50 / 66 | ~22.5 GB (mem-util 0.985) |
+| **Bulletproof, no cliffs** (production service, unpredictable inputs) | [`llamacpp/default`](../models/qwen3.6-27b/llama-cpp/compose/docker-compose.yml) | **262K** | 21 / 21 | ~20 GB |
 
 Run via `bash scripts/launch.sh` (interactive) or `bash scripts/switch.sh <variant>`.
 

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.dual-dflash-noviz.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.dual-dflash-noviz.yml
@@ -24,7 +24,7 @@ services:
     container_name: vllm-qwen36-27b-dual-dflash-noviz
     restart: "no"
     ports:
-      - "8013:8000"
+      - "${PORT:-8013}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../models-cache}:/root/.cache/huggingface
       - /opt/ai/vllm-src/vllm/model_executor/kernels/linear/mixed_precision/marlin.py:/usr/local/lib/python3.12/dist-packages/vllm/model_executor/kernels/linear/mixed_precision/marlin.py:ro

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.dual-dflash.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.dual-dflash.yml
@@ -30,7 +30,7 @@ services:
     container_name: vllm-qwen36-27b-dual-dflash
     restart: "no"
     ports:
-      - "8012:8000"
+      - "${PORT:-8012}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../models-cache}:/root/.cache/huggingface
       - /opt/ai/vllm-src/vllm/model_executor/kernels/linear/mixed_precision/marlin.py:/usr/local/lib/python3.12/dist-packages/vllm/model_executor/kernels/linear/mixed_precision/marlin.py:ro

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.dual-turbo.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.dual-turbo.yml
@@ -33,7 +33,7 @@ services:
     container_name: vllm-qwen36-27b-dual-turbo
     restart: "no"
     ports:
-      - "8011:8000"
+      - "${PORT:-8011}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../models-cache}:/root/.cache/huggingface
       - /opt/ai/vllm-src/vllm/model_executor/kernels/linear/mixed_precision/marlin.py:/usr/local/lib/python3.12/dist-packages/vllm/model_executor/kernels/linear/mixed_precision/marlin.py:ro

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.dual.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.dual.yml
@@ -42,7 +42,7 @@ services:
     container_name: vllm-qwen36-27b-dual
     restart: "no"
     ports:
-      - "8010:8000"
+      - "${PORT:-8010}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../models-cache}:/root/.cache/huggingface
       # Marlin pad-sub-tile-n patch (vLLM PR #40361) — required for TP=2

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.long-text.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.long-text.yml
@@ -63,7 +63,7 @@ services:
     container_name: vllm-qwen36-27b-long-text
     restart: "no"
     ports:
-      - "8020:8000"
+      - "${PORT:-8020}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../models-cache}:/root/.cache/huggingface
       - ../patches/genesis/vllm/_genesis:/usr/local/lib/python3.12/dist-packages/vllm/_genesis:ro

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.long-vision.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.long-vision.yml
@@ -54,7 +54,7 @@ services:
     container_name: vllm-qwen36-27b-long-vision
     restart: "no"
     ports:
-      - "8020:8000"
+      - "${PORT:-8020}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../models-cache}:/root/.cache/huggingface
       - ../patches/genesis/vllm/_genesis:/usr/local/lib/python3.12/dist-packages/vllm/_genesis:ro

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.minimal.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.minimal.yml
@@ -25,7 +25,7 @@ services:
     container_name: vllm-qwen36-27b-minimal
     restart: "no"
     ports:
-      - "8020:8000"
+      - "${PORT:-8020}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../models-cache}:/root/.cache/huggingface
     environment:

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.tools-text.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.tools-text.yml
@@ -27,7 +27,7 @@ services:
     container_name: vllm-qwen36-27b
     restart: "no"
     ports:
-      - "8020:8000"
+      - "${PORT:-8020}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../models-cache}:/root/.cache/huggingface
       # Genesis v7.14+ modular package (replaces patch_genesis_unified.py).

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.yml
@@ -89,7 +89,7 @@ services:
     container_name: vllm-qwen36-27b
     restart: "no"
     ports:
-      - "8020:8000"
+      - "${PORT:-8020}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../models-cache}:/root/.cache/huggingface
       # Genesis v7.14 modular package (mounted into vLLM's site-packages).

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -212,10 +212,29 @@ else
   }
 fi
 
+# Resolve the actual endpoint port the same way switch.sh does:
+# explicit $PORT > per-variant default. Mirrors VARIANT_DEFAULT_PORT in
+# switch.sh — keep in sync if you add a new variant.
+declare -A LAUNCH_DEFAULT_PORT=(
+  [vllm/default]=8020
+  [vllm/long-vision]=8020
+  [vllm/long-text]=8020
+  [vllm/tools-text]=8020
+  [vllm/minimal]=8020
+  [vllm/dual]=8010
+  [vllm/dual-turbo]=8011
+  [vllm/dual-dflash]=8012
+  [vllm/dual-dflash-noviz]=8013
+  [llamacpp/default]=8020
+  [llamacpp/concurrent]=8020
+)
+ENDPOINT_PORT="${PORT:-${LAUNCH_DEFAULT_PORT[$VARIANT]:-8020}}"
+ENDPOINT_URL="http://localhost:${ENDPOINT_PORT}"
+
 echo ""
-echo "[launch] done. Endpoint: http://localhost:8020"
+echo "[launch] done. Endpoint: ${ENDPOINT_URL}"
 echo "[launch] sample request:"
-echo "  curl -sf http://localhost:8020/v1/chat/completions \\"
+echo "  curl -sf ${ENDPOINT_URL}/v1/chat/completions \\"
 echo "    -H 'Content-Type: application/json' \\"
 echo "    -d '{\"model\":\"qwen3.6-27b-autoround\",\"messages\":[{\"role\":\"user\",\"content\":\"Capital of France?\"}],\"max_tokens\":30}'"
 echo ""

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -40,8 +40,32 @@ set -euo pipefail
 
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 COMPOSE_BIN="${COMPOSE_BIN:-docker compose}"
-READY_URL="${READY_URL:-http://localhost:8020/v1/models}"
 READY_TIMEOUT="${READY_TIMEOUT:-600}"
+
+# Load .env if present, so PORT / MODEL_DIR / etc. flow through to docker
+# compose AND to the ready-URL probe below.
+if [[ -f "${ROOT_DIR}/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "${ROOT_DIR}/.env"
+  set +a
+fi
+
+# Per-variant default port (matches each compose's "${PORT:-XXXX}:8000"
+# fallback). Used when neither $PORT nor $READY_URL is set explicitly.
+declare -A VARIANT_DEFAULT_PORT=(
+  [vllm/default]=8020
+  [vllm/long-vision]=8020
+  [vllm/long-text]=8020
+  [vllm/tools-text]=8020
+  [vllm/minimal]=8020
+  [vllm/dual]=8010
+  [vllm/dual-turbo]=8011
+  [vllm/dual-dflash]=8012
+  [vllm/dual-dflash-noviz]=8013
+  [llamacpp/default]=8020
+  [llamacpp/concurrent]=8020
+)
 
 # variant -> "engine|compose_dir|file"  (file relative to compose_dir)
 declare -A VARIANTS=(
@@ -113,6 +137,17 @@ up_variant() {
   (cd "${full_dir}" && ${COMPOSE_BIN} -f "${file}" up -d)
 }
 
+resolve_ready_url() {
+  # Precedence: $READY_URL (full override) → $PORT (port only, host=localhost)
+  # → per-variant default port from VARIANT_DEFAULT_PORT.
+  local variant="$1"
+  if [[ -n "${READY_URL:-}" ]]; then
+    return 0
+  fi
+  local port="${PORT:-${VARIANT_DEFAULT_PORT[$variant]:-8020}}"
+  READY_URL="http://localhost:${port}/v1/models"
+}
+
 wait_ready() {
   echo "[switch] waiting for ${READY_URL} (timeout ${READY_TIMEOUT}s)..."
   local elapsed=0 step=4
@@ -146,6 +181,7 @@ for arg in "$@"; do
   esac
 done
 
+resolve_ready_url "${VARIANT}"
 down_running
 up_variant "${VARIANT}"
 [[ $WAIT -eq 1 ]] && wait_ready


### PR DESCRIPTION
Bundled fix PR for three open issues + a 4th already fixed in master.

## Issues addressed

**Closes #7** — `launch ignores .env`
- vLLM composes were hardcoded to `8020:8000` etc. Now use `\${PORT:-XXXX}:8000` so `.env` `PORT` flows through.
- `MODEL_DIR` vs `MODELS_DIR` confusion: added a ⚠ callout in `.env.example` since the plural form was silently ignored.
- `scripts/switch.sh` + `scripts/launch.sh` now resolve the readiness URL from `\$PORT` (or per-variant default).

**Closes #4** — `tools-text.yml` fails with "Free memory ... less than desired"
- vLLM's startup memory check was failing on rigs with a desktop session holding ~280 MiB. Added FAQ entry documenting the two workarounds (free the VRAM, or lower mem-util).
- Defaults unchanged — 0.97 stays the right target for headless rigs; FAQ now signposts the workaround.

**Closes #1** — Per-config VRAM column feature request
- `docs/SINGLE_CARD.md` and `docs/DUAL_CARD.md` TL;DR tables now have a VRAM column with mem-util.
- DUAL_CARD footnote clarifies per-card semantics and which dual configs fit on 2× 20 GB rigs (relevant to fabriciomalta's 2× 3080-20GB use case).

**Closed #2** earlier today via `aab8ff4` (P68/P69 disable). The reply on that issue points at the fix.

## Test plan

- [x] `MODEL_DIR=/mnt/models PORT=9876 bash scripts/launch.sh --variant vllm/long-text` boots on the right host port
- [x] `bash scripts/launch.sh --variant vllm/dual` still defaults to 8010
- [x] `.env` with `PORT=9876` honored across all 8 vLLM composes (sed-applied uniformly)
- [x] FAQ entry renders correctly
- [x] VRAM columns in both TL;DR tables match the gen-vram.py source data

🤖 Generated with [Claude Code](https://claude.com/claude-code)