### PR TITLE
scripts/preflight.sh: surface 4090 / 5090 hint with FAQ deep-link

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -70,6 +70,16 @@ preflight_gpu() {
   fi
   echo "[preflight] gpu:     ${gpu_count}× detected"
   echo "$gpu_lines" | sed 's/^/[preflight]            /'
+  # Cross-rig friendliness: surface a hint when 4090 / 5090 cards are
+  # detected. Composes run cross-rig but per-class gotchas (ctx derate,
+  # VRAM envelope, SM-gated kernels) live in the FAQ — easier to catch
+  # the hint here than for a user to discover it after a confusing run.
+  if echo "$gpu_lines" | grep -qE "RTX 4090"; then
+    echo "[preflight] note:    4090 detected → docs/FAQ.md#can-i-use-a-4090-instead-of-a-3090 (ctx ceiling ~15–20% lower than headless 3090)"
+  fi
+  if echo "$gpu_lines" | grep -qE "RTX 5090"; then
+    echo "[preflight] note:    5090 detected → docs/FAQ.md#can-i-use-a-5090 (32 GB envelope unlocks single-card configs)"
+  fi
   # nvidia-container-toolkit check — needed for docker GPU access.
   if ! docker info 2>/dev/null | grep -qi 'Runtimes:.*nvidia'; then
     echo "[preflight] WARN:  Docker doesn't list the 'nvidia' runtime. If 'docker compose up' fails" >&2


### PR DESCRIPTION
Companion to the README cross-rig callout that landed in commit eea717f. Catches the user who skips the README and jumps straight to `launch.sh`.

## Change

`scripts/preflight.sh::preflight_gpu()` now greps `nvidia-smi -L` output. If a 4090 or 5090 is detected, it prints a single hint line with a FAQ deep-link:

```
[preflight] note:    4090 detected → docs/FAQ.md#can-i-use-a-4090-instead-of-a-3090 (ctx ceiling ~15–20% lower than headless 3090)
```
or
```
[preflight] note:    5090 detected → docs/FAQ.md#can-i-use-a-5090 (32 GB envelope unlocks single-card configs)
```

Mixed rigs (3090 + 4090, 3090 + 5090) get both notes. 3090-only rigs stay quiet. No behavior change beyond the additional log line.

## Verification

- `bash -n scripts/preflight.sh` clean
- On a 3090-only rig: hint does NOT fire (verified locally)
- Mock-tested against synthesized `nvidia-smi -L` outputs for 4090-only, 5090-only, and mixed 3090+4090: each class triggers the right hint

## Why a PR not a direct push

Maintainer convention: docs go direct to master; substantive script logic goes via PR. This is the latter, even though it's a 12-line additive change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)