### PR TITLE
Add Qwen3-Omni-30B-A3B vLLM-Omni compose (non-registry, 2×3090)

### DIFF
--- a/models/qwen3-omni-30b-a3b/vllm-omni/README.md
+++ b/models/qwen3-omni-30b-a3b/vllm-omni/README.md
@@ -1,0 +1,135 @@
+# Qwen3-Omni-30B-A3B on vLLM-Omni — 2× RTX 3090
+
+Run Alibaba's **Qwen3-Omni-30B-A3B-Instruct** (omni-modal: text / image / audio / video **in**, text **+ speech out**) on two RTX 3090s via the **vLLM-Omni** framework.
+
+> **Status: 🧪 Experimental.** The **text** path is validated on this rig (full 65 K context, needle-in-haystack recall clean at 60 K, coherent output). **Audio/speech output works in principle but is unvalidated here.** This model is **not** in the central registry (`compose_registry.py`) — launch it with **direct `docker compose`**, not `switch.sh` / `launch.sh`.
+
+Compose: [`compose/dual/autoround-int4/omni.yml`](compose/dual/autoround-int4/omni.yml) (+ its mounted `qwen3_omni_3090.yaml` deploy-config).
+
+---
+
+## What you get (and what you don't)
+
+| | |
+|---|---|
+| **Generates** | text ✅, speech ✅ (real-time TTS of its own reply) |
+| **Understands (input)** | text, image, audio, video ✅ |
+| **Does NOT generate** | images ❌, video ❌ — it's a conversation model, not a diffusion model |
+
+Architecture = Qwen's 3-stage **Thinker → Talker → Code2Wav** pipeline:
+- **Stage 0 — Thinker** (the 30B-A3B MoE text LLM): understands the prompt, generates the **text** reply. *This is all you need for text.*
+- **Stage 1 — Talker**: turns the reply into audio codec tokens.
+- **Stage 2 — Code2Wav**: vocoder, codec tokens → speech waveform.
+
+On 2× 3090 the stages are **stage-parallel** (one engine per role), **not** tensor-parallel:
+`thinker → GPU0` (~23 GB), `talker + code2wav → GPU1` (~16 GB).
+
+---
+
+## Why this exact image (don't "upgrade" it)
+
+Use **`vllm/vllm-omni:v0.20.0`** (the **stable** release: omni 0.20.0 + its matching vLLM 0.20.0). The newer tags are **internally version-skewed and crash on load**:
+
+| Image | Result |
+|---|---|
+| `vllm/vllm-omni:v0.20.0` | ✅ self-consistent — **use this** |
+| `:latest` == `:v0.21.0rc1` | ❌ omni 0.21 + vLLM 0.20 → `ImportError: split_routed_experts` |
+| `:v0.22.0rc1` (build) | ❌ needs symbols no released vLLM has → unbuildable |
+| stock `vllm/vllm-openai` (any tag) | ❌ wrong tool — crashes profiling the omni MM-encoder (`cu_seqlens must be on CUDA`) |
+
+Re-check only when vLLM-Omni publishes a **correctly-built 0.22 stable** image.
+
+---
+
+## Setup (step by step)
+
+### 1. Get the weights (~25 GB, ungated)
+```bash
+hf download Intel/Qwen3-Omni-30B-A3B-Instruct-int4-AutoRound \
+  --local-dir "$MODEL_DIR/qwen3-omni-30b-a3b-instruct-int4-autoround"
+```
+`$MODEL_DIR` is your models root (the dir mounted as `/models`). int4 AutoRound is mandatory — bf16 is ~60 GB and won't fit 2× 24 GB.
+
+### 2. Pull the engine image
+```bash
+docker pull vllm/vllm-omni:v0.20.0
+```
+
+### 3. Launch (both GPUs must be free)
+```bash
+cd models/qwen3-omni-30b-a3b/vllm-omni/compose/dual/autoround-int4
+MODEL_DIR=/your/models/dir docker compose -f omni.yml up -d
+```
+First boot takes ~3 min (loads 3 stages + cudagraph capture). Watch it:
+```bash
+docker logs -f vllm-omni-qwen3-omni-30b   # wait for "Application startup complete"
+curl http://localhost:8042/v1/models
+```
+
+### 4. Text request — **always pass `"modalities": ["text"]`**
+```bash
+curl localhost:8042/v1/chat/completions -H 'Content-Type: application/json' -d '{
+  "model": "/models/qwen3-omni-30b-a3b-instruct-int4-autoround",
+  "modalities": ["text"],
+  "messages": [{"role":"user","content":"In two sentences, what is an MoE model?"}],
+  "max_tokens": 256
+}'
+```
+> **`"modalities":["text"]` is not optional.** Without it the prompt is routed through the Talker (audio) stage, which hits a prefill shape bug and **takes the whole engine down**.
+
+---
+
+## Performance (measured on this rig)
+
+- **Context:** full **65,536** (native max) on the single-card thinker via fp8 KV. NIAH recall PASS at 60 K (50 % & 90 % depth).
+- **Decode:** ~12 tok/s single-stream (the multi-stage omni wrapper adds overhead vs a plain text model; this is expected).
+- **Prefill:** ~1,800 tok/s (a 60 K prompt ≈ 34 s).
+- **VRAM:** GPU0 ~23 GB (thinker), GPU1 ~16 GB (talker + code2wav).
+
+For pure text speed/quality the rig's Qwen3.6 / Gemma models are better — Qwen3-Omni earns its place for **multimodal understanding + speech**, not plain text.
+
+---
+
+## Speech / audio output (experimental, unvalidated here)
+
+The talker + code2wav stages are loaded and *can* produce speech, but we only smoke-tested them.
+- **fp8 KV (the default) breaks the Code2Wav vocoder** (`snake_activation` dtype error). For audio output you must run **bf16 KV**:
+  ```bash
+  KV_CACHE_DTYPE=auto MODEL_DIR=/your/models/dir docker compose -f omni.yml up -d
+  ```
+  (bf16 KV → less context headroom on the thinker.)
+- Omit `"modalities":["text"]` (or request audio) to exercise the speech path — expect to debug; the talker prefill path was fragile in our testing.
+
+---
+
+## Environment overrides
+
+| Var | Default | Purpose |
+|---|---|---|
+| `MODEL_DIR` | `../../../../../../models-cache` | host models root → `/models` |
+| `MODEL_SUBDIR` | `qwen3-omni-30b-a3b-instruct-int4-autoround` | weights subdir under `/models` |
+| `PORT` | `8042` | host port (container serves on 8091) |
+| `KV_CACHE_DTYPE` | `fp8` | `fp8` = full ctx text; `auto` = bf16 (needed for audio out) |
+| `VLLM_OMNI_IMAGE` | `vllm/vllm-omni:v0.20.0` | engine image (keep pinned — see above) |
+
+Tune per-stage VRAM/context in the mounted **`qwen3_omni_3090.yaml`** (thinker on GPU0, talker+code2wav on GPU1). If you raise the thinker's `max_model_len`, raise the **talker's too** — the prompt flows through every stage.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause → Fix |
+|---|---|
+| `ImportError: split_routed_experts` / `_resolve_module_name` | Wrong image. Use `vllm/vllm-omni:v0.20.0`. |
+| `cu_seqlens_q must be on CUDA` | You're on stock `vllm/vllm-openai`, not vLLM-Omni. Use the omni image. |
+| Engine dies on a chat request; `_get_talker_assistant_parts` shape error | Missing `"modalities":["text"]` → request hit the talker. Add it. |
+| `No available memory for the cache blocks` | Thinker gpu-util too low, or `max_model_len` too high for the KV pool. Keep thinker `gpu_memory_utilization ≥ 0.85`. |
+| `snake_activation: expected fp32 got bf16` | fp8 KV + audio. Set `KV_CACHE_DTYPE=auto` for the speech path. |
+| OOM on a long prompt | Both stages need `max_model_len ≥ prompt length` (prompt flows through all stages). |
+
+---
+
+## Notes for maintainers
+
+- **Not registry-wired on purpose** — it's a custom-engine (vLLM-Omni) exploratory deploy. No `compose_registry.py` entry, no `switch.sh`/`launch.sh` integration; direct `docker compose` only.
+- Co-locating an **image-generation** model on GPU1 alongside the audio stages was investigated and shelved: every quality image model drags an ~8 GB text encoder that blows the co-located budget. Image gen wants a dedicated card (time-share), not co-residence.

--- a/models/qwen3-omni-30b-a3b/vllm-omni/compose/dual/autoround-int4/omni.yml
+++ b/models/qwen3-omni-30b-a3b/vllm-omni/compose/dual/autoround-int4/omni.yml
@@ -1,0 +1,72 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3-Omni-30B-A3B-Instruct (Intel int4-AutoRound) — omni-modal:
+#              text/image/audio/video IN, text + speech OUT (NO image/video generation)
+#   Engine:    vLLM-Omni (vllm/vllm-omni:v0.20.0 — the STABLE image; rc tags are skew-broken)
+#   Topology:  Dual 3090 PCIe — STAGE-parallel (NOT TP=2): thinker -> GPU0, talker+code2wav -> GPU1
+#   Drafter:   none
+#   KV:        fp8 (default — full 65K ctx on the single-card thinker). ⚠️ fp8 breaks the Code2Wav
+#              vocoder → for SPEECH output set KV_CACHE_DTYPE=auto (bf16, lower ctx).
+#   Vision:    input only (sees image/audio/video); does NOT generate images/video
+#   Max ctx:   262144? NO — 65536 (the model's native max). Validated single-card via fp8 KV
+#              (NIAH recall PASS @ 60K, depth 50% & 90%).
+#   Genesis:   N/A — this is the omni multi-stage pipeline, not the Qwen3-Next text engine
+#   Status:    🧪 Experimental — TEXT path validated (full 65K, NIAH @60K, coherent). Audio/speech
+#              output is architecturally present but UNVALIDATED. NOT in the central registry
+#              (compose_registry.py) — launch via direct `docker compose`, not switch.sh/launch.sh.
+#   Caveats:
+#     • Pin the image to vllm/vllm-omni:v0.20.0. `latest` / `v0.21.0rc1` / `v0.22.0rc1` are
+#       version-skew-broken (ImportError: split_routed_experts / _resolve_module_name).
+#     • TEXT requests MUST send  "modalities": ["text"]  in the chat body. Without it the prompt
+#       routes through the Talker (audio) stage, which has a prefill shape bug and kills the engine.
+#     • fp8 KV (default) → full ctx for TEXT, but breaks Code2Wav (audio). Speech out → KV_CACHE_DTYPE=auto.
+#     • Uses BOTH cards (stage-parallel). Don't co-run another GPU-heavy service.
+#   Best for:  Qwen3-Omni text + multimodal *understanding* on 2x 3090 (RAG/long-doc, vision/audio in).
+# ---------------------------------------------------------------------------
+# See ../../../README.md (engine folder) for the full setup walk-through (weights download,
+# launch, text-request format, audio mode, troubleshooting).
+#
+# Quick start (both GPUs free):
+#   1. Weights on disk under $MODEL_DIR as  qwen3-omni-30b-a3b-instruct-int4-autoround/
+#      (hf download Intel/Qwen3-Omni-30B-A3B-Instruct-int4-AutoRound --local-dir ...)
+#   2. MODEL_DIR=/your/models docker compose -f omni.yml up -d
+#   3. curl http://localhost:8042/v1/models
+#   4. Text request — REMEMBER "modalities":["text"]:
+#      curl localhost:8042/v1/chat/completions -H 'Content-Type: application/json' -d '{
+#        "model":"/models/qwen3-omni-30b-a3b-instruct-int4-autoround",
+#        "modalities":["text"],
+#        "messages":[{"role":"user","content":"Hello"}],"max_tokens":128}'
+#
+# Override via .env / shell: VLLM_OMNI_IMAGE, MODEL_DIR, MODEL_SUBDIR, PORT, KV_CACHE_DTYPE.
+
+services:
+  vllm-omni-qwen3-omni-30b:
+    image: ${VLLM_OMNI_IMAGE:-vllm/vllm-omni:v0.20.0}
+    container_name: "${ESTATE_CONTAINER:-vllm-omni-qwen3-omni-30b}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8042}}:8091"
+    ipc: host
+    shm_size: "16gb"
+    environment:
+      # PCIe-no-NVLink: disable NVLink-assumed paths (stage connector uses host shared memory)
+      NCCL_P2P_DISABLE: "1"
+      NCCL_CUMEM_ENABLE: "0"
+    volumes:
+      - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+      - "./qwen3_omni_3090.yaml:/cfg/qwen3_omni_3090.yaml:ro"
+    # vLLM-Omni image has no ENTRYPOINT — the command is the full `vllm serve ...` invocation.
+    command: >-
+      vllm serve /models/${MODEL_SUBDIR:-qwen3-omni-30b-a3b-instruct-int4-autoround}
+      --omni
+      --deploy-config /cfg/qwen3_omni_3090.yaml
+      --port 8091
+      --trust-remote-code
+      --kv-cache-dtype ${KV_CACHE_DTYPE:-fp8}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/models/qwen3-omni-30b-a3b/vllm-omni/compose/dual/autoround-int4/qwen3_omni_3090.yaml
+++ b/models/qwen3-omni-30b-a3b/vllm-omni/compose/dual/autoround-int4/qwen3_omni_3090.yaml
@@ -1,0 +1,64 @@
+# Qwen3-Omni-MoE — 2x RTX 3090 (24 GB each) tuned deploy-config.
+# Mounted into the container by the sibling `omni.yml` compose at /cfg/qwen3_omni_3090.yaml.
+#
+# Default upstream qwen3_omni_moe.yaml targets 2x H100 80GB; the thinker's max_seq_len=65536
+# leaves no KV room on a 24 GB card after int4 weights + the vision/audio encoders. This
+# config shrinks per-stage budgets to fit 2x 3090:
+#   Stage 0 (thinker, the text/understanding LLM) -> GPU0
+#   Stage 1 (talker, audio codec tokens) + Stage 2 (code2wav, vocoder) -> GPU1
+# Full 65K context on the thinker is reached via fp8 KV (set on the compose command line).
+async_chunk: true
+
+connectors:
+  connector_of_shared_memory:
+    name: SharedMemoryConnector
+    extra:
+      codec_chunk_frames: 25
+      codec_left_context_frames: 25
+
+stages:
+  - stage_id: 0          # Thinker — multimodal understanding + text generation
+    max_model_len: 65536
+    max_num_batched_tokens: 2048
+    max_num_seqs: 8
+    gpu_memory_utilization: 0.92
+    trust_remote_code: true
+    enable_prefix_caching: false
+    devices: "0"
+    default_sampling_params:
+      temperature: 0.7
+      top_p: 0.9
+      max_tokens: 1024
+      seed: 42
+
+  - stage_id: 1          # Talker — text+hidden -> audio codec tokens (must match thinker max_model_len:
+    max_model_len: 65536 #          the prompt flows through every stage, so a short value broadcast-crashes it)
+    max_num_batched_tokens: 2048
+    max_num_seqs: 8
+    gpu_memory_utilization: 0.55
+    trust_remote_code: true
+    enable_prefix_caching: false
+    devices: "1"
+    input_connectors:
+      from_stage_0: connector_of_shared_memory
+    default_sampling_params:
+      temperature: 0.9
+      top_k: 50
+      max_tokens: 2048
+      seed: 42
+
+  - stage_id: 2          # Code2Wav — codec tokens -> speech waveform (vocoder; cudagraph-incompatible)
+    max_num_batched_tokens: 8192
+    max_num_seqs: 8
+    gpu_memory_utilization: 0.18
+    enforce_eager: true
+    trust_remote_code: true
+    enable_prefix_caching: false
+    async_scheduling: false
+    devices: "1"
+    input_connectors:
+      from_stage_1: connector_of_shared_memory
+    default_sampling_params:
+      temperature: 0.0
+      max_tokens: 8192
+      seed: 42

--- a/scripts/tests/test-compose-registry-disk.sh
+++ b/scripts/tests/test-compose-registry-disk.sh
@@ -26,12 +26,20 @@ def check(cond, msg):
         failures.append(msg)
 
 check(len(COMPOSE_REGISTRY) == 56, f"registry has 56 entries (got {len(COMPOSE_REGISTRY)})")
-check(len(disk_paths) == 57, f"disk has 57 compose files (got {len(disk_paths)})")
+check(len(disk_paths) == 58, f"disk has 58 compose files (got {len(disk_paths)})")
 check(registry_paths <= disk_paths, "all registry compose_path values exist on disk")
 parked_disk_only = disk_paths - registry_paths
+# Disk-only (non-registry) composes allowed: parked SGLang archives, plus the experimental
+# vLLM-Omni Qwen3-Omni compose (intentionally NOT registry-wired — custom-engine, direct
+# `docker compose`-only deploy; see models/qwen3-omni-30b-a3b/vllm-omni/README.md).
+def _allowed_disk_only(path):
+    return (
+        "/sglang/compose/" in f"/{path.as_posix()}"
+        or path == Path("models/qwen3-omni-30b-a3b/vllm-omni/compose/dual/autoround-int4/omni.yml")
+    )
 check(
-    all("/sglang/compose/" in f"/{path.as_posix()}" for path in parked_disk_only),
-    "only parked SGLang archive composes are disk-only",
+    all(_allowed_disk_only(path) for path in parked_disk_only),
+    "only parked SGLang archives + the non-registry vLLM-Omni compose are disk-only",
 )
 if parked_disk_only:
     print("INFO: disk-only parked composes: " + ", ".join(str(p) for p in sorted(parked_disk_only)))


### PR DESCRIPTION
## What

A self-contained, **non-registry** compose to run **Qwen3-Omni-30B-A3B-Instruct** (omni-modal: text/image/audio/video **in**, text **+ speech out**) on **2× RTX 3090** via the **vLLM-Omni** framework.

- `models/qwen3-omni-30b-a3b/vllm-omni/README.md` — full 2×3090 walk-through (weights, launch, request format, audio mode, troubleshooting)
- `…/compose/dual/autoround-int4/omni.yml` — the compose (`🧪 Experimental`)
- `…/compose/dual/autoround-int4/qwen3_omni_3090.yaml` — mounted per-stage deploy-config (thinker→GPU0, talker+code2wav→GPU1)

## Why non-registry

Custom engine (vLLM-Omni, not stock vLLM) + exploratory deploy → launched via **direct `docker compose`**, not `switch.sh`/`launch.sh`. No `compose_registry.py` entry by design, so it doesn't enter the curated catalog / default-resolver. Club members can still spin it up from the compose.

## Validated on-rig

- **Text:** full **65,536** context (native max) on the single-card thinker via fp8 KV; **NIAH recall PASS at 60K** (depth 50% & 90%); coherent.
- **VRAM:** GPU0 ~23 GB (thinker), GPU1 ~16 GB (talker + code2wav), stage-parallel.
- **Audio/speech out:** architecturally present, **unvalidated** here.

## Key gotchas (in the compose header + README)

- **Pin `vllm/vllm-omni:v0.20.0`** — `latest`/`v0.21.0rc1`/`v0.22.0rc1` are version-skew-broken (`split_routed_experts` / `_resolve_module_name`); stock `vllm/vllm-openai` crashes the omni MM-encoder.
- **Text requests must send `"modalities":["text"]`** — else the prompt routes through the talker (audio) stage, which has a prefill shape bug and kills the engine.
- **fp8 KV → full ctx for text but breaks Code2Wav (audio)** — `KV_CACHE_DTYPE=auto` for speech.

## Test change

`test-compose-registry-disk`: on-disk compose count 57→58, and the disk-only whitelist extended to allow this intentionally-non-registry compose (alongside the parked sglang archives). Full static gate suite: **41/41 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)