### PR TITLE
fix(profiles): cover the new ik-llama PRISM/APEX presets in the compat catalog (#235 follow-up)

### DIFF
--- a/scripts/lib/profiles/engines/llama-cpp-mainline.yml
+++ b/scripts/lib/profiles/engines/llama-cpp-mainline.yml
@@ -9,6 +9,7 @@ install:
 min_sm: 6.0
 supported_model_families:
   - qwen3-next-hybrid
+  - qwen3-next-moe
 features: {}
 supported_kv_formats:
   - q4_0

--- a/scripts/lib/profiles/hardware/a100-40gb.yml
+++ b/scripts/lib/profiles/hardware/a100-40gb.yml
@@ -12,6 +12,8 @@ supported_kv_formats:
   - turboquant_3bit_nc
   - int8_per_token_head
   - q4_0
+  - q5_0
+  - q8_0
   - k8v4
 kv_format_default:
   long_context: turboquant_3bit_nc

--- a/scripts/lib/profiles/hardware/h100-80gb.yml
+++ b/scripts/lib/profiles/hardware/h100-80gb.yml
@@ -13,6 +13,8 @@ supported_kv_formats:
   - turboquant_3bit_nc
   - int8_per_token_head
   - q4_0
+  - q5_0
+  - q8_0
   - k8v4
 kv_format_default:
   long_context: fp8_e4m3

--- a/scripts/lib/profiles/hardware/rtx-3060-12gb.yml
+++ b/scripts/lib/profiles/hardware/rtx-3060-12gb.yml
@@ -12,6 +12,8 @@ supported_kv_formats:
   - turboquant_3bit_nc
   - int8_per_token_head
   - q4_0
+  - q5_0
+  - q8_0
   - k8v4
 kv_format_default:
   long_context: turboquant_3bit_nc

--- a/scripts/lib/profiles/hardware/rtx-3090-ti.yml
+++ b/scripts/lib/profiles/hardware/rtx-3090-ti.yml
@@ -12,6 +12,8 @@ supported_kv_formats:
   - turboquant_3bit_nc
   - int8_per_token_head
   - q4_0
+  - q5_0
+  - q8_0
   - k8v4
 kv_format_default:
   long_context: turboquant_3bit_nc

--- a/scripts/lib/profiles/hardware/rtx-3090.yml
+++ b/scripts/lib/profiles/hardware/rtx-3090.yml
@@ -12,6 +12,8 @@ supported_kv_formats:
   - turboquant_3bit_nc
   - int8_per_token_head
   - q4_0
+  - q5_0
+  - q8_0
   - k8v4
 kv_format_default:
   long_context: turboquant_3bit_nc

--- a/scripts/lib/profiles/hardware/rtx-4090.yml
+++ b/scripts/lib/profiles/hardware/rtx-4090.yml
@@ -13,6 +13,8 @@ supported_kv_formats:
   - turboquant_3bit_nc
   - int8_per_token_head
   - q4_0
+  - q5_0
+  - q8_0
   - k8v4
 kv_format_default:
   long_context: fp8_e4m3

--- a/scripts/lib/profiles/hardware/rtx-5090.yml
+++ b/scripts/lib/profiles/hardware/rtx-5090.yml
@@ -13,6 +13,8 @@ supported_kv_formats:
   - turboquant_3bit_nc
   - int8_per_token_head
   - q4_0
+  - q5_0
+  - q8_0
   - k8v4
 kv_format_default:
   long_context: fp8_e4m3

--- a/scripts/lib/profiles/hardware/rtx-6000-pro-blackwell.yml
+++ b/scripts/lib/profiles/hardware/rtx-6000-pro-blackwell.yml
@@ -13,6 +13,8 @@ supported_kv_formats:
   - turboquant_3bit_nc
   - int8_per_token_head
   - q4_0
+  - q5_0
+  - q8_0
   - k8v4
 kv_format_default:
   long_context: fp8_e4m3

--- a/scripts/lib/profiles/hardware/rtx-a5000.yml
+++ b/scripts/lib/profiles/hardware/rtx-a5000.yml
@@ -12,6 +12,8 @@ supported_kv_formats:
   - turboquant_3bit_nc
   - int8_per_token_head
   - q4_0
+  - q5_0
+  - q8_0
   - k8v4
 kv_format_default:
   long_context: turboquant_3bit_nc

--- a/scripts/lib/profiles/patches.yml
+++ b/scripts/lib/profiles/patches.yml
@@ -368,6 +368,42 @@ patches:
       drop_when: "the Carnice weights ship a corrected default chat template, OR the override is re-vendored (the same drift_guard must clear the next re-vendor)"
     status: verified
 
+  - id: apex-qwen-chat-template
+    model: [qwen3.6-35b-a3b]
+    files:
+      - models/qwen3.6-35b-a3b/ik-llama/patches/apex-qwen-chat-template.jinja
+    load_bearing_when:
+      - composes:
+          - ik-llama/apex-mtp-compact
+          - ik-llama/apex-mtp-compact-long
+          - ik-llama/apex-mtp-quality-dual
+        reason: "mudler's APEX-MTP GGUF ships a chat template that emits empty <think></think> stubs on reasoning-disabled launches; the vendored APEX override makes thinking-off launches clean for the ik-llama APEX preset family. Wired via llama.cpp's --chat-template-file in the compose command + a read-only bind mount (vs froggeric's vLLM --chat-template). community-experimental: weights-gated, not yet live-validated on our rig."
+        evidence: "models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/mtp.yml command (--chat-template-file) + volumes block; PR #235 (conform of VykosX #223)"
+    delivery:               # DEPRECATED/READ-ONLY (test-only) — see header
+      dockerfile_bake: false
+      entrypoint_invoke: false
+      genesis: false
+    delivery_gaps: []
+    delivery_mechanism: chat_template
+    delivery_spec:
+      jinja: models/qwen3.6-35b-a3b/ik-llama/patches/apex-qwen-chat-template.jinja
+      mounted_at: /etc/apex-qwen-chat-template.jinja
+      mount_mode: ro
+      invoke: "--chat-template-file /etc/apex-qwen-chat-template.jinja"
+      wired_at: [volumes, command]
+      note: "vendored chat-template override for the mudler APEX-MTP GGUF on ik-llama; effective coverage is computed from the REAL merged compose graph so a child that removes the mount/arg is caught as a coverage loss."
+    drift_guard:
+      kind: behavioral
+      check: "A reasoning-disabled APEX launch produces no empty <think></think> stubs and tool/chat output stays coherent on the pinned ik-llama image with the APEX template mounted. Any behavioral/TPS comparison the guard performs MUST use the self-contained symmetric restart+settle protocol: identical `docker restart <container>` on BOTH arms -> wait for /health healthy -> fixed 60s settle -> >=3 bench.sh runs/arm -> compare the GRAND MEAN of the SAME canonical bench segment (NARRATIVE 800-word essay + CODE; never mix segments, never a single run). NOT yet live-validated (weights-gated); the first live APEX boot must clear this before status moves to verified."
+      on_fail: capability-degraded   # serves with the GGUF's default template, may re-emit empty <think></think> stubs
+    capability: chat-template-override
+    foundational: false
+    upstream:
+      ref: club-3090#235 (conform of VykosX #223); vendored for mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF
+      status: local-vendored
+      drop_when: "the APEX GGUF ships a corrected default chat template, OR the override is re-vendored (the same drift_guard must clear the next re-vendor)"
+    status: unverified
+
   - id: gemma-vllm-pr41800-truncate-prompt-tokens
     model: [gemma-4-31b]
     files:


### PR DESCRIPTION
Follow-up to #235. The pre-tag **full** test suite (which the narrower #235 gate subset had missed) caught that the new PRISM/APEX ik-llama presets exercised `(model, engine, KV)` combos the profile catalog didn't cover — reddening `test-profiles-compat` and `test-diagnose-profile`. This patches the catalog so the presets validate.

### Fixes
- **`engines/llama-cpp-mainline.yml`** — `supported_model_families += qwen3-next-moe`. The 35b-a3b APEX is an MoE; llama.cpp serves the MoE GGUF fine, the family list was just incomplete → fixes constraint **C10** for the 3 APEX entries.
- **`hardware/*.yml` (all 9)** — `supported_kv_formats += q5_0, q8_0`. These are llama.cpp KV quants the *engine* already lists but no *hardware* profile did, so the q8_0 presets (`prism-pro-dq-dual-vision`, `apex-mtp-compact-long`, `apex-mtp-quality-dual`) tripped **C5** "kv not supported by hardware". They're software KV quants that work on any CUDA card (laurimyllari runs q8_0 on a 4090).
- **`patches.yml`** — register the APEX chat-template (`apex-qwen-chat-template`, `status: unverified` since weights-gated) with the required symmetric-protocol `drift_guard` → resolves the orphan #235 introduced into `test-patch-attribution`.

### Validation
- ✅ `test-profiles-compat` + `test-diagnose-profile` now **PASS** (were the 2 real #235 regressions).
- ✅ APEX patch-attribution orphan resolved.
- Full suite **29/34**. The 5 remaining failures are **all pre-existing-at-v0.8.5 or test-isolation — none from the v0.8.5..master range**:
  - `test-patch-attribution` — 2 **pre-existing** sglang orphans (`patch_sglang_*`), red at v0.8.5; the APEX orphan this PR introduced is now fixed → back to the v0.8.5 baseline.
  - `test-generate-compose`, `test-setup-picker` (mocks a 5090 rig), `test-submit-bench` (0 fixtures) — all **red at v0.8.5**, env/fixture-absent in ad-hoc runs.
  - `test-loop-input` — `test-hwdetect` writes schema-2 fixtures into the shared `.pull-captures`; loop-input rejects them. **Passes in isolation** — a test-isolation issue, not a code defect.
- Leak-clean.

Unblocks the **v0.8.6** tag. (The sglang-orphan + test-isolation items are pre-existing follow-ups, not release blockers — they shipped at v0.8.5.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
