### PR TITLE
Fix verify-full to accept reasoning_content

### DIFF
--- a/scripts/verify-full.sh
+++ b/scripts/verify-full.sh
@@ -341,7 +341,7 @@ check_thinking() {
 import sys, json
 d = json.load(sys.stdin)
 msg = d['choices'][0]['message']
-reasoning = msg.get('reasoning') or ''
+reasoning = msg.get('reasoning') or msg.get('reasoning_content') or ''
 content = msg.get('content') or ''
 finish = d['choices'][0].get('finish_reason')
 print(f'{len(reasoning)}|{len(content)}|{finish}|{(reasoning[:60] or \"(empty)\").replace(chr(10), \" \")}|{(content[:60] or \"(empty)\").replace(chr(10), \" \")}')


### PR DESCRIPTION
## Summary

`verify-full.sh` always reports empty reasoning for llama.cpp based engines:
```
[6/8] Thinking / reasoning mode ...
  ✗ reasoning field empty (thinking mode didn't engage)
    → May indicate Genesis Patch 12 didn't land or chat_template_kwargs not honored. content='4.'
```
This is because the reasoning element is `reasoning_content` instead of `reasoning`.

Tested with vllm/default, llamacpp/mtp and ik-llama/iq4ks-mtp.

## Type of change

- [ ] New compose variant (`models/<model>/<engine>/compose/docker-compose.<name>.yml`)
- [ ] New patch / sidecar (`models/<model>/<engine>/patches/`)
- [ ] New script or tool (`scripts/`, `tools/`)
- [ ] New model (`models/<new-model>/`)
- [ ] Doc-only / typo
- [x] Other (describe): one-liner to accept either `reasoning` or `reasoning_content` in response
