### PR TITLE
gemma-26ba4b-single: raise max ctx 16K → 42K (NIAH-validated)

### DIFF
--- a/models/gemma-4-26b-a4b/vllm/compose/single/awq/mtp.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/single/awq/mtp.yml
@@ -6,13 +6,18 @@
 #   KV:        bfloat16 (Ampere fp8 dead for gemma4: fp8_e5m2 hits the
 #              gemma4_mm.py allowlist assert, fp8_e4m3 hits Triton fp8e4nv)
 #   Vision:    off (limit-mm-per-prompt image=0 audio=0)
-#   Max ctx:   16K (laddered max — KV pool 17,490 tok at 0.92 util on 1x 3090
-#              with the drafter loaded; 17,408 would leave <100 tok headroom)
+#   Max ctx:   42K (laddered max — KV pool 42,993 tok at 42000/0.92 util on 1x
+#              3090 with the drafter; vLLM boot-est ceiling 44,224. NIAH recall
+#              clean to 37.6K with no degradation, 2026-06-06)
 #   Genesis:   N/A — Gemma 4 family is not Qwen3-Next
 #   Status:    🧪 Experimental — AWQ MoE + external MTP on stock v0.22.0 (#326)
-#   Caveats:   Boot + coherence + tool-call validated 2026-06-06 on 1x RTX 3090
-#              (Marlin WNA16 MoE, ~22 GB). Single-card max ctx is 16K (vs 262K on
-#              the dual) — weights (17 GB) + drafter leave only ~17.5K KV tokens.
+#   Caveats:   Boot + coherence + tool-call + NIAH (clean to 37.6K) validated
+#              2026-06-06 on 1x RTX 3090 (Marlin WNA16 MoE). Single-card max ctx
+#              is 42K (vs 262K on the dual) — 17 GB weights + drafter leave only
+#              ~1.8 GiB for KV (~993 tok / 1.31 GB headroom → one full-42K request
+#              at a time; short requests pack more). For >42K single-card, use a
+#              llama.cpp GGUF with q8/q4 KV quant (vLLM gemma4 KV is bf16-only on
+#              Ampere). 0.92 util is the safe ceiling — do not raise it here.
 #              Promote to ⚠️ after rebench-full + soak. The AutoRound INT4-mixed
 #              sibling is Ampere-dead (uint8b128 has no sm_86 W4A16 kernel).
 # ---------------------------------------------------------------------------
@@ -80,7 +85,7 @@ services:
       - --pipeline-parallel-size
       - "${PP:-1}"
       - --max-model-len
-      - "${MAX_MODEL_LEN:-16384}"
+      - "${MAX_MODEL_LEN:-42000}"
       - --gpu-memory-utilization
       - "${GPU_MEMORY_UTILIZATION:-0.92}"
       - --max-num-seqs

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -508,12 +508,12 @@ COMPOSE_REGISTRY = {
     "vllm/gemma-26ba4b-single": _entry(
         model="gemma-4-26b-a4b", weights_variant="awq", workload="fast-chat",
         engine="vllm-stable", drafter="gemma-26b-it-assistant", kv_format="bf16",
-        tp=1, max_ctx=16384, max_num_seqs=256, mem_util=0.92,
+        tp=1, max_ctx=42000, max_num_seqs=256, mem_util=0.92,
         compose_path="models/gemma-4-26b-a4b/vllm/compose/single/awq/mtp.yml",
         default_port=8040,
         kvcalc_key="SKIP",
         status="experimental",
-        status_note="AWQ MoE + external MTP (gemma-26b-it-assistant n=4) on stock v0.22.0 — boot+coherence+tool-call validated 2026-06-06 (1x 3090, Marlin WNA16 MoE). Max ctx 16K (KV pool 17,490 tok after 17 GB weights + drafter). Promote after rebench-full + soak.",
+        status_note="AWQ MoE + external MTP (gemma-26b-it-assistant n=4) on stock v0.22.0 — boot+coherence+tool-call+NIAH(to 37.6K) validated 2026-06-06 (1x 3090, Marlin WNA16 MoE). Max ctx 42K laddered (KV pool 42,993 tok at 42000/0.92; vLLM boot-est ceiling 44,224); ~993 tok headroom, one full-42K request at a time. Promote after rebench-full + soak.",
     ),
     "vllm/gemma-26ba4b-dual": _entry(
         model="gemma-4-26b-a4b", weights_variant="awq", workload="fast-chat",

--- a/scripts/lib/profiles/profile_runtime.yml
+++ b/scripts/lib/profiles/profile_runtime.yml
@@ -649,7 +649,7 @@ profiles:
       param_slots:
         ports: { source: E.default_port, value: 8040 }
         tensor_parallel_size: { token: '${TP}', source: E.tp, value: 1 }
-        max_model_len: { token: '${MAX_MODEL_LEN}', source: E.max_ctx, value: 16384 }
+        max_model_len: { token: '${MAX_MODEL_LEN}', source: E.max_ctx, value: 42000 }
         gpu_memory_utilization: { token: '${GPU_MEMORY_UTILIZATION}', source: E.mem_util, value: 0.92 }
         kv_cache_dtype: { token: '${KV_CACHE_DTYPE}', source: 'kv_arg(E.kv_format)', kv_format: bf16, value: null }
         max_num_seqs: { token: '--max-num-seqs', source: E.max_num_seqs, value: 256 }


### PR DESCRIPTION
Raises `vllm/gemma-26ba4b-single` max-model-len **16,384 → 42,000** after live context laddering on 1× 3090 (AWQ + external MTP n=4, bf16 KV, 0.92 util). The shipped 16K was ~2.6× too conservative.

## Ceiling, measured
| Probe | Result |
|---|---|
| vLLM boot pre-check | estimates max **44,224**; 40,960 / 42,000 boot (pool 42,408 / 42,993 tok); 256K errors (5.98 GiB KV needed vs 1.82 avail) |
| kv-calc `--solve-max-ctx` (75,776) | optimistic — counts only the 5 full-attn layers' growing KV; engine pre-check is authoritative |
| **verify-stress NIAH** | clean recall at 10K / 30K + ceiling ladder **29K / 32K / 35K / 37K** (fillable to 37,639 = 91% of window), **zero degradation**, VRAM Δ0 across the ladder — no false ceiling / Cliff |

## Wired
- `max-model-len` 42,000 (pool 42,993 tok, ~993 headroom, 1.31 GB VRAM free at 0.92) — one full-42K request at a time; short requests pack more.
- Registry `max_ctx` + `profile_runtime` mirror; compose header records the ladder + NIAH evidence.
- **0.92 is the safe util ceiling** on a 24 GB card — higher risks OOM. For **>42K single-card**, the path is a llama.cpp GGUF with q8/q4 KV quant (vLLM gemma4 KV is bf16-only on Ampere; the weights, not SWA support, are the limit).

Gate **42/42**, single C12 verdict **TIGHT** (correct). Still 🧪 Experimental pending the #464 rebench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)