### PR TITLE
fix(llamacpp): pin image to server-cuda-b9246 (rolling tag broke at b9282, #187)

### DIFF
--- a/models/qwen3.6-27b/llama-cpp/README.md
+++ b/models/qwen3.6-27b/llama-cpp/README.md
@@ -22,7 +22,7 @@ For full pros/cons + general llama.cpp tuning, see [`/docs/engines/LLAMA_CPP.md`
 
 ## Docker compose (recommended)
 
-Two compose variants in [`compose/single/`](compose/single/) — both use the official rolling `ghcr.io/ggml-org/llama.cpp:server-cuda` image, **no custom build needed**, **no club-3090 patches** (unlike our vLLM track). MTP PR #22673 has merged upstream so the rolling tag has it natively. Pin to a specific build via `LLAMACPP_IMAGE=ghcr.io/ggml-org/llama.cpp:server-cuda-bXXXX` env if you want to lock against upstream drift; otherwise `docker compose pull` picks up upstream's latest. Bench numbers were measured on build `b9246` (2026-05-20); expect ±5% drift on newer builds.
+Two compose variants in [`compose/single/`](compose/single/) — both use the official `ghcr.io/ggml-org/llama.cpp` image (CUDA), **no custom build needed**, **no club-3090 patches** (unlike our vLLM track). MTP PR #22673 has merged upstream so this image has it natively. The composes are **pinned to build `server-cuda-b9246`** (validated 2026-05-20) — *not* the rolling `:server-cuda` tag, because that tag regressed at `b9282` (broken lib packaging → crash loop, [#187](https://github.com/noonghunna/club-3090/issues/187)). To follow a newer build, override `LLAMACPP_IMAGE=ghcr.io/ggml-org/llama.cpp:server-cuda-bXXXX` (validate it first). Bench numbers were measured on `b9246`; expect ±5% drift on newer builds.
 
 ### `single/mtp.yml` — MTP n=2, 262K ctx, no vision
 

--- a/models/qwen3.6-27b/llama-cpp/compose/single/mtp-vision.yml
+++ b/models/qwen3.6-27b/llama-cpp/compose/single/mtp-vision.yml
@@ -91,7 +91,11 @@
 
 services:
   llama-cpp-qwen36-27b-mtp-vision:
-    image: ${LLAMACPP_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda}
+    # Pinned to b9246 (validated 2026-05-20). The rolling `:server-cuda` tag
+    # regressed at b9282 (broken lib packaging: `libllama-common.so.0: cannot
+    # open shared object file` → crash loop) — see #187. Bump via env when a
+    # newer build is validated:  LLAMACPP_IMAGE=ghcr.io/ggml-org/llama.cpp:server-cuda-bXXXX
+    image: ${LLAMACPP_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda-b9246}
     container_name: "${ESTATE_CONTAINER:-llama-cpp-qwen36-27b}"
     restart: unless-stopped
     ports:

--- a/models/qwen3.6-27b/llama-cpp/compose/single/mtp.yml
+++ b/models/qwen3.6-27b/llama-cpp/compose/single/mtp.yml
@@ -76,7 +76,11 @@
 
 services:
   llama-cpp-qwen36-27b-mtp:
-    image: ${LLAMACPP_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda}
+    # Pinned to b9246 (validated 2026-05-20). The rolling `:server-cuda` tag
+    # regressed at b9282 (broken lib packaging: `libllama-common.so.0: cannot
+    # open shared object file` → crash loop) — see #187. Bump via env when a
+    # newer build is validated:  LLAMACPP_IMAGE=ghcr.io/ggml-org/llama.cpp:server-cuda-bXXXX
+    image: ${LLAMACPP_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda-b9246}
     container_name: "${ESTATE_CONTAINER:-llama-cpp-qwen36-27b}"
     restart: unless-stopped
     ports:

--- a/scripts/lib/profiles/engines/llama-cpp-mainline.yml
+++ b/scripts/lib/profiles/engines/llama-cpp-mainline.yml
@@ -22,5 +22,5 @@ supported_weight_formats:
 required_overlays: []
 vendored_overlays: []
 required_genesis: false
-notes: "Cliff-immune single-card fallback for Qwen GGUF serving. Uses upstream `ghcr.io/ggml-org/llama.cpp:server-cuda` (rolling tag — auto-bumps to latest upstream build). MTP PR #22673 merged upstream + draft-eagle3 + draft-mtp spec types available natively. Pin to a specific build via env: `LLAMACPP_IMAGE=ghcr.io/.../server-cuda-bXXXX` (e.g. if upstream regresses). No club-3090 patches on llama.cpp; we follow upstream as-is."
+notes: "Cliff-immune single-card fallback for Qwen GGUF serving. Uses upstream `ghcr.io/ggml-org/llama.cpp`, pinned to build `server-cuda-b9246` (NOT the rolling `:server-cuda` tag — it regressed at b9282 with a broken-lib crash loop, #187). MTP PR #22673 merged upstream + draft-eagle3 + draft-mtp spec types available natively. Bump via env once a newer build is validated: `LLAMACPP_IMAGE=ghcr.io/.../server-cuda-bXXXX`. No club-3090 patches on llama.cpp; we follow upstream as-is."
 


### PR DESCRIPTION
The upstream rolling `ghcr.io/ggml-org/llama.cpp:server-cuda` tag **regressed at `b9282`** — `llama-server` crash-loops with `libllama-common.so.0: cannot open shared object file` (broken lib packaging). Our `mtp.yml` / `mtp-vision.yml` defaulted to the rolling tag, so **every fresh `docker compose up` of the single-card llama.cpp path hit the crash loop** and `:8020` never came up. Reported in #187 (@rhossack, WSL2).

**Fix:** pin both composes to the validated build **`server-cuda-b9246`** (2026-05-20 — what all current BENCHMARKS rows were measured on, and what this whole session's testing ran on). Follow a newer build via `LLAMACPP_IMAGE=ghcr.io/ggml-org/llama.cpp:server-cuda-bXXXX` once validated. README + engine-profile notes updated to match.

Verified: both composes `docker compose config` clean with the pinned image. b9246 is validated (the session's multi-turn / aider / quality runs all ran on it).

Closes #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)