### PR TITLE
composes: PYTORCH_CUDA_ALLOC_CONF env-override knob (WSL2 boot-crash workaround)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,15 @@
 # tuning; see docs/USE_CASES.md for the curve.
 # MAX_MODEL_LEN=48000
 
+# PyTorch CUDA allocator config. Default keeps `expandable_segments:True`.
+# On some setups the engine crashes at boot inside `gptq_marlin_repack` with
+# `RuntimeError: CUDA driver error: device not ready`; setting this to
+# `expandable_segments:False` resolves it. Known occurrences: JusefPol on
+# NVLink (PR #31), this repo on single-card 3090 Ti / WSL2 / driver 596.36.
+# See docs/HARDWARE.md "disable PyTorch expandable_segments" for the full
+# failure signature.
+# PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
+
 
 # -----------------------------------------------------------------------------
 # Genesis patch tree (vLLM only)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 Changes that span the entire stack — engine version pins, script behavior, repo structure. Per-model dated history lives in `models/<name>/CHANGELOG.md`.
 
+## 2026-05-06 — `PYTORCH_CUDA_ALLOC_CONF` exposed as override knob (boot-crash workaround)
+
+A single-card RTX 3090 Ti rig on WSL2 (driver 596.36) hit `RuntimeError: CUDA driver error: device not ready` from `gptq_marlin_repack` immediately after weight load on the v7.72.2-uplift nightly pin. Bisect (default → minimal-no-Genesis → minimal + `CUDA_LAUNCH_BLOCKING=1`) ruled out Genesis, spec-decode, TQ3 KV, async-residual error, and TDR (registry already extended + Windows rebooted). Setting `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False` resolves the crash. Same env-var workaround as JusefPol's NVLink boot-crash report (PR #31), already hardcoded in the `dual-nvlink*.yml` composes.
+
+**Changes:**
+- All 14 single-card and PCIe dual-card composes: `PYTORCH_CUDA_ALLOC_CONF=...` → `${PYTORCH_CUDA_ALLOC_CONF:-...}` env-override knob (defaults preserved). Pattern matches existing `MAX_MODEL_LEN` / `GPU_MEMORY_UTILIZATION` overrides from #79.
+- `dual-nvlink.yml` / `dual-nvlink-turbo.yml`: untouched (their existing JusefPol-driven default already has `expandable_segments` off).
+- `.env.example`: documented the override under "vLLM tuning knobs".
+- `docs/HARDWARE.md`: new `### Fix — disable PyTorch expandable_segments` subsection with stack trace, what we ruled out, the override recipe, and a single observation about weight-load time (32 sec → 13 sec on this rig — uncontrolled, not a measured benchmark).
+- `docs/FAQ.md`: WSL2 question now cross-links to both the TDR and `expandable_segments` fix subsections.
+
+The exact failing call hasn't been isolated; the `cuMemMap` virtual-memory API used by `expandable_segments:True` is the suspected culprit since both known occurrences respond to the same workaround, but we haven't proven which call returns `cudaErrorNotReady`.
+
+**Override:** drop `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False` into a `.env` next to the compose, then `docker compose up -d` as usual.
+
 ## 2026-05-05 — v7.72.2-uplift: Genesis pin bump + sidecar consolidation + cross-rig PN59 finding ⭐
 
 Sander shipped Genesis [v7.72.2](https://github.com/Sandermage/genesis-vllm-patches/blob/main/CHANGELOG.md) on 2026-05-05 with 7 new patches (PN59-PN67), the v7.72.1 P68 xgrammar-incompat fix (closes [#57](https://github.com/noonghunna/club-3090/issues/57)), and v7.72.2 PN70 schema-subset filter. Branch `v7.72.2-uplift` aligns club-3090 with the new release.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -24,6 +24,8 @@ vLLM: NVIDIA-only (CUDA). llama.cpp: yes — pick the right Docker image (`ghcr.
 
 WSL2: yes, both engines. Make sure GPU passthrough is set up (`nvidia-smi` works inside WSL). Native Windows: vLLM doesn't support it; llama.cpp does — but use a native llama.cpp build, not Docker.
 
+Two gotchas to know about up front, both documented in HARDWARE.md alongside the WSL2 section: (1) Windows' default 2-second TDR can kill long kernels mid-flight (WSL2-specific) — see ["extend the TDR delay"](HARDWARE.md#fix--extend-the-tdr-delay-on-the-windows-host); (2) PyTorch's `expandable_segments:True` allocator can crash boot at `gptq_marlin_repack` on some setups (a WSL2 single-card 3090 Ti hit it; JusefPol previously hit it on NVLink dual-3090) — override available via `.env`, see ["disable PyTorch expandable_segments"](HARDWARE.md#fix--disable-pytorch-expandable_segments-if-boot-crashes-at-weight-repack).
+
 ---
 
 ## Engine choice

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -161,6 +161,40 @@ Three TDR options in increasing aggression:
 - **`TdrLevel=0`** (more permissive): disable TDR entirely — appropriate for dedicated AI rigs where the GPU isn't your display adapter
 - **Dual-boot Linux** (no TDR at all): sidesteps the whole class
 
+### Fix — disable PyTorch `expandable_segments` if boot crashes at weight repack
+
+A separate boot-time failure mode, distinct from TDR, surfaces with the same `device not ready` text:
+
+```
+File "/usr/local/lib/python3.12/dist-packages/vllm/_custom_ops.py", line 1279, in gptq_marlin_repack
+    return torch.ops._C.gptq_marlin_repack(...)
+RuntimeError: CUDA driver error: device not ready
+```
+
+The engine logs `Loading weights took N seconds` cleanly, then dies ~1 second later inside `process_weights_after_loading` → `gptq_marlin_repack`. `CUDA_LAUNCH_BLOCKING=1` does not move the failure site, which rules out async-residual error from a prior kernel.
+
+Setting `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False` resolves the crash. We haven't isolated the specific failing call — the suspicion is the `cuMemMap` virtual-memory API used internally by PyTorch's `expandable_segments:True` allocator, since (a) disabling that path fixes the crash and (b) JusefPol's NVLink boot-crash report (PR #31) responded to the same workaround. We list this section under WSL2 because that's where this PR's diagnostic rig hit it, but the failure mode itself is not strictly WSL2-only.
+
+Known occurrences:
+
+- JusefPol — NVLink-wired dual-3090 setups (PR #31). The `dual-nvlink*.yml` composes already hardcode `expandable_segments` off for that case.
+- club-3090 issue (this PR, 2026-05-06) — single-card RTX 3090 Ti on WSL2, driver 596.36, vLLM nightly `01d4d1ad` (the v7.72.2-uplift pin).
+
+#### Override
+
+All single-card and PCIe dual-card composes now expose `PYTORCH_CUDA_ALLOC_CONF` as a `${...}` override knob. Drop a `.env` next to the compose file (or export the var in your shell):
+
+```sh
+# models/qwen3.6-27b/vllm/compose/.env
+PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
+```
+
+Then `docker compose up -d` as usual. No edits to tracked files needed.
+
+#### Possible secondary effect on weight-load time
+
+On the WSL2 rig where this was diagnosed, weight-load time on a fresh boot (caches cleared) was 32 sec with `expandable_segments:True` and 13 sec with `expandable_segments:False`. This is a single observation, not a controlled A/B (cache state, FS warmth and other factors weren't held constant), so treat it as suggestive rather than measured. If you're chasing boot-time latency on WSL2 and not crashing, the override is harmless to try.
+
 ### Additional WSL2 considerations
 
 - vLLM auto-detects WSL2 and disables `pin_memory` (`Using 'pin_memory=False' as WSL is detected. This may slow down the performance.` in boot log) — expected behavior, can't be overridden cleanly.

--- a/models/qwen3.6-27b/CHANGELOG.md
+++ b/models/qwen3.6-27b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Dated history for Qwen3.6-27B configs in this repo. Combines the single-card and dual-card timelines (both were previously separate repos; consolidated here 2026-04-28).
 
+## 2026-05-06 — `PYTORCH_CUDA_ALLOC_CONF` override knob added to 14 composes
+
+Follow-up to the v7.72.2-uplift pin bump: a single-card RTX 3090 Ti rig on WSL2 (driver 596.36) hit `gptq_marlin_repack` boot crashes (`CUDA driver error: device not ready`) on the new nightly. The minimal compose (no Genesis, no spec-decode, no TQ3 KV) reproduced cleanly with just `--quantization auto_round`, and `CUDA_LAUNCH_BLOCKING=1` did not move the failure site (rules out async-residual error from a prior kernel).
+
+`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False` resolves the crash. This is the same workaround that already addresses JusefPol's NVLink boot-crash report (PR #31, hardcoded in the `dual-nvlink*.yml` composes). The exact failing call hasn't been isolated.
+
+All 14 single-card and PCIe dual-card composes now expose `PYTORCH_CUDA_ALLOC_CONF` as a `${...}:-` override knob (defaults preserved); affected users drop `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False` into a `.env`. The two `dual-nvlink*.yml` composes are unchanged.
+
+Single-observation note: weight-load on a fresh boot (caches cleared) was 32 sec with `expandable_segments:True` and 13 sec with `expandable_segments:False` on this rig. Not a controlled benchmark — cache state and other factors weren't held constant. Suggestive only.
+
+See [docs/HARDWARE.md](../../docs/HARDWARE.md#fix--disable-pytorch-expandable_segments-if-boot-crashes-at-weight-repack) for the full failure signature and override recipe.
+
 ## 2026-05-05 — v7.72.2-uplift: Genesis pin bump + sidecar consolidation ⭐
 
 Aligns Qwen3.6-27B configs with Genesis [v7.72.2](https://github.com/Sandermage/genesis-vllm-patches/blob/main/CHANGELOG.md) (pin SHA `7b9fd319`) and Sander's PROD-validated vLLM pin (`nightly-01d4d1ad375...`, allowlist entry #2).

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.bounded-thinking.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.bounded-thinking.yml
@@ -142,7 +142,10 @@ services:
       - NCCL_P2P_DISABLE=1
       - VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0
       - VLLM_NO_USAGE_STATS=1
-      - PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True,max_split_size_mb:512
+      # expandable_segments:True crashes boot on some setups (likely cuMemMap path).
+      # Known: JusefPol on NVLink (PR #31), WSL2 single-card 3090 Ti.
+      # Override via .env: PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
+      - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True,max_split_size_mb:512}
       - VLLM_FLOAT32_MATMUL_PRECISION=high
       - VLLM_USE_FLASHINFER_SAMPLER=1
       - OMP_NUM_THREADS=1

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.carnice-bf16mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.carnice-bf16mtp.yml
@@ -68,7 +68,10 @@ services:
       - VLLM_NO_USAGE_STATS=1
       - VLLM_USE_FLASHINFER_SAMPLER=1
       - OMP_NUM_THREADS=1
-      - PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True,max_split_size_mb:512
+      # expandable_segments:True crashes boot on some setups (likely cuMemMap path).
+      # Known: JusefPol on NVLink (PR #31), WSL2 single-card 3090 Ti.
+      # Override via .env: PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
+      - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True,max_split_size_mb:512}
     shm_size: "16gb"
     ipc: host
     deploy:

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.dual-dflash-noviz.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.dual-dflash-noviz.yml
@@ -56,7 +56,10 @@ services:
       - VLLM_NO_USAGE_STATS=1
       - VLLM_USE_FLASHINFER_SAMPLER=1
       - OMP_NUM_THREADS=1
-      - PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True,max_split_size_mb:512
+      # expandable_segments:True crashes boot on some setups (likely cuMemMap path).
+      # Known: JusefPol on NVLink (PR #31), WSL2 single-card 3090 Ti.
+      # Override via .env: PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
+      - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True,max_split_size_mb:512}
     shm_size: "16gb"
     ipc: host
     deploy:

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.dual-dflash.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.dual-dflash.yml
@@ -80,7 +80,10 @@ services:
       - VLLM_NO_USAGE_STATS=1
       - VLLM_USE_FLASHINFER_SAMPLER=1
       - OMP_NUM_THREADS=1
-      - PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True,max_split_size_mb:512
+      # expandable_segments:True crashes boot on some setups (likely cuMemMap path).
+      # Known: JusefPol on NVLink (PR #31), WSL2 single-card 3090 Ti.
+      # Override via .env: PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
+      - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True,max_split_size_mb:512}
     shm_size: "16gb"
     ipc: host
     deploy:

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.dual-turbo.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.dual-turbo.yml
@@ -66,7 +66,10 @@ services:
       - VLLM_NO_USAGE_STATS=1
       - VLLM_USE_FLASHINFER_SAMPLER=1
       - OMP_NUM_THREADS=1
-      - PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True,max_split_size_mb:512
+      # expandable_segments:True crashes boot on some setups (likely cuMemMap path).
+      # Known: JusefPol on NVLink (PR #31), WSL2 single-card 3090 Ti.
+      # Override via .env: PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
+      - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True,max_split_size_mb:512}
       - VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
       - VLLM_MARLIN_USE_ATOMIC_ADD=1
       - TRITON_CACHE_DIR=/root/.triton/cache

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.dual.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.dual.yml
@@ -67,7 +67,10 @@ services:
       - VLLM_NO_USAGE_STATS=1
       - VLLM_USE_FLASHINFER_SAMPLER=1
       - OMP_NUM_THREADS=1
-      - PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True,max_split_size_mb:512
+      # expandable_segments:True crashes boot on some setups (likely cuMemMap path).
+      # Known: JusefPol on NVLink (PR #31), WSL2 single-card 3090 Ti.
+      # Override via .env: PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
+      - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True,max_split_size_mb:512}
     shm_size: "16gb"
     ipc: host
     deploy:

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.dual4-dflash.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.dual4-dflash.yml
@@ -75,7 +75,10 @@ services:
       - VLLM_NO_USAGE_STATS=1
       - VLLM_USE_FLASHINFER_SAMPLER=1
       - OMP_NUM_THREADS=1
-      - PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True,max_split_size_mb:512
+      # expandable_segments:True crashes boot on some setups (likely cuMemMap path).
+      # Known: JusefPol on NVLink (PR #31), WSL2 single-card 3090 Ti.
+      # Override via .env: PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
+      - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True,max_split_size_mb:512}
     shm_size: "16gb"
     ipc: host
     deploy:

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.dual4.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.dual4.yml
@@ -79,7 +79,10 @@ services:
       - VLLM_NO_USAGE_STATS=1
       - VLLM_USE_FLASHINFER_SAMPLER=1
       - OMP_NUM_THREADS=1
-      - PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True,max_split_size_mb:512
+      # expandable_segments:True crashes boot on some setups (likely cuMemMap path).
+      # Known: JusefPol on NVLink (PR #31), WSL2 single-card 3090 Ti.
+      # Override via .env: PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
+      - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True,max_split_size_mb:512}
     shm_size: "16gb"
     ipc: host
     deploy:

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.long-text-no-mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.long-text-no-mtp.yml
@@ -132,7 +132,10 @@ services:
       # ~0.0055 mem-util ≈ 120 MiB KV pool. Disabling restores ~4K of ctx.
       - VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0
       - VLLM_NO_USAGE_STATS=1
-      - PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True,max_split_size_mb:512
+      # expandable_segments:True crashes boot on some setups (likely cuMemMap path).
+      # Known: JusefPol on NVLink (PR #31), WSL2 single-card 3090 Ti.
+      # Override via .env: PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
+      - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True,max_split_size_mb:512}
       - VLLM_FLOAT32_MATMUL_PRECISION=high
       - VLLM_USE_FLASHINFER_SAMPLER=1
       - OMP_NUM_THREADS=1

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.long-text.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.long-text.yml
@@ -142,7 +142,10 @@ services:
       # ~0.0055 mem-util ≈ 120 MiB KV pool. Disabling restores ~4K of ctx.
       - VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0
       - VLLM_NO_USAGE_STATS=1
-      - PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True,max_split_size_mb:512
+      # expandable_segments:True crashes boot on some setups (likely cuMemMap path).
+      # Known: JusefPol on NVLink (PR #31), WSL2 single-card 3090 Ti.
+      # Override via .env: PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
+      - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True,max_split_size_mb:512}
       - VLLM_FLOAT32_MATMUL_PRECISION=high
       - VLLM_USE_FLASHINFER_SAMPLER=1
       - OMP_NUM_THREADS=1

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.long-vision.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.long-vision.yml
@@ -109,7 +109,10 @@ services:
       - NCCL_P2P_DISABLE=1
       - VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0
       - VLLM_NO_USAGE_STATS=1
-      - PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True,max_split_size_mb:512
+      # expandable_segments:True crashes boot on some setups (likely cuMemMap path).
+      # Known: JusefPol on NVLink (PR #31), WSL2 single-card 3090 Ti.
+      # Override via .env: PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
+      - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True,max_split_size_mb:512}
       - VLLM_FLOAT32_MATMUL_PRECISION=high
       - VLLM_USE_FLASHINFER_SAMPLER=1
       - OMP_NUM_THREADS=1

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.minimal.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.minimal.yml
@@ -41,7 +41,10 @@ services:
       - NCCL_CUMEM_ENABLE=0
       - NCCL_P2P_DISABLE=1
       - VLLM_NO_USAGE_STATS=1
-      - PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+      # expandable_segments:True crashes boot on some setups (likely cuMemMap path).
+      # Known: JusefPol on NVLink (PR #31), WSL2 single-card 3090 Ti.
+      # Override via .env: PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
+      - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
       - OMP_NUM_THREADS=1
     shm_size: "16gb"
     ipc: host

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.tools-text.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.tools-text.yml
@@ -45,7 +45,10 @@ services:
       - NCCL_P2P_DISABLE=1
       - VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0
       - VLLM_NO_USAGE_STATS=1
-      - PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True,max_split_size_mb:512
+      # expandable_segments:True crashes boot on some setups (likely cuMemMap path).
+      # Known: JusefPol on NVLink (PR #31), WSL2 single-card 3090 Ti.
+      # Override via .env: PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
+      - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True,max_split_size_mb:512}
       - VLLM_FLOAT32_MATMUL_PRECISION=high
       - VLLM_USE_FLASHINFER_SAMPLER=1
       - OMP_NUM_THREADS=1

--- a/models/qwen3.6-27b/vllm/compose/docker-compose.yml
+++ b/models/qwen3.6-27b/vllm/compose/docker-compose.yml
@@ -114,7 +114,10 @@ services:
       - NCCL_P2P_DISABLE=1
       - VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=1
       - VLLM_NO_USAGE_STATS=1
-      - PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True,max_split_size_mb:512
+      # expandable_segments:True crashes boot on some setups (likely cuMemMap path).
+      # Known: JusefPol on NVLink (PR #31), WSL2 single-card 3090 Ti.
+      # Override via .env: PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
+      - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True,max_split_size_mb:512}
       - VLLM_FLOAT32_MATMUL_PRECISION=high
       - VLLM_USE_FLASHINFER_SAMPLER=1
       - OMP_NUM_THREADS=1


### PR DESCRIPTION
## Summary

A single-card RTX 3090 Ti rig on WSL2 hits `RuntimeError: CUDA driver error: device not ready` from `gptq_marlin_repack` immediately after weight load on the v7.72.2-uplift nightly pin (`vllm-openai:nightly-01d4d1ad`, driver 596.36). Bisect against the minimal compose (no Genesis, no spec-decode, no TQ3 KV) reproduced cleanly with just `--quantization auto_round`; `CUDA_LAUNCH_BLOCKING=1` did not move the failure site. TDR was ruled out (registry already extended + Windows rebooted).

`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False` resolves the crash. This is the same workaround that already addresses JusefPol's NVLink boot-crash (PR #31), hardcoded in the `dual-nvlink*.yml` composes since then.

The exact failing call hasn't been isolated — `cuMemMap` (the virtual-memory API used internally by `expandable_segments:True`) is the suspected culprit since both known occurrences respond to the same env-var fix, but we haven't proven which specific call returns `cudaErrorNotReady`.

## Changes

- **14 composes** (single-card + PCIe dual-card): hardcoded `PYTORCH_CUDA_ALLOC_CONF=...` → `${PYTORCH_CUDA_ALLOC_CONF:-...}` env-override knob with current values preserved as defaults. Pattern mirrors the `MAX_MODEL_LEN` / `GPU_MEMORY_UTILIZATION` knobs from #79.
- **`dual-nvlink.yml` / `dual-nvlink-turbo.yml`**: untouched. Their existing JusefPol-driven default already has `expandable_segments` off — adding an override would be a footgun.
- **`.env.example`**: new entry under "vLLM tuning knobs" documenting when to flip it.
- **`docs/HARDWARE.md`**: new `### Fix — disable PyTorch expandable_segments` subsection alongside the TDR fix. Includes stack trace, what was ruled out, the two known occurrences, override recipe, and a single uncontrolled observation about weight-load time on the diagnostic rig (32s → 13s, flagged as suggestive not measured).
- **`docs/FAQ.md`**: WSL2 question now cross-links both fix subsections.
- **`CHANGELOG.md`** (top-level) and **`models/qwen3.6-27b/CHANGELOG.md`**: dated 2026-05-06 entries.

## Override usage

\`\`\`sh
# models/qwen3.6-27b/vllm/compose/.env
PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
\`\`\`

Then \`docker compose up -d\` as usual. No edits to tracked files needed.

## Test plan

- [x] Verified \`gptq_marlin_repack\` boot crash is reproducible on the diagnostic rig with \`expandable_segments:True\` (default + minimal composes, both fail identically)
- [x] Verified \`expandable_segments:False\` boots cleanly on the **default** compose (full Genesis + MTP K=3 + TQ3 KV + cudagraph capture, end-to-end through \`Application startup complete\`)
- [x] Verified \`\${PYTORCH_CUDA_ALLOC_CONF:-...}\` shell substitution behaves correctly inside the compose \`environment:\` block
- [ ] Cross-rig validation on a non-WSL2 environment that previously worked (regression check that the env-var pattern doesn't break bare-metal)
- [ ] Confirm \`dual-nvlink*.yml\` users aren't impacted (no edits there, but worth a sanity boot if anyone has the hardware)

## Notes

- This was diagnosed and is verified on **single-card WSL2**. The fix is well-scoped (env-var name change, no behavior change at default) so blast radius is low, but the cross-rig validation tickbox above remains open.
- Regarding the weight-load timing observation: the 32s → 13s delta is on the same rig with caches cleared, but cache warmth, FS state, and other factors weren't held constant. The HARDWARE.md text flags it as suggestive only; not a benchmark claim.