### PR TITLE
Add dual NVLINK Docker Compose setup for Qwen3.6-27B

### DIFF
--- a/models/qwen3.6-27b/vllm/compose/docker-compose.dual-nvlink.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.dual-nvlink.yml
@@ -1,0 +1,114 @@
+# ===========================================================================
+# Dual RTX 3090 with NVLINK — DEFAULT for 2× cards. Qwen3.6-27B + MTP n=3 + fp8 KV + vision.
+# NOTE: this setup is still EXPERIMENTAL and requires plenty of long term testing. initial tests show everything working fine with higher speeds
+# What this gives you (vs the single-card default):
+#   - TP=2 across both 3090s
+#   - max_num_seqs=2 → 2 concurrent agents at full 262K context (KV pool 2.36×)
+#   - max_model_len=262144 → model's natural max, no rope_scaling needed
+#   - vision + tools + MTP n=3 + recall — everything on, no compromises
+#   - Measured (re-bench 2026-04-28 on club-3090 substrate, dev205 + Genesis v7.51-stable):
+#     69.05 narr (CV 2.3%) / 88.58 code (CV 3.4%) TPS single-stream, AL 3.4, VRAM 23.6 GB/card
+#
+# What's intentionally NOT enabled:
+#   - TurboQuant KV — sidesteps vllm#40831 entirely. fp8_e5m2 is plenty for
+#     262K across two cards. For 4-stream concurrency at 262K, switch to
+#     docker-compose.dual-turbo.yml (which uses TurboQuant KV + Genesis P65).
+#
+# Dependencies:
+#   - 2× RTX 3090 (Ampere SM 8.6), PCIe-only (no NVLink — works fine)
+#   - vLLM PR #40361 (Marlin pad-sub-tile-n) — patched files volume-mounted
+#     from /opt/ai/vllm-src/. PR is open upstream; drop the mount when it
+#     lands. See ../patches/README.md for the git-clone command.
+#
+# All dual-card variants in this dir:
+#
+#   File                                Ctx    Streams   Narr/Code TPS   KV       Vision
+#   docker-compose.dual.yml (this)      262K   2         69 / 89          fp8      ✅
+#   docker-compose.dual-turbo.yml       262K   4         54 / 73          TQ3      ✅
+#   docker-compose.dual-dflash.yml      185K   1         82 / 125         FP16     ✅
+#   docker-compose.dual-dflash-noviz... 200K   1         78 / 127         FP16     ❌
+#
+# Run:
+#   cd <repo>/models/qwen3.6-27b/vllm/compose
+#   docker compose -f docker-compose.dual.yml up -d
+# ===========================================================================
+services:
+  vllm-qwen36-27b-dual:
+    # Tracking latest nightly intentionally — this stack uses fp8 KV (not
+    # TurboQuant), so it doesn't accumulate the same anchor-drift exposure
+    # the single-card project does. Pin if you hit a regression; otherwise
+    # ride the wave.
+    image: vllm/vllm-openai:nightly-7a1eb8ac2ec4ea69338c51dc7afd4b15010abfa8
+    container_name: vllm-qwen36-27b-dual
+    restart: "no"
+    ports:
+      - "${PORT:-8010}:8000"
+    volumes:
+      - ${MODEL_DIR:-../../../../models-cache}:/root/.cache/huggingface
+      # torch.compile + Triton kernel caches — first boot warms (~60-90 sec);
+      # subsequent boots reuse cached graphs. Pattern from Sander's PROD launch.
+      # Closes club-3090 #22.
+      - ../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
+      - ../cache/triton:/root/.triton/cache
+      # Marlin pad-sub-tile-n patch (vLLM PR #40361) — required for TP=2
+      # on AutoRound W4A16 models where out-dim shards fall below 64.
+      - /opt/ai/vllm-src/vllm/model_executor/kernels/linear/mixed_precision/marlin.py:/usr/local/lib/python3.12/dist-packages/vllm/model_executor/kernels/linear/mixed_precision/marlin.py:ro
+      - /opt/ai/vllm-src/vllm/model_executor/kernels/linear/mixed_precision/MPLinearKernel.py:/usr/local/lib/python3.12/dist-packages/vllm/model_executor/kernels/linear/mixed_precision/MPLinearKernel.py:ro
+    environment:
+      - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
+      - VLLM_WORKER_MULTIPROC_METHOD=spawn
+      # PCIe-only stack — disable NCCL features that assume NVLink.
+      - NCCL_CUMEM_ENABLE=0
+      # P2P Enabled.
+      #- NCCL_P2P_DISABLE=1
+      # Specify Nvlink as the P2P level
+      - NCCL_P2P_LEVEL=NVL
+      - VLLM_NO_USAGE_STATS=1
+      - VLLM_USE_FLASHINFER_SAMPLER=1
+      - OMP_NUM_THREADS=1
+      #Removed expandable segments as it throws crash on startup with NVLINK setup
+      - PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:512
+    shm_size: "16gb"
+    ipc: host
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    command:
+      - --model
+      - /root/.cache/huggingface/qwen3.6-27b-autoround-int4
+      - --served-model-name
+      - qwen3.6-27b-autoround
+      - --quantization
+      - auto_round
+      - --dtype
+      - float16
+      - --tensor-parallel-size
+      - "2"
+      - --max-model-len
+      - "262144"
+      - --gpu-memory-utilization
+      - "0.92"
+      - --max-num-seqs
+      - "2"
+      - --max-num-batched-tokens
+      - "8192"
+      - --kv-cache-dtype
+      - fp8_e5m2
+      - --trust-remote-code
+      - --reasoning-parser
+      - qwen3
+      - --enable-auto-tool-choice
+      - --tool-call-parser
+      - qwen3_coder
+      - --enable-prefix-caching
+      - --enable-chunked-prefill
+      - --speculative-config
+      - '{"method":"mtp","num_speculative_tokens":3}'
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8000"

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.dual-nvlink.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.dual-nvlink.yml
@@ -1,48 +1,58 @@
 # ===========================================================================
-# Dual RTX 3090 with NVLINK — DEFAULT for 2× cards. Qwen3.6-27B + MTP n=3 + fp8 KV + vision.
-# NOTE: this setup is still EXPERIMENTAL and requires plenty of long term testing. initial tests show everything working fine with higher speeds
-# What this gives you (vs the single-card default):
-#   - TP=2 across both 3090s
-#   - max_num_seqs=2 → 2 concurrent agents at full 262K context (KV pool 2.36×)
-#   - max_model_len=262144 → model's natural max, no rope_scaling needed
-#   - vision + tools + MTP n=3 + recall — everything on, no compromises
-#   - Measured (re-bench 2026-04-28 on club-3090 substrate, dev205 + Genesis v7.51-stable):
-#     69.05 narr (CV 2.3%) / 88.58 code (CV 3.4%) TPS single-stream, AL 3.4, VRAM 23.6 GB/card
+# Dual RTX 3090 with NVLink — opt-in variant for users with the bridge installed.
+# Mirrors docker-compose.dual.yml but enables NCCL P2P over NVLink for faster
+# allreduce, and re-enables vLLM's custom all-reduce kernel (which `dual.yml`
+# disables for PCIe-only stacks).
+#
+# Status: COMMUNITY-CONTRIBUTED, EXPERIMENTAL.
+#   First landed via PR #31 (JusefPol). Initial reports show stable boot +
+#   higher TPS than `dual.yml` on NVLink-bridged 2× 3090 rigs, but the maintainer
+#   doesn't have NVLink hardware to validate, so this hasn't been canonical-benched.
+#   If you run this, please drop numbers in discussion #19 — paste-ready report
+#   via `bash scripts/report.sh`.
+#
+# What this gives you (vs the PCIe-only `dual.yml`):
+#   - NCCL P2P over NVLink (NCCL_P2P_LEVEL=NVL) — much faster allreduce on TP=2
+#   - Custom all-reduce ENABLED (--disable-custom-all-reduce removed) — NVLink
+#     makes vLLM's custom kernel a win where PCIe makes it a loss
+#   - PYTORCH_CUDA_ALLOC_CONF without `expandable_segments:True` — JusefPol
+#     reports it crashes on startup with NVLink wired up
 #
 # What's intentionally NOT enabled:
-#   - TurboQuant KV — sidesteps vllm#40831 entirely. fp8_e5m2 is plenty for
-#     262K across two cards. For 4-stream concurrency at 262K, switch to
-#     docker-compose.dual-turbo.yml (which uses TurboQuant KV + Genesis P65).
+#   - TurboQuant KV — same rationale as dual.yml: fp8_e5m2 is plenty for 262K.
+#     For 4-stream concurrency at 262K, switch to docker-compose.dual-turbo.yml.
 #
 # Dependencies:
-#   - 2× RTX 3090 (Ampere SM 8.6), PCIe-only (no NVLink — works fine)
-#   - vLLM PR #40361 (Marlin pad-sub-tile-n) — patched files volume-mounted
-#     from /opt/ai/vllm-src/. PR is open upstream; drop the mount when it
-#     lands. See ../patches/README.md for the git-clone command.
+#   - 2× RTX 3090 (Ampere SM 8.6) WITH NVLink bridge installed and `nvidia-smi
+#     topo -m` showing `NV*` between GPU0 and GPU1
+#   - vLLM PR #40361 (Marlin pad-sub-tile-n) — patched files vendored in-repo
+#     at ../patches/vllm-marlin-pad/. PR is open upstream; drop the mount when
+#     it lands. See ../patches/vllm-marlin-pad/README.md.
 #
 # All dual-card variants in this dir:
 #
-#   File                                Ctx    Streams   Narr/Code TPS   KV       Vision
-#   docker-compose.dual.yml (this)      262K   2         69 / 89          fp8      ✅
-#   docker-compose.dual-turbo.yml       262K   4         54 / 73          TQ3      ✅
-#   docker-compose.dual-dflash.yml      185K   1         82 / 125         FP16     ✅
-#   docker-compose.dual-dflash-noviz... 200K   1         78 / 127         FP16     ❌
+#   File                                Ctx    Streams   Narr/Code TPS   KV       Vision  NVLink
+#   docker-compose.dual.yml (DEFAULT)   262K   2         69 / 89          fp8      ✅      not used
+#   docker-compose.dual-nvlink.yml      262K   2         (community)      fp8      ✅      required
+#   docker-compose.dual-turbo.yml       262K   4         54 / 73          TQ3      ✅      not used
+#   docker-compose.dual-dflash.yml      185K   1         82 / 125         FP16     ✅      not used
+#   docker-compose.dual-dflash-noviz... 200K   1         78 / 127         FP16     ❌      not used
 #
 # Run:
 #   cd <repo>/models/qwen3.6-27b/vllm/compose
-#   docker compose -f docker-compose.dual.yml up -d
+#   docker compose -f docker-compose.dual-nvlink.yml up -d
 # ===========================================================================
 services:
-  vllm-qwen36-27b-dual:
+  vllm-qwen36-27b-dual-nvlink:
     # Tracking latest nightly intentionally — this stack uses fp8 KV (not
     # TurboQuant), so it doesn't accumulate the same anchor-drift exposure
     # the single-card project does. Pin if you hit a regression; otherwise
     # ride the wave.
     image: vllm/vllm-openai:nightly-7a1eb8ac2ec4ea69338c51dc7afd4b15010abfa8
-    container_name: vllm-qwen36-27b-dual
+    container_name: vllm-qwen36-27b-dual-nvlink
     restart: "no"
     ports:
-      - "${PORT:-8010}:8000"
+      - "${PORT:-8014}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../models-cache}:/root/.cache/huggingface
       # torch.compile + Triton kernel caches — first boot warms (~60-90 sec);
@@ -52,21 +62,21 @@ services:
       - ../cache/triton:/root/.triton/cache
       # Marlin pad-sub-tile-n patch (vLLM PR #40361) — required for TP=2
       # on AutoRound W4A16 models where out-dim shards fall below 64.
-      - /opt/ai/vllm-src/vllm/model_executor/kernels/linear/mixed_precision/marlin.py:/usr/local/lib/python3.12/dist-packages/vllm/model_executor/kernels/linear/mixed_precision/marlin.py:ro
-      - /opt/ai/vllm-src/vllm/model_executor/kernels/linear/mixed_precision/MPLinearKernel.py:/usr/local/lib/python3.12/dist-packages/vllm/model_executor/kernels/linear/mixed_precision/MPLinearKernel.py:ro
+      - ../patches/vllm-marlin-pad/marlin.py:/usr/local/lib/python3.12/dist-packages/vllm/model_executor/kernels/linear/mixed_precision/marlin.py:ro
+      - ../patches/vllm-marlin-pad/MPLinearKernel.py:/usr/local/lib/python3.12/dist-packages/vllm/model_executor/kernels/linear/mixed_precision/MPLinearKernel.py:ro
     environment:
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - VLLM_WORKER_MULTIPROC_METHOD=spawn
-      # PCIe-only stack — disable NCCL features that assume NVLink.
+      # NVLink bridge present — let NCCL use P2P (don't disable it the way
+      # dual.yml does for PCIe-only stacks) and pin the P2P level to NVLink
+      # so NCCL doesn't fall back to PCIe paths if topology query is fuzzy.
       - NCCL_CUMEM_ENABLE=0
-      # P2P Enabled.
-      #- NCCL_P2P_DISABLE=1
-      # Specify Nvlink as the P2P level
       - NCCL_P2P_LEVEL=NVL
       - VLLM_NO_USAGE_STATS=1
       - VLLM_USE_FLASHINFER_SAMPLER=1
       - OMP_NUM_THREADS=1
-      #Removed expandable segments as it throws crash on startup with NVLINK setup
+      # JusefPol report (PR #31): expandable_segments=True crashes on startup
+      # with NVLink wired in. Keep max_split_size_mb cap, drop the rest.
       - PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:512
     shm_size: "16gb"
     ipc: host
@@ -88,6 +98,9 @@ services:
       - float16
       - --tensor-parallel-size
       - "2"
+      # Custom all-reduce ENABLED (no --disable-custom-all-reduce) — NVLink
+      # makes vLLM's custom kernel a win. dual.yml disables it because PCIe
+      # P2P bandwidth makes the NCCL fallback faster there.
       - --max-model-len
       - "262144"
       - --gpu-memory-utilization

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -215,6 +215,7 @@ declare -A LAUNCH_DEFAULT_PORT=(
   [vllm/dual-turbo]=8011
   [vllm/dual-dflash]=8012
   [vllm/dual-dflash-noviz]=8013
+  [vllm/dual-nvlink]=8014
   [llamacpp/default]=8020
   [llamacpp/concurrent]=8020
 )
@@ -230,6 +231,7 @@ declare -A LAUNCH_DEFAULT_CONTAINER=(
   [vllm/dual-turbo]=vllm-qwen36-27b-dual-turbo
   [vllm/dual-dflash]=vllm-qwen36-27b-dual-dflash
   [vllm/dual-dflash-noviz]=vllm-qwen36-27b-dual-dflash-noviz
+  [vllm/dual-nvlink]=vllm-qwen36-27b-dual-nvlink
   [llamacpp/default]=llama-cpp-qwen36-27b
   [llamacpp/concurrent]=llama-cpp-qwen36-27b-concurrent
 )

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -28,6 +28,7 @@
 #     vllm/dual-turbo       262K + TQ3 + 4 streams + vision (multi-tenant)
 #     vllm/dual-dflash      185K + FP16 + DFlash N=5 + vision (peak code TPS)
 #     vllm/dual-dflash-noviz 200K + FP16 + DFlash N=5 + no vision (peak code, max ctx)
+#     vllm/dual-nvlink      262K + fp8 + 2 streams + vision (REQUIRES NVLink bridge — community/experimental)
 #
 #   Single-card llama.cpp:
 #     llamacpp/default      Q3_K_XL + 262K + q4_0 KV + vision (max ctx, no cliffs)
@@ -67,6 +68,7 @@ declare -A VARIANT_DEFAULT_PORT=(
   [vllm/dual-turbo]=8011
   [vllm/dual-dflash]=8012
   [vllm/dual-dflash-noviz]=8013
+  [vllm/dual-nvlink]=8014
   [llamacpp/default]=8020
   [llamacpp/concurrent]=8020
 )
@@ -84,6 +86,7 @@ declare -A VARIANTS=(
   [vllm/dual-turbo]="vllm|models/qwen3.6-27b/vllm/compose|docker-compose.dual-turbo.yml"
   [vllm/dual-dflash]="vllm|models/qwen3.6-27b/vllm/compose|docker-compose.dual-dflash.yml"
   [vllm/dual-dflash-noviz]="vllm|models/qwen3.6-27b/vllm/compose|docker-compose.dual-dflash-noviz.yml"
+  [vllm/dual-nvlink]="vllm|models/qwen3.6-27b/vllm/compose|docker-compose.dual-nvlink.yml"
   [llamacpp/default]="llamacpp|models/qwen3.6-27b/llama-cpp/compose|docker-compose.yml"
   [llamacpp/concurrent]="llamacpp|models/qwen3.6-27b/llama-cpp/compose|docker-compose.concurrent.yml"
 )


### PR DESCRIPTION
Added a dual NVLINK Docker Compose configuration for Qwen3.6-27B model with support for two RTX 3090 GPUs.