### PR TITLE
fix(launch): force LC_NUMERIC=C — VRAM-budget printf fails on comma-decimal locales (#159)

### DIFF
--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -40,6 +40,14 @@
 
 set -euo pipefail
 
+# The VRAM-budget block formats dot-decimal numbers emitted by kv-calc.py JSON
+# (e.g. "9.0") with `printf "%.2f"`. Under a comma-decimal LC_NUMERIC locale
+# (de_DE, fr_FR, …) bash printf rejects the dot — `printf: 9.0: invalid number`
+# / `Ungültige Zahl` — and the launcher aborts at the budget print (#159).
+# Force C numeric parsing for the whole script; LC_CTYPE/encoding is left
+# untouched so UTF-8 UI glyphs (—, ×, ⚠) still render.
+export LC_NUMERIC=C
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 SWITCH="${SWITCH:-${ROOT_DIR}/scripts/switch.sh}"
 VERIFY="${VERIFY:-${ROOT_DIR}/scripts/verify-full.sh}"


### PR DESCRIPTION
## Summary

`scripts/launch.sh`'s VRAM-budget block formats dot-decimal numbers from `kv-calc.py` JSON (e.g. `9.0`) with `printf "%.2f"`. Under a **comma-decimal `LC_NUMERIC` locale** (de_DE, fr_FR, …) bash `printf` rejects the dot input — `printf: 9.0: Ungültige Zahl` / `invalid number` — and the launcher aborts mid-budget-print. Reported by @chrischd83 (German locale) in [discussion #159](https://github.com/noonghunna/club-3090/discussions/159) (`9,00 GB`, `Zeile 940: printf: 9.0: Ungültige Zahl`).

Affects the whole budget block (lines ~948–956: Weights/KV/Activations/Cudagraph/Drafter/Predicted-peak), not just the first line.

## Fix

One line: `export LC_NUMERIC=C` immediately after `set -euo pipefail`, before any executable code. Forces C numeric parsing for the whole script so `printf "%f"` always accepts the tool-emitted dot-decimals regardless of the user's locale. **`LC_CTYPE`/encoding deliberately untouched** so UTF-8 UI glyphs (`—`, `×`, `⚠`) still render. Commented with the why + #159.

## Test plan

- [x] `bash -n scripts/launch.sh` clean
- [x] `export LC_NUMERIC=C` (line 49) precedes the first executable `printf "%.2f"` (line 948) and all numeric printf
- [x] `LC_NUMERIC=C printf "%.2f" 9.0` → `9.00` verified
- [x] leak-clean; scope = 1 file, +8/-0
- [ ] **Exact de_DE failure not reproducible on our rig** — no comma-decimal locale data installed (only C/POSIX/en_*). Mechanism is textbook (bash `printf` parses the input number under `LC_NUMERIC`); @chrischd83 on the German-locale machine is the definitive validator — asked them to confirm on the discussion.

Fixes discussion #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)