### PR TITLE
Generalize compose model presence preflight

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -582,6 +582,46 @@ preflight_hf_token() {
 #
 # Hard error (returns 1) — refuses to proceed if a required model dir is missing.
 # Skip via: PREFLIGHT_NO_COMPOSE_DEPS=1
+_preflight_compose_model_dir() {
+  local compose_file="$1"
+  local model_dir="${MODEL_DIR:-../../../../models-cache}"
+
+  # Resolve relative paths against the compose location. Do not require the
+  # directory to already exist; this function is often called before download.
+  if [[ "$model_dir" == ../* ]] || [[ "$model_dir" == ./* ]]; then
+    local compose_dir
+    compose_dir="$(cd -- "$(dirname -- "$compose_file")" && pwd)"
+    model_dir="${compose_dir}/${model_dir}"
+  fi
+  printf '%s' "$model_dir"
+}
+
+_preflight_compose_path_default() {
+  local value="$1"
+  value="$(_preflight_trim "$value")"
+  value="${value#\"}"
+  value="${value%\"}"
+  value="${value#\'}"
+  value="${value%\'}"
+  value="${value%,}"
+
+  # Compose files commonly use ${VAR:-default/path}. Presence checks should use
+  # the path the compose will use by default; explicit env overrides are handled
+  # by callers for user-facing knobs such as GGUF_FILE.
+  value="$(printf '%s' "$value" | sed -E 's#\$\{[A-Za-z_][A-Za-z0-9_]*:-([^}]*)\}#\1#g')"
+  value="$(printf '%s' "$value" | sed -E 's#\$\{MODEL_DIR[^}]*\}/?##g')"
+  value="${value#/models/}"
+  value="${value#/root/.cache/huggingface/}"
+  printf '%s' "$value"
+}
+
+_preflight_compose_vllm_subdir() {
+  local value
+  value="$(_preflight_compose_path_default "$1")"
+  value="${value%%/*}"
+  printf '%s' "$value"
+}
+
 preflight_compose_deps() {
   local compose_file="$1"
   if [[ "${PREFLIGHT_NO_COMPOSE_DEPS:-0}" == "1" ]]; then
@@ -592,76 +632,96 @@ preflight_compose_deps() {
     return 1
   fi
 
-  local model_dir="${MODEL_DIR:-../../../../models-cache}"
-  # Resolve relative to repo root (compose mounts use ${MODEL_DIR:-../../../../models-cache})
-  if [[ "$model_dir" == ../* ]] || [[ "$model_dir" == ./* ]]; then
-    model_dir="$(cd "${ROOT_DIR:-$(dirname "$0")/..}" && cd "$(dirname "$compose_file")" && cd "$model_dir" 2>/dev/null && pwd)"
-  fi
+  local model_dir
+  model_dir="$(_preflight_compose_model_dir "$compose_file")"
+
+  local compose_files=("$compose_file")
+  local compose_dir extends_file
+  compose_dir="$(cd -- "$(dirname -- "$compose_file")" && pwd)"
+  while IFS= read -r extends_file; do
+    extends_file="$(_preflight_trim "$extends_file")"
+    extends_file="${extends_file#\"}"
+    extends_file="${extends_file%\"}"
+    extends_file="${extends_file#'}"
+    extends_file="${extends_file%'}"
+    [[ -n "$extends_file" ]] || continue
+    [[ "$extends_file" == /* ]] || extends_file="${compose_dir}/${extends_file}"
+    [[ -f "$extends_file" ]] && compose_files+=("$extends_file")
+  done < <(grep -hE '^[[:space:]]*file:[[:space:]]*[^#[:space:]]+' "$compose_file" \
+    | sed -E 's/^[[:space:]]*file:[[:space:]]*//' || true)
 
   local missing=()
-  local hint_dflash=0
-  local hint_mtp=0
-  local hint_gguf=0
 
   # Engine detection: llama.cpp composes mount ${MODEL_DIR}:/models and pass
-  # `-m /models/<path>`; vLLM composes mount ${MODEL_DIR}:/root/.cache/huggingface
-  # and pass `--model /root/.cache/huggingface/<subdir>`.
+  # `-m /models/<path>` or `--model /models/<path>`; vLLM composes mount
+  # ${MODEL_DIR}:/root/.cache/huggingface and pass
+  # `/root/.cache/huggingface/<subdir>`.
   local is_llamacpp=0
-  if grep -qE 'image:.*ggml-org/llama\.cpp' "$compose_file"; then
+  if grep -qhE 'image:.*(ggml-org/llama\.cpp|ikawrakow/ik-llama)' "${compose_files[@]}"; then
     is_llamacpp=1
   fi
 
   if [[ $is_llamacpp -eq 1 ]]; then
-    # Scan for `-m /models/<path>` and `--mmproj /models/<path>` to learn what
-    # the compose actually expects. Falls back to the canonical defaults from
-    # docker-compose.yml if the variable expansion isn't grep-resolvable.
-    local gguf_in_container mmproj_in_container
-    gguf_in_container=$(grep -oE '\-m[[:space:]]+/models/[^[:space:]]+' "$compose_file" \
-      | head -1 | awk '{print $2}' | sed 's|^/models/||')
-    mmproj_in_container=$(grep -oE -- '--mmproj[[:space:]]+/models/[^[:space:]]+' "$compose_file" \
-      | head -1 | awk '{print $2}' | sed 's|^/models/||')
+    local gguf_paths=()
+    local mmproj_paths=()
+    local token path
 
-    # Strip ${VAR:-default} expansion: take the default after `:-` if present.
-    gguf_in_container="${gguf_in_container//\$\{GGUF_FILE:-/}"
-    gguf_in_container="${gguf_in_container%\}}"
-    mmproj_in_container="${mmproj_in_container//\$\{MMPROJ_FILE:-/}"
-    mmproj_in_container="${mmproj_in_container%\}}"
+    while IFS= read -r token; do
+      path="$(_preflight_compose_path_default "$token")"
+      [[ -n "$path" ]] && gguf_paths+=("$path")
+    done < <(grep -hoE -- '(^|[[:space:]])(-m|--model)[[:space:]]+/models/[^[:space:]]+' "${compose_files[@]}" \
+      | awk '{print $NF}' || true)
 
-    [[ -z "$gguf_in_container" ]]   && gguf_in_container="qwen3.6-27b-gguf/unsloth-q3kxl/Qwen3.6-27B-UD-Q3_K_XL.gguf"
-    [[ -z "$mmproj_in_container" ]] && mmproj_in_container="qwen3.6-27b-gguf/mmproj-F16.gguf"
+    while IFS= read -r token; do
+      path="$(_preflight_compose_path_default "$token")"
+      [[ -n "$path" ]] && mmproj_paths+=("$path")
+    done < <(grep -hoE -- '(^|[[:space:]])--mmproj[[:space:]]+/models/[^[:space:]]+' "${compose_files[@]}" \
+      | awk '{print $NF}' || true)
 
-    if [[ -n "${GGUF_FILE:-}" ]];   then gguf_in_container="$GGUF_FILE";     fi
-    if [[ -n "${MMPROJ_FILE:-}" ]]; then mmproj_in_container="$MMPROJ_FILE"; fi
-
-    if [[ ! -f "${model_dir}/${gguf_in_container}" ]]; then
-      missing+=("${gguf_in_container} (llama.cpp GGUF weights)")
-      hint_gguf=1
+    if [[ -n "${GGUF_FILE:-}" ]]; then
+      gguf_paths=("$GGUF_FILE")
     fi
-    if [[ ! -f "${model_dir}/${mmproj_in_container}" ]]; then
-      missing+=("${mmproj_in_container} (vision projector)")
-      hint_gguf=1
+    if [[ -n "${MMPROJ_FILE:-}" && ${#mmproj_paths[@]} -gt 0 ]]; then
+      mmproj_paths=("$MMPROJ_FILE")
     fi
+
+    for path in "${gguf_paths[@]}"; do
+      if [[ ! -f "${model_dir}/${path}" ]]; then
+        missing+=("${model_dir}/${path} (llama.cpp GGUF weights)")
+      fi
+    done
+    for path in "${mmproj_paths[@]}"; do
+      if [[ ! -f "${model_dir}/${path}" ]]; then
+        missing+=("${model_dir}/${path} (vision projector)")
+      fi
+    done
   else
-    # vLLM path — scan for --speculative-config blocks (DFlash draft, MTP head).
-    # The compose paths reference the in-container path /root/.cache/huggingface/<subdir>;
-    # the host path is ${MODEL_DIR}/<subdir> (set via the volumes: block).
-    if grep -qE '"model":[[:space:]]*"/root/.cache/huggingface/qwen3.6-27b-dflash"' "$compose_file"; then
-      if [[ ! -f "${model_dir}/qwen3.6-27b-dflash/config.json" ]]; then
-        missing+=("qwen3.6-27b-dflash (DFlash draft model)")
-        hint_dflash=1
-      fi
-    fi
-    if grep -qE '"model":[[:space:]]*"/root/.cache/huggingface/qwen3.6-27b-mtp-head"' "$compose_file"; then
-      if [[ ! -f "${model_dir}/qwen3.6-27b-mtp-head/config.json" ]]; then
-        missing+=("qwen3.6-27b-mtp-head (MTP draft head)")
-        hint_mtp=1
-      fi
-    fi
+    local seen_subdirs=" "
+    local subdir
 
-    # vLLM main model — every vLLM compose on this stack mounts AutoRound INT4.
-    if [[ ! -f "${model_dir}/qwen3.6-27b-autoround-int4/config.json" ]]; then
-      missing+=("qwen3.6-27b-autoround-int4 (main model)")
-    fi
+    # vLLM path — collect every in-container HF model path the compose names:
+    # main `--model` entries and JSON `--speculative-config` draft models.
+    while IFS= read -r token; do
+      subdir="$(_preflight_compose_vllm_subdir "$token")"
+      [[ -n "$subdir" ]] || continue
+      if [[ "$seen_subdirs" != *" ${subdir} "* ]]; then
+        seen_subdirs+="${subdir} "
+        if [[ ! -f "${model_dir}/${subdir}/config.json" ]]; then
+          missing+=("${model_dir}/${subdir}/config.json (HF model)")
+        fi
+      fi
+    done < <(grep -hoE '/root/\.cache/huggingface/[^"'\''[:space:],}:]+' "${compose_files[@]}" || true)
+
+    # Experimental SGLang composes mount individual MODEL_DIR subdirectories to
+    # /models/target and /models/drafter instead of using the HF cache mount.
+    while IFS= read -r token; do
+      path="$(_preflight_compose_path_default "$token")"
+      path="${path%%:*}"
+      [[ -n "$path" ]] || continue
+      if [[ ! -e "${model_dir}/${path}" ]]; then
+        missing+=("${model_dir}/${path} (MODEL_DIR volume path)")
+      fi
+    done < <(grep -hoE '\$\{MODEL_DIR[^}]*\}/[^"[:space:]]+' "${compose_files[@]}" || true)
   fi
 
   if [[ ${#missing[@]} -eq 0 ]]; then
@@ -670,30 +730,12 @@ preflight_compose_deps() {
 
   echo "[preflight] ERROR: compose '$compose_file' expects model files that aren't on host." >&2
   for item in "${missing[@]}"; do
-    echo "[preflight]   missing: ${model_dir}/${item}" >&2
+    echo "[preflight]   missing: ${item}" >&2
   done
   echo "[preflight]" >&2
   echo "[preflight] Fix:" >&2
-  if [[ $hint_gguf -eq 1 ]]; then
-    echo "[preflight]   hf download unsloth/Qwen3.6-27B-GGUF \\" >&2
-    echo "[preflight]     Qwen3.6-27B-UD-Q3_K_XL.gguf mmproj-F16.gguf \\" >&2
-    echo "[preflight]     --local-dir \${MODEL_DIR}/qwen3.6-27b-gguf/unsloth-q3kxl" >&2
-    echo "[preflight]   # (set MODEL_DIR first: export MODEL_DIR=\${MODEL_DIR:-/path/to/your/models})" >&2
-    echo "[preflight]   # mmproj lands at unsloth-q3kxl/ — move it up so the default --mmproj path resolves:" >&2
-    echo "[preflight]   #   mv \${MODEL_DIR}/qwen3.6-27b-gguf/unsloth-q3kxl/mmproj-F16.gguf \${MODEL_DIR}/qwen3.6-27b-gguf/" >&2
-    echo "[preflight]   (~16 GB total. setup.sh today only fetches the vLLM AutoRound weights;" >&2
-    echo "[preflight]    GGUF must be fetched separately for any llamacpp/* variant.)" >&2
-  fi
-  if [[ $hint_dflash -eq 1 ]]; then
-    echo "[preflight]   WITH_DFLASH_DRAFT=1 bash scripts/setup.sh qwen3.6-27b" >&2
-    echo "[preflight]   (downloads z-lab/Qwen3.6-27B-DFlash, ~1.75 GB; required for dual-dflash* composes)" >&2
-  fi
-  if [[ $hint_mtp -eq 1 ]]; then
-    echo "[preflight]   bash scripts/setup.sh qwen3.6-27b  (re-run with the right flags for MTP head)" >&2
-  fi
-  if [[ $hint_dflash -eq 0 ]] && [[ $hint_mtp -eq 0 ]] && [[ $hint_gguf -eq 0 ]]; then
-    echo "[preflight]   bash scripts/setup.sh qwen3.6-27b" >&2
-  fi
+  echo "[preflight]   Check the compose header for its model-specific hf download command." >&2
+  echo "[preflight]   If weights are already elsewhere, export MODEL_DIR=/path/to/models and retry." >&2
   echo "[preflight] Skip this check:  PREFLIGHT_NO_COMPOSE_DEPS=1 bash scripts/switch.sh ..." >&2
   return 1
 }

--- a/scripts/tests/test-preflight-compose-deps.sh
+++ b/scripts/tests/test-preflight-compose-deps.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "ASSERTION FAILED: expected output to contain: $needle" >&2
+    echo "--- output ---" >&2
+    echo "$haystack" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "ASSERTION FAILED: expected output not to contain: $needle" >&2
+    echo "--- output ---" >&2
+    echo "$haystack" >&2
+    exit 1
+  fi
+}
+
+run_deps() {
+  local compose="$1"
+  local model_dir="$2"
+  (
+    export ROOT_DIR MODEL_DIR="$model_dir"
+    source "${ROOT_DIR}/scripts/preflight.sh"
+    preflight_compose_deps "$compose"
+  ) 2>&1
+}
+
+expect_missing() {
+  local compose="$1"
+  local model_dir="$2"
+  local output
+
+  if output="$(run_deps "$compose" "$model_dir")"; then
+    echo "ASSERTION FAILED: expected missing-model failure for $compose" >&2
+    echo "--- output ---" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+  printf '%s' "$output"
+}
+
+ik_compose="${TMP_DIR}/ik.yml"
+cat > "$ik_compose" <<'YAML'
+services:
+  ik:
+    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu13-server}
+    command: >-
+      --model /models/${GGUF_FILE:-qwen3.6-27b-gguf/ubergarm-mtp-iq4ks/Qwen3.6-27B-MTP-IQ4_KS.gguf}
+YAML
+
+out="$(expect_missing "$ik_compose" "${TMP_DIR}/empty-models")"
+assert_contains "$out" "qwen3.6-27b-gguf/ubergarm-mtp-iq4ks/Qwen3.6-27B-MTP-IQ4_KS.gguf"
+assert_not_contains "$out" "qwen3.6-27b-autoround-int4"
+
+llama_compose="${TMP_DIR}/llama.yml"
+cat > "$llama_compose" <<'YAML'
+services:
+  llama:
+    image: ${LLAMACPP_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda-b9246}
+    command: >-
+      -m /models/${GGUF_FILE:-qwen3.6-27b-gguf/unsloth-mtp-q4km/Qwen3.6-27B-Q4_K_M.gguf}
+YAML
+mkdir -p "${TMP_DIR}/models/qwen3.6-27b-gguf/unsloth-mtp-q4km"
+touch "${TMP_DIR}/models/qwen3.6-27b-gguf/unsloth-mtp-q4km/Qwen3.6-27B-Q4_K_M.gguf"
+out="$(run_deps "$llama_compose" "${TMP_DIR}/models")"
+[[ -z "$out" ]]
+
+vllm_compose="${TMP_DIR}/gemma.yml"
+cat > "$vllm_compose" <<'YAML'
+services:
+  vllm:
+    image: ghcr.io/noonghunna/vllm-club3090:latest
+    command:
+      - --model
+      - /root/.cache/huggingface/gemma-4-31b-autoround-int4
+      - --speculative-config
+      - '{"model":"/root/.cache/huggingface/gemma-4-31b-it-assistant","num_speculative_tokens":4}'
+YAML
+out="$(expect_missing "$vllm_compose" "${TMP_DIR}/empty-models")"
+assert_contains "$out" "gemma-4-31b-autoround-int4/config.json"
+assert_contains "$out" "gemma-4-31b-it-assistant/config.json"
+assert_not_contains "$out" "qwen3.6-27b-autoround-int4"
+mkdir -p "${TMP_DIR}/models/gemma-4-31b-autoround-int4" "${TMP_DIR}/models/gemma-4-31b-it-assistant"
+touch "${TMP_DIR}/models/gemma-4-31b-autoround-int4/config.json" "${TMP_DIR}/models/gemma-4-31b-it-assistant/config.json"
+out="$(run_deps "$vllm_compose" "${TMP_DIR}/models")"
+[[ -z "$out" ]]
+
+
+extends_base="${TMP_DIR}/base.yml"
+extends_stub="${TMP_DIR}/stub.yml"
+cat > "$extends_base" <<'YAML'
+services:
+  vllm-base:
+    image: ghcr.io/noonghunna/vllm-club3090:latest
+    command:
+      - --model
+      - /root/.cache/huggingface/qwen3.6-27b-autoround-int4
+YAML
+cat > "$extends_stub" <<'YAML'
+services:
+  vllm-stub:
+    extends:
+      file: base.yml
+      service: vllm-base
+YAML
+out="$(expect_missing "$extends_stub" "${TMP_DIR}/empty-models")"
+assert_contains "$out" "qwen3.6-27b-autoround-int4/config.json"
+
+sglang_compose="${TMP_DIR}/sglang.yml"
+cat > "$sglang_compose" <<'YAML'
+services:
+  sglang:
+    image: ghcr.io/sgl-project/sglang:v0.5.12
+    volumes:
+      - "${MODEL_DIR:?MODEL_DIR is required}/qwen3.6-27b-autoround-int4:/models/target:ro"
+      - "${MODEL_DIR}/qwen3.6-27b-prism-eagle3/compressed:/models/drafter:ro"
+YAML
+out="$(expect_missing "$sglang_compose" "${TMP_DIR}/empty-models")"
+assert_contains "$out" "qwen3.6-27b-autoround-int4"
+assert_contains "$out" "qwen3.6-27b-prism-eagle3/compressed"
+mkdir -p "${TMP_DIR}/models/qwen3.6-27b-autoround-int4" "${TMP_DIR}/models/qwen3.6-27b-prism-eagle3/compressed"
+out="$(run_deps "$sglang_compose" "${TMP_DIR}/models")"
+[[ -z "$out" ]]
+
+echo "test-preflight-compose-deps: ok"


### PR DESCRIPTION
## Summary
- derive model presence checks from compose-declared llama.cpp/ik, vLLM, and direct MODEL_DIR paths instead of hardcoding qwen3.6-27b autoround
- scan one-level compose extends stubs so deprecated NVLink variants inherit the base compose model checks
- add regression coverage for ik GGUF, llama.cpp, Gemma vLLM + drafter, extends stubs, and SGLang-style direct mounts

## Validation
- bash -n scripts/preflight.sh scripts/tests/test-preflight-compose-deps.sh
- bash scripts/tests/test-preflight-compose-deps.sh
- bash scripts/tests/test-preflight-vram.sh
- bash scripts/tests/test-switch-registry-parity.sh
- empty MODEL_DIR sweep across 47 compose files: fail=47 ok=0
