### PR TITLE
feat(models): ik_llama Qwen3.6-27B IQ4_KS composes — text 262K + vision 160K

### DIFF
--- a/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp-vision.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp-vision.yml
@@ -1,0 +1,140 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-27B (ubergarm MTP-IQ4_KS GGUF) + mmproj-F16
+#   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp:cu13-server)
+#   Topology:  Single 3090 (TP=1)
+#   Drafter:   MTP n=2, p-min 0.0 (built-in MTP head)
+#   KV:        q4_0 K + q4_0 V
+#   Template:  froggeric v19 (--chat-template-file)
+#   Vision:    YES (mmproj-F16 mounted — multimodal input enabled)
+#   Default ctx: 163840 (160K) — full-res-vision default on ONE 3090, chosen for
+#              HEADROOM: 172K served single images but OOM-crashed under heavy
+#              back-to-back prefill stress (verify-stress); 160K leaves ~0.9 GB
+#              margin. REQUIRES -b 1024 (see below): a full 2048²/4M-pixel image
+#              encodes at ~23.65 GB. mmproj + encode buffers eat the VRAM the
+#              text profile spends on KV, so the vision ceiling (~180K) sits well
+#              below the text profile's 262K. Push higher only if you don't need
+#              prefill headroom — see VRAM RESIZING below.
+#   Status:    🧪 EVAL ONLY — task #402. NOT shipped. Sibling of iq4ks-mtp.yml
+#              with vision added (ampersandru's #152 config also loaded mmproj).
+#   Best for:  Multimodal chat / screenshot-debugging on ik_llama IQ4_KS.
+# ---------------------------------------------------------------------------
+# This is the VISION sibling of iq4ks-mtp.yml. Everything matches that file
+# (config source, justified deviations, froggeric validation) EXCEPT:
+#   + --mmproj + --image-{min,max}-tokens (vision projector mounted)
+#   + default ctx 160K + -b 1024 (vs the text profile's 262K + -b 4096)
+#
+# Why -b 1024 (NOT the text profile's 4096): on this ik_llama build the image-
+# encode graph makes the compute buffer scale hard with logical batch -b — at
+# -b 4096 it's ~4 GB (OOMs even at boot with vision); at -b 1024 it's ~1 GB,
+# which is what lets a full 4M-pixel image encode within 24 GB at 172K.
+# NOTE: -ub (UBATCH) is cosmetic here — the engine forces n_ubatch = n_batch,
+# so only -b moves the compute buffer. Validated 2026-05-21: 160K/-b1024 serves
+# a 2048² image at ~23.65 GB peak (~0.9 GB headroom).
+#
+# ⭐ VRAM RESIZING — trade context ↔ image resolution (single 3090, q4_0 KV).
+#   The 24 GB budget is split between KV (grows with CTX_SIZE) and the image-
+#   encode buffer (grows with IMAGE_MAX_TOKENS). The default 160K + 4096 (=4M-px
+#   /2048² images) peaks ~23.65 GB on a full-res image — ~0.9 GB headroom.
+#
+#   ► WANT HIGHER-RES IMAGES (sharp 4K UIs, fine-print docs)? Raise the image
+#     cap and pay for it by LOWERING context. Starting points (UNMEASURED —
+#     validate, see below):
+#       IMAGE_MAX_TOKENS=8192 CTX_SIZE=131072    # ~8M-px (2896²) images, 128K ctx
+#       IMAGE_MAX_TOKENS=6144 CTX_SIZE=147456    # ~6M-px images, 144K ctx
+#   ► WANT MORE CONTEXT (smaller images OK)? LOWER the image cap:
+#       IMAGE_MAX_TOKENS=1024 CTX_SIZE=200000    # ~1M-px (1024²) images, 200K ctx
+#
+#   Measured full-res (4M-px) ctx ladder on THIS rig (2026-05-21, -b 1024):
+#       160K → ~0.9 GB free (default) | 172K → ~0.7 GB | 175K → ~0.6 GB | 192K → OOM
+#   ⚠ Headroom at the top is THIN. 172K+ served single images but OOM-crashed
+#     under sustained heavy prefill (verify-stress battery) — the 160K default
+#     trades ~12K ctx for that margin. Go above 160K only if your workload is
+#     image + light text, not prefill-heavy agentic (large tool messages).
+#   ⚠ ALWAYS re-validate after resizing: boot, then run BOTH a real full-size
+#     image request AND `scripts/verify-stress.sh` (encode + prefill peaks are
+#     spiky; a tight config that serves one image can still OOM under load).
+#
+# Thinking-off: native lever is --reasoning off; validated to work WITH the
+# froggeric v19 template on ik_llama (2026-05-21) — clean suppression + tool
+# calls render. See ../../patches/froggeric-chat-template/PROVENANCE.md.
+#
+# Quick start:
+#   1. GGUF + vision projector:
+#        hf download ubergarm/Qwen3.6-27B-GGUF Qwen3.6-27B-MTP-IQ4_KS.gguf \
+#          --local-dir $MODEL_DIR/qwen3.6-27b-gguf/ubergarm-mtp-iq4ks
+#        hf download unsloth/Qwen3.6-27B-GGUF mmproj-F16.gguf \
+#          --local-dir $MODEL_DIR/qwen3.6-27b-gguf
+#   2. MODEL_DIR=/your/models/dir docker compose -f iq4ks-mtp-vision.yml up -d
+#   3. curl http://localhost:8020/v1/models  → should list the model.
+#
+# Override defaults via .env or shell:
+#   MODEL_DIR             host dir to mount as /models
+#   GGUF_FILE            path under /models (default: …ubergarm-mtp-iq4ks/Qwen3.6-27B-MTP-IQ4_KS.gguf)
+#   MMPROJ_FILE          path under /models (default: qwen3.6-27b-gguf/mmproj-F16.gguf)
+#   CTX_SIZE             KV pool size (default 163840 = 160K).
+#                        ⛔ DON'T RAISE past 160K for general use. 160K PASSED
+#                        verify-stress; 172K served single images but OOM-CRASHED
+#                        under heavy back-to-back prefill (big tool messages /
+#                        agentic loops). 160K is the stability-validated ceiling.
+#                        Raise ONLY for image + LIGHT-text workloads, and only
+#                        after re-running verify-stress — see VRAM RESIZING below.
+#   BATCH_SIZE           llama.cpp -b       (default: 1024 — REQUIRED for vision; -b 4096 OOMs at boot)
+#   UBATCH_SIZE          llama.cpp -ub      (cosmetic — engine forces n_ubatch=n_batch; only -b matters)
+#   NP                   parallel slots     (default: 1)
+#   KV_TYPE              K and V quant type (default: q4_0; q8_0 = higher KV quality)
+#   MTP_DRAFT_N_MAX      MTP draft tokens   (default: 2)
+#   DRAFT_P_MIN          draft accept floor (default: 0.0)
+#   REASONING            thinking gate      (default: off)
+#   CHAT_TEMPLATE_FILE   chat template path (default: /etc/qwen-froggeric-chat-template.jinja = v19)
+#   PORT                 host port          (default: 8020)
+#   CUDA_VISIBLE_DEVICES which GPU to use   (default: 0)
+
+services:
+  ik-llama-qwen36-27b-iq4ks-mtp-vision:
+    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu13-server}
+    container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b}"
+    restart: unless-stopped
+    ipc: host
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8020}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../models-cache}:/models:ro"
+      # froggeric v19 chat template (validated on ik_llama 2026-05-21 — see
+      # ../../patches/froggeric-chat-template/PROVENANCE.md).
+      - "../../patches/froggeric-chat-template/chat_template_v19.jinja:/etc/qwen-froggeric-chat-template.jinja:ro"
+    # server target ENTRYPOINT is /app/llama-server — args only below.
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      --model /models/${GGUF_FILE:-qwen3.6-27b-gguf/ubergarm-mtp-iq4ks/Qwen3.6-27B-MTP-IQ4_KS.gguf}
+      --mmproj /models/${MMPROJ_FILE:-qwen3.6-27b-gguf/mmproj-F16.gguf}
+      --image-min-tokens ${IMAGE_MIN_TOKENS:-1024}
+      --image-max-tokens ${IMAGE_MAX_TOKENS:-4096}
+      -ngl 99
+      --ctx-size ${CTX_SIZE:-163840}
+      -b ${BATCH_SIZE:-1024}
+      -ub ${UBATCH_SIZE:-1024}
+      -np ${NP:-1}
+      -ctk ${KV_TYPE:-q4_0}
+      -ctv ${KV_TYPE:-q4_0}
+      -khad
+      -ngld 99
+      --multi-token-prediction
+      --draft-max ${MTP_DRAFT_N_MAX:-2}
+      --draft-p-min ${DRAFT_P_MIN:-0.0}
+      --merge-qkv
+      -fa on
+      --jinja
+      --chat-template-file ${CHAT_TEMPLATE_FILE:-/etc/qwen-froggeric-chat-template.jinja}
+      --parallel-tool-calls
+      --reasoning ${REASONING:-off}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --chat-template-kwargs '{"preserve_thinking":true}'
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}"]
+              capabilities: [gpu]

--- a/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp.yml
@@ -1,0 +1,127 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-27B (ubergarm MTP-IQ4_KS GGUF — imatrix IQK quant)
+#   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp:cu13-server)
+#   Topology:  Single 3090 (TP=1)
+#   Drafter:   MTP n=2, p-min 0.0 (built-in MTP head)
+#   KV:        q4_0 K + q4_0 V (default — max-context-first; -khad Hadamard
+#              K-cache for quantized-KV accuracy. KV_TYPE=q8_0 = ampersandru's,
+#              higher KV fidelity, caps ~131-200K ctx)
+#   Template:  froggeric v19 (--chat-template-file) — see volumes block
+#   Vision:    NO (text-only this profile; mmproj is a separate axis → -vision.yml)
+#   Default ctx: 262144 — full native ctx (n_ctx_train) on ONE 3090, q4_0 KV.
+#              Bumped from 131072 → native max 2026-05-21, keeping -ub 1024 (NOT
+#              the -ub 512 the 21.5 GB datapoint below used). For lower VRAM /
+#              cross-rig-safe boot, set CTX_SIZE=131072.
+#   MAX ctx:   262144 (model native ceiling; n_ctx_train = n_ctx_orig_yarn = 262144).
+#              VRAM: default -ub 1024 @ 262144 → 22.5 GB / 24 (verified 2026-05-21,
+#              KV pre-allocated so this is steady-state; ~2.1 GB headroom — fine on a
+#              dedicated card, tight if anything else shares GPU 0). -ub 512 @ 262144
+#              → 21.5 GB if you need the extra ~1 GB back.
+#   Status:    🧪 EVAL ONLY — task #402. NOT shipped. Reproduces ampersandru's
+#              discussion #152 single-3090 result; our rig: ~61 narr / ~70 code
+#              wall TPS (+18-20% over shipped llamacpp/mtp Q4_K_M's 51/60).
+#   Best for:  TBD — gated on the controlled bench (TPS + 8-pack quality +
+#              soak + aider-30) vs shipped llamacpp/mtp Q4_K_M.
+# ---------------------------------------------------------------------------
+# Qwen3.6-27B on ik_llama.cpp — single 3090, IQ4_KS + q4_0 KV + MTP, 131K default (262K max).
+#
+# CONFIG SOURCE: ampersandru's authoritative launch flags from discussion #152
+# (comment 16999100). Reproduced verbatim:
+#     -ngl 99 --ctx-size 122880 -ngld 99 --multi-token-prediction
+#     --draft-max 2 --draft-p-min 0.0 --merge-qkv
+#
+# JUSTIFIED DEVIATIONS from his config:
+#   1. KV type — we DEFAULT q4_0 (max-context-first: enables the full 262K
+#      native ctx on one 3090). ampersandru's full config uses q8_0; both fit
+#      and are near-lossless. f16 KV would OOM at high ctx (8.3 GB @122K). For
+#      max KV fidelity set KV_TYPE=q8_0 (caps ~131-200K — q8_0 @262K ~10 GB OOMs).
+#   2. --reasoning off — stack-wide thinking-off-by-default policy (matches
+#      llama-cpp mtp.yml). Without it the Qwen3.6 template defaults thinking
+#      ON; short-budget requests return empty content (all tokens spent in
+#      <think>). Bench passes enable_thinking=false anyway; this aligns the
+#      raw endpoint to the same policy.
+#
+# Engine pinned by digest (engine policy):
+#   ghcr.io/ikawrakow/ik-llama-cpp:cu13-server
+#     @sha256:c13e0798e4117649962833adc932362b64cb7080cfc9dbb1235161f43f8d5c49
+#   cu13 = matches our CUDA 13.2 host driver.
+#
+# Quick start:
+#   1. Get the MTP-IQ4_KS GGUF:
+#        hf download ubergarm/Qwen3.6-27B-GGUF Qwen3.6-27B-MTP-IQ4_KS.gguf \
+#          --local-dir $MODEL_DIR/qwen3.6-27b-gguf/ubergarm-mtp-iq4ks
+#   2. From this directory:
+#        MODEL_DIR=/your/models/dir docker compose -f iq4ks-mtp.yml up -d
+#   3. curl http://localhost:8020/v1/models  → should list the model.
+#
+# Override defaults via .env or shell:
+#   MODEL_DIR              host dir to mount as /models
+#   GGUF_FILE             path under /models (default: …ubergarm-mtp-iq4ks/Qwen3.6-27B-MTP-IQ4_KS.gguf)
+#   CTX_SIZE              KV pool size       (default: 131072; MAX 262144 — see header)
+#   BATCH_SIZE           llama.cpp -b       (default: 4096 — matches llama-cpp mtp.yml)
+#   UBATCH_SIZE          llama.cpp -ub      (default: 1024; set 512 for 262144 ctx, ~2-4% TPS cost)
+#   NP                   parallel slots     (default: 1)
+#   KV_TYPE              K and V quant type (default: q4_0 = max-ctx; q8_0 = ampersandru's, higher fidelity)
+#   MTP_DRAFT_N_MAX      MTP draft tokens   (default: 2)
+#   DRAFT_P_MIN          draft accept floor (default: 0.0)
+#   REASONING            thinking gate      (default: off; set 'on' to enable reasoning — see below)
+#   REASONING_FORMAT     reasoning routing  (default: deepseek)
+#   CHAT_TEMPLATE_FILE   chat template path (default: /etc/qwen-froggeric-chat-template.jinja = v19)
+#
+# ⭐ TEST WITH REASONING ON (one env flip — machinery is pre-wired):
+#     REASONING=on MODEL_DIR=/your/models docker compose -f iq4ks-mtp.yml up -d
+#   The reasoning-format (deepseek) + chat-template-kwargs preserve_thinking:true
+#   are always present; only the --reasoning gate flips. When ON, also tune MTP
+#   deeper (MTP_DRAFT_N_MAX=5 DRAFT_P_MIN=0.5) — reasoning text drafts well, so
+#   a deeper draft pays off (Vincent's thinking-on profile). Default-off keeps
+#   n=2/p-min 0.0 (the thinking-off sweet spot).
+#   PORT                 host port          (default: 8020)
+#   CUDA_VISIBLE_DEVICES which GPU to use   (default: 0)
+
+services:
+  ik-llama-qwen36-27b-iq4ks-mtp:
+    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu13-server}
+    container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b}"
+    restart: unless-stopped
+    ipc: host
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8020}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../models-cache}:/models:ro"
+      # froggeric v19 chat template (fixes 7 Qwen3.6 template bugs; 2 target
+      # the tool-call path). Validated on ik_llama 2026-05-21: --reasoning off
+      # suppresses thinking cleanly + tool-calls render. See ../../patches/.../PROVENANCE.md.
+      - "../../patches/froggeric-chat-template/chat_template_v19.jinja:/etc/qwen-froggeric-chat-template.jinja:ro"
+    # server target ENTRYPOINT is /app/llama-server — args only below.
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      --model /models/${GGUF_FILE:-qwen3.6-27b-gguf/ubergarm-mtp-iq4ks/Qwen3.6-27B-MTP-IQ4_KS.gguf}
+      -ngl 99
+      --ctx-size ${CTX_SIZE:-262144}
+      -b ${BATCH_SIZE:-4096}
+      -ub ${UBATCH_SIZE:-1024}
+      -np ${NP:-1}
+      -ctk ${KV_TYPE:-q4_0}
+      -ctv ${KV_TYPE:-q4_0}
+      -khad
+      -ngld 99
+      --multi-token-prediction
+      --draft-max ${MTP_DRAFT_N_MAX:-2}
+      --draft-p-min ${DRAFT_P_MIN:-0.0}
+      --merge-qkv
+      -fa on
+      --jinja
+      --chat-template-file ${CHAT_TEMPLATE_FILE:-/etc/qwen-froggeric-chat-template.jinja}
+      --parallel-tool-calls
+      --reasoning ${REASONING:-off}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --chat-template-kwargs '{"preserve_thinking":true}'
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}"]
+              capabilities: [gpu]

--- a/models/qwen3.6-27b/ik-llama/patches/froggeric-chat-template/PROVENANCE.md
+++ b/models/qwen3.6-27b/ik-llama/patches/froggeric-chat-template/PROVENANCE.md
@@ -1,0 +1,33 @@
+# froggeric chat template (v19) — ik_llama copy
+
+Source: https://huggingface.co/froggeric/Qwen-Fixed-Chat-Templates
+
+- File: `chat_template_v19.jinja`
+- Downloaded: 2026-05-21 (fresh pull from the pinned commit, not copied from the vLLM tree)
+- Upstream revision: `c31fd393e531dbacd92b6deb99a2037cc949f950`
+- Upstream timestamp: 2026-05-16T13:44:07Z
+- Upstream release label: **v19**
+- SHA256: `4649b3fa3db3fda4d51173ed4ff0175fde7ece8bbceb9d595d04d862020c9746`
+  (verified identical to the adopted vLLM-tree snapshot at
+  `models/qwen3.6-27b/vllm/patches/froggeric-chat-template/chat_template.jinja`)
+
+## Why a separate ik copy (vs referencing the vLLM tree)
+
+Version pinned in the filename + ik track owns its template — no cross-tree
+mount dependency on `vllm/patches/`.
+
+## Why this is safe on ik_llama (where mtp.yml warns it isn't on mainline)
+
+`llama-cpp/.../mtp.yml` documents that on **mainline** llama.cpp the froggeric
+template "has no thinking-mode Jinja hook and silently suppresses
+`--reasoning off`", so that path ships native. **Empirically re-tested on
+ik_llama (cu13-server) 2026-05-21**: froggeric v19 + `--reasoning off`
+suppresses thinking cleanly (hard reasoning prompt → answer in `content`, no
+`<think>` leak, empty `reasoning_content`) AND renders tool-calls correctly.
+So on ik the same `--reasoning off` lever works; we keep it.
+
+## Quality status
+
+The +10pp `hermesagent-20` win was measured on **vLLM** (PR #157). NOT yet
+A/B-confirmed on ik_llama — froggeric-vs-native on toolcall-15 / hermesagent-20
+is the owed measurement (relevant to the IQ4_KS toolcall-regression question).

--- a/models/qwen3.6-27b/ik-llama/patches/froggeric-chat-template/chat_template_v19.jinja
+++ b/models/qwen3.6-27b/ik-llama/patches/froggeric-chat-template/chat_template_v19.jinja
@@ -1,0 +1,265 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id is defined and add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id is defined and add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- set ns_flags = namespace(enable_thinking=true, has_tools=false, last_tool_failed=false, consecutive_failures=0) %}
+{%- if enable_thinking is defined %}
+    {%- set ns_flags.enable_thinking = enable_thinking %}
+{%- endif %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- set system_content = '' %}
+{%- set has_system = false %}
+{%- if messages[0].role == 'system' or messages[0].role == 'developer' %}
+    {%- set has_system = true %}
+    {%- set system_content = render_content(messages[0].content, false, true)|trim %}
+    {%- if '<|think_off|>' in system_content %}
+        {%- set ns_flags.enable_thinking = false %}
+        {%- set system_content = system_content | replace('<|think_off|>', '') %}
+    {%- endif %}
+    {%- if '<|think_on|>' in system_content %}
+        {%- set ns_flags.enable_thinking = true %}
+        {%- set system_content = system_content | replace('<|think_on|>', '') %}
+    {%- endif %}
+    {%- set system_content = system_content | trim %}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {%- set ns_flags.has_tools = true %}
+    {{- '<|im_start|>system\n' }}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- '\n' }}
+        {%- set fn = tool.function if tool.function is defined else tool %}
+        {{- fn | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {%- set tool_instructions %}
+If you choose to call a function ONLY reply in the following format with NO suffix:
+
+<think>
+Brief explanation of tool call
+</think>
+<tool_call>
+<function=example_function_name>
+<parameter=example_parameter_1>
+value_1
+</parameter>
+<parameter=example_parameter_2>
+This is the value for the second parameter
+that can span
+multiple lines
+</parameter>
+</function>
+</tool_call>
+
+<IMPORTANT>
+Reminder:
+- You can use the <think></think> block to plan your next tool call OR to synthesize data and formulate your final response to the user.
+- ALL explanation and reasoning MUST be placed strictly inside the <think></think> block.
+- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags.
+- If you choose to call a tool, you MUST output the <tool_call> block IMMEDIATELY after closing </think>. Do NOT output any conversational text before the tool call.
+- The <tool_call> and <function> tags MUST be at the very beginning of a new line, with NO spaces or indentation before them.
+- To call multiple functions, output a separate, completely closed <tool_call></tool_call> block for EACH function. Do NOT nest <tool_call> blocks.
+- If you have gathered all necessary data and do not need to call a tool, answer the question like normal and provide your final response to the user IMMEDIATELY after closing </think>.
+</IMPORTANT>
+    {%- endset %}
+    {{- '\n\n' ~ tool_instructions | trim }}
+    {%- if has_system and system_content %}
+        {{- '\n\n' + system_content }}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- elif has_system and system_content %}
+    {{- '<|im_start|>system\n' + system_content + '<|im_end|>\n' }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set is_system = (message.role == "system" or message.role == "developer") %}
+    {%- set content = render_content(message.content, true, is_system)|trim %}
+    {%- if '<|think_off|>' in content %}
+        {%- set ns_flags.enable_thinking = false %}
+        {%- set content = content | replace('<|think_off|>', '') | trim %}
+    {%- elif '<|think_on|>' in content %}
+        {%- set ns_flags.enable_thinking = true %}
+        {%- set content = content | replace('<|think_on|>', '') | trim %}
+    {%- endif %}
+    {%- if is_system %}
+        {%- if not loop.first and content %}
+            {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>\n' }}
+        {%- set ns_flags.last_tool_failed = false %}
+        {%- set ns_flags.consecutive_failures = 0 %}
+    {%- elif message.role == "assistant" %}
+        {%- set ns_flags.last_tool_failed = false %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- set think_end_token = '' %}
+            {%- if '</think>' in content %}
+                {%- set think_end_token = '</think>' %}
+            {%- elif '</thinking>' in content %}
+                {%- set think_end_token = '</thinking>' %}
+            {%- elif '</ think>' in content %}
+                {%- set think_end_token = '</ think>' %}
+            {%- elif '</think >' in content %}
+                {%- set think_end_token = '</think >' %}
+            {%- endif %}
+            {%- if think_end_token %}
+                {%- set reasoning_parts = content.split(think_end_token) %}
+                {%- set reasoning_content = reasoning_parts[0] %}
+                {%- set content = reasoning_parts[1:] | join(think_end_token) %}
+                {%- if '<think>' in reasoning_content %}
+                    {%- set r_prefix = reasoning_content.split('<think>')[0] | trim %}
+                    {%- set reasoning_content = reasoning_content.split('<think>')[1:] | join('<think>') | trim %}
+                    {%- set content = (r_prefix ~ '\n' ~ content) | trim %}
+                {%- endif %}
+            {%- elif '<think>' in content %}
+                {%- set prefix = content.split('<think>')[0] %}
+                {%- set think_part = content.split('<think>')[1:] | join('<think>') %}
+                {%- if '<tool_call>' in think_part %}
+                    {%- set reasoning_content = think_part.split('<tool_call>')[0] %}
+                    {%- set content = prefix ~ '\n<tool_call>' ~ think_part.split('<tool_call>')[1:] | join('<tool_call>') %}
+                {%- else %}
+                    {%- set reasoning_content = think_part %}
+                    {%- set content = prefix %}
+                {%- endif %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content | trim %}
+        {%- set content = content | trim %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- if '<tool_call>' in content %}
+                {%- set content = content.split('<tool_call>')[0] | trim %}
+            {%- endif %}
+        {%- endif %}
+        {%- set show_think = true %}
+        {%- if preserve_thinking is defined and preserve_thinking == false %}
+            {%- set show_think = false %}
+        {%- endif %}
+        {%- if not reasoning_content %}
+            {%- set show_think = false %}
+        {%- endif %}
+        
+        {%- if show_think and ns_flags.enable_thinking is not false %}
+            {%- if content %}
+                {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n' + content }}
+            {%- else %}
+                {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>' }}
+            {%- endif %}
+        {%- else %}
+            {%- if content %}
+                {{- '<|im_start|>' + message.role + '\n' + content }}
+            {%- else %}
+                {{- '<|im_start|>' + message.role }}
+            {%- endif %}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {{- '\n<tool_call>\n' }}
+                {{- '<function=' ~ tool_call.name ~ '>\n' }}
+                {%- if tool_call.arguments is defined and tool_call.arguments is mapping %}
+                    {%- if tool_call.arguments | length > 0 %}
+                        {%- for args_name in tool_call.arguments %}
+                            {%- set args_value = tool_call.arguments[args_name] %}
+                            {{- '<parameter=' ~ args_name ~ '>\n' }}
+                            {%- set args_value = args_value | tojson if args_value is mapping or (args_value is iterable and args_value is not string) else args_value | string %}
+                            {{- args_value }}
+                            {{- '\n</parameter>\n' }}
+                        {%- endfor %}
+                    {%- endif %}
+                {%- elif tool_call.arguments is defined and tool_call.arguments is string %}
+                    {%- if tool_call.arguments | trim | length > 0 %}
+                        {{- tool_call.arguments }}
+                        {{- '\n' }}
+                    {%- endif %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- set content_lower = content | lower %}
+        {%- if content | length < 500
+            and '$ ' not in content
+            and 'took ' not in content_lower
+            and ('"error":' in content_lower or 'error:' in content_lower or 'exception:' in content_lower or 'traceback' in content_lower or 'command not found' in content_lower or 'invalid syntax' in content_lower or 'failed to' in content_lower) %}
+            {%- set ns_flags.last_tool_failed = true %}
+            {%- set ns_flags.consecutive_failures = ns_flags.consecutive_failures + 1 %}
+        {%- else %}
+            {%- set ns_flags.last_tool_failed = false %}
+            {%- set ns_flags.consecutive_failures = 0 %}
+        {%- endif %}
+        {%- if loop.index0 > 0 and messages[loop.index0 - 1].role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {%- if ns_flags.last_tool_failed %}
+            {%- if ns_flags.consecutive_failures >= 2 %}
+                {{- '\n\n⚠️ SYSTEM WARNING: ' ~ ns_flags.consecutive_failures ~ ' consecutive tool errors detected. Your previous approach is incorrect. You MUST use a fundamentally different approach or corrected arguments.' }}
+            {%- else %}
+                {{- '\n\n⚠️ SYSTEM WARNING: The previous tool call returned an error. Diagnose the failure and retry with completely corrected arguments.' }}
+            {%- endif %}
+        {%- endif %}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and messages[loop.index0 + 1].role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if ns_flags.enable_thinking is false %}
+        {{- '<think>\n</think>\n' }}
+    {%- elif ns_flags.last_tool_failed and ns_flags.consecutive_failures >= 2 %}
+        {{- '<think>\n</think>\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}

--- a/scripts/rebench-runtime.sh
+++ b/scripts/rebench-runtime.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# rebench-runtime.sh — the "runtime" tier of rebench: bench + verify-stress
+# + soak, skipping the two generation-quality legs (quality-full + aider).
+#
+# WHEN TO USE THIS instead of rebench-full.sh:
+#   When you changed a serving-config knob that affects throughput / VRAM /
+#   stability but NOT per-token generation quality, so re-scoring the 8-pack
+#   + aider would be ~1.5 hr of wasted cycles that can only reproduce the
+#   prior scores. Examples:
+#     - context-size ceiling bump (KV *type* unchanged)
+#     - --ubatch-size / --batch-size tuning
+#     - --gpu-memory-utilization / --mem-fraction-static
+#     - power-limit sweep
+#     - MTP n / draft-p-min retune (TPS + accept-rate, not answer text)
+#   If the change DOES touch generation (quant swap, KV-cache *type* change,
+#   chat-template change, model swap) → run full rebench-full.sh instead.
+#
+# Three legs (≈30-40 min on single-card, vs ~1.75-2 hr for the full matrix):
+#   1. bench.sh           — TPS narrative + code
+#   2. verify-stress.sh   — long-context needle ladder + prefill-OOM boundary
+#   3. soak-test.sh       — accumulating-context endurance (Cliff 2b)
+#
+# Usage (identical surface to rebench-full.sh — all flags pass through):
+#   bash scripts/rebench-runtime.sh                       # auto-detect running compose
+#   bash scripts/rebench-runtime.sh --tag ik-262k         # explicit tag
+#   bash scripts/rebench-runtime.sh --skip soak           # ALSO skip soak (merged)
+#
+# llama.cpp / ik_llama (non-vllm container names) — soak-test.sh's container
+# auto-detect only matches vllm-*; pass the endpoint + container explicitly
+# (see #403):
+#   CONTAINER=ik-llama-qwen36-27b URL=http://localhost:8020 MODEL=ik-iq4ks-mtp \
+#     bash scripts/rebench-runtime.sh --engine llama-cpp
+#
+# This is a thin preset over rebench-full.sh: it injects
+# `--skip quality-full,aider-polyglot` and merges any --skip you pass.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+BASE_SKIP="quality-full,aider-polyglot"
+USER_SKIP=""
+PASS_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip) USER_SKIP="${2:-}"; shift 2 ;;
+    *)      PASS_ARGS+=("$1"); shift ;;
+  esac
+done
+
+SKIP="$BASE_SKIP${USER_SKIP:+,$USER_SKIP}"
+
+echo "[rebench-runtime] runtime tier (bench + verify-stress + soak); --skip=$SKIP"
+exec bash "$ROOT_DIR/scripts/rebench-full.sh" --skip "$SKIP" "${PASS_ARGS[@]}"


### PR DESCRIPTION
## Summary
Adds the ik_llama.cpp serving path for Qwen3.6-27B (ubergarm MTP-IQ4_KS GGUF), validated on a single RTX 3090 (exploratory eval; discussion #152 follow-up).

- `models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp.yml` — **text, 262K ctx** (full native `n_ctx_train`), q4_0 KV, MTP n=2, froggeric v19. ~59 narr / 65 code TPS; verify-stress 7/7 to 90K; soak-continuous PASS. +18–20% TPS vs shipped `llamacpp/mtp` Q4_K_M.
- `models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp-vision.yml` — **vision, 160K ctx** + full-res (4M-px / 2048²) images at `-b 1024`; bench + verify-stress + soak all PASS. 160K chosen for headroom (172K served single images but OOM-crashed under sustained heavy prefill).
- `models/qwen3.6-27b/ik-llama/patches/froggeric-chat-template/` — v19 template + PROVENANCE.
- `scripts/rebench-runtime.sh` — bench + verify-stress + soak "runtime tier" suite (`rebench-full` minus the quality legs; for config-only changes).

## Notes
- **ik_llama quirk (documented in-header):** this build forces `n_ubatch = n_batch`, so only `-b` moves the compute buffer — `-ub` is a no-op here (distinct from mainline llama.cpp). For vision, `-b 1024` is required; `-b 4096` OOMs at boot because the image-encode graph balloons the compute buffer to ~4 GB.
- **MTP n=2 vs n=3 A/B:** n=2 wins (narrative +3.7%; code a wash within noise) — keeps the shipped default.
- Eval track — not yet wired into `COMPOSE_REGISTRY` / `switch.sh`.

## Test plan
- [x] text: bench / verify-stress 7/7 to 90K / soak-continuous PASS
- [x] vision: rebench-runtime (bench + verify-stress + soak) all PASS at 160K
- [x] full-res 2048² image served at ~23.65 GB / 24 GB