### PR TITLE
fix(rebench-report): surface ceiling VRAM margin in verify-stress section (#184)

### DIFF
--- a/scripts/rebench-report.py
+++ b/scripts/rebench-report.py
@@ -216,7 +216,28 @@ def parse_verify_stress(log: str) -> dict:
     overall = "PASS" if "All stress / boundary checks passed" in log else (
         "FAIL" if any(c["verdict"] == "FAIL" for c in checks) else "?"
     )
-    return {"checks": checks, "overall": overall}
+    result = {"checks": checks, "overall": overall}
+
+    # Ceiling VRAM margin (#184). verify-stress.sh prints free VRAM at the
+    # deepest rung and hard-fails below the guard, but a margin that *passes*
+    # the guard yet sits close to it can still OOM on a second run / server
+    # restart (laurimyllari's marginal-but-passing case). Surface the number so
+    # a PASS isn't mistaken for comfortable headroom.
+    free = thresh = None
+    m_thin = re.search(r"VRAM margin thin at ceiling:\s*(\d+)\s*MB free\s*<\s*(\d+)\s*MB", log)
+    if m_thin:
+        free, thresh = int(m_thin.group(1)), int(m_thin.group(2))
+    else:
+        m_ok = re.search(r"VRAM:\s*\d+\s*\S+\s*(\d+)\s*MB[^\n]*margin threshold=(\d+)", log)
+        if m_ok:
+            free, thresh = int(m_ok.group(1)), int(m_ok.group(2))
+    if free is not None and thresh:
+        result["ceiling_vram_free_mb"] = free
+        result["vram_threshold_mb"] = thresh
+        result["vram_status"] = (
+            "thin" if free < thresh else "marginal" if free < 2 * thresh else "comfortable"
+        )
+    return result
 
 
 # --- section: quality-full --------------------------------------------------
@@ -479,6 +500,16 @@ def render(report: dict) -> str:
         lines.append("|---|---|---|")
         for c in stress["checks"]:
             lines.append(f"| {c['idx']} | {c['desc']} | {c['verdict']} |")
+        if stress.get("ceiling_vram_free_mb") is not None:
+            free = stress["ceiling_vram_free_mb"]
+            thresh = stress["vram_threshold_mb"]
+            note = {
+                "thin": " — ⚠ **THIN** (below the sustained-agent guard; verify-stress fails this check)",
+                "marginal": " — ⚠ **marginal**: within 2× the guard, so a second run or server restart may OOM. Lower `CTX_SIZE` for sustained agent load.",
+                "comfortable": " — ✓ comfortable",
+            }[stress["vram_status"]]
+            lines.append("")
+            lines.append(f"**Ceiling VRAM margin:** {free} MB free (guard {thresh} MB){note}")
     else:
         lines.append("_(verify-stress log missing or unparsed)_")
     lines.append("")


### PR DESCRIPTION
Closes the rebench-report half of @laurimyllari's [#184](https://github.com/noonghunna/club-3090/discussions/184#discussioncomment-17042752) finding ("a full rebench passes but a second run OOMs — maybe rebench should flag low VRAM headroom").

**Root cause:** `verify-stress.sh` *already* hard-fails a ceiling free-VRAM margin below the sustained-agent guard (default `VRAM_MARGIN_MB=1024`). But a margin that **passes** the guard yet sits close to it can still OOM on a second run / server restart — laurimyllari's 4090-at-160K case (8/8 PASS, then a second rebench OOMed). The report **dropped the margin number entirely**, so the PASS read as comfortable headroom.

**Fix (rebench-report.py only — no change to verify-stress pass/fail):**
- `parse_verify_stress()` extracts the deepest-rung free VRAM + guard from the existing verify-stress output (both the thin-margin WARN line and the normal `VRAM: A → B MB … margin threshold=N` line), and classifies it: **thin** (< guard, already a verify-stress FAIL) / **marginal** (< 2× guard) / **comfortable**.
- The verify-stress report section now prints, e.g.:
  > **Ceiling VRAM margin:** 1500 MB free (guard 1024 MB) — ⚠ **marginal**: within 2× the guard, so a second run or server restart may OOM. Lower `CTX_SIZE` for sustained agent load.

**Validation:** parsed comfortable (3000 MB→comfortable), marginal (1500 MB→marginal, laurimyllari's case), thin (800 MB→FAIL+thin), and no-margin (graceful) logs. Python syntax OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)