### PR TITLE
dgemma: list as 🧪 experimental (discoverable in switch.sh --list)

### DIFF
--- a/models/diffusiongemma-26b-a4b/vllm/compose/dual/fp8/base.yml
+++ b/models/diffusiongemma-26b-a4b/vllm/compose/dual/fp8/base.yml
@@ -8,25 +8,12 @@
 #   Vision:    no (text diffusion)
 #   Max ctx:   262144 (NIAH retrieval validated to ~250K)
 #   Genesis:   N/A — Genesis is Qwen3-Next-specific
-#   Status:    ⏸️ Upstream-gated — works on Ampere, but boots only via the vendored
-#              overlay until vllm#45163 merges into a pinnable engine.
-#   Caveats:   The DiffusionGemma arch exists in NO released/nightly vLLM — only in
-#              the UNMERGED PR vllm#45163 (https://github.com/vllm-project/vllm/pull/45163).
-#              Delivery = stock PULLABLE nightly + a SIDELOADED overlay applied at
-#              boot (install_script), NOT a baked custom image:
-#                • image = stock `vllm/vllm-openai:nightly-2c9c07c8…` (everyone can pull it)
-#                • ../../../patches/dgemma-overlay/ = the vendored payload: the full
-#                  stock-nightly-vs-dgemma-branch delta (123 vllm/*.py files — the
-#                  PR's formal 41-file set version-skews, since load-bearing dgemma
-#                  changes like build_attn_metadata's `causal` kwarg live outside the
-#                  PR diff) + Codex's 3 fixes (marlin.py + marlin_utils_fp8.py K-pad
-#                  for fp8 Marlin W8A16 on sm_86's 99 KB shared mem; diffusion_gemma.py
-#                  TP-vocab soft-embed + :656 dtype cast). install.sh cp's it over the
-#                  installed vllm pkg before the server starts (fail-loud arch assert).
-#              REBASE when the nightly moves/is purged: re-pin the image + regenerate
-#              the overlay (see ../../../patches/dgemma-overlay/README.md). Not
-#              pinnable-stable until #45163 merges — then this collapses to one pin.
-#              Runs EAGER-ONLY (torch.compile works but gives no throughput gain).
+#   Status:    🧪 Experimental — DiffusionGemma (vLLM's first dLLM) sideloaded onto a
+#              stock nightly via the UNMERGED vllm#45163 overlay; under active validation,
+#              eager-only. Launch needs --force (non-functional status). The full sideload
+#              rationale (why the 123-file overlay not the PR's 41; the #45163 gating; the
+#              rebase-when-the-nightly-is-purged story) lives in the prose below +
+#              ../../../patches/dgemma-overlay/README.md.
 #   Quality:   8-pack 100/150 (67%) — toolcall 13/15 · instructfollow 13-15/15 ·
 #              structoutput 14/15 · dataextract 10/15 · reasonmath 11/15 ·
 #              bugfind 11/15 · hermesagent-20 14/20 (agentic tool-use works) ·

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -626,13 +626,12 @@ COMPOSE_REGISTRY = {
         compose_path="models/diffusiongemma-26b-a4b/vllm/compose/dual/fp8/base.yml",
         default_port=8042,
         kvcalc_key="SKIP",
-        status="upstream-gated",
-        status_note="DiffusionGemma dLLM (vLLM's first) on Ampere via vllm#45163 (UNMERGED) sideloaded onto a stock PULLABLE nightly — install_script overlay (full branch delta + Codex marlin-K-pad/TP-vocab/dtype fixes), NOT a baked image. Eager-only, gemma4 tool+reasoning parsers. 262K (NIAH->250K), 8-pack 100/150 (5-pack 84%), ~150-200 tok/s (peak ~490). max_new_tokens lifted 256->16384 (the model self-terminates ~1.2-1.8K words; no one-shot 10K). Upstream-gated: base nightly may be purged -> re-pin + regenerate overlay; promote when #45163 merges. 2026-06-11.",
+        status="experimental",
+        status_note="DiffusionGemma dLLM (vLLM's first) on Ampere via vllm#45163 (UNMERGED) sideloaded onto a stock PULLABLE nightly — install_script overlay (full branch delta + Codex marlin-K-pad/TP-vocab/dtype fixes), NOT a baked image. Eager-only, gemma4 tool+reasoning parsers. 262K (NIAH->250K), 8-pack 100/150 (5-pack 84%), ~150-200 tok/s (peak ~490). max_new_tokens lifted 256->16384 (the model self-terminates ~1.2-1.8K words; no one-shot 10K). Experimental: visible in --list (NA), launch needs --force; gated on the unmerged #45163 (base nightly may be purged -> re-pin + regenerate overlay). 2026-06-11.",
     ),
-    # DEFAULTS: intentionally NOT added — 'upstream-gated' is non-functional, so it
+    # DEFAULTS: intentionally NOT added — 'experimental' is non-functional, so it
     # degrades out of the curated <model>/default walk; reachable only by explicit
-    # slug `vllm/diffusiongemma-dual` (a DEFAULTS row would hand users a gated config
-    # via <engine>/default, which does NOT status-filter).
+    # slug `vllm/diffusiongemma-dual` (launch requires --force).
     "vllm/qwen-a3b-preview-single": _entry(
         model="qwen3.6-35b-a3b", weights_variant="autoround-int4", workload="fast-chat",
         engine="vllm-stable", drafter=None, kv_format="fp8_e5m2",


### PR DESCRIPTION
Follow-up to #358. A new model whose *only* variant is `upstream-gated` vanished entirely from `switch.sh --list` (which hides deprecated + upstream-gated), even though 22 `experimental` + 1 `preview` variants already display there with `(NA: …)` markers. There's no principled reason a parked-but-real **new model** should be less discoverable than 22 experimental configs.

Per maintainer call, list DiffusionGemma as **🧪 experimental** instead:
- Now shows in `switch.sh --list` as `vllm/diffusiongemma-dual … (NA: experimental, 262K)`.
- Launch still requires `--force` (experimental is non-functional) — unchanged.
- No `switch.sh` logic change; just the status (compose header + registry kept in sync, `test-compose-status-drift` green).

The #45163 gating / sideload rationale is still fully documented (compose prose, overlay README, `docs/UPSTREAM.md`).

Gate: status-drift, profiles-compat, diagnose-profile, model-default-resolver, patch-attribution, switch-registry-parity all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)