### PR TITLE
chore: retire vllm-club3090 image references (stack on stock vLLM)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,8 @@ Pin engine images only when we vendor patches into the running container. Otherw
 
 When adding the first vendored patch to a previously-rolling engine: pin in the same commit. When dropping the last patch: unpin in the same commit. Bump pins via PR with a `verify-full.sh` + `bench.sh` re-run, never silently.
 
+**Delivery model (vLLM):** patches reach the container by **volume-mounting into the pinned *stock* `vllm/vllm-openai` image** (python sidecars / site-package overlays / install scripts — see `delivery_mechanism` in `scripts/lib/profiles/patches.yml`), **not** by baking a custom image. The older baked-image path (`ghcr.io/noonghunna/vllm-club3090`, which shipped the release images through `club-v0.8.3`) is **retired** — no compose or engine-pin references it, and the `dockerfile_bake` `delivery:` block in `patches.yml` is legacy/test-only. The GHCR package is kept as historical release artifacts (users pinned to a `club-v0.8.x` tag can still pull); it is not deleted and not produced by anything in-repo.
+
 ### CHANGELOG
 - `CHANGELOG.md` (cross-cutting) and `models/<name>/CHANGELOG.md` (per-model) are **append-only history**. Don't rewrite past entries even when a finding is superseded — add a new entry. The historical trail is load-bearing for "why did we do X."
 - Old entries can reference files / patches that no longer exist. That's fine — leave them.

--- a/scripts/tests/test-preflight-compose-deps.sh
+++ b/scripts/tests/test-preflight-compose-deps.sh
@@ -93,7 +93,7 @@ vllm_compose="${TMP_DIR}/gemma.yml"
 cat > "$vllm_compose" <<'YAML'
 services:
   vllm:
-    image: ghcr.io/noonghunna/vllm-club3090:latest
+    image: vllm/vllm-openai:v0.21.0
     command:
       - --model
       - /root/.cache/huggingface/gemma-4-31b-autoround-int4
@@ -118,7 +118,7 @@ extends_stub="${TMP_DIR}/stub.yml"
 cat > "$extends_base" <<'YAML'
 services:
   vllm-base:
-    image: ghcr.io/noonghunna/vllm-club3090:latest
+    image: vllm/vllm-openai:v0.21.0
     command:
       - --model
       - /root/.cache/huggingface/qwen3.6-27b-autoround-int4


### PR DESCRIPTION
## What
Tidy the now-orphaned `vllm-club3090` references. Investigation confirmed **every vLLM compose and engine-pin defaults to stock `vllm/vllm-openai`** (`nightly-${VLLM_NIGHTLY_SHA}` / `v0.21.0` / `v0.22.0`) — nothing builds, pulls, or defaults to the baked `vllm-club3090` image. The stack migrated to **stock image + volume-mounted patches**; the baked image is retired by disuse.

## Changes
- **`test-preflight-compose-deps.sh`** — repoint the two test-fixture composes off `ghcr.io/noonghunna/vllm-club3090:latest` → `vllm/vllm-openai:v0.21.0`. The image is incidental to the test (it asserts on missing model *weights*, not the image); verified the test still passes.
- **`AGENTS.md`** (engine-pinning section) — document the real delivery model: vLLM patches are volume-mounted into the pinned *stock* image (not baked); the `vllm-club3090` baked-image path is retired (no compose/engine-pin references it; the `dockerfile_bake` `delivery:` block is legacy/test-only). The GHCR package is **kept** as historical release artifacts (`club-v0.8.x` pulls still work) — not deleted, not produced in-repo.

## Deliberately left alone
- The `dockerfile_bake` legacy `delivery:` block in `patches.yml` + `patch_attribution.py`'s handling — marked read-only/test-only and **covered by `test-patch-attribution.sh`**; removing them is a separate patch-attribution refactor, not a tidy.
- The `vllm-club3090` GHCR package — released artifacts; deletion would break anyone pinned to a `club-v0.8.x` tag.

## Verification
Full `tests/` suite green except the pre-existing fixture-only `test-submit-bench`. `test-preflight-compose-deps` + `test-patch-attribution` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
