### PR TITLE
switch.sh --list: show each slug's max context size

### DIFF
--- a/scripts/lib/registry-emit.sh
+++ b/scripts/lib/registry-emit.sh
@@ -52,6 +52,35 @@ def container_name(compose_path: str) -> str:
     return ""
 
 
+_CTX_ENV = re.compile(r"\$\{(?:MAX_MODEL_LEN|CTX_SIZE|CTX|MAX_CTX|N_CTX|MODEL_LEN)\s*:-\s*(\d+)\s*\}")
+_CTX_FLAG = re.compile(r"(?:--max-model-len|--ctx-size|--n-ctx|(?<!\w)-c)\s*\n?\s*\"?(\d{3,})")
+
+
+def compose_default_ctx(compose_path: str):
+    """The ctx the compose serves by DEFAULT (its ${VAR:-N} fallback or flag literal)."""
+    try:
+        txt = (root / compose_path).read_text()
+    except Exception:
+        return None
+    m = _CTX_ENV.search(txt) or _CTX_FLAG.search(txt)
+    return int(m.group(1)) if m else None
+
+
+def ctx_label(entry) -> str:
+    """Compact ctx label rounded to K. Single 'NK' when the registry max_ctx matches
+    the compose's default ctx; 'NK/MK' (validated registry / compose default) when
+    they drift — so the list surfaces registry<->compose context mismatches."""
+    reg = entry.get("max_ctx")
+    if not reg:
+        return ""
+    reg = int(reg)
+    comp = compose_default_ctx(entry["compose_path"])
+    label = f"{round(reg / 1000)}K"
+    if comp is not None and comp != reg:
+        label += f"/{round(comp / 1000)}K"
+    return label
+
+
 for key, entry in COMPOSE_REGISTRY.items():
     cp = entry["compose_path"]
     if "/compose/" not in cp:
@@ -80,9 +109,10 @@ for key, entry in COMPOSE_REGISTRY.items():
                 cname,
                 cp,
                 str(entry.get("status") or "production"),
-                # max_ctx as a compact label (262144 -> "262K"); empty if unset.
-                # Placed BEFORE status_note so status_note stays the LAST field.
-                (f"{int(entry['max_ctx']) // 1000}K" if entry.get("max_ctx") else ""),
+                # ctx label: 'NK' when registry max_ctx == compose default; 'NK/MK'
+                # (validated / compose) on drift. BEFORE status_note so the free-text
+                # note stays the LAST catch-all field.
+                ctx_label(entry),
                 # status_note is free text (may contain anything but a tab) — keep
                 # it as the LAST field so each reader's catch-all final var can
                 # absorb it without further splitting on its internal spaces.

--- a/scripts/lib/registry-emit.sh
+++ b/scripts/lib/registry-emit.sh
@@ -80,6 +80,9 @@ for key, entry in COMPOSE_REGISTRY.items():
                 cname,
                 cp,
                 str(entry.get("status") or "production"),
+                # max_ctx as a compact label (262144 -> "262K"); empty if unset.
+                # Placed BEFORE status_note so status_note stays the LAST field.
+                (f"{int(entry['max_ctx']) // 1000}K" if entry.get("max_ctx") else ""),
                 # status_note is free text (may contain anything but a tab) — keep
                 # it as the LAST field so each reader's catch-all final var can
                 # absorb it without further splitting on its internal spaces.
@@ -94,12 +97,15 @@ PY_EMIT
 }
 
 derive_switch_variant_tables() {
-  local root="$1" emit key switch_engine _launch_engine cdir cfile port _model _profile_engine _kvcalc _container _compose_path status status_note
+  local root="$1" emit key switch_engine _launch_engine cdir cfile port _model _profile_engine _kvcalc _container _compose_path status max_ctx status_note
+  # Self-declare so every caller (switch.sh + test-switch-registry-parity) gets a
+  # proper assoc array without each having to declare it.
+  declare -gA VARIANT_CTX
   if ! emit="$(registry_variant_rows "$root" 2>/dev/null)"; then
     echo "[switch] ERROR: could not derive variant tables from compose_registry.py" >&2
     exit 2
   fi
-  while IFS=$'\t' read -r kind key switch_engine _launch_engine cdir cfile port _model _profile_engine _kvcalc _container _compose_path status status_note; do
+  while IFS=$'\t' read -r kind key switch_engine _launch_engine cdir cfile port _model _profile_engine _kvcalc _container _compose_path status max_ctx status_note; do
     [[ -n "${kind:-}" ]] || continue
     case "$kind" in
       VARIANT)
@@ -111,6 +117,7 @@ derive_switch_variant_tables() {
         VARIANT_DEFAULT_PORT["$key"]="$port"
         VARIANT_STATUS["$key"]="${status:-production}"
         VARIANT_STATUS_NOTE["$key"]="${status_note:-}"
+        VARIANT_CTX["$key"]="${max_ctx:-}"
         ;;
     esac
   done <<< "$emit"
@@ -121,12 +128,12 @@ derive_switch_variant_tables() {
 }
 
 derive_launch_variant_tables() {
-  local root="$1" emit key _switch_engine launch_engine cdir cfile port model profile_engine kvcalc container _compose_path status status_note
+  local root="$1" emit key _switch_engine launch_engine cdir cfile port model profile_engine kvcalc container _compose_path status _max_ctx status_note
   if ! emit="$(registry_variant_rows "$root" 2>/dev/null)"; then
     echo "[launch] ERROR: could not derive variant tables from compose_registry.py" >&2
     exit 2
   fi
-  while IFS=$'\t' read -r kind key _switch_engine launch_engine cdir cfile port model profile_engine kvcalc container _compose_path status status_note; do
+  while IFS=$'\t' read -r kind key _switch_engine launch_engine cdir cfile port model profile_engine kvcalc container _compose_path status _max_ctx status_note; do
     [[ -n "${kind:-}" ]] || continue
     case "$kind" in
       VARIANT)

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -347,8 +347,8 @@ list_variants() {
     max_rank="$(topology_rank "$detected_topo")"
   fi
 
-  echo "Available variants — grouped by model · topology (right column: <quant>/<serving>.yml):"
-  echo "  Health: unmarked = production · (caveats) = works w/ documented limits · (NA: …) = needs --force"
+  echo "Available variants — grouped by model · topology (right cols: <quant>/<serving>.yml · max-ctx + health):"
+  echo "  Health: bare max-ctx = production · (caveats, <ctx>) = works w/ documented limits · (NA: …, <ctx>) = needs --force"
 
   # Counts: split into VISIBLE vs HIDDEN by the hardware filter, so the header
   # reflects what's actually shown (+ how many were hidden). Health split is
@@ -417,8 +417,8 @@ list_variants() {
         continue
       fi
       marker="$(status_marker "${VARIANT_STATUS[$v]:-production}")"
-      printf '%s\t%d\t%s\t%s\t%s/%s\t%s\n' \
-        "${dseg[1]:-?}" "$rank" "$topo" "$v" "${fseg[1]:-?}" "${fseg[2]:-${file}}" "$marker"
+      printf '%s\t%d\t%s\t%s\t%s/%s\t%s\t%s\n' \
+        "${dseg[1]:-?}" "$rank" "$topo" "$v" "${fseg[1]:-?}" "${fseg[2]:-${file}}" "$marker" "${VARIANT_CTX[$v]:-}"
     done
   } | sort -t$'\t' -k1,1 -k2,2n -k4,4 | awk -F'\t' '
     { rows[NR] = $0; cnt[$1]++ }
@@ -427,7 +427,12 @@ list_variants() {
         split(rows[i], f, "\t")
         if (f[1] != m) { printf "\n%s  (%d variants)\n", f[1], cnt[f[1]]; m = f[1]; t = "" }
         tl = (f[3] == t ? "" : f[3]); t = f[3]
-        printf "  %-8s %-34s %-36s %s\n", tl, f[4], f[5], f[6]
+        ann = f[6]; ctx = f[7]
+        if (ctx != "") {
+          if (ann == "") ann = ctx                  # production: bare max-ctx (stays "unmarked")
+          else sub(/\)$/, ", " ctx ")", ann)         # caveats / NA: fold ctx into the paren
+        }
+        printf "  %-8s %-34s %-36s %s\n", tl, f[4], f[5], ann
       }
     }
   '

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -349,6 +349,7 @@ list_variants() {
 
   echo "Available variants — grouped by model · topology (right cols: <quant>/<serving>.yml · max-ctx + health):"
   echo "  Health: bare max-ctx = production · (caveats, <ctx>) = works w/ documented limits · (NA: …, <ctx>) = needs --force"
+  echo "  Context: a single value = registry matches the compose default · 'A/B' = validated(registry)/compose-default mismatch"
 
   # Counts: split into VISIBLE vs HIDDEN by the hardware filter, so the header
   # reflects what's actually shown (+ how many were hidden). Health split is

--- a/scripts/tests/test-list-topology-filter.sh
+++ b/scripts/tests/test-list-topology-filter.sh
@@ -58,8 +58,8 @@ assert_contains     "$out" "1-GPU machine" "1-GPU prints the filter note"
 assert_contains     "$out" "--list --all" "1-GPU note points at --all"
 assert_contains     "$out" "hidden — --all" "1-GPU header tallies hidden count"
 # PR-A / PR-B intact: health markers + grouping + Defaults view still render.
-assert_contains "$out" "Health: unmarked = production" "PR-A health legend present (1-GPU)"
-assert_contains "$out" "(caveats)" "PR-A caveats marker present (1-GPU)"
+assert_contains "$out" "Health: bare max-ctx = production" "PR-A health legend present (1-GPU)"
+assert_contains "$out" "(caveats," "PR-A caveats marker present (1-GPU)"
 assert_contains "$out" "(NA:" "PR-A NA marker present (1-GPU)"
 assert_contains "$out" "Defaults — what" "PR-B Defaults view present (1-GPU)"
 


### PR DESCRIPTION
Adds the max context size to `switch.sh --list` so you can see what each slug serves at a glance.

**Format** — ctx in the rightmost column, next to the health status (your ask):
```
  single   beellama/dflash      beellama-q5ks-dflash/dflash.yml   (caveats, 102K)
           ik-llama/iq4ks-mtp   ubergarm-iq4ks/mtp.yml            200K
           vllm/minimal         autoround-int4/minimal.yml        32K
  dual     vllm/dual            autoround-int4/fp8-mtp.yml        262K
           vllm/dual-qwopus...  qwopus-bf16mtp/bf16-mtp.yml       (NA: preview, 262K)
```
- **production** → bare ctx (stays visually 'unmarked')
- **caveats / NA** → ctx folded into the health paren, comma-separated

**How:** `registry-emit.sh` threads `max_ctx` through the variant TSV as a compact label (`262144 → 262K`), placed *before* the free-text `status_note` (which must stay the last catch-all field). Both read loops updated; the switch loop self-declares + populates `VARIANT_CTX` (`declare -gA` so the parity test picks it up). `switch.sh` renders it; legend + the topology-filter test updated.

Label = each slug's **registry max_ctx** (the validated default) — so `vllm/gemma-int8` shows `98K` (its 262K is a `CTX=` override), not the headline.

Suite **38/38**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)