### PR TITLE
fix(launch): single-card default → llamacpp/default (off dead vllm/long-text)

### DIFF
--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -875,7 +875,11 @@ suggest_default_variant() {
     elif (( cards >= 2 )); then
       echo "vllm/dual"
     else
-      echo "vllm/long-text"
+      # Single card: llamacpp/default is the recommended path — full 262K, cliff-immune,
+      # and no purged-nightly dependency. The old vllm/long-text suggestion is dead
+      # (#167 image purge + single-card Cliff 2b); vLLM single-card users can still pick
+      # vllm/tools-text explicitly.
+      echo "llamacpp/default"
     fi
   else
     if (( cards >= 2 )); then echo "vllm/gemma-mtp"; else echo "vllm/gemma-mtp-tp1"; fi


### PR DESCRIPTION
`suggest_default_variant()` suggested **`vllm/long-text`** for single-card Qwen3.6-27B — which is dead twice over: its pinned vLLM nightly was purged from Docker Hub (#167) and it hits single-card Cliff 2b. Repoint to **`llamacpp/default`** (full 262K, cliff-immune, no nightly dependency), matching what `README`, `docs/SINGLE_CARD.md`, and `docs/INFERENCE_ENGINES.md` already recommend. Dual-card (`vllm/dual`) and explicit `--variant` paths are unchanged; vLLM single-card users can still pick `vllm/tools-text`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)