### PR TITLE
quality-test.sh: stop hardcoding --timeout-per-case 60 (pairs w/ benchlocal-cli #41)

### DIFF
--- a/scripts/quality-test.sh
+++ b/scripts/quality-test.sh
@@ -66,8 +66,10 @@ OPTIONS (extra)
                    /v1/models returns the first (often wrong) registered model.
   --timeout-per-case N
                    Pass through to benchlocal-cli as --timeout-per-case N
-                   (seconds). Default: 60. For aider-polyglot-30 on low-power
-                   single-card rigs, bump to 3600+ to avoid mid-batch kills.
+                   (seconds). When NOT set, benchlocal-cli uses per-pack
+                   metadata defaults (60s for the deterministic packs, 300s
+                   for cli-40 / hermesagent-20, 1800s for aider-polyglot-30;
+                   see benchlocal-cli #41). Set this only to override.
   --sandbox-log-dir DIR
                    Capture each sandboxed pack's container log to
                    DIR/sandbox-<pack_id>.log before teardown (forwarded to
@@ -97,8 +99,11 @@ ENV VARS
                    verbatim — no /v1/models override. If UNSET, auto-detected
                    from /v1/models (fixes the wrong-name → HTTP 404 footgun on
                    single-model composes). --model and MODEL are equivalent.
-  TIMEOUT_PER_CASE Per-scenario HTTP timeout in seconds (default: 60).
-                   --timeout-per-case overrides this when both are set.
+  TIMEOUT_PER_CASE Per-scenario HTTP timeout override in seconds. UNSET means
+                   benchlocal-cli's per-pack metadata default applies (60s for
+                   the deterministic packs, 300s for cli-40 / hermesagent-20,
+                   1800s for aider-polyglot-30; see benchlocal-cli #41).
+                   --timeout-per-case is equivalent.
   ENABLE_THINKING Set to 1 to send request-level enable_thinking=true via
                    benchlocal-cli --enable-thinking. Default: 0.
   THINKING_MAX_TOKENS
@@ -146,7 +151,17 @@ URL="${URL:-http://localhost:8020}"
 MODEL_EXPLICIT=0
 [[ -n "${MODEL:-}" ]] && MODEL_EXPLICIT=1
 MODEL="${MODEL:-qwen3.6-27b-autoround}"
-TIMEOUT_PER_CASE="${TIMEOUT_PER_CASE:-60}"
+
+# Track whether the user explicitly set TIMEOUT_PER_CASE (via env or
+# --timeout-per-case flag). When unset, we DON'T pass --timeout-per-case to
+# benchlocal-cli, so it uses per-pack metadata defaults (benchlocal-cli #41:
+# 60s deterministic, 300s cli-40/hermes, 1800s aider). Passing 60 by default
+# would have defeated those pack-aware budgets — the wrapper would override
+# every agentic pack back to 60s.
+TIMEOUT_PER_CASE_SET=0
+if [[ -n "${TIMEOUT_PER_CASE:-}" ]]; then
+  TIMEOUT_PER_CASE_SET=1
+fi
 
 # ---- arg parsing -------------------------------------------------------------
 
@@ -209,6 +224,7 @@ while [[ $# -gt 0 ]]; do
         echo "✗ --timeout-per-case requires a positive integer (seconds)" >&2
         exit 2
       fi
+      TIMEOUT_PER_CASE_SET=1
       shift 2
       ;;
     --sampling-from-server)
@@ -346,10 +362,15 @@ mkdir -p "$RESULTS_DIR"
 TS=$(date +%Y-%m-%dT%H-%M-%S)
 JSON_OUT="${RESULTS_DIR}/quality-${TS}.json"
 
-if [[ -n "$PACK" ]]; then
-  echo "[quality-test] pack=${PACK}  endpoint=${URL}  model=${MODEL}  timeout=${TIMEOUT_PER_CASE}s"
+if [[ "$TIMEOUT_PER_CASE_SET" == "1" ]]; then
+  TIMEOUT_DISPLAY="${TIMEOUT_PER_CASE}s"
 else
-  echo "[quality-test] mode=${MODE}  endpoint=${URL}  model=${MODEL}  timeout=${TIMEOUT_PER_CASE}s"
+  TIMEOUT_DISPLAY="pack-default (60s deterministic / 300s cli-40+hermes / 1800s aider)"
+fi
+if [[ -n "$PACK" ]]; then
+  echo "[quality-test] pack=${PACK}  endpoint=${URL}  model=${MODEL}  timeout=${TIMEOUT_DISPLAY}"
+else
+  echo "[quality-test] mode=${MODE}  endpoint=${URL}  model=${MODEL}  timeout=${TIMEOUT_DISPLAY}"
 fi
 echo "[quality-test] results JSON → ${JSON_OUT}"
 echo
@@ -359,10 +380,12 @@ CLI_ARGS=(
   run
   --endpoint "${URL}"
   --model "${MODEL}"
-  --timeout-per-case "${TIMEOUT_PER_CASE}"
   --output markdown
   --save-json "${JSON_OUT}"
 )
+if [[ "$TIMEOUT_PER_CASE_SET" == "1" ]]; then
+  CLI_ARGS+=(--timeout-per-case "${TIMEOUT_PER_CASE}")
+fi
 if [[ "$SANDBOXED_ONLY" == "1" ]]; then
   CLI_ARGS+=(--sandboxed-only)
 elif [[ -n "$PACK" ]]; then


### PR DESCRIPTION
The wrapper was always passing `--timeout-per-case 60` to benchlocal-cli, which — under [benchlocal-cli #41](https://github.com/noonghunna/benchlocal-cli/issues/41) (per-pack `timeout_per_case_default` metadata, fixed in [benchlocal-cli PR #43](https://github.com/noonghunna/benchlocal-cli/pull/43)) — would override the new agentic-pack defaults back to 60s and defeat the fix. cli-40 / hermesagent-20 / aider-polyglot-30 would still hit budget timeouts when run via `quality-test.sh`.

## Change

`TIMEOUT_PER_CASE` and `--timeout-per-case` now only pass through to benchlocal-cli when the user explicitly sets them. When unset, benchlocal-cli applies its per-pack metadata defaults:

- 60 s for the deterministic packs (toolcall-15 / instructfollow-15 / structoutput-15 / dataextract-15 / reasonmath-15 / bugfind-15)
- 300 s for cli-40 + hermesagent-20
- 1800 s for aider-polyglot-30

The log line now prints `timeout=pack-default (60s deterministic / 300s cli-40+hermes / 1800s aider)` when the user hasn't overridden, and `timeout=<N>s` when they have.

## Backward compatibility

Against the **old** benchlocal-cli (pre-#43), the CLI flag's own argparse default is `60.0` — so unsetting the wrapper override gives the same effective behavior as before (60s everywhere). Against the **new** benchlocal-cli, the per-pack metadata defaults apply. Either way the wrapper does the right thing; this PR does not need to land in lock-step with #43.

## Why this matters

This is the wrapper-coupling counterpart of benchlocal-cli PR #43. Without it, that PR's fix would not visibly affect `quality-test.sh` runs (which is how most users invoke benchlocal-cli). Surfaced during validation of `quality-test.sh --full` against the new ik-llama 35B-A3B compose ([discussion #241](https://github.com/noonghunna/club-3090/discussions/241), [PR #243](https://github.com/noonghunna/club-3090/pull/243)).

## Diffstat

`scripts/quality-test.sh` only. Help text + env doc + arg parsing + display + invocation, all in one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)