### PR TITLE
fix(35b-a3b): preview-single gpu-mem 0.92->0.95 for v0.22.0 boot

### DIFF
--- a/models/qwen3.6-35b-a3b/vllm/compose/single/autoround-int4/preview.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/single/autoround-int4/preview.yml
@@ -98,8 +98,12 @@ services:
       - "${PP:-1}"
       - --max-model-len
       - "${MAX_MODEL_LEN:-8192}"
+      # 0.95 (was 0.92): v0.22.0 CUDA-graph memory profiling (default since
+      # v0.21.0) trims effective KV — at 0.92 the single-card KV check OOM'd on
+      # v0.22.0 (~20 GB weights leave too little KV on one 24 GB card). 0.95 is
+      # the documented headless-Linux single-card default; WSL2 → 0.94 via .env.
       - --gpu-memory-utilization
-      - "${GPU_MEMORY_UTILIZATION:-0.92}"
+      - "${GPU_MEMORY_UTILIZATION:-0.95}"
       - --max-num-seqs
       - "1"
       - --max-num-batched-tokens

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -726,7 +726,7 @@ COMPOSE_REGISTRY = {
     "vllm/qwen-a3b-preview-single": _entry(
         model="qwen3.6-35b-a3b", weights_variant="autoround-int4", workload="fast-chat",
         engine="vllm-nightly-clean", drafter=None, kv_format="fp8_e5m2",
-        tp=1, max_ctx=8192, max_num_seqs=1, mem_util=0.92,
+        tp=1, max_ctx=8192, max_num_seqs=1, mem_util=0.95,
         compose_path="models/qwen3.6-35b-a3b/vllm/compose/single/autoround-int4/preview.yml",
         default_port=8050,
         kvcalc_key="qwen3.6-35b-a3b:qwen-a3b-preview-single",


### PR DESCRIPTION
## What

`vllm/qwen-a3b-preview-single` (TP=1) OOMs at the KV-cache check on stock
vLLM **v0.22.0**: ~20 GB of weights on one 24 GB card leaves only **0.07 GiB**
for KV at `mem_util=0.92`, so it can't even serve its 8K window.

## Root cause

v0.22.0's **CUDA-graph memory profiling** (default since v0.21.0) reserves
graph-capture memory up front, trimming effective KV vs the older nightly the
preview was originally tuned on. vLLM itself flags it: *"--gpu-memory-utilization=0.95
is equivalent to 0.9325 without CUDA graph profiling."* Not a weights/quant issue —
the weights load fine; it's purely the single-card VRAM budget.

## Fix

Bump the compose default **and** the registry `mem_util` `0.92 → 0.95` (which the
FAQ already documents as the headless-Linux single-card default). Validated on a
single 3090: boots clean, **KV 0.78 GiB / 31,129 tokens**, coherent output. WSL2
users dial `GPU_MEMORY_UTILIZATION=0.94` via `.env` (already in `docs/FAQ.md`).

Surfaced during #316 boot-validation (separate from the repo-id fix in #321).

## Tests
`for t in scripts/tests/*.sh` → 41/41 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
