### PR TITLE
quality-test: expose --timeout-per-case + bump aider-polyglot-30 to 3600s default

### DIFF
--- a/scripts/quality-test.sh
+++ b/scripts/quality-test.sh
@@ -53,18 +53,26 @@ OPTIONS
                    Skips the deterministic packs — useful when iterating on
                    sandbox verifiers without paying the deterministic-pack cost.
 
+OPTIONS (extra)
+  --timeout-per-case N
+                   Pass through to benchlocal-cli as --timeout-per-case N
+                   (seconds). Default: 60. For aider-polyglot-30 on low-power
+                   single-card rigs, bump to 3600+ to avoid mid-batch kills.
+
 ENV VARS
   URL              Endpoint base URL (default: auto-detected via preflight,
                    falls back to http://localhost:8020)
   MODEL            Served model name (default: auto-detected from /v1/models;
                    override only if you have a non-standard served-model-name)
-  TIMEOUT_PER_CASE Per-scenario HTTP timeout in seconds (default: 60)
+  TIMEOUT_PER_CASE Per-scenario HTTP timeout in seconds (default: 60).
+                   --timeout-per-case overrides this when both are set.
 
 EXAMPLES
   bash scripts/quality-test.sh                          # --medium against running compose
   bash scripts/quality-test.sh --quick                  # quicker, 2 packs only
   bash scripts/quality-test.sh --full                   # everything, needs Docker
   bash scripts/quality-test.sh --pack toolcall-15       # just the tool-call pack
+  bash scripts/quality-test.sh --pack aider-polyglot-30 --timeout-per-case 3600
   URL=http://localhost:8030 bash scripts/quality-test.sh # against a different port
 
 INSTALL benchlocal-cli (one-time)
@@ -127,6 +135,14 @@ while [[ $# -gt 0 ]]; do
     --list-packs)
       LIST_PACKS=1
       shift
+      ;;
+    --timeout-per-case)
+      TIMEOUT_PER_CASE="${2:-}"
+      if [[ -z "$TIMEOUT_PER_CASE" ]] || ! [[ "$TIMEOUT_PER_CASE" =~ ^[0-9]+$ ]]; then
+        echo "✗ --timeout-per-case requires a positive integer (seconds)" >&2
+        exit 2
+      fi
+      shift 2
       ;;
     -h|--help)
       usage

--- a/scripts/rebench-full.sh
+++ b/scripts/rebench-full.sh
@@ -51,6 +51,11 @@
 #                       canonical stability matrix when validating new
 #                       compose paths.)
 #   SOAK_TURNS          passed through to soak-test.sh (default: 5)
+#   AIDER_TIMEOUT_PER_CASE
+#                       Per-case timeout (seconds) for aider-polyglot-30
+#                       (default: 3600 — bumped from benchlocal-cli's
+#                       default to avoid mid-batch kills on slower /
+#                       power-capped / single-card rigs).
 #
 
 set -euo pipefail
@@ -277,9 +282,15 @@ URL="$URL" MODEL="$MODEL" \
     bash "$ROOT_DIR/scripts/soak-test.sh"
 
 # --- step 5: aider-polyglot-30 ----------------------------------------------
+# Default to 3600s per-case for aider on slower/single-card rigs. The 30
+# multi-turn coding exercises can run > 45 min on power-capped or single-card
+# setups; benchlocal-cli will kill mid-batch if its internal default fires.
+# Override via env: AIDER_TIMEOUT_PER_CASE=7200 bash scripts/rebench-full.sh
+AIDER_TIMEOUT_PER_CASE="${AIDER_TIMEOUT_PER_CASE:-3600}"
 URL="$URL" MODEL="$MODEL" \
   run_step aider-polyglot "$OUT_DIR/aider-polyglot.log" \
-    bash "$ROOT_DIR/scripts/quality-test.sh" --pack aider-polyglot-30
+    bash "$ROOT_DIR/scripts/quality-test.sh" --pack aider-polyglot-30 \
+      --timeout-per-case "$AIDER_TIMEOUT_PER_CASE"
 snapshot_quality_json "$OUT_DIR/aider-polyglot.json"
 
 # --- final GPU state snapshot ----------------------------------------------


### PR DESCRIPTION
## Summary

Surfaces a `--timeout-per-case N` CLI flag on `quality-test.sh` and bumps `aider-polyglot-30`'s default to **3600s (1 hour)** when invoked through `rebench-full.sh`. Motivated by [discussion #152](https://github.com/noonghunna/club-3090/discussions/152) — @ampersandru's external eval on single 3090 + 250W cap hit benchlocal-cli's lower default mid-batch (29/30 done, 30th killed mid-edit).

`benchlocal-cli` already accepts `--timeout-per-case`; `quality-test.sh` was just hiding it behind an env var.

## Changes

- **`quality-test.sh`** — add `--timeout-per-case N` flag with positive-integer validation; overrides the existing `TIMEOUT_PER_CASE` env var when both are set. Updated usage + examples.
- **`rebench-full.sh`** — default to `--timeout-per-case 3600` for the aider-polyglot-30 step. Override via `AIDER_TIMEOUT_PER_CASE` env. Added to the env-var documentation block.

## Test plan

- [x] `bash -n` on both scripts: OK
- [x] `--help` renders new flag + new env var doc
- [x] Bad value rejected (non-integer, missing arg)
- [x] Good value parses cleanly
- [x] `rebench-full --help` shows new `AIDER_TIMEOUT_PER_CASE` env var

## Upstream follow-ups (filed separately as benchlocal-cli issues)

- benchlocal-cli default `--timeout-per-case` is too tight for low-power / single-card rigs running aider-polyglot-30; should be bumped or per-pack
- benchlocal-cli `aider-polyglot-30` runner reports `0/1 fail` to the CLI summary when `failure_mode=agent_runner_timeout` fires mid-batch, even though the JSON captured graceful partial results. The summary should surface the partial pass-rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)