### PR TITLE
Profile-backed model-weight fetch registry + register ik-llama/iq4ks-two-stage

### DIFF
--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -276,6 +276,13 @@ COMPOSE_REGISTRY = {
         compose_path="models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp-vision.yml",
         default_port=8020,
     ),
+    "ik-llama/iq4ks-two-stage": _entry(
+        model="qwen3.6-27b", weights_variant="gguf", workload="fast-chat",
+        engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q4_0",
+        tp=1, max_ctx=200000, max_num_seqs=1, mem_util=None,
+        compose_path="models/qwen3.6-27b/ik-llama/compose/single/iq4ks-two-stage.yml",
+        default_port=8020,
+    ),
 
     # Gemma 4 31B, vLLM.
     "vllm/gemma-mtp-tp1": _entry(

--- a/scripts/lib/profiles/models/gemma-4-26b-a4b.yml
+++ b/scripts/lib/profiles/models/gemma-4-26b-a4b.yml
@@ -27,20 +27,40 @@ vision_capable: true                  # multimodal — vision_config + audio_con
 weights:
   autoround_int4_mixed:
     path: gemma-4-26b-a4b-autoround-int4-mixed
+    local_subdir: gemma-4-26b-a4b-autoround-int4-mixed
     size_gb: 16.0                      # measured post-download 2026-05-15
     format: autoround
     status: ampere-blocked             # moe_intermediate_size=704 % group_size=128 = 5.5
-                                       # → Marlin K-dim alignment fails on SM86.
-                                       # Boots fine on SM90+ (Cutlass W4A8 / Machete).
+    hf_repo: Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound
     hf_repos:
       - Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound
+    engine: vllm
+    kind: main
+    verify_glob: "*.safetensors"
   awq_compressed_tensors:
     path: gemma-4-26b-a4b-awq-4bit
+    local_subdir: gemma-4-26b-a4b-awq-4bit
     size_gb: 17.0                      # measured post-download 2026-05-15
     format: compressed-tensors         # AWQ pack-quantized via vLLM compressed-tensors loader
     status: production                 # via vLLM PR #40886 overlay (Ampere-bootable)
+    hf_repo: cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit
     hf_repos:
       - cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit
+    engine: vllm
+    kind: main
+    verify_glob: "*.safetensors"
+    setup_weights_key: awq
+  assistant:
+    path: gemma-4-26b-a4b-it-assistant
+    local_subdir: gemma-4-26b-a4b-it-assistant
+    size_gb: 0.97
+    format: fp16
+    status: production
+    hf_repo: google/gemma-4-26B-A4B-it-assistant
+    engine: vllm
+    kind: draft
+    verify_glob: "*.safetensors"
+    setup_env: WITH_ASSISTANT_DRAFT=1
 default_weight_variant: awq_compressed_tensors
 compatible_drafters:
   - gemma-26b-it-assistant            # dedicated 26B-A4B MTP assistant (separate weights from 31B)

--- a/scripts/lib/profiles/models/gemma-4-31b.yml
+++ b/scripts/lib/profiles/models/gemma-4-31b.yml
@@ -17,23 +17,59 @@ attention_k_eq_v: true
 weights:
   autoround_int4:
     path: gemma-4-31b-autoround-int4
+    local_subdir: gemma-4-31b-autoround-int4
     size_gb: 18.0
     format: autoround
     status: production
+    hf_repo: Intel/gemma-4-31B-it-int4-AutoRound
     hf_repos:
       - Intel/gemma-4-31B-it-int4-AutoRound
+    engine: vllm
+    kind: main
+    verify_glob: "*.safetensors"
   awq:
     path: gemma-4-31b-it-AWQ-4bit
+    local_subdir: gemma-4-31b-it-AWQ-4bit
     size_gb: 17.0
     format: awq
     status: production
+    hf_repo: cyankiwi/gemma-4-31B-it-AWQ-4bit
     hf_repos:
       - cyankiwi/gemma-4-31B-it-AWQ-4bit
+    engine: vllm
+    kind: main
+    verify_glob: "*.safetensors"
+    setup_weights_key: awq
+  assistant:
+    path: gemma-4-31b-it-assistant
+    local_subdir: gemma-4-31b-it-assistant
+    size_gb: 0.97
+    format: fp16
+    status: production
+    hf_repo: google/gemma-4-31B-it-assistant
+    engine: vllm
+    kind: draft
+    verify_glob: "*.safetensors"
+  dflash:
+    path: gemma-4-31b-it-dflash
+    local_subdir: gemma-4-31b-it-dflash
+    size_gb: 2.9
+    format: fp16
+    status: experimental
+    hf_repo: z-lab/gemma-4-31b-it-dflash
+    engine: vllm
+    kind: draft
+    verify_glob: "*.safetensors"
+    setup_env: WITH_DFLASH_DRAFT=1
   bf16:
     path: gemma-4-31b-bf16
+    local_subdir: gemma-4-31b-bf16
     size_gb: 58.0
     format: bf16
     status: historical
+    engine: vllm
+    kind: main
+    verify_glob: "*.safetensors"
 default_weight_variant: autoround_int4
 compatible_drafters:
   - gemma-it-assistant

--- a/scripts/lib/profiles/models/qwen3.6-27b.yml
+++ b/scripts/lib/profiles/models/qwen3.6-27b.yml
@@ -19,37 +19,130 @@ attention_k_eq_v: false
 weights:
   autoround_int4:
     path: qwen3.6-27b-autoround-int4
+    local_subdir: qwen3.6-27b-autoround-int4
     size_gb: 17.5
     format: autoround
     status: production
-    # v0.8.0 Pull-Gate Tier-1 lookup slugs (full HF repo ids).
+    hf_repo: Lorbus/Qwen3.6-27B-int4-AutoRound
     hf_repos:
       - Lorbus/Qwen3.6-27B-int4-AutoRound
       - Intel/Qwen3.6-27B-int4-AutoRound
+    engine: vllm
+    kind: main
+    verify_glob: "*.safetensors"
   awq:
     path: qwen3.6-27b-awq-int4
+    local_subdir: qwen3.6-27b-awq-int4
     size_gb: 17.0
     format: awq
     status: experimental
+    engine: vllm
+    kind: main
+    verify_glob: "*.safetensors"
+  dflash:
+    path: qwen3.6-27b-dflash
+    local_subdir: qwen3.6-27b-dflash
+    size_gb: 1.75
+    format: fp16
+    status: experimental
+    hf_repo: z-lab/Qwen3.6-27B-DFlash
+    engine: vllm
+    kind: draft
+    verify_glob: "*.safetensors"
+    setup_env: WITH_DFLASH_DRAFT=1
+  prism_eagle3:
+    path: qwen3.6-27b-prism-eagle3
+    local_subdir: qwen3.6-27b-prism-eagle3
+    size_gb: variable
+    format: safetensors
+    status: experimental
+    hf_repo: Ex0bit/Qwen3.6-27B-PRISM-EAGLE3
+    engine: sglang
+    kind: draft
+    verify_glob: "*.safetensors"
+    setup_env: WITH_PRISM_EAGLE3=1
+  mtp_head:
+    path: qwen3.6-27b-mtp-head
+    local_subdir: qwen3.6-27b-mtp-head
+    size_gb: variable
+    format: safetensors
+    status: historical
+    engine: vllm
+    kind: draft
+    verify_glob: "*.safetensors"
+    manual_note: "No direct download recipe is documented for qwen3.6-27b-mtp-head in this repo."
   gguf:
     path: qwen3.6-27b-gguf
+    local_subdir: qwen3.6-27b-gguf
     size_gb: variable
     format: gguf
     status: production
+    engine: llama-cpp
+    kind: gguf
+    verify_glob: "*.gguf"
+  gguf_q4km:
+    path: qwen3.6-27b-gguf/unsloth-mtp-q4km
+    local_subdir: qwen3.6-27b-gguf/unsloth-mtp-q4km
+    size_gb: variable
+    format: gguf
+    status: production
+    hf_repo: unsloth/Qwen3.6-27B-MTP-GGUF
+    files:
+      - Qwen3.6-27B-Q4_K_M.gguf
+    engine: llama-cpp
+    kind: gguf
+    verify_glob: "*.gguf"
+    setup_weights_key: gguf
+  gguf_mmproj_f16:
+    path: qwen3.6-27b-gguf
+    local_subdir: qwen3.6-27b-gguf
+    size_gb: variable
+    format: gguf
+    status: production
+    hf_repo: unsloth/Qwen3.6-27B-GGUF
+    files:
+      - mmproj-F16.gguf
+    engine: llama-cpp
+    kind: mmproj
+    verify_glob: "*.gguf"
+    setup_weights_key: gguf
+  gguf_iq4ks:
+    path: qwen3.6-27b-gguf/ubergarm-mtp-iq4ks
+    local_subdir: qwen3.6-27b-gguf/ubergarm-mtp-iq4ks
+    size_gb: variable
+    format: gguf
+    status: production
+    hf_repo: ubergarm/Qwen3.6-27B-GGUF
+    files:
+      - Qwen3.6-27B-MTP-IQ4_KS.gguf
+    engine: ik-llama
+    kind: gguf
+    verify_glob: "*.gguf"
+    setup_weights_key: iq4ks
   carnice_bf16mtp:
     path: carnice-v2-27b-int4-recipe-d-bf16mtp
+    local_subdir: carnice-v2-27b-int4-recipe-d-bf16mtp
     size_gb: 17.5
     format: autoround
     status: experimental
+    hf_repo: wasifb/Carnice_V2_27B_INT4_BF16MTP
     hf_repos:
       - wasifb/Carnice_V2_27B_INT4_BF16MTP
+    engine: vllm
+    kind: main
+    verify_glob: "*.safetensors"
   qwopus_bf16mtp:
     path: qwopus3.6-27b-int4-recipe-d-bf16mtp
+    local_subdir: qwopus3.6-27b-int4-recipe-d-bf16mtp
     size_gb: 17.5
     format: autoround
     status: experimental
     hf_repos:
       - Jackrong/Qwopus3.6-27B-v1-preview
+    engine: vllm
+    kind: main
+    verify_glob: "*.safetensors"
+    manual_note: "This compose expects a local Recipe-D INT4+BF16MTP artifact. The repo only documents the BF16 source Jackrong/Qwopus3.6-27B-v1-preview, not a directly downloadable packed artifact."
 default_weight_variant: autoround_int4
 compatible_drafters:
   - qwen-mtp-builtin

--- a/scripts/lib/profiles/models/qwen3.6-35b-a3b.yml
+++ b/scripts/lib/profiles/models/qwen3.6-35b-a3b.yml
@@ -31,33 +31,52 @@ vision_capable: true
 weights:
   autoround_int4:
     path: qwen3.6-35b-a3b-autoround-int4
+    local_subdir: qwen3.6-35b-a3b-autoround-int4
     size_gb: 20.0
     format: autoround
     status: production
-    # v0.8.0 Pull-Gate Tier-1 lookup slug (verified in
-    # vllm/compose/dual/preview.yml `target:` line).
+    hf_repo: Qwen/Qwen3-MoE-A3B-Instruct-AutoRound-Int4-mixed
     hf_repos:
       - Qwen/Qwen3-MoE-A3B-Instruct-AutoRound-Int4-mixed
+    engine: vllm
+    kind: main
+    verify_glob: "*.safetensors"
   gptq_int4:
     path: qwen3.6-35b-a3b-gptq-int4
+    local_subdir: qwen3.6-35b-a3b-gptq-int4
     size_gb: 22.0
     format: gptq
     status: experimental
+    engine: vllm
+    kind: main
+    verify_glob: "*.safetensors"
   gguf:
     path: qwen3.6-35b-a3b-gguf
+    local_subdir: qwen3.6-35b-a3b-gguf
     size_gb: 90.0
     format: gguf
     status: production
+    engine: llama-cpp
+    kind: gguf
+    verify_glob: "*.gguf"
   dflash:
     path: qwen3.6-35b-a3b-dflash
+    local_subdir: qwen3.6-35b-a3b-dflash
     size_gb: variable
     format: autoround
     status: experimental
+    engine: vllm
+    kind: draft
+    verify_glob: "*.safetensors"
   dflash_gguf:
     path: qwen3.6-35b-a3b-dflash-gguf
+    local_subdir: qwen3.6-35b-a3b-dflash-gguf
     size_gb: variable
     format: gguf
     status: experimental
+    engine: llama-cpp
+    kind: gguf
+    verify_glob: "*.gguf"
 default_weight_variant: autoround_int4
 compatible_drafters:
   - qwen-mtp-builtin

--- a/scripts/lib/profiles/weights.py
+++ b/scripts/lib/profiles/weights.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Weight download recipe reader for shell callers.
+
+The source of truth is ``scripts/lib/profiles/models/*.yml``. This module is
+intentionally thin: it prints shell-safe ``KEY=VALUE`` lines for setup.sh and
+preflight.sh, and exits non-zero if Python/PyYAML is unavailable so preflight
+can fall back to a generic missing-model hint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - exercised by shell fallback tests
+    yaml = None  # type: ignore[assignment]
+
+
+PROFILE_ROOT = Path(__file__).resolve().parent
+
+
+ALIASES = {
+    "qwen3.6-27b-autoround-int4": ("qwen3.6-27b", "autoround_int4"),
+    "qwen3.6-27b-dflash": ("qwen3.6-27b", "dflash"),
+    "qwen3.6-27b-prism-eagle3": ("qwen3.6-27b", "prism_eagle3"),
+    "qwen3.6-27b-mtp-head": ("qwen3.6-27b", "mtp_head"),
+    "qwen3.6-27b-gguf-q4km": ("qwen3.6-27b", "gguf_q4km"),
+    "qwen3.6-27b-mmproj-f16": ("qwen3.6-27b", "gguf_mmproj_f16"),
+    "qwen3.6-27b-gguf-iq4ks": ("qwen3.6-27b", "gguf_iq4ks"),
+    "qwen3.6-35b-a3b-autoround-int4": ("qwen3.6-35b-a3b", "autoround_int4"),
+    "gemma-4-31b-autoround-int4": ("gemma-4-31b", "autoround_int4"),
+    "gemma-4-31b-it-AWQ-4bit": ("gemma-4-31b", "awq"),
+    "gemma-4-31b-it-assistant": ("gemma-4-31b", "assistant"),
+    "gemma-4-31b-it-dflash": ("gemma-4-31b", "dflash"),
+    "gemma-4-26b-a4b-autoround-int4-mixed": ("gemma-4-26b-a4b", "autoround_int4_mixed"),
+    "gemma-4-26b-a4b-awq-4bit": ("gemma-4-26b-a4b", "awq_compressed_tensors"),
+    "gemma-4-26b-a4b-it-assistant": ("gemma-4-26b-a4b", "assistant"),
+    "carnice-v2-27b-int4-recipe-d-bf16mtp": ("qwen3.6-27b", "carnice_bf16mtp"),
+    "qwopus3.6-27b-int4-recipe-d-bf16mtp": ("qwen3.6-27b", "qwopus_bf16mtp"),
+}
+
+
+def _die(msg: str, code: int = 1) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def _require_yaml() -> None:
+    if os.environ.get("CLUB3090_WEIGHTS_READER_DISABLE") == "1":
+        _die("weight reader disabled", 2)
+    if yaml is None:
+        _die("PyYAML unavailable", 2)
+
+
+def _load_models() -> dict[str, dict[str, Any]]:
+    _require_yaml()
+    out: dict[str, dict[str, Any]] = {}
+    for path in sorted((PROFILE_ROOT / "models").glob("*.yml")):
+        with path.open("r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+        model_id = str(data.get("id") or path.stem)
+        out[model_id] = data
+    return out
+
+
+def _label(model: dict[str, Any], variant: str, meta: dict[str, Any]) -> str:
+    display = model.get("display_name") or model.get("id")
+    kind = str(meta.get("kind") or "weights")
+    return f"{display} {kind} ({variant})"
+
+
+def _recipe(model_id: str, variant: str) -> dict[str, str]:
+    models = _load_models()
+    model = models.get(model_id)
+    if not model:
+        _die(f"unknown model: {model_id}")
+    weights = model.get("weights") or {}
+    meta = weights.get(variant)
+    if not isinstance(meta, dict):
+        _die(f"unknown weight variant: {model_id}:{variant}")
+
+    files = meta.get("files") or []
+    if isinstance(files, str):
+        files = [files]
+
+    setup_env = str(meta.get("setup_env") or "")
+    setup_weights_key = str(meta.get("setup_weights_key") or "")
+    if not setup_env and setup_weights_key:
+        setup_env = f"WEIGHTS={setup_weights_key}"
+    if not setup_env and meta.get("hf_repo"):
+        setup_env = f"WEIGHT_KEY={model_id}:{variant}"
+
+    return {
+        "WEIGHT_KEY": f"{model_id}:{variant}",
+        "WEIGHT_VARIANT": variant,
+        "WEIGHT_LABEL": _label(model, variant, meta),
+        "WEIGHT_MODEL": model_id,
+        "WEIGHT_ENGINE": str(meta.get("engine") or ""),
+        "WEIGHT_KIND": str(meta.get("kind") or ""),
+        "WEIGHT_REPO": str(meta.get("hf_repo") or ""),
+        "WEIGHT_SUBDIR": str(meta.get("local_subdir") or meta.get("path") or ""),
+        "WEIGHT_FILES": " ".join(str(f) for f in files),
+        "WEIGHT_VERIFY_GLOB": str(meta.get("verify_glob") or "*.safetensors"),
+        "WEIGHT_SETUP_MODEL": model_id,
+        "WEIGHT_SETUP_ENV": setup_env,
+        "WEIGHT_MANUAL_NOTE": str(meta.get("manual_note") or ""),
+    }
+
+
+def _resolve_key(key: str) -> tuple[str, str]:
+    if ":" in key:
+        model_id, variant = key.split(":", 1)
+        return model_id, variant
+    if key in ALIASES:
+        return ALIASES[key]
+    models = _load_models()
+    matches: list[tuple[str, str]] = []
+    for model_id, model in models.items():
+        for variant, meta in (model.get("weights") or {}).items():
+            if key == meta.get("path") or key == meta.get("local_subdir"):
+                matches.append((model_id, variant))
+    if len(matches) == 1:
+        return matches[0]
+    _die(f"unknown weight key: {key}")
+
+
+def _lookup_path(rel: str) -> tuple[str, str]:
+    rel = rel.split(" (", 1)[0].strip()
+    rel = rel.removeprefix("./").removeprefix("/")
+    rel = rel.removeprefix("models/")
+    rel = rel.removeprefix("root/.cache/huggingface/")
+    rel = rel.removeprefix("/root/.cache/huggingface/")
+    if rel.endswith("/config.json"):
+        rel = rel[: -len("/config.json")]
+    rel = rel.split(":", 1)[0]
+
+    models = _load_models()
+    matches: list[tuple[int, str, str]] = []
+    for model_id, model in models.items():
+        for variant, meta in (model.get("weights") or {}).items():
+            subdir = str(meta.get("local_subdir") or meta.get("path") or "")
+            if not subdir:
+                continue
+            files = meta.get("files") or []
+            if isinstance(files, str):
+                files = [files]
+            exact_files = {f"{subdir}/{name}" for name in files}
+            if rel in exact_files:
+                matches.append((len(rel) + 1000, model_id, variant))
+            elif rel == subdir or rel.startswith(f"{subdir}/"):
+                matches.append((len(subdir), model_id, variant))
+    if not matches:
+        _die(f"no recipe for path: {rel}")
+    _, model_id, variant = sorted(matches, reverse=True)[0]
+    return model_id, variant
+
+
+def _print_env(recipe: dict[str, str]) -> None:
+    for key in sorted(recipe):
+        print(f"{key}={shlex.quote(recipe[key])}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    p_entry = sub.add_parser("entry")
+    p_entry.add_argument("key")
+    p_entry.add_argument("variant", nargs="?")
+    p_lookup = sub.add_parser("lookup")
+    p_lookup.add_argument("path")
+    args = parser.parse_args(argv)
+
+    if args.cmd == "entry":
+        if args.variant:
+            model_id, variant = args.key, args.variant
+        else:
+            model_id, variant = _resolve_key(args.key)
+    else:
+        model_id, variant = _lookup_path(args.path)
+
+    _print_env(_recipe(model_id, variant))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -584,7 +584,18 @@ preflight_hf_token() {
 # Skip via: PREFLIGHT_NO_COMPOSE_DEPS=1
 _preflight_compose_model_dir() {
   local compose_file="$1"
-  local model_dir="${MODEL_DIR:-../../../../models-cache}"
+  local model_dir
+
+  if [[ -n "${MODEL_DIR:-}" ]]; then
+    model_dir="${MODEL_DIR}"
+  else
+    local root_dir="${ROOT_DIR:-}"
+    if [[ -z "$root_dir" ]]; then
+      root_dir="$(cd -- "${_PREFLIGHT_DIR}/.." && pwd)"
+    fi
+    model_dir="${root_dir}/models-cache"
+    echo "[preflight] MODEL_DIR not set — defaulting to ${model_dir}" >&2
+  fi
 
   # Resolve relative paths against the compose location. Do not require the
   # directory to already exist; this function is often called before download.
@@ -620,6 +631,167 @@ _preflight_compose_vllm_subdir() {
   value="$(_preflight_compose_path_default "$1")"
   value="${value%%/*}"
   printf '%s' "$value"
+}
+
+_preflight_missing_rel() {
+  local model_dir="$1"
+  local item="$2"
+  local item_path="${item%% (*}"
+  local rel="${item_path#${model_dir}/}"
+  printf '%s' "$rel"
+}
+
+_preflight_list_has() {
+  local needle="$1"
+  shift
+  local value
+  for value in "$@"; do
+    [[ "$value" == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+_preflight_hf_cli_available() {
+  command -v hf >/dev/null 2>&1 || command -v huggingface-cli >/dev/null 2>&1
+}
+
+_preflight_setup_root() {
+  if [[ -n "${ROOT_DIR:-}" ]]; then
+    printf '%s' "$ROOT_DIR"
+  else
+    cd -- "${_PREFLIGHT_DIR}/.." && pwd
+  fi
+}
+
+_preflight_weights_reader() {
+  local root_dir
+  root_dir="$(_preflight_setup_root)"
+  printf '%s' "${root_dir}/scripts/lib/profiles/weights.py"
+}
+
+_preflight_weight_recipe_for_path() {
+  local rel="$1"
+  local reader env_lines
+  reader="$(_preflight_weights_reader)"
+  command -v python3 >/dev/null 2>&1 || return 1
+  [[ -f "$reader" ]] || return 1
+  env_lines="$(python3 "$reader" lookup "$rel" 2>/dev/null)" || return 1
+  eval "$env_lines"
+}
+
+_preflight_weight_recipe_for_key() {
+  local key="$1"
+  local reader env_lines
+  reader="$(_preflight_weights_reader)"
+  command -v python3 >/dev/null 2>&1 || return 1
+  [[ -f "$reader" ]] || return 1
+  env_lines="$(python3 "$reader" entry "$key" 2>/dev/null)" || return 1
+  eval "$env_lines"
+}
+
+_preflight_weight_hf_command() {
+  local model_dir_expr="${1:-\$MODEL_DIR}"
+  [[ -n "${WEIGHT_REPO:-}" ]] || return 1
+  if [[ -n "${WEIGHT_FILES:-}" ]]; then
+    printf 'hf download %s %s --local-dir %s/%s' \
+      "$WEIGHT_REPO" "$WEIGHT_FILES" "$model_dir_expr" "$WEIGHT_SUBDIR"
+  else
+    printf 'hf download %s --local-dir %s/%s' \
+      "$WEIGHT_REPO" "$model_dir_expr" "$WEIGHT_SUBDIR"
+  fi
+}
+
+_preflight_weight_setup_command() {
+  [[ -n "${WEIGHT_SETUP_MODEL:-}" ]] || return 1
+  if [[ -n "${WEIGHT_SETUP_ENV:-}" ]]; then
+    printf '%s bash scripts/setup.sh %s' "$WEIGHT_SETUP_ENV" "$WEIGHT_SETUP_MODEL"
+  else
+    printf 'bash scripts/setup.sh %s' "$WEIGHT_SETUP_MODEL"
+  fi
+}
+
+_preflight_weight_hint_keys() {
+  local model_dir="$1"
+  shift
+  local item rel key
+  local keys=()
+
+  for item in "$@"; do
+    rel="$(_preflight_missing_rel "$model_dir" "$item")"
+    if _preflight_weight_recipe_for_path "$rel"; then
+      key="$WEIGHT_KEY"
+      if ! _preflight_list_has "$key" "${keys[@]}"; then
+        keys+=("$key")
+        printf '%s\n' "$key"
+      fi
+    fi
+  done
+}
+
+_preflight_print_weight_hints() {
+  local model_dir="$1"
+  shift
+  local key any_hint=0 setup_cmd hf_cmd
+
+  echo "[preflight]   If weights are already elsewhere, export MODEL_DIR=/path/to/models and retry." >&2
+  while IFS= read -r key; do
+    [[ -n "$key" ]] || continue
+    _preflight_weight_recipe_for_key "$key" || continue
+    any_hint=1
+    echo "[preflight]" >&2
+    echo "[preflight]   ${WEIGHT_LABEL:-$key}:" >&2
+    if hf_cmd="$(_preflight_weight_hf_command '$MODEL_DIR' 2>/dev/null)"; then
+      echo "[preflight]     ${hf_cmd}" >&2
+    fi
+    if setup_cmd="$(_preflight_weight_setup_command 2>/dev/null)"; then
+      echo "[preflight]     or: MODEL_DIR=${model_dir} ${setup_cmd}" >&2
+    fi
+    if [[ -n "${WEIGHT_MANUAL_NOTE:-}" ]]; then
+      echo "[preflight]     note: ${WEIGHT_MANUAL_NOTE}" >&2
+    fi
+  done < <(_preflight_weight_hint_keys "$model_dir" "$@")
+
+  if [[ "$any_hint" != "1" ]]; then
+    echo "[preflight]   Check the compose header for its model-specific hf download command." >&2
+  fi
+}
+
+_preflight_offer_fetch_missing() {
+  local compose_file="$1"
+  local model_dir="$2"
+  shift 2
+
+  [[ "${PREFLIGHT_NO_FETCH_PROMPT:-0}" != "1" ]] || return 1
+  [[ -t 0 && -t 1 ]] || return 1
+  _preflight_hf_cli_available || return 1
+
+  local key setup_cmd answer root_dir
+  local keys=()
+  while IFS= read -r key; do
+    [[ -n "$key" ]] || continue
+    _preflight_weight_recipe_for_key "$key" || continue
+    [[ -n "${WEIGHT_SETUP_MODEL:-}" ]] || continue
+    [[ -n "${WEIGHT_REPO:-}" ]] || continue
+    if ! _preflight_list_has "$key" "${keys[@]}"; then
+      keys+=("$key")
+    fi
+  done < <(_preflight_weight_hint_keys "$model_dir" "$@")
+
+  [[ ${#keys[@]} -gt 0 ]] || return 1
+
+  echo "[preflight]" >&2
+  read -r -p "[preflight] Fetch missing weights now with scripts/setup.sh? [y/N]: " answer
+  [[ "$answer" =~ ^[Yy]$ ]] || return 1
+
+  root_dir="$(_preflight_setup_root)"
+  for key in "${keys[@]}"; do
+    _preflight_weight_recipe_for_key "$key" || continue
+    local env_args=("MODEL_DIR=${model_dir}" "WEIGHT_KEY=${key}")
+    echo "[preflight] fetching ${WEIGHT_LABEL:-$key} ..." >&2
+    env "${env_args[@]}" bash "${root_dir}/scripts/setup.sh" "${WEIGHT_SETUP_MODEL}"
+  done
+
+  PREFLIGHT_NO_FETCH_PROMPT=1 preflight_compose_deps "$compose_file"
 }
 
 preflight_compose_deps() {
@@ -734,8 +906,10 @@ preflight_compose_deps() {
   done
   echo "[preflight]" >&2
   echo "[preflight] Fix:" >&2
-  echo "[preflight]   Check the compose header for its model-specific hf download command." >&2
-  echo "[preflight]   If weights are already elsewhere, export MODEL_DIR=/path/to/models and retry." >&2
+  _preflight_print_weight_hints "$model_dir" "${missing[@]}"
+  if _preflight_offer_fetch_missing "$compose_file" "$model_dir" "${missing[@]}"; then
+    return 0
+  fi
   echo "[preflight] Skip this check:  PREFLIGHT_NO_COMPOSE_DEPS=1 bash scripts/switch.sh ..." >&2
   return 1
 }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,10 +5,8 @@
 #   bash scripts/setup.sh                # interactive model picker in a TTY
 #   bash scripts/setup.sh <model-name>   # scripted/CI positional form
 #
-# Currently supported:
-#   qwen3.6-27b   →  Lorbus/Qwen3.6-27B-int4-AutoRound + Genesis patches
-#   gemma-4-31b   →  Intel/gemma-4-31B-it-int4-AutoRound + Google MTP "assistant"
-#                    drafter (no Genesis — not yet integrated upstream as of v7.72.2)
+# Currently supported model families are listed in usage(). Exact repositories,
+# files, and local subdirectories live in scripts/lib/profiles/models/*.yml.
 #
 # What it does (per supported model):
 #   - clones Sandermage/genesis-vllm-patches into models/<model>/vllm/patches/genesis
@@ -29,9 +27,9 @@
 #   HF_TOKEN            HF token (public models, usually unnecessary)
 #   SKIP_MODEL          Set to 1 to skip the model download step
 #   SKIP_GENESIS        Set to 1 to skip cloning Genesis patches
-#   WITH_DFLASH_DRAFT   Set to 1 to ALSO download z-lab/Qwen3.6-27B-DFlash
-#                       (~1.75 GB; required ONLY for dual-dflash.yml /
-#                       dual-dflash-noviz.yml composes). Default: 0.
+#   WITH_DFLASH_DRAFT   Set to 1 to ALSO download the model family's DFlash
+#                       drafter when one is registered in profiles/models/*.yml.
+#                       Default: 0.
 #                       Note: draft model is still under training as of
 #                       2026-04-26; bench numbers in DUAL_CARD.md were
 #                       measured against that snapshot. AL improvements
@@ -44,6 +42,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+WEIGHTS_READER="${ROOT_DIR}/scripts/lib/profiles/weights.py"
 
 usage() {
   echo "Usage: $0 <model-name>"
@@ -54,15 +53,50 @@ usage() {
   echo ""
   echo "Supported model names:"
   echo "  qwen3.6-27b"
+  echo "  qwen3.6-35b-a3b"
   echo "  gemma-4-31b"
+  echo "  gemma-4-26b-a4b"
+  echo ""
+  echo "Exact catalog entry fetch: WEIGHT_KEY=<registry-key> $0 <model-name>"
 }
 
 model_label() {
   case "$1" in
     qwen3.6-27b) echo "Qwen 3.6 27B" ;;
+    qwen3.6-35b-a3b) echo "Qwen 3.6 35B-A3B" ;;
     gemma-4-31b) echo "Gemma 4 31B" ;;
+    gemma-4-26b-a4b) echo "Gemma 4 26B-A4B" ;;
     *) echo "$1" ;;
   esac
+}
+
+load_weight_recipe() {
+  local key="$1"
+  local env_lines
+  command -v python3 >/dev/null 2>&1 || {
+    echo "ERROR: python3 is required to read profile weight recipes." >&2
+    exit 1
+  }
+  env_lines="$(python3 "${WEIGHTS_READER}" entry "$key" 2>/dev/null)" || {
+    echo "ERROR: could not resolve weight recipe '${key}' from scripts/lib/profiles/models/*.yml." >&2
+    echo "       Install python3-yaml/PyYAML if missing, or check the catalog key." >&2
+    exit 1
+  }
+  eval "$env_lines"
+  if [[ -n "${WEIGHT_MODEL:-}" && "${WEIGHT_MODEL}" != "${MODEL_NAME}" ]]; then
+    echo "ERROR: weight recipe '${key}' belongs to ${WEIGHT_MODEL}, not ${MODEL_NAME}." >&2
+    exit 1
+  fi
+  if [[ -z "${WEIGHT_REPO:-}" ]]; then
+    echo "ERROR: weight recipe '${key}' has no direct download recipe." >&2
+    [[ -n "${WEIGHT_MANUAL_NOTE:-}" ]] && echo "       ${WEIGHT_MANUAL_NOTE}" >&2
+    exit 1
+  fi
+  MODEL_REPO="${WEIGHT_REPO}"
+  MODEL_SUBDIR="${WEIGHT_SUBDIR}"
+  GGUF_FILES="${WEIGHT_FILES}"
+  VERIFY_GLOB="${WEIGHT_VERIFY_GLOB:-*.safetensors}"
+  echo "[model]   ${WEIGHT_KEY} -> ${MODEL_REPO} ${WEIGHT_FILES} -> ${MODEL_SUBDIR}"
 }
 
 model_picker_line() {
@@ -128,71 +162,94 @@ else
   SETUP_BOTH_MODE=0
 fi
 
-# ALWAYS_DRAFT_REPO + ALWAYS_DRAFT_SUBDIR: a drafter that this model REQUIRES
-# (vs the optional WITH_DFLASH_DRAFT path). Empty for Qwen3.6 (no required
-# drafter); Google MTP drafter for Gemma 4 (canonical recipe per Gemma 4 docs +
-# our dual.yml compose).
-ALWAYS_DRAFT_REPO=""
-ALWAYS_DRAFT_SUBDIR=""
-
-# Per-model dflash drafter info (overrides defaults set later for non-qwen3.6).
-DFLASH_REPO_OVERRIDE=""
-DFLASH_SUBDIR_OVERRIDE=""
+# The profile YAMLs are the only source of download recipes. setup.sh only
+# maps friendly setup knobs (MODEL_NAME, WEIGHTS, WITH_*) to profile keys.
+ALWAYS_DRAFT_KEY=""
+DFLASH_KEY=""
+PRIMARY_WEIGHT_KEY=""
+EXTRA_WEIGHT_KEYS=()
+NEEDS_GENESIS=0
 
 case "${MODEL_NAME}" in
   qwen3.6-27b)
-    MODEL_REPO="Lorbus/Qwen3.6-27B-int4-AutoRound"
-    MODEL_SUBDIR="qwen3.6-27b-autoround-int4"
+    PRIMARY_WEIGHT_KEY="qwen3.6-27b:autoround_int4"
+    DFLASH_KEY="qwen3.6-27b:dflash"
     NEEDS_GENESIS=1
     ;;
+  qwen3.6-35b-a3b)
+    PRIMARY_WEIGHT_KEY="qwen3.6-35b-a3b:autoround_int4"
+    ;;
   gemma-4-31b)
-    MODEL_REPO="Intel/gemma-4-31B-it-int4-AutoRound"
-    MODEL_SUBDIR="gemma-4-31b-autoround-int4"
-    # Gemma 4 isn't Genesis-integrated yet — Sander's roadmap (disc #19) lists
-    # Gemma 4 as a follow-up. Until v7.73.x or later integrates it, skip Genesis
-    # entirely on this path.
-    NEEDS_GENESIS=0
-    # Google ships the MTP drafter with the canonical Gemma 4 recipe; our
-    # dual.yml compose requires it. Always-fetch (no opt-in flag).
-    ALWAYS_DRAFT_REPO="google/gemma-4-31B-it-assistant"
-    ALWAYS_DRAFT_SUBDIR="gemma-4-31b-it-assistant"
-    # DFlash drafter is z-lab/gemma-4-31B-it-DFlash (different repo than
-    # Qwen3.6's z-lab/Qwen3.6-27B-DFlash).
-    DFLASH_REPO_OVERRIDE="z-lab/gemma-4-31B-it-dflash"
-    DFLASH_SUBDIR_OVERRIDE="gemma-4-31b-it-dflash"
+    PRIMARY_WEIGHT_KEY="gemma-4-31b:autoround_int4"
+    ALWAYS_DRAFT_KEY="gemma-4-31b:assistant"
+    DFLASH_KEY="gemma-4-31b:dflash"
+    ;;
+  gemma-4-26b-a4b)
+    PRIMARY_WEIGHT_KEY="gemma-4-26b-a4b:autoround_int4_mixed"
     ;;
   *)
     echo "ERROR: unsupported model '${MODEL_NAME}'."
-    echo "Supported: qwen3.6-27b, gemma-4-31b"
-    echo "(To add a new model, extend the case dispatch in scripts/setup.sh)"
+    echo "Supported: qwen3.6-27b, qwen3.6-35b-a3b, gemma-4-31b, gemma-4-26b-a4b"
+    echo "(To add a new model, extend the model dispatch in scripts/setup.sh and profiles/models/*.yml)"
     exit 1
     ;;
 esac
 
-# ---------- Weights format (autoround vLLM default, or gguf for llama.cpp/ik_llama) ----------
-# WEIGHTS=gguf swaps the AutoRound vLLM repo above for the llama.cpp GGUF and
-# downloads just the file(s) it needs (a GGUF repo holds many quants). The
-# GGUF/llama.cpp path doesn't use Genesis. Default is unchanged (autoround).
+# ---------- Weights format / exact registry entry ----------
+# WEIGHTS selects a common weight variant for the model family. WEIGHT_KEY is
+# the exact catalog-entry path used by preflight's fetch-now flow.
 WEIGHTS="${WEIGHTS:-autoround}"
-GGUF_FILES=""   # empty → download whole repo dir (autoround); non-empty → specific files
-if [[ "${WEIGHTS}" == "gguf" ]]; then
+GGUF_FILES=""
+VERIFY_GLOB="*.safetensors"
+
+if [[ -n "${WEIGHT_KEY:-}" ]]; then
+  PRIMARY_WEIGHT_KEY="${WEIGHT_KEY}"
+elif [[ "${WEIGHTS}" == "gguf" ]]; then
   case "${MODEL_NAME}" in
     qwen3.6-27b)
-      MODEL_REPO="unsloth/Qwen3.6-27B-GGUF"
-      MODEL_SUBDIR="qwen3.6-27b-gguf/unsloth-mtp-q4km"
-      GGUF_FILES="Qwen3.6-27B-Q4_K_M.gguf mmproj-F16.gguf"  # Q4_K_M MTP + vision mmproj
+      PRIMARY_WEIGHT_KEY="qwen3.6-27b:gguf_q4km"
+      EXTRA_WEIGHT_KEYS+=("qwen3.6-27b:gguf_mmproj_f16")
       NEEDS_GENESIS=0
       ;;
     *)
       echo "ERROR: WEIGHTS=gguf is only wired for qwen3.6-27b right now." >&2
-      echo "       Use WEIGHTS=autoround (default), or download the GGUF manually." >&2
+      echo "       Use WEIGHT_KEY=<model>:<variant> for exact catalog entries." >&2
       exit 1 ;;
   esac
-  echo "[model]   WEIGHTS=gguf → ${MODEL_REPO} (${GGUF_FILES}) → ${MODEL_SUBDIR}"
+elif [[ "${WEIGHTS}" == "iq4ks" ]]; then
+  case "${MODEL_NAME}" in
+    qwen3.6-27b)
+      PRIMARY_WEIGHT_KEY="qwen3.6-27b:gguf_iq4ks"
+      NEEDS_GENESIS=0
+      ;;
+    *)
+      echo "ERROR: WEIGHTS=iq4ks is only wired for qwen3.6-27b." >&2
+      exit 1 ;;
+  esac
+elif [[ "${WEIGHTS}" == "awq" ]]; then
+  case "${MODEL_NAME}" in
+    gemma-4-31b) PRIMARY_WEIGHT_KEY="gemma-4-31b:awq" ;;
+    gemma-4-26b-a4b) PRIMARY_WEIGHT_KEY="gemma-4-26b-a4b:awq_compressed_tensors" ;;
+    *)
+      echo "ERROR: WEIGHTS=awq is only wired for gemma-4-31b and gemma-4-26b-a4b." >&2
+      exit 1 ;;
+  esac
 elif [[ "${WEIGHTS}" != "autoround" ]]; then
-  echo "ERROR: WEIGHTS='${WEIGHTS}' not recognized (use 'autoround' or 'gguf')." >&2
+  echo "ERROR: WEIGHTS='${WEIGHTS}' not recognized (use 'autoround', 'awq', 'gguf', or 'iq4ks')." >&2
   exit 1
 fi
+
+if [[ "${WITH_ASSISTANT_DRAFT:-0}" == "1" ]]; then
+  case "${MODEL_NAME}" in
+    gemma-4-31b) ALWAYS_DRAFT_KEY="gemma-4-31b:assistant" ;;
+    gemma-4-26b-a4b) ALWAYS_DRAFT_KEY="gemma-4-26b-a4b:assistant" ;;
+    *)
+      echo "ERROR: WITH_ASSISTANT_DRAFT=1 is only wired for Gemma models." >&2
+      exit 1 ;;
+  esac
+fi
+
+load_weight_recipe "${PRIMARY_WEIGHT_KEY}"
 
 # ---------- MODEL_DIR resolution ----------
 # Order of precedence:
@@ -429,132 +486,118 @@ if [[ "${SKIP_MODEL:-0}" == "1" ]]; then
   exit 0
 fi
 
-mkdir -p "${MODEL_DIR}/${MODEL_SUBDIR}"
-
-# Prefer `hf` CLI if available (faster with hf_transfer); fall back to curl.
-download_via_hf() {
-  echo "[model]   Using 'hf download' (hf_transfer if available) ..."
-  # ${GGUF_FILES} is intentionally unquoted: empty (autoround) → whole-repo
-  # download as before; set (gguf) → just those file(s) word-split as args.
-  HF_HUB_ENABLE_HF_TRANSFER=1 HF_HUB_DISABLE_XET=1 \
-    hf download "${MODEL_REPO}" ${GGUF_FILES} --local-dir "${MODEL_DIR}/${MODEL_SUBDIR}"
+_hf_download_repo() {
+  local repo="$1"
+  local subdir="$2"
+  local files="${3:-}"
+  mkdir -p "${MODEL_DIR}/${subdir}"
+  if command -v hf >/dev/null 2>&1; then
+    echo "[model]   Using 'hf download' (hf_transfer if available) ..."
+    # files is intentionally word-split: empty -> whole repo; non-empty -> selected files.
+    HF_HUB_ENABLE_HF_TRANSFER=1 HF_HUB_DISABLE_XET=1 \
+      hf download "$repo" ${files} --local-dir "${MODEL_DIR}/${subdir}"
+  elif command -v huggingface-cli >/dev/null 2>&1; then
+    echo "[model]   Using 'huggingface-cli download' ..."
+    HF_HUB_ENABLE_HF_TRANSFER=1 HF_HUB_DISABLE_XET=1 \
+      huggingface-cli download "$repo" ${files} --local-dir "${MODEL_DIR}/${subdir}"
+  else
+    echo "ERROR: neither 'hf' nor 'huggingface-cli' found. Install with:" >&2
+    echo "  pip install 'huggingface-hub[hf_transfer]'" >&2
+    echo "or:" >&2
+    echo "  uv tool install --with hf_transfer huggingface-hub" >&2
+    exit 1
+  fi
 }
 
-if command -v hf >/dev/null 2>&1; then
-  download_via_hf
-elif command -v huggingface-cli >/dev/null 2>&1; then
-  echo "[model]   Using 'huggingface-cli download' ..."
-  HF_HUB_ENABLE_HF_TRANSFER=1 HF_HUB_DISABLE_XET=1 \
-    huggingface-cli download "${MODEL_REPO}" ${GGUF_FILES} --local-dir "${MODEL_DIR}/${MODEL_SUBDIR}"
-else
-  echo "ERROR: neither 'hf' nor 'huggingface-cli' found. Install with:" >&2
-  echo "  pip install 'huggingface-hub[hf_transfer]'" >&2
-  echo "or:" >&2
-  echo "  uv tool install --with hf_transfer huggingface-hub" >&2
-  exit 1
-fi
+_verify_downloaded_files() {
+  local repo="$1"
+  local subdir="$2"
+  local verify_glob="$3"
+  local fail=0 count=0 f expected actual
 
-# ---------- SHA verification ----------
-VERIFY_GLOB="*.safetensors"; [[ "${WEIGHTS}" == "gguf" ]] && VERIFY_GLOB="*.gguf"
-echo "[verify]  Checking SHA256 of every ${VERIFY_GLOB} against HF x-linked-etag ..."
-cd "${MODEL_DIR}/${MODEL_SUBDIR}"
+  echo "[verify]  Checking SHA256 of every ${verify_glob} against HF x-linked-etag ..."
+  cd "${MODEL_DIR}/${subdir}"
+  for f in ${verify_glob}; do
+    [[ -f "$f" ]] || continue
+    count=$((count + 1))
+    expected="$(curl -sfI "https://huggingface.co/${repo}/resolve/main/$f" \
+      | grep -i '^x-linked-etag:' | tr -d '"\r' | awk '{print $NF}' || true)"
+    actual="$(sha256sum "$f" | awk '{print $1}')"
+    if [[ -z "$expected" ]]; then
+      printf "  %-50s SKIP (no etag)\n" "$f"
+    elif [[ "$expected" == "$actual" ]]; then
+      printf "  %-50s OK\n" "$f"
+    else
+      printf "  %-50s FAIL  exp=%.12s  act=%.12s\n" "$f" "$expected" "$actual"
+      fail=$((fail + 1))
+    fi
+  done
+  cd "${ROOT_DIR}"
 
-fail=0
-count=0
-for f in ${VERIFY_GLOB}; do
-  [[ -f "$f" ]] || continue
-  count=$((count + 1))
-  expected="$(curl -sfI "https://huggingface.co/${MODEL_REPO}/resolve/main/$f" \
-    | grep -i '^x-linked-etag:' | tr -d '"\r' | awk '{print $NF}' || true)"
-  actual="$(sha256sum "$f" | awk '{print $1}')"
-  if [[ -z "$expected" ]]; then
-    printf "  %-50s SKIP (no etag)\n" "$f"
-  elif [[ "$expected" == "$actual" ]]; then
-    printf "  %-50s OK\n" "$f"
-  else
-    printf "  %-50s FAIL  exp=%.12s  act=%.12s\n" "$f" "$expected" "$actual"
-    fail=$((fail + 1))
+  if [[ "$fail" != "0" ]]; then
+    echo "[verify]  ${fail} file(s) failed SHA check." >&2
+    echo "          Delete ${MODEL_DIR}/${subdir} and re-run setup.sh." >&2
+    exit 1
   fi
+  if [[ "$count" == "0" ]]; then
+    echo "[verify]  No ${verify_glob} found in ${MODEL_DIR}/${subdir} — download may have failed." >&2
+    exit 1
+  fi
+  echo "[done]    ${count} file(s) SHA-verified in ${subdir}."
+}
+
+download_weight_key() {
+  local key="$1"
+  load_weight_recipe "$key"
+  echo "[model]   Downloading ${WEIGHT_LABEL:-$key} ..."
+  _hf_download_repo "$WEIGHT_REPO" "$WEIGHT_SUBDIR" "$WEIGHT_FILES"
+  _verify_downloaded_files "$WEIGHT_REPO" "$WEIGHT_SUBDIR" "$WEIGHT_VERIFY_GLOB"
+}
+
+VERIFY_GLOB="${VERIFY_GLOB_OVERRIDE:-*.safetensors}"
+_hf_download_repo "${MODEL_REPO}" "${MODEL_SUBDIR}" "${GGUF_FILES}"
+_verify_downloaded_files "${MODEL_REPO}" "${MODEL_SUBDIR}" "${VERIFY_GLOB}"
+
+for extra_key in "${EXTRA_WEIGHT_KEYS[@]}"; do
+  download_weight_key "$extra_key"
 done
-cd "${ROOT_DIR}"
-
-if [[ "$fail" != "0" ]]; then
-  echo "[verify]  ${fail} shard(s) failed SHA check." >&2
-  echo "          Delete ${MODEL_DIR}/${MODEL_SUBDIR} and re-run setup.sh." >&2
-  exit 1
-fi
-
-if [[ "$count" == "0" ]]; then
-  echo "[verify]  No ${VERIFY_GLOB} found in ${MODEL_DIR}/${MODEL_SUBDIR} — download may have failed." >&2
-  exit 1
-fi
 
 echo ""
-echo "[done]    ${count} file(s) SHA-verified."
 [[ -d "${GENESIS_DIR}/.git" ]] && echo "          Genesis pinned at ${GENESIS_PIN} ($(cd "${GENESIS_DIR}" && git rev-parse --short HEAD))."
 echo ""
 
-# ---------- Optional DFlash draft model ----------
-# Required ONLY for `dual/dflash.yml` / `dual-dflash-noviz.yml`.
-# vLLM `method:"dflash"` spec-decode loads this as the draft. The compose
-# expects it at <MODEL_DIR>/qwen3.6-27b-dflash/ (~1.75 GB / card after load).
-#
-# Caveat: as of 2026-04-26, z-lab/Qwen3.6-27B-DFlash is still under training.
-# Published bench in docs/DUAL_CARD.md (82 narr / 125 code TPS on dual-3090)
-# was measured against the 2026-04-26 snapshot at peak code-prompt conditions.
-# Real agent traffic (mixed code + narrative + tool schemas) will see lower
-# AL until z-lab tags training-complete. See docs/UPSTREAM.md for the watch
-# entry and re-test trigger.
-# Per-model DFlash repo + subdir defaults. Override (Gemma 4) set in the case
-# dispatch above.
-DFLASH_REPO="${DFLASH_REPO_OVERRIDE:-z-lab/Qwen3.6-27B-DFlash}"
-DFLASH_SUBDIR="${DFLASH_SUBDIR_OVERRIDE:-qwen3.6-27b-dflash}"
-
-# Always-required drafter (Gemma 4 MTP "assistant"). Empty for models without
-# a canonical drafter shipped alongside the target weights (Qwen3.6).
-if [[ -n "${ALWAYS_DRAFT_REPO}" ]] && [[ "${SKIP_MODEL:-0}" != "1" ]]; then
-  if [[ -d "${MODEL_DIR}/${ALWAYS_DRAFT_SUBDIR}" ]] \
-     && find "${MODEL_DIR}/${ALWAYS_DRAFT_SUBDIR}" -name "*.safetensors" -print -quit | grep -q .; then
-    echo "[draft]   ${MODEL_DIR}/${ALWAYS_DRAFT_SUBDIR} already has weights — skipping."
-  else
-    echo "[draft]   Downloading required drafter ${ALWAYS_DRAFT_REPO} ..."
-    mkdir -p "${MODEL_DIR}/${ALWAYS_DRAFT_SUBDIR}"
-    if command -v hf >/dev/null 2>&1; then
-      HF_HUB_ENABLE_HF_TRANSFER=1 HF_HUB_DISABLE_XET=1 \
-        hf download "${ALWAYS_DRAFT_REPO}" --local-dir "${MODEL_DIR}/${ALWAYS_DRAFT_SUBDIR}"
-    elif command -v huggingface-cli >/dev/null 2>&1; then
-      HF_HUB_ENABLE_HF_TRANSFER=1 HF_HUB_DISABLE_XET=1 \
-        huggingface-cli download "${ALWAYS_DRAFT_REPO}" --local-dir "${MODEL_DIR}/${ALWAYS_DRAFT_SUBDIR}"
-    else
-      echo "[draft]   ERROR: neither 'hf' nor 'huggingface-cli' available — cannot download drafter." >&2
-      exit 1
-    fi
-    echo "[draft]   Downloaded ${ALWAYS_DRAFT_REPO} to ${MODEL_DIR}/${ALWAYS_DRAFT_SUBDIR}"
-  fi
+# ---------- Optional / companion draft models ----------
+if [[ -n "${ALWAYS_DRAFT_KEY:-}" ]] && [[ "${SKIP_MODEL:-0}" != "1" ]]; then
+  echo "[draft]   downloading required companion drafter ${ALWAYS_DRAFT_KEY} ..."
+  download_weight_key "${ALWAYS_DRAFT_KEY}"
   echo ""
 fi
 
 if [[ "${WITH_DFLASH_DRAFT:-0}" == "1" ]] && [[ "${SKIP_MODEL:-0}" != "1" ]]; then
-  echo "[dflash]  WITH_DFLASH_DRAFT=1 — downloading ${DFLASH_REPO} ..."
-  mkdir -p "${MODEL_DIR}/${DFLASH_SUBDIR}"
-  if command -v hf >/dev/null 2>&1; then
-    HF_HUB_ENABLE_HF_TRANSFER=1 HF_HUB_DISABLE_XET=1 \
-      hf download "${DFLASH_REPO}" --local-dir "${MODEL_DIR}/${DFLASH_SUBDIR}"
-  elif command -v huggingface-cli >/dev/null 2>&1; then
-    HF_HUB_ENABLE_HF_TRANSFER=1 HF_HUB_DISABLE_XET=1 \
-      huggingface-cli download "${DFLASH_REPO}" --local-dir "${MODEL_DIR}/${DFLASH_SUBDIR}"
-  else
-    echo "[dflash]  ERROR: neither 'hf' nor 'huggingface-cli' available — cannot download DFlash draft." >&2
+  if [[ -z "${DFLASH_KEY:-}" ]]; then
+    echo "ERROR: WITH_DFLASH_DRAFT=1 is not wired for ${MODEL_NAME}." >&2
     exit 1
   fi
-  echo "[dflash]  Downloaded ${DFLASH_REPO} to ${MODEL_DIR}/${DFLASH_SUBDIR}"
-elif [[ -d "${MODEL_DIR}/${DFLASH_SUBDIR}" ]]; then
-  echo "[dflash]  ${MODEL_DIR}/${DFLASH_SUBDIR} already exists — using existing draft."
+  echo "[dflash]  WITH_DFLASH_DRAFT=1 — downloading ${DFLASH_KEY} ..."
+  download_weight_key "${DFLASH_KEY}"
+  echo ""
 else
-  echo "[dflash]  Skipping DFlash draft model. Set WITH_DFLASH_DRAFT=1 to fetch"
-  echo "          ${DFLASH_REPO} (~1.75 GB; required only for dual-dflash composes)."
+  echo "[dflash]  Skipping DFlash draft model. Set WITH_DFLASH_DRAFT=1 to fetch it when a matching compose requires it."
 fi
+
 echo ""
+
+if [[ "${WITH_PRISM_EAGLE3:-0}" == "1" ]] && [[ "${SKIP_MODEL:-0}" != "1" ]]; then
+  case "${MODEL_NAME}" in
+    qwen3.6-27b)
+      download_weight_key qwen3.6-27b:prism_eagle3
+      ;;
+    *)
+      echo "ERROR: WITH_PRISM_EAGLE3=1 is only wired for qwen3.6-27b." >&2
+      exit 1 ;;
+  esac
+  echo ""
+fi
 
 # Note: vllm#40361 Marlin pad-sub-tile-n patched files are vendored in-repo
 # at models/qwen3.6-27b/vllm/patches/vllm-marlin-pad/. Dual-card composes
@@ -584,6 +627,23 @@ case "${MODEL_NAME}" in
   bash scripts/switch.sh vllm/gemma-mtp        # MTP drafter, TP=2, port 8030 (recommended)
   bash scripts/switch.sh vllm/gemma-mtp-tp1    # MTP drafter, TP=1 (single-card; upstream-blocked on Ampere fp8)
   bash scripts/switch.sh vllm/gemma-dflash     # DFlash drafter, TP=2, port 8032 (requires WITH_DFLASH_DRAFT=1)"
+    ;;
+  gemma-4-26b-a4b)
+    SAMPLE_CONTAINER="vllm-gemma-4-26b-a4b"
+    SAMPLE_COMPOSE_FLAGS_DUAL=""
+    SAMPLE_PORT="8035"
+    SAMPLE_MODEL_NAME="gemma-4-26b-a4b"
+    NEXT_STEPS_NOTE="Available variants:
+  bash scripts/switch.sh vllm/gemma-26b-awq
+  WITH_ASSISTANT_DRAFT=1 bash scripts/setup.sh gemma-4-26b-a4b  # fetch MTP assistant if using awq-mtp"
+    ;;
+  qwen3.6-35b-a3b)
+    SAMPLE_CONTAINER="vllm-qwen36-35b-a3b"
+    SAMPLE_COMPOSE_FLAGS_DUAL=""
+    SAMPLE_PORT="8040"
+    SAMPLE_MODEL_NAME="qwen3.6-35b-a3b-autoround"
+    NEXT_STEPS_NOTE="Preview variants:
+  bash scripts/switch.sh vllm/qwen35-preview"
     ;;
 esac
 

--- a/scripts/tests/test-model-weights-registry.sh
+++ b/scripts/tests/test-model-weights-registry.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+READER="${ROOT_DIR}/scripts/lib/profiles/weights.py"
+
+load_entry() {
+  local key="$1"
+  local env_lines
+  env_lines="$(python3 "$READER" entry "$key")"
+  eval "$env_lines"
+}
+
+load_lookup() {
+  local path="$1"
+  local env_lines
+  env_lines="$(python3 "$READER" lookup "$path")"
+  eval "$env_lines"
+}
+
+assert_entry() {
+  local key="$1" repo="$2" subdir="$3"
+  load_entry "$key"
+  if [[ "$WEIGHT_REPO" != "$repo" || "$WEIGHT_SUBDIR" != "$subdir" ]]; then
+    echo "ASSERTION FAILED: bad entry for $key" >&2
+    echo "  repo:   got '$WEIGHT_REPO' expected '$repo'" >&2
+    echo "  subdir: got '$WEIGHT_SUBDIR' expected '$subdir'" >&2
+    exit 1
+  fi
+}
+
+assert_lookup() {
+  local path="$1" expected="$2"
+  load_lookup "$path"
+  if [[ "$WEIGHT_KEY" != "$expected" ]]; then
+    echo "ASSERTION FAILED: lookup for $path -> $WEIGHT_KEY, expected $expected" >&2
+    exit 1
+  fi
+}
+
+assert_entry qwen3.6-27b:autoround_int4 Lorbus/Qwen3.6-27B-int4-AutoRound qwen3.6-27b-autoround-int4
+assert_entry qwen3.6-27b:dflash z-lab/Qwen3.6-27B-DFlash qwen3.6-27b-dflash
+assert_entry qwen3.6-27b:prism_eagle3 Ex0bit/Qwen3.6-27B-PRISM-EAGLE3 qwen3.6-27b-prism-eagle3
+assert_entry qwen3.6-27b:gguf_q4km unsloth/Qwen3.6-27B-MTP-GGUF qwen3.6-27b-gguf/unsloth-mtp-q4km
+assert_entry qwen3.6-27b:gguf_mmproj_f16 unsloth/Qwen3.6-27B-GGUF qwen3.6-27b-gguf
+assert_entry qwen3.6-27b:gguf_iq4ks ubergarm/Qwen3.6-27B-GGUF qwen3.6-27b-gguf/ubergarm-mtp-iq4ks
+assert_entry qwen3.6-35b-a3b:autoround_int4 Qwen/Qwen3-MoE-A3B-Instruct-AutoRound-Int4-mixed qwen3.6-35b-a3b-autoround-int4
+assert_entry gemma-4-31b:autoround_int4 Intel/gemma-4-31B-it-int4-AutoRound gemma-4-31b-autoround-int4
+assert_entry gemma-4-31b:awq cyankiwi/gemma-4-31B-it-AWQ-4bit gemma-4-31b-it-AWQ-4bit
+assert_entry gemma-4-31b:assistant google/gemma-4-31B-it-assistant gemma-4-31b-it-assistant
+assert_entry gemma-4-31b:dflash z-lab/gemma-4-31b-it-dflash gemma-4-31b-it-dflash
+assert_entry gemma-4-26b-a4b:autoround_int4_mixed Intel/gemma-4-26B-A4B-it-int4-mixed-AutoRound gemma-4-26b-a4b-autoround-int4-mixed
+assert_entry gemma-4-26b-a4b:awq_compressed_tensors cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit gemma-4-26b-a4b-awq-4bit
+assert_entry gemma-4-26b-a4b:assistant google/gemma-4-26B-A4B-it-assistant gemma-4-26b-a4b-it-assistant
+assert_entry qwen3.6-27b:carnice_bf16mtp wasifb/Carnice_V2_27B_INT4_BF16MTP carnice-v2-27b-int4-recipe-d-bf16mtp
+
+load_entry qwen3.6-27b:qwopus_bf16mtp
+[[ -z "$WEIGHT_REPO" ]]
+[[ "$WEIGHT_SUBDIR" == "qwopus3.6-27b-int4-recipe-d-bf16mtp" ]]
+[[ -n "$WEIGHT_MANUAL_NOTE" ]]
+
+# Legacy preflight aliases remain accepted for user-facing setup hints.
+load_entry qwen3.6-27b-gguf-iq4ks
+[[ "$WEIGHT_KEY" == "qwen3.6-27b:gguf_iq4ks" ]]
+
+assert_lookup qwen3.6-27b-autoround-int4/config.json qwen3.6-27b:autoround_int4
+assert_lookup qwen3.6-27b-gguf/unsloth-mtp-q4km/Qwen3.6-27B-Q4_K_M.gguf qwen3.6-27b:gguf_q4km
+assert_lookup qwen3.6-27b-gguf/mmproj-F16.gguf qwen3.6-27b:gguf_mmproj_f16
+assert_lookup qwen3.6-27b-gguf/ubergarm-mtp-iq4ks/Qwen3.6-27B-MTP-IQ4_KS.gguf qwen3.6-27b:gguf_iq4ks
+assert_lookup qwen3.6-27b-prism-eagle3/compressed qwen3.6-27b:prism_eagle3
+assert_lookup carnice-v2-27b-int4-recipe-d-bf16mtp/chat_template.jinja qwen3.6-27b:carnice_bf16mtp
+assert_lookup qwopus3.6-27b-int4-recipe-d-bf16mtp/config.json qwen3.6-27b:qwopus_bf16mtp
+
+echo "test-model-weights-registry: ok"

--- a/scripts/tests/test-preflight-compose-deps.sh
+++ b/scripts/tests/test-preflight-compose-deps.sh
@@ -37,6 +37,16 @@ run_deps() {
   ) 2>&1
 }
 
+run_deps_unset_model_dir() {
+  local compose="$1"
+  (
+    unset MODEL_DIR
+    export ROOT_DIR
+    source "${ROOT_DIR}/scripts/preflight.sh"
+    preflight_compose_deps "$compose"
+  ) 2>&1
+}
+
 expect_missing() {
   local compose="$1"
   local model_dir="$2"
@@ -62,6 +72,8 @@ YAML
 
 out="$(expect_missing "$ik_compose" "${TMP_DIR}/empty-models")"
 assert_contains "$out" "qwen3.6-27b-gguf/ubergarm-mtp-iq4ks/Qwen3.6-27B-MTP-IQ4_KS.gguf"
+assert_contains "$out" "hf download ubergarm/Qwen3.6-27B-GGUF Qwen3.6-27B-MTP-IQ4_KS.gguf"
+assert_contains "$out" "WEIGHTS=iq4ks bash scripts/setup.sh qwen3.6-27b"
 assert_not_contains "$out" "qwen3.6-27b-autoround-int4"
 
 llama_compose="${TMP_DIR}/llama.yml"
@@ -91,6 +103,9 @@ YAML
 out="$(expect_missing "$vllm_compose" "${TMP_DIR}/empty-models")"
 assert_contains "$out" "gemma-4-31b-autoround-int4/config.json"
 assert_contains "$out" "gemma-4-31b-it-assistant/config.json"
+assert_contains "$out" "hf download Intel/gemma-4-31B-it-int4-AutoRound"
+assert_contains "$out" "hf download google/gemma-4-31B-it-assistant"
+assert_contains "$out" "bash scripts/setup.sh gemma-4-31b"
 assert_not_contains "$out" "qwen3.6-27b-autoround-int4"
 mkdir -p "${TMP_DIR}/models/gemma-4-31b-autoround-int4" "${TMP_DIR}/models/gemma-4-31b-it-assistant"
 touch "${TMP_DIR}/models/gemma-4-31b-autoround-int4/config.json" "${TMP_DIR}/models/gemma-4-31b-it-assistant/config.json"
@@ -118,6 +133,20 @@ YAML
 out="$(expect_missing "$extends_stub" "${TMP_DIR}/empty-models")"
 assert_contains "$out" "qwen3.6-27b-autoround-int4/config.json"
 
+if out="$(run_deps_unset_model_dir "$extends_stub")"; then
+  echo "ASSERTION FAILED: expected missing-model failure with unset MODEL_DIR" >&2
+  echo "--- output ---" >&2
+  echo "$out" >&2
+  exit 1
+fi
+assert_contains "$out" "MODEL_DIR not set"
+assert_contains "$out" "defaulting to ${ROOT_DIR}/models-cache"
+
+out="$(CLUB3090_WEIGHTS_READER_DISABLE=1 expect_missing "$extends_stub" "${TMP_DIR}/empty-models")"
+assert_contains "$out" "qwen3.6-27b-autoround-int4/config.json"
+assert_contains "$out" "Check the compose header for its model-specific hf download command."
+assert_not_contains "$out" "hf download Lorbus/Qwen3.6-27B-int4-AutoRound"
+
 sglang_compose="${TMP_DIR}/sglang.yml"
 cat > "$sglang_compose" <<'YAML'
 services:
@@ -130,6 +159,8 @@ YAML
 out="$(expect_missing "$sglang_compose" "${TMP_DIR}/empty-models")"
 assert_contains "$out" "qwen3.6-27b-autoround-int4"
 assert_contains "$out" "qwen3.6-27b-prism-eagle3/compressed"
+assert_contains "$out" "hf download Ex0bit/Qwen3.6-27B-PRISM-EAGLE3"
+assert_contains "$out" "WITH_PRISM_EAGLE3=1 bash scripts/setup.sh qwen3.6-27b"
 mkdir -p "${TMP_DIR}/models/qwen3.6-27b-autoround-int4" "${TMP_DIR}/models/qwen3.6-27b-prism-eagle3/compressed"
 out="$(run_deps "$sglang_compose" "${TMP_DIR}/models")"
 [[ -z "$out" ]]

--- a/scripts/tests/test-switch-registry-parity.sh
+++ b/scripts/tests/test-switch-registry-parity.sh
@@ -140,6 +140,36 @@ for k in "${!SW_MAP[@]}"; do
   fi
 done
 
+# 3e. User-facing single-card compose coverage guard. A compose shipped under
+# models/*/{vllm,llama-cpp,ik-llama}/compose/single must not silently drift out
+# of COMPOSE_REGISTRY (discussions/184 / #379-class failure).
+while IFS=$'\t' read -r relpath registered; do
+  [[ -n "$relpath" ]] || continue
+  if [[ "$registered" != "1" ]]; then
+    note "single-card compose exists on disk but has no compose_registry.py entry: $relpath"
+  fi
+done < <(
+  python3 - "$ROOT_DIR" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+sys.path.insert(0, str(root))
+from scripts.lib.profiles.compose_registry import COMPOSE_REGISTRY
+
+registered_paths = {entry["compose_path"] for entry in COMPOSE_REGISTRY.values()}
+opt_out = {
+    # Add intentionally-internal single-card compose paths here with a comment.
+}
+for engine in ("vllm", "llama-cpp", "ik-llama"):
+    for path in sorted(root.glob(f"models/*/{engine}/compose/single/*.yml")):
+        rel = path.relative_to(root).as_posix()
+        if rel in opt_out:
+            continue
+        print(f"{rel}\t{1 if rel in registered_paths else 0}")
+PY
+)
+
 if [[ "$fail" -ne 0 ]]; then
   echo "[switch-registry-parity] FAIL" >&2
   exit 1


### PR DESCRIPTION
Phase 2+3 of the model-presence/fetch work (brief: `docs/codex-model-presence-fetch-brief.md`), built on the merged Phase-1 (#216).

- **Single source of truth:** weight download recipes moved into `scripts/lib/profiles/models/*.yml` `weights:`; new YAML reader `scripts/lib/profiles/weights.py`. The temporary bash registry is removed.
- preflight/setup.sh consume the reader for **pack-aware `hf download` + `WEIGHTS=…` hints** and TTY-gated **fetch-now via setup.sh**, with a **generic fallback if the reader/PyYAML is unavailable** (critical-path stays robust).
- **Registers `ik-llama/iq4ks-two-stage`** in `COMPOSE_REGISTRY` (was on-disk-only → `switch.sh`/`launch.sh` couldn't see it) — fixes discussions/184.
- **Drift guard:** a test asserts every user-facing single-card compose has a registry entry, so a shipped compose can't silently fall out of the launcher again.

**On-rig validation (Claude, grep-shim neutralized):** single source of truth confirmed (`model-weights.sh` gone); per-model hints correct (ik→ubergarm IQ4_KS, gemma-31b→cyankiwi AWQ, 35b→Qwen MoE AutoRound); **graceful fallback** verified (python3 masked → still HARD-errors on missing weights + generic hint, no crash/false-pass); `ik-llama/iq4ks-two-stage` resolves via switch/launch; registry + preflight-deps + switch-parity tests pass. The `test-setup-picker` failure is pre-existing on master (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)