### PR TITLE
studio: fix image-lane _min_caption fallback (empty arrays hard-block)

### DIFF
--- a/services/studio/build_studio_pipe.py
+++ b/services/studio/build_studio_pipe.py
@@ -188,14 +188,19 @@ class Pipe:
     )
 
     def _min_caption(self, text):
-        # Wrap any plain text in a schema-valid Ideogram-4 caption (so off-schema text never
-        # trips the model's "blocked by safety filter" fallback).
+        # Last-resort fallback when the director's JSON is unusable. Ideogram-4 blocks SPARSE
+        # captions: empty color_palette / empty elements -> "Image blocked by safety filter"
+        # (measured 2026-06-11). So every field is POPULATED — a non-empty palette + one
+        # full-subject element. Lower quality / object-framed vs a director caption, but it
+        # renders instead of hard-blocking.
         return json.dumps({
             "high_level_description": text,
-            "style_description": {"aesthetics": "clean, professional, high quality",
-                                  "lighting": "balanced natural lighting", "photo": "sharp, high resolution",
-                                  "medium": "digital", "color_palette": []},
-            "compositional_deconstruction": {"background": "simple complementary background", "elements": []},
+            "style_description": {"aesthetics": "clean, professional, photorealistic, high detail",
+                                  "lighting": "soft natural lighting", "photo": "sharp focus, high resolution, detailed",
+                                  "medium": "photograph", "color_palette": ["#3A3A3A", "#C8C8C8", "#7A7A7A", "#E8E8E8"]},
+            "compositional_deconstruction": {"background": "softly blurred complementary background",
+                                             "elements": [{"type": "obj", "bbox": [256, 256, 768, 768],
+                                                           "desc": text, "color_palette": ["#888888"]}]},
         })
 
     def _coerce_caption(self, s, fallback_text):

--- a/services/studio/studio_pipe.py
+++ b/services/studio/studio_pipe.py
@@ -120,14 +120,19 @@ class Pipe:
     )
 
     def _min_caption(self, text):
-        # Wrap any plain text in a schema-valid Ideogram-4 caption (so off-schema text never
-        # trips the model's "blocked by safety filter" fallback).
+        # Last-resort fallback when the director's JSON is unusable. Ideogram-4 blocks SPARSE
+        # captions: empty color_palette / empty elements -> "Image blocked by safety filter"
+        # (measured 2026-06-11). So every field is POPULATED — a non-empty palette + one
+        # full-subject element. Lower quality / object-framed vs a director caption, but it
+        # renders instead of hard-blocking.
         return json.dumps({
             "high_level_description": text,
-            "style_description": {"aesthetics": "clean, professional, high quality",
-                                  "lighting": "balanced natural lighting", "photo": "sharp, high resolution",
-                                  "medium": "digital", "color_palette": []},
-            "compositional_deconstruction": {"background": "simple complementary background", "elements": []},
+            "style_description": {"aesthetics": "clean, professional, photorealistic, high detail",
+                                  "lighting": "soft natural lighting", "photo": "sharp focus, high resolution, detailed",
+                                  "medium": "photograph", "color_palette": ["#3A3A3A", "#C8C8C8", "#7A7A7A", "#E8E8E8"]},
+            "compositional_deconstruction": {"background": "softly blurred complementary background",
+                                             "elements": [{"type": "obj", "bbox": [256, 256, 768, 768],
+                                                           "desc": text, "color_palette": ["#888888"]}]},
         })
 
     def _coerce_caption(self, s, fallback_text):


### PR DESCRIPTION
## What

The `_min_caption` fallback shipped in #377 (used when the director's JSON is unusable / enhance is off) wrapped text in a caption with **empty** `color_palette` and **empty** `elements`. But Ideogram-4 **hard-blocks sparse captions** — empty arrays denoise to the "Image blocked by safety filter" placeholder, the same failure as raw plain text (measured 2026-06-11). So the fallback didn't actually fall back: it blocked.

## Fix

Populate every field — a non-empty palette + one full-subject element — using the validated structure that renders instead of blocking. Quality is lower / object-framed vs a real director caption, but a last-resort fallback that *renders* beats one that hard-blocks.

## Note

This was found while investigating the native 🖼️ image button (same Ideogram-4 JSON-caption trap). The full finding — that the native button can't be cleanly fixed without per-prompt LLM JSON crafting — is reported separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)