### PR TITLE
feat(report): lspci PCIe/P2P diagnostics subsection (LnkSta/ACS/topology) (#148)

### DIFF
--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -258,6 +258,70 @@ else
   subsection "Topology"
   nvidia-smi topo -m 2>&1 | redact | details "PCIe / GPU topology matrix"
 
+  # lspci-based PCIe/P2P detail. nvidia-smi reports negotiated gen/width but
+  # cannot show trained link state vs capability side-by-side, ACS state on the
+  # upstream bridge, or the real PCIe topology tree — the three things that
+  # actually decide whether GPU↔GPU P2P engages (see issues #137, #351).
+  subsection "PCIe / P2P detail (lspci)"
+  if ! have lspci; then
+    echo "_lspci not available (pciutils not installed) — skipping PCIe/P2P detail._"
+  else
+    # sudo lspci -vvv is needed for full capability blocks (ACS lives in the
+    # extended config space, root-only). Degrade gracefully if sudo is
+    # unavailable / non-interactive — non-sudo lspci still shows LnkSta.
+    LSPCI_CMD=(lspci)
+    SUDO_NOTE=""
+    if [[ $EUID -ne 0 ]]; then
+      if have sudo && sudo -n true 2>/dev/null; then
+        LSPCI_CMD=(sudo lspci)
+      else
+        SUDO_NOTE="_Note: sudo unavailable/non-interactive — running lspci without root; ACS capability lines may be incomplete (LnkSta still accurate)._"
+      fi
+    fi
+
+    {
+      [[ -n "$SUDO_NOTE" ]] && { echo "$SUDO_NOTE"; echo; }
+
+      echo "# lspci -t  (PCIe topology tree)"
+      lspci -t 2>&1
+      echo
+
+      # Per NVIDIA VGA / 3D-controller function: trained link state vs
+      # capability + ACS state. Filter to the four load-bearing lines only —
+      # never dump the full -vvv block (keeps the report compact + redaction-safe).
+      # ACS (ACSCap/ACSCtl) lives on the UPSTREAM PCIe port, not the GPU
+      # endpoint — and ACS-redirect on that bridge is exactly what blocks P2P
+      # (issues #137, #351) — so for each GPU we also dump its upstream bridge.
+      dump_func() {
+        local slot="$1" label="$2"
+        echo "# lspci -vvv -s ${slot}  (${label}: LnkCap/LnkSta/ACSCap/ACSCtl)"
+        "${LSPCI_CMD[@]}" -vvv -s "$slot" 2>/dev/null \
+          | grep -E '^[[:space:]]*(LnkCap|LnkSta|ACSCap|ACSCtl):' \
+          || echo "  (no matching LnkCap/LnkSta/ACSCap/ACSCtl lines)"
+        echo
+      }
+      while read -r slot _; do
+        [[ -z "$slot" ]] && continue
+        dump_func "$slot" "GPU function"
+        # Resolve the upstream bridge via sysfs (../.. of the device node).
+        bridge=""
+        if [[ -e "/sys/bus/pci/devices/${slot}" ]]; then
+          bridge="$(basename "$(readlink -f "/sys/bus/pci/devices/${slot}/../" 2>/dev/null)" 2>/dev/null)"
+        fi
+        if [[ "$bridge" =~ ^[0-9a-fA-F]{4}: ]]; then
+          dump_func "$bridge" "upstream bridge of ${slot}"
+        else
+          echo "  (could not resolve upstream bridge for ${slot} — ACS state for P2P may be elsewhere in the tree)"
+          echo
+        fi
+      done < <(lspci -D 2>/dev/null | grep -iE 'VGA compatible controller.*NVIDIA|3D controller.*NVIDIA')
+
+      echo "# lspci -nnk | grep -A3 -i nvidia  (driver binding + device IDs)"
+      lspci -nnk 2>/dev/null | grep -A3 -i nvidia 2>/dev/null \
+        || echo "  (no NVIDIA functions found)"
+    } 2>&1 | redact | details "lspci PCIe/P2P detail (LnkSta / ACS / topology)"
+  fi
+
   subsection "Full nvidia-smi"
   nvidia-smi 2>&1 | redact | details "Full nvidia-smi output"
 fi


### PR DESCRIPTION
## Summary

Adds an `lspci`-based **PCIe / P2P detail** subsection to `scripts/report.sh`, co-located with the existing nvidia-smi Topology subsection so all PCIe data stays together. nvidia-smi only reports negotiated gen/width (unreliable at idle); it cannot show trained link state vs capability, ACS state on the upstream bridge, or the real PCIe topology tree — the three things that decide whether GPU↔GPU P2P engages (recurring class: #137 KVM passthrough, #351 in-container NVLink-not-engaging).

Captures:
- `lspci -t` — PCIe topology tree (flat/synthetic guest topology vs real bridge).
- Per NVIDIA VGA/3D function: `lspci -vvv` filtered to **only** `LnkCap:` / `LnkSta:` / `ACSCap:` / `ACSCtl:` (never the full verbose block — compact + redaction-safe). **Plus the resolved upstream PCIe bridge of each GPU**: ACS lives on the bridge, not the GPU endpoint, and ACS-redirect there is exactly what blocks P2P. Verified on the 2× 3090 rig that the RTX 3090 endpoint exposes no ACS at all — ACSCap/ACSCtl only appear once the upstream bridge is walked, so bridge resolution is required for the capture to be useful.
- `lspci -nnk | grep -A3 -i nvidia` — driver binding + device IDs (spots vfio-pci vs nvidia in-guest).

Graceful degradation mirrors existing optional captures: gated on `have lspci` (one-line skip note if pciutils absent); uses `sudo lspci -vvv` only when passwordless sudo is available, else degrades to non-sudo lspci with a one-line note (LnkSta still accurate, ACS may be incomplete). Never blocks or prompts. Output piped through the existing `redact` helper and wrapped in the existing `details` collapsible.

Scope: only `scripts/report.sh` (+64 lines, after the Topology subsection). No release/version/CHANGELOG touched. No dedicated `report.sh` test exists under `scripts/tests/`, so none modified.

## Acceptance (issue #148)

- [x] New subsection emitted by `report.sh` with the three captures above
- [x] Graceful skip when `lspci` absent; graceful sudo-less degradation with a note
- [x] Redacted + collapsible, consistent with existing sections
- [ ] Verified on the 2× 3090 rig that `LnkSta`/`ACSCtl` render correctly *(maintainer's retained gate — rendered locally during dev with LnkSta on GPU functions and ACSCap/ACSCtl on the upstream bridges, but final rig-render + redaction-safety sign-off is the maintainer's call)*

Local static validation done: `bash -n` clean (shellcheck not installed on host); subsection renders inside the collapsible through `redact`; lspci-absent skip path and sudo-less degradation path both confirmed error-free; diff grepped for internal-path leakage (none — only kernel-standard `/sys/bus/pci` paths).

Refs #137, #351
Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)