### PR TITLE
comfyui: claim pip cache for container uid (persist node deps across recreates)

### DIFF
--- a/services/comfyui/entrypoint.sh
+++ b/services/comfyui/entrypoint.sh
@@ -31,6 +31,17 @@ clone_or_update() {
 #    so host-side hf download / file moves work after container has touched them as root.
 chmod -R a+rwX /workspace/ComfyUI/models /workspace/ComfyUI/input /workspace/ComfyUI/output /workspace/ComfyUI/user 2>/dev/null || true
 
+# 0b. Claim the pip cache for the container user. The cache is a bind mount (so it
+#     persists across recreates), but it's host-owned (uid 1000) while this container
+#     runs as root — and pip DISABLES a cache dir it doesn't own, even a world-writable
+#     one (the "sudo without -H" safety check). A disabled cache means every recreate
+#     re-downloads all node deps (~10 min: matplotlib/opencv/insightface/nunchaku-149MB).
+#     chown it to the running uid so pip actually persists wheels; 0777 mode is preserved
+#     so the host user can still read/clear it.
+export PIP_CACHE_DIR="${PIP_CACHE_DIR:-/root/.cache/pip}"
+mkdir -p "$PIP_CACHE_DIR"
+chown -R "$(id -u):$(id -g)" "$PIP_CACHE_DIR" 2>/dev/null || true
+
 # 1. ComfyUI core — PINNED to a known-good commit (reproducible; this commit has
 #    native Ideogram-4 support and is validated on this stack). Floating on HEAD would
 #    let an upstream change silently break users. Set COMFYUI_REF=HEAD (or 'latest') to


### PR DESCRIPTION
## What

The committed ComfyUI service mounts a pip cache (`/mnt/models/comfyui/pip-cache` → `/root/.cache/pip`) to persist custom-node dep wheels across container recreates. But the host dir is owned by **uid 1000** while the container runs as **root**, and pip **disables a cache dir it doesn't own** — even a world-writable one (the "sudo without `-H`" safety check). So the cache was silently inert: every `gpu-mode comfyui` recreate re-downloaded **all** node deps (~10 min — matplotlib/opencv/insightface/onnxruntime + nunchaku 149 MB). Hit live on the 2026-06-11 video-studio rebuild.

## Fix

In the entrypoint's existing permissions-prep block (`# 0`), export `PIP_CACHE_DIR` and `chown -R` the cache dir to the running uid before any `pip install`:

```bash
export PIP_CACHE_DIR="${PIP_CACHE_DIR:-/root/.cache/pip}"
mkdir -p "$PIP_CACHE_DIR"
chown -R "$(id -u):$(id -g)" "$PIP_CACHE_DIR" 2>/dev/null || true
```

`0777` mode is preserved, so the host user can still read/clear the cache.

## Notes

- The **first** recreate after this still downloads once (to populate the now-claimed cache); recreates after that hit the cache and boot fast.
- `bash -n` clean. No test references `services/comfyui/entrypoint.sh` (catalog gate unaffected). The fix was also applied live to the running container's cache dir, so the next recreate benefits immediately.
