### PR TITLE
fix(preflight): catch missing llama.cpp GGUF before container boot

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -299,26 +299,67 @@ preflight_compose_deps() {
   local missing=()
   local hint_dflash=0
   local hint_mtp=0
+  local hint_gguf=0
 
-  # Scan compose file for model paths in --speculative-config blocks (DFlash draft, MTP head).
-  # The compose paths reference the in-container path /root/.cache/huggingface/<subdir>;
-  # the host path is ${MODEL_DIR}/<subdir> (set via the volumes: block).
-  if grep -qE '"model":[[:space:]]*"/root/.cache/huggingface/qwen3.6-27b-dflash"' "$compose_file"; then
-    if [[ ! -f "${model_dir}/qwen3.6-27b-dflash/config.json" ]]; then
-      missing+=("qwen3.6-27b-dflash (DFlash draft model)")
-      hint_dflash=1
-    fi
-  fi
-  if grep -qE '"model":[[:space:]]*"/root/.cache/huggingface/qwen3.6-27b-mtp-head"' "$compose_file"; then
-    if [[ ! -f "${model_dir}/qwen3.6-27b-mtp-head/config.json" ]]; then
-      missing+=("qwen3.6-27b-mtp-head (MTP draft head)")
-      hint_mtp=1
-    fi
+  # Engine detection: llama.cpp composes mount ${MODEL_DIR}:/models and pass
+  # `-m /models/<path>`; vLLM composes mount ${MODEL_DIR}:/root/.cache/huggingface
+  # and pass `--model /root/.cache/huggingface/<subdir>`.
+  local is_llamacpp=0
+  if grep -qE 'image:.*ggml-org/llama\.cpp' "$compose_file"; then
+    is_llamacpp=1
   fi
 
-  # Always check the main model exists (every compose mounts it).
-  if [[ ! -f "${model_dir}/qwen3.6-27b-autoround-int4/config.json" ]]; then
-    missing+=("qwen3.6-27b-autoround-int4 (main model)")
+  if [[ $is_llamacpp -eq 1 ]]; then
+    # Scan for `-m /models/<path>` and `--mmproj /models/<path>` to learn what
+    # the compose actually expects. Falls back to the canonical defaults from
+    # docker-compose.yml if the variable expansion isn't grep-resolvable.
+    local gguf_in_container mmproj_in_container
+    gguf_in_container=$(grep -oE '\-m[[:space:]]+/models/[^[:space:]]+' "$compose_file" \
+      | head -1 | awk '{print $2}' | sed 's|^/models/||')
+    mmproj_in_container=$(grep -oE -- '--mmproj[[:space:]]+/models/[^[:space:]]+' "$compose_file" \
+      | head -1 | awk '{print $2}' | sed 's|^/models/||')
+
+    # Strip ${VAR:-default} expansion: take the default after `:-` if present.
+    gguf_in_container="${gguf_in_container//\$\{GGUF_FILE:-/}"
+    gguf_in_container="${gguf_in_container%\}}"
+    mmproj_in_container="${mmproj_in_container//\$\{MMPROJ_FILE:-/}"
+    mmproj_in_container="${mmproj_in_container%\}}"
+
+    [[ -z "$gguf_in_container" ]]   && gguf_in_container="qwen3.6-27b/unsloth-q3kxl/Qwen3.6-27B-UD-Q3_K_XL.gguf"
+    [[ -z "$mmproj_in_container" ]] && mmproj_in_container="qwen3.6-27b/mmproj-F16.gguf"
+
+    if [[ -n "${GGUF_FILE:-}" ]];   then gguf_in_container="$GGUF_FILE";     fi
+    if [[ -n "${MMPROJ_FILE:-}" ]]; then mmproj_in_container="$MMPROJ_FILE"; fi
+
+    if [[ ! -f "${model_dir}/${gguf_in_container}" ]]; then
+      missing+=("${gguf_in_container} (llama.cpp GGUF weights)")
+      hint_gguf=1
+    fi
+    if [[ ! -f "${model_dir}/${mmproj_in_container}" ]]; then
+      missing+=("${mmproj_in_container} (vision projector)")
+      hint_gguf=1
+    fi
+  else
+    # vLLM path — scan for --speculative-config blocks (DFlash draft, MTP head).
+    # The compose paths reference the in-container path /root/.cache/huggingface/<subdir>;
+    # the host path is ${MODEL_DIR}/<subdir> (set via the volumes: block).
+    if grep -qE '"model":[[:space:]]*"/root/.cache/huggingface/qwen3.6-27b-dflash"' "$compose_file"; then
+      if [[ ! -f "${model_dir}/qwen3.6-27b-dflash/config.json" ]]; then
+        missing+=("qwen3.6-27b-dflash (DFlash draft model)")
+        hint_dflash=1
+      fi
+    fi
+    if grep -qE '"model":[[:space:]]*"/root/.cache/huggingface/qwen3.6-27b-mtp-head"' "$compose_file"; then
+      if [[ ! -f "${model_dir}/qwen3.6-27b-mtp-head/config.json" ]]; then
+        missing+=("qwen3.6-27b-mtp-head (MTP draft head)")
+        hint_mtp=1
+      fi
+    fi
+
+    # vLLM main model — every vLLM compose on this stack mounts AutoRound INT4.
+    if [[ ! -f "${model_dir}/qwen3.6-27b-autoround-int4/config.json" ]]; then
+      missing+=("qwen3.6-27b-autoround-int4 (main model)")
+    fi
   fi
 
   if [[ ${#missing[@]} -eq 0 ]]; then
@@ -331,6 +372,15 @@ preflight_compose_deps() {
   done
   echo "[preflight]" >&2
   echo "[preflight] Fix:" >&2
+  if [[ $hint_gguf -eq 1 ]]; then
+    echo "[preflight]   hf download unsloth/Qwen3.6-27B-GGUF \\" >&2
+    echo "[preflight]     --include 'Qwen3.6-27B-UD-Q3_K_XL.gguf' 'mmproj-F16.gguf' \\" >&2
+    echo "[preflight]     --local-dir ${model_dir}/qwen3.6-27b/unsloth-q3kxl" >&2
+    echo "[preflight]   # mmproj sometimes lands at unsloth-q3kxl/ — move it up:" >&2
+    echo "[preflight]   #   mv ${model_dir}/qwen3.6-27b/unsloth-q3kxl/mmproj-F16.gguf ${model_dir}/qwen3.6-27b/" >&2
+    echo "[preflight]   (~16 GB total. setup.sh today only fetches the vLLM AutoRound weights;" >&2
+    echo "[preflight]    GGUF must be fetched separately for any llamacpp/* variant.)" >&2
+  fi
   if [[ $hint_dflash -eq 1 ]]; then
     echo "[preflight]   WITH_DFLASH_DRAFT=1 bash scripts/setup.sh qwen3.6-27b" >&2
     echo "[preflight]   (downloads z-lab/Qwen3.6-27B-DFlash, ~1.75 GB; required for dual-dflash* composes)" >&2
@@ -338,7 +388,7 @@ preflight_compose_deps() {
   if [[ $hint_mtp -eq 1 ]]; then
     echo "[preflight]   bash scripts/setup.sh qwen3.6-27b  (re-run with the right flags for MTP head)" >&2
   fi
-  if [[ $hint_dflash -eq 0 ]] && [[ $hint_mtp -eq 0 ]]; then
+  if [[ $hint_dflash -eq 0 ]] && [[ $hint_mtp -eq 0 ]] && [[ $hint_gguf -eq 0 ]]; then
     echo "[preflight]   bash scripts/setup.sh qwen3.6-27b" >&2
   fi
   echo "[preflight] Skip this check:  PREFLIGHT_NO_COMPOSE_DEPS=1 bash scripts/switch.sh ..." >&2

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -374,9 +374,9 @@ preflight_compose_deps() {
   echo "[preflight] Fix:" >&2
   if [[ $hint_gguf -eq 1 ]]; then
     echo "[preflight]   hf download unsloth/Qwen3.6-27B-GGUF \\" >&2
-    echo "[preflight]     --include 'Qwen3.6-27B-UD-Q3_K_XL.gguf' 'mmproj-F16.gguf' \\" >&2
+    echo "[preflight]     Qwen3.6-27B-UD-Q3_K_XL.gguf mmproj-F16.gguf \\" >&2
     echo "[preflight]     --local-dir ${model_dir}/qwen3.6-27b/unsloth-q3kxl" >&2
-    echo "[preflight]   # mmproj sometimes lands at unsloth-q3kxl/ — move it up:" >&2
+    echo "[preflight]   # mmproj lands at unsloth-q3kxl/ — move it up so the default --mmproj path resolves:" >&2
     echo "[preflight]   #   mv ${model_dir}/qwen3.6-27b/unsloth-q3kxl/mmproj-F16.gguf ${model_dir}/qwen3.6-27b/" >&2
     echo "[preflight]   (~16 GB total. setup.sh today only fetches the vLLM AutoRound weights;" >&2
     echo "[preflight]    GGUF must be fetched separately for any llamacpp/* variant.)" >&2


### PR DESCRIPTION
## Summary

- `preflight_compose_deps` was vLLM-only — it always required AutoRound INT4 weights and never validated llama.cpp GGUF / mmproj mounts.
- Fresh users switching to `llamacpp/default` (per docs/SINGLE_CARD.md, the cliff-immune fallback we recommend) would hit a 600s container timeout with the GGUF-not-found error buried in docker logs. Reported by @syangsao on #58.
- This PR makes preflight engine-aware: detect llama.cpp composes by image, parse `-m /models/<path>` and `--mmproj /models/<path>` from the compose (resolving `${GGUF_FILE:-...}` / `${MMPROJ_FILE:-...}` defaults; env-var overrides win), and surface a copy-pasteable `hf download` one-liner when files are missing.

`setup.sh` stays vLLM-default so fresh clones don't pay 16 GB for a path most users won't take first — preflight-time guidance is the cheaper UX.

## Before / After

**Before** (syangsao's case):
```
$ bash scripts/switch.sh llamacpp/default
[switch] bringing up: llamacpp/default
[switch] waiting for http://localhost:8020/v1/models ... [600s timeout]
[switch] timeout — server not ready after 600s
```
Then user has to manually `docker logs llama-cpp-qwen36-27b` to find:
```
gguf_init_from_file: failed to open GGUF file '/models/qwen3.6-27b/unsloth-q3kxl/Qwen3.6-27B-UD-Q3_K_XL.gguf'
```

**After**:
```
$ bash scripts/switch.sh llamacpp/default
[preflight] ERROR: compose '...llama-cpp/compose/docker-compose.yml' expects model files that aren't on host.
[preflight]   missing: .../models-cache/qwen3.6-27b/unsloth-q3kxl/Qwen3.6-27B-UD-Q3_K_XL.gguf (llama.cpp GGUF weights)
[preflight]   missing: .../models-cache/qwen3.6-27b/mmproj-F16.gguf (vision projector)
[preflight] Fix:
[preflight]   hf download unsloth/Qwen3.6-27B-GGUF \
[preflight]     --include 'Qwen3.6-27B-UD-Q3_K_XL.gguf' 'mmproj-F16.gguf' \
[preflight]     --local-dir .../models-cache/qwen3.6-27b/unsloth-q3kxl
[preflight]   (~16 GB total. setup.sh today only fetches the vLLM AutoRound weights;
[preflight]    GGUF must be fetched separately for any llamacpp/* variant.)
```

## Test plan

- [x] llamacpp/default with no GGUF → preflight errors with clear fix
- [x] llamacpp/concurrent → same correct behavior
- [x] vllm/dual on populated /mnt/models/huggingface → exit 0, no regression
- [x] `bash -n scripts/preflight.sh` clean
- [ ] Cross-link from #58 once merged so syangsao can pick up the fix