### PR TITLE
feat(llama.cpp): Structured-CoT bounded-thinking compose + grammar-dialect fix

### DIFF
--- a/docs/STRUCTURED_COT.md
+++ b/docs/STRUCTURED_COT.md
@@ -156,7 +156,7 @@ Curl example:
 
 ```bash
 MODEL_ID="$(curl -s http://localhost:8020/v1/models | jq -r '.data[0].id')"
-GRAMMAR_JSON="$(jq -Rs . < tools/grammar-eval/deepseek-scratchpad.gbnf)"
+GRAMMAR_JSON="$(jq -Rs . < tools/grammar-eval/deepseek-scratchpad.llamacpp.gbnf)"   # llama.cpp variant (no underscores)
 
 curl -s http://localhost:8020/v1/chat/completions \
   -H 'Content-Type: application/json' \
@@ -180,7 +180,7 @@ Python client:
 from openai import OpenAI
 
 client = OpenAI(base_url="http://localhost:8020/v1", api_key="dummy")
-grammar = open("tools/grammar-eval/deepseek-scratchpad.gbnf", encoding="utf-8").read()
+grammar = open("tools/grammar-eval/deepseek-scratchpad.llamacpp.gbnf", encoding="utf-8").read()  # llama.cpp variant
 model_id = client.models.list().data[0].id
 
 r = client.chat.completions.create(
@@ -201,7 +201,7 @@ print("think:", reasoning)
 print("code :", m.content)
 ```
 
-Current validation status: compose/config wiring is in-tree; live grammar+MTP validation is still pending on the dev rig. The on-rig check should prove three things before BENCHMARKS gets a row: `deepseek-scratchpad.gbnf` parses under llama.cpp GBNF as-is, FREE vs FSM think-token counts differ, and grammar-masked decode still coexists with `--spec-type draft-mtp`. If grammar and MTP conflict, rerun this compose with MTP disabled and document the speed trade before treating the llama.cpp port as validated.
+**Validation status (on-rig, 2026-05-24): PASS — but the grammar needed a llama.cpp variant.** The xgrammar `deepseek-scratchpad.gbnf` does **not** parse under llama.cpp's GBNF — its underscored rule names (`line_char`, `line_chars`) trip `parse: error parsing grammar: expecting newline or end at _char`, and the server silently falls back to *unconstrained* generation (FREE == FSM token counts — the silent no-fire trap). The fix is [`deepseek-scratchpad.llamacpp.gbnf`](../tools/grammar-eval/deepseek-scratchpad.llamacpp.gbnf) — identical language, no underscores (llama.cpp rule names are `[a-zA-Z0-9-]` only). With that variant, all three gates pass: (1) **parses** (no error), (2) **fires** — `reasoning_content` is the `PLAN:/NOTE:/VERDICT:` structure, and (3) **coexists with `--spec-type draft-mtp`** (draft acceptance 0.66–0.88). Measured FREE→FSM: 2113→1009 tok (2.1×, hash-vs-BST prompt) and 934→331 tok (2.8×, bat-and-ball), temp 0.6. Full HE+/LCB bench + a BENCHMARKS row still pending.
 
 ### 4. (Optional) Reproduce the bench
 

--- a/docs/STRUCTURED_COT.md
+++ b/docs/STRUCTURED_COT.md
@@ -338,7 +338,7 @@ Grammar mask compute adds ~10% per-token TPS (~61 → 53 TPS in our bench). Per-
 
 ## What's saved on disk
 
-The full bench outputs (results.jsonl, summary.json, per-problem narrative with FREE/FSM/PT think bodies) are at `/home/wasif/structured-cot/runs/full-humaneval-2026-04-30/` and `/home/wasif/structured-cot/runs/full-lcb-v6-gpu1-2026-04-30/`. Internal diagnostics writeup with full setup details, vLLM CLI args, and port surprises is at [`models/qwen3.6-27b/vllm/diagnostics/structured-cot-bench.md`](../models/qwen3.6-27b/vllm/diagnostics/structured-cot-bench.md).
+The full bench outputs (results.jsonl, summary.json, per-problem narrative with FREE/FSM/PT think bodies) are kept in the local `structured-cot/runs/full-humaneval-2026-04-30/` and `full-lcb-v6-gpu1-2026-04-30/` run dirs (host-local, not committed). The diagnostics writeup with full setup details, vLLM CLI args, and port notes is at [`models/qwen3.6-27b/vllm/diagnostics/structured-cot-bench.md`](../models/qwen3.6-27b/vllm/diagnostics/structured-cot-bench.md).
 
 ## Credit
 

--- a/docs/STRUCTURED_COT.md
+++ b/docs/STRUCTURED_COT.md
@@ -53,17 +53,17 @@ Our FSM pass@1 lands within 2pp of theirs on both benchmarks — the technique r
 
 Pick a bounded-thinking variant when **all three** of:
 
-1. You're calling the API with `extra_body={"structured_outputs": {...}}` (grammar / JSON / regex / etc).
+1. You're calling the API with a grammar (`extra_body={"structured_outputs": {...}}` on vLLM, or the request body `grammar` field on llama.cpp).
 2. You want bounded thinking cost as a structural guarantee (not just "the prompt asks nicely").
 3. Your workload tolerates a ~10% per-token TPS hit in exchange for ~7-30× cheaper think output (per-problem wall-clock is faster, not slower).
 
-Pick `long-text` (the regular variant) when none of those apply. The bounded-thinking variants are otherwise identical to long-text (same 214K context, same MTP n=3, same TQ3 KV, same patches). The only difference is one vLLM flag — `--structured-outputs-config.enable_in_reasoning true`, which is what makes grammar enforcement actually fire inside the `<think>` block on this stack.
+Pick `long-text` (the regular variant) when none of those apply. The vLLM bounded-thinking variant is otherwise identical to long-text (same 214K context, same MTP n=3, same TQ3 KV, same patches). The only difference on that path is one vLLM flag — `--structured-outputs-config.enable_in_reasoning true`, which is what makes grammar enforcement actually fire inside the `<think>` block on this stack.
 
-### One compose ships — `bounded-thinking.yml` with the DeepSeek scratchpad as the recommended grammar
+### One vLLM compose ships — `bounded-thinking.yml` with the DeepSeek scratchpad as the recommended grammar
 
 After the Phase 3 grammar A/B (2026-05-04, full HE+ 164 + LCB v6 50, 5 grammars × 214 problems), the defensible finding is that **DeepSeek scratchpad is the only grammar that doesn't lose combined accuracy vs the original andthattoo G/A/E baseline while improving the harder LCB v6 slice** (LCB +4pp = 2 additional problems on n=50; design signal, not statistical proof). The +0.47pp combined edge (1 problem on n=214) is well below the noise floor and shouldn't be framed as a categorical accuracy win. The stronger evidence for DeepSeek is the LCB tie with Holiday + near-andthattoo HE+ retention, not the +1 combined number alone. The original andthattoo grammar remains excellent and ~4× tighter on think budget; we ship DeepSeek as the recommended default because preserving HE+ accuracy while gaining LCB headroom is the most defensible per-workload posture.
 
-We ship one compose, with the DeepSeek scratchpad as the recommended grammar:
+On vLLM, we ship one compose, with the DeepSeek scratchpad as the recommended grammar:
 
 ```bash
 bash scripts/switch.sh vllm/bounded-thinking
@@ -136,7 +136,74 @@ print("code :", m.content)
 
 The reasoning channel will contain exactly `GOAL: ... APPROACH: ... EDGE: ...`; the content channel will have the runnable code.
 
-### 3. (Optional) Reproduce the bench
+### 3. llama.cpp bounded-thinking port
+
+llama.cpp has a sibling structured-CoT compose for users who want the GGUF/MTP path instead of vLLM:
+
+```bash
+cd /path/to/club-3090
+bash scripts/switch.sh llamacpp/bounded-thinking
+# Or directly:
+cd models/qwen3.6-27b/llama-cpp/compose
+docker compose -f single/bounded-thinking.yml up -d
+```
+
+Endpoint: `http://localhost:8020/v1` (set `PORT=...` to override). The compose is intentionally the same runtime envelope as `llamacpp/mtp`: Q4_K_M MTP GGUF, MTP n=2, q4_0 KV, `-ub 512`, 200K context, no vision. The serving-policy difference is `REASONING=on` by default.
+
+The important API difference from vLLM: llama.cpp takes the grammar as the OpenAI-compatible request body `grammar` field. Do **not** wrap it in `structured_outputs`.
+
+Curl example:
+
+```bash
+MODEL_ID="$(curl -s http://localhost:8020/v1/models | jq -r '.data[0].id')"
+GRAMMAR_JSON="$(jq -Rs . < tools/grammar-eval/deepseek-scratchpad.gbnf)"
+
+curl -s http://localhost:8020/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d @- <<JSON
+{
+  "model": "${MODEL_ID}",
+  "messages": [
+    {"role": "system", "content": "You are an expert Python programmer. Keep reasoning inside the required thinking block. After reasoning, output runnable Python code directly."},
+    {"role": "user", "content": "Write a function add(a, b) that returns the sum."}
+  ],
+  "temperature": 0,
+  "max_tokens": 512,
+  "grammar": ${GRAMMAR_JSON}
+}
+JSON
+```
+
+Python client:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8020/v1", api_key="dummy")
+grammar = open("tools/grammar-eval/deepseek-scratchpad.gbnf", encoding="utf-8").read()
+model_id = client.models.list().data[0].id
+
+r = client.chat.completions.create(
+    model=model_id,
+    messages=[
+        {"role": "system", "content": "You are an expert Python programmer. Keep reasoning inside the required thinking block. After reasoning, output runnable Python code directly."},
+        {"role": "user", "content": "Write a function add(a, b) that returns the sum."},
+    ],
+    max_tokens=512,
+    temperature=0.0,
+    extra_body={"grammar": grammar},
+)
+
+m = r.choices[0].message
+extra = getattr(m, "model_extra", {}) or {}
+reasoning = getattr(m, "reasoning_content", None) or extra.get("reasoning_content") or extra.get("reasoning")
+print("think:", reasoning)
+print("code :", m.content)
+```
+
+Current validation status: compose/config wiring is in-tree; live grammar+MTP validation is still pending on the dev rig. The on-rig check should prove three things before BENCHMARKS gets a row: `deepseek-scratchpad.gbnf` parses under llama.cpp GBNF as-is, FREE vs FSM think-token counts differ, and grammar-masked decode still coexists with `--spec-type draft-mtp`. If grammar and MTP conflict, rerun this compose with MTP disabled and document the speed trade before treating the llama.cpp port as validated.
+
+### 4. (Optional) Reproduce the bench
 
 ```bash
 git clone https://github.com/andthattoo/structured-cot.git ~/structured-cot

--- a/models/qwen3.6-27b/llama-cpp/README.md
+++ b/models/qwen3.6-27b/llama-cpp/README.md
@@ -30,7 +30,7 @@ The single-card speed + context workhorse: ~51/60 TPS (narr/code), **200K ctx** 
 
 ### `single/bounded-thinking.yml` — MTP n=2, 200K ctx, reasoning on, grammar per request
 
-Structured-CoT variant for llama.cpp. It is intentionally the same runtime envelope as `single/mtp.yml` — Q4_K_M MTP GGUF, q4_0 KV, `-ub 512`, 200K context, no vision — with `REASONING=on` as the default. The grammar is not baked into the server; clients pass GBNF in the OpenAI-compatible request body `grammar` field. Use [`tools/grammar-eval/deepseek-scratchpad.gbnf`](../../../tools/grammar-eval/deepseek-scratchpad.gbnf) as the recommended default, or pass the original andthattoo / Holiday alternates client-side. See [`docs/STRUCTURED_COT.md`](../../../docs/STRUCTURED_COT.md) for request examples and validation status.
+Structured-CoT variant for llama.cpp. It is intentionally the same runtime envelope as `single/mtp.yml` — Q4_K_M MTP GGUF, q4_0 KV, `-ub 512`, 200K context, no vision — with `REASONING=on` as the default. The grammar is not baked into the server; clients pass GBNF in the OpenAI-compatible request body `grammar` field. Use [`tools/grammar-eval/deepseek-scratchpad.llamacpp.gbnf`](../../../tools/grammar-eval/deepseek-scratchpad.llamacpp.gbnf) as the recommended default, or pass the original andthattoo / Holiday alternates client-side. See [`docs/STRUCTURED_COT.md`](../../../docs/STRUCTURED_COT.md) for request examples and validation status.
 
 ### `single/mtp-vision.yml` — MTP n=2, 160K ctx, vision on
 

--- a/models/qwen3.6-27b/llama-cpp/README.md
+++ b/models/qwen3.6-27b/llama-cpp/README.md
@@ -22,11 +22,15 @@ For full pros/cons + general llama.cpp tuning, see [`/docs/engines/LLAMA_CPP.md`
 
 ## Docker compose (recommended)
 
-Two compose variants in [`compose/single/`](compose/single/) — both use the official `ghcr.io/ggml-org/llama.cpp` image (CUDA), **no custom build needed**, **no club-3090 patches** (unlike our vLLM track). MTP PR #22673 has merged upstream so this image has it natively. The composes are **pinned to build `server-cuda-b9246`** (validated 2026-05-20) — *not* the rolling `:server-cuda` tag, because that tag regressed at `b9282` (broken lib packaging → crash loop, [#187](https://github.com/noonghunna/club-3090/issues/187)). To follow a newer build, override `LLAMACPP_IMAGE=ghcr.io/ggml-org/llama.cpp:server-cuda-bXXXX` (validate it first). Bench numbers were measured on `b9246`; expect ±5% drift on newer builds.
+Three compose variants in [`compose/single/`](compose/single/) — all use the official `ghcr.io/ggml-org/llama.cpp` image (CUDA), **no custom build needed**, **no club-3090 patches** (unlike our vLLM track). MTP PR #22673 has merged upstream so this image has it natively. The composes are **pinned to build `server-cuda-b9246`** (validated 2026-05-20) — *not* the rolling `:server-cuda` tag, because that tag regressed at `b9282` (broken lib packaging → crash loop, [#187](https://github.com/noonghunna/club-3090/issues/187)). To follow a newer build, override `LLAMACPP_IMAGE=ghcr.io/ggml-org/llama.cpp:server-cuda-bXXXX` (validate it first). Bench numbers were measured on `b9246`; expect ±5% drift on newer builds.
 
 ### `single/mtp.yml` — MTP n=2, 200K ctx, no vision
 
 The single-card speed + context workhorse: ~51/60 TPS (narr/code), **200K ctx** (max-safe default @ `-ub 512` — fills cleanly with ~1.1 GB margin; 131K @ `-ub 1024` for faster prefill; 262K is the native max but *boots-not-fills*, see [`docs/CLIFFS.md`](../../../docs/CLIFFS.md)), 7/7 verify-stress boundary checks (incl. 60K + 91K needle recall), 102/150 (68%) on the 8-pack quality matrix. Best for IDE agents, opencode, Hermes, long-multi-turn agentic. Q4_K_M MTP GGUF (`unsloth/Qwen3.6-27B-MTP-GGUF` Q4_K_M).
+
+### `single/bounded-thinking.yml` — MTP n=2, 200K ctx, reasoning on, grammar per request
+
+Structured-CoT variant for llama.cpp. It is intentionally the same runtime envelope as `single/mtp.yml` — Q4_K_M MTP GGUF, q4_0 KV, `-ub 512`, 200K context, no vision — with `REASONING=on` as the default. The grammar is not baked into the server; clients pass GBNF in the OpenAI-compatible request body `grammar` field. Use [`tools/grammar-eval/deepseek-scratchpad.gbnf`](../../../tools/grammar-eval/deepseek-scratchpad.gbnf) as the recommended default, or pass the original andthattoo / Holiday alternates client-side. See [`docs/STRUCTURED_COT.md`](../../../docs/STRUCTURED_COT.md) for request examples and validation status.
 
 ### `single/mtp-vision.yml` — MTP n=2, 160K ctx, vision on
 

--- a/models/qwen3.6-27b/llama-cpp/compose/single/bounded-thinking.yml
+++ b/models/qwen3.6-27b/llama-cpp/compose/single/bounded-thinking.yml
@@ -20,14 +20,14 @@
 # Why no server grammar flag here: llama.cpp accepts GBNF through the OpenAI
 # request body's `grammar` field. Unlike vLLM, there is no separate
 # reasoning-scoped switch in this compose. The recommended grammar at
-# tools/grammar-eval/deepseek-scratchpad.gbnf is whole-response shaped for
+# tools/grammar-eval/deepseek-scratchpad.llamacpp.gbnf is whole-response shaped for
 # Qwen's generated stream after the chat template auto-prefixes `<think>\n`:
 # PLAN / NOTE* / VERDICT / `</think>\n\n` / free answer.
 #
 # Recommended request shape:
 #   - temperature: 0 for bench parity
 #   - max_tokens: 4096
-#   - grammar: contents of tools/grammar-eval/deepseek-scratchpad.gbnf
+#   - grammar: contents of tools/grammar-eval/deepseek-scratchpad.llamacpp.gbnf
 #
 # Optional alternates stay client-selectable: the original andthattoo G/A/E
 # grammar and tools/grammar-eval/holiday-tagline.gbnf. See

--- a/models/qwen3.6-27b/llama-cpp/compose/single/bounded-thinking.yml
+++ b/models/qwen3.6-27b/llama-cpp/compose/single/bounded-thinking.yml
@@ -1,0 +1,98 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-27B (Unsloth MTP-enabled Q4_K_M GGUF)
+#   Engine:    llama.cpp mainline (server-cuda-b9246 pin, same as mtp.yml)
+#   Topology:  Single 3090 (TP=1)
+#   Drafter:   MTP n=2 (--spec-type draft-mtp, inherited from mtp.yml)
+#   KV:        q4_0 K + q4_0 V
+#   Vision:    no
+#   Template:  native GGUF + --jinja + --reasoning on --reasoning-format deepseek
+#   Max ctx:   200000 default (@ -ub 512, same max-safe fill profile as mtp.yml)
+#   Status:    New structured-CoT port; live grammar+MTP validation pending
+#   Engine-profile: llama-cpp-local
+#   Best for:  bounded-thinking coding/reasoning workloads on the llama.cpp
+#              engine that boots today. Client sends a per-request GBNF grammar.
+# ---------------------------------------------------------------------------
+# llama.cpp bounded-thinking variant. This is intentionally almost identical
+# to mtp.yml: same image pin, Q4_K_M GGUF, MTP n=2, 200K ctx, q4_0 KV, and
+# no vision. The only serving-policy difference is REASONING defaults to on.
+#
+# Why no server grammar flag here: llama.cpp accepts GBNF through the OpenAI
+# request body's `grammar` field. Unlike vLLM, there is no separate
+# reasoning-scoped switch in this compose. The recommended grammar at
+# tools/grammar-eval/deepseek-scratchpad.gbnf is whole-response shaped for
+# Qwen's generated stream after the chat template auto-prefixes `<think>\n`:
+# PLAN / NOTE* / VERDICT / `</think>\n\n` / free answer.
+#
+# Recommended request shape:
+#   - temperature: 0 for bench parity
+#   - max_tokens: 4096
+#   - grammar: contents of tools/grammar-eval/deepseek-scratchpad.gbnf
+#
+# Optional alternates stay client-selectable: the original andthattoo G/A/E
+# grammar and tools/grammar-eval/holiday-tagline.gbnf. See
+# docs/STRUCTURED_COT.md for the accuracy/compression table and curl/Python
+# examples.
+#
+# Open validation gates for on-rig testing:
+#   1. Per-request grammar loads under llama.cpp GBNF as-is.
+#   2. FREE vs FSM think-token counts differ, proving the mask fires in the
+#      generated think block.
+#   3. Grammar-masked decode coexists with --spec-type draft-mtp; if not, run
+#      the same compose with MTP disabled for structured-CoT bench only and
+#      document the trade.
+# ===========================================================================
+# Hardware metadata (parsed by scripts/preflight.sh):
+# Requires-min-vram-gb: 24
+# Engine-profile: llama-cpp-local
+# Requires-min-gpu-count: 1
+# Tensor-parallel: 1
+services:
+  llama-cpp-qwen36-27b-bounded-thinking:
+    # Pinned to b9246 (validated 2026-05-20). The rolling `:server-cuda` tag
+    # regressed at b9282 (broken lib packaging: `libllama-common.so.0: cannot
+    # open shared object file` → crash loop) — see #187. Bump via env when a
+    # newer build is validated:  LLAMACPP_IMAGE=ghcr.io/ggml-org/llama.cpp:server-cuda-bXXXX
+    image: ${LLAMACPP_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda-b9246}
+    container_name: "${ESTATE_CONTAINER:-llama-cpp-qwen36-27b-bounded-thinking}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8020}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../models-cache}:/models:ro"
+    # ⚠ -np 1 is intentional on a single 24 GB card — do NOT raise it to
+    #   "parallelize." One GPU is compute-bound: extra slots divide its
+    #   throughput, they don't multiply it. At -np 4 each slot fell to
+    #   ~14 tok/s here — slow enough to trip agentic clients' per-request
+    #   timeouts (aider ran 1/30) — and -np>1 also auto-disables MTP and
+    #   can OOM the spec-context buffer. On a higher-throughput card (e.g.
+    #   5090) or multi-GPU the trade may flip — re-validate before raising.
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      -m /models/${GGUF_FILE:-qwen3.6-27b-gguf/unsloth-mtp-q4km/Qwen3.6-27B-Q4_K_M.gguf}
+      -c ${CTX_SIZE:-200000}
+      -b ${BATCH_SIZE:-4096}
+      -ub ${UBATCH_SIZE:-512}
+      -ngl 99
+      -fa on
+      --cache-type-k ${KV_TYPE:-q4_0}
+      --cache-type-v ${KV_TYPE:-q4_0}
+      -np ${NP:-1}
+      --spec-type draft-mtp
+      --spec-draft-n-max ${MTP_DRAFT_N_MAX:-2}
+      --jinja
+      --reasoning ${REASONING:-on}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}"]
+              capabilities: [compute, utility]

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -229,6 +229,7 @@ declare -A LAUNCH_VARIANT_COMPOSE=(
   [vllm/gemma-dflash]="models/gemma-4-31b/vllm/compose/dual/dflash.yml"
   [llamacpp/default]="models/qwen3.6-27b/llama-cpp/compose/single/mtp.yml"
   [llamacpp/mtp]="models/qwen3.6-27b/llama-cpp/compose/single/mtp.yml"
+  [llamacpp/bounded-thinking]="models/qwen3.6-27b/llama-cpp/compose/single/bounded-thinking.yml"
   [llamacpp/mtp-vision]="models/qwen3.6-27b/llama-cpp/compose/single/mtp-vision.yml"
   [ik-llama/iq4ks-mtp]="models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp.yml"
   [ik-llama/iq4ks-mtp-vision]="models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp-vision.yml"
@@ -241,7 +242,7 @@ declare -A LAUNCH_VARIANT_MODEL=(
   [vllm/dual-dflash-noviz]="qwen3.6-27b" [vllm/dual-nvlink]="qwen3.6-27b" [vllm/dual-nvlink-turbo]="qwen3.6-27b"
   [vllm/dual-nvlink-dflash]="qwen3.6-27b" [vllm/dual-nvlink-dflash-noviz]="qwen3.6-27b"
   [vllm/gemma-mtp]="gemma-4-31b" [vllm/gemma-mtp-tp1]="gemma-4-31b" [vllm/gemma-dflash]="gemma-4-31b"
-  [llamacpp/default]="qwen3.6-27b" [llamacpp/mtp]="qwen3.6-27b" [llamacpp/mtp-vision]="qwen3.6-27b"
+  [llamacpp/default]="qwen3.6-27b" [llamacpp/mtp]="qwen3.6-27b" [llamacpp/bounded-thinking]="qwen3.6-27b" [llamacpp/mtp-vision]="qwen3.6-27b"
   [ik-llama/iq4ks-mtp]="qwen3.6-27b" [ik-llama/iq4ks-mtp-vision]="qwen3.6-27b"
 )
 declare -A LAUNCH_VARIANT_ENGINE=(
@@ -251,7 +252,7 @@ declare -A LAUNCH_VARIANT_ENGINE=(
   [vllm/dual-dflash-noviz]="vllm" [vllm/dual-nvlink]="vllm" [vllm/dual-nvlink-turbo]="vllm"
   [vllm/dual-nvlink-dflash]="vllm" [vllm/dual-nvlink-dflash-noviz]="vllm"
   [vllm/gemma-mtp]="vllm" [vllm/gemma-mtp-tp1]="vllm" [vllm/gemma-dflash]="vllm"
-  [llamacpp/default]="llamacpp" [llamacpp/mtp]="llamacpp" [llamacpp/mtp-vision]="llamacpp"
+  [llamacpp/default]="llamacpp" [llamacpp/mtp]="llamacpp" [llamacpp/bounded-thinking]="llamacpp" [llamacpp/mtp-vision]="llamacpp"
   [ik-llama/iq4ks-mtp]="llamacpp" [ik-llama/iq4ks-mtp-vision]="llamacpp"
 )
 declare -A LAUNCH_VARIANT_KVCALC=(
@@ -277,6 +278,7 @@ declare -A LAUNCH_VARIANT_KVCALC=(
   [vllm/gemma-dflash]="gemma-4-31b:gemma-dual-dflash"
   [llamacpp/default]="SKIP"
   [llamacpp/mtp]="SKIP"
+  [llamacpp/bounded-thinking]="SKIP"
   [llamacpp/mtp-vision]="SKIP"
   [ik-llama/iq4ks-mtp]="SKIP"
   [ik-llama/iq4ks-mtp-vision]="SKIP"
@@ -287,7 +289,7 @@ LAUNCH_VARIANT_ORDER=(
   vllm/dual vllm/dual-turbo vllm/dual-dflash vllm/dual-dflash-noviz
   vllm/dual4 vllm/dual4-dflash
   vllm/gemma-mtp vllm/gemma-mtp-tp1 vllm/gemma-dflash
-  llamacpp/default llamacpp/mtp llamacpp/mtp-vision
+  llamacpp/default llamacpp/mtp llamacpp/bounded-thinking llamacpp/mtp-vision
   ik-llama/iq4ks-mtp ik-llama/iq4ks-mtp-vision
 )
 
@@ -1142,6 +1144,7 @@ declare -A LAUNCH_DEFAULT_PORT=(
   [vllm/gemma-dflash]=8032
   [llamacpp/default]=8020
   [llamacpp/mtp]=8020
+  [llamacpp/bounded-thinking]=8020
   [llamacpp/mtp-vision]=8020
   [ik-llama/iq4ks-mtp]=8020
   [ik-llama/iq4ks-mtp-vision]=8020
@@ -1169,6 +1172,7 @@ declare -A LAUNCH_DEFAULT_CONTAINER=(
   [vllm/gemma-dflash]=vllm-gemma-4-31b-dflash
   [llamacpp/default]=llama-cpp-qwen36-27b
   [llamacpp/mtp]=llama-cpp-qwen36-27b
+  [llamacpp/bounded-thinking]=llama-cpp-qwen36-27b-bounded-thinking
   [llamacpp/mtp-vision]=llama-cpp-qwen36-27b-vision
   [ik-llama/iq4ks-mtp]=ik-llama-qwen36-27b
   [ik-llama/iq4ks-mtp-vision]=ik-llama-qwen36-27b-vision

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -243,6 +243,13 @@ COMPOSE_REGISTRY = {
         compose_path="models/qwen3.6-27b/llama-cpp/compose/single/mtp.yml",
         default_port=8020,
     ),
+    "llamacpp/bounded-thinking": _entry(
+        model="qwen3.6-27b", weights_variant="gguf", workload="tool-heavy",
+        engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q4_0",
+        tp=1, max_ctx=200000, max_num_seqs=1, mem_util=None,
+        compose_path="models/qwen3.6-27b/llama-cpp/compose/single/bounded-thinking.yml",
+        default_port=8020,
+    ),
     "llamacpp/mtp-vision": _entry(
         model="qwen3.6-27b", weights_variant="gguf", workload="vision-coding",
         engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q4_0",

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -42,6 +42,7 @@
 #   Single-card llama.cpp:
 #     llamacpp/default      alias for llamacpp/mtp (Q4_K_M MTP, no vision)
 #     llamacpp/mtp          Q4_K_M MTP + 200K (max-safe @ -ub 512; 131K @ -ub 1024 faster prefill) + q4_0 KV (fast ~60 TPS code; no vision; cliff-immune)
+#     llamacpp/bounded-thinking Q4_K_M MTP + 200K + reasoning on + per-request GBNF grammar
 #     llamacpp/mtp-vision   Q4_K_M MTP + 49K + q4_0 KV + mmproj (fast + multimodal)
 #   Single-card ik_llama (IQ4_KS — ~0.5-0.8 GB leaner; best for VRAM-tight / WSL):
 #     ik-llama/iq4ks-mtp         IQ4_KS MTP + 262K + q4_0 KV (own image: ikawrakow/ik-llama-cpp)

--- a/tools/grammar-eval/README.md
+++ b/tools/grammar-eval/README.md
@@ -8,7 +8,8 @@ Tools to A/B-test alternative bounded-thinking grammars against the originally-s
 
 | File | Purpose |
 |---|---|
-| `deepseek-scratchpad.gbnf` | Recommended default grammar for bounded-thinking variants; xgrammar-compatible and used for the llama.cpp port request examples |
+| `deepseek-scratchpad.gbnf` | Recommended default grammar for bounded-thinking; **vLLM/xgrammar** (uses underscored rule names — does NOT parse on llama.cpp) |
+| `deepseek-scratchpad.llamacpp.gbnf` | **llama.cpp variant** of the above — identical language, rule names with no underscores (llama.cpp GBNF is `[a-zA-Z0-9-]` only). Use this for the llama.cpp bounded-thinking compose. Validated on-rig 2026-05-24. |
 | `holiday-tagline.gbnf` | Translated grammar, xgrammar-compatible |
 | [`TRANSLATION.md`](TRANSLATION.md) | Translation decisions + Phase-1 smoke results |
 | `smoke-test.py` | Phase-1 — verify the grammar parses + applies on vLLM |
@@ -16,7 +17,7 @@ Tools to A/B-test alternative bounded-thinking grammars against the originally-s
 
 ## Serving notes
 
-The recommended production/default grammar is [`deepseek-scratchpad.gbnf`](deepseek-scratchpad.gbnf). vLLM receives it as `extra_body={"structured_outputs": {"grammar": ...}}`; llama.cpp receives the same GBNF as the request body `grammar` field. See [`docs/STRUCTURED_COT.md`](../../docs/STRUCTURED_COT.md) for engine-specific request examples.
+The recommended production/default grammar is the DeepSeek scratchpad. **The two engines need different files** (same language, different rule-name dialect): vLLM uses [`deepseek-scratchpad.gbnf`](deepseek-scratchpad.gbnf) as `extra_body={"structured_outputs": {"grammar": ...}}`; **llama.cpp uses [`deepseek-scratchpad.llamacpp.gbnf`](deepseek-scratchpad.llamacpp.gbnf)** (no underscores in rule names) as the request body `grammar` field — the underscored vLLM version silently fails to parse on llama.cpp and falls back to unconstrained generation. See [`docs/STRUCTURED_COT.md`](../../docs/STRUCTURED_COT.md) for engine-specific request examples + validation status.
 
 ## How to run
 

--- a/tools/grammar-eval/README.md
+++ b/tools/grammar-eval/README.md
@@ -1,6 +1,6 @@
 # Grammar evaluation harness
 
-Tools to A/B-test alternative bounded-thinking grammars against the currently-shipped `andthattoo/structured-cot` GOAL/APPROACH/EDGE grammar (in [`docs/STRUCTURED_COT.md`](../../docs/STRUCTURED_COT.md)). Specifically targeting [Holiday_Purpose_3166's tagline grammar](https://www.reddit.com/r/LocalLLaMA/comments/1sx7w55/) from r/LocalLLaMA.
+Tools to A/B-test alternative bounded-thinking grammars against the originally-shipped `andthattoo/structured-cot` GOAL/APPROACH/EDGE grammar (in [`docs/STRUCTURED_COT.md`](../../docs/STRUCTURED_COT.md)). Specifically targeting [Holiday_Purpose_3166's tagline grammar](https://www.reddit.com/r/LocalLLaMA/comments/1sx7w55/) from r/LocalLLaMA.
 
 **The hypothesis:** the K (keywords, 1-5 free tokens) and R (result-keywords, 1-5 free tokens) fields in Holiday's grammar give the model a pressure-relief valve that GOAL/APPROACH/EDGE's rigid 3-line shape lacks. We have 6 documented HE+ regression cases (HE/97, 101, 108, 129, 137, 151) where FSM under-thinks and FREE wins; if Holiday's grammar rescues even some of those without losing too much compression, it's a Pareto improvement worth shipping.
 
@@ -8,10 +8,15 @@ Tools to A/B-test alternative bounded-thinking grammars against the currently-sh
 
 | File | Purpose |
 |---|---|
+| `deepseek-scratchpad.gbnf` | Recommended default grammar for bounded-thinking variants; xgrammar-compatible and used for the llama.cpp port request examples |
 | `holiday-tagline.gbnf` | Translated grammar, xgrammar-compatible |
 | [`TRANSLATION.md`](TRANSLATION.md) | Translation decisions + Phase-1 smoke results |
 | `smoke-test.py` | Phase-1 — verify the grammar parses + applies on vLLM |
 | `subset-bench.py` | Phase-2 — 30-prompt HE+ A/B vs current grammar + FREE + PROMPT_TERSE |
+
+## Serving notes
+
+The recommended production/default grammar is [`deepseek-scratchpad.gbnf`](deepseek-scratchpad.gbnf). vLLM receives it as `extra_body={"structured_outputs": {"grammar": ...}}`; llama.cpp receives the same GBNF as the request body `grammar` field. See [`docs/STRUCTURED_COT.md`](../../docs/STRUCTURED_COT.md) for engine-specific request examples.
 
 ## How to run
 

--- a/tools/grammar-eval/deepseek-scratchpad.llamacpp.gbnf
+++ b/tools/grammar-eval/deepseek-scratchpad.llamacpp.gbnf
@@ -1,0 +1,44 @@
+# DeepSeek "bounded scratchpad" grammar — llama.cpp GBNF variant.
+# Identical LANGUAGE to deepseek-scratchpad.gbnf (the vLLM/xgrammar version);
+# the ONLY difference is rule names contain no underscores. llama.cpp's GBNF
+# parser accepts rule names in [a-zA-Z0-9-] only — underscores (e.g. "line_char")
+# make it bail with "parse: error parsing grammar: expecting newline or end at
+# _char" and silently fall back to UNCONSTRAINED generation (FREE==FSM token
+# counts — the silent no-fire trap). Verified on-rig 2026-05-24: this variant
+# parses, fires (PLAN/NOTE/VERDICT), and coexists with --spec-type draft-mtp.
+# Send via the OpenAI request body's `grammar` field on llama-server.
+# Qwen3.6's chat template auto-prefixes "<think>\n", so root begins at PLAN:.
+#
+# Design philosophy: variable-count free-text NOTE lines (0-15) bounded by
+# explicit PLAN: opening and VERDICT: closing. Pressure-relief valve via
+# repeatable note count instead of Holiday's bounded-token-list approach.
+# Open vocabulary per line — no closed vocab sets, generalizes across domains.
+
+root ::= "PLAN: " line "\n" notes "VERDICT: " line "\n</think>\n\n" out
+
+# A "line" is one or more printable ASCII chars (incl tab) — no newline.
+line ::= linechar linechars
+linechar ::= [\x09\x20-\x7E]
+linechars ::= "" | linechar linechars
+
+# 0-15 NOTE lines. Right-recursive nullable cascade — same pattern as
+# holiday-tagline.gbnf's tail rules, just for line repetition rather than
+# character bounds. xgrammar handles this fine.
+notes ::= "" | n1
+n1 ::= "NOTE: " line "\n" n2
+n2 ::= "" | "NOTE: " line "\n" n3
+n3 ::= "" | "NOTE: " line "\n" n4
+n4 ::= "" | "NOTE: " line "\n" n5
+n5 ::= "" | "NOTE: " line "\n" n6
+n6 ::= "" | "NOTE: " line "\n" n7
+n7 ::= "" | "NOTE: " line "\n" n8
+n8 ::= "" | "NOTE: " line "\n" n9
+n9 ::= "" | "NOTE: " line "\n" n10
+n10 ::= "" | "NOTE: " line "\n" n11
+n11 ::= "" | "NOTE: " line "\n" n12
+n12 ::= "" | "NOTE: " line "\n" n13
+n13 ::= "" | "NOTE: " line "\n" n14
+n14 ::= "" | "NOTE: " line "\n" n15
+n15 ::= "" | "NOTE: " line "\n"
+
+out ::= [\x09\x0A\x0D\x20-\x7E]+


### PR DESCRIPTION
llama.cpp port of Structured-CoT (bounded-thinking). **Codex-implemented** (compose + registry/switch/launch wiring + docs), **Claude-validated on-rig** + grammar-dialect fix.

## What
- New compose `models/qwen3.6-27b/llama-cpp/compose/single/bounded-thinking.yml` — reasoning-on clone of `mtp.yml` (MTP n=2); grammar passed **client-side** per-request (no server flag, mirrors vLLM).
- Registered `llamacpp/bounded-thinking` (compose registry, switch.sh, launch.sh).
- New grammar `tools/grammar-eval/deepseek-scratchpad.llamacpp.gbnf` — llama.cpp-GBNF variant of the DeepSeek scratchpad.
- Docs: STRUCTURED_COT.md llama.cpp section + READMEs repointed to the variant; vLLM grammar untouched.

## The fix that made it work (on-rig)
The xgrammar `deepseek-scratchpad.gbnf` does **not** parse under llama.cpp's GBNF — underscored rule names (`line_char`) trip `parse: error parsing grammar: expecting newline or end at _char`, and llama-server **silently falls back to unconstrained generation** (FREE==FSM token counts). Fix: the no-underscore variant (llama.cpp rule names are `[a-zA-Z0-9-]` only).

## Validation (1× 3090, 2026-05-24) — all 3 gates PASS
- **Parse** ✓ (no error) · **Fires** ✓ `reasoning_content` = PLAN/NOTE/VERDICT · **MTP coexist** ✓ draft acceptance 0.66–0.88 with `--spec-type draft-mtp`
- FREE→FSM: **2113→1009 tok (2.1×)**, **934→331 (2.8×)** @ temp 0.6; answers correct (e.g. bat-and-ball $0.05).
- Static (Codex): compose config, registry/switch/launch parity, profiles compat, py_compile, diff --check.

Also redacted a pre-existing `/home/wasif/...` path in STRUCTURED_COT.md caught by the pre-commit scan. Full HE+/LCB bench + BENCHMARKS row are a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)