### PR TITLE
feat(eval): expose request-level thinking toggles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,13 @@
 # MIN_P=0.0
 # REPEAT_PENALTY=1.0
 
+# Request-level thinking toggle for eval/bench wrappers. Required when you want
+# quality-test.sh, rebench-full.sh, or bench.sh to measure a reasoning-on model
+# with chat_template_kwargs.enable_thinking=true. Default stays off for canonical
+# reproducible regression runs.
+# ENABLE_THINKING=1
+# THINKING_MAX_TOKENS=4096
+
 
 # -----------------------------------------------------------------------------
 # vLLM tuning knobs

--- a/docs/QUALITY_TEST.md
+++ b/docs/QUALITY_TEST.md
@@ -143,7 +143,24 @@ SAMPLING_FROM_SERVER=1 bash scripts/rebench-full.sh
 benchlocal-cli run --full --endpoint http://localhost:8020 --model <name> --temperature 0.8
 ```
 
-**Why it matters:** a reasoning / exploratory fine-tune (e.g. Qwopus3.6, whose author recommends temp 0.75–1) is *under-represented* at temp 0 — greedy decoding collapses the path-exploration the fine-tune was trained for. But high temp also *hurts* the deterministic packs (DataExtract / StructOutput want exact, repeatable output), so read **per-pack deltas**, not just the total — and keep canonical temp-0 as the bar for any apples-to-apples ranking.
+### Reasoning-on evals
+
+Serving with `--reasoning on` is necessary but not sufficient: the request also has to send `chat_template_kwargs.enable_thinking=true`. The wrappers default to thinking off for canonical, reproducible runs. Enable it explicitly when measuring a reasoning fine-tune:
+
+```bash
+# quality only
+bash scripts/quality-test.sh --full --enable-thinking --thinking-max-tokens 4096
+
+# full rebench: bench.sh + both quality-test.sh legs inherit it
+ENABLE_THINKING=1 THINKING_MAX_TOKENS=4096 SAMPLING_FROM_SERVER=1 bash scripts/rebench-full.sh
+
+# TPS bench only
+ENABLE_THINKING=1 bash scripts/bench.sh
+```
+
+If `/props` or the running container suggests reasoning is enabled but the wrapper is still sending `enable_thinking=false`, `quality-test.sh` / `bench.sh` print a warning rather than silently measuring the thinking-off path.
+
+**Why it matters:** a reasoning / exploratory fine-tune (e.g. Qwopus3.6, whose author recommends temp 0.75–1) is *under-represented* at temp 0 or with thinking disabled — greedy, thinking-off decoding collapses the path-exploration the fine-tune was trained for. But high temp and reasoning also *hurt* deterministic packs (DataExtract / StructOutput want exact, repeatable output), so read **per-pack deltas**, not just the total — and keep canonical temp-0 thinking-off as the bar for any apples-to-apples ranking.
 
 ## Compose `Quality:` schema field
 

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -40,6 +40,8 @@
 #                      llama.cpp containers enable this automatically.
 #   PP_FALLBACK_TOKENS Approximate filler-token target for PP=1. Default: 10000
 #   PP_MAX_TOKENS      Completion cap for the PP fallback request. Default: 16
+#   ENABLE_THINKING    Set to 1 to send chat_template_kwargs.enable_thinking=true
+#                      in bench requests. Default: 0.
 #
 # Usage:
 #   bash scripts/bench.sh
@@ -71,6 +73,7 @@ QUIET="${QUIET:-0}"
 PP="${PP:-0}"
 PP_FALLBACK_TOKENS="${PP_FALLBACK_TOKENS:-10000}"
 PP_MAX_TOKENS="${PP_MAX_TOKENS:-16}"
+ENABLE_THINKING="${ENABLE_THINKING:-0}"
 
 need() {
   command -v "$1" >/dev/null 2>&1 || { echo "ERROR: '$1' not in PATH." >&2; exit 1; }
@@ -92,6 +95,10 @@ fi
 PP_MODE="log"
 if [[ "$PP" == "1" || "$ENGINE_KIND" == "llamacpp" ]]; then
   PP_MODE="fallback"
+fi
+
+if [[ "$ENABLE_THINKING" == "1" ]]; then
+  echo "[bench] thinking: enabled (request chat_template_kwargs.enable_thinking=true)" >&2
 fi
 
 if [[ "${BENCH_MOCK:-0}" == "1" ]]; then
@@ -129,18 +136,57 @@ if ! curl -sf "${URL}/v1/models" >/dev/null; then
   exit 1
 fi
 
+server_reasoning_on() {
+  if curl -sf -m 3 "${URL}/props" 2>/dev/null | python3 -c '
+import json, sys
+try:
+    obj = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+
+def walk(x):
+    if isinstance(x, dict):
+        for k, v in x.items():
+            lk = str(k).lower()
+            if lk in {"reasoning", "enable_reasoning"}:
+                if v is True or str(v).lower() in {"1", "true", "on", "yes"}:
+                    return True
+            if walk(v):
+                return True
+    elif isinstance(x, list):
+        return any(walk(v) for v in x)
+    return False
+sys.exit(0 if walk(obj) else 1)
+' >/dev/null 2>&1; then
+    return 0
+  fi
+  if [[ -n "${CONTAINER:-}" && "${CONTAINER:-}" != "none" ]] \
+     && command -v docker >/dev/null 2>&1 \
+     && docker inspect "$CONTAINER" >/dev/null 2>&1; then
+    docker inspect "$CONTAINER" 2>/dev/null \
+      | grep -Eq -- '(--reasoning[= ]+on|"--reasoning"[[:space:]]*,[[:space:]]*"on")' && return 0
+  fi
+  return 1
+}
+
+if [[ "$ENABLE_THINKING" != "1" ]] && server_reasoning_on; then
+  echo "[bench] WARN: server appears to have reasoning enabled, but bench requests send enable_thinking=false. Use ENABLE_THINKING=1 for reasoning-on TPS." >&2
+fi
+
 python3 - "$URL" "$MODEL" "$WARMUPS" "$RUNS" "$QUIET" "$ONLY" \
             "$CONTAINER" "$PP_MODE" "$PP_FALLBACK_TOKENS" "$PP_MAX_TOKENS" \
+            "$ENABLE_THINKING" \
             "$PROMPT_NARR" "$MAX_TOKENS_NARR" \
             "$PROMPT_CODE" "$MAX_TOKENS_CODE" << 'PYEOF'
 import json, re, shutil, subprocess, sys, time, urllib.request, statistics as s
 
 (URL, MODEL, WARMUPS, RUNS, QUIET, ONLY,
  CONTAINER, PP_MODE, PP_FALLBACK_TOKENS, PP_MAX_TOKENS,
- PROMPT_NARR, MAX_NARR, PROMPT_CODE, MAX_CODE) = sys.argv[1:]
+ ENABLE_THINKING, PROMPT_NARR, MAX_NARR, PROMPT_CODE, MAX_CODE) = sys.argv[1:]
 WARMUPS = int(WARMUPS); RUNS = int(RUNS); QUIET = int(QUIET) == 1
 MAX_NARR = int(MAX_NARR); MAX_CODE = int(MAX_CODE)
 PP_FALLBACK_TOKENS = int(PP_FALLBACK_TOKENS); PP_MAX_TOKENS = int(PP_MAX_TOKENS)
+ENABLE_THINKING = ENABLE_THINKING == "1"
 
 def run_once(prompt, max_tokens):
     body = json.dumps({
@@ -151,7 +197,7 @@ def run_once(prompt, max_tokens):
         "top_p": 0.95,
         "stream": True,
         "stream_options": {"include_usage": True},
-        "chat_template_kwargs": {"enable_thinking": False},
+        "chat_template_kwargs": {"enable_thinking": ENABLE_THINKING},
     }).encode()
     req = urllib.request.Request(f"{URL}/v1/chat/completions", data=body,
                                  headers={"Content-Type": "application/json"})

--- a/scripts/quality-test.sh
+++ b/scripts/quality-test.sh
@@ -74,6 +74,14 @@ OPTIONS (extra)
                    --temp, vLLM --override-generation-config). Reads back via
                    GET /props and records the values. Tags the run as
                    non-canonical. Also settable via SAMPLING_FROM_SERVER=1 env.
+  --enable-thinking
+                   Forward to benchlocal-cli --enable-thinking so reasoning
+                   models are evaluated with request-level thinking enabled.
+                   Also settable via ENABLE_THINKING=1 env.
+  --thinking-max-tokens N
+                   Forward to benchlocal-cli --thinking-max-tokens N when
+                   --enable-thinking / ENABLE_THINKING=1 is active. Also
+                   settable via THINKING_MAX_TOKENS env.
 
 ENV VARS
   URL              Endpoint base URL (default: auto-detected via preflight,
@@ -84,6 +92,11 @@ ENV VARS
                    single-model composes). --model and MODEL are equivalent.
   TIMEOUT_PER_CASE Per-scenario HTTP timeout in seconds (default: 60).
                    --timeout-per-case overrides this when both are set.
+  ENABLE_THINKING Set to 1 to send request-level enable_thinking=true via
+                   benchlocal-cli --enable-thinking. Default: 0.
+  THINKING_MAX_TOKENS
+                   Optional thinking budget passed through to benchlocal-cli
+                   --thinking-max-tokens when thinking is enabled.
 
 EXAMPLES
   bash scripts/quality-test.sh                          # --medium against running compose
@@ -136,6 +149,8 @@ SANDBOXED_ONLY=0
 LIST_PACKS=0
 SANDBOX_LOG_DIR="${SANDBOX_LOG_DIR:-}"
 SAMPLING_FROM_SERVER="${SAMPLING_FROM_SERVER:-0}"
+ENABLE_THINKING="${ENABLE_THINKING:-0}"
+THINKING_MAX_TOKENS="${THINKING_MAX_TOKENS:-}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -191,6 +206,18 @@ while [[ $# -gt 0 ]]; do
     --sampling-from-server)
       SAMPLING_FROM_SERVER=1
       shift
+      ;;
+    --enable-thinking)
+      ENABLE_THINKING=1
+      shift
+      ;;
+    --thinking-max-tokens)
+      THINKING_MAX_TOKENS="${2:-}"
+      if [[ -z "$THINKING_MAX_TOKENS" ]] || ! [[ "$THINKING_MAX_TOKENS" =~ ^[0-9]+$ ]]; then
+        echo "✗ --thinking-max-tokens requires a positive integer" >&2
+        exit 2
+      fi
+      shift 2
       ;;
     -h|--help)
       usage
@@ -267,6 +294,43 @@ if [[ -z "${BENCHLOCAL_HERMES_RESOLVE_LOCALHOST:-}" ]] \
   echo "[quality-test] localhost URL detected — auto-set BENCHLOCAL_HERMES_RESOLVE_LOCALHOST=1 for hermes sandbox endpoint rewrite" >&2
 fi
 
+server_reasoning_on() {
+  if curl -sf -m 3 "${URL}/props" 2>/dev/null | python3 -c '
+import json, sys
+try:
+    obj = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+
+def walk(x):
+    if isinstance(x, dict):
+        for k, v in x.items():
+            lk = str(k).lower()
+            if lk in {"reasoning", "enable_reasoning"}:
+                if v is True or str(v).lower() in {"1", "true", "on", "yes"}:
+                    return True
+            if walk(v):
+                return True
+    elif isinstance(x, list):
+        return any(walk(v) for v in x)
+    return False
+sys.exit(0 if walk(obj) else 1)
+' >/dev/null 2>&1; then
+    return 0
+  fi
+  if [[ -n "${CONTAINER:-}" && "${CONTAINER:-}" != "none" ]] \
+     && command -v docker >/dev/null 2>&1 \
+     && docker inspect "$CONTAINER" >/dev/null 2>&1; then
+    docker inspect "$CONTAINER" 2>/dev/null \
+      | grep -Eq -- '(--reasoning[= ]+on|"--reasoning"[[:space:]]*,[[:space:]]*"on")' && return 0
+  fi
+  return 1
+}
+
+if [[ "$ENABLE_THINKING" != "1" ]] && server_reasoning_on; then
+  echo "[quality-test] WARN: server appears to have reasoning enabled, but requests will send enable_thinking=false. Use --enable-thinking or ENABLE_THINKING=1 for reasoning-on evals." >&2
+fi
+
 # ---- run benchlocal-cli ------------------------------------------------------
 
 RESULTS_DIR="${ROOT_DIR}/results/quality"
@@ -310,6 +374,16 @@ fi
 if [[ "$SAMPLING_FROM_SERVER" == "1" ]]; then
   CLI_ARGS+=(--sampling-from-server)
   echo "[quality-test] sampling: inherited from server (non-canonical)"
+fi
+if [[ "$ENABLE_THINKING" == "1" ]]; then
+  CLI_ARGS+=(--enable-thinking)
+  echo "[quality-test] thinking: enabled (non-canonical)"
+  if [[ -n "$THINKING_MAX_TOKENS" ]]; then
+    CLI_ARGS+=(--thinking-max-tokens "$THINKING_MAX_TOKENS")
+    echo "[quality-test] thinking max tokens: $THINKING_MAX_TOKENS"
+  fi
+elif [[ -n "$THINKING_MAX_TOKENS" ]]; then
+  echo "[quality-test] NOTE: THINKING_MAX_TOKENS is set but thinking is off; ignoring it. Set ENABLE_THINKING=1 or --enable-thinking." >&2
 fi
 
 # Run; capture exit code so we can also try to emit the compact one-liner

--- a/scripts/rebench-full.sh
+++ b/scripts/rebench-full.sh
@@ -62,6 +62,13 @@
 #                       to quality-test.sh --sampling-from-server. Useful when
 #                       the compose encodes the model's recommended sampling
 #                       (e.g. Qwopus temp=0.8). Tags runs as non-canonical.
+#   ENABLE_THINKING
+#                       Set to 1 to pass request-level enable_thinking=true
+#                       through bench.sh and both quality-test.sh invocations.
+#                       Required to measure reasoning-on models honestly.
+#   THINKING_MAX_TOKENS
+#                       Optional thinking budget forwarded to quality-test.sh
+#                       when ENABLE_THINKING=1.
 #
 
 set -euo pipefail
@@ -176,6 +183,7 @@ echo "  out dir:     $OUT_DIR"
 echo "  resume:      $RESUME"
 echo "  skips:       ${SKIP_CSV:-(none)}"
 echo "  hermes env:  BENCHLOCAL_HERMES_RESOLVE_LOCALHOST=${BENCHLOCAL_HERMES_RESOLVE_LOCALHOST:-0}"
+echo "  thinking:    ${ENABLE_THINKING:-0}${THINKING_MAX_TOKENS:+ (max_tokens=$THINKING_MAX_TOKENS)}"
 echo "==============================================================="
 date +"  started:     %Y-%m-%dT%H:%M:%SZ" -u
 echo
@@ -264,6 +272,7 @@ snapshot_quality_json() {
 
 # --- step 1: bench ----------------------------------------------------------
 URL="$URL" MODEL="$MODEL" RUNS="${RUNS:-3}" WARMUPS="${WARMUPS:-1}" \
+  ENABLE_THINKING="${ENABLE_THINKING:-0}" \
   run_step bench "$OUT_DIR/bench.log" \
     bash "$ROOT_DIR/scripts/bench.sh" || true
 
@@ -275,6 +284,8 @@ URL="$URL" MODEL="$MODEL" \
 # --- step 3: quality-test --full --------------------------------------------
 URL="$URL" MODEL="$MODEL" \
   SAMPLING_FROM_SERVER="${SAMPLING_FROM_SERVER:-0}" \
+  ENABLE_THINKING="${ENABLE_THINKING:-0}" \
+  THINKING_MAX_TOKENS="${THINKING_MAX_TOKENS:-}" \
   run_step quality-full "$OUT_DIR/quality-full.log" \
     bash "$ROOT_DIR/scripts/quality-test.sh" --full --sandbox-log-dir "$OUT_DIR"
 snapshot_quality_json "$OUT_DIR/quality-full.json"
@@ -296,6 +307,8 @@ URL="$URL" MODEL="$MODEL" \
 AIDER_TIMEOUT_PER_CASE="${AIDER_TIMEOUT_PER_CASE:-3600}"
 URL="$URL" MODEL="$MODEL" \
   SAMPLING_FROM_SERVER="${SAMPLING_FROM_SERVER:-0}" \
+  ENABLE_THINKING="${ENABLE_THINKING:-0}" \
+  THINKING_MAX_TOKENS="${THINKING_MAX_TOKENS:-}" \
   run_step aider-polyglot "$OUT_DIR/aider-polyglot.log" \
     bash "$ROOT_DIR/scripts/quality-test.sh" --pack aider-polyglot-30 \
       --timeout-per-case "$AIDER_TIMEOUT_PER_CASE" --sandbox-log-dir "$OUT_DIR"

--- a/scripts/tests/test-quality-thinking.sh
+++ b/scripts/tests/test-quality-thinking.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "ASSERTION FAILED: expected output to contain: $needle" >&2
+    echo "--- output ---" >&2
+    echo "$haystack" >&2
+    exit 1
+  fi
+}
+
+tmp_bin="$(mktemp -d)"
+tmp_log="$(mktemp)"
+before_list="$(mktemp)"
+after_list="$(mktemp)"
+find results/quality -maxdepth 1 -name 'quality-*.json' -print 2>/dev/null | sort > "$before_list" || true
+cleanup() {
+  find results/quality -maxdepth 1 -name 'quality-*.json' -print 2>/dev/null | sort > "$after_list" || true
+  comm -13 "$before_list" "$after_list" | xargs -r rm -f
+  rm -rf "$tmp_bin"
+  rm -f "$tmp_log" "$before_list" "$after_list"
+}
+trap cleanup EXIT
+
+cat > "${tmp_bin}/curl" <<'MOCK_CURL'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  case "$arg" in
+    */v1/models)
+      printf '{"data":[{"id":"mock-model"}]}'
+      exit 0
+      ;;
+    */props)
+      printf '{"reasoning":"on"}'
+      exit 0
+      ;;
+  esac
+done
+exit 0
+MOCK_CURL
+chmod +x "${tmp_bin}/curl"
+
+cat > "${tmp_bin}/benchlocal-cli" <<'MOCK_BENCHLOCAL'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${BENCHLOCAL_MOCK_LOG}"
+json_out=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --save-json)
+      json_out="${2:-}"
+      shift 2
+      ;;
+    list)
+      echo 'toolcall-15'
+      exit 0
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+if [[ -n "$json_out" ]]; then
+  mkdir -p "$(dirname "$json_out")"
+  cat > "$json_out" <<'JSON'
+{"packs":[{"pack_id":"toolcall-15","status":"ok","passed":1,"total":1,"score":1.0}]}
+JSON
+fi
+exit 0
+MOCK_BENCHLOCAL
+chmod +x "${tmp_bin}/benchlocal-cli"
+
+out="$(PATH="${tmp_bin}:$PATH" BENCHLOCAL_MOCK_LOG="$tmp_log" PREFLIGHT_NO_AUTODETECT=1 URL=http://mock MODEL=mock-model ENABLE_THINKING=1 THINKING_MAX_TOKENS=4096 bash scripts/quality-test.sh --quick 2>&1)"
+assert_contains "$out" "[quality-test] thinking: enabled"
+assert_contains "$out" "[quality-test] thinking max tokens: 4096"
+args="$(cat "$tmp_log")"
+assert_contains "$args" "--enable-thinking"
+assert_contains "$args" "--thinking-max-tokens 4096"
+
+: > "$tmp_log"
+out="$(PATH="${tmp_bin}:$PATH" BENCHLOCAL_MOCK_LOG="$tmp_log" PREFLIGHT_NO_AUTODETECT=1 URL=http://mock MODEL=mock-model bash scripts/quality-test.sh --quick 2>&1)"
+assert_contains "$out" "WARN: server appears to have reasoning enabled"
+args="$(cat "$tmp_log")"
+if [[ "$args" == *"--enable-thinking"* ]]; then
+  echo "ASSERTION FAILED: quality-test forwarded --enable-thinking while ENABLE_THINKING=0" >&2
+  echo "$args" >&2
+  exit 1
+fi
+
+echo "test-quality-thinking: ok"

--- a/scripts/tests/test-submit-bench.sh
+++ b/scripts/tests/test-submit-bench.sh
@@ -58,6 +58,9 @@ done
 
 out="$(BENCH_MOCK=1 RUNS=1 WARMUPS=0 bash scripts/bench.sh)"
 assert_contains "$out" "PP tok/s"
+out="$(ENABLE_THINKING=1 BENCH_MOCK=1 RUNS=1 WARMUPS=0 bash scripts/bench.sh 2>&1)"
+assert_contains "$out" "[bench] thinking: enabled"
+assert_contains "$out" "PP tok/s"
 out="$(BENCH_MOCK=1 PP=1 RUNS=1 WARMUPS=0 bash scripts/bench.sh)"
 assert_contains "$out" "summary [prompt-processing]"
 assert_contains "$out" "PP tok/s"


### PR DESCRIPTION
Closes #195

## Summary
- add request-level thinking controls to quality-test.sh: --enable-thinking, --thinking-max-tokens, ENABLE_THINKING, and THINKING_MAX_TOKENS
- propagate ENABLE_THINKING / THINKING_MAX_TOKENS through rebench-full.sh quality passes
- add ENABLE_THINKING support to bench.sh so TPS probes can send chat_template_kwargs.enable_thinking=true
- add best-effort warning when the server appears reasoning-on but eval wrappers are sending thinking=false
- document reasoning-on eval usage in .env.example and docs/QUALITY_TEST.md

## Validation
- bash -n scripts/quality-test.sh scripts/rebench-full.sh scripts/bench.sh scripts/tests/test-quality-thinking.sh scripts/tests/test-submit-bench.sh
- bash scripts/tests/test-quality-thinking.sh
- bash scripts/tests/test-submit-bench.sh
- git diff --check