### PR TITLE
fix(gemma): wire --reasoning-parser gemma4 — reasoning-on no longer breaks structured output

### DIFF
--- a/models/gemma-4-31b/vllm/compose/dual/autoround-int4/bf16-mtp.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/autoround-int4/bf16-mtp.yml
@@ -167,6 +167,14 @@ services:
       - --enable-auto-tool-choice
       - --tool-call-parser
       - gemma4
+      # Route Gemma-4's <|channel>thought…<channel|> reasoning trace into
+      # reasoning_content (vLLM ships Gemma4ReasoningParser). Without it,
+      # enable_thinking responses leave the trace in `content` → breaks
+      # JSON/structured output. Safe with thinking OFF (no-ops when the model
+      # emits no channel tokens). Validated 2026-05-31 on int8 (StructOutput
+      # 8→14, DataExtract 0→9 thinking-on; invalid_json eliminated).
+      - --reasoning-parser
+      - gemma4
       - --chat-template
       - /vllm-workspace/examples/tool_chat_template_gemma4.jinja
       - --speculative-config

--- a/models/gemma-4-31b/vllm/compose/dual/autoround-int4/int8.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/autoround-int4/int8.yml
@@ -231,6 +231,13 @@ services:
       - --enable-auto-tool-choice
       - --tool-call-parser
       - gemma4
+      # Route Gemma-4's <|channel>thought…<channel|> reasoning trace into
+      # reasoning_content (vLLM ships Gemma4ReasoningParser). Without it,
+      # enable_thinking responses leave the trace in `content` → breaks
+      # JSON/structured output. Safe with thinking OFF (no-ops when the model
+      # emits no channel tokens). Validated 2026-05-31.
+      - --reasoning-parser
+      - gemma4
       - --chat-template
       - /vllm-workspace/examples/tool_chat_template_gemma4.jinja
       # SPEC_N_MAX overridable for matched-config head-to-head against


### PR DESCRIPTION
vLLM ships `Gemma4ReasoningParser` but the gemma composes never enabled it, so `enable_thinking` responses left the `<|channel>thought…<channel|>` trace in `content` → JSON/structured packs returned `invalid_json`. **Not a Gemma or engine limit — a config gap** (the beellama/llama.cpp path handles the trace, which is why its reasoning-on results in #239 looked better).

## Fix
Add `--reasoning-parser gemma4` to **both** `gemma-int8-mtp` + `gemma-bf16-mtp`. The parser routes the reasoning trace into `reasoning_content`, leaving `content` as the clean answer.

**Strict improvement** — no-ops with thinking OFF (parser returns content unchanged when no `<|channel>` tokens present; boot + KV pool 447,199 unchanged), and unblocks clean reasoning-on. Default stays thinking-OFF.

## Validated live (int8 v0.22.0, thinking ON, parser active)
- Direct probe: `reasoning_content` now populated; `content` = clean ```json```.

| Pack | thinking-ON no-parser | **thinking-ON +parser** | thinking-OFF |
|---|---|---|---|
| StructOutput-15 | 8/15 | **14/15** | 14/15 |
| DataExtract-15 | **0/15** | **9/15** | 10/15 |

`invalid_json` eliminated — remaining DE fails are genuine field-accuracy, not parse failures. Full suite **41/41**.

(A full reasoning-on 8-pack with the parser is running to decide whether reasoning-on should become the default — early signal: InstructFollow 8→14.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)