### PR TITLE
feat(bench): measurement-record producer (v0.9.0 optimizer C1 corpus seed)

### DIFF
--- a/scripts/lib/profiles/measurement_record.py
+++ b/scripts/lib/profiles/measurement_record.py
@@ -1,0 +1,508 @@
+"""Measurement-record producer — turn a completed bench run into ONE structured
+record of measured runtime facts.
+
+WHAT THIS IS (and is NOT)
+=========================
+This is a *pure producer*. It reads the **output** of ``scripts/bench.sh`` (its
+stdout text, plus the ``nvidia-smi`` GPU line it prints) together with a config
+identity (a ``compose_registry`` tag) and emits a single measurement-record
+JSON. It writes that record to a per-rig, gitignored corpus directory.
+
+It is deliberately decoupled from live execution:
+
+  * it does NOT require a GPU, a running model, or a live bench;
+  * it parses *saved* bench output, so a maintainer can retro-capture a run
+    that already happened;
+  * it makes NO decisions — there is no lookup, no consumer, no timeout-sizing,
+    no optimizer accretion here. Those are gated behind a separate design
+    unlock (the v0.9.0 "compose optimizer" track). Adding any consumer logic to
+    this file would cross that boundary.
+
+SCHEMA
+======
+The frozen field names come from the optimizer design's measurement-record
+schema (the "stable measurement-record schema defined now" / "frozen here so
+tests/docs/M2 have a fixed target" paragraphs). They are used VERBATIM:
+
+    model_slug, arch, arch_class, engine_id, engine_pin, hardware, topology,
+    kv_dtype, max_model_len, max_num_seqs, mem_util, objective,
+    confidence_tier, margin_applied, result_class, smoke_status, soak_status,
+    kv_calc_version, provenance
+
+    provenance = {source, n_obs, cohort, last_confirmed, kv_calc_version}
+
+Fields a *bench run cannot legitimately know* (``objective``,
+``confidence_tier``, ``margin_applied`` — these are optimizer/deriver concerns)
+are emitted as ``None``/sentinel rather than fabricated. ``smoke_status`` and
+``soak_status`` default to ``"not-run"`` for a pure bench unless that data is
+supplied.
+
+PRODUCER-PROPOSED EXTENSIONS (not in the frozen contract)
+=========================================================
+Two additions the current frozen schema lacks live under the clearly-named
+``measured_extensions`` nested key, so a future reader knows they are
+producer-proposed, NOT yet in the frozen contract. They are candidates for the
+optimizer's Lock-criteria #6 schema-typing pass:
+
+  * ``decode_tps_by_ctx`` — TPS as a *context-depth ladder* (a dict keyed by
+    context-token depth), not a scalar. ``bench.sh`` today measures only the
+    short-context canonical prompts, so the ladder will have ONE point for now;
+    structuring it as a ladder lets depth points be added later without a
+    schema change. Alongside it: ``prefill_tps``, ``ttft_s``, ``wall_tps``,
+    and per-card peak VRAM.
+  * ``power_cap_w`` — the GPU power cap, captured as part of the conditions
+    fingerprint. The optimizer's cohort key does NOT include power cap, but a
+    230W-vs-370W throughput artifact has burned this stack before, so the cap
+    is captured to keep a record's TPS interpretable.
+
+See ``compose-optimizer-design.md`` Lock-criteria #6 (typed measurement-record
+schema) before promoting either extension into the frozen contract.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+try:  # package-relative when imported as scripts.lib.profiles.measurement_record
+    from .compose_registry import COMPOSE_REGISTRY
+except ImportError:  # pragma: no cover - direct-script fallback
+    from compose_registry import COMPOSE_REGISTRY  # type: ignore
+
+
+# Repo root = three parents up from this file (scripts/lib/profiles/ -> repo).
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Default corpus directory, repo-relative. ``results/`` is gitignored
+# (``results/*`` with explicit ``!`` negations for committed seed subsets), so
+# records written here are per-rig local data and are NOT committed by default.
+# A TPS from a 3090@370W is wrong for a 4090, so cross-rig records must never be
+# committed blindly; a curated committed seed subset (if ever wanted) is a
+# separate, later, deliberate act — not this producer's job.
+CORPUS_SUBDIR = "results/measurement-records"
+
+# Sentinel for fields a bench cannot know but the schema requires present.
+NOT_RUN = "not-run"
+
+
+# --------------------------------------------------------------------------- #
+# arch / arch_class derivation
+# --------------------------------------------------------------------------- #
+# ``arch`` is the model's family slug (the verbatim ``family:`` value from
+# scripts/lib/profiles/models/<id>.yml, consistent with how the [F] loop's
+# loop_input uses ``arch_family`` VERBATIM).
+#
+# ``arch_class`` is the optimizer's attention-family granularity
+# (MHA / GQA / MLA / deltanet-hybrid / sliding-window) that drives KV legality
+# and cliff-class behavior (design Lock-criteria #1). A bench does not
+# authoritatively measure attention family, so we map it only where it is
+# unambiguous from the known family slug, and leave it ``None`` otherwise
+# (fail-soft, never guess). Callers may override.
+_FAMILY_TO_ARCH_CLASS = {
+    "qwen3-next-hybrid": "deltanet-hybrid",
+    "qwen3-next-moe": "deltanet-hybrid",
+    "gemma4-swa-dense": "sliding-window",
+    "gemma4-swa-moe": "sliding-window",
+}
+
+
+def _read_model_family(model_slug: str) -> Optional[str]:
+    """Best-effort read of ``family:`` from models/<model_slug>.yml.
+
+    Uses a tiny line scan rather than importing a YAML lib or the full profile
+    loader — this keeps the producer dependency-light and GPU/IO-free. Returns
+    ``None`` if the file or key is absent (honest degrade, never crash).
+    """
+    path = _REPO_ROOT / "scripts" / "lib" / "profiles" / "models" / f"{model_slug}.yml"
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    m = re.search(r"^family:\s*(\S+)", text, re.MULTILINE)
+    return m.group(1) if m else None
+
+
+def _topology_from_tp(tp: int) -> str:
+    """Map a tensor-parallel degree to the repo's topology slug.
+
+    single (TP=1) / dual (TP=2) have no count ambiguity; TP>2 -> ``multi<N>``
+    (matches the compose layout's topology rule).
+    """
+    if tp == 1:
+        return "single"
+    if tp == 2:
+        return "dual"
+    return f"multi{tp}"
+
+
+# --------------------------------------------------------------------------- #
+# bench.sh stdout parsing
+# --------------------------------------------------------------------------- #
+@dataclass
+class BenchMetrics:
+    """Parsed numbers from one ``scripts/bench.sh`` stdout capture.
+
+    All fields optional — a partial bench (e.g. ``ONLY=code``, or no GPU line)
+    still yields a usable record. The producer never fabricates absent numbers.
+    """
+
+    decode_tps: Optional[float] = None      # mean decode_TPS (model decode rate)
+    wall_tps: Optional[float] = None        # mean wall_TPS (user-perceived)
+    ttft_s: Optional[float] = None          # mean TTFT, seconds
+    prefill_tps: Optional[float] = None     # mean PP tok/s (prompt-processing)
+    # Per-card peak VRAM in MiB, indexed by GPU index, from the nvidia-smi line.
+    vram_used_mib: dict[int, int] = field(default_factory=dict)
+    # Power cap (limit) in watts, from nvidia-smi power.limit if present.
+    power_cap_w: Optional[float] = None
+    # Power draw in watts, per GPU index, if present.
+    power_draw_w: dict[int, float] = field(default_factory=dict)
+
+
+def _f(s: str) -> Optional[float]:
+    try:
+        return float(s)
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_bench_output(text: str) -> BenchMetrics:
+    """Parse ``scripts/bench.sh`` stdout into a :class:`BenchMetrics`.
+
+    Robust to:
+      * narrative-only / code-only / both runs (takes the last summary block's
+        ``decode_TPS``/``wall_TPS``/``TTFT`` means — the canonical short-context
+        point);
+      * llama.cpp fallback PP block vs vLLM log-scraped ``PP tok/s``;
+      * presence/absence of the ``=== GPU state ===`` nvidia-smi line.
+    """
+    m = BenchMetrics()
+
+    # Summary lines look like:
+    #   wall_TPS       mean= 238.10   std=  0.00 ...
+    #   decode_TPS     mean= 245.10   std=  0.00 ...
+    #   PP tok/s       mean=2843.21   std=  0.00 ...
+    # Take the LAST occurrence of each (the final summary block).
+    for label, attr in (
+        (r"decode_TPS", "decode_tps"),
+        (r"wall_TPS", "wall_tps"),
+        (r"PP tok/s", "prefill_tps"),
+    ):
+        matches = re.findall(rf"^\s*{label}\s+mean=\s*([0-9.]+)", text, re.MULTILINE)
+        if matches:
+            setattr(m, attr, _f(matches[-1]))
+
+    # TTFT summary line:  TTFT          mean=   120ms  std= ...
+    ttft = re.findall(r"^\s*TTFT\s+mean=\s*([0-9.]+)ms", text, re.MULTILINE)
+    if ttft:
+        val = _f(ttft[-1])
+        m.ttft_s = (val / 1000.0) if val is not None else None
+
+    # nvidia-smi line (CSV, noheader):
+    #   index, utilization.gpu, memory.used, memory.total, power.draw,
+    #   temperature.gpu  — and power.limit only if the caller queried it.
+    # bench.sh queries: index,utilization.gpu,memory.used,memory.total,
+    #                   power.draw,temperature.gpu
+    # We parse defensively: locate the "memory.used" MiB token and a power
+    # "W" token positionally per row.
+    gpu_block = text.split("=== GPU state ===", 1)
+    if len(gpu_block) == 2:
+        for row in gpu_block[1].splitlines():
+            row = row.strip()
+            if not row or "," not in row:
+                continue
+            cells = [c.strip() for c in row.split(",")]
+            # First cell must be a GPU index (int).
+            try:
+                idx = int(cells[0])
+            except (ValueError, IndexError):
+                continue
+            for cell in cells[1:]:
+                mib = re.match(r"^([0-9]+)\s*MiB$", cell)
+                if mib and idx not in m.vram_used_mib:
+                    # First MiB cell in CSV order is memory.used.
+                    m.vram_used_mib[idx] = int(mib.group(1))
+                    continue
+                watt = re.match(r"^([0-9.]+)\s*W$", cell)
+                if watt and idx not in m.power_draw_w:
+                    m.power_draw_w[idx] = float(watt.group(1))
+
+    # Optional explicit power.limit line, if a caller appended one, e.g.:
+    #   power.limit: 370.00 W   (per-rig fingerprint)
+    plim = re.search(r"power\.limit[^0-9]*([0-9.]+)\s*W", text)
+    if plim:
+        m.power_cap_w = _f(plim.group(1))
+
+    return m
+
+
+# --------------------------------------------------------------------------- #
+# Record assembly
+# --------------------------------------------------------------------------- #
+def build_record(
+    *,
+    tag: str,
+    bench_metrics: BenchMetrics,
+    # Conditions fingerprint inputs the registry cannot know. These are
+    # provenance the caller supplies (or leaves None); the producer never
+    # invents them.
+    hardware: Optional[str] = None,
+    engine_pin: Optional[str] = None,
+    power_cap_w: Optional[float] = None,
+    # Bench outcome.
+    result_class: str = "boot-fit-measured",
+    # Pure-bench defaults; override if smoke/soak data is actually present.
+    smoke_status: str = NOT_RUN,
+    soak_status: str = NOT_RUN,
+    kv_calc_version: Optional[str] = None,
+    # Optimizer-only fields a bench cannot know — sentinel, never fabricated.
+    objective: Optional[str] = None,
+    confidence_tier: Optional[str] = None,
+    margin_applied: Optional[float] = None,
+    # arch_class override (attention-family granularity); else best-effort map.
+    arch_class: Optional[str] = None,
+    n_obs: int = 1,
+    last_confirmed: Optional[str] = None,
+) -> dict[str, Any]:
+    """Assemble ONE measurement record from a registry tag + parsed bench output.
+
+    Raises ``KeyError`` for an unknown tag (fail-loud — a typo'd tag should not
+    silently produce a garbage record).
+    """
+    entry = COMPOSE_REGISTRY[tag]
+
+    model_slug = entry["model"]
+    arch = _read_model_family(model_slug)  # family slug, used verbatim
+    if arch_class is None and arch is not None:
+        arch_class = _FAMILY_TO_ARCH_CLASS.get(arch)  # None if unknown — no guess
+
+    topology = _topology_from_tp(int(entry["tp"]))
+
+    # power_cap_w precedence: explicit arg > parsed from bench output > None.
+    eff_power_cap = power_cap_w if power_cap_w is not None else bench_metrics.power_cap_w
+
+    # Conditions fingerprint = (hardware, engine_pin, kv_dtype, topology,
+    # power_cap_w). power_cap_w is a producer extension (see module docstring):
+    # the optimizer cohort key omits it, but it is load-bearing for TPS
+    # interpretability on this stack.
+    fingerprint = {
+        "hardware": hardware,
+        "engine_pin": engine_pin,
+        "kv_dtype": entry["kv_format"],
+        "topology": topology,
+        "power_cap_w": eff_power_cap,
+    }
+
+    # provenance — frozen sub-schema {source, n_obs, cohort, last_confirmed,
+    # kv_calc_version}. A direct bench run is `source: measured`. The cohort key
+    # mirrors the optimizer's (hardware, engine_pin, arch, objective); objective
+    # is None for a pure bench (it is an optimizer input, not a bench fact).
+    provenance = {
+        "source": "measured",
+        "n_obs": n_obs,
+        "cohort": {
+            "hardware": hardware,
+            "engine_pin": engine_pin,
+            "arch": arch,
+            "objective": objective,
+        },
+        "last_confirmed": last_confirmed,
+        "kv_calc_version": kv_calc_version,
+    }
+
+    # --- Producer-proposed extensions (NOT in the frozen contract) ---------- #
+    # Candidates for the optimizer's Lock-criteria #6 schema-typing pass.
+    # decode_tps_by_ctx is a LADDER keyed by context-token depth. bench.sh today
+    # only measures the short canonical prompts, so there is ONE point now,
+    # keyed by the config's max_model_len-context... no: keyed by the actual
+    # measured prompt depth. We do not know the exact canonical prompt token
+    # depth from the summary alone, so we key the single point by the
+    # short-context canonical bucket label "canonical-short". Future depth
+    # points (e.g. "30000", "120000") slot in without a schema change.
+    decode_tps_by_ctx: dict[str, Optional[float]] = {}
+    if bench_metrics.decode_tps is not None:
+        decode_tps_by_ctx["canonical-short"] = bench_metrics.decode_tps
+
+    measured_extensions = {
+        # Flagged producer-proposed; see module docstring + design Lock #6.
+        "_note": (
+            "producer-proposed; NOT in frozen measurement-record schema. "
+            "Candidates for optimizer Lock-criteria #6 schema-typing pass."
+        ),
+        "decode_tps_by_ctx": decode_tps_by_ctx,
+        "prefill_tps": bench_metrics.prefill_tps,
+        "ttft_s": bench_metrics.ttft_s,
+        "wall_tps": bench_metrics.wall_tps,
+        "peak_vram_mib_by_gpu": {str(k): v for k, v in sorted(bench_metrics.vram_used_mib.items())},
+        "power_draw_w_by_gpu": {str(k): v for k, v in sorted(bench_metrics.power_draw_w.items())},
+        # power_cap_w is part of the conditions fingerprint AND an extension.
+        "power_cap_w": eff_power_cap,
+        "conditions_fingerprint": fingerprint,
+    }
+
+    record = {
+        # --- Frozen schema fields (verbatim names) --------------------------- #
+        "model_slug": model_slug,
+        "arch": arch,
+        "arch_class": arch_class,
+        "engine_id": entry["engine"],
+        "engine_pin": engine_pin,
+        "hardware": hardware,
+        "topology": topology,
+        "kv_dtype": entry["kv_format"],
+        "max_model_len": entry["max_ctx"],
+        "max_num_seqs": entry["max_num_seqs"],
+        "mem_util": entry["mem_util"],
+        "objective": objective,            # optimizer concern -> None for bench
+        "confidence_tier": confidence_tier,  # deriver concern -> None for bench
+        "margin_applied": margin_applied,    # optimizer concern -> None for bench
+        "result_class": result_class,
+        "smoke_status": smoke_status,
+        "soak_status": soak_status,
+        "kv_calc_version": kv_calc_version,
+        "provenance": provenance,
+        # --- Producer extensions (clearly namespaced) ------------------------ #
+        "measured_extensions": measured_extensions,
+        # Carry the registry tag for traceability (not a frozen field; aids
+        # the maintainer joining a record back to its config identity).
+        "_tag": tag,
+    }
+    return record
+
+
+# --------------------------------------------------------------------------- #
+# Corpus location + filename
+# --------------------------------------------------------------------------- #
+def short_fingerprint(record: dict[str, Any]) -> str:
+    """Stable 8-hex short hash of the conditions fingerprint.
+
+    Keyed by (hardware, engine_pin, kv_dtype, topology, power_cap_w) so records
+    from the same config under the same conditions append to one file, and a
+    condition change (e.g. 230W -> 370W) lands in a different file. ``None``
+    fields are rendered as the literal string "null" so a partially-known
+    fingerprint is still deterministic.
+    """
+    import hashlib
+
+    fp = record["measured_extensions"]["conditions_fingerprint"]
+    key = "|".join(
+        f"{k}={fp.get(k) if fp.get(k) is not None else 'null'}"
+        for k in ("hardware", "engine_pin", "kv_dtype", "topology", "power_cap_w")
+    )
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()[:8]
+
+
+def corpus_path_for(record: dict[str, Any], *, corpus_dir: Optional[Path] = None) -> Path:
+    """Compute the JSONL corpus file path for a record.
+
+    ``<corpus_dir>/<tag-slug>__<short-fingerprint>.jsonl`` (appended to). The
+    tag's ``/`` is slugified to ``-`` so it is a single path component.
+    """
+    base = corpus_dir if corpus_dir is not None else (_REPO_ROOT / CORPUS_SUBDIR)
+    tag_slug = record["_tag"].replace("/", "-")
+    return base / f"{tag_slug}__{short_fingerprint(record)}.jsonl"
+
+
+def write_record(record: dict[str, Any], *, corpus_dir: Optional[Path] = None) -> Path:
+    """Append one record as a JSON line to its corpus file. Returns the path.
+
+    Creates the corpus directory if needed. The corpus lives under a gitignored
+    ``results/`` subtree — per-rig local data, never committed by default.
+    """
+    path = corpus_path_for(record, corpus_dir=corpus_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, sort_keys=False) + "\n")
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# CLI — standalone, runs on SAVED bench output (no GPU, no live model)
+# --------------------------------------------------------------------------- #
+def _build_arg_parser():
+    import argparse
+
+    p = argparse.ArgumentParser(
+        prog="measurement_record",
+        description=(
+            "Emit ONE measurement-record JSON from a saved scripts/bench.sh "
+            "stdout capture + a compose_registry tag. Pure producer: reads "
+            "bench OUTPUT, writes a per-rig gitignored record. No GPU required."
+        ),
+    )
+    p.add_argument("--tag", required=True, help="compose_registry tag, e.g. ik-llama/iq4ks-mtp")
+    p.add_argument(
+        "--bench-output",
+        type=Path,
+        default=None,
+        help="Path to a saved bench.sh stdout capture. Default: read stdin.",
+    )
+    p.add_argument("--hardware", default=None, help="Hardware id, e.g. rtx-3090 (fingerprint).")
+    p.add_argument("--engine-pin", default=None, help="Engine pin/SHA (fingerprint + cohort).")
+    p.add_argument(
+        "--power-cap-w",
+        type=float,
+        default=None,
+        help="GPU power cap in watts (fingerprint). Overrides any parsed value.",
+    )
+    p.add_argument(
+        "--result-class",
+        default="boot-fit-measured",
+        help="Bench outcome class. Default: boot-fit-measured.",
+    )
+    p.add_argument("--smoke-status", default=NOT_RUN, help='Default: "not-run".')
+    p.add_argument("--soak-status", default=NOT_RUN, help='Default: "not-run".')
+    p.add_argument("--kv-calc-version", default=None, help="kv_calc_version content hash, if known.")
+    p.add_argument("--arch-class", default=None, help="Override attention-family arch_class.")
+    p.add_argument(
+        "--corpus-dir",
+        type=Path,
+        default=None,
+        help="Override corpus directory (default: <repo>/results/measurement-records).",
+    )
+    p.add_argument(
+        "--print-only",
+        action="store_true",
+        help="Print the record JSON to stdout and do NOT write the corpus file.",
+    )
+    return p
+
+
+def main(argv=None) -> int:
+    import sys
+
+    args = _build_arg_parser().parse_args(argv)
+
+    if args.bench_output is not None:
+        text = args.bench_output.read_text(encoding="utf-8")
+    else:
+        text = sys.stdin.read()
+
+    metrics = parse_bench_output(text)
+    record = build_record(
+        tag=args.tag,
+        bench_metrics=metrics,
+        hardware=args.hardware,
+        engine_pin=args.engine_pin,
+        power_cap_w=args.power_cap_w,
+        result_class=args.result_class,
+        smoke_status=args.smoke_status,
+        soak_status=args.soak_status,
+        kv_calc_version=args.kv_calc_version,
+        arch_class=args.arch_class,
+    )
+
+    if args.print_only:
+        print(json.dumps(record, indent=2, sort_keys=False))
+        return 0
+
+    path = write_record(record, corpus_dir=args.corpus_dir)
+    print(json.dumps(record, indent=2, sort_keys=False))
+    print(f"\n[measurement_record] appended -> {path}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/tests/test-measurement-record.sh
+++ b/scripts/tests/test-measurement-record.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-measurement-record.sh — producer-only measurement-record emitter.
+#
+# Validates scripts/lib/profiles/measurement_record.py WITHOUT a GPU or a
+# running model: it feeds a captured sample of `scripts/bench.sh` stdout (we
+# reuse bench.sh's own BENCH_MOCK=1 canonical output so the sample never
+# drifts from the real format) into the emitter and asserts the emitted JSON.
+#
+# Asserts:
+#   (a) every FROZEN schema field is present with the right value/source;
+#   (b) optimizer-only fields (objective/confidence_tier/margin_applied) are
+#       null — never fabricated by a bench;
+#   (c) smoke_status/soak_status default to "not-run" for a pure bench;
+#   (d) provenance carries {source,n_obs,cohort,last_confirmed,kv_calc_version};
+#   (e) the producer-proposed `measured_extensions` ladder + power_cap_w + VRAM
+#       parse correctly and are clearly namespaced;
+#   (f) topology derives from tp; arch/arch_class from the model family;
+#   (g) corpus path is under the gitignored results/ subtree and filename
+#       carries the conditions-fingerprint short hash; write+append works;
+#   (h) an unknown tag fails loud (KeyError), never a silent garbage record.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+export PYTHONPATH="$ROOT_DIR${PYTHONPATH:+:$PYTHONPATH}"
+
+# Capture REAL bench.sh canonical output via its built-in mock (no GPU/model).
+# We append a synthetic GPU-state block + power.limit line because BENCH_MOCK
+# short-circuits before the nvidia-smi section; the format mirrors what
+# bench.sh emits from `nvidia-smi --query-gpu=...,memory.used,...,power.draw`.
+BENCH_SAMPLE="$(BENCH_MOCK=1 bash scripts/bench.sh 2>/dev/null)"
+BENCH_SAMPLE+="
+=== GPU state ===
+0, 99 %, 22310 MiB, 24576 MiB, 351.20 W, 71
+power.limit: 370.00 W
+"
+
+export BENCH_SAMPLE
+
+python3 - "$ROOT_DIR" <<'PY'
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(sys.argv[1])
+
+from scripts.lib.profiles import measurement_record as mr
+
+sample = os.environ["BENCH_SAMPLE"]
+
+failures = []
+
+
+def check(cond, msg):
+    if not cond:
+        failures.append(msg)
+
+
+# --- parse ----------------------------------------------------------------- #
+metrics = mr.parse_bench_output(sample)
+check(metrics.decode_tps == 245.10, f"(e) decode_tps parse: {metrics.decode_tps}")
+check(metrics.wall_tps == 238.10, f"(e) wall_tps parse: {metrics.wall_tps}")
+check(abs((metrics.ttft_s or 0) - 0.120) < 1e-9, f"(e) ttft_s parse: {metrics.ttft_s}")
+check(metrics.vram_used_mib.get(0) == 22310, f"(g/e) vram parse: {metrics.vram_used_mib}")
+check(abs((metrics.power_draw_w.get(0) or 0) - 351.20) < 1e-9, f"(e) power_draw parse: {metrics.power_draw_w}")
+check(metrics.power_cap_w == 370.00, f"(e) power.limit parse: {metrics.power_cap_w}")
+
+# --- build (realistic ik-llama iq4ks Qwen3.6-27B single-card @370W) -------- #
+rec = mr.build_record(
+    tag="ik-llama/iq4ks-mtp",
+    bench_metrics=metrics,
+    hardware="rtx-3090",
+    engine_pin="ik-llama-cpp@b1234",
+    # power_cap_w left None on purpose -> must fall back to the parsed 370W.
+    result_class="boot-fit-measured",
+)
+
+# (a) frozen schema fields present + correct value/source
+FROZEN = [
+    "model_slug", "arch", "arch_class", "engine_id", "engine_pin", "hardware",
+    "topology", "kv_dtype", "max_model_len", "max_num_seqs", "mem_util",
+    "objective", "confidence_tier", "margin_applied", "result_class",
+    "smoke_status", "soak_status", "kv_calc_version", "provenance",
+]
+for fld in FROZEN:
+    check(fld in rec, f"(a) frozen field missing: {fld}")
+
+check(rec["model_slug"] == "qwen3.6-27b", f"(a) model_slug: {rec['model_slug']}")
+check(rec["engine_id"] == "llama-cpp-local", f"(a) engine_id: {rec['engine_id']}")
+check(rec["kv_dtype"] == "q4_0", f"(a) kv_dtype: {rec['kv_dtype']}")
+check(rec["max_model_len"] == 200000, f"(a) max_model_len: {rec['max_model_len']}")
+check(rec["max_num_seqs"] == 1, f"(a) max_num_seqs: {rec['max_num_seqs']}")
+check(rec["hardware"] == "rtx-3090", f"(a) hardware: {rec['hardware']}")
+check(rec["engine_pin"] == "ik-llama-cpp@b1234", f"(a) engine_pin: {rec['engine_pin']}")
+check(rec["result_class"] == "boot-fit-measured", f"(a) result_class: {rec['result_class']}")
+
+# (f) topology from tp=1 -> single ; arch/arch_class from family
+check(rec["topology"] == "single", f"(f) topology: {rec['topology']}")
+check(rec["arch"] == "qwen3-next-hybrid", f"(f) arch (family verbatim): {rec['arch']}")
+check(rec["arch_class"] == "deltanet-hybrid", f"(f) arch_class mapped: {rec['arch_class']}")
+
+# (b) optimizer-only fields must be null, never fabricated
+check(rec["objective"] is None, f"(b) objective not null: {rec['objective']}")
+check(rec["confidence_tier"] is None, f"(b) confidence_tier not null: {rec['confidence_tier']}")
+check(rec["margin_applied"] is None, f"(b) margin_applied not null: {rec['margin_applied']}")
+
+# (c) smoke/soak default to not-run for a pure bench
+check(rec["smoke_status"] == "not-run", f"(c) smoke_status: {rec['smoke_status']}")
+check(rec["soak_status"] == "not-run", f"(c) soak_status: {rec['soak_status']}")
+
+# (d) provenance sub-schema {source,n_obs,cohort,last_confirmed,kv_calc_version}
+prov = rec["provenance"]
+for k in ("source", "n_obs", "cohort", "last_confirmed", "kv_calc_version"):
+    check(k in prov, f"(d) provenance missing: {k}")
+check(prov["source"] == "measured", f"(d) provenance.source: {prov['source']}")
+check(prov["n_obs"] == 1, f"(d) provenance.n_obs: {prov['n_obs']}")
+check(prov["cohort"]["hardware"] == "rtx-3090", "(d) cohort.hardware")
+check(prov["cohort"]["arch"] == "qwen3-next-hybrid", "(d) cohort.arch")
+check(prov["cohort"]["objective"] is None, "(d) cohort.objective null")
+
+# (e) producer extensions clearly namespaced + populated
+ext = rec["measured_extensions"]
+check("_note" in ext and "NOT in frozen" in ext["_note"], "(e) extensions _note flag missing")
+check(ext["decode_tps_by_ctx"] == {"canonical-short": 245.10}, f"(e) ladder: {ext['decode_tps_by_ctx']}")
+check(ext["wall_tps"] == 238.10, f"(e) ext wall_tps: {ext['wall_tps']}")
+check(ext["prefill_tps"] is None or isinstance(ext["prefill_tps"], float), "(e) prefill_tps type")
+check(ext["peak_vram_mib_by_gpu"] == {"0": 22310}, f"(e) peak vram: {ext['peak_vram_mib_by_gpu']}")
+# power_cap_w fell back to the parsed 370W (no explicit override)
+check(ext["power_cap_w"] == 370.00, f"(e) ext power_cap_w fallback: {ext['power_cap_w']}")
+fp = ext["conditions_fingerprint"]
+check(fp["power_cap_w"] == 370.00, f"(e) fingerprint power_cap_w: {fp['power_cap_w']}")
+check(fp["kv_dtype"] == "q4_0" and fp["topology"] == "single", "(e) fingerprint kv/topology")
+
+# explicit power_cap_w arg must win over parsed value
+rec2 = mr.build_record(tag="ik-llama/iq4ks-mtp", bench_metrics=metrics,
+                       hardware="rtx-3090", power_cap_w=230.0)
+check(rec2["measured_extensions"]["power_cap_w"] == 230.0,
+      f"(e) explicit power_cap_w override: {rec2['measured_extensions']['power_cap_w']}")
+
+# (g) corpus path under gitignored results/ + fingerprint hash in name + write
+with tempfile.TemporaryDirectory() as td:
+    corpus = Path(td) / "mr"
+    path = mr.write_record(rec, corpus_dir=corpus)
+    check(path.parent == corpus, f"(g) corpus dir: {path.parent}")
+    check(path.name.startswith("ik-llama-iq4ks-mtp__"), f"(g) filename slug: {path.name}")
+    check(path.name.endswith(".jsonl"), f"(g) jsonl ext: {path.name}")
+    # append a second record -> two lines, same file (same fingerprint)
+    mr.write_record(rec, corpus_dir=corpus)
+    lines = path.read_text().strip().splitlines()
+    check(len(lines) == 2, f"(g) append: {len(lines)} lines")
+    json.loads(lines[0])  # valid JSON line
+
+# default corpus location is under results/ (gitignored subtree)
+default_path = mr.corpus_path_for(rec)
+check("results/measurement-records" in default_path.as_posix(),
+      f"(g) default corpus under results/: {default_path}")
+
+# (h) unknown tag fails loud
+try:
+    mr.build_record(tag="vllm/does-not-exist", bench_metrics=metrics)
+    failures.append("(h) unknown tag did NOT raise")
+except KeyError:
+    pass
+
+if failures:
+    print("FAIL test-measurement-record:")
+    for f in failures:
+        print(f"  - {f}")
+    sys.exit(1)
+print("PASS test-measurement-record (all assertions)")
+PY


### PR DESCRIPTION
## What

Producer-only measurement-record emitter — captures structured runtime facts from `bench.sh` runs into a gitignored per-rig corpus, seeding the v0.9.0 compose-optimizer's **C1 maintainer-corpus** (its highest-priority gap — the feedback loop starves without measured anchors from our own rigs). We run benches constantly and currently discard the structured data; this captures it from runs we already do.

**Scope is deliberately narrow — PRODUCER ONLY.** No lookup API, no consumer, no timeout-sizing integration, no optimizer `[F]`-loop accretion. Pure additive capture, no decision logic → lock-safe ahead of the optimizer's §2/§9 unlock.

## What it does

`scripts/lib/profiles/measurement_record.py` parses `bench.sh` stdout + a `compose_registry` tag → one measurement-record JSON, appended to `results/measurement-records/<tag>__<fingerprint>.jsonl` (already gitignored — per-rig data, not committed). Decoupled from live execution: runs on saved bench output (`bench.sh | tee run.txt` → `--bench-output run.txt`), so runs can be captured after the fact.

- **Frozen schema conformance** — uses the optimizer measurement-record field names verbatim (`compose-optimizer-design.md`); optimizer-only fields (`objective`/`confidence_tier`/`margin_applied`) emit `null`, not fabricated; `provenance` matches the frozen sub-schema.
- **Two producer-proposed extensions**, clearly namespaced under `measured_extensions` with a `_note` flagging them as candidates for the optimizer's Lock-criteria #6 typing pass:
  1. `decode_tps_by_ctx` — TPS as a **context-depth ladder** (one point now; depth points add later with no schema change) + `prefill_tps`/`ttft_s`/`wall_tps`/per-card peak VRAM.
  2. `power_cap_w` in the conditions fingerprint — the optimizer cohort key omits it, but it's the guard against the 230W-vs-370W throughput-artifact class.
- **`bench.sh` untouched** — wrapping its own progressive stdout would risk the live-progress behavior (PR #248); emitter runs standalone.

## Tests
`scripts/tests/test-measurement-record.sh` — GPU-free, reuses `bench.sh`'s `BENCH_MOCK=1` output so the sample never drifts from the real format. Covers all frozen fields, null optimizer fields, provenance sub-schema, the extensions, fingerprint filename, append, gitignored default, override precedence, fail-loud on unknown tag. Registry-adjacent tests still green.

## Not in scope (deferred to the optimizer §2/§9 unlock)
Lookup API · any consumer · timeout integration · `[F]`-loop accretion · `result_class` enum pinning (Lock #6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
