### PR TITLE
fix(gpu-mode): stop gemma-4-12b chat in video-studio + comfyui modes

### DIFF
--- a/scripts/gpu-mode.sh
+++ b/scripts/gpu-mode.sh
@@ -595,6 +595,7 @@ mode_comfyui() {
     stop_all_27b
     stop_deckard
     stop_all_gemma
+    stop_gemma_12b_chat
     start_comfyui
     echo ""
     echo -e "${GREEN}ComfyUI mode active.${NC} UI: http://192.168.86.33:8188"
@@ -612,6 +613,7 @@ mode_video_studio() {
     stop_all_27b
     stop_deckard
     stop_all_gemma
+    stop_gemma_12b_chat
     stop_diffusiongemma
     start_comfyui
     start_studio_director


### PR DESCRIPTION
## What

`mode_video_studio` and `mode_comfyui` both announce "Stopping: all GPU-bound LLM serving" and need **both** cards free (the 22B DiT splits across both GPUs via DisTorch; ComfyUI multi-GPU render uses both), but each called only `stop_all_gemma` — which stops the **31B vLLM** gemmas (`stop_gemma_mtp` + `stop_gemma_int8`), **not** the `gemma-4-12b` llama.cpp chat brain that `image-studio` pins to GPU1.

Result: an `image-studio → video-studio` (or `→ comfyui`) switch left `gemma-4-12b` resident — **~14 GB stuck on GPU1**.

## Why it matters

Measured on the 2× 3090 rig: after `gpu-mode video-studio`, GPU1 still held **13988 MiB** (the gemma PID was unchanged across the switch — it was never stopped). A video render's DisTorch **donor** parks the 22B weights on GPU1 (~21.9 GB): `14 + 21.9 = 35.9 GB > 24 GB` → silent OOM on the first render.

The bug only bites the **cross-mode** path — `image-studio` is the only mode that starts the 12b chat — which is exactly the path the unified-Studio cross-mode switching work exercises.

## Fix

Add `stop_gemma_12b_chat` to both modes, matching what `mode_diffusiongemma` and the other all-GPU modes already do.

## Verification

- `bash -n scripts/gpu-mode.sh` clean
- Full gate `for t in scripts/tests/*.sh; do bash "$t"; done` → 41/42 (the 1 red is the pre-existing untracked-WIP `test-compose-registry-disk` pollution, unrelated to `gpu-mode.sh`)
- Live: after stopping the stuck 12b on the rig, GPU1 drops 13988 → 266 MiB; director :8090 + comfyui :8188 both healthy → render-ready video-studio state

🤖 Generated with [Claude Code](https://claude.com/claude-code)