### PR TITLE
fix: BIND_HOST opt-in + localhost script fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,12 @@
 # one well-known port.
 # PORT=9876
 
+# Host interface to bind the API port on. Default is 0.0.0.0 (all interfaces).
+# Set to 127.0.0.1 to restrict to localhost — prevents IDE agents (Cline,
+# Cursor) from competing for the max-num-seqs=1 slot and causing verify-stress
+# HTTP 000 failures during benchmark runs.
+# BIND_HOST=127.0.0.1
+
 
 # -----------------------------------------------------------------------------
 # verify-full.sh / verify-stress.sh
@@ -121,3 +127,9 @@
 # 3 warmup + 5 measured. Lower these for a faster smoke test.
 # WARMUPS=3
 # RUNS=5
+
+# Hard wall-clock cap for soak-test.sh. Default: 1800s. On setups using
+# VLLM_ENFORCE_EAGER=1 (e.g. WSL2 or 5090 Laptop), long-context prefills
+# can exceed the 1800s budget before all 5 sessions complete. 3600s is
+# sufficient for the RTX 5090 Laptop with enforce_eager.
+# SOAK_TIMEOUT_S=3600

--- a/models/qwen3.6-27b/vllm/compose/dual/carnice-bf16mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/carnice-bf16mtp.yml
@@ -54,7 +54,7 @@ services:
     container_name: vllm-carnice-bf16mtp
     restart: "no"
     ports:
-      - "${PORT:-8070}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${PORT:-8070}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../models-cache}:/root/.cache/huggingface
       # Patched chat template: tells Carnice to output JSON tool calls

--- a/models/qwen3.6-27b/vllm/compose/dual/dflash-noviz.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/dflash-noviz.yml
@@ -49,7 +49,7 @@ services:
     container_name: vllm-qwen36-27b-dual-dflash-noviz
     restart: "no"
     ports:
-      - "${PORT:-8013}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${PORT:-8013}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../models-cache}:/root/.cache/huggingface
       # torch.compile + Triton kernel caches — first boot warms (~60-90 sec);

--- a/models/qwen3.6-27b/vllm/compose/dual/dflash.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/dflash.yml
@@ -73,7 +73,7 @@ services:
     container_name: vllm-qwen36-27b-dual-dflash
     restart: "no"
     ports:
-      - "${PORT:-8012}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${PORT:-8012}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../models-cache}:/root/.cache/huggingface
       # torch.compile + Triton kernel caches — first boot warms (~60-90 sec);

--- a/models/qwen3.6-27b/vllm/compose/dual/docker-compose.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     container_name: vllm-qwen36-27b-dual
     restart: "no"
     ports:
-      - "${PORT:-8010}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${PORT:-8010}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../models-cache}:/root/.cache/huggingface
       # torch.compile + Triton kernel caches — first boot warms (~60-90 sec);

--- a/models/qwen3.6-27b/vllm/compose/dual/nvlink-dflash-noviz.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/nvlink-dflash-noviz.yml
@@ -81,7 +81,7 @@ services:
     container_name: vllm-qwen36-27b-dual-nvlink-dflash-noviz
     restart: "no"
     ports:
-      - "${PORT:-8019}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${PORT:-8019}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../models-cache}:/root/.cache/huggingface
       # torch.compile + Triton kernel caches — first boot warms (~60-90 sec);

--- a/models/qwen3.6-27b/vllm/compose/dual/nvlink-dflash.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/nvlink-dflash.yml
@@ -77,7 +77,7 @@ services:
     container_name: vllm-qwen36-27b-dual-nvlink-dflash
     restart: "no"
     ports:
-      - "${PORT:-8018}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${PORT:-8018}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../models-cache}:/root/.cache/huggingface
       # torch.compile + Triton kernel caches — first boot warms (~60-90 sec);

--- a/models/qwen3.6-27b/vllm/compose/dual/nvlink-turbo.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/nvlink-turbo.yml
@@ -67,7 +67,7 @@ services:
     container_name: vllm-qwen36-27b-dual-nvlink-turbo
     restart: "no"
     ports:
-      - "${PORT:-8017}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${PORT:-8017}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../models-cache}:/root/.cache/huggingface
       # torch.compile + Triton kernel caches — first boot warms (~60-90 sec);

--- a/models/qwen3.6-27b/vllm/compose/dual/nvlink.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/nvlink.yml
@@ -67,7 +67,7 @@ services:
     container_name: vllm-qwen36-27b-dual-nvlink
     restart: "no"
     ports:
-      - "${PORT:-8014}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${PORT:-8014}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../models-cache}:/root/.cache/huggingface
       # torch.compile + Triton kernel caches — first boot warms (~60-90 sec);

--- a/models/qwen3.6-27b/vllm/compose/dual/turbo.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/turbo.yml
@@ -51,7 +51,7 @@ services:
     container_name: vllm-qwen36-27b-dual-turbo
     restart: "no"
     ports:
-      - "${PORT:-8011}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${PORT:-8011}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../models-cache}:/root/.cache/huggingface
       # torch.compile + Triton kernel caches — first boot warms (~60-90 sec);

--- a/models/qwen3.6-27b/vllm/compose/multi4/dflash.yml
+++ b/models/qwen3.6-27b/vllm/compose/multi4/dflash.yml
@@ -66,7 +66,7 @@ services:
     container_name: vllm-qwen36-27b-multi4-dflash
     restart: "no"
     ports:
-      - "${PORT:-8016}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${PORT:-8016}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../models-cache}:/root/.cache/huggingface
       # torch.compile + Triton kernel caches — first boot warms (~60-90 sec);

--- a/models/qwen3.6-27b/vllm/compose/multi4/docker-compose.yml
+++ b/models/qwen3.6-27b/vllm/compose/multi4/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     container_name: vllm-qwen36-27b-multi4
     restart: "no"
     ports:
-      - "${PORT:-8015}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${PORT:-8015}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../models-cache}:/root/.cache/huggingface
       # torch.compile + Triton kernel caches — first boot warms (~60-90 sec);

--- a/models/qwen3.6-27b/vllm/compose/single/bounded-thinking.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/bounded-thinking.yml
@@ -135,7 +135,7 @@ services:
     container_name: vllm-qwen36-27b-bounded-thinking
     restart: "no"
     ports:
-      - "${PORT:-8020}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${PORT:-8020}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../models-cache}:/root/.cache/huggingface
       # torch.compile + Triton kernel caches — first boot warms (~60-90 sec);

--- a/models/qwen3.6-27b/vllm/compose/single/docker-compose.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/docker-compose.yml
@@ -101,7 +101,7 @@ services:
     container_name: vllm-qwen36-27b
     restart: "no"
     ports:
-      - "${PORT:-8020}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${PORT:-8020}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../models-cache}:/root/.cache/huggingface
       # torch.compile + Triton kernel caches — first boot warms (~60-90 sec);

--- a/models/qwen3.6-27b/vllm/compose/single/long-text-no-mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/long-text-no-mtp.yml
@@ -115,7 +115,7 @@ services:
     container_name: vllm-qwen36-27b-long-text-no-mtp
     restart: "no"
     ports:
-      - "${PORT:-8021}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${PORT:-8021}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../models-cache}:/root/.cache/huggingface
       # torch.compile + Triton kernel caches — first boot warms (~60-90 sec

--- a/models/qwen3.6-27b/vllm/compose/single/long-text.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/long-text.yml
@@ -125,7 +125,7 @@ services:
     container_name: vllm-qwen36-27b-long-text
     restart: "no"
     ports:
-      - "${PORT:-8020}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${PORT:-8020}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../models-cache}:/root/.cache/huggingface
       # torch.compile + Triton kernel caches — first boot warms (~60-90 sec

--- a/models/qwen3.6-27b/vllm/compose/single/long-vision.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/long-vision.yml
@@ -101,7 +101,7 @@ services:
     container_name: vllm-qwen36-27b-long-vision
     restart: "no"
     ports:
-      - "${PORT:-8020}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${PORT:-8020}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../models-cache}:/root/.cache/huggingface
       # torch.compile + Triton kernel caches — first boot warms (~60-90 sec);

--- a/models/qwen3.6-27b/vllm/compose/single/minimal.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/minimal.yml
@@ -37,7 +37,7 @@ services:
     container_name: vllm-qwen36-27b-minimal
     restart: "no"
     ports:
-      - "${PORT:-8020}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${PORT:-8020}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../models-cache}:/root/.cache/huggingface
       # torch.compile + Triton kernel caches — first boot warms (~60-90 sec);

--- a/models/qwen3.6-27b/vllm/compose/single/tools-text.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/tools-text.yml
@@ -39,7 +39,7 @@ services:
     container_name: vllm-qwen36-27b
     restart: "no"
     ports:
-      - "${PORT:-8020}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${PORT:-8020}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../models-cache}:/root/.cache/huggingface
       # torch.compile + Triton kernel caches — first boot warms (~60-90 sec);

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -482,12 +482,13 @@ preflight_autodetect_endpoint() {
 
   local detected_name detected_port
   detected_name="${found_line%%|*}"
-  # Extract host port from "0.0.0.0:8011->8000/tcp" or "[::]:8011->8000/tcp" forms.
+  # Extract host port from "0.0.0.0:8011->8000/tcp", "[::]:8011->8000/tcp",
+  # or "127.0.0.1:8011->8000/tcp" forms (BIND_HOST=127.0.0.1 produces the last).
   # llama-cpp container maps to internal 8080, vllm to 8000 — match both.
   detected_port=$(echo "${found_line#*|}" \
-    | grep -oE '0\.0\.0\.0:[0-9]+->(8000|8080)/tcp' \
+    | grep -oE '([0-9]{1,3}\.){3}[0-9]{1,3}:[0-9]+->(8000|8080)/tcp' \
     | head -1 \
-    | sed -E 's|^0\.0\.0\.0:([0-9]+)->.*|\1|')
+    | sed -E 's|^[^:]+:([0-9]+)->.*|\1|')
 
   # Apply, but only fields the user didn't already set explicitly.
   if [[ -z "$explicit_container" && -n "$detected_name" ]]; then

--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -651,6 +651,7 @@ if [[ $DO_SOAK -eq 1 ]]; then
   if [[ -f scripts/soak-test.sh ]]; then
     soak_run_dir="results/report-soak-$(date +%Y%m%d-%H%M%S)"
     SOAK_MODE=continuous SOAK_SESSIONS=5 SOAK_TURNS=5 SOAK_OUTPUT="$soak_run_dir" \
+      SOAK_TIMEOUT_S="${SOAK_TIMEOUT_S:-1800}" \
       bash scripts/soak-test.sh 2>&1 | redact | details "soak-test stdout (5-session × 5-turn ramping conversation, ~25 min)"
     if [[ -f "$soak_run_dir/summary.md" ]]; then
       echo


### PR DESCRIPTION
## Summary

Adds `BIND_HOST` env var to all 18 vLLM compose files so the API port can be restricted to localhost, and fixes two scripts that broke when `BIND_HOST=127.0.0.1` was set.

**Motivation**: When running `max-num-seqs=1` variants (bounded-thinking, default, long-*, tools-text), any IDE agent (Cline, Cursor, Copilot) that probes the same port will preempt an in-flight verify-stress or soak run, causing spurious HTTP 000 / 429 failures. Binding to 127.0.0.1 prevents that without requiring firewall rules.

**Changes**:
- All 18 `docker-compose.*.yml` files: port binding changed from `"${PORT:-NNNN}:8000"` to `"${BIND_HOST:-0.0.0.0}:${PORT:-NNNN}:8000"` — default unchanged, opt-in via `.env`
- `scripts/preflight.sh`: port-detection regex broadened from `0.0.0.0:PORT->` to `[any IPv4]:PORT->` — was silently producing empty output (exit 1) when `BIND_HOST=127.0.0.1`
- `scripts/report.sh`: forward `SOAK_TIMEOUT_S` to `soak-test.sh` invocation — was silently using the 1800s default even when `.env` set `SOAK_TIMEOUT_S=3600`
- `.env.example`: docs for `BIND_HOST` and `SOAK_TIMEOUT_S`

## Test plan

- [ ] `docker compose up -d` with no `.env` — port binding unchanged (`0.0.0.0:8020->8000/tcp`)
- [ ] `BIND_HOST=127.0.0.1 docker compose up -d` — port binds to `127.0.0.1:8020->8000/tcp`; `preflight.sh` detects port correctly; `bash scripts/report.sh --full` runs to completion with correct soak timeout

Tested on RTX 5090 Laptop + WSL2 (driver 596.36) with bounded-thinking.yml + `BIND_HOST=127.0.0.1` + `SOAK_TIMEOUT_S=3600` — all 10 verify-full checks pass, soak 5/5 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)