### PR TITLE
feat(ik-llama): wire iq4ks-mtp + iq4ks-mtp-vision into launch.sh + switch.sh

### DIFF
--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -230,6 +230,8 @@ declare -A LAUNCH_VARIANT_COMPOSE=(
   [llamacpp/default]="models/qwen3.6-27b/llama-cpp/compose/single/mtp.yml"
   [llamacpp/mtp]="models/qwen3.6-27b/llama-cpp/compose/single/mtp.yml"
   [llamacpp/mtp-vision]="models/qwen3.6-27b/llama-cpp/compose/single/mtp-vision.yml"
+  [ik-llama/iq4ks-mtp]="models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp.yml"
+  [ik-llama/iq4ks-mtp-vision]="models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp-vision.yml"
 )
 declare -A LAUNCH_VARIANT_MODEL=(
   [vllm/default]="qwen3.6-27b" [vllm/long-vision]="qwen3.6-27b" [vllm/long-text]="qwen3.6-27b"
@@ -240,6 +242,7 @@ declare -A LAUNCH_VARIANT_MODEL=(
   [vllm/dual-nvlink-dflash]="qwen3.6-27b" [vllm/dual-nvlink-dflash-noviz]="qwen3.6-27b"
   [vllm/gemma-mtp]="gemma-4-31b" [vllm/gemma-mtp-tp1]="gemma-4-31b" [vllm/gemma-dflash]="gemma-4-31b"
   [llamacpp/default]="qwen3.6-27b" [llamacpp/mtp]="qwen3.6-27b" [llamacpp/mtp-vision]="qwen3.6-27b"
+  [ik-llama/iq4ks-mtp]="qwen3.6-27b" [ik-llama/iq4ks-mtp-vision]="qwen3.6-27b"
 )
 declare -A LAUNCH_VARIANT_ENGINE=(
   [vllm/default]="vllm" [vllm/long-vision]="vllm" [vllm/long-text]="vllm" [vllm/long-text-no-mtp]="vllm"
@@ -249,6 +252,7 @@ declare -A LAUNCH_VARIANT_ENGINE=(
   [vllm/dual-nvlink-dflash]="vllm" [vllm/dual-nvlink-dflash-noviz]="vllm"
   [vllm/gemma-mtp]="vllm" [vllm/gemma-mtp-tp1]="vllm" [vllm/gemma-dflash]="vllm"
   [llamacpp/default]="llamacpp" [llamacpp/mtp]="llamacpp" [llamacpp/mtp-vision]="llamacpp"
+  [ik-llama/iq4ks-mtp]="llamacpp" [ik-llama/iq4ks-mtp-vision]="llamacpp"
 )
 declare -A LAUNCH_VARIANT_KVCALC=(
   [vllm/default]="qwen3.6-27b:long-vision"
@@ -274,6 +278,8 @@ declare -A LAUNCH_VARIANT_KVCALC=(
   [llamacpp/default]="SKIP"
   [llamacpp/mtp]="SKIP"
   [llamacpp/mtp-vision]="SKIP"
+  [ik-llama/iq4ks-mtp]="SKIP"
+  [ik-llama/iq4ks-mtp-vision]="SKIP"
 )
 LAUNCH_VARIANT_ORDER=(
   vllm/long-vision vllm/long-text vllm/long-text-no-mtp vllm/bounded-thinking
@@ -282,6 +288,7 @@ LAUNCH_VARIANT_ORDER=(
   vllm/dual4 vllm/dual4-dflash
   vllm/gemma-mtp vllm/gemma-mtp-tp1 vllm/gemma-dflash
   llamacpp/default llamacpp/mtp llamacpp/mtp-vision
+  ik-llama/iq4ks-mtp ik-llama/iq4ks-mtp-vision
 )
 
 variant_hw_status() {
@@ -1132,6 +1139,8 @@ declare -A LAUNCH_DEFAULT_PORT=(
   [llamacpp/default]=8020
   [llamacpp/mtp]=8020
   [llamacpp/mtp-vision]=8020
+  [ik-llama/iq4ks-mtp]=8020
+  [ik-llama/iq4ks-mtp-vision]=8020
 )
 declare -A LAUNCH_DEFAULT_CONTAINER=(
   [vllm/default]=vllm-qwen36-27b
@@ -1157,6 +1166,8 @@ declare -A LAUNCH_DEFAULT_CONTAINER=(
   [llamacpp/default]=llama-cpp-qwen36-27b
   [llamacpp/mtp]=llama-cpp-qwen36-27b
   [llamacpp/mtp-vision]=llama-cpp-qwen36-27b
+  [ik-llama/iq4ks-mtp]=ik-llama-qwen36-27b
+  [ik-llama/iq4ks-mtp-vision]=ik-llama-qwen36-27b
 )
 ENDPOINT_PORT="${PORT:-${LAUNCH_DEFAULT_PORT[$VARIANT]:-8020}}"
 ENDPOINT_URL="http://localhost:${ENDPOINT_PORT}"

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -250,6 +250,25 @@ COMPOSE_REGISTRY = {
         default_port=8020,
     ),
 
+    # ik_llama.cpp — IQ4_KS (ubergarm). Same engine family as llamacpp, but the
+    # IQK quant is ~0.5-0.8 GB leaner on weights → best fit for VRAM-tight
+    # single-card (sub-24 GB, shared GPU, WSL display overhead). Its own image
+    # (ikawrakow/ik-llama-cpp), so unaffected by mainline llama.cpp drift.
+    "ik-llama/iq4ks-mtp": _entry(
+        model="qwen3.6-27b", weights_variant="gguf", workload="fast-chat",
+        engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q4_0",
+        tp=1, max_ctx=262144, max_num_seqs=1, mem_util=None,
+        compose_path="models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp.yml",
+        default_port=8020,
+    ),
+    "ik-llama/iq4ks-mtp-vision": _entry(
+        model="qwen3.6-27b", weights_variant="gguf", workload="vision-coding",
+        engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q4_0",
+        tp=1, max_ctx=163840, max_num_seqs=1, mem_util=None,
+        compose_path="models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp-vision.yml",
+        default_port=8020,
+    ),
+
     # Gemma 4 31B, vLLM.
     "vllm/gemma-mtp-tp1": _entry(
         model="gemma-4-31b", weights_variant="autoround_int4", workload="fast-chat",

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -43,6 +43,9 @@
 #     llamacpp/default      alias for llamacpp/mtp (Q4_K_M MTP, no vision)
 #     llamacpp/mtp          Q4_K_M MTP + 131K (full 262K via -ub 512) + q4_0 KV (fast ~60 TPS code; no vision; cliff-immune)
 #     llamacpp/mtp-vision   Q4_K_M MTP + 49K + q4_0 KV + mmproj (fast + multimodal)
+#   Single-card ik_llama (IQ4_KS — ~0.5-0.8 GB leaner; best for VRAM-tight / WSL):
+#     ik-llama/iq4ks-mtp         IQ4_KS MTP + 262K + q4_0 KV (own image: ikawrakow/ik-llama-cpp)
+#     ik-llama/iq4ks-mtp-vision  IQ4_KS MTP + 160K + q4_0 KV + mmproj (multimodal)
 #
 # Env overrides (rarely needed):
 #   COMPOSE_BIN     Default: "docker compose" (set to e.g. "podman compose" if needed)


### PR DESCRIPTION
The ik_llama composes shipped in #180 but were never added to `compose_registry.py` / `launch.sh`, so they were **raw-`docker compose`-only** — awkward now that ik IQ4_KS is the path we steer **VRAM-tight / WSL single-card** users toward (#187), since its ~0.5–0.8 GB leaner footprint is the one place ik's edge actually pays rent.

**Change:** register the two stable variants —
- `ik-llama/iq4ks-mtp` (262K, IQ4_KS+MTP)
- `ik-llama/iq4ks-mtp-vision` (160K + mmproj)

in `compose_registry.py` (so `switch.sh` derives them) and add them to every `launch.sh` variant map (compose / model / engine / kvcalc / order / default-port / default-container). Now `bash scripts/switch.sh ik-llama/iq4ks-mtp` works and the wizard lists them.

The experimental `iq4ks-two-stage` compose stays raw-compose-only until it's benched.

**Verified:** `compose_registry` imports cleanly (43→45 entries), ik present in all 7 launch maps + the order list, `bash -n` clean on launch.sh + switch.sh, both ik composes pass `docker compose config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)