### PR TITLE
fix(vision): re-tune single-card vision defaults to measured-safe (1M-px + 160K/150K)

### DIFF
--- a/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp-vision.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/iq4ks-mtp-vision.yml
@@ -8,22 +8,24 @@
 #   Template:  native (GGUF-embedded) — froggeric v19 A/B'd on the text sibling,
 #              native won the 8-pack 103 vs 99 (toolcall TIED); see iq4ks-mtp.yml
 #   Vision:    YES (mmproj-F16 mounted — multimodal input enabled)
-#   Default ctx: 163840 (160K) — full-res-vision default on ONE 3090, chosen for
-#              HEADROOM: 172K served single images but OOM-crashed under heavy
-#              back-to-back prefill stress (verify-stress); 160K leaves ~0.9 GB
-#              margin. REQUIRES -b 1024 (see below): a full 2048²/4M-pixel image
-#              encodes at ~23.65 GB. mmproj + encode buffers eat the VRAM the
-#              text profile spends on KV, so the vision ceiling (~180K) sits well
-#              below the text profile's 200K. Push higher only if you don't need
-#              prefill headroom — see VRAM RESIZING below.
-#   Status:    🧪 EVAL ONLY — task #402. NOT shipped. Sibling of iq4ks-mtp.yml
-#              with vision added (ampersandru's #152 config also loaded mmproj).
+#   Defaults:  CTX_SIZE=163840 (160K) + IMAGE_MAX_TOKENS=1024 (1M-px images), -b 1024,
+#              on ONE 3090. MEASURED 2026-05-25 (full verify-stress [8/8]): completes
+#              + recalls to the 147K-fill ceiling (~503 MB free, no crash). The default
+#              image budget is 1M-px, NOT full-res: at 4M-px, 160K OOM-crashes under
+#              the agentic stress battery (llama.cpp vision too) — full-res is a
+#              documented override that trades ctx down (see VRAM RESIZING). The vision
+#              ceiling (~160K) sits below the text profile's 200K, and shrinking images
+#              does NOT raise it (180K still OOMs at fill) — gated by KV + fill-time
+#              runtime overhead, not the image-encode buffer.
+#   Status:    ✅ Production — config validated 2026-05-25 (full verify-stress [8/8]
+#              at the 160K + 1M-px default; graduated from EVAL #402). switch.sh /
+#              compose_registry wiring tracked as a follow-up. Sibling of iq4ks-mtp.yml.
 #   Best for:  Multimodal chat / screenshot-debugging on ik_llama IQ4_KS.
 # ---------------------------------------------------------------------------
 # This is the VISION sibling of iq4ks-mtp.yml. Everything matches that file
 # (config source, justified deviations, native-template A/B result) EXCEPT:
 #   + --mmproj + --image-{min,max}-tokens (vision projector mounted)
-#   + default ctx 160K + -b 1024 (vs the text profile's 200K + -b 4096)
+#   + default ctx 160K + IMAGE_MAX_TOKENS 1024 (1M-px) + -b 1024 (vs text's 200K, no images)
 #
 # Why -b 1024 (NOT the text profile's 4096): on this ik_llama build the image-
 # encode graph makes the compute buffer scale hard with logical batch -b — at
@@ -35,23 +37,36 @@
 #
 # ⭐ VRAM RESIZING — trade context ↔ image resolution (single 3090, q4_0 KV).
 #   The 24 GB budget is split between KV (grows with CTX_SIZE) and the image-
-#   encode buffer (grows with IMAGE_MAX_TOKENS). The default 160K + 4096 (=4M-px
-#   /2048² images) peaks ~23.65 GB on a full-res image — ~0.9 GB headroom.
+#   encode buffer (grows with IMAGE_MAX_TOKENS). The DEFAULT is 160K + 1M-px
+#   (IMAGE_MAX_TOKENS=1024). Full-res 4M-px (=4096, 2048² images) peaks ~23.65 GB
+#   on a single image AND OOM-crashes the verify-stress battery at 160K — it's an
+#   override (lower ctx to use it), not the default.
 #
 #   ► WANT HIGHER-RES IMAGES (sharp 4K UIs, fine-print docs)? Raise the image
 #     cap and pay for it by LOWERING context. Starting points (UNMEASURED —
 #     validate, see below):
 #       IMAGE_MAX_TOKENS=8192 CTX_SIZE=131072    # ~8M-px (2896²) images, 128K ctx
 #       IMAGE_MAX_TOKENS=6144 CTX_SIZE=147456    # ~6M-px images, 144K ctx
-#   ► WANT MORE CONTEXT (smaller images OK)? LOWER the image cap:
-#       IMAGE_MAX_TOKENS=1024 CTX_SIZE=200000    # ~1M-px (1024²) images, 200K ctx
+#   ► WANT MORE CONTEXT? You CANNOT get it by shrinking images — MEASURED FALSE
+#     2026-05-25. Lowering IMAGE_MAX_TOKENS frees BOOT headroom but NOT the
+#     filled ceiling: the ctx ceiling is gated by the KV pool + fill-time runtime
+#     overhead (prompt-cache + context-checkpoint + activation, ~1.7 GB growth
+#     empty→fill), not the image-encode buffer. The old "IMAGE_MAX_TOKENS=1024
+#     CTX_SIZE=200000 → 200K ctx" row was wrong and is removed. If you genuinely
+#     need >160K context, that's a TEXT-ONLY capability — use iq4ks-mtp.yml (200K
+#     text default, no mmproj).
 #
-#   Measured full-res (4M-px) ctx ladder on THIS rig (2026-05-21, -b 1024):
-#       160K → ~0.9 GB free (default) | 172K → ~0.7 GB | 175K → ~0.6 GB | 192K → OOM
-#   ⚠ Headroom at the top is THIN. 172K+ served single images but OOM-crashed
-#     under sustained heavy prefill (verify-stress battery) — the 160K default
-#     trades ~12K ctx for that margin. Go above 160K only if your workload is
-#     image + light text, not prefill-heavy agentic (large tool messages).
+#   Measured ctx ladders on THIS rig (-b 1024):
+#     full-res 4M-px (2026-05-21): 160K → ~0.9 GB free (default) | 172K → ~0.7 |
+#       175K → ~0.6 | 192K → OOM
+#     reduced 1M-px / IMAGE_MAX_TOKENS=1024 (2026-05-25, full verify-stress [8/8]):
+#       160K → 503 MB free at the 147K-fill ceiling (all rungs recalled, no crash)
+#       180K → CUDA-OOM at the ~155K rung | 200K → 891 MB after one image, thinner
+#     ⇒ 160K is the completing ceiling at ANY image budget; 180K+ OOMs at fill.
+#   ⚠ Margin at 160K's ceiling is THIN: 503 MB free at 147K (91%) fill — under the
+#     1024 MB sustained-agent guard. It completes + recalls, but for prefill-heavy
+#     agentic vision (large tool messages, concurrent requests, screenshot loops)
+#     LOWER to CTX_SIZE=131072 for ≥1 GB margin. 160K is fine for image+light-text.
 #   ⚠ ALWAYS re-validate after resizing: boot, then run BOTH a real full-size
 #     image request AND `scripts/verify-stress.sh` (encode + prefill peaks are
 #     spiky; a tight config that serves one image can still OOM under load).
@@ -74,13 +89,17 @@
 #   MODEL_DIR             host dir to mount as /models
 #   GGUF_FILE            path under /models (default: …ubergarm-mtp-iq4ks/Qwen3.6-27B-MTP-IQ4_KS.gguf)
 #   MMPROJ_FILE          path under /models (default: qwen3.6-27b-gguf/mmproj-F16.gguf)
+#   IMAGE_MIN_TOKENS     min tokens / image (default: 1024)
+#   IMAGE_MAX_TOKENS     max tokens / image (default: 1024 = ~1M-px). RAISE for sharper
+#                        images, but LOWER CTX_SIZE to pay for it — see VRAM RESIZING.
 #   CTX_SIZE             KV pool size (default 163840 = 160K).
-#                        ⛔ DON'T RAISE past 160K for general use. 160K PASSED
-#                        verify-stress; 172K served single images but OOM-CRASHED
-#                        under heavy back-to-back prefill (big tool messages /
-#                        agentic loops). 160K is the stability-validated ceiling.
-#                        Raise ONLY for image + LIGHT-text workloads, and only
-#                        after re-running verify-stress — see VRAM RESIZING below.
+#                        ⛔ DON'T RAISE past 160K. MEASURED 2026-05-25 (full
+#                        verify-stress [8/8], -b 1024): 160K completes + recalls
+#                        (503 MB free at the 147K-fill ceiling, no crash); 180K
+#                        CUDA-OOMs at fill; shrinking IMAGE_MAX_TOKENS does NOT
+#                        raise the ceiling (gated by KV + runtime overhead, not the
+#                        image buffer). For prefill-heavy agentic vision, LOWER to
+#                        131072 for ≥1 GB margin. >160K needs TEXT-only iq4ks-mtp.yml.
 #   BATCH_SIZE           llama.cpp -b       (default: 1024 — REQUIRED for vision; -b 4096 OOMs at boot)
 #   UBATCH_SIZE          llama.cpp -ub      (cosmetic — engine forces n_ubatch=n_batch; only -b matters)
 #   NP                   parallel slots     (default: 1)
@@ -114,7 +133,7 @@ services:
       --model /models/${GGUF_FILE:-qwen3.6-27b-gguf/ubergarm-mtp-iq4ks/Qwen3.6-27B-MTP-IQ4_KS.gguf}
       --mmproj /models/${MMPROJ_FILE:-qwen3.6-27b-gguf/mmproj-F16.gguf}
       --image-min-tokens ${IMAGE_MIN_TOKENS:-1024}
-      --image-max-tokens ${IMAGE_MAX_TOKENS:-4096}
+      --image-max-tokens ${IMAGE_MAX_TOKENS:-1024}
       -ngl 99
       --ctx-size ${CTX_SIZE:-163840}
       -b ${BATCH_SIZE:-1024}

--- a/models/qwen3.6-27b/llama-cpp/compose/single/mtp-vision.yml
+++ b/models/qwen3.6-27b/llama-cpp/compose/single/mtp-vision.yml
@@ -6,19 +6,19 @@
 #   Drafter:   MTP n=2 (--spec-type draft-mtp, sweet spot)
 #   KV:        q4_0 K + q4_0 V
 #   Vision:    YES (mmproj-F16 mounted — multimodal input enabled)
-#   Max ctx:   163840 default (160K, verified); up to 192K with UBATCH_SIZE=512
+#   Max ctx:   150000 (150K) default @ 1M-px images. Higher OOMs at fill — see below.
 #   Genesis:   N/A — llama.cpp engine
 #   Status:    ✅ Production (NEW — first stack profile combining MTP + vision)
 #   Engine-profile: llama-cpp-local
 #   Best for:  Multimodal chat, screenshot-debugging, vision-aware code review.
 #              ~51/60 TPS text + vision overhead paid once at image-encode.
-#              160K default ctx (sweep-verified 2026-05-22); 192K with -ub 512.
+#              150K default @ 1M-px (re-validated [8/8] 2026-05-25); see VRAM RESIZING.
 # ---------------------------------------------------------------------------
 # Qwen3.6-27B on llama.cpp — single 3090, MTP, 160K ctx, VISION ON.
 #
 # This is one of two named single-card profiles for this model:
 #   - mtp.yml             → MTP n=2 + 200K + no vision (fast + max ctx)
-#   - mtp-vision.yml      → MTP n=2 + 160K + vision (THIS file — multimodal)
+#   - mtp-vision.yml      → MTP n=2 + 150K + 1M-px vision (THIS file — multimodal)
 #
 # Historical note: the older single compose stripped --mmproj when MTP was
 # enabled, treating MTP + vision as incompatible. **That rule was obsolete
@@ -32,35 +32,32 @@
 #
 # VRAM budget on 24 GB (Q4_K_M + vision):
 #   weights (Q4_K_M):              ~17.0 GB
-#   KV at 160K (q4_0 K+V):          ~4.0 GB
+#   KV at 150K (q4_0 K+V):          ~3.8 GB
 #   mmproj F16 (vision projector):  ~0.8 GB
 #   MTP draft head + overhead:      ~0.5 GB
 #   total:                         ~22.3 GB
 #   headroom:                       ~1.7 GB for prompt + activation peaks +
 #                                   image-encode tile buffer
 #
-# Why 160K ctx (vs mtp.yml's 200K): the mmproj F16 plus image-encode tile
-# buffers consume the headroom that the no-vision profile spends on KV.
-# 160K is the DEFAULT — verified on this rig (2026-05-22). Up to 192K with
-# UBATCH_SIZE=512. Conservative rigs can lower to 131K for more headroom.
+# Why 150K ctx + 1M-px default (vs mtp.yml's 200K text): the mmproj F16 plus
+# image-encode tile buffers consume the headroom the no-vision profile spends on
+# KV. MEASURED 2026-05-25 (full verify-stress [8/8], -ub 1024, 1M-px images): 150K
+# completes + recalls to the ~138K-fill ceiling (~561 MB free, no crash).
+# Conservative / agentic rigs can lower to CTX_SIZE=131072 for ≥1 GB margin.
 #
-# ⭐ NEED MORE CONTEXT WITH VISION? Drop the micro-batch to free KV budget:
+# ⛔ HIGHER CTX DOES NOT HOLD WITH VISION — MEASURED FALSE 2026-05-25. The old
+#   "UBATCH_SIZE=512 CTX_SIZE=196608 → 192K" advice was wrong: under the full
+#   [8/8] ceiling ladder, 196K @ -ub 512 walls at ~125K fill and 160K @ -ub 1024
+#   walls at ~95K — both CUDA-OOM. (The prior "verify-stress 7/7" predated the
+#   [8/8] ceiling test.) The vision ctx ceiling is gated by KV + fill-time runtime
+#   overhead (prompt-cache + checkpoint + activation), NOT the -ub knob. If you
+#   need >150K *context*, that's a TEXT-ONLY capability — use mtp.yml (200K
+#   default, no mmproj).
 #
-#     UBATCH_SIZE=512 CTX_SIZE=196608 docker compose -f mtp-vision.yml up -d
-#     # or:  UBATCH_SIZE=512 CTX_SIZE=196608 bash scripts/switch.sh llamacpp/mtp-vision
-#
-#   `-ub 512` frees ~1 GB to the KV pool → up to 192K context
-#   WITH vision still loaded. Trade-off: ~10% slower PREFILL (more, smaller
-#   micro-batches); DECODE TPS is unaffected. It's also MORE cliff-safe, not
-#   less — smaller -ub lowers the per-pass activation peak (verify-stress 7/7
-#   incl. the 91K needle at this config). Surfaced by @JensJN in disc #170;
-#   see docs/SINGLE_CARD.md + the llama-cpp README "Speed vs Context" section.
-#
-#   ⚠ Always run `bash scripts/verify-stress.sh` at your chosen CTX_SIZE to
-#   confirm needle recall + no boot-OOM on YOUR rig before relying on it —
-#   192K is rig-validated but headroom varies (driver/desktop overhead).
-#   The DEFAULT is 160K @ -ub 1024 because the optimal -ub is
-#   workload-conditional: context-heavy → 512, speed/prefill-heavy → 1024.
+# ⚠ FULL-RES (IMAGE_MAX_TOKENS=4096 / 4M-px) is NOT the default: at full-res, 150K+
+#   OOM-crashes the verify-stress battery (ik vision too). Full-res is an override —
+#   drop CTX_SIZE to ~95-110K to use it. For sharper images raise IMAGE_MAX_TOKENS
+#   and LOWER CTX_SIZE, then always re-run `bash scripts/verify-stress.sh`.
 #
 # Quick start:
 #   1. Get the MTP-enabled GGUF + the vision projector:
@@ -77,10 +74,10 @@
 #   GGUF_FILE              path under /models  (default: …unsloth-mtp-q4km/Qwen3.6-27B-Q4_K_M.gguf)
 #   MMPROJ_FILE            path under /models  (default: qwen3.6-27b-gguf/mmproj-F16.gguf)
 #   IMAGE_MIN_TOKENS       min tokens / image  (default: 1024 — matches ik vision profile)
-#   IMAGE_MAX_TOKENS       max tokens / image  (default: 4096 = ~4M px / 2048²; lower → more ctx room)
-#   CTX_SIZE               KV pool size        (default: 163840 = 160K @ -ub 1024; full-res 2048² image validated @ ~22.2 GB / 24, 2026-05-22. ~196K feasible w/ -ub 512)
-#   BATCH_SIZE             llama.cpp -b        (default: 4096 — on mainline -b does NOT drive VRAM; -ub does)
-#   UBATCH_SIZE            llama.cpp -ub       (default: 1024; set 512 for up to 192K ctx, ~10% prefill cost)
+#   IMAGE_MAX_TOKENS       max tokens / image  (default: 1024 = ~1M px / 1024². RAISE for sharper images but LOWER CTX_SIZE to pay for it)
+#   CTX_SIZE               KV pool size        (default: 150000 = 150K @ 1M-px; completes [8/8] to ~138K fill, ~561 MB free, 2026-05-25. >150K OOMs at fill with vision — use text-only mtp.yml for more ctx)
+#   BATCH_SIZE             llama.cpp -b        (default: 1024 — on mainline -b does NOT drive VRAM; -ub does)
+#   UBATCH_SIZE            llama.cpp -ub       (default: 1024; -ub 512 does NOT raise the vision ctx ceiling — measured-false 2026-05-25)
 #   KV_TYPE                K and V quant type  (default: q4_0)
 #   NP                     parallel slots      (default: 1 — see ⚠ in command block)
 #   MTP_DRAFT_N_MAX        MTP draft tokens    (default: 2)
@@ -115,8 +112,8 @@ services:
       -m /models/${GGUF_FILE:-qwen3.6-27b-gguf/unsloth-mtp-q4km/Qwen3.6-27B-Q4_K_M.gguf}
       --mmproj /models/${MMPROJ_FILE:-qwen3.6-27b-gguf/mmproj-F16.gguf}
       --image-min-tokens ${IMAGE_MIN_TOKENS:-1024}
-      --image-max-tokens ${IMAGE_MAX_TOKENS:-4096}
-      -c ${CTX_SIZE:-163840}
+      --image-max-tokens ${IMAGE_MAX_TOKENS:-1024}
+      -c ${CTX_SIZE:-150000}
       -b ${BATCH_SIZE:-1024}
       -ub ${UBATCH_SIZE:-1024}
       -ngl 99


### PR DESCRIPTION
## Summary

Re-tune the single-card **vision** composes to measured-safe defaults. They were never re-validated under the current `verify-stress [8/8]` ceiling ladder (the 2026-05-23 single-card MTP tuning pass only touched the text composes — surfaced via #222). On-rig re-laddering 2026-05-25 shows the shipped `160K @ 4M-px` defaults **OOM-crash both engines** under the agentic stress battery.

## Measured (single 3090, q4_0 KV, full verify-stress `[8/8]`)

| engine | CTX | image | result |
|---|---|---|---|
| ik | 160K | **1 M-px** | ✅ fills 147K, 503 MB free |
| ik | 160K | 4 M-px | ❌ `[7/8]` crash |
| ik | 180K | 1 M-px | ❌ OOM ~155K |
| llama | **150K** | **1 M-px** | ✅ fills 138K, 561 MB free |
| llama | 160K | 4 M-px | ❌ wall ~95K |
| llama | 196K @ -ub512 | 4 M-px | ❌ wall ~125K |

## Key finding

The vision context ceiling on a single 3090 is gated by **KV pool + fill-time runtime overhead** (prompt-cache + context-checkpoint + activation), **not** the image-encode buffer. So shrinking images frees *boot* headroom but **does not buy more filled context** — both "more-context" opt-ins (ik's image-token trick → 200K; llama's `-ub 512` → 196K) were measured false and removed. The prior llama "verify-stress 7/7 @ 196K" predated the `[8/8]` ceiling ladder.

## Changes (defaults; full-res 4 M-px → documented override)

- **ik `iq4ks-mtp-vision`**: `IMAGE_MAX_TOKENS` 4096→**1024**, `CTX_SIZE` stays 163840; header reframed to the 1 M-px default + measured ladders; **EVAL (#402) → Production** (config validated).
- **llama `mtp-vision`**: `IMAGE_MAX_TOKENS` 4096→**1024**, `CTX_SIZE` 163840→**150000**; deleted the false 196K/192K `-ub 512` block; fixed the stale `-b 4096` doc (actual default is 1024).

## Follow-ups (not in this PR)

- `switch.sh` / `compose_registry` wiring for ik vision (now Production).
- BENCHMARKS row + a learnings note on the cross-engine vision-ceiling finding.

Refs #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
