### PR TITLE
fix(kv-calc): shard qwen3-next-moe weights by TP (#260)

### DIFF
--- a/tools/kv-calc.py
+++ b/tools/kv-calc.py
@@ -168,9 +168,12 @@ QWEN_GDN_ACTIVATION_COEF = {
 # ---- Qwen MoE activation + built-in MTP workspace ----
 # Path-B low-anchor fit from the two v0.7.3 preview rows. The per-token GDN
 # coefficient follows the dense-Qwen shape; the small constant captures MoE
-# expert dispatch/router buffers. Current vLLM TP preview effectively keeps
-# the quantized MoE weights resident per card, so weights are not divided by TP
-# for qwen3-next-moe in _weights_per_card_gb().
+# expert dispatch/router buffers. NOTE: vLLM shards both attention and MoE
+# expert weights across TP ranks, so weights ARE divided by TP for
+# qwen3-next-moe in _weights_per_card_gb() (fixed in #260). The ≈budget peak
+# on the live rows is the elastic KV pool filling spare VRAM, not resident
+# full-quant weights — the old no-/tp assumption over-predicted long-ctx
+# configs (e.g. 262K) into a false FAIL.
 QWEN_MOE_ACTIVATION_COEF = {
     "fp16":               110,
     "bf16":               110,
@@ -332,11 +335,16 @@ def _weights_per_card_gb(spec, tp, weights_variant="default"):
     if spec["model_family"] == "qwen3-next-hybrid":
         return spec["weights_total_gb"] / tp
     elif spec["model_family"] == "qwen3-next-moe":
-        # Current vLLM MoE preview keeps expert weights effectively resident
-        # per TP rank; live 16K rows calibrate to full quant weight per card.
+        # vLLM shards attention + MoE expert weights across TP ranks, so
+        # per-card weights are /tp (#260). The old no-/tp assumption was
+        # mis-inferred from the live ≈budget peak — but that peak is the
+        # elastic KV pool filling spare VRAM (vLLM allocates all available
+        # KV memory as blocks), not resident full-quant weights. Not dividing
+        # over-predicted the fixed footprint and turned long-ctx configs
+        # (e.g. 262K dual, which fits) into a false FAIL.
         if weights_variant == "gptq":
-            return spec["weights_gptq_gb"]
-        return spec["weights_total_gb"]
+            return spec["weights_gptq_gb"] / tp
+        return spec["weights_total_gb"] / tp
     elif spec["model_family"] == "gemma4-swa-dense":
         if weights_variant == "awq":
             return spec["weights_awq_gb"] / tp
@@ -345,8 +353,13 @@ def _weights_per_card_gb(spec, tp, weights_variant="default"):
         else:  # int4 default
             return spec["weights_int4_gb"] / tp
     elif spec["model_family"] == "gemma4-swa-moe":
-        # Same MoE-residency assumption as Qwen A3B; validated by the
-        # v0.7.3 AWQ rows where TP=2 still peaks near a full AWQ shard/card.
+        # NOT /tp'd (unlike qwen3-next-moe, fixed in #260) — deliberately left
+        # pending its own re-calibration. The v0.7.3 AWQ rows peak at 23.45–
+        # 23.50 GB/card (TP=2, ~0.95 GB above the 22.08 budget), so the current
+        # no-/tp footprint produces a *protective* TIGHT verdict there. Dividing
+        # by TP without a measured fixed-footprint anchor would relax that to
+        # PASS for a config that genuinely runs at 23.5/24. Re-do with a proper
+        # boot-log anchor (KV-pool tokens → fixed = peak − pool) before /tp'ing.
         if weights_variant == "int4":
             return spec["weights_int4_gb"]
         return spec["weights_awq_gb"]
@@ -827,6 +840,17 @@ def predict(
         notes.append("⚠ Gemma 4 31B TP=1 needs ≥32 GB VRAM; 24 GB Ampere boot-OOMs (model weights + drafter + min KV)")
     if spec["model_family"] in {"qwen3-next-moe", "gemma4-swa-moe"}:
         notes.append("MoE projection uses low-anchor calibration; add max_ctx/max_num_seqs A/B rows before treating this as production-grade.")
+    if (
+        spec["model_family"] == "qwen3-next-moe"
+        and kv_pool_requested_gb > 0
+        and available_for_kv > kv_pool_requested_gb * 1.5
+    ):
+        notes.append(
+            f"DeltaNet-hybrid KV is cheap — one max_ctx={max_ctx:,} seq needs only "
+            f"{kv_pool_requested_gb:.2f} GB, but vLLM fills the ~{available_for_kv:.1f} GB available pool "
+            f"to budget (≈{available_for_kv / kv_pool_requested_gb:.1f}× concurrency headroom). The sub-budget "
+            f"'predicted total' is the single-seq floor, not spare VRAM you can repurpose."
+        )
     if tp > 4:
         notes.append("TP > 4 predictions are extrapolated; report deltas via scripts/report.sh --bench")
 


### PR DESCRIPTION
## What

`tools/kv-calc.py` `_weights_per_card_gb()` returned the **full** quant weight for the `qwen3-next-moe` family with **no `/tp`** division. vLLM shards both attention and MoE expert weights across TP ranks, so on dual-card this double-counted the fixed footprint (~20 GB instead of ~10), pushing long-context configs over budget into a **false FAIL**.

Concretely, Qwen3.6-35B-A3B INT4 at **262K / dual** predicted `Predicted total 22.33 GB (101%) → FAIL`, even though the config is fully live-validated (178/174 TPS wall · 182 decode, 2.05M-token KV pool / ~7.8× concurrency, NIAH-clean to 240K, soak PASS — see #259).

## Root cause

The old comment inferred "MoE weights stay resident per TP rank" from the observation that the live per-card peak sits at ≈budget. But that peak is the **elastic KV pool** filling spare VRAM (vLLM allocates *all* available KV memory as paged blocks), not resident full-quant weights. The cheap DeltaNet-hybrid KV means one 262K sequence needs only ~1.3 GB; vLLM grows the pool to fill the remaining ~9.7 GB → peak ≈ budget regardless of weight sharding.

## Fix

- Divide both `autoround` and `gptq` `qwen3-next-moe` weights by `tp`.
- Add an elastic-pool note so the now-sub-budget MoE `predicted total` reads as the single-seq floor (with the concurrency-headroom multiplier), not spare VRAM.
- `gemma4-swa-moe` is **deliberately left unchanged**: its TP=2 AWQ rows genuinely peak at 23.45–23.50/24, so the current no-`/tp` footprint yields a *protective* TIGHT verdict. `/tp`'ing it without a measured boot-log fixed-footprint anchor would falsely relax that to PASS — annotated inline as a follow-up.

## Verification

| Check | Before | After |
|---|---|---|
| 35B-A3B 262K/dual verdict | FAIL | **PASS** (exit 0) |
| `--calibration` | 18/18 | **18/18** (verdict-direction; MoE rows now display like dense) |
| `test-kv-generic-dense` | — | OK |
| `test-diagnose-profile` (+ simulated 262K registry) | — | OK |
| `test-submit-pull` / `test-kvcalc-version` | — | OK |

Full `scripts/tests/` suite green (the one unrelated red is `test-submit-bench`, fixture-dependent, identical on clean master without my change).

Unblocks #259 (Qwen3.6-35B-A3B 262K+vision promotion).

Closes #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
