### PR TITLE
feat(ik-llama/two-stage): ctx 131072→200000 + promote 🧪→⭐ code-optimized

### DIFF
--- a/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-two-stage.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-two-stage.yml
@@ -14,19 +14,23 @@
 #   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard (same as iq4ks-mtp.yml)
 #   Template:  native (GGUF-embedded) — see iq4ks-mtp.yml for A/B rationale
 #   Vision:    NO (text-only; mmproj is a separate axis → iq4ks-mtp-vision.yml)
-#   Default ctx: 131072 (validated). At the tuned ngram n_max=4 the per-step
-#              checkpoint is only ~0.6 GB, so 200K (iq4ks-mtp.yml's default)
-#              likely fits too — but that isn't boot+stress-validated here yet,
-#              so we ship the tested 131K. Bump CTX_SIZE to A/B it yourself.
-#   Status:    🧪 EXPERIMENTAL (community-test) — PR #1789, tuned + validated on
-#              1× 3090 (2026-05-24). ngram n_max swept {2,3,4,5,8,16}: code
-#              decode is an inverted-U peaking at n_max=4. At (ngram 4, MTP 3):
-#              code 97.8 TPS vs 72.4 for MTP-only (iq4ks-mtp.yml) = +35%;
-#              narrative ~tie (59 vs 60). Spec-dec is lossless — 8-pack quality
-#              98/150 == MTP-only's 100/150 within noise; verify-full all green.
-#              aider-polyglot leg re-running (first pass was a harness misconfig,
-#              not the model). Shipped 🧪 so others can A/B; BENCHMARKS row +
-#              SINGLE_CARD promotion follow once aider confirms.
+#   Default ctx: 200000 (verify-stress validated — fills to 183K with correct
+#              needle recall at every rung, matching iq4ks-mtp.yml). Ceiling VRAM
+#              margin is ~833 MB at 183K — just under the script's 1024 MB
+#              sustained-agent-load guard, but recall still passes and there's
+#              ~540 MB real headroom after the ~292 MB agent overhead. For heavy
+#              agentic use right at the ceiling, set CTX_SIZE=180224 (~1.4 GB
+#              margin) or 163840 (~1.9 GB). The ngram stage's 0.6 GB per-step
+#              checkpoint is what costs the top slice vs MTP-only's clean 200K.
+#   Status:    ⭐ Code-optimized single-card pick (sits alongside iq4ks-mtp.yml,
+#              the balanced/long-ctx ⭐). Tuned + validated on 1× 3090 @ 370 W
+#              (2026-05-24). ngram n_max swept {2,3,4,5,8,16}: code decode is an
+#              inverted-U peaking at n_max=4. At (ngram 4, MTP 3): code 97.8 TPS
+#              vs 72.4 for MTP-only (iq4ks-mtp.yml) = +35%; narrative ~tie
+#              (59 vs 60). Spec-dec is lossless: 8-pack 98/150 == MTP-only's
+#              100/150 and aider-polyglot 16/30 == MTP-only's 19/30, both within
+#              noise; verify-full all green. Same 200K ctx as iq4ks-mtp, ~0.8 GB
+#              leaner at idle. Use this for code; iq4ks-mtp for balanced/prose.
 #   Best for:  Code-heavy agentic workloads where context has repeated patterns
 #              (refactoring, test generation, boilerplate, import blocks).
 # ---------------------------------------------------------------------------
@@ -74,7 +78,7 @@
 # Override defaults via .env or shell:
 #   MODEL_DIR              host dir to mount as /models
 #   GGUF_FILE             path under /models
-#   CTX_SIZE              KV pool size       (default: 131072)
+#   CTX_SIZE              KV pool size       (default: 200000 — see Default ctx)
 #   BATCH_SIZE            llama.cpp -b       (default: 4096)
 #   UBATCH_SIZE           llama.cpp -ub      (default: 1024)
 #   NP                    parallel slots     (default: 1)
@@ -110,7 +114,7 @@ services:
       --port 8080
       --model /models/${GGUF_FILE:-qwen3.6-27b-gguf/ubergarm-mtp-iq4ks/Qwen3.6-27B-MTP-IQ4_KS.gguf}
       -ngl 99
-      --ctx-size ${CTX_SIZE:-131072}
+      --ctx-size ${CTX_SIZE:-200000}
       -b ${BATCH_SIZE:-4096}
       -ub ${UBATCH_SIZE:-1024}
       -np ${NP:-1}


### PR DESCRIPTION
Follow-up to #210 (ngram n_max tune). Now that the quality gate passed and ctx was explored on-rig, this **lifts the default ctx and promotes two-stage to a ⭐ code-optimized single-card pick**.

## Changes (compose only — comments + 2 serving values)
- `CTX_SIZE` default **131072 → 200000** (matches `iq4ks-mtp.yml`)
- Header `🧪 → ⭐`, ctx rationale rewritten, margin caveat + escape hatches documented

## ctx validation (verify-stress @ 200000, tuned ngram 4 / MTP 3)
All 4 ceiling-ladder rungs **PASS needle recall**, fills to **183K (91% of n_ctx)** — same depth as `iq4ks-mtp`:

| fill | recall | VRAM free |
|---|---|---:|
| 95K | ✓ | 1445 MB |
| 124K | ✓ | 1297 MB |
| 155K | ✓ | 1057 MB |
| 183K | ✓ | **833 MB** |

The 833 MB ceiling margin is just under the script's conservative **1024 MB** sustained-agent-load guard — recall still passes, with ~540 MB real headroom after the ~292 MB agent overhead. The ngram stage's 0.6 GB per-step checkpoint is what costs the top slice MTP-only had spare (we hit 205K on MTP-only before). **Escape hatches documented**: `CTX_SIZE=180224` (~1.4 GB margin) or `163840` (~1.9 GB) for heavy agentic right at the ceiling.

## Promotion basis (1× 3090 @ 370 W matched-power, 2026-05-24)
- **TPS**: code **97.8** = **+35%** vs MTP-only's 72.4; narrative ~tie (59 vs 60)
- **Quality (lossless spec-dec)**: 8-pack **98/150** ≈ MTP-only 100; aider-polyglot **16/30** ≈ MTP-only 19 — both within single-run noise
- **verify-full** all green; **~0.8 GB leaner** at idle than iq4ks-mtp

Positioning: **two-stage = code**, **iq4ks-mtp = balanced/prose** — both ⭐, same 200K ctx. SINGLE_CARD.md + BENCHMARKS.md row land as direct-to-master docs after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)