### PR TITLE
sglang: park EAGLE-3 path for Qwen3-Next (MTP wins everywhere)

### DIFF
--- a/docs/engines/SGLANG.md
+++ b/docs/engines/SGLANG.md
@@ -1,8 +1,16 @@
-# SGLang — experimental, dual-GPU EAGLE-3 path validated
+# SGLang — Qwen3-Next EAGLE-3 path PARKED; no shipped variant on this stack
 
-SGLang is a strong alternative to vLLM for high-throughput multi-tenant serving — RadixAttention prefix sharing, structured-output-aware scheduling. As of v0.5.12 it also has the **only working external-drafter spec-decode path for Qwen3-Next family on consumer Ampere** (EAGLE-3 via the Ex0bit `compressed/` drafter), where vLLM is blocked by DeltaNet KV rollback.
+SGLang is a strong alternative to vLLM for high-throughput multi-tenant serving — RadixAttention prefix sharing, structured-output-aware scheduling. We investigated it as a way to unlock **EAGLE-3 external-drafter spec-decode** for Qwen3-Next family (which vLLM doesn't support — blocked by DeltaNet KV rollback). The path reached boot + coherent output on dual 3090 with two vendored patches.
 
-**Status (2026-05-20):** lifted from "currently blocked" to "experimental, dual-GPU EAGLE-3 path validated to boot and serve coherent output." Single-3090 EAGLE-3 still blocked (separate VRAM-tight + SGLang OffloaderV1 bug). Performance numbers (TPS, accept rate, quality 8-pack) **not yet measured** — a prolonged testing session will fill those in.
+**Status (2026-05-21): PARKED.** Not currently a shipped variant on this stack for Qwen3-Next. Three independent findings drove the decision:
+
+1. **EAGLE-3 is sub-MTP for Qwen3-Next, even on Blackwell where it works.** Ex0bit's own published numbers on the [PRISM-PRO-DQ model card](https://huggingface.co/Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ) report native MTP = **121 TPS (1.51×)** vs EAGLE-3 chain = **111 TPS (1.39×)**. The model family has a strong built-in MTP head; routing through an external drafter is structurally slower.
+2. **CUTE_DSL capture-hang on Ampere.** SGLang v0.5.12's CUTE_DSL `get_version()` does `pkgutil.walk_packages` during cuda-graph capture, hits `cutlass.cute.experimental` which raises `NotImplementedError` on CUDA toolkit < 13.1, and deadlocks against the locked capture stream. Workaround `--disable-cuda-graph` caps decode at ~15-18 TPS. Three patch iterations (pre-import; sys.modules stub at engine init; per-process sys.modules stub at `sglang/__init__.py`) all failed — the walk re-fires during capture regardless of cache state.
+3. **vLLM-MTP-dual already beats this path on the same rig.** `vllm/dual/turbo.yml` (TP=2 + MTP + Genesis TQ3) delivers ~85 TPS on this dual-3090 setup vs ~15-18 TPS for SGLang+EAGLE3 with the cuda-graph workaround.
+
+The artifacts under [`models/qwen3.6-27b/sglang/`](../../models/qwen3.6-27b/sglang/) stay in the tree for archival reference; the README in that subtree has the full re-test triggers.
+
+**Verdict:** for Qwen3-Next on consumer Ampere, use vLLM MTP (`vllm/dual/turbo.yml`) or llama.cpp MTP (`llamacpp/mtp.yml`). SGLang may still be worth revisiting for OTHER model families where its RadixAttention or structured-output features are the headline — that's a per-model decision.
 
 ---
 

--- a/models/qwen3.6-27b/sglang/README.md
+++ b/models/qwen3.6-27b/sglang/README.md
@@ -1,10 +1,20 @@
-# Qwen3.6-27B on SGLang — experimental, dual 3090 validated to boot
+# Qwen3.6-27B on SGLang — PARKED, kept for archival only
 
-SGLang on this model unlocks **EAGLE-3 external-drafter spec-decode**, which neither vLLM (blocked by DeltaNet KV rollback) nor llama.cpp (no EAGLE-3 support) provides for Qwen3-Next family. The validation path is dual 3090 with two vendored patches.
-
-**Status (2026-05-20):** boot + small-completion validated on 2× RTX 3090 (TP=2). Performance numbers (TPS, accept rate, quality 8-pack) **not yet measured** — pending prolonged testing session. Single 3090 EAGLE-3 still blocked by SGLang OffloaderV1 + Qwen3-Next tied-weights bug.
+> **⚠ PARKED 2026-05-21 — not a recommended path on this stack.** SGLang + EAGLE-3 on Qwen3-Next was investigated as a way to unlock external-drafter spec-decode (which neither vLLM nor mainline llama.cpp provides for this model family). The investigation reached boot + coherent output on dual 3090 with two vendored patches, but **MTP wins on every axis** (TPS, complexity, hardware coverage). The compose files + patches stay in the tree for archival reference; production paths remain `vllm/dual/turbo.yml` (TP=2 + MTP + Genesis TQ3) and `llamacpp/mtp.yml` (single-card + MTP).
 
 For engine-level pros/cons, KV cache options, Ampere quirks, see [`../../../docs/engines/SGLANG.md`](../../../docs/engines/SGLANG.md).
+
+## Why parked
+
+Three independent findings, each sufficient on its own:
+
+1. **EAGLE-3 is sub-MTP for Qwen3-Next, even on the architecture where it works.** Ex0bit (the drafter author) publishes their own numbers on the [PRISM-PRO-DQ model card](https://huggingface.co/Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ): native MTP = **121 TPS (1.51×)** vs EAGLE-3 chain = **111 TPS (1.39×)** on Blackwell. Qwen3-Next has a strong built-in MTP head; routing through an external drafter is structurally slower for this model family.
+2. **CUTE_DSL capture-hang on Ampere.** SGLang v0.5.12's CUTE_DSL `get_version()` calls `pkgutil.walk_packages` during cuda-graph capture. The walk hits `cutlass.cute.experimental` (which raises `NotImplementedError` on CUDA toolkit < 13.1) and deadlocks against the locked capture stream. Workaround `--disable-cuda-graph` boots but caps decode at ~15-18 TPS (vs vLLM-MTP-dual ~85 TPS). Three patch iterations (pre-import, `sys.modules` stub at engine init, per-process `sys.modules` stub at `sglang/__init__.py`) all failed — the walk re-fires during capture regardless of cache state.
+3. **vLLM-MTP-dual already beats SGLang+EAGLE3+cuda-graph-off on the same rig.** Even if we ignored point 2 and accepted the cuda-graph penalty, `vllm/dual/turbo.yml` (TP=2 + MTP + Genesis TQ3) gives ~85 TPS on this dual-3090 setup. This SGLang path tops out around 15-18 TPS with the workaround.
+
+The artifacts in this tree document the SGLang state for the next person who comes to this question. If/when upstream lands a CUTE_DSL Ampere fallback OR an SGLang-specific MTP path materializes for Qwen3-Next, the [Re-test triggers](#re-test-triggers) section below tells you what to verify.
+
+**One-line summary:** SGLang AutoRound on Qwen3-Next is a working *engineering* path but an unattractive *production* path. MTP (vLLM or llama.cpp) is strictly better for this model.
 
 ---
 
@@ -12,9 +22,9 @@ For engine-level pros/cons, KV cache options, Ampere quirks, see [`../../../docs
 
 | Variant | Path | Status |
 |---|---|---|
-| Dual 3090 (TP=2) EAGLE-3 + AutoRound INT4 | [`compose/dual/eagle3-experimental.yml`](compose/dual/eagle3-experimental.yml) | ✅ Boots, serves coherent output. TPS/accept-rate pending. |
-| Single 3090 EAGLE-3 + AutoRound INT4 | [`compose/single/eagle3-experimental.yml`](compose/single/eagle3-experimental.yml) | ❌ Blocked on SGLang OffloaderV1 tied-weights bug; kept as reference |
-| Other quants (FenomAI AWQ-INT4, INT8 PTH) | TARGET_DIR override in dual YAML | ⚠️ Untested but YAML-ready |
+| Dual 3090 (TP=2) EAGLE-3 + AutoRound INT4 | [`compose/dual/eagle3-experimental.yml`](compose/dual/eagle3-experimental.yml) | ⚠ PARKED — boots + coherent output validated, but ~15-18 TPS with `--disable-cuda-graph` workaround vs ~85 TPS on `vllm/dual/turbo.yml` |
+| Single 3090 EAGLE-3 + AutoRound INT4 | [`compose/single/eagle3-experimental.yml`](compose/single/eagle3-experimental.yml) | ❌ PARKED — blocked on SGLang OffloaderV1 tied-weights bug; never reached first forward pass |
+| Other quants (FenomAI AWQ-INT4, INT8 PTH) | TARGET_DIR override in dual YAML | ⚠ PARKED — untested, would inherit the same EAGLE-3 < MTP structural disadvantage |
 
 ---
 
@@ -153,14 +163,17 @@ TARGET_DIR=qwen3.6-27b-int8 QUANTIZATION=compressed-tensors
 
 ---
 
-## Watch list
+## Re-test triggers (post-parking watch list)
+
+The path is parked because EAGLE-3 < MTP for Qwen3-Next (point 1 above) is a structural finding, not a fixable bug. The other two points are addressable upstream. Triggers to revisit:
 
 | Trigger | What it unblocks |
 |---|---|
-| [`sgl-project/sglang#20370`](https://github.com/sgl-project/sglang/pulls/20370) merges OR upstream lands an equivalent | We can drop `patch_sglang_autoround_fused_bf16.py` and follow rolling upstream tags |
-| SGLang `OffloaderV1` handles tied weights | Single 3090 EAGLE-3 becomes viable |
-| SGLang adds asymmetric K/V or sub-FP8 INT KV | Closes the KV-density gap vs vLLM TurboQuant; potentially ~262K context at TP=2 |
-| TPS/accept-rate bench completes | We can compare against `vllm/dual/dflash.yml` (vLLM-DFlash) and `vllm/dual/turbo.yml` (vLLM-MTP) directly |
+| **SGLang ships an MTP path for Qwen3-Next** (i.e. uses the model's built-in head, like vLLM Genesis P67 does) | The structural reason for parking disappears — SGLang then competes with vLLM on engine merits, not spec-decode shape |
+| **SGLang upstream lands a CUTE_DSL Ampere fallback** (gates the `cutlass.cute.experimental` walk on `SM >= 10.0`, or registers a stub before capture, or refactors `get_version()` not to walk during capture) | cuda-graph re-enables, recovers the ~80% decode TPS we lose to `--disable-cuda-graph` — moves the comparison from "vLLM 85 TPS vs SGLang 15-18 TPS" to something closer |
+| **SGLang `OffloaderV1` handles tied weights** | Single 3090 EAGLE-3 becomes a viable VRAM-tight target — but still pinned by point 1 above |
+| **SGLang adds asymmetric K/V or sub-FP8 INT KV** | Closes the KV-density gap vs vLLM TurboQuant; potentially ~262K context at TP=2 — independently useful regardless of the EAGLE-3 question |
+| [`sgl-project/sglang#20370`](https://github.com/sgl-project/sglang/pulls/20370) merges OR upstream lands an equivalent | We can drop `patch_sglang_autoround_fused_bf16.py` and follow rolling upstream tags (this fix is broadly useful — anyone running SGLang AutoRound on Qwen3-Next hits the same crash) |
 
 ---
 

--- a/models/qwen3.6-27b/sglang/compose/dual/eagle3-experimental.yml
+++ b/models/qwen3.6-27b/sglang/compose/dual/eagle3-experimental.yml
@@ -1,4 +1,16 @@
 # ===========================================================================
+# ⚠ PARKED 2026-05-21 — KEPT FOR ARCHIVAL ONLY, NOT A PRODUCTION PATH
+#
+# This compose boots and serves coherent output on dual 3090, but it sits at
+# ~15-18 TPS (with the mandatory --disable-cuda-graph workaround for the CUTE_DSL
+# capture-hang on Ampere). Production paths for Qwen3-Next are:
+#   - vllm/dual/turbo.yml (TP=2 + MTP + Genesis TQ3 → ~85 TPS)
+#   - llamacpp/mtp.yml (single 3090 + MTP → ~50 TPS)
+# Both use the model's built-in MTP head, which (per Ex0bit's own benches)
+# beats EAGLE-3 chain even on Blackwell where EAGLE-3 actually works.
+#
+# See README.md in this subtree for the full parking rationale + re-test triggers.
+# ===========================================================================
 # Profile (at-a-glance):
 #   Model:     Qwen3.6-27B (Lorbus AutoRound INT4 by default; INT8/AWQ via TARGET_DIR override)
 #   Topology:  Dual 3090 PCIe (TP=2, no NVLink → custom all-reduce disabled)
@@ -7,15 +19,15 @@
 #   Vision:    no (mmproj path untested with EAGLE3; disabled for first boot)
 #   Max ctx:   32768 (4× the single-card variant — TP=2 doubles KV budget)
 #   Genesis:   N/A — Genesis is vLLM-specific
-#   Status:    ⚠️ EXPERIMENTAL — gated on vendor fix for the Marlin alignment crash
-#              (currently blocks AutoRound INT4 single + dual; see /tmp/sglang-eagle3-failure.log).
-#              YAML is ready; live boot test runs once the fix lands.
-#   Caveats:   Same vendor patches as the single-card sibling (EAGLE-3 hook +
-#              AutoRound fused-BF16 mapper). Pinned to v0.5.12 per
-#              engine-image-pinning policy (AGENTS.md).
-#   Best for:  TP=2 EAGLE-3 spec-decode on quantized Qwen3-Next; sibling of
-#              vllm/dual/int8.yml for the SGLang track. Designed to also serve
-#              INT8 / W8A16 targets by overriding TARGET_DIR (see To run below).
+#   Status:    ⚠ PARKED 2026-05-21 — boots + coherent output validated, but sub-MTP
+#              throughput on consumer Ampere makes it a non-shipping path. The
+#              compose stays for archival reference; production path is
+#              vllm/dual/turbo.yml. See README.md "Why parked" for the 3 reasons.
+#   Caveats:   Two vendor patches required (EAGLE-3 hook + AutoRound fused-BF16
+#              mapper). cuda-graph MUST be disabled on Ampere (CUTE_DSL hang).
+#              Pinned to v0.5.12 per engine-image-pinning policy (AGENTS.md).
+#   Best for:  Archival / future re-test when SGLang ships MTP for Qwen3-Next OR
+#              upstream lands a CUTE_DSL Ampere fallback.
 # ---------------------------------------------------------------------------
 # Why this exists (separate from single-card eagle3-experimental.yml):
 #

--- a/models/qwen3.6-27b/sglang/compose/single/eagle3-experimental.yml
+++ b/models/qwen3.6-27b/sglang/compose/single/eagle3-experimental.yml
@@ -1,4 +1,16 @@
 # ===========================================================================
+# ⚠ PARKED 2026-05-21 — KEPT FOR ARCHIVAL ONLY, NEVER REACHED FIRST FORWARD PASS
+#
+# This single-card compose progresses through every boot phase but crashes at
+# the first forward pass with SGLang OffloaderV1's tied-weights bug on
+# Qwen3-Next (linear_attn.attn.dt_bias / linear_attn.dt_bias are tied params).
+# The dual-card sibling sidesteps this by avoiding CPU offload entirely, but
+# the dual-card path is itself parked (see ../dual/eagle3-experimental.yml).
+#
+# Production single-3090 path for Qwen3.6-27B is llamacpp/mtp.yml (~50 TPS,
+# 131K ctx, vision-capable). EAGLE-3 wouldn't beat MTP even if the OffloaderV1
+# bug were fixed — see ../../README.md "Why parked" for the structural reason.
+# ===========================================================================
 # Profile (at-a-glance):
 #   Model:     Qwen3.6-27B (Lorbus AutoRound INT4 — lm_head + mtp.fc + vision BF16)
 #   Topology:  Single 3090 (no TP, all on device 0)
@@ -7,14 +19,17 @@
 #   Vision:    no (mmproj path untested with EAGLE3; disabled for first boot)
 #   Max ctx:   8192 (initial conservative; push up after boot validates)
 #   Genesis:   N/A — Genesis is vLLM-specific
-#   Status:    ⚠️ EXPERIMENTAL — single-card EAGLE3 path unvalidated on Ampere
+#   Status:    ⚠ PARKED — never reached first forward pass (SGLang OffloaderV1
+#              tied-weights bug on Qwen3-Next DeltaNet). Kept as reference for
+#              the offloader path; dual-card sibling is the boot-validated
+#              variant (also parked, see ../dual/eagle3-experimental.yml).
 #   Caveats:   Vendored startup patches wire EAGLE-3 capture into
 #              Qwen3_5ForConditionalGeneration and keep AutoRound's BF16
 #              split-shard overrides intact for fused DeltaNet `in_proj_ba`.
 #              Pinned to v0.5.12 per engine-image-pinning policy (AGENTS.md).
-#              First exploration of the Ex0bit EAGLE3 path on this stack — see #171.
-#   Best for:  Probe whether SGLang's SPEC_V2 scheduler unblocks DeltaNet-family
-#              spec-decode on a quantized target (the gap MTP fills on llama.cpp/vLLM).
+#   Best for:  Archival reference. Future re-test when SGLang OffloaderV1
+#              ships tied-weights support — and ALSO when SGLang ships an
+#              MTP path for Qwen3-Next (the structural reason for parking).
 # ---------------------------------------------------------------------------
 # Single-card SGLang + EAGLE-3 spec-decode for Qwen3.6-27B AutoRound INT4.
 #


### PR DESCRIPTION
## Summary

Parks the SGLang + EAGLE-3 path for Qwen3-Next. The tree stays in the repo for archival reference; production paths remain `vllm/dual/turbo.yml` (TP=2 + MTP + Genesis TQ3) and `llamacpp/mtp.yml` (single + MTP).

## Why park

Three independent findings, each sufficient on its own:

1. **EAGLE-3 is sub-MTP for Qwen3-Next, even on Blackwell where it works.** Ex0bit's own published numbers on the [PRISM-PRO-DQ model card](https://huggingface.co/Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ): native MTP = **121 TPS (1.51×)** vs EAGLE-3 chain = **111 TPS (1.39×)**. The model has a strong built-in MTP head; routing through an external drafter is structurally slower for this family.
2. **CUTE_DSL capture-hang on Ampere.** SGLang v0.5.12's `cutlass_dsl/cutlass.py:449` (`get_version()`) does `pkgutil.walk_packages` during cuda-graph capture, hits `cutlass.cute.experimental` (which raises `NotImplementedError` on CUDA toolkit < 13.1), and deadlocks against the locked capture stream. Three patch iterations (pre-import, sys.modules stub at engine init, per-process sys.modules stub at `sglang/__init__.py`) all failed — the walk re-fires during capture regardless of cache state. Workaround `--disable-cuda-graph` caps decode at ~15-18 TPS.
3. **vLLM-MTP-dual already beats this path on the same rig.** `vllm/dual/turbo.yml` delivers ~85 TPS on dual-3090 vs ~15-18 TPS for SGLang+EAGLE3 with the cuda-graph workaround.

## What changes

- **`docs/engines/SGLANG.md`** — status flipped to "PARKED 2026-05-21" with the 3-finding rationale + production-path pointers.
- **`models/qwen3.6-27b/sglang/README.md`** — parking banner, full "Why parked" section, TL;DR statuses updated, re-test triggers expanded with SGLang-MTP-for-Qwen3-Next and CUTE_DSL-Ampere-fallback gates.
- **`compose/dual/eagle3-experimental.yml`** — PARKED banner above the existing profile header. Config unchanged; the compose still works as documented if anyone wants to repro.
- **`compose/single/eagle3-experimental.yml`** — PARKED banner. Single-card never reached first forward pass anyway (SGLang OffloaderV1 tied-weights bug on Qwen3-Next).

## What does NOT change

- The two vendored patches (`patch_sglang_eagle3.py`, `patch_sglang_autoround_fused_bf16.py`) stay in place. The AutoRound name-mapper fix is broadly useful — anyone running SGLang AutoRound on Qwen3-Next hits the same crash.
- The compose YAMLs themselves are unchanged at the config layer; only the documentation comments at the top got the parking banner.
- The investigation artifacts (the dual-card boot validation, the Marlin bug diagnosis via Codex, the SPEC_V2 + EAGLE-3 capture flow) all stay documented.

## Re-test triggers (post-parking watch list)

| Trigger | What it unblocks |
|---|---|
| SGLang ships MTP for Qwen3-Next | Removes the structural reason for parking |
| SGLang upstream lands CUTE_DSL Ampere fallback | cuda-graph re-enables; recovers ~80% decode TPS we lose to `--disable-cuda-graph` |
| SGLang OffloaderV1 handles tied weights | Single 3090 EAGLE-3 becomes a viable target — but still pinned by finding 1 |

## Test plan

- [x] YAML syntax validates for both compose files
- [x] No internal-path leaks in any new doc/banner content
- [x] Production-path references (`vllm/dual/turbo.yml`, `llamacpp/mtp.yml`) point to actual existing files in the tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)