### PR TITLE
fix(patch-attribution): register vendored gemma-4-31b pr41800 overlay (#153 follow-up)

### DIFF
--- a/scripts/lib/profiles/arch_patches.yml
+++ b/scripts/lib/profiles/arch_patches.yml
@@ -71,6 +71,7 @@ arches:
       - gemma-vllm-gemma4-tool-parser-fixes
       - gemma-vllm-gemma4-dflash
       - gemma-vllm-gemma4-dflash-int8
+      - gemma-vllm-pr41800-truncate-prompt-tokens
     valid_tp:
       tp_divisors: [1, 2, 4, 8, 16]
       marlin_alignment_required: false

--- a/scripts/lib/profiles/patches.yml
+++ b/scripts/lib/profiles/patches.yml
@@ -279,6 +279,44 @@ patches:
       drop_when: "each affected engine profile pins a vLLM nightly after d5b31c95"
     status: verified
 
+  - id: gemma-vllm-pr41800-truncate-prompt-tokens
+    model: [gemma-4-31b]
+    files:
+      - models/gemma-4-31b/vllm/patches/vllm-pr41800-truncate-prompt-tokens
+    load_bearing_when:
+      - composes:
+          - vllm/gemma-int8
+          - vllm/gemma-int8-262k
+          - vllm/gemma-awq
+          - vllm/gemma-int8-tq3
+          - vllm/gemma-dflash
+          - vllm/gemma-dflash-int8
+        reason: "Pre-d5b31c95 engine pins reject agent clients that send truncate_prompt_tokens."
+        evidence: "docs/UPSTREAM.md#41800 row; models/gemma-4-31b/vllm/patches/vllm-pr41800-truncate-prompt-tokens/README.md"
+    delivery:               # DEPRECATED/READ-ONLY (test-only) — see header
+      dockerfile_bake: false
+      entrypoint_invoke: true
+      genesis: false
+    delivery_gaps: []
+    delivery_mechanism: install_script
+    delivery_spec:
+      script: models/gemma-4-31b/vllm/patches/vllm-pr41800-truncate-prompt-tokens/install.sh
+      mounted_at: /etc/club3090/install-pr41800.sh
+      invoke: "bash /etc/club3090/install-pr41800.sh"
+      invoked_before: vllm-serve
+      wired_at: [volumes, entrypoint]
+    drift_guard:
+      kind: behavioral
+      check: "agent client sending truncate_prompt_tokens does not get HTTP 400 on the selected nightly (no-op if nightly post-d5b31c95)"
+      on_fail: capability-degraded
+    capability: truncate-prompt-tokens-kwarg
+    foundational: false
+    upstream:
+      ref: vllm-project/vllm#41800
+      status: merged
+      drop_when: "each affected engine profile pins a vLLM nightly after d5b31c95"
+    status: verified
+
   - id: gemma-vllm-gemma4-dflash
     model: [gemma-4-31b]
     files:


### PR DESCRIPTION
## Summary

PR #154 (#153 fix) vendored the gemma-4-31b `vllm-pr41800-truncate-prompt-tokens` overlay but omitted its patch-attribution entry. `test-patch-attribution` flags the `install.sh` as an **orphan artifact lacking a patches.yml entry** → rc=1. The repo has no PR-CI, so the #154 merge didn't catch it — **master is currently red on this test**.

Surfaced by the **v0.8.1 pre-tag gate** (full `scripts/tests` suite run in the CI condition with gitignored runtime state absent) — precisely the v0.8.0-lesson failure class that per-step verification cannot catch.

## Fix

- `scripts/lib/profiles/patches.yml`: add `gemma-vllm-pr41800-truncate-prompt-tokens`, mirroring the canonical `qwen-vllm-pr41800-truncate-prompt-tokens` entry — `model: [gemma-4-31b]`, the 6 gemma dual compose registry ids that bind-mount it, identical `delivery_spec` / `drift_guard` / `upstream` shape.
- `scripts/lib/profiles/arch_patches.yml`: add the patch id to `Gemma4ForConditionalGeneration` `required_patches` (the arch gemma-4-31b resolves to; pins `e47c98ef` are pre-`d5b31c95`), consistent with how the qwen arch lists its pr41800.

Engine-level overlay, no behavior change — attribution metadata only.

## Test plan

- [x] YAML well-formed (both files)
- [x] `test-patch-attribution` PASS (was rc=1 orphan)
- [x] **Full `scripts/tests` suite + `tools/kv-calc.py --calibration` 13/13 GREEN** in CI condition
- [x] leak-clean; scope = exactly the 2 registry files

Follow-up to #153 / #154. Required green for the v0.8.1 release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)