### PR TITLE
quality-test: respect explicit MODEL/--model (don't clobber from /v1/models)

### DIFF
--- a/scripts/quality-test.sh
+++ b/scripts/quality-test.sh
@@ -54,6 +54,10 @@ OPTIONS
                    sandbox verifiers without paying the deterministic-pack cost.
 
 OPTIONS (extra)
+  --model NAME     Pin the served-model-name. When set (here or via MODEL env),
+                   we use YOUR value and never override it from /v1/models —
+                   required for llama-swap / multi-model endpoints where
+                   /v1/models returns the first (often wrong) registered model.
   --timeout-per-case N
                    Pass through to benchlocal-cli as --timeout-per-case N
                    (seconds). Default: 60. For aider-polyglot-30 on low-power
@@ -62,8 +66,10 @@ OPTIONS (extra)
 ENV VARS
   URL              Endpoint base URL (default: auto-detected via preflight,
                    falls back to http://localhost:8020)
-  MODEL            Served model name (default: auto-detected from /v1/models;
-                   override only if you have a non-standard served-model-name)
+  MODEL            Served model name. If set (env or --model), it's respected
+                   verbatim — no /v1/models override. If UNSET, auto-detected
+                   from /v1/models (fixes the wrong-name → HTTP 404 footgun on
+                   single-model composes). --model and MODEL are equivalent.
   TIMEOUT_PER_CASE Per-scenario HTTP timeout in seconds (default: 60).
                    --timeout-per-case overrides this when both are set.
 
@@ -99,6 +105,13 @@ if [[ -f "${ROOT_DIR}/scripts/preflight.sh" ]]; then
 fi
 
 URL="${URL:-http://localhost:8020}"
+# Track whether the user explicitly set MODEL (via env or the --model flag).
+# If they did, we respect it and do NOT clobber it with the /v1/models
+# auto-detect below — critical for llama-swap / multi-model endpoints where
+# /v1/models returns the first (often wrong) registered model. Auto-detect
+# only kicks in when the user left MODEL unset.
+MODEL_EXPLICIT=0
+[[ -n "${MODEL:-}" ]] && MODEL_EXPLICIT=1
 MODEL="${MODEL:-qwen3.6-27b-autoround}"
 TIMEOUT_PER_CASE="${TIMEOUT_PER_CASE:-60}"
 
@@ -122,6 +135,15 @@ while [[ $# -gt 0 ]]; do
         echo "✗ --pack requires a pack id" >&2
         exit 2
       fi
+      shift 2
+      ;;
+    --model)
+      MODEL="${2:-}"
+      if [[ -z "$MODEL" ]]; then
+        echo "✗ --model requires a served-model-name" >&2
+        exit 2
+      fi
+      MODEL_EXPLICIT=1
       shift 2
       ;;
     --no-sandboxed)
@@ -184,13 +206,26 @@ if ! curl -sf -m 5 "${URL}/v1/models" >/dev/null 2>&1; then
   exit 1
 fi
 
-# Resolve actual served model id from the running endpoint, in case MODEL was wrong
+# Resolve the served model id from /v1/models. Behaviour depends on whether
+# the user explicitly set MODEL:
+#   - MODEL unset  → trust the endpoint, auto-detect (fixes the common "wrong
+#                    model name → HTTP 404" footgun on single-model composes).
+#   - MODEL set    → respect the user's value, do NOT override. Only warn if
+#                    the endpoint disagrees. This is the llama-swap / multi-model
+#                    case: /v1/models returns the first registered model (often
+#                    the wrong one), and clobbering the user's choice routes the
+#                    whole run at the wrong model (see disc #152, @ampersandru).
 DETECTED_MODEL=$(curl -sf -m 5 "${URL}/v1/models" 2>/dev/null \
   | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['data'][0]['id'])" 2>/dev/null \
   || echo "")
 if [[ -n "$DETECTED_MODEL" && "$DETECTED_MODEL" != "$MODEL" ]]; then
-  echo "[quality-test] model id from endpoint: ${DETECTED_MODEL} (overriding MODEL=${MODEL})" >&2
-  MODEL="$DETECTED_MODEL"
+  if [[ "$MODEL_EXPLICIT" == "1" ]]; then
+    echo "[quality-test] NOTE: endpoint /v1/models reports '${DETECTED_MODEL}', but you set MODEL='${MODEL}' — using YOUR value." >&2
+    echo "[quality-test]   (Expected on llama-swap/multi-model endpoints. Leave MODEL unset to auto-detect the first served model instead.)" >&2
+  else
+    echo "[quality-test] model id auto-detected from endpoint: ${DETECTED_MODEL} (set MODEL=... or --model to pin it)" >&2
+    MODEL="$DETECTED_MODEL"
+  fi
 fi
 
 # hermesagent-20 runs its agent inside a Docker sandbox container. Localhost-style


### PR DESCRIPTION
## Summary

Fixes a model-override footgun on llama-swap / multi-model endpoints, reported by @ampersandru in [discussion #152](https://github.com/noonghunna/club-3090/discussions/152).

`quality-test.sh` unconditionally replaced `MODEL` with the first id from `/v1/models` whenever they differed. That's the right behaviour for single-model composes (it fixes the common "wrong model name → HTTP 404" mistake), but on **llama-swap** the `/v1/models` endpoint lists *all* registered models and returns the first — so a user explicitly targeting Qwen3.6 got their run silently routed at Gemma4. @ampersandru was manually `sed`-ing out the override line on every run.

## New behaviour

| MODEL provided? | What happens |
|---|---|
| **Unset** | Auto-detect from `/v1/models` (unchanged — keeps the single-model footgun fix) |
| **Set (env or `--model`)** | Respected verbatim, **never overridden**; warn once if the endpoint disagrees |

- New `--model NAME` flag (equivalent to the `MODEL` env var)
- Tracks `MODEL_EXPLICIT` before the default is applied, gates auto-detect on it

## Test plan

Verified against a mock `/v1/models` returning a mismatched model:

- [x] **A** — `MODEL` unset → auto-detects the served id
- [x] **B** — `--model 'Qwen3.6-27B-ik'` → respects it, warns on mismatch ("using YOUR value")
- [x] **C** — `MODEL=…` env → same respect behaviour
- [x] `bash -n` clean, `--help` renders the new flag + updated MODEL doc

## Unblocks

@ampersandru (and any llama-swap / ramalama / multi-model user) can now run:

```bash
bash scripts/rebench-full.sh --url http://HOST:PORT --model 'Qwen3.6-27B MTP ik_llama:instruct' --engine llama-cpp
# or: bash scripts/quality-test.sh --pack toolcall-15 --model 'Qwen3.6-27B MTP ik_llama:instruct'
```

— without the run getting hijacked to whatever model `/v1/models` lists first. No more manual `sed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)