### PR TITLE
fix(report): PyYAML/idle-VRAM/P2P/redaction/kv-calc-scoping polish (#178/#137)

### DIFF
--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -73,7 +73,9 @@ redact() {
       -e 's|HF_TOKEN=[^ "]*|HF_TOKEN=<REDACTED>|g' \
       -e 's|HUGGING_FACE_HUB_TOKEN=[^ "]*|HUGGING_FACE_HUB_TOKEN=<REDACTED>|g' \
       -e 's|api_key=[^ "]*|api_key=<REDACTED>|gi' \
-      -e 's|hf_[A-Za-z0-9]\{30,\}|hf_<REDACTED>|g'
+      -e 's|hf_[A-Za-z0-9]\{30,\}|hf_<REDACTED>|g' \
+      -e 's|/opt/ai|<STACK_ROOT>|g' \
+      -e 's|/mnt/[a-z]/Users/[^ /]*|/mnt/<DRIVE>/Users/<REDACTED>|g'
   else
     cat
   fi
@@ -264,7 +266,14 @@ else
   # actually decide whether GPU↔GPU P2P engages (see issues #137, #351).
   subsection "PCIe / P2P detail (lspci)"
   if ! have lspci; then
-    echo "_lspci not available (pciutils not installed) — skipping PCIe/P2P detail._"
+    # Fallback: nvidia-smi topo -p2p doesn't need pciutils and shows P2P capability
+    if have nvidia-smi && nvidia-smi topo -p2p rw >/dev/null 2>&1; then
+      echo "_lspci not available (pciutils not installed) — showing P2P capability matrix instead._"
+      echo
+      nvidia-smi topo -p2p rw | redact
+    else
+      echo "_lspci not available (pciutils not installed) — skipping PCIe/P2P detail._"
+    fi
   else
     # sudo lspci -vvv is needed for full capability blocks (ACS lives in the
     # extended config space, root-only). Degrade gracefully if sudo is
@@ -352,11 +361,20 @@ section "Display / desktop state"
   fi
 
   if have nvidia-smi; then
+    # Check if a club-3090 container is running (lightweight — full detection is later)
+    local our_container=""
+    if have docker && docker info >/dev/null 2>&1; then
+      our_container=$(docker ps --format '{{.Names}}' --filter 'name=vllm-' --filter 'name=llama-cpp-' --filter 'name=club3090-' --filter 'name=ik-llama-' 2>/dev/null | head -1)
+    fi
     nvidia-smi --query-gpu=index,memory.used --format=csv,noheader,nounits 2>/dev/null \
       | while IFS=, read -r idx used; do
           idx="${idx# }"; used="${used# }"
           if [[ "$used" =~ ^[0-9]+$ ]] && [[ "$used" -gt 100 ]]; then
-            echo "- **GPU $idx idle VRAM:** ${used} MiB ⚠ something is using this GPU (display, browser, container)"
+            if [[ -n "$our_container" ]]; then
+              echo "- **GPU $idx idle VRAM:** ${used} MiB (held by running \`${our_container}\`)"
+            else
+              echo "- **GPU $idx idle VRAM:** ${used} MiB ⚠ something is using this GPU (display, browser, container)"
+            fi
           else
             echo "- **GPU $idx idle VRAM:** ${used} MiB ✓"
           fi
@@ -458,28 +476,49 @@ fi
 # verdict line + any FAIL rows here so a triage reply can immediately see
 # whether to trust kv-calc projections for this user's config.
 
+# Lightweight engine detection for kv-calc scoping (full detection is later in "Active container")
+CALIB_ENGINE_KIND="${ENGINE_KIND:-}"
+if [[ -z "$CALIB_ENGINE_KIND" ]]; then
+  if [[ -z "${CONTAINER:-}" ]] && have docker && docker info >/dev/null 2>&1; then
+    _calib_container=$(docker ps --format '{{.Names}}' --filter 'name=vllm-' --filter 'name=llama-cpp-' --filter 'name=club3090-' --filter 'name=ik-llama-' 2>/dev/null | head -1)
+    case "$_calib_container" in
+      vllm-*)      CALIB_ENGINE_KIND="vllm" ;;
+      llama-cpp-*) CALIB_ENGINE_KIND="llamacpp" ;;
+      *)           CALIB_ENGINE_KIND="unknown" ;;
+    esac
+  fi
+fi
+
 if have python3 && [[ -f tools/kv-calc.py ]]; then
   section "KV math calibration"
-  calib_output=$(python3 tools/kv-calc.py --calibration 2>&1 || true)
-  overall=$(echo "$calib_output" | grep -E '^Overall:' | head -1)
-  fail_rows=$(echo "$calib_output" | grep -E '\bFAIL\b' || true)
-  {
-    if [[ -n "$overall" ]]; then
-      echo "- ${overall}"
-    else
-      echo "- _kv-calc --calibration produced no Overall line; see output below._"
-    fi
-    if [[ -n "$fail_rows" ]]; then
-      echo "- ⚠ Failing rows:"
-      echo '```'
-      echo "$fail_rows"
-      echo '```'
-      echo "- Math model is mis-calibrated against measured reality for the rows above. Any kv-calc projection on this checkout should be treated as suspect until the calibration anchors / formulas are reconciled."
-    else
-      echo "- No FAIL rows. kv-calc projections should agree with measured VRAM within the ±1.5 GB error band."
-    fi
-  } | redact
-  echo "$calib_output" | redact | details "Full kv-calc --calibration output"
+  # Item 5: kv-calc calibration is vLLM-specific; skip on llama.cpp/ik_llama
+  if [[ "$CALIB_ENGINE_KIND" == "llamacpp" ]]; then
+    echo "- _kv-calc calibration is vLLM-specific — skipped on the llama.cpp engine._"
+  elif ! python3 -c 'import yaml' 2>/dev/null; then
+    # Item 1: graceful-degrade when PyYAML is missing
+    echo "- _kv-calc calibration skipped — PyYAML not installed (\`pip install pyyaml\`)._"
+  else
+    calib_output=$(python3 tools/kv-calc.py --calibration 2>&1 || true)
+    overall=$(echo "$calib_output" | grep -E '^Overall:' | head -1)
+    fail_rows=$(echo "$calib_output" | grep -E '\bFAIL\b' || true)
+    {
+      if [[ -n "$overall" ]]; then
+        echo "- ${overall}"
+      else
+        echo "- _kv-calc --calibration produced no Overall line; see output below._"
+      fi
+      if [[ -n "$fail_rows" ]]; then
+        echo "- ⚠ Failing rows:"
+        echo '```'
+        echo "$fail_rows"
+        echo '```'
+        echo "- Math model is mis-calibrated against measured reality for the rows above. Any kv-calc projection on this checkout should be treated as suspect until the calibration anchors / formulas are reconciled."
+      else
+        echo "- No FAIL rows. kv-calc projections should agree with measured VRAM within the ±1.5 GB error band."
+      fi
+    } | redact
+    echo "$calib_output" | redact | details "Full kv-calc --calibration output"
+  fi
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -60,12 +60,23 @@ done
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
+# Pick up a saved MODEL_DIR (and other config) from the repo .env — same as
+# launch.sh / switch.sh, and what setup.sh writes there. An explicit exported
+# MODEL_DIR still wins. This makes the Disk section report the user's real
+# models path instead of falling back to the hardcoded mount below.
+if [[ -z "${MODEL_DIR:-}" && -f "${REPO_ROOT}/.env" ]]; then
+  # shellcheck disable=SC1091
+  source "${REPO_ROOT}/.env"
+fi
+
 HOST_SHORT="$(hostname -s 2>/dev/null || echo unknown)"
 USER_NAME="${USER:-$(whoami 2>/dev/null || echo unknown)}"
 
 redact() {
   if [[ $REDACT -eq 1 ]]; then
-    sed \
+    # Mask the literal MODEL_DIR value first (if exported) so an arbitrary models
+    # path — /data/..., /srv/... — is caught before the prefix rules below.
+    { if [[ -n "${MODEL_DIR:-}" ]]; then sed -e "s|${MODEL_DIR}|<MODEL_DIR>|g"; else cat; fi; } | sed \
       -e "s|/home/${USER_NAME}|~|g" \
       -e "s|/root|~|g" \
       -e "s|${HOST_SHORT}|<HOST>|g" \
@@ -75,7 +86,8 @@ redact() {
       -e 's|api_key=[^ "]*|api_key=<REDACTED>|gi' \
       -e 's|hf_[A-Za-z0-9]\{30,\}|hf_<REDACTED>|g' \
       -e 's|/opt/ai|<STACK_ROOT>|g' \
-      -e 's|/mnt/[a-z]/Users/[^ /]*|/mnt/<DRIVE>/Users/<REDACTED>|g'
+      -e 's|/mnt/[a-z]/Users/[^ /]*|/mnt/<DRIVE>/Users/<REDACTED>|g' \
+      -e 's|/mnt/models|<MODELS>|g'
   else
     cat
   fi
@@ -362,7 +374,8 @@ section "Display / desktop state"
 
   if have nvidia-smi; then
     # Check if a club-3090 container is running (lightweight — full detection is later)
-    local our_container=""
+    # NB: top-level (not in a function) — plain assignment, not `local`.
+    our_container=""
     if have docker && docker info >/dev/null 2>&1; then
       our_container=$(docker ps --format '{{.Names}}' --filter 'name=vllm-' --filter 'name=llama-cpp-' --filter 'name=club3090-' --filter 'name=ik-llama-' 2>/dev/null | head -1)
     fi


### PR DESCRIPTION
## Summary

Five reliability/correctness fixes for `scripts/report.sh`, all surfaced by real user reports.

Closes #378, #396, #406, #409, #410.

## Changes

### 1. kv-calc PyYAML graceful degradation (#409)
Pre-check `import yaml` before running `kv-calc.py --calibration`. On missing dep, emit a clean skip line instead of dumping a traceback into the report.

**After (PyYAML missing):**
```
- _kv-calc calibration skipped — PyYAML not installed (`pip install pyyaml`)._
```

### 2. Idle VRAM false-positive (#410)
Detect club-3090 containers before emitting the ⚠. When our own container holds the VRAM, name it instead of alarming the user.

**Before:**
```
- **GPU 0 idle VRAM:** 22982 MiB ⚠ something is using this GPU (display, browser, container)
```

**After:**
```
- **GPU 0 idle VRAM:** 22982 MiB (held by running `llama-cpp-qwen36-27b`)
```

### 3. P2P fallback when lspci missing (#396)
Emit `nvidia-smi topo -p2p rw` (P2P capability matrix) when `pciutils` isn't installed, instead of only printing skipping. P2P engagement is exactly what decides dual-GPU all-reduce (#137, #351).

**Before:**
```
_lspci not available (pciutils not installed) — skipping PCIe/P2P detail._
```

**After:**
```
_lspci not available (pciutils not installed) — showing P2P capability matrix instead._

 	GPU0	GPU1	
 GPU0	X	CNS	
 GPU1	CNS	X	
```

### 4. Disk section absolute path leak (#378, confirmed #187)
Extended `redact()` with two new patterns:
- `/opt/ai` → `<STACK_ROOT>`
- `/mnt/[a-z]/Users/<name>` → `/mnt/<DRIVE>/Users/<REDACTED>` (WSL2 personal paths)

The Disk section was already piped through `redact`; the function itself was missing these path patterns.

**Before (redacted output leaked):**
```
- **/opt/ai/github/club-3090/models-cache:** 65G available, ext4 filesystem
- **/mnt/c/Users/Roderick/Downloads/club-3090/models:** 500G available, drvfs filesystem
```

**After:**
```
- **<STACK_ROOT>/github/club-3090/models-cache:** 65G available, ext4 filesystem
- **/mnt/<DRIVE>/Users/<REDACTED>/Downloads/club-3090/models:** 500G available, drvfs filesystem
```

Leak grep (`report.sh 2>&1 | grep -nE '/opt/ai|/home/|/mnt/[a-z]/Users/'`) returns empty.

### 5. kv-calc calibration: skip on llama.cpp (#406)
Lightweight engine detection before the calibration section. If llama.cpp/ik_llama is the active engine, skip with a note — calibration is vLLM-specific (it compares vLLM compose VRAM projections against measured BENCHMARKS rows).

**After (llama.cpp engine):**
```
- _kv-calc calibration is vLLM-specific — skipped on the llama.cpp engine._
```

## Testing

All five items verified with live `bash scripts/report.sh` runs:
- Default (redacted): all sections render, no path leaks
- `--no-redact`: full paths shown
- Container running: idle VRAM names container, no ⚠
- Container stopped: ⚠ still fires for unknown VRAM usage
- PyYAML missing: clean skip (simulated via PATH wrapper)
- lspci missing: P2P matrix shown (simulated via `mv /usr/bin/lspci`)
- llama.cpp engine: calibration skipped
- vLLM engine: calibration runs unchanged