### PR TITLE
fix(nvlink): add NVLINK_MODE=pcie_p2p for PCIe P2P without NVLink (#290)

### DIFF
--- a/scripts/detect_nvlink.sh
+++ b/scripts/detect_nvlink.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
-# NVLink auto-detection + override. Sources NVLINK_MODE from env (default: auto).
-# Exports: _NVLINK_ENABLED (0 or 1), sets NCCL/PYTORCH env vars accordingly.
+# NVLink / PCIe-P2P detection + override. Sources NVLINK_MODE from env (default: auto).
+# Exports: _NVLINK_ENABLED (0/1 — "fast P2P interconnect available → custom all-reduce ON")
+# and sets NCCL/PYTORCH env vars accordingly.
 # Handles 2-GPU setups (single NVLink bridge) and N-GPU setups (e.g. 2 bridges on 4 cards).
+#
+# NVLINK_MODE values:
+#   auto       — detect NVLink via nvidia-smi topo (default). No NVLink => P2P off.
+#   force_on   — assert NVLink present (NCCL_P2P_LEVEL=NVL).
+#   force_off  — no P2P at all (NCCL_P2P_DISABLE=1).
+#   pcie_p2p   — PCIe P2P WITHOUT NVLink (e.g. a patched consumer-GPU driver — the
+#                tinygrad/geohot P2P patch). Sets NCCL_P2P_LEVEL=PHB (or your own
+#                NCCL_P2P_LEVEL), leaves P2P ENABLED, and turns custom all-reduce ON.
+#                Explicit opt-in (like force_on) — auto can't tell the patch is loaded.
+#                See club-3090 #290.
 
 NVLINK_MODE="${NVLINK_MODE:-auto}"
+_P2P_LEVEL=NVL   # NCCL_P2P_LEVEL used when _NVLINK_ENABLED=1 (overridden by pcie_p2p)
 
 case "$NVLINK_MODE" in
   force_on)
@@ -12,7 +24,13 @@ case "$NVLINK_MODE" in
     ;;
   force_off)
     _NVLINK_ENABLED=0
-    echo "[nvlink] NVLINK_MODE=force_off — forcing PCIe mode"
+    echo "[nvlink] NVLINK_MODE=force_off — forcing PCIe mode (P2P off)"
+    ;;
+  pcie_p2p)
+    # Explicit opt-in for PCIe P2P (no NVLink) — e.g. a patched consumer-GPU driver.
+    _NVLINK_ENABLED=1
+    _P2P_LEVEL="${NCCL_P2P_LEVEL:-PHB}"
+    echo "[nvlink] NVLINK_MODE=pcie_p2p — forcing PCIe P2P (NCCL_P2P_LEVEL=$_P2P_LEVEL, custom all-reduce ON)"
     ;;
   auto)
     GPU_COUNT=$(nvidia-smi -L 2>/dev/null | grep -c 'GPU' || echo 0)
@@ -32,7 +50,7 @@ case "$NVLINK_MODE" in
         echo "[nvlink] detected NVLink ($LINK) between GPU0-GPU1 — enabling NVLink mode"
       else
         _NVLINK_ENABLED=0
-        echo "[nvlink] PCIe topology ($LINK) — using PCIe mode"
+        echo "[nvlink] PCIe topology ($LINK) — using PCIe mode (no NVLink; for patched-driver PCIe P2P set NVLINK_MODE=pcie_p2p)"
       fi
     else
       _NVLINK_ENABLED=0
@@ -40,20 +58,23 @@ case "$NVLINK_MODE" in
     fi
     ;;
   *)
-    echo "[nvlink] ERROR: invalid NVLINK_MODE=$NVLINK_MODE (must be auto|force_on|force_off)" >&2
+    echo "[nvlink] ERROR: invalid NVLINK_MODE=$NVLINK_MODE (must be auto|force_on|force_off|pcie_p2p)" >&2
     exit 1
     ;;
 esac
 
-# Apply environment overrides based on detection result
+# Apply environment overrides based on detection result.
+# _NVLINK_ENABLED=1 means a fast P2P interconnect is available (NVLink OR patched PCIe
+# P2P) — P2P stays on and the compose entrypoint enables custom all-reduce. The level is
+# NVL for NVLink, PHB (or the user's value) for pcie_p2p.
 if [ "$_NVLINK_ENABLED" -eq 1 ]; then
-  export NCCL_P2P_LEVEL=NVL
+  export NCCL_P2P_LEVEL="${_P2P_LEVEL:-NVL}"
   unset NCCL_P2P_DISABLE 2>/dev/null || true
   export PYTORCH_CUDA_ALLOC_CONF="${PYTORCH_CUDA_ALLOC_CONF:-max_split_size_mb:512}"
-  echo "[nvlink] NVLink ENABLED — NCCL_P2P_LEVEL=NVL, custom all-reduce ON, expandable_segments OFF"
+  echo "[nvlink] P2P ENABLED — NCCL_P2P_LEVEL=$NCCL_P2P_LEVEL, custom all-reduce ON, expandable_segments OFF"
 else
   export NCCL_P2P_DISABLE=1
   unset NCCL_P2P_LEVEL 2>/dev/null || true
   export PYTORCH_CUDA_ALLOC_CONF="${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True,max_split_size_mb:512}"
-  echo "[nvlink] NVLink DISABLED — NCCL_P2P_DISABLE=1, custom all-reduce OFF, expandable_segments ON"
+  echo "[nvlink] P2P DISABLED — NCCL_P2P_DISABLE=1, custom all-reduce OFF, expandable_segments ON"
 fi


### PR DESCRIPTION
Fixes the regression in #290 — thanks @hlo-world for the precise diagnosis (commit, exact lines, *and* fix options).

## Problem
`scripts/detect_nvlink.sh` (added in e00626a) models only two states — NVLink-present (`NCCL_P2P_LEVEL=NVL` + custom all-reduce on) and no-P2P (`NCCL_P2P_DISABLE=1`). On a no-NVLink rig, `auto`/`force_off` do `export NCCL_P2P_DISABLE=1; unset NCCL_P2P_LEVEL` — **clobbering a deliberate `NCCL_P2P_LEVEL=PHB`** set for patched-driver PCIe P2P (tinygrad/geohot). `force_on` sets `NVL` (NVLink-specific — excludes PCIe). And the entrypoint hardcodes `--disable-custom-all-reduce` in the non-NVLink branch, so there's no way to enable custom all-reduce for P2P.

## Fix
A third explicit-opt-in mode, `NVLINK_MODE=pcie_p2p`:
- `NCCL_P2P_LEVEL=PHB` (or your own `NCCL_P2P_LEVEL` if set),
- P2P **not** disabled,
- `_NVLINK_ENABLED=1` → the **existing** entrypoint enables custom all-reduce (drops `--disable-custom-all-reduce`).

Reuses the `_NVLINK_ENABLED` signal, so **no compose changes** — any dual compose picks it up via `NVLINK_MODE=pcie_p2p` in env.

## Safety / testing
Purely additive — `auto` / `force_on` / `force_off` produce identical env to before (verified):

| mode | `_NVLINK_ENABLED` | `NCCL_P2P_LEVEL` | `NCCL_P2P_DISABLE` |
|---|---|---|---|
| **pcie_p2p** (new) | 1 | PHB (or your value) | unset |
| force_on | 1 | NVL | unset |
| force_off / auto-no-NVLink | 0 | unset | 1 |

Full test suite **41/41 green**; `test-hwdetect.sh` passes.

## ⚠️ Needs your validation, @hlo-world
We **can't verify this on our hardware** — our reference rig is PCIe-only with no P2P capability (no patched driver), so we can't confirm P2P + custom all-reduce actually *engage* end-to-end. That blind spot is what let the original regression ship. Could you check out this branch and run a dual compose with `NVLINK_MODE=pcie_p2p` on your patched-driver rig?
- Does vLLM now recognize P2P over PCIe?
- Stable with custom all-reduce on (no hang/crash)?
- A quick TPS delta vs `force_off` would be 🔥.

If it works we merge; if a knob needs changing (default level, or custom-all-reduce should stay off for some setups), your call. Thanks again!
