### PR TITLE
feat(ik-llama): PRISM-PRO-DQ + APEX-MTP presets, conformed to <quant>/ layout (supersedes #223)

### DIFF
--- a/models/qwen3.6-27b/ik-llama/compose/dual/ex0bit-prism-pro-dq/mtp-vision.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/dual/ex0bit-prism-pro-dq/mtp-vision.yml
@@ -1,0 +1,96 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-27B-PRISM-PRO-DQ (Ex0bit dynamic-quant GGUF) + mmproj-F16
+#   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp:cu13-server)
+#   Topology:  Dual 3090 (TP=2)
+#   Drafter:   MTP n=5, p-min 0.0
+#   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
+#   Vision:    YES — qwen3.6 mmproj-F16 mounted for multimodal input
+#   Default ctx: 196608
+#   Status:    🧪 EVAL ONLY — PRISM-PRO-DQ dual-card multimodal lane
+#   Best for:  Dual-card testing of PRISM-PRO-DQ with long context, native MTP, and embedded vision.
+# ---------------------------------------------------------------------------
+# Qwen3.6-27B-PRISM-PRO-DQ on ik_llama.cpp — dual 3090, dynamic-quant GGUF,
+# native MTP, and embedded vision tower.
+#
+# target: Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ
+# draft: unsloth/Qwen3.6-27B-GGUF
+#
+# Quick start:
+#   1. Get the GGUF + mmproj:
+#        hf download Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ Qwen3.6-27B-PRISM-PRO-DQ.gguf \
+#          --local-dir $MODEL_DIR/qwen3.6-27b-gguf/ex0bit-prism-pro-dq
+#        hf download unsloth/Qwen3.6-27B-GGUF mmproj-F16.gguf \
+#          --local-dir $MODEL_DIR/qwen3.6-27b-gguf
+#   2. From this directory:
+#        MODEL_DIR=/your/models/dir CUDA_VISIBLE_DEVICES=0,1 docker compose -f prism-pro-dq-mtp-vision.yml up -d
+#
+# Override defaults via .env or shell:
+#   MODEL_DIR              host dir to mount as /models  (default: ../../../../../../models-cache)
+#   GGUF_FILE              path under /models  (default: qwen3.6-27b-gguf/ex0bit-prism-pro-dq/Qwen3.6-27B-PRISM-PRO-DQ.gguf)
+#   MMPROJ_FILE            path under /models  (default: qwen3.6-27b-gguf/mmproj-F16.gguf)
+#   CTX_SIZE               KV pool size        (default: 196608)
+#   BATCH_SIZE             llama.cpp -b        (default: 2048)
+#   UBATCH_SIZE            llama.cpp -ub       (default: 2048)
+#   NP                     parallel slots      (default: 1)
+#   KV_TYPE                K and V quant type  (default: q4_0)
+#   IMAGE_MIN_TOKENS       image min tokens    (default: 1024)
+#   IMAGE_MAX_TOKENS       image max tokens    (default: 4096)
+#   MTP_DRAFT_N_MAX        MTP draft tokens    (default: 5)
+#   DRAFT_P_MIN            draft accept floor  (default: 0.0)
+#   TENSOR_SPLIT           manual tensor split (default: 1,1)
+#   REASONING              thinking gate       (default: off)
+#   REASONING_FORMAT       reasoning routing   (default: deepseek)
+#   PORT                   host port           (default: 8010)
+#   CUDA_VISIBLE_DEVICES   which GPUs to use   (default: 0,1)
+
+services:
+  ik-llama-qwen36-27b-prism-pro-dq-dual:
+    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu13-server}
+    container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b-prism-pro-dq-dual}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8010}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      --model /models/${GGUF_FILE:-qwen3.6-27b-gguf/ex0bit-prism-pro-dq/Qwen3.6-27B-PRISM-PRO-DQ.gguf}
+      --mmproj /models/${MMPROJ_FILE:-qwen3.6-27b-gguf/mmproj-F16.gguf}
+      --image-min-tokens ${IMAGE_MIN_TOKENS:-1024}
+      --image-max-tokens ${IMAGE_MAX_TOKENS:-4096}
+      --split-mode layer
+      --tensor-split ${TENSOR_SPLIT:-1,1}
+      -ngl 99
+      --ctx-size ${CTX_SIZE:-196608}
+      -b ${BATCH_SIZE:-2048}
+      -ub ${UBATCH_SIZE:-2048}
+      -np ${NP:-1}
+      -ctk ${KV_TYPE:-q4_0}
+      -ctv ${KV_TYPE:-q4_0}
+      -khad
+      -vhad
+      -ngld 99
+      --multi-token-prediction
+      --draft-max ${MTP_DRAFT_N_MAX:-5}
+      --draft-p-min ${DRAFT_P_MIN:-0.0}
+      --recurrent-ckpt-mode auto
+      --merge-qkv
+      -fa on
+      --jinja
+      --parallel-tool-calls
+      --reasoning ${REASONING:-off}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0,1}}"]
+              capabilities: [gpu]

--- a/models/qwen3.6-27b/ik-llama/compose/dual/ex0bit-prism-pro-dq/mtp.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/dual/ex0bit-prism-pro-dq/mtp.yml
@@ -1,0 +1,80 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-27B-PRISM-PRO-DQ (Ex0bit dynamic-quant GGUF)
+#   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp:cu13-server)
+#   Topology:  Dual 3090 (TP=2)
+#   Drafter:   MTP n=4, p-min 0.0
+#   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
+#   Vision:    NO
+#   Default ctx: 196608
+#   Status:    🧪 EVAL ONLY — PRISM-PRO-DQ dual-card text lane
+#   Best for:  Text-first dual-card PRISM serving when you want extra context
+#              headroom without the multimodal overhead of the vision lane.
+# ---------------------------------------------------------------------------
+# Qwen3.6-27B-PRISM-PRO-DQ on ik_llama.cpp — dual 3090, text-only, native MTP.
+#
+# target: Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ
+#
+# Override defaults via .env or shell:
+#   MODEL_DIR              host dir to mount as /models  (default: ../../../../../../models-cache)
+#   GGUF_FILE              path under /models  (default: qwen3.6-27b-gguf/ex0bit-prism-pro-dq/Qwen3.6-27B-PRISM-PRO-DQ.gguf)
+#   CTX_SIZE               KV pool size        (default: 196608)
+#   BATCH_SIZE             llama.cpp -b        (default: 1024)
+#   UBATCH_SIZE            llama.cpp -ub       (default: 512)
+#   NP                     parallel slots      (default: 1)
+#   KV_TYPE                K and V quant type  (default: q4_0)
+#   MTP_DRAFT_N_MAX        MTP draft tokens    (default: 4)
+#   DRAFT_P_MIN            draft accept floor  (default: 0.0)
+#   TENSOR_SPLIT           manual tensor split (default: 1,1)
+#   REASONING              thinking gate       (default: off)
+#   REASONING_FORMAT       reasoning routing   (default: deepseek)
+#   PORT                   host port           (default: 8053)
+#   CUDA_VISIBLE_DEVICES   which GPUs to use   (default: 0,1)
+
+services:
+  ik-llama-qwen36-27b-prism-pro-dq-dual:
+    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu13-server}
+    container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b-prism-pro-dq-dual}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8053}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      --model /models/${GGUF_FILE:-qwen3.6-27b-gguf/ex0bit-prism-pro-dq/Qwen3.6-27B-PRISM-PRO-DQ.gguf}
+      --split-mode layer
+      --tensor-split ${TENSOR_SPLIT:-1,1}
+      -ngl 99
+      --ctx-size ${CTX_SIZE:-196608}
+      -b ${BATCH_SIZE:-1024}
+      -ub ${UBATCH_SIZE:-512}
+      -np ${NP:-1}
+      -ctk ${KV_TYPE:-q4_0}
+      -ctv ${KV_TYPE:-q4_0}
+      -khad
+      -vhad
+      -ngld 99
+      --multi-token-prediction
+      --draft-max ${MTP_DRAFT_N_MAX:-4}
+      --draft-p-min ${DRAFT_P_MIN:-0.0}
+      --recurrent-ckpt-mode auto
+      --merge-qkv
+      -fa on
+      --jinja
+      --parallel-tool-calls
+      --reasoning ${REASONING:-off}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0,1}}"]
+              capabilities: [gpu]

--- a/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/long.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/long.yml
@@ -1,0 +1,78 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-27B-PRISM-PRO-DQ (Ex0bit dynamic-quant GGUF)
+#   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp:cu13-server)
+#   Topology:  Single 3090 (TP=1)
+#   Drafter:   MTP n=5, p-min 0.0
+#   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
+#   Vision:    embedded tower preserved in the GGUF; tuned for text-first use
+#   Default ctx: 180000
+#   Status:    🧪 EVAL ONLY — PRISM-PRO-DQ single-card long-context lane
+#   Best for:  The best balance we found between PRISM single-card speed and a
+#              much larger stable context budget on this dual-3090 host.
+# ---------------------------------------------------------------------------
+# Qwen3.6-27B-PRISM-PRO-DQ on ik_llama.cpp — single 3090, dynamic-quant GGUF
+# tuned for longer-context text-first use.
+#
+# target: Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ
+#
+# Override defaults via .env or shell:
+#   MODEL_DIR              host dir to mount as /models  (default: ../../../../../../models-cache)
+#   GGUF_FILE              path under /models  (default: qwen3.6-27b-gguf/ex0bit-prism-pro-dq/Qwen3.6-27B-PRISM-PRO-DQ.gguf)
+#   CTX_SIZE               KV pool size        (default: 180000)
+#   BATCH_SIZE             llama.cpp -b        (default: 4096)
+#   UBATCH_SIZE            llama.cpp -ub       (default: 1024)
+#   NP                     parallel slots      (default: 1)
+#   KV_TYPE                K and V quant type  (default: q4_0)
+#   MTP_DRAFT_N_MAX        MTP draft tokens    (default: 5)
+#   DRAFT_P_MIN            draft accept floor  (default: 0.0)
+#   REASONING              thinking gate       (default: off)
+#   REASONING_FORMAT       reasoning routing   (default: deepseek)
+#   PORT                   host port           (default: 8052)
+#   CUDA_VISIBLE_DEVICES   which GPU to use    (default: 0)
+
+services:
+  ik-llama-qwen36-27b-prism-pro-dq-long:
+    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu13-server}
+    container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b-prism-pro-dq-long}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8052}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      --model /models/${GGUF_FILE:-qwen3.6-27b-gguf/ex0bit-prism-pro-dq/Qwen3.6-27B-PRISM-PRO-DQ.gguf}
+      -ngl 99
+      --ctx-size ${CTX_SIZE:-180000}
+      -b ${BATCH_SIZE:-4096}
+      -ub ${UBATCH_SIZE:-1024}
+      -np ${NP:-1}
+      -ctk ${KV_TYPE:-q4_0}
+      -ctv ${KV_TYPE:-q4_0}
+      -khad
+      -vhad
+      -ngld 99
+      --multi-token-prediction
+      --draft-max ${MTP_DRAFT_N_MAX:-5}
+      --draft-p-min ${DRAFT_P_MIN:-0.0}
+      --recurrent-ckpt-mode auto
+      --merge-qkv
+      -fa on
+      --jinja
+      --parallel-tool-calls
+      --reasoning ${REASONING:-off}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}"]
+              capabilities: [gpu]

--- a/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/mtp.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/mtp.yml
@@ -1,0 +1,84 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-27B-PRISM-PRO-DQ (Ex0bit dynamic-quant GGUF)
+#   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp:cu13-server)
+#   Topology:  Single 3090 (TP=1)
+#   Drafter:   MTP n=4, p-min 0.0 (best code TPS on the latest 1x3090 retune)
+#   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
+#   Vision:    embedded tower preserved in the GGUF; this preset is tuned for text-first use
+#   Default ctx: 122880
+#   Status:    🧪 EVAL ONLY — PRISM-PRO-DQ single-card MTP lane
+#   Best for:  Testing Ex0bit's PRISM-PRO-DQ GGUF on the lean ik-llama MTP path.
+# ---------------------------------------------------------------------------
+# Qwen3.6-27B-PRISM-PRO-DQ on ik_llama.cpp — single 3090, dynamic-quant GGUF
+# on the shipped IQ4_KS-style MTP runtime shape.
+#
+# target: Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ
+#
+# Quick start:
+#   1. Get the GGUF:
+#        hf download Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ Qwen3.6-27B-PRISM-PRO-DQ.gguf \
+#          --local-dir $MODEL_DIR/qwen3.6-27b-gguf/ex0bit-prism-pro-dq
+#   2. From this directory:
+#        MODEL_DIR=/your/models/dir docker compose -f prism-pro-dq-mtp.yml up -d
+#
+# Override defaults via .env or shell:
+#   MODEL_DIR              host dir to mount as /models  (default: ../../../../../../models-cache)
+#   GGUF_FILE              path under /models  (default: qwen3.6-27b-gguf/ex0bit-prism-pro-dq/Qwen3.6-27B-PRISM-PRO-DQ.gguf)
+#   CTX_SIZE               KV pool size        (default: 122880)
+#   BATCH_SIZE             llama.cpp -b        (default: 4096)
+#   UBATCH_SIZE            llama.cpp -ub       (default: 1024)
+#   NP                     parallel slots      (default: 1)
+#   KV_TYPE                K and V quant type  (default: q4_0; q8_0 booted up to 220K here but long-fill OOMed around 110K, so q4 remains the safe single-card default)
+#   MTP_DRAFT_N_MAX        MTP draft tokens    (default: 4)
+#   DRAFT_P_MIN            draft accept floor  (default: 0.0)
+#   REASONING              thinking gate       (default: off)
+#   REASONING_FORMAT       reasoning routing   (default: deepseek)
+#   PORT                   host port           (default: 8020)
+#   CUDA_VISIBLE_DEVICES   which GPU to use    (default: 0)
+
+services:
+  ik-llama-qwen36-27b-prism-pro-dq:
+    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu13-server}
+    container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b-prism-pro-dq}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8020}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      --model /models/${GGUF_FILE:-qwen3.6-27b-gguf/ex0bit-prism-pro-dq/Qwen3.6-27B-PRISM-PRO-DQ.gguf}
+      -ngl 99
+      --ctx-size ${CTX_SIZE:-122880}
+      -b ${BATCH_SIZE:-4096}
+      -ub ${UBATCH_SIZE:-1024}
+      -np ${NP:-1}
+      -ctk ${KV_TYPE:-q4_0}
+      -ctv ${KV_TYPE:-q4_0}
+      -khad
+      -vhad
+      -ngld 99
+      --multi-token-prediction
+      --draft-max ${MTP_DRAFT_N_MAX:-4}
+      --draft-p-min ${DRAFT_P_MIN:-0.0}
+      --recurrent-ckpt-mode auto
+      --merge-qkv
+      -fa on
+      --jinja
+      --parallel-tool-calls
+      --reasoning ${REASONING:-off}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}"]
+              capabilities: [gpu]

--- a/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/two-stage.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/two-stage.yml
@@ -1,0 +1,86 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-27B-PRISM-PRO-DQ (Ex0bit dynamic-quant GGUF)
+#   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp:cu13-server)
+#   Topology:  Single 3090 (TP=1)
+#   Drafter:   TWO-STAGE ngram-mod + MTP fallback
+#   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
+#   Vision:    embedded tower preserved in the GGUF; this preset is tuned for text-first use
+#   Default ctx: 200000
+#   Status:    🧪 EVAL ONLY — PRISM-PRO-DQ single-card two-stage lane
+#   Best for:  Code-heavy testing of Ex0bit's PRISM-PRO-DQ GGUF on the two-stage ik-llama path.
+# ---------------------------------------------------------------------------
+# Qwen3.6-27B-PRISM-PRO-DQ on ik_llama.cpp — single 3090, dynamic-quant GGUF
+# on the shipped two-stage speculative-decoding runtime shape.
+#
+# target: Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ
+#
+# Quick start:
+#   1. Get the GGUF:
+#        hf download Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ Qwen3.6-27B-PRISM-PRO-DQ.gguf \
+#          --local-dir $MODEL_DIR/qwen3.6-27b-gguf/ex0bit-prism-pro-dq
+#   2. From this directory:
+#        MODEL_DIR=/your/models/dir docker compose -f prism-pro-dq-two-stage.yml up -d
+#
+# Override defaults via .env or shell:
+#   MODEL_DIR              host dir to mount as /models  (default: ../../../../../../models-cache)
+#   GGUF_FILE              path under /models  (default: qwen3.6-27b-gguf/ex0bit-prism-pro-dq/Qwen3.6-27B-PRISM-PRO-DQ.gguf)
+#   CTX_SIZE               KV pool size        (default: 200000)
+#   BATCH_SIZE             llama.cpp -b        (default: 4096)
+#   UBATCH_SIZE            llama.cpp -ub       (default: 1024)
+#   NP                     parallel slots      (default: 1)
+#   KV_TYPE                K and V quant type  (default: q4_0)
+#   NGRAM_N_MAX            ngram max draft     (default: 4)
+#   NGRAM_N_MIN            ngram min accept    (default: 2)
+#   NGRAM_SIZE_N           ngram lookup size   (default: 16)
+#   MTP_N_MAX              MTP max draft       (default: 3)
+#   MTP_P_MIN              MTP accept floor    (default: 0.0)
+#   REASONING              thinking gate       (default: off)
+#   REASONING_FORMAT       reasoning routing   (default: deepseek)
+#   PORT                   host port           (default: 8020)
+#   CUDA_VISIBLE_DEVICES   which GPU to use    (default: 0)
+
+services:
+  ik-llama-qwen36-27b-prism-pro-dq-two-stage:
+    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu13-server}
+    container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b-prism-pro-dq-two-stage}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8020}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      --model /models/${GGUF_FILE:-qwen3.6-27b-gguf/ex0bit-prism-pro-dq/Qwen3.6-27B-PRISM-PRO-DQ.gguf}
+      -ngl 99
+      --ctx-size ${CTX_SIZE:-200000}
+      -b ${BATCH_SIZE:-4096}
+      -ub ${UBATCH_SIZE:-1024}
+      -np ${NP:-1}
+      -ctk ${KV_TYPE:-q4_0}
+      -ctv ${KV_TYPE:-q4_0}
+      -khad
+      -vhad
+      -ngld 99
+      --spec-stage ngram-mod:n_max=${NGRAM_N_MAX:-4},n_min=${NGRAM_N_MIN:-2},spec-ngram-size-n=${NGRAM_SIZE_N:-16}
+      --spec-stage mtp:n_max=${MTP_N_MAX:-3},draft-p-min=${MTP_P_MIN:-0.0}
+      --recurrent-ckpt-mode auto
+      --merge-qkv
+      -fa on
+      --jinja
+      --parallel-tool-calls
+      --reasoning ${REASONING:-off}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}"]
+              capabilities: [gpu]

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/dual/mudler-apex-quality/mtp.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/dual/mudler-apex-quality/mtp.yml
@@ -1,0 +1,79 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-35B-A3B-APEX-MTP (mudler APEX Quality GGUF)
+#   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp:cu13-server)
+#   Topology:  Dual 3090 (TP=2)
+#   Drafter:   MTP n=5, p-min 0.0
+#   KV:        q8_0 K + q8_0 V
+#   Vision:    NO
+#   Default ctx: 196608
+#   Status:    🧪 EVAL ONLY — dual-card APEX quality bring-up lane
+#   Best for:  Long-context dual-card MoE testing of mudler's APEX-MTP Quality
+#              GGUF on the ik-llama path while keeping full-context q8 KV on the
+#              paired 3090 rig.
+# ---------------------------------------------------------------------------
+# Qwen3.6-35B-A3B MoE on ik_llama.cpp — dual 3090, APEX Quality GGUF.
+#
+# target: mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF
+#
+# Override defaults via .env or shell:
+#   MODEL_DIR              host dir to mount as /models  (default: ../../../../../../models-cache)
+#   GGUF_FILE              path under /models  (default: qwen3.6-35b-a3b-gguf/mudler-apex-mtp/Qwen3.6-35B-A3B-APEX-MTP-I-Quality.gguf)
+#   CTX_SIZE               KV pool size        (default: 196608)
+#   BATCH_SIZE             llama.cpp -b        (default: 2048)
+#   UBATCH_SIZE            llama.cpp -ub       (default: 512)
+#   NP                     parallel slots      (default: 1)
+#   KV_TYPE                K and V quant type  (default: q8_0)
+#   MTP_DRAFT_N_MAX        MTP draft tokens    (default: 5)
+#   DRAFT_P_MIN            draft accept floor  (default: 0.0)
+#   TENSOR_SPLIT           manual tensor split (default: 1,1)
+#   REASONING              thinking gate       (default: off)
+#   REASONING_FORMAT       reasoning routing   (default: deepseek)
+#   PORT                   host port           (default: 8055)
+#   CUDA_VISIBLE_DEVICES   which GPUs to use   (default: 0,1)
+
+services:
+  ik-llama-qwen36-35b-a3b-apex-quality-dual:
+    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu13-server}
+    container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-35b-a3b-apex-quality-dual}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8055}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+      - ../../../patches/apex-qwen-chat-template.jinja:/etc/apex-qwen-chat-template.jinja:ro
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      --model /models/${GGUF_FILE:-qwen3.6-35b-a3b-gguf/mudler-apex-mtp/Qwen3.6-35B-A3B-APEX-MTP-I-Quality.gguf}
+      --fit
+      --fit-margin 256
+      --split-mode graph
+      --max-gpu 2
+      --ctx-size ${CTX_SIZE:-196608}
+      -b ${BATCH_SIZE:-2048}
+      -ub ${UBATCH_SIZE:-512}
+      -np ${NP:-1}
+      -ctk ${KV_TYPE:-q8_0}
+      -ctv ${KV_TYPE:-q8_0}
+      --multi-token-prediction
+      --draft-max ${MTP_DRAFT_N_MAX:-5}
+      --draft-p-min ${DRAFT_P_MIN:-0.0}
+      --merge-qkv
+      -fa on
+      --jinja
+      --chat-template-file /etc/apex-qwen-chat-template.jinja
+      --reasoning ${REASONING:-off}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0,1}}"]
+              capabilities: [gpu]

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/long.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/long.yml
@@ -1,0 +1,81 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-35B-A3B-APEX-MTP (mudler APEX compact GGUF)
+#   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp:cu13-server)
+#   Topology:  Single 3090 (TP=1)
+#   Drafter:   MTP n=2, p-min 0.0
+#   KV:        q8_0 K + q8_0 V + -khad/-vhad Hadamard
+#   Vision:    NO
+#   Default ctx: 262144
+#   Status:    🧪 EVAL ONLY — single-card APEX compact long-context lane
+#   Best for:  Great single-card APEX throughput while still stretching the fit
+#              path toward the largest stable context that stayed fast here.
+# ---------------------------------------------------------------------------
+# Qwen3.6-35B-A3B MoE on ik_llama.cpp — single 3090, APEX compact GGUF.
+#
+# target: mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF
+#
+# Override defaults via .env or shell:
+#   MODEL_DIR              host dir to mount as /models  (default: ../../../../../../models-cache)
+#   GGUF_FILE              path under /models  (default: qwen3.6-35b-a3b-gguf/mudler-apex-mtp/Qwen3.6-35B-A3B-APEX-MTP-I-Compact.gguf)
+#   CTX_SIZE               KV pool size        (default: 262144)
+#   BATCH_SIZE             llama.cpp -b        (default: 4096)
+#   UBATCH_SIZE            llama.cpp -ub       (default: 512)
+#   NP                     parallel slots      (default: 3)
+#   KV_TYPE                K and V quant type  (default: q8_0)
+#   MTP_DRAFT_N_MAX        MTP draft tokens    (default: 4)
+#   DRAFT_P_MIN            draft accept floor  (default: 0.0)
+#   REASONING              thinking gate       (default: off)
+#   REASONING_FORMAT       reasoning routing   (default: deepseek)
+#   PORT                   host port           (default: 8056)
+#   CUDA_VISIBLE_DEVICES   which GPU to use    (default: 0)
+
+services:
+  ik-llama-qwen36-35b-a3b-apex-compact-long:
+    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu13-server}
+    container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-35b-a3b-apex-compact-long}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8056}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+      - ../../../patches/apex-qwen-chat-template.jinja:/etc/apex-qwen-chat-template.jinja:ro
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      --model /models/${GGUF_FILE:-qwen3.6-35b-a3b-gguf/mudler-apex-mtp/Qwen3.6-35B-A3B-APEX-MTP-I-Compact.gguf}
+      --fit
+      --fit-margin 256
+      -ngl 99
+      --ctx-size ${CTX_SIZE:-262144}
+      -b ${BATCH_SIZE:-4096}
+      -ub ${UBATCH_SIZE:-512}
+      -np ${NP:-3}
+      -ctk ${KV_TYPE:-q8_0}
+      -ctv ${KV_TYPE:-q8_0}
+      -khad
+      -vhad
+      -ngld 99
+      --multi-token-prediction
+      --draft-max ${MTP_DRAFT_N_MAX:-4}
+      --draft-p-min ${DRAFT_P_MIN:-0.0}
+      --recurrent-ckpt-mode auto
+      --merge-qkv
+      -fa on
+      --jinja
+      --chat-template-file /etc/apex-qwen-chat-template.jinja
+      --parallel-tool-calls
+      --reasoning ${REASONING:-off}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}"]
+              capabilities: [gpu]

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/mtp.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/mtp.yml
@@ -1,0 +1,87 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-35B-A3B-APEX-MTP (mudler APEX compact GGUF)
+#   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp:cu13-server)
+#   Topology:  Single 3090 (TP=1)
+#   Drafter:   MTP n=2, p-min 0.0
+#   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
+#   Vision:    NO
+#   Default ctx: 200000
+#   Status:    🧪 EVAL ONLY — single-card APEX compact bring-up lane
+#   Best for:  Fast single-card testing of mudler's APEX-MTP compact MoE GGUF
+#              on the ik-llama path when the 23.5 GB Quality file is too tight
+#              for a practical 24 GB single-card context budget.
+# ---------------------------------------------------------------------------
+# Qwen3.6-35B-A3B MoE on ik_llama.cpp — single 3090, APEX compact GGUF.
+#
+# target: mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF
+#
+# Why the compact file here:
+#   The I-Quality file is ~23.5 GB and leaves too little single-card VRAM for
+#   a useful speculative-decoding + KV budget on a 24 GB 3090. The compact file
+#   is ~17.3 GB and is the practical single-card APEX starting point.
+#
+# Override defaults via .env or shell:
+#   MODEL_DIR              host dir to mount as /models  (default: ../../../../../../models-cache)
+#   GGUF_FILE              path under /models  (default: qwen3.6-35b-a3b-gguf/mudler-apex-mtp/Qwen3.6-35B-A3B-APEX-MTP-I-Compact.gguf)
+#   CTX_SIZE               KV pool size        (default: 200000)
+#   BATCH_SIZE             llama.cpp -b        (default: 4096)
+#   UBATCH_SIZE            llama.cpp -ub       (default: 1024)
+#   NP                     parallel slots      (default: 1)
+#   KV_TYPE                K and V quant type  (default: q4_0)
+#   MTP_DRAFT_N_MAX        MTP draft tokens    (default: 5)
+#   DRAFT_P_MIN            draft accept floor  (default: 0.0)
+#   REASONING              thinking gate       (default: off)
+#   REASONING_FORMAT       reasoning routing   (default: deepseek)
+#   PORT                   host port           (default: 8054)
+#   CUDA_VISIBLE_DEVICES   which GPU to use    (default: 0)
+
+services:
+  ik-llama-qwen36-35b-a3b-apex-compact:
+    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu13-server}
+    container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-35b-a3b-apex-compact}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8054}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+      - ../../../patches/apex-qwen-chat-template.jinja:/etc/apex-qwen-chat-template.jinja:ro
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      --model /models/${GGUF_FILE:-qwen3.6-35b-a3b-gguf/mudler-apex-mtp/Qwen3.6-35B-A3B-APEX-MTP-I-Compact.gguf}
+      --fit
+      --fit-margin 256
+      -ngl 99
+      --ctx-size ${CTX_SIZE:-200000}
+      -b ${BATCH_SIZE:-4096}
+      -ub ${UBATCH_SIZE:-1024}
+      -np ${NP:-1}
+      -ctk ${KV_TYPE:-q4_0}
+      -ctv ${KV_TYPE:-q4_0}
+      -khad
+      -vhad
+      -ngld 99
+      --multi-token-prediction
+      --draft-max ${MTP_DRAFT_N_MAX:-5}
+      --draft-p-min ${DRAFT_P_MIN:-0.0}
+      --recurrent-ckpt-mode auto
+      --merge-qkv
+      -fa on
+      --jinja
+      --chat-template-file /etc/apex-qwen-chat-template.jinja
+      --parallel-tool-calls
+      --reasoning ${REASONING:-off}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}"]
+              capabilities: [gpu]

--- a/models/qwen3.6-35b-a3b/ik-llama/patches/apex-qwen-chat-template.jinja
+++ b/models/qwen3.6-35b-a3b/ik-llama/patches/apex-qwen-chat-template.jinja
@@ -1,0 +1,154 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- if (preserve_thinking is defined and preserve_thinking is true) or (loop.index0 > ns.last_query_index and reasoning_content) %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | string if args_value is string else args_value | tojson | safe %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -319,6 +319,73 @@ COMPOSE_REGISTRY = {
         kvcalc_key="SKIP",
     ),
 
+    # Qwen3.6-27B PRISM-PRO-DQ (Ex0bit dynamic-quant GGUF) — community-experimental, ik-llama.
+    "ik-llama/prism-pro-dq-mtp": _entry(
+        model="qwen3.6-27b", weights_variant="ex0bit-prism-pro-dq", workload="fast-chat",
+        engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q4_0",
+        tp=1, max_ctx=122880, max_num_seqs=1, mem_util=None,
+        compose_path="models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/mtp.yml",
+        default_port=8020,
+        kvcalc_key="SKIP",
+    ),
+    "ik-llama/prism-pro-dq-long": _entry(
+        model="qwen3.6-27b", weights_variant="ex0bit-prism-pro-dq", workload="long-ctx-single",
+        engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q4_0",
+        tp=1, max_ctx=180000, max_num_seqs=1, mem_util=None,
+        compose_path="models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/long.yml",
+        default_port=8052,
+        kvcalc_key="SKIP",
+    ),
+    "ik-llama/prism-pro-dq-two-stage": _entry(
+        model="qwen3.6-27b", weights_variant="ex0bit-prism-pro-dq", workload="tool-heavy",
+        engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q4_0",
+        tp=1, max_ctx=200000, max_num_seqs=1, mem_util=None,
+        compose_path="models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/two-stage.yml",
+        default_port=8020,
+        kvcalc_key="SKIP",
+    ),
+    "ik-llama/prism-pro-dq-dual": _entry(
+        model="qwen3.6-27b", weights_variant="ex0bit-prism-pro-dq", workload="tool-heavy",
+        engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q4_0",
+        tp=2, max_ctx=196608, max_num_seqs=1, mem_util=None,
+        compose_path="models/qwen3.6-27b/ik-llama/compose/dual/ex0bit-prism-pro-dq/mtp.yml",
+        default_port=8053,
+        kvcalc_key="SKIP",
+    ),
+    "ik-llama/prism-pro-dq-dual-vision": _entry(
+        model="qwen3.6-27b", weights_variant="ex0bit-prism-pro-dq", workload="vision-coding",
+        engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q8_0",
+        tp=2, max_ctx=262144, max_num_seqs=1, mem_util=None,
+        compose_path="models/qwen3.6-27b/ik-llama/compose/dual/ex0bit-prism-pro-dq/mtp-vision.yml",
+        default_port=8010,
+        kvcalc_key="SKIP",
+    ),
+    # Qwen3.6-35B-A3B APEX-MTP (mudler MoE GGUF — Compact + Quality) — community-experimental, ik-llama.
+    "ik-llama/apex-mtp-compact": _entry(
+        model="qwen3.6-35b-a3b", weights_variant="mudler-apex-compact", workload="fast-chat",
+        engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q4_0",
+        tp=1, max_ctx=163840, max_num_seqs=1, mem_util=None,
+        compose_path="models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/mtp.yml",
+        default_port=8054,
+        kvcalc_key="SKIP",
+    ),
+    "ik-llama/apex-mtp-compact-long": _entry(
+        model="qwen3.6-35b-a3b", weights_variant="mudler-apex-compact", workload="long-ctx-single",
+        engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q8_0",
+        tp=1, max_ctx=196608, max_num_seqs=1, mem_util=None,
+        compose_path="models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/long.yml",
+        default_port=8056,
+        kvcalc_key="SKIP",
+    ),
+    "ik-llama/apex-mtp-quality-dual": _entry(
+        model="qwen3.6-35b-a3b", weights_variant="mudler-apex-quality", workload="long-ctx-single",
+        engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q8_0",
+        tp=2, max_ctx=196608, max_num_seqs=1, mem_util=None,
+        compose_path="models/qwen3.6-35b-a3b/ik-llama/compose/dual/mudler-apex-quality/mtp.yml",
+        default_port=8055,
+        kvcalc_key="SKIP",
+    ),
+
     # Gemma 4 31B, vLLM.
     "vllm/gemma-mtp-tp1": _entry(
         model="gemma-4-31b", weights_variant="autoround-int4", workload="fast-chat",

--- a/scripts/lib/profiles/models/qwen3.6-27b.yml
+++ b/scripts/lib/profiles/models/qwen3.6-27b.yml
@@ -119,6 +119,18 @@ weights:
     kind: gguf
     verify_glob: "*.gguf"
     setup_weights_key: iq4ks
+  ex0bit-prism-pro-dq:
+    path: qwen3.6-27b-gguf/ex0bit-prism-pro-dq
+    local_subdir: qwen3.6-27b-gguf/ex0bit-prism-pro-dq
+    size_gb: variable
+    format: gguf
+    status: community-experimental
+    hf_repo: Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ
+    files:
+      - Qwen3.6-27B-PRISM-PRO-DQ.gguf
+    engine: ik-llama
+    kind: gguf
+    verify_glob: "*.gguf"
   carnice-bf16mtp:
     path: carnice-v2-27b-int4-recipe-d-bf16mtp
     local_subdir: carnice-v2-27b-int4-recipe-d-bf16mtp

--- a/scripts/lib/profiles/models/qwen3.6-35b-a3b.yml
+++ b/scripts/lib/profiles/models/qwen3.6-35b-a3b.yml
@@ -77,6 +77,30 @@ weights:
     engine: llama-cpp
     kind: gguf
     verify_glob: "*.gguf"
+  mudler-apex-compact:
+    path: qwen3.6-35b-a3b-gguf/mudler-apex-mtp
+    local_subdir: qwen3.6-35b-a3b-gguf/mudler-apex-mtp
+    size_gb: variable
+    format: gguf
+    status: community-experimental
+    hf_repo: mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF
+    files:
+      - Qwen3.6-35B-A3B-APEX-MTP-I-Compact.gguf
+    engine: ik-llama
+    kind: gguf
+    verify_glob: "*.gguf"
+  mudler-apex-quality:
+    path: qwen3.6-35b-a3b-gguf/mudler-apex-mtp
+    local_subdir: qwen3.6-35b-a3b-gguf/mudler-apex-mtp
+    size_gb: variable
+    format: gguf
+    status: community-experimental
+    hf_repo: mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF
+    files:
+      - Qwen3.6-35B-A3B-APEX-MTP-I-Quality.gguf
+    engine: ik-llama
+    kind: gguf
+    verify_glob: "*.gguf"
 default_weight_variant: autoround-int4
 compatible_drafters:
   - qwen-mtp-builtin

--- a/scripts/tests/test-compose-registry-disk.sh
+++ b/scripts/tests/test-compose-registry-disk.sh
@@ -25,8 +25,8 @@ def check(cond, msg):
         print(f"FAIL: {msg}")
         failures.append(msg)
 
-check(len(COMPOSE_REGISTRY) == 47, f"registry has 47 entries (got {len(COMPOSE_REGISTRY)})")
-check(len(disk_paths) == 47, f"disk has 47 compose files (got {len(disk_paths)})")
+check(len(COMPOSE_REGISTRY) == 55, f"registry has 55 entries (got {len(COMPOSE_REGISTRY)})")
+check(len(disk_paths) == 55, f"disk has 55 compose files (got {len(disk_paths)})")
 check(registry_paths <= disk_paths, "all registry compose_path values exist on disk")
 parked_disk_only = disk_paths - registry_paths
 check(


### PR DESCRIPTION
Conforms #223 (VykosX's PRISM-PRO-DQ + APEX-MTP preset families) to the post-refactor convention — the `<topology>/<quant>/<serving>.yml` layout (#231) and registry-derived launchers (#234). His branch is on a fork, so the conform lands here; **all credit to @VykosX** (co-authored on the commit). **Supersedes #223.**

### Presets added (8, ik-llama, `community-experimental`)
- **qwen3.6-27b — Ex0bit PRISM-PRO-DQ** (`ex0bit-prism-pro-dq/`): `single/{mtp,long,two-stage}` + `dual/{mtp,mtp-vision}`
- **qwen3.6-35b-a3b — mudler APEX-MTP** (the two-dir case — one repo, two quant files): `mudler-apex-compact/` `single/{mtp,long}` + `mudler-apex-quality/` `dual/mtp`

### Conform work
- Relocated to `<topology>/<quant>/<serving>.yml` (redundant prefix stripped); **+1 `../`** on every relocated mount (models-cache + APEX chat-template).
- Weights variants added to `models/*.yml`; 8 `compose_registry.py` entries (`weights_variant`=slug, `kvcalc_key=SKIP`).
- **Launchable for free** via #234's registry derivation — `ik-llama/prism-pro-dq-*`, `ik-llama/apex-mtp-*` — no `launch.sh` edits.
- Dropped from #223: the `launch.sh` array edits (superseded by #234) and the root `UPSTREAM_CHANGES.md`.

### Validation
- **7/7 gates PASS** — registry-disk (incl. `quant slug ↔ weights_variant` + `weights_variant ∈ ModelProfile`), mounts-resolve, model-weights-registry, switch+launch parity, default-resolver, launch-compat — plus `kv-calc --calibration` 22/22.
- **Structural merge:** validated via `docker compose config` + the full gate suite. Live boot is **weights-gated** (the PRISM/APEX GGUFs aren't on our rig), so this ships `community-experimental` crediting @VykosX's reported numbers — consistent with how other community presets ship.

### Deferred
- @VykosX's proposed `iq4ks-two-stage` `fast-chat → tool-heavy` reclassification (edits an existing entry) — left for a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
