### PR TITLE
feat(compose): add dual/bf16-int4.yml (AWQ BF16+INT4 mixed quant)

### DIFF
--- a/models/qwen3.6-27b/vllm/compose/dual/bf16-int4.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/bf16-int4.yml
@@ -1,0 +1,152 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-27B (cyankiwi AWQ BF16-INT4, compressed-tensors)
+#   Topology:  Dual 3090 (TP=2, NVLink auto-detected via NVLINK_MODE)
+#   Drafter:   MTP n=5 (built-in)
+#   KV:        fp16 (AWQ BF16+INT4 mixed quant, compressed-tensors format)
+#   Vision:    yes
+#   Max ctx:   190K total (across all 4 streams)
+#   Genesis:   none
+#   Status:    Experimental
+#   Best for:  Multi-stream interactivity (4 seqs, 190K total ctx across all streams)
+# ---------------------------------------------------------------------------
+# Dual RTX 3090 — AWQ BF16+INT4 mixed quant variant with MTP n=5 speculative
+# decoding and 4-stream concurrency. Uses compressed-tensors format from
+# cyankiwi/Qwen3.6-27B-AWQ-BF16-INT4 (~27 GB, 6 safetensors shards).
+#
+# What this gives you (vs the dual/docker-compose.yml default):
+#   - AWQ mixed BF16+INT4 quantization (compressed-tensors) instead of AutoRound
+#   - MTP n=5 speculative decoding (vs n=3 in the default compose)
+#   - max_num_seqs=4 for multi-stream interactivity
+#   - 190K total context across all streams (not per-stream)
+#   - FP16 KV cache (default for compressed-tensors AWQ)
+#   - performance-mode=interactivity for low-latency decoding
+#
+# Dependencies:
+#   - 2x RTX 3090 (Ampere SM 8.6), PCIe or NVLink (auto-detected)
+#   - cyankiwi/Qwen3.6-27B-AWQ-BF16-INT4 model weights (~27 GB)
+#   - vLLM PR #40361 (Marlin pad-sub-tile-n) — patched files volume-mounted
+#
+# All dual-card variants in this dir:
+#
+#   File                                    Ctx       Streams   KV       Quant              Topology
+#   dual/docker-compose.yml                 262K      2         fp8      AutoRound INT4     2x PCIe/NVLink
+#   dual/turbo.yml                          262K      4         TQ3      AutoRound INT4     2x PCIe
+#   dual/dflash.yml                         185K      1         FP16     AutoRound INT4     2x PCIe
+#   dual/dflash-noviz.yml                   200K      1         FP16     AutoRound INT4     2x PCIe
+#   dual/bf16-int4.yml (this)              190K total 6         FP16     AWQ BF16+INT4      2x PCIe/NVLink
+#   dual/nvlink-dflash.yml                  185K      1         FP16     AutoRound INT4     2x NVLink
+#   dual/nvlink-dflash-noviz.yml            188K      1         FP16     AutoRound INT4     2x NVLink
+#
+# Run:
+#   cd <repo>/models/qwen3.6-27b/vllm/compose
+#   docker compose -f dual/bf16-int4.yml up -d
+# ===========================================================================
+# Hardware metadata (parsed by scripts/preflight.sh):
+# Requires-min-vram-gb: 24
+# Engine-profile: vllm-nightly-mtp
+# Requires-min-gpu-count: 2
+# Tensor-parallel: 2
+services:
+  vllm-qwen36-27b-bf16-int4:
+    # Tracking latest nightly intentionally — this stack uses fp16 KV (not
+    # TurboQuant), so it doesn't accumulate the same anchor-drift exposure
+    # the single-card project does. Pin if you hit a regression; otherwise
+    # ride the wave.
+    image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
+    container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b-bf16-int4}"
+    restart: "no"
+    ports:
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-5000}}:8000"
+    volumes:
+      - ${MODEL_DIR:-../../../../../models-cache}/qwen3.6-27b-awq-bf16-int4:/root/models/Qwen3.6-27B-AWQ-BF16-INT4:ro
+      - ../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
+      - ../../cache/triton:/root/.triton/cache
+      # Marlin pad-sub-tile-n patch (vLLM PR #40361) — required for TP=2
+      # on W4A16 models where out-dim shards fall below 64.
+      - ../../patches/vllm-marlin-pad/marlin.py:/usr/local/lib/python3.12/dist-packages/vllm/model_executor/kernels/linear/mixed_precision/marlin.py:ro
+      - ../../patches/vllm-marlin-pad/MPLinearKernel.py:/usr/local/lib/python3.12/dist-packages/vllm/model_executor/kernels/linear/mixed_precision/MPLinearKernel.py:ro
+      # vLLM PR #35936 required-tool fallback (drop when upstream lands).
+      - ../../patches/vllm-pr35936-required-fallback/vllm/entrypoints/openai/chat_completion/serving.py:/etc/club3090/pr35936-chat-completion-serving.py:ro
+      - ../../patches/vllm-pr35936-required-fallback/vllm/entrypoints/openai/engine/serving.py:/etc/club3090/pr35936-engine-serving.py:ro
+      - ../../patches/vllm-pr35936-required-fallback/install.sh:/etc/club3090/install-pr35936.sh:ro
+      # vLLM PR #41800 (truncate_prompt_tokens kwarg) overlay.
+      - ../../patches/vllm-pr41800-truncate-prompt-tokens/install.sh:/etc/club3090/install-pr41800.sh:ro
+      # froggeric/Qwen-Fixed-Chat-Templates qwen3.6 — fixes 7 default-template bugs.
+      - ../../patches/froggeric-chat-template/chat_template.jinja:/etc/qwen-froggeric-chat-template.jinja:ro
+      # NVLink auto-detection — runs inside container at boot.
+      - ../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
+      - VLLM_WORKER_MULTIPROC_METHOD=spawn
+      - NVLINK_MODE=${NVLINK_MODE:-auto}
+      - NCCL_CUMEM_ENABLE=0
+      - NCCL_P2P_DISABLE=1
+      - VLLM_NO_USAGE_STATS=1
+      - VLLM_USE_FLASHINFER_SAMPLER=1
+      - OMP_NUM_THREADS=1
+      - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True,max_split_size_mb:512}
+    shm_size: "16gb"
+    ipc: host
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    entrypoint:
+      - bash
+      - -c
+      - |
+        # Install PR #35936 overlay before vllm imports (drop when upstream lands).
+        bash /etc/club3090/install-pr35936.sh
+        bash /etc/club3090/install-pr41800.sh
+        # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
+        source /etc/club3090/detect_nvlink.sh
+        if [ "${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} "$@"
+        else
+          exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$@"
+        fi
+      - --
+    command:
+      - --model
+      - /root/models/Qwen3.6-27B-AWQ-BF16-INT4
+      - --served-model-name
+      - qwen3.6-27b
+      - --quantization
+      - compressed-tensors
+      - --dtype
+      - float16
+      - --tensor-parallel-size
+      - "${TP:-2}"
+      - --pipeline-parallel-size
+      - "${PP:-1}"
+      - --max-model-len
+      - "${MAX_MODEL_LEN:-190000}"
+      - --gpu-memory-utilization
+      - "${GPU_MEMORY_UTILIZATION:-0.93}"
+      - --max-num-seqs
+      - "4"
+      - --max-num-batched-tokens
+      - "8192"
+      - --trust-remote-code
+      - --reasoning-parser
+      - qwen3
+      - --enable-auto-tool-choice
+      - --tool-call-parser
+      - qwen3_coder
+      - --enable-prefix-caching
+      - --enable-chunked-prefill
+      - --speculative-config
+      - '{"method":"mtp","num_speculative_tokens":5}'
+      - --performance-mode
+      - interactivity
+      - --chat-template
+      - /etc/qwen-froggeric-chat-template.jinja
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8000"

--- a/models/qwen3.6-27b/vllm/compose/dual/docker-compose.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/docker-compose.yml
@@ -44,6 +44,7 @@
 #   dual/dflash-noviz.yml 200K   1         78 / 127         FP16     ❌      2× PCIe
 #   dual/nvlink-dflash.yml   185K   1         (community)      FP16     ✅      2× NVLink
 #   dual/nvlink-dflash-noviz.yml 188K   1         (community)      FP16     ❌      2× NVLink
+#   dual/bf16-int4.yml       190K total 4         (community)          FP16     ✅      2× PCIe/NVLink
 #
 # Run:
 #   cd <repo>/models/qwen3.6-27b/vllm/compose

--- a/models/qwen3.6-27b/vllm/patches/froggeric-chat-template/chat_template.jinja
+++ b/models/qwen3.6-27b/vllm/patches/froggeric-chat-template/chat_template.jinja
@@ -215,7 +215,7 @@
 {%- endfor %}
 {%- if add_generation_prompt %}
     {{- '<|im_start|>assistant\n' }}
-    {%- if ns_flags.enable_thinking is false %}
+    {%- if ns_flags.enable_thinking in (False, '') %}
         {{- '<think>\n\n</think>\n\n' }}
     {%- else %}
         {{- '<think>\n' }}

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -229,6 +229,7 @@ declare -A LAUNCH_VARIANT_MODEL=(
   [vllm/dual4-dflash]="qwen3.6-27b" [vllm/dual-turbo]="qwen3.6-27b" [vllm/dual-dflash]="qwen3.6-27b"
   [vllm/dual-dflash-noviz]="qwen3.6-27b" [vllm/dual-nvlink]="qwen3.6-27b" [vllm/dual-nvlink-turbo]="qwen3.6-27b"
   [vllm/dual-nvlink-dflash]="qwen3.6-27b" [vllm/dual-nvlink-dflash-noviz]="qwen3.6-27b"
+  [vllm/dual-bf16-int4]="qwen3.6-27b"
   [vllm/gemma-mtp]="gemma-4-31b" [vllm/gemma-mtp-tp1]="gemma-4-31b" [vllm/gemma-dflash]="gemma-4-31b"
   [llamacpp/default]="qwen3.6-27b" [llamacpp/concurrent]="qwen3.6-27b"
 )
@@ -238,6 +239,7 @@ declare -A LAUNCH_VARIANT_ENGINE=(
   [vllm/dual4]="vllm" [vllm/dual4-dflash]="vllm" [vllm/dual-turbo]="vllm" [vllm/dual-dflash]="vllm"
   [vllm/dual-dflash-noviz]="vllm" [vllm/dual-nvlink]="vllm" [vllm/dual-nvlink-turbo]="vllm"
   [vllm/dual-nvlink-dflash]="vllm" [vllm/dual-nvlink-dflash-noviz]="vllm"
+  [vllm/dual-bf16-int4]="vllm"
   [vllm/gemma-mtp]="vllm" [vllm/gemma-mtp-tp1]="vllm" [vllm/gemma-dflash]="vllm"
   [llamacpp/default]="llamacpp" [llamacpp/concurrent]="llamacpp"
 )
@@ -259,6 +261,7 @@ declare -A LAUNCH_VARIANT_KVCALC=(
   [vllm/dual-nvlink-turbo]="qwen3.6-27b:dual-turbo"
   [vllm/dual-nvlink-dflash]="qwen3.6-27b:dual-dflash"
   [vllm/dual-nvlink-dflash-noviz]="qwen3.6-27b:dual-dflash-noviz"
+  [vllm/dual-bf16-int4]="SKIP"
   [vllm/gemma-mtp]="gemma-4-31b:gemma-dual"
   [vllm/gemma-mtp-tp1]="gemma-4-31b:gemma-single"
   [vllm/gemma-dflash]="gemma-4-31b:gemma-dual-dflash"
@@ -268,7 +271,7 @@ declare -A LAUNCH_VARIANT_KVCALC=(
 LAUNCH_VARIANT_ORDER=(
   vllm/long-vision vllm/long-text vllm/long-text-no-mtp vllm/bounded-thinking
   vllm/default vllm/tools-text vllm/minimal
-  vllm/dual vllm/dual-turbo vllm/dual-dflash vllm/dual-dflash-noviz
+  vllm/dual vllm/dual-turbo vllm/dual-dflash vllm/dual-dflash-noviz vllm/dual-bf16-int4
   vllm/dual4 vllm/dual4-dflash
   vllm/gemma-mtp vllm/gemma-mtp-tp1 vllm/gemma-dflash
   llamacpp/default llamacpp/concurrent
@@ -369,6 +372,7 @@ choose_variant() {
 model_label() {
   case "$1" in
     qwen3.6-27b) echo "Qwen 3.6 27B" ;;
+    qwen3.6-27b-bf16-int4) echo "Qwen 3.6 27B (AWQ BF16+INT4)" ;;
     gemma-4-31b) echo "Gemma 4 31B" ;;
     *) echo "$1" ;;
   esac
@@ -376,7 +380,7 @@ model_label() {
 
 normalize_model_name() {
   case "$1" in
-    qwen3.6-27b|qwen3.6-27b-gguf) echo "qwen3.6-27b" ;;
+    qwen3.6-27b|qwen3.6-27b-gguf|qwen3.6-27b-bf16-int4) echo "qwen3.6-27b" ;;
     gemma-4-31b|gemma-4-31b-awq|gemma-4-31b-gguf) echo "gemma-4-31b" ;;
     *) echo "$1" ;;
   esac
@@ -400,6 +404,7 @@ detect_installed_models() {
   MODEL_ENGINES=()
   [[ -d "${MODEL_DIR}/qwen3.6-27b-autoround-int4" ]] && add_installed_model_engine "qwen3.6-27b" "vllm"
   [[ -d "${MODEL_DIR}/qwen3.6-27b-gguf" ]] && add_installed_model_engine "qwen3.6-27b" "llamacpp"
+  [[ -d "${MODEL_DIR}/qwen3.6-27b-awq-bf16-int4" ]] && add_installed_model_engine "qwen3.6-27b" "vllm"
   [[ -d "${MODEL_DIR}/gemma-4-31b-autoround-int4" ]] && add_installed_model_engine "gemma-4-31b" "vllm"
   [[ -d "${MODEL_DIR}/gemma-4-31b-it-AWQ-4bit" ]] && add_installed_model_engine "gemma-4-31b" "vllm"
   [[ -d "${MODEL_DIR}/gemma-4-31b-gguf" ]] && add_installed_model_engine "gemma-4-31b" "llamacpp"
@@ -1026,6 +1031,7 @@ if [[ -z "$VARIANT" ]]; then
   echo "club-3090 launcher — pick model, GPU set, and serving variant." >&2
   echo "(Use --variant <name> next time to skip the wizard.)" >&2
   choose_model
+  choose_variant
   choose_gpus
   print_topology_advisory
   pick_parallelism

--- a/scripts/lib/compose-meta.sh
+++ b/scripts/lib/compose-meta.sh
@@ -326,6 +326,12 @@ compose_hw_model_status() {
       )
       friendly_need="needs 20 GB+ VRAM (24 GB recommended)"
       ;;
+    qwen3.6-27b-bf16-int4)
+      candidates=(
+        "${repo_root}/models/qwen3.6-27b/vllm/compose/dual/bf16-int4.yml"
+      )
+      friendly_need="needs 48 GB VRAM across two cards"
+      ;;
     gemma-4-31b)
       candidates=(
         "${repo_root}/models/gemma-4-31b/vllm/compose/dual/docker-compose.yml"

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -180,6 +180,13 @@ COMPOSE_REGISTRY = {
         compose_path="models/qwen3.6-27b/vllm/compose/dual/qwopus-bf16mtp.yml",
         default_port=8071,
     ),
+    "vllm/dual-bf16-int4": _entry(
+        model="qwen3.6-27b", weights_variant="awq_bf16_int4", workload="multi-stream-tenant",
+        engine="vllm-nightly-mtp", drafter="qwen-mtp-builtin", kv_format="bf16",
+        tp=2, max_ctx=190000, max_num_seqs=4, mem_util=0.94,
+        compose_path="models/qwen3.6-27b/vllm/compose/dual/bf16-int4.yml",
+        default_port=5000,
+    ),
     "vllm/dual-nvlink": _entry(
         model="qwen3.6-27b", weights_variant="autoround_int4", workload="long-ctx-single",
         engine="vllm-nightly-clean", drafter="qwen-mtp-builtin", kv_format="fp8_e5m2",

--- a/scripts/lib/profiles/models/qwen3.6-27b.yml
+++ b/scripts/lib/profiles/models/qwen3.6-27b.yml
@@ -42,6 +42,11 @@ weights:
     size_gb: 17.5
     format: autoround
     status: experimental
+  awq_bf16_int4:
+    path: qwen3.6-27b-awq-bf16-int4
+    size_gb: 27.0
+    format: awq_compressed_tensors
+    status: experimental
 default_weight_variant: autoround_int4
 compatible_drafters:
   - qwen-mtp-builtin

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,9 +6,10 @@
 #   bash scripts/setup.sh <model-name>   # scripted/CI positional form
 #
 # Currently supported:
-#   qwen3.6-27b   →  Lorbus/Qwen3.6-27B-int4-AutoRound + Genesis patches
-#   gemma-4-31b   →  Intel/gemma-4-31B-it-int4-AutoRound + Google MTP "assistant"
-#                    drafter (no Genesis — not yet integrated upstream as of v7.72.2)
+#   qwen3.6-27b             →  Lorbus/Qwen3.6-27B-int4-AutoRound + Genesis patches
+#   qwen3.6-27b-bf16-int4   →  cyankiwi/Qwen3.6-27B-AWQ-BF16-INT4 (compressed-tensors, dual-card)
+#   gemma-4-31b             →  Intel/gemma-4-31B-it-int4-AutoRound + Google MTP "assistant"
+#                              drafter (no Genesis — not yet integrated upstream as of v7.72.2)
 #
 # What it does (per supported model):
 #   - clones Sandermage/genesis-vllm-patches into models/<model>/vllm/patches/genesis
@@ -49,12 +50,14 @@ usage() {
   echo ""
   echo "Supported model names:"
   echo "  qwen3.6-27b"
+  echo "  qwen3.6-27b-bf16-int4"
   echo "  gemma-4-31b"
 }
 
 model_label() {
   case "$1" in
     qwen3.6-27b) echo "Qwen 3.6 27B" ;;
+    qwen3.6-27b-bf16-int4) echo "Qwen 3.6 27B (AWQ BF16+INT4)" ;;
     gemma-4-31b) echo "Gemma 4 31B" ;;
     *) echo "$1" ;;
   esac
@@ -79,17 +82,21 @@ pick_model_interactive() {
   echo "[setup] Which model to download?" >&2
   echo "" >&2
   model_picker_line "1" "qwen3.6-27b" "~14 GB AutoRound INT4" >&2
-  model_picker_line "2" "gemma-4-31b" "~21 GB AutoRound INT4 + drafter" >&2
-  echo "  3. Both           (~30 GB total)  downloads both model families" >&2
+  model_picker_line "2" "qwen3.6-27b-bf16-int4" "~27 GB AWQ BF16+INT4" >&2
+  model_picker_line "3" "gemma-4-31b" "~21 GB AutoRound INT4 + drafter" >&2
+  echo "  4. Both Qwen3.6  (~41 GB total)  downloads both Qwen3.6 quant variants" >&2
+  echo "  5. All            (~62 GB total)  downloads all model families" >&2
   echo "" >&2
   while true; do
     local pick
-    read -rp "Choice [1-3]: " pick
+    read -rp "Choice [1-5]: " pick
     case "$pick" in
       1) echo "qwen3.6-27b"; return ;;
-      2) echo "gemma-4-31b"; return ;;
-      3) echo "both"; return ;;
-      *) echo "  ! invalid — pick 1, 2, or 3" >&2 ;;
+      2) echo "qwen3.6-27b-bf16-int4"; return ;;
+      3) echo "gemma-4-31b"; return ;;
+      4) echo "both-qwen"; return ;;
+      5) echo "all"; return ;;
+      *) echo "  ! invalid — pick 1, 2, 3, 4, or 5" >&2 ;;
     esac
   done
 }
@@ -118,6 +125,15 @@ if [[ "${MODEL_NAME}" == "both" ]]; then
   # Resolve MODEL_DIR once in the parent by reusing the normal prompt below,
   # then recurse through the positional form for each model.
   SETUP_BOTH_MODE=1
+  SETUP_BOTH_PICK="both"
+  MODEL_NAME="qwen3.6-27b"
+elif [[ "${MODEL_NAME}" == "both-qwen" ]]; then
+  SETUP_BOTH_MODE=1
+  SETUP_BOTH_PICK="both-qwen"
+  MODEL_NAME="qwen3.6-27b"
+elif [[ "${MODEL_NAME}" == "all" ]]; then
+  SETUP_BOTH_MODE=1
+  SETUP_BOTH_PICK="all"
   MODEL_NAME="qwen3.6-27b"
 else
   SETUP_BOTH_MODE=0
@@ -140,6 +156,11 @@ case "${MODEL_NAME}" in
     MODEL_SUBDIR="qwen3.6-27b-autoround-int4"
     NEEDS_GENESIS=1
     ;;
+  qwen3.6-27b-bf16-int4)
+    MODEL_REPO="cyankiwi/Qwen3.6-27B-AWQ-BF16-INT4"
+    MODEL_SUBDIR="qwen3.6-27b-awq-bf16-int4"
+    NEEDS_GENESIS=0
+    ;;
   gemma-4-31b)
     MODEL_REPO="Intel/gemma-4-31B-it-int4-AutoRound"
     MODEL_SUBDIR="gemma-4-31b-autoround-int4"
@@ -158,7 +179,7 @@ case "${MODEL_NAME}" in
     ;;
   *)
     echo "ERROR: unsupported model '${MODEL_NAME}'."
-    echo "Supported: qwen3.6-27b, gemma-4-31b"
+    echo "Supported: qwen3.6-27b, qwen3.6-27b-bf16-int4, gemma-4-31b"
     echo "(To add a new model, extend the case dispatch in scripts/setup.sh)"
     exit 1
     ;;
@@ -233,13 +254,37 @@ fi
 MODEL_DIR="${MODEL_DIR:-${ROOT_DIR}/models-cache}"
 if [[ "${SETUP_BOTH_MODE:-0}" == "1" ]]; then
   export MODEL_DIR
-  echo "[setup] downloading both supported models into ${MODEL_DIR}"
-  echo ""
-  bash "$0" qwen3.6-27b
-  echo ""
-  bash "$0" gemma-4-31b
-  echo ""
-  echo "[setup] ✓ Both models downloaded."
+  case "${SETUP_BOTH_PICK:-both}" in
+    both)
+      echo "[setup] downloading both supported models into ${MODEL_DIR}"
+      echo ""
+      bash "$0" qwen3.6-27b
+      echo ""
+      bash "$0" gemma-4-31b
+      echo ""
+      echo "[setup] ✓ Both models downloaded."
+      ;;
+    both-qwen)
+      echo "[setup] downloading both Qwen3.6 variants into ${MODEL_DIR}"
+      echo ""
+      bash "$0" qwen3.6-27b
+      echo ""
+      bash "$0" qwen3.6-27b-bf16-int4
+      echo ""
+      echo "[setup] ✓ Both Qwen3.6 variants downloaded."
+      ;;
+    all)
+      echo "[setup] downloading all models into ${MODEL_DIR}"
+      echo ""
+      bash "$0" qwen3.6-27b
+      echo ""
+      bash "$0" qwen3.6-27b-bf16-int4
+      echo ""
+      bash "$0" gemma-4-31b
+      echo ""
+      echo "[setup] ✓ All models downloaded."
+      ;;
+  esac
   echo "[setup] Next: bash scripts/launch.sh"
   exit 0
 fi
@@ -255,10 +300,13 @@ cd "${ROOT_DIR}"
 source "${ROOT_DIR}/scripts/preflight.sh"
 
 # Required disk: model is ~14 GB on disk; 25 GB gives buffer for download
-# temp files + safetensors + tokenizer/config. Add ~3 GB if also pulling
-# the DFlash draft (~1.75 GB packed + buffer for download tempfiles).
+# temp files + safetensors + tokenizer/config. The AWQ BF16-INT4 variant is
+# ~27 GB, needs 35 GB. Add ~3 GB if also pulling the DFlash draft
+# (~1.75 GB packed + buffer for download tempfiles).
 if [[ "${WITH_DFLASH_DRAFT:-0}" == "1" ]]; then
   PREFLIGHT_DISK_GB="${PREFLIGHT_DISK_GB:-28}"
+elif [[ "${MODEL_NAME}" == "qwen3.6-27b-bf16-int4" ]]; then
+  PREFLIGHT_DISK_GB="${PREFLIGHT_DISK_GB:-35}"
 else
   PREFLIGHT_DISK_GB="${PREFLIGHT_DISK_GB:-25}"
 fi
@@ -539,6 +587,14 @@ case "${MODEL_NAME}" in
     SAMPLE_MODEL_NAME="qwen3.6-27b-autoround"
     NEXT_STEPS_NOTE="Or dual-card vLLM (Marlin patched files already vendored in-repo):
   cd models/${MODEL_NAME}/vllm/compose && docker compose -f dual/docker-compose.yml up -d"
+    ;;
+  qwen3.6-27b-bf16-int4)
+    SAMPLE_CONTAINER="vllm-qwen36-27b-bf16-int4"
+    SAMPLE_COMPOSE_FLAGS_DUAL=" -f dual/bf16-int4.yml"
+    SAMPLE_PORT="5000"
+    SAMPLE_MODEL_NAME="qwen3.6-27b"
+    NEXT_STEPS_NOTE="Dual-card vLLM (AWQ BF16+INT4, 6 streams):
+  cd models/qwen3.6-27b/vllm/compose && docker compose -f dual/bf16-int4.yml up -d"
     ;;
   gemma-4-31b)
     SAMPLE_CONTAINER="vllm-gemma-4-31b-mtp"

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -35,6 +35,7 @@
 #     vllm/dual-nvlink-turbo    262K + TQ3 + 4 streams + vision (NVLink stub — auto-detected via dual/)
 #     vllm/dual-nvlink-dflash   185K + FP16 + DFlash N=5 + vision (NVLink stub — auto-detected via dual/)
 #     vllm/dual-nvlink-dflash-noviz 188K + FP16 + DFlash N=5 + no vision (NVLink stub — auto-detected via dual/)
+#     vllm/dual-bf16-int4   190K total + AWQ BF16+INT4 mixed + 4 streams (multi-stream interactivity)
 #     vllm/gemma-mtp        Gemma-4-31B + Google MTP drafter (32K, bf16 KV, vision — community/experimental, pre-merge)
 #
 #   Single-card llama.cpp:
@@ -84,6 +85,7 @@ declare -A VARIANT_DEFAULT_PORT=(
   [vllm/dual-nvlink-turbo]=8017
   [vllm/dual-nvlink-dflash]=8018
   [vllm/dual-nvlink-dflash-noviz]=8019
+  [vllm/dual-bf16-int4]=5000
   [vllm/gemma-mtp]=8030
   [vllm/gemma-mtp-tp1]=8031
   [vllm/gemma-dflash]=8032
@@ -110,6 +112,7 @@ declare -A VARIANTS=(
   [vllm/dual-nvlink-turbo]="vllm|models/qwen3.6-27b/vllm/compose|dual/nvlink-turbo.yml"
   [vllm/dual-nvlink-dflash]="vllm|models/qwen3.6-27b/vllm/compose|dual/nvlink-dflash.yml"
   [vllm/dual-nvlink-dflash-noviz]="vllm|models/qwen3.6-27b/vllm/compose|dual/nvlink-dflash-noviz.yml"
+  [vllm/dual-bf16-int4]="vllm|models/qwen3.6-27b/vllm/compose|dual/bf16-int4.yml"
   [vllm/gemma-mtp]="vllm|models/gemma-4-31b/vllm/compose|dual/docker-compose.yml"
   [vllm/gemma-mtp-tp1]="vllm|models/gemma-4-31b/vllm/compose|single/docker-compose.yml"
   [vllm/gemma-dflash]="vllm|models/gemma-4-31b/vllm/compose|dual/dflash.yml"


### PR DESCRIPTION
<!--
Thanks for the PR. Most reviews stall on missing rig context — this template is
the data we'd ask for individually otherwise. Tick what applies; explain N/A
where it doesn't.

For typo / doc-only changes, ignore everything below the "Summary" section.
-->

## Summary

<!-- One paragraph. What problem does this solve, what's the measured impact,
what existing variant did you compare against, what's the trade-off? -->

Add cyankiwi/Qwen3.6-27B-AWQ-BF16-INT4 (~27 GB, compressed-tensors) as a new weight variant. Dual-card TP=2, MTP n=5, 190K total context across 4 streams (not per-stream), FP16 KV. This variant trades off context for quality, as the SSM layers remain full-precision. Decode speed is 75TPS on narrative, 112TPS on code.

## Type of change

- [x] New compose variant (`models/<model>/<engine>/compose/docker-compose.<name>.yml`)
- [ ] New patch / sidecar (`models/<model>/<engine>/patches/`)
- [ ] New script or tool (`scripts/`, `tools/`)
- [ ] New model (`models/<new-model>/`)
- [ ] Doc-only / typo
- [ ] Other (describe)

## Verification

- [x] **Full rig + validation report attached** — single command captures everything:
  ```bash
  bash scripts/report.sh --full > my-rig.md
  ```
  Runs hardware + stack + boot log capture **plus** verify-full + verify-stress 7/7 + SOAK_MODE=continuous + canonical bench in one ~35-min pass. Paste contents as a PR comment. See [docs/CLIFFS.md](../docs/CLIFFS.md) for why the soak-continuous step is load-bearing (catches Cliff 2b, which verify-stress doesn't).
- [ ] **BENCHMARKS row added** — under the appropriate model section, mirroring existing column shape (incl. `Rig` column).
- [ ] **CHANGELOG entry added** in `models/<model>/CHANGELOG.md`.

If you'd rather run the steps separately:

- `bash scripts/report.sh > my-rig.md` (rig only, ~2 sec)
- `bash scripts/verify-full.sh` — fast functional smoke
- `bash scripts/verify-stress.sh` — 7/7 boundary checks incl. Cliff 2 needles
- `SOAK_MODE=continuous SOAK_SESSIONS=5 SOAK_TURNS=5 bash scripts/soak-test.sh` — required for new single-card composes (catches Cliff 2b)
- `bash scripts/bench.sh` — canonical TPS (3 warmups + 5 measured)

### N/A justifications (if any boxes above are unchecked)

- Did not update CHANGELOG since the file states that they're auto-created at the top. Please let me know if you'd like one with a version bump, and I'll add it in!

<!-- e.g. "N/A — short-prompt-only path; soak-continuous would not exercise the multi-turn regime"
       or "N/A — doc-only change, no compose touched" -->

## Cross-links

<!-- Issue this PR closes / contributes to. Upstream PRs / issues this depends on.
Sandermage Genesis tickets if relevant. -->

- Closes #
- Related upstream:
