### PR TITLE
fix(#169): distinct default container_name per llama.cpp/ik single variant

### DIFF
--- a/docs/SINGLE_CARD.md
+++ b/docs/SINGLE_CARD.md
@@ -244,6 +244,18 @@ GPU_MEMORY_UTILIZATION=0.80 \
 
 Generally prefer **dropping `MAX_MODEL_LEN` first** (clean KV budget reduction, predictable behavior) over `GPU_MEMORY_UTILIZATION` (interacts with profiling overhead in non-obvious ways). Drop both if your envelope is really tight.
 
+### Running two llama.cpp / ik variants at once
+
+Each variant ships a **distinct default `container_name`** (`llamacpp/mtp` → `llama-cpp-qwen36-27b`, `llamacpp/mtp-vision` → `llama-cpp-qwen36-27b-vision`; ik's `iq4ks-mtp` / `-vision` / `-two-stage` likewise), so they no longer collide on the docker name. They **do** still share the default host port `8020`, so give the second one a port with `ESTATE_PORT` (and, if you want a custom name, `ESTATE_CONTAINER`):
+
+```bash
+# text workhorse on :8020 + vision variant on :8030, side by side
+bash scripts/switch.sh llamacpp/mtp
+ESTATE_PORT=8030 bash scripts/switch.sh llamacpp/mtp-vision
+```
+
+(Whether both fit depends on your VRAM envelope — two full-context single-card servers won't co-reside on one 24 GB card; drop `CTX_SIZE` on one, or use this across two cards.)
+
 ---
 
 ## Quick start

--- a/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp-vision.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp-vision.yml
@@ -94,7 +94,7 @@
 services:
   ik-llama-qwen36-27b-iq4ks-mtp-vision:
     image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu13-server}
-    container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b}"
+    container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b-vision}"
     restart: unless-stopped
     ports:
       - "${ESTATE_PORT:-${PORT:-8020}}:8080"

--- a/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp-vision.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp-vision.yml
@@ -14,7 +14,7 @@
 #              margin. REQUIRES -b 1024 (see below): a full 2048²/4M-pixel image
 #              encodes at ~23.65 GB. mmproj + encode buffers eat the VRAM the
 #              text profile spends on KV, so the vision ceiling (~180K) sits well
-#              below the text profile's 262K. Push higher only if you don't need
+#              below the text profile's 200K. Push higher only if you don't need
 #              prefill headroom — see VRAM RESIZING below.
 #   Status:    🧪 EVAL ONLY — task #402. NOT shipped. Sibling of iq4ks-mtp.yml
 #              with vision added (ampersandru's #152 config also loaded mmproj).
@@ -23,7 +23,7 @@
 # This is the VISION sibling of iq4ks-mtp.yml. Everything matches that file
 # (config source, justified deviations, native-template A/B result) EXCEPT:
 #   + --mmproj + --image-{min,max}-tokens (vision projector mounted)
-#   + default ctx 160K + -b 1024 (vs the text profile's 262K + -b 4096)
+#   + default ctx 160K + -b 1024 (vs the text profile's 200K + -b 4096)
 #
 # Why -b 1024 (NOT the text profile's 4096): on this ik_llama build the image-
 # encode graph makes the compute buffer scale hard with logical batch -b — at

--- a/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-two-stage.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-two-stage.yml
@@ -11,7 +11,7 @@
 #   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard (same as iq4ks-mtp.yml)
 #   Template:  native (GGUF-embedded) — see iq4ks-mtp.yml for A/B rationale
 #   Vision:    NO (text-only; mmproj is a separate axis → iq4ks-mtp-vision.yml)
-#   Default ctx: 131072 — lower than iq4ks-mtp.yml's 262K because two-stage
+#   Default ctx: 131072 — lower than iq4ks-mtp.yml's 200K because two-stage
 #              needs ngram context history to match against. 131K gives plenty
 #              of pattern surface while leaving headroom for the ngram index.
 #   Status:    🧪 EXPERIMENTAL — PR #1789 is 7 days old (2026-05-15). Boots +

--- a/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-two-stage.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-two-stage.yml
@@ -78,7 +78,7 @@
 services:
   ik-llama-qwen36-27b-two-stage:
     image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu13-server}
-    container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b}"
+    container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b-two-stage}"
     restart: unless-stopped
     ports:
       - "${ESTATE_PORT:-${PORT:-8020}}:8080"

--- a/models/qwen3.6-27b/llama-cpp/compose/single/mtp-vision.yml
+++ b/models/qwen3.6-27b/llama-cpp/compose/single/mtp-vision.yml
@@ -96,7 +96,7 @@ services:
     # open shared object file` → crash loop) — see #187. Bump via env when a
     # newer build is validated:  LLAMACPP_IMAGE=ghcr.io/ggml-org/llama.cpp:server-cuda-bXXXX
     image: ${LLAMACPP_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda-b9246}
-    container_name: "${ESTATE_CONTAINER:-llama-cpp-qwen36-27b}"
+    container_name: "${ESTATE_CONTAINER:-llama-cpp-qwen36-27b-vision}"
     restart: unless-stopped
     ports:
       - "${ESTATE_PORT:-${PORT:-8020}}:8080"

--- a/models/qwen3.6-27b/llama-cpp/compose/single/mtp-vision.yml
+++ b/models/qwen3.6-27b/llama-cpp/compose/single/mtp-vision.yml
@@ -17,7 +17,7 @@
 # Qwen3.6-27B on llama.cpp — single 3090, MTP, 160K ctx, VISION ON.
 #
 # This is one of two named single-card profiles for this model:
-#   - mtp.yml             → MTP n=2 + 262K + no vision (fast + max ctx)
+#   - mtp.yml             → MTP n=2 + 200K + no vision (fast + max ctx)
 #   - mtp-vision.yml      → MTP n=2 + 160K + vision (THIS file — multimodal)
 #
 # Historical note: the older single compose stripped --mmproj when MTP was
@@ -39,7 +39,7 @@
 #   headroom:                       ~1.7 GB for prompt + activation peaks +
 #                                   image-encode tile buffer
 #
-# Why 160K ctx (vs mtp.yml's 262K): the mmproj F16 plus image-encode tile
+# Why 160K ctx (vs mtp.yml's 200K): the mmproj F16 plus image-encode tile
 # buffers consume the headroom that the no-vision profile spends on KV.
 # 160K is the DEFAULT — verified on this rig (2026-05-22). Up to 192K with
 # UBATCH_SIZE=512. Conservative rigs can lower to 131K for more headroom.

--- a/scripts/gpu-mode.sh
+++ b/scripts/gpu-mode.sh
@@ -206,9 +206,10 @@ show_status() {
         m=$(curl -sf -m 2 http://localhost:8011/v1/models | python3 -c "import sys,json;d=json.load(sys.stdin);print(', '.join(x['id'] for x in d.get('data',[])))" 2>/dev/null)
         echo -e "  ${GREEN}▶${NC} 27b-turbo @ :8011       → ${m:-unknown} (TurboQuant_3bit_nc + MTP n=3 + v7.14, 4-stream concurrency)"
     fi
-    # :8020 = llama.cpp single-card (any of llamacpp/default, llamacpp/mtp,
-    # llamacpp/mtp-vision — they all default to container llama-cpp-qwen36-27b
-    # so active compose variant can't be inferred from container name alone).
+    # :8020 = llama.cpp single-card. llamacpp/default + llamacpp/mtp share the
+    # base container llama-cpp-qwen36-27b (same compose, collapsed 2026-05-22);
+    # llamacpp/mtp-vision now defaults to llama-cpp-qwen36-27b-vision (#169).
+    # All still match the llama-cpp-* prefix used for detection below.
     if curl -sf -m 2 http://localhost:8020/v1/models >/dev/null 2>&1; then
         local m
         m=$(curl -sf -m 2 http://localhost:8020/v1/models | python3 -c "import sys,json;d=json.load(sys.stdin);print(', '.join(x['id'] for x in d.get('data',[])))" 2>/dev/null)

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -1169,9 +1169,10 @@ declare -A LAUNCH_DEFAULT_CONTAINER=(
   [vllm/gemma-dflash]=vllm-gemma-4-31b-dflash
   [llamacpp/default]=llama-cpp-qwen36-27b
   [llamacpp/mtp]=llama-cpp-qwen36-27b
-  [llamacpp/mtp-vision]=llama-cpp-qwen36-27b
+  [llamacpp/mtp-vision]=llama-cpp-qwen36-27b-vision
   [ik-llama/iq4ks-mtp]=ik-llama-qwen36-27b
-  [ik-llama/iq4ks-mtp-vision]=ik-llama-qwen36-27b
+  [ik-llama/iq4ks-mtp-vision]=ik-llama-qwen36-27b-vision
+  [ik-llama/iq4ks-two-stage]=ik-llama-qwen36-27b-two-stage
 )
 ENDPOINT_PORT="${PORT:-${LAUNCH_DEFAULT_PORT[$VARIANT]:-8020}}"
 ENDPOINT_URL="http://localhost:${ENDPOINT_PORT}"


### PR DESCRIPTION
Closes #169.

All llama.cpp + ik single composes shipped the **same** default `container_name`, so bringing up a second variant failed with a docker name conflict (the `ESTATE_CONTAINER` override existed but was undocumented).

### Change
Distinct default per non-base variant; the base workhorses keep their names to avoid breaking hardcoded refs / benchlocal `docker logs <base>`:

| Variant | Default container_name |
|---|---|
| `llamacpp/mtp` (= `llamacpp/default`) | `llama-cpp-qwen36-27b` *(unchanged)* |
| `llamacpp/mtp-vision` | `llama-cpp-qwen36-27b-vision` |
| `ik/iq4ks-mtp` | `ik-llama-qwen36-27b` *(unchanged)* |
| `ik/iq4ks-mtp-vision` | `ik-llama-qwen36-27b-vision` |
| `ik/iq4ks-two-stage` | `ik-llama-qwen36-27b-two-stage` |

- `launch.sh`: track the two renames in `LAUNCH_DEFAULT_CONTAINER`, **and add the missing `ik-llama/iq4ks-two-stage` entry** (latent bug — it fell back to the wrong default container).
- `gpu-mode.sh`: comment-only update.
- `docs/SINGLE_CARD.md`: "run two variants at once" snippet (ports still default to `8020`, so the second one uses `ESTATE_PORT`, per the issue's example).

### Audit (the issue's caveat — all clear)
The autodetect globs in `preflight/soak/switch/health/update` are **prefix-anchored** (`^llama-cpp-qwen36-27b`, no `$`) and `gpu-mode` uses `== llama-cpp-*`, so suffixed names still match — verified, no logic change needed.

### Out of scope / notes
- **Gemma 4** composes already carry distinct container_names; their shared *ports* (`:8032` ×3, `:8033` ×2) are `ESTATE_PORT`-managed, same pattern as Qwen — left as-is.
- **benchlocal-cli** (separate repo) targets the *base* names, which are unchanged → unaffected.

### Validation
- `docker compose config` resolves each distinct name ✓
- every new name still matches the autodetect glob ✓
- `bash -n` (launch.sh, gpu-mode.sh) + `test-launch-compat.sh` pass ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)