### PR TITLE
feat(switch): hardware-filter --list by GPU count; add --all

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ bash scripts/launch.sh
 #    Or partial flags (wizard fills the rest):
 #      bash scripts/launch.sh --model qwen3.6-27b --gpus 0,1
 #      bash scripts/launch.sh --tp 2 --pp 1               # override vLLM parallelism
-#    See all variants + the per-model defaults view:
-#      bash scripts/switch.sh --list
+#    See the variants this machine can run + the per-model defaults view
+#    (hardware-filtered by GPU count; add --all to see every variant):
+#      bash scripts/switch.sh --list          # runnable here
+#      bash scripts/switch.sh --list --all    # everything
 #    Pin your own default so bare `launch.sh` goes straight there:
 #      bash scripts/switch.sh --set-default ik-llama/iq4ks-mtp   # clear: --clear-default qwen3.6-27b
 
@@ -217,7 +219,7 @@ curl -s http://localhost:8020/v1/models | jq .
 docker compose -f <the-same-compose-file> down
 ```
 
-`MODEL_DIR` is the only env var you must set — it's mounted as `/models`, and defaults to the in-repo `models-cache/` if your weights live there. Everything else has a sane default baked in; each compose **header** documents its own overrides (`GGUF_FILE`, `CTX_SIZE`, `UBATCH_SIZE`, …) and the exact `docker compose` line. `bash scripts/switch.sh --list` lists every variant, and a successful `switch.sh` run prints the compose path it used — so you can always recover the `-f` target.
+`MODEL_DIR` is the only env var you must set — it's mounted as `/models`, and defaults to the in-repo `models-cache/` if your weights live there. Everything else has a sane default baked in; each compose **header** documents its own overrides (`GGUF_FILE`, `CTX_SIZE`, `UBATCH_SIZE`, …) and the exact `docker compose` line. `bash scripts/switch.sh --list` lists the variants runnable on this machine (hardware-filtered by GPU count; `--all` shows every variant), and a successful `switch.sh` run prints the compose path it used — so you can always recover the `-f` target.
 
 > ⚠ Launching directly skips the preflight that catches under-VRAM / wrong-GPU-count mistakes. If the container exits, check `docker logs <container> 2>&1 | tail -50`.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -251,7 +251,7 @@ After setup, run `bash scripts/launch.sh`. The wizard asks which model (filtered
 
 Two parts: *what's available* and *what happens if I don't have it yet.*
 
-**List everything.** `bash scripts/switch.sh --list` prints every variant, generated live from the compose registry (the single source of truth) — so the list never drifts from what the stack can actually run.
+**List what your machine can run.** `bash scripts/switch.sh --list` prints the variants runnable on *this* box — generated live from the compose registry (the single source of truth), then filtered to the topologies your GPU count supports (1 GPU → single-card configs only; 2 → single + dual; 4+ → everything). It prints a one-line note when it hides anything; add `--all` (`bash scripts/switch.sh --list --all`, or `--list-all`) to see every variant regardless of GPU count. Detection fails open — if it can't tell how many GPUs you have, it shows everything.
 
 **Switch to one you've already downloaded.** Either re-run the wizard (`bash scripts/launch.sh`, which filters the menu to models present in `MODEL_DIR` and verifies the boot), or go direct by slug:
 

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -10,7 +10,9 @@
 #   bash scripts/switch.sh <variant>            # switch + tail until ready
 #   bash scripts/switch.sh <variant> --no-wait  # switch and return immediately
 #   bash scripts/switch.sh --force <variant>    # skip hardware/free-VRAM preflight
-#   bash scripts/switch.sh --list               # show all variants + the defaults view
+#   bash scripts/switch.sh --list               # variants runnable on THIS machine + defaults
+#   bash scripts/switch.sh --list --all         # every variant regardless of GPU count
+#   bash scripts/switch.sh --list-all           # alias for --list --all
 #   bash scripts/switch.sh --defaults           # just the per-model defaults view
 #   bash scripts/switch.sh --down               # just bring down whatever's up
 #   bash scripts/switch.sh --set-default <slug>  # pin <slug> as YOUR default for its model (.env)
@@ -275,6 +277,49 @@ status_marker() {
   esac
 }
 
+# Map a topology word (as `switch_topology_from_gpus` emits it, or as a
+# compose file's first path segment carries it) to a numeric rank, so we can
+# compare "can this machine run that slug?". single=1, dual=2, multi*=3+.
+# Unknown → 9 (sorts last; never filtered out by accident). Echoes the rank.
+topology_rank() {
+  case "$1" in
+    single)  printf '1' ;;
+    dual)    printf '2' ;;
+    multi*)  printf '3' ;;
+    *)       printf '9' ;;
+  esac
+}
+
+# Is GPU detection RELIABLE for the hardware filter? True iff we have a
+# concrete signal: an explicit selector (CUDA/NVIDIA_VISIBLE_DEVICES naming
+# specific GPUs) OR nvidia-smi present AND reporting ≥1 GPU. Without either we
+# can't trust the count — switch_topology_from_gpus falls back to "single" in
+# that case, but for the --list filter we must FAIL OPEN (show all) rather than
+# hide dual/multi based on a guess. Returns 0 (reliable) / 1 (unknown).
+list_gpu_detect_reliable() {
+  local selector="${NVIDIA_VISIBLE_DEVICES:-${CUDA_VISIBLE_DEVICES:-}}"
+  if [[ -n "$selector" && "$selector" != "all" && "$selector" != "void" ]]; then
+    return 0
+  fi
+  if command -v nvidia-smi >/dev/null 2>&1; then
+    local n
+    n="$(nvidia-smi --query-gpu=index --format=csv,noheader 2>/dev/null | sed '/^$/d' | wc -l | tr -d ' ')"
+    [[ "${n:-0}" -ge 1 ]] && return 0
+  fi
+  return 1
+}
+
+# Human GPU-count label for a detected topology word, for the filter note
+# (e.g. "single" → "1", "dual" → "2", "multi4" → "4", "multi6" → "6").
+topology_gpu_label() {
+  case "$1" in
+    single)  printf '1' ;;
+    dual)    printf '2' ;;
+    multi*)  printf '%s' "${1#multi}" ;;
+    *)       printf '?' ;;
+  esac
+}
+
 list_variants() {
   # Grouped by model · topology so each slug's binding is visible at a glance.
   # VARIANTS stores "<engine>|<dir>|<file>" where
@@ -283,33 +328,82 @@ list_variants() {
   # (the registry emitter splits compose_path on "/compose/", so dir stops at
   #  /compose and the topology+quant live in file). Engine is the slug prefix.
   # The trailing column is the health marker derived from the registry status.
+  #
+  # Hardware filter (PR-C): a dual/multi slug can't run on a 1-GPU box, so by
+  # default we hide slugs whose topology rank exceeds what this machine can run
+  # (detected via switch_topology_from_gpus, which reads CUDA/NVIDIA_VISIBLE_-
+  # DEVICES then nvidia-smi). `--list --all` (LIST_ALL=1) shows everything for
+  # discoverability. Fail-open: if detection is unavailable we show ALL rather
+  # than hide based on a failed probe.
+  local show_all="${LIST_ALL:-0}" detected_topo max_rank
+  detected_topo="$(switch_topology_from_gpus 2>/dev/null || true)"
+  if [[ -z "$detected_topo" ]] || ! list_gpu_detect_reliable; then
+    # Detection unavailable / count unknown → fail-open, show everything. We do
+    # NOT hide dual/multi off the back of switch_topology_from_gpus's "single"
+    # fallback when there's no real signal (no selector, no nvidia-smi).
+    show_all=1
+    max_rank=9
+  else
+    max_rank="$(topology_rank "$detected_topo")"
+  fi
+
   echo "Available variants — grouped by model · topology (right column: <quant>/<serving>.yml):"
   echo "  Health: unmarked = production · (caveats) = works w/ documented limits · (NA: …) = needs --force"
-  # Counts: supported models · total variants · health split.
-  local _prod=0 _cav=0 _na=0
-  declare -A _seen_models=()
+
+  # Counts: split into VISIBLE vs HIDDEN by the hardware filter, so the header
+  # reflects what's actually shown (+ how many were hidden). Health split is
+  # over the VISIBLE set; the by-topology hidden tally drives the note.
+  local _prod=0 _cav=0 _na=0 _hidden=0
+  declare -A _seen_models=() _hidden_by_topo=()
   for v in "${!VARIANTS[@]}"; do
     IFS='|' read -r _e _d _f <<< "${VARIANTS[$v]}"
-    IFS=/ read -ra _ds <<< "$_d"; _seen_models["${_ds[1]:-?}"]=1
+    IFS=/ read -ra _ds <<< "$_d"
+    IFS=/ read -ra _fs <<< "$_f"
+    local _vtopo="${_fs[0]:-unknown}" _vrank
+    _vrank="$(topology_rank "$_vtopo")"
+    if [[ "$show_all" != "1" && "$_vrank" -gt "$max_rank" ]]; then
+      _hidden=$((_hidden + 1))
+      _hidden_by_topo["$_vtopo"]=$(( ${_hidden_by_topo["$_vtopo"]:-0} + 1 ))
+      continue
+    fi
+    _seen_models["${_ds[1]:-?}"]=1
     case "${VARIANT_STATUS[$v]:-production}" in
       production) _prod=$((_prod + 1)) ;;
       caveats)    _cav=$((_cav + 1)) ;;
       *)          _na=$((_na + 1)) ;;
     esac
   done
-  echo "  Models: ${#_seen_models[@]} · variants: ${#VARIANTS[@]} (${_prod} production · ${_cav} caveats · ${_na} NA)"
+  local _visible=$(( _prod + _cav + _na ))
+  # List the hidden topologies in rank order so both the header tally and the
+  # filter note name exactly what's missing (e.g. "dual/multi4"). Pure bash —
+  # no external grep/sort dependency.
+  local _topo_list="" _t
+  local _hidden_topos
+  _hidden_topos="$(
+    for _t in "${!_hidden_by_topo[@]}"; do
+      printf '%s\t%s\n' "$(topology_rank "$_t")" "$_t"
+    done | sort -k1,1n -k2,2 | cut -f2
+  )"
+  while IFS= read -r _t; do
+    [[ -n "$_t" ]] || continue
+    _topo_list="${_topo_list:+$_topo_list/}$_t"
+  done <<< "$_hidden_topos"
+  local _hidden_note=""
+  if [[ "$_hidden" -gt 0 ]]; then
+    _hidden_note="  (+${_hidden} ${_topo_list} hidden — --all)"
+  fi
+  echo "  Models: ${#_seen_models[@]} · variants: ${_visible} (${_prod} production · ${_cav} caveats · ${_na} NA)${_hidden_note}"
+
   {
     for v in "${!VARIANTS[@]}"; do
       IFS='|' read -r eng dir file <<< "${VARIANTS[$v]}"
       IFS=/ read -ra dseg <<< "$dir"    # dseg[1] = model
       IFS=/ read -ra fseg <<< "$file"   # fseg[0]=topology fseg[1]=quant fseg[2]=serving
       topo="${fseg[0]:-unknown}"
-      case "$topo" in
-        single) rank=1 ;;
-        dual)   rank=2 ;;
-        multi*) rank=3 ;;
-        *)      rank=9 ;;
-      esac
+      rank="$(topology_rank "$topo")"
+      if [[ "$show_all" != "1" && "$rank" -gt "$max_rank" ]]; then
+        continue
+      fi
       marker="$(status_marker "${VARIANT_STATUS[$v]:-production}")"
       printf '%s\t%d\t%s\t%s\t%s/%s\t%s\n' \
         "${dseg[1]:-?}" "$rank" "$topo" "$v" "${fseg[1]:-?}" "${fseg[2]:-${file}}" "$marker"
@@ -325,6 +419,14 @@ list_variants() {
       }
     }
   '
+  # Don't silently hide: one-line note when (and only when) the filter dropped
+  # something. No note under --all or when nothing was hidden.
+  if [[ "$_hidden" -gt 0 ]]; then
+    local _gpu_label
+    _gpu_label="$(topology_gpu_label "$detected_topo")"
+    echo
+    echo "(showing ${detected_topo}-GPU configs for this ${_gpu_label}-GPU machine — use --list --all for ${_topo_list})"
+  fi
   echo
   show_defaults_view
   echo
@@ -626,10 +728,16 @@ wait_ready() {
 WAIT=1
 FORCE="${FORCE:-0}"
 VARIANT=""
+LIST_REQUESTED=0
+LIST_ALL=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -h|--help) usage ;;
-    --list) list_variants ;;
+    # --list is deferred (not run inline) so `--list --all` works in either
+    # order; --all toggles the hardware filter off. --list-all is the sibling.
+    --list) LIST_REQUESTED=1 ;;
+    --all) LIST_ALL=1 ;;
+    --list-all) LIST_REQUESTED=1; LIST_ALL=1 ;;
     --defaults) defaults_view_standalone ;;
     --set-default)
       [[ -n "${2:-}" ]] || { echo "ERROR: --set-default needs a <slug> (e.g. vllm/dual)." >&2; exit 1; }
@@ -653,6 +761,17 @@ while [[ $# -gt 0 ]]; do
   esac
   shift
 done
+
+# --list (possibly with --all) is a terminal action — run it once, after the
+# whole arg vector is parsed, so order doesn't matter.
+if [[ "$LIST_REQUESTED" -eq 1 ]]; then
+  list_variants   # exits
+fi
+# --all only makes sense alongside --list / --list-all.
+if [[ "$LIST_ALL" -eq 1 ]]; then
+  echo "ERROR: --all only applies to --list (try: bash scripts/switch.sh --list --all)." >&2
+  exit 1
+fi
 
 [[ -n "$VARIANT" ]] || usage
 VARIANT="$(resolve_default_variant "$VARIANT")"

--- a/scripts/tests/test-list-topology-filter.sh
+++ b/scripts/tests/test-list-topology-filter.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# PR-C — hardware-aware --list topology filter.
+#
+# `switch.sh --list` should show only the topologies the machine can actually
+# run (single on a 1-GPU box; single+dual on a 2-GPU box; everything on 4+),
+# and `--list --all` / `--list-all` should always show everything. Detection
+# reads CUDA_VISIBLE_DEVICES (what switch_topology_from_gpus consults first),
+# so we simulate GPU counts by setting it. Fail-open: with no detection signal
+# at all, show everything. Must not regress PR-A health markers/grouping or
+# PR-B's Defaults view.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+# Keep the filter independent of whatever GPUs this host actually has and of a
+# stray .env pin: pin MODEL_DIR + force a known model. The filter is about
+# topology rank, not weights on disk.
+export MODEL_DIR="${MODEL_DIR:-/mnt/models/huggingface}"
+
+SWITCH="$ROOT_DIR/scripts/switch.sh"
+
+fail=0
+note() { echo "FAIL: $1" >&2; fail=1; }
+
+assert_contains() {
+  local hay="$1" needle="$2" msg="$3"
+  [[ "$hay" == *"$needle"* ]] || note "${msg}: output lacks '${needle}'"
+}
+assert_not_contains() {
+  local hay="$1" needle="$2" msg="$3"
+  [[ "$hay" != *"$needle"* ]] || note "${msg}: output unexpectedly contains '${needle}'"
+}
+
+# Count rows whose slug column matches a topology by grepping for the
+# topology's compose-file path segment in the *visible* listing. We assert on
+# slugs we know are bound to each topology in the shipped registry.
+SINGLE_SLUG="ik-llama/iq4ks-mtp"      # single
+DUAL_SLUG="vllm/dual"                 # dual
+MULTI_SLUG="vllm/dual4"              # multi4
+
+run_list() {
+  # $1 = CUDA_VISIBLE_DEVICES value (empty string → unset); rest = extra args.
+  local cuda="$1"; shift
+  if [[ -n "$cuda" ]]; then
+    CUDA_VISIBLE_DEVICES="$cuda" NVIDIA_VISIBLE_DEVICES="" bash "$SWITCH" "$@" 2>&1
+  else
+    NVIDIA_VISIBLE_DEVICES="" CUDA_VISIBLE_DEVICES="" bash "$SWITCH" "$@" 2>&1
+  fi
+}
+
+# --- 1 GPU: only single slugs, with the note --------------------------------
+out="$(run_list 0 --list)"
+assert_contains     "$out" "$SINGLE_SLUG" "1-GPU shows single slugs"
+assert_not_contains "$out" "$DUAL_SLUG"   "1-GPU hides dual slugs"
+assert_not_contains "$out" "$MULTI_SLUG"  "1-GPU hides multi4 slugs"
+assert_contains     "$out" "1-GPU machine" "1-GPU prints the filter note"
+assert_contains     "$out" "--list --all" "1-GPU note points at --all"
+assert_contains     "$out" "hidden — --all" "1-GPU header tallies hidden count"
+# PR-A / PR-B intact: health markers + grouping + Defaults view still render.
+assert_contains "$out" "Health: unmarked = production" "PR-A health legend present (1-GPU)"
+assert_contains "$out" "(caveats)" "PR-A caveats marker present (1-GPU)"
+assert_contains "$out" "(NA:" "PR-A NA marker present (1-GPU)"
+assert_contains "$out" "Defaults — what" "PR-B Defaults view present (1-GPU)"
+
+# --- 2 GPUs: single + dual, no multi4 ---------------------------------------
+out="$(run_list 0,1 --list)"
+assert_contains     "$out" "$SINGLE_SLUG" "2-GPU shows single slugs"
+assert_contains     "$out" "$DUAL_SLUG"   "2-GPU shows dual slugs"
+assert_not_contains "$out" "$MULTI_SLUG"  "2-GPU hides multi4 slugs"
+assert_contains     "$out" "2-GPU machine" "2-GPU prints the filter note"
+assert_contains     "$out" "multi4 hidden" "2-GPU note names multi4 as hidden"
+
+# --- --all on a 1-GPU box: everything, NO note ------------------------------
+out="$(run_list 0 --list --all)"
+assert_contains     "$out" "$SINGLE_SLUG" "--all shows single slugs"
+assert_contains     "$out" "$DUAL_SLUG"   "--all shows dual slugs"
+assert_contains     "$out" "$MULTI_SLUG"  "--all shows multi4 slugs"
+assert_not_contains "$out" "hidden — --all" "--all suppresses the hidden tally"
+assert_not_contains "$out" "GPU machine — use" "--all suppresses the filter note"
+
+# --- --list-all alias behaves identically to --list --all -------------------
+alias_out="$(run_list 0 --list-all)"
+assert_contains     "$alias_out" "$DUAL_SLUG"  "--list-all shows dual slugs"
+assert_contains     "$alias_out" "$MULTI_SLUG" "--list-all shows multi4 slugs"
+assert_not_contains "$alias_out" "GPU machine — use" "--list-all suppresses note"
+
+# --- order independence: --all --list == --list --all -----------------------
+reorder_out="$(run_list 0 --all --list)"
+assert_contains "$reorder_out" "$MULTI_SLUG" "--all --list (reordered) shows multi4"
+
+# --- --all without --list is rejected (not silently swallowed) --------------
+if guard_out="$(bash "$SWITCH" --all 2>&1)"; then
+  note "--all without --list unexpectedly succeeded"
+else
+  assert_contains "$guard_out" "--all only applies to --list" "--all-without-list error message"
+fi
+
+# --- fail-open: no selector + no nvidia-smi → show ALL, no note --------------
+# Build a minimal PATH that deliberately omits nvidia-smi so detection has no
+# signal; the filter must NOT hide dual/multi off a guess.
+TMPBIN="$(mktemp -d)"
+for b in bash sed awk sort cut tr wc env mktemp cat mv rm cp head tail printf grep python3 dirname docker curl jq; do
+  src="$(command -v "$b" 2>/dev/null)" && ln -sf "$src" "$TMPBIN/$b"
+done
+failopen_out="$(PATH="$TMPBIN" CUDA_VISIBLE_DEVICES="" NVIDIA_VISIBLE_DEVICES="" "$TMPBIN/bash" "$SWITCH" --list 2>&1)"
+rm -rf "$TMPBIN"
+assert_contains     "$failopen_out" "$DUAL_SLUG"  "fail-open shows dual slugs"
+assert_contains     "$failopen_out" "$MULTI_SLUG" "fail-open shows multi4 slugs"
+assert_not_contains "$failopen_out" "GPU machine — use" "fail-open prints no filter note"
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "[list-topology-filter] FAIL" >&2
+  exit 1
+fi
+echo "test-list-topology-filter: ok"


### PR DESCRIPTION
## What

`scripts/switch.sh --list` now filters to the topologies the machine can actually run, and adds an `--all` escape hatch.

- **Hardware filter:** detect GPU count → max runnable topology (single=1, dual=2, multi*=3+) via the existing `switch_topology_from_gpus` (reads `CUDA_VISIBLE_DEVICES`/`NVIDIA_VISIBLE_DEVICES`, then `nvidia-smi`). `--list` shows only slugs whose topology rank ≤ detected: 1 GPU → single only, 2 → single+dual, 4+ → everything.
- **`--all` / `--list-all`:** show every variant regardless of GPU count (discoverability for someone planning to add a card). `--list` is deferred until the whole arg vector is parsed, so `--list --all` works in either order. `--all` without `--list` is rejected with a clear error.
- **Don't silently hide:** when the filter drops anything, print a one-line note naming the detected GPU count and the exact hidden topologies (e.g. `(showing single-GPU configs for this 1-GPU machine — use --list --all for dual/multi4)`), plus a `(+N <topos> hidden — --all)` tally in the header. No note under `--all` or when nothing is hidden.
- **Fail-open:** if detection has no signal (no selector and no `nvidia-smi`), show ALL — never hide off a guessed "single" fallback.
- **Counts** (header total + per-model `(N variants)`) reflect the visible/filtered set. PR-A (#265) health markers + model·topology grouping and PR-B (#266) Defaults view are unchanged.

## Why

On a single-GPU box, `--list` previously showed dual/multi slugs that can't run there (need ≥2 GPUs) — pure noise. This filters them out by default while keeping full discoverability behind `--all`.

## Verification

- `bash -n scripts/switch.sh` clean.
- Simulated GPU counts via `CUDA_VISIBLE_DEVICES`:
  - `=0` → only `single` slugs + the note; no dual/multi rows.
  - `=0,1` → single + dual, no multi4; note names only `multi4` as hidden.
  - `=0 --list --all` → all 45 variants, no note.
  - `--list-all` alias, `--all --list` reorder, and the `--all`-without-`--list` guard all behave.
  - Fail-open (no selector + `nvidia-smi` off PATH) → all 45, no note.
  - Health markers, counts, and the Defaults view render in every case.
- New test `scripts/tests/test-list-topology-filter.sh` asserts the single-GPU filter hides dual/multi, `--all`/`--list-all` show them, order independence, the guard, and fail-open.
- Full suite (`for t in scripts/tests/test-*.sh; do bash "$t"; done`): **37 pass, 1 fail** — the single failure is `test-submit-bench.sh` (missing fixtures), which fails identically on the clean base (confirmed via stash), so it's pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)