### PR TITLE
feat(ik-llama): add PRISM and APEX preset families

### DIFF
--- a/UPSTREAM_CHANGES.md
+++ b/UPSTREAM_CHANGES.md
@@ -6,6 +6,7 @@ This branch ports the live `/opt/ai/club-3090` custom ik-llama work onto the cur
 
 - Adds the PRISM-PRO-DQ preset family for `qwen3.6-27b` on the ik-llama path.
 - Adds the APEX-MTP preset family for `qwen3.6-35b-a3b` on the ik-llama path.
+- Adds an APEX-only local Qwen chat-template override for ik-llama so reasoning-disabled launches stop emitting empty `<think></think>` stubs.
 - Wires every new preset into `scripts/launch.sh` so `launch.sh` can discover, select, port-map, and name the containers correctly.
 - Extends `scripts/lib/profiles/compose_registry.py` so the upstream profile catalog exposes the new presets with the right topology, workload, context, and KV metadata.
 - Fixes the `ik-llama/apex-mtp-compact` registry metadata to report `kv_format="q4_0"` so the catalog matches the compose header and the actual single-card compact lane.
@@ -84,6 +85,16 @@ This branch ports the live `/opt/ai/club-3090` custom ik-llama work onto the cur
   - Default context: `196608`
   - Positioning: long-context dual-card APEX Quality lane that keeps full-context `q8` KV on the paired rig
 
+### APEX template fix
+
+- Added `models/qwen3.6-35b-a3b/ik-llama/patches/apex-qwen-chat-template.jinja`.
+- This is a local APEX-only Qwen 35B-A3B template override for ik-llama, not the froggeric vLLM template path.
+- It patches the assistant reasoning guard from:
+  - `loop.index0 > ns.last_query_index`
+- to:
+  - `loop.index0 > ns.last_query_index and reasoning_content`
+- The three APEX composes now mount that template and pass it through `--chat-template-file`, which prevents empty reasoning stubs from being emitted when reasoning is disabled.
+
 ## Launcher and Registry Integration
 
 - `scripts/launch.sh`
@@ -110,3 +121,4 @@ This branch ports the live `/opt/ai/club-3090` custom ik-llama work onto the cur
 - `models/qwen3.6-35b-a3b/ik-llama/compose/single/apex-mtp-compact.yml`
 - `models/qwen3.6-35b-a3b/ik-llama/compose/single/apex-mtp-compact-long.yml`
 - `models/qwen3.6-35b-a3b/ik-llama/compose/dual/apex-mtp-quality.yml`
+- `models/qwen3.6-35b-a3b/ik-llama/patches/apex-qwen-chat-template.jinja`

--- a/UPSTREAM_CHANGES.md
+++ b/UPSTREAM_CHANGES.md
@@ -1,0 +1,112 @@
+# Upstream Changes for Club-3090
+
+This branch ports the live `/opt/ai/club-3090` custom ik-llama work onto the current upstream `master`/`v0.8.5` tree.
+
+## Summary
+
+- Adds the PRISM-PRO-DQ preset family for `qwen3.6-27b` on the ik-llama path.
+- Adds the APEX-MTP preset family for `qwen3.6-35b-a3b` on the ik-llama path.
+- Wires every new preset into `scripts/launch.sh` so `launch.sh` can discover, select, port-map, and name the containers correctly.
+- Extends `scripts/lib/profiles/compose_registry.py` so the upstream profile catalog exposes the new presets with the right topology, workload, context, and KV metadata.
+- Fixes the `ik-llama/apex-mtp-compact` registry metadata to report `kv_format="q4_0"` so the catalog matches the compose header and the actual single-card compact lane.
+- Reclassifies `ik-llama/iq4ks-two-stage` as `tool-heavy` instead of `fast-chat`, which matches the compose header and the intended code-first/two-stage use case.
+
+## New PRISM-PRO-DQ Presets
+
+### Single-card lanes
+
+- `ik-llama/prism-pro-dq-mtp`
+  - File: `models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-mtp.yml`
+  - Topology: single 3090
+  - Drafter: native MTP `n=4`, `p-min=0.0`
+  - KV: `q4_0`
+  - Default context: `122880`
+  - Positioning: lean text-first PRISM lane for fast single-card MTP evaluation
+
+- `ik-llama/prism-pro-dq-long`
+  - File: `models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-long.yml`
+  - Topology: single 3090
+  - Drafter: native MTP `n=5`, `p-min=0.0`
+  - KV: `q4_0`
+  - Default context: `180000`
+  - Positioning: single-card long-context compromise with better context headroom than the lean MTP lane
+
+- `ik-llama/prism-pro-dq-two-stage`
+  - File: `models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-two-stage.yml`
+  - Topology: single 3090
+  - Drafter: two-stage `ngram-mod + MTP fallback`
+  - KV: `q4_0`
+  - Default context: `200000`
+  - Positioning: code-heavy PRISM evaluation on the two-stage speculative path
+
+### Dual-card lanes
+
+- `ik-llama/prism-pro-dq-dual`
+  - File: `models/qwen3.6-27b/ik-llama/compose/dual/prism-pro-dq-mtp.yml`
+  - Topology: dual 3090
+  - Drafter: native MTP `n=4`, `p-min=0.0`
+  - KV: `q4_0`
+  - Default context: `196608`
+  - Positioning: text-first dual-card PRISM serving with more context headroom than the multimodal lane
+
+- `ik-llama/prism-pro-dq-dual-vision`
+  - File: `models/qwen3.6-27b/ik-llama/compose/dual/prism-pro-dq-mtp-vision.yml`
+  - Topology: dual 3090
+  - Drafter: native MTP `n=5`, `p-min=0.0`
+  - KV: `q4_0`
+  - Default context: `196608`
+  - Vision: enabled via `mmproj-F16`
+  - Positioning: dual-card multimodal PRISM lane with embedded vision preserved
+
+## New APEX-MTP Presets
+
+- `ik-llama/apex-mtp-compact`
+  - File: `models/qwen3.6-35b-a3b/ik-llama/compose/single/apex-mtp-compact.yml`
+  - Topology: single 3090
+  - Drafter: native MTP `n=2`, `p-min=0.0`
+  - KV: `q4_0`
+  - Default context: `200000`
+  - Positioning: practical single-card APEX entry point when the `I-Quality` file is too tight for a usable 24 GB speculative/KV budget
+
+- `ik-llama/apex-mtp-compact-long`
+  - File: `models/qwen3.6-35b-a3b/ik-llama/compose/single/apex-mtp-compact-long.yml`
+  - Topology: single 3090
+  - Drafter: native MTP `n=2`, `p-min=0.0`
+  - KV: `q8_0`
+  - Default context: `262144`
+  - Positioning: highest-context single-card APEX compact lane that still stayed fast on the test rig
+
+- `ik-llama/apex-mtp-quality-dual`
+  - File: `models/qwen3.6-35b-a3b/ik-llama/compose/dual/apex-mtp-quality.yml`
+  - Topology: dual 3090
+  - Drafter: native MTP `n=5`, `p-min=0.0`
+  - KV: `q8_0`
+  - Default context: `196608`
+  - Positioning: long-context dual-card APEX Quality lane that keeps full-context `q8` KV on the paired rig
+
+## Launcher and Registry Integration
+
+- `scripts/launch.sh`
+  - Adds compose-path entries for every PRISM and APEX lane.
+  - Adds model ownership for the new `qwen3.6-27b` PRISM and `qwen3.6-35b-a3b` APEX variants.
+  - Adds engine-family registration so the new presets route through the llama.cpp/ik-llama launch path.
+  - Adds `KVCALC=SKIP` coverage so the new ik-llama presets don't fall into unsupported KV calculator paths.
+  - Adds launch ordering, default ports, and default container names for the entire PRISM/APEX family.
+  - Carries forward the already-existing `ik-llama/iq4ks-two-stage` launch wiring that was missing from upstream `launch.sh`.
+
+- `scripts/lib/profiles/compose_registry.py`
+  - Registers all PRISM/APEX presets so they show up in profile-backed selection flows.
+  - Sets the new presets' workload classes, topology, context limits, and default ports.
+  - Corrects `ik-llama/apex-mtp-compact` to `kv_format="q4_0"`.
+  - Changes `ik-llama/iq4ks-two-stage` to `workload="tool-heavy"` to match its two-stage/code-oriented purpose.
+
+## Files Added
+
+- `models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-mtp.yml`
+- `models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-long.yml`
+- `models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-two-stage.yml`
+- `models/qwen3.6-27b/ik-llama/compose/dual/prism-pro-dq-mtp.yml`
+- `models/qwen3.6-27b/ik-llama/compose/dual/prism-pro-dq-mtp-vision.yml`
+- `models/qwen3.6-35b-a3b/ik-llama/compose/single/apex-mtp-compact.yml`
+- `models/qwen3.6-35b-a3b/ik-llama/compose/single/apex-mtp-compact-long.yml`
+- `models/qwen3.6-35b-a3b/ik-llama/compose/dual/apex-mtp-quality.yml`

--- a/models/qwen3.6-27b/ik-llama/compose/dual/prism-pro-dq-mtp-vision.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/dual/prism-pro-dq-mtp-vision.yml
@@ -1,0 +1,96 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-27B-PRISM-PRO-DQ (Ex0bit dynamic-quant GGUF) + mmproj-F16
+#   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp:cu13-server)
+#   Topology:  Dual 3090 (TP=2)
+#   Drafter:   MTP n=5, p-min 0.0
+#   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
+#   Vision:    YES — qwen3.6 mmproj-F16 mounted for multimodal input
+#   Default ctx: 196608
+#   Status:    🧪 EVAL ONLY — PRISM-PRO-DQ dual-card multimodal lane
+#   Best for:  Dual-card testing of PRISM-PRO-DQ with long context, native MTP, and embedded vision.
+# ---------------------------------------------------------------------------
+# Qwen3.6-27B-PRISM-PRO-DQ on ik_llama.cpp — dual 3090, dynamic-quant GGUF,
+# native MTP, and embedded vision tower.
+#
+# target: Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ
+# draft: unsloth/Qwen3.6-27B-GGUF
+#
+# Quick start:
+#   1. Get the GGUF + mmproj:
+#        hf download Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ Qwen3.6-27B-PRISM-PRO-DQ.gguf \
+#          --local-dir $MODEL_DIR/qwen3.6-27b-gguf/ex0bit-prism-pro-dq
+#        hf download unsloth/Qwen3.6-27B-GGUF mmproj-F16.gguf \
+#          --local-dir $MODEL_DIR/qwen3.6-27b-gguf
+#   2. From this directory:
+#        MODEL_DIR=/your/models/dir CUDA_VISIBLE_DEVICES=0,1 docker compose -f prism-pro-dq-mtp-vision.yml up -d
+#
+# Override defaults via .env or shell:
+#   MODEL_DIR              host dir to mount as /models  (default: ../../../../../models-cache)
+#   GGUF_FILE              path under /models  (default: qwen3.6-27b-gguf/ex0bit-prism-pro-dq/Qwen3.6-27B-PRISM-PRO-DQ.gguf)
+#   MMPROJ_FILE            path under /models  (default: qwen3.6-27b-gguf/mmproj-F16.gguf)
+#   CTX_SIZE               KV pool size        (default: 196608)
+#   BATCH_SIZE             llama.cpp -b        (default: 2048)
+#   UBATCH_SIZE            llama.cpp -ub       (default: 2048)
+#   NP                     parallel slots      (default: 1)
+#   KV_TYPE                K and V quant type  (default: q4_0)
+#   IMAGE_MIN_TOKENS       image min tokens    (default: 1024)
+#   IMAGE_MAX_TOKENS       image max tokens    (default: 4096)
+#   MTP_DRAFT_N_MAX        MTP draft tokens    (default: 5)
+#   DRAFT_P_MIN            draft accept floor  (default: 0.0)
+#   TENSOR_SPLIT           manual tensor split (default: 1,1)
+#   REASONING              thinking gate       (default: off)
+#   REASONING_FORMAT       reasoning routing   (default: deepseek)
+#   PORT                   host port           (default: 8010)
+#   CUDA_VISIBLE_DEVICES   which GPUs to use   (default: 0,1)
+
+services:
+  ik-llama-qwen36-27b-prism-pro-dq-dual:
+    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu13-server}
+    container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b-prism-pro-dq-dual}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8010}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../models-cache}:/models:ro"
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      --model /models/${GGUF_FILE:-qwen3.6-27b-gguf/ex0bit-prism-pro-dq/Qwen3.6-27B-PRISM-PRO-DQ.gguf}
+      --mmproj /models/${MMPROJ_FILE:-qwen3.6-27b-gguf/mmproj-F16.gguf}
+      --image-min-tokens ${IMAGE_MIN_TOKENS:-1024}
+      --image-max-tokens ${IMAGE_MAX_TOKENS:-4096}
+      --split-mode layer
+      --tensor-split ${TENSOR_SPLIT:-1,1}
+      -ngl 99
+      --ctx-size ${CTX_SIZE:-196608}
+      -b ${BATCH_SIZE:-2048}
+      -ub ${UBATCH_SIZE:-2048}
+      -np ${NP:-1}
+      -ctk ${KV_TYPE:-q4_0}
+      -ctv ${KV_TYPE:-q4_0}
+      -khad
+      -vhad
+      -ngld 99
+      --multi-token-prediction
+      --draft-max ${MTP_DRAFT_N_MAX:-5}
+      --draft-p-min ${DRAFT_P_MIN:-0.0}
+      --recurrent-ckpt-mode auto
+      --merge-qkv
+      -fa on
+      --jinja
+      --parallel-tool-calls
+      --reasoning ${REASONING:-off}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0,1}}"]
+              capabilities: [gpu]

--- a/models/qwen3.6-27b/ik-llama/compose/dual/prism-pro-dq-mtp.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/dual/prism-pro-dq-mtp.yml
@@ -1,0 +1,80 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-27B-PRISM-PRO-DQ (Ex0bit dynamic-quant GGUF)
+#   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp:cu13-server)
+#   Topology:  Dual 3090 (TP=2)
+#   Drafter:   MTP n=4, p-min 0.0
+#   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
+#   Vision:    NO
+#   Default ctx: 196608
+#   Status:    🧪 EVAL ONLY — PRISM-PRO-DQ dual-card text lane
+#   Best for:  Text-first dual-card PRISM serving when you want extra context
+#              headroom without the multimodal overhead of the vision lane.
+# ---------------------------------------------------------------------------
+# Qwen3.6-27B-PRISM-PRO-DQ on ik_llama.cpp — dual 3090, text-only, native MTP.
+#
+# target: Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ
+#
+# Override defaults via .env or shell:
+#   MODEL_DIR              host dir to mount as /models  (default: ../../../../../models-cache)
+#   GGUF_FILE              path under /models  (default: qwen3.6-27b-gguf/ex0bit-prism-pro-dq/Qwen3.6-27B-PRISM-PRO-DQ.gguf)
+#   CTX_SIZE               KV pool size        (default: 196608)
+#   BATCH_SIZE             llama.cpp -b        (default: 1024)
+#   UBATCH_SIZE            llama.cpp -ub       (default: 512)
+#   NP                     parallel slots      (default: 1)
+#   KV_TYPE                K and V quant type  (default: q4_0)
+#   MTP_DRAFT_N_MAX        MTP draft tokens    (default: 4)
+#   DRAFT_P_MIN            draft accept floor  (default: 0.0)
+#   TENSOR_SPLIT           manual tensor split (default: 1,1)
+#   REASONING              thinking gate       (default: off)
+#   REASONING_FORMAT       reasoning routing   (default: deepseek)
+#   PORT                   host port           (default: 8053)
+#   CUDA_VISIBLE_DEVICES   which GPUs to use   (default: 0,1)
+
+services:
+  ik-llama-qwen36-27b-prism-pro-dq-dual:
+    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu13-server}
+    container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b-prism-pro-dq-dual}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8053}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../models-cache}:/models:ro"
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      --model /models/${GGUF_FILE:-qwen3.6-27b-gguf/ex0bit-prism-pro-dq/Qwen3.6-27B-PRISM-PRO-DQ.gguf}
+      --split-mode layer
+      --tensor-split ${TENSOR_SPLIT:-1,1}
+      -ngl 99
+      --ctx-size ${CTX_SIZE:-196608}
+      -b ${BATCH_SIZE:-1024}
+      -ub ${UBATCH_SIZE:-512}
+      -np ${NP:-1}
+      -ctk ${KV_TYPE:-q4_0}
+      -ctv ${KV_TYPE:-q4_0}
+      -khad
+      -vhad
+      -ngld 99
+      --multi-token-prediction
+      --draft-max ${MTP_DRAFT_N_MAX:-4}
+      --draft-p-min ${DRAFT_P_MIN:-0.0}
+      --recurrent-ckpt-mode auto
+      --merge-qkv
+      -fa on
+      --jinja
+      --parallel-tool-calls
+      --reasoning ${REASONING:-off}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0,1}}"]
+              capabilities: [gpu]

--- a/models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-long.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-long.yml
@@ -1,0 +1,78 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-27B-PRISM-PRO-DQ (Ex0bit dynamic-quant GGUF)
+#   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp:cu13-server)
+#   Topology:  Single 3090 (TP=1)
+#   Drafter:   MTP n=5, p-min 0.0
+#   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
+#   Vision:    embedded tower preserved in the GGUF; tuned for text-first use
+#   Default ctx: 180000
+#   Status:    🧪 EVAL ONLY — PRISM-PRO-DQ single-card long-context lane
+#   Best for:  The best balance we found between PRISM single-card speed and a
+#              much larger stable context budget on this dual-3090 host.
+# ---------------------------------------------------------------------------
+# Qwen3.6-27B-PRISM-PRO-DQ on ik_llama.cpp — single 3090, dynamic-quant GGUF
+# tuned for longer-context text-first use.
+#
+# target: Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ
+#
+# Override defaults via .env or shell:
+#   MODEL_DIR              host dir to mount as /models  (default: ../../../../../models-cache)
+#   GGUF_FILE              path under /models  (default: qwen3.6-27b-gguf/ex0bit-prism-pro-dq/Qwen3.6-27B-PRISM-PRO-DQ.gguf)
+#   CTX_SIZE               KV pool size        (default: 180000)
+#   BATCH_SIZE             llama.cpp -b        (default: 4096)
+#   UBATCH_SIZE            llama.cpp -ub       (default: 1024)
+#   NP                     parallel slots      (default: 1)
+#   KV_TYPE                K and V quant type  (default: q4_0)
+#   MTP_DRAFT_N_MAX        MTP draft tokens    (default: 5)
+#   DRAFT_P_MIN            draft accept floor  (default: 0.0)
+#   REASONING              thinking gate       (default: off)
+#   REASONING_FORMAT       reasoning routing   (default: deepseek)
+#   PORT                   host port           (default: 8052)
+#   CUDA_VISIBLE_DEVICES   which GPU to use    (default: 0)
+
+services:
+  ik-llama-qwen36-27b-prism-pro-dq-long:
+    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu13-server}
+    container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b-prism-pro-dq-long}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8052}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../models-cache}:/models:ro"
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      --model /models/${GGUF_FILE:-qwen3.6-27b-gguf/ex0bit-prism-pro-dq/Qwen3.6-27B-PRISM-PRO-DQ.gguf}
+      -ngl 99
+      --ctx-size ${CTX_SIZE:-180000}
+      -b ${BATCH_SIZE:-4096}
+      -ub ${UBATCH_SIZE:-1024}
+      -np ${NP:-1}
+      -ctk ${KV_TYPE:-q4_0}
+      -ctv ${KV_TYPE:-q4_0}
+      -khad
+      -vhad
+      -ngld 99
+      --multi-token-prediction
+      --draft-max ${MTP_DRAFT_N_MAX:-5}
+      --draft-p-min ${DRAFT_P_MIN:-0.0}
+      --recurrent-ckpt-mode auto
+      --merge-qkv
+      -fa on
+      --jinja
+      --parallel-tool-calls
+      --reasoning ${REASONING:-off}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}"]
+              capabilities: [gpu]

--- a/models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-mtp.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-mtp.yml
@@ -1,0 +1,84 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-27B-PRISM-PRO-DQ (Ex0bit dynamic-quant GGUF)
+#   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp:cu13-server)
+#   Topology:  Single 3090 (TP=1)
+#   Drafter:   MTP n=4, p-min 0.0 (best code TPS on the latest 1x3090 retune)
+#   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
+#   Vision:    embedded tower preserved in the GGUF; this preset is tuned for text-first use
+#   Default ctx: 122880
+#   Status:    🧪 EVAL ONLY — PRISM-PRO-DQ single-card MTP lane
+#   Best for:  Testing Ex0bit's PRISM-PRO-DQ GGUF on the lean ik-llama MTP path.
+# ---------------------------------------------------------------------------
+# Qwen3.6-27B-PRISM-PRO-DQ on ik_llama.cpp — single 3090, dynamic-quant GGUF
+# on the shipped IQ4_KS-style MTP runtime shape.
+#
+# target: Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ
+#
+# Quick start:
+#   1. Get the GGUF:
+#        hf download Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ Qwen3.6-27B-PRISM-PRO-DQ.gguf \
+#          --local-dir $MODEL_DIR/qwen3.6-27b-gguf/ex0bit-prism-pro-dq
+#   2. From this directory:
+#        MODEL_DIR=/your/models/dir docker compose -f prism-pro-dq-mtp.yml up -d
+#
+# Override defaults via .env or shell:
+#   MODEL_DIR              host dir to mount as /models  (default: ../../../../../models-cache)
+#   GGUF_FILE              path under /models  (default: qwen3.6-27b-gguf/ex0bit-prism-pro-dq/Qwen3.6-27B-PRISM-PRO-DQ.gguf)
+#   CTX_SIZE               KV pool size        (default: 122880)
+#   BATCH_SIZE             llama.cpp -b        (default: 4096)
+#   UBATCH_SIZE            llama.cpp -ub       (default: 1024)
+#   NP                     parallel slots      (default: 1)
+#   KV_TYPE                K and V quant type  (default: q4_0; q8_0 booted up to 220K here but long-fill OOMed around 110K, so q4 remains the safe single-card default)
+#   MTP_DRAFT_N_MAX        MTP draft tokens    (default: 4)
+#   DRAFT_P_MIN            draft accept floor  (default: 0.0)
+#   REASONING              thinking gate       (default: off)
+#   REASONING_FORMAT       reasoning routing   (default: deepseek)
+#   PORT                   host port           (default: 8020)
+#   CUDA_VISIBLE_DEVICES   which GPU to use    (default: 0)
+
+services:
+  ik-llama-qwen36-27b-prism-pro-dq:
+    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu13-server}
+    container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b-prism-pro-dq}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8020}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../models-cache}:/models:ro"
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      --model /models/${GGUF_FILE:-qwen3.6-27b-gguf/ex0bit-prism-pro-dq/Qwen3.6-27B-PRISM-PRO-DQ.gguf}
+      -ngl 99
+      --ctx-size ${CTX_SIZE:-122880}
+      -b ${BATCH_SIZE:-4096}
+      -ub ${UBATCH_SIZE:-1024}
+      -np ${NP:-1}
+      -ctk ${KV_TYPE:-q4_0}
+      -ctv ${KV_TYPE:-q4_0}
+      -khad
+      -vhad
+      -ngld 99
+      --multi-token-prediction
+      --draft-max ${MTP_DRAFT_N_MAX:-4}
+      --draft-p-min ${DRAFT_P_MIN:-0.0}
+      --recurrent-ckpt-mode auto
+      --merge-qkv
+      -fa on
+      --jinja
+      --parallel-tool-calls
+      --reasoning ${REASONING:-off}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}"]
+              capabilities: [gpu]

--- a/models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-two-stage.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-two-stage.yml
@@ -1,0 +1,86 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-27B-PRISM-PRO-DQ (Ex0bit dynamic-quant GGUF)
+#   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp:cu13-server)
+#   Topology:  Single 3090 (TP=1)
+#   Drafter:   TWO-STAGE ngram-mod + MTP fallback
+#   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
+#   Vision:    embedded tower preserved in the GGUF; this preset is tuned for text-first use
+#   Default ctx: 200000
+#   Status:    🧪 EVAL ONLY — PRISM-PRO-DQ single-card two-stage lane
+#   Best for:  Code-heavy testing of Ex0bit's PRISM-PRO-DQ GGUF on the two-stage ik-llama path.
+# ---------------------------------------------------------------------------
+# Qwen3.6-27B-PRISM-PRO-DQ on ik_llama.cpp — single 3090, dynamic-quant GGUF
+# on the shipped two-stage speculative-decoding runtime shape.
+#
+# target: Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ
+#
+# Quick start:
+#   1. Get the GGUF:
+#        hf download Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ Qwen3.6-27B-PRISM-PRO-DQ.gguf \
+#          --local-dir $MODEL_DIR/qwen3.6-27b-gguf/ex0bit-prism-pro-dq
+#   2. From this directory:
+#        MODEL_DIR=/your/models/dir docker compose -f prism-pro-dq-two-stage.yml up -d
+#
+# Override defaults via .env or shell:
+#   MODEL_DIR              host dir to mount as /models  (default: ../../../../../models-cache)
+#   GGUF_FILE              path under /models  (default: qwen3.6-27b-gguf/ex0bit-prism-pro-dq/Qwen3.6-27B-PRISM-PRO-DQ.gguf)
+#   CTX_SIZE               KV pool size        (default: 200000)
+#   BATCH_SIZE             llama.cpp -b        (default: 4096)
+#   UBATCH_SIZE            llama.cpp -ub       (default: 1024)
+#   NP                     parallel slots      (default: 1)
+#   KV_TYPE                K and V quant type  (default: q4_0)
+#   NGRAM_N_MAX            ngram max draft     (default: 4)
+#   NGRAM_N_MIN            ngram min accept    (default: 2)
+#   NGRAM_SIZE_N           ngram lookup size   (default: 16)
+#   MTP_N_MAX              MTP max draft       (default: 3)
+#   MTP_P_MIN              MTP accept floor    (default: 0.0)
+#   REASONING              thinking gate       (default: off)
+#   REASONING_FORMAT       reasoning routing   (default: deepseek)
+#   PORT                   host port           (default: 8020)
+#   CUDA_VISIBLE_DEVICES   which GPU to use    (default: 0)
+
+services:
+  ik-llama-qwen36-27b-prism-pro-dq-two-stage:
+    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu13-server}
+    container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b-prism-pro-dq-two-stage}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8020}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../models-cache}:/models:ro"
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      --model /models/${GGUF_FILE:-qwen3.6-27b-gguf/ex0bit-prism-pro-dq/Qwen3.6-27B-PRISM-PRO-DQ.gguf}
+      -ngl 99
+      --ctx-size ${CTX_SIZE:-200000}
+      -b ${BATCH_SIZE:-4096}
+      -ub ${UBATCH_SIZE:-1024}
+      -np ${NP:-1}
+      -ctk ${KV_TYPE:-q4_0}
+      -ctv ${KV_TYPE:-q4_0}
+      -khad
+      -vhad
+      -ngld 99
+      --spec-stage ngram-mod:n_max=${NGRAM_N_MAX:-4},n_min=${NGRAM_N_MIN:-2},spec-ngram-size-n=${NGRAM_SIZE_N:-16}
+      --spec-stage mtp:n_max=${MTP_N_MAX:-3},draft-p-min=${MTP_P_MIN:-0.0}
+      --recurrent-ckpt-mode auto
+      --merge-qkv
+      -fa on
+      --jinja
+      --parallel-tool-calls
+      --reasoning ${REASONING:-off}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}"]
+              capabilities: [gpu]

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/dual/apex-mtp-quality.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/dual/apex-mtp-quality.yml
@@ -41,6 +41,7 @@ services:
       - "${ESTATE_PORT:-${PORT:-8055}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../models-cache}:/models:ro"
+      - ../../patches/apex-qwen-chat-template.jinja:/etc/apex-qwen-chat-template.jinja:ro
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -61,6 +62,7 @@ services:
       --merge-qkv
       -fa on
       --jinja
+      --chat-template-file /etc/apex-qwen-chat-template.jinja
       --reasoning ${REASONING:-off}
       --reasoning-format ${REASONING_FORMAT:-deepseek}
       --temp ${TEMP:-${TEMPERATURE:-0.6}}

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/dual/apex-mtp-quality.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/dual/apex-mtp-quality.yml
@@ -1,0 +1,77 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-35B-A3B-APEX-MTP (mudler APEX Quality GGUF)
+#   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp:cu13-server)
+#   Topology:  Dual 3090 (TP=2)
+#   Drafter:   MTP n=5, p-min 0.0
+#   KV:        q8_0 K + q8_0 V
+#   Vision:    NO
+#   Default ctx: 196608
+#   Status:    🧪 EVAL ONLY — dual-card APEX quality bring-up lane
+#   Best for:  Long-context dual-card MoE testing of mudler's APEX-MTP Quality
+#              GGUF on the ik-llama path while keeping full-context q8 KV on the
+#              paired 3090 rig.
+# ---------------------------------------------------------------------------
+# Qwen3.6-35B-A3B MoE on ik_llama.cpp — dual 3090, APEX Quality GGUF.
+#
+# target: mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF
+#
+# Override defaults via .env or shell:
+#   MODEL_DIR              host dir to mount as /models  (default: ../../../../../models-cache)
+#   GGUF_FILE              path under /models  (default: qwen3.6-35b-a3b-gguf/mudler-apex-mtp/Qwen3.6-35B-A3B-APEX-MTP-I-Quality.gguf)
+#   CTX_SIZE               KV pool size        (default: 196608)
+#   BATCH_SIZE             llama.cpp -b        (default: 2048)
+#   UBATCH_SIZE            llama.cpp -ub       (default: 512)
+#   NP                     parallel slots      (default: 1)
+#   KV_TYPE                K and V quant type  (default: q8_0)
+#   MTP_DRAFT_N_MAX        MTP draft tokens    (default: 5)
+#   DRAFT_P_MIN            draft accept floor  (default: 0.0)
+#   TENSOR_SPLIT           manual tensor split (default: 1,1)
+#   REASONING              thinking gate       (default: off)
+#   REASONING_FORMAT       reasoning routing   (default: deepseek)
+#   PORT                   host port           (default: 8055)
+#   CUDA_VISIBLE_DEVICES   which GPUs to use   (default: 0,1)
+
+services:
+  ik-llama-qwen36-35b-a3b-apex-quality-dual:
+    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu13-server}
+    container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-35b-a3b-apex-quality-dual}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8055}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../models-cache}:/models:ro"
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      --model /models/${GGUF_FILE:-qwen3.6-35b-a3b-gguf/mudler-apex-mtp/Qwen3.6-35B-A3B-APEX-MTP-I-Quality.gguf}
+      --fit
+      --fit-margin 256
+      --split-mode graph
+      --max-gpu 2
+      --ctx-size ${CTX_SIZE:-196608}
+      -b ${BATCH_SIZE:-2048}
+      -ub ${UBATCH_SIZE:-512}
+      -np ${NP:-1}
+      -ctk ${KV_TYPE:-q8_0}
+      -ctv ${KV_TYPE:-q8_0}
+      --multi-token-prediction
+      --draft-max ${MTP_DRAFT_N_MAX:-5}
+      --draft-p-min ${DRAFT_P_MIN:-0.0}
+      --merge-qkv
+      -fa on
+      --jinja
+      --reasoning ${REASONING:-off}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0,1}}"]
+              capabilities: [gpu]

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/single/apex-mtp-compact-long.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/single/apex-mtp-compact-long.yml
@@ -39,6 +39,7 @@ services:
       - "${ESTATE_PORT:-${PORT:-8056}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../models-cache}:/models:ro"
+      - ../../patches/apex-qwen-chat-template.jinja:/etc/apex-qwen-chat-template.jinja:ro
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -62,6 +63,7 @@ services:
       --merge-qkv
       -fa on
       --jinja
+      --chat-template-file /etc/apex-qwen-chat-template.jinja
       --parallel-tool-calls
       --reasoning ${REASONING:-off}
       --reasoning-format ${REASONING_FORMAT:-deepseek}

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/single/apex-mtp-compact-long.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/single/apex-mtp-compact-long.yml
@@ -1,0 +1,79 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-35B-A3B-APEX-MTP (mudler APEX compact GGUF)
+#   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp:cu13-server)
+#   Topology:  Single 3090 (TP=1)
+#   Drafter:   MTP n=2, p-min 0.0
+#   KV:        q8_0 K + q8_0 V + -khad/-vhad Hadamard
+#   Vision:    NO
+#   Default ctx: 262144
+#   Status:    🧪 EVAL ONLY — single-card APEX compact long-context lane
+#   Best for:  Great single-card APEX throughput while still stretching the fit
+#              path toward the largest stable context that stayed fast here.
+# ---------------------------------------------------------------------------
+# Qwen3.6-35B-A3B MoE on ik_llama.cpp — single 3090, APEX compact GGUF.
+#
+# target: mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF
+#
+# Override defaults via .env or shell:
+#   MODEL_DIR              host dir to mount as /models  (default: ../../../../../models-cache)
+#   GGUF_FILE              path under /models  (default: qwen3.6-35b-a3b-gguf/mudler-apex-mtp/Qwen3.6-35B-A3B-APEX-MTP-I-Compact.gguf)
+#   CTX_SIZE               KV pool size        (default: 262144)
+#   BATCH_SIZE             llama.cpp -b        (default: 4096)
+#   UBATCH_SIZE            llama.cpp -ub       (default: 512)
+#   NP                     parallel slots      (default: 3)
+#   KV_TYPE                K and V quant type  (default: q8_0)
+#   MTP_DRAFT_N_MAX        MTP draft tokens    (default: 4)
+#   DRAFT_P_MIN            draft accept floor  (default: 0.0)
+#   REASONING              thinking gate       (default: off)
+#   REASONING_FORMAT       reasoning routing   (default: deepseek)
+#   PORT                   host port           (default: 8056)
+#   CUDA_VISIBLE_DEVICES   which GPU to use    (default: 0)
+
+services:
+  ik-llama-qwen36-35b-a3b-apex-compact-long:
+    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu13-server}
+    container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-35b-a3b-apex-compact-long}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8056}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../models-cache}:/models:ro"
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      --model /models/${GGUF_FILE:-qwen3.6-35b-a3b-gguf/mudler-apex-mtp/Qwen3.6-35B-A3B-APEX-MTP-I-Compact.gguf}
+      --fit
+      --fit-margin 256
+      -ngl 99
+      --ctx-size ${CTX_SIZE:-262144}
+      -b ${BATCH_SIZE:-4096}
+      -ub ${UBATCH_SIZE:-512}
+      -np ${NP:-3}
+      -ctk ${KV_TYPE:-q8_0}
+      -ctv ${KV_TYPE:-q8_0}
+      -khad
+      -vhad
+      -ngld 99
+      --multi-token-prediction
+      --draft-max ${MTP_DRAFT_N_MAX:-4}
+      --draft-p-min ${DRAFT_P_MIN:-0.0}
+      --recurrent-ckpt-mode auto
+      --merge-qkv
+      -fa on
+      --jinja
+      --parallel-tool-calls
+      --reasoning ${REASONING:-off}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}"]
+              capabilities: [gpu]

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/single/apex-mtp-compact.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/single/apex-mtp-compact.yml
@@ -1,0 +1,85 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-35B-A3B-APEX-MTP (mudler APEX compact GGUF)
+#   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp:cu13-server)
+#   Topology:  Single 3090 (TP=1)
+#   Drafter:   MTP n=2, p-min 0.0
+#   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
+#   Vision:    NO
+#   Default ctx: 200000
+#   Status:    🧪 EVAL ONLY — single-card APEX compact bring-up lane
+#   Best for:  Fast single-card testing of mudler's APEX-MTP compact MoE GGUF
+#              on the ik-llama path when the 23.5 GB Quality file is too tight
+#              for a practical 24 GB single-card context budget.
+# ---------------------------------------------------------------------------
+# Qwen3.6-35B-A3B MoE on ik_llama.cpp — single 3090, APEX compact GGUF.
+#
+# target: mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF
+#
+# Why the compact file here:
+#   The I-Quality file is ~23.5 GB and leaves too little single-card VRAM for
+#   a useful speculative-decoding + KV budget on a 24 GB 3090. The compact file
+#   is ~17.3 GB and is the practical single-card APEX starting point.
+#
+# Override defaults via .env or shell:
+#   MODEL_DIR              host dir to mount as /models  (default: ../../../../../models-cache)
+#   GGUF_FILE              path under /models  (default: qwen3.6-35b-a3b-gguf/mudler-apex-mtp/Qwen3.6-35B-A3B-APEX-MTP-I-Compact.gguf)
+#   CTX_SIZE               KV pool size        (default: 200000)
+#   BATCH_SIZE             llama.cpp -b        (default: 4096)
+#   UBATCH_SIZE            llama.cpp -ub       (default: 1024)
+#   NP                     parallel slots      (default: 1)
+#   KV_TYPE                K and V quant type  (default: q4_0)
+#   MTP_DRAFT_N_MAX        MTP draft tokens    (default: 5)
+#   DRAFT_P_MIN            draft accept floor  (default: 0.0)
+#   REASONING              thinking gate       (default: off)
+#   REASONING_FORMAT       reasoning routing   (default: deepseek)
+#   PORT                   host port           (default: 8054)
+#   CUDA_VISIBLE_DEVICES   which GPU to use    (default: 0)
+
+services:
+  ik-llama-qwen36-35b-a3b-apex-compact:
+    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu13-server}
+    container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-35b-a3b-apex-compact}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8054}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../models-cache}:/models:ro"
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      --model /models/${GGUF_FILE:-qwen3.6-35b-a3b-gguf/mudler-apex-mtp/Qwen3.6-35B-A3B-APEX-MTP-I-Compact.gguf}
+      --fit
+      --fit-margin 256
+      -ngl 99
+      --ctx-size ${CTX_SIZE:-200000}
+      -b ${BATCH_SIZE:-4096}
+      -ub ${UBATCH_SIZE:-1024}
+      -np ${NP:-1}
+      -ctk ${KV_TYPE:-q4_0}
+      -ctv ${KV_TYPE:-q4_0}
+      -khad
+      -vhad
+      -ngld 99
+      --multi-token-prediction
+      --draft-max ${MTP_DRAFT_N_MAX:-5}
+      --draft-p-min ${DRAFT_P_MIN:-0.0}
+      --recurrent-ckpt-mode auto
+      --merge-qkv
+      -fa on
+      --jinja
+      --parallel-tool-calls
+      --reasoning ${REASONING:-off}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}"]
+              capabilities: [gpu]

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/single/apex-mtp-compact.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/single/apex-mtp-compact.yml
@@ -45,6 +45,7 @@ services:
       - "${ESTATE_PORT:-${PORT:-8054}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../models-cache}:/models:ro"
+      - ../../patches/apex-qwen-chat-template.jinja:/etc/apex-qwen-chat-template.jinja:ro
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -68,6 +69,7 @@ services:
       --merge-qkv
       -fa on
       --jinja
+      --chat-template-file /etc/apex-qwen-chat-template.jinja
       --parallel-tool-calls
       --reasoning ${REASONING:-off}
       --reasoning-format ${REASONING_FORMAT:-deepseek}

--- a/models/qwen3.6-35b-a3b/ik-llama/patches/apex-qwen-chat-template.jinja
+++ b/models/qwen3.6-35b-a3b/ik-llama/patches/apex-qwen-chat-template.jinja
@@ -1,0 +1,154 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- if (preserve_thinking is defined and preserve_thinking is true) or (loop.index0 > ns.last_query_index and reasoning_content) %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | string if args_value is string else args_value | tojson | safe %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -233,6 +233,15 @@ declare -A LAUNCH_VARIANT_COMPOSE=(
   [llamacpp/mtp-vision]="models/qwen3.6-27b/llama-cpp/compose/single/mtp-vision.yml"
   [ik-llama/iq4ks-mtp]="models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp.yml"
   [ik-llama/iq4ks-mtp-vision]="models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp-vision.yml"
+  [ik-llama/iq4ks-two-stage]="models/qwen3.6-27b/ik-llama/compose/single/iq4ks-two-stage.yml"
+  [ik-llama/prism-pro-dq-mtp]="models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-mtp.yml"
+  [ik-llama/prism-pro-dq-long]="models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-long.yml"
+  [ik-llama/prism-pro-dq-two-stage]="models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-two-stage.yml"
+  [ik-llama/prism-pro-dq-dual]="models/qwen3.6-27b/ik-llama/compose/dual/prism-pro-dq-mtp.yml"
+  [ik-llama/prism-pro-dq-dual-vision]="models/qwen3.6-27b/ik-llama/compose/dual/prism-pro-dq-mtp-vision.yml"
+  [ik-llama/apex-mtp-compact]="models/qwen3.6-35b-a3b/ik-llama/compose/single/apex-mtp-compact.yml"
+  [ik-llama/apex-mtp-compact-long]="models/qwen3.6-35b-a3b/ik-llama/compose/single/apex-mtp-compact-long.yml"
+  [ik-llama/apex-mtp-quality-dual]="models/qwen3.6-35b-a3b/ik-llama/compose/dual/apex-mtp-quality.yml"
 )
 declare -A LAUNCH_VARIANT_MODEL=(
   [vllm/default]="qwen3.6-27b" [vllm/long-vision]="qwen3.6-27b" [vllm/long-text]="qwen3.6-27b"
@@ -243,7 +252,10 @@ declare -A LAUNCH_VARIANT_MODEL=(
   [vllm/dual-nvlink-dflash]="qwen3.6-27b" [vllm/dual-nvlink-dflash-noviz]="qwen3.6-27b"
   [vllm/gemma-mtp]="gemma-4-31b" [vllm/gemma-mtp-tp1]="gemma-4-31b" [vllm/gemma-dflash]="gemma-4-31b"
   [llamacpp/default]="qwen3.6-27b" [llamacpp/mtp]="qwen3.6-27b" [llamacpp/bounded-thinking]="qwen3.6-27b" [llamacpp/mtp-vision]="qwen3.6-27b"
-  [ik-llama/iq4ks-mtp]="qwen3.6-27b" [ik-llama/iq4ks-mtp-vision]="qwen3.6-27b"
+  [ik-llama/iq4ks-mtp]="qwen3.6-27b" [ik-llama/iq4ks-mtp-vision]="qwen3.6-27b" [ik-llama/iq4ks-two-stage]="qwen3.6-27b"
+  [ik-llama/prism-pro-dq-mtp]="qwen3.6-27b" [ik-llama/prism-pro-dq-long]="qwen3.6-27b" [ik-llama/prism-pro-dq-two-stage]="qwen3.6-27b"
+  [ik-llama/prism-pro-dq-dual]="qwen3.6-27b" [ik-llama/prism-pro-dq-dual-vision]="qwen3.6-27b"
+  [ik-llama/apex-mtp-compact]="qwen3.6-35b-a3b" [ik-llama/apex-mtp-compact-long]="qwen3.6-35b-a3b" [ik-llama/apex-mtp-quality-dual]="qwen3.6-35b-a3b"
 )
 declare -A LAUNCH_VARIANT_ENGINE=(
   [vllm/default]="vllm" [vllm/long-vision]="vllm" [vllm/long-text]="vllm" [vllm/long-text-no-mtp]="vllm"
@@ -253,7 +265,10 @@ declare -A LAUNCH_VARIANT_ENGINE=(
   [vllm/dual-nvlink-dflash]="vllm" [vllm/dual-nvlink-dflash-noviz]="vllm"
   [vllm/gemma-mtp]="vllm" [vllm/gemma-mtp-tp1]="vllm" [vllm/gemma-dflash]="vllm"
   [llamacpp/default]="llamacpp" [llamacpp/mtp]="llamacpp" [llamacpp/bounded-thinking]="llamacpp" [llamacpp/mtp-vision]="llamacpp"
-  [ik-llama/iq4ks-mtp]="llamacpp" [ik-llama/iq4ks-mtp-vision]="llamacpp"
+  [ik-llama/iq4ks-mtp]="llamacpp" [ik-llama/iq4ks-mtp-vision]="llamacpp" [ik-llama/iq4ks-two-stage]="llamacpp"
+  [ik-llama/prism-pro-dq-mtp]="llamacpp" [ik-llama/prism-pro-dq-long]="llamacpp" [ik-llama/prism-pro-dq-two-stage]="llamacpp"
+  [ik-llama/prism-pro-dq-dual]="llamacpp" [ik-llama/prism-pro-dq-dual-vision]="llamacpp"
+  [ik-llama/apex-mtp-compact]="llamacpp" [ik-llama/apex-mtp-compact-long]="llamacpp" [ik-llama/apex-mtp-quality-dual]="llamacpp"
 )
 declare -A LAUNCH_VARIANT_KVCALC=(
   [vllm/default]="qwen3.6-27b:long-vision"
@@ -282,6 +297,15 @@ declare -A LAUNCH_VARIANT_KVCALC=(
   [llamacpp/mtp-vision]="SKIP"
   [ik-llama/iq4ks-mtp]="SKIP"
   [ik-llama/iq4ks-mtp-vision]="SKIP"
+  [ik-llama/iq4ks-two-stage]="SKIP"
+  [ik-llama/prism-pro-dq-mtp]="SKIP"
+  [ik-llama/prism-pro-dq-long]="SKIP"
+  [ik-llama/prism-pro-dq-two-stage]="SKIP"
+  [ik-llama/prism-pro-dq-dual]="SKIP"
+  [ik-llama/prism-pro-dq-dual-vision]="SKIP"
+  [ik-llama/apex-mtp-compact]="SKIP"
+  [ik-llama/apex-mtp-compact-long]="SKIP"
+  [ik-llama/apex-mtp-quality-dual]="SKIP"
 )
 LAUNCH_VARIANT_ORDER=(
   vllm/long-vision vllm/long-text vllm/long-text-no-mtp vllm/bounded-thinking
@@ -290,7 +314,9 @@ LAUNCH_VARIANT_ORDER=(
   vllm/dual4 vllm/dual4-dflash
   vllm/gemma-mtp vllm/gemma-mtp-tp1 vllm/gemma-dflash
   llamacpp/default llamacpp/mtp llamacpp/bounded-thinking llamacpp/mtp-vision
-  ik-llama/iq4ks-mtp ik-llama/iq4ks-mtp-vision
+  ik-llama/iq4ks-mtp ik-llama/iq4ks-mtp-vision ik-llama/iq4ks-two-stage
+  ik-llama/prism-pro-dq-mtp ik-llama/prism-pro-dq-long ik-llama/prism-pro-dq-two-stage ik-llama/prism-pro-dq-dual ik-llama/prism-pro-dq-dual-vision
+  ik-llama/apex-mtp-compact ik-llama/apex-mtp-compact-long ik-llama/apex-mtp-quality-dual
 )
 
 variant_hw_status() {
@@ -1148,6 +1174,15 @@ declare -A LAUNCH_DEFAULT_PORT=(
   [llamacpp/mtp-vision]=8020
   [ik-llama/iq4ks-mtp]=8020
   [ik-llama/iq4ks-mtp-vision]=8020
+  [ik-llama/iq4ks-two-stage]=8020
+  [ik-llama/prism-pro-dq-mtp]=8020
+  [ik-llama/prism-pro-dq-long]=8052
+  [ik-llama/prism-pro-dq-two-stage]=8020
+  [ik-llama/prism-pro-dq-dual]=8053
+  [ik-llama/prism-pro-dq-dual-vision]=8010
+  [ik-llama/apex-mtp-compact]=8054
+  [ik-llama/apex-mtp-compact-long]=8056
+  [ik-llama/apex-mtp-quality-dual]=8055
 )
 declare -A LAUNCH_DEFAULT_CONTAINER=(
   [vllm/default]=vllm-qwen36-27b
@@ -1177,6 +1212,14 @@ declare -A LAUNCH_DEFAULT_CONTAINER=(
   [ik-llama/iq4ks-mtp]=ik-llama-qwen36-27b
   [ik-llama/iq4ks-mtp-vision]=ik-llama-qwen36-27b-vision
   [ik-llama/iq4ks-two-stage]=ik-llama-qwen36-27b-two-stage
+  [ik-llama/prism-pro-dq-mtp]=ik-llama-qwen36-27b-prism-pro-dq
+  [ik-llama/prism-pro-dq-long]=ik-llama-qwen36-27b-prism-pro-dq-long
+  [ik-llama/prism-pro-dq-two-stage]=ik-llama-qwen36-27b-prism-pro-dq-two-stage
+  [ik-llama/prism-pro-dq-dual]=ik-llama-qwen36-27b-prism-pro-dq-dual
+  [ik-llama/prism-pro-dq-dual-vision]=ik-llama-qwen36-27b-prism-pro-dq-dual
+  [ik-llama/apex-mtp-compact]=ik-llama-qwen36-35b-a3b-apex-compact
+  [ik-llama/apex-mtp-compact-long]=ik-llama-qwen36-35b-a3b-apex-compact-long
+  [ik-llama/apex-mtp-quality-dual]=ik-llama-qwen36-35b-a3b-apex-quality-dual
 )
 ENDPOINT_PORT="${PORT:-${LAUNCH_DEFAULT_PORT[$VARIANT]:-8020}}"
 ENDPOINT_URL="http://localhost:${ENDPOINT_PORT}"

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -277,11 +277,67 @@ COMPOSE_REGISTRY = {
         default_port=8020,
     ),
     "ik-llama/iq4ks-two-stage": _entry(
-        model="qwen3.6-27b", weights_variant="gguf", workload="fast-chat",
+        model="qwen3.6-27b", weights_variant="gguf", workload="tool-heavy",
         engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q4_0",
         tp=1, max_ctx=200000, max_num_seqs=1, mem_util=None,
         compose_path="models/qwen3.6-27b/ik-llama/compose/single/iq4ks-two-stage.yml",
         default_port=8020,
+    ),
+    "ik-llama/prism-pro-dq-mtp": _entry(
+        model="qwen3.6-27b", weights_variant="gguf", workload="fast-chat",
+        engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q4_0",
+        tp=1, max_ctx=122880, max_num_seqs=1, mem_util=None,
+        compose_path="models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-mtp.yml",
+        default_port=8020,
+    ),
+    "ik-llama/prism-pro-dq-long": _entry(
+        model="qwen3.6-27b", weights_variant="gguf", workload="long-ctx-single",
+        engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q4_0",
+        tp=1, max_ctx=180000, max_num_seqs=1, mem_util=None,
+        compose_path="models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-long.yml",
+        default_port=8052,
+    ),
+    "ik-llama/prism-pro-dq-two-stage": _entry(
+        model="qwen3.6-27b", weights_variant="gguf", workload="tool-heavy",
+        engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q4_0",
+        tp=1, max_ctx=200000, max_num_seqs=1, mem_util=None,
+        compose_path="models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-two-stage.yml",
+        default_port=8020,
+    ),
+    "ik-llama/prism-pro-dq-dual": _entry(
+        model="qwen3.6-27b", weights_variant="gguf", workload="tool-heavy",
+        engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q4_0",
+        tp=2, max_ctx=196608, max_num_seqs=1, mem_util=None,
+        compose_path="models/qwen3.6-27b/ik-llama/compose/dual/prism-pro-dq-mtp.yml",
+        default_port=8053,
+    ),
+    "ik-llama/prism-pro-dq-dual-vision": _entry(
+        model="qwen3.6-27b", weights_variant="gguf", workload="vision-coding",
+        engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q8_0",
+        tp=2, max_ctx=262144, max_num_seqs=1, mem_util=None,
+        compose_path="models/qwen3.6-27b/ik-llama/compose/dual/prism-pro-dq-mtp-vision.yml",
+        default_port=8010,
+    ),
+    "ik-llama/apex-mtp-compact": _entry(
+        model="qwen3.6-35b-a3b", weights_variant="gguf", workload="fast-chat",
+        engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q4_0",
+        tp=1, max_ctx=163840, max_num_seqs=1, mem_util=None,
+        compose_path="models/qwen3.6-35b-a3b/ik-llama/compose/single/apex-mtp-compact.yml",
+        default_port=8054,
+    ),
+    "ik-llama/apex-mtp-compact-long": _entry(
+        model="qwen3.6-35b-a3b", weights_variant="gguf", workload="long-ctx-single",
+        engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q8_0",
+        tp=1, max_ctx=196608, max_num_seqs=1, mem_util=None,
+        compose_path="models/qwen3.6-35b-a3b/ik-llama/compose/single/apex-mtp-compact-long.yml",
+        default_port=8056,
+    ),
+    "ik-llama/apex-mtp-quality-dual": _entry(
+        model="qwen3.6-35b-a3b", weights_variant="gguf", workload="long-ctx-single",
+        engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q8_0",
+        tp=2, max_ctx=196608, max_num_seqs=1, mem_util=None,
+        compose_path="models/qwen3.6-35b-a3b/ik-llama/compose/dual/apex-mtp-quality.yml",
+        default_port=8055,
     ),
 
     # Gemma 4 31B, vLLM.
@@ -404,4 +460,3 @@ COMPOSE_REGISTRY = {
         default_port=8052,
     ),
 }
-


### PR DESCRIPTION
# Upstream Changes for Club-3090

This branch ports the live `/opt/ai/club-3090` custom ik-llama work onto the current upstream `master`/`v0.8.5` tree.

## Summary

- Adds the PRISM-PRO-DQ preset family for `qwen3.6-27b` on the ik-llama path.
- Adds the APEX-MTP preset family for `qwen3.6-35b-a3b` on the ik-llama path.
- Adds an APEX-only local Qwen chat-template override for ik-llama so reasoning-disabled launches stop emitting empty `<think></think>` stubs.
- Wires every new preset into `scripts/launch.sh` so `launch.sh` can discover, select, port-map, and name the containers correctly.
- Extends `scripts/lib/profiles/compose_registry.py` so the upstream profile catalog exposes the new presets with the right topology, workload, context, and KV metadata.
- Fixes the `ik-llama/apex-mtp-compact` registry metadata to report `kv_format="q4_0"` so the catalog matches the compose header and the actual single-card compact lane.
- Reclassifies `ik-llama/iq4ks-two-stage` as `tool-heavy` instead of `fast-chat`, which matches the compose header and the intended code-first/two-stage use case.

## New PRISM-PRO-DQ Presets

### Single-card lanes

- `ik-llama/prism-pro-dq-mtp`
  - File: `models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-mtp.yml`
  - Topology: single 3090
  - Drafter: native MTP `n=4`, `p-min=0.0`
  - KV: `q4_0`
  - Default context: `122880`
  - Positioning: lean text-first PRISM lane for fast single-card MTP evaluation

- `ik-llama/prism-pro-dq-long`
  - File: `models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-long.yml`
  - Topology: single 3090
  - Drafter: native MTP `n=5`, `p-min=0.0`
  - KV: `q4_0`
  - Default context: `180000`
  - Positioning: single-card long-context compromise with better context headroom than the lean MTP lane

- `ik-llama/prism-pro-dq-two-stage`
  - File: `models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-two-stage.yml`
  - Topology: single 3090
  - Drafter: two-stage `ngram-mod + MTP fallback`
  - KV: `q4_0`
  - Default context: `200000`
  - Positioning: code-heavy PRISM evaluation on the two-stage speculative path

### Dual-card lanes

- `ik-llama/prism-pro-dq-dual`
  - File: `models/qwen3.6-27b/ik-llama/compose/dual/prism-pro-dq-mtp.yml`
  - Topology: dual 3090
  - Drafter: native MTP `n=4`, `p-min=0.0`
  - KV: `q4_0`
  - Default context: `196608`
  - Positioning: text-first dual-card PRISM serving with more context headroom than the multimodal lane

- `ik-llama/prism-pro-dq-dual-vision`
  - File: `models/qwen3.6-27b/ik-llama/compose/dual/prism-pro-dq-mtp-vision.yml`
  - Topology: dual 3090
  - Drafter: native MTP `n=5`, `p-min=0.0`
  - KV: `q4_0`
  - Default context: `196608`
  - Vision: enabled via `mmproj-F16`
  - Positioning: dual-card multimodal PRISM lane with embedded vision preserved

## New APEX-MTP Presets

- `ik-llama/apex-mtp-compact`
  - File: `models/qwen3.6-35b-a3b/ik-llama/compose/single/apex-mtp-compact.yml`
  - Topology: single 3090
  - Drafter: native MTP `n=2`, `p-min=0.0`
  - KV: `q4_0`
  - Default context: `200000`
  - Positioning: practical single-card APEX entry point when the `I-Quality` file is too tight for a usable 24 GB speculative/KV budget

- `ik-llama/apex-mtp-compact-long`
  - File: `models/qwen3.6-35b-a3b/ik-llama/compose/single/apex-mtp-compact-long.yml`
  - Topology: single 3090
  - Drafter: native MTP `n=2`, `p-min=0.0`
  - KV: `q8_0`
  - Default context: `262144`
  - Positioning: highest-context single-card APEX compact lane that still stayed fast on the test rig

- `ik-llama/apex-mtp-quality-dual`
  - File: `models/qwen3.6-35b-a3b/ik-llama/compose/dual/apex-mtp-quality.yml`
  - Topology: dual 3090
  - Drafter: native MTP `n=5`, `p-min=0.0`
  - KV: `q8_0`
  - Default context: `196608`
  - Positioning: long-context dual-card APEX Quality lane that keeps full-context `q8` KV on the paired rig

### APEX template fix

- Added `models/qwen3.6-35b-a3b/ik-llama/patches/apex-qwen-chat-template.jinja`.
- This is a local APEX-only Qwen 35B-A3B template override for ik-llama, not the froggeric vLLM template path.
- It patches the assistant reasoning guard from:
  - `loop.index0 > ns.last_query_index`
- to:
  - `loop.index0 > ns.last_query_index and reasoning_content`
- The three APEX composes now mount that template and pass it through `--chat-template-file`, which prevents empty reasoning stubs from being emitted when reasoning is disabled.

## Launcher and Registry Integration

- `scripts/launch.sh`
  - Adds compose-path entries for every PRISM and APEX lane.
  - Adds model ownership for the new `qwen3.6-27b` PRISM and `qwen3.6-35b-a3b` APEX variants.
  - Adds engine-family registration so the new presets route through the llama.cpp/ik-llama launch path.
  - Adds `KVCALC=SKIP` coverage so the new ik-llama presets don't fall into unsupported KV calculator paths.
  - Adds launch ordering, default ports, and default container names for the entire PRISM/APEX family.
  - Carries forward the already-existing `ik-llama/iq4ks-two-stage` launch wiring that was missing from upstream `launch.sh`.

- `scripts/lib/profiles/compose_registry.py`
  - Registers all PRISM/APEX presets so they show up in profile-backed selection flows.
  - Sets the new presets' workload classes, topology, context limits, and default ports.
  - Corrects `ik-llama/apex-mtp-compact` to `kv_format="q4_0"`.
  - Changes `ik-llama/iq4ks-two-stage` to `workload="tool-heavy"` to match its two-stage/code-oriented purpose.

## Files Added

- `models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-mtp.yml`
- `models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-long.yml`
- `models/qwen3.6-27b/ik-llama/compose/single/prism-pro-dq-two-stage.yml`
- `models/qwen3.6-27b/ik-llama/compose/dual/prism-pro-dq-mtp.yml`
- `models/qwen3.6-27b/ik-llama/compose/dual/prism-pro-dq-mtp-vision.yml`
- `models/qwen3.6-35b-a3b/ik-llama/compose/single/apex-mtp-compact.yml`
- `models/qwen3.6-35b-a3b/ik-llama/compose/single/apex-mtp-compact-long.yml`
- `models/qwen3.6-35b-a3b/ik-llama/compose/dual/apex-mtp-quality.yml`
- `models/qwen3.6-35b-a3b/ik-llama/patches/apex-qwen-chat-template.jinja`
