### PR TITLE
Image Studio P1 follow-up: setup UX + LiteLLM route + architecture docs

### DIFF
--- a/docs/IMAGE_STUDIO.md
+++ b/docs/IMAGE_STUDIO.md
@@ -12,6 +12,45 @@ they're mutually exclusive (see [Single-GPU](#single-gpu)).
 
 ---
 
+## Architecture
+
+```
+                          Browser
+                             │
+                             ▼
+              ┌──────────────────────────────────────────┐
+              │  Open WebUI   :8080   (the front-end)     │
+              │    • chat            • 🖼️  image button    │
+              └───────┬──────────────────────┬────────────┘
+            chat      │                       │   image gen
+        (OpenAI API)  │                       │  (ComfyUI API)
+                      ▼                       ▼
+        ┌─────────────────────────┐   ┌───────────────────────────┐
+        │ gemma-4-12b   :8069     │   │ ComfyUI        :8188       │
+        │ llama.cpp               │   │ Ideogram-4 fp8 workflow    │
+        │ GPU 1  ·  ~14 GB        │   │ GPU 0  ·  ~18.5 GB @1024²  │
+        └────────────┬────────────┘   └─────────────┬─────────────┘
+                     │  (also routed via            │  loads from
+              LiteLLM :4000 gateway —               ▼
+              + the rest of the LLM      models/{diffusion_models,
+              catalog when their gpu-      text_encoders, vae}
+              mode is up)                  (Ideogram-4 fp8 set, ~27 GB)
+```
+
+- **Two GPUs, concurrent.** Validated live: image gen ~18–22 GB on **GPU 0** *and* the chat
+  model ~14 GB on **GPU 1** at the same time — sampled during a real generation.
+- **Open WebUI** owns the UX: chat goes to a text model; the 🖼️ button POSTs the prompt to
+  ComfyUI's API and pulls back the image.
+- **Chat routing.** By default Open WebUI talks **directly** to gemma-4-12b (`:8069`) — a clean
+  picker that only shows the model that's actually live in image-studio mode. gemma-4-12b is
+  **also** registered on the **LiteLLM gateway** (`:4000`) alongside the full LLM catalog, so
+  API clients / `benchlocal` can reach it the same way as every other model (the catalog's big
+  models only respond when their own `gpu-mode` is up — they're GPU-mutex with ComfyUI).
+- **ComfyUI** is a **fixed Docker service** (`services/comfyui`), pinned to a known-good ComfyUI
+  commit; it lazy-loads the Ideogram-4 weights into VRAM only *during* a generation.
+
+---
+
 ## Quickstart
 
 ```bash
@@ -24,10 +63,23 @@ stack up via `gpu-mode image-studio`. Then open:
 - **Open WebUI** → `http://<your-host>:8080` — start here (chat + 🖼️ image button)
 - **ComfyUI** → `http://<your-host>:8188` — full node-graph control
 
+### First run
+
+1. **Create your account.** Open the Open WebUI URL and **sign up** — the *first* account
+   created becomes the **admin**. (The setup script doesn't pre-set credentials; you choose
+   them here. There's no hardcoded secret — Open WebUI generates its own per deployment.)
+2. **Chat.** Pick **`gemma-4-12b…`** in the model selector (top of the chat) and talk to it.
+3. **Generate an image.** Send a prompt, then click the **🖼️ image icon** on the assistant's
+   reply — it renders via Ideogram-4 on ComfyUI and appears inline. Image generation is
+   **already enabled and wired** (the setup sets `ENABLE_IMAGE_GENERATION` + the ComfyUI
+   backend); you can inspect/tweak it under **Admin → Settings → Images** (steps, size, CFG).
+
 > First image after a cold ComfyUI takes ~2 min (it loads ~20 GB of weights). Warm
 > generations are ~70 s at 1024².
 
-Skip flags: `SKIP_DOWNLOAD=1` (weights already present), `SKIP_BUILD=1` (image already built).
+The script asks for confirmation before the heavy build/download; pass `--yes` (or `CI=1`)
+to skip the prompt. Skip flags: `SKIP_DOWNLOAD=1` (weights already present),
+`SKIP_BUILD=1` (image already built).
 
 ---
 
@@ -79,9 +131,16 @@ than native 2048²).
 ## Chat model
 
 Default is **gemma-4-12b** on the spare GPU (`:8069`), so chat and image gen run at the
-same time. To use your full LLM catalog instead, point Open WebUI at LiteLLM — see the
-commented `OPENAI_API_BASE_URL` block in `services/openwebui/docker-compose.yml`. (LiteLLM's
-larger models are GPU-mutex with ComfyUI, so you'd lose simultaneous image gen.)
+same time. Open WebUI points **directly** at it — a clean picker showing only the model
+that's actually live in image-studio mode.
+
+It's **also** registered on the **LiteLLM gateway** (`:4000`, `model_name: gemma-4-12b`) next
+to the rest of the catalog, so API clients reach it the same way as every other model. To
+make Open WebUI itself route through LiteLLM (and see the whole catalog), swap to the
+commented `OPENAI_API_BASE_URL` block in `services/openwebui/docker-compose.yml` — but note
+LiteLLM's *larger* models are GPU-mutex with ComfyUI, so they only respond when their own
+`gpu-mode` is up (you'd see them in the picker but they'd error in image-studio mode). That's
+exactly why the bundle defaults to gemma-direct.
 
 ### Single-GPU
 
@@ -114,9 +173,13 @@ installs requirements on first run. Tail it: `sudo docker logs -f comfyui`.
 
 - Image model: Ideogram-4 fp8 (`services/comfyui/download_ideogram4.sh`) — two transformers
   + Qwen3-VL-8B text encoder + flux2 VAE, in the ComfyUI models tree.
-- ComfyUI HEAD (native Ideogram-4 support) built via `services/comfyui/Dockerfile`.
-- Open WebUI pinned to a tested release, image-gen wired via `services/openwebui/imagegen.env`.
-- Chat: `models/gemma-4-12b/llama-cpp/compose/single/unsloth-q8kxl/base.yml` on the spare GPU.
+- ComfyUI built via `services/comfyui/Dockerfile`, **pinned to a known-good commit** (native
+  Ideogram-4 support; `COMFYUI_REF=HEAD` to float). Entrypoint is mounted so the pin applies
+  on `up` without a rebuild.
+- Open WebUI pinned to `v0.9.6`; image-gen wired via `services/openwebui/imagegen.env`; secret
+  key auto-generated per deployment.
+- Chat: `models/gemma-4-12b/llama-cpp/compose/single/unsloth-q8kxl/base.yml` on the spare GPU,
+  also routed on LiteLLM (`services/litellm/config.yaml`).
 
 > **Video & audio generation** are planned follow-ons (this page will gain `video-studio` /
 > `audio-studio` sections as they land).

--- a/scripts/setup-image-studio.sh
+++ b/scripts/setup-image-studio.sh
@@ -36,7 +36,36 @@ warn() { echo -e "\033[1;33m$*\033[0m"; }
 ok()   { echo -e "\033[0;32m$*\033[0m"; }
 
 # --- 0. Preflight + plan ----------------------------------------------------
-command -v docker >/dev/null 2>&1 || { echo "ERROR: docker not found." >&2; exit 1; }
+# Reuse the repo's preflight library (docker / gpu / disk), then add image-studio
+# specifics. Hard-fail before the long build/download if something's missing.
+# shellcheck disable=SC1091
+. "$REPO_DIR/scripts/preflight.sh" 2>/dev/null || true
+MODEL_DIR_RESOLVED="$(grep -E '^MODEL_DIR=' "$REPO_DIR/.env" 2>/dev/null | tail -1 | cut -d= -f2-)"
+MODEL_DIR_RESOLVED="${MODEL_DIR_RESOLVED:-/mnt/models/huggingface}"
+if declare -f preflight_docker >/dev/null 2>&1; then
+    preflight_docker || exit 1                                   # docker + compose v2 + daemon
+    preflight_gpu 1  || exit 1                                   # >=1 GPU (coexist needs 2 — warned below)
+    [ -z "${SKIP_BUILD:-}" ]    && { preflight_disk / 32 || exit 1; }                      # comfyui-local image (~27 GB) + base pull
+    [ -z "${SKIP_DOWNLOAD:-}" ] && { preflight_disk /mnt/models/comfyui 30 || exit 1; }    # Ideogram-4 set (~27 GB)
+    preflight_gpu_idle || true                                   # soft warn if VRAM already in use
+else
+    command -v docker >/dev/null 2>&1 || { echo "ERROR: docker not found." >&2; exit 1; }
+fi
+# Image-studio specifics (not in preflight.sh):
+if [ -z "${SKIP_DOWNLOAD:-}" ] && ! command -v hf >/dev/null 2>&1; then
+    echo "[preflight] ERROR: 'hf' (huggingface_hub CLI) not found — needed for the weight download." >&2
+    echo "            Fix: pip install -U huggingface_hub   (or SKIP_DOWNLOAD=1 if weights are present)." >&2
+    exit 1
+fi
+GEMMA_GGUF="$MODEL_DIR_RESOLVED/gemma-4-12b-gguf/unsloth-ud-q8kxl/gemma-4-12b-it-UD-Q8_K_XL.gguf"
+GEMMA_MISSING=""
+if [ ! -f "$GEMMA_GGUF" ]; then
+    GEMMA_MISSING=1
+    echo "[preflight] WARN:  gemma-4-12b GGUF not found at $GEMMA_GGUF" >&2
+    echo "            The chat model won't start until it's present (image gen still works). Fetch it:" >&2
+    echo "              hf download unsloth/gemma-4-12b-it-GGUF gemma-4-12b-it-UD-Q8_K_XL.gguf \\" >&2
+    echo "                --local-dir \"$(dirname "$GEMMA_GGUF")\"" >&2
+fi
 NGPU=$(nvidia-smi -L 2>/dev/null | wc -l)
 
 say "═══ club-3090 image-studio setup ═══"

--- a/scripts/setup-image-studio.sh
+++ b/scripts/setup-image-studio.sh
@@ -1,38 +1,69 @@
 #!/usr/bin/env bash
 # One-shot setup for the club-3090 IMAGE-STUDIO bundle:
-#   ComfyUI (Ideogram-4 image gen) + OpenWebUI front-end + gemma-4-12b chat,
-#   coexisting on a 2-GPU box (ComfyUI→GPU0, chat→GPU1).
+#   ComfyUI (Ideogram-4 image gen) + Open WebUI front-end + gemma-4-12b chat,
+#   coexisting on a 2-GPU box (ComfyUI -> GPU0, chat -> GPU1).
 #
-#   bash scripts/setup-image-studio.sh            # build + download + bring up
-#   SKIP_DOWNLOAD=1 bash scripts/setup-image-studio.sh   # skip the 27 GB weight pull
-#   SKIP_BUILD=1    bash scripts/setup-image-studio.sh   # skip the ComfyUI image build
+# Usage:
+#   bash scripts/setup-image-studio.sh           # build + download + bring up (asks to confirm)
+#   bash scripts/setup-image-studio.sh --yes      # skip the confirmation prompt
 #
-# Idempotent: re-running re-pulls/rebuilds only what changed. Brings the stack up
-# via `gpu-mode image-studio`.
+# Env knobs:
+#   SKIP_BUILD=1     skip the ComfyUI image build (already built)
+#   SKIP_DOWNLOAD=1  skip the ~27 GB Ideogram-4 weight pull (already on disk)
+#   ASSUME_YES=1     same as --yes (also auto-yes when not a TTY / under CI)
+#   LANIP=<ip>       host IP shown in the final URLs (auto-detected otherwise)
+#
+# Idempotent: re-running rebuilds/re-pulls only what changed, then brings the
+# stack up via `gpu-mode image-studio`.
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 COMFYUI_DIR="$REPO_DIR/services/comfyui"
-LANIP="${LANIP:-$(hostname -I 2>/dev/null | tr ' ' '\n' | grep -E '^192\.168\.' | head -1)}"
+LANIP="${LANIP:-$(hostname -I 2>/dev/null | tr ' ' '\n' | grep -E '^(192\.168|10\.|172\.)' | head -1)}"
 LANIP="${LANIP:-<host-ip>}"
+
+ASSUME_YES="${ASSUME_YES:-}"
+case "${1:-}" in
+  -y|--yes) ASSUME_YES=1 ;;
+  -h|--help) sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+esac
+# Auto-yes when non-interactive (piped / nohup / CI) so we never hang on the prompt.
+[ -t 0 ] || ASSUME_YES=1
+[ -n "${CI:-}" ] && ASSUME_YES=1
 
 say()  { echo -e "\033[0;36m$*\033[0m"; }
 warn() { echo -e "\033[1;33m$*\033[0m"; }
 ok()   { echo -e "\033[0;32m$*\033[0m"; }
 
-# --- 0. Preflight -----------------------------------------------------------
+# --- 0. Preflight + plan ----------------------------------------------------
 command -v docker >/dev/null 2>&1 || { echo "ERROR: docker not found." >&2; exit 1; }
 NGPU=$(nvidia-smi -L 2>/dev/null | wc -l)
+
 say "═══ club-3090 image-studio setup ═══"
 echo "  repo:  $REPO_DIR"
 echo "  GPUs:  $NGPU"
+echo ""
+echo "  This will:"
+[ -z "${SKIP_BUILD:-}" ]    && echo "    • build the ComfyUI image (comfyui-local) — pulls a ~9 GB CUDA base (one-time, slow)" \
+                            || echo "    • (skip build — SKIP_BUILD set)"
+[ -z "${SKIP_DOWNLOAD:-}" ] && echo "    • download the Ideogram-4 model set (~27 GB) into the ComfyUI models tree" \
+                            || echo "    • (skip download — SKIP_DOWNLOAD set)"
+echo "    • start the bundle via 'gpu-mode image-studio':"
+echo "        - ComfyUI / Ideogram-4   → GPU 0, port 8188"
+echo "        - gemma-4-12b chat        → GPU 1, port 8069"
+echo "        - Open WebUI + LiteLLM + SearXNG (always-on)"
+echo ""
 if [ "${NGPU:-0}" -lt 2 ]; then
     warn "  ⚠ <2 GPUs — image gen and a local chat model can't run at once (GPU-mutex)."
-    warn "    The bundle will run ComfyUI image gen; for chat use 'gpu-mode chat' (LiteLLM)"
-    warn "    or run gemma-4-12b only while ComfyUI is down. Continuing…"
+    warn "    The bundle will run ComfyUI image gen only; for chat use 'gpu-mode chat'."
+fi
+if [ -z "$ASSUME_YES" ]; then
+    printf "  Proceed? [y/N] "
+    read -r reply
+    case "$reply" in [yY]|[yY][eE][sS]) ;; *) echo "  aborted."; exit 0 ;; esac
 fi
 
-# --- 1. Build the ComfyUI image (clones ComfyUI HEAD + nodes on first boot) --
+# --- 1. Build the ComfyUI image (clones a pinned ComfyUI + nodes on first boot) ---
 if [ -z "${SKIP_BUILD:-}" ]; then
     say "── [1/3] Building ComfyUI image (comfyui-local:latest) ──"
     (cd "$COMFYUI_DIR" && sudo docker compose build)
@@ -52,12 +83,23 @@ fi
 say "── [3/3] Starting the bundle (gpu-mode image-studio) ──"
 bash "$REPO_DIR/scripts/gpu-mode.sh" image-studio
 
+# --- Done — onboarding -------------------------------------------------------
 echo ""
 ok "═══ Image-studio ready ═══"
-echo "  Open WebUI:  http://$LANIP:8080   ← chat + 🖼️ image button (start here)"
-echo "  ComfyUI:     http://$LANIP:8188   ← full node-graph control"
+echo "  Open WebUI:  http://$LANIP:8080   ← start here (chat + image)"
+echo "  ComfyUI:     http://$LANIP:8188   ← optional: full node-graph control"
 echo ""
-warn "First image after a cold ComfyUI is slow (~2 min, loads ~20 GB); warm gens ~70 s."
-warn "Image button not showing in OpenWebUI? You're on a PRE-EXISTING data volume — OpenWebUI"
-warn "only reads the image-gen env on a FRESH volume. Set it in Admin → Settings → Images"
-warn "(Engine=ComfyUI, Base URL=http://host.docker.internal:8188), or recreate the volume."
+say  "  Get started:"
+echo "    1. Open the Open WebUI URL and SIGN UP — the FIRST account you create"
+echo "       becomes the admin. (No credentials are pre-set; you choose them here.)"
+echo "    2. Pick the chat model 'gemma-4-12b…' in the top selector and chat normally."
+echo "    3. Generate an image: send a prompt, then click the 🖼️ image icon on the"
+echo "       reply — it renders via Ideogram-4 on ComfyUI. (Image gen is pre-wired."
+echo "       Toggle/inspect it under Admin → Settings → Images.)"
+echo ""
+warn "  Notes:"
+warn "    • First image after a cold ComfyUI is slow (~2 min, loads ~20 GB); warm ~70 s."
+warn "    • 🖼️ button missing / image gen unconfigured? You reused an existing Open WebUI"
+warn "      volume — the image-gen env only auto-applies on a FRESH volume. Set it in"
+warn "      Admin → Settings → Images (Engine=ComfyUI, Base URL=http://host.docker.internal:8188)."
+warn "    • 2048² fits but is tight (~22 GB, batch 1); prefer 1024² + upscale for routine high-res."

--- a/services/litellm/config.yaml
+++ b/services/litellm/config.yaml
@@ -26,6 +26,18 @@ model_list:
       api_base: http://host.docker.internal:8030/v1
       api_key: EMPTY
 
+  # Gemma 4 12B (Unsloth UD-Q8_K_XL GGUF, llama.cpp) — the IMAGE-STUDIO chat brain.
+  # Small enough to coexist with ComfyUI image gen (runs on the spare GPU). Started by
+  # `gpu-mode image-studio` → llama-cpp-gemma4-12b at :8069. This is the one route that's
+  # LIVE in image-studio mode (the big-model routes above are GPU-mutex with ComfyUI).
+  # The bundle's Open WebUI points DIRECT to :8069 by default (clean picker); this route
+  # makes gemma-4-12b reachable through the gateway too (e.g. for benchlocal / API clients).
+  - model_name: gemma-4-12b
+    litellm_params:
+      model: openai/gemma-4-12b
+      api_base: http://host.docker.internal:8069/v1
+      api_key: EMPTY
+
   # NOTE: Gemma 4 26B-A4B is intentionally NOT routed — the registry default
   # (vllm/gemma-a4b, :8041) is the autoround-int4-mixed compose, which is
   # SM86-blocked (Marlin K-dim 704/128). The working AWQ variant


### PR DESCRIPTION
Follow-up to #345 — maintainer-feedback hardening of the image-studio bundle.

## Setup UX (`scripts/setup-image-studio.sh`)
- **Pre-run plan + confirm prompt** before the heavy build/download (`--yes` / `CI=1` / non-TTY auto-yes so it never hangs in pipelines).
- `--help` / usage banner documenting the env knobs.
- A proper **"Get started"** block in the final output:
  1. **Create your account** — open Open WebUI and sign up; the *first* account becomes the admin (no credentials are pre-set, no shared secret).
  2. Pick the `gemma-4-12b` chat model.
  3. **Generate an image** — send a prompt, click the 🖼️ icon on the reply.
- States the fresh-vs-existing-volume wiring caveat up front.

## LiteLLM (`services/litellm/config.yaml`)
- Adds a **`gemma-4-12b` route** (→ `:8069`), so the image-studio chat brain is reachable through the gateway like every other model. It's the one route that's *live* in image-studio mode (the big-model routes are GPU-mutex with ComfyUI). Open WebUI still points **direct** to `:8069` by default for a clean picker; routing OWUI through LiteLLM is the documented opt-in.
- Live-validated: `gemma-4-12b` responds through LiteLLM `:4000`.

## Docs (`docs/IMAGE_STUDIO.md`)
- **Architecture section + ASCII diagram**: front-end → (chat / image), the 2-GPU split, the LiteLLM gateway, where ComfyUI loads weights from.
- Explicit **first-run** + **how-to-generate-an-image-in-chat** steps.
- **Chat-routing** explanation (gemma-direct default vs LiteLLM gateway, and why).
- Accuracy fixes: ComfyUI **pinned commit** (not floating HEAD), Open WebUI `v0.9.6`, auto-generated secret.

## Answers to the questions that prompted this
- *Does it touch LiteLLM?* Now yes — gemma-4-12b is a gateway route; OWUI defaults to gemma-direct for a clean picker (documented).
- *Does setup wire OWUI↔ComfyUI?* Yes on a **fresh** volume (env auto-applies); existing volumes → Admin → Settings → Images. Now stated in the script + docs.
- *Tell users to enable image gen in chat?* Documented — it's pre-enabled; users click the 🖼️ icon on a reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
