### PR TITLE
fix(verify-stress): add CTX_SIZE-scaled ceiling ladder (#199)

### DIFF
--- a/models/qwopus3.6-27b-v2/llama-cpp/compose/single/mtp.yml
+++ b/models/qwopus3.6-27b-v2/llama-cpp/compose/single/mtp.yml
@@ -1,0 +1,99 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwopus3.6-27B-v2-MTP (Jackrong) — Qwen3.6-27B fine-tune, distilled
+#              on Claude-Opus-4.6/4.7 reasoning traces ("TraceInversion"), with a
+#              custom-processed MTP head. Q4_K_M GGUF. Text-only (no mmproj).
+#   Engine:    llama.cpp (ghcr.io/ggml-org/llama.cpp:server-cuda, pinned b9246)
+#   Topology:  Single 3090 (TP=1)
+#   Drafter:   built-in MTP head, n=2 (--spec-type draft-mtp)
+#   KV:        q4_0 K + q4_0 V (densest mainline, Ampere-fast)
+#   Vision:    NO (repo ships no mmproj)
+#   Template:  native (GGUF-embedded) + thinking-off by default — see REASONING note
+#   Max ctx:   131072 default (@ -ub 1024); base Qwen3.6 reaches 262K @ -ub 512
+#   Status:    🧪 EVAL — unvalidated on this rig. Same DeltaNet arch + cliff
+#              behavior as base Qwen3.6-27B (cliff-immune ggml memory model).
+#
+#   ⚠ FIRST-BOOT CHECK (the whole point of this model is the MTP head):
+#     Jackrong used a CUSTOM Qwen-MTP split/merge methodology. Confirm our b9246
+#     build actually ENGAGES it — `docker logs <c> | grep -iE 'draft|mtp|spec'`
+#     should show the MTP/spec-decode path init + a non-zero accept rate under
+#     load. If MTP does NOT engage, this is just a slower Qwen3.6 fine-tune with
+#     none of the claimed ~1.66x speedup — fall back to plain decode + flag it.
+#
+#   Card claim (GB10, NOT Ampere — won't transfer in absolute terms): 10.46 vs
+#   6.29 t/s base (~1.66x via MTP), -27.7% completion tokens (more compact CoT),
+#   30/30 on their bench. Verify the *ratio* + token-compactness on our rig, not
+#   the absolute t/s.
+#
+# Quick start:
+#   1. Get the GGUF (SHA-verified):
+#        WEIGHTS=... (manual) hf download Jackrong/Qwopus3.6-27B-v2-MTP-GGUF \
+#          Qwopus3.6-27B-v2-MTP-Q4_K_M.gguf \
+#          --local-dir $MODEL_DIR/qwopus3.6-27b-v2-gguf/jackrong-mtp-q4km
+#   2. From this directory (single card → stop any other :8020 container first):
+#        MODEL_DIR=/your/models/dir docker compose -f mtp.yml up -d
+#   3. curl http://localhost:8020/v1/models  → should list the model.
+#
+# Override defaults via .env or shell:
+#   MODEL_DIR              host dir to mount as /models  (default: ../../../../../models-cache)
+#   GGUF_FILE             path under /models  (default: qwopus3.6-27b-v2-gguf/jackrong-mtp-q4km/Qwopus3.6-27B-v2-MTP-Q4_K_M.gguf)
+#   CTX_SIZE             KV pool size   (default: 131072 @ -ub 1024; for 262K set CTX_SIZE=262144 UBATCH_SIZE=512)
+#   BATCH_SIZE           llama.cpp -b   (default: 4096)
+#   UBATCH_SIZE          llama.cpp -ub  (default: 1024; lower to 512 to fund 262K)
+#   NP                   parallel slots (default: 1 — see ⚠ below)
+#   KV_TYPE              K and V quant  (default: q4_0)
+#   MTP_DRAFT_N_MAX      MTP draft tokens (default: 2 — base-Qwen sweet spot; A/B 3 here)
+#   REASONING            thinking gate  (default: off — but this is a REASONING model:
+#                        set REASONING=on to evaluate the Opus-trace CoT it was trained for)
+#   REASONING_FORMAT     reasoning routing (default: deepseek)
+#   TEMP / TEMPERATURE   sampling temp  (default: 0.8 — fine-tuner (Kyle Hessling) recommends
+#                        0.75-1: "higher temp lets the fine-tune shine + is more stable; SWE-bench
+#                        at temp 1, game at 0.8". TEMP wins over TEMPERATURE. Matches club-3090 #194.)
+#   TOP_P / TOP_K / MIN_P  sampling     (defaults: 0.95 / 20 / 0.0)
+#   REPEAT_PENALTY       repeat penalty (default: 1.0)
+#   PORT                 host port      (default: 8020)
+#   CUDA_VISIBLE_DEVICES which GPU      (default: 0)
+# ---------------------------------------------------------------------------
+
+services:
+  llama-cpp-qwopus36-v2-mtp:
+    image: ${LLAMACPP_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda-b9246}
+    container_name: "${ESTATE_CONTAINER:-llama-cpp-qwopus36-v2}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8020}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../models-cache}:/models:ro"
+    # ⚠ -np 1 is intentional on a single 24 GB card — do NOT raise it to
+    #   "parallelize." One GPU is compute-bound: extra slots divide its
+    #   throughput, they don't multiply it; -np>1 also auto-disables MTP. On a
+    #   higher-throughput card (5090) or multi-GPU the trade may flip.
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      -m /models/${GGUF_FILE:-qwopus3.6-27b-v2-gguf/jackrong-mtp-q4km/Qwopus3.6-27B-v2-MTP-Q4_K_M.gguf}
+      -c ${CTX_SIZE:-131072}
+      -b ${BATCH_SIZE:-4096}
+      -ub ${UBATCH_SIZE:-1024}
+      -ngl 99
+      -fa on
+      --cache-type-k ${KV_TYPE:-q4_0}
+      --cache-type-v ${KV_TYPE:-q4_0}
+      -np ${NP:-1}
+      --spec-type draft-mtp
+      --spec-draft-n-max ${MTP_DRAFT_N_MAX:-2}
+      --jinja
+      --reasoning ${REASONING:-off}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.8}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}"]
+              capabilities: [compute, utility]

--- a/scripts/tests/test-verify-stress-ceiling.sh
+++ b/scripts/tests/test-verify-stress-ceiling.sh
@@ -227,6 +227,147 @@ for i in 1 2 3 4 5 6 7 8; do
   assert_contains "$out" "[${i}/8]" "probe ${i} header"
 done
 
+# ---- Test: streaming NIAH helper timing extraction ----
+# Extract the Python streaming helper from verify-stress.sh and test it
+# with mocked HTTP responses matching the REAL llama.cpp response shape.
+
+# Extract the Python code from send_streaming_niah
+STREAMING_PY="$(mktemp --suffix=.py)"
+sed -n "/^send_streaming_niah/,/^}/p" scripts/verify-stress.sh \
+  | sed -n "/<<'PYEOF'/,/PYEOF/p" \
+  | sed '1d;$d' > "$STREAMING_PY"
+
+# Test 1: llama.cpp streaming response with timings object
+# Real shape (confirmed against live endpoint):
+#   timings: {prompt_n, prompt_ms, prompt_per_second, ...}
+#   usage: {prompt_tokens, completion_tokens, ...}
+MOCK_RESULT="$(mktemp --suffix=.json)"
+MOCK_REQ="$(mktemp --suffix=.json)"
+MOCK_TEST="$(mktemp --suffix=.py)"
+echo '{"model":"test","messages":[{"role":"user","content":"hi"}],"max_tokens":10}' > "$MOCK_REQ"
+
+cat > "$MOCK_TEST" <<'PYTEST'
+import json, sys, urllib.request, urllib.error
+
+# Mock streaming chunks matching REAL llama.cpp response shape
+chunks = [
+    {"choices": [{"delta": {"content": "Paris"}, "finish_reason": None}], "id": "1"},
+    {
+        "choices": [{"delta": {}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 14, "completion_tokens": 1, "total_tokens": 15},
+        "timings": {
+            "prompt_n": 14, "prompt_ms": 346.811,
+            "prompt_per_token_ms": 24.772, "prompt_per_second": 40.368,
+            "predicted_n": 1, "predicted_ms": 17.554,
+            "predicted_per_token_ms": 17.554, "predicted_per_second": 56.968,
+        },
+    },
+]
+
+class MockResponse:
+    def __init__(self):
+        self._lines = [f"data: {json.dumps(c)}\n".encode() for c in chunks] + [b"data: [DONE]\n"]
+    def getcode(self): return 200
+    def __enter__(self): return self
+    def __exit__(self, *a): pass
+    def __iter__(self): return iter(self._lines)
+
+urllib.request.urlopen = lambda req, timeout=None: MockResponse()
+
+# Rewrite sys.argv so the streaming helper sees the right args
+# argv[0]=script, argv[1]=req_file, argv[2]=result_file, argv[3]=url, argv[4]=timeout
+streaming_py = sys.argv[1]
+sys.argv = [sys.argv[0]] + sys.argv[2:]
+exec(open(streaming_py).read())
+PYTEST
+
+python3 "$MOCK_TEST" "$STREAMING_PY" "$MOCK_REQ" "$MOCK_RESULT" "http://mock" "60" 2>&1
+
+if [[ -f "$MOCK_RESULT" ]]; then
+  result_http="$(python3 -c "import json; print(json.load(open('$MOCK_RESULT'))['http_code'])" 2>/dev/null)"
+  result_tps="$(python3 -c "import json; print(json.load(open('$MOCK_RESULT'))['prefill_tps'])" 2>/dev/null)"
+  result_ms="$(python3 -c "import json; print(json.load(open('$MOCK_RESULT'))['prefill_ms'])" 2>/dev/null)"
+  result_tok="$(python3 -c "import json; print(json.load(open('$MOCK_RESULT'))['prompt_tokens'])" 2>/dev/null)"
+  result_content="$(python3 -c "import json; print(json.load(open('$MOCK_RESULT'))['content'])" 2>/dev/null)"
+  assert_eq "streaming: llama.cpp http_code" "200" "$result_http"
+  assert_eq "streaming: llama.cpp prompt_tokens" "14" "$result_tok"
+  assert_eq "streaming: llama.cpp content" "Paris" "$result_content"
+  assert_eq "streaming: llama.cpp prefill_tps" "40.4" "$result_tps"
+  # prefill_ms should be ~346.8
+  ms_ok="$(python3 -c "print('ok' if abs(float('${result_ms}') - 346.8) < 1 else 'fail')" 2>/dev/null)"
+  assert_eq "streaming: llama.cpp prefill_ms ~346.8" "ok" "$ms_ok"
+else
+  echo "FAIL: streaming test 1 — no result file" >&2
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 2: vLLM-style response (no timings, cross-engine fallback)
+rm -f "$MOCK_RESULT"
+cat > "$MOCK_TEST" <<'PYTEST'
+import json, sys, urllib.request
+
+chunks = [
+    {"choices": [{"delta": {"content": "42"}, "finish_reason": None}]},
+    {
+        "choices": [{"delta": {}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 124000, "completion_tokens": 2, "total_tokens": 124002},
+    },
+]
+
+class MockResponse:
+    def __init__(self):
+        self._lines = [f"data: {json.dumps(c)}\n".encode() for c in chunks] + [b"data: [DONE]\n"]
+    def getcode(self): return 200
+    def __enter__(self): return self
+    def __exit__(self, *a): pass
+    def __iter__(self): return iter(self._lines)
+
+urllib.request.urlopen = lambda req, timeout=None: MockResponse()
+streaming_py = sys.argv[1]
+sys.argv = [sys.argv[0]] + sys.argv[2:]
+exec(open(streaming_py).read())
+PYTEST
+
+python3 "$MOCK_TEST" "$STREAMING_PY" "$MOCK_REQ" "$MOCK_RESULT" "http://mock" "60" 2>&1
+
+if [[ -f "$MOCK_RESULT" ]]; then
+  result_tps="$(python3 -c "import json; print(json.load(open('$MOCK_RESULT'))['prefill_tps'])" 2>/dev/null)"
+  result_tok="$(python3 -c "import json; print(json.load(open('$MOCK_RESULT'))['prompt_tokens'])" 2>/dev/null)"
+  assert_eq "streaming: vLLM prompt_tokens" "124000" "$result_tok"
+  # prefill_tps should be computed from prompt_tokens / TTFT (positive number)
+  tps_positive="$(python3 -c "print('ok' if float('${result_tps}') > 0 else 'fail')" 2>/dev/null)"
+  assert_eq "streaming: vLLM prefill_tps > 0 (cross-engine fallback)" "ok" "$tps_positive"
+else
+  echo "FAIL: streaming test 2 — no result file" >&2
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 3: HTTP 500 error handling
+rm -f "$MOCK_RESULT"
+cat > "$MOCK_TEST" <<'PYTEST'
+import json, sys, urllib.request, urllib.error
+
+def mock_urlopen(req, timeout=None):
+    raise urllib.error.HTTPError(
+        'http://mock/v1/chat/completions', 500, 'OOM', {}, None)
+urllib.request.urlopen = mock_urlopen
+streaming_py = sys.argv[1]
+sys.argv = [sys.argv[0]] + sys.argv[2:]
+exec(open(streaming_py).read())
+PYTEST
+
+python3 "$MOCK_TEST" "$STREAMING_PY" "$MOCK_REQ" "$MOCK_RESULT" "http://mock" "60" 2>&1
+
+if [[ -f "$MOCK_RESULT" ]]; then
+  result_http="$(python3 -c "import json; print(json.load(open('$MOCK_RESULT'))['http_code'])" 2>/dev/null)"
+  assert_eq "streaming: HTTP 500 error handling" "500" "$result_http"
+else
+  echo "FAIL: streaming test 3 — no result file" >&2
+  FAIL=$((FAIL + 1))
+fi
+
+rm -f "$STREAMING_PY" "$MOCK_RESULT" "$MOCK_REQ" "$MOCK_TEST"
+
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"
 if [[ "$FAIL" -gt 0 ]]; then

--- a/scripts/tests/test-verify-stress-ceiling.sh
+++ b/scripts/tests/test-verify-stress-ceiling.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# Test for verify-stress.sh ceiling ladder (#199) — validates:
+#   1. get_n_ctx() reads llama.cpp /props → default_generation_settings.n_ctx (nested)
+#   2. get_n_ctx() falls back to top-level n_ctx (some llama.cpp forks)
+#   3. get_n_ctx() falls back to /v1/models → max_model_len (vLLM)
+#   4. get_n_ctx() returns 0 when detection fails
+#   5. get_vram_free_mb() sums across GPUs (dual + single)
+#   6. Ladder rung computation is correct for various n_ctx values
+#   7. SKIP_CEILING=1 / SKIP_LONGCTX=1 skip the ceiling ladder
+#   8. All 8 probe headers [N/8] are present in output
+#   9. Small compose skips the ladder (ceiling ≤ start)
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+PASS=0
+FAIL=0
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $label: expected '$expected', got '$actual'" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+assert_contains() {
+  local haystack="$1" needle="$2" label="${3:-}"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: ${label:-assert_contains}: expected output to contain: $needle" >&2
+    echo "--- output (last 30 lines) ---" >&2
+    echo "$haystack" | tail -30 >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Extract helpers to temp file (avoids bash -c quoting issues with
+# embedded python one-liners that contain single quotes).
+HELPERS_FILE="$(mktemp --suffix=.sh)"
+sed -n '/^get_n_ctx()/,/^}/p' scripts/verify-stress.sh > "$HELPERS_FILE"
+sed -n '/^get_vram_free_mb()/,/^}/p' scripts/verify-stress.sh >> "$HELPERS_FILE"
+
+tmp_dir="$(mktemp -d)"
+cleanup() { rm -rf "$tmp_dir" "$HELPERS_FILE"; }
+trap cleanup EXIT
+
+# Mock curl helper: match against the full arg string (not per-arg).
+make_curl_mock() {
+  cat > "${tmp_dir}/curl" <<EOF
+#!/usr/bin/env bash
+all="\$*"
+case "\$all" in
+$1
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "${tmp_dir}/curl"
+}
+
+# ---- Test get_n_ctx with REAL llama.cpp /props shape (nested) ----
+# This is the critical test — real llama.cpp nests n_ctx inside
+# default_generation_settings, NOT at top-level.
+make_curl_mock '  */props*) printf '"'"'{"default_generation_settings":{"n_ctx":262144,"temperature":0.8}}'"'"'; exit 0 ;;'
+
+result="$(ENGINE_KIND=llamacpp URL=http://mock CONTAINER=none \
+  PATH="${tmp_dir}:$PATH" \
+  bash -c "source '$HELPERS_FILE'; get_n_ctx")"
+assert_eq "get_n_ctx from /props NESTED (real llama.cpp)" "262144" "$result"
+
+# ---- Test get_n_ctx with top-level n_ctx (some forks/old versions) ----
+make_curl_mock '  */props*) printf '"'"'{"n_ctx":131072}'"'"'; exit 0 ;;'
+
+result="$(ENGINE_KIND=llamacpp URL=http://mock CONTAINER=none \
+  PATH="${tmp_dir}:$PATH" \
+  bash -c "source '$HELPERS_FILE'; get_n_ctx")"
+assert_eq "get_n_ctx from /props TOP-LEVEL (fork/old)" "131072" "$result"
+
+# ---- Test get_n_ctx with both nested and top-level (nested wins) ----
+make_curl_mock '  */props*) printf '"'"'{"n_ctx":999,"default_generation_settings":{"n_ctx":200000}}'"'"'; exit 0 ;;'
+
+result="$(ENGINE_KIND=llamacpp URL=http://mock CONTAINER=none \
+  PATH="${tmp_dir}:$PATH" \
+  bash -c "source '$HELPERS_FILE'; get_n_ctx")"
+assert_eq "get_n_ctx nested wins over top-level" "200000" "$result"
+
+# ---- Test get_n_ctx fallback to /v1/models (vLLM) ----
+make_curl_mock '
+  */props*) exit 1 ;;
+  */v1/models*) printf '"'"'{"data":[{"id":"mock","max_model_len":131072}]}'"'"'; exit 0 ;;'
+
+result="$(ENGINE_KIND=vllm URL=http://mock CONTAINER=none \
+  PATH="${tmp_dir}:$PATH" \
+  bash -c "source '$HELPERS_FILE'; get_n_ctx")"
+assert_eq "get_n_ctx fallback to /v1/models (vLLM)" "131072" "$result"
+
+# ---- Test get_n_ctx returns 0 on total failure ----
+make_curl_mock ''
+
+result="$(ENGINE_KIND=unknown URL=http://mock CONTAINER=none \
+  PATH="${tmp_dir}:/usr/bin:/bin" \
+  bash -c "source '$HELPERS_FILE'; get_n_ctx")"
+assert_eq "get_n_ctx returns 0 on failure" "0" "$result"
+
+# ---- Test get_n_ctx with 512K compose (nested) ----
+make_curl_mock '  */props*) printf '"'"'{"default_generation_settings":{"n_ctx":524288}}'"'"'; exit 0 ;;'
+
+result="$(ENGINE_KIND=llamacpp URL=http://mock CONTAINER=none \
+  PATH="${tmp_dir}:$PATH" \
+  bash -c "source '$HELPERS_FILE'; get_n_ctx")"
+assert_eq "get_n_ctx 512K compose (nested)" "524288" "$result"
+
+# ---- Test get_vram_free_mb dual GPU ----
+cat > "${tmp_dir}/nvidia-smi" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  *memory.free*) printf "12000\n11500\n" ;;
+esac
+EOF
+chmod +x "${tmp_dir}/nvidia-smi"
+
+result="$(PATH="${tmp_dir}:/usr/bin:/bin" \
+  bash -c "source '$HELPERS_FILE'; get_vram_free_mb")"
+assert_eq "get_vram_free_mb dual-GPU sum" "23500" "$result"
+
+# ---- Test get_vram_free_mb single GPU ----
+cat > "${tmp_dir}/nvidia-smi" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  *memory.free*) printf "23000\n" ;;
+esac
+EOF
+chmod +x "${tmp_dir}/nvidia-smi"
+
+result="$(PATH="${tmp_dir}:/usr/bin:/bin" \
+  bash -c "source '$HELPERS_FILE'; get_vram_free_mb")"
+assert_eq "get_vram_free_mb single-GPU" "23000" "$result"
+
+# ---- Test ladder rung computation ----
+compute_ladder() {
+  local n_ctx="$1" start="${2:-95000}" step="${3:-30000}" frac="${4:-0.92}"
+  python3 -c "
+start, top, step = ${start}, int(${n_ctx} * ${frac}), ${step}
+if top <= start:
+    print('SKIP')
+else:
+    rungs = list(range(start, top, step))
+    if not rungs or rungs[-1] != top:
+        rungs.append(top)
+    print(' '.join(str(r) for r in rungs))
+"
+}
+
+# 262K compose: 95000 → 125000 → 155000 → 185000 → 215000 → 241172
+ladder="$(compute_ladder 262144)"
+assert_eq "ladder 262K" "95000 125000 155000 185000 215000 241172" "$ladder"
+
+# 131K compose: 95000 → 120586
+ladder="$(compute_ladder 131072)"
+assert_eq "ladder 131K" "95000 120586" "$ladder"
+
+# 200K compose: 95000 → 125000 → 155000 → 184000
+ladder="$(compute_ladder 200000)"
+assert_eq "ladder 200K" "95000 125000 155000 184000" "$ladder"
+
+# 512K compose: 95000 → 125000 → ... → 482344
+ladder="$(compute_ladder 524288)"
+rung_count="$(echo "$ladder" | wc -w)"
+assert_eq "ladder 512K rung count" "14" "$rung_count"
+first="$(echo "$ladder" | awk '{print $1}')"
+last="$(echo "$ladder" | awk '{print $NF}')"
+assert_eq "ladder 512K first rung" "95000" "$first"
+assert_eq "ladder 512K last rung" "482344" "$last"
+
+# 32K compose: ceiling = 29440 < start 95000 → SKIP
+ladder="$(compute_ladder 32768)"
+assert_eq "ladder 32K (too small)" "SKIP" "$ladder"
+
+# Custom step size: 15000
+ladder="$(compute_ladder 262144 95000 15000)"
+rung_count="$(echo "$ladder" | wc -w)"
+assert_eq "ladder 262K step=15K rung count" "11" "$rung_count"
+
+# Custom fraction: 0.80
+ladder="$(compute_ladder 262144 95000 30000 0.80)"
+last="$(echo "$ladder" | awk '{print $NF}')"
+assert_eq "ladder 262K frac=0.80 last rung" "209715" "$last"
+
+# ---- Test: full script with SKIP_CEILING / SKIP_LONGCTX ----
+make_curl_mock '
+  */v1/models*) printf '"'"'{"data":[{"id":"mock-model","max_model_len":262144}]}'"'"'; exit 0 ;;
+  */props*) printf '"'"'{"default_generation_settings":{"n_ctx":262144}}'"'"'; exit 0 ;;
+  */v1/chat/completions*) printf '"'"'{"choices":[{"message":{"content":"mock response"},"finish_reason":"stop"}],"usage":{"prompt_tokens":100,"completion_tokens":10}}'"'"'; exit 0 ;;'
+
+cat > "${tmp_dir}/nvidia-smi" <<'MOCK_NVIDIA'
+#!/usr/bin/env bash
+case "$*" in
+  *memory.free*) echo "23500" ;;
+  *) echo "NVIDIA-SMI mock" ;;
+esac
+MOCK_NVIDIA
+chmod +x "${tmp_dir}/nvidia-smi"
+
+cat > "${tmp_dir}/docker" <<'MOCK_DOCKER'
+#!/usr/bin/env bash
+printf '{"Config":{"Image":"mock","Env":[]},"Args":[]}'
+MOCK_DOCKER
+chmod +x "${tmp_dir}/docker"
+
+# Test: SKIP_CEILING=1 skips probe 8
+out="$(PATH="${tmp_dir}:$PATH" PREFLIGHT_NO_AUTODETECT=1 URL=http://mock MODEL=mock-model \
+  CONTAINER=none SKIP_CEILING=1 SKIP_LONGCTX=1 SKIP_TOOL_PREFILL=1 \
+  bash scripts/verify-stress.sh 2>&1)" || true
+assert_contains "$out" "[8/8]" "probe 8 header printed"
+assert_contains "$out" "SKIP_CEILING=1" "SKIP_CEILING skip message"
+
+# Test: SKIP_LONGCTX=1 also skips ceiling ladder
+out="$(PATH="${tmp_dir}:$PATH" PREFLIGHT_NO_AUTODETECT=1 URL=http://mock MODEL=mock-model \
+  CONTAINER=none SKIP_LONGCTX=1 SKIP_TOOL_PREFILL=1 \
+  bash scripts/verify-stress.sh 2>&1)" || true
+assert_contains "$out" "SKIP_LONGCTX=1" "SKIP_LONGCTX also skips ceiling"
+
+# Verify all 8 probe headers are present
+for i in 1 2 3 4 5 6 7 8; do
+  assert_contains "$out" "[${i}/8]" "probe ${i} header"
+done
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+echo "test-verify-stress-ceiling: ok"

--- a/scripts/tests/test-verify-stress-ceiling.sh
+++ b/scripts/tests/test-verify-stress-ceiling.sh
@@ -112,31 +112,73 @@ result="$(ENGINE_KIND=llamacpp URL=http://mock CONTAINER=none \
   bash -c "source '$HELPERS_FILE'; get_n_ctx")"
 assert_eq "get_n_ctx 512K compose (nested)" "524288" "$result"
 
-# ---- Test get_vram_free_mb dual GPU ----
+# ---- Test get_vram_free_mb dual GPU (no container context — sums all) ----
 cat > "${tmp_dir}/nvidia-smi" <<'EOF'
 #!/usr/bin/env bash
 case "$*" in
   *memory.free*) printf "12000\n11500\n" ;;
+  *index*) printf "0\n1\n" ;;
 esac
 EOF
 chmod +x "${tmp_dir}/nvidia-smi"
 
-result="$(PATH="${tmp_dir}:/usr/bin:/bin" \
+result="$(CONTAINER=none PATH="${tmp_dir}:/usr/bin:/bin" \
   bash -c "source '$HELPERS_FILE'; get_vram_free_mb")"
-assert_eq "get_vram_free_mb dual-GPU sum" "23500" "$result"
+assert_eq "get_vram_free_mb dual-GPU sum (no container)" "23500" "$result"
 
 # ---- Test get_vram_free_mb single GPU ----
 cat > "${tmp_dir}/nvidia-smi" <<'EOF'
 #!/usr/bin/env bash
 case "$*" in
   *memory.free*) printf "23000\n" ;;
+  *index*) printf "0\n" ;;
 esac
 EOF
 chmod +x "${tmp_dir}/nvidia-smi"
 
-result="$(PATH="${tmp_dir}:/usr/bin:/bin" \
+result="$(CONTAINER=none PATH="${tmp_dir}:/usr/bin:/bin" \
   bash -c "source '$HELPERS_FILE'; get_vram_free_mb")"
 assert_eq "get_vram_free_mb single-GPU" "23000" "$result"
+
+# ---- Test get_vram_free_mb scoping: multi-GPU host, single-GPU container ----
+# Simulates dual-3090 host with compose pinned to GPU 0 via DeviceRequests.
+# GPU 0 has 381 MB free (model), GPU 1 has 24126 MB free (idle).
+# Old behavior: sum = 24507 (inflated). Fix: query only GPU 0 → 381.
+cat > "${tmp_dir}/nvidia-smi" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  *-i\ 0*memory.free*|*memory.free*-i\ 0*) printf "381\n" ;;
+  *memory.free*)
+    # When -i is passed, only return that GPU's value
+    if echo "$*" | grep -q '\-i'; then
+      gpu="$(echo "$*" | sed 's/.*-i *\([^ ]*\).*/\1/')"
+      case "$gpu" in
+        0) printf "381\n" ;;
+        1) printf "24126\n" ;;
+        *) printf "0\n" ;;
+      esac
+    else
+      printf "381\n24126\n"
+    fi
+    ;;
+  *index*) printf "0\n1\n" ;;
+esac
+EOF
+chmod +x "${tmp_dir}/nvidia-smi"
+
+cat > "${tmp_dir}/docker" <<'MOCK_DOCKER'
+#!/usr/bin/env bash
+case "$*" in
+  *inspect*)
+    printf '[{"HostConfig":{"DeviceRequests":[{"Driver":"nvidia","DeviceIDs":["0"],"Capabilities":[["compute","utility"]]}]},"Config":{"Image":"mock","Env":["NVIDIA_VISIBLE_DEVICES=all"]}}]'
+    ;;
+esac
+MOCK_DOCKER
+chmod +x "${tmp_dir}/docker"
+
+result="$(CONTAINER=mock-container PATH="${tmp_dir}:/usr/bin:/bin" \
+  bash -c "source '$HELPERS_FILE'; get_vram_free_mb")"
+assert_eq "get_vram_free_mb scoped to GPU 0 (Bug 1 fix)" "381" "$result"
 
 # ---- Test ladder rung computation ----
 compute_ladder() {
@@ -226,6 +268,14 @@ assert_contains "$out" "SKIP_LONGCTX=1" "SKIP_LONGCTX also skips ceiling"
 for i in 1 2 3 4 5 6 7 8; do
   assert_contains "$out" "[${i}/8]" "probe ${i} header"
 done
+
+# Note: Bug 3 (no-op ladder must FAIL) is validated by code review + live test.
+# The summary logic checks any_sizing_error before any_fail and emits FAIL.
+# "All rungs skipped" now emits FAIL instead of skip. Unit-testing the
+# summary branch requires mocking send_streaming_niah (Python urllib),
+# which is beyond the curl-mock approach used here. Validated live:
+# old code said "All stress checks passed" with all-400 ladder;
+# new code says "filler→token sizing error" and increments FAILED.
 
 # ---- Test: streaming NIAH helper timing extraction ----
 # Extract the Python streaming helper from verify-stress.sh and test it

--- a/scripts/verify-stress.sh
+++ b/scripts/verify-stress.sh
@@ -162,6 +162,125 @@ case "$ENGINE_KIND" in
   *) LOG_CMD="check your engine's stdout/stderr or container logs" ;;
 esac
 
+# --------------------------------------------------------------------
+# Streaming NIAH helper — sends a needle-in-haystack request with
+# stream:true, measures TTFT, extracts prefill throughput.
+#
+# Usage: send_streaming_niah <req_file> <result_file> <url> <timeout_s>
+#
+# Writes a JSON result to <result_file> with:
+#   http_code, content, prompt_tokens, completion_tokens,
+#   ttft_ms, total_wall_ms,
+#   prefill_tps, prefill_ms, prefill_n
+#
+# Prefill throughput:
+#   - Primary (llama.cpp): timings.prompt_per_second + timings.prompt_ms
+#     from the final streaming chunk (confirmed against live endpoint).
+#   - Fallback (cross-engine): prompt_tokens / TTFT_seconds.
+#   - If neither available: prefill_tps=null.
+# --------------------------------------------------------------------
+send_streaming_niah() {
+  local _req_file="$1" _result_file="$2" _url="$3" _timeout="$4"
+  python3 - "$_req_file" "$_result_file" "$_url" "$_timeout" <<'PYEOF'
+import json, os, sys, time, urllib.request, urllib.error
+
+req_file, result_file, url, timeout_s = sys.argv[1], sys.argv[2], sys.argv[3], int(sys.argv[4])
+
+with open(req_file) as f:
+    req = json.load(f)
+
+# Enable streaming + usage in final chunk
+req["stream"] = True
+req["stream_options"] = {"include_usage": True}
+
+body = json.dumps(req).encode("utf-8")
+http_req = urllib.request.Request(
+    f"{url}/v1/chat/completions",
+    data=body,
+    headers={"Content-Type": "application/json"},
+)
+
+t_send = time.time()
+ttft = None
+content_parts = []
+usage = None
+timings = None
+result = {"http_code": 0, "error": None}
+
+try:
+    with urllib.request.urlopen(http_req, timeout=timeout_s) as resp:
+        result["http_code"] = resp.getcode() or 200
+        for raw_line in resp:
+            line = raw_line.decode("utf-8", errors="ignore").rstrip()
+            if not line.startswith("data: "):
+                continue
+            payload = line[6:]
+            if payload == "[DONE]":
+                break
+            try:
+                chunk = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+
+            # First content token → TTFT
+            choices = chunk.get("choices") or []
+            if choices and ttft is None:
+                delta = choices[0].get("delta", {})
+                if delta.get("content") or delta.get("reasoning_content"):
+                    ttft = time.time() - t_send
+
+            # Accumulate streamed content
+            if choices:
+                c = (choices[0].get("delta", {}).get("content", "") or "")
+                if c:
+                    content_parts.append(c)
+
+            # Final chunk carries usage + timings (llama.cpp)
+            if "usage" in chunk:
+                usage = chunk["usage"]
+            if "timings" in chunk:
+                timings = chunk["timings"]
+
+    t_total = time.time() - t_send
+
+    result["content"] = "".join(content_parts)
+    result["prompt_tokens"] = (usage or {}).get("prompt_tokens", 0)
+    result["completion_tokens"] = (usage or {}).get("completion_tokens", 0)
+    result["ttft_ms"] = round(ttft * 1000) if ttft is not None else None
+    result["total_wall_ms"] = round(t_total * 1000)
+
+    # Prefill throughput: prefer llama.cpp timings (server-measured, precise)
+    if timings and timings.get("prompt_per_second"):
+        result["prefill_tps"] = round(timings["prompt_per_second"], 1)
+        result["prefill_ms"] = round(timings["prompt_ms"], 1) if timings.get("prompt_ms") else None
+        result["prefill_n"] = timings.get("prompt_n")
+    elif ttft and usage and usage.get("prompt_tokens") and ttft > 0:
+        # Cross-engine fallback: prompt_tokens / TTFT
+        result["prefill_tps"] = round(usage["prompt_tokens"] / ttft, 1)
+        result["prefill_ms"] = round(ttft * 1000)
+        result["prefill_n"] = usage["prompt_tokens"]
+    else:
+        result["prefill_tps"] = None
+        result["prefill_ms"] = None
+        result["prefill_n"] = None
+
+except urllib.error.HTTPError as e:
+    result["http_code"] = e.code
+    result["error"] = str(e)
+    # Try to read the error body for diagnostics
+    try:
+        result["error_body"] = e.read().decode("utf-8", errors="replace")[:500]
+    except Exception:
+        pass
+except Exception as e:
+    result["http_code"] = 0
+    result["error"] = str(e)
+
+with open(result_file, "w") as f:
+    json.dump(result, f)
+PYEOF
+}
+
 echo "Running STRESS / boundary test against ${URL}"
 echo "  model=${MODEL}  container=${CONTAINER}  engine=${ENGINE_KIND}"
 echo "  This script does the heavy stuff (longctx needle ladder + ~25K-token tool prefill)."
@@ -249,41 +368,52 @@ with open(os.environ['REQ_FILE'], 'w') as f:
 EOF
     local secret
     secret="$(cat "$secret_file")"
-    local resp content_raw prompt_tok http_code resp_file
-    resp_file="$(mktemp --suffix=.json)"
-    http_code="$(curl -s -m "${STRESS_LONGCTX_TIMEOUT_S}" -o "${resp_file}" -w '%{http_code}' \
-      "${URL}/v1/chat/completions" \
-      -H "Content-Type: application/json" \
-      --data-binary "@${req_file}")" || http_code="000"
+    local result_file http_code
+    result_file="$(mktemp --suffix=.json)"
+    send_streaming_niah "$req_file" "$result_file" "$URL" "$STRESS_LONGCTX_TIMEOUT_S"
     rm -f "$secret_file" "$req_file"
+    http_code="$(python3 -c "import json; print(json.load(open('$result_file'))['http_code'])" 2>/dev/null || echo 0)"
     if [[ "$http_code" == "400" ]]; then
       printf "    \033[33m⊘\033[0m scale=%d: HTTP 400 (exceeds --max-model-len, expected — clean rejection)\n" "$filler_scale"
-      rm -f "$resp_file"
+      rm -f "$result_file"
       any_skipped=1
       continue
     elif [[ "$http_code" != "200" ]]; then
       printf "    \033[31m✗\033[0m scale=%d: HTTP %s (request failed)\n" "$filler_scale" "$http_code"
-      rm -f "$resp_file"
+      rm -f "$result_file"
       any_fail=1
       continue
     fi
-    resp="$(cat "${resp_file}")"
-    rm -f "${resp_file}"
-    prompt_tok="$(echo "$resp" | python3 -c "import sys,json; print(json.load(sys.stdin)['usage']['prompt_tokens'])" 2>/dev/null)"
-    content_raw="$(echo "$resp" | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0]['message']['content'])" 2>/dev/null)"
+    local prompt_tok content_raw prefill_tps prefill_ms
+    prompt_tok="$(python3 -c "import json; d=json.load(open('$result_file')); print(d.get('prompt_tokens',0))" 2>/dev/null || echo 0)"
+    content_raw="$(python3 -c "import json; d=json.load(open('$result_file')); print(d.get('content',''))" 2>/dev/null || echo '')"
+    prefill_tps="$(python3 -c "import json; d=json.load(open('$result_file')); v=d.get('prefill_tps'); print(v if v is not None else '')" 2>/dev/null || echo '')"
+    prefill_ms="$(python3 -c "import json; d=json.load(open('$result_file')); v=d.get('prefill_ms'); print(v if v is not None else '')" 2>/dev/null || echo '')"
+    rm -f "$result_file"
+    local prefill_str=""
+    if [[ -n "$prefill_tps" ]]; then
+      prefill_str="  prefill=${prefill_tps} t/s"
+      if [[ -n "$prefill_ms" ]]; then
+        local prefill_s
+        prefill_s="$(python3 -c "print(f'{${prefill_ms}/1000:.0f}')" 2>/dev/null || echo '')"
+        if [[ -n "$prefill_s" ]]; then
+          prefill_str="  prefill=${prefill_tps} t/s (${prefill_s}s)"
+        fi
+      fi
+    fi
     local all_match=1
     for tok in $secret; do
       echo "$content_raw" | grep -qiF "$tok" || all_match=0
     done
     if [[ "$all_match" == "1" ]]; then
-      printf "    \033[32m✓\033[0m %6s tokens: recalled '%s' (got: %s)\n" "$prompt_tok" "$secret" "$(echo "$content_raw" | head -c 60 | tr '\n' ' ')"
+      printf "    \033[32m✓\033[0m %6s tokens: recalled '%s' (got: %s)%s\n" "$prompt_tok" "$secret" "$(echo "$content_raw" | head -c 60 | tr '\n' ' ')" "$prefill_str"
       any_pass=1
     else
       # Recall miss at HTTP 200 = attention quality degradation, not a system
       # failure. Log it as informational (yellow △), break out of the ladder
       # — deeper rungs will only be worse — and pass the probe so the
       # pipeline moves to the next stage.
-      printf "    \033[33m△\033[0m %6s tokens: recall MISS (expected '%s', got '%s') — system OK, quality ceiling reached\n" "$prompt_tok" "$secret" "$(echo "$content_raw" | head -c 80 | tr '\n' ' ')"
+      printf "    \033[33m△\033[0m %6s tokens: recall MISS (expected '%s', got '%s') — system OK, quality ceiling reached%s\n" "$prompt_tok" "$secret" "$(echo "$content_raw" | head -c 80 | tr '\n' ' ')" "$prefill_str"
       any_recall_miss=1
       break
     fi
@@ -991,10 +1121,9 @@ print(' '.join(str(r) for r in rungs))
     filler_scale="$(python3 -c "print(max(100, int(${target_tokens} / 3.5)))")"
 
     # Build + send the NIAH request
-    local secret_file req_file resp_file http_code
+    local secret_file req_file http_code
     secret_file="$(mktemp --suffix=.secret)"
     req_file="$(mktemp --suffix=.json)"
-    resp_file="$(mktemp --suffix=.json)"
 
     MODEL_VAR="${MODEL}" SECRET_FILE="${secret_file}" REQ_FILE="${req_file}" \
       FILLER_SCALE="${filler_scale}" python3 - <<'EOF'
@@ -1039,11 +1168,12 @@ EOF
     local secret
     secret="$(cat "$secret_file")"
 
-    http_code="$(curl -s -m "${rung_timeout}" -o "${resp_file}" -w '%{http_code}' \
-      "${URL}/v1/chat/completions" \
-      -H "Content-Type: application/json" \
-      --data-binary "@${req_file}")" || http_code="000"
+    local result_file
+    result_file="$(mktemp --suffix=.json)"
+    send_streaming_niah "$req_file" "$result_file" "$URL" "$rung_timeout"
     rm -f "$secret_file" "$req_file"
+
+    http_code="$(python3 -c "import json; print(json.load(open('$result_file'))['http_code'])" 2>/dev/null || echo 0)"
 
     # Capture VRAM after this rung
     local vram_after_rung
@@ -1053,14 +1183,29 @@ EOF
       vram_str="  VRAM_free=${vram_after_rung}MB"
     fi
 
+    # Extract prefill data from result
+    local prefill_tps prefill_ms prefill_str
+    prefill_tps="$(python3 -c "import json; d=json.load(open('$result_file')); v=d.get('prefill_tps'); print(v if v is not None else '')" 2>/dev/null || echo '')"
+    prefill_ms="$(python3 -c "import json; d=json.load(open('$result_file')); v=d.get('prefill_ms'); print(v if v is not None else '')" 2>/dev/null || echo '')"
+    prefill_str=""
+    if [[ -n "$prefill_tps" ]]; then
+      prefill_str="  prefill=${prefill_tps} t/s"
+      if [[ -n "$prefill_ms" ]]; then
+        local prefill_s
+        prefill_s="$(python3 -c "print(f'{${prefill_ms}/1000:.0f}')" 2>/dev/null || echo '')"
+        if [[ -n "$prefill_s" ]]; then
+          prefill_str="  prefill=${prefill_tps} t/s (${prefill_s}s)"
+        fi
+      fi
+    fi
+
     # Evaluate
     case "$http_code" in
       200)
-        local resp prompt_tok content_raw all_match
-        resp="$(cat "${resp_file}")"
-        rm -f "${resp_file}"
-        prompt_tok="$(echo "$resp" | python3 -c "import sys,json; print(json.load(sys.stdin)['usage']['prompt_tokens'])" 2>/dev/null || echo 0)"
-        content_raw="$(echo "$resp" | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0]['message']['content'])" 2>/dev/null || echo '')"
+        local prompt_tok content_raw all_match
+        prompt_tok="$(python3 -c "import json; d=json.load(open('$result_file')); print(d.get('prompt_tokens',0))" 2>/dev/null || echo 0)"
+        content_raw="$(python3 -c "import json; d=json.load(open('$result_file')); print(d.get('content',''))" 2>/dev/null || echo '')"
+        rm -f "$result_file"
         all_match=1
         for tok in $secret; do
           echo "$content_raw" | grep -qiF "$tok" || all_match=0
@@ -1068,8 +1213,8 @@ EOF
         local pct=0
         [[ "$prompt_tok" -gt 0 && "$n_ctx" -gt 0 ]] && pct=$(( prompt_tok * 100 / n_ctx ))
         if [[ "$all_match" == "1" ]]; then
-          printf "    \033[32m✓\033[0m rung %d/%d: target=%dK  actual=%dK tok (%d%%)  recalled '%s'%s\n" \
-            "$rung_idx" "$rung_count" "$((target_tokens / 1000))" "$((prompt_tok / 1000))" "$pct" "$secret" "$vram_str"
+          printf "    \033[32m✓\033[0m rung %d/%d: target=%dK  actual=%dK tok (%d%%)  recalled '%s'%s%s\n" \
+            "$rung_idx" "$rung_count" "$((target_tokens / 1000))" "$((prompt_tok / 1000))" "$pct" "$secret" "$prefill_str" "$vram_str"
           any_pass=1
           last_pass_tokens="$prompt_tok"
           last_pass_pct="$pct"
@@ -1079,9 +1224,9 @@ EOF
           # Log it, break out of the ladder, and pass the probe so the
           # pipeline moves to the next stage without wasting time on
           # unreliable depths.
-          printf "    \033[33m△\033[0m rung %d/%d: target=%dK  actual=%dK tok (%d%%)  recall MISS (got: '%s') — quality ceiling reached%s\n" \
+          printf "    \033[33m△\033[0m rung %d/%d: target=%dK  actual=%dK tok (%d%%)  recall MISS (got: '%s') — quality ceiling reached%s%s\n" \
             "$rung_idx" "$rung_count" "$((target_tokens / 1000))" "$((prompt_tok / 1000))" "$pct" \
-            "$(echo "$content_raw" | head -c 60 | tr '\n' ' ')" "$vram_str"
+            "$(echo "$content_raw" | head -c 60 | tr '\n' ' ')" "$prefill_str" "$vram_str"
           any_recall_miss=1
           if [[ "$first_recall_miss_tokens" -eq 0 ]]; then
             first_recall_miss_tokens="$prompt_tok"
@@ -1093,7 +1238,7 @@ EOF
       400)
         printf "    \033[33m⊘\033[0m rung %d/%d: target=%dK  HTTP 400 (exceeds engine limit — clean rejection)%s\n" \
           "$rung_idx" "$rung_count" "$((target_tokens / 1000))" "$vram_str"
-        rm -f "${resp_file}"
+        rm -f "$result_file"
         any_skipped=1
         # Engine's hard limit — no point trying deeper rungs
         break
@@ -1102,7 +1247,7 @@ EOF
         printf "    \033[31m✗\033[0m rung %d/%d: target=%dK  HTTP 500 (OOM at ~%d%% of n_ctx=%d)%s\n" \
           "$rung_idx" "$rung_count" "$((target_tokens / 1000))" \
           "$(( target_tokens * 100 / n_ctx ))" "$n_ctx" "$vram_str"
-        rm -f "${resp_file}"
+        rm -f "$result_file"
         any_fail=1
         if [[ "$first_fail_tokens" -eq 0 ]]; then
           first_fail_tokens="$target_tokens"
@@ -1113,7 +1258,7 @@ EOF
       000)
         printf "    \033[31m✗\033[0m rung %d/%d: target=%dK  timeout/crash (>%ds)%s\n" \
           "$rung_idx" "$rung_count" "$((target_tokens / 1000))" "$rung_timeout" "$vram_str"
-        rm -f "${resp_file}"
+        rm -f "$result_file"
         any_fail=1
         if [[ "$first_fail_tokens" -eq 0 ]]; then
           first_fail_tokens="$target_tokens"
@@ -1124,7 +1269,7 @@ EOF
       *)
         printf "    \033[31m✗\033[0m rung %d/%d: target=%dK  unexpected HTTP %s%s\n" \
           "$rung_idx" "$rung_count" "$((target_tokens / 1000))" "$http_code" "$vram_str"
-        rm -f "${resp_file}"
+        rm -f "$result_file"
         any_fail=1
         if [[ "$first_fail_tokens" -eq 0 ]]; then
           first_fail_tokens="$target_tokens"

--- a/scripts/verify-stress.sh
+++ b/scripts/verify-stress.sh
@@ -8,12 +8,12 @@
 # Run before publishing, after any major patch / vLLM image bump, or when
 # investigating prefill-OOM regressions specifically.
 #
-# This is SLOW (large prompts, long-ctx needle ladder up to ~115K tokens,
-# ~25K-token tool prefill) — allow ~5–10 minutes on dual-card, longer on
-# single-card configurations where the longest depths get rejected by the
-# engine pre-check (HTTP 400, treated as graceful skip).
+# This is SLOW (large prompts, long-ctx needle ladder from ~10K up to
+# ~92% of CTX_SIZE, ~25K-token tool prefill) — allow ~10–20 minutes on
+# dual-card, longer on single-card configurations where the longest depths
+# get rejected by the engine pre-check (HTTP 400, treated as graceful skip).
 #
-# Checks (in order — Cliff 2 territory deferred to last):
+# Checks (in order — Cliff 2 territory deferred to last, ceiling rung last):
 #   1. Long-context needle SMALL rungs (10K + 30K) — recall ladder at 2
 #      depths that DON'T hit Cliff 2. Each depth gets its own random secret
 #      to defeat caching. Depths above the deployed --max-model-len are
@@ -31,11 +31,18 @@
 #   6. Reasoning-heavy — math/algorithm problem + max_tokens=8192 to give the
 #      model real reasoning room. Stresses spec-decode AL collapse + mamba
 #      cache_mode='align' interactions.
-#   7. Long-context needle LARGE rungs (60K + 90K) — runs LAST because hitting
-#      Cliff 2 (DeltaNet GDN forward state OOM at 50-60K single-prompt) crashes
-#      the engine on 24 GB single-card. Putting it last preserves engine
-#      liveness for probes 2-6 even when 7 inevitably crashes the engine.
-#      On dual-card or higher-VRAM rigs that can carry 60K+ this passes.
+#   7. Long-context needle LARGE rungs (60K + 90K) — Cliff 2 territory.
+#      On 24 GB single-card, 60K+ single-prompt may crash the engine (DeltaNet
+#      GDN forward state OOM). Putting it late preserves engine liveness for
+#      probes 2-6. On dual-card or higher-VRAM rigs that can carry 60K+ this
+#      passes.
+#   8. Context CEILING ladder (CTX_SIZE-scaled, #199) — staggers NIAH rungs
+#      from ~95K tokens up to ~92% of n_ctx in ~30K increments (configurable
+#      via CEILING_STEP_TOKENS). Each rung captures VRAM before/after so you
+#      get a margin curve, not just pass/fail. Stops at the first failure —
+#      that depth IS the real ceiling. Catches the false-ceiling class of bug
+#      (#197: hermes agent OOM at 127K on a compose that "passed" at 90K).
+#      Example ladder for a 262K compose: 95K → 125K → 155K → 185K → 215K → 241K.
 #
 # Usage:
 #   CONTAINER=<your-container> bash scripts/verify-stress.sh
@@ -46,9 +53,24 @@
 #   CONTAINER              Default: vllm-qwen36-27b
 #   SKIP_LONGCTX           Set to 1 to skip the long-context needle ladder.
 #   SKIP_TOOL_PREFILL      Set to 1 to skip the tool-response prefill test.
+#   SKIP_CEILING           Set to 1 to skip the context ceiling ladder (#199).
 #   PREFILL_TARGET_CHARS   Tool-response prefill payload size in chars
 #                          (default: 100000 ≈ 25K tokens; set higher to
 #                          push closer to the cliff under investigation).
+#   CEILING_FRACTION       Fraction of n_ctx to target for the top ceiling
+#                          rung (default: 0.92). Lower to test a safer fill.
+#   CEILING_STEP_TOKENS    Token increment between ceiling ladder rungs
+#                          (default: 30000). Smaller = more precise wall
+#                          location but more rungs (each rung is a full
+#                          NIAH request at that depth).
+#   CEILING_START_TOKENS   First ceiling rung target in tokens (default:
+#                          95000 — just above probe 7's ~90K). The ladder
+#                          starts here and steps up by CEILING_STEP_TOKENS
+#                          until CEILING_FRACTION × n_ctx.
+#   VRAM_MARGIN_MB         Minimum free-VRAM (MB) required after a ceiling
+#                          rung. Below this → warn even on HTTP 200.
+#                          (default: 1024 = 1 GB; absorbs agent checkpoint
+#                          overhead that single-shot NIAH doesn't exercise).
 #   STRESS_LONGCTX_TIMEOUT_S       Curl timeout for long-context needle checks
 #                          (default: 300, auto-bumped to 600 if container has
 #                          VLLM_ENFORCE_EAGER=1 — eager prefill at 60K+ can
@@ -158,7 +180,7 @@ check_longctx() {
   # Header only when called from probe 1 (default); probe 7 (large rungs)
   # prints its own header before calling us.
   if [[ -z "${LONGCTX_SCALES:-}" ]]; then
-    echo "[1/7] Long-context needle small rungs (10K / 30K) ..."
+    echo "[1/8] Long-context needle small rungs (10K / 30K) ..."
   fi
   if [[ "${SKIP_LONGCTX:-0}" == "1" ]]; then
     skip "SKIP_LONGCTX=1"
@@ -168,6 +190,7 @@ check_longctx() {
   local any_fail=0
   local any_pass=0
   local any_skipped=0
+  local any_recall_miss=0
 
   local deployed_max
   deployed_max="$(curl -sf -m 5 "${URL}/v1/models" 2>/dev/null \
@@ -256,25 +279,33 @@ EOF
       printf "    \033[32m✓\033[0m %6s tokens: recalled '%s' (got: %s)\n" "$prompt_tok" "$secret" "$(echo "$content_raw" | head -c 60 | tr '\n' ' ')"
       any_pass=1
     else
-      printf "    \033[31m✗\033[0m %6s tokens: expected '%s', got '%s'\n" "$prompt_tok" "$secret" "$(echo "$content_raw" | head -c 80 | tr '\n' ' ')"
-      any_fail=1
+      # Recall miss at HTTP 200 = attention quality degradation, not a system
+      # failure. Log it as informational (yellow △), break out of the ladder
+      # — deeper rungs will only be worse — and pass the probe so the
+      # pipeline moves to the next stage.
+      printf "    \033[33m△\033[0m %6s tokens: recall MISS (expected '%s', got '%s') — system OK, quality ceiling reached\n" "$prompt_tok" "$secret" "$(echo "$content_raw" | head -c 80 | tr '\n' ' ')"
+      any_recall_miss=1
+      break
     fi
   done
 
   if [[ "$any_fail" == "0" ]] && [[ "$any_pass" == "1" ]]; then
     if [[ "$any_skipped" == "1" ]]; then
       pass "all in-budget long-ctx depths recalled secret (above-budget depths cleanly rejected by engine pre-check)"
+    elif [[ "$any_recall_miss" == "1" ]]; then
+      pass "all system requests succeeded (some recall misses at depth — attention quality, not system health)"
     else
       pass "all long-ctx depths recalled secret correctly"
     fi
   elif [[ "$any_fail" == "0" ]] && [[ "$any_pass" == "0" ]]; then
-    skip "all depths above --max-model-len (deployed=${deployed_max:-unknown}); shrink ladder or raise ctx"
-  elif [[ "$any_pass" == "1" ]]; then
-    fail "partial recall — some in-budget depths failed" \
-         "Attention quality degrades at longer contexts on this config OR the deployment crashed mid-test. Check: ${LOG_CMD}"
+    if [[ "$any_recall_miss" == "1" ]]; then
+      pass "all system requests succeeded (all recall missed — attention quality degraded, but system filled every depth)"
+    else
+      skip "all depths above --max-model-len (deployed=${deployed_max:-unknown}); shrink ladder or raise ctx"
+    fi
   else
-    fail "no depth recalled the secret (all failed, none succeeded)" \
-         "Either container crashed early in the ladder or attention is broken. Check: ${LOG_CMD}"
+    fail "system-level failures during long-ctx needle ladder (HTTP 5xx / timeout / crash)" \
+         "One or more depths returned non-200 (not a recall miss). Check: ${LOG_CMD}"
   fi
 }
 run_check "longctx" check_longctx
@@ -286,7 +317,7 @@ run_check "longctx" check_longctx
 #    idle but OOMs the moment a real-world tool reply is loaded).
 # --------------------------------------------------------------------
 check_tool_prefill() {
-  echo "[2/7] Tool response prefill OOM (~25K-token mock tool response) ..."
+  echo "[2/8] Tool response prefill OOM (~25K-token mock tool response) ..."
   if [[ "${SKIP_TOOL_PREFILL:-0}" == "1" ]]; then
     skip "SKIP_TOOL_PREFILL=1"
     return 0
@@ -408,7 +439,7 @@ run_check "tool_prefill" check_tool_prefill
 # that fires on real coding-agent prompts but NOT on the synthetic 25K tool
 # prefill above. See club-3090#16. Fail-fast: one request, ~10s if green,
 # instant HTTP 500 if the bug fires.
-echo "[3/7] IDE-agent one-shot prompt (sys + tool schemas + user request) ..."
+echo "[3/8] IDE-agent one-shot prompt (sys + tool schemas + user request) ..."
 check_ide_agent() {
   local req_file resp_file http_code body
   req_file="$(mktemp --suffix=.json)"
@@ -518,7 +549,7 @@ run_check "ide_agent" check_ide_agent
 # 4. Multi-turn agent — sys + tools + user → assistant(tool_call) → tool reply
 # → user followup. Different inductor compile path than check #3 (single-turn)
 # because the assistant + tool messages reshape the prefill that gets compiled.
-echo "[4/7] Multi-turn agent prompt (sys + tools + 4-turn history) ..."
+echo "[4/8] Multi-turn agent prompt (sys + tools + 4-turn history) ..."
 check_multiturn_agent() {
   local req_file resp_file http_code body
   req_file="$(mktemp --suffix=.json)"
@@ -605,7 +636,7 @@ run_check "multiturn_agent" check_multiturn_agent
 # plan + code. Catches DS conv state crash (genesis-vllm-patches#17) on configs
 # where VLLM_SSM_CONV_STATE_LAYOUT=DS + spec-decode + AL>1 + this prompt shape
 # trip the NotImplementedError in vllm/model_executor/layers/mamba/mamba_utils.py.
-echo "[5/7] LCB-coding shape (LeetCode-style problem + structured plan) ..."
+echo "[5/8] LCB-coding shape (LeetCode-style problem + structured plan) ..."
 check_lcb_coding() {
   local req_file resp_file http_code body
   req_file="$(mktemp --suffix=.json)"
@@ -678,7 +709,7 @@ run_check "lcb_coding" check_lcb_coding
 # over a long generation. Catches regressions where generation completes but
 # AL collapses past a certain decode depth, or where long generations trigger
 # state-copy bugs that don't fire on short outputs.
-echo "[6/7] Reasoning-heavy (math problem + max_tokens=8192) ..."
+echo "[6/8] Reasoning-heavy (math problem + max_tokens=8192) ..."
 check_reasoning_heavy() {
   local req_file resp_file http_code body
   req_file="$(mktemp --suffix=.json)"
@@ -747,7 +778,7 @@ run_check "reasoning_heavy" check_reasoning_heavy
 # Cliff 2 (DeltaNet GDN forward state OOM at 50-60K single-prompt) on a 24 GB
 # single card crashes the engine. We want all the OTHER probes to run on a
 # live engine first; this probe is the architectural ceiling check.
-echo "[7/7] Long-context needle large rungs (60K / 90K — Cliff 2 territory) ..."
+echo "[7/8] Long-context needle large rungs (60K / 90K — Cliff 2 territory) ..."
 check_longctx_large() {
   if [[ "${SKIP_LONGCTX:-0}" == "1" ]]; then
     skip "SKIP_LONGCTX=1"
@@ -755,7 +786,398 @@ check_longctx_large() {
   fi
   LONGCTX_SCALES="900 1400" check_longctx
 }
+# Engine health check after crash-prone probes (7, 8).
+# If the engine died (OOM, crash), attempt to restart the container so
+# subsequent pipeline steps (soak-test, quality-test) don't cascade-fail.
+# No-op when CONTAINER=none (endpoint-first mode — can't restart a host server).
+engine_healthy() {
+  curl -sf -m 5 "${URL}/v1/models" >/dev/null 2>&1
+}
+
+ensure_engine_alive() {
+  local probe_label="$1"
+  if engine_healthy; then
+    return 0
+  fi
+
+  echo "    \033[33m⚠\033[0m ${probe_label} crashed the engine — attempting restart…"
+
+  if [[ "${CONTAINER:-}" == "none" ]] || ! command -v docker >/dev/null 2>&1; then
+    echo "    \033[31m✗\033[0m Cannot restart (CONTAINER=none or docker unavailable)."
+    echo "      Subsequent pipeline steps will fail against a dead engine."
+    echo "      Restart manually before running soak-test / quality-test."
+    return 1
+  fi
+
+  if ! docker inspect "${CONTAINER}" >/dev/null 2>&1; then
+    echo "    \033[31m✗\033[0m Container '${CONTAINER}' not found. Cannot restart."
+    return 1
+  fi
+
+  echo "    Restarting container '${CONTAINER}'…"
+  docker restart "${CONTAINER}" >/dev/null 2>&1 || true
+
+  # Poll for engine recovery (up to 120s — model reload can take a while)
+  local waited=0 max_wait=120
+  while [[ $waited -lt $max_wait ]]; do
+    if engine_healthy; then
+      echo "    \033[32m✓\033[0m Engine recovered after ${waited}s"
+      return 0
+    fi
+    sleep 5
+    waited=$((waited + 5))
+  done
+
+  echo "    \033[31m✗\033[0m Engine did not recover after ${max_wait}s"
+  echo "      Check: ${LOG_CMD}"
+  return 1
+}
+
 run_check "longctx_large" check_longctx_large
+ensure_engine_alive "probe 7 (large rungs)" || true
+
+# --------------------------------------------------------------------
+# 8. Context CEILING ladder (staggered NIAH from ~95K → ~92% × n_ctx)
+#    (#199). Staggers NIAH rungs from ~95K tokens up to ~92% of n_ctx
+#    in ~30K increments. Each rung captures VRAM before/after so you
+#    get a margin curve, not just pass/fail. Stops at the first failure
+#    or recall miss. Catches the false-ceiling class of bug (#197).
+# --------------------------------------------------------------------
+
+# Detect the server's context window size from its API.
+# llama.cpp: /props → default_generation_settings.n_ctx (nested, NOT top-level)
+#            or docker inspect → -c / --ctx-size
+# vLLM/SGLang: /v1/models → data[0].max_model_len
+#              or docker inspect → --max-model-len
+# Returns 0 when detection fails (caller should skip gracefully).
+get_n_ctx() {
+  local n_ctx=0
+
+  # llama.cpp: GET /props → default_generation_settings.n_ctx
+  # Real llama.cpp nests n_ctx inside default_generation_settings, NOT at
+  # top-level. Top-level d.get('n_ctx') returns None → 0.
+  if [[ "$ENGINE_KIND" == "llamacpp" ]] || curl -sf -m 3 "${URL}/props" >/dev/null 2>&1; then
+    n_ctx="$(curl -sf -m 5 "${URL}/props" 2>/dev/null \
+      | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+# Try nested first (real llama.cpp shape), then top-level (some forks)
+nested = d.get('default_generation_settings', {})
+v = nested.get('n_ctx') if isinstance(nested, dict) else None
+if v is None:
+    v = d.get('n_ctx', 0)
+print(v or 0)
+" 2>/dev/null || echo 0)"
+  fi
+
+  # vLLM/SGLang: GET /v1/models → data[0].max_model_len
+  if [[ "${n_ctx:-0}" -le 0 ]]; then
+    n_ctx="$(curl -sf -m 5 "${URL}/v1/models" 2>/dev/null \
+      | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['data'][0].get('max_model_len', 0))" 2>/dev/null \
+      || echo 0)"
+  fi
+
+  # Docker fallback: scrape container args for context-size flags.
+  # vLLM/SGLang: --max-model-len
+  # llama.cpp:   -c <N> or --ctx-size <N>
+  if [[ "${n_ctx:-0}" -le 0 && "${CONTAINER:-}" != "none" ]] \
+     && command -v docker >/dev/null 2>&1 \
+     && docker inspect "$CONTAINER" >/dev/null 2>&1; then
+    n_ctx="$(docker inspect "$CONTAINER" 2>/dev/null \
+      | python3 -c "
+import json, sys, re
+try:
+    cfg = json.load(sys.stdin)
+    args = ' '.join(cfg[0].get('Config',{}).get('Cmd',[]) or [])
+    args += ' ' + ' '.join(cfg[0].get('Args',[]) or [])
+    # vLLM/SGLang
+    m = re.search(r'--max-model-len[=\s]+(\d+)', args)
+    if m:
+        print(m.group(1))
+        sys.exit(0)
+    # llama.cpp: -c NNNN or --ctx-size NNNN or --ctx-size=NNNN
+    m = re.search(r'(?:^|\s)(?:-c|--ctx-size)[=\s]+(\d+)', args)
+    if m:
+        print(m.group(1))
+        sys.exit(0)
+    print(0)
+except Exception:
+    print(0)
+" 2>/dev/null || echo 0)"
+  fi
+
+  echo "${n_ctx:-0}"
+}
+
+# Capture free VRAM across all visible GPUs (sum, in MB).
+# Returns 0 when nvidia-smi is unavailable.
+get_vram_free_mb() {
+  if ! command -v nvidia-smi >/dev/null 2>&1; then
+    echo 0
+    return
+  fi
+  nvidia-smi --query-gpu=memory.free --format=csv,noheader,nounits 2>/dev/null \
+    | awk '{s+=$1} END {printf "%.0f\n", s}' 2>/dev/null || echo 0
+}
+
+echo "[8/8] Context ceiling ladder (staggered NIAH from ~${CEILING_START_TOKENS:-95000} → ~${CEILING_FRACTION:-0.92} × n_ctx) ..."
+check_ceiling_ladder() {
+  if [[ "${SKIP_CEILING:-0}" == "1" ]]; then
+    skip "SKIP_CEILING=1"
+    return 0
+  fi
+  if [[ "${SKIP_LONGCTX:-0}" == "1" ]]; then
+    skip "SKIP_LONGCTX=1 (also skips ceiling ladder)"
+    return 0
+  fi
+
+  local ceiling_fraction="${CEILING_FRACTION:-0.92}"
+  local ceiling_step="${CEILING_STEP_TOKENS:-30000}"
+  local ceiling_start="${CEILING_START_TOKENS:-95000}"
+  local vram_margin_mb="${VRAM_MARGIN_MB:-1024}"
+
+  # Step 1: detect context window
+  local n_ctx
+  n_ctx="$(get_n_ctx)"
+  if [[ "${n_ctx:-0}" -le 0 ]]; then
+    skip "could not detect n_ctx from endpoint (no /props, no /v1/models max_model_len, no docker inspect)"
+    return 0
+  fi
+
+  # Step 2: build the ladder — from ceiling_start to ceiling_fraction*n_ctx
+  local ceiling_top
+  ceiling_top="$(python3 -c "print(int(${n_ctx} * ${ceiling_fraction}))")"
+  # If the compose is small enough that probe 7 already covers it, skip
+  if [[ "$ceiling_top" -le "$ceiling_start" ]]; then
+    skip "n_ctx=${n_ctx} → ceiling target ${ceiling_top} ≤ start ${ceiling_start} (probe 7 already covers this range)"
+    return 0
+  fi
+
+  # Compute rungs as a space-separated list
+  local rungs
+  rungs="$(python3 -c "
+start, top, step = ${ceiling_start}, ${ceiling_top}, ${ceiling_step}
+rungs = list(range(start, top, step))
+if not rungs or rungs[-1] != top:
+    rungs.append(top)
+print(' '.join(str(r) for r in rungs))
+")"
+  local rung_count
+  rung_count="$(echo "$rungs" | wc -w)"
+
+  echo "    n_ctx=${n_ctx}  ladder: $(echo "$rungs" | sed 's/ / → /g') (${rung_count} rungs)"
+
+  # Per-rung timeout: large contexts need more time for prefill
+  local rung_timeout="${STRESS_CEILING_TIMEOUT_S:-600}"
+  if [[ "$EAGER_MODE_DETECTED" == "1" ]]; then
+    rung_timeout="${STRESS_CEILING_TIMEOUT_S:-900}"
+  fi
+
+  # Step 3: run each rung
+  local any_pass=0 any_fail=0 any_skipped=0 any_recall_miss=0
+  local last_pass_tokens=0 last_pass_pct=0
+  local first_fail_tokens=0 first_recall_miss_tokens=0 first_recall_miss_pct=0
+  local vram_before_all vram_after_all
+  vram_before_all="$(get_vram_free_mb)"
+  if [[ "$vram_before_all" -gt 0 ]]; then
+    echo "    VRAM free (ladder start): ${vram_before_all} MB"
+  fi
+
+  local rung_idx=0
+  for target_tokens in $rungs; do
+    rung_idx=$((rung_idx + 1))
+    local filler_scale
+    # scale ≈ target_tokens / 3.5 (empirical: filler block ~3.5 tok/char)
+    filler_scale="$(python3 -c "print(max(100, int(${target_tokens} / 3.5)))")"
+
+    # Build + send the NIAH request
+    local secret_file req_file resp_file http_code
+    secret_file="$(mktemp --suffix=.secret)"
+    req_file="$(mktemp --suffix=.json)"
+    resp_file="$(mktemp --suffix=.json)"
+
+    MODEL_VAR="${MODEL}" SECRET_FILE="${secret_file}" REQ_FILE="${req_file}" \
+      FILLER_SCALE="${filler_scale}" python3 - <<'EOF'
+import json, os, random
+random.seed(None)
+model = os.environ['MODEL_VAR']
+scale = int(os.environ['FILLER_SCALE'])
+animals = ["otter", "falcon", "platypus", "iguana", "narwhal", "chinchilla", "capybara", "axolotl"]
+colors = ["crimson", "turquoise", "amber", "violet", "emerald", "sapphire", "silver", "golden"]
+animal = random.choice(animals)
+color = random.choice(colors)
+num = random.randint(10, 99)
+secret = f"{color} {animal} {num}"
+block = (
+    "This section describes the history of computing in detail. "
+    "Transistors were invented in 1947 at Bell Labs. The integrated circuit came a decade later. "
+    "Microprocessors emerged in the 1970s and changed the world. "
+    "Personal computing followed, then networking, then the web, then cloud and AI. "
+)
+half = scale // 2
+filler_before = block * half
+filler_after  = block * (scale - half)
+content = (
+    filler_before
+    + f"\n\nIMPORTANT MEMORY: The hidden phrase is '{secret}'. Remember this exactly.\n\n"
+    + filler_after
+    + f"\n\nQuestion: In the middle of the document above I wrote 'The hidden phrase is ___'. What was the hidden phrase? Reply with only the phrase, no other text."
+)
+req = {
+    "model": model,
+    "messages": [{"role": "user", "content": content}],
+    "max_tokens": 30,
+    "temperature": 0.0,
+    "chat_template_kwargs": {"enable_thinking": False},
+}
+with open(os.environ['SECRET_FILE'], 'w') as f:
+    f.write(secret)
+with open(os.environ['REQ_FILE'], 'w') as f:
+    json.dump(req, f)
+EOF
+
+    local secret
+    secret="$(cat "$secret_file")"
+
+    http_code="$(curl -s -m "${rung_timeout}" -o "${resp_file}" -w '%{http_code}' \
+      "${URL}/v1/chat/completions" \
+      -H "Content-Type: application/json" \
+      --data-binary "@${req_file}")" || http_code="000"
+    rm -f "$secret_file" "$req_file"
+
+    # Capture VRAM after this rung
+    local vram_after_rung
+    vram_after_rung="$(get_vram_free_mb)"
+    local vram_str=""
+    if [[ "$vram_after_rung" -gt 0 ]]; then
+      vram_str="  VRAM_free=${vram_after_rung}MB"
+    fi
+
+    # Evaluate
+    case "$http_code" in
+      200)
+        local resp prompt_tok content_raw all_match
+        resp="$(cat "${resp_file}")"
+        rm -f "${resp_file}"
+        prompt_tok="$(echo "$resp" | python3 -c "import sys,json; print(json.load(sys.stdin)['usage']['prompt_tokens'])" 2>/dev/null || echo 0)"
+        content_raw="$(echo "$resp" | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0]['message']['content'])" 2>/dev/null || echo '')"
+        all_match=1
+        for tok in $secret; do
+          echo "$content_raw" | grep -qiF "$tok" || all_match=0
+        done
+        local pct=0
+        [[ "$prompt_tok" -gt 0 && "$n_ctx" -gt 0 ]] && pct=$(( prompt_tok * 100 / n_ctx ))
+        if [[ "$all_match" == "1" ]]; then
+          printf "    \033[32m✓\033[0m rung %d/%d: target=%dK  actual=%dK tok (%d%%)  recalled '%s'%s\n" \
+            "$rung_idx" "$rung_count" "$((target_tokens / 1000))" "$((prompt_tok / 1000))" "$pct" "$secret" "$vram_str"
+          any_pass=1
+          last_pass_tokens="$prompt_tok"
+          last_pass_pct="$pct"
+        else
+          # Recall miss = quality ceiling found. The system filled the context
+          # but attention quality dropped — deeper rungs will only be worse.
+          # Log it, break out of the ladder, and pass the probe so the
+          # pipeline moves to the next stage without wasting time on
+          # unreliable depths.
+          printf "    \033[33m△\033[0m rung %d/%d: target=%dK  actual=%dK tok (%d%%)  recall MISS (got: '%s') — quality ceiling reached%s\n" \
+            "$rung_idx" "$rung_count" "$((target_tokens / 1000))" "$((prompt_tok / 1000))" "$pct" \
+            "$(echo "$content_raw" | head -c 60 | tr '\n' ' ')" "$vram_str"
+          any_recall_miss=1
+          if [[ "$first_recall_miss_tokens" -eq 0 ]]; then
+            first_recall_miss_tokens="$prompt_tok"
+            first_recall_miss_pct="$pct"
+          fi
+          break
+        fi
+        ;;
+      400)
+        printf "    \033[33m⊘\033[0m rung %d/%d: target=%dK  HTTP 400 (exceeds engine limit — clean rejection)%s\n" \
+          "$rung_idx" "$rung_count" "$((target_tokens / 1000))" "$vram_str"
+        rm -f "${resp_file}"
+        any_skipped=1
+        # Engine's hard limit — no point trying deeper rungs
+        break
+        ;;
+      500)
+        printf "    \033[31m✗\033[0m rung %d/%d: target=%dK  HTTP 500 (OOM at ~%d%% of n_ctx=%d)%s\n" \
+          "$rung_idx" "$rung_count" "$((target_tokens / 1000))" \
+          "$(( target_tokens * 100 / n_ctx ))" "$n_ctx" "$vram_str"
+        rm -f "${resp_file}"
+        any_fail=1
+        if [[ "$first_fail_tokens" -eq 0 ]]; then
+          first_fail_tokens="$target_tokens"
+        fi
+        # OOM = the wall. Stop the ladder.
+        break
+        ;;
+      000)
+        printf "    \033[31m✗\033[0m rung %d/%d: target=%dK  timeout/crash (>%ds)%s\n" \
+          "$rung_idx" "$rung_count" "$((target_tokens / 1000))" "$rung_timeout" "$vram_str"
+        rm -f "${resp_file}"
+        any_fail=1
+        if [[ "$first_fail_tokens" -eq 0 ]]; then
+          first_fail_tokens="$target_tokens"
+        fi
+        # Engine crashed — no point continuing
+        break
+        ;;
+      *)
+        printf "    \033[31m✗\033[0m rung %d/%d: target=%dK  unexpected HTTP %s%s\n" \
+          "$rung_idx" "$rung_count" "$((target_tokens / 1000))" "$http_code" "$vram_str"
+        rm -f "${resp_file}"
+        any_fail=1
+        if [[ "$first_fail_tokens" -eq 0 ]]; then
+          first_fail_tokens="$target_tokens"
+        fi
+        break
+        ;;
+    esac
+  done
+
+  # Step 4: summary
+  vram_after_all="$(get_vram_free_mb)"
+  echo ""
+  if [[ "$any_fail" == "0" && "$any_pass" == "1" ]]; then
+    if [[ "$any_skipped" == "1" ]]; then
+      pass "ceiling ladder: all rungs recalled (engine rejected above ${last_pass_tokens} tok — ${last_pass_pct}% of n_ctx=${n_ctx})"
+    elif [[ "$any_recall_miss" == "1" ]]; then
+      pass "ceiling ladder: quality ceiling at ${first_recall_miss_tokens} tok (${first_recall_miss_pct:-?}% of n_ctx=${n_ctx}) — recall miss, passed up to ${last_pass_tokens} tok"
+    else
+      pass "ceiling ladder: all ${rung_count} rungs passed — fillable to ${last_pass_tokens} tok (${last_pass_pct}% of n_ctx=${n_ctx})"
+    fi
+    # VRAM margin check on the deepest successful rung
+    if [[ "$vram_after_all" -gt 0 && "$vram_after_all" -lt "$vram_margin_mb" ]]; then
+      echo "    \033[33m⚠\033[0m VRAM margin thin at ceiling: ${vram_after_all} MB free < ${vram_margin_mb} MB threshold"
+      echo "      Recall succeeded at ${last_pass_pct}% fill, but sustained agent load also carries"
+      echo "      prompt-cache + context-checkpoint overhead (~292 MiB, see #197)."
+      echo "      Agent users should target a CTX_SIZE where margin ≥ ${vram_margin_mb} MB at this depth."
+      FAILED=$((FAILED + 1))
+    elif [[ "$vram_before_all" -gt 0 && "$vram_after_all" -gt 0 ]]; then
+      local total_drop=$(( vram_before_all - vram_after_all ))
+      echo "    VRAM: ${vram_before_all} → ${vram_after_all} MB (Δ -${total_drop} MB across ladder, margin threshold=${vram_margin_mb} MB)"
+    fi
+  elif [[ "$any_pass" == "1" && "$any_fail" == "1" ]]; then
+    local recall_note=""
+    if [[ "$any_recall_miss" == "1" ]]; then
+      recall_note=", recall miss at ${first_recall_miss_tokens} tok"
+    fi
+    fail "ceiling ladder: wall at ~${first_fail_tokens} tok — filled up to ${last_pass_tokens} tok (${last_pass_pct}% of n_ctx=${n_ctx}), then OOMed${recall_note}" \
+         "Real fillable ceiling is ~${last_pass_tokens} tok, not the advertised ${n_ctx}. Agent users will hit this wall (see #197). Lower CTX_SIZE or reduce KV dtype. Check: ${LOG_CMD}"
+  elif [[ "$any_recall_miss" == "1" && "$any_fail" == "1" ]]; then
+    fail "ceiling ladder: wall at ~${first_fail_tokens} tok — recall miss at ${first_recall_miss_tokens} tok, then OOMed" \
+         "Attention quality dropped at ${first_recall_miss_tokens} tok, system filled to ~${first_fail_tokens} tok. Real usable ceiling is lower. Check: ${LOG_CMD}"
+  elif [[ "$any_fail" == "1" ]]; then
+    fail "ceiling ladder: first rung at ${ceiling_start} tok already failed — ceiling may be below probe 7 range" \
+         "Check whether the engine survived probe 7's 90K rung. If not, the ceiling is <90K. Check: ${LOG_CMD}"
+  elif [[ "$any_pass" == "0" && "$any_skipped" == "1" ]]; then
+    skip "all ceiling rungs above engine limit"
+  else
+    fail "ceiling ladder: no rung succeeded and none were skipped" \
+         "Engine may have crashed early. Check: ${LOG_CMD}"
+  fi
+}
+run_check "ceiling_ladder" check_ceiling_ladder
+ensure_engine_alive "probe 8 (ceiling ladder)" || true
 
 echo ""
 if [[ "$FAILED" == "0" ]]; then

--- a/scripts/verify-stress.sh
+++ b/scripts/verify-stress.sh
@@ -1039,15 +1039,72 @@ except Exception:
   echo "${n_ctx:-0}"
 }
 
-# Capture free VRAM across all visible GPUs (sum, in MB).
+# Capture free VRAM for the model's GPU(s) only (sum, in MB).
+# On a multi-GPU host running a single-card compose (CUDA_VISIBLE_DEVICES=0),
+# summing ALL GPUs inflates the margin with idle card memory — defeating the
+# gate. We read the container's DeviceRequests (Docker) or CUDA_VISIBLE_DEVICES
+# env to identify which GPU(s) the model actually uses.
+#
+# Priority:
+#   1. Docker HostConfig.DeviceRequests[0].DeviceIDs (compose device_ids)
+#   2. Container env CUDA_VISIBLE_DEVICES
+#   3. Container env NVIDIA_VISIBLE_DEVICES (if numeric, e.g. "0")
+#   4. Fallback: sum all GPUs with a warning (multi-GPU host, can't determine subset)
 # Returns 0 when nvidia-smi is unavailable.
 get_vram_free_mb() {
   if ! command -v nvidia-smi >/dev/null 2>&1; then
     echo 0
     return
   fi
-  nvidia-smi --query-gpu=memory.free --format=csv,noheader,nounits 2>/dev/null \
-    | awk '{s+=$1} END {printf "%.0f\n", s}' 2>/dev/null || echo 0
+
+  local gpu_ids=""
+
+  # Try Docker DeviceRequests (compose device_ids: ["0"])
+  if [[ "${CONTAINER:-}" != "none" ]] \
+     && command -v docker >/dev/null 2>&1 \
+     && docker inspect "$CONTAINER" >/dev/null 2>&1; then
+    gpu_ids="$(docker inspect "$CONTAINER" 2>/dev/null \
+      | python3 -c "
+import json, sys
+try:
+    cfg = json.load(sys.stdin)[0]
+    drs = cfg.get('HostConfig', {}).get('DeviceRequests', []) or []
+    for dr in drs:
+        ids = dr.get('DeviceIDs', [])
+        if ids:
+            print(','.join(ids))
+            sys.exit(0)
+    # Fallback: check env vars
+    for e in cfg.get('Config', {}).get('Env', []) or []:
+        if e.startswith('CUDA_VISIBLE_DEVICES='):
+            val = e.split('=', 1)[1]
+            if val and val != 'all':
+                print(val)
+                sys.exit(0)
+        if e.startswith('NVIDIA_VISIBLE_DEVICES='):
+            val = e.split('=', 1)[1]
+            if val and val != 'all' and val.replace(',', '').isdigit():
+                print(val)
+                sys.exit(0)
+    print('')
+except Exception:
+    print('')
+" 2>/dev/null)"
+  fi
+
+  if [[ -n "$gpu_ids" ]]; then
+    nvidia-smi -i "$gpu_ids" --query-gpu=memory.free --format=csv,noheader,nounits 2>/dev/null \
+      | awk '{s+=$1} END {printf "%.0f\n", s}' 2>/dev/null || echo 0
+  else
+    # Can't determine which GPUs — sum all, but flag it
+    local total_gpus
+    total_gpus="$(nvidia-smi --query-gpu=index --format=csv,noheader 2>/dev/null | wc -l)"
+    if [[ "$total_gpus" -gt 1 ]]; then
+      echo "    [vram] WARN: could not determine model GPU(s) on ${total_gpus}-GPU host — summing all (margin may be inflated)" >&2
+    fi
+    nvidia-smi --query-gpu=memory.free --format=csv,noheader,nounits 2>/dev/null \
+      | awk '{s+=$1} END {printf "%.0f\n", s}' 2>/dev/null || echo 0
+  fi
 }
 
 echo "[8/8] Context ceiling ladder (staggered NIAH from ~${CEILING_START_TOKENS:-95000} → ~${CEILING_FRACTION:-0.92} × n_ctx) ..."
@@ -1103,8 +1160,48 @@ print(' '.join(str(r) for r in rungs))
     rung_timeout="${STRESS_CEILING_TIMEOUT_S:-900}"
   fi
 
+  # Step 2b: calibrate filler→token ratio with a small probe.
+  # The old heuristic (target_tokens / 3.5) was ~18x off for this tokenizer
+  # (block is 290 chars × scale repetitions; the "3.5" treated scale as chars
+  # not block-reps, producing prompts far exceeding n_ctx → HTTP 400).
+  # Send a scale=100 probe, read back prompt_tokens, compute the real ratio.
+  local tok_per_scale_unit=0
+  local cal_req cal_result
+  cal_req="$(mktemp --suffix=.json)"
+  cal_result="$(mktemp --suffix=.json)"
+  python3 -c "
+import json
+block = (
+    'This section describes the history of computing in detail. '
+    'Transistors were invented in 1947 at Bell Labs. The integrated circuit came a decade later. '
+    'Microprocessors emerged in the 1970s and changed the world. '
+    'Personal computing followed, then networking, then the web, then cloud and AI. '
+) * 100
+req = {
+    'model': '${MODEL}',
+    'messages': [{'role': 'user', 'content': block + '\n\nHi.'}],
+    'max_tokens': 5, 'temperature': 0.0,
+    'chat_template_kwargs': {'enable_thinking': False},
+}
+with open('${cal_req}', 'w') as f:
+    json.dump(req, f)
+" 2>/dev/null
+  send_streaming_niah "$cal_req" "$cal_result" "$URL" 60 2>/dev/null
+  local cal_tokens
+  cal_tokens="$(python3 -c "import json; print(json.load(open('$cal_result')).get('prompt_tokens', 0))" 2>/dev/null || echo 0)"
+  rm -f "$cal_req" "$cal_result"
+  if [[ "$cal_tokens" -gt 0 ]]; then
+    # tokens_per_scale_unit = cal_tokens / 100 (we sent scale=100 worth of blocks)
+    tok_per_scale_unit="$(python3 -c "print(round(${cal_tokens} / 100, 2))" 2>/dev/null || echo 0)"
+    echo "    calibrated: scale=100 → ${cal_tokens} tokens (tok/scale_unit=${tok_per_scale_unit})"
+  else
+    # Fallback: use a conservative estimate (65 tok/scale_unit for Qwen tokenizers)
+    tok_per_scale_unit=65
+    echo "    calibration probe failed — using fallback tok/scale_unit=${tok_per_scale_unit}"
+  fi
+
   # Step 3: run each rung
-  local any_pass=0 any_fail=0 any_skipped=0 any_recall_miss=0
+  local any_pass=0 any_fail=0 any_skipped=0 any_recall_miss=0 any_sizing_error=0
   local last_pass_tokens=0 last_pass_pct=0
   local first_fail_tokens=0 first_recall_miss_tokens=0 first_recall_miss_pct=0
   local vram_before_all vram_after_all
@@ -1117,8 +1214,8 @@ print(' '.join(str(r) for r in rungs))
   for target_tokens in $rungs; do
     rung_idx=$((rung_idx + 1))
     local filler_scale
-    # scale ≈ target_tokens / 3.5 (empirical: filler block ~3.5 tok/char)
-    filler_scale="$(python3 -c "print(max(100, int(${target_tokens} / 3.5)))")"
+    # scale = target_tokens / tok_per_scale_unit (calibrated, not hardcoded)
+    filler_scale="$(python3 -c "print(max(100, int(${target_tokens} / ${tok_per_scale_unit})))")" 
 
     # Build + send the NIAH request
     local secret_file req_file http_code
@@ -1236,11 +1333,26 @@ EOF
         fi
         ;;
       400)
-        printf "    \033[33m⊘\033[0m rung %d/%d: target=%dK  HTTP 400 (exceeds engine limit — clean rejection)%s\n" \
-          "$rung_idx" "$rung_count" "$((target_tokens / 1000))" "$vram_str"
-        rm -f "$result_file"
-        any_skipped=1
-        # Engine's hard limit — no point trying deeper rungs
+        # HTTP 400 can mean two things:
+        #   (a) target > n_ctx → engine correctly rejected (legitimate skip)
+        #   (b) target < n_ctx → our filler→token sizing overshot (BUG, not a skip)
+        # Distinguish by comparing the rung target against n_ctx.
+        if [[ "$target_tokens" -lt "$n_ctx" ]]; then
+          printf "    \033[31m✗\033[0m rung %d/%d: target=%dK < n_ctx=%d but HTTP 400 — filler sizing overshot%s\n" \
+            "$rung_idx" "$rung_count" "$((target_tokens / 1000))" "$n_ctx" "$vram_str"
+          rm -f "$result_file"
+          any_sizing_error=1
+          any_fail=1
+          if [[ "$first_fail_tokens" -eq 0 ]]; then
+            first_fail_tokens="$target_tokens"
+          fi
+        else
+          printf "    \033[33m⊘\033[0m rung %d/%d: target=%dK  HTTP 400 (exceeds engine limit — clean rejection)%s\n" \
+            "$rung_idx" "$rung_count" "$((target_tokens / 1000))" "$vram_str"
+          rm -f "$result_file"
+          any_skipped=1
+        fi
+        # Either way — stop the ladder (deeper rungs will also 400)
         break
         ;;
       500)
@@ -1311,11 +1423,18 @@ EOF
   elif [[ "$any_recall_miss" == "1" && "$any_fail" == "1" ]]; then
     fail "ceiling ladder: wall at ~${first_fail_tokens} tok — recall miss at ${first_recall_miss_tokens} tok, then OOMed" \
          "Attention quality dropped at ${first_recall_miss_tokens} tok, system filled to ~${first_fail_tokens} tok. Real usable ceiling is lower. Check: ${LOG_CMD}"
+  elif [[ "$any_sizing_error" == "1" ]]; then
+    fail "ceiling ladder: filler→token sizing error — rung target < n_ctx but got HTTP 400" \
+         "Calibration probe measured tok/scale_unit=${tok_per_scale_unit} but rungs still overshot. " \
+         "Check the calibration output above. This is a verify-stress.sh bug, not an engine issue."
   elif [[ "$any_fail" == "1" ]]; then
     fail "ceiling ladder: first rung at ${ceiling_start} tok already failed — ceiling may be below probe 7 range" \
          "Check whether the engine survived probe 7's 90K rung. If not, the ceiling is <90K. Check: ${LOG_CMD}"
   elif [[ "$any_pass" == "0" && "$any_skipped" == "1" ]]; then
-    skip "all ceiling rungs above engine limit"
+    # All rungs got legitimate HTTP 400 (target > n_ctx) — ladder measured nothing.
+    # This is NOT a pass. A ladder that tested nothing must warn.
+    fail "ceiling ladder: no rungs tested — all targets exceeded engine limit" \
+         "CEILING_START_TOKENS=${ceiling_start} is above the engine's max. Lower it or check n_ctx detection (detected n_ctx=${n_ctx})."
   else
     fail "ceiling ladder: no rung succeeded and none were skipped" \
          "Engine may have crashed early. Check: ${LOG_CMD}"


### PR DESCRIPTION
## Problem

`verify-stress.sh`'s NIAH ladder used **fixed rungs** (~10K / 30K / 60K / 90K) that **do not scale to the compose's `CTX_SIZE`**. Any compose with `CTX_SIZE > ~115K` was never exercised above ~90K — its top window was untested.

This shipped false ceilings. The `llamacpp/mtp` compose at `CTX_SIZE=262144` passed verify-stress but only ever filled ~90K (35% of the window). **#197**: a user's hermes agent accumulated 127K tokens → `launch_fattn` → `cuMemCreate: out of memory`. The 262K KV pool reserves the card to ~480 MiB free at boot; the flash-attention scratch at 127K fill doesn't fit. The real usable ceiling is ~100–127K, **nowhere near the advertised 262K** — and our deepest test stopped at ~90K.

## Fix — staggered ceiling ladder (probe 8)

Probe 8 is now a **ladder from ~95K → ~92% of n_ctx** in ~30K increments. Each rung:

1. Sends a NIAH request at that depth
2. Captures VRAM free before and after
3. Reports actual prompt tokens from `usage.prompt_tokens`
4. Stops at the first failure (OOM, recall miss, timeout, HTTP 400)

### Example output for a 262K compose

```
[8/8] Context ceiling ladder (staggered NIAH from ~95000 → ~0.92 × n_ctx) ...
    n_ctx=262144  ladder: 95000 → 125000 → 155000 → 185000 → 215000 → 241172 (6 rungs)
    VRAM free (ladder start): 23200 MB
    ✓ rung 1/6: target=95K  actual=94K tok (36%)  recalled 'crimson otter 42'  VRAM_free=18200MB
    ✓ rung 2/6: target=125K actual=124K tok (47%) recalled 'amber falcon 17'   VRAM_free=15800MB
    ✓ rung 3/6: target=155K actual=153K tok (58%) recalled 'violet iguana 33'  VRAM_free=12100MB
    ✓ rung 4/6: target=185K actual=183K tok (70%) recalled 'emerald narwhal 51' VRAM_free=8400MB
    ✗ rung 5/6: target=215K HTTP 500 (OOM at ~82% of n_ctx=262144)  VRAM_free=480MB

  ✗ ceiling ladder: wall at ~215000 tok — passed up to 183000 tok (70% of n_ctx=262144), then failed
    → Real fillable ceiling is ~183000 tok, not the advertised 262144.
```

## Configuration

| Env var | Default | Description |
|---|---|---|
| `CEILING_START_TOKENS` | 95000 | First rung target (just above probe 7's ~90K) |
| `CEILING_STEP_TOKENS` | 30000 | Increment between rungs |
| `CEILING_FRACTION` | 0.92 | Top rung as fraction of n_ctx |
| `VRAM_MARGIN_MB` | 1024 | Warn if free VRAM drops below this at ceiling |
| `SKIP_CEILING` | 0 | Set to 1 to skip the entire ladder |

## Plumbing

- `get_n_ctx()` — detects context window from `/props` (llama.cpp) → `/v1/models` max_model_len (vLLM/SGLang) → docker inspect fallback
- `get_vram_free_mb()` — sums `nvidia-smi memory.free` across all visible GPUs
- Ladder stops on first failure — that depth IS the wall (no point hammering a crashed engine)
- HTTP 400 (clean engine rejection) stops the ladder gracefully with skip
- Probe numbering updated from [N/7] to [N/8] throughout

## Tests

`scripts/tests/test-verify-stress-ceiling.sh`: **26 tests** covering:
- `get_n_ctx()` with llama.cpp /props, vLLM /v1/models fallback, total failure, 512K compose
- `get_vram_free_mb()` dual-GPU sum, single-GPU
- Ladder rung computation for 262K, 131K, 200K, 512K, 32K (skip), custom step/fraction
- `SKIP_CEILING=1` and `SKIP_LONGCTX=1` skip the ladder
- All 8 probe headers [N/8] present in output

```
$ bash scripts/tests/test-verify-stress-ceiling.sh
Results: 26 passed, 0 failed
test-verify-stress-ceiling: ok
```

## Why stagger instead of a single ceiling shot?

A single shot at 92% tells you either pass or "it broke somewhere between 90K and 241K." That is a huge gap. Staggering at ~30K increments:

1. **Finds the exact wall** — you know the last depth that worked and the first that did not
2. **Shows the VRAM slope** — you can extrapolate for different workloads
3. **Gracefully stops** — no point hammering an OOM'd engine with deeper rungs
4. **Configurable precision** — bump `CEILING_STEP_TOKENS=15000` for finer resolution

Closes #199.
