### PR TITLE
feat(compose): expose sampling defaults via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,22 @@
 
 
 # -----------------------------------------------------------------------------
+# Sampling defaults
+# -----------------------------------------------------------------------------
+
+# Server-side sampling defaults for clients that do not send sampling params.
+# Per-request OpenAI API fields still override these. The compose files keep
+# model-specific fallbacks (Qwen/Carnice 0.6, Qwopus 0.8, Gemma 1.0); set these
+# only when you deliberately want one default across the variant you are booting.
+# TEMP=0.8
+# TEMPERATURE=0.8  # alias used only when TEMP is unset
+# TOP_P=0.95
+# TOP_K=20
+# MIN_P=0.0
+# REPEAT_PENALTY=1.0
+
+
+# -----------------------------------------------------------------------------
 # vLLM tuning knobs
 # -----------------------------------------------------------------------------
 

--- a/models/gemma-4-26b-a4b/vllm/compose/dual/awq-mtp.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/dual/awq-mtp.yml
@@ -73,6 +73,8 @@ services:
         exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} "$@"
       - --
     command:
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:--1},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/gemma-4-26b-a4b/vllm/compose/dual/awq.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/dual/awq.yml
@@ -83,6 +83,8 @@ services:
         exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} "$@"
       - --
     command:
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:--1},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/gemma-4-26b-a4b/vllm/compose/dual/docker-compose.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/dual/docker-compose.yml
@@ -91,6 +91,8 @@ services:
         fi
       - --
     command:
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:--1},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/gemma-4-26b-a4b/vllm/compose/single/docker-compose.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/single/docker-compose.yml
@@ -76,6 +76,8 @@ services:
               count: all
               capabilities: [gpu]
     command:
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:--1},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/gemma-4-31b/vllm/compose/dual/awq.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/awq.yml
@@ -124,6 +124,8 @@ services:
         fi
       - --
     command:
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:--1},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/gemma-4-31b/vllm/compose/dual/bf16.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/bf16.yml
@@ -158,6 +158,8 @@ services:
         fi
       - --
     command:
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:--1},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/gemma-4-31b/vllm/compose/dual/dflash-int8.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/dflash-int8.yml
@@ -189,6 +189,8 @@ services:
         fi
       - --
     command:
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:--1},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/gemma-4-31b/vllm/compose/dual/dflash.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/dflash.yml
@@ -154,6 +154,8 @@ services:
         fi
       - --
     command:
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:--1},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/gemma-4-31b/vllm/compose/dual/docker-compose.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/docker-compose.yml
@@ -106,6 +106,8 @@ services:
         fi
       - --
     command:
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:--1},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/gemma-4-31b/vllm/compose/dual/int8-tq3.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/int8-tq3.yml
@@ -274,6 +274,8 @@ services:
               count: all
               capabilities: [gpu]
     command:
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:--1},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/gemma-4-31b/vllm/compose/dual/int8.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/int8.yml
@@ -163,6 +163,8 @@ services:
         fi
       - --
     command:
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:--1},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/gemma-4-31b/vllm/compose/single/docker-compose.yml
+++ b/models/gemma-4-31b/vllm/compose/single/docker-compose.yml
@@ -92,6 +92,8 @@ services:
     # 2026-05-08: nightly-1acd67a795... has transformers 5.8.0). Entrypoint
     # upgrade dropped.
     command:
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:--1},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp-vision.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp-vision.yml
@@ -135,6 +135,11 @@ services:
       --parallel-tool-calls
       --reasoning ${REASONING:-off}
       --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
     deploy:
       resources:
         reservations:

--- a/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp.yml
@@ -132,6 +132,11 @@ services:
       --parallel-tool-calls
       --reasoning ${REASONING:-off}
       --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
     deploy:
       resources:
         reservations:

--- a/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-two-stage.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-two-stage.yml
@@ -114,6 +114,11 @@ services:
       --parallel-tool-calls
       --reasoning ${REASONING:-off}
       --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
     deploy:
       resources:
         reservations:

--- a/models/qwen3.6-27b/llama-cpp/compose/single/mtp-vision.yml
+++ b/models/qwen3.6-27b/llama-cpp/compose/single/mtp-vision.yml
@@ -129,6 +129,11 @@ services:
       --jinja
       --reasoning ${REASONING:-off}
       --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
     deploy:
       resources:
         reservations:

--- a/models/qwen3.6-27b/llama-cpp/compose/single/mtp.yml
+++ b/models/qwen3.6-27b/llama-cpp/compose/single/mtp.yml
@@ -111,6 +111,11 @@ services:
       --jinja
       --reasoning ${REASONING:-off}
       --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
     deploy:
       resources:
         reservations:

--- a/models/qwen3.6-27b/vllm/compose/dual/bf16.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/bf16.yml
@@ -137,6 +137,8 @@ services:
       # rate. Use SPEC_N_MAX=4 to A/B against Gemma's n=4.
       - --speculative-config
       - '{"method":"mtp","num_speculative_tokens":${SPEC_N_MAX:-4}}'
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/qwen3.6-27b/vllm/compose/dual/carnice-bf16mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/carnice-bf16mtp.yml
@@ -155,6 +155,8 @@ services:
       - --enable-chunked-prefill
       - --speculative-config
       - '{"method":"mtp","num_speculative_tokens":3}'
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/qwen3.6-27b/vllm/compose/dual/dflash-noviz.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/dflash-noviz.yml
@@ -167,6 +167,8 @@ services:
       - --enable-chunked-prefill
       - --speculative-config
       - '{"method":"dflash","model":"/root/.cache/huggingface/qwen3.6-27b-dflash","num_speculative_tokens":5}'
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/qwen3.6-27b/vllm/compose/dual/dflash.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/dflash.yml
@@ -190,6 +190,8 @@ services:
       - --enable-chunked-prefill
       - --speculative-config
       - '{"method":"dflash","model":"/root/.cache/huggingface/qwen3.6-27b-dflash","num_speculative_tokens":5}'
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/qwen3.6-27b/vllm/compose/dual/docker-compose.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/docker-compose.yml
@@ -178,6 +178,8 @@ services:
       - --enable-chunked-prefill
       - --speculative-config
       - '{"method":"mtp","num_speculative_tokens":3}'
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/qwen3.6-27b/vllm/compose/dual/int8.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/int8.yml
@@ -142,6 +142,8 @@ services:
       # rate. Use SPEC_N_MAX=4 to A/B against Gemma's n=4.
       - --speculative-config
       - '{"method":"mtp","num_speculative_tokens":${SPEC_N_MAX:-3}}'
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/qwen3.6-27b/vllm/compose/dual/qwopus-bf16mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/qwopus-bf16mtp.yml
@@ -128,6 +128,8 @@ services:
       - --enable-chunked-prefill
       - --speculative-config
       - '{"method":"mtp","num_speculative_tokens":3}'
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.8}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/qwen3.6-27b/vllm/compose/dual/tq3-mtp-genesis.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/tq3-mtp-genesis.yml
@@ -298,6 +298,8 @@ services:
       - --enable-chunked-prefill
       - --speculative-config
       - '{"method":"mtp","num_speculative_tokens":3}'
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/qwen3.6-27b/vllm/compose/dual/tq3-mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/tq3-mtp.yml
@@ -190,6 +190,8 @@ services:
       # rate. Use SPEC_N_MAX=4 to A/B against Gemma's n=4.
       - --speculative-config
       - '{"method":"mtp","num_speculative_tokens":${SPEC_N_MAX:-3}}'
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/qwen3.6-27b/vllm/compose/dual/tq3-nomtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/tq3-nomtp.yml
@@ -171,6 +171,8 @@ services:
       # at time of writing). Higher n re-uses the same MTP layer for the
       # extra draft steps and emits a vLLM warning about reduced acceptance
       # rate. Use SPEC_N_MAX=4 to A/B against Gemma's n=4.
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/qwen3.6-27b/vllm/compose/dual/turbo.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/turbo.yml
@@ -286,6 +286,8 @@ services:
       - --enable-chunked-prefill
       - --speculative-config
       - '{"method":"mtp","num_speculative_tokens":3}'
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/qwen3.6-27b/vllm/compose/multi4/dflash.yml
+++ b/models/qwen3.6-27b/vllm/compose/multi4/dflash.yml
@@ -176,6 +176,8 @@ services:
       - --enable-chunked-prefill
       - --speculative-config
       - '{"method":"dflash","model":"/root/.cache/huggingface/qwen3.6-27b-dflash","num_speculative_tokens":5}'
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/qwen3.6-27b/vllm/compose/multi4/docker-compose.yml
+++ b/models/qwen3.6-27b/vllm/compose/multi4/docker-compose.yml
@@ -182,6 +182,8 @@ services:
       - --enable-chunked-prefill
       - --speculative-config
       - '{"method":"mtp","num_speculative_tokens":3}'
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/qwen3.6-27b/vllm/compose/single/bounded-thinking.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/bounded-thinking.yml
@@ -355,6 +355,8 @@ services:
       - --no-scheduler-reserve-full-isl
       - --speculative-config
       - '{"method":"mtp","num_speculative_tokens":3}'
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/qwen3.6-27b/vllm/compose/single/docker-compose.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/docker-compose.yml
@@ -295,6 +295,8 @@ services:
       # FULL_AND_PIECEWISE → PIECEWISE for spec-decode K+1 verify; 1-token
       # decode batches still get cudagraph capture. Forcing FULL_AND_PIECEWISE
       # explicitly produces no measurable benefit (verified 2026-04-27).
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/qwen3.6-27b/vllm/compose/single/long-text-no-mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/long-text-no-mtp.yml
@@ -406,6 +406,8 @@ services:
       # TTFT-bounded throughput matters more than per-token decode speed.
       # - --speculative-config
       # - '{"method":"mtp","num_speculative_tokens":3}'
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/qwen3.6-27b/vllm/compose/single/long-text.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/long-text.yml
@@ -417,6 +417,8 @@ services:
       - --no-scheduler-reserve-full-isl
       - --speculative-config
       - '{"method":"mtp","num_speculative_tokens":3}'
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/qwen3.6-27b/vllm/compose/single/long-vision.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/long-vision.yml
@@ -318,6 +318,8 @@ services:
       - --no-scheduler-reserve-full-isl
       - --speculative-config
       - '{"method":"mtp","num_speculative_tokens":3}'
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/qwen3.6-27b/vllm/compose/single/minimal.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/minimal.yml
@@ -133,6 +133,8 @@ services:
       - --enable-prefix-caching
       - --enable-chunked-prefill
       # No --speculative-config (this is the minimal variant — no spec-decode)
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/qwen3.6-27b/vllm/compose/single/tools-text.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/tools-text.yml
@@ -195,6 +195,8 @@ services:
       - --enable-chunked-prefill
       - --speculative-config
       - '{"method":"mtp","num_speculative_tokens":3}'
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/qwen3.6-35b-a3b/vllm/compose/dual/preview-mtp.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/dual/preview-mtp.yml
@@ -58,6 +58,8 @@ services:
               count: all
               capabilities: [gpu]
     command:
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/qwen3.6-35b-a3b/vllm/compose/dual/preview.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/dual/preview.yml
@@ -84,6 +84,8 @@ services:
               count: all
               capabilities: [gpu]
     command:
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/qwen3.6-35b-a3b/vllm/compose/single/preview.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/single/preview.yml
@@ -78,6 +78,8 @@ services:
               count: all
               capabilities: [gpu]
     command:
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port


### PR DESCRIPTION
## Summary
- add sampling env overrides to tracked llama.cpp and ik_llama composes via native flags: TEMP/TEMPERATURE, TOP_P, TOP_K, MIN_P, REPEAT_PENALTY
- add vLLM server defaults through --override-generation-config with the same env knobs
- keep model-specific compose fallbacks: Qwen/Carnice 0.6, Qwopus 0.8, Gemma 1.0
- document the knobs in .env.example so users can override from .env without editing YAML

Closes #193.

## Notes
- Per-request OpenAI API sampling params still override these server defaults.
- Left the existing untracked local models/qwopus3.6-27b-v2/ directory untouched.

## Validation
- docker compose config on all 40 modified compose YAMLs
- YAML parse of 46 tracked model YAML files
- TEMPERATURE/TOP_P/TOP_K/MIN_P/REPEAT_PENALTY interpolation spot-checks for vLLM and llama.cpp
- bash scripts/tests/test-profiles-compat.sh
- bash scripts/tests/test-switch-registry-parity.sh
- git diff --check

## Known unrelated local failure
- bash scripts/tests/test-generate-compose.sh currently fails on the existing llamacpp/default refusal-message expectation: expected substring '!= vllm', got 'engine profile not found: llama-cpp-local'. This path is not touched by the sampling compose changes.