### PR TITLE
fix: post-PR-A compose-path fixes (gpu-mode.sh + 2 patch READMEs)

### DIFF
--- a/models/qwen3.6-27b/vllm/patches/vllm-pr40798-rebased/README.md
+++ b/models/qwen3.6-27b/vllm/patches/vllm-pr40798-rebased/README.md
@@ -1,7 +1,7 @@
 # vLLM PR #40798 overlay — TurboQuant max-workspace pre-allocation
 
 Vendored 2026-05-11 to unblock `turboquant_3bit_nc` KV + MTP on Qwen 3.6 27B
-(`dual/int8-tq3.yml`).
+(`dual/autoround-int4/tq3-mtp.yml`).
 
 ## Source
 
@@ -59,5 +59,5 @@ reports `MERGED`. Then bump the nightly pin past the merge commit.
 ## Verified on
 
 - vLLM nightly: `1acd67a7`
-- Compose: `dual/int8-tq3.yml` (Qwen 3.6 27B AutoRound INT4, TQ3 KV, MTP n=3, 262K, 2 streams)
+- Compose: `dual/autoround-int4/tq3-mtp.yml` (Qwen 3.6 27B AutoRound INT4, TQ3 KV, MTP n=3, 262K, 2 streams)
 - 2026-05-11

--- a/models/qwen3.6-27b/vllm/patches/vllm-pr40914-k1-only/README.md
+++ b/models/qwen3.6-27b/vllm/patches/vllm-pr40914-k1-only/README.md
@@ -80,7 +80,7 @@ rebased before merge so it doesn't revert #41434).
 ## Verified on
 
 - vLLM nightly: `1acd67a7` (includes merged #41434)
-- Compose: `dual/int8-tq3.yml`
+- Compose: `dual/autoround-int4/tq3-mtp.yml`
 - Qwen 3.6 27B AutoRound INT4, TQ3 KV, MTP n=3, 262K × 2 streams
 - 2026-05-11
 

--- a/scripts/gpu-mode.sh
+++ b/scripts/gpu-mode.sh
@@ -9,8 +9,12 @@ set -e
 # both deprecated 2026-05-10 — supporting services moved into services/).
 CLUB3090_DIR="/opt/ai/github/club-3090"
 COMPOSE_BASE="$CLUB3090_DIR/services"
-DUAL_27B_DIR="$CLUB3090_DIR/models/qwen3.6-27b/vllm/compose/dual"
-GEMMA_DUAL_DIR="$CLUB3090_DIR/models/gemma-4-31b/vllm/compose/dual"
+# Post-PR-A (<quant>/ layer): dual composes live under <topology>/<quant>/.
+# Point each var at the quant dir so `compose_at` cd's into it — mount-safe,
+# the same invocation switch.sh uses (project dir = compose-file dir).
+DUAL_27B_DIR="$CLUB3090_DIR/models/qwen3.6-27b/vllm/compose/dual/autoround-int4"
+GEMMA_DUAL_DIR="$CLUB3090_DIR/models/gemma-4-31b/vllm/compose/dual/autoround-int4"
+GEMMA_DUAL_AWQ_DIR="$CLUB3090_DIR/models/gemma-4-31b/vllm/compose/dual/awq"
 
 # Estate planner state file (v0.7.0+). Instances booted via launch.sh --estate
 # or --estate-file are tracked here and persist via Docker `restart:
@@ -71,11 +75,11 @@ stop_service() {
 # Project-specific helpers
 start_27b_dual_mtp() {
     printf "  ${GREEN}▲${NC} Starting 27b-dual-mtp..."
-    compose_at "$DUAL_27B_DIR" "up -d" docker-compose.yml && echo "done" || echo "failed"
+    compose_at "$DUAL_27B_DIR" "up -d" fp8-mtp.yml && echo "done" || echo "failed"
 }
 stop_27b_dual_mtp() {
     printf "  ${RED}▼${NC} Stopping 27b-dual-mtp..."
-    compose_at "$DUAL_27B_DIR" "down" docker-compose.yml && echo "done" || echo "skipped"
+    compose_at "$DUAL_27B_DIR" "down" fp8-mtp.yml && echo "done" || echo "skipped"
 }
 
 start_27b_dual_dflash() {
@@ -127,11 +131,11 @@ stop_comfyui() {
 # --- Gemma 4 31B dual-card serving variants ---------------------------------
 start_gemma_mtp() {
     printf "  ${GREEN}▲${NC} Starting gemma-mtp..."
-    compose_at "$GEMMA_DUAL_DIR" "up -d" docker-compose.yml && echo "done" || echo "failed"
+    compose_at "$GEMMA_DUAL_DIR" "up -d" bf16-mtp.yml && echo "done" || echo "failed"
 }
 stop_gemma_mtp() {
     printf "  ${RED}▼${NC} Stopping gemma-mtp..."
-    compose_at "$GEMMA_DUAL_DIR" "down" docker-compose.yml && echo "done" || echo "skipped"
+    compose_at "$GEMMA_DUAL_DIR" "down" bf16-mtp.yml && echo "done" || echo "skipped"
 }
 
 start_gemma_dflash() {
@@ -163,11 +167,11 @@ stop_gemma_dflash_int8() {
 
 start_gemma_awq() {
     printf "  ${GREEN}▲${NC} Starting gemma-awq..."
-    compose_at "$GEMMA_DUAL_DIR" "up -d" awq.yml && echo "done" || echo "failed"
+    compose_at "$GEMMA_DUAL_AWQ_DIR" "up -d" bf16-mtp.yml && echo "done" || echo "failed"
 }
 stop_gemma_awq() {
     printf "  ${RED}▼${NC} Stopping gemma-awq..."
-    compose_at "$GEMMA_DUAL_DIR" "down" awq.yml && echo "done" || echo "skipped"
+    compose_at "$GEMMA_DUAL_AWQ_DIR" "down" bf16-mtp.yml && echo "done" || echo "skipped"
 }
 
 # Stop every Gemma serving variant before starting a new one


### PR DESCRIPTION
Follow-up to #231 (compose `<quant>/` layer). Two compose-path references outside the #231 doc sweep were left stale.

### `scripts/gpu-mode.sh` — broken by #231
The rig mode-switcher (symlinked into `/usr/local/bin`) `cd`'d into the `dual/` topology dir and `-f`'d bare filenames (`turbo.yml`, `docker-compose.yml`, …) that #231 moved under `<quant>/`.

- Repointed `DUAL_27B_DIR` / `GEMMA_DUAL_DIR` at the `autoround-int4` quant dir — **mount-safe**, same cd-into-compose-dir invocation `switch.sh` uses (project dir = compose-file dir, which is what #231's `+1 ../` depth assumes).
- Added `GEMMA_DUAL_AWQ_DIR` for the `awq` mode (gemma's only non-autoround dual compose).
- Renamed the two ex-`docker-compose.yml` defaults: qwen → `fp8-mtp.yml`, gemma → `bf16-mtp.yml`.
- All 13 mode targets verified to resolve on disk; `bash -n` clean.

### `vllm-pr40798` / `vllm-pr40914` patch READMEs — pre-#231 staleness
Both cited `dual/int8-tq3.yml`. Commit `6182922` split `int8-tq3` into the `tq3-*` family; the READMEs describe **"TQ3 KV + MTP n=3"**, which is `tq3-mtp.yml` (whose tombstone header itself cites #40914). → `dual/autoround-int4/tq3-mtp.yml`.

### Surfaced here, deferred to PR-B
`launch.sh` `LAUNCH_VARIANT_COMPOSE[vllm/gemma-mtp]` points at a **non-existent** `dual/autoround-int4/fp8-mtp.yml` — gemma's dual default is `bf16-mtp.yml` (the registry is correct). PR-B's registry-derivation eliminates this drift class; `test-launch-compat` doesn't sweep launch.sh's array paths, so it wasn't caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
