### PR TITLE
Fail loud on hollow measured records in measurement_record

### DIFF
--- a/scripts/lib/profiles/measurement_record.py
+++ b/scripts/lib/profiles/measurement_record.py
@@ -88,6 +88,33 @@ CORPUS_SUBDIR = "results/measurement-records"
 NOT_RUN = "not-run"
 
 
+class MeasuredRecordError(ValueError):
+    """A measured record is missing data it MUST carry to be trustworthy.
+
+    Raised (fail-loud) when ``result_class`` says a record is *measured* but the
+    parse produced no decode TPS (or no parseable bench summary block at all).
+    A measured record with null TPS is worse than no record — it looks like real
+    calibration data while carrying none — so the producer refuses to write it.
+    This mirrors the module's existing fail-loud posture for an unknown registry
+    tag (``KeyError``). Soft gaps (e.g. a malformed GPU-state line) are surfaced
+    as ``parse_warnings`` instead, not raised.
+    """
+
+
+def _is_measured_result_class(result_class: Optional[str]) -> bool:
+    """True if ``result_class`` denotes a MEASURED record.
+
+    The frozen 3-state runtime contract uses ``boot-fit predicted|measured`` and
+    the producer's default is ``boot-fit-measured``. We treat any class whose
+    final ``-``-delimited token is ``measured`` (e.g. ``boot-fit-measured``) as
+    measured. ``predicted`` / ``unknown`` / ``*-derived`` classes are NOT
+    measured and impose no decode-TPS requirement.
+    """
+    if not result_class:
+        return False
+    return result_class.strip().lower().split("-")[-1] == "measured"
+
+
 # --------------------------------------------------------------------------- #
 # arch / arch_class derivation
 # --------------------------------------------------------------------------- #
@@ -146,7 +173,11 @@ class BenchMetrics:
     """Parsed numbers from one ``scripts/bench.sh`` stdout capture.
 
     All fields optional — a partial bench (e.g. ``ONLY=code``, or no GPU line)
-    still yields a usable record. The producer never fabricates absent numbers.
+    still yields a usable :class:`BenchMetrics`. The producer never fabricates
+    absent numbers. Whether an absent number is *tolerable* is decided later in
+    :func:`build_record`: for a MEASURED ``result_class`` a missing decode TPS
+    is fatal (fail-loud), while a missing GPU line is a soft warning. The parse
+    provenance fields below let ``build_record`` tell those cases apart.
     """
 
     decode_tps: Optional[float] = None      # mean decode_TPS (model decode rate)
@@ -159,6 +190,18 @@ class BenchMetrics:
     power_cap_w: Optional[float] = None
     # Power draw in watts, per GPU index, if present.
     power_draw_w: dict[int, float] = field(default_factory=dict)
+
+    # --- Parse provenance (drift / hollow-record detection) ----------------- #
+    # How many ``=== summary [...] ===`` blocks carrying a ``decode_TPS mean=``
+    # line we matched. Zero on a measured record means bench-output drift (the
+    # summary section the producer keys off is absent or unparseable) -> the
+    # record must NOT be written with null TPS. See ``build_record``.
+    decode_summary_blocks: int = 0
+    # ``=== GPU state ===`` marker seen at all (regardless of parseability).
+    gpu_state_section_present: bool = False
+    # A ``=== GPU state ===`` section was present but yielded no usable
+    # per-GPU VRAM row -> malformed GPU-state line (soft gap -> warn, not raise).
+    gpu_state_unparsed: bool = False
 
 
 def _f(s: str) -> Optional[float]:
@@ -193,6 +236,12 @@ def parse_bench_output(text: str) -> BenchMetrics:
         matches = re.findall(rf"^\s*{label}\s+mean=\s*([0-9.]+)", text, re.MULTILINE)
         if matches:
             setattr(m, attr, _f(matches[-1]))
+        if label == r"decode_TPS":
+            # ``decode_TPS mean=`` lines appear ONLY inside a summary block, so
+            # the count is the count of parseable decode-summary blocks. Zero on
+            # a measured record => the summary section the producer keys off is
+            # absent / unparseable (bench-output drift). build_record fails loud.
+            m.decode_summary_blocks = len(matches)
 
     # TTFT summary line:  TTFT          mean=   120ms  std= ...
     ttft = re.findall(r"^\s*TTFT\s+mean=\s*([0-9.]+)ms", text, re.MULTILINE)
@@ -209,6 +258,7 @@ def parse_bench_output(text: str) -> BenchMetrics:
     # "W" token positionally per row.
     gpu_block = text.split("=== GPU state ===", 1)
     if len(gpu_block) == 2:
+        m.gpu_state_section_present = True
         for row in gpu_block[1].splitlines():
             row = row.strip()
             if not row or "," not in row:
@@ -228,6 +278,11 @@ def parse_bench_output(text: str) -> BenchMetrics:
                 watt = re.match(r"^([0-9.]+)\s*W$", cell)
                 if watt and idx not in m.power_draw_w:
                     m.power_draw_w[idx] = float(watt.group(1))
+        # Section present but no usable per-GPU VRAM row => malformed GPU-state
+        # line. Soft gap (VRAM is a fingerprint extension, not the core
+        # measured TPS): warn in build_record, do NOT raise.
+        if not m.vram_used_mib:
+            m.gpu_state_unparsed = True
 
     # Optional explicit power.limit line, if a caller appended one, e.g.:
     #   power.limit: 370.00 W   (per-rig fingerprint)
@@ -268,10 +323,26 @@ def build_record(
 ) -> dict[str, Any]:
     """Assemble ONE measurement record from a registry tag + parsed bench output.
 
-    Raises ``KeyError`` for an unknown tag (fail-loud — a typo'd tag should not
-    silently produce a garbage record).
+    Fail-loud, never write hollow calibration data:
+
+      * ``KeyError`` for an unknown tag (a typo'd tag should not silently
+        produce a garbage record);
+      * :class:`MeasuredRecordError` when ``result_class`` says the record is
+        *measured* (e.g. ``boot-fit-measured``) but the parse produced **no
+        decode TPS** — either because the bench summary block is absent /
+        unparseable (output drift) or no ``decode_TPS mean=`` was found. A
+        measured record with null TPS looks like real data to the optimizer's
+        calibration backbone but carries none, so the producer refuses it.
+
+    Softer gaps that do NOT invalidate the measured TPS (e.g. a malformed /
+    absent ``=== GPU state ===`` line, so per-GPU VRAM is unknown) are surfaced
+    as a top-level ``parse_warnings`` list on the record rather than raised, so
+    the record is still written but the gap is explicit (never a silent null).
+    Genuinely-optional/unknowable optimizer fields (``objective``,
+    ``confidence_tier``, ...) stay ``None`` — that is not a gap.
     """
     entry = COMPOSE_REGISTRY[tag]
+    parse_warnings: list[str] = []
 
     model_slug = entry["model"]
     arch = _read_model_family(model_slug)  # family slug, used verbatim
@@ -325,6 +396,45 @@ def build_record(
     if bench_metrics.decode_tps is not None:
         decode_tps_by_ctx["canonical-short"] = bench_metrics.decode_tps
 
+    # --- Fail-loud validation for MEASURED records -------------------------- #
+    # The producer's whole value is the measured decode TPS. For a measured
+    # result_class, refuse to emit a record with null TPS — distinguish the two
+    # ways it goes null so the error names the actual cause:
+    #   1. No parseable bench summary block at all => bench-output drift.
+    #   2. A summary block parsed but no decode number => incomplete metrics.
+    if _is_measured_result_class(result_class):
+        if bench_metrics.decode_summary_blocks == 0:
+            raise MeasuredRecordError(
+                f"result_class={result_class!r} is a MEASURED record but no "
+                "parseable bench summary block was found (expected a "
+                "'=== summary [...] ===' section with a 'decode_TPS mean=' "
+                "line). This is scripts/bench.sh output drift -- refusing to "
+                "write a hollow record with null TPS. Check the bench capture "
+                "format, or pass a non-measured --result-class if this run "
+                "genuinely produced no decode metrics."
+            )
+        if not decode_tps_by_ctx:
+            raise MeasuredRecordError(
+                f"result_class={result_class!r} is a MEASURED record but the "
+                "parse produced no decode TPS (empty decode_tps_by_ctx). A "
+                "measured record with null TPS is worse than no record for "
+                "optimizer calibration -- refusing to write it."
+            )
+
+    # Soft gap: GPU-state line absent/malformed -> per-GPU VRAM unknown. Warn,
+    # do NOT raise (VRAM is a fingerprint extension, not the core measured TPS).
+    if bench_metrics.gpu_state_unparsed:
+        parse_warnings.append(
+            "GPU-state section present but unparseable: no per-GPU VRAM row "
+            "matched (expected 'index, ... , <N> MiB, ...' from nvidia-smi); "
+            "peak_vram_mib_by_gpu is empty."
+        )
+    elif not bench_metrics.gpu_state_section_present:
+        parse_warnings.append(
+            "no '=== GPU state ===' section in bench output; per-GPU VRAM and "
+            "power-draw are unknown (peak_vram_mib_by_gpu is empty)."
+        )
+
     measured_extensions = {
         # Flagged producer-proposed; see module docstring + design Lock #6.
         "_note": (
@@ -365,6 +475,10 @@ def build_record(
         "provenance": provenance,
         # --- Producer extensions (clearly namespaced) ------------------------ #
         "measured_extensions": measured_extensions,
+        # Soft-gap diagnostics (never a silent null): a list naming each
+        # expected-but-absent/malformed datum that did NOT rise to a fail-loud
+        # raise. Empty list on a clean, well-formed bench output.
+        "parse_warnings": parse_warnings,
         # Carry the registry tag for traceability (not a frozen field; aids
         # the maintainer joining a record back to its config identity).
         "_tag": tag,
@@ -481,18 +595,27 @@ def main(argv=None) -> int:
         text = sys.stdin.read()
 
     metrics = parse_bench_output(text)
-    record = build_record(
-        tag=args.tag,
-        bench_metrics=metrics,
-        hardware=args.hardware,
-        engine_pin=args.engine_pin,
-        power_cap_w=args.power_cap_w,
-        result_class=args.result_class,
-        smoke_status=args.smoke_status,
-        soak_status=args.soak_status,
-        kv_calc_version=args.kv_calc_version,
-        arch_class=args.arch_class,
-    )
+    try:
+        record = build_record(
+            tag=args.tag,
+            bench_metrics=metrics,
+            hardware=args.hardware,
+            engine_pin=args.engine_pin,
+            power_cap_w=args.power_cap_w,
+            result_class=args.result_class,
+            smoke_status=args.smoke_status,
+            soak_status=args.soak_status,
+            kv_calc_version=args.kv_calc_version,
+            arch_class=args.arch_class,
+        )
+    except MeasuredRecordError as exc:
+        # Fail loud, but with a clean operator message (not a raw traceback).
+        print(f"[measurement_record] ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    # Surface soft-gap warnings so a partial record is never silently accepted.
+    for w in record.get("parse_warnings", []):
+        print(f"[measurement_record] WARNING: {w}", file=sys.stderr)
 
     if args.print_only:
         print(json.dumps(record, indent=2, sort_keys=False))

--- a/scripts/tests/test-measurement-record.sh
+++ b/scripts/tests/test-measurement-record.sh
@@ -20,6 +20,11 @@ set -euo pipefail
 #   (g) corpus path is under the gitignored results/ subtree and filename
 #       carries the conditions-fingerprint short hash; write+append works;
 #   (h) an unknown tag fails loud (KeyError), never a silent garbage record.
+#   (i) a MEASURED record built from bench output MISSING the decode summary
+#       fails loud (MeasuredRecordError), never a hollow null-TPS record;
+#   (j) a MEASURED record with a malformed/absent GPU-state line surfaces a
+#       parse_warnings entry (not a silent null), without raising;
+#   (k) regression: the complete well-formed sample yields EMPTY parse_warnings.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
@@ -136,6 +141,10 @@ fp = ext["conditions_fingerprint"]
 check(fp["power_cap_w"] == 370.00, f"(e) fingerprint power_cap_w: {fp['power_cap_w']}")
 check(fp["kv_dtype"] == "q4_0" and fp["topology"] == "single", "(e) fingerprint kv/topology")
 
+# (k) regression: complete, well-formed sample => clean record, NO warnings
+check("parse_warnings" in rec, "(k) parse_warnings field missing")
+check(rec["parse_warnings"] == [], f"(k) happy path has warnings: {rec['parse_warnings']}")
+
 # explicit power_cap_w arg must win over parsed value
 rec2 = mr.build_record(tag="ik-llama/iq4ks-mtp", bench_metrics=metrics,
                        hardware="rtx-3090", power_cap_w=230.0)
@@ -166,6 +175,69 @@ try:
     failures.append("(h) unknown tag did NOT raise")
 except KeyError:
     pass
+
+# (i) MEASURED record + bench output missing the decode summary => fail loud.
+# Strip the summary block from the sample (keep the GPU-state line) so only the
+# decode metric is gone; the parser must report zero decode-summary blocks and
+# build_record must refuse rather than write null TPS.
+no_summary = "\n".join(
+    ln for ln in sample.splitlines()
+    if "decode_TPS" not in ln and "wall_TPS" not in ln and "=== summary" not in ln
+)
+m_nosum = mr.parse_bench_output(no_summary)
+check(m_nosum.decode_tps is None, f"(i) precondition decode_tps gone: {m_nosum.decode_tps}")
+check(m_nosum.decode_summary_blocks == 0, f"(i) precondition summary blocks: {m_nosum.decode_summary_blocks}")
+try:
+    mr.build_record(tag="ik-llama/iq4ks-mtp", bench_metrics=m_nosum,
+                    hardware="rtx-3090", result_class="boot-fit-measured")
+    failures.append("(i) measured record w/ no decode summary did NOT raise")
+except mr.MeasuredRecordError:
+    pass
+
+# A NON-measured result_class with the same missing-decode input must NOT raise
+# (the requirement is scoped to measured records only).
+try:
+    rec_pred = mr.build_record(tag="ik-llama/iq4ks-mtp", bench_metrics=m_nosum,
+                               hardware="rtx-3090", result_class="boot-fit-predicted")
+    check(rec_pred["measured_extensions"]["decode_tps_by_ctx"] == {},
+          "(i) predicted record ladder should be empty, not fabricated")
+except mr.MeasuredRecordError:
+    failures.append("(i) non-measured result_class wrongly raised on missing decode")
+
+# (j) MEASURED record + malformed GPU-state line => parse_warnings, NOT raise.
+# Keep the decode summary; corrupt the GPU-state row so no VRAM MiB matches.
+bad_gpu = """\
+=== summary [narrative] (n=1) ===
+  wall_TPS       mean= 238.10   std=  0.00
+  decode_TPS     mean= 245.10   std=  0.00
+  TTFT          mean=   120ms  std=    0ms
+=== GPU state ===
+<nvidia-smi unavailable: query failed>
+"""
+m_badgpu = mr.parse_bench_output(bad_gpu)
+check(m_badgpu.decode_tps == 245.10, f"(j) precondition decode parsed: {m_badgpu.decode_tps}")
+check(m_badgpu.gpu_state_section_present, "(j) precondition GPU section present")
+check(m_badgpu.gpu_state_unparsed, "(j) precondition GPU section flagged unparsed")
+check(m_badgpu.vram_used_mib == {}, f"(j) precondition no VRAM rows: {m_badgpu.vram_used_mib}")
+rec_badgpu = mr.build_record(tag="ik-llama/iq4ks-mtp", bench_metrics=m_badgpu,
+                             hardware="rtx-3090", result_class="boot-fit-measured")
+check(len(rec_badgpu["parse_warnings"]) >= 1, "(j) no parse_warnings surfaced for bad GPU line")
+check(any("GPU-state" in w for w in rec_badgpu["parse_warnings"]),
+      f"(j) GPU-state warning not named: {rec_badgpu['parse_warnings']}")
+# record is still WRITTEN (soft gap), and the measured TPS is intact
+check(rec_badgpu["measured_extensions"]["decode_tps_by_ctx"] == {"canonical-short": 245.10},
+      "(j) decode TPS lost despite only GPU line being bad")
+check(rec_badgpu["measured_extensions"]["peak_vram_mib_by_gpu"] == {},
+      "(j) VRAM should be empty, not fabricated")
+
+# An absent GPU-state section also warns (distinct message), still no raise.
+no_gpu = "\n".join(ln for ln in bad_gpu.splitlines() if "GPU state" not in ln and "nvidia-smi" not in ln)
+m_nogpu = mr.parse_bench_output(no_gpu)
+check(not m_nogpu.gpu_state_section_present, "(j) precondition no GPU section")
+rec_nogpu = mr.build_record(tag="ik-llama/iq4ks-mtp", bench_metrics=m_nogpu,
+                            hardware="rtx-3090", result_class="boot-fit-measured")
+check(any("GPU state" in w for w in rec_nogpu["parse_warnings"]),
+      f"(j) absent-GPU-section warning not surfaced: {rec_nogpu['parse_warnings']}")
 
 if failures:
     print("FAIL test-measurement-record:")


### PR DESCRIPTION
## Why

Addresses the Codex review **Medium** finding on #249 (the measurement-record producer).

The producer's design says "never fabricate absent numbers" — fine for genuinely-optional fields. But for a record with `result_class="boot-fit-measured"` (a MEASURED record), `build_record` could still emit a record with **no decode TPS** — silently writing nulls — if `bench.sh`'s output format drifted (summary block missing/unparseable) or a metric was absent. A measured record with null TPS is worse than no record once these feed optimizer calibration: it looks like real data.

## What changed

`scripts/lib/profiles/measurement_record.py`:

- **Fail loud (raise) on a missing decode number for a measured record.** New `MeasuredRecordError` (a `ValueError` subclass), raised by `build_record` when `result_class` is measured but either:
  1. no parseable bench summary block was found (`decode_TPS mean=` absent → `bench.sh` output drift), or
  2. the parse produced no decode TPS (empty `decode_tps_by_ctx`).
  This matches the module's existing fail-loud posture (it already raises `KeyError` on an unknown registry tag).
- **Warn (not raise) on softer gaps.** A malformed/absent `=== GPU state ===` line means per-GPU VRAM is unknown — but VRAM is a fingerprint *extension*, not the core measured TPS. So it's surfaced in a new top-level **`parse_warnings`** list instead of raising. The record is still written, but the gap is explicit — never a silent null.
- **Parse provenance** added to `BenchMetrics` (`decode_summary_blocks`, `gpu_state_section_present`, `gpu_state_unparsed`) so `build_record` can distinguish "output drift" from "incomplete metrics" from "bad GPU line" and name the actual cause.
- Non-measured classes (`predicted`/`derived`) impose no decode-TPS requirement; genuinely-optional optimizer fields (`objective`, `confidence_tier`, …) stay `null`.
- CLI catches `MeasuredRecordError` (exit code 2, clean operator message — not a raw traceback) and echoes `parse_warnings` to stderr.

### Fail-loud vs parse_warnings decision

Followed the finding's preferred split: **raise** on a missing decode number for a measured record (the producer's whole value is the measured TPS), **warn** on soft gaps like a malformed GPU-state line. The raise mirrors the module's pre-existing `KeyError`-on-bad-tag style, so the error-handling posture is consistent.

## Tests

`scripts/tests/test-measurement-record.sh` extended (same bash-wrapper + inline-Python style, still driven by `bench.sh`'s `BENCH_MOCK=1` sample so the format can't drift):

- **(i)** measured record built from bench output **missing the decode summary** → asserts `MeasuredRecordError`; plus a non-measured `result_class` with the same input does NOT raise.
- **(j)** measured record with a **malformed GPU-state line** → asserts a `parse_warnings` entry naming the GPU-state gap, the record is still written, and the measured TPS is intact (not lost). Also covers an entirely **absent** GPU-state section (distinct warning).
- **(k)** regression: the complete, well-formed `BENCH_MOCK=1` sample still produces a clean record with **empty `parse_warnings`** (happy path unbroken).

All assertions pass (`PASS test-measurement-record`). Scope is strictly `measurement_record.py` + its test — `bench.sh`, the registry, and other tooling are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)