### PR TITLE
soak-test.sh: add qwen3.6-35b-a3b to container auto-detect glob

### DIFF
--- a/scripts/soak-test.sh
+++ b/scripts/soak-test.sh
@@ -48,7 +48,9 @@
 #
 # Env (advanced — flags above cover the common cases):
 #   CONTAINER              Running container. Default: first vllm-qwen36-27b*
-#                          container from `docker ps`.
+#                          / vllm-qwen36-35b-a3b* / vllm-gemma-4-31b* (or the
+#                          matching llama-cpp-/ik-llama-/sglang- variants)
+#                          from `docker ps`.
 #   ENDPOINT / URL         OpenAI endpoint. Default: mapped container port for
 #                          8000/tcp, falling back to http://localhost:8020.
 #   MODEL                  Served model. Default: first id from /v1/models.
@@ -105,7 +107,9 @@ OPTIONS
 
 ENV (advanced — auto-detected by default)
   CONTAINER         Running container. Default: first vllm-qwen36-27b* /
-                    vllm-gemma-4-31b* from docker ps. Use CONTAINER=none for
+                    vllm-qwen36-35b-a3b* / vllm-gemma-4-31b* (or the
+                    matching llama-cpp-/ik-llama-/sglang- variants) from
+                    docker ps. Use CONTAINER=none for
                     host-mode engines (e.g. llama.cpp host build).
   ENDPOINT / URL    OpenAI endpoint. Default: mapped container port → fallback
                     http://localhost:8020.
@@ -216,8 +220,9 @@ auto_container() {
   # Canonical club-3090 container prefixes across engines (mirror of
   # preflight.sh::preflight_autodetect_endpoint). llama-cpp / ik-llama were
   # previously missing here → rc=2 on llama.cpp/ik rebench-full soak step (#403).
+  # 35b-a3b added 2026-05-28: ik-llama-qwen36-35b-a3b-apex-* + future siblings.
   docker ps --format '{{.Names}}' 2>/dev/null \
-    | grep -E '^(vllm-qwen36-27b|llama-cpp-qwen36-27b|ik-llama-qwen36-27b|vllm-gemma-4-31b|sglang-qwen36-27b)' \
+    | grep -E '^(vllm-qwen36-27b|llama-cpp-qwen36-27b|ik-llama-qwen36-27b|vllm-qwen36-35b-a3b|llama-cpp-qwen36-35b-a3b|ik-llama-qwen36-35b-a3b|vllm-gemma-4-31b|sglang-qwen36-27b)' \
     | head -1 || true
 }
 
@@ -274,7 +279,7 @@ if [[ "$HOST_MODE" == "1" ]]; then
   CONTAINER="none"
 else
   CONTAINER="${CONTAINER:-$(auto_container)}"
-  [[ -n "$CONTAINER" ]] || die "no running club-3090 container found (vllm-/llama-cpp-/ik-llama-/sglang- × qwen36-27b/gemma-4-31b); set CONTAINER=... or CONTAINER=none for host engines"
+  [[ -n "$CONTAINER" ]] || die "no running club-3090 container found (vllm-/llama-cpp-/ik-llama-/sglang- × qwen36-27b/qwen36-35b-a3b/gemma-4-31b); set CONTAINER=... or CONTAINER=none for host engines"
   docker inspect "$CONTAINER" >/dev/null 2>&1 || die "container '$CONTAINER' not found (use CONTAINER=none for host engine builds)"
   [[ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null || echo false)" == "true" ]] \
     || die "container '$CONTAINER' is not running"


### PR DESCRIPTION
`scripts/soak-test.sh::auto_container()` hardcodes the engine × model prefixes it'll match (`vllm-qwen36-27b`, `llama-cpp-qwen36-27b`, `ik-llama-qwen36-27b`, `vllm-gemma-4-31b`, `sglang-qwen36-27b`). On a running `ik-llama-qwen36-35b-a3b-*` container the auto-detect misses, the script aborts with `no running club-3090 container found`, and the soak step gets skipped.

Hit during #242 validation when running `soak-continuous` against the new ik-llama 35B-A3B apex-fit compose. Workaround was `CONTAINER=ik-llama-qwen36-35b-a3b-apex-fit bash scripts/soak-test.sh ...` — works fine, just not auto-detected.

## Change

One regex + two doc strings:

- `auto_container()` grep adds `vllm-qwen36-35b-a3b`, `llama-cpp-qwen36-35b-a3b`, `ik-llama-qwen36-35b-a3b` to the prefix alternation. Same family-name pattern as the existing 27B entries.
- The `no running ... container found` error message lists `qwen36-35b-a3b` alongside `qwen36-27b` and `gemma-4-31b`.
- Env-doc header comment and `--help` text updated to mention 35b-a3b plus the engine-prefix family.

## Verification

- `bash -n scripts/soak-test.sh` — clean.
- Regex matches `ik-llama-qwen36-35b-a3b-apex-fit`, `vllm-qwen36-35b-a3b-preview`, `llama-cpp-qwen36-35b-a3b-test`, and the existing 27B/Gemma names; doesn't match unrelated names.
- 9 insertions / 4 deletions, scoped to one file.

Related: the broader 35B-A3B variant landing in #243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)