### PR TITLE
fix(compose): single-card MTP CTX_SIZE default 262144 → 200000 (llama.cpp + ik_llama)

### DIFF
--- a/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp.yml
@@ -11,14 +11,18 @@
 #   Template:  native (GGUF-embedded) — A/B'd froggeric v19 here, native won
 #              the 8-pack 103 vs 99 (toolcall TIED 9/9); see header note below
 #   Vision:    NO (text-only this profile; mmproj is a separate axis → -vision.yml)
-#   Default ctx: 262144 — full native ctx (n_ctx_train) on ONE 3090, q4_0 KV.
-#              Bumped from 131072 → native max 2026-05-21, keeping -ub 1024 (NOT
-#              the -ub 512 the 21.5 GB datapoint below used). For lower VRAM /
+#   Default ctx: 200000 — cross-engine-aligned with llama-cpp mtp.yml's measured
+#              max-safe fill (2026-05-23), q4_0 KV, -ub 1024. Was 262144 (full
+#              n_ctx_train) but that is a *boot* ceiling, not a verified *fill*
+#              ceiling on ik — see the "boots ≠ fills" note below. For lower VRAM /
 #              cross-rig-safe boot, set CTX_SIZE=131072.
 #   MAX ctx:   262144 (model native ceiling; n_ctx_train = n_ctx_orig_yarn = 262144).
-#              VRAM: default -ub 1024 @ 262144 → 22.5 GB / 24 (verified 2026-05-21,
-#              KV pre-allocated so this is steady-state; ~2.1 GB headroom — fine on a
-#              dedicated card, tight if anything else shares GPU 0). -ub 512 @ 262144
+#              ⚠ "boots ≠ fills": -ub 1024 @ 262144 boots at 22.5 GB / 24 with the KV
+#              pool pre-reserved (verified 2026-05-21) — but that is a boot number, it
+#              does NOT mean a prompt fills to 262K. The mainline llama-cpp twin walls
+#              at ~125K (FA transient scratch at high fill — docs/CLIFFS.md 2026-05-23);
+#              ik's fillable ceiling is not yet laddered (ik is ~0.5 GB leaner, so ≥ that
+#              is expected). Default lowered to 200000 for fill-safety. -ub 512 @ 262144
 #              → 21.5 GB if you need the extra ~1 GB back.
 #   Status:    ✅ Shipped (advanced-quant track, #180). In the wizard +
 #              `bash scripts/switch.sh ik-llama/iq4ks-mtp`.
@@ -30,7 +34,7 @@
 #   Best for:  VRAM-tight single-card (sub-24 GB, shared GPU, WSL display tax)
 #              where the leaner footprint matters; or if you want IQK quants.
 # ---------------------------------------------------------------------------
-# Qwen3.6-27B on ik_llama.cpp — single 3090, IQ4_KS + q4_0 KV + MTP, 131K default (262K max).
+# Qwen3.6-27B on ik_llama.cpp — single 3090, IQ4_KS + q4_0 KV + MTP, 200K default (262K native max).
 #
 # CONFIG SOURCE: ampersandru's authoritative launch flags from discussion #152
 # (comment 16999100). Reproduced verbatim:
@@ -71,7 +75,7 @@
 # Override defaults via .env or shell:
 #   MODEL_DIR              host dir to mount as /models
 #   GGUF_FILE             path under /models (default: …ubergarm-mtp-iq4ks/Qwen3.6-27B-MTP-IQ4_KS.gguf)
-#   CTX_SIZE              KV pool size       (default: 131072; MAX 262144 — see header)
+#   CTX_SIZE              KV pool size       (default: 200000; native MAX 262144 — see header)
 #   BATCH_SIZE           llama.cpp -b       (default: 4096 — matches llama-cpp mtp.yml)
 #   UBATCH_SIZE          llama.cpp -ub      (default: 1024; set 512 for 262144 ctx, ~2-4% TPS cost)
 #   NP                   parallel slots     (default: 1)
@@ -113,7 +117,7 @@ services:
       --port 8080
       --model /models/${GGUF_FILE:-qwen3.6-27b-gguf/ubergarm-mtp-iq4ks/Qwen3.6-27B-MTP-IQ4_KS.gguf}
       -ngl 99
-      --ctx-size ${CTX_SIZE:-262144}
+      --ctx-size ${CTX_SIZE:-200000}
       -b ${BATCH_SIZE:-4096}
       -ub ${UBATCH_SIZE:-1024}
       -np ${NP:-1}

--- a/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp.yml
@@ -11,18 +11,21 @@
 #   Template:  native (GGUF-embedded) — A/B'd froggeric v19 here, native won
 #              the 8-pack 103 vs 99 (toolcall TIED 9/9); see header note below
 #   Vision:    NO (text-only this profile; mmproj is a separate axis → -vision.yml)
-#   Default ctx: 200000 — cross-engine-aligned with llama-cpp mtp.yml's measured
-#              max-safe fill (2026-05-23), q4_0 KV, -ub 1024. Was 262144 (full
-#              n_ctx_train) but that is a *boot* ceiling, not a verified *fill*
-#              ceiling on ik — see the "boots ≠ fills" note below. For lower VRAM /
+#   Default ctx: 200000 — ik's MEASURED max-safe fill (ceiling-laddered on-rig
+#              2026-05-23), q4_0 KV. Was 262144 (full n_ctx_train) but that is a
+#              *boot* ceiling, not a *fill* ceiling — see the "boots ≠ fills" note
+#              below. The ~0.5 GB weight lean does NOT buy more ctx than mainline:
+#              ik forces n_ubatch=n_batch (=4096) so its larger graph buffer eats
+#              the lean → ~same free VRAM as mainline at equal ctx. For lower VRAM /
 #              cross-rig-safe boot, set CTX_SIZE=131072.
 #   MAX ctx:   262144 (model native ceiling; n_ctx_train = n_ctx_orig_yarn = 262144).
 #              ⚠ "boots ≠ fills": -ub 1024 @ 262144 boots at 22.5 GB / 24 with the KV
 #              pool pre-reserved (verified 2026-05-21) — but that is a boot number, it
 #              does NOT mean a prompt fills to 262K. The mainline llama-cpp twin walls
 #              at ~125K (FA transient scratch at high fill — docs/CLIFFS.md 2026-05-23);
-#              ik's fillable ceiling is not yet laddered (ik is ~0.5 GB leaner, so ≥ that
-#              is expected). Default lowered to 200000 for fill-safety. -ub 512 @ 262144
+#              ik laddered on-rig 2026-05-23: 224K fills 205K but leaves only 477 MB at
+#              the ceiling; 210K fills 193K leaving 863 MB — both under the 1024 MB
+#              agent-safety margin. 200000 (≈1131 MB at ceiling) is the safe default. -ub 512 @ 262144
 #              → 21.5 GB if you need the extra ~1 GB back.
 #   Status:    ✅ Shipped (advanced-quant track, #180). In the wizard +
 #              `bash scripts/switch.sh ik-llama/iq4ks-mtp`.

--- a/models/qwen3.6-27b/llama-cpp/compose/single/mtp.yml
+++ b/models/qwen3.6-27b/llama-cpp/compose/single/mtp.yml
@@ -7,7 +7,8 @@
 #   KV:        q4_0 K + q4_0 V (densest mainline, Ampere-fast)
 #   Vision:    no (mmproj NOT mounted — for vision, see mtp-vision.yml)
 #   Template:  native (GGUF-embedded) — froggeric A/B'd here, regressed 8-pack 102→95
-#   Max ctx:   262144 default (@ -ub 512); 131072 also fine (@ -ub 1024, faster prefill)
+#   Max ctx:   200000 default (@ -ub 512, fills ~183K w/ ~1.1 GB margin); 262144 boots but
+#              walls ~125K (FA scratch at fill — see CTX_SIZE note); 131072 = faster prefill @ -ub 1024
 #   Genesis:   N/A — llama.cpp engine; Genesis is vLLM/Qwen3-Next-specific
 #   Status:    ✅ Production
 #   Engine-profile: llama-cpp-local
@@ -15,11 +16,11 @@
 #              speed + ctx workhorse. ~51 narr / ~60 code TPS, 7/7 verify-stress
 #              (incl. 60K + 91K needle), 102/150 quality (68%) on the 8-pack.
 # ---------------------------------------------------------------------------
-# Qwen3.6-27B on llama.cpp — single 3090, MTP, 262K ctx, no vision.
+# Qwen3.6-27B on llama.cpp — single 3090, MTP, 200K ctx, no vision.
 #
 # This is one of TWO named single-card profiles for this model (collapsed from
 # three on 2026-05-22 — the old vanilla Q3_K_XL `docker-compose.yml` was retired
-# once Q4_K_M was shown to reach the full 262K too; see the CTX_SIZE note below):
+# once Q4_K_M was shown to cover long context too; see the CTX_SIZE note below):
 #   - mtp.yml         → MTP n=2 + no vision (THIS file). `llamacpp/default`
 #                       is now an ALIAS for this profile.
 #   - mtp-vision.yml  → MTP n=2 + vision (multimodal)
@@ -61,11 +62,13 @@
 # Override defaults via .env or shell:
 #   MODEL_DIR              host dir to mount as /models  (default: ../../../../../models-cache)
 #   GGUF_FILE              path under /models  (default: qwen3.6-27b-gguf/unsloth-mtp-q4km/Qwen3.6-27B-Q4_K_M.gguf)
-#   CTX_SIZE               KV pool size        (default: 262144 = full native @ -ub 512;
-#                          boots ~23 GB, MTP active, verify-stress 7/7 + soak PASS, 2026-05-22.
-#                          For faster prefill / more headroom: CTX_SIZE=131072 UBATCH_SIZE=1024.)
+#   CTX_SIZE               KV pool size        (default: 200000 @ -ub 512 — fills ~183K with
+#                          ~1.1 GB free, the max-safe single-card value. 262144 boots ~23 GB,
+#                          MTP active, passes verify-stress(91K) + soak — but only *fills* to
+#                          ~125K before OOMing on the FA scratch at high fill: a false ceiling.
+#                          See docs/CLIFFS.md (2026-05-23). Faster prefill: CTX_SIZE=131072 UBATCH_SIZE=1024.)
 #   BATCH_SIZE             llama.cpp -b        (default: 4096 — on mainline -b does NOT drive VRAM)
-#   UBATCH_SIZE            llama.cpp -ub       (default: 512 — funds the 262K default; raise to 1024 at 131K)
+#   UBATCH_SIZE            llama.cpp -ub       (default: 512 — funds the 200K default; raise to 1024 at 131K)
 #   KV_TYPE                K and V quant type  (default: q4_0)
 #   NP                     parallel slots      (default: 1 — see ⚠ below)
 #   MTP_DRAFT_N_MAX        MTP draft tokens    (default: 2 — sweet spot per BENCHMARKS.md)
@@ -98,7 +101,7 @@ services:
       --host 0.0.0.0
       --port 8080
       -m /models/${GGUF_FILE:-qwen3.6-27b-gguf/unsloth-mtp-q4km/Qwen3.6-27B-Q4_K_M.gguf}
-      -c ${CTX_SIZE:-262144}
+      -c ${CTX_SIZE:-200000}
       -b ${BATCH_SIZE:-4096}
       -ub ${UBATCH_SIZE:-512}
       -ngl 99


### PR DESCRIPTION
## What

Lowers the **single-card MTP** context default from `262144` to `200000` on both engines:

| File | Knob | Before | After |
|---|---|---|---|
| `models/qwen3.6-27b/llama-cpp/compose/single/mtp.yml` | `-c` | 262144 | **200000** |
| `models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp.yml` | `--ctx-size` | 262144 | **200000** |

(`llamacpp/default` is an alias for the llama.cpp file, so this covers both `llamacpp/default` and `llamacpp/mtp`.)

## Why — "boots ≠ fills"

On a single 24 GB 3090, `CTX_SIZE=262144` is a **false ceiling**: it boots, pre-reserves its KV pool, and passes `verify-stress` (91K needle) + soak — but a prompt only **fills to ~125K** before OOMing. The wall is **not** the GDN cliff (Cliff 2) and **not** the reserved KV pool — it's the **flash-attention transient scratch at high fill** (`launch_fattn` / `cuMemCreate`), which scales with *populated* context, not what was reserved at boot.

Measured via the #200 ceiling-ladder probe (Q4_K_M, q4_0 KV, MTP n=2, `-ub 512`, single 3090):

| `CTX_SIZE` | Fills to | % declared | Free VRAM at top | Verdict |
|---|---|---|---|---|
| 262144 | ~125K | 47% | walls at 155K rung | false ceiling |
| **200000** | **183K** | **91%** | **1177 MB** | ✅ clears the 1024 MB margin gate |
| 224000 (math) | fills | — | ~400 MB | knife-edge, below margin |

So the old default advertised more context than it could fill — exactly the OOM @syangsao hit in #197.

## Scope notes

- **llama.cpp** change is the directly-measured config. ✅
- **ik_llama** change is now **laddered on-rig (2026-05-23)** — 200K is ik's *measured* max-safe ceiling. The ~0.5 GB weight lean does **not** buy more ctx: ik forces `n_ubatch=n_batch` (=4096) vs mainline `-ub 512`, so its larger graph buffer eats the lean and at equal ctx ik has ~the same free VRAM as mainline. Ladder (all rungs recall; only the 1024 MB margin gate fails): **224K → fills 205K, 477 MB at ceiling ✗; 210K → fills 193K, 863 MB ✗; 200K → ≈1131 MB ✓**. So the lean is margin-at-equal-ctx, not more-ctx — exactly what discussions/184 concluded. Also fixes a pre-existing header contradiction (`262144`/`131072`/`131072` claimed as "default" in three places). [commit `1d93343`]
- **Untouched:** the vision composes (`mtp-vision.yml` / `iq4ks-mtp-vision.yml`, 160K — mmproj competes for headroom, separately validated) and `iq4ks-two-stage.yml` (131K). Bumping vision up to 200K would risk OOM with images loaded.

## Follow-ups

- [x] Run the ceiling ladder on ik_llama — **done 2026-05-23: confirms 200K** (210K/224K both miss the 1024 MB margin: 863 / 477 MB). The lean is margin-not-ctx.
- [ ] Update @syangsao on #197 with the measured 200K number once merged.

Forensic detail: `docs/CLIFFS.md` 2026-05-23 note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
