### PR TITLE
fix(launch): nudge users at MODEL_DIR/.env when weights aren't found

### DIFF
--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -444,6 +444,8 @@ choose_model() {
     if [[ -z "${MODEL_ENGINES[$MODEL_NAME]:-}" ]]; then
       echo "[launch] ERROR: ${MODEL_NAME} is not installed under ${MODEL_DIR}." >&2
       echo "[launch]        Run: bash scripts/setup.sh ${MODEL_NAME}" >&2
+      echo "[launch]        Already have weights elsewhere? Point MODEL_DIR at them, e.g.:" >&2
+      echo "[launch]          echo 'MODEL_DIR=/path/to/your/models' >> .env   # launch.sh, switch.sh + docker compose all read it" >&2
       exit 1
     fi
     return
@@ -451,6 +453,8 @@ choose_model() {
   if [[ "${#MODEL_ORDER[@]}" -eq 0 ]]; then
     echo "[launch] ERROR: no supported model weights found under ${MODEL_DIR}." >&2
     echo "[launch]        Run: bash scripts/setup.sh" >&2
+    echo "[launch]        Already have weights elsewhere? Point MODEL_DIR at them, e.g.:" >&2
+    echo "[launch]          echo 'MODEL_DIR=/path/to/your/models' >> .env   # launch.sh, switch.sh + docker compose all read it" >&2
     exit 1
   fi
   if [[ "${#MODEL_ORDER[@]}" -eq 1 ]]; then


### PR DESCRIPTION
The most common first-run stumble (latest: #187) is having model weights *outside* the repo tree (D: drive on WSL, `~/models`, a NAS) while `MODEL_DIR` still points at the in-repo `models-cache` default. The wizard then errors `not found under <dir>` with no hint that **`MODEL_DIR` is the lever** — and people don't discover the `.env` mechanism.

Both "not found" errors now print:
```
Already have weights elsewhere? Point MODEL_DIR at them, e.g.:
  echo 'MODEL_DIR=/path/to/your/models' >> .env   # launch.sh, switch.sh + docker compose all read it
```

Pure messaging change; `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)