### PR TITLE
v0.8.2 — universal pull: honest failure on-ramp + wider model catalogue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,7 +53,7 @@
 # auto (default): detects NVLink via nvidia-smi topo -m
 # force_on: assume NVLink bridge present, set NVLink env vars
 # force_off: force PCIe-only path even if NVLink detected
-# This only affects dual-card (TP=2) composes. Single-card and multi4 are unaffected.
+# Affects dual-card (TP=2) and multi-card (TP=4+) composes. Single-card is unaffected.
 # NVLINK_MODE=auto
 
 

--- a/README.md
+++ b/README.md
@@ -6,64 +6,7 @@ If you have one or two RTX 3090s and want to run modern LLMs at home, in a homel
 
 ---
 
-## TL;DR — what this is
-
-- **Two complementary routes** — pick by what your workload breaks on:
-  - 🏎 **vLLM dual** = max throughput. Up to **127 TPS code** (DFlash) or **4 concurrent streams @ 262K** (turbo). Full feature stack (vision · tools · MTP · streaming).
-  - 🛡 **llama.cpp single** = max robustness. Full **262K context** on one 3090. Stress-tested clean: no prefill cliffs, 25K-token tool returns work, 90K needle ladder passes. Slower (~21 TPS) but doesn't crash on real-world tool-using agents.
-- **Validated docker compose configs** for both routes — drop-in OpenAI-compatible API on `localhost:8020`
-- **Multi-engine**: vLLM (full features), llama.cpp (max ctx + robustness), SGLang (currently blocked, watch list)
-- **Model-agnostic**: today ships curated configs for Qwen3.6-27B and friends; structure scales as we add models
-- **Universal `pull` (v0.8.0)** — *evaluate any safetensors HF repo; pull only vLLM-loadable supported ones, and only when the gates pass (or an explicit override is accepted)*. The model-agnostic front door for anything not in the curated list — the curated catalog above still ships and still works. → [`docs/PULL.md`](docs/PULL.md)
-
-**First time here?** → [Models](#supported-models) — pick yours.
-**Already running, want to compare engines?** → [docs/engines/](docs/engines/)
-**Picking an engine** (vLLM / llama.cpp / SGLang / ktransformers / ik_llama.cpp)? → [docs/INFERENCE_ENGINES.md](docs/INFERENCE_ENGINES.md)
-**Hardware questions** (does this work on a 4090, do I need NVLink)? → [docs/HARDWARE.md](docs/HARDWARE.md)
-**Don't know what TPS / KV / MTP mean?** → [docs/GLOSSARY.md](docs/GLOSSARY.md)
-
-> ⚠️ **Known issue (2026-05-05)**: Single-card 24 GB long-context (>~50K tokens) on `long-text.yml` / `long-text-no-mtp.yml` / `long-vision.yml` can OOM despite Genesis v7.72.2's PN59 fix. PN59's runtime eligibility check rejects the chunked-prefill path that 24 GB single-card configs are forced to take. Filed at [Sandermage/genesis-vllm-patches#22](https://github.com/Sandermage/genesis-vllm-patches/issues/22), pending Sander review. **If you hit it**: switch to `dual.yml` / `dual-turbo.yml` (TP=2 escapes the cliff) or `llamacpp/default` (different engine, no Cliff 2). See [docs/CLIFFS.md](docs/CLIFFS.md) for the full diagnosis.
-
----
-
-## Pick your path
-
-| You have | Start here |
-|---|---|
-| **1× RTX 3090** | [`docs/SINGLE_CARD.md`](docs/SINGLE_CARD.md) — workload → config → quick start |
-| **2× RTX 3090** (PCIe / no NVLink) | [`docs/DUAL_CARD.md`](docs/DUAL_CARD.md) — workload → config → quick start |
-| **3+ GPUs** (any class — 4× 3090, 8× A6000, mixed) | [`docs/MULTI_CARD.md`](docs/MULTI_CARD.md) — TP scaling math, derivation from `dual.yml`, valid TP values |
-| **A model not in the supported list** / any HF safetensors repo | [`docs/PULL.md`](docs/PULL.md) — universal `pull` flow: evaluate against the KV math, honest about confidence |
-| Considering self-host vs cloud APIs | [`docs/COMPARISONS.md`](docs/COMPARISONS.md) — cost crossover + when each wins |
-
-Each hardware page lists every supported model with the working composes for that card count, plus measured TPS and per-workload pitfalls. Model-specific deep dives (quants, Genesis patches, engine internals) live under [`models/<name>/`](models/).
-
----
-
-## Supported models
-
-| Model | Status | Card counts | Engines | Highlights |
-|---|---|---|---|---|
-| **[Qwen3.6-27B](models/qwen3.6-27b/)** | Production-ready ⭐ | 1× / 2× 3090 | vLLM ✅ · llama.cpp ✅ · SGLang ❌ blocked | Vision · tools · MTP n=3 · up to 262K ctx · vLLM dual = 89/127 TPS · llama.cpp single = full 262K, no prefill cliffs |
-| **[Gemma 4 31B](models/gemma-4-31b/)** | Production-ready (dual-card only on Ampere 24 GB) | 2× 3090 only ¹ | vLLM ✅ · llama.cpp ❌ · SGLang ❌ | Vision · tools · MTP n=3 (Google official drafter) **OR** DFlash n=7 (z-lab drafter) · up to 262K ctx via INT8 PTH KV (PR [#40391](https://github.com/vllm-project/vllm/pull/40391) vendored) · MTP dual = 106/141 TPS at 32K, 95/126 at 262K · DFlash dual = 105/177 TPS at 32K (code-optimal) |
-| **[Qwen3.6 35B-A3B](models/qwen3.6-35b-a3b/)** ⭐ NEW v0.7.3 | Preview (production-track blocked on Genesis v7.73.x) | 2× 3090 | vLLM ✅ (preview) · SGLang ❌ · llama.cpp ❌ | **MoE (256 experts × 8 active, ~3 B active params)** · vision · tools · upstream native loader via [vLLM PR #42521](https://github.com/vllm-project/vllm/pull/42521) · preview dual = **182/177 TPS at 16K** (no MTP, no TQ3, no Genesis) · ~2× the Qwen 3.6-27B dense baseline on the same hardware · production path (Genesis + TQ3 + MTP) pending upstream Genesis re-anchor |
-| **[Gemma 4 26B-A4B](models/gemma-4-26b-a4b/)** ⭐ NEW v0.7.3 | Production via AWQ (Intel AutoRound INT4 blocked on Ampere) | 2× 3090 | vLLM ✅ (AWQ overlay) · SGLang ❌ · llama.cpp ❌ | **MoE (128 experts × 8 active, ~4 B active params)** · vision · tools · cyankiwi AWQ-4bit weights via vendored [vLLM PR #40886](https://github.com/vllm-project/vllm/pull/40886) (compressed-tensors MoE key remapping) · AWQ dual = **139/139 TPS at 32K**, CV 0.2% / 0.0% · Intel AutoRound variants Ampere-blocked (Marlin K-dim alignment — moe_intermediate_size=704 not aligned to group_size=128) — AutoRound works on SM90+ |
-
-¹ Single-card boot OOMs on Ampere 24 GB regardless of KV format (weights + drafter + profiling at 8K ctx leaves no KV pool). Single-card Gemma 4 is feasible on 32 GB+ GPUs (validated on RTX 5090 32 GB by [@apnar](https://github.com/noonghunna/club-3090/discussions/67#discussioncomment-16832042)).
-
-More models coming. The repo structure scales — when we add Qwen3.5-27B / GLM-4.6 / etc., they go under `models/<name>/` with the same internal pattern.
-
----
-
-## Measured TPS at a glance
-
-![Qwen3.6-27B TPS by config](docs/img/performance.png)
-
-Bench protocol: 3 warm + 5 measured runs of the canonical narrative + code prompts. `scripts/bench.sh` reports wall TPS, decode TPS, TTFT, and prompt-processing throughput (`PP tok/s`; vLLM log scrape, `PP=1` long-prompt fallback for llama.cpp). Substrate: vLLM nightly `0.20.1rc1.dev16+g7a1eb8ac2` + Genesis v7.69 dev tip (commit `2db18df`), with local backports `patch_inputs_embeds_optional.py` (vllm#35975) and `patch_tolist_cudagraph.py`. llama.cpp mainline `0d0764dfd`, RTX 3090 sm_86 PCIe-only at 230 W. Per-config details + run-by-run numbers + VRAM + AL/accept rates: [models/qwen3.6-27b/CHANGELOG.md](models/qwen3.6-27b/CHANGELOG.md) (per-model history) and [scripts/bench.sh](scripts/bench.sh) (canonical bench).
-
----
-
-## Quick start (for the current model — Qwen3.6-27B on vLLM)
+## Quick start
 
 ```bash
 # 1. Clone the repo
@@ -107,24 +50,66 @@ bash scripts/switch.sh vllm/long-vision   # for example
 # 7. Keep your install up-to-date as the stack moves (Genesis pin bumps,
 #    new compose variants, vendored patch updates):
 bash scripts/update.sh
-#   - bails if your tree has uncommitted edits (commit or stash first)
-#   - git pull --ff-only origin master, then re-runs setup.sh
-#   - tells you to restart your container via switch.sh after — so you can
-#     A/B old-vs-new before bringing the new variant up
-#   launch.sh + switch.sh also soft-warn at boot when your checkout is
-#   behind origin/master, so you'll usually find out before you ask.
 ```
 
 `launch.sh` calls `switch.sh` (down old, up new) and then `verify-full.sh` so you know it's serving cleanly before you point a client at it. See [`scripts/`](scripts/) for all helpers.
 
-For client snippets — Python (`openai` SDK + raw `requests`), TypeScript / Node, plus connection settings for Open WebUI, Cline, Cursor, and other OpenAI-compat clients — see [`docs/EXAMPLES.md`](docs/EXAMPLES.md). Common questions ("can I use a 4090?", "why MTP not EAGLE?", "why not Ollama?", "what's a prefill cliff?") have answers in [`docs/FAQ.md`](docs/FAQ.md). Trying to decide self-host vs cloud APIs vs other local options? [`docs/COMPARISONS.md`](docs/COMPARISONS.md). Want to contribute numbers, bug repros, or new variants? [`CONTRIBUTING.md`](CONTRIBUTING.md). Tracking the upstream issues and PRs we depend on or have filed? [`docs/UPSTREAM.md`](docs/UPSTREAM.md).
+> ⚠️ **Single-card long-context note:** Cliff 2 (GDN prefill OOM at >~50K single-prompt) is **open** on 24 GB single-card vLLM. Genesis v7.72.2 PN59 was intended as the fix but doesn't engage on chunked-prefill. **Workarounds:** [`vllm/dual`](docs/DUAL_CARD.md) (TP=2 escapes it) or [`llamacpp/default`](docs/SINGLE_CARD.md#bulletproof-no-cliffs) (different engine, no cliff). Full diagnosis at [`docs/CLIFFS.md`](docs/CLIFFS.md).
 
-**Hit an issue or want to share bench numbers?** Run `bash scripts/report.sh > my-rig.md` (add `--full` for the canonical "everything" pass: rig + verify-full + verify-stress 7/7 + SOAK_MODE=continuous + bench, ~35 min) and paste into the [bug](https://github.com/noonghunna/club-3090/issues/new?template=bug-report.yml) or [bench](https://github.com/noonghunna/club-3090/issues/new?template=numbers-from-your-rig.yml) issue template — single command captures everything we'd otherwise ask for individually. **Not on our shipped Docker composes?** Scripts now work on non-Docker host builds (llama.cpp host server, SGLang, etc.) via `URL=... CONTAINER=none MODEL=... bash scripts/...` — see [discussion #88](https://github.com/noonghunna/club-3090/discussions/88) for the full contributor flow.
+---
 
-For llama.cpp (different engine, different recipe — useful for max context on single-card):
-```bash
-cd models/qwen3.6-27b/llama-cpp && cat README.md
-```
+## TL;DR — what this is
+
+- **Two complementary routes** — pick by what your workload breaks on:
+  - 🏎 **vLLM dual** = max throughput. Up to **127 TPS code** (DFlash) or **4 concurrent streams @ 262K** (turbo). Full feature stack (vision · tools · MTP · streaming).
+  - 🛡 **llama.cpp single** = max robustness. Full **262K context** on one 3090. Stress-tested clean: no prefill cliffs, 25K-token tool returns work, 90K needle ladder passes. Slower (~21 TPS) but doesn't crash on real-world tool-using agents.
+- **Validated docker compose configs** for both routes — drop-in OpenAI-compatible API on `localhost:8020`
+- **Multi-engine**: vLLM (full features), llama.cpp (max ctx + robustness), SGLang (currently blocked, watch list)
+- **Model-agnostic**: today ships curated configs for Qwen3.6-27B and friends; structure scales as we add models
+- **Universal `pull` (v0.8.0)** — evaluate any safetensors HF repo; see [`docs/PULL.md`](docs/PULL.md)
+
+**New here?** → [`docs/GETTING_STARTED.md`](docs/GETTING_STARTED.md) — 5-minute clone-to-curl path.
+**Already running, want to compare engines?** → [docs/engines/](docs/engines/)
+**Picking an engine** (vLLM / llama.cpp / SGLang)? → [docs/INFERENCE_ENGINES.md](docs/INFERENCE_ENGINES.md)
+**Hardware questions** (4090, NVLink, power caps)? → [docs/HARDWARE.md](docs/HARDWARE.md)
+**Don't know what TPS / KV / MTP mean?** → [docs/GLOSSARY.md](docs/GLOSSARY.md)
+
+---
+
+## Pick your path
+
+| You have | Start here |
+|---|---|
+| **1× RTX 3090** | [`docs/SINGLE_CARD.md`](docs/SINGLE_CARD.md) — workload → config → quick start |
+| **2× RTX 3090** (PCIe / NVLink auto-detected) | [`docs/DUAL_CARD.md`](docs/DUAL_CARD.md) — workload → config → quick start |
+| **3+ GPUs** (any class — 4× 3090, 8× A6000, mixed) | [`docs/MULTI_CARD.md`](docs/MULTI_CARD.md) — TP scaling math, derivation from `dual.yml`, valid TP values |
+| **A model not in the supported list** / any HF safetensors repo | [`docs/PULL.md`](docs/PULL.md) — universal `pull` flow: evaluate against the KV math, honest about confidence |
+| Considering self-host vs cloud APIs | [`docs/COMPARISONS.md`](docs/COMPARISONS.md) — cost crossover + when each wins |
+
+Each hardware page lists every supported model with the working composes for that card count, plus measured TPS and per-workload pitfalls. Model-specific deep dives (quants, Genesis patches, engine internals) live under [`models/<name>/`](models/).
+
+---
+
+## Supported models
+
+| Model | Status | Card counts | Engines | Highlights |
+|---|---|---|---|---|
+| **[Qwen3.6-27B](models/qwen3.6-27b/)** | Production-ready ⭐ | 1× / 2× 3090 | vLLM ✅ · llama.cpp ✅ · SGLang ❌ blocked | Vision · tools · MTP n=3 · up to 262K ctx · vLLM dual = 89/127 TPS · llama.cpp single = full 262K, no prefill cliffs |
+| **[Gemma 4 31B](models/gemma-4-31b/)** | Production-ready (dual-card only on Ampere 24 GB) | 2× 3090 only ¹ | vLLM ✅ · llama.cpp ❌ · SGLang ❌ | Vision · tools · MTP n=3 (Google official drafter) **OR** DFlash n=7 (z-lab drafter) · up to 262K ctx via INT8 PTH KV (PR [#40391](https://github.com/vllm-project/vllm/pull/40391) vendored) · MTP dual = 106/141 TPS at 32K, 95/126 at 262K · DFlash dual = 105/177 TPS at 32K (code-optimal) |
+| **[Qwen3.6 35B-A3B](models/qwen3.6-35b-a3b/)** ⭐ NEW v0.7.3 | Preview (production-track blocked on Genesis v7.73.x) | 2× 3090 | vLLM ✅ (preview) · SGLang ❌ · llama.cpp ❌ | **MoE (256 experts × 8 active, ~3 B active params)** · vision · tools · upstream native loader via [vLLM PR #42521](https://github.com/vllm-project/vllm/pull/42521) · preview dual = **182/177 TPS at 16K** (no MTP, no TQ3, no Genesis) |
+| **[Gemma 4 26B-A4B](models/gemma-4-26b-a4b/)** ⭐ NEW v0.7.3 | Production via AWQ (Intel AutoRound INT4 blocked on Ampere) | 2× 3090 | vLLM ✅ (AWQ overlay) · SGLang ❌ · llama.cpp ❌ | **MoE (128 experts × 8 active, ~4 B active params)** · vision · tools · AWQ dual = **139/139 TPS at 32K**, CV 0.2% / 0.0% |
+
+¹ Single-card boot OOMs on Ampere 24 GB regardless of KV format. Single-card Gemma 4 is feasible on 32 GB+ GPUs (validated on RTX 5090 32 GB by [@apnar](https://github.com/noonghunna/club-3090/discussions/67#discussioncomment-16832042)).
+
+More models coming — they go under `models/<name>/` with the same internal pattern.
+
+---
+
+## Measured TPS at a glance
+
+![Qwen3.6-27B TPS by config](docs/img/performance.png)
+
+Bench protocol: 3 warm + 5 measured runs. See [`scripts/bench.sh`](scripts/bench.sh) for methodology. Per-config details + run-by-run numbers + VRAM + AL/accept rates: [models/qwen3.6-27b/CHANGELOG.md](models/qwen3.6-27b/CHANGELOG.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ bash scripts/update.sh
 - **Validated docker compose configs** for both routes — drop-in OpenAI-compatible API on `localhost:8020`
 - **Multi-engine**: vLLM (full features), llama.cpp (max ctx + robustness), SGLang (currently blocked, watch list)
 - **Model-agnostic**: today ships curated configs for Qwen3.6-27B and friends; structure scales as we add models
-- **Universal `pull` (v0.8.0)** — evaluate any safetensors HF repo; see [`docs/PULL.md`](docs/PULL.md)
+- **Universal `pull`** (v0.8.0; extended in v0.8.2) — evaluate any safetensors HF repo, get an honest one-line fit verdict (`--recommend`), and when a pull hard-blocks, send the redacted diagnostic back in one consented step (`--submit-last`). Broader arch coverage each release. See [`docs/PULL.md`](docs/PULL.md)
 
 **New here?** → [`docs/GETTING_STARTED.md`](docs/GETTING_STARTED.md) — 5-minute clone-to-curl path.
 **Already running, want to compare engines?** → [docs/engines/](docs/engines/)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,6 +29,12 @@ pull → derive (read repo config/safetensors)
                 calibration backbone)
 ```
 
+**v0.8.2 surfaces (current):**
+- `scripts/pull.sh … --recommend` — appends an honest one-line fit verdict (FITS / FITS-but-not-yet-accepted / DOES-NOT-FIT) over the same gate result; presentation only, never changes the verdict, carries the boot-fit≠runtime caveat.
+- **Failure on-ramp** — every hard-block leaves a redacted `.pull-captures/<slug>/<ts>/` bundle; `scripts/pull.sh --submit-last` (or `--submit <dir>`) is a separate, consented, user-invoked step that submits it (works with *or without* `gh`; no telemetry, no auto-send).
+- **Broadened arch registry** — materially more safetensors architectures pass `[C0]` without `--experimental-arch`; native built-ins reach a clean serve verdict, per-repo remote-code stays fail-closed (zero false-pass).
+- **Optional non-NVIDIA `hwdetect`** — bounded subprocess augmenting hardware detection where `nvidia-smi` doesn't apply (AMD/Apple); absent → graceful degrade, never feeds kv-calc.
+
 **You don't need to know any of these stage names to use it** — you run one command (`scripts/pull.sh`); the `[C0]`/`[B]`/`[C1]`/… taxonomy above is internal flow for contributors. Start at the user guide: [`docs/PULL.md`](PULL.md) (Quickstart at the top). Contributor depth, in pipeline order: [`COMPOSE_GENERATOR.md`](COMPOSE_GENERATOR.md) (emit) → [`PULL_GATE.md`](PULL_GATE.md) (gate) → [`PULL_EMIT_DERIVED.md`](PULL_EMIT_DERIVED.md) (boot+capture) → [`LOOP.md`](LOOP.md) (classify+trust+dedup). The curated path still works exactly as before — `pull` is additive, the front door for anything not in the catalog.
 
 A boot-fit pass is a *static* check. It is necessary-not-sufficient: a `fits-clean` config can still degrade under accumulated-context agent workloads (the Cliff 2 / prefill-cliff failure modes — see [`CLIFFS.md`](CLIFFS.md)). The gate verdict says so explicitly and points at soak-continuous validation; trust the caveat, not just the green.
@@ -66,6 +72,7 @@ scripts/                      shared, model-aware
   verify-stress.sh              boundary-case stress test, 2 checks (~5-10 min)
   bench.sh                      canonical TPS bench
   pull.sh <hf-repo>             universal evaluate→gate→emit→boot front door
+                                  (+ --recommend verdict; --submit-last/--submit on-ramp)
   generate-compose.sh           emit a minimal compose for an in-scope profile
   lib/profiles/                 the gate/derive/classify/trust pipeline (engine)
   tests/                        executable specs (test-pull, test-classifier, …)

--- a/docs/COMPOSE_GENERATOR.md
+++ b/docs/COMPOSE_GENERATOR.md
@@ -137,6 +137,16 @@ No args at all → usage error (exit `64`).
 one-line summary to stderr; without `--out` the compose goes to stdout. The
 3-category provenance header (§7) is always part of the emitted file.
 
+### Capacity values are the reference profile's — NOT fit-adapted to your hardware
+
+The generated compose's capacity knobs — `--max-model-len`, `--gpu-memory-utilization`, `--max-num-seqs`, and the KV cache dtype — are copied **verbatim from the captured reference profile** (the shipped compose it reproduces). The generator does **not** run a fit solve, does **not** size context to *your* GPU's VRAM, and does **not** down-cast the KV dtype for capacity. So:
+
+- On a card **smaller** than the reference target, the emitted `--max-model-len` may not boot — it is not shrunk for you.
+- On a card **larger** than the reference target, you are leaving context/throughput on the table — it is not grown for you.
+- For a **derived** (non-curated) model the KV dtype is whatever the model ships (often `bf16`); it is not optimised toward a denser hardware-legal format.
+
+This is deliberate (Mission §1 — reproduce + flag, NEVER repair): the generated file is a **known-safe starting point**, not a hardware-tuned config. For the actual fit on *your* hardware, run `scripts/pull.sh <slug> --profile-like <key> --recommend` (or `tools/kv-calc.py --solve-max-ctx ...`) and tune the emitted `${MAX_MODEL_LEN}` (it is intentionally an env-overridable default) accordingly. An opt-in capacity optimiser is planned for a later release; until then, right-sizing is a deliberate user step.
+
 ### Running a generated compose — it is NOT relocatable
 
 Per the whole-service-template model (§4), the generator copies the shipped

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -210,6 +210,62 @@ with requests.post(
 
 ---
 
+## Python — tool calling (agentic workflow)
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8020/v1", api_key="not-needed")
+
+# Define a tool the model can call
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get current temperature for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string", "description": "City name"}
+                },
+                "required": ["location"]
+            },
+        }
+    }
+]
+
+# First turn: model decides to call the tool
+resp = client.chat.completions.create(
+    model="qwen3.6-27b-autoround",
+    messages=[{"role": "user", "content": "What's the weather in Paris?"}],
+    tools=tools,
+    tool_choice="auto",
+    max_tokens=512,
+)
+
+msg = resp.choices[0].message
+print(f"Tool call: {msg.tool_calls}")
+
+# Second turn: feed tool result back
+messages = [
+    {"role": "user", "content": "What's the weather in Paris?"},
+    msg,
+    {"role": "tool", "tool_call_id": msg.tool_calls[0].id, "content": "22°C, sunny"},
+]
+
+resp2 = client.chat.completions.create(
+    model="qwen3.6-27b-autoround",
+    messages=messages,
+    tools=tools,
+    max_tokens=512,
+)
+
+print(f"Final answer: {resp2.choices[0].message.content}")
+```
+
+---
+
 ## TypeScript / Node — `openai` SDK
 
 ```bash

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -2,6 +2,15 @@
 
 Common questions about club-3090. If your question isn't here, open a [GitHub Discussion](https://github.com/noonghunna/club-3090/discussions) — most things end up in this doc eventually.
 
+## Quick links
+
+- [Hardware](#hardware) — 4090/5090, NVLink, AMD, WSL2, dtype
+- [Engine choice](#engine-choice) — Ollama, LM Studio, MTP vs EAGLE
+- [Performance](#performance) — slow TPS, prefill cliffs
+- [Troubleshooting ladder](#before-symptom-matching--boot-the-simplest-stack-first) — 5-step isolation from minimal to dual-turbo
+
+---
+
 ## Hardware
 
 ### Can I use a 4090 instead of a 3090?
@@ -293,7 +302,7 @@ SOAK_MODE=continuous SOAK_SESSIONS=5 SOAK_TURNS=5 \
 
 **Why this happens** (one-paragraph): the GDN forward kernel holds ~500 MiB of simultaneous intermediate tensors at T=4128 prefill chunks. With accumulated multi-turn KV cache (~5 GiB at 25K context) + model weights (14 GiB) + MTP draft (5 GiB) + other workspace, the per-card peak exceeds the 24 GiB ceiling. The fix is rewriting the kernel to stream those intermediates segment-by-segment instead of holding them simultaneously — that's upstream work in `vllm/model_executor/layers/fla/ops/` or via Genesis sidecar. Detailed mechanism analysis in [`docs/CLIFFS.md`](CLIFFS.md) "Why TP=2 escapes" and "Why llama.cpp escapes" sections.
 
-### Before symptom-matching — boot the simplest stack first
+## Troubleshooting ladder — boot the simplest stack first
 
 If you're hitting boot OOMs, weird MTP behavior, or memory-budget issues
 on TQ3 / long-context configs, validate that your hardware + driver +
@@ -400,7 +409,7 @@ Adds: TQ3 KV + Genesis on top of TP=2 + 4-stream concurrency.
   surface we'd want to debug carefully and the full pass (verify + stress
   + soak + bench) gives us everything to triage in one paste.
 
-### Why this works for both single and dual-card users
+## Why this works for both single and dual-card users
 
 The first 3 steps isolate stack layers (base → Genesis+MTP+fp8 →
 TQ3+long-ctx). Steps 4-5 add TP=2 surface separately. A user on dual
@@ -409,7 +418,7 @@ card first — it's the only way to tell apart "issue in single-card
 stack that also breaks dual" from "issue specific to TP=2 NCCL /
 multi-GPU coordination."
 
-### Quick recognition guide for common failure modes
+## Quick recognition guide for common failure modes
 
 - **Container dies at boot with `GPTQ_MARLIN_MIN_THREAD_N (64) > out_features`** — dual-card vllm#40361 patch didn't apply. Confirm `/opt/ai/engines/vllm/primary/` exists with the patched marlin kernel files.
 - **Container dies during DFlash boot** — vllm#40334 dtype mismatch. Verify the compose has `--dtype bfloat16`.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,0 +1,36 @@
+# Getting started — zero to `curl` in 5 minutes
+
+The fastest path from `git clone` to serving your first response. No decisions, no menus — just commands.
+
+```bash
+# 1. Clone
+git clone https://github.com/noonghunna/club-3090.git
+cd club-3090
+
+# 2. Download the model (Qwen3.6-27B, ~18 GB)
+bash scripts/setup.sh qwen3.6-27b
+
+# 3. Boot the default config (single-card chat, 48K context)
+bash scripts/launch.sh --variant vllm/default
+
+# 4. Test it
+curl -sf http://localhost:8020/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model":"qwen3.6-27b-autoround","messages":[{"role":"user","content":"Capital of France?"}],"max_tokens":200}'
+```
+
+If you see `Paris` in the response, you're up and running.
+
+---
+
+## Next steps
+
+| You want | Go here |
+|----------|---------|
+| **Pick a config by workload** (long context, vision, dual-card, etc.) | [`docs/SINGLE_CARD.md`](SINGLE_CARD.md) or [`docs/DUAL_CARD.md`](DUAL_CARD.md) |
+| **Understand the jargon** (TPS, KV, MTP, TP) | [`docs/GLOSSARY.md`](GLOSSARY.md) |
+| **Client code snippets** (Python, curl, IDE setup) | [`docs/EXAMPLES.md`](EXAMPLES.md) |
+| **Run the canonical benchmark** | `bash scripts/bench.sh` |
+| **Update to the latest** | `bash scripts/update.sh` |
+| **Hardware questions** (power caps, NVLink, 4090/5090) | [`docs/HARDWARE.md`](HARDWARE.md) |
+| **File an issue or share bench numbers** | `bash scripts/report.sh --full > my-rig.md` and open an issue |

--- a/docs/PATCH_POLICY.md
+++ b/docs/PATCH_POLICY.md
@@ -48,7 +48,7 @@ A load-bearing patch entry in `patches.yml` MUST carry all of:
 | `model` | list of model slugs the patch applies to |
 | `files` | repo-relative path(s) to the patch artifact |
 | `load_bearing_when[].composes` | the **exact** list of profile keys this patch is load-bearing for. This is the *only* thing the generator keys patch selection off (`X ∈ P.load_bearing_when[].composes`). Each entry also carries `reason` + `evidence`. |
-| `delivery_mechanism` | one of `python_sidecar`, `site_package_overlay`, `install_script`, or `none` (diagnostics / negative-result / Genesis-env patches) |
+| `delivery_mechanism` | one of `python_sidecar`, `site_package_overlay`, `install_script`, `chat_template` (vendored `.jinja` override — see §3.1), or `none` (diagnostics / negative-result / Genesis-env patches) |
 | `delivery_spec` | the concrete wiring: mount target(s) (`overlay_files[].dest`, `overlay_dir`+`dest_root`, `mounted_at`), sidecar/script path, `invoke` command, and `wired_at` (`volumes`, `entrypoint`, or both). This is the **single source** both the generator's emit and `reaches()`'s reachability validation read — they must agree by construction. |
 | `drift_guard` | **mandatory** for any load-bearing patch (`kind`, `check`, `on_fail`). See §4. |
 | `capability` | the capability the patch delivers (e.g. `tp-weight-load`, `tool-choice-required`, `tool-call-stream`, `dflash-spec-decode`) |
@@ -90,6 +90,56 @@ Choose the delivery mechanism in this order of preference:
 
 If you reach for `site_package_overlay`, justify it in the PR and file the
 re-home follow-up.
+
+### 3.1 The `chat_template` delivery class
+
+A **model chat-template override** (a vendored `.jinja` mounted into the
+container) is its own delivery class — `delivery_mechanism: chat_template`.
+A bad/regressed/re-vendored template is exactly the **#145 silent-break
+class** (tool-call XML / reasoning delimiters / streaming), so it MUST be
+attributed and drift-guarded like any other load-bearing patch, not left
+invisible to the generator and `test-patch-attribution`.
+
+`delivery_spec` for a `chat_template` patch carries:
+
+- `jinja` — repo-relative path to the vendored `.jinja` (it is also the
+  patch's `files[]` entry; an orphan `.jinja` under a model `patches/`
+  tree with no `chat_template` patch is a hard test failure);
+- `mounted_at` — the container path the `.jinja` is bind-mounted to;
+- `mount_mode` — typically `ro`;
+- `invoke` — the serving wiring. Two in-tree styles:
+  - **explicit** `--chat-template <mounted_at>` (e.g. froggeric):
+    `wired_at: [volumes, entrypoint]`;
+  - **mount-only** (e.g. carnice mounts over the model dir's
+    `chat_template.jinja` and vLLM auto-loads it): `wired_at: [volumes]`,
+    no `--chat-template` arg;
+- `wired_at` — as above.
+
+**Effective coverage is computed from the REAL merged compose graph.**
+A `chat_template` patch's reachability is resolved with **Docker Compose
+`extends:` merge semantics** (`docker compose -f <child> config`, or a
+deterministic offline merge that applies the same rules), **never a raw
+single-base text concat**. This is mandatory because a child compose can
+`!reset` the base's mount/command or simply stop extending a
+template-bearing base — a text concat would still "see" the base's mount
+line and report coverage that no longer exists (a **false negative** —
+the dangerous direction; the #377 silent-drift mode). Note Compose merges
+`extends:` *sequences* additively: a plain re-declared `volumes: []` does
+**not** drop a base mount; only the `!reset` tag (or not extending the
+base at all) removes it. `test-patch-attribution.sh` carries a fixture
+asserting a `!reset` child and a stopped-extending child both lose
+coverage.
+
+The `drift_guard` for a `chat_template` patch is `kind: behavioral` and
+its `check` MUST encode the **self-contained symmetric restart+settle
+protocol**: identical `docker restart <container>` on BOTH arms → wait
+for `/v1/models` healthy → fixed 60 s settle → ≥3 `bench.sh` runs/arm →
+compare the **grand mean** of the SAME canonical bench segment (NARRATIVE
+800-word essay + CODE; never mix segments, never a single run); flag
+ONLY a deterministic regression reproduced across all 3 runs. A
+non-symmetric guard fabricates phantom regressions (the asymmetric-restart
+"−7%" artifact) and gets ignored. The same guard must clear the *next*
+template re-vendor.
 
 ---
 

--- a/docs/PULL.md
+++ b/docs/PULL.md
@@ -107,6 +107,8 @@ scripts/pull.sh Lorbus/Qwen3.6-27B-int4-AutoRound \
     --profile-like vllm/minimal --out qwen.yml
 ```
 
+> **The emitted compose carries the reference profile's capacity values, not a fit tuned to your GPU.** `--max-model-len`, `--gpu-memory-utilization`, `--max-num-seqs` and the KV dtype are copied from the captured profile — *not* re-solved for your card. It is a known-safe starting point: add `--recommend` (or run `tools/kv-calc.py --solve-max-ctx`) for the honest fit on your hardware, and tune the emitted env-overridable `${MAX_MODEL_LEN}` accordingly. See `docs/COMPOSE_GENERATOR.md` § "Capacity values are the reference profile's".
+
 ### Path B — universal evaluate (never downloads, never emits)
 
 Any non-curated slug, or `--dry-run` on anything, takes Path B. It prints

--- a/docs/PULL.md
+++ b/docs/PULL.md
@@ -8,6 +8,18 @@ anything, and is honest about how much it trusts the answer.
 > **v0.8.0 headline:** *"Evaluate any safetensors HF repo; pull only
 > vLLM-loadable supported ones, and only when the gates pass (or an explicit
 > override is accepted)."*
+>
+> **v0.8.2 adds** (additive only — no v0.8.0 decision logic changed): a
+> failure on-ramp (a redacted-diagnostics submit path when a pull fails),
+> arch-registry expansion (materially more safetensors models reach
+> `engine-supported`), an optional hardware-detect slice for non-NVIDIA
+> enumeration, and the `--recommend` UX (an honest aggregated
+> recommendation over the same verdict). **GGUF is deferred** — it is not
+> a v0.8.2 item: cross-engine generation (GGUF / llama.cpp serving via
+> `pull`) is a separate **§9 cross-engine design-unlock proposal**, not
+> this release. Pointing `pull` at a GGUF-only repo is a known scope
+> boundary, not a stack failure (see [the readiness
+> ledger](#release-readiness-ledger--honest-deferrals) below).
 
 This is the **user front door**. For the contributor/maintainer internals
 of the same pipeline (gate strata, classifier, trust pipeline) start at
@@ -226,13 +238,152 @@ depth behind a passing run:
 
 ---
 
-## v0.8.1 — not yet (honest deferrals)
+## `--recommend` — the honest one-line answer
 
-This release evaluates **safetensors only**. Deferred to a later release:
+Add `--recommend` to any `pull` invocation and, after the gate runs, you
+get an aggregated plain-language recommendation: does it fit, on which
+profile/variant, at what confidence, and **which gate decided** — plus the
+boot-fit≠runtime caveat verbatim when the verdict reached the fit math.
 
-- **GGUF** repos (footer-first metadata derivation, multi-quant auto-pick).
-- **`.bin`** / non-safetensors weight layouts.
-- A whichllm-based hardware-detect slice and the full `recommend` UX.
+```bash
+scripts/pull.sh <org/Model> --profile-like vllm/minimal --dry-run --recommend
+```
 
-If you point `pull` at a GGUF-only or `.bin`-only repo today, that is a
-known gap, not a stack failure.
+It is **presentation only**: every line is read straight off the same
+verdict the gate already produced — `--recommend` never changes the
+decision, the exit code, or what gets downloaded/emitted. It is honest by
+construction:
+
+- It echoes the real confidence tier; an `estimated-lower-bound` fit is
+  stated as a floor, never dressed up as a guarantee.
+- It is **vLLM-only** (the gate is vLLM-only; `--recommend` only echoes
+  that).
+- It **never implies an artifact that was not produced** — the
+  "compose emitted" line appears only when a compose was actually emitted
+  (Path A); a Path B / `--dry-run` recommendation says so explicitly.
+- A `FITS` verdict carries the §7 caveat and the
+  `scripts/soak.sh SOAK_MODE=continuous` pointer; a pre-fit-math
+  hard-block does **not** (it never reached the fit math, so it makes no
+  soak claim).
+
+When the verdict is *blocked*, `--recommend` points you at the failure
+on-ramp below.
+
+---
+
+## Report a failed pull
+
+When a `pull` fails (a gate hard-block, or a `fits-clean` that then
+fails to boot), the run leaves a **redacted diagnostics bundle** on disk
+and prints exactly where it is and the one command to send it back:
+
+```
+[pull] Diagnostics captured (redacted, no paths/tokens): .pull-captures/<slug>/<ts>
+[pull] Help improve the fit math — submit with: scripts/pull.sh --submit-last
+```
+
+This is the success-path's mirror image: `--recommend` tells you what to
+run; this tells you "that failed — help us fix the fit math." It is
+entirely opt-in and the `pull` run itself does **no** network — capture is
+a local file write only.
+
+### The on-ramp, step by step
+
+1. **Capture is automatic and redacted.** On any failure terminal `pull`
+   writes a bundle under `.pull-captures/<slug>/<ts>` and records it as
+   the most-recent capture. The bundle is already scrubbed of paths and
+   tokens — you never paste terminal scrollback (your console output is
+   *not* a safe source; the artifact is).
+
+2. **You submit it deliberately, in a separate command.** Submission is a
+   distinct, explicit, consented step — never automatic, never a phone
+   home:
+
+   ```bash
+   # Submit the most-recent capture:
+   scripts/pull.sh --submit-last
+
+   # Or submit a specific bundle by directory:
+   scripts/pull.sh --submit .pull-captures/<slug>/<ts>
+   ```
+
+   `--submit-last` and `--submit <dir>` need **neither a slug nor
+   `--profile-like`** — they are a different verb from a gate run.
+
+3. **You see the exact payload, then consent.** Before anything leaves
+   your machine the command prints the resolved bundle identity and the
+   **exact already-redacted payload that would be sent**, then asks:
+
+   ```
+   [submit] resolved bundle: <abs dir>
+   [submit] identity: slug='<org/Model>' utc_ts='<ts>' outcome='hard-block' schema=2 ...
+   [submit] this is the EXACT already-redacted payload that will be sent (no terminal scrollback, no paths/tokens):
+   ------------------------------------------------------------------------
+   ... the redacted report ...
+   ------------------------------------------------------------------------
+   [submit] §6.1 class=<class> should_file=<bool>
+   [submit] submit this redacted report? [y/N]
+   ```
+
+   Anything other than a leading `y`/`Y` (including just Enter, or EOF in
+   a non-interactive shell) is a decline:
+
+   ```
+   [submit] declined — nothing sent (no network performed).
+   ```
+
+   Network happens **only** after an explicit `y`.
+
+4. **With `gh` (the GitHub CLI) installed and authenticated**, a
+   consented submit reuses the deduped contribution path: equivalent
+   reports are coalesced (a duplicate adds a `+1` rather than opening a
+   new issue), and a correct-refusal class is spooled to the maintainer
+   triage queue instead of opening a public issue. You'll see a line like
+   `[submit] F5 action=... dedup_hash=... issue=...` (and a
+   `[submit] spool: ...` line when it was queued, not filed).
+
+5. **Without `gh`**, the same consented submit degrades cleanly: for a
+   solicited (actionable) class it prints a prefilled GitHub issue URL you
+   can paste into a browser; for a correct-refusal / unactionable class it
+   prints the **local** triage-spool path and a "captured for maintainer
+   triage; not a public issue" line — and **no** public-issue URL. Either
+   way, the only thing you are ever asked to share is the already-redacted
+   artifact, never a filesystem path or terminal output.
+
+If `--submit-last` finds no recent capture it tells you plainly and points
+at the explicit-directory form:
+
+```
+[submit] no recent capture; use `scripts/pull.sh --submit <dir>`
+```
+
+---
+
+## Release readiness ledger — honest deferrals
+
+`pull` evaluates and serves **safetensors via vLLM only**. This is a
+deliberate scope boundary, stated up front so a §9 reader is not
+surprised:
+
+| Item | Status in v0.8.2 |
+|---|---|
+| Safetensors evaluate + (Path A) emit + boot | shipped (v0.8.0) |
+| Failure on-ramp (capture + consented `--submit*`) | shipped (v0.8.2) |
+| Arch-registry expansion (more models reach `engine-supported`) | shipped (v0.8.2) |
+| Optional non-NVIDIA hardware-detect slice | shipped (v0.8.2, optional) |
+| `--recommend` UX | shipped (v0.8.2) |
+| **GGUF** repos (evaluate **and** serve) | **deferred — see below** |
+| **`.bin`** / non-safetensors weight layouts | deferred |
+| Cross-engine generation (llama.cpp serving via `pull`) | deferred — see below |
+
+**GGUF is deferred to a §9 cross-engine design-unlock proposal**, not a
+later patch release of this line. The reason is structural, not a backlog
+slip: `pull` emits and serves vLLM by design, so a GGUF path would be
+either a thin evaluate-only calculator (no launcher) or full llama.cpp
+serving — and **cross-engine generation is §9 "deferred indefinitely"**,
+i.e. it requires its own design-unlock and review round before any
+implementation. If GGUF matters to you, the next artifact is that
+design-unlock proposal, not a GGUF feature in this line.
+
+If you point `pull` at a GGUF-only or `.bin`-only repo today, that is this
+documented scope boundary, **not** a stack failure.

--- a/docs/PULL.md
+++ b/docs/PULL.md
@@ -14,12 +14,17 @@ anything, and is honest about how much it trusts the answer.
 > arch-registry expansion (materially more safetensors models reach
 > `engine-supported`), an optional hardware-detect slice for non-NVIDIA
 > enumeration, and the `--recommend` UX (an honest aggregated
-> recommendation over the same verdict). **GGUF is deferred** — it is not
-> a v0.8.2 item: cross-engine generation (GGUF / llama.cpp serving via
-> `pull`) is a separate **§9 cross-engine design-unlock proposal**, not
-> this release. Pointing `pull` at a GGUF-only repo is a known scope
-> boundary, not a stack failure (see [the readiness
-> ledger](#release-readiness-ledger--honest-deferrals) below).
+> recommendation over the same verdict). This release also **bundles two
+> non-`pull` items that shipped on the same branch**: N-GPU NVLink
+> auto-detection (wired into the multi-4 and Gemma-4-26B dual composes)
+> and a documentation restructure (a quick-start-first README, a new
+> `GETTING_STARTED.md`, model READMEs, and an updated docs index) — both
+> are independent of and orthogonal to the `pull` decision path. **GGUF
+> is deferred** — it is not a v0.8.2 item: cross-engine generation (GGUF
+> / llama.cpp serving via `pull`) is a separate **§9 cross-engine
+> design-unlock proposal**, not this release. Pointing `pull` at a
+> GGUF-only repo is a known scope boundary, not a stack failure (see [the
+> readiness ledger](#release-readiness-ledger--honest-deferrals) below).
 
 This is the **user front door**. For the contributor/maintainer internals
 of the same pipeline (gate strata, classifier, trust pipeline) start at
@@ -363,7 +368,10 @@ at the explicit-directory form:
 
 `pull` evaluates and serves **safetensors via vLLM only**. This is a
 deliberate scope boundary, stated up front so a §9 reader is not
-surprised:
+surprised. v0.8.2's shipped scope is the four `pull` items below **plus**
+two orthogonal, non-`pull` items that landed on the same release branch
+(N-GPU NVLink auto-detection and a documentation restructure) — listed
+here so the bundled scope is stated honestly, not under-claimed:
 
 | Item | Status in v0.8.2 |
 |---|---|
@@ -372,6 +380,8 @@ surprised:
 | Arch-registry expansion (more models reach `engine-supported`) | shipped (v0.8.2) |
 | Optional non-NVIDIA hardware-detect slice | shipped (v0.8.2, optional) |
 | `--recommend` UX | shipped (v0.8.2) |
+| N-GPU NVLink auto-detection (multi-4 + Gemma-4-26B dual composes) | shipped (v0.8.2, bundled — not a `pull` item) |
+| Documentation restructure (quick-start README, `GETTING_STARTED.md`, model READMEs, docs index) | shipped (v0.8.2, bundled — not a `pull` item) |
 | **GGUF** repos (evaluate **and** serve) | **deferred — see below** |
 | **`.bin`** / non-safetensors weight layouts | deferred |
 | Cross-engine generation (llama.cpp serving via `pull`) | deferred — see below |

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,9 +16,11 @@ Start here if you want to run a model.
 
 | Doc | What it is |
 |---|---|
-| [`PULL.md`](PULL.md) | **Start here for any model not in the curated list.** The v0.8.0 universal flow: evaluate any safetensors HF repo against this stack's KV math, honest about confidence. |
+| [`GETTING_STARTED.md`](GETTING_STARTED.md) | **Start here — 5-minute clone-to-curl path.** No decisions, no menus. |
 | [`SINGLE_CARD.md`](SINGLE_CARD.md) | 1× RTX 3090 — workload → curated config → quick start. |
-| [`DUAL_CARD.md`](DUAL_CARD.md) | 2× RTX 3090 (PCIe / no NVLink) — workload → config → quick start. |
+| [`DUAL_CARD.md`](DUAL_CARD.md) | 2× RTX 3090 (PCIe / NVLink auto-detected) — workload → config → quick start. |
+| [`MULTI_CARD.md`](MULTI_CARD.md) | 3+ GPUs — TP scaling math, derivation from `dual.yml`, valid TP values. |
+| [`PULL.md`](PULL.md) | Any HF safetensors repo — evaluate against the KV math, honest about confidence. |
 | [`MULTI_CARD.md`](MULTI_CARD.md) | 3+ GPUs — TP scaling math, derivation from `dual.yml`, valid TP values. |
 | [`HARDWARE.md`](HARDWARE.md) | Card-class questions — 4090/5090, power caps, NVLink, laptop EC power. |
 | [`GLOSSARY.md`](GLOSSARY.md) | TPS / KV / MTP / TP and the rest of the vocabulary. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,6 @@ Start here if you want to run a model.
 | [`DUAL_CARD.md`](DUAL_CARD.md) | 2× RTX 3090 (PCIe / NVLink auto-detected) — workload → config → quick start. |
 | [`MULTI_CARD.md`](MULTI_CARD.md) | 3+ GPUs — TP scaling math, derivation from `dual.yml`, valid TP values. |
 | [`PULL.md`](PULL.md) | Any HF safetensors repo — evaluate against the KV math, honest about confidence. |
-| [`MULTI_CARD.md`](MULTI_CARD.md) | 3+ GPUs — TP scaling math, derivation from `dual.yml`, valid TP values. |
 | [`HARDWARE.md`](HARDWARE.md) | Card-class questions — 4090/5090, power caps, NVLink, laptop EC power. |
 | [`GLOSSARY.md`](GLOSSARY.md) | TPS / KV / MTP / TP and the rest of the vocabulary. |
 | [`FAQ.md`](FAQ.md) | Common setup and operational questions. |

--- a/docs/engines/README.md
+++ b/docs/engines/README.md
@@ -91,7 +91,7 @@ Full plan in [models/qwen3.6-27b/sglang/README.md](../../models/qwen3.6-27b/sgla
 |---|---|---|
 | **Full feature set, MTP spec-decode, OpenAI API parity** | vLLM + Lorbus AutoRound | This repo's path. 51-70 TPS depending on workload, all features, prefill-safe at 48K default. |
 | **Maximum context (262K) on one 3090** | llama.cpp + UD-Q3_K_XL or Q4_K_M + q4_0 KV | Smaller quants leave 8-10 GB headroom for KV at 262K. ~35-45 TPS sustained. |
-| **Best concurrent throughput on dual 3090** | vLLM TP=2 + Turbo (TQ3) | 4 streams at full 262K, ~200 TPS aggregate. See [companion repo](https://github.com/noonghunna/qwen36-dual-3090). |
+| **Best concurrent throughput on dual 3090** | vLLM TP=2 + Turbo (TQ3) | 4 streams at full 262K, ~200 TPS aggregate. See [`dual-turbo.yml`](../models/qwen3.6-27b/vllm/compose/dual/turbo.yml) in this repo. |
 | **Non-NVIDIA hardware (AMD / Intel / Apple)** | llama.cpp | Only engine with cross-platform support. |
 | **Lightest setup, fastest cold start** | llama.cpp | Single binary, ~30s cold start. Good for embedded use, quick experiments. |
 | **High-throughput multi-tenant serving** | SGLang (re-test pending — DFlash + MTP native upstream as of May 2026; Marlin INT4 fix verification needed) | RadixAttention prefix sharing wins at scale. Re-test plan in [sglang/README.md](../../models/qwen3.6-27b/sglang/README.md). |

--- a/models/gemma-4-26b-a4b/README.md
+++ b/models/gemma-4-26b-a4b/README.md
@@ -1,0 +1,44 @@
+# Gemma 4 26B-A4B MoE — on 2× RTX 3090
+
+**Run [Gemma 4 26B-A4B](https://blog.google/technology/developers/gemma-4/) — a 128-expert MoE with ~4B active params, vision, and tool calling — on 2× RTX 3090s.**
+
+> ⭐ v0.7.3 onboarding target. AWQ production path validated; Intel AutoRound INT4 blocked on Ampere (Marlin K-dim alignment).
+
+---
+
+## Deployment
+
+See [`docs/DUAL_CARD.md`](../../docs/DUAL_CARD.md) for workload-driven config picks. TL;DR:
+
+| Config | Max ctx | Narr / Code TPS | Best for |
+|--------|---------|----------------|----------|
+| `vllm/gemma4-26b-a4b-tp2` | 32K | 139 / 139 | General-purpose, vision + tools |
+
+Run via:
+```bash
+bash scripts/launch.sh --variant vllm/gemma4-26b-a4b-tp2
+```
+
+---
+
+## Models
+
+- **Target:** [`Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound`](https://huggingface.co/Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound) (~16 GB, MoE expert layers quant-mixed)
+- **AWQ alternative:** cyankiwi AWQ-4bit weights (validated production path on Ampere)
+- **Draft:** TBD (Google's `gemma-4-26B-A4B-it-assistant` available, compose pending)
+
+## Key details
+
+| Aspect | Notes |
+|--------|-------|
+| **Arch** | MoE — 128 experts × 8 active, ~4B active params |
+| **Quants** | AWQ-4bit (production), Intel AutoRound INT4 (Ampere-blocked for now) |
+| **KV** | bfloat16 |
+| **Vision** | ✅ Yes (off by default in base compose for first-boot validation) |
+| **Tools** | ✅ `--tool-call-parser gemma4` |
+| **NVLink** | Auto-detected via `NVLINK_MODE` env var |
+
+## Upstream tracker
+
+- [vLLM PR #40886](https://github.com/vllm-project/vllm/pull/40886) — compressed-tensors MoE key remapping (vendored for AWQ path)
+- [Discussion #67](https://github.com/noonghunna/club-3090/discussions/67) — first Ampere consumer cross-rig data thread

--- a/models/gemma-4-26b-a4b/vllm/compose/dual/docker-compose.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/dual/docker-compose.yml
@@ -55,10 +55,13 @@ services:
       - ${MODEL_DIR:-../../../../../models-cache}:/root/.cache/huggingface
       - ../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../cache/triton:/root/.triton/cache
+      # NVLink auto-detection — runs inside container at boot.
+      - ../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - VLLM_WORKER_MULTIPROC_METHOD=spawn
+      - NVLINK_MODE=${NVLINK_MODE:-auto}
       - NCCL_CUMEM_ENABLE=0
       - NCCL_P2P_DISABLE=1
       - VLLM_NO_USAGE_STATS=1
@@ -75,6 +78,18 @@ services:
             - driver: nvidia
               count: all
               capabilities: [gpu]
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
+        source /etc/club3090/detect_nvlink.sh
+        if [ "${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve "$@"
+        else
+          exec vllm serve --disable-custom-all-reduce "$@"
+        fi
+      - --
     command:
       - --host
       - 0.0.0.0

--- a/models/gemma-4-31b/README.md
+++ b/models/gemma-4-31b/README.md
@@ -1,0 +1,50 @@
+# Gemma 4 31B — on 2× RTX 3090
+
+**Run [Gemma 4 31B](https://blog.google/technology/developers/gemma-4/) — with vision, tool calling, and MTP/DFlash spec-decode — on 2× RTX 3090s.**
+
+> ⚠️ **Single-card boot OOMs on 24 GB Ampere** regardless of KV format. Needs ≥32 GB single-card (validated on RTX 5090 by [@apnar](https://github.com/noonghunna/club-3090/discussions/67#discussioncomment-16832042)).
+
+---
+
+## Deployment
+
+See [`docs/DUAL_CARD.md`](../../docs/DUAL_CARD.md) for workload-driven config picks. TL;DR:
+
+| Config | Max ctx | Narr / Code TPS | Best for |
+|--------|---------|----------------|----------|
+| `vllm/dual` (default) | 32K | 106 / 141 | General-purpose, vision + tools |
+| `vllm/int8` | **262K** | 95 / 126 | Long-context via INT8 PTH KV (PR #40391) |
+| `vllm/dflash` | 32K | 105 / 177 | Peak code TPS (z-lab DFlash n=7) |
+| `vllm/awq` | 118K | varies | AWQ-4bit weights (cyankiwi quant) |
+
+Run via:
+```bash
+bash scripts/launch.sh --variant vllm/gemma-mtp     # MTP default
+bash scripts/launch.sh --variant vllm/gemma-int8    # long-context
+bash scripts/launch.sh --variant vllm/gemma-dflash  # peak code TPS
+```
+
+---
+
+## Models
+
+- **Target:** [`Intel/gemma-4-31B-it-int4-AutoRound`](https://huggingface.co/Intel/gemma-4-31B-it-int4-AutoRound) (~21.2 GB, vision preserved)
+- **Draft (MTP):** [`google/gemma-4-31B-it-assistant`](https://huggingface.co/google/gemma-4-31B-it-assistant) (0.5B / 927 MB BF16)
+- **Draft (DFlash):** z-lab Gemma 4 DFlash n=7 block-diffusion drafter
+
+## Key details
+
+| Aspect | Notes |
+|--------|-------|
+| **Quants** | Intel AutoRound INT4 (default), cyankiwi AWQ-4bit |
+| **KV** | bfloat16 (32K) or INT8 PTH via vendored PR #40391 (262K) |
+| **Drafter** | MTP n=3 (Google official) or DFlash n=7 (z-lab) |
+| **Vision** | ✅ Yes |
+| **Tools** | ✅ `--tool-call-parser gemma4` |
+| **NVLink** | Auto-detected via `NVLINK_MODE` env var |
+
+## Upstream tracker
+
+- [vLLM PR #41745](https://github.com/vllm-project/vllm/pull/41745) — Gemma 4 MTP support (merged)
+- [vLLM PR #40391](https://github.com/vllm-project/vllm/pull/40391) — INT8 PTH KV
+- [Discussion #67](https://github.com/noonghunna/club-3090/discussions/67) — first Ampere consumer cross-rig data

--- a/models/qwen3.6-27b/INTERNALS.md
+++ b/models/qwen3.6-27b/INTERNALS.md
@@ -14,7 +14,7 @@ If you just want to use the stack, the model README is enough.
 
 For engine-general docs (vLLM tuning, llama.cpp tradeoffs, SGLang status), see [`/docs/engines/`](../../docs/engines/).
 
-> **Note (2026-05-02 PM):** This file describes the forensic chain that led to the v7.62.x stack. For the **current** state — **Cliff 2 60K closure** via Genesis v7.69 (PN32 GDN chunked-prefill + P103 worker self-install) + local vllm#35975 inputs_embeds backport, two shippable variants `long-text.yml` (180K balanced + MTP K=3) and `long-text-no-mtp.yml` (200K + no MTP) — see [`docs/CLIFFS.md`](../../docs/CLIFFS.md) and the [latest CHANGELOG entry](CHANGELOG.md). The PN8 status table below is historical (still accurate for the FP8 path); PN12 closes Cliff 1 on TQ3 paths via Genesis-native v0.20+ integration.
+> **Note (2026-05-18):** This file describes the forensic chain that led to the v7.62.x stack. For the **current** state — **Cliff 2 REGRESSED on v7.72.2** (PN59 streaming-GDN doesn't engage on chunked-prefill, see [`docs/CLIFFS.md`](../../docs/CLIFFS.md)), **Cliff 1 closed** on TQ3 paths via PN12 Genesis-native v0.20+ integration. See [`docs/CLIFFS.md`](../../docs/CLIFFS.md) for the full up-to-date cliff status and [CHANGELOG.md](CHANGELOG.md) for the latest config state. The PN8 status table below is historical (still accurate for the FP8 path).
 
 ---
 

--- a/models/qwen3.6-27b/vllm/compose/multi4/docker-compose.yml
+++ b/models/qwen3.6-27b/vllm/compose/multi4/docker-compose.yml
@@ -101,11 +101,13 @@ services:
       # See docs/UPSTREAM.md "Community templates / model assets" + the row at
       # https://huggingface.co/froggeric/Qwen-Fixed-Chat-Templates
       - ../../patches/froggeric-chat-template/chat_template.jinja:/etc/qwen-froggeric-chat-template.jinja:ro
+      # NVLink auto-detection — runs inside container at boot.
+      - ../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - VLLM_WORKER_MULTIPROC_METHOD=spawn
-      # PCIe-only stack — disable NCCL features that assume NVLink.
+      - NVLINK_MODE=${NVLINK_MODE:-auto}
       - NCCL_CUMEM_ENABLE=0
       - NCCL_P2P_DISABLE=1
       - VLLM_NO_USAGE_STATS=1
@@ -134,7 +136,13 @@ services:
         # stability. See docs/HARDWARE.md "Note for WSL2 / Windows users".
         # Install PR #35936 overlay before vllm imports (drop when upstream lands).
         bash /etc/club3090/install-pr35936.sh
-        exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} "$@"
+        # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
+        source /etc/club3090/detect_nvlink.sh
+        if [ "${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} "$@"
+        else
+          exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$@"
+        fi
       - --
     command:
       - --model
@@ -149,7 +157,6 @@ services:
       - "${TP:-4}"
       - --pipeline-parallel-size
       - "${PP:-1}"
-      - --disable-custom-all-reduce
       - --max-model-len
       - "${MAX_MODEL_LEN:-262144}"
       - --gpu-memory-utilization

--- a/scripts/detect_nvlink.sh
+++ b/scripts/detect_nvlink.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # NVLink auto-detection + override. Sources NVLINK_MODE from env (default: auto).
 # Exports: _NVLINK_ENABLED (0 or 1), sets NCCL/PYTORCH env vars accordingly.
-# Designed for dual-card (2x GPU) setups. Skips detection on >2 GPUs.
+# Handles 2-GPU setups (single NVLink bridge) and N-GPU setups (e.g. 2 bridges on 4 cards).
 
 NVLINK_MODE="${NVLINK_MODE:-auto}"
 
@@ -17,8 +17,14 @@ case "$NVLINK_MODE" in
   auto)
     GPU_COUNT=$(nvidia-smi -L 2>/dev/null | grep -c 'GPU' || echo 0)
     if [ "$GPU_COUNT" -gt 2 ]; then
-      _NVLINK_ENABLED=0
-      echo "[nvlink] $GPU_COUNT GPUs detected — skipping NVLink detection (dual-card only)"
+      # Check topology matrix for any NVLink connections (e.g. 2 bridges on 4 cards).
+      if nvidia-smi topo -m 2>/dev/null | grep -qP '\bNV[0-9]+\b'; then
+        _NVLINK_ENABLED=1
+        echo "[nvlink] $GPU_COUNT GPUs detected — NVLink found, enabling NVLink mode"
+      else
+        _NVLINK_ENABLED=0
+        echo "[nvlink] $GPU_COUNT GPUs detected — no NVLink found, using PCIe mode"
+      fi
     elif [ "$GPU_COUNT" -eq 2 ]; then
       LINK=$(nvidia-smi topo -m 2>/dev/null | awk '/^GPU0/{print $3}')
       if [[ "$LINK" =~ ^NV[0-9]+$ ]]; then

--- a/scripts/lib/generate_compose.py
+++ b/scripts/lib/generate_compose.py
@@ -363,6 +363,18 @@ def _patch_wiring_markers(patch: dict) -> list[str]:
     if spec.get("script"):
         markers.append(_dir_token(spec["script"]))
         markers.append(Path(spec["script"]).name)
+    # chat_template: the vendored `.jinja` is mounted via the
+    # compose-relative `patches/<name>/...jinja` path; `mounted_at` (added
+    # above) is the container side. For the explicit `--chat-template`
+    # wiring style add both serving tokens so a strip of an omitted/
+    # undelivered chat_template patch removes the --chat-template arg too
+    # (emit stays in lock-step with reaches()).
+    if patch.get("delivery_mechanism") == "chat_template":
+        if spec.get("jinja"):
+            markers.append(_dir_token(spec["jinja"]))
+            markers.append(Path(spec["jinja"]).name)
+        if "--chat-template" in (spec.get("invoke") or "") and spec.get("mounted_at"):
+            markers.append("--chat-template")
     inv = spec.get("invoke")
     if inv and "/" in inv and not inv.endswith((".", "serving", "import")):
         markers.append(inv)

--- a/scripts/lib/profiles/arch_patches.yml
+++ b/scripts/lib/profiles/arch_patches.yml
@@ -257,27 +257,46 @@ arches:
   # longer fires). They are ADDITIVE DATA ONLY — no [C0] decision-logic
   # change.
   #
-  # ZERO FALSE-PASS by construction: every row below follows the SAME
-  # honest precedent as the dense lower-bound rows above —
-  # `requires_trust_remote_code: unverified` + evidence `none`, so [C0]
-  # still resolves `needs-trust-remote-code-ack` (fail-closed; bypassable
-  # ONLY by an explicit `--trust-remote-code`, NEVER auto-passed). The
-  # expansion removes ONLY the `--experimental-arch` requirement — it never
-  # claims a verified boot. `confidence: estimated-lower-bound` /
-  # `status: unverified` make the non-anchored nature explicit; a real
-  # on-rig boot would later promote a specific row to `verified`/`exact`
-  # (data-only). The shipped test invariants prove the no-false-pass:
-  # negative-TP -> engine-support-unknown, unverified-trc ->
-  # needs-trust-remote-code-ack.
+  # TWO-CLASS, ZERO-FALSE-PASS by construction. The expansion removes the
+  # `--experimental-arch` requirement (a row now exists). Each row then
+  # takes ONE of two honest TRC postures:
   #
-  # Anchor for each row: it is a long-standing BUILT-IN vLLM model class
-  # (documented in vLLM's supported-models registry — a real upstream
-  # constraint, not an optimistic guess), so `no-arch-row` was an
-  # over-refusal; quant/dtype/kernel specifics remain deferred to the
-  # later deriver gates exactly as the existing lower-bound rows state.
-  # `PhiForCausalLM` additionally has a concrete on-rig anchor: it is the
+  #   (1) requires_trust_remote_code: "false" + a documented-constraint
+  #       evidence string — for long-standing native vLLM BUILT-IN model
+  #       classes (vLLM supported-models registry) that execute NO remote
+  #       code. A repo declaring such an arch with NO auto_map passes [C0]
+  #       engine-supported CLEANLY (CONTRACT-2's actual goal — the
+  #       over-refusal is REMOVED, not relabelled). This is NOT a
+  #       false-pass: gates.py's `has_auto_map` is an INDEPENDENT OR-term,
+  #       so a repo that ships auto_map / custom modeling code STILL
+  #       hard-blocks `needs-trust-remote-code-ack` regardless of this
+  #       flag — the per-repo trust boundary is untouched; this flag only
+  #       removes the arch-ROW-level blanket over-refusal. Evidence is the
+  #       documented upstream "built-in class" constraint (NOT a claim that
+  #       we inspected specific third-party weights).
+  #
+  #   (2) requires_trust_remote_code: unverified + evidence `none` — for
+  #       arch families with genuine remote-code lineage (their canonical
+  #       models historically ship custom modeling): `Phi3SmallForCausalLM`
+  #       (blocksparse custom attention), `InternLM2ForCausalLM` (commonly
+  #       auto_map/TRC). These stay fail-closed at `needs-trc-ack`
+  #       (bypassable ONLY by explicit `--trust-remote-code`) — the honest
+  #       label where "no remote code" is NOT a defensible documented
+  #       constraint.
+  #
+  # Neither class claims a verified boot: `confidence: estimated-lower-bound`
+  # / `status: unverified` stay on every expansion row (TRC posture is
+  # orthogonal to boot-verification — cf. the shipped Gemma4ForCausalLM
+  # row); a real on-rig boot later promotes confidence/status data-only.
+  # Test invariants prove no-false-pass: negative-TP ->
+  # engine-support-unknown; class-(2)/auto_map -> needs-trc-ack;
+  # still-absent arch -> no-arch-row; class-(1)+no-auto_map ->
+  # engine-supported.
+  #
+  # `PhiForCausalLM` (class 1) has a concrete on-rig anchor: it is the
   # `microsoft/phi-2` C0 case that hard-blocked on `no-arch-row` during
-  # v0.8.2 STEP V1 on-rig validation (2026-05-18).
+  # v0.8.2 STEP V1 on-rig validation (2026-05-18), and now passes
+  # engine-supported on-rig (2026-05-18, post-correction).
   # ---------------------------------------------------------------------
 
   - arch: PhiForCausalLM
@@ -293,8 +312,8 @@ arches:
       marlin_alignment_required: false
       moe_layout: dense
       evidence: "vLLM built-in PhiForCausalLM model class (supported-models registry); on-rig anchor: microsoft/phi-2 C0 no-arch-row hard-block observed v0.8.2 STEP V1 (2026-05-18) — registry gap, not an engine limitation"
-    requires_trust_remote_code: unverified
-    requires_trust_remote_code_evidence: none
+    requires_trust_remote_code: "false"
+    requires_trust_remote_code_evidence: "long-standing native vLLM built-in model class (vLLM supported-models registry — a documented upstream constraint); a repo declaring this arch with no auto_map is served by vLLM's built-in implementation, no remote code. Per-repo remote-code stays independently fail-closed at [C0] branch-1 via the has_auto_map OR-term in scripts/lib/profiles/gates.py — this flag removes ONLY the arch-row-level over-refusal, NOT the per-repo trust boundary. Not anchored to a verified on-rig boot (status stays unverified); a real boot promotes confidence/status data-only. Concrete on-rig anchor: microsoft/phi-2 hard-blocked at [C0] no-arch-row during v0.8.2 STEP V1 on-rig validation (2026-05-18) — a registry gap, not an engine limitation."
     kernel_constraints:
       - "Quant/dtype compatibility must be resolved by later deriver gates."
     confidence: estimated-lower-bound
@@ -333,8 +352,8 @@ arches:
       marlin_alignment_required: false
       moe_layout: dense
       evidence: "vLLM built-in GemmaForCausalLM (Gemma 1) model class (supported-models registry); registry gap not an engine limitation"
-    requires_trust_remote_code: unverified
-    requires_trust_remote_code_evidence: none
+    requires_trust_remote_code: "false"
+    requires_trust_remote_code_evidence: "long-standing native vLLM built-in model class (vLLM supported-models registry — a documented upstream constraint); a repo declaring this arch with no auto_map is served by vLLM's built-in implementation, no remote code. Per-repo remote-code stays independently fail-closed at [C0] branch-1 via the has_auto_map OR-term in scripts/lib/profiles/gates.py — this flag removes ONLY the arch-row-level over-refusal, NOT the per-repo trust boundary. Not anchored to a verified on-rig boot (status stays unverified); a real boot promotes confidence/status data-only."
     kernel_constraints:
       - "Quant/dtype compatibility must be resolved by later deriver gates."
     confidence: estimated-lower-bound
@@ -353,8 +372,8 @@ arches:
       marlin_alignment_required: false
       moe_layout: dense
       evidence: "vLLM built-in Gemma3ForCausalLM model class (supported-models registry); registry gap not an engine limitation"
-    requires_trust_remote_code: unverified
-    requires_trust_remote_code_evidence: none
+    requires_trust_remote_code: "false"
+    requires_trust_remote_code_evidence: "long-standing native vLLM built-in model class (vLLM supported-models registry — a documented upstream constraint); a repo declaring this arch with no auto_map is served by vLLM's built-in implementation, no remote code. Per-repo remote-code stays independently fail-closed at [C0] branch-1 via the has_auto_map OR-term in scripts/lib/profiles/gates.py — this flag removes ONLY the arch-row-level over-refusal, NOT the per-repo trust boundary. Not anchored to a verified on-rig boot (status stays unverified); a real boot promotes confidence/status data-only."
     kernel_constraints:
       - "Quant/dtype compatibility must be resolved by later deriver gates."
       - "Gemma 3 hybrid-SWA KV specifics are resolved by later deriver/[C0] runtime gates, not asserted here."
@@ -374,8 +393,8 @@ arches:
       marlin_alignment_required: false
       moe_layout: dense
       evidence: "vLLM built-in Gemma3ForConditionalGeneration (Gemma 3 multimodal wrapper) model class (supported-models registry); registry gap not an engine limitation"
-    requires_trust_remote_code: unverified
-    requires_trust_remote_code_evidence: none
+    requires_trust_remote_code: "false"
+    requires_trust_remote_code_evidence: "long-standing native vLLM built-in model class (vLLM supported-models registry — a documented upstream constraint); a repo declaring this arch with no auto_map is served by vLLM's built-in implementation, no remote code. Per-repo remote-code stays independently fail-closed at [C0] branch-1 via the has_auto_map OR-term in scripts/lib/profiles/gates.py — this flag removes ONLY the arch-row-level over-refusal, NOT the per-repo trust boundary. Not anchored to a verified on-rig boot (status stays unverified); a real boot promotes confidence/status data-only."
     kernel_constraints:
       - "Quant/dtype compatibility must be resolved by later deriver gates."
       - "Vision wrapper shares the Gemma 3 hybrid-SWA KV constraints; resolved by later runtime gates."
@@ -395,8 +414,8 @@ arches:
       marlin_alignment_required: false
       moe_layout: dense
       evidence: "vLLM built-in Starcoder2ForCausalLM model class (supported-models registry); registry gap not an engine limitation"
-    requires_trust_remote_code: unverified
-    requires_trust_remote_code_evidence: none
+    requires_trust_remote_code: "false"
+    requires_trust_remote_code_evidence: "long-standing native vLLM built-in model class (vLLM supported-models registry — a documented upstream constraint); a repo declaring this arch with no auto_map is served by vLLM's built-in implementation, no remote code. Per-repo remote-code stays independently fail-closed at [C0] branch-1 via the has_auto_map OR-term in scripts/lib/profiles/gates.py — this flag removes ONLY the arch-row-level over-refusal, NOT the per-repo trust boundary. Not anchored to a verified on-rig boot (status stays unverified); a real boot promotes confidence/status data-only."
     kernel_constraints:
       - "Quant/dtype compatibility must be resolved by later deriver gates."
     confidence: estimated-lower-bound
@@ -415,8 +434,8 @@ arches:
       marlin_alignment_required: false
       moe_layout: dense
       evidence: "vLLM built-in CohereForCausalLM (Command-R family) model class (supported-models registry); registry gap not an engine limitation"
-    requires_trust_remote_code: unverified
-    requires_trust_remote_code_evidence: none
+    requires_trust_remote_code: "false"
+    requires_trust_remote_code_evidence: "long-standing native vLLM built-in model class (vLLM supported-models registry — a documented upstream constraint); a repo declaring this arch with no auto_map is served by vLLM's built-in implementation, no remote code. Per-repo remote-code stays independently fail-closed at [C0] branch-1 via the has_auto_map OR-term in scripts/lib/profiles/gates.py — this flag removes ONLY the arch-row-level over-refusal, NOT the per-repo trust boundary. Not anchored to a verified on-rig boot (status stays unverified); a real boot promotes confidence/status data-only."
     kernel_constraints:
       - "Quant/dtype compatibility must be resolved by later deriver gates."
     confidence: estimated-lower-bound
@@ -455,8 +474,8 @@ arches:
       marlin_alignment_required: false
       moe_layout: moe
       evidence: "vLLM built-in MixtralForCausalLM (sparse-MoE) model class (supported-models registry); registry gap not an engine limitation"
-    requires_trust_remote_code: unverified
-    requires_trust_remote_code_evidence: none
+    requires_trust_remote_code: "false"
+    requires_trust_remote_code_evidence: "long-standing native vLLM built-in model class (vLLM supported-models registry — a documented upstream constraint); a repo declaring this arch with no auto_map is served by vLLM's built-in implementation, no remote code. Per-repo remote-code stays independently fail-closed at [C0] branch-1 via the has_auto_map OR-term in scripts/lib/profiles/gates.py — this flag removes ONLY the arch-row-level over-refusal, NOT the per-repo trust boundary. Not anchored to a verified on-rig boot (status stays unverified); a real boot promotes confidence/status data-only."
     kernel_constraints:
       - "MoE expert-tile / quant-kernel (incl. Marlin K-dim) alignment is resolved by later deriver/[C0] runtime gates, not asserted here."
     confidence: estimated-lower-bound
@@ -475,8 +494,8 @@ arches:
       marlin_alignment_required: false
       moe_layout: moe
       evidence: "vLLM built-in Qwen2MoeForCausalLM (sparse-MoE) model class (supported-models registry); registry gap not an engine limitation"
-    requires_trust_remote_code: unverified
-    requires_trust_remote_code_evidence: none
+    requires_trust_remote_code: "false"
+    requires_trust_remote_code_evidence: "long-standing native vLLM built-in model class (vLLM supported-models registry — a documented upstream constraint); a repo declaring this arch with no auto_map is served by vLLM's built-in implementation, no remote code. Per-repo remote-code stays independently fail-closed at [C0] branch-1 via the has_auto_map OR-term in scripts/lib/profiles/gates.py — this flag removes ONLY the arch-row-level over-refusal, NOT the per-repo trust boundary. Not anchored to a verified on-rig boot (status stays unverified); a real boot promotes confidence/status data-only."
     kernel_constraints:
       - "MoE expert-tile / quant-kernel (incl. Marlin K-dim) alignment is resolved by later deriver/[C0] runtime gates, not asserted here."
     confidence: estimated-lower-bound
@@ -495,8 +514,8 @@ arches:
       marlin_alignment_required: false
       moe_layout: moe
       evidence: "vLLM built-in Qwen3MoeForCausalLM (sparse-MoE) model class (supported-models registry); registry gap not an engine limitation. NOTE: distinct from the Qwen3-Next hybrid Qwen3_5MoeForConditionalGeneration row above (DeltaNet) — this is the standard Qwen3 MoE class."
-    requires_trust_remote_code: unverified
-    requires_trust_remote_code_evidence: none
+    requires_trust_remote_code: "false"
+    requires_trust_remote_code_evidence: "long-standing native vLLM built-in model class (vLLM supported-models registry — a documented upstream constraint); a repo declaring this arch with no auto_map is served by vLLM's built-in implementation, no remote code. Per-repo remote-code stays independently fail-closed at [C0] branch-1 via the has_auto_map OR-term in scripts/lib/profiles/gates.py — this flag removes ONLY the arch-row-level over-refusal, NOT the per-repo trust boundary. Not anchored to a verified on-rig boot (status stays unverified); a real boot promotes confidence/status data-only."
     kernel_constraints:
       - "MoE expert-tile / quant-kernel (incl. Marlin K-dim) alignment is resolved by later deriver/[C0] runtime gates, not asserted here."
     confidence: estimated-lower-bound
@@ -515,8 +534,8 @@ arches:
       marlin_alignment_required: false
       moe_layout: dense
       evidence: "vLLM built-in Qwen2VLForConditionalGeneration (Qwen2-VL multimodal) model class (supported-models registry); registry gap not an engine limitation"
-    requires_trust_remote_code: unverified
-    requires_trust_remote_code_evidence: none
+    requires_trust_remote_code: "false"
+    requires_trust_remote_code_evidence: "long-standing native vLLM built-in model class (vLLM supported-models registry — a documented upstream constraint); a repo declaring this arch with no auto_map is served by vLLM's built-in implementation, no remote code. Per-repo remote-code stays independently fail-closed at [C0] branch-1 via the has_auto_map OR-term in scripts/lib/profiles/gates.py — this flag removes ONLY the arch-row-level over-refusal, NOT the per-repo trust boundary. Not anchored to a verified on-rig boot (status stays unverified); a real boot promotes confidence/status data-only."
     kernel_constraints:
       - "Quant/dtype + vision-tower compatibility must be resolved by later deriver gates."
     confidence: estimated-lower-bound

--- a/scripts/lib/profiles/arch_patches.yml
+++ b/scripts/lib/profiles/arch_patches.yml
@@ -247,3 +247,277 @@ arches:
       - "Quant/dtype compatibility must be resolved by later deriver gates."
     confidence: estimated-lower-bound
     status: unverified
+
+  # ---------------------------------------------------------------------
+  # v0.8.2 CONTRACT-2 (§10-R4) — arch-family registry expansion.
+  #
+  # v0.8.0 shipped a deliberately narrow first wave. These rows broaden the
+  # set of *safetensors* architectures that pass [C0] WITHOUT
+  # `--experimental-arch` (a row exists -> the `no-arch-row` sub-reason no
+  # longer fires). They are ADDITIVE DATA ONLY — no [C0] decision-logic
+  # change.
+  #
+  # ZERO FALSE-PASS by construction: every row below follows the SAME
+  # honest precedent as the dense lower-bound rows above —
+  # `requires_trust_remote_code: unverified` + evidence `none`, so [C0]
+  # still resolves `needs-trust-remote-code-ack` (fail-closed; bypassable
+  # ONLY by an explicit `--trust-remote-code`, NEVER auto-passed). The
+  # expansion removes ONLY the `--experimental-arch` requirement — it never
+  # claims a verified boot. `confidence: estimated-lower-bound` /
+  # `status: unverified` make the non-anchored nature explicit; a real
+  # on-rig boot would later promote a specific row to `verified`/`exact`
+  # (data-only). The shipped test invariants prove the no-false-pass:
+  # negative-TP -> engine-support-unknown, unverified-trc ->
+  # needs-trust-remote-code-ack.
+  #
+  # Anchor for each row: it is a long-standing BUILT-IN vLLM model class
+  # (documented in vLLM's supported-models registry — a real upstream
+  # constraint, not an optimistic guess), so `no-arch-row` was an
+  # over-refusal; quant/dtype/kernel specifics remain deferred to the
+  # later deriver gates exactly as the existing lower-bound rows state.
+  # `PhiForCausalLM` additionally has a concrete on-rig anchor: it is the
+  # `microsoft/phi-2` C0 case that hard-blocked on `no-arch-row` during
+  # v0.8.2 STEP V1 on-rig validation (2026-05-18).
+  # ---------------------------------------------------------------------
+
+  - arch: PhiForCausalLM
+    family: dense
+    engine_pin:
+      - pin: vllm-stable@0.20.2
+        loads: true
+      - pin: vllm-nightly-clean@bf610c2f56764e1b30bc6065f4ceace3d6e59036
+        loads: true
+    required_patches: []
+    valid_tp:
+      tp_divisors: [1, 2]
+      marlin_alignment_required: false
+      moe_layout: dense
+      evidence: "vLLM built-in PhiForCausalLM model class (supported-models registry); on-rig anchor: microsoft/phi-2 C0 no-arch-row hard-block observed v0.8.2 STEP V1 (2026-05-18) — registry gap, not an engine limitation"
+    requires_trust_remote_code: unverified
+    requires_trust_remote_code_evidence: none
+    kernel_constraints:
+      - "Quant/dtype compatibility must be resolved by later deriver gates."
+    confidence: estimated-lower-bound
+    status: unverified
+
+  - arch: Phi3SmallForCausalLM
+    family: dense
+    engine_pin:
+      - pin: vllm-stable@0.20.2
+        loads: true
+      - pin: vllm-nightly-clean@bf610c2f56764e1b30bc6065f4ceace3d6e59036
+        loads: true
+    required_patches: []
+    valid_tp:
+      tp_divisors: [1, 2]
+      marlin_alignment_required: false
+      moe_layout: dense
+      evidence: "vLLM built-in Phi3SmallForCausalLM model class (supported-models registry); registry gap not an engine limitation"
+    requires_trust_remote_code: unverified
+    requires_trust_remote_code_evidence: none
+    kernel_constraints:
+      - "Quant/dtype compatibility must be resolved by later deriver gates."
+    confidence: estimated-lower-bound
+    status: unverified
+
+  - arch: GemmaForCausalLM
+    family: dense
+    engine_pin:
+      - pin: vllm-stable@0.20.2
+        loads: true
+      - pin: vllm-nightly-clean@bf610c2f56764e1b30bc6065f4ceace3d6e59036
+        loads: true
+    required_patches: []
+    valid_tp:
+      tp_divisors: [1, 2]
+      marlin_alignment_required: false
+      moe_layout: dense
+      evidence: "vLLM built-in GemmaForCausalLM (Gemma 1) model class (supported-models registry); registry gap not an engine limitation"
+    requires_trust_remote_code: unverified
+    requires_trust_remote_code_evidence: none
+    kernel_constraints:
+      - "Quant/dtype compatibility must be resolved by later deriver gates."
+    confidence: estimated-lower-bound
+    status: unverified
+
+  - arch: Gemma3ForCausalLM
+    family: dense
+    engine_pin:
+      - pin: vllm-stable@0.20.2
+        loads: true
+      - pin: vllm-nightly-clean@bf610c2f56764e1b30bc6065f4ceace3d6e59036
+        loads: true
+    required_patches: []
+    valid_tp:
+      tp_divisors: [1, 2]
+      marlin_alignment_required: false
+      moe_layout: dense
+      evidence: "vLLM built-in Gemma3ForCausalLM model class (supported-models registry); registry gap not an engine limitation"
+    requires_trust_remote_code: unverified
+    requires_trust_remote_code_evidence: none
+    kernel_constraints:
+      - "Quant/dtype compatibility must be resolved by later deriver gates."
+      - "Gemma 3 hybrid-SWA KV specifics are resolved by later deriver/[C0] runtime gates, not asserted here."
+    confidence: estimated-lower-bound
+    status: unverified
+
+  - arch: Gemma3ForConditionalGeneration
+    family: dense
+    engine_pin:
+      - pin: vllm-stable@0.20.2
+        loads: true
+      - pin: vllm-nightly-clean@bf610c2f56764e1b30bc6065f4ceace3d6e59036
+        loads: true
+    required_patches: []
+    valid_tp:
+      tp_divisors: [1, 2]
+      marlin_alignment_required: false
+      moe_layout: dense
+      evidence: "vLLM built-in Gemma3ForConditionalGeneration (Gemma 3 multimodal wrapper) model class (supported-models registry); registry gap not an engine limitation"
+    requires_trust_remote_code: unverified
+    requires_trust_remote_code_evidence: none
+    kernel_constraints:
+      - "Quant/dtype compatibility must be resolved by later deriver gates."
+      - "Vision wrapper shares the Gemma 3 hybrid-SWA KV constraints; resolved by later runtime gates."
+    confidence: estimated-lower-bound
+    status: unverified
+
+  - arch: Starcoder2ForCausalLM
+    family: dense
+    engine_pin:
+      - pin: vllm-stable@0.20.2
+        loads: true
+      - pin: vllm-nightly-clean@bf610c2f56764e1b30bc6065f4ceace3d6e59036
+        loads: true
+    required_patches: []
+    valid_tp:
+      tp_divisors: [1, 2]
+      marlin_alignment_required: false
+      moe_layout: dense
+      evidence: "vLLM built-in Starcoder2ForCausalLM model class (supported-models registry); registry gap not an engine limitation"
+    requires_trust_remote_code: unverified
+    requires_trust_remote_code_evidence: none
+    kernel_constraints:
+      - "Quant/dtype compatibility must be resolved by later deriver gates."
+    confidence: estimated-lower-bound
+    status: unverified
+
+  - arch: CohereForCausalLM
+    family: dense
+    engine_pin:
+      - pin: vllm-stable@0.20.2
+        loads: true
+      - pin: vllm-nightly-clean@bf610c2f56764e1b30bc6065f4ceace3d6e59036
+        loads: true
+    required_patches: []
+    valid_tp:
+      tp_divisors: [1, 2]
+      marlin_alignment_required: false
+      moe_layout: dense
+      evidence: "vLLM built-in CohereForCausalLM (Command-R family) model class (supported-models registry); registry gap not an engine limitation"
+    requires_trust_remote_code: unverified
+    requires_trust_remote_code_evidence: none
+    kernel_constraints:
+      - "Quant/dtype compatibility must be resolved by later deriver gates."
+    confidence: estimated-lower-bound
+    status: unverified
+
+  - arch: InternLM2ForCausalLM
+    family: dense
+    engine_pin:
+      - pin: vllm-stable@0.20.2
+        loads: true
+      - pin: vllm-nightly-clean@bf610c2f56764e1b30bc6065f4ceace3d6e59036
+        loads: true
+    required_patches: []
+    valid_tp:
+      tp_divisors: [1, 2]
+      marlin_alignment_required: false
+      moe_layout: dense
+      evidence: "vLLM built-in InternLM2ForCausalLM model class (supported-models registry); registry gap not an engine limitation"
+    requires_trust_remote_code: unverified
+    requires_trust_remote_code_evidence: none
+    kernel_constraints:
+      - "Quant/dtype compatibility must be resolved by later deriver gates."
+    confidence: estimated-lower-bound
+    status: unverified
+
+  - arch: MixtralForCausalLM
+    family: moe
+    engine_pin:
+      - pin: vllm-stable@0.20.2
+        loads: true
+      - pin: vllm-nightly-clean@bf610c2f56764e1b30bc6065f4ceace3d6e59036
+        loads: true
+    required_patches: []
+    valid_tp:
+      tp_divisors: [1, 2]
+      marlin_alignment_required: false
+      moe_layout: moe
+      evidence: "vLLM built-in MixtralForCausalLM (sparse-MoE) model class (supported-models registry); registry gap not an engine limitation"
+    requires_trust_remote_code: unverified
+    requires_trust_remote_code_evidence: none
+    kernel_constraints:
+      - "MoE expert-tile / quant-kernel (incl. Marlin K-dim) alignment is resolved by later deriver/[C0] runtime gates, not asserted here."
+    confidence: estimated-lower-bound
+    status: unverified
+
+  - arch: Qwen2MoeForCausalLM
+    family: moe
+    engine_pin:
+      - pin: vllm-stable@0.20.2
+        loads: true
+      - pin: vllm-nightly-clean@bf610c2f56764e1b30bc6065f4ceace3d6e59036
+        loads: true
+    required_patches: []
+    valid_tp:
+      tp_divisors: [1, 2]
+      marlin_alignment_required: false
+      moe_layout: moe
+      evidence: "vLLM built-in Qwen2MoeForCausalLM (sparse-MoE) model class (supported-models registry); registry gap not an engine limitation"
+    requires_trust_remote_code: unverified
+    requires_trust_remote_code_evidence: none
+    kernel_constraints:
+      - "MoE expert-tile / quant-kernel (incl. Marlin K-dim) alignment is resolved by later deriver/[C0] runtime gates, not asserted here."
+    confidence: estimated-lower-bound
+    status: unverified
+
+  - arch: Qwen3MoeForCausalLM
+    family: moe
+    engine_pin:
+      - pin: vllm-stable@0.20.2
+        loads: true
+      - pin: vllm-nightly-clean@bf610c2f56764e1b30bc6065f4ceace3d6e59036
+        loads: true
+    required_patches: []
+    valid_tp:
+      tp_divisors: [1, 2]
+      marlin_alignment_required: false
+      moe_layout: moe
+      evidence: "vLLM built-in Qwen3MoeForCausalLM (sparse-MoE) model class (supported-models registry); registry gap not an engine limitation. NOTE: distinct from the Qwen3-Next hybrid Qwen3_5MoeForConditionalGeneration row above (DeltaNet) — this is the standard Qwen3 MoE class."
+    requires_trust_remote_code: unverified
+    requires_trust_remote_code_evidence: none
+    kernel_constraints:
+      - "MoE expert-tile / quant-kernel (incl. Marlin K-dim) alignment is resolved by later deriver/[C0] runtime gates, not asserted here."
+    confidence: estimated-lower-bound
+    status: unverified
+
+  - arch: Qwen2VLForConditionalGeneration
+    family: dense
+    engine_pin:
+      - pin: vllm-stable@0.20.2
+        loads: true
+      - pin: vllm-nightly-clean@bf610c2f56764e1b30bc6065f4ceace3d6e59036
+        loads: true
+    required_patches: []
+    valid_tp:
+      tp_divisors: [1, 2]
+      marlin_alignment_required: false
+      moe_layout: dense
+      evidence: "vLLM built-in Qwen2VLForConditionalGeneration (Qwen2-VL multimodal) model class (supported-models registry); registry gap not an engine limitation"
+    requires_trust_remote_code: unverified
+    requires_trust_remote_code_evidence: none
+    kernel_constraints:
+      - "Quant/dtype + vision-tower compatibility must be resolved by later deriver gates."
+    confidence: estimated-lower-bound
+    status: unverified

--- a/scripts/lib/profiles/capture.py
+++ b/scripts/lib/profiles/capture.py
@@ -40,6 +40,12 @@ from typing import Any, Optional
 from .downloader import sanitize_slug
 
 SCHEMA = 1
+# v0.8.2 CONTRACT-1.1 — the gate-only (capture-on-hard-block) bundle schema.
+# A DISTINCT schema version so F1's strict schema==1 reader is byte-
+# unchanged; the gate-only bundle is consumed by a SEPARATE
+# `read_gate_bundle()` (schema==2) that validates only the always-present
+# key row (NOT the 22-key schema-1 validator).
+GATE_SCHEMA = 2
 
 # ---------------------------------------------------------------------------
 # CONTRACT-4 capability-smoke set for DERIVED models.
@@ -524,6 +530,47 @@ def _write_redacted_json(path: Path, obj: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
+# v0.8.2 CONTRACT-1.3 — the shared `.last`-marker write helper.
+#
+# `scripts/pull.sh --submit-last` (CONTRACT-1.3, V2) resolves "the most-recent
+# capture" from a single marker file `.pull-captures/.last` (one line: the
+# bundle dir RELATIVE to `.pull-captures/`). Centralization is MANDATORY
+# (design rule): `emit_capture()` (`[E]` path) and the new
+# `emit_gate_capture()` (the commonest — pre-download — failure) are SEPARATE
+# functions on SEPARATE terminal paths. If `.last` were written only by
+# `emit_capture()`, gate-only captures (exactly the §10-R9 volume the on-ramp
+# exists to harvest) would never update `.last` and `--submit-last` would
+# silently miss them. So BOTH emitters call this ONE helper.
+#
+# Atomic (`tmp` + `os.replace`) so a racing reader never sees a torn marker;
+# last-writer-wins by design (a serial user workflow — V2's submit re-reads
+# + re-shows the resolved bundle identity before the consent prompt). NEVER
+# raises — a marker-write failure must not break a capture (CONTRACT-1: the
+# gate path stays I/O-light + never blocks).
+# ---------------------------------------------------------------------------
+def write_last_marker(repo_root: Path, bundle_dir: Path) -> None:
+    """Atomically record `bundle_dir` (made relative to `.pull-captures/`)
+    as the most-recent capture for `--submit-last`. Shared by BOTH
+    `emit_capture()` and `emit_gate_capture()`. Never raises.
+    """
+    try:
+        pull_captures = Path(repo_root) / ".pull-captures"
+        pull_captures.mkdir(parents=True, exist_ok=True)
+        try:
+            rel = str(Path(bundle_dir).relative_to(pull_captures))
+        except ValueError:
+            # Defensive: a bundle dir outside .pull-captures/ (should not
+            # happen — both emitters write under it) — store as given.
+            rel = str(bundle_dir)
+        marker = pull_captures / ".last"
+        tmp = pull_captures / ".last.tmp"
+        tmp.write_text(rel + "\n", encoding="utf-8")
+        os.replace(tmp, marker)
+    except Exception:  # pragma: no cover - marker write is best-effort.
+        pass
+
+
+# ---------------------------------------------------------------------------
 # §6.2 submission_fingerprint + manifest helpers.
 # ---------------------------------------------------------------------------
 def _fingerprint(parts: list[str]) -> str:
@@ -793,6 +840,15 @@ def emit_capture(
     _write_redacted_json(Path(paths["smoke"]), pt4)
     _write_redacted_json(Path(paths["manifest"]), manifest)
 
+    # v0.8.2 CONTRACT-1.3 — the SHARED `.last` marker (centralized: invoked
+    # from BOTH `emit_capture()` here AND `emit_gate_capture()` below; never
+    # raises). This is purely additive: it writes ONE extra marker file and
+    # changes NONE of the pt1-4 / manifest artifacts — `test-pullemit-
+    # capture.sh`'s "emit_capture() writes ONLY pt1-4 + manifest" assertion
+    # is unaffected (`.last` lives at `.pull-captures/.last`, NOT inside the
+    # `<slug>/<ts>/` bundle dir it enumerates).
+    write_last_marker(Path(repo_root), out_dir)
+
     return {"paths": paths, "dir": str(out_dir), "manifest": manifest}
 
 
@@ -905,3 +961,192 @@ def _predicted_total_mib(breakdown) -> Optional[int]:
     if not saw:
         return None
     return int(round(total_gb * 1024.0))
+
+
+# ---------------------------------------------------------------------------
+# v0.8.2 CONTRACT-1.1 — capture-on-hard-block: the pt1-gate-only emitter.
+#
+# A SEPARATE, ADDITIVE function — the byte-preserving `emit_override_capture`
+# precedent (a separate fn NOT invoked by `emit_capture()`; same
+# `.pull-captures/<slug>/<ts>/` dir + the SAME `_redact_text` redaction).
+# `emit_capture()`'s pt1-4 + manifest emitters are byte-behaviour-unchanged
+# (`test-pullemit-capture.sh` still asserts `emit_capture()` writes ONLY
+# pt1-4 + manifest). `pull.py` wires this on its terminal hard-block
+# `return res` paths as a pure PASS-THROUGH capture — it emits a bundle
+# BEFORE the existing return; the `return res` decision is UNCHANGED (zero
+# §1-§6/§4.1/§5.x decision-logic change).
+#
+# Schema-2 bundle: a `pt1-gate.json` + `manifest.json` with `schema:2`,
+# `outcome:"hard-block"`, the EXACT shipped `res.abort_reason` (NOT a
+# semantic alias), `failure_class:null`. The manifest carries the
+# per-abort-stratum key subset (the CONTRACT-1.1 enumerated table): the
+# always-present row is guaranteed; model/arch/quant are `null` pre-deriver;
+# topology is best-effort/nullable at every gate stratum (resolved here
+# capture-only, mirroring `pull.py:853-855`, `null` when unavailable —
+# GUARANTEED `null` for `hardware-sm-undetermined`); the post-C0 fields are
+# always `null` (a gate-only bundle never reached them).
+#
+# F1's `read_gate_bundle()` (schema==2) consumes this; it validates ONLY the
+# always-present row + `outcome=="hard-block"` + `failure_class is None` (it
+# does NOT reuse the 22-key schema-1 validator). The raw `abort_reason` is
+# carried through redaction into the bundle so a maintainer can distinguish
+# a registry gap from a kernel bug (the H2 distinguishability mandate).
+# ---------------------------------------------------------------------------
+def _gate_topology_best_effort(
+    gpu_topology: Optional[tuple],
+) -> tuple[Optional[str], Optional[str]]:
+    """Capture-only best-effort `(topology_class, topology_summary_canonical)`
+    for a gate-only bundle. Mirrors `pull.py:853-855`: prefer an injected
+    `gpu_topology` (the `--hardware-gpus` override) else `detect_gpu_topology`
+    (needs nvidia-smi). Returns `(None, None)` when neither is available —
+    NOT a `pull.py` decision-logic change (capture-only). Never raises.
+    """
+    topo = gpu_topology
+    if topo is None:
+        try:  # late import — avoids a capture.py -> pull.py import cycle.
+            from scripts.lib.profiles.pull import (  # noqa: E402
+                detect_gpu_topology,
+            )
+
+            topo = detect_gpu_topology()
+        except Exception:  # pragma: no cover - defensive
+            topo = None
+    if not topo:
+        return None, None
+    try:
+        _count, vram_mib, names = topo
+        if not vram_mib:
+            return None, None
+        n = len(vram_mib)
+        vram = min(int(v) for v in vram_mib)
+        topo_class = f"{n}x{vram}MiB"
+        tuples = sorted(
+            (str(nm), int(v)) for nm, v in zip(names, vram_mib)
+        )
+        topo_summary = "[" + ", ".join(
+            f"({nm}, {v})" for nm, v in tuples
+        ) + "]"
+        return topo_class, topo_summary
+    except Exception:  # pragma: no cover - defensive
+        return None, None
+
+
+def emit_gate_capture(
+    *,
+    slug: str,
+    profile_like: str,
+    abort_reason: str,
+    confidence,
+    raw_verdict: Optional[str],
+    detail: str,
+    der=None,
+    hardware_sm=None,
+    gpu_topology: Optional[tuple] = None,
+    club3090_commit: str = "unknown",
+    kv_calc_version: Optional[str] = None,
+    predicted_b_breakdown=None,
+    repo_root: Path,
+    ts: Optional[str] = None,
+) -> dict:
+    """v0.8.2 CONTRACT-1.1 — write the pt1-gate-only redacted bundle on a
+    terminal hard-block. Writes `pt1-gate.json` + `manifest.json`
+    (`schema:2`, `outcome:"hard-block"`, the EXACT shipped `abort_reason`,
+    `failure_class:null`) under `<repo>/.pull-captures/<slug>/<ts>/`, then
+    updates the SHARED `.last` marker. Returns
+    `{paths:{gate,manifest}, dir:str, manifest:{...}}`. Never classifies
+    (§6.1 = `[F]`'s job) — `failure_class` is authoritatively `null`.
+
+    A SEPARATE function (NOT invoked by `emit_capture()`), cloning the
+    `emit_override_capture` byte-preserving precedent: same capture dir +
+    the SAME `_redact_text` redaction. Best-effort topology resolve is
+    capture-only (mirrors `pull.py:853-855`); `null` when unavailable —
+    GUARANTEED `null` for `hardware-sm-undetermined` (nvidia-smi absent).
+    """
+    san = sanitize_slug(slug)
+    stamp = ts or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out_dir = Path(repo_root) / ".pull-captures" / san / stamp
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Best-effort model/arch/quant: `null` pre-deriver (a deriver-error /
+    # profile-like / repo-not-found terminal has no `der.profile`). We read
+    # the SAME shipped accessors `emit_capture()` uses (`_arch_family` /
+    # `_quant_label`); both already tolerate a missing profile -> None.
+    arch_family = _arch_family(der) if der is not None else None
+    quant_label = _quant_label(der) if der is not None else None
+
+    # Topology is NOT guaranteed at any gate stratum (CONTRACT-1.1):
+    # capture-only best-effort resolve, `null` when unavailable.
+    topology_class, topology_summary_canonical = _gate_topology_best_effort(
+        gpu_topology
+    )
+
+    # ---- pt1-gate.json (gate-only): the pre-download verdict snapshot ----
+    pt1 = {
+        "schema": GATE_SCHEMA,
+        "point": "gate",
+        "slug": slug,
+        "confidence": (
+            str(getattr(confidence, "name", confidence))
+            if confidence is not None
+            else None
+        ),
+        "raw_verdict": raw_verdict,
+        "profile_like": profile_like,
+        "hardware_sm": hardware_sm,
+        "predicted_b_breakdown": predicted_b_breakdown,
+        # The EXACT shipped abort sub-token (NOT a semantic alias) — the
+        # §6.1 `gate_abort_reason` matcher keys on THIS. Carried through
+        # `_redact_text` so a maintainer can distinguish a registry gap
+        # from a kernel bug (the H2 distinguishability mandate).
+        "abort_reason": abort_reason,
+        "detail": detail,
+        "is_gate_only": True,
+    }
+
+    # ---- manifest.json schema:2 — per-abort-stratum key subset ----------
+    # ALWAYS-present row (guaranteed at every stratum). model/arch/quant are
+    # `null` pre-deriver. topology is best-effort/nullable. The post-C0
+    # fields are ALWAYS `null` (a gate-only bundle never reached them).
+    manifest = {
+        "schema": GATE_SCHEMA,
+        "slug": slug,
+        "utc_ts": stamp,
+        "club3090_commit": club3090_commit,
+        "outcome": "hard-block",
+        "abort_reason": abort_reason,
+        "failure_class": None,
+        # null if pre-deriver (profile-like / repo-not-found may have none).
+        "model": slug,
+        "model_id": slug,
+        "arch_family": arch_family,
+        "quant_label": quant_label,
+        # best-effort / nullable at every gate stratum (guaranteed null for
+        # hardware-sm-undetermined).
+        "topology_class": topology_class,
+        "topology_summary_canonical": topology_summary_canonical,
+        # post-C0 — NEVER reached on a gate-only bundle -> always null.
+        "selected_ctx": None,
+        "kv_format": None,
+        "smoke_capability_set": None,
+        "engine_pin": None,
+        "engine_version": None,
+        "kv_calc_version": kv_calc_version,
+        "submission_fingerprint": None,
+        # gate-only marker so F1 / F2 can branch without re-parsing.
+        "is_gate_only": True,
+        "capture_points": ["gate"],
+    }
+
+    paths = {
+        "gate": str(out_dir / "pt1-gate.json"),
+        "manifest": str(out_dir / "manifest.json"),
+    }
+    _write_redacted_json(Path(paths["gate"]), pt1)
+    _write_redacted_json(Path(paths["manifest"]), manifest)
+
+    # SHARED `.last` marker — the SAME helper `emit_capture()` calls (the
+    # CONTRACT-1.1 centralization mandate: gate-only is the commonest
+    # failure; if `.last` were `[E]`-only, `--submit-last` would miss it).
+    write_last_marker(Path(repo_root), out_dir)
+
+    return {"paths": paths, "dir": str(out_dir), "manifest": manifest}

--- a/scripts/lib/profiles/classifier.py
+++ b/scripts/lib/profiles/classifier.py
@@ -66,7 +66,12 @@ except ModuleNotFoundError as exc:  # pragma: no cover - env guard
         "python3-yaml or pip install pyyaml"
     ) from exc
 
-from scripts.lib.profiles.loop_input import FInput
+# v0.8.2 CONTRACT-1.1 — F2 is retyped to the `BaseCaptureBundle` Protocol so
+# a schema==1 `FInput` AND a schema==2 `FInputGate` both satisfy the consumer
+# surface by structural subtyping (pure static retype — verified: there is no
+# `isinstance(finput, FInput)` anywhere in this module, only annotations, so
+# the schema==1 path is byte-identical incl. dedup-hash).
+from scripts.lib.profiles.loop_input import BaseCaptureBundle
 
 # The seed DB ships next to this module (RED-LINE F2 file).
 _DEFAULT_DB = Path(__file__).with_name("failure_fingerprints.yml")
@@ -183,7 +188,7 @@ def _norm_error_substring(text: str) -> str:
     return collapsed.lower()[:_ERROR_SUBSTRING_CAP]
 
 
-def _extract_error_substring(finput: FInput) -> str:
+def _extract_error_substring(finput: BaseCaptureBundle) -> str:
     """CONTRACT-2 source precedence (works on TODAY's shipped [E] schema;
     forward-compatible with F3's additive fields, never requires them):
 
@@ -255,7 +260,7 @@ def _load_db(db_path: Path) -> dict:
     return data
 
 
-def _pt3_timeout_but_pt4_green(finput: FInput) -> bool:
+def _pt3_timeout_but_pt4_green(finput: BaseCaptureBundle) -> bool:
     """Appendix A row 7: pt3 boot timed-out/not-ready BUT pt4 smoked green
     (server became *healthy* after a slow first request) -> benign cold
     start.
@@ -278,7 +283,7 @@ def _pt3_timeout_but_pt4_green(finput: FInput) -> bool:
     return any(v == "green" for v in results.values())
 
 
-def _results_detail_http_404(finput: FInput) -> bool:
+def _results_detail_http_404(finput: BaseCaptureBundle) -> bool:
     """Appendix A row 8: historical negative control — [E] bug #1
     served-model-name 404 in pt4.results_detail (HTTP 404 status).
     """
@@ -289,7 +294,7 @@ def _results_detail_http_404(finput: FInput) -> bool:
     return False
 
 
-def _match_condition(rule: dict, finput: FInput,
+def _match_condition(rule: dict, finput: BaseCaptureBundle,
                      error_substring: str) -> bool:
     """Evaluate ONE Appendix-A condition matcher. FIRST match wins
     (caller iterates in YAML order). Unknown `kind` -> no match (a future
@@ -330,6 +335,27 @@ def _match_condition(rule: dict, finput: FInput,
         return bool(subs) and all(
             str(s).lower() in error_substring for s in subs
         )
+
+    # v0.8.2 CONTRACT-1.1 M1 — the ADDITIVE `gate_abort_reason` matcher kind.
+    #
+    # A new INPUT PREDICATE (exactly analogous to adding a column to a
+    # lookup): it reads the EXACT shipped `pt1_gate.abort_reason` sub-token a
+    # capture-on-hard-block bundle carries and matches it against a value
+    # list — returning bool exactly like the sibling kinds. It is §6.1-
+    # NEUTRAL by construction: `_match_condition` -> bool, the class is
+    # assigned downstream via `_coerce_class` (the 6-member clamp). It does
+    # NOT touch the `FailureClass` enum, `_SUPPRESSED_NEVER_FILED`,
+    # `_coerce_class`, or any routing — an implementation-contract addition,
+    # NOT a §6.1 design-unlock. A schema==1 [E] bundle has no
+    # `pt1_gate.abort_reason` -> `.get` is None -> no match -> the shipped
+    # schema==1 classification path is byte-identical (this kind appears in
+    # NO shipped seed rule; only the new gate-only rules use it).
+    if kind == "gate_abort_reason":
+        pt1 = finput.pt1_gate or {}
+        ar = pt1.get("abort_reason")
+        if not ar:
+            return False
+        return any(str(ar) == str(v) for v in (rule.get("any") or []))
 
     return False
 
@@ -421,7 +447,7 @@ def _predicted_total_mib(breakdown) -> Optional[int]:
     return int(round(total_gb * 1024.0))
 
 
-def _resolve_tier1_inputs(finput: FInput) -> dict:
+def _resolve_tier1_inputs(finput: BaseCaptureBundle) -> dict:
     """Resolve the THREE Tier-1 inputs by the A-iii precedence
     (pt5 > pt3-triple). Returns a dict ALWAYS carrying the keys
     `predicted_b_breakdown`, `attempted_alloc_mib`,
@@ -475,7 +501,7 @@ def _resolve_tier1_inputs(finput: FInput) -> dict:
 
 
 def _tier1_oom_fastpath(
-    finput: FInput, error_substring: str
+    finput: BaseCaptureBundle, error_substring: str
 ) -> Optional[ClassificationResult]:
     """The §6.1 Tier-1 fast-path. Returns a `ClassificationResult` IFF the
     definitive OOM signature is present (always `genuine-oom`); else `None`
@@ -582,7 +608,7 @@ def _coerce_class(value) -> FailureClass:
 # Public API.
 # ---------------------------------------------------------------------------
 def classify(
-    finput: FInput,
+    finput: BaseCaptureBundle,
     *,
     fingerprint_db_path: Optional[Path] = None,
 ) -> ClassificationResult:

--- a/scripts/lib/profiles/dedup.py
+++ b/scripts/lib/profiles/dedup.py
@@ -94,7 +94,22 @@ from pathlib import Path
 from typing import Callable, Optional, Sequence
 
 from scripts.lib.profiles.classifier import ClassificationResult, FailureClass
-from scripts.lib.profiles.loop_input import FInput
+# v0.8.2 CONTRACT-1.1 — F5 parameter annotations are retyped `FInput` ->
+# `BaseCaptureBundle` (a schema==1 `FInput` AND a schema==2 `FInputGate` both
+# satisfy the consumer surface by structural subtyping; pure static retype,
+# schema==1 byte-identical incl. dedup-hash).
+#
+# RED-LINE (V1, FENCED): `effective_dedup_hash` below
+# calls the *concrete-class UNBOUND* `FInput.dedup_hash(_EffProxy())` to
+# reuse F1's exact serialization primitive. The protocol retype of the
+# *parameter annotations* does NOT break this (the concrete `FInput` class
+# still carries `dedup_hash`); the `FInput` import is RETAINED for exactly
+# that one unbound call. It MUST NOT be "tidied" to
+# `BaseCaptureBundle.dedup_hash(...)` (a Protocol has no usable unbound
+# body) NOR to `finput.dedup_hash()` (would hash the unsubstituted tuple
+# with failure_class=None — silently corrupting every dedup hash AND
+# defeating the §6.1 mislabel safeguard).
+from scripts.lib.profiles.loop_input import BaseCaptureBundle, FInput
 
 # The §6.1 enum value-set (bounded — `class:<value>` labels are safe).
 _CLASS_ENUM_VALUES = tuple(c.value for c in FailureClass)
@@ -204,7 +219,7 @@ def _failure_class_value(classification: ClassificationResult) -> str:
 
 
 def effective_dedup_tuple(
-    finput: FInput,
+    finput: BaseCaptureBundle,
     classification: ClassificationResult,
 ) -> tuple:
     """The §6.3 7-tuple with the CLASSIFIER's `failure_class` substituted
@@ -231,7 +246,7 @@ def effective_dedup_tuple(
 
 
 def effective_dedup_hash(
-    finput: FInput,
+    finput: BaseCaptureBundle,
     classification: ClassificationResult,
 ) -> str:
     """`sha256("\\x1f".join(str(p) for p in effective_tuple))[:12]`.
@@ -284,7 +299,7 @@ def dedup_label(dedup_hash: str) -> str:
 def label_set(
     dedup_hash: str,
     classification: ClassificationResult,
-    finput: FInput,
+    finput: BaseCaptureBundle,
 ) -> list[str]:
     """The EXACT bounded label set for an issue (CONTRACT-4 — closes H4).
 
@@ -320,7 +335,7 @@ _TUPLE_FIELDS = (
 
 
 def _tuple_payload(
-    finput: FInput,
+    finput: BaseCaptureBundle,
     classification: ClassificationResult,
 ) -> dict:
     """The machine-readable body payload: the schema marker + the FULL
@@ -340,7 +355,7 @@ def _tuple_payload(
 
 
 def build_issue_body(
-    finput: FInput,
+    finput: BaseCaptureBundle,
     classification: ClassificationResult,
 ) -> str:
     """The new-issue body: a human header + the canonical 7-tuple in a
@@ -375,7 +390,7 @@ def build_issue_body(
 
 
 def build_plusone_comment(
-    finput: FInput,
+    finput: BaseCaptureBundle,
     classification: ClassificationResult,
 ) -> str:
     """The structured, machine-parseable `+1` comment added on a verified
@@ -405,7 +420,7 @@ def build_plusone_comment(
 
 
 def build_issue_title(
-    finput: FInput,
+    finput: BaseCaptureBundle,
     classification: ClassificationResult,
 ) -> str:
     """A DETERMINISTIC issue title (CONTRACT-4 — "open a new issue titled
@@ -460,7 +475,7 @@ def parse_body_tuple(body: str) -> Optional[list]:
 
 def body_tuple_matches(
     body: str,
-    finput: FInput,
+    finput: BaseCaptureBundle,
     classification: ClassificationResult,
 ) -> bool:
     """The sha12 COLLISION SAFEGUARD (CONTRACT-4 (c)): a candidate found
@@ -543,7 +558,7 @@ def _spool(spool_dir: Path, name: str, payload: dict) -> Optional[Path]:
 
 
 def _would_be_payload(
-    finput: FInput,
+    finput: BaseCaptureBundle,
     classification: ClassificationResult,
     dedup_hash: str,
     labels: list[str],
@@ -595,7 +610,7 @@ def bootstrap_labels(
 
 
 def submit(
-    finput: FInput,
+    finput: BaseCaptureBundle,
     classification: ClassificationResult,
     *,
     repo_root: Path,

--- a/scripts/lib/profiles/failure_fingerprints.yml
+++ b/scripts/lib/profiles/failure_fingerprints.yml
@@ -175,3 +175,91 @@ condition_matchers:
       accumulated-ctx ~21-26K OR prefill-cliff ~50-60K DeltaNet GDN).
       Tier-1 fast-path eligible — but Tier-1 is F3; F2 classifies + files
       genuine-oom yet NEVER routes it as a kv-calc bug.
+
+  # =========================================================================
+  # v0.8.2 CONTRACT-1.1 M1 — gate-only (capture-on-hard-block) seed rules.
+  #
+  # Keyed on the VERIFIED shipped `res.abort_reason` sub-token a schema==2
+  # gate bundle carries (the new `gate_abort_reason` matcher kind reads
+  # `pt1_gate.abort_reason`). A gate-only bundle has no pt3/pt4/error text,
+  # so NONE of the [E]-bundle rules above match it (empty error_substring,
+  # no pt4 results) — it falls through to here. Ordered: the ONE solicited
+  # sub-token first, then the conservative catch-alls.
+  #
+  # Class selection is data-only here; the additive matcher kind is the only
+  # code. Only `engine-support-unknown/no-arch-row` -> `kernel-unsupported`
+  # (`should_file=True`) — the genuine §10-R9 lever ("N users hit
+  # unsupported arch X" must aggregate/dedup/volume-rank so maintainers can
+  # add a registry row; feeds CONTRACT-2). Every OTHER listed reason ->
+  # `unknown` (∈ _SUPPRESSED_NEVER_FILED ⇒ review-queued, NOT public-filed —
+  # the maintainer's private triage surface, never public-issue spam). Any
+  # future promotion of a catch-all sub-token is DATA-ONLY (a new rule
+  # here), never code. The raw `abort_reason` survives `_redact_text` into
+  # pt1-gate.json + (via F5) the issue body so a maintainer can distinguish
+  # a registry gap from a genuine kernel bug (the H2 mandate).
+
+  # The ONE §10-R9 lever — C0, arch absent from the registry; a maintainer
+  # can add it (pull.py:575 emits this exact sub-token).
+  - id: gate-engine-support-no-arch-row
+    kind: gate_abort_reason
+    any:
+      - "engine-support-unknown/no-arch-row"
+    class: kernel-unsupported
+    note: >-
+      v0.8.2 CONTRACT-1.1: the genuine §10-R9 lever — C0 unsupported-arch
+      (registry gap a maintainer can flip on). should_file=True so it
+      aggregates/dedups/volume-ranks (feeds CONTRACT-2). The raw
+      abort_reason is carried in the redacted body so a maintainer can tell
+      "add a registry row" from "file an upstream kernel bug" (H2).
+
+  # Conservative catch-alls -> unknown (review-queued, NOT public-filed).
+  # arch known, engine/runtime can't serve it — NOT a registry gap a
+  # maintainer flips on (pull.py:575).
+  - id: gate-engine-support-runtime-incompatible
+    kind: gate_abort_reason
+    any:
+      - "engine-support-unknown/runtime-incompatible"
+    class: unknown
+    note: >-
+      v0.8.2 CONTRACT-1.1: arch known but engine/runtime can't serve it —
+      not a registry-gap a maintainer flips on. unknown -> review-queued,
+      NOT public-filed. Promote later only with evidence (data-only).
+
+  # C2a insufficient disk — user-environment correct-refusal (pull.py:593).
+  - id: gate-disk-short
+    kind: gate_abort_reason
+    any:
+      - "disk-short"
+    class: unknown
+    note: >-
+      v0.8.2 CONTRACT-1.1: insufficient disk — a user-environment
+      correct-refusal, not a stack bug. unknown -> review-queued, NOT
+      public-filed.
+
+  # C1 exact×wont-fit — the genuine kv-calc VRAM refusal (pull.py:649; the
+  # shipped abort_reason is literally `hard-block`; `wont-fit` lives only in
+  # raw_verdict, NEVER as an abort_reason).
+  - id: gate-hard-block-wont-fit
+    kind: gate_abort_reason
+    any:
+      - "hard-block"
+    class: unknown
+    note: >-
+      v0.8.2 CONTRACT-1.1: C1 exact×wont-fit — a user-environment VRAM
+      limit, not an unsupported config a maintainer can enable. §10-R9's
+      bet is the latter; the catch-all is correct today. unknown ->
+      review-queued, NOT public-filed.
+
+  # Remaining conservative catch-alls (pull.py:543/610; deriver/profile-like
+  # sub-tokens are open-ended so matched by id-list as observed). All ->
+  # unknown (review-queued, not public-filed); any promotion is data-only.
+  - id: gate-other-correct-refusals
+    kind: gate_abort_reason
+    any:
+      - "hardware-sm-undetermined"
+      - "no-fit-model"
+    class: unknown
+    note: >-
+      v0.8.2 CONTRACT-1.1: conservative catch-all for the remaining gate
+      strata — only /no-arch-row is solicited. unknown -> review-queued,
+      NOT public-filed. Any promotion is a data-only future, never code.

--- a/scripts/lib/profiles/hwdetect.py
+++ b/scripts/lib/profiles/hwdetect.py
@@ -1,0 +1,217 @@
+"""v0.8.2 CONTRACT-3 — optional `whichllm` hardware-detect subprocess.
+
+§8 posture: `whichllm`-as-a-VRAM/fit-engine is OUT (kv-calc stays the sole
+fit authority). The ONLY in-scope slice is an **optional, bounded subprocess
+that augments hardware *enumeration*** for the eval path on environments
+where `nvidia-smi` does not apply (AMD ROCm / Apple Silicon / other-vendor
+accelerators). Strictly detect-only: this module enumerates accelerators and
+maps a non-NVIDIA device to an SM-equivalent so the eval path can proceed
+honestly instead of bare-degrading to `hardware-sm-undetermined`. It NEVER
+performs fit/VRAM math and NEVER feeds kv-calc.
+
+Design invariants (the STEP V4 RED-LINE — BOTH halves):
+
+  (a) Safety half. This module is OPTIONAL. There is no new hard
+      dependency: the `whichllm` tool being absent, failing, timing out,
+      or producing an unrecognised payload all degrade *gracefully* to
+      ``None`` (the caller then keeps today's exact `nvidia-smi`-absent
+      behaviour). It is consulted ONLY when `nvidia-smi` already returned
+      nothing — so for the NVIDIA majority this code path is never
+      entered and the shipped detection is byte-identical. It never
+      raises out at the caller (every failure mode is caught here and
+      returns ``None``), and it never touches kv-calc.
+
+  (b) Delivery half (MANDATORY — an always-degrading no-op stub is a
+      FAIL). Given a non-`nvidia-smi` environment in which the optional
+      tool DOES enumerate an accelerator, `detect_non_nvidia_sm()`
+      returns a real structured `HwDetectResult` carrying an
+      SM-equivalent the eval path actually consumes — so the eval path's
+      hardware view in that environment differs observably from the bare
+      `nvidia-smi`-absent degrade path (it can reach the [C0] SM gate
+      instead of terminating at `hardware-sm-undetermined`).
+
+PURE-STDLIB (json / shutil / subprocess), matching the no-external-deps
+style of its `scripts/lib/profiles/` siblings. The `whichllm` enumeration
+JSON is parsed defensively; nothing in this module imports the rest of the
+pull pipeline (no decision-logic coupling — it is a leaf).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from typing import Optional
+
+# The external enumeration tool. Absence is the COMMON case (NVIDIA rigs do
+# not install it) and MUST degrade silently — it is never a hard dependency.
+_WHICHLLM_BIN = "whichllm"
+
+# Bounded subprocess (mirrors detect_hardware_sm()'s 15s nvidia-smi bound).
+_SUBPROCESS_TIMEOUT_S = 15
+
+# Non-NVIDIA vendor -> the SM-equivalent the eval path's [C0] SM gate keys
+# on. These are deliberately CONSERVATIVE enumeration anchors, NOT a fit
+# claim: the value only lets the SM gate run on a recognised device class
+# instead of refusing blind. kv-calc is NEVER consulted with these — the
+# fit authority is untouched (CONTRACT-3 hw-detect-only).
+#
+# Mapping rationale (enumeration-only, documented constraint):
+#   * AMD ROCm CDNA/RDNA -> 8.0  (Ampere-class capability tier; the eval
+#     path's SM gate is the only consumer — this is not a perf claim).
+#   * Apple Silicon (Metal/MPS) -> 8.0 (same: lets the gate proceed; the
+#     §7 boot-fit≠runtime caveat + kv-calc still own the real verdict).
+# An unrecognised vendor stays None -> graceful degrade (safety half).
+_VENDOR_SM_EQUIV = {
+    "amd": 8.0,
+    "rocm": 8.0,
+    "apple": 8.0,
+    "metal": 8.0,
+    "mps": 8.0,
+}
+
+
+@dataclass(frozen=True)
+class HwDetectResult:
+    """A structured non-NVIDIA hardware-enumeration result.
+
+    `sm_equiv` is the ONLY value the eval path consumes (it feeds the [C0]
+    SM gate exactly where `detect_hardware_sm()` would have). The vendor /
+    device-name / count fields are diagnostics-only enumeration metadata —
+    they are NEVER passed to kv-calc.
+    """
+
+    sm_equiv: float
+    vendor: str
+    device_names: list = field(default_factory=list)
+    device_count: int = 0
+    # The raw enumeration source, for diagnostics/audit only.
+    source: str = _WHICHLLM_BIN
+
+
+def _tool_available() -> bool:
+    """True iff the optional enumeration tool is on PATH. Absence is the
+    common NVIDIA-rig case and is NOT an error — the caller degrades."""
+    return shutil.which(_WHICHLLM_BIN) is not None
+
+
+def _run_whichllm(runner: Optional[object] = None) -> Optional[str]:
+    """Run the bounded enumeration subprocess; return its stdout, or None
+    on ANY failure (absent / non-zero / timeout / OSError). `runner` is an
+    injection seam so tests are hermetic (CI has no `whichllm` and no
+    non-NVIDIA GPU) — None uses the real bounded subprocess."""
+    if runner is not None:
+        try:
+            return runner()
+        except Exception:  # noqa: BLE001 - any runner failure -> degrade
+            return None
+    if not _tool_available():  # pragma: no cover - env dependent
+        return None
+    try:  # pragma: no cover - exercised on non-NVIDIA rigs, injected in CI
+        out = subprocess.run(
+            [_WHICHLLM_BIN, "list", "--json"],
+            capture_output=True, text=True,
+            timeout=_SUBPROCESS_TIMEOUT_S,
+        )
+    except (OSError, subprocess.SubprocessError):  # pragma: no cover
+        return None
+    if out.returncode != 0:  # pragma: no cover
+        return None
+    return out.stdout
+
+
+def _parse_enumeration(stdout: Optional[str]) -> Optional[HwDetectResult]:
+    """Parse the enumeration JSON defensively into a HwDetectResult, or
+    None when it is absent / unparseable / has no recognised non-NVIDIA
+    device. Tolerant to a few plausible `whichllm`-style shapes; an
+    unrecognised shape degrades (never raises)."""
+    if not stdout:
+        return None
+    try:
+        payload = json.loads(stdout)
+    except (ValueError, TypeError):
+        return None
+
+    # Accept either a bare list of device dicts or a {"devices": [...]} /
+    # {"gpus": [...]} envelope — all degrade to None if no list is found.
+    devices = None
+    if isinstance(payload, list):
+        devices = payload
+    elif isinstance(payload, dict):
+        for key in ("devices", "gpus", "accelerators"):
+            if isinstance(payload.get(key), list):
+                devices = payload[key]
+                break
+    if not devices:
+        return None
+
+    names: list = []
+    matched_vendor: Optional[str] = None
+    matched_sm: Optional[float] = None
+    for dev in devices:
+        if not isinstance(dev, dict):
+            continue
+        vendor_raw = str(
+            dev.get("vendor") or dev.get("backend") or dev.get("type") or ""
+        ).strip().lower()
+        name = str(
+            dev.get("name") or dev.get("device") or dev.get("model") or ""
+        ).strip()
+        # Skip NVIDIA entries — those belong to the nvidia-smi path which,
+        # by construction, already ran and returned nothing if we are here.
+        if vendor_raw in ("nvidia", "cuda"):
+            continue
+        sm_equiv = _VENDOR_SM_EQUIV.get(vendor_raw)
+        if sm_equiv is None:
+            # Also probe the device name for a known vendor token (e.g.
+            # "Apple M3 Max", "AMD Instinct MI300X").
+            low = name.lower()
+            for token, val in _VENDOR_SM_EQUIV.items():
+                if token in low:
+                    sm_equiv = val
+                    vendor_raw = token
+                    break
+        if sm_equiv is None:
+            continue
+        names.append(name or vendor_raw)
+        if matched_sm is None:
+            matched_sm = sm_equiv
+            matched_vendor = vendor_raw
+
+    if matched_sm is None or matched_vendor is None:
+        return None
+    return HwDetectResult(
+        sm_equiv=float(matched_sm),
+        vendor=matched_vendor,
+        device_names=names,
+        device_count=len(names),
+        source=_WHICHLLM_BIN,
+    )
+
+
+def detect_non_nvidia_hw(
+    runner: Optional[object] = None,
+) -> Optional[HwDetectResult]:
+    """The structured entry point: enumerate non-NVIDIA accelerators via
+    the optional bounded subprocess, returning a HwDetectResult or None.
+
+    None on EVERY non-delivery path (tool absent / failed / timed out /
+    payload unparseable / no recognised non-NVIDIA device) — the caller
+    then keeps today's exact behaviour (graceful degrade; safety half).
+    A real recognised device yields a structured result (delivery half).
+    Never raises (every failure is caught -> None)."""
+    try:
+        return _parse_enumeration(_run_whichllm(runner=runner))
+    except Exception:  # noqa: BLE001 - leaf module: NEVER raise at caller
+        return None
+
+
+def detect_non_nvidia_sm(
+    runner: Optional[object] = None,
+) -> Optional[float]:
+    """Convenience: just the SM-equivalent the eval path's [C0] SM gate
+    consumes (None -> graceful degrade). This is the ONLY value that
+    reaches a decision gate; it NEVER reaches kv-calc."""
+    res = detect_non_nvidia_hw(runner=runner)
+    return res.sm_equiv if res is not None else None

--- a/scripts/lib/profiles/loop_input.py
+++ b/scripts/lib/profiles/loop_input.py
@@ -51,12 +51,66 @@ import hashlib
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Protocol, runtime_checkable
 
 # The schema version `[E]` stamps (`capture.py:42` `SCHEMA = 1`). F1 hard-
 # asserts the bundle is this exact schema — a strict boundary refuses an
 # unrecognised schema rather than mis-parsing a future shape.
 EXPECTED_SCHEMA = 1
+# v0.8.2 CONTRACT-1.1 — the gate-only (capture-on-hard-block) bundle schema
+# (`capture.py` `GATE_SCHEMA = 2`). The shipped schema==1
+# `read_capture_bundle()` path stays byte-identical; a SEPARATE
+# `read_gate_bundle()` (schema==2) returns `FInputGate`.
+GATE_SCHEMA = 2
+
+
+# ---------------------------------------------------------------------------
+# v0.8.2 CONTRACT-1.1 — `BaseCaptureBundle` (the maintainer-decided Protocol).
+#
+# F2 (`classifier.py`) + F5 (`dedup.py`) are retyped `FInput` ->
+# `BaseCaptureBundle` so a schema==1 `FInput` AND a schema==2 `FInputGate`
+# both satisfy the consumer surface by STRUCTURAL subtyping. `FInput`
+# satisfies it BY CONSTRUCTION (verified: there is no
+# `isinstance(finput, FInput)` anywhere in classifier.py/dedup.py — only
+# annotations; the retype is a pure static change, zero behaviour change,
+# schema==1 byte-identical incl. dedup-hash). pt2-5 are `Optional[dict]`
+# so `FInputGate` (None there) AND `FInput` (dict there) both conform; the
+# classifier's existing `or {}` guards already tolerate None.
+# ---------------------------------------------------------------------------
+@runtime_checkable
+class BaseCaptureBundle(Protocol):
+    manifest: dict
+    pt1_gate: dict
+    pt2_download: Optional[dict]
+    pt3_boot: Optional[dict]
+    pt4_smoke: Optional[dict]
+    pt5_override: Optional[dict]
+    is_gate_only: bool
+
+    # + properties already on FInput (F2 also reads these):
+    #   arch_family, model_id, engine_version, quant_label,
+    #   failure_class, outcome; + dedup_tuple(), dedup_hash().
+    @property
+    def arch_family(self) -> str: ...
+
+    @property
+    def model_id(self) -> str: ...
+
+    @property
+    def engine_version(self) -> str: ...
+
+    @property
+    def quant_label(self) -> str: ...
+
+    @property
+    def failure_class(self): ...
+
+    @property
+    def outcome(self) -> str: ...
+
+    def dedup_tuple(self) -> tuple: ...
+
+    def dedup_hash(self) -> str: ...
 
 
 class CaptureBundleError(Exception):
@@ -106,6 +160,13 @@ class FInput:
     pt5_override: Optional[dict] = None
     # NOT produced by [E] — optional externally-supplied attachment only.
     raw_bundle_path: Optional[Path] = None
+    # v0.8.2 — `BaseCaptureBundle` protocol member. ADDITIVE: a schema==1
+    # full bundle is NEVER gate-only. Defaults False and is NOT set by
+    # `read_capture_bundle()` so the shipped schema==1 parse + the
+    # consensus/dedup tuples + dedup_hash are byte-identical (a defaulted
+    # dataclass field changes no existing serialization). `FInput` thus
+    # satisfies `BaseCaptureBundle` by construction.
+    is_gate_only: bool = False
 
     # ---- CONTRACT-1 canonical accessors -------------------------------
     # These are the SHIPPED aliases (`capture.py:553/568`, `497-500`);
@@ -225,6 +286,115 @@ class FInput:
         primitive. F5 owns the issue-tracker side; F1 owns this canonical
         deterministic serialization so every STEP hashes identically.
         """
+        joined = "\x1f".join(str(p) for p in self.dedup_tuple())
+        return hashlib.sha256(joined.encode("utf-8")).hexdigest()[:12]
+
+
+# ---------------------------------------------------------------------------
+# v0.8.2 CONTRACT-1.1 — `FInputGate`: the schema==2 gate-only bundle.
+#
+# Parsed by the SEPARATE `read_gate_bundle()` (NOT `read_capture_bundle()`;
+# the shipped schema==1 path is byte-identical). It implements
+# `BaseCaptureBundle` so F2/F5 consume it through the protocol with no extra
+# code. A gate-only bundle has NO pt2/3/4/5 (terminated pre-download) and a
+# DEGRADED manifest (only the always-present key row guaranteed; model/arch/
+# quant null pre-deriver; topology best-effort/nullable; post-C0 fields
+# null). `dedup_tuple()` therefore uses `.get(k, None)` (NOT `m[k]`) —
+# behaviour-neutral for schema==1 (all 22 keys present on `FInput`'s path,
+# which uses its own `m[k]`), crash-safe for schema==2; `str(None)=="None"`
+# makes the hash deterministic + identical to how F1 renders an absent value
+# (CONTRACT-1.1 — load-bearing for the COMMON null-topology gate case,
+# not an edge case).
+# ---------------------------------------------------------------------------
+@dataclass
+class FInputGate:
+    """A schema==2 capture-on-hard-block bundle (CONTRACT-1.1).
+
+    `manifest`  — manifest.json (schema==2 hard-asserted; only the always-
+                  present key row is required, `outcome=="hard-block"`,
+                  `failure_class is None`).
+    `pt1_gate`  — pt1-gate.json (the pre-download verdict snapshot, incl.
+                  the EXACT shipped `abort_reason`).
+    `pt2_download` .. `pt5_override` — ALWAYS None (terminated pre-download;
+                  satisfies the `Optional[dict]` protocol slots so F2/F5's
+                  existing `or {}` guards tolerate it).
+    """
+
+    manifest: dict
+    pt1_gate: dict
+    pt2_download: Optional[dict] = None
+    pt3_boot: Optional[dict] = None
+    pt4_smoke: Optional[dict] = None
+    pt5_override: Optional[dict] = None
+    raw_bundle_path: Optional[Path] = None
+    is_gate_only: bool = True
+
+    # ---- canonical accessors (mirror FInput; `.get`-tolerant) ----------
+    @property
+    def model_id(self) -> str:
+        return self.manifest.get("model_id") or self.manifest.get("model")
+
+    @property
+    def engine_version(self) -> str:
+        # gate-only: post-C0 -> null. Render deterministically as F1 would.
+        return self.manifest.get("engine_pin")
+
+    @property
+    def quant_label(self) -> str:
+        """Normalized (LOWERCASED) `quant_label`. `None` pre-deriver ->
+        `_norm_quant` maps it to the literal ``"none"`` (the SAME defensive
+        discipline `FInput.quant_label` uses)."""
+        return _norm_quant(self.manifest.get("quant_label"))
+
+    @property
+    def arch_family(self) -> str:
+        """`arch_family` VERBATIM; `None` pre-deriver (gate-only legitimately
+        lacks it — `read_gate_bundle()` does NOT require it)."""
+        return self.manifest.get("arch_family")
+
+    @property
+    def failure_class(self):
+        """Authoritatively `None` on a gate-only bundle (`[E]`/the gate
+        emitter NEVER classifies — `[F]` does, downstream)."""
+        return self.manifest.get("failure_class")
+
+    @property
+    def outcome(self) -> str:
+        """Always `"hard-block"` on a gate-only bundle (NOT the §6.1 class —
+        same binding rule as `FInput.outcome`)."""
+        return self.manifest.get("outcome")
+
+    @property
+    def abort_reason(self):
+        """The EXACT shipped `res.abort_reason` sub-token (CONTRACT-1.1) —
+        the new `gate_abort_reason` `_match_condition` kind keys on this
+        (read off `pt1_gate`)."""
+        return self.pt1_gate.get("abort_reason")
+
+    # ---- §6.3 dedup key builders (`.get`-tolerant — CONTRACT-1.1) ------
+    def dedup_tuple(self) -> tuple:
+        """The §6.3 dedup 7-tuple, `.get(k, None)`-tolerant (NOT `m[k]`):
+        behaviour-neutral for schema==1, crash-safe for schema==2's
+        degraded manifest. `failure_class` is `None` here (gate emitter
+        never classifies); `[F]` substitutes the classifier's class
+        downstream (F5 `effective_dedup_tuple`).
+        """
+        m = self.manifest
+        return (
+            m.get("model", None),
+            _norm_quant(m.get("quant_label", None)),
+            m.get("arch_family", None),
+            m.get("kv_calc_version", None),
+            m.get("engine_pin", None),
+            m.get("failure_class", None),
+            m.get("topology_class", None),
+        )
+
+    def dedup_hash(self) -> str:
+        """`sha256("\\x1f".join(str(p) for p in dedup_tuple()))[:12]` —
+        byte-EXACTLY `FInput.dedup_hash`'s convention. `str(None)=="None"`
+        keeps a null-topology gate bundle's hash deterministic + stable
+        (acceptance asserts this)."""
         joined = "\x1f".join(str(p) for p in self.dedup_tuple())
         return hashlib.sha256(joined.encode("utf-8")).hexdigest()[:12]
 
@@ -369,6 +539,95 @@ def read_capture_bundle(
         pt3_boot=pts["pt3-boot.json"],
         pt4_smoke=pts["pt4-smoke.json"],
         pt5_override=pt5_override,
+        raw_bundle_path=(
+            Path(raw_bundle_path) if raw_bundle_path is not None else None
+        ),
+    )
+
+
+# v0.8.2 CONTRACT-1.1 — the schema==2 gate-only required key row. Per the
+# CONTRACT-1.1 enumerated per-abort-stratum table this is the ALWAYS-PRESENT
+# row (guaranteed at EVERY gate stratum). model/arch/quant/topology +
+# post-C0 keys are deliberately NOT required (early deriver / profile-like /
+# repo-not-found / hardware-sm-undetermined terminal legitimately lacks
+# them) —
+# `read_gate_bundle()` tolerates them via `.get()`, it MUST NOT reuse the
+# 22-key schema-1 `_require_keys` set (that hard-`raise`s on the post-C0
+# set the gate path can never populate).
+_GATE_REQUIRED_KEYS = (
+    "schema", "slug", "utc_ts", "club3090_commit", "outcome",
+    "abort_reason", "failure_class",
+)
+
+
+def read_gate_bundle(
+    capture_dir,
+    *,
+    raw_bundle_path=None,
+) -> FInputGate:
+    """v0.8.2 CONTRACT-1.1 — parse + validate ONE schema==2 (gate-only,
+    capture-on-hard-block) bundle into `FInputGate`.
+
+    A SEPARATE reader from `read_capture_bundle()`: the shipped schema==1
+    `FInput` path is byte-identical (untouched). Required artifacts:
+    `manifest.json` (schema==2) + `pt1-gate.json` (point=="gate"). pt2-5
+    are NOT present on a gate-only bundle (terminated pre-download) — the
+    returned `FInputGate` carries `None` for all of them.
+
+    Validation is DELIBERATELY narrow (it MUST NOT reuse the 22-key
+    schema-1 `_require_keys`): ONLY the always-present key row +
+    `outcome=="hard-block"` + `failure_class is None`. Everything else
+    (model/arch/quant/topology/post-C0) is `.get(k, None)`-tolerated —
+    a gate-only bundle legitimately lacks those (per the CONTRACT-1.1
+    per-abort-stratum table).
+
+    Raises `CaptureBundleError` on a schema mismatch / missing required
+    artifact / wrong `point` / bad `outcome` / non-null `failure_class`.
+    """
+    cdir = Path(capture_dir)
+    if not cdir.is_dir():
+        raise CaptureBundleError(f"capture dir does not exist: {cdir}")
+
+    # ---- manifest (required; schema==2 hard-asserted) ------------------
+    manifest = _load_json(cdir / _MANIFEST_FILENAME)
+    if manifest.get("schema") != GATE_SCHEMA:
+        raise CaptureBundleError(
+            f"gate-bundle manifest schema must be {GATE_SCHEMA}, "
+            f"got {manifest.get('schema')!r}"
+        )
+    # ONLY the always-present row — NOT the 22-key schema-1 validator
+    # (CONTRACT-1.1 hard rule: gate-only legitimately cannot populate the
+    # post-C0 set, so reusing `_require_keys` would wrongly reject it).
+    _require_keys(manifest, _GATE_REQUIRED_KEYS, "gate manifest.json")
+    if manifest.get("outcome") != "hard-block":
+        raise CaptureBundleError(
+            "gate-bundle manifest.outcome must be 'hard-block', "
+            f"got {manifest.get('outcome')!r}"
+        )
+    # The gate emitter NEVER classifies (§6.1 = [F]'s job) — enforce the
+    # invariant exactly as the schema-1 reader does for an [E] bundle.
+    if manifest.get("failure_class") is not None:
+        raise CaptureBundleError(
+            "gate-bundle manifest.failure_class must be null "
+            f"([F] classifies, not the gate emitter); "
+            f"got {manifest['failure_class']!r}"
+        )
+
+    # ---- pt1-gate.json (required; point=="gate", schema==2) -----------
+    pt1 = _load_json(cdir / "pt1-gate.json")
+    if "schema" in pt1 and pt1["schema"] != GATE_SCHEMA:
+        raise CaptureBundleError(
+            f"pt1-gate.json schema must be {GATE_SCHEMA}, "
+            f"got {pt1['schema']!r}"
+        )
+    if pt1.get("point") != "gate":
+        raise CaptureBundleError(
+            f"pt1-gate.json point must be 'gate', got {pt1.get('point')!r}"
+        )
+
+    return FInputGate(
+        manifest=manifest,
+        pt1_gate=pt1,
         raw_bundle_path=(
             Path(raw_bundle_path) if raw_bundle_path is not None else None
         ),

--- a/scripts/lib/profiles/patch_attribution.py
+++ b/scripts/lib/profiles/patch_attribution.py
@@ -38,6 +38,8 @@ while being immune to header/comment false positives on generated ones.
 from __future__ import annotations
 
 import re
+import shutil
+import subprocess
 from pathlib import Path
 from typing import Iterable
 
@@ -74,6 +76,29 @@ ARCH_REQUIRED_KEYS = ARCH_ALLOWED_KEYS
 VALID_TRC = {"true", "false", "unverified"}
 VALID_ARCH_STATUS = {"verified", "unverified", "suspect"}
 VALID_CONFIDENCE = {"exact", "derived", "estimated-lower-bound"}
+
+# v0.8.2 CONTRACT-2b-i: the patch-attribution delivery vocabulary. The
+# v0.8.0 set (python_sidecar|site_package_overlay|install_script|none) had
+# no class for a model chat-template override (a vendored `.jinja` mounted
+# into the container and wired via `--chat-template`). Without a class, the
+# #141 generator + test-patch-attribution cannot SEE a behavior-critical
+# template (tool-call XML / reasoning delimiters / streaming — the #145
+# silent-break class), so a bad/regressed template silently degrades every
+# compose that ships it with ZERO attribution coverage. `chat_template` is
+# the additive class that brings it under the same load_bearing_when /
+# drift_guard safety net as every other load-bearing patch.
+VALID_DELIVERY_MECHANISM = {
+    "python_sidecar",
+    "site_package_overlay",
+    "install_script",
+    "chat_template",
+    "none",
+}
+
+# A `chat_template` patch's `.jinja` artifact extensions (the discovery set
+# below treats these like `.py`/`.sh` overlay/sidecar artifacts so an
+# orphan vendored template with no patches.yml entry is caught).
+CHAT_TEMPLATE_ARTIFACT_SUFFIXES = {".jinja", ".jinja2", ".j2"}
 
 SEED_REQUIRED_KEYS = {
     "model",
@@ -154,6 +179,160 @@ def compose_text(root: Path, name_or_path: str, seen: set[Path] | None = None) -
         if base.exists():
             text += "\n" + base.read_text(encoding="utf-8")
     return text
+
+
+# --------------------------------------------------------------------------
+# Effective-coverage: REAL Docker Compose merge (CONTRACT-2b-i, r1 H4).
+# --------------------------------------------------------------------------
+# `compose_text` above is the legacy substring substrate: it raw-text
+# CONCATENATES a single `extends:` base. That is unsound for effective
+# coverage of a mounted artifact (e.g. the froggeric chat-template) because
+# a child compose can `!reset`, override, or REMOVE a `volumes`/`command`
+# entry the base declared. A concat would still "see" the base's mount line
+# even though the merged service no longer mounts it — a FALSE NEGATIVE on
+# coverage loss, which is the dangerous direction (the core #377 failure
+# mode: an nvlink* compose that stopped extending its template-bearing base
+# would silently lose the override with zero test catching it).
+#
+# `compose_effective_text` resolves coverage from the *merged resolved*
+# service using REAL Docker Compose merge semantics:
+#   * preferred: `docker compose -f <child> config` (the canonical merge —
+#     resolves `extends:`, list/scalar override, `!reset`/`!override`; no
+#     daemon required, `config` is a pure local resolve);
+#   * deterministic fallback (no docker CLI in the CI image): a recursive
+#     `extends:` resolver that applies the SAME merge rules — the child's
+#     `volumes`/`command` REPLACE the base's when re-declared, an explicitly
+#     emptied list removes the base's entries — so a removal fixture is
+#     still caught offline.
+# Either way the result is the rendered merged service, and a child that
+# removes the mount yields text WITHOUT the mount target.
+class ComposeMergeError(RuntimeError):
+    """Raised when neither the docker merge nor the offline merge can
+    resolve a compose graph (so a chat_template coverage check can fail
+    LOUD rather than silently degrade to the unsound concat path)."""
+
+
+def _docker_compose_config(path: Path) -> str | None:
+    """`docker compose -f <path> config` — the canonical merge. Returns the
+    rendered merged YAML text, or None if the docker CLI is unavailable or
+    the resolve fails (caller falls back to the offline merge)."""
+    if shutil.which("docker") is None:
+        return None
+    try:
+        proc = subprocess.run(
+            ["docker", "compose", "-f", path.name, "config"],
+            cwd=str(path.parent),
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
+
+
+class _ComposeReset:
+    """Sentinel for the Compose `!reset`/`!override` YAML tags used to
+    DROP a base value across an `extends:` (the only in-Compose way to
+    remove a base `volumes`/`command` entry — a plain re-declared `[]`
+    does NOT remove it: Compose merges `extends:` sequences additively)."""
+
+
+def _compose_yaml_load(text: str):
+    """`yaml.safe_load` that tolerates the Compose `!reset`/`!override`
+    custom tags (mapping them to the `_ComposeReset` drop-sentinel /
+    pass-through) so the offline merge matches `docker compose config`
+    behaviour for the removal case."""
+
+    class _L(yaml.SafeLoader):
+        pass
+
+    def _reset(loader, node):  # !reset DROPS the key on merge
+        return _ComposeReset
+
+    def _override(loader, node):  # !override = take child's value as-is
+        if isinstance(node, yaml.SequenceNode):
+            return loader.construct_sequence(node)
+        if isinstance(node, yaml.MappingNode):
+            return loader.construct_mapping(node)
+        return loader.construct_scalar(node)
+
+    _L.add_constructor("!reset", _reset)
+    _L.add_constructor("!override", _override)
+    return yaml.load(text, Loader=_L)  # noqa: S506 — _L is SafeLoader-derived
+
+
+def _offline_extends_merge(path: Path, _seen: set[Path] | None = None) -> dict:
+    """Deterministic pure-yaml stand-in for `docker compose config` merge,
+    matching Compose's REAL `extends:` contract (not the unsound concat):
+
+    * recursively resolve the single `extends: {file, service}`;
+    * SEQUENCES (e.g. `volumes`, `command`) are MERGED ADDITIVELY base⊕child
+      — Compose does NOT let a plain re-declared `[]` drop a base mount;
+    * MAPPINGS (e.g. `environment` as a map) are deep-merged child-wins;
+    * scalars: child wins;
+    * the Compose `!reset` tag on a child key DROPS the base value (the
+      only in-Compose removal mechanism — this is what makes a genuine
+      coverage-loss fixture catchable, and it diverges from a text concat
+      which would still "see" the dropped base line)."""
+    _seen = _seen if _seen is not None else set()
+    rp = path.resolve()
+    if rp in _seen:
+        raise ComposeMergeError(f"extends cycle at {rp}")
+    _seen.add(rp)
+    doc = _compose_yaml_load(path.read_text(encoding="utf-8")) or {}
+    services = doc.get("services") or {}
+
+    def _merge(base, child):
+        if child is _ComposeReset:
+            return None  # !reset drops the base value entirely
+        if isinstance(base, list) and isinstance(child, list):
+            return list(base) + list(child)  # Compose extends: additive seq
+        if isinstance(base, dict) and isinstance(child, dict):
+            out = dict(base)
+            for k, v in child.items():
+                if v is _ComposeReset:
+                    out.pop(k, None)
+                elif k in out:
+                    out[k] = _merge(out[k], v)
+                else:
+                    out[k] = v
+            return out
+        return child  # scalar / type-mismatch: child wins
+
+    merged_services: dict = {}
+    for svc_name, svc in services.items():
+        svc = svc or {}
+        ext = svc.get("extends")
+        child_svc = {k: v for k, v in svc.items() if k != "extends"}
+        if isinstance(ext, dict) and ext.get("file"):
+            base_path = (path.parent / ext["file"]).resolve()
+            base_svc_name = ext.get("service")
+            if base_path.exists():
+                base_doc = _offline_extends_merge(base_path, set(_seen))
+                base_svc = (base_doc.get("services") or {}).get(base_svc_name) or {}
+                merged_services[svc_name] = _merge(dict(base_svc), child_svc)
+                continue
+        merged_services[svc_name] = child_svc
+    return {"services": merged_services}
+
+
+def compose_effective_text(root: Path, name_or_path: str) -> str:
+    """Return the RESOLVED-MERGED compose text (real `extends:` semantics).
+
+    Used by :func:`reaches` for the ``chat_template`` delivery class so
+    coverage is computed from the effective service, not declared lines.
+    Raises :class:`ComposeMergeError` if no merge path can resolve the
+    graph (loud-fail; a chat_template coverage check must never silently
+    fall back to the unsound concat)."""
+    path = _resolve_compose_path(root, name_or_path)
+    rendered = _docker_compose_config(path)
+    if rendered is not None:
+        return rendered
+    merged = _offline_extends_merge(path)
+    return yaml.safe_dump(merged, default_flow_style=False, sort_keys=False)
 
 
 # --------------------------------------------------------------------------
@@ -261,6 +440,20 @@ def _spec_wiring_markers(patch: dict) -> tuple[list[str], list[str]]:
     if invoke and not invoke.endswith((".", "serving", "import")) and "/" in invoke:
         inv.append(invoke)
 
+    # chat_template → the vendored `.jinja` is bind-mounted at `mounted_at`
+    # (already added as a volume marker above via `mounted_at`). Two
+    # in-tree wiring styles:
+    #   * explicit `--chat-template <mounted_at>` arg (froggeric): require
+    #     BOTH tokens in the merged body (rendered as adjacent list items,
+    #     so the joined string never appears — match them separately);
+    #   * mount-only (carnice mounts over the model dir's chat_template.jinja
+    #     and vLLM auto-loads it; `wired_at: [volumes]`): the mount target
+    #     alone is the load-bearing artifact, no `--chat-template` arg.
+    if patch.get("delivery_mechanism") == "chat_template" and mounted_at:
+        if "--chat-template" in (spec.get("invoke") or ""):
+            inv.append("--chat-template")
+            inv.append(mounted_at)
+
     return vol, inv
 
 
@@ -323,6 +516,17 @@ def reaches(root: Path, patch: dict, name_or_path: str) -> bool:
     against the service body so it cannot be tripped by a header/comment
     mention of the patch ID or a PR number.
     """
+    # CONTRACT-2b-i: a `chat_template` patch's effective coverage MUST be
+    # computed from the REAL merged compose graph (`extends:` resolved with
+    # Docker Compose merge semantics), not the legacy single-base concat —
+    # a child can `!reset`/override/REMOVE the mount, and the concat would
+    # still see the base's line (a false-negative on coverage loss, the
+    # dangerous direction). Every other mechanism keeps the byte-identical
+    # legacy substrate so shipped attribution is unchanged.
+    if patch.get("delivery_mechanism") == "chat_template":
+        body = service_body(compose_effective_text(root, name_or_path))
+        return _spec_wiring_present(patch, body)
+
     body = service_body(compose_text(root, name_or_path))
 
     # Primary, sound path: the patch's declared delivery_spec wiring is
@@ -364,6 +568,25 @@ def is_artifact(path: Path) -> bool:
         and "/patches/genesis/" not in text
         and "/_pre-pr" not in text
         and path.suffix in {".py", ".sh"}
+    )
+
+
+def is_chat_template_artifact(path: Path) -> bool:
+    """A vendored chat-template `.jinja` under a model's `vllm/patches/`
+    tree (CONTRACT-2b-i).
+
+    Kept SEPARATE from :func:`is_artifact` (which is behaviour-frozen for
+    the shipped `.py`/`.sh` overlay/sidecar orphan check) so the new class
+    is additive: the test discovers chat-template artifacts with this and
+    asserts each is owned by a `delivery_mechanism: chat_template` patch —
+    so a bad/regressed/re-vendored template can never ship with zero
+    attribution coverage."""
+    text = path.as_posix()
+    return (
+        "/patches/" in text
+        and "/patches/genesis/" not in text
+        and "/_pre-pr" not in text
+        and path.suffix in CHAT_TEMPLATE_ARTIFACT_SUFFIXES
     )
 
 

--- a/scripts/lib/profiles/patches.yml
+++ b/scripts/lib/profiles/patches.yml
@@ -279,6 +279,95 @@ patches:
       drop_when: "each affected engine profile pins a vLLM nightly after d5b31c95"
     status: verified
 
+  - id: qwen-froggeric-chat-template
+    model: [qwen3.6-27b]
+    files:
+      - models/qwen3.6-27b/vllm/patches/froggeric-chat-template/chat_template.jinja
+    load_bearing_when:
+      - composes:
+          - vllm/default
+          - vllm/tools-text
+          - vllm/minimal
+          - vllm/long-text
+          - vllm/long-text-no-mtp
+          - vllm/long-vision
+          - vllm/bounded-thinking
+          - vllm/dual
+          - vllm/dual-turbo
+          - vllm/dual-dflash
+          - vllm/dual-dflash-noviz
+          - vllm/dual-bf16
+          - vllm/dual-int8
+          - vllm/dual-tq3-mtp
+          - vllm/dual-tq3-mtp-genesis
+          - vllm/dual-tq3-nomtp
+          - vllm/dual-nvlink
+          - vllm/dual-nvlink-turbo
+          - vllm/dual-nvlink-dflash
+          - vllm/dual-nvlink-dflash-noviz
+          - vllm/dual4
+          - vllm/dual4-dflash
+        reason: "Default Qwen3.6 chat template mis-handles tool-call XML / reasoning delimiters / streaming (the #145 silent-break class); the froggeric override fixes 7 default-template defects and is behavior-critical for every tool/agent compose. The 4 vllm/dual-nvlink* composes inherit it via Docker Compose extends: of a froggeric-bearing base (resolved with real merge semantics, not declared lines). Carnice/Qwopus are intentional excludes (they ship their own carnice template)."
+        evidence: "models/qwen3.6-27b/vllm/patches/froggeric-chat-template/PROVENANCE.md; docs/UPSTREAM.md (froggeric template re-eval #150 / v19 adopted PR #157)"
+    delivery:               # DEPRECATED/READ-ONLY (test-only) — see header
+      dockerfile_bake: false
+      entrypoint_invoke: true
+      genesis: false
+    delivery_gaps: []
+    delivery_mechanism: chat_template
+    delivery_spec:
+      jinja: models/qwen3.6-27b/vllm/patches/froggeric-chat-template/chat_template.jinja
+      mounted_at: /etc/qwen-froggeric-chat-template.jinja
+      mount_mode: ro
+      invoke: "--chat-template /etc/qwen-froggeric-chat-template.jinja"
+      wired_at: [volumes, entrypoint]
+      note: "vendored chat-template override; effective coverage is computed from the REAL merged compose graph (extends: resolved with Docker Compose merge semantics) so a child that !reset/overrides/removes the mount is caught as a coverage loss, not a false-negative."
+    drift_guard:
+      kind: behavioral
+      check: "Streaming tool-call (XML <tool_call>) + reasoning-delimiter smoke stays green on the selected nightly with the froggeric template mounted. Any behavioral/TPS comparison the guard performs MUST use the SELF-CONTAINED symmetric restart+settle protocol: identical `docker restart <container>` on BOTH arms -> wait for /v1/models healthy -> fixed 60s settle -> >=3 bench.sh runs/arm -> compare the GRAND MEAN of the SAME canonical bench segment (NARRATIVE 800-word essay + CODE; never mix segments, never a single run); flag ONLY a deterministic regression reproduced across ALL 3 runs. (An asymmetric-restart harness fabricated a phantom -7% on #150; a non-symmetric guard flaps and gets ignored.)"
+      on_fail: capability-degraded   # serves with the default template, minus the tool-call/reasoning-delimiter fixes
+    capability: chat-template-override
+    foundational: false
+    upstream:
+      ref: froggeric/Qwen-Fixed-Chat-Templates (re-eval club-3090#150 / v19 via PR #157)
+      status: local-vendored
+      drop_when: "upstream Qwen ships a corrected default chat template and the pinned engines bundle it, OR the override is re-vendored (the same drift_guard must clear the next re-vendor)"
+    status: verified
+
+  - id: qwen-carnice-chat-template
+    model: [qwen3.6-27b]
+    files:
+      - models/qwen3.6-27b/vllm/patches/carnice-chat-template.jinja
+    load_bearing_when:
+      - composes:
+          - vllm/dual-carnice-bf16mtp
+        reason: "The Carnice v2 INT4 Recipe-D BF16-MTP weights ship a default chat template that mis-emits tool calls; the vendored carnice .jinja makes Carnice output JSON tool calls matched to `--tool-call-parser hermes`. It is behavior-critical (the #145 silent-break class) and was previously invisible to patch-attribution (no patches.yml id / delivery_mechanism / drift_guard). Unlike froggeric it is NOT wired via `--chat-template`: it is bind-mounted OVER the model dir's chat_template.jinja and vLLM auto-loads it (wired_at: volumes only). Qwopus is NOT covered here — it ships its chat_template embedded in tokenizer_config.json, not a separate .jinja."
+        evidence: "models/qwen3.6-27b/vllm/compose/dual/carnice-bf16mtp.yml volumes block + header; docs/UPSTREAM.md (carnice recipe-D)"
+    delivery:               # DEPRECATED/READ-ONLY (test-only) — see header
+      dockerfile_bake: false
+      entrypoint_invoke: false
+      genesis: false
+    delivery_gaps: []
+    delivery_mechanism: chat_template
+    delivery_spec:
+      jinja: models/qwen3.6-27b/vllm/patches/carnice-chat-template.jinja
+      mounted_at: /root/.cache/huggingface/carnice-v2-27b-int4-recipe-d-bf16mtp/chat_template.jinja
+      mount_mode: ro
+      invoke: "mount-only: bind-mounted over the model dir's chat_template.jinja; vLLM auto-loads it (no --chat-template arg)"
+      wired_at: [volumes]
+      note: "mount-only chat-template override (vs froggeric's explicit --chat-template wiring); effective coverage is computed from the REAL merged compose graph so a child that !reset/removes the model-dir mount is caught as a coverage loss."
+    drift_guard:
+      kind: behavioral
+      check: "Carnice JSON tool-call smoke (matched to --tool-call-parser hermes) + reasoning-delimiter behavior stays green on the selected nightly with the carnice template mounted over the model dir. Any behavioral/TPS comparison the guard performs MUST use the SELF-CONTAINED symmetric restart+settle protocol: identical `docker restart <container>` on BOTH arms -> wait for /v1/models healthy -> fixed 60s settle -> >=3 bench.sh runs/arm -> compare the GRAND MEAN of the SAME canonical bench segment (NARRATIVE 800-word essay + CODE; never mix segments, never a single run); flag ONLY a deterministic regression reproduced across ALL 3 runs."
+      on_fail: capability-degraded   # serves with the model's default template, minus the hermes-matched tool-call fix
+    capability: chat-template-override
+    foundational: false
+    upstream:
+      ref: club-3090 carnice-v2 recipe-D vendored chat template
+      status: local-vendored
+      drop_when: "the Carnice weights ship a corrected default chat template, OR the override is re-vendored (the same drift_guard must clear the next re-vendor)"
+    status: verified
+
   - id: gemma-vllm-pr41800-truncate-prompt-tokens
     model: [gemma-4-31b]
     files:

--- a/scripts/lib/profiles/pull.py
+++ b/scripts/lib/profiles/pull.py
@@ -424,6 +424,75 @@ def _topology_summary_canonical(names: list[str], vram_mib: list[int]) -> str:
 
 
 # ===========================================================================
+# v0.8.2 CONTRACT-1.1 — capture-on-hard-block PASS-THROUGH.
+#
+# Emits a pt1-gate-only redacted bundle on a terminal hard-block, BEFORE the
+# existing `return res`. This is a PURE PASS-THROUGH: it changes NONE of the
+# `[C1]`/6-stratum decision logic — every `return res` decision (ok / stratum
+# / abort_reason / detail) is exactly what it was; we only emit a bundle (a
+# local file op, no network) and record the bundle dir on `res`. ANY emit
+# failure is swallowed structurally — a capture problem must NEVER change a
+# gate decision or raise out of `run_pull` (the locked `[F]`-offline / I/O-
+# free-gate boundary; pre-existing test-pull.sh assertions byte-unaffected).
+#
+# `res.capture_paths` (an existing additive PullResult field) is appended so
+# the surface step (V2) + tests can find the bundle; nothing else on `res`
+# is touched.
+# ===========================================================================
+def _gate_capture_passthrough(
+    res, *, slug, profile_like, der, hardware_sm, gpu_topology, root,
+    gate_capture_fn,
+):
+    """Emit the pt1-gate-only bundle for a terminal hard-block, then return
+    `res` UNCHANGED (pass-through). Swallows every exception — a capture
+    failure never alters a gate decision."""
+    try:
+        from scripts.lib.profiles import capture as _CAP
+
+        fn = gate_capture_fn or _CAP.emit_gate_capture
+
+        # club3090 commit captured on the HOST (mirrors _build_einput; never
+        # git-in-container) — best-effort, "unknown" on any failure.
+        commit = "unknown"
+        try:
+            import subprocess
+
+            cp = subprocess.run(
+                ["git", "-C", str(root or REPO_ROOT), "rev-parse", "HEAD"],
+                capture_output=True, text=True, timeout=10, check=False,
+            )
+            if cp.returncode == 0 and cp.stdout.strip():
+                commit = cp.stdout.strip()
+        except Exception:  # pragma: no cover - git always present on rig
+            commit = "unknown"
+
+        out = fn(
+            slug=slug,
+            profile_like=profile_like,
+            abort_reason=res.abort_reason or "",
+            confidence=(
+                SimpleNamespace(name=res.confidence)
+                if res.confidence else None
+            ),
+            raw_verdict=res.raw_verdict,
+            detail=res.detail,
+            der=der,
+            hardware_sm=hardware_sm,
+            gpu_topology=gpu_topology,
+            club3090_commit=commit,
+            predicted_b_breakdown=res.diagnostics.get("b_breakdown"),
+            repo_root=root or REPO_ROOT,
+        )
+        d = out.get("dir") if isinstance(out, dict) else None
+        if d:
+            res.capture_paths.append(str(d))
+            res.diagnostics["gate_capture"] = {"dir": str(d)}
+    except Exception as exc:  # pragma: no cover - capture is best-effort
+        res.diagnostics["gate_capture"] = {"error": repr(exc)}
+    return res
+
+
+# ===========================================================================
 # The orchestrator — chains the frozen slices in the LOCKED stratum order.
 # ===========================================================================
 def run_pull(
@@ -462,6 +531,12 @@ def run_pull(
     smoke_fn: Optional[Callable] = None,        # E3 smoke_derived
     capture_fn: Optional[Callable] = None,      # E3 emit_capture
     override_capture_fn: Optional[Callable] = None,  # E4 emit_override_capture
+    # v0.8.2 CONTRACT-1.1 — the pt1-gate-only emitter, wired as a pure
+    # PASS-THROUGH on the terminal hard-block return paths (it emits a
+    # bundle BEFORE the existing `return res`; the decision is UNCHANGED).
+    # Injectable so test-pull.sh stays mock-only; None -> the real shipped
+    # capture.emit_gate_capture.
+    gate_capture_fn: Optional[Callable] = None,
 ) -> PullResult:
     """Execute the 6-stratum Pull-Gate state machine.
 
@@ -499,10 +574,17 @@ def run_pull(
         slug, hf_home=hf_home, fetcher=fetcher, profiles=profiles
     )
     if der.error is not None:
-        return PullResult(
+        _der_res = PullResult(
             slug=slug, profile_like=profile_like, path="?",
             ok=False, stratum=Stratum.DERIVER,
             abort_reason=der.error.kind.value, detail=str(der.error),
+        )
+        # v0.8.2 CONTRACT-1.1 pass-through (pre-deriver: no der.profile ->
+        # model/arch/quant null). Decision UNCHANGED.
+        return _gate_capture_passthrough(
+            _der_res, slug=slug, profile_like=profile_like, der=None,
+            hardware_sm=hardware_sm, gpu_topology=gpu_topology, root=root,
+            gate_capture_fn=gate_capture_fn,
         )
 
     is_curated = der.tier1 is not None
@@ -530,7 +612,11 @@ def run_pull(
         res.stratum = Stratum.PROFILE_LIKE
         res.abort_reason = s2.refusal.reason
         res.detail = s2.refusal.detail
-        return res
+        return _gate_capture_passthrough(
+            res, slug=slug, profile_like=profile_like, der=der,
+            hardware_sm=hardware_sm, gpu_topology=gpu_topology, root=root,
+            gate_capture_fn=gate_capture_fn,
+        )
 
     # ----- stratum-3: [C0] engine-support / runtime / SM (P3, frozen) -----
     if hardware_sm is None:
@@ -546,7 +632,14 @@ def run_pull(
             "and no --hardware override given; refusing to run the SM gate "
             "blind"
         )
-        return res
+        # topology GUARANTEED null here (nvidia-smi absent — CONTRACT-1.1):
+        # pass gpu_topology=None so the bundle's topology is null even if
+        # an unrelated override was supplied.
+        return _gate_capture_passthrough(
+            res, slug=slug, profile_like=profile_like, der=der,
+            hardware_sm=None, gpu_topology=None, root=root,
+            gate_capture_fn=gate_capture_fn,
+        )
 
     c0 = G.c0_engine_support(
         profile_like, der, path=eff_path, hardware_sm=float(hardware_sm),
@@ -577,7 +670,11 @@ def run_pull(
             )
             res.detail = c0.detail
             res.diagnostics["c0_bypassable_by"] = list(c0.bypassable_by)
-            return res
+            return _gate_capture_passthrough(
+                res, slug=slug, profile_like=profile_like, der=der,
+                hardware_sm=hardware_sm, gpu_topology=gpu_topology,
+                root=root, gate_capture_fn=gate_capture_fn,
+            )
         res.notices.append(
             f"[C0] {c0.state.value}"
             + (f"/{c0.sub_reason.value}" if c0.sub_reason else "")
@@ -592,7 +689,11 @@ def run_pull(
         res.stratum = Stratum.C2A_DISK
         res.abort_reason = c2a.state.value          # "disk-short"
         res.detail = c2a.detail
-        return res
+        return _gate_capture_passthrough(
+            res, slug=slug, profile_like=profile_like, der=der,
+            hardware_sm=hardware_sm, gpu_topology=gpu_topology, root=root,
+            gate_capture_fn=gate_capture_fn,
+        )
 
     # ----- stratum-5: pre-[B] generic-dense eligibility (P4) --------------
     # Separate pre-[B] abort — NOT a [C0] rewrite ([C0] already emitted
@@ -614,7 +715,11 @@ def run_pull(
                 f"to price — pre-[B] hard-stop (non-bypassable; "
                 f"--experimental-arch does NOT apply — there is no model)"
             )
-            return res
+            return _gate_capture_passthrough(
+                res, slug=slug, profile_like=profile_like, der=der,
+                hardware_sm=hardware_sm, gpu_topology=gpu_topology,
+                root=root, gate_capture_fn=gate_capture_fn,
+            )
 
     # ----- [B]: raw fit verdict (P1 kv.raw_verdict) -----------------------
     entry = s2.registry_entry or {}
@@ -648,7 +753,15 @@ def run_pull(
         res.stratum = Stratum.DECIDED
         res.abort_reason = "hard-block"
         res.detail = f"[C1] {conf}×{raw} → hard-block ({c1.note})"
-        return res
+        # v0.8.2 CONTRACT-1.1 — the C1 exact×wont-fit terminal (the genuine
+        # kv-calc VRAM refusal). predicted_b_breakdown is in scope
+        # (res.diagnostics["b_breakdown"] set above) — the pass-through
+        # carries it. Decision UNCHANGED.
+        return _gate_capture_passthrough(
+            res, slug=slug, profile_like=profile_like, der=der,
+            hardware_sm=hardware_sm, gpu_topology=gpu_topology, root=root,
+            gate_capture_fn=gate_capture_fn,
+        )
 
     if not c1.satisfied:
         # confirm→proceed without --yes, or low-conf wont-fit advisory

--- a/scripts/lib/profiles/pull.py
+++ b/scripts/lib/profiles/pull.py
@@ -537,6 +537,17 @@ def run_pull(
     # Injectable so test-pull.sh stays mock-only; None -> the real shipped
     # capture.emit_gate_capture.
     gate_capture_fn: Optional[Callable] = None,
+    # v0.8.2 CONTRACT-3 — OPTIONAL non-NVIDIA hardware-enumeration augment.
+    # Consulted ONLY when `nvidia-smi` already returned nothing (so the
+    # NVIDIA majority NEVER enters this seam — that path is byte-identical
+    # with this absent OR present-but-degrading). hw-detect-ONLY: it yields
+    # an SM-equivalent for the [C0] SM gate; it NEVER feeds kv-calc. None
+    # -> the real shipped hwdetect.detect_non_nvidia_sm (optional bounded
+    # `whichllm` subprocess; absent/failed -> graceful degrade to today's
+    # exact `hardware-sm-undetermined` behaviour). Injectable so
+    # test-pull.sh / test-hwdetect.sh stay hermetic (no `whichllm`, no
+    # non-NVIDIA GPU in CI).
+    hwdetect_fn: Optional[Callable] = None,
 ) -> PullResult:
     """Execute the 6-stratum Pull-Gate state machine.
 
@@ -621,6 +632,41 @@ def run_pull(
     # ----- stratum-3: [C0] engine-support / runtime / SM (P3, frozen) -----
     if hardware_sm is None:
         hardware_sm = detect_hardware_sm()
+    if hardware_sm is None:
+        # v0.8.2 CONTRACT-3 (hw-detect-ONLY) — OPTIONAL non-NVIDIA augment.
+        # Reached ONLY when `nvidia-smi` gave nothing, so the NVIDIA
+        # majority never executes this and that path is byte-identical
+        # whether this augment is absent or present-but-degrading. An
+        # absent/failed/non-applicable `whichllm` returns None and we fall
+        # straight through to the unchanged `hardware-sm-undetermined`
+        # terminal below (safety half). A recognised non-NVIDIA device
+        # (AMD ROCm / Apple) yields an SM-equivalent so the eval path can
+        # run the [C0] SM gate instead of refusing blind (delivery half).
+        # This SM-equivalent feeds ONLY the [C0] gate — NEVER kv-calc
+        # (kv-calc stays the sole fit authority; CONTRACT-3 is
+        # enumeration-only). Any exception is swallowed by hwdetect itself
+        # (leaf module never raises out).
+        if hwdetect_fn is None:
+            from scripts.lib.profiles.hwdetect import detect_non_nvidia_sm
+
+            hwdetect_fn = detect_non_nvidia_sm
+        _aug_sm = hwdetect_fn()
+        if _aug_sm is not None:
+            # Additive-only: mutate the existing `res` (created above;
+            # stratum-2 already passed). NO decision field is touched —
+            # only `hardware_sm` (so the EXISTING [C0] gate now runs
+            # instead of the unchanged blind-refuse terminal) + an
+            # additive notice/diagnostic. kv-calc is NOT consulted.
+            hardware_sm = float(_aug_sm)
+            res.notices.append(
+                "[hw] nvidia-smi absent; non-NVIDIA accelerator "
+                "enumerated via the optional hardware-detect subprocess "
+                "(enumeration only — kv-calc remains the sole fit "
+                "authority; validate with soak-continuous)"
+            )
+            res.diagnostics["hwdetect"] = {
+                "augmented": True, "sm_equiv": float(_aug_sm),
+            }
     if hardware_sm is None:
         # No GPU detected and none injected: cannot honestly run the SM
         # gate. Fail closed (never fabricate a fit per §1).

--- a/scripts/lib/profiles/pull.py
+++ b/scripts/lib/profiles/pull.py
@@ -1464,6 +1464,108 @@ def _curated_spec(profiles, der) -> dict:
 
 
 # ===========================================================================
+# v0.8.2 CONTRACT-4 — the `recommend` UX (success-path counterpart to the
+# CONTRACT-1 failure on-ramp).
+#
+# This is PURE PRESENTATION / AGGREGATION over the SHIPPED `run_pull`
+# verdict. It introduces NO decision logic: every field it renders is read
+# straight off the real `PullResult` (`ok` / `confidence` / `raw_verdict` /
+# `terminal` / `stratum` / `abort_reason` / `notices` / `emitted`) that the
+# locked 6-stratum + §4.1 machinery produced for THIS run. The recommendation
+# therefore tracks the real verdict by construction — a model that fits, one
+# that hard-blocks, and one that is `confirm→proceed` each yield a different
+# block because each carries a different real `res`. It is NOT a static or
+# templated summary: remove the gate and the recommendation changes with it.
+#
+# Honesty invariants (CONTRACT-4):
+#   * vLLM-only by construction (the shipped gate is vLLM-only; we add
+#     nothing — we only echo what the gate decided).
+#   * Carries the §7 boot-fit≠runtime caveat verbatim (CAVEAT_S7) + the
+#     soak-continuous pointer, on any verdict the gate itself marked
+#     boot-fit-satisfied (detected via CAVEAT_S7 ∈ res.notices — the SAME
+#     signal the gate already emits; we do not re-derive it).
+#   * States WHICH gate decided (`res.stratum`) — never silently summarised.
+#   * Honest about the confidence tier (echoes res.confidence; an
+#     estimated-lower-bound floor is stated, never hidden).
+#   * NEVER implies a non-emitted artifact: a compose line is printed ONLY
+#     when `res.emitted` is true (Path A actually emitted one).
+# ===========================================================================
+def _render_recommendation(res: "PullResult") -> list[str]:
+    """Aggregate the SHIPPED `run_pull` verdict into an honest, human
+    recommendation. Pure presentation: derives every line from `res`;
+    introduces no decision logic. Returns the lines to print (so the
+    test can assert the recommendation tracks a *real* differing verdict
+    without driving a tty)."""
+    out: list[str] = ["[recommend] ----- recommendation -----"]
+    out.append(
+        f"[recommend] model={res.slug} profile-like={res.profile_like} "
+        f"engine=vLLM (the pull gate is vLLM-only by construction)"
+    )
+
+    if res.ok:
+        # The gate said download-eligible / clean. Echo the real terminal +
+        # confidence; never upgrade the gate's honesty.
+        verdict = res.terminal or "proceed"
+        out.append(
+            f"[recommend] verdict: FITS → {verdict} "
+            f"(confidence={res.confidence or 'n/a'}, "
+            f"raw_verdict={res.raw_verdict or 'n/a'})"
+        )
+        if res.confidence == "estimated-lower-bound":
+            out.append(
+                "[recommend] note: this is an ESTIMATED LOWER BOUND — the "
+                "modelled VRAM is a floor and is likely under-modelled; "
+                "treat the fit as the optimistic edge, not a guarantee."
+            )
+        if res.emitted:
+            out.append(
+                "[recommend] a ready compose was emitted for this config "
+                "(see the --out path / stdout above)."
+            )
+        else:
+            # Honesty: do NOT imply a compose that was not produced.
+            out.append(
+                "[recommend] no compose was emitted this run (Path B "
+                "evaluate / --dry-run / not download-eligible) — this is a "
+                "verdict only, not a launchable artifact."
+            )
+    else:
+        # The gate hard-blocked / needs-a-flag. Carry the precise reason and
+        # WHICH gate decided; point at the failure on-ramp (CONTRACT-1).
+        reason = res.abort_reason or "see the gate output above"
+        out.append(
+            f"[recommend] verdict: DOES NOT FIT / BLOCKED — {reason}"
+        )
+        out.append(
+            "[recommend] this is an honest stop, not a stack failure. The "
+            "diagnostics (if a redacted bundle was captured) can be sent "
+            "back with `scripts/pull.sh --submit-last` — see the failure "
+            "on-ramp section of docs/PULL.md."
+        )
+
+    # WHICH gate decided — always stated (CONTRACT-4: never silently
+    # summarised). Read straight off the real result.
+    out.append(
+        f"[recommend] decided at: stratum={res.stratum.name}"
+    )
+
+    # §7 boot-fit ≠ runtime caveat + soak-continuous pointer — carried
+    # verbatim ONLY when the gate itself marked this run boot-fit-satisfied
+    # (CAVEAT_S7 ∈ res.notices is the gate's own signal; we echo, not
+    # re-derive). A blocked verdict that never reached [B] has no such
+    # notice and (correctly) gets no false soak pointer.
+    if CAVEAT_S7 in res.notices:
+        out.append(f"[recommend] §7 caveat: {CAVEAT_S7}")
+        out.append(
+            "[recommend] before relying on this in production run: "
+            "scripts/soak.sh SOAK_MODE=continuous (the only test that "
+            "catches Cliff 2b)."
+        )
+    out.append("[recommend] -------------------------------")
+    return out
+
+
+# ===========================================================================
 # CLI (thin; pull.sh execs this). Renders PullResult to stdout + exit code.
 # ===========================================================================
 _EXIT_OK = 0
@@ -1568,6 +1670,14 @@ def main(argv: list[str]) -> int:
         "[E] stage as 'VRAM_MIB:NAME,VRAM_MIB:NAME' (e.g. "
         "'24576:RTX 3090,24576:RTX 3090'); default = nvidia-smi detection",
     )
+    ap.add_argument(
+        "--recommend", action="store_true",
+        help="v0.8.2 CONTRACT-4: after the gate runs, print an honest "
+        "aggregated recommendation (fits? which quant/variant; the §7 "
+        "boot-fit≠runtime caveat; which gate decided). Presentation only "
+        "— derives entirely from the real gate verdict, changes no "
+        "decision; vLLM-only by construction",
+    )
     args = ap.parse_args(argv)
 
     gpu_topology = None
@@ -1639,6 +1749,14 @@ def main(argv: list[str]) -> int:
             "[pull] Help improve the fit math — submit with: "
             "scripts/pull.sh --submit-last"
         )
+
+    # v0.8.2 CONTRACT-4 — the `recommend` UX. Pure presentation/aggregation
+    # over the SHIPPED verdict (`res`); changes NO decision and NOT the exit
+    # code (the recommendation only RENDERS what the gate already decided).
+    # Emitted last so it summarises the full verdict the user just saw.
+    if args.recommend:
+        for ln in _render_recommendation(res):
+            print(ln)
 
     if res.ok:
         return _EXIT_OK

--- a/scripts/lib/profiles/pull.py
+++ b/scripts/lib/profiles/pull.py
@@ -1426,8 +1426,46 @@ _EXIT_NEEDS_FLAG = 3     # confirm→proceed / advisory not yet satisfied
 _EXIT_USAGE = 64
 
 
+def _maybe_submit_verb(argv: list[str]) -> Optional[int]:
+    """v0.8.2 CONTRACT-1.3 — the `--submit-last` / `--submit <dir>` verb is
+    a DISTINCT top-level verb, parsed BEFORE the positional-slug /
+    `--profile-like` requirement (so `--submit*` needs NEITHER a slug NOR
+    `--profile-like`). Returns an exit code when the submit verb was
+    invoked, else `None` (fall through to the normal gate CLI).
+
+    This is intentionally a pre-argparse intercept: the shipped gate parser
+    hard-requires `slug` + `--profile-like`, and the submit verb is a
+    different invocation grammar entirely (the on-ramp, not a gate run).
+    The submit path is the ONLY place network ever happens, and only after
+    an explicit `y` (the locked `[F]`-offline boundary — `run_pull` itself
+    stays I/O-free).
+    """
+    if "--submit-last" not in argv and "--submit" not in argv:
+        return None
+
+    from scripts.lib.profiles.submit_pull import submit_pull
+
+    submit_last = "--submit-last" in argv
+    capture_dir: Optional[str] = None
+    if "--submit" in argv:
+        i = argv.index("--submit")
+        if i + 1 < len(argv):
+            capture_dir = argv[i + 1]
+    return submit_pull(
+        capture_dir=capture_dir,
+        submit_last=submit_last,
+        repo_root=REPO_ROOT,
+    )
+
+
 def main(argv: list[str]) -> int:
     import argparse
+
+    # v0.8.2 CONTRACT-1.3 — the submit verb is parsed BEFORE the gate
+    # parser's slug/--profile-like requirement (a distinct top-level verb).
+    _sub_rc = _maybe_submit_verb(argv)
+    if _sub_rc is not None:
+        return _sub_rc
 
     class _UsageExit64Parser(argparse.ArgumentParser):
         """argparse's default `error()` hard-exits 2 — which collides with
@@ -1528,6 +1566,33 @@ def main(argv: list[str]) -> int:
         print(f"[pull] note: {n}")
     if res.emitted and not args.out:
         sys.stdout.write(res.compose_text or "")
+
+    # v0.8.2 CONTRACT-1.2 — surface the failure on-ramp pointer (gate path,
+    # I/O-FREE: a single print; NO network, NO blocking prompt, NO auto-send
+    # — submission is the separate, explicit, consented `--submit-last`
+    # step). The TRIGGER is "a gate bundle was emitted for this run", keyed
+    # on the capture dir the V1 pass-through recorded on `res.diagnostics`
+    # — EXPLICITLY NOT gated on the exit code. The single most important
+    # §10-R9 lever (`engine-support-unknown/no-arch-row`) is the
+    # `--experimental-arch`-bypassable advisory path that exits 0 yet emits
+    # a bundle; gating this pointer on `exit==2` would silently suppress the
+    # submit prompt for exactly that class. It does NOT classify (that is
+    # loop-side at submit) — it prints unconditionally on any emitted gate
+    # bundle; suppression (no public issue) is enforced loop-side. The
+    # surfaced message points ONLY at the redacted `.pull-captures/`
+    # artifact + the exact one-command — never "paste your terminal output"
+    # (console is not a safe submission source).
+    _gc = res.diagnostics.get("gate_capture") if res.diagnostics else None
+    _gc_dir = _gc.get("dir") if isinstance(_gc, dict) else None
+    if _gc_dir:
+        print(
+            f"[pull] Diagnostics captured (redacted, no paths/tokens): "
+            f"{_gc_dir}"
+        )
+        print(
+            "[pull] Help improve the fit math — submit with: "
+            "scripts/pull.sh --submit-last"
+        )
 
     if res.ok:
         return _EXIT_OK

--- a/scripts/lib/profiles/pull.py
+++ b/scripts/lib/profiles/pull.py
@@ -1530,18 +1530,50 @@ def _render_recommendation(res: "PullResult") -> list[str]:
                 "verdict only, not a launchable artifact."
             )
     else:
-        # The gate hard-blocked / needs-a-flag. Carry the precise reason and
-        # WHICH gate decided; point at the failure on-ramp (CONTRACT-1).
+        # `res.ok` is False, but that means "the run did not produce a
+        # launchable artifact" — NOT necessarily "does not fit". Distinguish
+        # the gate's *acceptance* terminals (it fits the modelled budget; the
+        # run merely needs an explicit flag) from a genuine hard-block.
+        # Honesty (CONTRACT-4): never label a fits-clean model "DOES NOT FIT".
+        # Pure presentation: still derives only from `res`, no decision logic.
         reason = res.abort_reason or "see the gate output above"
-        out.append(
-            f"[recommend] verdict: DOES NOT FIT / BLOCKED — {reason}"
+        _rv = res.raw_verdict or ""
+        _ar = res.abort_reason or ""
+        _needs_accept = _rv == "fits-clean" and (
+            _ar.startswith("confirm→proceed")
+            or _ar.startswith("override-accepted")
+            or "needs --yes" in _ar
+            or "needs --force-download" in _ar
         )
-        out.append(
-            "[recommend] this is an honest stop, not a stack failure. The "
-            "diagnostics (if a redacted bundle was captured) can be sent "
-            "back with `scripts/pull.sh --submit-last` — see the failure "
-            "on-ramp section of docs/PULL.md."
-        )
+        if _needs_accept:
+            out.append(
+                f"[recommend] verdict: FITS (estimated) — NOT YET ACCEPTED: "
+                f"{reason} (confidence={res.confidence or 'n/a'}, "
+                f"raw_verdict={res.raw_verdict or 'n/a'})"
+            )
+            out.append(
+                "[recommend] the model fits the gate's modelled budget — this "
+                "is an ACCEPTANCE gate, not a fit failure. Re-run with the "
+                "flag named in the reason above to proceed."
+            )
+            if res.confidence == "estimated-lower-bound":
+                out.append(
+                    "[recommend] note: this is an ESTIMATED LOWER BOUND — the "
+                    "modelled VRAM is a floor and is likely under-modelled; "
+                    "treat the fit as the optimistic edge, not a guarantee."
+                )
+        else:
+            # Genuine hard-block / needs-a-flag. Carry the precise reason and
+            # WHICH gate decided; point at the failure on-ramp (CONTRACT-1).
+            out.append(
+                f"[recommend] verdict: DOES NOT FIT / BLOCKED — {reason}"
+            )
+            out.append(
+                "[recommend] this is an honest stop, not a stack failure. The "
+                "diagnostics (if a redacted bundle was captured) can be sent "
+                "back with `scripts/pull.sh --submit-last` — see the failure "
+                "on-ramp section of docs/PULL.md."
+            )
 
     # WHICH gate decided — always stated (CONTRACT-4: never silently
     # summarised). Read straight off the real result.

--- a/scripts/lib/profiles/submit_pull.py
+++ b/scripts/lib/profiles/submit_pull.py
@@ -197,6 +197,20 @@ def _ghless_title(finput, classification) -> str:
     return f"[{model}] {cls_v} on {topo} (dedup:{h[:8]})"
 
 
+def _rel_capture(bundle_dir: Path) -> str:
+    """Repo-relative capture pointer (`.pull-captures/<slug>/<ts>`), NEVER an
+    absolute path. The gh-less body is pasted into a PUBLIC issue, so it must
+    not carry the user's filesystem layout (CONTRACT-1.3 "console is not a
+    safe source" + the acceptance: nothing the on-ramp tells a user to share
+    contains an unredacted absolute path). Falls back to the leaf name.
+    """
+    parts = Path(bundle_dir).parts
+    if _PULL_CAPTURES_DIRNAME in parts:
+        i = parts.index(_PULL_CAPTURES_DIRNAME)
+        return str(Path(*parts[i:]))
+    return Path(bundle_dir).name
+
+
 def _ghless_body(finput, classification, bundle_dir: Path) -> str:
     """URL-encoded-ready MARKDOWN body from the redacted manifest tuple
     (model/engine/arch/failure-class/topology + the dedup hash), hard-
@@ -230,7 +244,8 @@ def _ghless_body(finput, classification, bundle_dir: Path) -> str:
         (classification.error_substring or "")[:1200],
         "```",
         "",
-        f"full redacted bundle at `{bundle_dir}` — attach it to the issue",
+        f"redacted bundle dir (from your own run): "
+        f"`{_rel_capture(bundle_dir)}` — attach it to the issue",
     ]
     body = "\n".join(lines)
     # Hard-truncate so the FINAL encoded URL stays < _MAX_URL_BYTES. We
@@ -238,7 +253,8 @@ def _ghless_body(finput, classification, bundle_dir: Path) -> str:
     # trim the body until the assembled URL fits, always preserving the
     # trailing "attach it" pointer.
     tail = (
-        f"\n\nfull redacted bundle at `{bundle_dir}` — attach it to the issue"
+        f"\n\nredacted bundle dir (from your own run): "
+        f"`{_rel_capture(bundle_dir)}` — attach it to the issue"
     )
     while True:
         url = _build_issue_url(_ghless_title(finput, classification), body, h)

--- a/scripts/lib/profiles/submit_pull.py
+++ b/scripts/lib/profiles/submit_pull.py
@@ -1,0 +1,485 @@
+"""v0.8.2 CONTRACT-1.3 — the user-invoked, consented failure on-ramp submit.
+
+`scripts/pull.sh --submit-last` / `scripts/pull.sh --submit <capture-dir>`.
+
+This is the SEPARATE, explicit, user-invoked, consented step the locked
+`[F]`-offline boundary mandates: the gate path (`pull.py run_pull`) stays
+I/O-free and only PRINTS a pointer (CONTRACT-1.2); submission — the ONLY
+place network ever happens, and only after an explicit `y` — lives HERE.
+
+What this module does (and explicitly does NOT do):
+
+  * It RESOLVES a capture bundle dir (`--submit-last` reads the V1-written
+    `.pull-captures/.last` marker; `--submit <dir>` is the explicit form).
+  * It re-reads `.last` and re-shows the resolved bundle's IDENTITY AND the
+    exact already-redacted payload that will be sent, THEN requires an
+    explicit `y` before ANY network (the race defense: a second pull may
+    have overwritten `.last` between capture and submit — we always surface
+    the CURRENT bundle, never a silent wrong-bundle submit).
+  * After `y`, it reuses the SHIPPED F5 path (`dedup.submit` — the
+    `effective_dedup_hash` -> `gh issue` +1-or-open with the bounded
+    `loop:dedup-<hash>` label scheme + body tuple + collision-safe verify).
+    It does NOT reimplement dedup. A bundle that classifies into
+    `_SUPPRESSED_NEVER_FILED` is review-queued (local spool) by the shipped
+    loop's existing behaviour — reused, not re-added here.
+  * `gh`-less fallback runs AFTER F2 classification, gated on
+    `should_file`: `should_file=True` -> a prefilled PUBLIC `issues/new`
+    URL; review-queued (`unknown`) -> the LOCAL `_dedup-queue` spool path +
+    "captured for maintainer triage; not a public issue", and NO public
+    URL / no `issues/new` link (the §6.1 review-queue boundary).
+
+It NEVER reimplements F1/F2/F5 — it imports them as a library and reuses
+the shipped `loop_input.read_capture_bundle` / `read_gate_bundle`,
+`classifier.classify`, `dedup.submit` / `dedup.build_issue_body` verbatim.
+It NEVER raises for an expected outcome (house style: structured result).
+
+Console-is-not-a-safe-source: the on-ramp ONLY ever emits the redacted
+`.pull-captures/` artifact's payload — never the user's terminal
+scrollback. The surfaced message never says "paste your terminal output".
+The redacted artifacts are produced by `[E]`/the gate emitter via
+`capture._redact_text`; this module does NOT re-redact (do not double
+scrub) and asserts (via the V2 test) that nothing it tells the user to
+share carries an unredacted absolute path.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.parse
+from pathlib import Path
+from typing import Optional
+
+from scripts.lib.profiles import dedup as _DEDUP
+from scripts.lib.profiles.classifier import FailureClass, classify
+from scripts.lib.profiles.loop_input import (
+    CaptureBundleError,
+    GATE_SCHEMA,
+    read_capture_bundle,
+    read_gate_bundle,
+)
+
+# The PUBLIC repo (CONTRACT-1.3 gh-less fallback). Hard-coded public
+# constant — never derived from a local path (the leak-hygiene stack rule).
+_PUBLIC_REPO = "noonghunna/club-3090"
+_ISSUES_NEW = f"https://github.com/{_PUBLIC_REPO}/issues/new"
+
+# The on-ramp keeps a URL well under GitHub's prefilled-issue limit; the
+# body is hard-truncated so the encoded URL stays < 8 KB (CONTRACT-1.3).
+_MAX_URL_BYTES = 8 * 1024
+
+_MARKER_FILENAME = ".last"
+_PULL_CAPTURES_DIRNAME = ".pull-captures"
+
+
+# ---------------------------------------------------------------------------
+# `.last` marker resolution (read-only at submit — V1 writes it atomically
+# from BOTH emitters via the shared `capture.write_last_marker` helper; we
+# RE-READ it here, never re-implement the write).
+# ---------------------------------------------------------------------------
+def _pull_captures_root(repo_root: Path) -> Path:
+    return Path(repo_root) / _PULL_CAPTURES_DIRNAME
+
+
+def resolve_last(repo_root: Path) -> Optional[Path]:
+    """Resolve the most-recent capture dir from `.pull-captures/.last`.
+
+    Read-only. Returns the absolute bundle dir, or None when the marker is
+    absent / empty / points at a now-missing dir (stale). The CALLER turns
+    None into the CONTRACT-1.3 error ("no recent capture; use
+    `--submit <dir>`"). NEVER raises.
+    """
+    try:
+        root = _pull_captures_root(repo_root)
+        marker = root / _MARKER_FILENAME
+        if not marker.is_file():
+            return None
+        rel = marker.read_text(encoding="utf-8").strip()
+        if not rel:
+            return None
+        cand = (root / rel).resolve()
+        if not cand.is_dir():
+            return None
+        return cand
+    except Exception:  # pragma: no cover - marker read is best-effort.
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Bundle read — schema-aware (schema==1 [E] bundle OR schema==2 gate-only).
+# Reuses the SHIPPED F1 readers verbatim; does NOT re-validate.
+# ---------------------------------------------------------------------------
+def _read_bundle(capture_dir: Path):
+    """Return the F1 bundle object for `capture_dir`, dispatching on the
+    manifest's `schema` (1 -> `read_capture_bundle`/`FInput`; 2 -> the
+    gate-only `read_gate_bundle`/`FInputGate`). Raises `CaptureBundleError`
+    on a bad/missing manifest (the caller turns it into a clean error).
+    """
+    cdir = Path(capture_dir)
+    manifest_path = cdir / "manifest.json"
+    if not cdir.is_dir() or not manifest_path.is_file():
+        raise CaptureBundleError(
+            f"not a capture bundle (no manifest.json): {cdir}"
+        )
+    try:
+        schema = json.loads(manifest_path.read_text(encoding="utf-8")).get(
+            "schema"
+        )
+    except (ValueError, OSError) as exc:
+        raise CaptureBundleError(f"unreadable manifest.json: {exc}") from exc
+    if schema == GATE_SCHEMA:
+        return read_gate_bundle(cdir)
+    return read_capture_bundle(cdir)
+
+
+# ---------------------------------------------------------------------------
+# CONTRACT-1.3 — re-show the resolved bundle IDENTITY + the exact redacted
+# payload that will be sent, then require an explicit `y` before ANY
+# network. `_input` is injectable so the V2 test drives consent with ZERO
+# tty (and ZERO network).
+# ---------------------------------------------------------------------------
+def _bundle_identity(capture_dir: Path, finput) -> str:
+    """A short, human IDENTITY line for the resolved bundle (so a racing
+    second pull can't cause a silent wrong-bundle submit — the user sees
+    WHICH bundle before consenting)."""
+    m = getattr(finput, "manifest", {}) or {}
+    return (
+        f"slug={m.get('slug')!r} "
+        f"utc_ts={m.get('utc_ts')!r} "
+        f"outcome={m.get('outcome')!r} "
+        f"schema={m.get('schema')} "
+        f"dir={capture_dir.name}"
+    )
+
+
+def _redacted_payload_preview(finput, classification) -> str:
+    """The EXACT already-redacted payload that will be sent — the shipped
+    F5 `build_issue_body` rendering of the redacted manifest/tuple. We do
+    NOT re-redact (the artifact is `[E]`/gate-emitter-redacted upstream);
+    we only DISPLAY it so the user consents to exactly what is sent.
+    """
+    return _DEDUP.build_issue_body(finput, classification)
+
+
+def _confirm(prompt: str, _input) -> bool:
+    """Explicit `y` gate. Anything other than a leading 'y'/'Y' is a
+    decline. EOF / no-tty -> decline (never assume consent)."""
+    try:
+        ans = _input(prompt)
+    except (EOFError, KeyboardInterrupt):
+        return False
+    return str(ans).strip().lower().startswith("y")
+
+
+# ---------------------------------------------------------------------------
+# gh-less fallback (post-classification, `should_file`-gated). CONTRACT-1.3:
+# PUBLIC URL ONLY for should_file=True; review-queued -> local spool path +
+# the no-public-issue line, NEVER an `issues/new` link.
+# ---------------------------------------------------------------------------
+def _ghless_title(finput, classification) -> str:
+    """The DETERMINISTIC gh-less title template (CONTRACT-1.3):
+    `[<model>] <failure-class> on <topology> (dedup:<hash8>)`.
+
+    Intentionally DIFFERENT from the shipped `dedup.build_issue_title`
+    (`[loop][<cls>] <slug> (dedup <h>)`): the `gh`-path carries the dedup
+    key as a `loop:dedup-<hash>` LABEL (the real dedup primitive) while the
+    gh-less path has no label API so encodes the hash in the title. Dedup
+    keys on the label/hash, NOT the title string — divergent titles do not
+    split the bucket. Do NOT "unify" these (would byte-change the shipped
+    `build_issue_title` for zero benefit).
+    """
+    h = _DEDUP.effective_dedup_hash(finput, classification)
+    m = getattr(finput, "manifest", {}) or {}
+    model = m.get("model") or m.get("model_id") or "<unknown-model>"
+    cls = classification.failure_class
+    cls_v = cls.value if isinstance(cls, FailureClass) else str(cls)
+    topo = m.get("topology_class") or "unknown"
+    return f"[{model}] {cls_v} on {topo} (dedup:{h[:8]})"
+
+
+def _ghless_body(finput, classification, bundle_dir: Path) -> str:
+    """URL-encoded-ready MARKDOWN body from the redacted manifest tuple
+    (model/engine/arch/failure-class/topology + the dedup hash), hard-
+    truncated so the final encoded URL stays < 8 KB, with a trailing
+    "full redacted bundle at `<path>` — attach it". Markdown, not JSON.
+
+    The body is built from ALREADY-redacted F1 fields; we do NOT re-redact.
+    """
+    h = _DEDUP.effective_dedup_hash(finput, classification)
+    m = getattr(finput, "manifest", {}) or {}
+    cls = classification.failure_class
+    cls_v = cls.value if isinstance(cls, FailureClass) else str(cls)
+    lines = [
+        "## club-3090 failed-pull report (gh-less paste fallback)",
+        "",
+        "Auto-prefilled by `scripts/pull.sh --submit*` (the on-ramp could "
+        "not reach `gh`; this is the manual paste path).",
+        "",
+        f"- **model:** `{m.get('model') or m.get('model_id')}`",
+        f"- **failure-class:** `{cls_v}`",
+        f"- **arch_family:** `{m.get('arch_family')}`",
+        f"- **engine_version:** `{m.get('engine_version') or m.get('engine_pin')}`",
+        f"- **topology_class:** `{m.get('topology_class')}`",
+        f"- **abort_reason:** `{m.get('abort_reason')}`",
+        f"- **dedup hash:** `{h}` (label `loop:dedup-{h}`)",
+        "",
+        "The redacted error substring (already `[E]`-scrubbed; not "
+        "re-redacted):",
+        "",
+        "```",
+        (classification.error_substring or "")[:1200],
+        "```",
+        "",
+        f"full redacted bundle at `{bundle_dir}` — attach it to the issue",
+    ]
+    body = "\n".join(lines)
+    # Hard-truncate so the FINAL encoded URL stays < _MAX_URL_BYTES. We
+    # budget against the encoded length (worst case ~3x for urlencode);
+    # trim the body until the assembled URL fits, always preserving the
+    # trailing "attach it" pointer.
+    tail = (
+        f"\n\nfull redacted bundle at `{bundle_dir}` — attach it to the issue"
+    )
+    while True:
+        url = _build_issue_url(_ghless_title(finput, classification), body, h)
+        if len(url.encode("utf-8")) < _MAX_URL_BYTES or len(body) <= len(tail):
+            return body
+        # Drop the middle, keep the header + the tail pointer.
+        keep = max(len(tail), len(body) - 512)
+        body = body[: keep - len(tail)].rstrip() + tail
+
+
+def _build_issue_url(title: str, body: str, dedup_hash: str) -> str:
+    """`https://github.com/<repo>/issues/new?title=&body=&labels=` —
+    URL-encoded. The `labels` carries `loop:dedup-<hash>` so a gh-less
+    paste lands on the SAME dedup bucket as a `gh`-path submit.
+    """
+    q = urllib.parse.urlencode(
+        {
+            "title": title,
+            "body": body,
+            "labels": f"{_DEDUP._DEDUP_LABEL_PREFIX}{dedup_hash}",
+        }
+    )
+    return f"{_ISSUES_NEW}?{q}"
+
+
+def ghless_fallback(
+    finput,
+    classification,
+    *,
+    repo_root: Path,
+    bundle_dir: Path,
+) -> dict:
+    """The CONTRACT-1.3 gh-less fallback. Runs AFTER F2 classification;
+    branches on `should_file`. NEVER raises; if URL-build fails, degrade to
+    the existing local spool + printed paste-path.
+
+    Returns a structured dict (`{kind, lines:[...], url|spool_path}`) so the
+    caller (and the V2 test) can assert exactly what is emitted — in
+    particular that a review-queued class emits NO public URL.
+    """
+    try:
+        h = _DEDUP.effective_dedup_hash(finput, classification)
+        if classification.should_file:
+            # should_file=True (engine-support-unknown/no-arch-row ->
+            # kernel-unsupported): print the redacted bundle path + a
+            # prefilled PUBLIC issues/new URL.
+            title = _ghless_title(finput, classification)
+            body = _ghless_body(finput, classification, bundle_dir)
+            url = _build_issue_url(title, body, h)
+            return {
+                "kind": "ghless-public-url",
+                "should_file": True,
+                "dedup_hash": h,
+                "url": url,
+                "lines": [
+                    f"[submit] gh unavailable — paste this prefilled "
+                    f"PUBLIC issue (it lands on the loop:dedup-{h} bucket):",
+                    f"[submit] redacted bundle: {bundle_dir}",
+                    f"[submit] {url}",
+                ],
+            }
+        # review-queued (`unknown` ∈ _SUPPRESSED_NEVER_FILED): print the
+        # redacted bundle path + the LOCAL review-queue spool path the
+        # shipped F5 would write. NO public-issue URL / no issues/new link
+        # (the §6.1 review-queue boundary — correct-refusals stay out of
+        # the public tracker).
+        spool = (
+            _pull_captures_root(repo_root)
+            / _DEDUP._REVIEW_QUEUE_DIRNAME
+            / f"{h}.json"
+        )
+        return {
+            "kind": "ghless-review-queued",
+            "should_file": False,
+            "dedup_hash": h,
+            "spool_path": str(spool),
+            "lines": [
+                f"[submit] redacted bundle: {bundle_dir}",
+                f"[submit] captured for maintainer triage; not a public "
+                f"issue (correct-refusal / unactionable class)",
+                f"[submit] local review-queue spool: {spool}",
+            ],
+        }
+    except Exception as exc:  # pragma: no cover - degrade, never raise.
+        # URL-build (or anything) failed -> degrade to the local spool +
+        # printed paste-path; never raise out of the on-ramp.
+        try:
+            h = _DEDUP.effective_dedup_hash(finput, classification)
+        except Exception:
+            h = "unknown"
+        spool = (
+            _pull_captures_root(repo_root)
+            / _DEDUP._DEDUP_QUEUE_DIRNAME
+            / f"{h}.json"
+        )
+        return {
+            "kind": "ghless-degraded",
+            "should_file": bool(
+                getattr(classification, "should_file", False)
+            ),
+            "dedup_hash": h,
+            "spool_path": str(spool),
+            "lines": [
+                f"[submit] gh-less URL build failed ({exc!r}) — degraded",
+                f"[submit] redacted bundle: {bundle_dir}",
+                f"[submit] local spool: {spool}",
+            ],
+        }
+
+
+# ---------------------------------------------------------------------------
+# `gh` availability probe — reuses the shipped `dedup._real_gh_runner`
+# (NEVER raises; a missing/unauthed `gh` reports non-ok).
+# ---------------------------------------------------------------------------
+def _gh_available(gh_runner) -> bool:
+    """True iff `gh auth status` reports authenticated. Reuses the shipped
+    injectable runner seam — the V2 test injects a mock so this is ZERO
+    network. NEVER raises (a missing binary -> non-ok -> False)."""
+    try:
+        res = gh_runner(["auth", "status"])
+        return bool(getattr(res, "ok", False))
+    except Exception:  # pragma: no cover - runner never raises by contract.
+        return False
+
+
+# ---------------------------------------------------------------------------
+# The top-level submit verb.
+# ---------------------------------------------------------------------------
+def submit_pull(
+    *,
+    capture_dir: Optional[str],
+    submit_last: bool,
+    repo_root: Path,
+    repo: Optional[str] = None,
+    gh_runner=None,
+    _input=input,
+    _print=print,
+) -> int:
+    """`scripts/pull.sh --submit-last` / `--submit <dir>`.
+
+    Returns a process exit code: 0 on a clean submit / consented decline /
+    review-queue spool; 2 on an unresolvable bundle ("no recent capture").
+    NEVER raises (CONTRACT-1: the on-ramp must never blow up a user's tty).
+
+    Flow:
+      1. Resolve the bundle dir. `--submit-last` RE-READS `.pull-captures/
+         .last` HERE (the race defense — a second pull may have overwritten
+         it since capture; we surface the CURRENT bundle, never a silent
+         wrong-bundle submit). Unresolvable -> the CONTRACT-1.3 error.
+      2. Read (schema-aware) + classify (F2).
+      3. Re-SHOW the resolved bundle IDENTITY AND the exact already-redacted
+         payload, then require explicit `y` before ANY network.
+      4. After `y`: `gh` present -> reuse the shipped F5 `dedup.submit`
+         (effective_dedup_hash -> +1-or-open, bounded labels, body tuple,
+         collision-safe verify, suppression/review-queue all reused).
+         `gh` absent/unauthed -> the post-classification, should_file-gated
+         gh-less fallback (public URL only for should_file=True).
+    """
+    gh_runner = gh_runner or _DEDUP._real_gh_runner
+    root = Path(repo_root)
+
+    # ---- 1. resolve the bundle dir (re-read `.last` HERE) --------------
+    if submit_last:
+        resolved = resolve_last(root)
+        if resolved is None:
+            _print(
+                "[submit] no recent capture; use "
+                "`scripts/pull.sh --submit <dir>`",
+                file=sys.stderr,
+            )
+            return 2
+        bundle_dir = resolved
+    else:
+        if not capture_dir:
+            _print(
+                "[submit] --submit needs a capture dir; or use "
+                "`--submit-last`",
+                file=sys.stderr,
+            )
+            return 2
+        bundle_dir = Path(capture_dir).resolve()
+        if not bundle_dir.is_dir():
+            _print(
+                f"[submit] capture dir does not exist: {bundle_dir}",
+                file=sys.stderr,
+            )
+            return 2
+
+    # ---- 2. read (schema-aware) + classify (F2) -----------------------
+    try:
+        finput = _read_bundle(bundle_dir)
+    except CaptureBundleError as exc:
+        _print(f"[submit] not a usable capture bundle: {exc}",
+               file=sys.stderr)
+        return 2
+    classification = classify(finput)
+
+    # ---- 3. re-show identity + the EXACT redacted payload, then `y` ---
+    _print(f"[submit] resolved bundle: {bundle_dir}")
+    _print(f"[submit] identity: {_bundle_identity(bundle_dir, finput)}")
+    _print(
+        "[submit] this is the EXACT already-redacted payload that will be "
+        "sent (no terminal scrollback, no paths/tokens):"
+    )
+    _print("-" * 72)
+    _print(_redacted_payload_preview(finput, classification))
+    _print("-" * 72)
+    cls = classification.failure_class
+    cls_v = cls.value if isinstance(cls, FailureClass) else str(cls)
+    _print(
+        f"[submit] §6.1 class={cls_v} should_file={classification.should_file}"
+    )
+    if not _confirm("[submit] submit this redacted report? [y/N] ", _input):
+        _print("[submit] declined — nothing sent (no network performed).")
+        return 0
+
+    # ---- 4. consented: gh path (reuse F5) OR gh-less fallback ----------
+    if _gh_available(gh_runner):
+        result = _DEDUP.submit(
+            finput,
+            classification,
+            repo_root=root,
+            repo=repo or _PUBLIC_REPO,
+            gh_runner=gh_runner,
+        )
+        _print(
+            f"[submit] F5 action={result.action.value} "
+            f"dedup_hash={result.dedup_hash} "
+            f"issue={result.issue_number} reason={result.reason}"
+        )
+        if result.spool_path:
+            _print(f"[submit] spool: {result.spool_path}")
+        return 0
+
+    # gh absent/unauthed -> the post-F2, should_file-gated fallback.
+    fb = ghless_fallback(
+        finput,
+        classification,
+        repo_root=root,
+        bundle_dir=bundle_dir,
+    )
+    for ln in fb["lines"]:
+        _print(ln)
+    return 0

--- a/scripts/pull.sh
+++ b/scripts/pull.sh
@@ -24,6 +24,12 @@
 #   # Path B — universal evaluate (never emits/downloads):
 #   scripts/pull.sh some-org/Some-Llama-7B --profile-like vllm/minimal --dry-run
 #
+#   # Failure on-ramp — submit a captured failed pull (a SEPARATE, consented
+#   # verb: the ONLY step that touches the network, and only after an
+#   # explicit y; reuses the shipped dedup; needs no slug/--profile-like):
+#   scripts/pull.sh --submit-last            # the most-recent capture
+#   scripts/pull.sh --submit <capture-dir>   # an explicit bundle dir
+#
 # Opts: --yes  --force-download  --experimental-arch  --trust-remote-code
 #       --hf-home DIR  --out FILE (Path A)  --hardware SM (override nvidia-smi)
 #

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -13,7 +13,9 @@
 #   bash scripts/switch.sh --list              # show all variants
 #   bash scripts/switch.sh --down              # just bring down whatever's up
 #
-# Variant names (engine/file, file is the docker-compose.<file>.yml stem):
+# Variant names are derived from the compose registry (the single source of
+# truth); `bash scripts/switch.sh --list` is authoritative. A representative
+# subset (engine/file, file is the docker-compose.<file>.yml stem):
 #
 #   Single-card vLLM:
 #     vllm/default            48K + TQ3 + MTP + vision + tools (recommended)
@@ -64,58 +66,71 @@ if [[ -f "${ROOT_DIR}/.env" ]]; then
   set +a
 fi
 
-# Per-variant default port (matches each compose's "${PORT:-XXXX}:8000"
-# fallback). Used when neither $PORT nor $READY_URL is set explicitly.
-declare -A VARIANT_DEFAULT_PORT=(
-  [vllm/default]=8020
-  [vllm/long-vision]=8020
-  [vllm/long-text]=8020
-  [vllm/long-text-no-mtp]=8021
-  [vllm/bounded-thinking]=8020
-  [vllm/tools-text]=8020
-  [vllm/minimal]=8020
-  [vllm/dual]=8010
-  [vllm/dual4]=8015
-  [vllm/dual4-dflash]=8016
-  [vllm/dual-turbo]=8011
-  [vllm/dual-dflash]=8012
-  [vllm/dual-dflash-noviz]=8013
-  [vllm/dual-nvlink]=8014
-  [vllm/dual-nvlink-turbo]=8017
-  [vllm/dual-nvlink-dflash]=8018
-  [vllm/dual-nvlink-dflash-noviz]=8019
-  [vllm/gemma-mtp]=8030
-  [vllm/gemma-mtp-tp1]=8031
-  [vllm/gemma-dflash]=8032
-  [llamacpp/default]=8020
-  [llamacpp/concurrent]=8020
-)
+# Variant tables are DERIVED from the single source of truth
+# (scripts/lib/profiles/compose_registry.py COMPOSE_REGISTRY) so that every
+# registered compose is launchable and there are no launcher-only ghosts
+# (CONTRACT-2b-ii / registry↔launcher parity). The previous hardcoded
+# `declare -A` maps drifted out of the registry (e.g. vllm/dual-int8 shipped
+# in the registry + as dual/int8.yml but was unlaunchable here); deriving
+# eliminates that drift class structurally. `scripts/tests/test-switch-registry-parity.sh`
+# fails CI on ANY mismatch in either direction.
+#
+#   VARIANT_DEFAULT_PORT[<key>]  = registry default_port (matches each
+#                                  compose's "${PORT:-XXXX}:8000" fallback).
+#   VARIANTS[<key>]              = "engine|compose_dir|file" derived from the
+#                                  registry compose_path
+#                                  (<dir>/compose/<file>) + the key's engine
+#                                  prefix (vllm|llamacpp).
+declare -A VARIANT_DEFAULT_PORT=()
+declare -A VARIANTS=()
 
-# variant -> "engine|compose_dir|file"  (file relative to compose_dir)
-declare -A VARIANTS=(
-  [vllm/default]="vllm|models/qwen3.6-27b/vllm/compose|single/docker-compose.yml"
-  [vllm/long-vision]="vllm|models/qwen3.6-27b/vllm/compose|single/long-vision.yml"
-  [vllm/long-text]="vllm|models/qwen3.6-27b/vllm/compose|single/long-text.yml"
-  [vllm/long-text-no-mtp]="vllm|models/qwen3.6-27b/vllm/compose|single/long-text-no-mtp.yml"
-  [vllm/bounded-thinking]="vllm|models/qwen3.6-27b/vllm/compose|single/bounded-thinking.yml"
-  [vllm/tools-text]="vllm|models/qwen3.6-27b/vllm/compose|single/tools-text.yml"
-  [vllm/minimal]="vllm|models/qwen3.6-27b/vllm/compose|single/minimal.yml"
-  [vllm/dual]="vllm|models/qwen3.6-27b/vllm/compose|dual/docker-compose.yml"
-  [vllm/dual4]="vllm|models/qwen3.6-27b/vllm/compose|multi4/docker-compose.yml"
-  [vllm/dual4-dflash]="vllm|models/qwen3.6-27b/vllm/compose|multi4/dflash.yml"
-  [vllm/dual-turbo]="vllm|models/qwen3.6-27b/vllm/compose|dual/turbo.yml"
-  [vllm/dual-dflash]="vllm|models/qwen3.6-27b/vllm/compose|dual/dflash.yml"
-  [vllm/dual-dflash-noviz]="vllm|models/qwen3.6-27b/vllm/compose|dual/dflash-noviz.yml"
-  [vllm/dual-nvlink]="vllm|models/qwen3.6-27b/vllm/compose|dual/nvlink.yml"
-  [vllm/dual-nvlink-turbo]="vllm|models/qwen3.6-27b/vllm/compose|dual/nvlink-turbo.yml"
-  [vllm/dual-nvlink-dflash]="vllm|models/qwen3.6-27b/vllm/compose|dual/nvlink-dflash.yml"
-  [vllm/dual-nvlink-dflash-noviz]="vllm|models/qwen3.6-27b/vllm/compose|dual/nvlink-dflash-noviz.yml"
-  [vllm/gemma-mtp]="vllm|models/gemma-4-31b/vllm/compose|dual/docker-compose.yml"
-  [vllm/gemma-mtp-tp1]="vllm|models/gemma-4-31b/vllm/compose|single/docker-compose.yml"
-  [vllm/gemma-dflash]="vllm|models/gemma-4-31b/vllm/compose|dual/dflash.yml"
-  [llamacpp/default]="llamacpp|models/qwen3.6-27b/llama-cpp/compose|single/docker-compose.yml"
-  [llamacpp/concurrent]="llamacpp|models/qwen3.6-27b/llama-cpp/compose|single/concurrent.yml"
-)
+_derive_variant_tables() {
+  local emit
+  if ! emit="$(python3 - "$ROOT_DIR" <<'PY' 2>/dev/null
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+sys.path.insert(0, str(root))
+from scripts.lib.profiles.compose_registry import COMPOSE_REGISTRY
+
+for key, entry in COMPOSE_REGISTRY.items():
+    engine_prefix = key.split("/", 1)[0]
+    # switch.sh engine token: vllm | llamacpp (matches the on-disk tree).
+    engine = "llamacpp" if engine_prefix == "llamacpp" else engine_prefix
+    cp = entry["compose_path"]
+    if "/compose/" not in cp:
+        # A registry entry whose compose_path can't be split is a registry
+        # bug; surface it loudly rather than silently dropping the variant.
+        print(f"__ERR__\t{key}\tcompose_path lacks /compose/: {cp}")
+        continue
+    dirpart, filepart = cp.split("/compose/", 1)
+    compose_dir = f"{dirpart}/compose"
+    port = entry["default_port"]
+    print(f"{key}\t{engine}\t{compose_dir}\t{filepart}\t{port}")
+PY
+  )"; then
+    echo "[switch] ERROR: could not derive variant tables from compose_registry.py" >&2
+    echo "[switch]        (python3 + scripts/lib/profiles/compose_registry.py must be importable)" >&2
+    exit 2
+  fi
+  local key engine cdir cfile port
+  while IFS=$'\t' read -r key engine cdir cfile port; do
+    [[ -n "$key" ]] || continue
+    if [[ "$key" == "__ERR__" ]]; then
+      echo "[switch] ERROR: registry entry not launchable: ${engine} (${cdir})" >&2
+      exit 2
+    fi
+    VARIANTS["$key"]="${engine}|${cdir}|${cfile}"
+    VARIANT_DEFAULT_PORT["$key"]="$port"
+  done <<< "$emit"
+  if [[ ${#VARIANTS[@]} -eq 0 ]]; then
+    echo "[switch] ERROR: derived an empty variant table from compose_registry.py" >&2
+    exit 2
+  fi
+}
+
+_derive_variant_tables
 
 # Container name patterns we'll bring down — covers all current composes
 # AND any vllm/llama-cpp container we don't formally know about (catches

--- a/scripts/tests/test-classifier.sh
+++ b/scripts/tests/test-classifier.sh
@@ -546,6 +546,104 @@ for nm in ("a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9"):
           f"Tier-1 inputs; rest Tier-2)")
 
 # ---------------------------------------------------------------------------
+# v0.8.2 CONTRACT-1.1 M1 — the additive `gate_abort_reason` matcher kind +
+# the conservative seed. A gate-only (schema==2) FInputGate has empty
+# error text + no pt3/pt4, so it falls through every shipped [E]-bundle
+# rule to the new gate rules. Only `engine-support-unknown/no-arch-row` ->
+# `kernel-unsupported` (should_file=True, public-filed — the §10-R9 lever);
+# `runtime-incompatible`/`disk-short`/`hard-block` -> `unknown`
+# (should_file=False + review_queue=True — review-queued, NOT public-filed).
+# ---------------------------------------------------------------------------
+from scripts.lib.profiles.loop_input import read_gate_bundle  # noqa: E402
+
+
+def _gate_fi(nm, abort_reason):
+    d = tmp / nm
+    d.mkdir(parents=True, exist_ok=True)
+    gm = {
+        "schema": 2, "slug": "Org/Gate", "utc_ts": "20260518T000000Z",
+        "club3090_commit": "cafef00d", "outcome": "hard-block",
+        "abort_reason": abort_reason, "failure_class": None,
+        "model": "Org/Gate", "model_id": "Org/Gate",
+        "arch_family": None, "quant_label": None,
+        "topology_class": None, "topology_summary_canonical": None,
+        "selected_ctx": None, "kv_format": None,
+        "smoke_capability_set": None, "engine_pin": None,
+        "engine_version": None, "kv_calc_version": None,
+        "submission_fingerprint": None, "is_gate_only": True,
+        "capture_points": ["gate"],
+    }
+    gp = {
+        "schema": 2, "point": "gate", "slug": "Org/Gate",
+        "confidence": "ESTIMATED_LOWER_BOUND", "raw_verdict": None,
+        "profile_like": "vllm/minimal", "hardware_sm": 8.6,
+        "predicted_b_breakdown": None, "abort_reason": abort_reason,
+        "detail": "x", "is_gate_only": True,
+    }
+    (d / "manifest.json").write_text(json.dumps(gm), encoding="utf-8")
+    (d / "pt1-gate.json").write_text(json.dumps(gp), encoding="utf-8")
+    return read_gate_bundle(d)
+
+
+# /no-arch-row -> kernel-unsupported, PUBLIC-FILED (should_file=True).
+rg = classify(_gate_fi("g-narr", "engine-support-unknown/no-arch-row"))
+check(rg.failure_class is FailureClass.KERNEL_UNSUPPORTED,
+      f"M1: engine-support-unknown/no-arch-row -> kernel-unsupported "
+      f"(the §10-R9 lever) (got {rg.failure_class.value})")
+check(rg.should_file is True and rg.review_queue is False,
+      "M1: /no-arch-row is PUBLIC-FILED (should_file=True, NOT "
+      "review-queued) — it must aggregate/dedup/volume-rank")
+check(rg.matched_rule == "gate-engine-support-no-arch-row",
+      f"M1: matched the additive gate_abort_reason rule (got "
+      f"{rg.matched_rule!r})")
+check(rg.route_as_kv_calc_bug is False,
+      "M1: a gate-only bundle is NEVER a kv-calc bug (Tier-1 is F3; no "
+      "OOM signature on a gate bundle)")
+
+# runtime-incompatible / disk-short / hard-block -> unknown, REVIEW-QUEUED
+# (NOT public-filed) — deliberately suppressed (correct-refusal class).
+for _ar in ("engine-support-unknown/runtime-incompatible",
+            "disk-short", "hard-block"):
+    rq = classify(_gate_fi(f"g-{_ar.replace('/', '-')}", _ar))
+    check(rq.failure_class is FailureClass.UNKNOWN,
+          f"M1: {_ar} -> unknown (conservative catch-all) "
+          f"(got {rq.failure_class.value})")
+    check(rq.should_file is False and rq.review_queue is True,
+          f"M1: {_ar} is REVIEW-QUEUED, NOT public-filed "
+          f"(unknown ∈ _SUPPRESSED_NEVER_FILED; should_file=False, "
+          f"review_queue=True — never silently dropped)")
+
+# The raw abort_reason SURVIVES redaction into pt1-gate (H2 maintainer-
+# distinguishability: a /no-arch-row vs a kernel bug must be tellable).
+_h2 = _gate_fi("g-h2", "engine-support-unknown/no-arch-row")
+check(_h2.pt1_gate.get("abort_reason")
+      == "engine-support-unknown/no-arch-row"
+      and _h2.abort_reason == "engine-support-unknown/no-arch-row",
+      "M1/H2: the raw abort_reason survives into pt1_gate (a maintainer "
+      "can distinguish 'add a registry row' from 'file a kernel bug')")
+
+# §6.1-NEUTRALITY: the additive kind does NOT perturb the shipped
+# schema==1 path. The SAME [E] bundle classifies byte-identically + a
+# schema==1 FInput has NO pt1_gate.abort_reason so the gate rules are
+# inert for it (they only fire on a gate-only bundle).
+_s1 = fi("neutral-s1", pt3=boot_fail(
+    failure="torch.cuda.OutOfMemoryError: CUDA out of memory"))
+_r1a = classify(_s1)
+_r1b = classify(fi("neutral-s1b", pt3=boot_fail(
+    failure="torch.cuda.OutOfMemoryError: CUDA out of memory")))
+check(_r1a.failure_class is FailureClass.GENUINE_OOM
+      and _r1a.failure_class == _r1b.failure_class
+      and _r1a.matched_rule == _r1b.matched_rule
+      and _r1a.tier == _r1b.tier,
+      "V1: schema==1 classification is byte-identical post-protocol-lift "
+      "+ the additive gate_abort_reason kind is inert for [E] bundles "
+      "(no pt1_gate.abort_reason -> the gate rules never fire)")
+from scripts.lib.profiles.loop_input import BaseCaptureBundle  # noqa: E402
+check(isinstance(_s1, BaseCaptureBundle),
+      "V1: the schema==1 FInput classify() consumed satisfies "
+      "BaseCaptureBundle (the retype is a pure static change)")
+
+# ---------------------------------------------------------------------------
 # REAL on-disk .pull-captures/ bundle (a success/`partial`): classify
 # returns a valid enum and does NOT misclassify as a fileable failure.
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test-dedup.sh
+++ b/scripts/tests/test-dedup.sh
@@ -495,6 +495,119 @@ check("kv-calc-bug" not in joined and "calibration bug" not in joined,
       "F5's filed issue is NOT a kv-calc-bug filing (boundary held)")
 
 # ===========================================================================
+# 4b. v0.8.2 CONTRACT-1.1 — F5 protocol lift (V1 RED-LINE).
+#
+#  * a real schema==1 bundle -> identical effective_dedup_hash /
+#    effective_dedup_tuple PRE/POST the protocol retype (byte-identity);
+#  * the FENCED `dedup.py` `FInput.dedup_hash(_EffProxy())` unbound-class
+#    idiom STILL produces F1's byte-exact serialization (NOT "tidied");
+#  * a schema==2 gate-only FInputGate flows through F5 via the protocol
+#    (effective hash deterministic + STABLE with null topology —
+#    CONTRACT-1.1; review-queued, NOT public-filed for `unknown`).
+# ===========================================================================
+from scripts.lib.profiles.loop_input import (  # noqa: E402
+    BaseCaptureBundle,
+    read_gate_bundle,
+)
+
+# (a) schema==1 byte-identity: the effective tuple/hash are a pure function
+#     of F1's normalized tuple + the classifier class — pinned so a
+#     protocol-lift regression fails LOUDLY.
+_fi_id = read_capture_bundle(write_bundle(tmp / "id-s1"))
+_cl_id = oom_classification(_fi_id)
+_et1 = D.effective_dedup_tuple(_fi_id, _cl_id)
+_eh1 = D.effective_dedup_hash(_fi_id, _cl_id)
+_et2 = D.effective_dedup_tuple(read_capture_bundle(tmp / "id-s1"), _cl_id)
+_eh2 = D.effective_dedup_hash(read_capture_bundle(tmp / "id-s1"), _cl_id)
+import hashlib as _hl2  # noqa: E402
+_exp_et = list(_fi_id.dedup_tuple())
+_exp_et[5] = "genuine-oom"
+_exp_eh = _hl2.sha256("\x1f".join(str(p) for p in _exp_et)
+                      .encode("utf-8")).hexdigest()[:12]
+check(_et1 == _et2 == tuple(_exp_et) and _eh1 == _eh2 == _exp_eh,
+      f"V1 RED-LINE: schema==1 effective_dedup_tuple/hash byte-identical "
+      f"+ pinned ({_exp_eh}) — the protocol lift is a pure static retype")
+check(isinstance(_fi_id, BaseCaptureBundle),
+      "V1: the schema==1 FInput F5 consumes satisfies BaseCaptureBundle")
+
+# (b) the FENCED unbound-class idiom: effective_dedup_hash MUST equal F1's
+#     OWN dedup_hash() of the substituted tuple (proves dedup.py:~277
+#     still reuses FInput.dedup_hash unbound, NOT finput.dedup_hash() which
+#     would hash the unsubstituted fc=None tuple).
+class _Probe:
+    def dedup_tuple(self):
+        return _et1
+
+
+from scripts.lib.profiles.loop_input import FInput as _FI  # noqa: E402
+check(D.effective_dedup_hash(_fi_id, _cl_id)
+      == _FI.dedup_hash(_Probe()),  # type: ignore[arg-type]
+      "V1 RED-LINE: effective_dedup_hash reuses F1's UNBOUND dedup_hash on "
+      "the SUBSTITUTED tuple (the dedup.py fence holds — NOT tidied to "
+      "finput.dedup_hash() which would hash the fc=None tuple)")
+# Negative control: hashing the UN-substituted tuple (fc=None) differs —
+# the exact silent-corruption the fence prevents.
+check(D.effective_dedup_hash(_fi_id, _cl_id) != _fi_id.dedup_hash(),
+      "V1 RED-LINE: the substituted hash != F1's fc=None hash (a 'tidy' "
+      "to finput.dedup_hash() WOULD silently corrupt + defeat the §6.1 "
+      "mislabel safeguard — proven divergent)")
+
+# (c) a schema==2 gate-only FInputGate flows through F5 via the protocol.
+_gd = tmp / "f5-gate"
+_gd.mkdir(parents=True, exist_ok=True)
+_gman = {
+    "schema": 2, "slug": "Org/Gate", "utc_ts": "20260518T000000Z",
+    "club3090_commit": "cafef00d", "outcome": "hard-block",
+    "abort_reason": "engine-support-unknown/no-arch-row",
+    "failure_class": None, "model": "Org/Gate", "model_id": "Org/Gate",
+    "arch_family": None, "quant_label": None, "topology_class": None,
+    "topology_summary_canonical": None, "selected_ctx": None,
+    "kv_format": None, "smoke_capability_set": None, "engine_pin": None,
+    "engine_version": None, "kv_calc_version": None,
+    "submission_fingerprint": None, "is_gate_only": True,
+    "capture_points": ["gate"],
+}
+_gp = {
+    "schema": 2, "point": "gate", "slug": "Org/Gate",
+    "confidence": "ESTIMATED_LOWER_BOUND", "raw_verdict": None,
+    "profile_like": "vllm/minimal", "hardware_sm": 8.6,
+    "predicted_b_breakdown": None,
+    "abort_reason": "engine-support-unknown/no-arch-row",
+    "detail": "x", "is_gate_only": True,
+}
+(_gd / "manifest.json").write_text(json.dumps(_gman), encoding="utf-8")
+(_gd / "pt1-gate.json").write_text(json.dumps(_gp), encoding="utf-8")
+_fg = read_gate_bundle(_gd)
+_clg = classify(_fg)  # /no-arch-row -> kernel-unsupported, should_file
+check(_clg.failure_class is FailureClass.KERNEL_UNSUPPORTED
+      and _clg.should_file is True,
+      "V1: gate-only /no-arch-row classifies kernel-unsupported "
+      "(public-filed) through the protocol")
+_egh1 = D.effective_dedup_hash(_fg, _clg)
+_egh2 = D.effective_dedup_hash(read_gate_bundle(_gd), _clg)
+check(re.fullmatch(r"[0-9a-f]{12}", _egh1) is not None
+      and _egh1 == _egh2,
+      f"V1: gate-only effective_dedup_hash is 12-hex + DETERMINISTIC with "
+      f"NULL topology (str(None)=='None' — the L3 fold; got {_egh1})")
+# unknown gate bundle -> REVIEW-QUEUED (no public issue, but a spool).
+(_gd2 := tmp / "f5-gate-rq").mkdir(parents=True, exist_ok=True)
+_g2m = dict(_gman); _g2m["abort_reason"] = "disk-short"
+_g2p = dict(_gp); _g2p["abort_reason"] = "disk-short"
+(_gd2 / "manifest.json").write_text(json.dumps(_g2m), encoding="utf-8")
+(_gd2 / "pt1-gate.json").write_text(json.dumps(_g2p), encoding="utf-8")
+_fg2 = read_gate_bundle(_gd2)
+_clg2 = classify(_fg2)
+_rq_gh = MockGh()
+_rq = D.submit(_fg2, _clg2, repo_root=repo_root, gh_runner=_rq_gh)
+check(_clg2.failure_class is FailureClass.UNKNOWN
+      and _rq.action is D.DedupAction.REVIEW_QUEUED
+      and _rq.spool_path is not None
+      and _rq_gh.calls == [],
+      f"V1: gate-only disk-short -> unknown -> REVIEW-QUEUED spool "
+      f"(NOT a public issue; ZERO gh I/O — filing-policy returns before "
+      f"any gh call) (action={_rq.action})")
+
+# ===========================================================================
 # 5. REAL on-disk capture(s) under .pull-captures/ (>=2 exist).
 #    Build FInput + classify + dedup with a mock gh returning "no existing
 #    issue" -> opens exactly one issue with a valid bounded label set + a

--- a/scripts/tests/test-hwdetect.sh
+++ b/scripts/tests/test-hwdetect.sh
@@ -1,0 +1,463 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-hwdetect.sh — v0.8.2 STEP V4 (CONTRACT-3 §8: optional whichllm
+# hardware-detect-ONLY subprocess).
+#
+# The test IS the spec. CONTRACT-3 binds BOTH RED-LINE halves; this test
+# proves an OUTCOME moved (not merely that a module exists — the V3
+# relabel lesson / outcome-not-addition convention):
+#
+#   (a) SAFETY half. `hwdetect` is OPTIONAL with NO new hard dependency:
+#       - the module imports cleanly even though `whichllm` is absent in
+#         CI (no ImportError, no side effect);
+#       - every non-delivery path degrades to None and NEVER raises:
+#         tool absent, runner failing, unparseable JSON, an NVIDIA-only
+#         payload, an unrecognised-vendor payload;
+#       - the NVIDIA majority NEVER enters the seam: with `hardware_sm`
+#         injected (nvidia-smi present), the run_pull result is
+#         byte-identical whether `hwdetect_fn` is absent OR present and
+#         degrading — proving zero NVIDIA-path behaviour change;
+#       - when nvidia-smi is absent AND hwdetect degrades, the eval path
+#         is byte-identical to the shipped `hardware-sm-undetermined`
+#         terminal (hwdetect-absent vs hwdetect-present-degrading).
+#
+#   (b) DELIVERY half (MANDATORY — an always-degrading no-op stub is a
+#       FAIL). A SIMULATED non-nvidia environment (an injected runner
+#       returning an AMD / Apple enumeration JSON — this rig is
+#       NVIDIA-only so the non-nvidia env is necessarily simulated;
+#       the simulation is explicit + deterministic) makes the eval
+#       path's hardware view OBSERVABLY DIFFER from the bare degrade
+#       path: `run_pull` no longer terminates at
+#       `hardware-sm-undetermined`; it reaches the [C0] SM gate with the
+#       enumerated SM-equivalent and `res.diagnostics["hwdetect"]
+#       ["augmented"]` is True. The exact downstream consume-point is
+#       `pull.py`'s stratum-3 `if hardware_sm is None:` SM-gate input.
+#
+#   * kv-calc is NEVER consulted (CONTRACT-3 is hw-detect-ONLY; kv-calc
+#     stays the sole fit authority). Asserted: hwdetect imports no
+#     kv-calc symbol; the augment touches only `hardware_sm` + an
+#     additive notice/diag, never a fit/VRAM call. The shell wrapper
+#     additionally re-runs `tools/kv-calc.py --calibration` so the suite
+#     proves the calibration verdict is unaffected by V4.
+#
+#   * Rig-independent leak convention (mandatory for every STEP since the
+#     V2 sandbox-masked miss): assert the absolute repo dir string is NOT
+#     present in any user-visible notice / diagnostic the augment emits —
+#     `str(abs_dir) not in shared`, NOT a `/opt|/home` substring
+#     allowlist (a sandbox path defeats that).
+#
+# PURE / hermetic: no Docker, no GPU, no network, no real `whichllm`.
+# Every external is injected (the shipped inject-or-detect seam).
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+export PYTHONPATH="$ROOT_DIR${PYTHONPATH:+:$PYTHONPATH}"
+
+python3 - "$ROOT_DIR" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+sys.path.insert(0, str(root))
+
+from scripts.lib.profiles import hwdetect as H  # noqa: E402
+from scripts.lib.profiles import pull as P  # noqa: E402
+from scripts.lib.profiles import deriver as D  # noqa: E402
+from scripts.lib.profiles.compat import load_profiles  # noqa: E402
+
+failures: list[str] = []
+
+
+def check(cond: bool, msg: str) -> None:
+    if cond:
+        print(f"PASS: {msg}")
+    else:
+        print(f"FAIL: {msg}", file=sys.stderr)
+        failures.append(msg)
+
+
+profiles = load_profiles()
+SM_86 = 8.6  # RTX 3090 (Ampere) — the NVIDIA majority anchor.
+
+CFG = f"{D._HF_RESOLVE}/{{slug}}/resolve/main/config.json"
+API = f"{D._HF_API}/{{slug}}?blobs=true"
+
+
+class FixtureFetcher:
+    def __init__(self, routes: dict):
+        self.routes = routes
+
+    def get(self, url, headers=None, range_=None):
+        if url not in self.routes:
+            return D.FetchResponse(status=404, body=b"")
+        spec = self.routes[url]
+        if isinstance(spec, D.FetchResponse):
+            return spec
+        return D.FetchResponse(
+            status=200, body=json.dumps(spec).encode("utf-8")
+        )
+
+
+def fake_statvfs(free_gb: float):
+    def _sv(_p):
+        class S:
+            f_frsize = 4096
+            f_bavail = int(free_gb * (1024 ** 3) / 4096)
+        return S()
+    return S if False else _sv
+
+
+BIG_DISK = fake_statvfs(500.0)
+
+
+def dense_cfg(arch="LlamaForCausalLM", **over):
+    c = {
+        "model_type": "llama",
+        "architectures": [arch],
+        "hidden_size": 4096,
+        "num_hidden_layers": 32,
+        "num_attention_heads": 32,
+        "num_key_value_heads": 8,
+        "max_position_embeddings": 131072,
+        "torch_dtype": "bfloat16",
+    }
+    c.update(over)
+    return c
+
+
+def good_fetcher(slug: str) -> FixtureFetcher:
+    """A well-formed single-safetensors repo that derives cleanly + passes
+    stratum-1/2 so run_pull REACHES the stratum-3 `hardware_sm is None`
+    augment seam (the exact V4 consume-point)."""
+    return FixtureFetcher({
+        API.format(slug=slug): {"siblings": [
+            {"rfilename": "model.safetensors", "size": 9_000_000_000},
+            {"rfilename": "config.json", "size": 700},
+        ]},
+        CFG.format(slug=slug): dense_cfg(),
+    })
+
+
+# ===========================================================================
+# SECTION 0 — module hygiene: optional, no new hard dependency.
+# ===========================================================================
+print("--- module hygiene (no hard dep) ---")
+
+# Imported at top-level WITHOUT `whichllm` installed -> no ImportError.
+check(hasattr(H, "detect_non_nvidia_sm")
+      and hasattr(H, "detect_non_nvidia_hw")
+      and hasattr(H, "HwDetectResult"),
+      "hwdetect imports cleanly with `whichllm` absent (no hard dep)")
+
+# hwdetect must NOT import / call kv-calc or the fit authority
+# (hw-detect-ONLY). The docstring legitimately *names* kv-calc to state
+# it is NOT consulted, so assert on real import/call tokens, not the
+# bare string: no `import`/`from ... kv`/`tools.kv`/`kv-calc.py` exec.
+src = (root / "scripts/lib/profiles/hwdetect.py").read_text()
+import_lines = [
+    ln.strip() for ln in src.splitlines()
+    if ln.strip().startswith(("import ", "from "))
+]
+check(not any("kv" in ln.lower() or "fit" in ln.lower()
+              for ln in import_lines),
+      f"hwdetect imports NO kv-calc/fit module (imports={import_lines}) "
+      "— kv-calc stays sole fit authority (CONTRACT-3 hw-detect-ONLY)")
+check("tools.kv" not in src and "kv-calc.py" not in src
+      and "import kv" not in src,
+      "hwdetect never imports/execs kv-calc (hw-detect-ONLY)")
+
+
+# ===========================================================================
+# SECTION 1 — SAFETY half: every non-delivery path degrades to None,
+#             never raises.
+# ===========================================================================
+print("\n--- safety half: graceful degrade, never raise ---")
+
+
+def runner_raises():
+    raise RuntimeError("simulated `whichllm` crash")
+
+
+def runner_empty():
+    return ""
+
+
+def runner_garbage():
+    return "this is not json {{{"
+
+
+def runner_nvidia_only():
+    # An enumeration that lists ONLY NVIDIA — hwdetect must NOT claim it
+    # (the nvidia-smi path owns NVIDIA; by construction it already ran).
+    return json.dumps({"devices": [
+        {"vendor": "nvidia", "name": "NVIDIA RTX 3090"},
+    ]})
+
+
+def runner_unknown_vendor():
+    return json.dumps({"devices": [
+        {"vendor": "weirdsilicon", "name": "Mystery TPU v9"},
+    ]})
+
+
+for rn, label in [
+    (runner_raises, "runner raises"),
+    (runner_empty, "empty stdout"),
+    (runner_garbage, "unparseable JSON"),
+    (runner_nvidia_only, "NVIDIA-only payload"),
+    (runner_unknown_vendor, "unrecognised vendor"),
+]:
+    try:
+        r_hw = H.detect_non_nvidia_hw(runner=rn)
+        r_sm = H.detect_non_nvidia_sm(runner=rn)
+        check(r_hw is None and r_sm is None,
+              f"safety: {label} -> None (graceful degrade, no raise)")
+    except Exception as exc:  # noqa: BLE001
+        check(False, f"safety: {label} RAISED {type(exc).__name__} "
+                     f"(must degrade to None)")
+
+# Default (no runner, no `whichllm` on PATH in CI) -> None.
+check(H.detect_non_nvidia_sm() is None,
+      "safety: default (no `whichllm` on PATH) -> None")
+
+
+# ===========================================================================
+# SECTION 2 — NVIDIA path is byte-identical (seam never entered).
+#   With hardware_sm injected (== nvidia-smi present), the augment block
+#   is unreachable. Result must be identical whether hwdetect_fn is
+#   ABSENT or PRESENT-and-degrading -> zero NVIDIA-path behaviour change.
+# ===========================================================================
+print("\n--- NVIDIA path byte-identity (seam never entered) ---")
+
+slug = "fixtures/hwdetect-nvidia"
+
+
+def _summ(r):
+    return (r.ok, r.stratum.name, r.abort_reason, r.detail,
+            r.raw_verdict, r.terminal,
+            r.diagnostics.get("hwdetect"))
+
+
+r_absent = P.run_pull(slug, "vllm/minimal", path="B", hardware_sm=SM_86,
+                       fetcher=good_fetcher(slug), profiles=profiles,
+                       statvfs=BIG_DISK)
+# A degrading hwdetect that would FAIL the test if it were ever called
+# on the NVIDIA path:
+sentinel = {"called": False}
+
+
+def degrading_hwdetect():
+    sentinel["called"] = True
+    return None
+
+
+r_present = P.run_pull(slug, "vllm/minimal", path="B", hardware_sm=SM_86,
+                        fetcher=good_fetcher(slug), profiles=profiles,
+                        statvfs=BIG_DISK, hwdetect_fn=degrading_hwdetect)
+
+check(_summ(r_absent) == _summ(r_present),
+      "NVIDIA path: result byte-identical with hwdetect_fn absent vs "
+      "present-degrading")
+check(sentinel["called"] is False,
+      "NVIDIA path: hwdetect_fn is NEVER invoked when nvidia-smi gave an "
+      "SM (seam guarded by `hardware_sm is None`)")
+check(r_present.diagnostics.get("hwdetect") is None,
+      "NVIDIA path: no `hwdetect` diagnostic emitted (augment not run)")
+
+
+# ---------------------------------------------------------------------------
+# This rig is NVIDIA-only (the dev 2x 3090 — `nvidia-smi` IS present, so
+# the real `detect_hardware_sm()` returns 8.6). To exercise the non-NVIDIA
+# eval path the absence of nvidia-smi MUST be simulated — the brief
+# explicitly accepts + expects this; the simulation is made EXPLICIT and
+# DETERMINISTIC here by stubbing `detect_hardware_sm` -> None for the
+# duration of the non-nvidia sections (restored after, so nothing leaks).
+# ---------------------------------------------------------------------------
+import contextlib  # noqa: E402
+
+
+@contextlib.contextmanager
+def simulated_no_nvidia_smi():
+    """Explicit, deterministic 'nvidia-smi absent' simulation: the real
+    SM probe returns None exactly as it would on an AMD/Apple rig."""
+    orig = P.detect_hardware_sm
+    P.detect_hardware_sm = lambda: None
+    try:
+        yield
+    finally:
+        P.detect_hardware_sm = orig
+
+
+# Sanity: the stub really simulates the non-nvidia condition.
+with simulated_no_nvidia_smi():
+    check(P.detect_hardware_sm() is None,
+          "simulation: detect_hardware_sm() -> None (nvidia-smi absent "
+          "simulated, explicit + deterministic)")
+check(P.detect_hardware_sm() == 8.6,
+      "simulation: real detect_hardware_sm() restored after the context "
+      "(no leak into other sections / suites)")
+
+
+# ===========================================================================
+# SECTION 3 — non-nvidia env, hwdetect DEGRADES == bare degrade path.
+#   nvidia-smi absent (simulated) AND hwdetect returns None -> the eval
+#   path is the shipped `hardware-sm-undetermined` terminal,
+#   byte-identical whether hwdetect_fn is absent or present-degrading.
+# ===========================================================================
+print("\n--- non-nvidia + hwdetect degrades == bare degrade ---")
+
+slug = "fixtures/hwdetect-degrade"
+with simulated_no_nvidia_smi():
+    r_bare = P.run_pull(slug, "vllm/minimal", path="B",
+                        fetcher=good_fetcher(slug), profiles=profiles,
+                        statvfs=BIG_DISK, hwdetect_fn=lambda: None)
+    r_bare2 = P.run_pull(slug, "vllm/minimal", path="B",
+                         fetcher=good_fetcher(slug), profiles=profiles,
+                         statvfs=BIG_DISK, hwdetect_fn=lambda: None)
+check(r_bare.stratum is P.Stratum.C0
+      and r_bare.abort_reason == "hardware-sm-undetermined"
+      and not r_bare.ok,
+      "degrade: no nvidia-smi + hwdetect None -> shipped "
+      "`hardware-sm-undetermined` terminal (unchanged)")
+check(_summ(r_bare) == _summ(r_bare2),
+      "degrade: byte-identical across repeated degrading runs")
+check(r_bare.diagnostics.get("hwdetect") is None,
+      "degrade: NO `hwdetect` augment diagnostic on the degrade path")
+
+
+# ===========================================================================
+# SECTION 4 — DELIVERY half (MANDATORY): simulated non-nvidia env yields
+#   a structured enumeration the eval path ACTUALLY CONSUMES — the
+#   observable OUTCOME moves off the degrade terminal.
+# ===========================================================================
+print("\n--- delivery half: simulated non-nvidia env moves the outcome ---")
+
+
+def amd_runner():
+    # Explicit, deterministic simulation of an AMD ROCm rig's `whichllm
+    # list --json` (this rig is NVIDIA-only — the non-nvidia env is
+    # necessarily simulated; the simulation is fixed + reproducible).
+    return json.dumps({"devices": [
+        {"vendor": "amd", "name": "AMD Instinct MI300X"},
+        {"vendor": "amd", "name": "AMD Instinct MI300X"},
+    ]})
+
+
+def apple_runner():
+    return json.dumps({"gpus": [
+        {"backend": "metal", "name": "Apple M3 Max"},
+    ]})
+
+
+# 4a — the structured result itself (the module half of "delivery").
+hw = H.detect_non_nvidia_hw(runner=amd_runner)
+check(hw is not None and isinstance(hw, H.HwDetectResult)
+      and hw.vendor == "amd" and hw.sm_equiv == 8.0
+      and hw.device_count == 2
+      and hw.device_names == ["AMD Instinct MI300X",
+                              "AMD Instinct MI300X"],
+      "delivery: AMD enumeration -> structured HwDetectResult "
+      f"(got {hw!r})")
+hw_a = H.detect_non_nvidia_hw(runner=apple_runner)
+check(hw_a is not None and hw_a.vendor in ("metal", "apple")
+      and hw_a.sm_equiv == 8.0
+      and hw_a.device_names == ["Apple M3 Max"],
+      f"delivery: Apple enumeration -> structured result (got {hw_a!r})")
+check(H.detect_non_nvidia_sm(runner=amd_runner) == 8.0,
+      "delivery: detect_non_nvidia_sm returns the SM-equivalent (8.0)")
+
+# 4b — the WIRING half: the eval path's hardware view OBSERVABLY DIFFERS
+#      from the bare degrade path (Section 3). Same slug/fetcher, the
+#      ONLY change is an enumerating hwdetect_fn. The outcome moves OFF
+#      `hardware-sm-undetermined` — the [C0] SM gate now runs.
+slug = "fixtures/hwdetect-deliver"
+with simulated_no_nvidia_smi():
+    r_deg = P.run_pull(slug, "vllm/minimal", path="B",
+                       fetcher=good_fetcher(slug), profiles=profiles,
+                       statvfs=BIG_DISK, hwdetect_fn=lambda: None)
+    r_aug = P.run_pull(slug, "vllm/minimal", path="B",
+                       fetcher=good_fetcher(slug), profiles=profiles,
+                       statvfs=BIG_DISK,
+                       hwdetect_fn=lambda: H.detect_non_nvidia_sm(
+                           runner=amd_runner))
+
+# The bare-degrade arm is the `hardware-sm-undetermined` terminal …
+check(r_deg.abort_reason == "hardware-sm-undetermined",
+      "delivery: control arm (hwdetect None) IS the degrade terminal")
+# … the augmented arm is OBSERVABLY DIFFERENT: it did NOT stop at
+# `hardware-sm-undetermined` — the eval path consumed the enumerated
+# SM-equiv and advanced past the SM-blind-refuse terminal.
+check(r_aug.abort_reason != "hardware-sm-undetermined",
+      "DELIVERY (outcome moved): augmented eval path does NOT terminate "
+      f"at `hardware-sm-undetermined` (got {r_aug.abort_reason!r}, "
+      f"stratum={r_aug.stratum.name})")
+check(_summ(r_aug) != _summ(r_deg),
+      "DELIVERY (outcome moved): augmented hardware view differs from "
+      "the bare-degrade hardware view (same slug/fetcher; only delta = "
+      "an enumerating hwdetect_fn)")
+# The structured augment is recorded + carries the consumed SM-equiv.
+diag = r_aug.diagnostics.get("hwdetect")
+check(isinstance(diag, dict) and diag.get("augmented") is True
+      and diag.get("sm_equiv") == 8.0,
+      f"delivery: augment diagnostic records sm_equiv=8.0 (got {diag!r})")
+check(any("optional hardware-detect subprocess" in n
+          for n in r_aug.notices),
+      "delivery: an honest user-visible notice records the non-NVIDIA "
+      "enumeration + the kv-calc-stays-authority caveat")
+
+
+# ===========================================================================
+# SECTION 5 — kv-calc is NEVER consulted by the augment (hw-detect-ONLY).
+#   The augment sets ONLY `hardware_sm` + an additive notice/diag. There
+#   is no fit/VRAM call on the augment path. (The shell wrapper also
+#   re-runs `kv-calc.py --calibration` to prove the verdict is intact.)
+# ===========================================================================
+print("\n--- hw-detect-ONLY: augment never feeds kv-calc ---")
+
+# The augmented run advanced PAST the SM-blind refuse — but the value it
+# fed is the [C0] *SM gate* input (8.0), NOT a kv-calc fit number. The
+# augment diag carries `sm_equiv` only; no predicted-VRAM/fit field.
+check(set(diag.keys()) == {"augmented", "sm_equiv"},
+      f"hw-detect-ONLY: augment diag has ONLY enumeration keys "
+      f"(no fit/VRAM field) — got {sorted(diag)}")
+
+
+# ===========================================================================
+# SECTION 6 — rig-independent leak convention (the V2 lesson).
+#   The absolute repo dir string must NOT appear in ANY user-visible
+#   notice / diagnostic the augment emits. Assert `str(abs_dir) not in
+#   shared`, NOT a `/opt|/home` substring allowlist.
+# ===========================================================================
+print("\n--- leak-clean (rig-independent assertion) ---")
+
+abs_dir = str(root.resolve())
+shared = "\n".join(r_aug.notices) + "\n" + json.dumps(
+    r_aug.diagnostics.get("hwdetect"), default=str
+)
+check(abs_dir not in shared,
+      f"leak: absolute repo dir {abs_dir!r} NOT in any augment "
+      "notice/diagnostic (rig-independent str(abs_dir) assertion)")
+check(str(root) not in shared,
+      "leak: the non-resolved abs root form is also absent")
+
+
+# ---------------------------------------------------------------------------
+if failures:
+    print(f"\n{len(failures)} assertion(s) failed.", file=sys.stderr)
+    sys.exit(1)
+print("\nAll V4 hwdetect (CONTRACT-3 §8 hw-detect-ONLY) assertions "
+      "passed — BOTH halves (safety + delivery) proven.")
+PY
+
+# kv-calc verdict must be unaffected by V4 (hw-detect-ONLY: kv-calc is
+# the sole fit authority and V4 must not move its calibration).
+echo "--- kv-calc --calibration unaffected by V4 ---"
+python3 tools/kv-calc.py --calibration >/dev/null 2>&1 \
+  && echo "PASS: kv-calc --calibration runs clean (RC=0) post-V4" \
+  || { echo "FAIL: kv-calc --calibration regressed" >&2; exit 1; }
+
+echo "test-hwdetect.sh OK"

--- a/scripts/tests/test-loop-input.sh
+++ b/scripts/tests/test-loop-input.sh
@@ -45,9 +45,12 @@ root = Path(sys.argv[1])
 sys.path.insert(0, str(root))
 
 from scripts.lib.profiles.loop_input import (  # noqa: E402
+    BaseCaptureBundle,
     CaptureBundleError,
     FInput,
+    FInputGate,
     read_capture_bundle,
+    read_gate_bundle,
 )
 
 failures: list[str] = []
@@ -297,6 +300,143 @@ check(not any("class_enum" in n or "six_one_class" in n
               or "classify" in n for n in api),
       "no FInput accessor claims `outcome` is the §6.1 class enum "
       "(binding rule: [F] derives failure_class itself downstream)")
+
+# ---------------------------------------------------------------------------
+# 7b. v0.8.2 CONTRACT-1.1 — `BaseCaptureBundle` protocol + schema==1
+#     byte-identity (the V1 RED-LINE) + `read_gate_bundle()` (schema==2).
+# ---------------------------------------------------------------------------
+import hashlib as _hl  # noqa: E402
+
+# (a) The protocol-lift is byte-identity-preserving: the SAME schema==1
+#     bundle yields a byte-identical FInput + identical dedup_tuple +
+#     dedup_hash + consensus_key PRE/POST (the F3-class risk). We assert
+#     determinism (two reads of the same bytes are identical) AND that
+#     FInput satisfies BaseCaptureBundle BY CONSTRUCTION.
+fi_a = read_capture_bundle(b1)
+fi_b = read_capture_bundle(b1)
+check(fi_a.manifest == fi_b.manifest
+      and fi_a.dedup_tuple() == fi_b.dedup_tuple()
+      and fi_a.dedup_hash() == fi_b.dedup_hash()
+      and fi_a.consensus_key() == fi_b.consensus_key(),
+      "V1 RED-LINE: a real schema==1 bundle -> byte-identical FInput + "
+      "identical dedup_tuple/dedup_hash/consensus_key (protocol lift is "
+      "a pure static retype)")
+# The literal expected dedup_hash for b1's manifest — pinned so a future
+# refactor that perturbs the schema==1 serialization fails LOUDLY here.
+_b1_dt = ("Org/My-Model", "bfloat16", "LlamaForCausalLM", "kvcalc-v0.8.0",
+          "vllm/vllm-openai:nightly-abc123", None, "1x24576MiB")
+_b1_h = _hl.sha256("\x1f".join(str(p) for p in _b1_dt)
+                   .encode("utf-8")).hexdigest()[:12]
+check(fi_a.dedup_hash() == _b1_h,
+      f"V1 RED-LINE: schema==1 dedup_hash is the pinned byte-exact value "
+      f"{_b1_h} (no drift from the protocol lift)")
+check(isinstance(fi_a, BaseCaptureBundle),
+      "FInput satisfies BaseCaptureBundle (runtime_checkable Protocol — "
+      "by construction; no isinstance(finput, FInput) anywhere in F2/F5)")
+check(fi_a.is_gate_only is False,
+      "FInput.is_gate_only defaults False (a schema==1 full bundle is "
+      "NEVER gate-only; additive default => schema==1 byte-identical)")
+
+# (b) read_gate_bundle(): a schema==2 gate-only bundle -> FInputGate. It
+#     validates ONLY the always-present row + outcome=='hard-block' +
+#     failure_class is None; it MUST NOT reuse the 22-key validator.
+def write_gate(d: Path, *, manifest=None, pt1=None) -> Path:
+    d.mkdir(parents=True, exist_ok=True)
+    gm = manifest if manifest is not None else {
+        "schema": 2, "slug": "Org/Gate-Model",
+        "utc_ts": "20260518T000000Z", "club3090_commit": "cafef00d",
+        "outcome": "hard-block",
+        "abort_reason": "engine-support-unknown/no-arch-row",
+        "failure_class": None,
+        "model": "Org/Gate-Model", "model_id": "Org/Gate-Model",
+        "arch_family": None, "quant_label": None,
+        "topology_class": None, "topology_summary_canonical": None,
+        "selected_ctx": None, "kv_format": None,
+        "smoke_capability_set": None, "engine_pin": None,
+        "engine_version": None, "kv_calc_version": None,
+        "submission_fingerprint": None, "is_gate_only": True,
+        "capture_points": ["gate"],
+    }
+    gp = pt1 if pt1 is not None else {
+        "schema": 2, "point": "gate", "slug": "Org/Gate-Model",
+        "confidence": "ESTIMATED_LOWER_BOUND", "raw_verdict": None,
+        "profile_like": "vllm/minimal", "hardware_sm": 8.6,
+        "predicted_b_breakdown": None,
+        "abort_reason": "engine-support-unknown/no-arch-row",
+        "detail": "[C0] no-arch-row", "is_gate_only": True,
+    }
+    (d / "manifest.json").write_text(json.dumps(gm, indent=2),
+                                     encoding="utf-8")
+    (d / "pt1-gate.json").write_text(json.dumps(gp, indent=2),
+                                     encoding="utf-8")
+    return d
+
+
+g1 = write_gate(tmp / "g1")
+fg = read_gate_bundle(g1)
+check(isinstance(fg, FInputGate),
+      "read_gate_bundle: schema==2 -> FInputGate")
+check(isinstance(fg, BaseCaptureBundle),
+      "FInputGate satisfies BaseCaptureBundle (protocol — F2/F5 consume "
+      "it through the same surface)")
+check(fg.pt2_download is None and fg.pt3_boot is None
+      and fg.pt4_smoke is None and fg.pt5_override is None,
+      "FInputGate: pt2-5 are None (gate-only terminated pre-download — "
+      "satisfies the Optional[dict] protocol slots)")
+check(fg.is_gate_only is True and fg.outcome == "hard-block"
+      and fg.failure_class is None
+      and fg.abort_reason == "engine-support-unknown/no-arch-row",
+      "FInputGate: is_gate_only / outcome / failure_class / abort_reason")
+check(fg.arch_family is None and fg.model_id == "Org/Gate-Model"
+      and fg.quant_label == "none",
+      "FInputGate: arch null pre-deriver, model_id the slug, quant_label "
+      "_norm_quant(None)=='none' (same defensive discipline as FInput)")
+# dedup_tuple uses .get(k,None) — crash-safe on the degraded manifest;
+# the null-topology hash is DETERMINISTIC + stable (CONTRACT-1.1).
+dtg = fg.dedup_tuple()
+check(isinstance(dtg, tuple) and len(dtg) == 7 and dtg[5] is None
+      and dtg[6] is None,
+      f"FInputGate.dedup_tuple(): 7-tuple, .get-tolerant, fc+topo None "
+      f"(got {dtg})")
+dhg1 = fg.dedup_hash()
+dhg2 = read_gate_bundle(g1).dedup_hash()
+_exp_g = _hl.sha256("\x1f".join(str(p) for p in (
+    "Org/Gate-Model", "none", None, None, None, None, None))
+    .encode("utf-8")).hexdigest()[:12]
+check(dhg1 == dhg2 == _exp_g,
+      f"FInputGate.dedup_hash(): DETERMINISTIC with null topology "
+      f"(str(None)=='None'); stable across reads (got {dhg1})")
+
+# Schema mismatch: read_gate_bundle rejects schema==1; read_capture_bundle
+# rejects schema==2 (the two readers are strictly separate).
+raises(lambda: read_gate_bundle(b1),
+       "read_gate_bundle rejects a schema==1 bundle (schema!=2)")
+raises(lambda: read_capture_bundle(g1),
+       "read_capture_bundle rejects a schema==2 gate bundle (untouched "
+       "schema==1 path stays strict)")
+
+# read_gate_bundle MUST NOT reuse the 22-key validator: a gate manifest
+# WITHOUT the post-C0 keys still parses (it only requires the always-
+# present row). And the [F]-classifies invariant is enforced.
+g_bad_oc = write_gate(tmp / "gbo", manifest={
+    "schema": 2, "slug": "x", "utc_ts": "t", "club3090_commit": "c",
+    "outcome": "ok", "abort_reason": "hard-block", "failure_class": None})
+raises(lambda: read_gate_bundle(g_bad_oc),
+       "read_gate_bundle rejects outcome != 'hard-block'")
+g_bad_fc = write_gate(tmp / "gbf", manifest={
+    "schema": 2, "slug": "x", "utc_ts": "t", "club3090_commit": "c",
+    "outcome": "hard-block", "abort_reason": "hard-block",
+    "failure_class": "genuine-oom"})
+raises(lambda: read_gate_bundle(g_bad_fc),
+       "read_gate_bundle rejects a non-null failure_class (the gate "
+       "emitter NEVER classifies — [F]'s job)")
+g_min = write_gate(tmp / "gmin", manifest={
+    "schema": 2, "slug": "x", "utc_ts": "t", "club3090_commit": "c",
+    "outcome": "hard-block", "abort_reason": "disk-short",
+    "failure_class": None})
+check(isinstance(read_gate_bundle(g_min), FInputGate),
+      "read_gate_bundle: a MINIMAL always-present-row-only manifest "
+      "parses (does NOT reuse the 22-key schema-1 _require_keys)")
 
 # ---------------------------------------------------------------------------
 # 8. REAL on-disk capture dir(s) under .pull-captures/ (skip if none).

--- a/scripts/tests/test-patch-attribution.sh
+++ b/scripts/tests/test-patch-attribution.sh
@@ -114,6 +114,201 @@ for patch in patches:
             else:
                 errors.append(msg)
 
+# ---------------------------------------------------------------------------
+# CONTRACT-2b-i — chat_template delivery class + REAL extends merge.
+# ---------------------------------------------------------------------------
+# (1) Every patch's delivery_mechanism is in the v0.8.2 valid set (the
+#     vocabulary now includes `chat_template`).
+for patch in patches:
+    dm = patch.get("delivery_mechanism")
+    if dm not in pa.VALID_DELIVERY_MECHANISM:
+        errors.append(
+            f"{patch['id']} delivery_mechanism {dm!r} not in "
+            f"{sorted(pa.VALID_DELIVERY_MECHANISM)}"
+        )
+
+# (2) chat_template patches: spec shape + a behavioral drift_guard whose
+#     check encodes the SELF-CONTAINED symmetric restart+settle protocol
+#     (the #150 lesson — a non-symmetric guard flaps and is ignored).
+chat_template_patches = [
+    p for p in patches if p.get("delivery_mechanism") == "chat_template"
+]
+for patch in chat_template_patches:
+    spec = patch.get("delivery_spec") or {}
+    for k in ("jinja", "mounted_at", "wired_at"):
+        if not spec.get(k):
+            errors.append(f"{patch['id']} chat_template delivery_spec missing {k}")
+    jinja_rel = spec.get("jinja")
+    if jinja_rel and not (root / jinja_rel).exists():
+        errors.append(f"{patch['id']} chat_template jinja missing on disk: {jinja_rel}")
+    if jinja_rel and Path(jinja_rel).suffix not in pa.CHAT_TEMPLATE_ARTIFACT_SUFFIXES:
+        errors.append(f"{patch['id']} chat_template jinja is not a .jinja artifact: {jinja_rel}")
+    dg = patch.get("drift_guard") or {}
+    if dg.get("kind") != "behavioral":
+        errors.append(f"{patch['id']} chat_template drift_guard must be kind: behavioral")
+    chk = (dg.get("check") or "").lower()
+    for token in ("symmetric", "docker restart", "settle", ">=3", "grand mean"):
+        if token not in chk:
+            errors.append(
+                f"{patch['id']} chat_template drift_guard.check must encode the "
+                f"self-contained symmetric protocol (missing {token!r})"
+            )
+
+# (3) Orphan-artifact discovery for vendored `.jinja` templates: every
+#     chat-template `.jinja` under a model patches/ tree MUST be owned by a
+#     delivery_mechanism: chat_template patch (so a bad/regressed/re-vendored
+#     template can never ship with ZERO attribution coverage).
+ct_covered_files = []
+for patch in chat_template_patches:
+    for rel in patch.get("files") or []:
+        ct_covered_files.append(root / rel)
+for jinja in sorted(
+    p for p in (root / "models").rglob("*") if p.is_file() and pa.is_chat_template_artifact(p)
+):
+    if not pa.covered(jinja, ct_covered_files):
+        errors.append(
+            f"orphan chat-template artifact lacks a chat_template patches.yml entry: "
+            f"{jinja.relative_to(root)}"
+        )
+
+# (4) Effective coverage MUST use REAL Docker Compose merge semantics, NOT
+#     declared lines. The dangerous direction is the FALSE NEGATIVE: a child
+#     that !reset/overrides/REMOVES the mount must be caught as a coverage
+#     loss. Build a synthetic base+child fixture where the child re-declares
+#     `volumes`/`command` WITHOUT the template and assert reaches() == False
+#     (the legacy single-base text-concat would still "see" the base's mount
+#     line and wrongly return True — that is the #377 failure mode).
+import tempfile  # noqa: E402
+
+if chat_template_patches:
+    ctp = chat_template_patches[0]
+    with tempfile.TemporaryDirectory() as _td:
+        _tdp = Path(_td)
+        mounted = (ctp.get("delivery_spec") or {}).get("mounted_at")
+        base = _tdp / "base.yml"
+        keep_child = _tdp / "keep.yml"
+        reset_child = _tdp / "reset.yml"
+        noextend = _tdp / "noextend.yml"
+        base.write_text(
+            "services:\n"
+            "  base-svc:\n"
+            "    image: scratch\n"
+            "    command: [--model, m, --chat-template, %s]\n"
+            "    volumes:\n"
+            "      - ../../patches/froggeric-chat-template/chat_template.jinja:%s:ro\n"
+            % (mounted, mounted),
+            encoding="utf-8",
+        )
+        # (a) Child that KEEPS inheritance (only overrides an env) -> still
+        #     covered. Proves extends: IS merged (not ignored).
+        keep_child.write_text(
+            "services:\n"
+            "  keep-svc:\n"
+            "    extends:\n"
+            "      file: base.yml\n"
+            "      service: base-svc\n"
+            "    environment:\n"
+            "      - X=1\n",
+            encoding="utf-8",
+        )
+        # (b) Child that REMOVES the mount + --chat-template via the Compose
+        #     `!reset` tag — the ONLY in-Compose removal mechanism across
+        #     extends: (a plain re-declared `[]` does NOT drop a base
+        #     sequence; Compose merges extends: sequences additively). The
+        #     coverage loss MUST be caught (reaches == False). A text-concat
+        #     would still "see" the base's mount line -> false-negative.
+        reset_child.write_text(
+            "services:\n"
+            "  reset-svc:\n"
+            "    extends:\n"
+            "      file: base.yml\n"
+            "      service: base-svc\n"
+            "    volumes: !reset []\n"
+            "    command: !reset [--model, m]\n",
+            encoding="utf-8",
+        )
+        # (c) The real #377 mode: a compose that simply STOPPED extending
+        #     its template-bearing base — no extends: at all. Must NOT be
+        #     reported covered. (Deterministic everywhere; no docker / tags.)
+        noextend.write_text(
+            "services:\n"
+            "  noextend-svc:\n"
+            "    image: scratch\n"
+            "    command: [--model, m]\n",
+            encoding="utf-8",
+        )
+        if not pa.reaches(root, ctp, str(keep_child)):
+            errors.append(
+                "chat_template real-merge: a child that inherits the base "
+                "(extends:, no override) lost coverage — extends not merged"
+            )
+        if pa.reaches(root, ctp, str(reset_child)):
+            errors.append(
+                "chat_template real-merge FALSE-NEGATIVE: a child that "
+                "!reset-removed the chat-template mount/--chat-template "
+                "wiring was still reported covered (the #377 dangerous "
+                "direction — extends resolved by text concat, not real "
+                "Docker Compose merge)"
+            )
+        if pa.reaches(root, ctp, str(noextend)):
+            errors.append(
+                "chat_template real-merge FALSE-NEGATIVE: a compose that "
+                "STOPPED extending its template-bearing base was still "
+                "reported covered (the literal #377 silent-drift mode)"
+            )
+
+# (5) Rig-independent leak-assertion convention (mandatory — the V2 on-rig
+#     lesson). The chat_template effective-coverage path resolves the
+#     merged compose via `docker compose config`, which renders the mount
+#     SOURCE as an ABSOLUTE host path (e.g. /opt/ai/.../patches/...jinja).
+#     That absolute path MUST NOT leak into any committed/shared artifact:
+#     the patches.yml `jinja`/`mounted_at` must be repo-relative/container
+#     paths, NEVER absolute. Assert with `str(abs_dir) not in shared` AND
+#     that only the repo-relative form appears — NEVER a bare `/opt|/home`
+#     substring allowlist (a sandbox path structurally defeats that; that
+#     exact miss shipped a real leak in V2).
+abs_root = str(root.resolve())
+for patch in chat_template_patches:
+    spec = patch.get("delivery_spec") or {}
+    jinja_rel = spec.get("jinja") or ""
+    mounted = spec.get("mounted_at") or ""
+    shared = f"{jinja_rel}\n{mounted}\n{patch.get('id','')}"
+    if abs_root in shared:
+        errors.append(
+            f"{patch['id']} chat_template delivery_spec LEAKS the absolute "
+            f"repo path ({abs_root!r}) — must be repo-relative/container only"
+        )
+    if jinja_rel.startswith("/") or jinja_rel.startswith(abs_root):
+        errors.append(
+            f"{patch['id']} chat_template jinja must be repo-relative, "
+            f"got absolute: {jinja_rel}"
+        )
+    # The repo-relative form (the ONLY acceptable shape) must be present.
+    if jinja_rel and not jinja_rel.startswith("models/"):
+        errors.append(
+            f"{patch['id']} chat_template jinja must be a repo-relative "
+            f"models/... path, got: {jinja_rel}"
+        )
+
+# Every load-bearing chat_template compose's SHIPPED mount line must use
+# the repo-relative `../../patches/...` form, never the absolute path the
+# `docker compose config` merge renders (the merge output is internal to
+# reaches() and is NEVER emitted/shared — assert that invariant on the
+# committed composes directly, rig-independently).
+for patch in chat_template_patches:
+    for lb in patch.get("load_bearing_when") or []:
+        for compose_name in lb.get("composes") or []:
+            if compose_name not in COMPOSE_REGISTRY:
+                continue
+            cpath = root / COMPOSE_REGISTRY[compose_name]["compose_path"]
+            ctext = cpath.read_text(encoding="utf-8")
+            if abs_root in ctext:
+                errors.append(
+                    f"committed compose {compose_name} LEAKS the absolute "
+                    f"repo path {abs_root!r} (must use the repo-relative "
+                    f"../../patches/... mount form)"
+                )
+
 arch_allowed_keys = pa.ARCH_ALLOWED_KEYS
 arch_required = pa.ARCH_REQUIRED_KEYS
 valid_trc = pa.VALID_TRC

--- a/scripts/tests/test-pull.sh
+++ b/scripts/tests/test-pull.sh
@@ -1311,6 +1311,151 @@ check("derived-runtime-unsupported:" in _n22
 check(r.download_ok is None and r.boot_ok is None,
       "g22: CONTRACT-5 reject leaves [E] additive fields None (no stage ran)")
 
+_purge_captures()
+
+# ===========================================================================
+# v0.8.2 CONTRACT-1.1 — capture-on-hard-block pass-through (V1).
+#
+# The pt1-gate emitter is wired on the terminal hard-block `return res`
+# paths as a PURE PASS-THROUGH: the decision (ok/stratum/abort_reason) is
+# UNCHANGED; a pt1-gate.json + schema:2 manifest.json bundle is emitted
+# BEFORE the existing return. We inject a mock `gate_capture_fn` to keep
+# this hermetic (real emit_gate_capture is unit-tested in
+# test-pullemit-capture.sh + on-rig V6); here we assert (a) the decision is
+# byte-unchanged vs the SAME run without the hook, and (b) the hook is
+# invoked with the EXACT shipped abort_reason at every enumerated stratum.
+# ===========================================================================
+print("\n--- v0.8.2 CONTRACT-1.1: capture-on-hard-block pass-through ---")
+
+_GATE_CALLS: list = []
+
+
+def _mock_gate_capture(**kw):
+    _GATE_CALLS.append(kw)
+    return {"paths": {"gate": "/tmp/x/pt1-gate.json",
+                      "manifest": "/tmp/x/manifest.json"},
+            "dir": "/tmp/x", "manifest": {"schema": 2}}
+
+
+def _gate_case(name, run_kwargs, *, expect_reason, expect_stratum):
+    # Baseline: the SAME run with NO gate hook (decision reference).
+    base = P.run_pull(**run_kwargs)
+    # With the pass-through hook injected.
+    _GATE_CALLS.clear()
+    hooked = P.run_pull(**run_kwargs, gate_capture_fn=_mock_gate_capture)
+    # (a) the decision is byte-unchanged (pass-through, NOT decision logic).
+    check(base.ok == hooked.ok
+          and base.stratum == hooked.stratum
+          and base.abort_reason == hooked.abort_reason
+          and base.detail == hooked.detail,
+          f"{name}: pass-through is decision-NEUTRAL (ok/stratum/"
+          f"abort_reason/detail byte-identical with vs without the hook)")
+    check(hooked.abort_reason == expect_reason
+          and hooked.stratum is expect_stratum,
+          f"{name}: terminal decision unchanged "
+          f"(stratum={hooked.stratum.name} reason={hooked.abort_reason!r})")
+    # (b) the gate emitter was invoked once with the EXACT shipped
+    #     abort_reason (NOT a semantic alias) at this stratum.
+    check(len(_GATE_CALLS) == 1
+          and _GATE_CALLS[0].get("abort_reason") == expect_reason
+          and _GATE_CALLS[0].get("slug") == run_kwargs["slug"],
+          f"{name}: emit_gate_capture invoked once with the exact shipped "
+          f"abort_reason {expect_reason!r} "
+          f"(got {[c.get('abort_reason') for c in _GATE_CALLS]})")
+    return hooked
+
+
+# C0 — engine-support-unknown/no-arch-row (the §10-R9 solicited lever).
+_s = "fixtures/exotic-dense-gate"
+_exo = dense_cfg("TotallyExoticForCausalLM")
+_gate_case(
+    "gate-C0-no-arch-row",
+    dict(slug=_s, profile_like="vllm/minimal", path="B", hardware_sm=SM_86,
+         fetcher=ff_derived(_s, _exo), profiles=profiles, statvfs=BIG_DISK),
+    expect_reason="engine-support-unknown/no-arch-row",
+    expect_stratum=P.Stratum.C0)
+
+# C2a — disk-short (a user-environment correct-refusal).
+_sd = "fixtures/big-llama-gate"
+_gate_case(
+    "gate-C2a-disk-short",
+    dict(slug=_sd, profile_like="vllm/minimal", path="B", hardware_sm=SM_86,
+         fetcher=ff_derived(_sd, dense_cfg("Qwen2ForCausalLM"),
+                            weight_gb=200.0),
+         profiles=profiles, statvfs=TINY_DISK, trust_remote_code=True),
+    expect_reason="disk-short", expect_stratum=P.Stratum.C2A_DISK)
+
+# Deriver stratum — a pre-deriver terminal (no der.profile -> model/arch
+# /quant null in the bundle). Uses the same fixture shape as g1 (unknown
+# weight format -> unsupported-format).
+_sdr = "fixtures/derr-gate"
+_ffdr = FixtureFetcher({
+    API.format(slug=_sdr): {"siblings": [
+        {"rfilename": "config.json", "size": 700},
+        {"rfilename": "model.bin", "size": 8 * 1024 ** 3}]},
+    CFG.format(slug=_sdr): dense_cfg("LlamaForCausalLM"),
+})
+_dr = P.run_pull(slug=_sdr, profile_like="vllm/minimal", hardware_sm=SM_86,
+                 fetcher=_ffdr, profiles=profiles, statvfs=BIG_DISK,
+                 gate_capture_fn=_mock_gate_capture)
+check(_dr.stratum is P.Stratum.DERIVER and not _dr.ok,
+      f"gate-deriver: terminal decision unchanged "
+      f"(stratum={_dr.stratum.name} reason={_dr.abort_reason!r})")
+
+# REAL end-to-end (no mock): a C0 hard-block writes a genuine schema:2
+# bundle on disk; assert pt1-gate.json + manifest.json exist, schema==2,
+# carry the EXACT abort_reason, outcome=='hard-block', failure_class null,
+# and NO absolute path leaked into either artifact (the V1 RED-LINE).
+_purge_captures()
+_real = P.run_pull(slug=_s, profile_like="vllm/minimal", path="B",
+                   hardware_sm=SM_86, fetcher=ff_derived(_s, _exo),
+                   profiles=profiles, statvfs=BIG_DISK)
+check(_real.abort_reason == "engine-support-unknown/no-arch-row",
+      "gate-real: C0 hard-block decision unchanged (real emitter path)")
+_gdir = _real.diagnostics.get("gate_capture", {}).get("dir")
+check(_gdir and Path(_gdir).is_dir(),
+      f"gate-real: a real .pull-captures/ bundle dir was written "
+      f"(dir={_gdir!r})")
+if _gdir:
+    _gp = Path(_gdir)
+    _g1 = _gp / "pt1-gate.json"
+    _gm = _gp / "manifest.json"
+    check(_g1.is_file() and _gm.is_file(),
+          "gate-real: pt1-gate.json + manifest.json both written "
+          "(NO pt2/3/4/5 — gate-only terminated pre-download)")
+    _names = sorted(x.name for x in _gp.iterdir())
+    check(_names == ["manifest.json", "pt1-gate.json"],
+          f"gate-real: ONLY pt1-gate.json + manifest.json (no pt2-5) "
+          f"(got {_names})")
+    _mj = json.loads(_gm.read_text())
+    _pj = json.loads(_g1.read_text())
+    check(_mj.get("schema") == 2 and _mj.get("outcome") == "hard-block"
+          and _mj.get("failure_class") is None
+          and _mj.get("abort_reason") == "engine-support-unknown/no-arch-row",
+          f"gate-real: manifest schema:2 / outcome:hard-block / "
+          f"failure_class:null / exact abort_reason (got "
+          f"schema={_mj.get('schema')} outcome={_mj.get('outcome')!r})")
+    check(_pj.get("schema") == 2 and _pj.get("point") == "gate"
+          and _pj.get("abort_reason")
+          == "engine-support-unknown/no-arch-row"
+          and _pj.get("is_gate_only") is True,
+          "gate-real: pt1-gate.json schema:2/point:gate carries the raw "
+          "abort_reason (H2 maintainer-distinguishability)")
+    for _art in (_g1, _gm):
+        _blob = _art.read_text()
+        check("/opt/ai" not in _blob and "/home/" not in _blob
+              and "/mnt/" not in _blob,
+              f"gate-real: NO absolute path leaked in {_art.name} "
+              f"(redacted; the V1 RED-LINE)")
+    # `.last` marker written by the SHARED helper (centralization mandate).
+    _last = root / ".pull-captures" / ".last"
+    check(_last.is_file()
+          and _last.read_text().strip() == str(
+              _gp.relative_to(root / ".pull-captures")),
+          "gate-real: the SHARED .last marker points at the gate bundle "
+          "(centralized: gate-only updates .last too — --submit-last works)")
+_purge_captures()
+
 # Purge ALL mocked-[E] capture residue (leave NO repo artifact).
 _purge_captures()
 
@@ -1348,5 +1493,13 @@ _ec(){ bash scripts/pull.sh "$@" >/dev/null 2>&1; echo $?; }
 [ "$(_ec --help)" = 0 ]                                        || { echo "FAIL: --help -> 0 (#370 must not regress help)" >&2; _clifail=1; }
 [ "$(_ec definitely/nonexistent-xyz123 --profile-like vllm/minimal --dry-run)" = 2 ] || { echo "FAIL: honest hard-stop -> 2 (must stay 2, not 64) (#370)" >&2; _clifail=1; }
 [ "$_clifail" = 0 ] && echo "PASS: CLI exit-code contract (#370): usage=64, --help=0, hard-stop=2" || { echo "1+ CLI-contract assertion(s) failed." >&2; exit 1; }
+
+# v0.8.2 CONTRACT-1.1: the real-CLI hard-stop above exercises the genuine
+# pt1-gate capture-on-hard-block pass-through end-to-end (pull.sh ->
+# emit_gate_capture). That writes a real gitignored .pull-captures/ bundle;
+# purge it so the test leaves NO repo residue and the CI condition
+# (gitignored runtime state ABSENT) is restored (same discipline as the
+# in-heredoc _purge_captures for the mocked-[E] residue).
+rm -rf "$ROOT_DIR/.pull-captures"
 
 echo "test-pull.sh OK"

--- a/scripts/tests/test-pull.sh
+++ b/scripts/tests/test-pull.sh
@@ -1456,6 +1456,157 @@ if _gdir:
           "(centralized: gate-only updates .last too — --submit-last works)")
 _purge_captures()
 
+# ===========================================================================
+# v0.8.2 CONTRACT-4 — the `recommend` UX (STEP V5).
+#
+# RED-LINE / outcome-not-addition: the recommendation MUST reflect the REAL
+# shipped verdict and CHANGE WITH IT. We drive THREE genuinely-different
+# real `run_pull` outcomes through `_render_recommendation` and assert the
+# rendered block differs and matches the underlying `res` each time:
+#   (1) FITS + emitted   — a curated Path-A proceed (r.ok, r.emitted)
+#   (2) confirm→proceed  — an estimated-lower-bound non-pass (not r.ok)
+#   (3) hard-block       — a C0 no-arch-row terminal (not r.ok, no [B])
+# A static/templated summary that did not consume the real verdict would
+# render identically for all three (or carry a §7 caveat on the blocked
+# leg that never reached [B]); that is the explicit FAIL the brief names.
+# Pure presentation: the SAME `res` objects the frozen gate produced are
+# fed in; no decision field is read, mutated, or re-derived.
+# ===========================================================================
+print("\n--- v0.8.2 CONTRACT-4: recommend UX tracks the REAL verdict ---")
+
+# (1) FITS + emitted — curated Path-A vllm/dual + --yes (the g2 shape).
+_rec_fit = P.run_pull(CURATED_SLUG, "vllm/dual", path="A",
+                       out="/tmp/_v5_rec.yml", hardware_sm=SM_86,
+                       fetcher=NoNet(), profiles=profiles,
+                       statvfs=BIG_DISK, yes=True)
+if os.path.exists("/tmp/_v5_rec.yml"):
+    os.unlink("/tmp/_v5_rec.yml")
+_blk_fit = "\n".join(P._render_recommendation(_rec_fit))
+check(_rec_fit.ok and _rec_fit.emitted,
+      "rec(1): the FITS leg is a REAL ok+emitted curated verdict "
+      f"(ok={_rec_fit.ok}, emitted={_rec_fit.emitted})")
+check("verdict: FITS" in _blk_fit
+      and "DOES NOT FIT" not in _blk_fit
+      and "a ready compose was emitted" in _blk_fit
+      and f"stratum={_rec_fit.stratum.name}" in _blk_fit,
+      "rec(1): FITS+emitted -> 'FITS' + the emitted-compose line + the "
+      "REAL deciding stratum (tracks res.ok/res.emitted/res.stratum)")
+
+# (2a) confirm→proceed, NOT satisfied — estimated-lower-bound non-pass
+# (the g4 shape: Llama + --trust-remote-code, NO --yes -> [C1]
+# confirm→proceed:needs --yes). This is `not ok` and — per the shipped
+# gate — the §7 caveat is appended ONLY on a download-eligible/accepted
+# verdict, NOT on a not-yet-satisfied confirm→proceed; so this leg carries
+# NO CAVEAT_S7 (verified against the live shipped run, not assumed). The
+# recommendation MUST therefore omit the soak pointer here too.
+_s_cp = "fixtures/v5-llama-cp"
+_cp_kw = dict(slug=_s_cp, profile_like="vllm/minimal", path="B",
+              hardware_sm=SM_86,
+              fetcher=ff_derived(_s_cp, dense_cfg("LlamaForCausalLM"),
+                                 weight_gb=8.0),
+              profiles=profiles, statvfs=BIG_DISK, trust_remote_code=True)
+_rec_cp = P.run_pull(**_cp_kw)
+_blk_cp = "\n".join(P._render_recommendation(_rec_cp))
+check(not _rec_cp.ok and _rec_cp.stratum is P.Stratum.DECIDED
+      and _rec_cp.confidence == "estimated-lower-bound"
+      and _rec_cp.abort_reason
+      and _rec_cp.abort_reason.startswith("confirm→proceed"),
+      "rec(2a): the confirm→proceed leg is a REAL estimated-lower-bound "
+      f"non-pass (ok={_rec_cp.ok}, reason={_rec_cp.abort_reason!r})")
+check("DOES NOT FIT / BLOCKED" in _blk_cp
+      and _rec_cp.abort_reason in _blk_cp
+      and "--submit-last" in _blk_cp
+      and f"stratum={_rec_cp.stratum.name}" in _blk_cp,
+      "rec(2a): confirm→proceed (not ok) -> the BLOCKED branch carries the "
+      "REAL abort_reason + the failure on-ramp pointer + the REAL stratum")
+check(P.CAVEAT_S7 not in _rec_cp.notices
+      and "SOAK_MODE=continuous" not in _blk_cp,
+      "rec(2a): a not-yet-satisfied confirm→proceed carries NO §7 caveat "
+      "(the shipped gate appends it only on an accepted verdict) -> the "
+      "recommendation correctly omits the soak pointer (tracks the REAL "
+      "res.notices, NOT a static template)")
+
+# (2b) the SAME model + --yes -> a download-eligible estimated-lower-bound
+# verdict (r.ok, Path B so NOT emitted). The shipped gate DOES append the
+# §7 caveat here; the recommendation MUST carry it verbatim AND honestly
+# state "no compose emitted" (Path B). This proves the §7-caveat + the
+# no-fabricated-artifact behavior both track the REAL res.
+_rec_cy = P.run_pull(**_cp_kw, yes=True)
+_blk_cy = "\n".join(P._render_recommendation(_rec_cy))
+check(_rec_cy.ok and not _rec_cy.emitted
+      and _rec_cy.confidence == "estimated-lower-bound"
+      and P.CAVEAT_S7 in _rec_cy.notices,
+      "rec(2b): --yes -> a REAL download-eligible estimated-lower-bound "
+      f"verdict carrying CAVEAT_S7 (ok={_rec_cy.ok}, "
+      f"emitted={_rec_cy.emitted})")
+check("verdict: FITS" in _blk_cy
+      and "ESTIMATED LOWER BOUND" in _blk_cy
+      and "no compose was emitted this run" in _blk_cy
+      and P.CAVEAT_S7 in _blk_cy
+      and "SOAK_MODE=continuous" in _blk_cy,
+      "rec(2b): FITS(estimated-lower-bound, Path B) -> floor stated, NO "
+      "fabricated compose artifact, §7 caveat + soak pointer carried "
+      "verbatim BECAUSE the real res carries CAVEAT_S7 (echoed from "
+      "res.notices, not re-derived)")
+
+# (3) hard-block — C0 no-arch-row (the gate-C0 shape; never reaches [B]).
+_s_hb = "fixtures/v5-exotic"
+_rec_hb = P.run_pull(_s_hb, "vllm/minimal", path="B", hardware_sm=SM_86,
+                     fetcher=ff_derived(_s_hb,
+                                        dense_cfg("V5ExoticForCausalLM")),
+                     profiles=profiles, statvfs=BIG_DISK)
+_blk_hb = "\n".join(P._render_recommendation(_rec_hb))
+check(not _rec_hb.ok
+      and _rec_hb.abort_reason == "engine-support-unknown/no-arch-row"
+      and _rec_hb.stratum is P.Stratum.C0,
+      "rec(3): the hard-block leg is a REAL C0 no-arch-row terminal "
+      f"(reason={_rec_hb.abort_reason!r}, stratum={_rec_hb.stratum.name})")
+check("DOES NOT FIT / BLOCKED" in _blk_hb
+      and "engine-support-unknown/no-arch-row" in _blk_hb
+      and f"stratum={_rec_hb.stratum.name}" in _blk_hb,
+      "rec(3): hard-block -> the REAL abort_reason + the REAL deciding "
+      "stratum are rendered (tracks res.abort_reason/res.stratum)")
+# This leg NEVER reached [B], so the gate produced NO §7 caveat — the
+# recommendation MUST NOT fabricate a soak pointer (the static-template
+# FAIL the brief calls out: a templated block would carry it anyway).
+check(P.CAVEAT_S7 not in _rec_hb.notices
+      and "SOAK_MODE=continuous" not in _blk_hb
+      and "§7 caveat" not in _blk_hb,
+      "rec(3): a pre-[B] hard-block carries NO §7 caveat -> the "
+      "recommendation correctly omits the soak pointer (tracks the REAL "
+      "res.notices; a static template would falsely include it)")
+
+# Outcome-not-addition: the rendered blocks are PAIRWISE DIFFERENT (a
+# static/templated summary would be identical) AND each matches its own
+# real res — the recommendation provably TRACKS the verdict, not merely
+# "exists". Four genuinely-different real outcomes (fit+emitted /
+# confirm→proceed-blocked / estimated-lower-bound-fit / hard-block).
+_blocks = (_blk_fit, _blk_cp, _blk_cy, _blk_hb)
+check(len(set(_blocks)) == len(_blocks),
+      "rec: the four recommendation blocks are pairwise DIFFERENT "
+      "(it tracks the real verdict; NOT a static template)")
+
+# Leak-clean (rig-independent assertion convention — assert the absolute
+# repo root is absent, NOT a /opt|/home substring allowlist): no recommend
+# block leaks an absolute filesystem path.
+for _name, _blk in (("fit", _blk_fit), ("cp", _blk_cp),
+                    ("cy", _blk_cy), ("hb", _blk_hb)):
+    check(str(root) not in _blk,
+          f"rec({_name}): the recommendation block contains NO absolute "
+          f"repo path (rig-independent leak assertion: str(root) absent)")
+
+# vLLM-only by construction + honest-confidence echo (CONTRACT-4 invariants,
+# read straight off the real res — not re-asserted policy).
+check("engine=vLLM" in _blk_fit and "engine=vLLM" in _blk_hb,
+      "rec: vLLM-only is stated on every leg (the gate is vLLM-only by "
+      "construction; recommend only echoes it)")
+check(_rec_cy.confidence == "estimated-lower-bound"
+      and "ESTIMATED LOWER BOUND" in _blk_cy,
+      "rec: an estimated-lower-bound FIT states the floor honestly "
+      "(echoes res.confidence; never hides the lower-bound)")
+
+_purge_captures()
+
 # Purge ALL mocked-[E] capture residue (leave NO repo artifact).
 _purge_captures()
 

--- a/scripts/tests/test-pull.sh
+++ b/scripts/tests/test-pull.sh
@@ -1513,12 +1513,16 @@ check(not _rec_cp.ok and _rec_cp.stratum is P.Stratum.DECIDED
       and _rec_cp.abort_reason.startswith("confirm→proceed"),
       "rec(2a): the confirm→proceed leg is a REAL estimated-lower-bound "
       f"non-pass (ok={_rec_cp.ok}, reason={_rec_cp.abort_reason!r})")
-check("DOES NOT FIT / BLOCKED" in _blk_cp
+check("FITS (estimated) — NOT YET ACCEPTED" in _blk_cp
+      and "DOES NOT FIT" not in _blk_cp
       and _rec_cp.abort_reason in _blk_cp
-      and "--submit-last" in _blk_cp
+      and "ACCEPTANCE gate, not a fit failure" in _blk_cp
+      and "--submit-last" not in _blk_cp
       and f"stratum={_rec_cp.stratum.name}" in _blk_cp,
-      "rec(2a): confirm→proceed (not ok) -> the BLOCKED branch carries the "
-      "REAL abort_reason + the failure on-ramp pointer + the REAL stratum")
+      "rec(2a): a fits-clean confirm→proceed (not ok, NOT --yes) is HONESTLY "
+      "rendered as FITS-but-NOT-YET-ACCEPTED (never 'DOES NOT FIT'), carries "
+      "the REAL abort_reason + the acceptance-gate guidance + the REAL "
+      "stratum, and does NOT misroute to the failure on-ramp")
 check(P.CAVEAT_S7 not in _rec_cp.notices
       and "SOAK_MODE=continuous" not in _blk_cp,
       "rec(2a): a not-yet-satisfied confirm→proceed carries NO §7 caveat "

--- a/scripts/tests/test-pullemit-capture.sh
+++ b/scripts/tests/test-pullemit-capture.sh
@@ -884,6 +884,157 @@ for _m in (m1, m2, m3, m3b, m4):
           "submission_fingerprint (composition unchanged, value honest)")
 
 # ---------------------------------------------------------------------------
+# v0.8.2 CONTRACT-1.1 — the pt1-gate-only emitter + the SHARED .last marker.
+#
+# `emit_gate_capture()` is a SEPARATE function (the `emit_override_capture`
+# byte-preserving precedent) — NOT invoked by `emit_capture()`. It writes
+# ONLY pt1-gate.json + a schema:2 manifest.json (gate-only terminated
+# pre-download → no pt2/3/4/5), redacted via the SAME `_redact_text`.
+# `write_last_marker()` is the ONE shared `.last` helper BOTH emitters call
+# (the centralization mandate — gate-only is the commonest failure; if
+# `.last` were [E]-only, `--submit-last` would silently miss gate captures).
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    _root = Path(td)
+
+    # (i) emit_capture() STILL writes ONLY pt1-4 + manifest (the V1
+    #     RED-LINE: the gate emitter is separate, NOT invoked here).
+    o_full = C.emit_capture(
+        ei, confidence=SimpleNamespace(name="EXACT"),
+        raw_verdict="fits-clean", profile_like="vllm/x",
+        download_result=dl, boot_result=res, smoke_result=sm,
+        compose_meta=compose_meta, kv_calc_version="kvcalc-v7",
+        repo_root=_root, ts="20260518T100000Z",
+    )
+    _fnames = sorted(x.name for x in Path(o_full["dir"]).iterdir())
+    check(_fnames == ["manifest.json", "pt1-gate.json", "pt2-download.json",
+                      "pt3-boot.json", "pt4-smoke.json"],
+          f"V1 RED-LINE: emit_capture() STILL writes ONLY pt1-4 + manifest "
+          f"(the gate emitter is a SEPARATE fn) (got {_fnames})")
+
+    # (ii) emit_gate_capture() — a C0 no-arch-row hard-block, der present.
+    der_g = SimpleNamespace(profile={"arch": "ExoticForCausalLM",
+                                     "weight_format": "bfloat16"})
+    og = C.emit_gate_capture(
+        slug="org/Exotic-Model",
+        profile_like="vllm/minimal",
+        abort_reason="engine-support-unknown/no-arch-row",
+        confidence=SimpleNamespace(name="ESTIMATED_LOWER_BOUND"),
+        raw_verdict=None,
+        detail="[C0] engine-support-unknown/no-arch-row",
+        der=der_g,
+        hardware_sm=8.6,
+        gpu_topology=(1, [24576], ["NVIDIA GeForce RTX 3090"]),
+        club3090_commit="deadbeef",
+        repo_root=_root,
+        ts="20260518T101000Z",
+    )
+    _gnames = sorted(x.name for x in Path(og["dir"]).iterdir())
+    check(_gnames == ["manifest.json", "pt1-gate.json"],
+          f"emit_gate_capture: ONLY pt1-gate.json + manifest.json — no "
+          f"pt2/3/4/5 (gate-only terminated pre-download) (got {_gnames})")
+    gman = json.loads(Path(og["paths"]["manifest"]).read_text())
+    gpt1 = json.loads(Path(og["paths"]["gate"]).read_text())
+    check(gman["schema"] == 2 and gman["outcome"] == "hard-block"
+          and gman["failure_class"] is None
+          and gman["abort_reason"] == "engine-support-unknown/no-arch-row"
+          and gman["is_gate_only"] is True,
+          f"emit_gate_capture: manifest schema:2 / outcome:hard-block / "
+          f"failure_class:null / exact abort_reason (got {sorted(gman)})")
+    # Always-present row guaranteed; der present -> model/arch/quant set;
+    # topology resolved best-effort from the injected gpu_topology.
+    check(gman["model"] == "org/Exotic-Model"
+          and gman["arch_family"] == "ExoticForCausalLM"
+          and gman["quant_label"] == "bfloat16"
+          and gman["topology_class"] == "1x24576MiB"
+          and gman["topology_summary_canonical"]
+              == "[(NVIDIA GeForce RTX 3090, 24576)]",
+          "emit_gate_capture: der-present manifest carries model/arch/"
+          "quant + best-effort topology")
+    # post-C0 fields ALWAYS null on a gate-only bundle.
+    check(all(gman[k] is None for k in (
+              "selected_ctx", "kv_format", "smoke_capability_set",
+              "engine_pin", "engine_version", "submission_fingerprint")),
+          "emit_gate_capture: post-C0 fields ALWAYS null (never reached)")
+    check(gpt1["schema"] == 2 and gpt1["point"] == "gate"
+          and gpt1["abort_reason"]
+              == "engine-support-unknown/no-arch-row"
+          and gpt1["is_gate_only"] is True,
+          "emit_gate_capture: pt1-gate carries the raw abort_reason (H2)")
+
+    # (iii) pre-deriver (der=None) -> model/arch/quant null; topology null
+    #       when neither override nor nvidia-smi.
+    og2 = C.emit_gate_capture(
+        slug="org/NoDeriver",
+        profile_like="vllm/minimal",
+        abort_reason="unsupported-format",
+        confidence=None, raw_verdict=None,
+        detail="deriver: unsupported-format",
+        der=None, hardware_sm=None, gpu_topology=None,
+        club3090_commit="deadbeef", repo_root=_root,
+        ts="20260518T102000Z",
+    )
+    gm2 = json.loads(Path(og2["paths"]["manifest"]).read_text())
+    # arch/quant are GUARANTEED null pre-deriver (no der.profile). Topology
+    # is BEST-EFFORT (CONTRACT-1.1): null when neither --hardware-gpus nor
+    # nvidia-smi — but on a rig WITH nvidia-smi the capture-only resolve
+    # legitimately populates it (mirrors pull.py:853-855). So assert the
+    # guaranteed-null invariants + topology being either null OR a valid
+    # deterministic serialization (never fabricated/garbage).
+    check(gm2["arch_family"] is None and gm2["quant_label"] is None
+          and gm2["model"] == "org/NoDeriver",
+          "emit_gate_capture: pre-deriver -> arch/quant null (no "
+          "der.profile), model still the slug")
+    _tc, _ts2 = gm2["topology_class"], gm2["topology_summary_canonical"]
+    check((_tc is None and _ts2 is None)
+          or (isinstance(_tc, str) and _tc.endswith("MiB")
+              and isinstance(_ts2, str) and _ts2.startswith("[")),
+          f"emit_gate_capture: topology is best-effort — null XOR a valid "
+          f"deterministic serialization, never fabricated "
+          f"(class={_tc!r} summary={_ts2!r})")
+
+    # (iv) redaction: a leaky abort_reason/detail is _redact_text-scrubbed.
+    og3 = C.emit_gate_capture(
+        slug="org/Leaky",
+        profile_like="vllm/minimal",
+        abort_reason="hard-block",
+        confidence=None, raw_verdict="wont-fit",
+        detail="refused near /opt/ai/secret/model and /mnt/models/x",
+        der=None, hardware_sm=8.6, gpu_topology=None,
+        club3090_commit="deadbeef", repo_root=_root,
+        ts="20260518T103000Z",
+    )
+    for _a in og3["paths"].values():
+        _b = Path(_a).read_text()
+        check("/opt/ai" not in _b and "/mnt/models" not in _b,
+              f"emit_gate_capture: leaky path scrubbed from "
+              f"{Path(_a).name} (same _redact_text discipline)")
+
+    # (v) the SHARED `.last` marker — written by BOTH emitters (the
+    #     centralization mandate). The last writer wins; it points at the
+    #     RELATIVE bundle dir under .pull-captures/.
+    _last = _root / ".pull-captures" / ".last"
+    check(_last.is_file(),
+          "write_last_marker: .pull-captures/.last exists after a capture")
+    check(_last.read_text().strip()
+          == str(Path(og3["dir"]).relative_to(_root / ".pull-captures")),
+          "write_last_marker: .last points at the MOST-RECENT bundle "
+          "(last-writer-wins; relative path)")
+    # emit_capture() ALSO updates the SAME shared marker (not [E]-only).
+    o_full2 = C.emit_capture(
+        ei, confidence=SimpleNamespace(name="EXACT"),
+        raw_verdict="fits-clean", profile_like="vllm/x",
+        download_result=dl, boot_result=res, smoke_result=sm,
+        compose_meta=compose_meta, kv_calc_version="kvcalc-v7",
+        repo_root=_root, ts="20260518T104000Z",
+    )
+    check(_last.read_text().strip()
+          == str(Path(o_full2["dir"]).relative_to(
+              _root / ".pull-captures")),
+          "write_last_marker: emit_capture() ALSO updates the SHARED "
+          ".last (centralized — NOT wired into emit_capture only)")
+
+# ---------------------------------------------------------------------------
 # CONTRACT-5 G1 — live-topology verify gate (F6).
 #
 # `topology_summary_canonical` live wiring

--- a/scripts/tests/test-pullgate-gates.sh
+++ b/scripts/tests/test-pullgate-gates.sh
@@ -404,10 +404,152 @@ check(
     "disk-short (gate order is C0 -> C2a, monotonic)",
 )
 
+# ---------------------------------------------------------------------------
+# CONTRACT-2 (§10-R4) — arch-family registry expansion: ZERO FALSE-PASS.
+# ---------------------------------------------------------------------------
+# The expansion must (a) measurably broaden the `--experimental-arch`-free
+# pass rate — a previously `no-arch-row` arch now has a row, so the
+# `--experimental-arch` requirement is gone; AND (b) NEVER false-pass — an
+# `unverified`-TRC expansion row still resolves `needs-trust-remote-code-ack`
+# (fail-closed, bypassable ONLY by `--trust-remote-code`), and an arch that
+# is STILL absent still hard-blocks `no-arch-row`.
+arches_now = G._gc().load_arches(root)
+expansion_arches = [
+    r for r in arches_now
+    if r.get("confidence") == "estimated-lower-bound"
+    and r.get("status") == "unverified"
+]
+check(
+    len(expansion_arches) >= 12,
+    f"CONTRACT-2: registry expansion present "
+    f"({len(expansion_arches)} estimated-lower-bound rows; was a narrow "
+    f"first wave)",
+)
+
+
+def _mk_cfg(slug, arch):
+    r = D.DeriveResult(slug=slug)
+    r.tier1 = None
+    r.profile = {"arch": arch, "auto_map": False, "weight_format": "safetensors"}
+    return r
+
+
+# (a) PhiForCausalLM = the real microsoft/phi-2 C0 case that hard-blocked on
+#     `no-arch-row` during v0.8.2 STEP V1 on-rig validation. With the
+#     expansion it NO LONGER requires `--experimental-arch` ...
+phi = G.c0_engine_support(
+    "vllm/minimal", _mk_cfg("microsoft/phi-2", "PhiForCausalLM"),
+    path="B", hardware_sm=SM_86,
+)
+check(
+    phi.sub_reason != G.C0SubReason.NO_ARCH_ROW
+    and G.BYPASS_EXPERIMENTAL_ARCH not in phi.bypassable_by,
+    f"CONTRACT-2: PhiForCausalLM (microsoft/phi-2 on-rig anchor) no longer "
+    f"requires --experimental-arch (got {phi.state.value}/"
+    f"{phi.sub_reason}/{phi.bypassable_by})",
+)
+# ... yet stays TRC-fail-closed — ZERO FALSE-PASS (never auto-passed; the
+#     unverified-TRC row resolves needs-trc-ack, bypassable ONLY by an
+#     explicit --trust-remote-code).
+check(
+    phi.state == G.C0State.NEEDS_TRC_ACK
+    and phi.bypassable_by == (G.BYPASS_TRUST_REMOTE_CODE,),
+    f"CONTRACT-2 zero-false-pass: PhiForCausalLM stays TRC-fail-closed "
+    f"(needs-trc-ack, --trust-remote-code only; got {phi.state.value}/"
+    f"{phi.bypassable_by})",
+)
+
+# (b) An arch STILL absent from the registry must STILL hard-block
+#     `no-arch-row` requiring `--experimental-arch` (the unsupported-arch
+#     hard-block is intact — the expansion did not weaken the gate).
+absent = G.c0_engine_support(
+    "vllm/minimal", _mk_cfg("acme/exotic", "DefinitelyNotARealArch9000"),
+    path="B", hardware_sm=SM_86,
+)
+check(
+    absent.state == G.C0State.ENGINE_SUPPORT_UNKNOWN
+    and absent.sub_reason == G.C0SubReason.NO_ARCH_ROW
+    and absent.bypassable_by == (G.BYPASS_EXPERIMENTAL_ARCH,),
+    f"CONTRACT-2 zero-false-pass: an unsupported arch STILL hard-blocks "
+    f"no-arch-row (got {absent.state.value}/{absent.sub_reason}/"
+    f"{absent.bypassable_by})",
+)
+
+# (c) Every expansion row's declarative flags are defensible by schema (the
+#     test-patch-attribution arch-schema gate already enforces structure;
+#     here assert the no-false-pass-bearing fields specifically): each
+#     carries unverified TRC + evidence none (so it CANNOT silently pass),
+#     a non-empty integer tp_divisors, and a moe_layout.
+for r in expansion_arches:
+    a = r.get("arch", "<?>")
+    check(
+        r.get("requires_trust_remote_code") == "unverified"
+        and r.get("requires_trust_remote_code_evidence") == "none",
+        f"CONTRACT-2 zero-false-pass: expansion arch {a} is TRC-fail-closed "
+        f"(unverified + evidence none)",
+    )
+    vt = r.get("valid_tp") or {}
+    check(
+        isinstance(vt.get("tp_divisors"), list)
+        and bool(vt.get("tp_divisors"))
+        and all(isinstance(x, int) for x in vt["tp_divisors"])
+        and vt.get("moe_layout") in {"dense", "moe"},
+        f"CONTRACT-2: expansion arch {a} carries defensible declarative "
+        f"flags (tp_divisors + moe_layout)",
+    )
+
+# (d) #146-shape worked acceptance case (do NOT fetch the PR). PR #146
+#     hand-edited compose_registry.py + qwen3.6-27b.yml to add an
+#     `awq_bf16_int4` variant. The expanded machinery must cleanly
+#     absorb/validate exactly this shape: a manually-added model-YAML
+#     weights variant is well-formed AND any registry entry that uses it
+#     resolves to a launchable compose whose backing arch
+#     (Qwen3NextForCausalLM — already a verified row) has defensible flags.
+import copy  # noqa: E402
+
+import yaml as _yaml  # noqa: E402
+
+_m = _yaml.safe_load(
+    (root / "scripts/lib/profiles/models/qwen3.6-27b.yml").read_text()
+)
+# Synthesize the #146-shaped manual addition in-memory (no repo mutation).
+_synth = copy.deepcopy(_m)
+_synth["weights"]["awq_bf16_int4"] = {
+    "path": "qwen3.6-27b-awq-bf16-int4",
+    "size_gb": 17.0,
+    "format": "awq",
+    "status": "experimental",
+}
+_v = _synth["weights"]["awq_bf16_int4"]
+check(
+    {"path", "size_gb", "format", "status"} <= set(_v)
+    and isinstance(_v["size_gb"], (int, float))
+    and _v["format"] in {"awq", "autoround", "gguf", "bf16", "int8"},
+    "CONTRACT-2 #146-shape: a hand-added awq_bf16_int4 weights variant is "
+    "schema-well-formed (the expanded machinery absorbs the manual add)",
+)
+# Its backing arch is the already-verified Qwen3NextForCausalLM row — the
+# expansion's flag schema validates it: defensible (status verified,
+# confidence exact, real TRC evidence), launchable on a loads:true pin.
+_qn = next(
+    (r for r in arches_now if r.get("arch") == "Qwen3NextForCausalLM"), None
+)
+check(
+    _qn is not None
+    and _qn.get("status") == "verified"
+    and _qn.get("confidence") == "exact"
+    and _qn.get("requires_trust_remote_code") == "false"
+    and _qn.get("requires_trust_remote_code_evidence") not in (None, "", "none")
+    and any(p.get("loads") for p in _qn.get("engine_pin") or []),
+    "CONTRACT-2 #146-shape: the awq_bf16_int4 variant's backing arch "
+    "(Qwen3NextForCausalLM) carries defensible flags (verified/exact, real "
+    "TRC evidence, loads:true pin) — the worked-case validates cleanly",
+)
+
 if failures:
     print(f"\n{len(failures)} assertion(s) failed.", file=sys.stderr)
     sys.exit(1)
-print("\nAll Pull-Gate gates (stratum-2 + [C0] + [C2a]) assertions passed.")
+print("\nAll Pull-Gate gates (stratum-2 + [C0] + [C2a] + CONTRACT-2) assertions passed.")
 PY
 
 echo "test-pullgate-gates.sh OK"

--- a/scripts/tests/test-pullgate-gates.sh
+++ b/scripts/tests/test-pullgate-gates.sh
@@ -435,28 +435,44 @@ def _mk_cfg(slug, arch):
 
 
 # (a) PhiForCausalLM = the real microsoft/phi-2 C0 case that hard-blocked on
-#     `no-arch-row` during v0.8.2 STEP V1 on-rig validation. With the
-#     expansion it NO LONGER requires `--experimental-arch` ...
+#     `no-arch-row` during v0.8.2 STEP V1 on-rig validation. It is a
+#     long-standing native vLLM built-in class with no remote code, so the
+#     arch row carries requires_trust_remote_code:"false" (documented
+#     upstream constraint). A repo declaring it with NO auto_map now passes
+#     [C0] engine-supported CLEANLY (CONTRACT-2 delivered — the over-refusal
+#     is removed, not merely relabelled).
 phi = G.c0_engine_support(
     "vllm/minimal", _mk_cfg("microsoft/phi-2", "PhiForCausalLM"),
     path="B", hardware_sm=SM_86,
 )
 check(
-    phi.sub_reason != G.C0SubReason.NO_ARCH_ROW
-    and G.BYPASS_EXPERIMENTAL_ARCH not in phi.bypassable_by,
-    f"CONTRACT-2: PhiForCausalLM (microsoft/phi-2 on-rig anchor) no longer "
-    f"requires --experimental-arch (got {phi.state.value}/"
-    f"{phi.sub_reason}/{phi.bypassable_by})",
+    phi.state == G.C0State.ENGINE_SUPPORTED
+    and phi.sub_reason is None
+    and phi.bypassable_by == (),
+    f"CONTRACT-2 DELIVERED: PhiForCausalLM (microsoft/phi-2 on-rig anchor, "
+    f"no auto_map) passes [C0] engine-supported with NO bypass flag "
+    f"(got {phi.state.value}/{phi.sub_reason}/{phi.bypassable_by})",
 )
-# ... yet stays TRC-fail-closed — ZERO FALSE-PASS (never auto-passed; the
-#     unverified-TRC row resolves needs-trc-ack, bypassable ONLY by an
-#     explicit --trust-remote-code).
+# ZERO FALSE-PASS is preserved PER-REPO: the SAME native arch from a repo
+# that ships auto_map (custom/remote modeling code) STILL hard-blocks
+# needs-trc-ack — the row's "false" only removes the arch-row-level
+# over-refusal; gates.py's independent `has_auto_map` OR-term keeps the
+# per-repo trust boundary fail-closed.
+_phi_am = D.DeriveResult(slug="evil/phi")
+_phi_am.tier1 = None
+_phi_am.profile = {
+    "arch": "PhiForCausalLM", "auto_map": True,
+    "weight_format": "safetensors",
+}
+phi_am = G.c0_engine_support(
+    "vllm/minimal", _phi_am, path="B", hardware_sm=SM_86,
+)
 check(
-    phi.state == G.C0State.NEEDS_TRC_ACK
-    and phi.bypassable_by == (G.BYPASS_TRUST_REMOTE_CODE,),
-    f"CONTRACT-2 zero-false-pass: PhiForCausalLM stays TRC-fail-closed "
-    f"(needs-trc-ack, --trust-remote-code only; got {phi.state.value}/"
-    f"{phi.bypassable_by})",
+    phi_am.state == G.C0State.NEEDS_TRC_ACK
+    and phi_am.bypassable_by == (G.BYPASS_TRUST_REMOTE_CODE,),
+    f"CONTRACT-2 zero-false-pass: a PhiForCausalLM repo WITH auto_map STILL "
+    f"hard-blocks needs-trc-ack (per-repo safety intact despite row "
+    f"TRC=false; got {phi_am.state.value}/{phi_am.bypassable_by})",
 )
 
 # (b) An arch STILL absent from the registry must STILL hard-block
@@ -475,19 +491,35 @@ check(
     f"{absent.bypassable_by})",
 )
 
-# (c) Every expansion row's declarative flags are defensible by schema (the
-#     test-patch-attribution arch-schema gate already enforces structure;
-#     here assert the no-false-pass-bearing fields specifically): each
-#     carries unverified TRC + evidence none (so it CANNOT silently pass),
-#     a non-empty integer tp_divisors, and a moe_layout.
+# (c) Every expansion row's declarative flags are defensible — and the
+#     no-false-pass invariant is now a TWO-CLASS rule (post the V3 on-rig
+#     CONTRACT-2-delivery correction):
+#       * requires_trust_remote_code:"false"  -> a deliberately-blessed
+#         long-standing native vLLM built-in class; MUST carry a non-empty,
+#         non-"none" documented-constraint evidence string (never blank).
+#         Per-repo remote-code is still independently gated by gates.py's
+#         has_auto_map OR-term, so this is NOT a false-pass.
+#       * requires_trust_remote_code:"unverified" -> conservative
+#         fail-closed; MUST carry evidence "none".
+#     Anything else (true / missing) is a hard fail. Plus a non-empty
+#     integer tp_divisors and a moe_layout.
 for r in expansion_arches:
     a = r.get("arch", "<?>")
-    check(
-        r.get("requires_trust_remote_code") == "unverified"
-        and r.get("requires_trust_remote_code_evidence") == "none",
-        f"CONTRACT-2 zero-false-pass: expansion arch {a} is TRC-fail-closed "
-        f"(unverified + evidence none)",
-    )
+    _trc = r.get("requires_trust_remote_code")
+    _ev = r.get("requires_trust_remote_code_evidence")
+    if _trc == "false":
+        check(
+            isinstance(_ev, str) and _ev not in ("", "none") and len(_ev) > 40,
+            f"CONTRACT-2: blessed-native arch {a} (TRC=false) carries a "
+            f"non-empty documented-constraint evidence anchor (got {_ev!r:.60})",
+        )
+    else:
+        check(
+            _trc == "unverified" and _ev == "none",
+            f"CONTRACT-2 zero-false-pass: non-blessed expansion arch {a} is "
+            f"TRC-fail-closed (unverified + evidence none; got "
+            f"{_trc!r}/{_ev!r:.40})",
+        )
     vt = r.get("valid_tp") or {}
     check(
         isinstance(vt.get("tp_divisors"), list)

--- a/scripts/tests/test-submit-pull.sh
+++ b/scripts/tests/test-submit-pull.sh
@@ -411,9 +411,22 @@ fb = S.ghless_fallback(fi, cl, repo_root=rr, bundle_dir=gd)
 import urllib.parse as _up2  # noqa: E402
 _decoded_body = _up2.unquote(
     _up2.parse_qs(_up2.urlparse(fb["url"]).query)["body"][0])
-check("/opt/ai" not in _decoded_body and "/home/" not in _decoded_body,
+_PCN = ".pull-captures"
+check("/opt/ai" not in _decoded_body and "/home/" not in _decoded_body
+      and "/mnt/" not in _decoded_body,
       "leak-hygiene: the gh-less URL body (built from the [E]-redacted "
       "manifest) carries NO unredacted internal absolute path")
+# RIG-INDEPENDENT (the real catch the /opt|/home check missed when gd was a
+# tmp sandbox dir): the ABSOLUTE bundle dir must NEVER appear in the public-
+# paste body; only the repo-relative `.pull-captures/...` pointer may.
+check(str(gd) not in _decoded_body,
+      "leak-hygiene: the gh-less body MUST NOT contain the absolute capture "
+      f"dir ({gd}) — public-paste content is repo-relative only")
+check(_PCN in _decoded_body and not any(
+          _seg.startswith("/") for _seg in _decoded_body.split("`")
+          if _PCN in _seg),
+      "leak-hygiene: the gh-less body's bundle pointer is repo-relative "
+      f"(`{_PCN}/<slug>/<ts>`), never an absolute path")
 # The redacted-bundle pointer the message prints is the local capture dir
 # (a tmp path here, by design the on-ramp's only emitted artifact) — assert
 # the message NEVER instructs pasting terminal scrollback.

--- a/scripts/tests/test-submit-pull.sh
+++ b/scripts/tests/test-submit-pull.sh
@@ -1,0 +1,465 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-submit-pull.sh — v0.8.2 STEP V2 (CONTRACT-1.2 / 1.3).
+#
+# Contract test for the user-invoked, consented failure on-ramp:
+#   scripts/pull.sh --submit-last / --submit <capture-dir>
+# + the CONTRACT-1.2 surfacing pointer. The test IS the spec; the code is
+# fixed to it. NO live Docker / GPU / HF-API and ZERO network / ZERO real
+# `gh`: every `gh` invocation goes through an INJECTED mock `gh_runner`;
+# consent is driven via an injected `_input`; capture bundles are built by
+# the REAL `capture.emit_gate_capture` (genuine schema:2 artifacts) parsed
+# via F1's read_gate_bundle and classified via the REAL F2 `classify`.
+#
+# Coverage (every CONTRACT-1.2 / 1.3 + RED-LINE assertion as a
+# failing-then-passing check):
+#   * `--submit-last` resolves `.pull-captures/.last` (the V1 shared marker,
+#     read-only here); absent/stale -> the exact CONTRACT-1.3 error.
+#   * the `.last`-marker RACE: a SECOND terminal capture overwrites `.last`
+#     between capture and `--submit-last`; the verb RE-READS `.last` and
+#     re-shows the CURRENT bundle identity (no silent wrong-bundle submit).
+#   * consent: explicit `y` required; a decline performs ZERO network.
+#   * gh present (mock auth ok) -> reuses the SHIPPED F5 `dedup.submit`
+#     (effective_dedup_hash, bounded labels, +1-or-open) — NOT reimplemented.
+#   * gh-less + should_file=True (engine-support-unknown/no-arch-row ->
+#     kernel-unsupported): a prefilled PUBLIC issues/new URL carrying the
+#     loop:dedup-<hash> label.
+#   * gh-less + review-queued (`unknown` -> a correct-refusal abort_reason):
+#     the LOCAL _review-queue spool path + the no-public-issue line and
+#     ABSOLUTELY NO public issues/new URL (the §6.1 review-queue boundary).
+#   * CONTRACT-1.2: the surfacing pointer + `.last` fire whenever a gate
+#     bundle was EMITTED, regardless of exit code — proven on the
+#     bundle-emitted-but-exit-0 bypassable C0 path (NOT only exit-2).
+#   * leak-hygiene: nothing the on-ramp tells the user to share carries an
+#     unredacted absolute path.
+#   * gate path stays I/O-free: run_pull performs NO network / NO prompt /
+#     NO auto-send (the surfacing is a single stdout line, post-return).
+#   * import-time safety: importing submit_pull then kv-calc --calibration
+#     stays Overall: 22/22.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+export PYTHONPATH="$ROOT_DIR${PYTHONPATH:+:$PYTHONPATH}"
+
+python3 - "$ROOT_DIR" <<'PY'
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+from contextlib import redirect_stdout, redirect_stderr
+from pathlib import Path
+
+root = Path(sys.argv[1])
+sys.path.insert(0, str(root))
+
+from scripts.lib.profiles import capture as CAP  # noqa: E402
+from scripts.lib.profiles import dedup as D  # noqa: E402
+from scripts.lib.profiles import submit_pull as S  # noqa: E402
+from scripts.lib.profiles.classifier import (  # noqa: E402
+    FailureClass,
+    classify,
+)
+from scripts.lib.profiles.loop_input import read_gate_bundle  # noqa: E402
+
+failures: list[str] = []
+
+
+def check(cond: bool, msg: str) -> None:
+    if cond:
+        print(f"PASS: {msg}")
+    else:
+        print(f"FAIL: {msg}", file=sys.stderr)
+        failures.append(msg)
+
+
+# ---------------------------------------------------------------------------
+# Mock gh_runner — ZERO network / `gh`. Records argv; `auth status` ok/not.
+# (Reuses the shipped D.GhResult seam so the type matches dedup.submit.)
+# ---------------------------------------------------------------------------
+class MockGh:
+    def __init__(self, *, authed=True):
+        self.calls: list[list[str]] = []
+        self.authed = authed
+        self.list_response = "[]"
+
+    def __call__(self, argv):
+        argv = list(argv)
+        self.calls.append(argv)
+        if argv[:2] == ["auth", "status"]:
+            return D.GhResult(self.authed, 0 if self.authed else 1, "",
+                              "" if self.authed else "not logged in")
+        if not self.authed:
+            return D.GhResult(False, 127, "", "gh not found (mock)")
+        if argv[:2] == ["issue", "list"]:
+            return D.GhResult(True, 0, self.list_response, "")
+        if argv[:2] == ["issue", "create"]:
+            return D.GhResult(
+                True, 0,
+                "https://github.com/noonghunna/club-3090/issues/777", "")
+        if argv[:2] == ["issue", "comment"]:
+            return D.GhResult(True, 0, "", "")
+        if argv[:2] == ["label", "create"]:
+            return D.GhResult(True, 0, "", "")
+        return D.GhResult(True, 0, "", "")
+
+
+def emit_gate(repo_root: Path, *, slug, abort_reason, ts) -> Path:
+    """Build a REAL schema:2 gate bundle via the shipped emitter (also
+    writes the shared `.last` marker — V1 centralization)."""
+    out = CAP.emit_gate_capture(
+        slug=slug,
+        profile_like="vllm/minimal",
+        abort_reason=abort_reason,
+        confidence=None,
+        raw_verdict=None,
+        detail=f"gate hard-block: {abort_reason}",
+        der=None,
+        hardware_sm=8.6,
+        gpu_topology=(2, [24576, 24576], ["RTX 3090", "RTX 3090"]),
+        club3090_commit="cafef00d",
+        kv_calc_version="kvcalc-v0.8.0",
+        repo_root=repo_root,
+        ts=ts,
+    )
+    return Path(out["dir"])
+
+
+def run_submit(repo_root, *, submit_last=True, capture_dir=None,
+                consent="y", gh):
+    """Invoke the verb capturing stdout/stderr; ZERO network (mock gh)."""
+    out, err = io.StringIO(), io.StringIO()
+    answers = iter([consent])
+
+    def _inp(_prompt):
+        try:
+            return next(answers)
+        except StopIteration:
+            return ""
+
+    with redirect_stdout(out), redirect_stderr(err):
+        rc = S.submit_pull(
+            capture_dir=capture_dir,
+            submit_last=submit_last,
+            repo_root=Path(repo_root),
+            gh_runner=gh,
+            _input=_inp,
+        )
+    return rc, out.getvalue(), err.getvalue()
+
+
+# ===========================================================================
+# 1. --submit-last with NO marker -> the exact CONTRACT-1.3 error, rc=2.
+# ===========================================================================
+rr = Path(tempfile.mkdtemp())
+gh = MockGh(authed=True)
+rc, so, se = run_submit(rr, gh=gh)
+check(rc == 2 and "no recent capture" in se
+      and "--submit <dir>" in se,
+      "no `.last` -> the CONTRACT-1.3 error 'no recent capture; use "
+      "`--submit <dir>`' (rc=2)")
+check(gh.calls == [],
+      "unresolvable bundle -> ZERO gh calls (no network before resolve)")
+
+# ===========================================================================
+# 2. gh present + should_file=True (no-arch-row) -> reuses SHIPPED F5
+#    dedup.submit (NOT reimplemented). Consent `y` required first.
+# ===========================================================================
+rr = Path(tempfile.mkdtemp())
+gd = emit_gate(rr, slug="Org/Exotic",
+               abort_reason="engine-support-unknown/no-arch-row",
+               ts="20260518T000001Z")
+# Sanity: the real F1/F2 route this to kernel-unsupported / should_file.
+_fi = read_gate_bundle(gd)
+_cl = classify(_fi)
+check(_cl.failure_class is FailureClass.KERNEL_UNSUPPORTED
+      and _cl.should_file is True,
+      "no-arch-row gate bundle classifies kernel-unsupported/should_file "
+      "(the §10-R9 solicited lever) via the REAL shipped F2")
+
+gh = MockGh(authed=True)
+rc, so, se = run_submit(rr, gh=gh, consent="y")
+check(rc == 0 and "F5 action=" in so,
+      "gh present + consent y -> reuses the shipped F5 dedup.submit "
+      f"(rc={rc})")
+check(any(c[:2] == ["issue", "list"] for c in gh.calls)
+      and any(c[:2] == ["issue", "create"] for c in gh.calls),
+      "F5 ran the shipped path (gh issue list then create) — NOT a "
+      "reimplemented submit")
+
+# ===========================================================================
+# 3. Consent gate: a decline performs ZERO network.
+# ===========================================================================
+gh = MockGh(authed=True)
+rc, so, se = run_submit(rr, gh=gh, consent="n")
+issue_calls = [c for c in gh.calls if c[:1] == ["issue"]]
+check(rc == 0 and "declined" in so and not issue_calls,
+      "explicit decline -> nothing sent, ZERO `gh issue` network calls")
+
+# ===========================================================================
+# 4. The `.last`-marker RACE (RED-LINE): a SECOND capture overwrites
+#    `.last` between capture and --submit-last; the verb RE-READS `.last`
+#    and re-shows the CURRENT bundle identity (no silent wrong-bundle).
+# ===========================================================================
+rr = Path(tempfile.mkdtemp())
+g_first = emit_gate(rr, slug="Org/First",
+                    abort_reason="engine-support-unknown/no-arch-row",
+                    ts="20260518T000010Z")
+# A second terminal capture (a racing pull) overwrites `.last`.
+g_second = emit_gate(rr, slug="Org/Second",
+                     abort_reason="engine-support-unknown/no-arch-row",
+                     ts="20260518T000011Z")
+marker = (rr / ".pull-captures" / ".last").read_text().strip()
+check(marker == str(g_second.relative_to(rr / ".pull-captures")),
+      "the shared `.last` marker is last-writer-wins (points at the SECOND "
+      "capture after the racing pull)")
+gh = MockGh(authed=True)
+rc, so, se = run_submit(rr, gh=gh, consent="n")  # decline; only inspect.
+check("Org/Second" in so and "Org/First" not in so,
+      "--submit-last RE-READS `.last` at submit + re-shows the CURRENT "
+      "(SECOND) bundle identity — NO silent wrong-bundle submit")
+check(S.resolve_last(rr).resolve() == g_second.resolve(),
+      "resolve_last() resolves the marker's CURRENT target (the race "
+      "defense is keyed on a re-read, not a stale capture-time value)")
+
+# ===========================================================================
+# 5. gh-less + should_file=True -> a prefilled PUBLIC issues/new URL with
+#    the loop:dedup-<hash> label; NO `gh issue` calls.
+# ===========================================================================
+rr = Path(tempfile.mkdtemp())
+gd = emit_gate(rr, slug="Org/Exotic",
+               abort_reason="engine-support-unknown/no-arch-row",
+               ts="20260518T000020Z")
+gh = MockGh(authed=False)  # gh unavailable / unauthed.
+rc, so, se = run_submit(rr, gh=gh, consent="y")
+fi = read_gate_bundle(gd)
+cl = classify(fi)
+h = D.effective_dedup_hash(fi, cl)
+check(rc == 0
+      and "https://github.com/noonghunna/club-3090/issues/new?" in so
+      and f"loop%3Adedup-{h}" in so.replace("loop:dedup-", "loop%3Adedup-")
+      or f"loop:dedup-{h}" in so,
+      "gh-less + should_file=True -> a prefilled PUBLIC issues/new URL "
+      "(carries the loop:dedup-<hash> label)")
+issue_calls = [c for c in gh.calls if c[:1] == ["issue"]]
+check(not issue_calls,
+      "gh-less path makes ZERO `gh issue` network calls (paste-only)")
+
+# Use the structured fallback API to assert the URL precisely.
+fb = S.ghless_fallback(fi, cl, repo_root=rr, bundle_dir=gd)
+check(fb["kind"] == "ghless-public-url" and fb["should_file"] is True
+      and fb["url"].startswith(
+          "https://github.com/noonghunna/club-3090/issues/new?")
+      and f"loop:dedup-{h}" in __import__("urllib.parse",
+          fromlist=["unquote"]).unquote(fb["url"]),
+      "ghless_fallback(should_file=True): public issues/new URL, "
+      "loop:dedup-<hash> label, deterministic")
+# Title template: [<model>] <failure-class> on <topology> (dedup:<hash8>)
+import urllib.parse as _up  # noqa: E402
+_q = _up.parse_qs(_up.urlparse(fb["url"]).query)
+_title = _q["title"][0]
+check(_title == f"[Org/Exotic] kernel-unsupported on 2x24576MiB "
+      f"(dedup:{h[:8]})",
+      f"gh-less deterministic title template (got {_title!r})")
+
+# ===========================================================================
+# 6. gh-less + review-queued (`unknown` correct-refusal) -> the LOCAL
+#    _review-queue spool path + the no-public-issue line; ABSOLUTELY NO
+#    public issues/new URL (the §6.1 review-queue boundary, RED-LINE).
+# ===========================================================================
+rr = Path(tempfile.mkdtemp())
+gd = emit_gate(rr, slug="Org/DiskShort", abort_reason="disk-short",
+               ts="20260518T000030Z")
+fi = read_gate_bundle(gd)
+cl = classify(fi)
+check(cl.failure_class is FailureClass.UNKNOWN
+      and cl.should_file is False,
+      "disk-short gate bundle classifies `unknown`/should_file=False "
+      "(a correct-refusal — review-queued, NOT public-filed)")
+gh = MockGh(authed=False)
+rc, so, se = run_submit(rr, gh=gh, consent="y")
+check(rc == 0
+      and "not a public issue" in so
+      and "_review-queue" in so
+      and "issues/new" not in so
+      and "github.com" not in so,
+      "gh-less + review-queued -> local _review-queue spool path + the "
+      "no-public-issue line, ABSOLUTELY NO public issues/new URL")
+fb = S.ghless_fallback(fi, cl, repo_root=rr, bundle_dir=gd)
+check(fb["kind"] == "ghless-review-queued"
+      and fb["should_file"] is False
+      and "url" not in fb
+      and fb["spool_path"].endswith("_review-queue/"
+                                    f"{D.effective_dedup_hash(fi, cl)}.json"),
+      "ghless_fallback(review-queued): NO `url` key, points at the "
+      "_review-queue spool — the §6.1 boundary the suppression design "
+      "exists to keep clean")
+
+# ===========================================================================
+# 7. CONTRACT-1.2 RED-LINE — the surfacing pointer + `.last` fire whenever
+#    a gate bundle was EMITTED, regardless of exit code. Proven on the
+#    bundle-emitted-but-exit-0 bypassable C0 path (NOT only exit-2).
+# ===========================================================================
+from scripts.lib.profiles import pull as P  # noqa: E402
+
+
+class _Diag(dict):
+    pass
+
+
+def _fake_res(*, ok, abort_reason, gate_dir):
+    """A minimal PullResult-shaped object exercising main()'s surfacing
+    branch directly (the surfacing is keyed on
+    res.diagnostics['gate_capture']['dir'], NOT the exit code)."""
+    r = P.PullResult(
+        slug="Org/Phi", profile_like="vllm/minimal",
+        path="B", ok=ok, stratum=P.Stratum.C0,
+    )
+    r.abort_reason = abort_reason
+    r.diagnostics = {"gate_capture": {"dir": gate_dir}}
+    return r
+
+
+# Exit-0 bypassable advisory path (ok-ish / non-abort-2) WITH an emitted
+# bundle vs exit-2 hard-block WITH an emitted bundle: BOTH must surface.
+buf0 = io.StringIO()
+r0 = _fake_res(ok=True, abort_reason=None, gate_dir="/x/cap/exit0")
+with redirect_stdout(buf0):
+    # Mirror main()'s post-return surfacing branch verbatim.
+    _gc = r0.diagnostics.get("gate_capture")
+    _gd0 = _gc.get("dir") if isinstance(_gc, dict) else None
+    if _gd0:
+        print(f"[pull] Diagnostics captured (redacted, no paths/tokens): "
+              f"{_gd0}")
+        print("[pull] Help improve the fit math — submit with: "
+              "scripts/pull.sh --submit-last")
+out0 = buf0.getvalue()
+check("Diagnostics captured" in out0 and "--submit-last" in out0,
+      "CONTRACT-1.2: an emitted gate bundle on the EXIT-0 bypassable path "
+      "still surfaces the submit pointer (NOT gated on exit==2 — the "
+      "no-arch-row §10-R9 lever is the exit-0 path)")
+
+# Negative control: NO gate bundle emitted -> NO surfacing line.
+buf_n = io.StringIO()
+with redirect_stdout(buf_n):
+    _gc = ({}).get("gate_capture")
+    _gdn = _gc.get("dir") if isinstance(_gc, dict) else None
+    if _gdn:
+        print("[pull] Diagnostics captured ...")
+check("Diagnostics captured" not in buf_n.getvalue(),
+      "CONTRACT-1.2: NO gate bundle emitted -> NO surfacing line "
+      "(trigger is bundle-emitted, precisely)")
+
+# The real main() wiring: assert the surfacing branch reads
+# diagnostics['gate_capture']['dir'] (source inspection — keyed on the
+# bundle, not the exit code).
+import inspect  # noqa: E402
+_msrc = inspect.getsource(P.main)
+# The surfacing branch lives BEFORE `if res.ok:` and is keyed on the
+# emitted gate-bundle dir; isolate that span and prove no exit-code gate.
+_surf = _msrc.split('res.diagnostics.get("gate_capture")')[1].split(
+    "if res.ok:")[0]
+check('res.diagnostics.get("gate_capture")' in _msrc
+      and '.get("dir")' in _surf
+      and "Diagnostics captured" in _surf
+      and "--submit-last" in _surf
+      and "_EXIT_ABORT" not in _surf
+      and "_EXIT_NEEDS_FLAG" not in _surf
+      and "res.ok" not in _surf,
+      "CONTRACT-1.2 wiring: main() surfacing is keyed on the emitted gate "
+      "bundle dir, with NO exit-code gate around it")
+
+# ===========================================================================
+# 8. Gate path is I/O-FREE (RED-LINE): submit_pull is the ONLY network
+#    site; run_pull has no submit/network/prompt. Source-level proof
+#    (run_pull never imports/calls submit_pull or gh).
+# ===========================================================================
+_rp_src = inspect.getsource(P.run_pull)
+check("submit_pull" not in _rp_src and "gh_runner" not in _rp_src
+      and "_real_gh_runner" not in _rp_src and "input(" not in _rp_src,
+      "RED-LINE: run_pull (the gate path) has NO submit/gh/network/blocking-"
+      "prompt — submission is the separate, explicit, consented verb only")
+# submit_pull REUSES dedup.submit + dedup.effective_dedup_hash (it never
+# reimplements the F5 hash/serialization primitive — every dedup-hash use
+# is qualified `_DEDUP.effective_dedup_hash`, never a local sha256 join).
+_sp_src = inspect.getsource(S)
+import re as _re  # noqa: E402
+_unqualified_eff = _re.findall(
+    r"(?<!_DEDUP\.)\beffective_dedup_hash\s*\(", _sp_src)
+check("_DEDUP.submit(" in _sp_src
+      and "_DEDUP.effective_dedup_hash(" in _sp_src
+      and not _unqualified_eff
+      and "hashlib" not in _sp_src
+      and "sha256" not in _sp_src,
+      "RED-LINE: submit_pull REUSES the shipped dedup.submit / "
+      "dedup.effective_dedup_hash — it does NOT reimplement F5 dedup "
+      "(no local hashlib/sha256, no unqualified effective_dedup_hash)")
+
+# ===========================================================================
+# 9. Leak-hygiene (RED-LINE): nothing the on-ramp tells the user to share
+#    carries an unredacted absolute host path.
+# ===========================================================================
+rr = Path(tempfile.mkdtemp())
+gd = emit_gate(rr, slug="Org/Exotic",
+               abort_reason="engine-support-unknown/no-arch-row",
+               ts="20260518T000040Z")
+fi = read_gate_bundle(gd)
+cl = classify(fi)
+fb = S.ghless_fallback(fi, cl, repo_root=rr, bundle_dir=gd)
+import urllib.parse as _up2  # noqa: E402
+_decoded_body = _up2.unquote(
+    _up2.parse_qs(_up2.urlparse(fb["url"]).query)["body"][0])
+check("/opt/ai" not in _decoded_body and "/home/" not in _decoded_body,
+      "leak-hygiene: the gh-less URL body (built from the [E]-redacted "
+      "manifest) carries NO unredacted internal absolute path")
+# The redacted-bundle pointer the message prints is the local capture dir
+# (a tmp path here, by design the on-ramp's only emitted artifact) — assert
+# the message NEVER instructs pasting terminal scrollback.
+for ln in fb["lines"]:
+    check("paste your terminal" not in ln.lower()
+          and "terminal output" not in ln.lower(),
+          "leak-hygiene: the on-ramp never tells the user to paste their "
+          "terminal scrollback (console is not a safe submission source)")
+
+# ===========================================================================
+# 10. import-time safety: importing submit_pull then kv-calc --calibration
+#     stays Overall: 22/22 (no import side effects on the calibrator).
+# ===========================================================================
+import subprocess  # noqa: E402
+_cp = subprocess.run(
+    [sys.executable, str(root / "tools" / "kv-calc.py"), "--calibration"],
+    capture_output=True, text=True, cwd=str(root))
+check("Overall: 22/22 (100%)" in _cp.stdout,
+      "import-time safety: submit_pull import does not perturb "
+      "kv-calc --calibration (still Overall: 22/22)")
+
+# ===========================================================================
+if failures:
+    print(f"\nSUMMARY: {len(failures)} assertion(s) FAILED.",
+          file=sys.stderr)
+    for f in failures:
+        print(f"  - {f}", file=sys.stderr)
+    sys.exit(1)
+
+print("\nSUMMARY: all v0.8.2 STEP V2 submit/on-ramp assertions passed "
+      "(CONTRACT-1.2 surfacing keyed on bundle-emitted-not-exit-code; "
+      "CONTRACT-1.3 --submit-last/--submit, consent, .last race re-read, "
+      "F5 reuse, gh-less should_file branch with NO public URL for "
+      "review-queued; gate path I/O-free; leak-clean).")
+PY
+
+# ---------------------------------------------------------------------------
+# CLI-contract: the submit verb is parsed BEFORE the slug/--profile-like
+# requirement (a distinct top-level verb). NO network (no real `gh` resolves
+# because no `.last` exists in a clean CI tree -> the rc=2 error path).
+# ---------------------------------------------------------------------------
+rm -rf "$ROOT_DIR/.pull-captures"
+_sc(){ bash scripts/pull.sh "$@" >/dev/null 2>&1; echo $?; }
+[ "$(_sc --submit-last)" = 2 ]   || { echo "FAIL: --submit-last with no .last -> 2 (parsed w/o slug/--profile-like)" >&2; exit 1; }
+[ "$(_sc --submit /nonexistent-xyz)" = 2 ] || { echo "FAIL: --submit <bad> -> 2 (parsed w/o slug/--profile-like)" >&2; exit 1; }
+echo "PASS: --submit*/--submit-last is a distinct top-level verb (needs no slug/--profile-like; rc=2 on unresolvable, no network)"
+rm -rf "$ROOT_DIR/.pull-captures"
+
+echo "test-submit-pull.sh OK"

--- a/scripts/tests/test-switch-registry-parity.sh
+++ b/scripts/tests/test-switch-registry-parity.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# CONTRACT-2b-ii — switch.sh ↔ compose_registry.py parity (registry↔launcher).
+#
+# The v0.8.0 compose_registry.py is the single source of truth for what is
+# serveable. switch.sh used to carry a hardcoded `declare -A VARIANTS` map
+# that drifted out of the registry (e.g. vllm/dual-int8 shipped in the
+# registry + as dual/int8.yml but was unlaunchable via switch.sh), which
+# cost a real A/B a config pivot. switch.sh now DERIVES its variant tables
+# from the registry; this test fails CI on ANY mismatch in EITHER direction
+# so the drift class cannot return:
+#
+#   - zero registered-but-unlaunchable composes (registry ⊆ launcher);
+#   - zero launcher-only ghosts (launcher ⊆ registry);
+#   - the derived "engine|dir|file" + default_port for every variant matches
+#     what the registry resolves (so the derivation can't silently corrupt a
+#     mapping while staying key-set-consistent);
+#   - every derived compose file exists on disk.
+#
+# Pure / deterministic: no docker, no GPU, no network. switch.sh's
+# `_derive_variant_tables` is exercised by sourcing the live emitter the
+# same way switch.sh does, then compared to the registry directly.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+# 1. The registry's authoritative expansion (engine|dir|file + port).
+REG_EXPECTED="$(python3 - "$ROOT_DIR" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+sys.path.insert(0, str(root))
+from scripts.lib.profiles.compose_registry import COMPOSE_REGISTRY
+
+for key, entry in COMPOSE_REGISTRY.items():
+    engine_prefix = key.split("/", 1)[0]
+    engine = "llamacpp" if engine_prefix == "llamacpp" else engine_prefix
+    cp = entry["compose_path"]
+    assert "/compose/" in cp, f"registry {key} compose_path lacks /compose/: {cp}"
+    dirpart, filepart = cp.split("/compose/", 1)
+    compose_dir = f"{dirpart}/compose"
+    print(f"{key}\t{engine}|{compose_dir}|{filepart}\t{entry['default_port']}")
+PY
+)"
+
+# 2. switch.sh's DERIVED tables (re-run the exact emitter switch.sh embeds by
+#    extracting and sourcing the function so we test the shipped code path,
+#    not a re-implementation).
+declare -A REG_MAP REG_PORT
+while IFS=$'\t' read -r key spec port; do
+  [[ -n "$key" ]] || continue
+  REG_MAP["$key"]="$spec"
+  REG_PORT["$key"]="$port"
+done <<< "$REG_EXPECTED"
+
+fail=0
+note() { echo "FAIL: $1" >&2; fail=1; }
+
+# The launcher's AUTHORITATIVE resolved variant set = the FULL shipped
+# `switch.sh --list` code path (so a manual post-derivation `VARIANTS[...]=`
+# ghost is caught too, not just the derivation function in isolation).
+# `--list` prints `  <key>  →  <dir>/<file>`. The engine token is derived
+# exactly as switch.sh does (key prefix: vllm | llamacpp).
+LIST_OUT="$(bash "$ROOT_DIR/scripts/switch.sh" --list 2>/dev/null)"
+
+declare -A SW_MAP
+while IFS= read -r line; do
+  # match "  vllm/foo  →  models/.../compose/dir/file.yml"
+  if [[ "$line" =~ ^[[:space:]]+([a-z0-9/_-]+)[[:space:]]+→[[:space:]]+(.+)$ ]]; then
+    key="${BASH_REMATCH[1]}"
+    relpath="${BASH_REMATCH[2]}"
+    [[ -n "$key" && "$key" == */* ]] || continue
+    engine_prefix="${key%%/*}"
+    engine="$engine_prefix"
+    [[ "$engine_prefix" == "llamacpp" ]] && engine="llamacpp"
+    if [[ "$relpath" != *"/compose/"* ]]; then
+      note "switch.sh --list emitted a non-/compose/ path for '$key': $relpath"
+      continue
+    fi
+    cdir="${relpath%%/compose/*}/compose"
+    cfile="${relpath#*/compose/}"
+    SW_MAP["$key"]="${engine}|${cdir}|${cfile}"
+  fi
+done <<< "$LIST_OUT"
+
+# Port table: re-run the SHIPPED derivation function in isolation to dump
+# VARIANT_DEFAULT_PORT (the `--list` path doesn't surface ports). Combined
+# with 3a/3b on the full `--list` set, any key-level ghost is already
+# caught; this adds value-level port parity.
+declare -A SW_PORT
+while IFS=$'\t' read -r key port; do
+  [[ -n "$key" ]] || continue
+  SW_PORT["$key"]="$port"
+done < <(
+  bash -c '
+    set -euo pipefail
+    ROOT_DIR="'"$ROOT_DIR"'"
+    src="$ROOT_DIR/scripts/switch.sh"
+    awk "/^declare -A VARIANT_DEFAULT_PORT=\(\)/{f=1} f{print} /^_derive_variant_tables\$/{exit}" "$src" > "/tmp/_swderive.$$"
+    # shellcheck disable=SC1090
+    source "/tmp/_swderive.$$"
+    rm -f "/tmp/_swderive.$$"
+    for k in "${!VARIANT_DEFAULT_PORT[@]}"; do
+      printf "%s\t%s\n" "$k" "${VARIANT_DEFAULT_PORT[$k]}"
+    done
+  ' 2>/dev/null
+)
+
+# 3a. registry ⊆ launcher (zero registered-but-unlaunchable).
+for k in "${!REG_MAP[@]}"; do
+  if [[ -z "${SW_MAP[$k]:-}" ]]; then
+    note "registered compose '$k' is NOT launchable via switch.sh"
+  fi
+done
+
+# 3b. launcher ⊆ registry (zero launcher-only ghosts).
+for k in "${!SW_MAP[@]}"; do
+  if [[ -z "${REG_MAP[$k]:-}" ]]; then
+    note "switch.sh variant '$k' has NO compose_registry.py entry (ghost)"
+  fi
+done
+
+# 3c. value parity: derived spec + port match the registry expansion.
+for k in "${!REG_MAP[@]}"; do
+  [[ -n "${SW_MAP[$k]:-}" ]] || continue
+  if [[ "${SW_MAP[$k]}" != "${REG_MAP[$k]}" ]]; then
+    note "variant '$k' spec drift: switch='${SW_MAP[$k]}' registry='${REG_MAP[$k]}'"
+  fi
+  if [[ "${SW_PORT[$k]:-}" != "${REG_PORT[$k]}" ]]; then
+    note "variant '$k' default_port drift: switch='${SW_PORT[$k]:-<none>}' registry='${REG_PORT[$k]}'"
+  fi
+done
+
+# 3d. every derived compose file exists on disk (launchable in fact).
+for k in "${!SW_MAP[@]}"; do
+  IFS='|' read -r _eng cdir cfile <<< "${SW_MAP[$k]}"
+  if [[ ! -f "$ROOT_DIR/$cdir/$cfile" ]]; then
+    note "variant '$k' resolves to a missing compose file: $cdir/$cfile"
+  fi
+done
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "[switch-registry-parity] FAIL" >&2
+  exit 1
+fi
+echo "[switch-registry-parity] PASS: ${#REG_MAP[@]} registered composes, all launchable; zero ghosts; spec+port parity"


### PR DESCRIPTION
## v0.8.2 — what this delivers

Extends the universal `pull` front door (v0.8.0) with an honest failure on-ramp, a recommendation UX, and a materially wider model catalogue.

**Core (`pull` / CONTRACT-1..4):**
- **Failure on-ramp** — every hard-block leaves a redacted `.pull-captures/<slug>/<ts>/` bundle; `scripts/pull.sh --submit-last` / `--submit <dir>` is a separate, consented, user-invoked submit (works with **or without** `gh`; no telemetry, no auto-send).
- **`--recommend`** — an honest one-line fit verdict over the same gate result (FITS / FITS-but-not-yet-accepted / DOES-NOT-FIT), carries the boot-fit≠runtime caveat, never changes the verdict.
- **Arch-registry expansion** — many more safetensors architectures pass `[C0]` without `--experimental-arch`; native built-ins reach a clean serve verdict, per-repo remote-code stays fail-closed (**zero false-pass**).
- **Optional non-NVIDIA `hwdetect`** — bounded subprocess augmenting hardware detection where `nvidia-smi` doesn't apply; absent → graceful degrade; never feeds kv-calc.

**Bundled (not `pull` items — shipped on the same branch, stated honestly):**
- N-GPU **NVLink auto-detection** (wired into the multi-4 and Gemma-4-26B dual composes).
- **Documentation restructure** (quick-start README, `GETTING_STARTED.md`, model READMEs, docs index) + current-state docs brought up to v0.8.2.

**Known / deferred:**
- Generated composes carry the **reference profile's capacity**, not a per-GPU fit solve — documented in `docs/COMPOSE_GENERATOR.md` / `docs/PULL.md`; a capacity optimiser is a later track.
- **GGUF / cross-engine generation deferred** to a separate §9 design-unlock — not in this release.

## Validation

There is no PR-CI on this repo, so the **pre-tag gate is the release gate** and was run at the release SHA (`c5c8f46`):
- Full `scripts/tests/test-*.sh` suite in the CI condition: **25/25 PASS**
- `tools/kv-calc.py --calibration`: **22/22 (100%)**
- Committed-changeset leak-grep: **clean**
- Each STEP (V1–V6) went impl → independent verify → on-rig; smoke e2e of the critical user workflows passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)