### PR TITLE
feat: add Qwen3.6-40B-Deckard to catalog (llamacpp/deckard40B-dual-mtp)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -250,6 +250,18 @@ Tested via `URL=http://localhost:8004 MODEL=luce-dflash bash scripts/verify-stre
 
 ---
 
+## Qwen3.6-40B-Deckard
+
+Dense 40B uncensored community merge of Qwen3.6. Q6_K GGUF with BF16 MTP head injected from the 27B. Dual 3090 only (31 GB > 24 GB). llama.cpp mainline server-cuda, rolling tag (2026-06-09 digest).
+
+### Dual-card (2× RTX 3090) — llama.cpp
+
+| Compose | Rig | KV | Max ctx | Narr / Code TPS | PP tok/s | Peak VRAM | Date | Notes |
+| --- | --- | --- | ---: | ---: | ---: | ---: | --- | --- |
+| `mtp.yml` (MTP n=2) | @noonghunna (2× 3090, PCIe) | q8_0/q8_0 | 131072 | 36 / 46 (MTP on) | — | ~16.4+17.8 GB @16K | 2026-06-09 | 🧪 Unverified. MTP n=2 sweet spot (41.60 tok/s aggregate, 0.81 accept). MTP off: 22.7 narr (+59%/+104% with MTP). 128K ceiling @q8_0 KV (192K OOMs). Deterministic 8-pack (think-off, MTP-off): **62/75** (toolcall 15 · instructfollow 14 · structoutput 13 · dataextract 10 · reasonmath 10). Full /150 + MTP-on A/B pending. Soak: —. |
+
+---
+
 ## See also
 
 - [docs/SINGLE_CARD.md](docs/SINGLE_CARD.md) — single-card variant picker

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -258,7 +258,7 @@ Dense 40B uncensored community merge of Qwen3.6. Q6_K GGUF with BF16 MTP head in
 
 | Compose | Rig | KV | Max ctx | Narr / Code TPS | PP tok/s | Peak VRAM | Date | Notes |
 | --- | --- | --- | ---: | ---: | ---: | ---: | --- | --- |
-| `mtp.yml` (MTP n=2) | @noonghunna (2× 3090, PCIe) | q8_0/q8_0 | 131072 | 36 / 46 (MTP on) | — | ~16.4+17.8 GB @16K | 2026-06-09 | 🧪 Unverified. MTP n=2 sweet spot (41.60 tok/s aggregate, 0.81 accept). MTP off: 22.7 narr (+59%/+104% with MTP). 128K ceiling @q8_0 KV (192K OOMs). Deterministic 8-pack (think-off, MTP-off): **62/75** (toolcall 15 · instructfollow 14 · structoutput 13 · dataextract 10 · reasonmath 10). Full /150 + MTP-on A/B pending. Soak: —. |
+| `mtp.yml` (MTP n=2) | @noonghunna (2× 3090, PCIe) | q8_0/q8_0 | 131072 | 36 / 46 (MTP on) | — | ~16.4+17.8 GB @16K | 2026-06-09 | 🧪 Experimental. MTP n=2 sweet spot (41.60 tok/s aggregate, 0.81 accept). MTP off: 22.7 narr (+59%/+104% with MTP). 128K ceiling @q8_0 KV (192K OOMs). 8-pack (think-off): **105/150** — MTP-off == MTP-on (spec-dec lossless); det 62/75 (toolcall 15·instructfollow 14·structoutput 13·dataextract 10·reasonmath 10) + sandbox 43/75 (bugfind 13·hermesagent 15/20·cli-40 15/40). **verify-full 8/8**, **soak-continuous PASS** (0 MiB growth, 0/25 silent-empty, 25 turns). ≈ Qwen3.6-27B band. Profile arch fields TBD (config.json) before ✅. |
 
 ---
 

--- a/models/qwen3.6-40b-deckard/llama-cpp/compose/dual/mtp-q6k/mtp.yml
+++ b/models/qwen3.6-40b-deckard/llama-cpp/compose/dual/mtp-q6k/mtp.yml
@@ -1,0 +1,110 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-40B-Deckard (uncensored dense merge, Q6_K MTP GGUF)
+#   Engine:    llama.cpp (mainline server-cuda, rolling tag, draft-mtp)
+#   Topology:  Dual 3090 (layer-split -ts 1,1)
+#   Drafter:   MTP n=2 (--spec-type draft-mtp, sweet-spot — see BENCHMARKS.md)
+#   KV:        q8_0 K + q8_0 V
+#   Vision:    no
+#   Template:  native (GGUF-embedded)
+#   Max ctx:   131072 (q8_0 KV; 192K OOMs on the dual split)
+#   Genesis:   N/A — llama.cpp engine
+#   Status:    🧪 Unverified
+#   Caveats:   Dual-only (31 GB > 24 GB, no single-card); both-cards → mutually
+#              exclusive with the image-studio. Quality /150 + soak still pending.
+#   Engine-profile: llama-cpp-local
+#   Best for:  Uncensored dual-card chat/agentic; ~41 tok/s (MTP n=2), 128K ctx.
+# ---------------------------------------------------------------------------
+# Qwen3.6-40B-Deckard on llama.cpp — dual 3090, MTP n=2, 128K ctx, no vision.
+#
+# Deckard is a **dense 40B uncensored** community merge of the Qwen3.6 family
+# (thinking model; emits <think>). Built from DavidAU's Qwen3.6-40B Opus-Deckard
+# Q6_K GGUF with a BF16-precision MTP head injected from the base Qwen3.6-27B
+# architecture (community MTP injection — see the model README on disk).
+#
+# Why dual-only: the Q6_K GGUF is 31 GB — it cannot fit a single 24 GB card.
+# Layer-split across both 3090s via `-ts 1,1` (tensor-split), which pipelines
+# layers across the PCIe bus (no NVLink needed — layer-split avoids cross-GPU
+# all-reduce).
+#
+# MTP win (dense model): MTP on vs off at n=2: off 22.7 → on **36 narrative /
+# 46 code tok/s** (+59% / +104%), draft acceptance 76–80%. Dense models benefit
+# more from MTP than MoE (no MoE routing penalty on the draft head).
+#
+# Context ceiling (q8_0 KV): 32K/64K/128K boot OK (44 GB total @128K, 34.8
+# tok/s); **192K OOMs → max stable = 131072**. q4_0 KV would go higher but has
+# not been tested yet.
+#
+# Engine pin: validated on the rolling `ghcr.io/ggml-org/llama.cpp:server-cuda`
+# tag as of 2026-06-09 (digest sha256:1c4ff61a…). The MTP flag `--spec-type
+# draft-mtp` has been available since PR #22673 (mainline b9240+). The catalog's
+# existing llama.cpp engine profile pins b9246 via compose-level defaults; this
+# compose uses the rolling tag since the validated build is newer. Bump to a
+# specific build tag once the maintainer validates a stable pin.
+#
+# Override defaults via .env or shell:
+#   MODEL_DIR              host dir to mount as /models  (default: ../../../../../../models-cache)
+#   GGUF_FILE              path under /models  (default: qwen3.6-40b-deckard-gguf/mtp-q6k/Qwen3.6-40B-Deckard-MTP-Q6_K.gguf)
+#   CTX_SIZE               KV pool size        (default: 131072; 192K OOMs at q8_0 KV)
+#   BATCH_SIZE             llama.cpp -b        (default: 4096)
+#   UBATCH_SIZE            llama.cpp -ub       (default: 512)
+#   KV_TYPE                K and V quant type  (default: q8_0)
+#   NP                     parallel slots      (default: 1)
+#   MTP_DRAFT_N_MAX        MTP draft tokens    (default: 2 — sweet spot per BENCHMARKS.md)
+#   TENSOR_SPLIT           manual tensor split (default: 1,1)
+#   SERVED_NAME            --alias value       (default: deckard-40b)
+#   REASONING              thinking gate       (default: off — stack-wide policy)
+#   REASONING_FORMAT       reasoning routing   (default: deepseek — hygiene)
+#   PORT                   host port           (default: 8199)
+#   CUDA_VISIBLE_DEVICES   which GPUs to use   (default: 0,1)
+#
+# Quick start:
+#   1. Get the MTP-enabled GGUF (community MTP injection from DavidAU's Q6_K):
+#        # The MTP GGUF was injected locally — see the model README on disk.
+#        # Base GGUF: DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-...-GGUF
+#   2. From this directory:
+#        MODEL_DIR=/your/models/dir docker compose -f mtp.yml up -d
+#   3. curl http://localhost:8199/v1/models  → should list deckard-40b.
+
+services:
+  llama-cpp-deckard-40b:
+    image: ${LLAMACPP_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda}
+    container_name: "${ESTATE_CONTAINER:-llama-cpp-deckard-40b}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8199}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+    # ⚠ -np 1 is intentional — do NOT raise it. One decode stream per dual-card
+    #   config; extra slots divide throughput and can OOM the spec-context buffer.
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      -m /models/${GGUF_FILE:-qwen3.6-40b-deckard-gguf/mtp-q6k/Qwen3.6-40B-Deckard-MTP-Q6_K.gguf}
+      --alias ${SERVED_NAME:-deckard-40b}
+      -c ${CTX_SIZE:-131072}
+      -b ${BATCH_SIZE:-4096}
+      -ub ${UBATCH_SIZE:-512}
+      -ngl 99
+      -ts ${TENSOR_SPLIT:-1,1}
+      -fa on
+      --cache-type-k ${KV_TYPE:-q8_0}
+      --cache-type-v ${KV_TYPE:-q8_0}
+      -np ${NP:-1}
+      --spec-type draft-mtp
+      --spec-draft-n-max ${MTP_DRAFT_N_MAX:-2}
+      --jinja
+      --reasoning ${REASONING:-off}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/models/qwen3.6-40b-deckard/llama-cpp/compose/dual/mtp-q6k/mtp.yml
+++ b/models/qwen3.6-40b-deckard/llama-cpp/compose/dual/mtp-q6k/mtp.yml
@@ -1,7 +1,7 @@
 # ===========================================================================
 # Profile (at-a-glance):
 #   Model:     Qwen3.6-40B-Deckard (uncensored dense merge, Q6_K MTP GGUF)
-#   Engine:    llama.cpp (mainline server-cuda, rolling tag, draft-mtp)
+#   Engine:    llama.cpp (mainline server-cuda-b9570, draft-mtp)
 #   Topology:  Dual 3090 (layer-split -ts 1,1)
 #   Drafter:   MTP n=2 (--spec-type draft-mtp, sweet-spot — see BENCHMARKS.md)
 #   KV:        q8_0 K + q8_0 V
@@ -9,7 +9,7 @@
 #   Template:  native (GGUF-embedded)
 #   Max ctx:   131072 (q8_0 KV; 192K OOMs on the dual split)
 #   Genesis:   N/A — llama.cpp engine
-#   Status:    🧪 Unverified
+#   Status:    🧪 Experimental
 #   Caveats:   Dual-only (31 GB > 24 GB, no single-card); both-cards → mutually
 #              exclusive with the image-studio. Quality /150 + soak still pending.
 #   Engine-profile: llama-cpp-local
@@ -35,12 +35,14 @@
 # tok/s); **192K OOMs → max stable = 131072**. q4_0 KV would go higher but has
 # not been tested yet.
 #
-# Engine pin: validated on the rolling `ghcr.io/ggml-org/llama.cpp:server-cuda`
-# tag as of 2026-06-09 (digest sha256:1c4ff61a…). The MTP flag `--spec-type
-# draft-mtp` has been available since PR #22673 (mainline b9240+). The catalog's
-# existing llama.cpp engine profile pins b9246 via compose-level defaults; this
-# compose uses the rolling tag since the validated build is newer. Bump to a
-# specific build tag once the maintainer validates a stable pin.
+# Engine pin: validated on `ghcr.io/ggml-org/llama.cpp:server-cuda-b9570`
+# (the IMMUTABLE tag for the 2026-06-09 build, digest sha256:1c4ff61a…). MTP
+# `--spec-type draft-mtp` (PR #22673, mainline) works on it. We pin the immutable
+# bXXXX — NOT the rolling `:server-cuda` (it regressed at b9282 with a crash loop,
+# #187). The shared `llama-cpp-local` engine pins the older b9246 (for the 27B —
+# too old for Deckard-40B), so we pin the newer b9570 at the compose level via
+# LLAMACPP_IMAGE rather than bumping the shared engine pin. Bump via .env once a
+# newer build is validated:  LLAMACPP_IMAGE=ghcr.io/ggml-org/llama.cpp:server-cuda-bXXXX
 #
 # Override defaults via .env or shell:
 #   MODEL_DIR              host dir to mount as /models  (default: ../../../../../../models-cache)
@@ -68,7 +70,7 @@
 
 services:
   llama-cpp-deckard-40b:
-    image: ${LLAMACPP_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda}
+    image: ${LLAMACPP_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda-b9570}
     container_name: "${ESTATE_CONTAINER:-llama-cpp-deckard-40b}"
     restart: unless-stopped
     ports:

--- a/models/qwen3.6-40b-deckard/llama-cpp/compose/dual/mtp-q6k/mtp.yml
+++ b/models/qwen3.6-40b-deckard/llama-cpp/compose/dual/mtp-q6k/mtp.yml
@@ -11,7 +11,8 @@
 #   Genesis:   N/A — llama.cpp engine
 #   Status:    🧪 Experimental
 #   Caveats:   Dual-only (31 GB > 24 GB, no single-card); both-cards → mutually
-#              exclusive with the image-studio. Quality /150 + soak still pending.
+#              exclusive with the image-studio. 8-pack 105/150 (MTP lossless) +
+#              soak PASS; 🧪 pending profile config.json arch confirm before ✅.
 #   Engine-profile: llama-cpp-local
 #   Best for:  Uncensored dual-card chat/agentic; ~41 tok/s (MTP n=2), 128K ctx.
 # ---------------------------------------------------------------------------

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -861,6 +861,9 @@ suggest_default_variant() {
       # vllm/tools-text explicitly.
       echo "llamacpp/default"
     fi
+  elif [[ "$MODEL_NAME" == "qwen3.6-40b-deckard" ]]; then
+    # Deckard: only one compose (dual llama.cpp MTP). Dual-only (31 GB > 24 GB).
+    echo "llamacpp/deckard40B-dual-mtp"
   else
     if (( cards >= 2 )); then
       echo "vllm/gemma-bf16-mtp"

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -60,6 +60,7 @@ def _entry(
     required_sm=None,
     status="production",
     status_note=None,
+    category=None,
 ):
     if status not in STATUS_VALUES:
         raise ValueError(
@@ -90,6 +91,8 @@ def _entry(
         entry["recommended_engine_features"] = list(recommended_engine_features)
     if required_sm is not None:
         entry["required_sm"] = required_sm
+    if category is not None:
+        entry["category"] = category
     return entry
 
 
@@ -634,6 +637,22 @@ COMPOSE_REGISTRY = {
         default_port=8051,
         kvcalc_key="qwen3.6-35b-a3b:qwen-35b-a3b-dual",
     ),
+
+    # Qwen3.6-40B-Deckard — dense 40B uncensored community merge, llama.cpp dual.
+    # First dual llama.cpp compose in the catalog. Q6_K GGUF (31 GB) requires both
+    # cards; layer-split via -ts 1,1. MTP n=2 sweet spot (41.6 tok/s, 0.81 accept).
+    # kv_format q8_0 (K+V). kvcalc SKIP (llama.cpp family — no vLLM kv-calc).
+    "llamacpp/deckard40B-dual-mtp": _entry(
+        model="qwen3.6-40b-deckard", weights_variant="mtp-q6k", workload="fast-chat",
+        engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q8_0",
+        tp=2, max_ctx=131072, max_num_seqs=1, mem_util=None,
+        compose_path="models/qwen3.6-40b-deckard/llama-cpp/compose/dual/mtp-q6k/mtp.yml",
+        default_port=8199,
+        kvcalc_key="SKIP",
+        status="experimental",
+        status_note="Dense 40B uncensored Qwen3.6 merge (Q6_K MTP GGUF, 31 GB) on dual 3090 llama.cpp. MTP n=2 sweet spot (~41.6 tok/s, 0.81 accept). 128K ctx ceiling @q8_0 KV (192K OOMs). Dual-only. Quality /150 + soak pending — NOT promoted past 🧪.",
+        category="uncensored",
+    ),
 }
 
 
@@ -657,6 +676,8 @@ DEFAULTS = {
     ("gemma-4-26b-a4b", "vllm", "dual"): "vllm/gemma-26ba4b-dual",
     ("qwen3.6-35b-a3b", "vllm", "single"): "vllm/qwen-a3b-preview-single",
     ("qwen3.6-35b-a3b", "vllm", "dual"): "vllm/qwen-35b-a3b-dual",
+    # Deckard: only one compose (dual llama.cpp MTP), so the dual default is trivial.
+    ("qwen3.6-40b-deckard", "llamacpp", "dual"): "llamacpp/deckard40B-dual-mtp",
 }
 
 

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -650,7 +650,7 @@ COMPOSE_REGISTRY = {
         default_port=8199,
         kvcalc_key="SKIP",
         status="experimental",
-        status_note="Dense 40B uncensored Qwen3.6 merge (Q6_K MTP GGUF, 31 GB) on dual 3090 llama.cpp. MTP n=2 sweet spot (~41.6 tok/s, 0.81 accept). 128K ctx ceiling @q8_0 KV (192K OOMs). Dual-only. Quality /150 + soak pending — NOT promoted past 🧪.",
+        status_note="Dense 40B uncensored Qwen3.6 merge (Q6_K MTP GGUF, 31 GB) on dual 3090 llama.cpp. MTP n=2 sweet spot (~41.6 tok/s, 0.81 accept). 128K ctx ceiling @q8_0 KV (192K OOMs). Dual-only. verify-full 8/8, 8-pack 105/150 (MTP off==on, spec-dec lossless), soak-continuous PASS (0 MiB growth, 0/25 silent-empty). 🧪 pending profile config.json arch confirm before ✅.",
         category="uncensored",
     ),
 }

--- a/scripts/lib/profiles/drafters/qwen-mtp-builtin.yml
+++ b/scripts/lib/profiles/drafters/qwen-mtp-builtin.yml
@@ -5,6 +5,7 @@ spec_method: mtp
 model_compat:
   - qwen3.6-27b
   - qwen3.6-35b-a3b
+  - qwen3.6-40b-deckard
 n_default: 3
 n_max: 3
 download: false

--- a/scripts/lib/profiles/models/qwen3.6-40b-deckard.yml
+++ b/scripts/lib/profiles/models/qwen3.6-40b-deckard.yml
@@ -1,0 +1,61 @@
+schema_version: 1
+id: qwen3.6-40b-deckard
+display_name: Qwen 3.6 40B Deckard
+family: qwen3-next-hybrid
+# Dense 40B uncensored community merge of the Qwen3.6 family. The expanded 40B
+# preserves the 27B's 5120 hidden dimension (confirmed from model README on disk).
+# Architecture: Qwen3-Next hybrid (DeltaNet GDN + standard attention).
+hidden_size: 5120
+# num_hidden_layers: TBD — confirm from config.json once safetensors are available.
+# The README states 24 attention layers (1.5× the 27B's 16). If the GDN:attn
+# ratio stays 3:1 (as in the 27B: 48 GDN / 16 attn), total would be 96 layers
+# (72 GDN + 24 attn). NOT YET CONFIRMED — mark as TBD until config.json is
+# available or a boot log reveals it.
+num_hidden_layers: 96
+num_gdn_layers: 72
+num_attn_layers: 24
+num_attn_heads: 24
+num_kv_heads: 4
+head_dim_attn: 256
+# DeltaNet linear attention params — inherited from the Qwen3-Next hybrid family.
+# These are ASSUMED identical to the 27B (same hidden_size, same family); confirm
+# from config.json.
+linear_num_v_heads: 48
+linear_num_k_heads: 16
+linear_v_head_dim: 128
+linear_k_head_dim: 128
+linear_conv_kernel_dim: 4
+max_ctx_supported: 262144
+attention_k_eq_v: false
+# MTP: the GGUF has a BF16-precision MTP head injected from the base Qwen3.6-27B.
+# The injection preserves the 27B's MTP architecture (1 hidden layer).
+vision_capable: true
+weights:
+  mtp-q6k:
+    path: qwen3.6-40b-deckard-gguf/mtp-q6k
+    local_subdir: qwen3.6-40b-deckard-gguf/mtp-q6k
+    size_gb: 31
+    format: gguf
+    status: experimental
+    # HF source: the MTP-injected GGUF was created by injecting a BF16 MTP head
+    # into DavidAU's Q6_K GGUF from:
+    #   DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF
+    # The MTP-injected variant is a separate community artifact. The exact HF
+    # repo hosting the MTP-injected GGUF is not yet confirmed — using mtp-q6k
+    # as the weights_variant to match the on-disk layout.
+    hf_repo: DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF
+    files:
+      - Qwen3.6-40B-Deckard-MTP-Q6_K.gguf
+    engine: llama-cpp
+    kind: gguf
+    verify_glob: "*.gguf"
+default_weight_variant: mtp-q6k
+compatible_drafters:
+  - qwen-mtp-builtin
+# num_kv_heads=4 supports TP up to 4 (each rank needs ≥1 KV head).
+# Practically limited to TP=2 on this rig (2× 3090).
+valid_tp:
+  - 1
+  - 2
+  - 4
+requires_genesis: false

--- a/scripts/tests/test-compose-registry-disk.sh
+++ b/scripts/tests/test-compose-registry-disk.sh
@@ -26,7 +26,7 @@ def check(cond, msg):
         failures.append(msg)
 
 check(len(COMPOSE_REGISTRY) == 44, f"registry has 44 entries (got {len(COMPOSE_REGISTRY)})")
-check(len(disk_paths) == 49, f"disk has 49 compose files (got {len(disk_paths)})")
+check(len(disk_paths) == 45, f"disk has 45 compose files (got {len(disk_paths)})")
 check(registry_paths <= disk_paths, "all registry compose_path values exist on disk")
 parked_disk_only = disk_paths - registry_paths
 # Disk-only (non-registry) composes allowed: parked SGLang archives, plus the experimental

--- a/scripts/tests/test-compose-registry-disk.sh
+++ b/scripts/tests/test-compose-registry-disk.sh
@@ -25,8 +25,8 @@ def check(cond, msg):
         print(f"FAIL: {msg}")
         failures.append(msg)
 
-check(len(COMPOSE_REGISTRY) == 43, f"registry has 43 entries (got {len(COMPOSE_REGISTRY)})")
-check(len(disk_paths) == 44, f"disk has 44 compose files (got {len(disk_paths)})")
+check(len(COMPOSE_REGISTRY) == 44, f"registry has 44 entries (got {len(COMPOSE_REGISTRY)})")
+check(len(disk_paths) == 49, f"disk has 49 compose files (got {len(disk_paths)})")
 check(registry_paths <= disk_paths, "all registry compose_path values exist on disk")
 parked_disk_only = disk_paths - registry_paths
 # Disk-only (non-registry) composes allowed: parked SGLang archives, plus the experimental

--- a/scripts/tests/test-profiles-compat.sh
+++ b/scripts/tests/test-profiles-compat.sh
@@ -24,7 +24,7 @@ run_test "load_profiles parses all profile groups" <<'PY'
 from scripts.lib.profiles.compat import load_profiles
 p = load_profiles()
 assert len(p.hardware) == 9
-assert len(p.models) == 5
+assert len(p.models) == 6
 assert len(p.workloads) == 5
 assert len(p.engines) == 11
 assert len(p.drafters) == 9

--- a/services/litellm/config.yaml
+++ b/services/litellm/config.yaml
@@ -43,3 +43,12 @@ model_list:
   # SM86-blocked (Marlin K-dim 704/128). The working AWQ variant
   # (vllm/gemma-a4b-awq, :8042) is not a gpu-mode primary; add a route here if
   # it gets promoted.
+
+  # Qwen3.6-40B-Deckard (dense 40B uncensored, llama.cpp dual 3090, MTP n=2).
+  # Launched via `launch.sh llamacpp/deckard40B-dual-mtp` → llama-cpp-deckard-40b at :8199.
+  # Both-cards mode (GPU-mutex with image-studio and all single-card services).
+  - model_name: deckard-40b
+    litellm_params:
+      model: openai/deckard-40b
+      api_base: http://host.docker.internal:8199/v1
+      api_key: EMPTY


### PR DESCRIPTION
## Summary

Add **Qwen3.6-40B-Deckard** (dense 40B uncensored community merge) to the club-3090 catalog as `llamacpp/deckard40B-dual-mtp`. Dual-3090 llama.cpp with embedded MTP head (Q6_K GGUF, 31 GB).

**Status: 🧪 Unverified** — quality eval /150 + soak still running on the live eval container (`deckard-40b` on `:8199`). NOT promoted past experimental.

## Files changed (9)

| File | Change |
|---|---|
| `models/qwen3.6-40b-deckard/llama-cpp/compose/dual/mtp-q6k/mtp.yml` | **New** — compose with full profile header |
| `scripts/lib/profiles/models/qwen3.6-40b-deckard.yml` | **New** — model profile (family: qwen3-next-hybrid) |
| `scripts/lib/profiles/compose_registry.py` | Add `_entry()` for `llamacpp/deckard40B-dual-mtp` + `category` field (new, default `None`) + DEFAULTS wiring |
| `scripts/lib/profiles/drafters/qwen-mtp-builtin.yml` | Add `qwen3.6-40b-deckard` to `model_compat` |
| `scripts/launch.sh` | Add `suggest_default_variant` case for Deckard |
| `services/litellm/config.yaml` | Add `deckard-40b` route → `:8199` |
| `BENCHMARKS.md` | New section with validated MTP n=2 numbers |
| `scripts/tests/test-compose-registry-disk.sh` | Registry count 43→44, disk 44→49 |
| `scripts/tests/test-profiles-compat.sh` | Model count 5→6 |

## Wrinkle decisions

### 1. First dual llama.cpp compose in the catalog

Every existing llama.cpp compose was single-card; all dual composes were vLLM (TP=2) or ik-llama/beellama. This compose uses:
- **`count: all`** in `deploy.resources.reservations.devices` (exposes both GPUs)
- **`-ts ${TENSOR_SPLIT:-1,1}`** (tensor-split layer-split across both cards)
- **`-ngl 99`** (all layers to GPU)

No launcher code changes were needed — the compose `deploy` section handles GPU reservation directly. The `launch.sh` `suggest_default_variant` function got a new case for `qwen3.6-40b-deckard`.

### 2. Engine pin

The Deckard eval was validated on the **rolling** `ghcr.io/ggml-org/llama.cpp:server-cuda` tag (2026-06-09 digest `sha256:1c4ff61a`). The compose uses this rolling tag as its default (matching the engine profile `spec`), NOT the `server-cuda-b9246` pin that the qwen3.6-27b composes use. The `--spec-type draft-mtp` flag has been available since b9240+, so the validated build supports it. **No engine pin bump for other models** — each compose controls its own `LLAMACPP_IMAGE` default.

## `category` field

Added `category=None` (default) to the `_entry()` signature as a first-class registry attribute. Deckard is tagged `category="uncensored"`. No category *view* yet — just the data field. Future `switch --list --by-category` can consume it.

## Static test results

| Test | Result |
|---|---|
| `test-compose-registry-disk` | ✅ registry count, DEFAULTS, per-entry checks all pass. ⚠ Pre-existing: nex-n2-mini disk-only composes (not caused by this PR) |
| `test-compose-status-drift` | ✅ |
| `test-switch-registry-parity` | ✅ 44 registered composes |
| `test-launch-registry-parity` | ✅ 44 registered composes |
| `test-default-resolver` | ✅ |
| `test-profiles-compat` | ✅ |
| `test-model-default-resolver` | ✅ |
| `test-compose-mounts-resolve` | ✅ |
| `test-model-weights-registry` | ✅ |
| `test-patch-attribution` | ✅ |

## What was NOT done (live validation — GPUs busy)

- **Boot/bench/soak/quality NOT run** — the running quality eval container (`deckard-40b` on `:8199`, both GPUs) must not be disturbed. Maintainer to validate post-eval.
- **Status stays 🧪** until the full gate passes (verify-full + verify-stress + bench + soak + quality-test).
- **OWUI live wiring** — both-cards mode needs the image-studio down + GPUs free.

## Note

The `qwen3.6-40b-deckard/default` resolver returns `None` while status is `experimental` — this is by design (`FUNCTIONAL_STATUSES = {production, caveats}`). Users must specify the slug explicitly (`launch.sh llamacpp/deckard40B-dual-mtp`) until status is promoted.

Per-model learnings file: `/opt/ai/learnings/qwen3.6-40b-deckard.md` (outside repo, stack-private).