### PR TITLE
fix(ik-llama): switch byteshape-iq4xs to cu12-server (cu13 silent CPU fallback on RTX 3090)

### DIFF
--- a/models/qwen3.6-35b-a3b/ik-llama/compose/single/byteshape-iq4xs/mtp.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/single/byteshape-iq4xs/mtp.yml
@@ -1,7 +1,7 @@
 # ===========================================================================
 # Profile (at-a-glance):
 #   Model:     Qwen3.6-35B-A3B (byteshape IQ4_XS 4.19bpw GGUF)
-#   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp:cu13-server)
+#   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp:cu12-server)
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   MTP n=2, p-min 0.0 (built-in MTP head — byteshape/Qwen3.6-35B-A3B-MTP-GGUF)
 #   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
@@ -16,7 +16,7 @@
 #   Caveats:   Single-rig validation (1× 3090, 370 W) — cross-rig numbers welcome. Agent-pack
 #              scores (hermesagent-20 11/20 = 55%, cli-40 17/40 = 42%) are typical for the
 #              35B-A3B class (the apex sibling scores similarly). Intake fixes vs PR #293:
-#              image cu12→cu13-server, port 8020→8058.
+#              image cu13→cu12-server (cu13 silent CPU fallback on sm_86), port 8020→8058.
 #   Quality:   toolcall-15 15/15 (100%) · instructfollow-15 14/15 (93%) · structoutput-15 14/15 (93%) · dataextract-15 13/15 (87%) · reasonmath-15 13/15 (87%) · bugfind-15 13/15 (87%) · hermesagent-20 11/20 (55%) · cli-40 17/40 (42%) (--full, our 1× 3090, 2026-06-02 — 110/150 total)
 #   Best for:  Single-card Qwen3.6-35B-A3B — author's best overall 8-pack on the rig (111/150, 74%)
 # ---------------------------------------------------------------------------
@@ -51,7 +51,7 @@
 
 services:
   ik-llama-qwen36-35b-a3b-byteshape-iq4xs:
-    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu13-server}
+    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu12-server}
     container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-35b-a3b-byteshape}"
     restart: unless-stopped
     ports:

--- a/scripts/tests/test-preflight-compose-deps.sh
+++ b/scripts/tests/test-preflight-compose-deps.sh
@@ -65,7 +65,7 @@ ik_compose="${TMP_DIR}/ik.yml"
 cat > "$ik_compose" <<'YAML'
 services:
   ik:
-    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu13-server}
+    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp:cu12-server}
     command: >-
       --model /models/${GGUF_FILE:-qwen3.6-27b-gguf/ubergarm-mtp-iq4ks/Qwen3.6-27B-MTP-IQ4_KS.gguf}
 YAML


### PR DESCRIPTION
## Problem

`cu13-server` (CUDA 13.1.1) silently falls back to CPU on RTX 3090 (sm_86, consumer Ampere).

**Rig:** driver 580.126.09, CUDA runtime 13.0, RTX 3090 24 GB (sm_86)

**Symptom:** weights load to VRAM correctly, but all compute ops run on CPU. No kernel error, no warning — the only signal is decode throughput dropping to ~2 tok/s (CPU speed) instead of the expected ~115 tok/s. Easy to miss if you don't watch actual token rate.

**Root cause:** RTX 3090 consumer lacks CUDA Forward Compatibility support. `cu13-server` requires Forward Compat to run its CUDA 13.1.1 runtime on a driver reporting CUDA 13.0 — the consumer variant simply doesn't have that path, so it silently degrades.

## Fix

Switch `byteshape-iq4xs/mtp.yml` from `cu13-server` to `cu12-server` (CUDA 12.6.2). This is the last remaining `cu13-server` reference in a shipped ik-llama compose — all other ik-llama composes were already switched on 2026-05-28.

Also updates the `test-preflight-compose-deps.sh` test fixture to match.

## Validation

- `cu12-server` restores full GPU decode on this rig (~115 tok/s, matches BENCHMARKS row)
- `verify-full` 8/8 pass on byteshape IQ4_XS compose with cu12-server
- All other shipped ik-llama composes already run cu12-server with no issues

## Scope

2 files changed:
- `models/qwen3.6-35b-a3b/ik-llama/compose/single/byteshape-iq4xs/mtp.yml` — image + comment
- `scripts/tests/test-preflight-compose-deps.sh` — test fixture inline compose