### PR TITLE
studio: fix OWUI native 🖼️ image button via ComfyUI reverse-proxy shim

### DIFF
--- a/docs/VIDEO_STUDIO.md
+++ b/docs/VIDEO_STUDIO.md
@@ -226,10 +226,10 @@ image director outputs the JSON caption; the pipe validates it and falls back to
 your text in a minimal caption if needed. Measured on this rig: plain text → 100% blocked;
 the same prompt as a JSON caption → clean render (~80 s warm @1024²).
 
-> ⚠️ **Open WebUI's native 🖼️ image button has the same trap.** It templates your plain text
-> straight into the Ideogram-4 workflow (`services/openwebui/imagegen.env`), so it hits the
-> "blocked by safety filter" placeholder. Use the **Studio · Image lane** (which crafts the
-> JSON) instead; fixing the native button needs a JSON-wrapping step — tracked in *Follow-ups*.
+> **Open WebUI's native 🖼️ image button works too — via the image shim.** It used to hit the
+> same trap (plain text → "blocked" placeholder). Now OWUI's `COMFYUI_BASE_URL` points at the
+> **studio-image-shim** (`:8191`), a transparent ComfyUI reverse-proxy that asks the director
+> to craft the JSON caption on `POST /prompt` before forwarding. See *Native image button* below.
 
 The lane is **category-aware**: the director infers logo / poster / UI-mockup / photo /
 illustration and fills the JSON with the levers that matter (logos → vector/flat/negative
@@ -238,6 +238,27 @@ Ask for it in quotes. Refine the same way as video — *"monochrome"*, *"tighter
 vector style"* — it evolves the prior caption. Defaults 1024×1024, 20 steps; the long edge is
 capped at `image_max_edge` (1024) so the image gen coexists with the director on GPU0 (2048²
 + director = OOM; raise the cap and stop the director for 2K stills).
+
+### Native image button (via the image shim)
+
+OWUI's built-in 🖼️ image button (on a chat message) also renders Ideogram-4 stills — but it
+sends **plain text** to the image engine, which trips the same "blocked by safety filter"
+placeholder, and OWUI's own image-prompt-generation can't help (it returns `{"prompt":"<string>"}`
+and nesting the Ideogram JSON inside that string defeats the task models — escaping fails).
+
+The fix is **`services/studio/image-shim/`** (`:8191`): a transparent **ComfyUI reverse-proxy**.
+OWUI's `COMFYUI_BASE_URL` points at it (`imagegen.env`), with OWUI's image-prompt-generation
+turned **off**. The shim proxies every ComfyUI call (incl. the `/ws` progress socket) straight
+through — *except* `POST /prompt`, where it reads the plain-text prompt node, asks the director
+(qwen `:8090`) for a rich Ideogram-4 JSON caption, and rewrites the node before forwarding. The
+escaping is done in **Python** (reliable), so the model never has to produce nested JSON. Blast
+radius = image generation only — title/tag/etc. task-generation is untouched (that's why it's a
+ComfyUI proxy, not an OWUI task-model override).
+
+`gpu-mode video-studio` and `image-studio` start the shim (and, in image-studio, the director it
+needs). Validated on the rig: plain "a mountain landscape at sunrise" / "a serene lake" / a logo
+all render clean through the shim. If the shim is down, point `COMFYUI_BASE_URL` back at `:8188`
+(plain text will then hit the placeholder) or use the **Studio · Image lane**.
 
 ## VRAM / GPU split
 
@@ -276,10 +297,8 @@ abliterated.)
 - **Native temporal-extend** for smoother joins on fast-motion scenes (vs last-frame I2V).
 - **Image→video long clips**: chaining currently starts from text (seg 1 = t2v); extend an
   attached image past 15 s is future.
-- **Fix Open WebUI's native 🖼️ image button**: it sends plain text to Ideogram-4 → the
-  "blocked by safety filter" placeholder (see *Image lane*). Needs a JSON-caption wrapping
-  step (a fixed wrapper in `imagegen.env`'s workflow, or routing the button through the
-  director). Until then, point users at the **Studio · Image** lane.
+- ~~**Fix Open WebUI's native 🖼️ image button**~~ ✅ done — the **image shim** (`:8191`) crafts
+  the Ideogram JSON via the director on `POST /prompt` (see *Native image button*).
 - **Uncensored stills**: Ideogram-4 is safety-trained (and the lane crafts to its schema), so
   the image lane is *aligned*. Uncensored *motion* is covered by the Sulphur video lane;
   uncensored *stills* would need a different image model (e.g. a `frames=1` render on an

--- a/scripts/gpu-mode.sh
+++ b/scripts/gpu-mode.sh
@@ -168,6 +168,13 @@ start_studio_orchestrator() {
     printf "  ${GREEN}▲${NC} Starting studio-orchestrator (:8190, long-clip chaining)..."
     compose_at "$COMPOSE_BASE/studio/orchestrator" "up -d --build" && echo "done" || echo "failed"
 }
+# Native-button image shim (:8191): ComfyUI reverse-proxy that crafts Ideogram-4 JSON
+# captions (via the director) so OWUI's native 🖼️ image button renders instead of hitting
+# the "blocked by safety filter" placeholder. Needs the director (:8090) up.
+start_studio_image_shim() {
+    printf "  ${GREEN}▲${NC} Starting studio-image-shim (:8191, native-button Ideogram captions)..."
+    compose_at "$COMPOSE_BASE/studio/image-shim" "up -d --build" && echo "done" || echo "failed"
+}
 
 # ComfyUI pinned to GPU 0 (image-studio split — leaves the other card for the chat LLM).
 start_comfyui_gpu0() {
@@ -619,6 +626,7 @@ mode_video_studio() {
     start_studio_director
     start_studio_gallery
     start_studio_orchestrator
+    start_studio_image_shim
     start_service openwebui
     start_service litellm
     start_service searxng
@@ -651,6 +659,8 @@ mode_image_studio() {
     else
         start_comfyui_gpu0
         start_gemma_12b_chat
+        start_studio_director       # qwen director on GPU0 (~4.6GB) — crafts Ideogram JSON for the image shim
+        start_studio_image_shim     # native 🖼️ button -> clean Ideogram images (see docs/VIDEO_STUDIO.md)
     fi
     start_service openwebui
     start_service litellm

--- a/services/openwebui/imagegen.env
+++ b/services/openwebui/imagegen.env
@@ -4,9 +4,19 @@
 # value wins — reconfigure in Admin -> Settings -> Images (or recreate the volume).
 # Workflow is the validated native-fp8 two-transformer (DualModelGuider) graph;
 # node-map binds OpenWebUI's prompt/seed/size/steps inputs to the graph node ids.
+#
+# COMFYUI_BASE_URL points at the STUDIO IMAGE SHIM (:8191), not ComfyUI directly. Ideogram-4
+# is trained on structured JSON captions and blocks plain text with an "Image blocked by
+# safety filter" placeholder; the shim is a transparent ComfyUI reverse-proxy that asks the
+# Studio director (qwen) to craft a JSON caption from the prompt before forwarding. We turn
+# OWUI's own image-prompt-generation OFF (ENABLE_IMAGE_PROMPT_GENERATION=false) so the raw
+# user text reaches the shim and the director does the crafting. See docs/VIDEO_STUDIO.md
+# "Native image button". (Bypass: point this back at :8188 to talk to ComfyUI directly —
+# then plain-text prompts hit the safety placeholder.)
 ENABLE_IMAGE_GENERATION=true
+ENABLE_IMAGE_PROMPT_GENERATION=false
 IMAGE_GENERATION_ENGINE=comfyui
-COMFYUI_BASE_URL=http://host.docker.internal:8188
+COMFYUI_BASE_URL=http://host.docker.internal:8191
 IMAGE_GENERATION_MODEL=ideogram4_fp8_scaled.safetensors
 IMAGE_SIZE=1024x1024
 IMAGE_STEPS=20

--- a/services/studio/README.md
+++ b/services/studio/README.md
@@ -17,6 +17,7 @@ and the measured length limits live in **[../../docs/VIDEO_STUDIO.md](../../docs
 | `gallery/` | `docker compose` for an always-on nginx media gallery (`:8189`) over ComfyUI's output dir — keeps generated media browsable + links alive even when ComfyUI is down. |
 | `enhancer/` | `docker compose` for the "director" LLM (`:8090`, OpenAI-compatible). |
 | `orchestrator/` | `docker compose` + Dockerfile for the long-clip engine (`:8190`): chains ~10 s segments into one combined video for requests >15 s. The pipe POSTs here when you ask for a length. |
+| `image-shim/` | `docker compose` + Dockerfile for the native-button image shim (`:8191`): a transparent ComfyUI reverse-proxy that crafts an Ideogram-4 JSON caption (via the director) on `POST /prompt`, so OWUI's built-in 🖼️ image button renders instead of the "blocked by safety filter" placeholder. Point OWUI's `COMFYUI_BASE_URL` at it. See VIDEO_STUDIO.md "Native image button". |
 | `extend_chain.py` | The same chaining as a standalone host CLI (handy for scripted long renders). |
 
 ## Install the pipe into Open WebUI

--- a/services/studio/image-shim/Dockerfile
+++ b/services/studio/image-shim/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+RUN pip install --no-cache-dir aiohttp==3.10.11
+WORKDIR /app
+COPY shim.py /app/shim.py
+EXPOSE 8191
+CMD ["python3", "/app/shim.py"]

--- a/services/studio/image-shim/docker-compose.yml
+++ b/services/studio/image-shim/docker-compose.yml
@@ -1,0 +1,18 @@
+# Studio image shim — a transparent ComfyUI reverse-proxy that makes Open WebUI's NATIVE
+# 🖼️ image button work with Ideogram-4. It proxies everything to ComfyUI untouched EXCEPT
+# POST /prompt, where it asks the director (qwen :8090) to craft a rich Ideogram-4 JSON
+# caption (escaping done in Python) and rewrites the prompt node. Point OWUI's
+# COMFYUI_BASE_URL at this (:8191) and turn OWUI image-prompt-generation OFF.
+# No GPU (ComfyUI + director do the work). See docs/VIDEO_STUDIO.md "Native image button".
+services:
+  studio-image-shim:
+    build: .
+    image: studio-image-shim:latest
+    container_name: studio-image-shim
+    restart: unless-stopped
+    network_mode: host          # reach ComfyUI :8188 + director :8090 on localhost; serve :8191
+    environment:
+      - COMFYUI_UPSTREAM=${COMFYUI_UPSTREAM:-http://127.0.0.1:8188}
+      - DIRECTOR_URL=${STUDIO_DIRECTOR_URL:-http://127.0.0.1:8090/v1}
+      - DIRECTOR_MODEL=${STUDIO_DIRECTOR_MODEL:-qwen3.5-4b-uncensored}
+      - SHIM_PORT=${STUDIO_SHIM_PORT:-8191}

--- a/services/studio/image-shim/shim.py
+++ b/services/studio/image-shim/shim.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Studio image shim — a transparent ComfyUI reverse-proxy that makes Open WebUI's
+NATIVE 🖼️ image button work with Ideogram-4.
+
+Why this exists
+---------------
+Ideogram-4 is trained on STRUCTURED JSON captions; plain text denoises to a gray
+"Image blocked by safety filter" placeholder (an in-weights fallback). OWUI's native
+image button sends the user's plain text straight into the ComfyUI workflow → blocked.
+OWUI's image-prompt-generation LLM step can't help: it returns `{"prompt": "<string>"}`,
+and nesting the Ideogram JSON inside that string defeats the task models (escaping fails).
+
+Fix: point OWUI's `COMFYUI_BASE_URL` at this shim instead of ComfyUI directly, and turn
+OWUI's image-prompt-generation OFF. The shim proxies EVERYTHING to real ComfyUI
+(including the `/ws` progress socket) untouched, EXCEPT `POST /prompt`: there it reads the
+plain-text prompt node, asks the Studio director (qwen, :8090) to craft a rich Ideogram-4
+JSON caption (the escaping is done in Python — reliable, unlike asking the model), rewrites
+the node, and forwards. Blast radius = image generation only; OWUI's title/tag/etc. task
+generation is untouched (that's why this is a ComfyUI proxy, not a task-model override).
+
+Env:
+  COMFYUI_UPSTREAM   real ComfyUI base url      (default http://127.0.0.1:8188)
+  DIRECTOR_URL       director OpenAI base + /v1  (default http://127.0.0.1:8090/v1)
+  DIRECTOR_MODEL     director model id           (default qwen3.5-4b-uncensored)
+  SHIM_PORT          listen port                 (default 8191)
+"""
+import os, json, asyncio, aiohttp
+from aiohttp import web, WSMsgType
+
+UPSTREAM = os.environ.get("COMFYUI_UPSTREAM", "http://127.0.0.1:8188").rstrip("/")
+DIRECTOR_URL = os.environ.get("DIRECTOR_URL", "http://127.0.0.1:8090/v1").rstrip("/")
+DIRECTOR_MODEL = os.environ.get("DIRECTOR_MODEL", "qwen3.5-4b-uncensored")
+PORT = int(os.environ.get("SHIM_PORT", "8191"))
+
+# Kept in sync with services/studio/build_studio_pipe.py DIRECTOR_IMG_SYS (image lane).
+DIRECTOR_IMG_SYS = (
+    "You are an award-winning art director writing prompts for Ideogram-4, which is trained on "
+    "STRUCTURED JSON captions. First silently infer the KIND of image the user wants — "
+    "logo/brandmark, graphic design/poster, UI or product mockup, photograph, or "
+    "illustration/concept art — then output ONE JSON object and NOTHING ELSE (no markdown, no "
+    "code fences, no commentary), with EXACTLY these keys:\n"
+    '{"high_level_description": "<one vivid sentence describing the whole image>", '
+    '"style_description": {"aesthetics": "<style/genre cues for the inferred kind>", '
+    '"lighting": "<lighting>", "photo": "<capture or render detail>", '
+    '"medium": "<e.g. photograph, vector, 3D, gouache>", "color_palette": ["#RRGGBB", "#RRGGBB"]}, '
+    '"compositional_deconstruction": {"background": "<background>", "elements": '
+    '[{"type": "obj", "bbox": [x0, y0, x1, y1], "desc": "<object>", "color_palette": ["#RRGGBB"]}]}}\n'
+    "bbox coordinates are integers in a 0-1024 canvas (top-left origin). Use the levers that matter "
+    "for the inferred kind: logos -> vector/flat/bold negative space/scalable/1-2 colours; posters -> "
+    "layout hierarchy, typographic feel, print palette; product/UI -> realistic materials, studio "
+    "light, neutral background; photos -> camera and lens (e.g. 85mm f/1.4), lighting, depth of field; "
+    "illustration -> medium, line weight, palette, rendering style. If the user wants visible "
+    "text/lettering, put the EXACT words in quotes inside high_level_description and the relevant "
+    "element desc. Add tasteful professional detail the user didn't mention while honouring intent. "
+    "Output ONLY the JSON object."
+)
+
+
+def _min_caption(text):
+    # Populated fallback — sparse/empty captions hard-block on Ideogram-4 (measured).
+    return json.dumps({
+        "high_level_description": text,
+        "style_description": {"aesthetics": "clean, professional, photorealistic, high detail",
+                              "lighting": "soft natural lighting", "photo": "sharp focus, high resolution, detailed",
+                              "medium": "photograph", "color_palette": ["#3A3A3A", "#C8C8C8", "#7A7A7A", "#E8E8E8"]},
+        "compositional_deconstruction": {"background": "softly blurred complementary background",
+                                         "elements": [{"type": "obj", "bbox": [256, 256, 768, 768],
+                                                       "desc": text, "color_palette": ["#888888"]}]},
+    })
+
+
+def _coerce_caption(s, fallback_text):
+    t = (s or "").strip()
+    if t.startswith("```"):
+        t = t.strip("`")
+        t = t[4:] if t[:4].lower() == "json" else t
+        t = t.strip()
+    try:
+        obj = json.loads(t)
+        if isinstance(obj, dict) and obj.get("high_level_description"):
+            return json.dumps(obj)
+    except Exception:
+        pass
+    return _min_caption(fallback_text)
+
+
+async def _craft_caption(session, brief):
+    """Ask the director for a rich Ideogram JSON caption; retry once on a flaky call, then
+    fall back to a populated wrap (the director's first call after idle can miss)."""
+    body = {"model": DIRECTOR_MODEL,
+            "messages": [{"role": "system", "content": DIRECTOR_IMG_SYS},
+                         {"role": "user", "content": brief}],
+            "max_tokens": 700, "temperature": 0.7,
+            "chat_template_kwargs": {"enable_thinking": False}}
+    last_err = None
+    for attempt in range(3):
+        try:
+            async with session.post(DIRECTOR_URL + "/chat/completions", json=body,
+                                    timeout=aiohttp.ClientTimeout(total=120)) as r:
+                data = await r.json()
+                raw = (data["choices"][0]["message"]["content"] or "").strip()
+            # Only accept a VALID director caption; otherwise retry (don't settle for min_caption yet).
+            try:
+                obj = json.loads(raw[4:].strip() if raw[:4].lower() == "json" else raw.strip("`").strip()
+                                 if raw.startswith("```") else raw)
+                if isinstance(obj, dict) and obj.get("high_level_description"):
+                    return json.dumps(obj)
+            except Exception:
+                pass
+            last_err = "invalid director JSON"
+        except Exception as e:
+            last_err = repr(e)
+        await asyncio.sleep(1.0)
+    print(f"[shim] director unusable after retries ({last_err}) -> min_caption", flush=True)
+    return _min_caption(brief)
+
+
+def _find_text_node(wf):
+    """Locate the prompt text node OWUI wrote into. Prefer 'pos'; else first CLIPTextEncode
+    whose text is not already a JSON caption."""
+    n = wf.get("pos")
+    if isinstance(n, dict) and n.get("class_type") == "CLIPTextEncode":
+        return "pos"
+    for nid, node in wf.items():
+        if isinstance(node, dict) and node.get("class_type") == "CLIPTextEncode":
+            return nid
+    return None
+
+
+async def prompt_handler(request):
+    """Intercept ComfyUI /prompt: rewrite the plain-text prompt into an Ideogram caption."""
+    raw_body = await request.read()
+    try:
+        body = json.loads(raw_body)
+        wf = body.get("prompt", {})
+        nid = _find_text_node(wf)
+        if nid:
+            cur = (wf[nid].get("inputs", {}) or {}).get("text", "")
+            # Only craft if it's plain text (not already a JSON caption).
+            if isinstance(cur, str) and cur.strip() and not cur.strip().startswith("{"):
+                async with aiohttp.ClientSession() as s:
+                    caption = await _craft_caption(s, cur.strip())
+                wf[nid]["inputs"]["text"] = caption
+                raw_body = json.dumps(body).encode()
+                print(f"[shim] crafted Ideogram caption for {cur.strip()[:60]!r} ({len(caption)} chars)", flush=True)
+    except Exception as e:
+        print(f"[shim] /prompt rewrite error: {e!r}", flush=True)  # forward unchanged
+    async with aiohttp.ClientSession() as s:
+        async with s.post(UPSTREAM + "/prompt", data=raw_body,
+                          headers={"Content-Type": "application/json"}) as r:
+            body = await r.read()
+            return web.Response(body=body, status=r.status,
+                                headers={"Content-Type": r.headers.get("Content-Type", "application/json")})
+
+
+async def ws_handler(request):
+    """Relay the ComfyUI progress websocket (OWUI waits on it for completion)."""
+    client_ws = web.WebSocketResponse()
+    await client_ws.prepare(request)
+    qs = request.query_string
+    url = UPSTREAM.replace("http://", "ws://").replace("https://", "wss://") + "/ws" + (("?" + qs) if qs else "")
+    try:
+        async with aiohttp.ClientSession() as s:
+            async with s.ws_connect(url) as up:
+                async def c2u():
+                    async for m in client_ws:
+                        if m.type == WSMsgType.TEXT: await up.send_str(m.data)
+                        elif m.type == WSMsgType.BINARY: await up.send_bytes(m.data)
+                        elif m.type in (WSMsgType.CLOSE, WSMsgType.CLOSING, WSMsgType.CLOSED): break
+                async def u2c():
+                    async for m in up:
+                        if m.type == WSMsgType.TEXT: await client_ws.send_str(m.data)
+                        elif m.type == WSMsgType.BINARY: await client_ws.send_bytes(m.data)
+                        elif m.type in (WSMsgType.CLOSE, WSMsgType.CLOSING, WSMsgType.CLOSED): break
+                await asyncio.gather(c2u(), u2c())
+    except Exception:
+        pass
+    return client_ws
+
+
+async def proxy_handler(request):
+    """Transparent passthrough for every other ComfyUI endpoint (/history, /view, /upload, ...)."""
+    url = UPSTREAM + request.raw_path
+    data = await request.read()
+    hdrs = {k: v for k, v in request.headers.items() if k.lower() not in ("host", "content-length")}
+    async with aiohttp.ClientSession(auto_decompress=False) as s:
+        async with s.request(request.method, url, data=data if data else None,
+                             headers=hdrs, allow_redirects=False) as r:
+            body = await r.read()
+            out_hdrs = {k: v for k, v in r.headers.items()
+                        if k.lower() not in ("content-encoding", "transfer-encoding", "content-length", "connection")}
+            return web.Response(body=body, status=r.status, headers=out_hdrs)
+
+
+async def health(request):
+    return web.json_response({"ok": True, "upstream": UPSTREAM, "director": DIRECTOR_URL})
+
+
+def make_app():
+    app = web.Application(client_max_size=64 * 1024 * 1024)
+    app.router.add_get("/shim/health", health)
+    app.router.add_get("/ws", ws_handler)
+    app.router.add_post("/prompt", prompt_handler)
+    app.router.add_route("*", "/{tail:.*}", proxy_handler)
+    return app
+
+
+if __name__ == "__main__":
+    web.run_app(make_app(), host="0.0.0.0", port=PORT)


### PR DESCRIPTION
## What

OWUI's native 🖼️ image button sends **plain text** to Ideogram-4, which is trained on **structured JSON captions** and renders an "Image blocked by safety filter" placeholder for off-schema input. OWUI's own image-prompt-generation can't fix it: it returns `{"prompt":"<string>"}`, and nesting the Ideogram JSON inside that string defeats the task models (measured: gemma-12b **0/3**, qwen-4b **1/3** valid escapes).

Adds **`services/studio/image-shim/`** (`:8191`) — a transparent **ComfyUI reverse-proxy**. OWUI's `COMFYUI_BASE_URL` points at it (and OWUI image-prompt-generation is turned **off**), so the raw prompt reaches the shim. The shim proxies everything through (including the `/ws` progress socket) **except** `POST /prompt`: there it reads the plain-text prompt node, asks the director (qwen `:8090`) for a rich Ideogram-4 JSON caption, and rewrites the node — **escaping done in Python** (reliable), so the model never produces nested JSON. Retries the director once; falls back to a populated caption if unusable.

**Blast radius = image generation only.** OWUI's title/tag/search-query/etc. task-generation is untouched — this is a ComfyUI proxy, not an OWUI task-model override (which would have hijacked all task-gen globally).

## Wiring

- `gpu-mode video-studio` + `image-studio` start the shim; `image-studio` also starts the director (qwen, GPU0 ~4.6 GB) it depends on.
- `services/openwebui/imagegen.env`: `COMFYUI_BASE_URL` → `:8191`, `ENABLE_IMAGE_PROMPT_GENERATION=false` (fresh deploys; existing volumes set it in the DB / Admin → Images — PersistentConfig).
- `docs/VIDEO_STUDIO.md` "Native image button" section + README `image-shim/` row.

## Validation (on the rig, end-to-end through the shim's `/prompt`)

- Plain `"a mountain landscape at sunrise"` / `"a serene lake surrounded by autumn forest"` / `'a logo for "Nimbus"'` → director crafts the caption → **all render clean** (visually confirmed; ~80 s warm). Plain text without the shim = 100% blocked.
- Shim passthrough (`/system_stats`, `/history`, `/view`) + `/ws` relay work; OWUI container reaches the shim at the configured `base_url`.
- Gate `for t in scripts/tests/*.sh; do bash "$t"; done` → 41/42 (the 1 red is the pre-existing untracked `nex-n2-mini` disk pollution, unrelated to `services/studio` / `scripts` / `docs`).

> The only leg not directly exercised is the literal in-UI button click (needs an OWUI auth token); every component + the OWUI→shim reachability is validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)