### PR TITLE
compose: parametrize VLLM_ENFORCE_EAGER, KV_CACHE_DTYPE, P40/P82/PN54 across all variants

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,38 @@
 # Skip cloning Genesis (e.g. you only intend to run llama.cpp / SGLang).
 # SKIP_GENESIS=1
 
+# VLLM_ENFORCE_EAGER — disable CUDA graph capture. Costs ~20-30% TPS but
+# eliminates graph-capture OOM and Cliff 2 GDN activation spikes at runtime.
+# Required on WSL2 at 180K+ context (CUDA graph reservation leaves insufficient
+# KV cache headroom). Also useful when CUDA graph capture itself OOMs on boot.
+# VLLM_ENFORCE_EAGER=1
+
+# KV cache quantisation. Each compose variant ships a calibrated default:
+#   turboquant_3bit_nc — 3-bit TQ k8v4, lowest memory per KV slot, best for
+#                        long-context on 24 GB (bounded-thinking, dual-turbo,
+#                        long-text, long-vision, docker-compose.yml).
+#   fp8_e5m2           — 8-bit FP8, higher quality, used on variants with more
+#                        KV headroom (tools-text, minimal, dual, dual-nvlink).
+# Override only if you have a specific reason — switching fp8→TQ3 frees ~50%
+# KV memory (important at 180K ctx), switching TQ3→fp8 costs that headroom.
+# KV_CACHE_DTYPE=turboquant_3bit_nc
+
+# Genesis P40 — TQ k8v4 GQA grouping kernel. Gain: +15-30% TPS on
+# compute-regime GPUs (L2 cache >= 24 MB: RTX 5090, A100, H100).
+# No gain on RTX 3090 (6 MB L2). Default off.
+# GENESIS_ENABLE_P40=1
+
+# Genesis P82 — SGLang-style acceptance threshold OR-clause for MTP spec-decode.
+# Biased toward small-batch single-stream workloads (bounded-thinking, default).
+# Cross-rig data: +10.5% on 3090 INT4, +12% on A5000 FP8. Default off.
+# Note: Genesis will skip this automatically if upstream has absorbed the patch.
+# GENESIS_ENABLE_P82=1
+
+# Genesis PN54 — GDN contiguous-call deduplication (Cliff 2b OOM mitigation).
+# Reduces peak activation memory during long-context GDN forward passes.
+# Default off (opt-in while cross-rig data is still being collected).
+# GENESIS_ENABLE_PN54=1
+
 
 # -----------------------------------------------------------------------------
 # Host port mapping (PORT)
@@ -132,4 +164,38 @@
 # VLLM_ENFORCE_EAGER=1 (e.g. WSL2 or 5090 Laptop), long-context prefills
 # can exceed the 1800s budget before all 5 sessions complete. 3600s is
 # sufficient for the RTX 5090 Laptop with enforce_eager.
+
+# =============================================================================
+# Validated rig profiles
+# =============================================================================
+# Copy the relevant block into your .env and adjust as needed.
+#
+# ── RTX 5090 Laptop + WSL2 (driver 596.36, 24 GB, EC-managed power) ─────────
+# Validated 2026-05-08 against bounded-thinking.yml (issue #102).
+# Results: 35.91 narr / 46.43 code wall TPS, TTFT ~165ms, soak PASS 5/5,
+#          MTP acceptance 3.32-3.56, avg draft rate 77-85%.
+#
+# Notes:
+#   - VLLM_ENFORCE_EAGER required: CUDA graph reservation eats ~4 GiB, leaving
+#     insufficient KV headroom for 180K context on 24 GB VRAM.
+#   - KV_CACHE_DTYPE: keep turboquant_3bit_nc (3-bit < fp8 8-bit in KV memory).
+#     Switching to fp8_e5m2 raises the KV floor from ~2 GiB to 6.64 GiB and
+#     prevents the engine from starting at 180K ctx.
+#   - GENESIS_ENABLE_P40: RTX 5090 has 88 MB L2 — well above the 24 MB
+#     threshold for the GQA grouping kernel to pay off.
+#   - GENESIS_ENABLE_P82: upstream drift in rejection_sampler.py caused Genesis
+#     to skip this patch on the 2026-05-08 run (no TPS delta). Re-enable when
+#     the pin is bumped and verify with bench.sh.
+#   - Software power cap (nvidia-smi -pl): N/A — laptop EC manages the power
+#     envelope. Observed load draw ~94 W (95 W EC profile), max 175 W TDP.
+#     Use -lgc/-lmc clock-lock (see docs/HARDWARE.md) for sweep characterisation.
+#   - SOAK_TIMEOUT_S: 3600 needed because eager-mode prefills at accumulated
+#     long context regularly hit 200-290s, exceeding the 1800s default budget
+#     before all 5 sessions complete.
+#
+# PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False,max_split_size_mb:512
+# GPU_MEMORY_UTILIZATION=0.94
+# VLLM_ENFORCE_EAGER=1
+# GENESIS_ENABLE_P40=1
+# GENESIS_ENABLE_P82=1
 # SOAK_TIMEOUT_S=3600

--- a/models/qwen3.6-27b/vllm/compose/dual/carnice-bf16mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/carnice-bf16mtp.yml
@@ -94,6 +94,14 @@ services:
             - driver: nvidia
               count: all
               capabilities: [gpu]
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # VLLM_ENFORCE_EAGER=1 in .env disables CUDA graphs — use on
+        # hardware where graph capture causes OOM or instability (e.g. WSL2).
+        exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} "$@"
+      - --
     command:
       - --model
       - /root/.cache/huggingface/carnice-v2-27b-int4-recipe-d-bf16mtp
@@ -115,7 +123,7 @@ services:
       - --max-num-batched-tokens
       - "8192"
       - --kv-cache-dtype
-      - fp8_e5m2
+      - "${KV_CACHE_DTYPE:-fp8_e5m2}"
       - --trust-remote-code
       - --reasoning-parser
       - qwen3

--- a/models/qwen3.6-27b/vllm/compose/dual/dflash-noviz.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/dflash-noviz.yml
@@ -82,6 +82,14 @@ services:
             - driver: nvidia
               count: all
               capabilities: [gpu]
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # VLLM_ENFORCE_EAGER=1 in .env disables CUDA graphs — use on
+        # hardware where graph capture causes OOM or instability (e.g. WSL2).
+        exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} "$@"
+      - --
     command:
       - --model
       - /root/.cache/huggingface/qwen3.6-27b-autoround-int4

--- a/models/qwen3.6-27b/vllm/compose/dual/dflash.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/dflash.yml
@@ -106,6 +106,14 @@ services:
             - driver: nvidia
               count: all
               capabilities: [gpu]
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # VLLM_ENFORCE_EAGER=1 in .env disables CUDA graphs — use on
+        # hardware where graph capture causes OOM or instability (e.g. WSL2).
+        exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} "$@"
+      - --
     command:
       - --model
       - /root/.cache/huggingface/qwen3.6-27b-autoround-int4

--- a/models/qwen3.6-27b/vllm/compose/dual/docker-compose.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/docker-compose.yml
@@ -126,7 +126,7 @@ services:
       - --max-num-batched-tokens
       - "8192"
       - --kv-cache-dtype
-      - fp8_e5m2
+      - "${KV_CACHE_DTYPE:-fp8_e5m2}"
       - --trust-remote-code
       - --reasoning-parser
       - qwen3

--- a/models/qwen3.6-27b/vllm/compose/dual/nvlink-dflash-noviz.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/nvlink-dflash-noviz.yml
@@ -116,6 +116,14 @@ services:
             - driver: nvidia
               count: all
               capabilities: [gpu]
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # VLLM_ENFORCE_EAGER=1 in .env disables CUDA graphs — use on
+        # hardware where graph capture causes OOM or instability (e.g. WSL2).
+        exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} "$@"
+      - --
     command:
       - --model
       - /root/.cache/huggingface/qwen3.6-27b-autoround-int4

--- a/models/qwen3.6-27b/vllm/compose/dual/nvlink-dflash.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/nvlink-dflash.yml
@@ -112,6 +112,14 @@ services:
             - driver: nvidia
               count: all
               capabilities: [gpu]
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # VLLM_ENFORCE_EAGER=1 in .env disables CUDA graphs — use on
+        # hardware where graph capture causes OOM or instability (e.g. WSL2).
+        exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} "$@"
+      - --
     command:
       - --model
       - /root/.cache/huggingface/qwen3.6-27b-autoround-int4

--- a/models/qwen3.6-27b/vllm/compose/dual/nvlink-turbo.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/nvlink-turbo.yml
@@ -176,13 +176,18 @@ services:
       - GENESIS_ENABLE_PN30_DS_LAYOUT_SPEC_DECODE=1
       - GENESIS_PREALLOC_TOKEN_BUDGET=4128
       - GENESIS_BUFFER_MODE=shared
+      # P40 — TQ k8v4 GQA grouping kernel (+15-30% on compute-regime GPUs, L2>=24MB).
+      # Default off (RTX 3090: 6MB L2 = no gain). Enable on RTX 5090/A100/H100.
+      - GENESIS_ENABLE_P40=${GENESIS_ENABLE_P40:-0}
+      # PN54 — GDN contiguous-call deduplication (Cliff 2b OOM mitigation).
+      - GENESIS_ENABLE_PN54=${GENESIS_ENABLE_PN54:-0}
       # Explicit OFFs to match Sandermage's PROD env-var set verbatim:
       # P78 (P78_TOLIST_CAPTURE_GUARD) — superseded by our patch_tolist_cudagraph.py
       # P81 (FP8 block-scaled M<=8) — FP8-specific, no-op on our TQ3 path
       # P82 — biased on small-batch single-stream Lorbus INT4 + MTP K=3 (Sander PROD)
       - GENESIS_ENABLE_P78_TOLIST_CAPTURE_GUARD=0
       - GENESIS_ENABLE_P81_FP8_BLOCK_SCALED_M_LE_8=0
-      - GENESIS_ENABLE_P82=0
+      - GENESIS_ENABLE_P82=${GENESIS_ENABLE_P82:-0}
       - GENESIS_P82_THRESHOLD_SINGLE=0.3
     shm_size: "16gb"
     ipc: host
@@ -248,7 +253,7 @@ services:
       # capacity for activation headroom on the smaller-VRAM sub-class. See
       # docs/HARDWARE.md "Note for sub-24 GB cards" + #47 for cross-rig data.
       - --kv-cache-dtype
-      - turboquant_3bit_nc
+      - "${KV_CACHE_DTYPE:-turboquant_3bit_nc}"
       - --trust-remote-code
       - --reasoning-parser
       - qwen3

--- a/models/qwen3.6-27b/vllm/compose/dual/nvlink.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/nvlink.yml
@@ -135,7 +135,7 @@ services:
       - --max-num-batched-tokens
       - "8192"
       - --kv-cache-dtype
-      - fp8_e5m2
+      - "${KV_CACHE_DTYPE:-fp8_e5m2}"
       - --trust-remote-code
       - --reasoning-parser
       - qwen3

--- a/models/qwen3.6-27b/vllm/compose/dual/turbo.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/turbo.yml
@@ -158,13 +158,18 @@ services:
       - GENESIS_ENABLE_PN30_DS_LAYOUT_SPEC_DECODE=1
       - GENESIS_PREALLOC_TOKEN_BUDGET=4128
       - GENESIS_BUFFER_MODE=shared
+      # P40 — TQ k8v4 GQA grouping kernel (+15-30% on compute-regime GPUs, L2>=24MB).
+      # Default off (RTX 3090: 6MB L2 = no gain). Enable on RTX 5090/A100/H100.
+      - GENESIS_ENABLE_P40=${GENESIS_ENABLE_P40:-0}
+      # PN54 — GDN contiguous-call deduplication (Cliff 2b OOM mitigation).
+      - GENESIS_ENABLE_PN54=${GENESIS_ENABLE_PN54:-0}
       # Explicit OFFs to match Sandermage's PROD env-var set verbatim:
       # P78 (P78_TOLIST_CAPTURE_GUARD) — superseded by our patch_tolist_cudagraph.py
       # P81 (FP8 block-scaled M<=8) — FP8-specific, no-op on our TQ3 path
       # P82 — biased on small-batch single-stream Lorbus INT4 + MTP K=3 (Sander PROD)
       - GENESIS_ENABLE_P78_TOLIST_CAPTURE_GUARD=0
       - GENESIS_ENABLE_P81_FP8_BLOCK_SCALED_M_LE_8=0
-      - GENESIS_ENABLE_P82=0
+      - GENESIS_ENABLE_P82=${GENESIS_ENABLE_P82:-0}
       - GENESIS_P82_THRESHOLD_SINGLE=0.3
     shm_size: "16gb"
     ipc: host
@@ -228,7 +233,7 @@ services:
       # capacity for activation headroom on the smaller-VRAM sub-class. See
       # docs/HARDWARE.md "Note for sub-24 GB cards" + #47 for cross-rig data.
       - --kv-cache-dtype
-      - turboquant_3bit_nc
+      - "${KV_CACHE_DTYPE:-turboquant_3bit_nc}"
       - --trust-remote-code
       - --reasoning-parser
       - qwen3

--- a/models/qwen3.6-27b/vllm/compose/multi4/dflash.yml
+++ b/models/qwen3.6-27b/vllm/compose/multi4/dflash.yml
@@ -99,6 +99,14 @@ services:
             - driver: nvidia
               count: all
               capabilities: [gpu]
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # VLLM_ENFORCE_EAGER=1 in .env disables CUDA graphs — use on
+        # hardware where graph capture causes OOM or instability (e.g. WSL2).
+        exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} "$@"
+      - --
     command:
       - --model
       - /root/.cache/huggingface/qwen3.6-27b-autoround-int4

--- a/models/qwen3.6-27b/vllm/compose/multi4/docker-compose.yml
+++ b/models/qwen3.6-27b/vllm/compose/multi4/docker-compose.yml
@@ -134,7 +134,7 @@ services:
       - --max-num-batched-tokens
       - "8192"
       - --kv-cache-dtype
-      - fp8_e5m2
+      - "${KV_CACHE_DTYPE:-fp8_e5m2}"
       - --trust-remote-code
       - --reasoning-parser
       - qwen3

--- a/models/qwen3.6-27b/vllm/compose/single/bounded-thinking.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/bounded-thinking.yml
@@ -222,13 +222,18 @@ services:
       - GENESIS_ENABLE_PN30_DS_LAYOUT_SPEC_DECODE=1
       - GENESIS_PREALLOC_TOKEN_BUDGET=4128
       - GENESIS_BUFFER_MODE=shared
+      # P40 — TQ k8v4 GQA grouping kernel (+15-30% on compute-regime GPUs, L2>=24MB).
+      # Default off (RTX 3090: 6MB L2 = no gain). Enable on RTX 5090/A100/H100.
+      - GENESIS_ENABLE_P40=${GENESIS_ENABLE_P40:-0}
+      # PN54 — GDN contiguous-call deduplication (Cliff 2b OOM mitigation).
+      - GENESIS_ENABLE_PN54=${GENESIS_ENABLE_PN54:-0}
       # Explicit OFFs to match Sandermage's PROD env-var set verbatim:
       # P78 (P78_TOLIST_CAPTURE_GUARD) — superseded by our patch_tolist_cudagraph.py
       # P81 (FP8 block-scaled M<=8) — FP8-specific, no-op on our TQ3 path
       # P82 — biased on small-batch single-stream Lorbus INT4 + MTP K=3 (Sander PROD)
       - GENESIS_ENABLE_P78_TOLIST_CAPTURE_GUARD=0
       - GENESIS_ENABLE_P81_FP8_BLOCK_SCALED_M_LE_8=0
-      - GENESIS_ENABLE_P82=0
+      - GENESIS_ENABLE_P82=${GENESIS_ENABLE_P82:-0}
       - GENESIS_P82_THRESHOLD_SINGLE=0.3
       # VLLM_SSM_CONV_STATE_LAYOUT=DS — RE-ENABLED with our local PN30
       # dst-shaped temp fix (patch_pn30_dst_shaped_temp_fix.py, applied at
@@ -296,7 +301,7 @@ services:
       - --max-num-batched-tokens
       - "4128"
       - --kv-cache-dtype
-      - turboquant_3bit_nc
+      - "${KV_CACHE_DTYPE:-turboquant_3bit_nc}"
       - --language-model-only
       - --trust-remote-code
       - --reasoning-parser

--- a/models/qwen3.6-27b/vllm/compose/single/docker-compose.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/docker-compose.yml
@@ -160,6 +160,11 @@ services:
       # actually firing today; P98 will engage once the marker fix lands.
       # Belt+suspenders pattern matches long-text.yml + long-text-no-mtp.yml.
       - GENESIS_ENABLE_P98=1
+      # P40 — TQ k8v4 GQA grouping kernel (+15-30% on compute-regime GPUs, L2>=24MB).
+      # Default off (RTX 3090: 6MB L2 = no gain). Enable on RTX 5090/A100/H100.
+      - GENESIS_ENABLE_P40=${GENESIS_ENABLE_P40:-0}
+      # PN54 — GDN contiguous-call deduplication (Cliff 2b OOM mitigation).
+      - GENESIS_ENABLE_PN54=${GENESIS_ENABLE_PN54:-0}
       # P68/P69 deliberately DISABLED (2026-04-29) — same reasoning as
       # tools-text.yml: 8000-char threshold breaks IDE-agent flows with
       # silent finish_reason=stop. Bisected on club-3090 issue #2.
@@ -234,7 +239,7 @@ services:
       - --max-num-batched-tokens
       - "4128"
       - --kv-cache-dtype
-      - turboquant_3bit_nc
+      - "${KV_CACHE_DTYPE:-turboquant_3bit_nc}"
       # For maximum context, switch to single/long-text.yml (218K, no
       # vision) or single/long-vision.yml (198K + vision). Both carry
       # the PN12 anchor sidecar that closes Cliff 1 on TQ3 paths.

--- a/models/qwen3.6-27b/vllm/compose/single/long-text-no-mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/long-text-no-mtp.yml
@@ -244,13 +244,18 @@ services:
       - GENESIS_ENABLE_P15B_FA_VARLEN_CLAMP=1
       - GENESIS_PREALLOC_TOKEN_BUDGET=4128
       - GENESIS_BUFFER_MODE=shared
+      # P40 — TQ k8v4 GQA grouping kernel (+15-30% on compute-regime GPUs, L2>=24MB).
+      # Default off (RTX 3090: 6MB L2 = no gain). Enable on RTX 5090/A100/H100.
+      - GENESIS_ENABLE_P40=${GENESIS_ENABLE_P40:-0}
+      # PN54 — GDN contiguous-call deduplication (Cliff 2b OOM mitigation).
+      - GENESIS_ENABLE_PN54=${GENESIS_ENABLE_PN54:-0}
       # Explicit OFFs to match Sandermage's PROD env-var set verbatim:
       # P78 (P78_TOLIST_CAPTURE_GUARD) — superseded by our patch_tolist_cudagraph.py
       # P81 (FP8 block-scaled M<=8) — FP8-specific, no-op on our TQ3 path
       # P82 — biased on small-batch single-stream Lorbus INT4 + MTP K=3 (Sander PROD)
       - GENESIS_ENABLE_P78_TOLIST_CAPTURE_GUARD=0
       - GENESIS_ENABLE_P81_FP8_BLOCK_SCALED_M_LE_8=0
-      - GENESIS_ENABLE_P82=0
+      - GENESIS_ENABLE_P82=${GENESIS_ENABLE_P82:-0}
       - GENESIS_P82_THRESHOLD_SINGLE=0.3
       # P82 stays OFF — biased on small-batch single-stream Lorbus INT4 + MTP K=3
       # per Sandermage's PROD memory feedback_p82_*. P78 stays OFF (deprecated).
@@ -345,7 +350,7 @@ services:
       - --max-num-batched-tokens
       - "4128"
       - --kv-cache-dtype
-      - turboquant_3bit_nc
+      - "${KV_CACHE_DTYPE:-turboquant_3bit_nc}"
       # Drops the vision tower → frees ~1 GB VRAM → lifts engine ceiling from
       # 198K (long-vision at 0.98) to 218K (this variant at 0.985). This is the only difference vs long-vision.
       - --language-model-only

--- a/models/qwen3.6-27b/vllm/compose/single/long-text.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/long-text.yml
@@ -261,13 +261,18 @@ services:
       - GENESIS_ENABLE_P15B_FA_VARLEN_CLAMP=1
       - GENESIS_PREALLOC_TOKEN_BUDGET=4128
       - GENESIS_BUFFER_MODE=shared
+      # P40 — TQ k8v4 GQA grouping kernel (+15-30% on compute-regime GPUs, L2>=24MB).
+      # Default off (RTX 3090: 6MB L2 = no gain). Enable on RTX 5090/A100/H100.
+      - GENESIS_ENABLE_P40=${GENESIS_ENABLE_P40:-0}
+      # PN54 — GDN contiguous-call deduplication (Cliff 2b OOM mitigation).
+      - GENESIS_ENABLE_PN54=${GENESIS_ENABLE_PN54:-0}
       # Explicit OFFs to match Sandermage's PROD env-var set verbatim:
       # P78 (P78_TOLIST_CAPTURE_GUARD) — superseded by our patch_tolist_cudagraph.py
       # P81 (FP8 block-scaled M<=8) — FP8-specific, no-op on our TQ3 path
       # P82 — biased on small-batch single-stream Lorbus INT4 + MTP K=3 (Sander PROD)
       - GENESIS_ENABLE_P78_TOLIST_CAPTURE_GUARD=0
       - GENESIS_ENABLE_P81_FP8_BLOCK_SCALED_M_LE_8=0
-      - GENESIS_ENABLE_P82=0
+      - GENESIS_ENABLE_P82=${GENESIS_ENABLE_P82:-0}
       - GENESIS_P82_THRESHOLD_SINGLE=0.3
       # P82 stays OFF — biased on small-batch single-stream Lorbus INT4 + MTP K=3
       # per Sandermage's PROD memory feedback_p82_*. P78 stays OFF (deprecated).
@@ -362,7 +367,7 @@ services:
       - --max-num-batched-tokens
       - "4128"
       - --kv-cache-dtype
-      - turboquant_3bit_nc
+      - "${KV_CACHE_DTYPE:-turboquant_3bit_nc}"
       # Drops the vision tower → frees ~1 GB VRAM → lifts engine ceiling from
       # 198K (long-vision at 0.98) to 218K (this variant at 0.985). This is the only difference vs long-vision.
       - --language-model-only

--- a/models/qwen3.6-27b/vllm/compose/single/long-vision.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/long-vision.yml
@@ -188,13 +188,18 @@ services:
       - GENESIS_ENABLE_PN30_DS_LAYOUT_SPEC_DECODE=1
       - GENESIS_PREALLOC_TOKEN_BUDGET=4128
       - GENESIS_BUFFER_MODE=shared
+      # P40 — TQ k8v4 GQA grouping kernel (+15-30% on compute-regime GPUs, L2>=24MB).
+      # Default off (RTX 3090: 6MB L2 = no gain). Enable on RTX 5090/A100/H100.
+      - GENESIS_ENABLE_P40=${GENESIS_ENABLE_P40:-0}
+      # PN54 — GDN contiguous-call deduplication (Cliff 2b OOM mitigation).
+      - GENESIS_ENABLE_PN54=${GENESIS_ENABLE_PN54:-0}
       # Explicit OFFs to match Sandermage's PROD env-var set verbatim:
       # P78 (P78_TOLIST_CAPTURE_GUARD) — superseded by our patch_tolist_cudagraph.py
       # P81 (FP8 block-scaled M<=8) — FP8-specific, no-op on our TQ3 path
       # P82 — biased on small-batch single-stream Lorbus INT4 + MTP K=3 (Sander PROD)
       - GENESIS_ENABLE_P78_TOLIST_CAPTURE_GUARD=0
       - GENESIS_ENABLE_P81_FP8_BLOCK_SCALED_M_LE_8=0
-      - GENESIS_ENABLE_P82=0
+      - GENESIS_ENABLE_P82=${GENESIS_ENABLE_P82:-0}
       - GENESIS_P82_THRESHOLD_SINGLE=0.3
       # VLLM_SSM_CONV_STATE_LAYOUT=DS — RE-ENABLED with our local PN30
       # dst-shaped temp fix (patch_pn30_dst_shaped_temp_fix.py, applied at
@@ -265,7 +270,7 @@ services:
       - --max-num-batched-tokens
       - "4128"
       - --kv-cache-dtype
-      - turboquant_3bit_nc
+      - "${KV_CACHE_DTYPE:-turboquant_3bit_nc}"
       - --trust-remote-code
       - --reasoning-parser
       - qwen3

--- a/models/qwen3.6-27b/vllm/compose/single/minimal.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/minimal.yml
@@ -67,6 +67,14 @@ services:
             - driver: nvidia
               count: all
               capabilities: [gpu]
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # VLLM_ENFORCE_EAGER=1 in .env disables CUDA graphs — use on
+        # hardware where graph capture causes OOM or instability (e.g. WSL2).
+        exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} "$@"
+      - --
     command:
       - --model
       - /root/.cache/huggingface/qwen3.6-27b-autoround-int4
@@ -85,7 +93,7 @@ services:
       - --max-num-seqs
       - "1"
       - --kv-cache-dtype
-      - fp8_e5m2
+      - "${KV_CACHE_DTYPE:-fp8_e5m2}"
       - --trust-remote-code
       - --reasoning-parser
       - qwen3

--- a/models/qwen3.6-27b/vllm/compose/single/tools-text.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/tools-text.yml
@@ -91,6 +91,12 @@ services:
       - GENESIS_ENABLE_PN17_FA2_LSE_CLAMP=1
       - GENESIS_ENABLE_PN19_SCOPED_MAX_SPLIT=1
       - GENESIS_ENABLE_PN59_STREAMING_GDN=1
+
+      # P40 — TQ k8v4 GQA grouping kernel (+15-30% on compute-regime GPUs, L2>=24MB).
+      # Default off (RTX 3090: 6MB L2 = no gain). Enable on RTX 5090/A100/H100.
+      - GENESIS_ENABLE_P40=${GENESIS_ENABLE_P40:-0}
+      # PN54 — GDN contiguous-call deduplication (Cliff 2b OOM mitigation).
+      - GENESIS_ENABLE_PN54=${GENESIS_ENABLE_PN54:-0}
     shm_size: "16gb"
     ipc: host
     deploy:
@@ -144,7 +150,7 @@ services:
       - "2048"
       # fp8_e5m2 (not turboquant) — required for tool calls to work with MTP.
       - --kv-cache-dtype
-      - fp8_e5m2
+      - "${KV_CACHE_DTYPE:-fp8_e5m2}"
       # Dropping the MoonViT vision tower frees ~0.86 GB for KV cache,
       # pushing max_model_len from 20K → 75K vs docker-compose.tools.yml.
       - --language-model-only


### PR DESCRIPTION
## Summary

Promotes five previously-hardcoded vLLM/Genesis knobs to `.env`-overridable variables across all compose variants. **All defaults are unchanged** — existing users see identical behavior out of the box.

Motivated by RTX 5090 Laptop + WSL2 (issue #102): that rig needs `VLLM_ENFORCE_EAGER=1` (CUDA graph reservation eats ~4 GiB, leaving insufficient KV headroom at 180K ctx on 24 GB VRAM) and `GENESIS_ENABLE_P40=1` (88 MB L2 cache on 5090 is well above the 24 MB threshold for the GQA grouping kernel gain). Previously these required editing compose files directly.

**Changes across 18 compose files + `.env.example`**:

- **`VLLM_ENFORCE_EAGER`** — `${VLLM_ENFORCE_EAGER:+--enforce-eager}` entrypoint hook added to 7 files that lacked it: `carnice-bf16mtp`, `dual-dflash`, `dual-dflash-noviz`, `dual-nvlink-dflash`, `dual-nvlink-dflash-noviz`, `dual4-dflash`, `minimal` (the other 11 already had the hook)

- **`KV_CACHE_DTYPE`** — hardcoded dtype made parametric in all 13 variants, each preserving its own default:
  - `turboquant_3bit_nc` (default): `bounded-thinking`, `docker-compose.yml`, `long-text`, `long-text-no-mtp`, `long-vision`, `dual-turbo`, `dual-nvlink-turbo`
  - `fp8_e5m2` (default): `carnice-bf16mtp`, `dual`, `dual-nvlink`, `dual4`, `minimal`, `tools-text`

- **`GENESIS_ENABLE_P40` + `GENESIS_ENABLE_PN54`** — opt-in stanzas (default `0`) added to all 8 Genesis-using variants: `bounded-thinking`, `docker-compose.yml`, `dual-turbo`, `dual-nvlink-turbo`, `long-text`, `long-text-no-mtp`, `long-vision`, `tools-text`

- **`GENESIS_ENABLE_P82`** — promoted from hardcoded `0` → `${GENESIS_ENABLE_P82:-0}` in 6 spec-decode variants: `bounded-thinking`, `dual-turbo`, `dual-nvlink-turbo`, `long-text`, `long-text-no-mtp`, `long-vision`

- **`.env.example`** — documentation added for all five knobs plus a validated **RTX 5090 Laptop + WSL2 profile block** (issue #102):
  ```
  PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False,max_split_size_mb:512
  GPU_MEMORY_UTILIZATION=0.94
  VLLM_ENFORCE_EAGER=1
  GENESIS_ENABLE_P40=1
  GENESIS_ENABLE_P82=1
  SOAK_TIMEOUT_S=3600
  ```
  Results: 35.91 narr / 46.43 code wall TPS, TTFT ~165ms, soak PASS 5/5, MTP acceptance 3.32–3.56 (validated 2026-05-08).

## Test plan

- [ ] Boot any existing variant with no `.env` — behavior identical to before this PR
- [ ] `VLLM_ENFORCE_EAGER=1` in `.env` + any variant that previously lacked the hook → `--enforce-eager` appears in vllm serve args
- [ ] `KV_CACHE_DTYPE=fp8_e5m2` in `.env` with a TQ3-default variant → engine boots with fp8 KV (verify via container logs)
- [ ] `GENESIS_ENABLE_P40=1` in `.env` → Genesis logs show P40 applied
- [ ] RTX 5090 Laptop + WSL2: copy profile block from `.env.example` into `.env` → bounded-thinking boots and passes verify-full.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)