### PR TITLE
Fix beellama onboarding: preflight drafter check + refresh stale b9459 image refs

### DIFF
--- a/models/gemma-4-31b/beellama/compose/dual/beellama-q4ks-dflash/dflash.yml
+++ b/models/gemma-4-31b/beellama/compose/dual/beellama-q4ks-dflash/dflash.yml
@@ -15,9 +15,10 @@
 #              Multi-GPU DFlash fix VALIDATED on Anbeeld's official v0.3.0 image (sm_86, FA_ALL_QUANTS=1,
 #              single + dual cross-ring, 2026-06-01); image injected centrally from beellama-local
 #              install.spec. Promote 🧪→⚠️ when Anbeeld tags a STABLE release AND prose accept recovers.
-#   Caveats:   External dep: Anbeeld/beellama.cpp issue #39 (multi-GPU DFlash). Our shipped image
-#              default (b9459-07ac3ce) STILL has the bug; the fixes are on the v0.3.0 dev branch,
-#              which we built + validated on 2× 3090 (efe856397, 2026-06-01):
+#   Caveats:   External dep: Anbeeld/beellama.cpp issue #39 (multi-GPU DFlash). The fix shipped in
+#              v0.3.0 — launchers inject Anbeeld's OFFICIAL server-cuda-v0.3.0 and the compose
+#              `image:` default is now our multi-arch v0.3.0 build (efe856397); both carry the fix,
+#              validated on 2× 3090 (2026-06-01):
 #                ✅ Multi-GPU crash FIXED — no "decode failed -1"; boot now logs "drafter=1
 #                   devices; enabling GPU cross ring". --spec-draft-device CUDA0 no longer
 #                   ggml_aborts (Anbeeld's "explicit draft device" fix).
@@ -30,12 +31,12 @@
 #                ❌ MTP (--spec-type mtp + radamanthys-assistant Q8_0): "unknown model
 #                   architecture: gemma4_mtp" — unsupported on this build (distinct from the
 #                   CLOSED Anbeeld #36, which was garbage MTP *output* on Qwen, not arch-load).
-#              TRY IT NOW (gated): the v0.3.0 fix is now in Anbeeld's OFFICIAL image — validated on
-#              Ampere sm_86 (FA_ALL_QUANTS=1, single + dual cross-ring, 2026-06-01). Preferred:
-#                BEELLAMA_IMAGE=ghcr.io/anbeeld/beellama.cpp:server-cuda-v0.3.0-e0663be2713c \
+#              RUN IT: the launcher injects the OFFICIAL v0.3.0 image automatically (no prefix needed),
+#              validated on Ampere sm_86 (FA_ALL_QUANTS=1, single + dual cross-ring, 2026-06-01):
 #                bash scripts/switch.sh --force beellama/gemma-dflash-dual
-#              (fallback: our self-hosted ghcr.io/noonghunna/beellama-cpp:multiarch-v0.3.0-efe856397.
-#              Pin the commit tag — NOT -dev, which moves. Repoint default → Anbeeld's STABLE tag when it ships.)
+#              5090/sm_120 (not in the official sm_86/89 build): prefix
+#                BEELLAMA_IMAGE=ghcr.io/noonghunna/beellama-cpp:multiarch-v0.3.0-efe856397
+#              Pin the commit tag — NOT -dev, which moves. Repoint default → Anbeeld's STABLE tag when it ships.
 #              Filed PR Anbeeld#48 (FA_ALL_QUANTS Dockerfile fix + CUDA→GHCR nightly workflow).
 #              Findings: club-3090 disc #288 + beellama #39. Tracked: docs/UPSTREAM.md.
 #              UN-PARK TRIGGER: Anbeeld tags a STABLE release (not the dev branch) carrying these
@@ -65,7 +66,7 @@
 #   curl http://localhost:8062/v1/models
 services:
   beellama-gemma4-31b-dual:
-    image: ${BEELLAMA_IMAGE:-ghcr.io/noonghunna/beellama-cpp:multiarch-b9459-07ac3ce}
+    image: ${BEELLAMA_IMAGE:-ghcr.io/noonghunna/beellama-cpp:multiarch-v0.3.0-efe856397}
     container_name: "${ESTATE_CONTAINER:-beellama-gemma4-31b-dual}"
     restart: unless-stopped
     ports:

--- a/models/gemma-4-31b/beellama/compose/single/beellama-q4ks-dflash/dflash.yml
+++ b/models/gemma-4-31b/beellama/compose/single/beellama-q4ks-dflash/dflash.yml
@@ -29,14 +29,17 @@
 #              ~+292 MB cache+checkpoint overhead and CAN OOM at high fill — set
 #              CTX_SIZE=102400 for full headroom (~1.1 GB margin, gate-clean). 140K
 #              (beellama-advised) is rejected: OOMs at ~125K under load (real wall ~95K).
-#              (2) Defaults to our UNOFFICIAL multi-arch image
-#              ghcr.io/noonghunna/beellama-cpp:multiarch-b9459-07ac3ce (sm_86/89/120 =
-#              3090/4090/5090; MIT build of Anbeeld/beellama.cpp). sm_89/sm_120 are
-#              compiled but UNVALIDATED — only sm_86/3090 verified on club-3090's rig;
-#              4090/5090 users please report via numbers-from-your-rig.
-#              (3) Community fork chain, no official upstream Docker yet; re-point to
-#              mainline llama.cpp#23398 (Gemma-4 MTP) when it merges — docs/UPSTREAM.md.
-#              Override BEELLAMA_IMAGE= to pin another build.
+#              (2) Launchers inject Anbeeld's OFFICIAL image
+#              ghcr.io/anbeeld/beellama.cpp:server-cuda-v0.3.0 (sm_86/89 = 3090/4090);
+#              only sm_86/3090 verified on club-3090's rig — 4090 (sm_89) users please
+#              report via numbers-from-your-rig. 5090/sm_120 is NOT in the official build:
+#              prefix BEELLAMA_IMAGE=ghcr.io/noonghunna/beellama-cpp:multiarch-v0.3.0-efe856397
+#              (our multi-arch sm_86/89/120 build; sm_120 compiled-not-validated). That
+#              same multi-arch build is the compose `image:` fallback for a direct
+#              `docker compose up` (no launcher).
+#              (3) v0.3.0 carries a known prose-DFlash acceptance regression (CODE
+#              unaffected); re-point to mainline llama.cpp#23398 (Gemma-4 MTP) when it
+#              merges — docs/UPSTREAM.md. Override BEELLAMA_IMAGE= to pin another build.
 #   Quality:   toolcall-15 12/15 · instructfollow-15 14/15 · structoutput-15 13/15 ·
 #              dataextract-15 11/15 · reasonmath-15 13/15 · bugfind-15 14/15 ·
 #              hermesagent-20 13/20 · cli-40 19/40 = 109/150 (73%) think-off; 114/150
@@ -66,8 +69,9 @@
 # so `command:` below is just the server flags (same shape as ik-llama / llama-cpp composes).
 #
 # Quick start:
-#   1. Pull the image: docker pull ghcr.io/noonghunna/beellama-cpp:multiarch-b9459-07ac3ce
-#      (other GPU arches: build the fork — see Caveats / docs/INFERENCE_ENGINES.md).
+#   1. Pull the image: docker pull ghcr.io/anbeeld/beellama.cpp:server-cuda-v0.3.0-e0663be2713c
+#      (Anbeeld's official sm_86/89 = 3090/4090. 5090/sm_120: use
+#       ghcr.io/noonghunna/beellama-cpp:multiarch-v0.3.0-efe856397 — see Caveats.)
 #   2. Get the GGUFs (target + DFlash draft):
 #        hf download unsloth/gemma-4-31B-it-GGUF gemma-4-31B-it-Q4_K_S.gguf \
 #          --local-dir $MODEL_DIR/gemma-4-31b-gguf/unsloth-q4ks
@@ -95,7 +99,7 @@
 
 services:
   beellama-gemma4-31b-dflash:
-    image: ${BEELLAMA_IMAGE:-ghcr.io/noonghunna/beellama-cpp:multiarch-b9459-07ac3ce}
+    image: ${BEELLAMA_IMAGE:-ghcr.io/noonghunna/beellama-cpp:multiarch-v0.3.0-efe856397}
     container_name: "${ESTATE_CONTAINER:-beellama-gemma4-31b}"
     restart: unless-stopped
     ports:

--- a/models/qwen3.6-27b/beellama/compose/single/beellama-q5ks-dflash/dflash.yml
+++ b/models/qwen3.6-27b/beellama/compose/single/beellama-q5ks-dflash/dflash.yml
@@ -15,14 +15,18 @@
 #   Status:    ⚠️ Production w/ caveats
 #   Caveats:   single-GPU DEFAULT for Qwen3.6-27B (code-throughput leader ~100 TPS +
 #              slight 8-pack quality edge over ik-llama, think-off). Three caveats:
-#              (1) Defaults to our UNOFFICIAL multi-arch image
-#              ghcr.io/noonghunna/beellama-cpp:multiarch-b9459-07ac3ce (sm_86/89/120 =
-#              RTX 3090/4090/5090; MIT build of Anbeeld/beellama.cpp). sm_89/sm_120 are
-#              COMPILED but UNVALIDATED — only sm_86/3090 is verified on club-3090's rig;
-#              4090/5090 users please report via the numbers-from-your-rig template.
+#              (1) Launchers inject Anbeeld's OFFICIAL image
+#              ghcr.io/anbeeld/beellama.cpp:server-cuda-v0.3.0 (sm_86/89 = RTX 3090/4090);
+#              only sm_86/3090 is verified on club-3090's rig — 4090 (sm_89) users please
+#              report via the numbers-from-your-rig template. 5090/sm_120 is NOT in the
+#              official build: prefix
+#              BEELLAMA_IMAGE=ghcr.io/noonghunna/beellama-cpp:multiarch-v0.3.0-efe856397
+#              (our multi-arch sm_86/89/120 build; sm_120 compiled-not-validated). That
+#              same multi-arch build is the compose `image:` fallback for a direct
+#              `docker compose up` (no launcher) so any supported card boots.
 #              (2) Usable ctx ceiling 160K (200K OOMs on prefill) — ships 102K.
-#              (3) Community fork chain, no official upstream Docker yet (Anbeeld v0.3.0
-#              WIP — docs/UPSTREAM.md). Override BEELLAMA_IMAGE= to pin another build.
+#              (3) v0.3.0 carries a known prose-DFlash acceptance regression (CODE is
+#              unaffected — docs/UPSTREAM.md). Override BEELLAMA_IMAGE= to pin another build.
 #   Quality:   toolcall-15 13/15 · instructfollow-15 14/15 · structoutput-15 14/15 ·
 #              dataextract-15 8/15 · reasonmath-15 12/15 · bugfind-15 14/15 ·
 #              hermesagent-20 14/20 · cli-40 18/40 = 107/150 (71%) think-off; 113/150
@@ -56,8 +60,9 @@
 # so `command:` below is just the server flags (same shape as ik-llama / llama-cpp composes).
 #
 # Quick start:
-#   1. Pull the image: docker pull ghcr.io/noonghunna/beellama-cpp:multiarch-b9459-07ac3ce
-#      (multi-arch sm_86/89/120 = 3090/4090/5090; sm_89/120 unvalidated — see Caveats).
+#   1. Pull the image: docker pull ghcr.io/anbeeld/beellama.cpp:server-cuda-v0.3.0-e0663be2713c
+#      (Anbeeld's official sm_86/89 = 3090/4090. 5090/sm_120: use
+#       ghcr.io/noonghunna/beellama-cpp:multiarch-v0.3.0-efe856397 — see Caveats.)
 #   2. Get the GGUFs (target + DFlash draft):
 #        hf download unsloth/Qwen3.6-27B-GGUF Qwen3.6-27B-Q5_K_S.gguf \
 #          --local-dir $MODEL_DIR/qwen3.6-27b-gguf/unsloth-q5ks
@@ -85,7 +90,7 @@
 
 services:
   beellama-qwen36-27b-dflash:
-    image: ${BEELLAMA_IMAGE:-ghcr.io/noonghunna/beellama-cpp:multiarch-b9459-07ac3ce}
+    image: ${BEELLAMA_IMAGE:-ghcr.io/noonghunna/beellama-cpp:multiarch-v0.3.0-efe856397}
     container_name: "${ESTATE_CONTAINER:-beellama-qwen36-27b}"
     restart: unless-stopped
     ports:

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -410,7 +410,7 @@ COMPOSE_REGISTRY = {
         default_port=8060,
         kvcalc_key="SKIP",
         status="caveats",
-        status_note="Single-GPU default. Unofficial multi-arch image beellama-cpp:multiarch-b9459-07ac3ce (sm_86/89/120); sm_89/sm_120 compiled-not-validated on club-3090's 3090-only rig. Usable ctx ceiling 160K (200K OOMs on prefill); ships 102K. Community fork chain, no official Docker yet (Anbeeld v0.3.0 WIP — docs/UPSTREAM.md).",
+        status_note="Single-GPU default. Launchers inject Anbeeld's official beellama.cpp server-cuda-v0.3.0 image (sm_86/89 = 3090/4090); sm_89 compiled-not-validated on club-3090's 3090-only rig. 5090/sm_120: prefix BEELLAMA_IMAGE=ghcr.io/noonghunna/beellama-cpp:multiarch-v0.3.0-efe856397 (sm_120 compiled-not-validated). Usable ctx ceiling 160K (200K OOMs on prefill); ships 102K. v0.3.0 has a known prose-DFlash acceptance regression (code unaffected — docs/UPSTREAM.md).",
     ),
 
     # Qwen3.6-27B PRISM-PRO-DQ (Ex0bit dynamic-quant GGUF) — community-experimental, ik-llama.
@@ -562,7 +562,7 @@ COMPOSE_REGISTRY = {
         default_port=8061,
         kvcalc_key="SKIP",
         status="caveats",
-        status_note="Single-GPU default — the only viable fast single-card Gemma-4 path on Ampere. Unofficial multi-arch image beellama-cpp:multiarch-b9459-07ac3ce (sm_86/89/120); sm_89/sm_120 compiled-not-validated on club-3090's 3090-only rig. Community fork chain, no official Docker yet (Anbeeld v0.3.0 WIP); re-point to mainline llama.cpp#23398 Gemma-4 MTP when it merges — docs/UPSTREAM.md.",
+        status_note="Single-GPU default — the only viable fast single-card Gemma-4 path on Ampere. Launchers inject Anbeeld's official beellama.cpp server-cuda-v0.3.0 image (sm_86/89 = 3090/4090); sm_89 compiled-not-validated on club-3090's 3090-only rig. 5090/sm_120: prefix BEELLAMA_IMAGE=ghcr.io/noonghunna/beellama-cpp:multiarch-v0.3.0-efe856397 (sm_120 compiled-not-validated). v0.3.0 has a known prose-DFlash acceptance regression (code unaffected); re-point to mainline llama.cpp#23398 Gemma-4 MTP when it merges — docs/UPSTREAM.md.",
     ),
     # Dual-card beellama Gemma-4 (layer-split, 262K) — PARKED upstream-gated 2026-05-31.
     # Boots + recalls 262K fine, but DFlash spec-dec is broken on multi-GPU in our pinned

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -841,19 +841,34 @@ preflight_compose_deps() {
   # ${MODEL_DIR}:/root/.cache/huggingface and pass
   # `/root/.cache/huggingface/<subdir>`.
   local is_llamacpp=0
-  if grep -qhE 'image:.*(ggml-org/llama\.cpp|ikawrakow/ik-llama)' "${compose_files[@]}"; then
+  # beellama.cpp (ghcr.io/{anbeeld/beellama.cpp,noonghunna/beellama-cpp}) is a
+  # llama.cpp-family server: it mounts ${MODEL_DIR}:/models and passes
+  # `-m /models/<path>` (+ `--spec-draft-model /models/<path>` for DFlash/MTP),
+  # so it belongs on the GGUF presence path, NOT the vLLM HF-cache path.
+  if grep -qhE 'image:.*(ggml-org/llama\.cpp|ikawrakow/ik-llama|beellama)' "${compose_files[@]}"; then
     is_llamacpp=1
   fi
 
   if [[ $is_llamacpp -eq 1 ]]; then
     local gguf_paths=()
+    local draft_paths=()
     local mmproj_paths=()
     local token path
 
+    # Target weights: -m / --model
     while IFS= read -r token; do
       path="$(_preflight_compose_path_default "$token")"
       [[ -n "$path" ]] && gguf_paths+=("$path")
     done < <(grep -hoE -- '(^|[[:space:]])(-m|--model)[[:space:]]+/models/[^[:space:]]+' "${compose_files[@]}" \
+      | awk '{print $NF}' || true)
+
+    # Speculative drafter: beellama --spec-draft-model, llama.cpp -md/--model-draft.
+    # A missing drafter GGUF otherwise surfaces only as a cryptic in-container
+    # "failed to open GGUF file" crash (see #288 beellama onboarding reports).
+    while IFS= read -r token; do
+      path="$(_preflight_compose_path_default "$token")"
+      [[ -n "$path" ]] && draft_paths+=("$path")
+    done < <(grep -hoE -- '(^|[[:space:]])(--spec-draft-model|--model-draft|-md)[[:space:]]+/models/[^[:space:]]+' "${compose_files[@]}" \
       | awk '{print $NF}' || true)
 
     while IFS= read -r token; do
@@ -862,8 +877,13 @@ preflight_compose_deps() {
     done < <(grep -hoE -- '(^|[[:space:]])--mmproj[[:space:]]+/models/[^[:space:]]+' "${compose_files[@]}" \
       | awk '{print $NF}' || true)
 
+    # Env overrides mirror the compose knobs (GGUF_FILE / DRAFT_FILE / MMPROJ_FILE),
+    # each replacing only its own path class.
     if [[ -n "${GGUF_FILE:-}" ]]; then
       gguf_paths=("$GGUF_FILE")
+    fi
+    if [[ -n "${DRAFT_FILE:-}" && ${#draft_paths[@]} -gt 0 ]]; then
+      draft_paths=("$DRAFT_FILE")
     fi
     if [[ -n "${MMPROJ_FILE:-}" && ${#mmproj_paths[@]} -gt 0 ]]; then
       mmproj_paths=("$MMPROJ_FILE")
@@ -872,6 +892,11 @@ preflight_compose_deps() {
     for path in "${gguf_paths[@]}"; do
       if [[ ! -f "${model_dir}/${path}" ]]; then
         missing+=("${model_dir}/${path} (llama.cpp GGUF weights)")
+      fi
+    done
+    for path in "${draft_paths[@]}"; do
+      if [[ ! -f "${model_dir}/${path}" ]]; then
+        missing+=("${model_dir}/${path} (speculative drafter GGUF)")
       fi
     done
     for path in "${mmproj_paths[@]}"; do

--- a/scripts/tests/test-preflight-compose-deps.sh
+++ b/scripts/tests/test-preflight-compose-deps.sh
@@ -165,4 +165,32 @@ mkdir -p "${TMP_DIR}/models/qwen3.6-27b-autoround-int4" "${TMP_DIR}/models/qwen3
 out="$(run_deps "$sglang_compose" "${TMP_DIR}/models")"
 [[ -z "$out" ]]
 
+# beellama.cpp DFlash: the image is NOT ggml-org/ik-llama (so it must still be
+# detected as a llama.cpp-family GGUF server), and the drafter is named via
+# --spec-draft-model (not -m). A present target + MISSING drafter must refuse
+# with the drafter path + its hf-download hint — the #288 George report, where
+# a missing drafter otherwise crashed cryptically in-container.
+beellama_compose="${TMP_DIR}/beellama.yml"
+cat > "$beellama_compose" <<'YAML'
+services:
+  beellama:
+    image: ${BEELLAMA_IMAGE:-ghcr.io/anbeeld/beellama.cpp:server-cuda-v0.3.0-e0663be2713c}
+    command: >-
+      -m /models/${GGUF_FILE:-qwen3.6-27b-gguf/unsloth-q5ks/Qwen3.6-27B-Q5_K_S.gguf}
+      --spec-draft-model /models/${DRAFT_FILE:-qwen3.6-27b-gguf/anbeeld-dflash-iq4xs/Qwen3.6-27B-DFlash-IQ4_XS.gguf}
+YAML
+mkdir -p "${TMP_DIR}/bl-models/qwen3.6-27b-gguf/unsloth-q5ks"
+touch "${TMP_DIR}/bl-models/qwen3.6-27b-gguf/unsloth-q5ks/Qwen3.6-27B-Q5_K_S.gguf"
+out="$(expect_missing "$beellama_compose" "${TMP_DIR}/bl-models")"
+assert_contains "$out" "qwen3.6-27b-gguf/anbeeld-dflash-iq4xs/Qwen3.6-27B-DFlash-IQ4_XS.gguf"
+assert_contains "$out" "speculative drafter GGUF"
+assert_contains "$out" "hf download Anbeeld/Qwen3.6-27B-DFlash-GGUF Qwen3.6-27B-DFlash-IQ4_XS.gguf"
+# the target is present, so it must NOT be reported missing
+assert_not_contains "$out" "unsloth-q5ks/Qwen3.6-27B-Q5_K_S.gguf (llama.cpp GGUF weights)"
+# add the drafter → must pass
+mkdir -p "${TMP_DIR}/bl-models/qwen3.6-27b-gguf/anbeeld-dflash-iq4xs"
+touch "${TMP_DIR}/bl-models/qwen3.6-27b-gguf/anbeeld-dflash-iq4xs/Qwen3.6-27B-DFlash-IQ4_XS.gguf"
+out="$(run_deps "$beellama_compose" "${TMP_DIR}/bl-models")"
+[[ -z "$out" ]]
+
 echo "test-preflight-compose-deps: ok"


### PR DESCRIPTION
## Why

Two community reports on discussion #288 hit the **same wall**: a beellama config
that started the container but then died — eddie's `beellama/gemma-dflash` timed
out at 600s, and GeorgeWithAJ's `beellama/dflash` crashed with
`failed to open GGUF file '…/anbeeld-dflash-iq4xs/…' (No such file or directory)`.
In George's case the **target loaded fine** — only the DFlash **drafter** was
missing. Both got a cryptic in-container stack trace instead of preflight's
clear "download this:" hint.

## Root cause

`scripts/preflight.sh` has a model-presence check that's *supposed* to refuse +
print the `hf download` command (made catalog-general in #432). It silently
skipped beellama because of two gaps:

1. **Image detection** — `is_llamacpp` matched only `ggml-org/llama.cpp` /
   `ikawrakow/ik-llama`, not `beellama`. So beellama composes took the *vLLM*
   branch, looked for `…/config.json` (which beellama doesn't use), found
   nothing → the check was a no-op.
2. **Drafter** — even on the llama.cpp branch the GGUF grep matched only
   `-m`/`--model` (the target), never `--spec-draft-model` (the drafter).

Either gap alone reproduces both reports.

## Changes

**Fix (commit 1)**
- Add `beellama` to the `is_llamacpp` image regex.
- Collect drafter paths from `--spec-draft-model` / `--model-draft` / `-md` into
  their own presence check, with a `DRAFT_FILE` env override mirroring the
  existing `GGUF_FILE` / `MMPROJ_FILE` overrides.
- New `test-preflight-compose-deps` case: a beellama target-present +
  drafter-missing compose must refuse with the drafter path + its
  `hf download Anbeeld/Qwen3.6-27B-DFlash-GGUF …` hint; both present must pass.

**Stale image refs (commit 2)** — discovered while tracing the reports
- The 2 single composes + the gemma-q4ks dual still defaulted to the old
  self-hosted `multiarch-b9459-07ac3ce` (pre-#296). b9459 is the pre-v0.3.0
  build — the gemma-q4ks dual even documented that its default "STILL has the
  [multi-GPU DFlash] bug". A direct `docker compose up` (no launcher) would pull
  it. Bumped all three `image:` defaults to `multiarch-v0.3.0-efe856397` (matches
  the q8kxl duals) and refreshed the Caveats / Pull-the-image prose + the two
  registry `status_note`s to the current reality (launchers inject Anbeeld's
  official `server-cuda-v0.3.0`; 5090/sm_120 uses the multiarch build).
- Dropped the obsolete "no official Docker yet (v0.3.0 WIP)" claim; noted the
  known v0.3.0 prose-DFlash acceptance regression (code unaffected) instead.
- Preserved the two **historical** b9459 references (the 2026-05-30 benchmark
  attribution + the old-build prose-accept comparison).

## Validation

- `for t in scripts/tests/*.sh; do bash "$t"; done` → **41/41 green** (incl. the
  new beellama case + `test-compose-status-drift` + `test-compose-registry-disk`).
- Live check against the real `beellama/dflash` compose: target present, drafter
  absent → preflight now **refuses (rc=1)** and prints the drafter path labelled
  `speculative drafter GGUF` plus the exact
  `hf download Anbeeld/Qwen3.6-27B-DFlash-GGUF Qwen3.6-27B-DFlash-IQ4_XS.gguf …`
  command (the weights registry already carried the recipe). Add the drafter →
  passes.

## Related

The matching user-facing troubleshooting block ("Times out, or crashes with
'failed to open GGUF / No such file'") was added to the #288 how-to-test guide.
