### PR TITLE
fix(#168): scope report.sh kv-calc calibration to the running model + skip ik_llama

### DIFF
--- a/scripts/lib/report_calib.sh
+++ b/scripts/lib/report_calib.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# scripts/lib/report_calib.sh — helpers for report.sh's "KV math calibration"
+# section (club-3090 #168). Pure functions: sourcing this file has no side
+# effects, so it can be unit-tested directly (see scripts/tests/test-report-calib.sh).
+#
+# Why these exist:
+#   - kv-calc's prediction model is vLLM-memory-model-coupled, so its
+#     calibration is not a valid sanity-check on the llama.cpp / ik_llama
+#     (ggml) engines — those must be skipped.
+#   - `kv-calc.py --calibration` always prints the full catalog (all 4 models);
+#     a bug-reporter should see only the model they're actually running.
+
+# Map a running container name to its kv-calc engine family.
+# Echoes: vllm | llamacpp | unknown
+# "llamacpp" intentionally covers BOTH mainline llama.cpp and ik_llama — both
+# use the ggml allocator, so kv-calc's vLLM memory model applies to neither.
+calib_engine_for_container() {
+  case "$1" in
+    vllm-*)                 echo "vllm" ;;
+    llama-cpp-*|ik-llama-*) echo "llamacpp" ;;
+    *)                      echo "unknown" ;;
+  esac
+}
+
+# Map a running container name to its kv-calc model id (a MODEL_SPECS key in
+# tools/kv-calc.py, which is also the `== <id> ==` section header in
+# `--calibration` output). Echoes the model id, or "" if unrecognized.
+# Order matters: the more specific MoE names are matched before the dense ones.
+calib_model_for_container() {
+  case "$1" in
+    *qwen36-35b-a3b*)  echo "qwen3.6-35b-a3b" ;;
+    *gemma-4-26b-a4b*) echo "gemma-4-26b-a4b" ;;
+    *gemma-4-31b*)     echo "gemma-4-31b" ;;
+    *qwen36-27b*)      echo "qwen3.6-27b" ;;
+    *)                 echo "" ;;
+  esac
+}
+
+# Filter `kv-calc.py --calibration` output (stdin) to a single model's section.
+# Keeps everything before the first "== " header (banner + legend), the matching
+# "== <model> ==" block, and any trailing "Overall:" line; drops other models.
+# Arg 1: model id. If empty, passes stdin through unchanged (full matrix).
+calib_filter_model_section() {
+  local model="$1"
+  if [[ -z "$model" ]]; then cat; return; fi
+  awk -v target="== ${model} ==" '
+    BEGIN { before_first = 1 }
+    /^== / { before_first = 0; in_section = ($0 == target) }
+    {
+      if (before_first)       { print; next }   # banner + legend
+      if ($0 ~ /^Overall:/)   { print; next }   # global verdict line
+      if (in_section)         { print }         # the wanted section only
+    }
+  '
+}

--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -15,6 +15,7 @@
 #   bash scripts/report.sh --full            # ALL four: verify + stress + soak + bench (~35 min, the canonical "everything" pass for cross-rig contributions)
 #   bash scripts/report.sh --no-redact       # disable path/host/user redaction
 #   bash scripts/report.sh --container NAME  # override container auto-detection
+#   bash scripts/report.sh --full-calibration  # kv-calc matrix for ALL models (default: only the running model; skipped on llama.cpp/ik_llama)
 #   bash scripts/report.sh > my-rig.md       # capture for paste
 #
 # Why --soak is its own flag:
@@ -34,6 +35,9 @@ DO_SOAK=0
 DO_BENCH=0
 REDACT=1
 CONTAINER=""
+# KV-calc calibration is scoped to the running model by default (#168). Set to 1
+# (flag or REPORT_FULL_CALIBRATION=1) to emit the full catalog-wide matrix.
+FULL_CALIBRATION="${REPORT_FULL_CALIBRATION:-0}"
 
 print_help() {
   sed -n '2,/^set/p' "$0" | sed 's/^# \?//' | head -n -1
@@ -48,6 +52,7 @@ while [[ $# -gt 0 ]]; do
     --full) DO_VERIFY=1; DO_STRESS=1; DO_SOAK=1; DO_BENCH=1; shift ;;
     --no-redact) REDACT=0; shift ;;
     --container) CONTAINER="${2:-}"; shift 2 ;;
+    --full-calibration) FULL_CALIBRATION=1; shift ;;
     -h|--help) print_help; exit 0 ;;
     *) echo "Unknown arg: $1" >&2; echo "Try: bash scripts/report.sh --help" >&2; exit 1 ;;
   esac
@@ -59,6 +64,9 @@ done
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
+
+# KV-calc calibration helpers (engine/model detection + per-model filter, #168).
+source "$REPO_ROOT/scripts/lib/report_calib.sh"
 
 # Pick up a saved MODEL_DIR (and other config) from the repo .env — same as
 # launch.sh / switch.sh, and what setup.sh writes there. An explicit exported
@@ -489,29 +497,34 @@ fi
 # verdict line + any FAIL rows here so a triage reply can immediately see
 # whether to trust kv-calc projections for this user's config.
 
-# Lightweight engine detection for kv-calc scoping (full detection is later in "Active container")
-CALIB_ENGINE_KIND="${ENGINE_KIND:-}"
-if [[ -z "$CALIB_ENGINE_KIND" ]]; then
-  if [[ -z "${CONTAINER:-}" ]] && have docker && docker info >/dev/null 2>&1; then
-    _calib_container=$(docker ps --format '{{.Names}}' --filter 'name=vllm-' --filter 'name=llama-cpp-' --filter 'name=club3090-' --filter 'name=ik-llama-' 2>/dev/null | head -1)
-    case "$_calib_container" in
-      vllm-*)      CALIB_ENGINE_KIND="vllm" ;;
-      llama-cpp-*) CALIB_ENGINE_KIND="llamacpp" ;;
-      *)           CALIB_ENGINE_KIND="unknown" ;;
-    esac
-  fi
+# Engine + model detection for kv-calc scoping (#168). Resolve the active
+# container (explicit --container wins; else first running club-3090 container),
+# then map it to a kv-calc engine family + model id via scripts/lib/report_calib.sh.
+_calib_container="${CONTAINER:-}"
+if [[ -z "$_calib_container" ]] && have docker && docker info >/dev/null 2>&1; then
+  _calib_container=$(docker ps --format '{{.Names}}' --filter 'name=vllm-' --filter 'name=llama-cpp-' --filter 'name=club3090-' --filter 'name=ik-llama-' 2>/dev/null | head -1)
 fi
+CALIB_ENGINE_KIND="${ENGINE_KIND:-$(calib_engine_for_container "$_calib_container")}"
+CALIB_MODEL_ID="$(calib_model_for_container "$_calib_container")"
 
 if have python3 && [[ -f tools/kv-calc.py ]]; then
   section "KV math calibration"
-  # Item 5: kv-calc calibration is vLLM-specific; skip on llama.cpp/ik_llama
+  # kv-calc is vLLM-memory-model-coupled; skip on the ggml engines (llama.cpp + ik_llama).
   if [[ "$CALIB_ENGINE_KIND" == "llamacpp" ]]; then
-    echo "- _kv-calc calibration is vLLM-specific — skipped on the llama.cpp engine._"
+    echo "- _kv-calc calibration is vLLM-specific — skipped on the llama.cpp / ik_llama engine (ggml uses a different allocator)._"
   elif ! python3 -c 'import yaml' 2>/dev/null; then
     # Item 1: graceful-degrade when PyYAML is missing
     echo "- _kv-calc calibration skipped — PyYAML not installed (\`pip install pyyaml\`)._"
   else
-    calib_output=$(python3 tools/kv-calc.py --calibration 2>&1 || true)
+    # #168: scope to the running model by default; --full-calibration (or
+    # REPORT_FULL_CALIBRATION=1) restores the catalog-wide matrix. Falls back to
+    # the full matrix when the model can't be resolved.
+    calib_scope=""
+    if [[ "$FULL_CALIBRATION" != "1" && -n "$CALIB_MODEL_ID" ]]; then
+      calib_scope="$CALIB_MODEL_ID"
+      echo "- _Scoped to the running model \`${CALIB_MODEL_ID}\` — pass \`--full-calibration\` for all calibrated models._"
+    fi
+    calib_output=$(python3 tools/kv-calc.py --calibration 2>&1 | calib_filter_model_section "$calib_scope" || true)
     overall=$(echo "$calib_output" | grep -E '^Overall:' | head -1)
     fail_rows=$(echo "$calib_output" | grep -E '\bFAIL\b' || true)
     {

--- a/scripts/tests/test-report-calib.sh
+++ b/scripts/tests/test-report-calib.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Unit test for scripts/lib/report_calib.sh (club-3090 #168):
+# container→engine, container→model, and the per-model calibration filter.
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=/dev/null
+source "${ROOT_DIR}/scripts/lib/report_calib.sh"
+
+fail=0
+check() {  # check <label> <expected> <actual>
+  if [[ "$2" != "$3" ]]; then
+    echo "FAIL: $1 — expected [$2], got [$3]" >&2
+    fail=1
+  fi
+}
+
+# --- container → engine family ------------------------------------------------
+check "engine vllm"          "vllm"     "$(calib_engine_for_container vllm-qwen36-27b-dual)"
+check "engine llama.cpp"     "llamacpp" "$(calib_engine_for_container llama-cpp-qwen36-27b)"
+check "engine llama.cpp-vis" "llamacpp" "$(calib_engine_for_container llama-cpp-qwen36-27b-vision)"
+check "engine ik_llama"      "llamacpp" "$(calib_engine_for_container ik-llama-qwen36-27b)"        # #168: was 'unknown' → ran calibration
+check "engine ik_llama-2stg" "llamacpp" "$(calib_engine_for_container ik-llama-qwen36-27b-two-stage)"
+check "engine unknown"       "unknown"  "$(calib_engine_for_container some-other-container)"
+check "engine empty"         "unknown"  "$(calib_engine_for_container '')"
+
+# --- container → kv-calc model id --------------------------------------------
+check "model qwen-27b dense"  "qwen3.6-27b"     "$(calib_model_for_container vllm-qwen36-27b-dual-turbo)"
+check "model qwen-27b llama"  "qwen3.6-27b"     "$(calib_model_for_container llama-cpp-qwen36-27b)"
+check "model qwen-27b ik"     "qwen3.6-27b"     "$(calib_model_for_container ik-llama-qwen36-27b-vision)"
+check "model qwen-35b-a3b"    "qwen3.6-35b-a3b" "$(calib_model_for_container vllm-qwen36-35b-a3b-preview-mtp-tp2)"
+check "model gemma-31b"       "gemma-4-31b"     "$(calib_model_for_container vllm-gemma-4-31b-mtp)"
+check "model gemma-26b-a4b"   "gemma-4-26b-a4b" "$(calib_model_for_container vllm-gemma-4-26b-a4b-awq-tp2)"
+check "model unknown"         ""                "$(calib_model_for_container mystery-box)"
+
+# --- per-model section filter -------------------------------------------------
+fixture=$'========================================================================================\nCalibration — predicted per-card VRAM vs measured BENCHMARKS rows\n========================================================================================\n\n  Predicted = weights + activation + overhead.\n\n== qwen3.6-27b ==\n  dual          19.91 GB   PASS\n  Verdict accuracy: 11/11 (100%)\n\n== gemma-4-31b ==\n  gemma-dual-int8   22.80 GB   TIGHT\n  Verdict accuracy: 4/4 (100%)\n\nOverall: 17/17 (100%)'
+
+scoped="$(printf '%s\n' "$fixture" | calib_filter_model_section qwen3.6-27b)"
+case "$scoped" in
+  *"== qwen3.6-27b =="*) ;;
+  *) echo "FAIL: filter dropped the target section header" >&2; fail=1 ;;
+esac
+case "$scoped" in
+  *"gemma-4-31b"*) echo "FAIL: filter leaked the gemma section" >&2; fail=1 ;;
+esac
+case "$scoped" in
+  *"Calibration — predicted"*) ;;
+  *) echo "FAIL: filter dropped the banner/legend" >&2; fail=1 ;;
+esac
+case "$scoped" in
+  *"Overall: 17/17"*) ;;
+  *) echo "FAIL: filter dropped the Overall line" >&2; fail=1 ;;
+esac
+check "filter keeps target rows" "1" "$(printf '%s\n' "$scoped" | grep -c 'dual          19.91')"
+
+# empty model id → passthrough (full matrix)
+full="$(printf '%s\n' "$fixture" | calib_filter_model_section '')"
+check "empty filter = passthrough" "$(printf '%s\n' "$fixture" | wc -l)" "$(printf '%s\n' "$full" | wc -l)"
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "test-report-calib: FAILED" >&2
+  exit 1
+fi
+echo "test-report-calib: ok"


### PR DESCRIPTION
Closes #168.

`report.sh --full` always emitted kv-calc's **full catalog-wide** calibration matrix (4 models × every compose) regardless of what the reporter is running, and the vLLM-only skip **didn't cover ik_llama**.

### Fixes
- **(a) Scope to the running model.** Resolve the active container → kv-calc model id → filter `--calibration` to that model's `== <id> ==` section. A Qwen single-card reporter no longer gets Gemma/MoE rows.
- **(b) ggml-engine skip gap.** The skip matched only `llama-cpp-*`; `ik-llama-*` fell through to `unknown` and **ran the inapplicable calibration anyway**. Both ggml engines now emit the skip note (*"kv-calc is vLLM-specific — skipped on the llama.cpp / ik_llama engine"*).
- **(c) Opt-in full matrix.** `--full-calibration` (or `REPORT_FULL_CALIBRATION=1`) restores the catalog-wide matrix for maintainer triage. Unresolved model → falls back to full matrix.

### Testable by design
Logic is factored into a pure, side-effect-free lib **`scripts/lib/report_calib.sh`** (`calib_engine_for_container` / `calib_model_for_container` / `calib_filter_model_section`), sourced by `report.sh`. New **`scripts/tests/test-report-calib.sh`** covers:
- engine map incl. the **ik_llama regression** (was `unknown`, now `llamacpp`)
- model map for all four models (dense + MoE, vLLM + ggml containers)
- the section filter — keeps banner + target section + `Overall:`, drops other models; empty id = passthrough

### Validation
- `bash -n` (report.sh + lib) ✓
- `test-report-calib.sh` ✓
- live `kv-calc --calibration` scoped to `qwen3.6-27b` keeps only that section + the `Overall:` line ✓

Acceptance items 1–4 from the issue are met (the live-container assertions are exercised at unit level via the container→engine/model maps + filter, rather than booting a container in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)