### PR TITLE
Expose benchlocal --reasoning suite + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cd club-3090
 # 2. Pick/download + SHA-verify the model (interactive hardware-aware picker)
 #    (asks you which model, then where to put model weights — pick in-repo
 #     default, ~/models, or a custom path on a different drive. To skip prompts:
-#     `export MODEL_DIR=/mnt/your-drive/models` and pass the model name. See FAQ.)
+#     `export MODEL_DIR=/path/to/models` and pass the model name. See FAQ.)
 bash scripts/setup.sh
 #    Or scripted:
 #      bash scripts/setup.sh qwen3.6-27b
@@ -113,6 +113,14 @@ More models coming — they go under `models/<name>/` with the same internal pat
 ![Qwen3.6-27B TPS by config](docs/img/performance.png)
 
 Bench protocol: 3 warm + 5 measured runs. See [`scripts/bench.sh`](scripts/bench.sh) for methodology. Per-config details + run-by-run numbers + VRAM + AL/accept rates: [models/qwen3.6-27b/CHANGELOG.md](models/qwen3.6-27b/CHANGELOG.md).
+
+Behavioral quality gates live in [`docs/QUALITY_TEST.md`](docs/QUALITY_TEST.md):
+
+```bash
+bash scripts/quality-test.sh --quick
+bash scripts/quality-test.sh --full
+bash scripts/quality-test.sh --reasoning
+```
 
 ---
 

--- a/docs/QUALITY_TEST.md
+++ b/docs/QUALITY_TEST.md
@@ -11,7 +11,7 @@ verify.sh         — fast smoke (15s,        "does it serve")
 verify-full.sh    — functional (1-2min,     "does everything work")
 verify-stress.sh  — boundary (5-10min,      "does it survive stress")
 bench.sh          — throughput (3-5min,     "what's the TPS")
-quality-test.sh   — behavioral (10-30min,   "does it produce useful output")  ← THIS
+quality-test.sh   — behavioral (10-90min,   "does it produce useful output")  ← THIS
 soak-test.sh      — stability (30-60min,    "does it stay healthy over time")
 ```
 
@@ -39,6 +39,15 @@ Three **sandboxed** packs add execution-backed verification via Docker sandboxes
 
 A separate eval-expansion pack, **AiderPolyglot-30** (multi-language code editing across cpp/go/java/js/python/rust), runs *independently* — not bundled into `--quick`/`--medium`/`--full`. Drive it via `benchlocal-cli run --pack aider-polyglot-30 --enable-sandboxed-packs`, or as the `aider` leg of [`rebench-full.sh`](../scripts/rebench-full.sh).
 
+The **reasoning suite** is also separate from `--full`; run it with `--reasoning` when you specifically want code/math/science reasoning signal under thinking-on pack defaults:
+
+| Pack | Verifier | Why it matters for club-3090 users |
+|---|---|---|
+| **HumanEval+-30** | Code execution sandbox over HumanEval+ functional tests | Small Python coding tasks; catches code-reasoning regressions quickly. |
+| **LiveCodeBench-v6-30** | Code execution sandbox over public LCB functional tests | Harder post-2025 coding tasks; exposes budget runaway and algorithmic failures. |
+| **GSM-Symbolic-30** | Deterministic `answer_match` exact numeric scoring | Symbolic grade-school math without LLM-as-judge. |
+| **GPQA-Diamond** | Deterministic `answer_match` exact letter scoring | Science QA placeholder; gated metadata-only until dataset access is materialized, so it reports `dataset-unavailable` instead of committing restricted data. |
+
 ## Modes
 
 | Mode | Packs | Budget | When to run |
@@ -46,8 +55,9 @@ A separate eval-expansion pack, **AiderPolyglot-30** (multi-language code editin
 | `--quick` | ToolCall + InstructFollow (2) | ~10-15 min | Per-commit gate; pre-push smoke. The two packs that catch the highest-value regressions for IDE-agent users. No Docker. |
 | `--medium` (default) | + StructOutput + DataExtract + ReasonMath (5) | ~25-30 min | Pre-release; pin bumps; new compose authoring. Generates the `Quality:` line for the compose schema. No Docker. |
 | `--full` | + BugFind + HermesAgent + CLI (8) | ~45-60 min | Cross-rig comparison; quality A/B vs another quant. **The 3 added packs are Docker-sandboxed — needs Docker.** |
+| `--reasoning` | HumanEval+ + LiveCodeBench v6 + GSM-Symbolic + GPQA-Diamond metadata (4) | ~30-90+ min | Dedicated reasoning/code suite. Thinking defaults on for all 4 packs; HumanEval+ and LCB need Docker. |
 
-`--full` runs the sandbox packs by default. `--no-sandboxed` drops `--full` back to the 5-pack deterministic scope (no Docker); `--sandboxed-only` runs just the 3 sandbox packs.
+`--full` runs the sandbox packs by default. `--no-sandboxed` drops `--full` back to the 5-pack deterministic scope (no Docker); `--sandboxed-only` runs just the 3 sandbox packs. `--reasoning` is independent of `--full`; use it for the four reasoning packs, with GPQA skipped until gated data is available.
 
 ## Install (one-time)
 
@@ -73,6 +83,9 @@ bash scripts/quality-test.sh --quick
 # full mode (pin bumps, cross-rig comparison)
 bash scripts/quality-test.sh --full
 
+# dedicated reasoning suite (thinking-on pack defaults; code packs need Docker)
+bash scripts/quality-test.sh --reasoning
+
 # explicit endpoint override
 URL=http://localhost:8011 bash scripts/quality-test.sh --quick
 
@@ -84,6 +97,12 @@ bash scripts/quality-test.sh --full --no-sandboxed
 
 # run ONLY the 3 sandbox packs
 bash scripts/quality-test.sh --sandboxed-only
+
+# run individual reasoning packs
+bash scripts/quality-test.sh --pack humaneval-plus-30 --enable-thinking --thinking-max-tokens 16384 --timeout-per-case 300
+bash scripts/quality-test.sh --pack lcb-v6-30 --enable-thinking --thinking-max-tokens 16384 --timeout-per-case 300
+bash scripts/quality-test.sh --pack gsm-symbolic-30
+bash scripts/quality-test.sh --pack gpqa-diamond
 ```
 
 Output:
@@ -145,20 +164,23 @@ benchlocal-cli run --full --endpoint http://localhost:8020 --model <name> --temp
 
 ### Reasoning-on evals
 
-Serving with `--reasoning on` is necessary but not sufficient: the request also has to send `chat_template_kwargs.enable_thinking=true`. The wrappers default to thinking off for canonical, reproducible runs. Enable it explicitly when measuring a reasoning fine-tune:
+Serving with a model's reasoning flag enabled is necessary but not sufficient: the request also has to send `chat_template_kwargs.enable_thinking=true`. `benchlocal-cli` honors each pack's `default_thinking` metadata, so the dedicated `--reasoning` suite defaults thinking on for all four packs while many format/extraction packs stay answer-only. Use `--enable-thinking` only when you want to force thinking on for every pack in a broader mode such as `--full`:
 
 ```bash
-# quality only
-bash scripts/quality-test.sh --full --enable-thinking --thinking-max-tokens 4096
+# dedicated reasoning suite; default thinking is on for these packs
+bash scripts/quality-test.sh --reasoning --thinking-max-tokens 16384
+
+# force thinking on for every full-suite pack
+bash scripts/quality-test.sh --full --enable-thinking --thinking-max-tokens 16384
 
 # full rebench: bench.sh + both quality-test.sh legs inherit it
-ENABLE_THINKING=1 THINKING_MAX_TOKENS=4096 SAMPLING_FROM_SERVER=1 bash scripts/rebench-full.sh
+ENABLE_THINKING=1 THINKING_MAX_TOKENS=16384 SAMPLING_FROM_SERVER=1 bash scripts/rebench-full.sh
 
 # TPS bench only
 ENABLE_THINKING=1 bash scripts/bench.sh
 ```
 
-If `/props` or the running container suggests reasoning is enabled but the wrapper is still sending `enable_thinking=false`, `quality-test.sh` / `bench.sh` print a warning rather than silently measuring the thinking-off path.
+If `/props` or the running container suggests reasoning is enabled but the wrapper is not forcing thinking on globally, `quality-test.sh` / `bench.sh` print a warning; pack defaults still apply, and `--enable-thinking` forces every pack on. `--thinking-max-tokens` now passes through independently and only affects packs whose thinking gate resolves on. The default is 16K; hard LiveCodeBench items may still exhaust that budget, so compare with `benchlocal-cli run --reasoning --no-thinking` when diagnosing budget runaway.
 
 **Why it matters:** a reasoning / exploratory fine-tune (e.g. Qwopus3.6, whose author recommends temp 0.75–1) is *under-represented* at temp 0 or with thinking disabled — greedy, thinking-off decoding collapses the path-exploration the fine-tune was trained for. But high temp and reasoning also *hurt* deterministic packs (DataExtract / StructOutput want exact, repeatable output), so read **per-pack deltas**, not just the total — and keep canonical temp-0 thinking-off as the bar for any apples-to-apples ranking.
 

--- a/scripts/quality-test.sh
+++ b/scripts/quality-test.sh
@@ -85,9 +85,10 @@ OPTIONS (extra)
                    models are evaluated with request-level thinking enabled.
                    Also settable via ENABLE_THINKING=1 env.
   --thinking-max-tokens N
-                   Forward to benchlocal-cli --thinking-max-tokens N when
-                   --enable-thinking / ENABLE_THINKING=1 is active. Also
-                   settable via THINKING_MAX_TOKENS env.
+                   Forward to benchlocal-cli --thinking-max-tokens N. The
+                   budget applies only to packs whose thinking gate resolves on
+                   (pack default or --enable-thinking). Also settable via
+                   THINKING_MAX_TOKENS env.
 
 ENV VARS
   URL              Endpoint base URL (default: auto-detected via preflight,
@@ -101,14 +102,14 @@ ENV VARS
   ENABLE_THINKING Set to 1 to send request-level enable_thinking=true via
                    benchlocal-cli --enable-thinking. Default: 0.
   THINKING_MAX_TOKENS
-                   Optional thinking budget passed through to benchlocal-cli
-                   --thinking-max-tokens when thinking is enabled.
+                   Optional thinking budget passed through to benchlocal-cli.
+                   Applies only to packs whose thinking gate resolves on.
 
 EXAMPLES
   bash scripts/quality-test.sh                          # --medium against running compose
   bash scripts/quality-test.sh --quick                  # quicker, 2 packs only
   bash scripts/quality-test.sh --full                   # everything, needs Docker
-  bash scripts/quality-test.sh --reasoning              # HE+/LCB/GSM reasoning fast subsets
+  bash scripts/quality-test.sh --reasoning              # HE+/LCB/GSM/GPQA reasoning suite
   bash scripts/quality-test.sh --pack toolcall-15       # just the tool-call pack
   bash scripts/quality-test.sh --pack aider-polyglot-30 --timeout-per-case 3600
   URL=http://localhost:8030 bash scripts/quality-test.sh # against a different port
@@ -335,7 +336,7 @@ sys.exit(0 if walk(obj) else 1)
 }
 
 if [[ "$ENABLE_THINKING" != "1" ]] && server_reasoning_on; then
-  echo "[quality-test] WARN: server appears to have reasoning enabled, but requests will send enable_thinking=false. Use --enable-thinking or ENABLE_THINKING=1 for reasoning-on evals." >&2
+  echo "[quality-test] WARN: server appears to have reasoning enabled, but --enable-thinking is not forced. Pack defaults still apply; use --enable-thinking or ENABLE_THINKING=1 to force thinking on for every pack." >&2
 fi
 
 # ---- run benchlocal-cli ------------------------------------------------------
@@ -385,12 +386,10 @@ fi
 if [[ "$ENABLE_THINKING" == "1" ]]; then
   CLI_ARGS+=(--enable-thinking)
   echo "[quality-test] thinking: enabled (non-canonical)"
-  if [[ -n "$THINKING_MAX_TOKENS" ]]; then
-    CLI_ARGS+=(--thinking-max-tokens "$THINKING_MAX_TOKENS")
-    echo "[quality-test] thinking max tokens: $THINKING_MAX_TOKENS"
-  fi
-elif [[ -n "$THINKING_MAX_TOKENS" ]]; then
-  echo "[quality-test] NOTE: THINKING_MAX_TOKENS is set but thinking is off; ignoring it. Set ENABLE_THINKING=1 or --enable-thinking." >&2
+fi
+if [[ -n "$THINKING_MAX_TOKENS" ]]; then
+  CLI_ARGS+=(--thinking-max-tokens "$THINKING_MAX_TOKENS")
+  echo "[quality-test] thinking max tokens: $THINKING_MAX_TOKENS (applies to thinking-enabled packs)"
 fi
 
 # Run; capture exit code so we can also try to emit the compact one-liner

--- a/scripts/quality-test.sh
+++ b/scripts/quality-test.sh
@@ -38,12 +38,18 @@ MODES
              ~15-25 min, no Docker required
   --full     8 packs:  + bugfind-15, hermesagent-20, cli-40
              ~25-40 min, requires Docker (auto-starts sandbox containers)
+  --reasoning
+             Reasoning suite: humaneval-plus-30, lcb-v6-30, gpqa-diamond
+             metadata gate, gsm-symbolic-30. Separate from --full; code
+             packs require Docker.
 
   --pack PACK_ID   Run a single pack (overrides mode flag).
                    Available IDs:
                      toolcall-15  instructfollow-15  structoutput-15
                      dataextract-15  reasonmath-15
                      bugfind-15  cli-40  hermesagent-20  (require Docker)
+                     humaneval-plus-30  lcb-v6-30  gsm-symbolic-30
+                     gpqa-diamond  (gated metadata-only until access approved)
 
 OPTIONS
   -h, --help       Show this help and exit
@@ -102,6 +108,7 @@ EXAMPLES
   bash scripts/quality-test.sh                          # --medium against running compose
   bash scripts/quality-test.sh --quick                  # quicker, 2 packs only
   bash scripts/quality-test.sh --full                   # everything, needs Docker
+  bash scripts/quality-test.sh --reasoning              # HE+/LCB/GSM reasoning fast subsets
   bash scripts/quality-test.sh --pack toolcall-15       # just the tool-call pack
   bash scripts/quality-test.sh --pack aider-polyglot-30 --timeout-per-case 3600
   URL=http://localhost:8030 bash scripts/quality-test.sh # against a different port
@@ -154,7 +161,7 @@ THINKING_MAX_TOKENS="${THINKING_MAX_TOKENS:-}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --quick|--medium|--full)
+    --quick|--medium|--full|--reasoning)
       MODE="$1"
       shift
       ;;

--- a/scripts/tests/test-quality-thinking.sh
+++ b/scripts/tests/test-quality-thinking.sh
@@ -77,10 +77,23 @@ chmod +x "${tmp_bin}/benchlocal-cli"
 
 out="$(PATH="${tmp_bin}:$PATH" BENCHLOCAL_MOCK_LOG="$tmp_log" PREFLIGHT_NO_AUTODETECT=1 URL=http://mock MODEL=mock-model ENABLE_THINKING=1 THINKING_MAX_TOKENS=4096 bash scripts/quality-test.sh --quick 2>&1)"
 assert_contains "$out" "[quality-test] thinking: enabled"
-assert_contains "$out" "[quality-test] thinking max tokens: 4096"
+assert_contains "$out" "[quality-test] thinking max tokens: 4096 (applies to thinking-enabled packs)"
 args="$(cat "$tmp_log")"
 assert_contains "$args" "--enable-thinking"
 assert_contains "$args" "--thinking-max-tokens 4096"
+
+
+: > "$tmp_log"
+out="$(PATH="${tmp_bin}:$PATH" BENCHLOCAL_MOCK_LOG="$tmp_log" PREFLIGHT_NO_AUTODETECT=1 URL=http://mock MODEL=mock-model THINKING_MAX_TOKENS=8192 bash scripts/quality-test.sh --reasoning 2>&1)"
+assert_contains "$out" "[quality-test] thinking max tokens: 8192 (applies to thinking-enabled packs)"
+args="$(cat "$tmp_log")"
+assert_contains "$args" "--reasoning"
+assert_contains "$args" "--thinking-max-tokens 8192"
+if [[ "$args" == *"--enable-thinking"* ]]; then
+  echo "ASSERTION FAILED: quality-test forced --enable-thinking when only THINKING_MAX_TOKENS was set" >&2
+  echo "$args" >&2
+  exit 1
+fi
 
 : > "$tmp_log"
 out="$(PATH="${tmp_bin}:$PATH" BENCHLOCAL_MOCK_LOG="$tmp_log" PREFLIGHT_NO_AUTODETECT=1 URL=http://mock MODEL=mock-model bash scripts/quality-test.sh --quick 2>&1)"


### PR DESCRIPTION
Surfaces the benchlocal reasoning suite on the club-3090 side (pairs with noonghunna/benchlocal-cli#27).

- `scripts/quality-test.sh`: `--reasoning` mode parsing + help; fixes `--thinking-max-tokens` to pass through to **pack-default** thinking (not only when `--enable-thinking` is forced).
- `docs/QUALITY_TEST.md`: `--reasoning` row in the Modes table, the 4 reasoning packs in "What the packs measure", `--pack` examples, thinking-budget guidance raised 4K→16K.
- `README.md`: `quality-test.sh --reasoning` line in the Benchmarks section.

**Validation:** `bash -n` clean; `scripts/tests/test-quality-thinking.sh` passes; internal-path scan clean. Live `:8020` end-to-end eval pending (GPU busy with a reference run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)