### PR TITLE
scripts: endpoint-first --url/--model/--engine for non-Docker engines

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -131,6 +131,17 @@ So pick by workload: INT8 PTH if you want max single-stream TPS and don't need m
 
 If your numbers on the same compose look different from ours by >15%, the most likely sources of the gap are: power cap (370W vs 290W = ~10-15%), vLLM nightly (pre-#41434 was ~15% slower on Qwen3-Next due to GPU↔CPU syncs in attention), Genesis patches loaded vs not (~10-15% via P67 + PN12 + PN25 on Qwen3-Next), MTP `n` value, or the prompt shape. Run `bash scripts/rebench-full.sh` to capture the canonical 5-phase numbers and we can compare apples-to-apples — see the [Numbers from your rig](https://github.com/noonghunna/club-3090/issues/new?template=numbers-from-your-rig.yml) issue template to share them back.
 
+If you're running an OpenAI-compatible endpoint that **isn't** one of our pre-baked Docker composes — `llama-swap`, `ramalama`, a host-build `llama-server`, `ik_llama.cpp`, raw vLLM, etc. — pass it explicitly:
+
+```bash
+bash scripts/rebench-full.sh \
+  --url http://HOST:PORT \
+  --model 'served-model-name' \
+  --engine vllm|llama-cpp|sglang|other
+```
+
+The chained scripts run in host-only mode (no `docker logs` / `docker inspect` scrapes) when `--url` is set, so the entire suite works against any OpenAI-API endpoint.
+
 ---
 
 ## Community

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -312,8 +312,10 @@ if command -v nvidia-smi >/dev/null 2>&1; then
              --format=csv,noheader
 fi
 
-# MTP / spec-decode stats
-if command -v docker >/dev/null 2>&1 && docker inspect "${CONTAINER}" >/dev/null 2>&1; then
+# MTP / spec-decode stats — only when running against a Docker container we own.
+# Skipped silently in endpoint-first mode (CONTAINER=none).
+if [[ "${CONTAINER:-}" != "none" ]] && command -v docker >/dev/null 2>&1 \
+   && docker inspect "${CONTAINER}" >/dev/null 2>&1; then
   echo ""
   echo "=== Last 3 SpecDecoding metrics ==="
   docker logs "${CONTAINER}" 2>&1 | grep "SpecDecoding metrics" | tail -3 || true

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -786,9 +786,19 @@ preflight_autodetect_endpoint() {
   fi
 
   # Scan for one of our containers + its `0.0.0.0:<host>->8000/tcp` mapping.
+  # Recognises the canonical club-3090 prefixes (vllm-qwen36-27b,
+  # llama-cpp-qwen36-27b, vllm-gemma-4-31b) plus the sglang experimental tree.
+  # Users running endpoint-first via `--url` to rebench-full.sh bypass this
+  # entirely (PREFLIGHT_NO_AUTODETECT=1 set there).
+  #
+  # The `|| true` is load-bearing: grep -E returns 1 when no container
+  # matches, which under `set -euo pipefail` in the caller silently aborts
+  # rebench-full.sh before it reaches its own "endpoint not responding"
+  # error path. Empty `found_line` is what we want for the no-container case.
   local found_line
   found_line=$(docker ps --format '{{.Names}}|{{.Ports}}' 2>/dev/null \
-    | grep -E '^(vllm-qwen36-27b|llama-cpp-qwen36-27b|vllm-gemma-4-31b)' | head -1)
+    | grep -E '^(vllm-qwen36-27b|llama-cpp-qwen36-27b|vllm-gemma-4-31b|sglang-qwen36-27b)' \
+    | head -1 || true)
   if [[ -z "$found_line" ]]; then
     return 0   # nothing running; defaults stand
   fi
@@ -797,9 +807,9 @@ preflight_autodetect_endpoint() {
   detected_name="${found_line%%|*}"
   # Extract host port from "0.0.0.0:8011->8000/tcp", "[::]:8011->8000/tcp",
   # or "127.0.0.1:8011->8000/tcp" forms (BIND_HOST=127.0.0.1 produces the last).
-  # llama-cpp container maps to internal 8080, vllm to 8000 — match both.
+  # llama-cpp container maps to internal 8080, vllm to 8000, sglang to 30000.
   detected_port=$(echo "${found_line#*|}" \
-    | grep -oE '([0-9]{1,3}\.){3}[0-9]{1,3}:[0-9]+->(8000|8080)/tcp' \
+    | grep -oE '([0-9]{1,3}\.){3}[0-9]{1,3}:[0-9]+->(8000|8080|30000)/tcp' \
     | head -1 \
     | sed -E 's|^[^:]+:([0-9]+)->.*|\1|')
 

--- a/scripts/rebench-full.sh
+++ b/scripts/rebench-full.sh
@@ -29,7 +29,18 @@
 #   bash scripts/rebench-full.sh --resume             # skip steps that have
 #                                                       artifacts already
 #
-# Env overrides (rarely needed — preflight auto-detects):
+# Endpoint-first mode (for non-Docker engines: llama-swap, ramalama, host-
+# build llama-server, or any OpenAI-compatible server):
+#   bash scripts/rebench-full.sh \
+#     --url http://192.168.1.50:8887 \
+#     --model 'Qwen3.6-27B MTP ik_llama:instruct' \
+#     --engine llama-cpp                              # vllm|llama-cpp|sglang|other
+#
+#   When --url is passed, autodetect is skipped and the chained scripts run
+#   in host-only mode (CONTAINER=none) — no docker logs / docker inspect
+#   scrapes, which are graceful no-ops when absent.
+#
+# Env overrides (rarely needed — preflight auto-detects when running our composes):
 #   URL                 endpoint (default: auto-detect from running container)
 #   MODEL               served-model-name (default: GET /v1/models)
 #   TAG                 output-dir basename (default: ${MODEL}-YYYYMMDD-HHMM)
@@ -55,13 +66,19 @@ cd "$ROOT_DIR"
 SKIP_CSV=""
 RESUME=0
 TAG_OVERRIDE=""
+URL_FLAG=""
+MODEL_FLAG=""
+ENGINE_FLAG=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --skip)     SKIP_CSV="$2"; shift 2 ;;
     --tag)      TAG_OVERRIDE="$2"; shift 2 ;;
     --resume)   RESUME=1; shift ;;
+    --url)      URL_FLAG="$2"; shift 2 ;;
+    --model)    MODEL_FLAG="$2"; shift 2 ;;
+    --engine)   ENGINE_FLAG="$2"; shift 2 ;;
     -h|--help)
-      sed -n '2,40p' "$0"
+      sed -n '2,55p' "$0"
       exit 0
       ;;
     *)
@@ -71,6 +88,19 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# --- endpoint-first mode ----------------------------------------------------
+# When --url is passed, the user is targeting an OpenAI-compatible endpoint
+# that may not be one of our pre-baked containers (llama-swap, ramalama,
+# host-build llama-server, raw vLLM, etc). Skip container autodetect and
+# tell the chained scripts to run in host mode (CONTAINER=none).
+if [[ -n "$URL_FLAG" ]]; then
+  export URL="$URL_FLAG"
+  export PREFLIGHT_NO_AUTODETECT=1
+  export CONTAINER="none"
+  [[ -n "$MODEL_FLAG" ]] && export MODEL="$MODEL_FLAG"
+  [[ -n "$ENGINE_FLAG" ]] && export ENGINE_KIND="$ENGINE_FLAG"
+fi
+
 skip_step() {
   IFS=',' read -ra SKIPS <<< "$SKIP_CSV"
   for s in "${SKIPS[@]}"; do [[ "$s" == "$1" ]] && return 0; done
@@ -79,6 +109,7 @@ skip_step() {
 
 # --- endpoint + model auto-detect ------------------------------------------
 # Source preflight if available; it sets URL + CONTAINER from running compose.
+# Skipped silently when PREFLIGHT_NO_AUTODETECT=1 (set above by --url).
 if [[ -f "$ROOT_DIR/scripts/preflight.sh" ]]; then
   # shellcheck source=preflight.sh
   source "$ROOT_DIR/scripts/preflight.sh"
@@ -88,7 +119,13 @@ URL="${URL:-http://localhost:8010}"
 
 if ! curl -sf -m 5 "$URL/v1/models" >/dev/null 2>&1; then
   echo "✗ endpoint $URL/v1/models not responding" >&2
-  echo "  start a compose first: gpu-mode <mode>" >&2
+  if [[ -n "$URL_FLAG" ]]; then
+    echo "  --url '$URL_FLAG' not reachable; check the host/port + model server health." >&2
+  else
+    echo "  start a compose first: gpu-mode <mode>" >&2
+    echo "  or pass an external endpoint:" >&2
+    echo "    bash scripts/rebench-full.sh --url http://HOST:PORT --model NAME --engine vllm|llama-cpp|sglang|other" >&2
+  fi
   exit 1
 fi
 
@@ -133,17 +170,20 @@ date +"  started:     %Y-%m-%dT%H:%M:%SZ" -u
 echo
 
 # --- capture container snapshot (one-shot, used by rebench-report.py) ------
-# Picks the first vllm-*/llama-cpp-* container — same heuristic preflight uses.
-CONTAINER_NAME=$(docker ps --format '{{.Names}}' 2>/dev/null \
-  | grep -E '^(vllm-|llama-cpp-)' | head -1 || true)
-if [[ -n "$CONTAINER_NAME" ]]; then
-  docker inspect "$CONTAINER_NAME" > "$OUT_DIR/container-config.json" 2>/dev/null || true
-  # Boot log: capture lines that the report parser needs (KV pool size,
-  # max concurrency, model load footprint, MTP detection). Trimmed to keep
-  # the file small; full container log is still available via `docker logs`.
-  docker logs "$CONTAINER_NAME" 2>&1 \
-    | grep -E "GPU KV cache size|Maximum concurrency|Available KV cache memory|Model loading took|Detected MTP|kv_cache_dtype|num_speculative_tokens" \
-    > "$OUT_DIR/vllm-boot.log" 2>/dev/null || true
+# Picks the first vllm-*/llama-cpp-*/sglang-* container — same heuristic
+# preflight uses. Silently no-ops in endpoint-first mode (CONTAINER=none).
+if [[ "${CONTAINER:-}" != "none" ]] && command -v docker >/dev/null 2>&1; then
+  CONTAINER_NAME=$(docker ps --format '{{.Names}}' 2>/dev/null \
+    | grep -E '^(vllm-|llama-cpp-|sglang-)' | head -1 || true)
+  if [[ -n "$CONTAINER_NAME" ]]; then
+    docker inspect "$CONTAINER_NAME" > "$OUT_DIR/container-config.json" 2>/dev/null || true
+    # Boot log: capture lines that the report parser needs (KV pool size,
+    # max concurrency, model load footprint, MTP detection). Trimmed to keep
+    # the file small; full container log is still available via `docker logs`.
+    docker logs "$CONTAINER_NAME" 2>&1 \
+      | grep -E "GPU KV cache size|Maximum concurrency|Available KV cache memory|Model loading took|Detected MTP|kv_cache_dtype|num_speculative_tokens" \
+      > "$OUT_DIR/vllm-boot.log" 2>/dev/null || true
+  fi
 fi
 nvidia-smi --query-gpu=index,utilization.gpu,memory.used,memory.total,power.draw,temperature.gpu \
   --format=csv,noheader > "$OUT_DIR/gpu-state-start.log" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Adds `--url`, `--model`, `--engine` flags to `rebench-full.sh` so users running OpenAI-compatible endpoints **outside** our pre-baked Docker composes (llama-swap, ramalama, host-build `llama-server`, `ik_llama.cpp`, raw vLLM, etc) can run the canonical 5-phase suite without script edits or env-soup.

Motivated by [ampersandru's external eval in discussion #152](https://github.com/noonghunna/club-3090/discussions/152) — he had to set `PREFLIGHT_NO_AUTODETECT=1` manually + patch scripts to bypass our `docker ps` autodetect assumptions. With this PR:

```bash
bash scripts/rebench-full.sh \
  --url http://192.168.29.235:8887 \
  --model 'Qwen3.6-27B MTP ik_llama:instruct' \
  --engine llama-cpp
```

— and the whole `bench + verify-stress + quality-full + soak + aider-polyglot` chain runs against any OpenAI-API endpoint.

## Changes

- **`rebench-full.sh`** — `--url/--model/--engine` flags. When `--url` is set we export `PREFLIGHT_NO_AUTODETECT=1` + `CONTAINER=none` so the chained scripts skip the Docker scrapes (they no-op cleanly).
- **`rebench-full.sh`** — container-snapshot block now wrapped in `[[ "$CONTAINER" != "none" ]] && command -v docker`.
- **`rebench-full.sh`** — endpoint-not-responding error now distinguishes the `--url` case (check host/port) from the default case (start a compose or pass `--url`).
- **`bench.sh`** — same `CONTAINER=none` guard for the trailing `docker logs ... grep SpecDecoding metrics` block.
- **`preflight.sh`** — fix a pre-existing silent-exit: `grep -E` in the autodetect pipeline returns 1 when no container matches, which under `set -euo pipefail` in the caller silently killed `rebench-full.sh` **before** it reached its own endpoint-error path. Added `|| true` to the pipe. (This is the bug ampersandru-class users would hit when running with nothing matching our regex.)
- **`preflight.sh`** — regex now also recognises `sglang-qwen36-27b` containers + port 30000 (added with the v0.7.x sglang experimental tree but not auto-detected).
- **`docs/FAQ.md`** — document the new `--url` flag under "Numbers from your rig".

## Backward compatibility

Strictly additive:
- New flags only fire when `--url` is passed
- The `CONTAINER != "none"` guards default to empty string (which is `!= "none"`), so the existing Docker-running path still hits the existing snapshot + SpecDecoding scrape paths
- The autodetect regex is **expanded** (sglang prefix added) — existing 3 prefixes unchanged

## Test plan

- [x] `bash -n` on all three scripts: clean
- [x] `--help` renders the new endpoint-first block
- [x] Default no-flag mode now exits cleanly with a helpful error (was silent `exit 1` pre-fix)
- [x] `--url http://localhost:65535 --model fake` skips autodetect, emits external-endpoint-specific hint
- [x] Default mode (no flags, no compose running) still hits `preflight_autodetect_endpoint` → falls through to endpoint-not-responding (verified via `bash -x` trace)
- [ ] End-to-end smoke against a live compose — left for follow-up (got blocked by stale Docker network state in this session; functional correctness validated via static inspection + dry-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)