### PR TITLE
Image Studio bundle (P1): Ideogram-4 image gen + gemma-4-12b chat + Open WebUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ If you have one or two RTX 3090s and want to run modern LLMs at home, in a homel
 
 > 🎯 **4090 or 5090 owner?** The composes run cross-rig — contributors have benched both with measured numbers: **[Can I use a 4090? →](docs/FAQ.md#can-i-use-a-4090-instead-of-a-3090)** · **[Can I use a 5090? →](docs/FAQ.md#can-i-use-a-5090)**. The tooling is calibrated for 3090s but the configs are class-aware; per-class gotchas (4090's tighter idle VRAM, 5090's 32 GB envelope) + cross-rig benchmark rows live in the FAQ.
 
+> 🎨 **Want image generation too?** The **[Image Studio bundle](docs/IMAGE_STUDIO.md)** runs Ideogram-4 image gen + a chat model + Open WebUI together on two GPUs — one command: `bash scripts/setup-image-studio.sh`.
+
 ---
 
 ## Quick start

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -163,6 +163,8 @@ Yes — but **not through the LLM stack.** The text models (Qwen3.6 / Gemma) and
 
 Open-weight models that fit one 3090 (run in ComfyUI): **FLUX.1-dev** (Q8 — aesthetic benchmark), **Qwen-Image** (best text-in-image), **FLUX.2-klein-4B** / **Z-Image-Turbo** (lighter/faster), **HiDream-I1**, **Ideogram-4** (top open quality, ~whole card). Video: **Cosmos3-Nano** / **LTX-2** are feasible on one card; **Wan2.2** / **HunyuanVideo-1.5** are tight. Worked-out shortlist + VRAM sizes: [`models/qwen3-omni-30b-a3b/vllm-omni/README.md`](../models/qwen3-omni-30b-a3b/vllm-omni/README.md).
 
+**Turnkey path:** the **[Image Studio bundle](IMAGE_STUDIO.md)** wires this up for you — `bash scripts/setup-image-studio.sh` (or `gpu-mode image-studio`) brings up Ideogram-4 image gen on one card + a gemma-4-12b chat model on the other + Open WebUI as the front end, so chat and image gen coexist on a 2-GPU box. See [`IMAGE_STUDIO.md`](IMAGE_STUDIO.md).
+
 ### Why does my image model OOM even though the transformer quant is small?
 
 The **text encoder.** Image models bundle a big one — FLUX.1 → T5-XXL (~5–8 GB), FLUX.2-klein / Z-Image → Qwen3-4B (~8 GB), Ideogram-4 → Qwen3-VL-8B, FLUX.2-*dev* → Mistral-3-24B. A "4 GB" transformer GGUF can still need **12–16 GB** once the encoder + VAE + activations load. **Always size the full pipeline, not just the transformer.** GGUF shrinks only the transformer; the encoder needs separate quant or CPU offload. (For diffusion, GGUF **Q5/Q6 ≈ near-lossless**, and FLUX-class tolerates Q4 well.)

--- a/docs/IMAGE_STUDIO.md
+++ b/docs/IMAGE_STUDIO.md
@@ -1,0 +1,122 @@
+# Image Studio — local image generation + chat
+
+A self-hosted bundle that gives you **text-to-image generation and an LLM chat in one
+browser UI**, both running locally on your own GPUs:
+
+- **[ComfyUI](https://github.com/comfyanonymous/ComfyUI)** runs **Ideogram-4** (fp8) for image generation.
+- **[Open WebUI](https://github.com/open-webui/open-webui)** is the front-end — chat plus a 🖼️ image button that calls ComfyUI.
+- **gemma-4-12b** (llama.cpp) is the default chat model, sized to **coexist** with image gen on a second GPU.
+
+On a 2-GPU box the two run at once (image gen on GPU 0, chat on GPU 1). On a single GPU
+they're mutually exclusive (see [Single-GPU](#single-gpu)).
+
+---
+
+## Quickstart
+
+```bash
+bash scripts/setup-image-studio.sh
+```
+
+That builds the ComfyUI image, downloads the Ideogram-4 model set (~27 GB), and brings the
+stack up via `gpu-mode image-studio`. Then open:
+
+- **Open WebUI** → `http://<your-host>:8080` — start here (chat + 🖼️ image button)
+- **ComfyUI** → `http://<your-host>:8188` — full node-graph control
+
+> First image after a cold ComfyUI takes ~2 min (it loads ~20 GB of weights). Warm
+> generations are ~70 s at 1024².
+
+Skip flags: `SKIP_DOWNLOAD=1` (weights already present), `SKIP_BUILD=1` (image already built).
+
+---
+
+## Two front-ends — which to use
+
+| Want… | Use | Why |
+|---|---|---|
+| **Easy** — type a prompt, get an image, chat | **Open WebUI** (`:8080`) | One box + the 🖼️ button. Your daily driver. |
+| **Control** — steps, CFG, seed, structured prompts, img2img | **ComfyUI** (`:8188`) | The node graph. Drop in when you want to tune. |
+
+In Open WebUI, image generation rides on the chat: send a prompt, then click the **🖼️
+picture icon** on the assistant's reply to render it via Ideogram-4. (It won't appear in
+the model selector — that's only for chat models.)
+
+In ComfyUI, load the bundled **Ideogram 4** template (Workflow → Browse Templates → Image).
+All model files are already in place, so it loads with no missing nodes.
+
+---
+
+## Modes (`gpu-mode`)
+
+Image gen, video gen, and chat are **GPU-mutually-exclusive** at the heavy end (a video
+model wants both cards; image + a small chat model fit on one card each). So the switcher
+is a resource-mode manager:
+
+| Mode | What it runs | GPUs |
+|---|---|---|
+| `gpu-mode image-studio` | ComfyUI/Ideogram-4 + gemma-4-12b chat + Open WebUI | GPU 0 (image) + GPU 1 (chat) |
+| `gpu-mode comfyui` | ComfyUI only (all GPUs) — for video / large image jobs | all |
+| `gpu-mode chat` | Open WebUI + LiteLLM (no local GPU model) | none |
+
+Within ComfyUI, switch *what* you generate by loading a different workflow/template.
+
+---
+
+## VRAM by resolution (Ideogram-4 fp8, measured on one RTX 3090)
+
+| Resolution | Peak VRAM | Time | Notes |
+|---|---|---|---|
+| 1024×1024 | ~18.5 GB | ~70 s warm | comfortable on a 24 GB card |
+| 2048×2048 | ~21.8 GB (89%) | ~320 s | fits but tight — **batch size 1 only**; larger or batched → OOM |
+
+It runs **single-device** — a second GPU doesn't speed up one generation. For routine
+high-res, prefer **generate at 1024² then upscale** (higher quality and lower peak VRAM
+than native 2048²).
+
+---
+
+## Chat model
+
+Default is **gemma-4-12b** on the spare GPU (`:8069`), so chat and image gen run at the
+same time. To use your full LLM catalog instead, point Open WebUI at LiteLLM — see the
+commented `OPENAI_API_BASE_URL` block in `services/openwebui/docker-compose.yml`. (LiteLLM's
+larger models are GPU-mutex with ComfyUI, so you'd lose simultaneous image gen.)
+
+### Single-GPU
+
+With one GPU, image gen and a local chat model can't run together. `gpu-mode image-studio`
+detects this and starts ComfyUI only; for chat use `gpu-mode chat` (LiteLLM) or run a local
+model while ComfyUI is down.
+
+---
+
+## Troubleshooting
+
+**Image button missing / image gen not configured in Open WebUI.** Open WebUI's image
+settings are *PersistentConfig* — the values in `services/openwebui/imagegen.env` apply only
+on a **fresh data volume** (first boot). If you reused an existing `open-webui-data` volume,
+set it manually: **Admin → Settings → Images** → Engine `ComfyUI`, Base URL
+`http://host.docker.internal:8188`, then load the Ideogram-4 workflow (or recreate the volume).
+
+**Out of memory at high resolution.** Drop back to 1024² (+ upscale), and keep batch size 1
+at 2048². Ideogram-4 fp8 peaks ~21.8 GB at 2048² — there's little headroom on a 24 GB card.
+
+**First generation is very slow.** Cold ComfyUI loads ~20 GB (two fp8 transformers + the
+text encoder). The first request after boot warms it; subsequent ones are ~70 s.
+
+**First ComfyUI boot takes minutes.** The entrypoint clones ComfyUI + custom nodes and
+installs requirements on first run. Tail it: `sudo docker logs -f comfyui`.
+
+---
+
+## What's installed
+
+- Image model: Ideogram-4 fp8 (`services/comfyui/download_ideogram4.sh`) — two transformers
+  + Qwen3-VL-8B text encoder + flux2 VAE, in the ComfyUI models tree.
+- ComfyUI HEAD (native Ideogram-4 support) built via `services/comfyui/Dockerfile`.
+- Open WebUI pinned to a tested release, image-gen wired via `services/openwebui/imagegen.env`.
+- Chat: `models/gemma-4-12b/llama-cpp/compose/single/unsloth-q8kxl/base.yml` on the spare GPU.
+
+> **Video & audio generation** are planned follow-ons (this page will gain `video-studio` /
+> `audio-studio` sections as they land).

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Start here if you want to run a model.
 | [`FAQ.md`](FAQ.md) | Common setup and operational questions. |
 | [`COMPARISONS.md`](COMPARISONS.md) | Self-host vs cloud APIs — cost crossover and when each wins. |
 | [`EXAMPLES.md`](EXAMPLES.md) | Worked end-to-end usage examples. |
+| [`IMAGE_STUDIO.md`](IMAGE_STUDIO.md) | **Local image generation** (Ideogram-4 via ComfyUI) + chat in one UI (Open WebUI), coexisting on 2 GPUs. |
 
 ---
 

--- a/scripts/gpu-mode.sh
+++ b/scripts/gpu-mode.sh
@@ -15,6 +15,9 @@ COMPOSE_BASE="$CLUB3090_DIR/services"
 DUAL_27B_DIR="$CLUB3090_DIR/models/qwen3.6-27b/vllm/compose/dual/autoround-int4"
 GEMMA_DUAL_DIR="$CLUB3090_DIR/models/gemma-4-31b/vllm/compose/dual/autoround-int4"
 GEMMA_DUAL_AWQ_DIR="$CLUB3090_DIR/models/gemma-4-31b/vllm/compose/dual/awq"
+# Image-studio chat brain: gemma-4-12b single-card (llama.cpp), pinned to the spare GPU
+# so it coexists with ComfyUI image gen (different card). See `gpu-mode image-studio`.
+GEMMA_12B_DIR="$CLUB3090_DIR/models/gemma-4-12b/llama-cpp/compose/single/unsloth-q8kxl"
 
 # Estate planner state file (v0.7.0+). Instances booted via launch.sh --estate
 # or --estate-file are tracked here and persist via Docker `restart:
@@ -54,6 +57,23 @@ compose_at() {
             env_args=(--env-file "$CLUB3090_DIR/.env")
         fi
         (cd "$dir" && sudo docker compose "${env_args[@]}" -f "$file" $action)
+    fi
+}
+
+# Like compose_at, but injects per-invocation env assignments that survive `sudo`.
+# `sudo docker compose` sanitizes the caller's environment, so vars set in the shell
+# don't reach compose interpolation — pass them as leading `VAR=val` args to the
+# command instead (`sudo VAR=val docker compose ...`).
+# Args: <dir> <action> <file> [VAR=val ...]
+compose_at_env() {
+    local dir=$1 action=$2 file=$3; shift 3
+    local envs=("$@")
+    if [ -f "$dir/$file" ]; then
+        local env_args=()
+        if [ -f "$CLUB3090_DIR/.env" ]; then
+            env_args=(--env-file "$CLUB3090_DIR/.env")
+        fi
+        (cd "$dir" && sudo "${envs[@]}" docker compose "${env_args[@]}" -f "$file" $action)
     fi
 }
 
@@ -126,6 +146,26 @@ start_comfyui() {
 stop_comfyui() {
     printf "  ${RED}▼${NC} Stopping comfyui..."
     compose_at "$COMPOSE_BASE/comfyui" "down" && echo "done" || echo "skipped"
+}
+
+# ComfyUI pinned to GPU 0 (image-studio split — leaves the other card for the chat LLM).
+start_comfyui_gpu0() {
+    printf "  ${GREEN}▲${NC} Starting comfyui (GPU0)..."
+    compose_at_env "$COMPOSE_BASE/comfyui" "up -d" docker-compose.yml COMFYUI_CUDA_VISIBLE_DEVICES=0 \
+        && echo "done" || echo "failed"
+}
+
+# --- gemma-4-12b chat brain (llama.cpp single-card) — image-studio's coexisting LLM ---
+# Pinned to the spare GPU (1) so it runs alongside ComfyUI on GPU0. Serves OpenAI API :8069.
+start_gemma_12b_chat() {
+    printf "  ${GREEN}▲${NC} Starting gemma-4-12b-chat (GPU1)..."
+    compose_at_env "$GEMMA_12B_DIR" "up -d" base.yml ESTATE_GPUS=1 CTX_SIZE=32768 PORT=8069 \
+        && echo "done" || echo "failed"
+}
+stop_gemma_12b_chat() {
+    printf "  ${RED}▼${NC} Stopping gemma-4-12b-chat..."
+    compose_at_env "$GEMMA_12B_DIR" "down" base.yml ESTATE_GPUS=1 CTX_SIZE=32768 PORT=8069 \
+        && echo "done" || echo "skipped"
 }
 
 # --- Gemma 4 31B dual-card serving variants ---------------------------------
@@ -206,6 +246,11 @@ show_status() {
         local m
         m=$(curl -sf -m 2 http://localhost:8032/v1/models | python3 -c "import sys,json;d=json.load(sys.stdin);print(', '.join(x['id'] for x in d.get('data',[])))" 2>/dev/null)
         echo -e "  ${GREEN}▶${NC} gemma-int8 @ :8032        → ${m:-unknown} (INT8 PTH KV)"
+    fi
+    if curl -sf -m 2 http://localhost:8069/v1/models >/dev/null 2>&1; then
+        local m
+        m=$(curl -sf -m 2 http://localhost:8069/v1/models | python3 -c "import sys,json;d=json.load(sys.stdin);print(', '.join(x['id'] for x in d.get('data',[])))" 2>/dev/null)
+        echo -e "  ${GREEN}▶${NC} gemma-4-12b @ :8069      → ${m:-unknown} (image-studio chat brain, GPU1, llama.cpp)"
     fi
     if curl -sf -m 2 http://localhost:8188/ >/dev/null 2>&1; then
         echo -e "  ${GREEN}▶${NC} ComfyUI @ :8188          → image/video generation (GPU-bound, mutex with LLM)"
@@ -457,6 +502,40 @@ mode_comfyui() {
     echo -e "${YELLOW}Tail: sudo docker logs -f comfyui${NC}"
 }
 
+mode_image_studio() {
+    echo -e "${CYAN}═══ Switching to IMAGE-STUDIO mode (image gen + chat, 2-card split) ═══${NC}"
+    echo "Starting: ComfyUI/Ideogram-4 on GPU0 + gemma-4-12b chat on GPU1 + Open WebUI"
+    echo "Stopping: all dual-card LLM serving (Qwen + Gemma-31B)"
+    echo ""
+    local ngpu
+    ngpu=$(nvidia-smi -L 2>/dev/null | wc -l)
+    stop_service ollama
+    stop_all_27b
+    stop_all_gemma
+    if [ "${ngpu:-0}" -lt 2 ]; then
+        echo -e "${YELLOW}⚠ Only ${ngpu:-0} GPU detected — image gen + a local chat model can't coexist"
+        echo -e "  (both are GPU-resident). Starting ComfyUI image gen only.${NC}"
+        echo -e "  ${YELLOW}For chat: use 'gpu-mode chat' (LiteLLM) or run gemma-4-12b when ComfyUI is down.${NC}"
+        start_comfyui   # default (all GPUs) — single-card box, nothing to split
+    else
+        start_comfyui_gpu0
+        start_gemma_12b_chat
+    fi
+    start_service openwebui
+    start_service litellm
+    start_service searxng
+    echo ""
+    echo -e "${GREEN}Image-studio mode active.${NC}"
+    echo -e "  Open WebUI:  http://192.168.86.33:8080   (chat + 🖼️ image button)"
+    echo -e "  ComfyUI:     http://192.168.86.33:8188   (full node graph / control)"
+    if [ "${ngpu:-0}" -ge 2 ]; then
+        echo -e "  Chat model:  gemma-4-12b @ :8069 (GPU1) — OpenWebUI default"
+    fi
+    echo -e "${YELLOW}First ComfyUI boot ~2-3 min (clones HEAD + nodes); first image ~2 min cold / ~70 s warm.${NC}"
+    echo -e "${YELLOW}If the OpenWebUI image button is missing on an existing volume: Admin → Settings → Images.${NC}"
+    echo -e "${YELLOW}Tail: sudo docker logs -f comfyui | sudo docker logs -f llama-cpp-gemma4-12b${NC}"
+}
+
 mode_bigmodel() {
     echo -e "${CYAN}═══ Switching to BIG MODEL mode ═══${NC}"
     echo "Stopping ALL containers to maximize RAM + VRAM..."
@@ -638,8 +717,10 @@ usage() {
     echo "  gemma-int8         alias for 'gemma' (INT8 PTH KV; 98K default, CTX=262144 MAX_NUM_SEQS=1 for native 262K)"
     echo "  gemma-mtp          bf16 KV fallback — 32K, stock vLLM v0.22.0, no overlay (:8030)"
     echo ""
-    echo "  Image / Video Gen (mutex with all LLM modes — GPU-bound):"
-    echo "  comfyui            ComfyUI :8188 (FLUX, HunyuanVideo, Wan2.2-Animate)"
+    echo "  Image / Video Gen:"
+    echo "  image-studio       ⭐ Ideogram-4 image gen (GPU0) + gemma-4-12b chat (GPU1) + Open WebUI"
+    echo "                     — chat + image coexist on 2 cards (alias: imagestudio)"
+    echo "  comfyui            ComfyUI :8188 only, all GPUs (FLUX/Hunyuan/Wan; mutex with LLM)"
     echo ""
     echo "  bigmodel           Stop everything, max RAM+VRAM for one-off llama-server / custom workloads"
     echo "  off                Stop all services"
@@ -665,6 +746,7 @@ case "${1:-}" in
     gemma-int8)         mode_gemma_int8 ;;
     gemma-mtp)          mode_gemma ;;
     comfyui)            mode_comfyui ;;
+    image-studio|imagestudio) mode_image_studio ;;
     bigmodel)           mode_bigmodel ;;
     off)                mode_off ;;
     status)             show_status ;;

--- a/scripts/setup-image-studio.sh
+++ b/scripts/setup-image-studio.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# One-shot setup for the club-3090 IMAGE-STUDIO bundle:
+#   ComfyUI (Ideogram-4 image gen) + OpenWebUI front-end + gemma-4-12b chat,
+#   coexisting on a 2-GPU box (ComfyUI→GPU0, chat→GPU1).
+#
+#   bash scripts/setup-image-studio.sh            # build + download + bring up
+#   SKIP_DOWNLOAD=1 bash scripts/setup-image-studio.sh   # skip the 27 GB weight pull
+#   SKIP_BUILD=1    bash scripts/setup-image-studio.sh   # skip the ComfyUI image build
+#
+# Idempotent: re-running re-pulls/rebuilds only what changed. Brings the stack up
+# via `gpu-mode image-studio`.
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMFYUI_DIR="$REPO_DIR/services/comfyui"
+LANIP="${LANIP:-$(hostname -I 2>/dev/null | tr ' ' '\n' | grep -E '^192\.168\.' | head -1)}"
+LANIP="${LANIP:-<host-ip>}"
+
+say()  { echo -e "\033[0;36m$*\033[0m"; }
+warn() { echo -e "\033[1;33m$*\033[0m"; }
+ok()   { echo -e "\033[0;32m$*\033[0m"; }
+
+# --- 0. Preflight -----------------------------------------------------------
+command -v docker >/dev/null 2>&1 || { echo "ERROR: docker not found." >&2; exit 1; }
+NGPU=$(nvidia-smi -L 2>/dev/null | wc -l)
+say "═══ club-3090 image-studio setup ═══"
+echo "  repo:  $REPO_DIR"
+echo "  GPUs:  $NGPU"
+if [ "${NGPU:-0}" -lt 2 ]; then
+    warn "  ⚠ <2 GPUs — image gen and a local chat model can't run at once (GPU-mutex)."
+    warn "    The bundle will run ComfyUI image gen; for chat use 'gpu-mode chat' (LiteLLM)"
+    warn "    or run gemma-4-12b only while ComfyUI is down. Continuing…"
+fi
+
+# --- 1. Build the ComfyUI image (clones ComfyUI HEAD + nodes on first boot) --
+if [ -z "${SKIP_BUILD:-}" ]; then
+    say "── [1/3] Building ComfyUI image (comfyui-local:latest) ──"
+    (cd "$COMFYUI_DIR" && sudo docker compose build)
+else
+    echo "  (SKIP_BUILD set — skipping image build)"
+fi
+
+# --- 2. Download the Ideogram-4 model set (~27 GB) --------------------------
+if [ -z "${SKIP_DOWNLOAD:-}" ]; then
+    say "── [2/3] Downloading Ideogram-4 model set (~27 GB; skip with SKIP_DOWNLOAD=1) ──"
+    bash "$COMFYUI_DIR/download_ideogram4.sh"
+else
+    echo "  (SKIP_DOWNLOAD set — skipping weight download)"
+fi
+
+# --- 3. Bring the stack up via gpu-mode -------------------------------------
+say "── [3/3] Starting the bundle (gpu-mode image-studio) ──"
+bash "$REPO_DIR/scripts/gpu-mode.sh" image-studio
+
+echo ""
+ok "═══ Image-studio ready ═══"
+echo "  Open WebUI:  http://$LANIP:8080   ← chat + 🖼️ image button (start here)"
+echo "  ComfyUI:     http://$LANIP:8188   ← full node-graph control"
+echo ""
+warn "First image after a cold ComfyUI is slow (~2 min, loads ~20 GB); warm gens ~70 s."
+warn "Image button not showing in OpenWebUI? You're on a PRE-EXISTING data volume — OpenWebUI"
+warn "only reads the image-gen env on a FRESH volume. Set it in Admin → Settings → Images"
+warn "(Engine=ComfyUI, Base URL=http://host.docker.internal:8188), or recreate the volume."

--- a/services/comfyui/docker-compose.yml
+++ b/services/comfyui/docker-compose.yml
@@ -16,6 +16,9 @@ services:
       - /mnt/models/comfyui/user:/workspace/ComfyUI/user
       # Folder-aliasing yaml so loaders find files whether they look in unet/ or diffusion_models/
       - ./extra_model_paths.yaml:/workspace/ComfyUI/extra_model_paths.yaml:ro
+      # Mount the entrypoint (overrides the image-baked copy) so bootstrap/pin changes
+      # apply on `up` without a full image rebuild.
+      - ./entrypoint.sh:/entrypoint.sh:ro
       # Pip cache so re-launches don't re-download every wheel
       - /mnt/models/comfyui/pip-cache:/root/.cache/pip
       # Share existing HF cache (so anything already pulled by vLLM/SGLang is reusable)
@@ -30,6 +33,9 @@ services:
       # Honored in entrypoint.sh (only exported when non-empty — empty CUDA_VISIBLE_DEVICES
       # would hide ALL GPUs).
       - COMFYUI_CUDA_VISIBLE_DEVICES=${COMFYUI_CUDA_VISIBLE_DEVICES:-}
+      # ComfyUI version pin: empty → the entrypoint's pinned commit (reproducible, has
+      # Ideogram-4). Set COMFYUI_REF=HEAD to float on upstream master (bleeding edge).
+      - COMFYUI_REF=${COMFYUI_REF:-}
     shm_size: "8gb"
     deploy:
       resources:

--- a/services/comfyui/docker-compose.yml
+++ b/services/comfyui/docker-compose.yml
@@ -24,6 +24,12 @@ services:
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HOME=/root/.cache/huggingface
       - PYTHONUNBUFFERED=1
+      # GPU pin (opt-in): empty = all reserved GPUs visible (default — image on cuda:0,
+      # video can use both). Set to e.g. "0" to confine ComfyUI to one card so a chat LLM
+      # can run on the other (the `gpu-mode image-studio` 2-card split passes "0").
+      # Honored in entrypoint.sh (only exported when non-empty — empty CUDA_VISIBLE_DEVICES
+      # would hide ALL GPUs).
+      - COMFYUI_CUDA_VISIBLE_DEVICES=${COMFYUI_CUDA_VISIBLE_DEVICES:-}
     shm_size: "8gb"
     deploy:
       resources:

--- a/services/comfyui/download_ideogram4.sh
+++ b/services/comfyui/download_ideogram4.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Downloads the Ideogram-4 (fp8) image-generation model set for the image-studio
+# bundle into the ComfyUI models tree. ComfyUI HEAD has native Ideogram-4 support
+# (Ideogram4Scheduler / DualModelGuider) — no custom node needed.
+#
+# Two fp8 transformers (main + unconditional) + the Qwen3-VL-8B text encoder +
+# flux2 VAE. ~27 GB total. Validated single-3090: 1024² ~18.5 GB / ~70 s.
+#
+# Run:  ./download_ideogram4.sh          (foreground)
+#       nohup ./download_ideogram4.sh > /tmp/ideogram4-dl.log 2>&1 &   (background)
+#
+# Lands files where ComfyUI's loaders look:
+#   models/diffusion_models/ideogram4_fp8_scaled.safetensors
+#   models/diffusion_models/ideogram4_unconditional_fp8_scaled.safetensors
+#   models/text_encoders/qwen3vl_8b_fp8_scaled.safetensors
+#   models/vae/flux2-vae.safetensors
+set -uo pipefail
+
+ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
+LOG_TS() { date +%H:%M:%S; }
+log()  { echo "[$(LOG_TS)] $*"; }
+step() { log ""; log "=== $* ==="; }
+
+command -v hf >/dev/null 2>&1 || { echo "ERROR: 'hf' (huggingface_hub CLI) not found. pip install -U huggingface_hub" >&2; exit 1; }
+mkdir -p "$ROOT/diffusion_models" "$ROOT/text_encoders" "$ROOT/vae"
+
+step "1/4  Ideogram-4 fp8 transformer (main, ~8.7 GB)"
+hf download Comfy-Org/Ideogram-4 \
+    diffusion_models/ideogram4_fp8_scaled.safetensors \
+    --local-dir "$ROOT"
+
+step "2/4  Ideogram-4 fp8 transformer (unconditional, ~8.7 GB)"
+hf download Comfy-Org/Ideogram-4 \
+    diffusion_models/ideogram4_unconditional_fp8_scaled.safetensors \
+    --local-dir "$ROOT"
+
+step "3/4  Qwen3-VL-8B fp8 text encoder (~9.9 GB)"
+hf download Comfy-Org/Qwen3-VL \
+    text_encoders/qwen3vl_8b_fp8_scaled.safetensors \
+    --local-dir "$ROOT"
+
+step "4/4  flux2 VAE (~321 MB)"
+# This repo nests the VAE under split_files/vae/. Stage then flatten to vae/.
+hf download Comfy-Org/flux2-dev \
+    split_files/vae/flux2-vae.safetensors \
+    --local-dir "$ROOT"
+if [ -f "$ROOT/split_files/vae/flux2-vae.safetensors" ] && [ ! -e "$ROOT/vae/flux2-vae.safetensors" ]; then
+    ln -s ../split_files/vae/flux2-vae.safetensors "$ROOT/vae/flux2-vae.safetensors"
+fi
+
+step "DONE — Ideogram-4 set in $ROOT"
+ls -lh "$ROOT/diffusion_models/"ideogram4_*fp8_scaled.safetensors \
+       "$ROOT/text_encoders/qwen3vl_8b_fp8_scaled.safetensors" \
+       "$ROOT/vae/flux2-vae.safetensors" 2>/dev/null | awk '{print "  "$5"  "$NF}'

--- a/services/comfyui/entrypoint.sh
+++ b/services/comfyui/entrypoint.sh
@@ -3,6 +3,14 @@
 # pulls latest on subsequent runs, then launches the ComfyUI server on :8188.
 set -euo pipefail
 
+# Optional GPU pin: confine ComfyUI to specific card(s) so a chat LLM can use the rest
+# (the `gpu-mode image-studio` 2-card split passes "0"). Only export when non-empty —
+# CUDA_VISIBLE_DEVICES="" would hide ALL GPUs.
+if [ -n "${COMFYUI_CUDA_VISIBLE_DEVICES:-}" ]; then
+    export CUDA_VISIBLE_DEVICES="$COMFYUI_CUDA_VISIBLE_DEVICES"
+    echo "[bootstrap] CUDA_VISIBLE_DEVICES pinned to $CUDA_VISIBLE_DEVICES"
+fi
+
 COMFY_ROOT="/workspace/ComfyUI"
 PIP_OPTS="--no-input --retries 10 --timeout 60"
 

--- a/services/comfyui/entrypoint.sh
+++ b/services/comfyui/entrypoint.sh
@@ -31,20 +31,43 @@ clone_or_update() {
 #    so host-side hf download / file moves work after container has touched them as root.
 chmod -R a+rwX /workspace/ComfyUI/models /workspace/ComfyUI/input /workspace/ComfyUI/output /workspace/ComfyUI/user 2>/dev/null || true
 
-# 1. ComfyUI core — clone into a tmp dir then sync over (target dir is non-empty due to bind mounts)
+# 1. ComfyUI core — PINNED to a known-good commit (reproducible; this commit has
+#    native Ideogram-4 support and is validated on this stack). Floating on HEAD would
+#    let an upstream change silently break users. Set COMFYUI_REF=HEAD (or 'latest') to
+#    float on origin/master instead (needed for bleeding-edge models — re-pin after
+#    validating). Bump this default in the same change that re-validates image gen.
+COMFYUI_REF="${COMFYUI_REF:-cb9f6394160808f7d25163f6cc2ea300c6841ef9}"
+checkout_comfy_ref() {  # $1 = repo dir
+    local r="$1"
+    if [ "$COMFYUI_REF" = "HEAD" ] || [ "$COMFYUI_REF" = "latest" ]; then
+        echo "[bootstrap] ComfyUI: floating on origin/master (COMFYUI_REF=$COMFYUI_REF)"
+        git -C "$r" fetch --depth 1 origin 2>/dev/null || true
+        git -C "$r" reset --hard origin/master 2>/dev/null || git -C "$r" pull --ff-only || true
+    else
+        echo "[bootstrap] ComfyUI: pinned to ${COMFYUI_REF:0:12}"
+        git -C "$r" fetch --depth 1 origin "$COMFYUI_REF" 2>/dev/null || git -C "$r" fetch origin 2>/dev/null || true
+        git -C "$r" checkout -q -f "$COMFYUI_REF" 2>/dev/null \
+          || git -C "$r" reset --hard "$COMFYUI_REF" 2>/dev/null \
+          || echo "[bootstrap] WARN: could not checkout $COMFYUI_REF (offline?) — using current tree"
+    fi
+}
 if [ ! -f "$COMFY_ROOT/main.py" ]; then
     echo "[bootstrap] Cloning ComfyUI into temp..."
     rm -rf /tmp/_comfy_clone
-    git clone --depth 1 https://github.com/comfyanonymous/ComfyUI.git /tmp/_comfy_clone
+    # Full clone (not --depth 1) so an arbitrary pinned commit is checkout-able.
+    git clone https://github.com/comfyanonymous/ComfyUI.git /tmp/_comfy_clone
+    if [ "$COMFYUI_REF" != "HEAD" ] && [ "$COMFYUI_REF" != "latest" ]; then
+        git -C /tmp/_comfy_clone checkout -q -f "$COMFYUI_REF" 2>/dev/null \
+          || echo "[bootstrap] WARN: pinned ref $COMFYUI_REF not found in fresh clone — using HEAD"
+    fi
     mkdir -p "$COMFY_ROOT"
-    # Move everything except dirs that exist as bind mounts (models, input, output, user)
+    # Copy everything except dirs that exist as bind mounts (models, input, output, user)
     cp -an /tmp/_comfy_clone/. "$COMFY_ROOT/"
     rm -rf /tmp/_comfy_clone
 elif [ -d "$COMFY_ROOT/.git" ]; then
-    echo "[bootstrap] ComfyUI already present, pulling..."
-    git -C "$COMFY_ROOT" pull --ff-only || true
+    checkout_comfy_ref "$COMFY_ROOT"
 else
-    echo "[bootstrap] ComfyUI present without .git; skipping pull."
+    echo "[bootstrap] ComfyUI present without .git; skipping pin/update."
 fi
 
 cd "$COMFY_ROOT"

--- a/services/openwebui/docker-compose.yml
+++ b/services/openwebui/docker-compose.yml
@@ -1,16 +1,28 @@
 services:
   open-webui:
-    image: ghcr.io/open-webui/open-webui:main
+    # Pinned (was :main) — v0.9.6 live-validated 2026-06-09: image-gen + chat config
+    # survive the migration. Bump deliberately, re-validate the image-gen wiring.
+    image: ghcr.io/open-webui/open-webui:v0.9.6
     container_name: open-webui
     restart: unless-stopped
     ports:
       - "8080:8080"
     volumes:
       - open-webui-data:/app/backend/data
+    env_file:
+      # Image generation: Ideogram-4 → ComfyUI (:8188). PersistentConfig — applies on a
+      # FRESH volume; on an existing volume set it in Admin → Settings → Images instead.
+      - ./imagegen.env
     environment:
+      # Chat model — DEFAULT: gemma-4-12b on the spare GPU (coexists with ComfyUI image gen).
+      # Bring it up with `gpu-mode image-studio`; it serves an OpenAI API on :8069 (no auth).
+      - OPENAI_API_BASE_URL=http://host.docker.internal:8069/v1
+      - OPENAI_API_KEY=sk-noauth
+      # Alternative — route chat through LiteLLM (the full catalog, but GPU-mutex with
+      # ComfyUI). Swap the two lines above for these:
+      #   - OPENAI_API_BASE_URL=http://host.docker.internal:4000/v1
+      #   - OPENAI_API_KEY=sk-litellm-master-key
       - OLLAMA_BASE_URL=http://host.docker.internal:11434
-      - OPENAI_API_BASE_URL=http://host.docker.internal:4000/v1
-      - OPENAI_API_KEY=sk-litellm-master-key
       - WEBUI_SECRET_KEY=change-this-secret-key
 
       # --- Web search / RAG ---

--- a/services/openwebui/docker-compose.yml
+++ b/services/openwebui/docker-compose.yml
@@ -23,7 +23,11 @@ services:
       #   - OPENAI_API_BASE_URL=http://host.docker.internal:4000/v1
       #   - OPENAI_API_KEY=sk-litellm-master-key
       - OLLAMA_BASE_URL=http://host.docker.internal:11434
-      - WEBUI_SECRET_KEY=change-this-secret-key
+      # Leave empty → Open WebUI generates a strong random key on first boot and persists it
+      # in the data volume (.webui_secret_key). NEVER ship a hardcoded shared secret (it would
+      # let anyone forge session tokens). Override via the host env only to share sessions
+      # across replicas: WEBUI_SECRET_KEY=<your-secret> docker compose up -d
+      - WEBUI_SECRET_KEY=${WEBUI_SECRET_KEY:-}
 
       # --- Web search / RAG ---
       - ENABLE_RAG_WEB_SEARCH=true

--- a/services/openwebui/imagegen.env
+++ b/services/openwebui/imagegen.env
@@ -1,0 +1,14 @@
+# OpenWebUI image-generation config — Ideogram-4 on the ComfyUI backend.
+# Loaded via `env_file:` in docker-compose.yml. These are OpenWebUI PersistentConfig
+# keys: they apply on a FRESH data volume (first boot). On an EXISTING volume the DB
+# value wins — reconfigure in Admin -> Settings -> Images (or recreate the volume).
+# Workflow is the validated native-fp8 two-transformer (DualModelGuider) graph;
+# node-map binds OpenWebUI's prompt/seed/size/steps inputs to the graph node ids.
+ENABLE_IMAGE_GENERATION=true
+IMAGE_GENERATION_ENGINE=comfyui
+COMFYUI_BASE_URL=http://host.docker.internal:8188
+IMAGE_GENERATION_MODEL=ideogram4_fp8_scaled.safetensors
+IMAGE_SIZE=1024x1024
+IMAGE_STEPS=20
+COMFYUI_WORKFLOW={"unet_main":{"class_type":"UNETLoader","inputs":{"unet_name":"ideogram4_fp8_scaled.safetensors","weight_dtype":"default"}},"unet_uncond":{"class_type":"UNETLoader","inputs":{"unet_name":"ideogram4_unconditional_fp8_scaled.safetensors","weight_dtype":"default"}},"clip":{"class_type":"CLIPLoader","inputs":{"clip_name":"qwen3vl_8b_fp8_scaled.safetensors","type":"ideogram4"}},"vae":{"class_type":"VAELoader","inputs":{"vae_name":"flux2-vae.safetensors"}},"pos":{"class_type":"CLIPTextEncode","inputs":{"text":"placeholder","clip":["clip",0]}},"neg":{"class_type":"ConditioningZeroOut","inputs":{"conditioning":["pos",0]}},"guider":{"class_type":"DualModelGuider","inputs":{"model":["unet_main",0],"positive":["pos",0],"cfg":3.5,"model_negative":["unet_uncond",0],"negative":["neg",0]}},"sigmas":{"class_type":"Ideogram4Scheduler","inputs":{"steps":20,"width":1024,"height":1024,"mu":0.5,"std":1.75}},"sampler":{"class_type":"KSamplerSelect","inputs":{"sampler_name":"euler"}},"noise":{"class_type":"RandomNoise","inputs":{"noise_seed":42}},"latent":{"class_type":"EmptyFlux2LatentImage","inputs":{"width":1024,"height":1024,"batch_size":1}},"samp":{"class_type":"SamplerCustomAdvanced","inputs":{"noise":["noise",0],"guider":["guider",0],"sampler":["sampler",0],"sigmas":["sigmas",0],"latent_image":["latent",0]}},"decode":{"class_type":"VAEDecode","inputs":{"samples":["samp",0],"vae":["vae",0]}},"save":{"class_type":"SaveImage","inputs":{"images":["decode",0],"filename_prefix":"owui_ideogram4"}}}
+COMFYUI_WORKFLOW_NODES=[{"type":"model","key":"unet_name","node_ids":["unet_main"]},{"type":"prompt","key":"text","node_ids":["pos"]},{"type":"width","key":"width","node_ids":["sigmas","latent"]},{"type":"height","key":"height","node_ids":["sigmas","latent"]},{"type":"steps","key":"steps","node_ids":["sigmas"]},{"type":"seed","key":"noise_seed","node_ids":["noise"]},{"type":"n","key":"batch_size","node_ids":["latent"]}]


### PR DESCRIPTION
## What

Adds a turnkey **image-studio bundle** to the supporting services: local image generation (**Ideogram-4** via ComfyUI) + a chat model + **Open WebUI** as the front end, coexisting on a 2-GPU box (image on one card, chat on the other).

One command:

```bash
bash scripts/setup-image-studio.sh
```

…builds the ComfyUI image, downloads the Ideogram-4 fp8 set, and brings the stack up via `gpu-mode image-studio`. See **[docs/IMAGE_STUDIO.md](docs/IMAGE_STUDIO.md)**.

## Changes

- **`services/comfyui/download_ideogram4.sh`** (new) — fetch the Ideogram-4 fp8 set (2 transformers + Qwen3-VL-8B encoder + flux2 VAE) into the ComfyUI models tree.
- **`services/comfyui/`** — opt-in GPU pin (`COMFYUI_CUDA_VISIBLE_DEVICES`); **ComfyUI pinned to a known-good commit** (`COMFYUI_REF`, has native Ideogram-4 support; set `=HEAD` to float); entrypoint mounted so pin/bootstrap edits apply on `up` without a full image rebuild.
- **`services/openwebui/`** — pinned `:v0.9.6`; image-gen wired via `imagegen.env` (the validated Ideogram-4 workflow + OWUI node-map); default chat → a small local model (gemma-4-12b) so chat + image coexist; **`WEBUI_SECRET_KEY` no longer hardcoded** — empty → Open WebUI generates & persists a per-deployment key (the old shared placeholder let anyone forge session tokens).
- **`scripts/gpu-mode.sh`** — new **`image-studio`** mode: ComfyUI on GPU 0 + gemma-4-12b chat on GPU 1 (2-card split); single-GPU falls back to image-only with a note.
- **`scripts/setup-image-studio.sh`** (new) — one-shot build + download + bring-up.
- **`docs/IMAGE_STUDIO.md`** (new) + index / README / FAQ pointers.

## Validated (2× RTX 3090)

- End-to-end: Open WebUI → ComfyUI → Ideogram-4 returns an image (~70 s warm @ 1024²).
- **Chat + image concurrent** — image gen (~18–22 GB, GPU 0) alongside the chat model (~14 GB, GPU 1), sampled live during a generation.
- VRAM by resolution: 1024² ~18.5 GB / ~70 s · 2048² ~21.8 GB / ~320 s (batch 1).
- ComfyUI pin + the secret-key fix confirmed in the live boot log; repo test suite unaffected.

## Notes / follow-ups

- **PersistentConfig**: the image-gen `imagegen.env` applies on a **fresh** Open WebUI volume; on an existing volume set it in *Admin → Settings → Images* (documented in IMAGE_STUDIO.md).
- Image-only for now. **Video** (HunyuanVideo-1.5 / Wan 2.2 / Kandinsky-5.0 / LTX-2) and **audio** (ACE-Step / Qwen3-TTS) are planned as `video-studio` / `audio-studio` modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
