### PR TITLE
fix(gemma-4-31b): vendor missing vllm-pr41800 overlay into model tree (closes #153)

### DIFF
--- a/models/gemma-4-31b/vllm/patches/vllm-pr41800-truncate-prompt-tokens/README.md
+++ b/models/gemma-4-31b/vllm/patches/vllm-pr41800-truncate-prompt-tokens/README.md
@@ -1,0 +1,103 @@
+# vLLM PR #41800 overlay — `truncate_prompt_tokens` kwarg on `get_max_tokens`
+
+## What this fixes
+
+Agentic clients (opencode, codex-cli, and similar IDE/agent runtimes) send `truncate_prompt_tokens` on chat-completion requests. Pre-[vLLM PR #41800](https://github.com/vllm-project/vllm/pull/41800), `vllm.entrypoints.utils.get_max_tokens()` doesn't accept that kwarg — and the kwarg propagates from the request handler down into the function call — so requests fail with:
+
+```
+HTTP 400: {"error":{"message":"get_max_tokens() got an unexpected keyword argument 'truncate_prompt_tokens'",...}}
+```
+
+The fix is upstream PR #41800 (merged 2026-05-06 at commit `d5b31c95`). It adds the kwarg to the function signature and a small body block that clamps `input_length` to `min(input_length, truncate_prompt_tokens or max_model_len)` before the existing length check.
+
+## When this overlay is needed
+
+This overlay is needed on engines pinned to vLLM SHAs that **predate `d5b31c95`**:
+
+| Engine | Pinned SHA | Pre-fix? |
+|---|---|---|
+| `vllm-nightly-mtp` | `01d4d1ad` (2026-05-04) | ✅ needs overlay |
+| `vllm-nightly-dflash` | `e47c98ef` (~2026-05-05) | ✅ needs overlay (20 commits behind d5b31c95) |
+| `vllm-nightly-full` | `e47c98ef` | ✅ needs overlay |
+| `vllm-nightly-clean` | `bf610c2f` (2026-05-15) | ❌ already includes fix |
+
+If a compose routes through `vllm-nightly-clean`, the overlay is unnecessary — the function signature already accepts the kwarg upstream.
+
+## How the overlay works
+
+`install.sh` is a Python anchor-based in-place patcher. It does two surgical edits to the in-container `/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/utils.py`:
+
+1. **Signature**: adds `truncate_prompt_tokens: int | None = None,` to `get_max_tokens`'s signature, anchored to the existing `override_max_tokens: int | None = None,` line.
+2. **Body**: inserts a 6-line truncation-aware `input_length` adjustment block before the existing `if max_model_len < input_length:` check, anchored to that line.
+
+Each insertion carries a sentinel comment (`# PATCH: truncate_prompt_tokens kwarg (club3090/pr41800)`) so re-running the install on an already-patched file is a no-op. Post-patch the file is AST-validated before write.
+
+Why anchor-based and not full-file replacement: the PR diff is +14 / -0 across a 200-line file — replacing the full file would shadow other upstream changes in `utils.py`. Anchor-based insertion is drift-resistant to unrelated upstream movement.
+
+## Canonical source
+
+This is a vendored, byte-identical mirror of the canonical overlay at
+`models/qwen3.6-27b/vllm/patches/vllm-pr41800-truncate-prompt-tokens/`.
+`install.sh` is model-agnostic (it patches engine-level `vllm/entrypoints/utils.py`),
+so it is copied verbatim per the per-model-tree `../../patches/` convention.
+Keep `install.sh` identical to the qwen3.6-27b copy; track upstream/drop state in `docs/UPSTREAM.md` only.
+
+## Composes that wire this overlay in (Gemma 4 31b tree)
+
+* `models/gemma-4-31b/vllm/compose/dual/int8.yml`
+* `models/gemma-4-31b/vllm/compose/dual/awq.yml`
+* `models/gemma-4-31b/vllm/compose/dual/int8-tq3.yml`
+* `models/gemma-4-31b/vllm/compose/dual/dflash.yml`
+* `models/gemma-4-31b/vllm/compose/dual/dflash-int8.yml`
+
+## How to add this overlay to another affected compose
+
+In any compose that routes through `vllm-nightly-mtp` / `vllm-nightly-dflash` / `vllm-nightly-full`, add:
+
+1. **Volume mount** in the `volumes:` block:
+
+   ```yaml
+       - ../../patches/vllm-pr41800-truncate-prompt-tokens/install.sh:/etc/club3090/install-pr41800.sh:ro
+   ```
+
+2. **Install line** in the `entrypoint:` bash script, before `exec vllm serve`:
+
+   ```bash
+   bash /etc/club3090/install-pr41800.sh
+   ```
+
+Run `bash install.sh` (the file in this directory) standalone to test against a transient vLLM container before wiring into a compose. See the smoke test in the next section.
+
+## Smoke test
+
+```bash
+docker run --rm --entrypoint /bin/bash \
+  -v $(pwd)/install.sh:/install.sh:ro \
+  vllm/vllm-openai:nightly-01d4d1ad375dc5854779c593eee093bcebb0cada \
+  -c '
+    python3 -c "from vllm.entrypoints.utils import get_max_tokens; import inspect; print(inspect.signature(get_max_tokens))"
+    bash /install.sh
+    python3 -c "from vllm.entrypoints.utils import get_max_tokens; import inspect; print(inspect.signature(get_max_tokens))"
+  '
+```
+
+Expected: signature lacks `truncate_prompt_tokens` BEFORE install, has it AFTER. Verified on `01d4d1ad` (2026-05-15).
+
+## When to drop this overlay
+
+When **both** are true:
+
+1. PR #41800 has merged upstream (it has — 2026-05-06 at `d5b31c95`)
+2. The engine's pinned nightly SHA bumps past `d5b31c95`
+
+For the Genesis-anchored engines, the bump happens with Sander's next Genesis release cycle (v7.73.x). For `vllm-nightly-dflash` and `vllm-nightly-full`, the bump happens when their respective overlays (PR #41703 DFlash, PR #42102 INT8 PTH KV) are re-validated against a newer nightly.
+
+Track in `docs/UPSTREAM.md`.
+
+## Source
+
+- vLLM PR #41800: https://github.com/vllm-project/vllm/pull/41800
+- Merged commit: `d5b31c95`
+- Tracking issue: noonghunna/club-3090#139
+- Triggered by: noonghunna/club-3090#138 (SEVENID's opencode boot failure)
+- Patch summary: +7 lines in `vllm/entrypoints/utils.py` (the actual fix) + 5 call-site forward-compat additions in other files (we skip those — the signature fix alone unblocks all known TypeError reports)

--- a/models/gemma-4-31b/vllm/patches/vllm-pr41800-truncate-prompt-tokens/install.sh
+++ b/models/gemma-4-31b/vllm/patches/vllm-pr41800-truncate-prompt-tokens/install.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Install vLLM PR #41800 — `truncate_prompt_tokens` kwarg on get_max_tokens.
+#
+# WHY THIS OVERLAY EXISTS:
+# opencode (and other agentic clients like codex-cli) send `truncate_prompt_tokens`
+# on chat-completion requests. Pre-#41800, vLLM's `get_max_tokens()` doesn't
+# accept that kwarg — and somewhere upstream of the function the kwarg gets
+# unpacked into the call — so requests fail with:
+#   HTTP 400: get_max_tokens() got an unexpected keyword argument 'truncate_prompt_tokens'
+#
+# PR: https://github.com/vllm-project/vllm/pull/41800
+# Merged: 2026-05-06 at commit d5b31c95
+# Affected pins on master:
+#   - vllm-nightly-mtp (01d4d1ad, 2026-05-04) — pre-fix
+#   - vllm-nightly-dflash (e47c98ef) — pre-fix
+#   - vllm-nightly-full (e47c98ef) — pre-fix
+#   (vllm-nightly-clean at bf610c2f is POST-fix; doesn't need the overlay)
+#
+# Tracking issue: #139 (noonghunna/club-3090)
+# Triggered by: #138 — SEVENID's opencode boot failure on dual-dflash-noviz.
+#
+# WHY A PYTHON ANCHOR-BASED PATCHER:
+# The PR is +7 lines in `vllm/entrypoints/utils.py` (the actual fix) plus a
+# handful of forward-compat call-site additions in 5 other files. The
+# function-signature change in utils.py is the ONLY thing required to fix
+# the TypeError — once `get_max_tokens` accepts the kwarg, requests stop
+# crashing. The call-site changes are nice-to-have semantic completeness
+# (actually applying the truncation), so we patch those too via anchors.
+#
+# Idempotent: each anchor checks for a sentinel marker before inserting.
+
+set -euo pipefail
+
+# Container's vLLM install path. Override via env if vLLM moves.
+SITE_PACKAGES="${CLUB3090_PR41800_SITE_PACKAGES:-/usr/local/lib/python3.12/dist-packages}"
+
+UTILS_PY="$SITE_PACKAGES/vllm/entrypoints/utils.py"
+
+if [ ! -f "$UTILS_PY" ]; then
+  echo "[club3090/pr41800] ERROR: $UTILS_PY not found; aborting overlay install" >&2
+  exit 1
+fi
+
+python3 - <<'PY'
+import os
+import re
+import sys
+
+site_packages = os.environ.get(
+    "CLUB3090_PR41800_SITE_PACKAGES",
+    "/usr/local/lib/python3.12/dist-packages",
+)
+utils_py = f"{site_packages}/vllm/entrypoints/utils.py"
+
+SENTINEL = "# PATCH: truncate_prompt_tokens kwarg (club3090/pr41800)"
+
+# Function signature update: add `truncate_prompt_tokens: int | None = None,`
+# as a kwarg on `get_max_tokens`. Anchor on the existing line that closes
+# the signature (`override_max_tokens: int | None = None,` line right before `) -> int:`).
+SIGNATURE_ANCHOR_RE = re.compile(
+    r'^(?P<indent>[ \t]+)override_max_tokens: int \| None = None,\n(?P<close>[ \t]*\) -> int:)',
+    re.MULTILINE,
+)
+SIGNATURE_INSERT = '''    override_max_tokens: int | None = None,
+    truncate_prompt_tokens: int | None = None,  # PATCH: truncate_prompt_tokens kwarg (club3090/pr41800)
+) -> int:'''
+
+# Body update: insert truncation-aware input_length adjustment BEFORE the
+# `if max_model_len < input_length:` check. Anchor on that line.
+BODY_ANCHOR_RE = re.compile(
+    r'^(?P<indent>[ \t]+)if max_model_len < input_length:',
+    re.MULTILINE,
+)
+BODY_INSERT = '''    # PATCH: truncate_prompt_tokens kwarg (club3090/pr41800)
+    if truncate_prompt_tokens is not None:
+        limit = truncate_prompt_tokens
+        input_length = min(
+            input_length,
+            max_model_len if limit == -1 else limit,
+        )
+    if max_model_len < input_length:'''
+
+with open(utils_py, "r", encoding="utf-8") as f:
+    src = f.read()
+
+if SENTINEL in src:
+    print(f"[club3090/pr41800] {utils_py}: sentinel present, patch already applied; no-op", file=sys.stderr)
+    sys.exit(0)
+
+# Upstream-fix detection: if the function signature already accepts the kwarg
+# (i.e. the engine pinned a post-#41800 nightly), the overlay is unnecessary
+# and should no-op gracefully so composes that mount it on a post-fix image
+# (e.g. via vllm-nightly-clean) still boot cleanly.
+UPSTREAM_RE = re.compile(
+    r'def get_max_tokens\([^)]*truncate_prompt_tokens\b',
+    re.DOTALL,
+)
+if UPSTREAM_RE.search(src):
+    print(f"[club3090/pr41800] {utils_py}: upstream get_max_tokens() already accepts truncate_prompt_tokens; no-op", file=sys.stderr)
+    sys.exit(0)
+
+# Apply signature patch first (so the function accepts the kwarg)
+m = SIGNATURE_ANCHOR_RE.search(src)
+if not m:
+    print(
+        f"[club3090/pr41800] ERROR: signature anchor "
+        f"'override_max_tokens: int | None = None, ... ) -> int:' not found in {utils_py}. "
+        f"vLLM nightly may have changed entrypoints/utils.py — overlay needs re-anchoring.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+src = SIGNATURE_ANCHOR_RE.sub(SIGNATURE_INSERT, src, count=1)
+
+# Apply body patch
+m = BODY_ANCHOR_RE.search(src)
+if not m:
+    print(
+        f"[club3090/pr41800] ERROR: body anchor 'if max_model_len < input_length:' not found in {utils_py} "
+        f"after signature patch. vLLM nightly diverged unexpectedly — overlay needs re-anchoring.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+src = BODY_ANCHOR_RE.sub(BODY_INSERT, src, count=1)
+
+with open(utils_py, "w", encoding="utf-8") as f:
+    f.write(src)
+
+# Quick validity check
+import ast
+try:
+    ast.parse(src)
+except SyntaxError as e:
+    print(f"[club3090/pr41800] ERROR: post-patch utils.py is not valid Python: {e}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"[club3090/pr41800] {utils_py}: signature + body patches applied (truncate_prompt_tokens kwarg)", file=sys.stderr)
+PY
+
+echo "[club3090/pr41800] install complete" >&2


### PR DESCRIPTION
## Summary

5 Gemma 4 31b dual composes (`int8`, `awq`, `int8-tq3`, `dflash`, `dflash-int8`) bind-mount `../../patches/vllm-pr41800-truncate-prompt-tokens/install.sh`, but commit `1d7aad1` ("vendor truncate_prompt_tokens overlay across all pre-fix engines", #139) wired the mounts **without copying the overlay dir into the gemma-4-31b tree** — only the qwen3.6-27b tree got it. Per the per-model-tree `../../patches/` convention every other Gemma patch mount already follows, the relative path resolves into the gemma tree, so the bind source was missing and `docker compose up` failed on all 5 (reported in #153).

**Why not just drop the mount:** all 5 route through pre-`d5b31c95` engines (`vllm-nightly-full` / `vllm-nightly-dflash`, pins `e47c98ef` / `01d4d1ad`) that genuinely need the `truncate_prompt_tokens` kwarg fix — dropping it would reintroduce the #138-class HTTP 400 for opencode/agentic clients. The overlay is engine-level / model-agnostic, so the correct fix is the per-model-tree vendor `1d7aad1` intended.

**Fix:** `install.sh` copied **byte-identical** from the canonical `models/qwen3.6-27b/...` copy; README's compose list re-scoped to the Gemma tree + a canonical-source pointer added so the co-located doc isn't misleading. `install.sh` must stay identical to the qwen copy; upstream/drop state continues to be tracked in `docs/UPSTREAM.md` only.

Only the Gemma tree was dangling — no other model tree affected.

## Test plan

- [x] All 5 affected composes resolve the bind-mount path (`readlink -f`) and parse via `docker compose config` with the mount present
- [x] `install.sh` `diff`-identical to the canonical qwen3.6-27b copy
- [x] **Live patcher smoke test** against `nightly-01d4d1ad` (a pre-fix SHA the Gemma `dflash` composes pin): `get_max_tokens` signature `has_kwarg=False` BEFORE → `truncate_prompt_tokens: int | None = None` present + AST-valid AFTER → idempotent re-run detects sentinel and no-ops
- [x] Scope = exactly the 2 vendored files; leak-clean
- [ ] (Optional, not run — needs rig/GPU) live `docker compose up` boot of a Gemma dual compose; breakage class here is purely the missing bind source, which the vendor restores

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)