### PR TITLE
fix(rebench): always capture sandboxed-pack logs to results/rebench/<tag>/

### DIFF
--- a/scripts/quality-test.sh
+++ b/scripts/quality-test.sh
@@ -62,6 +62,11 @@ OPTIONS (extra)
                    Pass through to benchlocal-cli as --timeout-per-case N
                    (seconds). Default: 60. For aider-polyglot-30 on low-power
                    single-card rigs, bump to 3600+ to avoid mid-batch kills.
+  --sandbox-log-dir DIR
+                   Capture each sandboxed pack's container log to
+                   DIR/sandbox-<pack_id>.log before teardown (forwarded to
+                   benchlocal-cli). Without it, sandbox logs are lost on
+                   container cleanup. Also settable via SANDBOX_LOG_DIR env.
 
 ENV VARS
   URL              Endpoint base URL (default: auto-detected via preflight,
@@ -122,6 +127,7 @@ PACK=""
 NO_SANDBOX=0
 SANDBOXED_ONLY=0
 LIST_PACKS=0
+SANDBOX_LOG_DIR="${SANDBOX_LOG_DIR:-}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -157,6 +163,14 @@ while [[ $# -gt 0 ]]; do
     --list-packs)
       LIST_PACKS=1
       shift
+      ;;
+    --sandbox-log-dir)
+      SANDBOX_LOG_DIR="${2:-}"
+      if [[ -z "$SANDBOX_LOG_DIR" ]]; then
+        echo "✗ --sandbox-log-dir requires a directory" >&2
+        exit 2
+      fi
+      shift 2
       ;;
     --timeout-per-case)
       TIMEOUT_PER_CASE="${2:-}"
@@ -274,6 +288,12 @@ else
 fi
 if [[ "$NO_SANDBOX" == "1" && "$SANDBOXED_ONLY" != "1" ]]; then
   CLI_ARGS+=(--no-sandboxed-packs)
+fi
+# Capture each sandboxed pack's container log before teardown (else it's lost).
+if [[ -n "$SANDBOX_LOG_DIR" ]]; then
+  mkdir -p "$SANDBOX_LOG_DIR"
+  CLI_ARGS+=(--sandbox-log-dir "$SANDBOX_LOG_DIR")
+  echo "[quality-test] sandbox logs → ${SANDBOX_LOG_DIR}/sandbox-<pack>.log"
 fi
 
 # Run; capture exit code so we can also try to emit the compact one-liner

--- a/scripts/rebench-full.sh
+++ b/scripts/rebench-full.sh
@@ -269,7 +269,7 @@ URL="$URL" MODEL="$MODEL" \
 # --- step 3: quality-test --full --------------------------------------------
 URL="$URL" MODEL="$MODEL" \
   run_step quality-full "$OUT_DIR/quality-full.log" \
-    bash "$ROOT_DIR/scripts/quality-test.sh" --full
+    bash "$ROOT_DIR/scripts/quality-test.sh" --full --sandbox-log-dir "$OUT_DIR"
 snapshot_quality_json "$OUT_DIR/quality-full.json"
 
 # --- step 4: soak-test ------------------------------------------------------
@@ -290,7 +290,7 @@ AIDER_TIMEOUT_PER_CASE="${AIDER_TIMEOUT_PER_CASE:-3600}"
 URL="$URL" MODEL="$MODEL" \
   run_step aider-polyglot "$OUT_DIR/aider-polyglot.log" \
     bash "$ROOT_DIR/scripts/quality-test.sh" --pack aider-polyglot-30 \
-      --timeout-per-case "$AIDER_TIMEOUT_PER_CASE"
+      --timeout-per-case "$AIDER_TIMEOUT_PER_CASE" --sandbox-log-dir "$OUT_DIR"
 snapshot_quality_json "$OUT_DIR/aider-polyglot.json"
 
 # --- final GPU state snapshot ----------------------------------------------


### PR DESCRIPTION
## Summary

`rebench-full` was discarding the sandboxed packs' container logs — they lived in the ephemeral aider/hermes/bugfind/cli sandbox containers and went away on cleanup. So when an agentic result was surprising (e.g. the ik_llama IQ4_KS **aider 15/30** batch), there was no inspectable trace of *what the model produced or why a test failed* — only the aggregate pass/fail survived.

benchlocal-cli already supports `--sandbox-log-dir` (v0.8.1) — it dumps each sandboxed pack's container log to `DIR/sandbox-<pack_id>.log` **before teardown** and stamps `verifier_trace.sandbox_log_file`. We just weren't passing it.

This wires it through so **every** rebench run self-retains its sandbox logs:

- `rebench-full.sh` passes `--sandbox-log-dir "$OUT_DIR"` to step 3 (`quality-test.sh --full`) and step 5 (`aider-polyglot-30`). So `results/rebench/<tag>/` now also gets `sandbox-bugfind-15.log`, `sandbox-hermesagent-20.log`, `sandbox-cli-40.log`, `sandbox-aider-polyglot-30.log` alongside the existing `bench.log` / `verify-stress.log` / `quality-full.log` / `soak.log` / `*.json` — one self-contained folder per run.
- `quality-test.sh` gains a `--sandbox-log-dir DIR` flag (also `SANDBOX_LOG_DIR` env) that forwards to benchlocal-cli, so it works standalone too.

Non-sandboxed steps (bench / verify-stress / soak) already write their own logs — unaffected.

## Test plan

- [x] `bash -n` clean on both scripts
- [x] Plumbing verified: a stubbed `benchlocal-cli` confirms `quality-test.sh ... --sandbox-log-dir /tmp/x` forwards `--sandbox-log-dir /tmp/x` into the CLI args
- [ ] Confirm `sandbox-<pack>.log` files appear in `results/rebench/<tag>/` on the next real `rebench-full` run (benchlocal's `--sandbox-log-dir` behavior is established/tested in v0.8.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)