### PR TITLE
Operational robustness (#281): orphan-safe switch.sh · reboot-surviving vLLM · multi-GPU power sweep

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -180,6 +180,12 @@
 # HTTP 000 failures during benchmark runs.
 # BIND_HOST=127.0.0.1
 
+# Docker restart policy for launched model containers. Default: unless-stopped
+# — a stack started via launch.sh / switch.sh comes back automatically after a
+# host (VM / bare-metal) reboot, but stays down once you stop it (switch.sh
+# --down or docker stop). Set to "no" to opt out of auto-restart entirely.
+# CLUB3090_RESTART=unless-stopped
+
 
 # -----------------------------------------------------------------------------
 # verify-full.sh / verify-stress.sh

--- a/models/gemma-4-26b-a4b/vllm/compose/dual/autoround-int4-mixed/bf16.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/dual/autoround-int4-mixed/bf16.yml
@@ -48,7 +48,7 @@ services:
   vllm-gemma-4-26b-a4b-tp2:
     image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
     container_name: "${ESTATE_CONTAINER:-vllm-gemma-4-26b-a4b-tp2}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${ESTATE_PORT:-${PORT:-8041}}:8000"
     volumes:

--- a/models/gemma-4-26b-a4b/vllm/compose/dual/awq/bf16.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/dual/awq/bf16.yml
@@ -42,7 +42,7 @@ services:
   vllm-gemma-4-26b-a4b-awq-tp2:
     image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
     container_name: "${ESTATE_CONTAINER:-vllm-gemma-4-26b-a4b-awq-tp2}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${ESTATE_PORT:-${PORT:-8042}}:8000"
     volumes:

--- a/models/gemma-4-26b-a4b/vllm/compose/dual/awq/mtp.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/dual/awq/mtp.yml
@@ -35,7 +35,7 @@ services:
   vllm-gemma-4-26b-a4b-awq-mtp-tp2:
     image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
     container_name: "${ESTATE_CONTAINER:-vllm-gemma-4-26b-a4b-awq-mtp-tp2}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${ESTATE_PORT:-${PORT:-8043}}:8000"
     volumes:

--- a/models/gemma-4-26b-a4b/vllm/compose/single/autoround-int4-mixed/bf16.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/single/autoround-int4-mixed/bf16.yml
@@ -48,7 +48,7 @@ services:
   vllm-gemma-4-26b-a4b-tp1:
     image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
     container_name: "${ESTATE_CONTAINER:-vllm-gemma-4-26b-a4b-tp1}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${ESTATE_PORT:-${PORT:-8040}}:8000"
     volumes:

--- a/models/gemma-4-31b/vllm/compose/dual/autoround-int4/bf16-mtp.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/autoround-int4/bf16-mtp.yml
@@ -59,7 +59,7 @@ services:
   vllm-gemma-4-31b-mtp:
     image: ${VLLM_IMAGE:-vllm/vllm-openai:v0.22.0}
     container_name: "${ESTATE_CONTAINER:-vllm-gemma-4-31b-mtp}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${ESTATE_PORT:-${PORT:-8030}}:8000"
     volumes:

--- a/models/gemma-4-31b/vllm/compose/dual/autoround-int4/int8.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/autoround-int4/int8.yml
@@ -99,7 +99,7 @@ services:
   vllm-gemma-4-31b-mtp-int8:
     image: ${VLLM_IMAGE:-vllm/vllm-openai:v0.21.0}
     container_name: "${ESTATE_CONTAINER:-vllm-gemma-4-31b-mtp-int8}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${ESTATE_PORT:-${PORT:-8032}}:8000"
     volumes:

--- a/models/gemma-4-31b/vllm/compose/single/autoround-int4/fp8-mtp.yml
+++ b/models/gemma-4-31b/vllm/compose/single/autoround-int4/fp8-mtp.yml
@@ -66,7 +66,7 @@ services:
   vllm-gemma-4-31b-mtp-tp1:
     image: ${VLLM_IMAGE:-vllm/vllm-openai:v0.21.0}
     container_name: "${ESTATE_CONTAINER:-vllm-gemma-4-31b-mtp-tp1}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${ESTATE_PORT:-${PORT:-8031}}:8000"
     volumes:

--- a/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/bf16.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/bf16.yml
@@ -33,7 +33,7 @@ services:
     # drift between Qwen and Gemma legs.
     image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b-dual-bf16}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8012}}:8000"
     volumes:

--- a/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/dflash-noviz.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/dflash-noviz.yml
@@ -53,7 +53,7 @@ services:
   vllm-qwen36-27b-dual-dflash:
     image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b-dual-dflash-noviz}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8013}}:8000"
     volumes:

--- a/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/dflash.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/dflash.yml
@@ -77,7 +77,7 @@ services:
   vllm-qwen36-27b-dual-dflash:
     image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b-dual-dflash}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8012}}:8000"
     volumes:

--- a/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml
@@ -64,7 +64,7 @@ services:
     # Override with VLLM_IMAGE=... if you need a specific build.
     image: ${VLLM_IMAGE:-vllm/vllm-openai:v0.22.0}
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b-dual}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8010}}:8000"
     volumes:

--- a/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/int8.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/int8.yml
@@ -33,7 +33,7 @@ services:
     # drift between Qwen and Gemma legs.
     image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b-dual-int8}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8011}}:8000"
     volumes:

--- a/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/tq3-mtp-genesis.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/tq3-mtp-genesis.yml
@@ -81,7 +81,7 @@ services:
     # post-#41434 main, then re-evaluate.
     image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b-dual-tq3-mtp-genesis}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8015}}:8000"
     volumes:

--- a/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/tq3-mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/tq3-mtp.yml
@@ -76,7 +76,7 @@ services:
     # drift between Qwen and Gemma legs.
     image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b-dual-int8-tq3}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8013}}:8000"
     volumes:

--- a/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/tq3-nomtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/tq3-nomtp.yml
@@ -49,7 +49,7 @@ services:
     # drift between Qwen and Gemma legs.
     image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b-dual-int8-tq3-nomtp}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8014}}:8000"
     volumes:

--- a/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/turbo.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/turbo.yml
@@ -54,7 +54,7 @@ services:
   vllm-qwen36-27b-dual-turbo:
     image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b-dual-turbo}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8011}}:8000"
     volumes:

--- a/models/qwen3.6-27b/vllm/compose/dual/carnice-bf16mtp/bf16-mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/carnice-bf16mtp/bf16-mtp.yml
@@ -57,7 +57,7 @@ services:
   vllm-carnice-bf16mtp:
     image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
     container_name: "${ESTATE_CONTAINER:-vllm-carnice-bf16mtp}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8070}}:8000"
     volumes:

--- a/models/qwen3.6-27b/vllm/compose/dual/qwopus-bf16mtp/bf16-mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/qwopus-bf16mtp/bf16-mtp.yml
@@ -42,7 +42,7 @@ services:
   vllm-qwopus-bf16mtp:
     image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
     container_name: "${ESTATE_CONTAINER:-vllm-qwopus-bf16mtp}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${ESTATE_PORT:-${PORT:-8071}}:8000"
     volumes:

--- a/models/qwen3.6-27b/vllm/compose/multi4/autoround-int4/dflash.yml
+++ b/models/qwen3.6-27b/vllm/compose/multi4/autoround-int4/dflash.yml
@@ -69,7 +69,7 @@ services:
   vllm-qwen36-27b-multi4-dflash:
     image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b-multi4-dflash}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8016}}:8000"
     volumes:

--- a/models/qwen3.6-27b/vllm/compose/multi4/autoround-int4/fp8-mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/multi4/autoround-int4/fp8-mtp.yml
@@ -70,7 +70,7 @@ services:
     # ride the wave.
     image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b-multi4}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8015}}:8000"
     volumes:

--- a/models/qwen3.6-27b/vllm/compose/single/autoround-int4/bounded-thinking.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/autoround-int4/bounded-thinking.yml
@@ -138,7 +138,7 @@ services:
   vllm-qwen36-27b-bounded-thinking:
     image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b-bounded-thinking}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8020}}:8000"
     volumes:

--- a/models/qwen3.6-27b/vllm/compose/single/autoround-int4/long-text-no-mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/autoround-int4/long-text-no-mtp.yml
@@ -118,7 +118,7 @@ services:
   vllm-qwen36-27b-long-text-no-mtp:
     image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b-long-text-no-mtp}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8021}}:8000"
     volumes:

--- a/models/qwen3.6-27b/vllm/compose/single/autoround-int4/long-text.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/autoround-int4/long-text.yml
@@ -128,7 +128,7 @@ services:
   vllm-qwen36-27b-long-text:
     image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b-long-text}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8020}}:8000"
     volumes:

--- a/models/qwen3.6-27b/vllm/compose/single/autoround-int4/long-vision.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/autoround-int4/long-vision.yml
@@ -104,7 +104,7 @@ services:
   vllm-qwen36-27b-long-vision:
     image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b-long-vision}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8020}}:8000"
     volumes:

--- a/models/qwen3.6-27b/vllm/compose/single/autoround-int4/minimal.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/autoround-int4/minimal.yml
@@ -40,7 +40,7 @@ services:
   vllm-qwen36-27b-minimal:
     image: ${VLLM_IMAGE:-vllm/vllm-openai:v0.22.0}
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b-minimal}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8020}}:8000"
     volumes:

--- a/models/qwen3.6-27b/vllm/compose/single/autoround-int4/tools-text.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/autoround-int4/tools-text.yml
@@ -42,7 +42,7 @@ services:
   vllm-qwen36-27b:
     image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8020}}:8000"
     volumes:

--- a/models/qwen3.6-27b/vllm/compose/single/autoround-int4/tq3-mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/autoround-int4/tq3-mtp.yml
@@ -104,7 +104,7 @@ services:
   vllm-qwen36-27b:
     image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8020}}:8000"
     volumes:

--- a/models/qwen3.6-35b-a3b/vllm/compose/dual/autoround-int4/fp8.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/dual/autoround-int4/fp8.yml
@@ -61,7 +61,7 @@ services:
     # tracked in club-3090 #254.) Override with VLLM_IMAGE=... for a specific build.
     image: ${VLLM_IMAGE:-vllm/vllm-openai:v0.22.0}
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-35b-a3b-dual}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8051}}:8000"
     volumes:

--- a/models/qwen3.6-35b-a3b/vllm/compose/single/autoround-int4/preview.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/single/autoround-int4/preview.yml
@@ -52,7 +52,7 @@ services:
   vllm-qwen36-35b-a3b-preview:
     image: ${VLLM_IMAGE:-vllm/vllm-openai:nightly-${VLLM_NIGHTLY_SHA}}
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-35b-a3b-preview}"
-    restart: "no"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8050}}:8000"
     volumes:

--- a/scripts/lib/generate_compose.py
+++ b/scripts/lib/generate_compose.py
@@ -911,7 +911,7 @@ def generate_from_profile(root: Path, einput) -> tuple[str, dict]:
         f"  {svc}:",
         f"    image: {image}",
         f'    container_name: "${{ESTATE_CONTAINER:-{svc}}}"',
-        '    restart: "no"',
+        "    restart: ${CLUB3090_RESTART:-unless-stopped}",
         "    ports:",
         f'      - "${{BIND_HOST:-0.0.0.0}}:${{ESTATE_PORT:-${{PORT:-{port}}}}}:8000"',
         "    volumes:",

--- a/scripts/lib/registry-emit.sh
+++ b/scripts/lib/registry-emit.sh
@@ -127,15 +127,16 @@ PY_EMIT
 }
 
 derive_switch_variant_tables() {
-  local root="$1" emit key switch_engine _launch_engine cdir cfile port _model _profile_engine _kvcalc _container _compose_path status max_ctx status_note
-  # Self-declare so every caller (switch.sh + test-switch-registry-parity) gets a
-  # proper assoc array without each having to declare it.
-  declare -gA VARIANT_CTX
+  local root="$1" emit key switch_engine _launch_engine cdir cfile port _model _profile_engine _kvcalc container _compose_path status max_ctx status_note
+  # Self-declare so every caller (switch.sh + test-switch-registry-parity) gets
+  # proper assoc arrays without each having to declare them. VARIANT_CONTAINER
+  # (slug -> container name) drives switch.sh's registry-derived orphan teardown.
+  declare -gA VARIANT_CTX VARIANT_CONTAINER
   if ! emit="$(registry_variant_rows "$root" 2>/dev/null)"; then
     echo "[switch] ERROR: could not derive variant tables from compose_registry.py" >&2
     exit 2
   fi
-  while IFS=$'\t' read -r kind key switch_engine _launch_engine cdir cfile port _model _profile_engine _kvcalc _container _compose_path status max_ctx status_note; do
+  while IFS=$'\t' read -r kind key switch_engine _launch_engine cdir cfile port _model _profile_engine _kvcalc container _compose_path status max_ctx status_note; do
     [[ -n "${kind:-}" ]] || continue
     case "$kind" in
       VARIANT)
@@ -148,6 +149,7 @@ derive_switch_variant_tables() {
         VARIANT_STATUS["$key"]="${status:-production}"
         VARIANT_STATUS_NOTE["$key"]="${status_note:-}"
         VARIANT_CTX["$key"]="${max_ctx:-}"
+        VARIANT_CONTAINER["$key"]="${container:-}"
         ;;
     esac
   done <<< "$emit"

--- a/scripts/power-cap-sweep.sh
+++ b/scripts/power-cap-sweep.sh
@@ -137,6 +137,8 @@ set -euo pipefail
 
 # Defaults — override via flags
 GPU_INDEX=0
+GPU_INDEX_SET=0      # set to 1 once --gpu is explicitly passed (distinguishes from the default 0)
+GPUS=""              # explicit --gpus a,b list; empty → auto-detect the workload's GPUs
 CAPS=""              # empty → auto-derive from card's min/max power limits at STEP_SIZE granularity
 RESET=1              # 1 = reset to stock at end; 0 = leave at last cap
 COOLING="unspecified" # air|water|aio|unspecified — affects how to read the data
@@ -165,7 +167,8 @@ INCLUDE_COMMIT=0      # --include-commit stamps the club-3090 git short SHA in
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --gpu)         GPU_INDEX="$2"; shift 2 ;;
+    --gpu)         GPU_INDEX="$2"; GPU_INDEX_SET=1; shift 2 ;;
+    --gpus)        GPUS="$2"; shift 2 ;;
     --caps)        CAPS="$2"; shift 2 ;;
     --cooling)     COOLING="$2"; shift 2 ;;
     --step-size)   STEP_SIZE="$2"; shift 2 ;;
@@ -252,6 +255,94 @@ if [ "$COOLING" = "unspecified" ]; then
   echo
 fi
 
+# --- Multi-GPU helpers -------------------------------------------------------
+# A TP=N serving workload spans several cards, so the sweep operates on a SET of
+# GPUs, not a single index. These helpers resolve that set, capture each card's
+# envelope, aggregate per-tick power across cards, and restore caps on exit.
+
+gpu_indices_from_container() {
+  # Echo the comma-separated GPU indices a container is pinned to, or "" if it
+  # uses all GPUs / can't be determined (caller then falls back to all GPUs).
+  local c="$1" nvd
+  nvd="$(docker inspect "$c" 2>/dev/null \
+    | grep -o 'NVIDIA_VISIBLE_DEVICES=[^"]*' | head -1 | cut -d= -f2)"
+  case "${nvd:-}" in
+    ""|all|void|none) echo "" ;;
+    *) echo "$nvd" | tr -d ' ' ;;
+  esac
+}
+
+resolve_gpu_indices() {
+  # Echo the comma-separated set of GPUs to sweep. Precedence:
+  #   --gpus a,b  >  --gpu N  >  container-detected  >  all GPUs (warn).
+  local csv=""
+  if [ -n "${GPUS:-}" ]; then
+    csv="$GPUS"
+  elif [ "${GPU_INDEX_SET:-0}" -eq 1 ]; then
+    csv="$GPU_INDEX"
+  elif [ -n "${CONTAINER:-}" ] && [ "${CONTAINER}" != "none" ]; then
+    csv="$(gpu_indices_from_container "$CONTAINER")"
+  fi
+  if [ -z "$csv" ]; then
+    csv="$(nvidia-smi --query-gpu=index --format=csv,noheader 2>/dev/null | tr -d ' ' | paste -sd, -)"
+    [ -n "$csv" ] && echo "[warn] could not scope the workload's GPUs — sweeping ALL GPUs (${csv}). Pass --gpus a,b to scope." >&2
+  fi
+  echo "$csv" | tr -d ' '
+}
+
+aggregate_gpu_sample() {
+  # Collapse N per-GPU nvidia-smi CSV lines (one sampler tick) into ONE synthetic
+  # line: power.draw SUMMED, utilization/temp MAX, throttle reasons OR'd,
+  # clocks/pstate from the first card. Keeps the same 9-field schema the
+  # downstream median/throttle post-processing expects — so multi-GPU needs no
+  # change there. For a single GPU it is a pass-through (sum == that GPU).
+  awk -F',' '
+    { for (i = 1; i <= NF; i++) gsub(/^[ \t]+|[ \t]+$/, "", $i)
+      sumP += $3 + 0
+      if (($2 + 0) > maxU) maxU = $2 + 0
+      if (($4 + 0) > maxT) maxT = $4 + 0
+      if (NR == 1) { sm = $5; mem = $6; ps = $7 }
+      if ($8 == "Active") pwr = "Active"
+      if ($9 == "Active") therm = "Active"
+      n++ }
+    END { if (n > 0) printf "agg, %d, %.2f, %d, %s, %s, %s, %s, %s\n",
+            maxU, sumP, maxT, sm, mem, ps,
+            (pwr == "Active" ? "Active" : "Not Active"),
+            (therm == "Active" ? "Active" : "Not Active") }'
+}
+
+capture_envelopes() {
+  # Populate INIT_ARR[idx] (current power.limit — for --no-reset restore) and
+  # STOCK_ARR[idx] (factory default_limit — for the default reset) for every GPU
+  # in GPU_INDICES, and derive the SYMMETRIC sweep range as the intersection of
+  # all cards' envelopes: floor = max of per-card mins, ceiling = min of per-card
+  # maxes, so a single cap value is valid on every card. STOCK_TDP (used only for
+  # the 50%-of-stock floor) takes the lowest card's default.
+  local idx mn mx df lim
+  MIN_LIMIT=""; MAX_LIMIT=""; STOCK_TDP=""
+  for idx in "${GPU_INDICES[@]}"; do
+    df=$(nvidia-smi --query-gpu=power.default_limit --format=csv,noheader,nounits -i "$idx" | head -1 | tr -d ' ')
+    mn=$(nvidia-smi --query-gpu=power.min_limit     --format=csv,noheader,nounits -i "$idx" | head -1 | tr -d ' ')
+    mx=$(nvidia-smi --query-gpu=power.max_limit     --format=csv,noheader,nounits -i "$idx" | head -1 | tr -d ' ')
+    lim=$(nvidia-smi --query-gpu=power.limit        --format=csv,noheader,nounits -i "$idx" | head -1 | tr -d ' ')
+    INIT_ARR[$idx]="$lim"
+    STOCK_ARR[$idx]="$df"
+    if [ -z "$MIN_LIMIT" ] || awk "BEGIN{exit !($mn > $MIN_LIMIT)}"; then MIN_LIMIT="$mn"; fi
+    if [ -z "$MAX_LIMIT" ] || awk "BEGIN{exit !($mx < $MAX_LIMIT)}"; then MAX_LIMIT="$mx"; fi
+    if [ -z "$STOCK_TDP" ] || awk "BEGIN{exit !($df < $STOCK_TDP)}"; then STOCK_TDP="$df"; fi
+  done
+}
+
+restore_gpus() {
+  # On end/exit: RESET=1 (default) → set each GPU to its factory stock; --no-reset
+  # (RESET=0) → restore each GPU to the limit it had when the sweep started.
+  local idx target
+  for idx in "${GPU_INDICES[@]}"; do
+    if [ "${RESET:-1}" -eq 1 ]; then target="${STOCK_ARR[$idx]:-}"; else target="${INIT_ARR[$idx]:-}"; fi
+    [ -n "$target" ] && nvidia-smi -pl "$target" -i "$idx" >/dev/null 2>&1 || true
+  done
+}
+
 # Sanity checks
 if [ "$EUID" -ne 0 ]; then
   echo "[error] must run as root (nvidia-smi -pl requires sudo)" >&2
@@ -308,12 +399,22 @@ fi
 export URL CONTAINER MODEL
 echo "[setup] target:   container=$CONTAINER url=$URL model=$MODEL"
 
-# Capture card's power envelope (so we can reset cleanly + auto-derive sweep range)
-STOCK_TDP=$(nvidia-smi --query-gpu=power.default_limit --format=csv,noheader,nounits -i "$GPU_INDEX" | head -1 | tr -d ' ')
-MIN_LIMIT=$(nvidia-smi --query-gpu=power.min_limit     --format=csv,noheader,nounits -i "$GPU_INDEX" | head -1 | tr -d ' ')
-MAX_LIMIT=$(nvidia-smi --query-gpu=power.max_limit     --format=csv,noheader,nounits -i "$GPU_INDEX" | head -1 | tr -d ' ')
-GPU_NAME=$(nvidia-smi --query-gpu=name                  --format=csv,noheader            -i "$GPU_INDEX" | head -1)
-GPU_VRAM=$(nvidia-smi --query-gpu=memory.total          --format=csv,noheader,nounits     -i "$GPU_INDEX" | head -1 | tr -d ' ')
+# Resolve the set of GPUs to sweep (a TP=N workload spans several cards).
+GPU_LIST_CSV="$(resolve_gpu_indices)"
+IFS=',' read -ra GPU_INDICES <<< "$GPU_LIST_CSV"
+if [ "${#GPU_INDICES[@]}" -eq 0 ] || [ -z "${GPU_INDICES[0]:-}" ]; then
+  echo "[error] could not determine which GPU(s) to sweep — pass --gpus 0,1 (or --gpu N)." >&2
+  exit 1
+fi
+PRIMARY_GPU="${GPU_INDICES[0]}"
+declare -A INIT_ARR=() STOCK_ARR=()
+echo "[setup] GPUs:     ${GPU_LIST_CSV}"
+
+# Capture each card's power envelope: per-GPU INIT/STOCK arrays + the intersected
+# symmetric sweep range (MIN_LIMIT/MAX_LIMIT/STOCK_TDP). See capture_envelopes().
+capture_envelopes
+GPU_NAME=$(nvidia-smi --query-gpu=name         --format=csv,noheader        -i "$PRIMARY_GPU" | head -1)
+GPU_VRAM=$(nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits -i "$PRIMARY_GPU" | head -1 | tr -d ' ')
 
 SAMPLER_PID=""
 cleanup() {
@@ -332,8 +433,8 @@ cleanup() {
   # (SIGKILL bypasses this trap entirely — that's a kernel-level guarantee.)
   pkill -TERM -P $$ 2>/dev/null || true
 
-  if [ "${RESET:-1}" -eq 1 ] && [ -n "${STOCK_TDP:-}" ]; then
-    nvidia-smi -pl "$STOCK_TDP" -i "$GPU_INDEX" >/dev/null 2>&1 || true
+  if [ -n "${GPU_LIST_CSV:-}" ]; then
+    restore_gpus
   fi
 }
 trap cleanup EXIT INT TERM
@@ -673,7 +774,7 @@ run_concurrency_probe() {
   (
     while true; do
       nvidia-smi --query-gpu=index,utilization.gpu,power.draw,temperature.gpu \
-        --format=csv,noheader,nounits -i "$GPU_INDEX" 2>/dev/null | head -1
+        --format=csv,noheader,nounits -i "$PRIMARY_GPU" 2>/dev/null | head -1
       sleep 0.25
     done
   ) > "$sample_file" &
@@ -834,7 +935,7 @@ PY
 
 # Persistence mode (one-time; idempotent). Do this before optional
 # auto-calibration so clocks/caps behave consistently during probes.
-nvidia-smi -pm 1 -i "$GPU_INDEX" >/dev/null 2>&1 || true
+for _gi in "${GPU_INDICES[@]}"; do nvidia-smi -pm 1 -i "$_gi" >/dev/null 2>&1 || true; done
 
 if [ "$LOAD_MODE" = "decode-concurrent" ] && [ "$CONCURRENCY_AUTO" -eq 1 ]; then
   echo "[calibrate] --concurrency auto: probing stream count at ${HIGHEST_CAP}W cap"
@@ -843,7 +944,7 @@ import sys
 print(f"{float(sys.argv[1]) * 100:.0f}%")
 PY
 ) of cap; max probe concurrency: ${MAX_CONCURRENCY_PROBE}"
-  nvidia-smi -pl "$HIGHEST_CAP" -i "$GPU_INDEX" >/dev/null
+  for _gi in "${GPU_INDICES[@]}"; do nvidia-smi -pl "$HIGHEST_CAP" -i "$_gi" >/dev/null; done
   sleep 2
 
   CAL_DIR=$(mktemp -d /tmp/power-cap-autoload.XXXXXX)
@@ -980,7 +1081,7 @@ if [ "$LOAD_MODE" = "prefill-heavy" ]; then
       echo "[calibrate] could not detect model context — proceeding without clamp (set MODEL_MAX_CTX env if needed)"
     fi
     echo "[calibrate] prefill-heavy: sizing prompt at ${HIGHEST_CAP}W cap for ~${TARGET_PREFILL_SECONDS}s at the fastest cap"
-    nvidia-smi -pl "$HIGHEST_CAP" -i "$GPU_INDEX" >/dev/null
+    for _gi in "${GPU_INDICES[@]}"; do nvidia-smi -pl "$HIGHEST_CAP" -i "$_gi" >/dev/null; done
     sleep 2
     CAL_LOG="/tmp/power-cap-prefill-calibration.log"
     : > "$CAL_LOG"
@@ -1026,7 +1127,7 @@ PY
   fi
 fi
 
-echo "[setup] GPU $GPU_INDEX: $GPU_NAME ($GPU_VRAM MiB)"
+echo "[setup] GPUs ${GPU_LIST_CSV}: $GPU_NAME ($GPU_VRAM MiB)"
 echo "[setup] power envelope: ${MIN_LIMIT}W (min) → ${STOCK_TDP}W (default) → ${MAX_LIMIT}W (max)"
 echo "[setup] cooling:   $COOLING"
 if [ "$AUTO_DERIVED" -eq 1 ]; then
@@ -1120,7 +1221,7 @@ fi
 # Sweep
 RESULTS_FILE=/tmp/power-cap-summary.md
 {
-  echo "# Power-cap sweep — $GPU_NAME (GPU $GPU_INDEX)"
+  echo "# Power-cap sweep — $GPU_NAME (GPUs $GPU_LIST_CSV)"
   echo ""
   echo "**GPU:** $GPU_NAME &nbsp; **VRAM:** ${GPU_VRAM} MiB &nbsp; **Stock TDP:** ${STOCK_TDP}W &nbsp; **Cooling:** ${COOLING}"
   echo "**Model:** \`${MODEL}\` &nbsp; **Engine:** \`${CONTAINER}\` &nbsp; **Endpoint:** ${URL}"
@@ -1160,17 +1261,21 @@ for CAP in "${CAP_ARRAY[@]}"; do
   CAP_START_NS=$(date +%s%N)
   CAP_START_UTC=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   echo "================================================"
-  echo "=== Cap: ${CAP}W (GPU $GPU_INDEX) @ ${CAP_START_UTC} ==="
+  echo "=== Cap: ${CAP}W (GPUs $GPU_LIST_CSV) @ ${CAP_START_UTC} ==="
   echo "================================================"
 
-  # Apply cap
-  if ! nvidia-smi -pl "$CAP" -i "$GPU_INDEX" 2>&1 | tail -1; then
-    echo "[warn] failed to set ${CAP}W — skipping"
+  # Apply cap to every participating GPU (symmetric sweep)
+  _cap_ok=1
+  for _gi in "${GPU_INDICES[@]}"; do
+    nvidia-smi -pl "$CAP" -i "$_gi" >/dev/null 2>&1 || _cap_ok=0
+  done
+  if [ "$_cap_ok" -ne 1 ]; then
+    echo "[warn] failed to set ${CAP}W on one or more GPUs — skipping"
     continue
   fi
 
   # Verify cap applied
-  ACTUAL_LIMIT=$(nvidia-smi --query-gpu=power.limit --format=csv,noheader,nounits -i "$GPU_INDEX" | head -1 | tr -d ' ')
+  ACTUAL_LIMIT=$(nvidia-smi --query-gpu=power.limit --format=csv,noheader,nounits -i "$PRIMARY_GPU" | head -1 | tr -d ' ')
   echo "[verify] limit set to: ${ACTUAL_LIMIT}W"
   echo
 
@@ -1187,7 +1292,7 @@ for CAP in "${CAP_ARRAY[@]}"; do
   (
     while true; do
       nvidia-smi --query-gpu=index,utilization.gpu,power.draw,temperature.gpu,clocks.current.sm,clocks.current.memory,pstate,clocks_throttle_reasons.sw_power_cap,clocks_throttle_reasons.hw_thermal_slowdown \
-        --format=csv,noheader,nounits -i "$GPU_INDEX" 2>/dev/null | head -1
+        --format=csv,noheader,nounits -i "$GPU_LIST_CSV" 2>/dev/null | aggregate_gpu_sample
       sleep 0.5
     done
   ) > "$SAMPLE_FILE" &
@@ -1377,7 +1482,7 @@ else:
 
   # Fallback to bench.sh GPU-state line if sampler returned ?
   if [ "$ACTUAL_POWER" = "?" ]; then
-    GPU_STATE_LINE=$(grep -A2 "GPU state" "$LOG_FILE" | grep ",$GPU_INDEX," | head -1 || grep -A2 "GPU state" "$LOG_FILE" | grep "^${GPU_INDEX}," | head -1 || echo "")
+    GPU_STATE_LINE=$(grep -A2 "GPU state" "$LOG_FILE" | grep ",$PRIMARY_GPU," | head -1 || grep -A2 "GPU state" "$LOG_FILE" | grep "^${PRIMARY_GPU}," | head -1 || echo "")
     ACTUAL_POWER=$(echo "$GPU_STATE_LINE" | awk -F', ' '{print $5}' | grep -oE '[0-9]+\.?[0-9]*' | head -1 || echo "?")
     GPU_TEMP=$(echo "$GPU_STATE_LINE"     | awk -F', ' '{print $6}' | tr -d ' ' || echo "?")
   fi
@@ -1495,11 +1600,11 @@ fi
 
 # Reset
 if [ "$RESET" -eq 1 ]; then
-  echo "[reset] restoring GPU $GPU_INDEX to stock TDP (${STOCK_TDP}W)"
-  nvidia-smi -pl "$STOCK_TDP" -i "$GPU_INDEX" 2>&1 | tail -1
+  echo "[reset] restoring GPUs ${GPU_LIST_CSV} to stock TDP"
 else
-  echo "[reset] --no-reset specified; GPU $GPU_INDEX left at last cap"
+  echo "[reset] --no-reset: restoring GPUs ${GPU_LIST_CSV} to their pre-sweep limits"
 fi
+restore_gpus
 
 # Append context to results file
 {
@@ -1514,7 +1619,7 @@ fi
     done <<< "$PLATEAU_LINES"
     echo ""
   fi
-  echo "**Reset:** $([ $RESET -eq 1 ] && echo "auto-reset to ${STOCK_TDP}W stock" || echo "left at last cap (--no-reset)")"
+  echo "**Reset:** $([ $RESET -eq 1 ] && echo "auto-reset to per-GPU stock" || echo "restored to pre-sweep limits (--no-reset)")"
   echo ""
   echo "**Notes:**"
   case "$LOAD_MODE" in

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -112,15 +112,14 @@ declare -A VARIANT_DEFAULT_PORT=()
 declare -A VARIANTS=()
 declare -A VARIANT_STATUS=()
 declare -A VARIANT_STATUS_NOTE=()
+declare -A VARIANT_CONTAINER=()
 # shellcheck source=lib/registry-emit.sh
 source "${ROOT_DIR}/scripts/lib/registry-emit.sh"
 derive_switch_variant_tables "${ROOT_DIR}"
 
-# Container name patterns we'll bring down — covers all current composes
-# AND any vllm/llama-cpp container we don't formally know about (catches
-# locally-built variants and one-off `docker run` instances that would
-# otherwise pin GPU memory invisibly to switch.sh).
-RUNNING_PATTERN="^(vllm-|llama-cpp-)"
+# Teardown is registry-derived from VARIANT_CONTAINER (see down_running()). This
+# replaced a fixed `^(vllm-|llama-cpp-)` regex that missed beellama-/ik-llama-/
+# sglang- containers and leaked their VRAM across switches (#281).
 
 
 PRIMARY_MODEL="${PRIMARY_MODEL:-qwen3.6-27b}"
@@ -500,24 +499,37 @@ defaults_view_standalone() {
 }
 
 down_running() {
-  local running
-  running=$(docker ps --format '{{.Names}}' 2>/dev/null | grep -E "$RUNNING_PATTERN" || true)
-  if [[ -z "$running" ]]; then
-    echo "[switch] no club-3090 container running"
-    return
-  fi
+  # Closed-world teardown: bring down ONLY containers switch.sh manages — those
+  # whose name is in the registry-derived VARIANT_CONTAINER set — each via its
+  # own compose file (+ --remove-orphans). Containers we don't manage (the
+  # auxiliary services stack, estate instances with a distinct ESTATE_CONTAINER
+  # name, unrelated user containers) are left untouched; gpu_preflight() is the
+  # safety net for any non-managed process still pinning the GPU. This catches
+  # beellama-/ik-llama-/sglang- containers the old prefix regex missed (#281).
+  local running c
+  running=$(docker ps --format '{{.Names}}' 2>/dev/null || true)
+  # Set of container names we manage (deduped, non-empty values of the map).
+  local -A managed=()
+  local slug
+  for slug in "${!VARIANT_CONTAINER[@]}"; do
+    [[ -n "${VARIANT_CONTAINER[$slug]}" ]] && managed["${VARIANT_CONTAINER[$slug]}"]=1
+  done
+  local brought_down=0
   for c in $running; do
+    [[ -n "${managed[$c]:-}" ]] || continue   # not ours — leave it alone
+    brought_down=1
     echo "[switch] bringing down: ${c}"
-    # find the compose dir from the container's labels — fallback to direct stop
+    # derive the compose dir/file from the container's labels — stop fallback
     local lbl_dir lbl_file
     lbl_dir=$(docker inspect --format '{{ index .Config.Labels "com.docker.compose.project.working_dir"}}' "$c" 2>/dev/null || true)
     lbl_file=$(docker inspect --format '{{ index .Config.Labels "com.docker.compose.project.config_files"}}' "$c" 2>/dev/null || true)
     if [[ -n "$lbl_dir" && -n "$lbl_file" ]]; then
-      (cd "$lbl_dir" && ${COMPOSE_BIN} -f "$lbl_file" down) || docker stop "$c" >/dev/null
+      (cd "$lbl_dir" && ${COMPOSE_BIN} -f "$lbl_file" down --remove-orphans) || docker stop "$c" >/dev/null
     else
       docker stop "$c" >/dev/null
     fi
   done
+  [[ "$brought_down" -eq 1 ]] || echo "[switch] no club-3090 container running"
 }
 
 gpu_preflight() {
@@ -677,7 +689,7 @@ up_variant() {
 
   echo "[switch] bringing up: ${v}  (${dir}/${file})"
   export_variant_engine_pin "$v"
-  (cd "${full_dir}" && ${COMPOSE_BIN} -f "${file}" up -d)
+  (cd "${full_dir}" && ${COMPOSE_BIN} -f "${file}" up -d --remove-orphans)
 }
 
 resolve_ready_url() {
@@ -695,10 +707,8 @@ wait_ready() {
   # Find the container we just brought up so we can detect crashes mid-boot
   # AND surface stage progress markers from its logs while we wait.
   local container
-  container=$(docker ps --format '{{.Names}}' 2>/dev/null \
-    | grep -E '^(vllm-qwen36-27b|llama-cpp-qwen36-27b|vllm-gemma-4-31b)' | head -1)
-
-  if [[ -z "$container" ]]; then
+  container="${VARIANT_CONTAINER[$VARIANT]:-}"
+  if [[ -z "$container" ]] || ! docker ps --format '{{.Names}}' 2>/dev/null | grep -Fxq -- "$container"; then
     # Compose started but no container is up — almost always a syntax error
     # or env-var issue caught before vLLM even started.
     echo "[switch] ERROR: no container running after 'compose up' — boot failed before vLLM started." >&2

--- a/scripts/tests/test-compose-restart-policy.sh
+++ b/scripts/tests/test-compose-restart-policy.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Test: vLLM composes use the reboot-surviving restart knob.
+#
+# Contract:
+#   1. Every shipped vLLM compose declares
+#        restart: ${CLUB3090_RESTART:-unless-stopped}
+#      — none ships restart: "no" (which would NOT come back after a host
+#      reboot, defeating launch.sh-as-a-service usage).
+#   2. The pull/derived emitter (generate_compose.py generate_from_profile)
+#      emits the same knob, so newly-derived composes don't reintroduce "no".
+#
+# Why unless-stopped: it is the only Docker policy that reliably restarts on
+# daemon boot (host VM/bare-metal reboot) yet honors a manual stop
+# (switch.sh --down / docker stop). The ${CLUB3090_RESTART:-...} form lets a
+# user opt out with CLUB3090_RESTART=no. The ik-llama/llama-cpp/beellama
+# composes already use a literal unless-stopped and are out of scope here.
+set -uo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+KNOB='${CLUB3090_RESTART:-unless-stopped}'
+fail=0
+
+# 1. Shipped vLLM composes all carry the knob.
+bad="$(python3 - "$KNOB" <<'PY'
+import glob, sys, yaml
+knob = sys.argv[1]
+for f in sorted(glob.glob("models/*/vllm/compose/**/*.yml", recursive=True)):
+    try:
+        d = yaml.safe_load(open(f)) or {}
+    except Exception as e:
+        print(f"{f}: YAML parse error: {e}"); continue
+    for name, body in (d.get("services") or {}).items():
+        if not isinstance(body, dict):
+            continue
+        r = body.get("restart")
+        if r is None:
+            print(f"{f}: service '{name}' has no restart: key")
+        elif str(r) != knob:
+            print(f"{f}: service '{name}' restart={r!r} (want {knob!r})")
+PY
+)"
+if [[ -n "$bad" ]]; then
+  echo "FAIL: vLLM composes not on the reboot-surviving restart knob:" >&2
+  echo "$bad" | sed 's/^/  /' >&2
+  fail=1
+fi
+
+# 2. Derived emitter (generate_compose.py) emits the knob, not "no".
+if grep -q 'restart: "no"' scripts/lib/generate_compose.py; then
+  echo "FAIL: generate_compose.py still emits restart: \"no\" for derived composes" >&2
+  fail=1
+fi
+if ! grep -qF 'restart: ${CLUB3090_RESTART:-unless-stopped}' scripts/lib/generate_compose.py; then
+  echo "FAIL: generate_compose.py does not emit the CLUB3090_RESTART knob" >&2
+  fail=1
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "[compose-restart-policy] FAIL" >&2
+  exit 1
+fi
+echo "[compose-restart-policy] PASS: all vLLM composes + derived emitter use \${CLUB3090_RESTART:-unless-stopped}"

--- a/scripts/tests/test-power-cap-sweep-multigpu.sh
+++ b/scripts/tests/test-power-cap-sweep-multigpu.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Test: power-cap-sweep.sh multi-GPU logic (pure functions, mocked nvidia-smi/docker).
+#
+# Covers the bug-prone logic of the multi-GPU sweep redesign:
+#   1. resolve_gpu_indices  — --gpus > --gpu > container-detect > all-GPUs fallback
+#   2. gpu_indices_from_container — read NVIDIA_VISIBLE_DEVICES / device requests
+#   3. aggregate_gpu_sample — collapse N per-GPU sampler lines to one synthetic
+#      line: SUM power, MAX util/temp, OR throttle (keeps downstream untouched)
+#   4. capture_envelopes    — per-GPU INIT/STOCK arrays + intersected MIN/MAX range
+#   5. restore_gpus         — RESET=1 -> stock per GPU; --no-reset -> captured per GPU
+#
+# The end-to-end sweep (setting caps, measuring) needs a real dual-GPU rig; this
+# guards the logic that is wrong/subtle, with mocks. Functions are extracted with
+# sed (the repo pattern) so the script's main body doesn't run.
+set -uo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); }
+no()  { echo "FAIL: $1" >&2; FAIL=$((FAIL+1)); }
+eq()  { if [[ "$2" == "$3" ]]; then ok; else no "$1: expected '$3', got '$2'"; fi; }
+
+# --- Extract the functions under test -----------------------------------------
+HELPERS="$(mktemp --suffix=.sh)"
+for fn in gpu_indices_from_container resolve_gpu_indices aggregate_gpu_sample capture_envelopes restore_gpus; do
+  sed -n "/^${fn}()/,/^}/p" scripts/power-cap-sweep.sh >> "$HELPERS"
+done
+
+tmp="$(mktemp -d)"
+cleanup() { rm -rf "$tmp" "$HELPERS"; }
+trap cleanup EXIT
+
+# --- Mock nvidia-smi: 2 GPUs; query values + record -pl calls -----------------
+cat > "$tmp/nvidia-smi" <<'EOF'
+#!/usr/bin/env bash
+declare -A MINV=([0]=100 [1]=100) MAXV=([0]=400 [1]=420) DEFV=([0]=370 [1]=390) LIMV=([0]=300 [1]=310)
+args="$*"
+# set power limit: -pl <W> -i <idx>
+if [[ "$args" == *"-pl "* ]]; then
+  w=""; idx=""; prev=""
+  for a in "$@"; do case "$prev" in -pl) w="$a";; -i) idx="$a";; esac; prev="$a"; done
+  echo "PL idx=$idx w=$w" >> "$NVSMI_LOG"; echo "set to ${w} W"; exit 0
+fi
+if [[ "$1" == "-L" ]]; then echo "GPU 0: Mock"; echo "GPU 1: Mock"; exit 0; fi
+if [[ "$1" == "-pm" ]]; then exit 0; fi
+# query: find -i index (absent for the all-indices listing)
+idx=""; prev=""; has_i=0
+for a in "$@"; do [[ "$prev" == "-i" ]] && { idx="$a"; has_i=1; }; prev="$a"; done
+if [[ "$args" == *"--query-gpu=index"* && "$has_i" -eq 0 ]]; then printf '0\n1\n'; exit 0; fi
+case "$args" in
+  *power.default_limit*) echo "${DEFV[$idx]}";;
+  *power.min_limit*)     echo "${MINV[$idx]}";;
+  *power.max_limit*)     echo "${MAXV[$idx]}";;
+  *power.limit*)         echo "${LIMV[$idx]}";;
+  *name*)                echo "Mock GPU";;
+  *memory.total*)        echo "24576";;
+  *)                     echo "";;
+esac
+EOF
+chmod +x "$tmp/nvidia-smi"
+
+# --- Mock docker: inspect returns NVIDIA_VISIBLE_DEVICES for a known container -
+cat > "$tmp/docker" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "inspect" ]]; then
+  # Env listing form used by gpu_indices_from_container.
+  echo "PATH=/usr/bin"
+  echo "NVIDIA_VISIBLE_DEVICES=${MOCK_NVD:-0,1}"
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "$tmp/docker"
+
+export PATH="$tmp:$PATH"
+export NVSMI_LOG="$tmp/nvsmi.log"
+
+# shellcheck source=/dev/null
+source "$HELPERS"
+
+# --- 1. resolve_gpu_indices precedence ----------------------------------------
+out="$(GPUS="0,1" GPU_INDEX_SET=0 GPU_INDEX=0 CONTAINER=none resolve_gpu_indices)";        eq "resolve --gpus explicit" "$out" "0,1"
+out="$(GPUS="" GPU_INDEX_SET=1 GPU_INDEX=1 CONTAINER=none resolve_gpu_indices)";            eq "resolve --gpu single"    "$out" "1"
+out="$(GPUS="" GPU_INDEX_SET=0 GPU_INDEX=0 CONTAINER=vllm MOCK_NVD=0,1 resolve_gpu_indices 2>/dev/null)"; eq "resolve from container" "$out" "0,1"
+out="$(GPUS="" GPU_INDEX_SET=0 GPU_INDEX=0 CONTAINER=none resolve_gpu_indices 2>/dev/null)"; eq "resolve fallback all GPUs" "$out" "0,1"
+
+# --- 2. gpu_indices_from_container 'all' -> empty (caller falls back) ----------
+out="$(MOCK_NVD=all gpu_indices_from_container vllm)";  eq "container NVD=all -> empty" "$out" ""
+
+# --- 3. aggregate_gpu_sample: SUM power, MAX util/temp, OR throttle ------------
+agg="$(printf '%s\n%s\n' \
+  '0, 95, 320.50, 70, 1800, 9501, P2, Active, Not Active' \
+  '1, 88, 310.00, 72, 1755, 9501, P2, Not Active, Not Active' | aggregate_gpu_sample)"
+eq "aggregate -> summed/max/or" "$agg" "agg, 95, 630.50, 72, 1800, 9501, P2, Active, Not Active"
+# single GPU passes through (sum == that GPU)
+agg1="$(printf '%s\n' '0, 90, 300.00, 65, 1700, 9501, P2, Not Active, Not Active' | aggregate_gpu_sample)"
+eq "aggregate single GPU" "$agg1" "agg, 90, 300.00, 65, 1700, 9501, P2, Not Active, Not Active"
+
+# --- 4. capture_envelopes: intersected range + per-GPU arrays -----------------
+declare -A INIT_ARR=() STOCK_ARR=()
+GPU_INDICES=(0 1)
+capture_envelopes
+eq "MIN_LIMIT = max(per-gpu min)" "$MIN_LIMIT" "100"
+eq "MAX_LIMIT = min(per-gpu max)" "$MAX_LIMIT" "400"
+eq "INIT_ARR[0] = current limit"  "${INIT_ARR[0]}" "300"
+eq "INIT_ARR[1] = current limit"  "${INIT_ARR[1]}" "310"
+eq "STOCK_ARR[0] = default limit" "${STOCK_ARR[0]}" "370"
+eq "STOCK_ARR[1] = default limit" "${STOCK_ARR[1]}" "390"
+
+# --- 5. restore_gpus: stock (default) vs captured (--no-reset) -----------------
+: > "$NVSMI_LOG"
+RESET=1 restore_gpus
+got="$(sort "$NVSMI_LOG" | tr '\n' ';')"
+eq "RESET=1 restores stock per GPU" "$got" "PL idx=0 w=370;PL idx=1 w=390;"
+: > "$NVSMI_LOG"
+RESET=0 restore_gpus
+got="$(sort "$NVSMI_LOG" | tr '\n' ';')"
+eq "--no-reset restores captured per GPU" "$got" "PL idx=0 w=300;PL idx=1 w=310;"
+
+echo "----------------------------------------"
+echo "PASS: $PASS  FAIL: $FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1
+echo "OK: power-cap-sweep multi-GPU logic"

--- a/scripts/tests/test-switch-orphan-teardown.sh
+++ b/scripts/tests/test-switch-orphan-teardown.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Test for switch.sh down_running() closed-world teardown (orphan cleanup).
+#
+# Contract: switch.sh tears down ONLY containers it manages — i.e. whose name
+# is in the registry-derived VARIANT_CONTAINER set — via each container's own
+# compose file WITH --remove-orphans. Anything not in that set (the services
+# stack, estate instances with distinct ESTATE_CONTAINER names, unrelated user
+# containers) is left strictly alone.
+#
+# Validates:
+#   1. A managed vLLM container is torn down.
+#   2. A managed ik-llama container is torn down (the bug: old RUNNING_PATTERN
+#      ^(vllm-|llama-cpp-) missed ik-llama-/sglang-/beellama-).
+#   3. An unrelated container (not in the managed set) is left alone.
+#   4. A services-stack container (litellm) is left alone.
+#   5. Teardown passes --remove-orphans.
+#   6. When only unmanaged containers run, nothing is torn down and the
+#      "no club-3090 container running" path is taken.
+#
+# Harness: extract down_running() via sed, source it, inject a VARIANT_CONTAINER
+# managed set + a mock `docker` on PATH that records compose-down / stop calls.
+set -uo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+PASS=0
+FAIL=0
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: ${label}: expected output to CONTAIN: ${needle}" >&2
+    echo "--- teardown log ---" >&2
+    printf '%s\n' "$haystack" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+assert_not_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: ${label}: expected output to NOT contain: ${needle}" >&2
+    echo "--- teardown log ---" >&2
+    printf '%s\n' "$haystack" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# --- Extract the function under test (avoids running switch.sh's main) --------
+HELPERS_FILE="$(mktemp --suffix=.sh)"
+sed -n '/^down_running()/,/^}/p' scripts/switch.sh > "$HELPERS_FILE"
+
+tmp_dir="$(mktemp -d)"
+cleanup() { rm -rf "$tmp_dir" "$HELPERS_FILE"; }
+trap cleanup EXIT
+
+# --- Mock `docker`: records compose-down / stop to $DOCKER_MOCK_LOG -----------
+# Labels are returned non-empty so the compose-down branch is taken; the
+# config_files label embeds the container name so the log identifies which
+# container was brought down.
+cat > "${tmp_dir}/docker" <<'EOF'
+#!/usr/bin/env bash
+sub="$1"; shift || true
+case "$sub" in
+  ps)
+    for n in $DOCKER_MOCK_RUNNING; do printf '%s\n' "$n"; done
+    ;;
+  inspect)
+    fmt=""; cname=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --format) fmt="$2"; shift 2 || true ;;
+        *) cname="$1"; shift ;;
+      esac
+    done
+    if [[ "$fmt" == *working_dir* ]]; then
+      printf '%s\n' "$DOCKER_MOCK_WORKDIR"
+    elif [[ "$fmt" == *config_files* ]]; then
+      printf 'compose-%s.yml\n' "$cname"
+    fi
+    ;;
+  stop)
+    printf 'STOP %s\n' "$1" >> "$DOCKER_MOCK_LOG"
+    ;;
+  compose)
+    printf 'COMPOSE %s\n' "$*" >> "$DOCKER_MOCK_LOG"
+    ;;
+  *) : ;;
+esac
+exit 0
+EOF
+chmod +x "${tmp_dir}/docker"
+
+export DOCKER_MOCK_LOG="${tmp_dir}/calls.log"
+export DOCKER_MOCK_WORKDIR="${tmp_dir}"   # real dir so (cd "$lbl_dir") succeeds
+export PATH="${tmp_dir}:$PATH"
+export COMPOSE_BIN="docker compose"
+
+# Managed set, as derive_switch_variant_tables would populate it (default
+# container names, ESTATE_CONTAINER unwrapped). Spans all engine prefixes.
+declare -A VARIANT_CONTAINER=(
+  ["vllm/default"]="vllm-qwen36-27b"
+  ["vllm/dual"]="vllm-qwen36-27b-dual"
+  ["ik-llama/iq4ks-mtp"]="ik-llama-qwen36-27b"
+  ["beellama/dflash"]="beellama-qwen36-27b"
+  ["llamacpp/default"]="llama-cpp-qwen36-27b"
+)
+
+# shellcheck source=/dev/null
+source "$HELPERS_FILE"
+
+# --- Scenario 1: mixed managed + unmanaged containers running -----------------
+: > "$DOCKER_MOCK_LOG"
+export DOCKER_MOCK_RUNNING="vllm-qwen36-27b unrelated-db ik-llama-qwen36-27b litellm"
+( set +u; down_running ) >/dev/null 2>&1 || true
+log="$(cat "$DOCKER_MOCK_LOG")"
+
+assert_contains     "$log" "compose-vllm-qwen36-27b.yml"     "managed vLLM container torn down"
+assert_contains     "$log" "compose-ik-llama-qwen36-27b.yml" "managed ik-llama container torn down (the bug)"
+assert_not_contains "$log" "unrelated-db"                    "unrelated container left alone"
+assert_not_contains "$log" "litellm"                         "services-stack container left alone"
+assert_contains     "$log" "--remove-orphans"                "teardown passes --remove-orphans"
+
+# --- Scenario 2: only unmanaged containers running ----------------------------
+: > "$DOCKER_MOCK_LOG"
+export DOCKER_MOCK_RUNNING="litellm openwebui some-db"
+out="$( set +u; down_running 2>&1 )" || true
+log="$(cat "$DOCKER_MOCK_LOG")"
+
+assert_not_contains "$log" "COMPOSE"                          "nothing torn down when only unmanaged running"
+assert_not_contains "$log" "STOP"                             "nothing stopped when only unmanaged running"
+assert_contains     "$out" "no club-3090 container running"   "reports no managed container running"
+
+# --- Summary ------------------------------------------------------------------
+echo "----------------------------------------"
+echo "PASS: $PASS   FAIL: $FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1
+echo "OK: switch.sh closed-world teardown"


### PR DESCRIPTION
Lands @tekgnosis-net's three operational-robustness fixes from #281. Re-based onto current master because the original fork PR (#282) couldn't merge cleanly — master moved heavily under the recent compose prune + `switch.sh`/`registry-emit.sh` rewrites. **Supersedes #282; closes #281.** Full credit to @tekgnosis-net (`Co-Authored-By`).

## Fixes

**1. `switch.sh` orphan-safe teardown** (#281 fix 1) — *the urgent one*
`down_running()` matched a fixed `^(vllm-|llama-cpp-)` regex, so switching away from a `beellama-`/`ik-llama-`/`sglang-` container left it pinning VRAM → next boot OOMs. **This is a live bug for the `beellama` single-card defaults we just shipped.** Replaced with a **registry-derived closed-world teardown**: `registry-emit.sh` now emits `VARIANT_CONTAINER` (slug → container name); `down_running()` brings down only managed containers (+ `--remove-orphans`) and leaves others alone; `wait_ready`/`up_variant` use the map too. Verified the map covers `beellama-gemma4-31b`, `beellama-qwen36-27b`, `ik-llama-*`, etc.

**2. vLLM reboot survival** (#281 fix 2)
29 vLLM composes `restart: "no"` → `restart: ${CLUB3090_RESTART:-unless-stopped}` (the llama.cpp-family composes already used `unless-stopped`). Auto-restart is on by default for always-on serving; opt out with `CLUB3090_RESTART=no`. `generate_compose.py` emits the knob; `.env.example` documents it.

**3. `power-cap-sweep.sh` multi-GPU** (#281 fix 3)
`resolve_gpu_indices` (`--gpus` > `--gpu` > container-detect > all+warn), **sums board power across cards** (was GPU 0 only → ~2× optimistic TPS/W on TP=N), and restores pre-sweep caps on exit.

## Test
New: `test-switch-orphan-teardown`, `test-compose-restart-policy`, `test-power-cap-sweep-multigpu`. Full suite **41/41**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
