### PR TITLE
fix(rebench): soak/preflight container globs + aider model-basename for llama-family engines (#403)

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -423,7 +423,7 @@ preflight_gpu_idle() {
 preflight_running() {
   command -v docker >/dev/null 2>&1 || return 0
   local running
-  running=$(docker ps --format '{{.Names}}' 2>/dev/null | grep -E '^(vllm-qwen36-27b|llama-cpp-qwen36-27b|vllm-gemma-4-31b)' || true)
+  running=$(docker ps --format '{{.Names}}' 2>/dev/null | grep -E '^(vllm-qwen36-27b|llama-cpp-qwen36-27b|ik-llama-qwen36-27b|vllm-gemma-4-31b)' || true)
   if [[ -n "$running" ]]; then
     echo "[preflight] note:    a club-3090 container is already running:"
     echo "$running" | sed 's/^/[preflight]            /'
@@ -787,7 +787,7 @@ preflight_autodetect_endpoint() {
 
   # Scan for one of our containers + its `0.0.0.0:<host>->8000/tcp` mapping.
   # Recognises the canonical club-3090 prefixes (vllm-qwen36-27b,
-  # llama-cpp-qwen36-27b, vllm-gemma-4-31b) plus the sglang experimental tree.
+  # llama-cpp-qwen36-27b, ik-llama-qwen36-27b, vllm-gemma-4-31b) plus the sglang experimental tree.
   # Users running endpoint-first via `--url` to rebench-full.sh bypass this
   # entirely (PREFLIGHT_NO_AUTODETECT=1 set there).
   #
@@ -797,7 +797,7 @@ preflight_autodetect_endpoint() {
   # error path. Empty `found_line` is what we want for the no-container case.
   local found_line
   found_line=$(docker ps --format '{{.Names}}|{{.Ports}}' 2>/dev/null \
-    | grep -E '^(vllm-qwen36-27b|llama-cpp-qwen36-27b|vllm-gemma-4-31b|sglang-qwen36-27b)' \
+    | grep -E '^(vllm-qwen36-27b|llama-cpp-qwen36-27b|ik-llama-qwen36-27b|vllm-gemma-4-31b|sglang-qwen36-27b)' \
     | head -1 || true)
   if [[ -z "$found_line" ]]; then
     return 0   # nothing running; defaults stand

--- a/scripts/rebench-full.sh
+++ b/scripts/rebench-full.sh
@@ -305,7 +305,13 @@ URL="$URL" MODEL="$MODEL" \
 # setups; benchlocal-cli will kill mid-batch if its internal default fires.
 # Override via env: AIDER_TIMEOUT_PER_CASE=7200 bash scripts/rebench-full.sh
 AIDER_TIMEOUT_PER_CASE="${AIDER_TIMEOUT_PER_CASE:-3600}"
-URL="$URL" MODEL="$MODEL" \
+# ik_llama reports its model id as the full GGUF path (leading + embedded
+# slashes); litellm inside the aider sandbox can't route a slash-laden model
+# id (#15/#16 family) → every exercise errors before the model → 0/30.
+# Mainline llama.cpp already reports a basename. Strip to basename for the
+# aider/litellm path — the server accepts any id (serves the one loaded model).
+AIDER_MODEL="${MODEL##*/}"
+URL="$URL" MODEL="$AIDER_MODEL" \
   SAMPLING_FROM_SERVER="${SAMPLING_FROM_SERVER:-0}" \
   ENABLE_THINKING="${ENABLE_THINKING:-0}" \
   THINKING_MAX_TOKENS="${THINKING_MAX_TOKENS:-}" \

--- a/scripts/soak-test.sh
+++ b/scripts/soak-test.sh
@@ -213,19 +213,25 @@ else
 fi
 
 auto_container() {
+  # Canonical club-3090 container prefixes across engines (mirror of
+  # preflight.sh::preflight_autodetect_endpoint). llama-cpp / ik-llama were
+  # previously missing here → rc=2 on llama.cpp/ik rebench-full soak step (#403).
   docker ps --format '{{.Names}}' 2>/dev/null \
-    | grep -E '^(vllm-qwen36-27b|vllm-gemma-4-31b)' \
+    | grep -E '^(vllm-qwen36-27b|llama-cpp-qwen36-27b|ik-llama-qwen36-27b|vllm-gemma-4-31b|sglang-qwen36-27b)' \
     | head -1 || true
 }
 
 endpoint_from_container() {
   local container="$1"
-  local mapped port
-  mapped="$(docker port "$container" 8000/tcp 2>/dev/null | head -1 || true)"
-  if [[ -n "$mapped" ]]; then
-    port="${mapped##*:}"
-    [[ "$port" =~ ^[0-9]+$ ]] && { printf 'http://localhost:%s\n' "$port"; return 0; }
-  fi
+  local mapped port internal
+  # vllm maps internal 8000, llama.cpp / ik_llama map 8080, sglang maps 30000.
+  for internal in 8000 8080 30000; do
+    mapped="$(docker port "$container" "${internal}/tcp" 2>/dev/null | head -1 || true)"
+    if [[ -n "$mapped" ]]; then
+      port="${mapped##*:}"
+      [[ "$port" =~ ^[0-9]+$ ]] && { printf 'http://localhost:%s\n' "$port"; return 0; }
+    fi
+  done
   printf 'http://localhost:8020\n'
 }
 
@@ -268,7 +274,7 @@ if [[ "$HOST_MODE" == "1" ]]; then
   CONTAINER="none"
 else
   CONTAINER="${CONTAINER:-$(auto_container)}"
-  [[ -n "$CONTAINER" ]] || die "no running vllm-qwen36-27b*/vllm-gemma-4-31b* container found; set CONTAINER=... or CONTAINER=none for host engines"
+  [[ -n "$CONTAINER" ]] || die "no running club-3090 container found (vllm-/llama-cpp-/ik-llama-/sglang- × qwen36-27b/gemma-4-31b); set CONTAINER=... or CONTAINER=none for host engines"
   docker inspect "$CONTAINER" >/dev/null 2>&1 || die "container '$CONTAINER' not found (use CONTAINER=none for host engine builds)"
   [[ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null || echo false)" == "true" ]] \
     || die "container '$CONTAINER' is not running"


### PR DESCRIPTION
Two rebench-full robustness fixes for llama.cpp / ik_llama engines, both **caught and validated live** during a full 200K thinking-off rebench of `llamacpp/mtp` + `ik-llama/iq4ks-mtp` this session.

## 1. soak/preflight container autodetect (`Closes #403`)
`soak-test.sh::auto_container` matched only `vllm-*` → `rc=2 "no running container"` on the soak step of any llama.cpp/ik rebench-full, **aborting the chain before the aider step**. Also `preflight_autodetect_endpoint` (used by rebench-full/verify-stress) was missing `ik-llama-qwen36-27b` — so the ik leg's autodetect was a latent gap too.

- `soak-test.sh`: `auto_container` now mirrors the canonical engine-prefix set (vllm/llama-cpp/ik-llama/vllm-gemma/sglang); `endpoint_from_container` probes internal **8080/30000** (llama.cpp/sglang), not just 8000.
- `preflight.sh`: add `ik-llama-qwen36-27b` to `preflight_autodetect_endpoint` + the already-running warning glob.

**Validated:** soak went `rc=2` → `PASS` on the llama.cpp leg; ik leg autodetected `container=ik-llama-qwen36-27b` cleanly.

## 2. aider model-id basename for the litellm path
ik_llama reports its served-model-name as the **full GGUF path** (`/models/.../X.gguf`). bench/quality/soak handle it, but litellm inside the aider sandbox can't route a slash-laden / leading-slash model id (#15/#16 family) → every exercise errors before the model → **0/30 in ~5 min**. Mainline reports a basename, so it got a real 22/30.

- `rebench-full.sh`: basename `MODEL` for the aider step only (`${MODEL##*/}`). The server accepts any id (serves the one loaded model).

**Validated:** ik aider went **0/30 → 19/30** after the fix.

## Test
Full 200K thinking-off rebench-full completed end-to-end on both engines after these fixes (bench / verify-stress / quality-full / soak / aider-polyglot-30 all green-path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)