### PR TITLE
Bump vllm/minimal + vllm/dual to stable v0.22.0 (off nightly)

### DIFF
--- a/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml
@@ -61,7 +61,7 @@ services:
     # means no patch overlays are anchored here, so we ride stable releases.
     # Bump the tag to a newer stable after a verify-stress + soak gate.
     # Override with VLLM_IMAGE=... if you need a specific build.
-    image: ${VLLM_IMAGE:-vllm/vllm-openai:v0.21.0}
+    image: ${VLLM_IMAGE:-vllm/vllm-openai:v0.22.0}
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b-dual}"
     restart: "no"
     ports:

--- a/models/qwen3.6-27b/vllm/compose/single/autoround-int4/minimal.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/autoround-int4/minimal.yml
@@ -38,7 +38,7 @@
 # Tensor-parallel: 1
 services:
   vllm-qwen36-27b-minimal:
-    image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
+    image: ${VLLM_IMAGE:-vllm/vllm-openai:v0.22.0}
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b-minimal}"
     restart: "no"
     ports:
@@ -50,15 +50,10 @@ services:
       # Closes club-3090 #22.
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
-      # vLLM PR #35936 required-tool fallback (drop when upstream lands).
-      # vLLM PR #35936 required-tool fallback — sidecar pattern (drop when upstream lands).
-      # Bind-mounted at side paths so install.sh can copy into vLLM's site-packages
-      # BEFORE Genesis runs — avoids the RO-mount conflict with Genesis P64/P68/P69
-      # which write to chat_completion/serving.py at vllm-import time. See
-      # patches/vllm-pr35936-required-fallback/install.sh + README.md.
-      - ../../../patches/vllm-pr35936-required-fallback/vllm/entrypoints/openai/chat_completion/serving.py:/etc/club3090/pr35936-chat-completion-serving.py:ro
-      - ../../../patches/vllm-pr35936-required-fallback/vllm/entrypoints/openai/engine/serving.py:/etc/club3090/pr35936-engine-serving.py:ro
-      - ../../../patches/vllm-pr35936-required-fallback/install.sh:/etc/club3090/install-pr35936.sh:ro
+      # (vLLM PR #35936 required-tool-fallback overlay dropped 2026-05-31 with the
+      # move to stable v0.22.0 — its serving.py did `import vllm.beam_search`, removed
+      # in newer vLLM, so it crashes on v0.22.0; the bug it patched doesn't trip on
+      # current stable. See docs/UPSTREAM.md #35936.)
       # froggeric/Qwen-Fixed-Chat-Templates qwen3.6 — fixes 7 default-template
       # bugs (empty <think></think> spam, </thinking> hallucination, unclosed
       # think before tool call, no-user-query crash, developer role, etc.).
@@ -94,8 +89,6 @@ services:
       - |
         # VLLM_ENFORCE_EAGER=1 in .env disables CUDA graphs — use on
         # hardware where graph capture causes OOM or instability (e.g. WSL2).
-        # Install PR #35936 overlay before vllm imports (drop when upstream lands).
-        bash /etc/club3090/install-pr35936.sh
         exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} "$@"
       - --
     command:

--- a/scripts/tests/test-launch-compat.sh
+++ b/scripts/tests/test-launch-compat.sh
@@ -96,7 +96,7 @@ assert_contains "$out" "VLLM_IMAGE=vllm/vllm-openai:v0.21.0"
 
 if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
   out="$(VLLM_NIGHTLY_SHA="$CLEAN_SHA" docker compose -f "$ROOT_DIR/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml" config 2>/dev/null)"
-  assert_contains "$out" "image: vllm/vllm-openai:v0.21.0"
+  assert_contains "$out" "image: vllm/vllm-openai:v0.22.0"
 
   out="$(VLLM_NIGHTLY_SHA="$CLEAN_SHA" VLLM_IMAGE=vllm/vllm-openai:latest docker compose -f "$ROOT_DIR/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml" config 2>/dev/null)"
   assert_contains "$out" "image: vllm/vllm-openai:latest"


### PR DESCRIPTION
Moves the two **default** qwen3.6-27b vLLM composes off the purge-prone nightly (#167) onto immutable **v0.22.0** — the engine the 35B-A3B already runs on.

- **`vllm/minimal`**: `nightly → v0.22.0`; **dropped the PR-35936 overlay + its install** (its `serving.py` does `import vllm.beam_search`, removed in newer vLLM → would crash on v0.22.0; the bug it patched doesn't trip on current stable). Kept the froggeric chat template.
- **`vllm/dual`**: `v0.21.0 → v0.22.0` (already overlay-free since cf1f14f).

**Validated live on 2×3090, stock v0.22.0** (no Genesis, no source overlays):
| compose | engine | probes | VRAM |
|---|---|---|---|
| `vllm/minimal` TP=1 | v0.22.0 | 5/5 coherent | 21.1 GB |
| `vllm/dual` TP=2 + MTP n=3 | v0.22.0 | 5/5 coherent | 22.3 GB |

No first-call warmup garble. Confirms qwen-27b AutoRound INT4 + fp8 KV (**+ built-in MTP, no Genesis**) runs clean on stable v0.22.0 — the path off the nightly treadmill. Test-launch-compat v0.21.0→v0.22.0 expectation updated. **Suite 38/38.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)