### PR TITLE
Align gemma sampling default to model card (top_k -1 → 64)

### DIFF
--- a/models/gemma-4-26b-a4b/vllm/compose/dual/autoround-int4-mixed/bf16.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/dual/autoround-int4-mixed/bf16.yml
@@ -92,7 +92,7 @@ services:
       - --
     command:
       - --override-generation-config
-      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:--1},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
+      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-64},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/gemma-4-26b-a4b/vllm/compose/dual/awq/bf16.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/dual/awq/bf16.yml
@@ -84,7 +84,7 @@ services:
       - --
     command:
       - --override-generation-config
-      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:--1},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
+      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-64},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/gemma-4-26b-a4b/vllm/compose/dual/awq/mtp.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/dual/awq/mtp.yml
@@ -74,7 +74,7 @@ services:
       - --
     command:
       - --override-generation-config
-      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:--1},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
+      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-64},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/gemma-4-26b-a4b/vllm/compose/single/autoround-int4-mixed/bf16.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/single/autoround-int4-mixed/bf16.yml
@@ -77,7 +77,7 @@ services:
               capabilities: [gpu]
     command:
       - --override-generation-config
-      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:--1},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
+      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-64},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/gemma-4-31b/vllm/compose/dual/autoround-int4/bf16-mtp.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/autoround-int4/bf16-mtp.yml
@@ -107,7 +107,7 @@ services:
       - --
     command:
       - --override-generation-config
-      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:--1},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
+      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-64},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/gemma-4-31b/vllm/compose/dual/autoround-int4/int8.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/autoround-int4/int8.yml
@@ -164,7 +164,7 @@ services:
       - --
     command:
       - --override-generation-config
-      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:--1},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
+      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-64},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port

--- a/models/gemma-4-31b/vllm/compose/single/autoround-int4/fp8-mtp.yml
+++ b/models/gemma-4-31b/vllm/compose/single/autoround-int4/fp8-mtp.yml
@@ -93,7 +93,7 @@ services:
     # upgrade dropped.
     command:
       - --override-generation-config
-      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:--1},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
+      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-64},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host
       - 0.0.0.0
       - --port


### PR DESCRIPTION
All 7 gemma vLLM composes forced `top_k: -1`, overriding the model's own `generation_config.json` recommendation of `top_k: 64` (both gemma-4-31b and gemma-4-26b-a4b specify 64). `top_k -1` + `temp 1.0` samples the full vocab tail and is more incoherence-prone; 64 truncates it per the model card.

**Not the #274 fix** — a live dual-3090 repro showed that bug's observable garble on a homogeneous rig is a first-request-after-boot warmup artifact that self-clears (reproduced at both top_k -1 and 64; clean at temp 0/0.6 and every call after the first), independent of top_k/temp/the #40391 overlay. #274's *persistent* case is a TP=2 all-reduce issue on a Thunderbolt mixed-GPU rig (out of our test envelope). This change is model-card hygiene, correct on its own. Suite 38/38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)