### PR TITLE
rebench: fail-fast verify-full preflight + fix runtime skip set (#303 fallout)

### DIFF
--- a/scripts/rebench-full.sh
+++ b/scripts/rebench-full.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
-# rebench-full.sh — canonical 5-step rebench against the currently-running
-# model. Built to eliminate the recurring mistakes from manual runs:
+# rebench-full.sh — canonical rebench against the currently-running model
+# (a fail-fast verify-full preflight + 5 measured steps). Built to eliminate
+# the recurring mistakes from manual runs:
 #
 #   - Wrong cwd (`scripts/X.sh: No such file or directory`)
 #   - Forgot `--save-json` on benchlocal-cli direct invocations
@@ -11,12 +12,16 @@
 #   - No idempotent resume — every interrupt redoes the whole matrix
 #
 # Order matches docs/QUALITY_TEST.md "test pipeline":
+#   0. verify-full.sh          — functional preflight, FAIL-FAST (~2 min)
 #   1. bench.sh                — TPS narrative + code (~5 min)
 #   2. verify-stress.sh        — long-context + boundary (~10-15 min)
 #   3. quality-test.sh --full  — 8 packs /150, think-OFF (~45-60 min)
 #   4. quality-test.sh --full --enable-thinking — 8 packs /150, think-ON (~60-90 min)
 #   5. soak-test.sh fresh-mode — stability over 50 turns (~15-20 min)
 #
+# verify-full is a HARD GATE: if the endpoint isn't functional we abort before
+# the multi-hour run rather than benching a broken server. Bypass with
+# --skip verify-full (e.g. you just ran it while tuning); --resume skips it too.
 # Total per leg: ~2.5-3.5 hr. (think-ON 8-pack replaced the old aider-polyglot
 # step 2026-06-03; aider available standalone via quality-test.sh --pack aider-polyglot-30.)
 # NOTE: the think-ON leg only scores correctly if the server PARSES reasoning —
@@ -269,6 +274,19 @@ snapshot_quality_json() {
     cp "$src" "$target"
   fi
 }
+
+# --- step 0: verify-full (fail-fast functional preflight) -------------------
+# ~2 min smoke (boots / serves / tool-calls / streams / coherent output). If the
+# endpoint isn't functional there's no point spending hours on bench → soak, so
+# we ABORT here. Skipped cleanly by --skip verify-full or --resume (run_step
+# returns 0 in both cases → no abort); only a real run-and-fail aborts.
+if ! URL="$URL" MODEL="$MODEL" \
+     run_step verify-full "$OUT_DIR/verify-full.log" \
+       bash "$ROOT_DIR/scripts/verify-full.sh"; then
+  echo "[rebench] ✗ verify-full failed — endpoint not functional; aborting before the multi-hour run." >&2
+  echo "          Fix the server, or re-run with --skip verify-full to bypass the preflight." >&2
+  exit 1
+fi
 
 # --- step 1: bench ----------------------------------------------------------
 URL="$URL" MODEL="$MODEL" RUNS="${RUNS:-3}" WARMUPS="${WARMUPS:-1}" \

--- a/scripts/rebench-runtime.sh
+++ b/scripts/rebench-runtime.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 #
-# rebench-runtime.sh — the "runtime" tier of rebench: bench + verify-stress
-# + soak, skipping the two generation-quality legs (quality-full + aider).
+# rebench-runtime.sh — the "runtime" tier of rebench: verify-full (preflight)
+# + bench + verify-stress + soak, skipping the two generation-quality legs
+# (quality-full think-OFF + quality-thinking think-ON).
 #
 # WHEN TO USE THIS instead of rebench-full.sh:
 #   When you changed a serving-config knob that affects throughput / VRAM /
 #   stability but NOT per-token generation quality, so re-scoring the 8-pack
-#   + aider would be ~1.5 hr of wasted cycles that can only reproduce the
-#   prior scores. Examples:
+#   twice (think-OFF + think-ON) would be ~1.5-2.5 hr of wasted cycles that can
+#   only reproduce the prior scores. Examples:
 #     - context-size ceiling bump (KV *type* unchanged)
 #     - --ubatch-size / --batch-size tuning
 #     - --gpu-memory-utilization / --mem-fraction-static
@@ -16,7 +17,11 @@
 #   If the change DOES touch generation (quant swap, KV-cache *type* change,
 #   chat-template change, model swap) → run full rebench-full.sh instead.
 #
-# Three legs (≈30-40 min on single-card, vs ~1.75-2 hr for the full matrix):
+# Preflight + three legs (≈30-40 min on single-card, vs ~2.5-3.5 hr for the
+# full matrix):
+#   0. verify-full.sh     — functional preflight, FAIL-FAST (inherited from
+#                           rebench-full; NOT skipped — a runtime knob can break
+#                           serving, so we still gate on it)
 #   1. bench.sh           — TPS narrative + code
 #   2. verify-stress.sh   — long-context needle ladder + prefill-OOM boundary
 #   3. soak-test.sh       — accumulating-context endurance (Cliff 2b)
@@ -33,13 +38,14 @@
 #     bash scripts/rebench-runtime.sh --engine llama-cpp
 #
 # This is a thin preset over rebench-full.sh: it injects
-# `--skip quality-full,aider-polyglot` and merges any --skip you pass.
+# `--skip quality-full,quality-thinking` and merges any --skip you pass.
+# (verify-full is intentionally NOT skipped — it's the fail-fast preflight.)
 
 set -euo pipefail
 
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 
-BASE_SKIP="quality-full,aider-polyglot"
+BASE_SKIP="quality-full,quality-thinking"
 USER_SKIP=""
 PASS_ARGS=()
 while [[ $# -gt 0 ]]; do
@@ -51,5 +57,5 @@ done
 
 SKIP="$BASE_SKIP${USER_SKIP:+,$USER_SKIP}"
 
-echo "[rebench-runtime] runtime tier (bench + verify-stress + soak); --skip=$SKIP"
+echo "[rebench-runtime] runtime tier (verify-full + bench + verify-stress + soak); --skip=$SKIP"
 exec bash "$ROOT_DIR/scripts/rebench-full.sh" --skip "$SKIP" "${PASS_ARGS[@]}"


### PR DESCRIPTION
## What

Two coupled `rebench` tooling fixes.

### `rebench-full.sh` — fail-fast `verify-full` preflight (step 0)
Runs `verify-full` before the multi-hour matrix. If the endpoint isn't functional (not serving, 404 on a served-name mismatch, dead tool-calls, cudagraph-warmup gibberish), it **aborts in ~2 min** instead of grinding bench → verify-stress → quality → soak on a broken server.

- Skipped cleanly by `--skip verify-full` (e.g. you just ran it while tuning) or `--resume` — `run_step` returns 0 in both cases, so the fail-fast `if !` doesn't fire. Only a real run-and-fail aborts.
- `set -e` is suppressed inside the `if !` condition, matching how `run_step` already behaves under the existing callers' `|| true`.

### `rebench-runtime.sh` — fix the skip set broken by #303
The runtime tier hard-coded `BASE_SKIP="quality-full,aider-polyglot"`. #303 removed the aider step and added `quality-thinking` (think-ON), so the runtime tier was silently **running the ~60–90 min think-ON 8-pack it's designed to skip** — no longer the ~30–40 min tier it advertises.

- Corrected to `BASE_SKIP="quality-full,quality-thinking"`.
- `verify-full` is intentionally **not** skipped, so the runtime tier inherits the fail-fast preflight (a runtime-config knob — ctx bump, `-ub`, MTP `n` — can break serving).
- Header / leg list / timing refreshed.

## Test
- `bash -n` clean on both.
- Skip/resume paths reasoned through: `run_step` returns 0 on skip → no spurious abort; fail-fast fires only on a real verify-full failure.
