### PR TITLE
preflight: resolve ${VAR:-default} model paths in compose-deps check (switch.sh launch fix)

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -635,6 +635,10 @@ _preflight_compose_path_default() {
   value="$(printf '%s' "$value" | sed -E 's#\$\{MODEL_DIR[^}]*\}/?##g')"
   value="${value#/models/}"
   value="${value#/root/.cache/huggingface/}"
+  # Strip a trailing `}` left when a path is the DEFAULT inside an outer
+  # ${VAR:-/root/.cache/huggingface/<path>} — the path grep anchors mid-expansion
+  # so it captures `<path>}`. A real model subdir never ends in `}`.
+  value="${value%\}}"
   printf '%s' "$value"
 }
 
@@ -919,7 +923,13 @@ preflight_compose_deps() {
           missing+=("${model_dir}/${subdir}/config.json (HF model)")
         fi
       fi
-    done < <(grep -hoE '/root/\.cache/huggingface/[^"'\''[:space:],}:]+' "${compose_files[@]}" || true)
+    # Char-class must NOT exclude `:` or `}` — model paths can be
+    # `/root/.cache/huggingface/${MODEL_SUBDIR:-default}` (vLLM) and excluding
+    # those truncated the token to `${MODEL_SUBDIR` before _preflight_compose_path_default
+    # could resolve the `:-default`, causing a false "missing" (the gemma-4-12b
+    # MODEL_SUBDIR/SPEC_MODEL_SUBDIR composes). Stop only at real delimiters
+    # (quote / whitespace / comma); the `${VAR:-default}` resolver runs downstream.
+    done < <(grep -hv '^[[:space:]]*#' "${compose_files[@]}" 2>/dev/null | grep -oE '/root/\.cache/huggingface/[^"'\''[:space:],]+' || true)
 
     # Experimental SGLang composes mount individual MODEL_DIR subdirectories to
     # /models/target and /models/drafter instead of using the HF cache mount.


### PR DESCRIPTION
## Problem

`preflight_compose_deps` (the model-presence check run by `switch.sh` / `setup.sh`) falsely reported **"missing model files"** for every gemma-12b compose, so `switch.sh --force vllm/gemma-12b-…` aborted before launching — the canonical launch path was broken for all 4 composes.

Root cause: the vLLM model-path grep's char-class excluded `:` and `}`, so an env-default path like
```
--model /root/.cache/huggingface/${MODEL_SUBDIR:-gemma-4-12b-autoround-int8}
```
was truncated to `${MODEL_SUBDIR` **before** `_preflight_compose_path_default` (which already resolves `${VAR:-default}`) could run.

## Fix (two hardenings in `preflight.sh`)

1. **Path grep** stops only at real delimiters (quote / whitespace / comma), not `:`/`}`, so `${VAR:-default}` survives to the resolver. Also **skips comment lines** so a path written in prose isn't mistaken for a dependency.
2. **`_preflight_compose_path_default`** strips a trailing `}` left when a path is the *default* inside an outer `${VAR:-/root/.cache/huggingface/<path>}` (the grep anchors mid-expansion → `<path>}`).

## Verified

- All 4 gemma-12b composes now pass `preflight_compose_deps` (dual-bf16-mtp, single-int8-mtp, beellama, llamacpp).
- qwen3.6-27b + gemma-4-31b composes still pass (no regression).
- Guard suite **41/41** in isolation (the one transient fail during the run was `bench.sh` mock-mode autodetect colliding with a concurrently-running soak service — unrelated to this change; passes with `PREFLIGHT_NO_AUTODETECT=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)