### PR TITLE
chore: make setup script work with WEIGHTS=FP8 and qwen3.6-27b

### DIFF
--- a/scripts/lib/profiles/models/qwen3.6-27b.yml
+++ b/scripts/lib/profiles/models/qwen3.6-27b.yml
@@ -45,6 +45,7 @@ weights:
     size_gb: 29
     format: fp8
     status: experimental
+    hf_repo: Qwen/Qwen3.6-27B-FP8
     engine: vllm
     kind: main
     verify_glob: "*.safetensors"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -255,6 +255,16 @@ elif [[ "${WEIGHTS}" == "awq" ]]; then
       echo "ERROR: WEIGHTS=awq is only wired for gemma-4-31b and gemma-4-26b-a4b." >&2
       exit 1 ;;
   esac
+elif [[ "${WEIGHTS}" == "fp8" ]]; then
+  case "${MODEL_NAME}" in
+    qwen3.6-27b)
+      PRIMARY_WEIGHT_KEY="qwen3.6-27b:fp8"
+      NEEDS_GENESIS=0
+      ;;
+    *)
+      echo "ERROR: WEIGHTS=ft8 is only wired for qwen3.6-27b." >&2
+      exit 1 ;;
+  esac
 elif [[ "${WEIGHTS}" != "autoround" ]]; then
   echo "ERROR: WEIGHTS='${WEIGHTS}' not recognized (use 'autoround', 'awq', 'gguf', or 'iq4ks')." >&2
   exit 1


### PR DESCRIPTION
## Summary

Wasn't able to ```export WEIGHTS=fp8 && bash scripts/setup.sh qwen3.6-27b``` for ```dual-max``` because setup did not check for fp8.

This adds that check and adds target to pull the hf model from Qwen hf repo.

Just a quick fix, if owner intentionally left this workflow unreachable because fp8 is experimental, then please close without merging. Thanks.