### PR TITLE
studio: integrated voices for video — Kokoro TTS + layer-aware audio mixdown

### DIFF
--- a/docs/VIDEO_STUDIO.md
+++ b/docs/VIDEO_STUDIO.md
@@ -128,6 +128,8 @@ just name it and the director keeps it — e.g. *"…top-down drone shot, golden
 - **Lane** — pick the model: **🎬 LTX-2.3** (video + audio) or **🔓 Sulphur** (uncensored).
 - **Image → video** — attach an image (optionally with a motion note like *"slow zoom in,
   leaves drifting"*); it animates your still.
+- **Voiceover** — add *"voiceover: …"* / *"narration: '…'"* / *"say: …"* and a Kokoro voice is
+  mixed over the clip (ducked under the ambient, normalized). See *Integrated audio*.
 - **Refine** — just reply with the change: *"more moody"*, *"make it night"*, *"slower
   camera"*, *"add rain"*. It evolves the last prompt; a brand-new idea starts fresh.
 
@@ -208,6 +210,28 @@ upscaler + a refine pass). On this hardware that 2-stage path renders a **diamon
 mesh** over every frame. The fix — and what the pipe ships — is **single-stage**: splice
 the distilled LoRA onto the base sampler, 8 steps, cfg 1, no upscaler. Clean output. The
 workflow (`workflows/ltx_distilled_distorch.json`) already encodes this.
+
+## Integrated audio (voices for video)
+
+The video lanes already render a clip *with* native ambient audio. The Studio can add a
+**voiceover/narration** on top: include a directive in your message and the pipe generates a
+voice and mixes it over the clip.
+
+- **Ask for it:** *"a fox padding through a neon alley at night, **voiceover: the city never
+  sleeps, and neither do we**"* — or `narration: "..."`, or `say: ...`. The pipe pulls the
+  spoken line out (so it doesn't pollute the video prompt), renders the clip, then narrates.
+- **Engine:** **`studio-tts`** (`:8192`) — **Kokoro-82M** on **CPU** (never touches the GPUs),
+  so it adds no VRAM pressure and runs after the render (voice ≈ 1–2 s of compute).
+- **Layer-aware mixdown** (ffmpeg): the Kokoro voice is mixed over the clip's native audio, the
+  **bed is ducked** under the voice (`sidechaincompress`), and the master is **loudness-normalized**
+  (`loudnorm`, −16 LUFS); output audio is capped to the clip length. The mix stage is structured
+  to accept more layers (generated music / SFX) later without a rewrite — only the voice layer is
+  populated today (that's the planned audio-studio's job). Pick a voice with the `narrate_voice`
+  valve (`af_heart`, `am_adam`, `bf_emma`, …); if `studio-tts` is unreachable the clip is returned
+  silent (un-narrated).
+
+> Lightweight "voices for video." A dedicated audio-studio (long-form TTS, ACE-Step music, SFX,
+> full multi-layer mix) is the planned next phase.
 
 ## Image lanes (Ideogram-4 design · Chroma uncensored)
 
@@ -309,6 +333,8 @@ gemma-12b chat or a 2048² still needs a `gpu-mode` change.
 | `t5xxl_fp16.safetensors` + Flux `ae.safetensors` | `text_encoders/`, `vae/flux/` | Chroma (shared with Flux ecosystem) |
 
 Director GGUF (`Qwen3.5-4B-Uncensored-…`) → `/mnt/models/huggingface/qwen3.5-4b-gguf/…`.
+
+Narration TTS (CPU): `kokoro-v1.0.onnx` + `voices-v1.0.bin` (kokoro-onnx GitHub release / [onnx-community/Kokoro-82M-v1.0-ONNX](https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX)) → `/mnt/models/comfyui/models/tts/kokoro/`.
 
 ## On the uncensored models
 

--- a/scripts/gpu-mode.sh
+++ b/scripts/gpu-mode.sh
@@ -175,6 +175,12 @@ start_studio_image_shim() {
     printf "  ${GREEN}▲${NC} Starting studio-image-shim (:8191, native-button Ideogram captions)..."
     compose_at "$COMPOSE_BASE/studio/image-shim" "up -d --build" && echo "done" || echo "failed"
 }
+# Integrated-voices TTS + audio mixdown (:8192, Kokoro on CPU). The pipe POSTs /narrate after a
+# video render to mix a voiceover over the clip's native audio (ducked + normalized). No GPU.
+start_studio_tts() {
+    printf "  ${GREEN}▲${NC} Starting studio-tts (:8192, Kokoro voices + mixdown, CPU)..."
+    compose_at "$COMPOSE_BASE/studio/tts" "up -d --build" && echo "done" || echo "failed"
+}
 
 # ComfyUI pinned to GPU 0 (image-studio split — leaves the other card for the chat LLM).
 start_comfyui_gpu0() {
@@ -627,6 +633,7 @@ mode_video_studio() {
     start_studio_gallery
     start_studio_orchestrator
     start_studio_image_shim
+    start_studio_tts
     start_service openwebui
     start_service litellm
     start_service searxng

--- a/services/studio/README.md
+++ b/services/studio/README.md
@@ -19,6 +19,7 @@ architecture, capabilities and the measured length limits live in **[../../docs/
 | `enhancer/` | `docker compose` for the "director" LLM (`:8090`, OpenAI-compatible). |
 | `orchestrator/` | `docker compose` + Dockerfile for the long-clip engine (`:8190`): chains ~10 s segments into one combined video for requests >15 s. The pipe POSTs here when you ask for a length. |
 | `image-shim/` | `docker compose` + Dockerfile for the native-button image shim (`:8191`): a transparent ComfyUI reverse-proxy that crafts an Ideogram-4 JSON caption (via the director) on `POST /prompt`, so OWUI's built-in 🖼️ image button renders instead of the "blocked by safety filter" placeholder. Point OWUI's `COMFYUI_BASE_URL` at it. See VIDEO_STUDIO.md "Native image button". |
+| `tts/` | `docker compose` + Dockerfile for integrated voices (`:8192`): **Kokoro-82M** (ONNX, CPU) generates a voiceover and a **layer-aware ffmpeg mixdown** ducks it over the clip's native audio + loudness-normalizes. The pipe POSTs `/narrate` when the message has a `voiceover:`/`narration:` directive. No GPU. See VIDEO_STUDIO.md "Integrated audio". |
 | `extend_chain.py` | The same chaining as a standalone host CLI (handy for scripted long renders). |
 
 ## Install the pipe into Open WebUI

--- a/services/studio/build_studio_pipe.py
+++ b/services/studio/build_studio_pipe.py
@@ -76,7 +76,7 @@ title: Studio (text/image -> video · image)
 author: club-3090
 description: Type a rough idea — the studio director (qwen) crafts it into a professional, artistic prompt and generates. Video lanes: LTX (video+audio) or Sulphur (uncensored), text->video or attach an image. Image lanes: Ideogram-4 (graphic design / logo / photo / art) or Chroma (uncensored). Refine anytime by just saying what to change.
 required_open_webui_version: 0.5.0
-version: 0.8.0
+version: 0.9.0
 """
 # ── Pipeline defaults (this rig, 2x 3090, measured 2026-06-11) ──────────────────
 #  Video lanes: ltx = LTX-2.3-distilled (video+audio) · sulphur = uncensored dev fine-tune
@@ -115,6 +115,9 @@ class Pipe:
         image_max_edge: int = Field(default=1024, description="Cap on the image long edge. 1024 lets the image gen coexist with the director on GPU0 (~23GB); 2048 would OOM unless the director is stopped first.")
         chroma_steps: int = Field(default=26, description="Chroma (uncensored image lane) sampler steps.")
         chroma_cfg: float = Field(default=3.5, description="Chroma CFG scale (Chroma is de-distilled — real CFG + negative prompt, unlike Ideogram).")
+        enable_narration: bool = Field(default=True, description="Video lanes only: if the message includes a voiceover (e.g. 'voiceover: ...' or 'narration: \"...\"'), generate a Kokoro voice and mix it over the clip's audio (ducked + normalized).")
+        tts_url: str = Field(default="http://host.docker.internal:8192", description="Studio TTS + mixdown service (Kokoro, CPU). Generates the voiceover and ducks it over the clip's native audio. If unreachable, the clip is returned without narration.")
+        narrate_voice: str = Field(default="af_heart", description="Kokoro voice id for narration (e.g. af_heart, af_bella, am_adam, bf_emma, bm_george).")
 
     def __init__(self):
         self.valves = self.Valves()
@@ -306,6 +309,28 @@ class Pipe:
         return json.load(urllib.request.urlopen(
             self.valves.orchestrator_url.rstrip("/") + "/job/" + jid, timeout=30))
 
+    # ── integrated narration (video lanes): parse a voiceover directive, synth + mix via the TTS svc ──
+    def _narration(self, text):
+        """Returns (spoken_text, scene_text). spoken='' if no voiceover was asked. The directive
+        is stripped from scene_text so it doesn't pollute the video prompt / duration parse."""
+        for p in (r'(?:voice[\s-]?over|narrat(?:e|ion|or)?|say(?:ing)?)\s*(?:that\s+)?[:=\-]?\s*["“‘\'](.+?)["”’\']',
+                  r'(?:voice[\s-]?over|narration|narrate|say(?:ing)?)\s*[:=\-]\s*([^\n]+)'):
+            m = re.search(p, text, re.I)
+            if m:
+                spoken = m.group(1).strip().strip('"“”‘’\'')
+                scene = (text[:m.start()] + " " + text[m.end():]).strip(" ,.\n-")
+                return spoken, (scene or text)
+        return "", text
+
+    def _narrate(self, fn, sub, text, voice):
+        body = json.dumps({"video": fn, "subfolder": sub or "", "text": text, "voice": voice}).encode()
+        req = urllib.request.Request(self.valves.tts_url.rstrip("/") + "/narrate", data=body,
+                                     headers={"Content-Type": "application/json"})
+        r = json.load(urllib.request.urlopen(req, timeout=self.valves.timeout_s))
+        if r.get("filename"):
+            return r["filename"], r.get("subfolder", "")
+        raise RuntimeError(r.get("error", "narration failed"))
+
     def _submit(self, wf):
         req = urllib.request.Request(self.valves.comfyui_url + "/prompt",
                                      data=json.dumps({"prompt": wf, "client_id": "owui-studio"}).encode(),
@@ -457,20 +482,24 @@ class Pipe:
                 user_prompt = "subtle natural motion, gentle camera movement"
             else:
                 return "Type a scene to generate (or attach an image to animate)."
+        # Voiceover? (video lanes) — pull the spoken line out so it doesn't pollute the video prompt.
+        narration, scene_prompt = ("", user_prompt)
+        if self.valves.enable_narration:
+            narration, scene_prompt = self._narration(user_prompt)
         fr = ((min(int(self.valves.frames), 361) - 1) // 8) * 8 + 1   # capped + LTX-valid 8k+1
         prior_spec = self._prior_spec(body)
-        final_prompt = user_prompt
-        if self.valves.enhance and user_prompt:
+        final_prompt = scene_prompt
+        if self.valves.enhance and scene_prompt:
             await status("\U0001F3A8 Director crafting the shot…")
             try:
-                final_prompt = await loop.run_in_executor(None, self._enhance, user_prompt, mode == "i2v", prior_spec)
+                final_prompt = await loop.run_in_executor(None, self._enhance, scene_prompt, mode == "i2v", prior_spec)
             except Exception:
-                final_prompt = user_prompt
+                final_prompt = scene_prompt
 
         # Long clip? If the user asked for >15s (text→video), chain ~10s segments via the
         # orchestrator into one combined video. Falls through to a single capped clip if
         # the orchestrator is unreachable.
-        target = self._target_seconds(user_prompt) if mode == "t2v" else 0
+        target = self._target_seconds(scene_prompt) if mode == "t2v" else 0
         if target > 15:
             segments = min(self.valves.max_seconds // 10, max(2, math.ceil(target / 10)))
             jid = None
@@ -492,14 +521,23 @@ class Pipe:
                         last = p
                         await status("\U0001F3AC rendering segment " + p + " (~" + str(segments * 10) + "s total, a few min each)…")
                     if j.get("status") == "done":
-                        await status("Done", True)
                         base = self.valves.browser_base.rstrip("/")
                         fn = j.get("filename"); sub = j.get("subfolder", "video")
+                        nlabel = ""
+                        if narration:
+                            await status("\U0001F5E3️ Adding narration…")
+                            try:
+                                fn, sub = await loop.run_in_executor(None, self._narrate, fn, sub, narration, self.valves.narrate_voice)
+                                nlabel = " · \U0001F5E3️ narration"
+                            except Exception:
+                                pass
+                        await status("Done", True)
                         url = base + "/" + ((sub + "/") if sub else "") + fn
                         marker = "<!--SPEC:" + base64.b64encode(final_prompt.encode()).decode() + "-->"
-                        return ("**" + label + " · text→video · " + str(segments) + " segments (~" + str(segments * 10) + "s)**\n\n"
+                        return ("**" + label + " · text→video · " + str(segments) + " segments (~" + str(segments * 10) + "s)" + nlabel + "**\n\n"
                                 "**Prompt used:** " + final_prompt + "\n\n"
-                                "▶️ **[Open / download the video](" + url + ")**\n\n"
+                                + (("**Narration:** “" + narration + "”\n\n") if (narration and nlabel) else "")
+                                + "▶️ **[Open / download the video](" + url + ")**\n\n"
                                 "_Want changes? Just say what to tweak and I’ll re-craft and regenerate._ "
                                 "_(Browse all media: " + base + "/ )_" + marker)
                     if j.get("status") == "error":
@@ -515,20 +553,30 @@ class Pipe:
         except Exception as e:
             await status("Failed", True)
             return "⚠️ Generation failed: " + str(e)
-        await status("Done", True)
         if not fn:
+            await status("Failed", True)
             return "Generation finished but no video output was found."
+        nlabel = ""
+        if narration:
+            await status("\U0001F5E3️ Adding narration…")
+            try:
+                fn, sub = await loop.run_in_executor(None, self._narrate, fn, sub, narration, self.valves.narrate_voice)
+                nlabel = " · \U0001F5E3️ narration"
+            except Exception:
+                pass
+        await status("Done", True)
         base = self.valves.browser_base.rstrip("/")
         url = base + "/" + ((sub + "/") if sub else "") + fn
         marker = "<!--SPEC:" + base64.b64encode(final_prompt.encode()).decode() + "-->"
         secs = int(round(fr / 24))
-        return ("**" + label + " · " + kind + " · " + str(fr) + " frames (~" + str(secs) + "s)**\n\n"
+        return ("**" + label + " · " + kind + " · " + str(fr) + " frames (~" + str(secs) + "s)" + nlabel + "**\n\n"
                 "**Prompt used:** " + final_prompt + "\n\n"
-                "▶️ **[Open / download the video](" + url + ")**\n\n"
+                + (("**Narration:** “" + narration + "”\n\n") if (narration and nlabel) else "")
+                + "▶️ **[Open / download the video](" + url + ")**\n\n"
                 "_Want changes? Just say what to tweak — e.g. “more moody”, “make it night”, "
-                "“slower camera” — and I’ll re-craft from this and regenerate._ "
+                "“slower camera”, or “voiceover: …” — and I’ll re-craft from this and regenerate._ "
                 "_(Browse all media: " + base + "/ )_" + marker)
 '''.replace('__WF_JSON__', WF_JSON)
 
 open(OUT_PATH, 'w').write(PIPE)
-print("wrote %s (%d bytes; 6 workflows: ltx/sulphur x t2v/i2v + ideogram-4 + chroma image)" % (OUT_PATH, len(PIPE)))
+print("wrote %s (%d bytes; 6 workflows + integrated narration (Kokoro TTS))" % (OUT_PATH, len(PIPE)))

--- a/services/studio/studio_pipe.py
+++ b/services/studio/studio_pipe.py
@@ -4,7 +4,7 @@ title: Studio (text/image -> video · image)
 author: club-3090
 description: Type a rough idea — the studio director (qwen) crafts it into a professional, artistic prompt and generates. Video lanes: LTX (video+audio) or Sulphur (uncensored), text->video or attach an image. Image lanes: Ideogram-4 (graphic design / logo / photo / art) or Chroma (uncensored). Refine anytime by just saying what to change.
 required_open_webui_version: 0.5.0
-version: 0.8.0
+version: 0.9.0
 """
 # ── Pipeline defaults (this rig, 2x 3090, measured 2026-06-11) ──────────────────
 #  Video lanes: ltx = LTX-2.3-distilled (video+audio) · sulphur = uncensored dev fine-tune
@@ -43,6 +43,9 @@ class Pipe:
         image_max_edge: int = Field(default=1024, description="Cap on the image long edge. 1024 lets the image gen coexist with the director on GPU0 (~23GB); 2048 would OOM unless the director is stopped first.")
         chroma_steps: int = Field(default=26, description="Chroma (uncensored image lane) sampler steps.")
         chroma_cfg: float = Field(default=3.5, description="Chroma CFG scale (Chroma is de-distilled — real CFG + negative prompt, unlike Ideogram).")
+        enable_narration: bool = Field(default=True, description="Video lanes only: if the message includes a voiceover (e.g. 'voiceover: ...' or 'narration: \"...\"'), generate a Kokoro voice and mix it over the clip's audio (ducked + normalized).")
+        tts_url: str = Field(default="http://host.docker.internal:8192", description="Studio TTS + mixdown service (Kokoro, CPU). Generates the voiceover and ducks it over the clip's native audio. If unreachable, the clip is returned without narration.")
+        narrate_voice: str = Field(default="af_heart", description="Kokoro voice id for narration (e.g. af_heart, af_bella, am_adam, bf_emma, bm_george).")
 
     def __init__(self):
         self.valves = self.Valves()
@@ -234,6 +237,28 @@ class Pipe:
         return json.load(urllib.request.urlopen(
             self.valves.orchestrator_url.rstrip("/") + "/job/" + jid, timeout=30))
 
+    # ── integrated narration (video lanes): parse a voiceover directive, synth + mix via the TTS svc ──
+    def _narration(self, text):
+        """Returns (spoken_text, scene_text). spoken='' if no voiceover was asked. The directive
+        is stripped from scene_text so it doesn't pollute the video prompt / duration parse."""
+        for p in (r'(?:voice[\s-]?over|narrat(?:e|ion|or)?|say(?:ing)?)\s*(?:that\s+)?[:=\-]?\s*["“‘\'](.+?)["”’\']',
+                  r'(?:voice[\s-]?over|narration|narrate|say(?:ing)?)\s*[:=\-]\s*([^\n]+)'):
+            m = re.search(p, text, re.I)
+            if m:
+                spoken = m.group(1).strip().strip('"“”‘’\'')
+                scene = (text[:m.start()] + " " + text[m.end():]).strip(" ,.\n-")
+                return spoken, (scene or text)
+        return "", text
+
+    def _narrate(self, fn, sub, text, voice):
+        body = json.dumps({"video": fn, "subfolder": sub or "", "text": text, "voice": voice}).encode()
+        req = urllib.request.Request(self.valves.tts_url.rstrip("/") + "/narrate", data=body,
+                                     headers={"Content-Type": "application/json"})
+        r = json.load(urllib.request.urlopen(req, timeout=self.valves.timeout_s))
+        if r.get("filename"):
+            return r["filename"], r.get("subfolder", "")
+        raise RuntimeError(r.get("error", "narration failed"))
+
     def _submit(self, wf):
         req = urllib.request.Request(self.valves.comfyui_url + "/prompt",
                                      data=json.dumps({"prompt": wf, "client_id": "owui-studio"}).encode(),
@@ -385,20 +410,24 @@ class Pipe:
                 user_prompt = "subtle natural motion, gentle camera movement"
             else:
                 return "Type a scene to generate (or attach an image to animate)."
+        # Voiceover? (video lanes) — pull the spoken line out so it doesn't pollute the video prompt.
+        narration, scene_prompt = ("", user_prompt)
+        if self.valves.enable_narration:
+            narration, scene_prompt = self._narration(user_prompt)
         fr = ((min(int(self.valves.frames), 361) - 1) // 8) * 8 + 1   # capped + LTX-valid 8k+1
         prior_spec = self._prior_spec(body)
-        final_prompt = user_prompt
-        if self.valves.enhance and user_prompt:
+        final_prompt = scene_prompt
+        if self.valves.enhance and scene_prompt:
             await status("\U0001F3A8 Director crafting the shot…")
             try:
-                final_prompt = await loop.run_in_executor(None, self._enhance, user_prompt, mode == "i2v", prior_spec)
+                final_prompt = await loop.run_in_executor(None, self._enhance, scene_prompt, mode == "i2v", prior_spec)
             except Exception:
-                final_prompt = user_prompt
+                final_prompt = scene_prompt
 
         # Long clip? If the user asked for >15s (text→video), chain ~10s segments via the
         # orchestrator into one combined video. Falls through to a single capped clip if
         # the orchestrator is unreachable.
-        target = self._target_seconds(user_prompt) if mode == "t2v" else 0
+        target = self._target_seconds(scene_prompt) if mode == "t2v" else 0
         if target > 15:
             segments = min(self.valves.max_seconds // 10, max(2, math.ceil(target / 10)))
             jid = None
@@ -420,14 +449,23 @@ class Pipe:
                         last = p
                         await status("\U0001F3AC rendering segment " + p + " (~" + str(segments * 10) + "s total, a few min each)…")
                     if j.get("status") == "done":
-                        await status("Done", True)
                         base = self.valves.browser_base.rstrip("/")
                         fn = j.get("filename"); sub = j.get("subfolder", "video")
+                        nlabel = ""
+                        if narration:
+                            await status("\U0001F5E3️ Adding narration…")
+                            try:
+                                fn, sub = await loop.run_in_executor(None, self._narrate, fn, sub, narration, self.valves.narrate_voice)
+                                nlabel = " · \U0001F5E3️ narration"
+                            except Exception:
+                                pass
+                        await status("Done", True)
                         url = base + "/" + ((sub + "/") if sub else "") + fn
                         marker = "<!--SPEC:" + base64.b64encode(final_prompt.encode()).decode() + "-->"
-                        return ("**" + label + " · text→video · " + str(segments) + " segments (~" + str(segments * 10) + "s)**\n\n"
+                        return ("**" + label + " · text→video · " + str(segments) + " segments (~" + str(segments * 10) + "s)" + nlabel + "**\n\n"
                                 "**Prompt used:** " + final_prompt + "\n\n"
-                                "▶️ **[Open / download the video](" + url + ")**\n\n"
+                                + (("**Narration:** “" + narration + "”\n\n") if (narration and nlabel) else "")
+                                + "▶️ **[Open / download the video](" + url + ")**\n\n"
                                 "_Want changes? Just say what to tweak and I’ll re-craft and regenerate._ "
                                 "_(Browse all media: " + base + "/ )_" + marker)
                     if j.get("status") == "error":
@@ -443,16 +481,26 @@ class Pipe:
         except Exception as e:
             await status("Failed", True)
             return "⚠️ Generation failed: " + str(e)
-        await status("Done", True)
         if not fn:
+            await status("Failed", True)
             return "Generation finished but no video output was found."
+        nlabel = ""
+        if narration:
+            await status("\U0001F5E3️ Adding narration…")
+            try:
+                fn, sub = await loop.run_in_executor(None, self._narrate, fn, sub, narration, self.valves.narrate_voice)
+                nlabel = " · \U0001F5E3️ narration"
+            except Exception:
+                pass
+        await status("Done", True)
         base = self.valves.browser_base.rstrip("/")
         url = base + "/" + ((sub + "/") if sub else "") + fn
         marker = "<!--SPEC:" + base64.b64encode(final_prompt.encode()).decode() + "-->"
         secs = int(round(fr / 24))
-        return ("**" + label + " · " + kind + " · " + str(fr) + " frames (~" + str(secs) + "s)**\n\n"
+        return ("**" + label + " · " + kind + " · " + str(fr) + " frames (~" + str(secs) + "s)" + nlabel + "**\n\n"
                 "**Prompt used:** " + final_prompt + "\n\n"
-                "▶️ **[Open / download the video](" + url + ")**\n\n"
+                + (("**Narration:** “" + narration + "”\n\n") if (narration and nlabel) else "")
+                + "▶️ **[Open / download the video](" + url + ")**\n\n"
                 "_Want changes? Just say what to tweak — e.g. “more moody”, “make it night”, "
-                "“slower camera” — and I’ll re-craft from this and regenerate._ "
+                "“slower camera”, or “voiceover: …” — and I’ll re-craft from this and regenerate._ "
                 "_(Browse all media: " + base + "/ )_" + marker)

--- a/services/studio/tts/Dockerfile
+++ b/services/studio/tts/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+# espeak-ng = Kokoro G2P fallback; ffmpeg = mixdown; libsndfile1 = soundfile WAV I/O.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        espeak-ng ffmpeg libsndfile1 \
+    && rm -rf /var/lib/apt/lists/*
+# kokoro-onnx pulls onnxruntime (CPU) + misaki (G2P). Pin onnxruntime to the CPU wheel.
+RUN pip install --no-cache-dir kokoro-onnx soundfile aiohttp
+WORKDIR /app
+COPY tts.py /app/tts.py
+EXPOSE 8192
+CMD ["python3", "/app/tts.py"]

--- a/services/studio/tts/docker-compose.yml
+++ b/services/studio/tts/docker-compose.yml
@@ -1,0 +1,21 @@
+# Studio TTS + audio-mixdown — integrated voices for video (Phase 3a). Kokoro-82M (ONNX, CPU,
+# never touches the GPUs) generates a voiceover; a layer-aware ffmpeg mixdown ducks the clip's
+# native LTX/Sulphur ambient under the voice and loudness-normalizes. The pipe POSTs /narrate
+# after the video render. No GPU → safe always-on alongside the gallery/orchestrator.
+# See docs/VIDEO_STUDIO.md "Integrated audio".
+services:
+  studio-tts:
+    build: .
+    image: studio-tts:latest
+    container_name: studio-tts
+    restart: unless-stopped
+    network_mode: host          # reachable at host:8192; reads/writes the mounted output dir
+    environment:
+      - KOKORO_MODEL=${KOKORO_MODEL:-/models/kokoro/kokoro-v1.0.onnx}
+      - KOKORO_VOICES=${KOKORO_VOICES:-/models/kokoro/voices-v1.0.bin}
+      - OUTPUT_DIR=/output
+      - DEFAULT_VOICE=${STUDIO_TTS_VOICE:-af_heart}
+      - TTS_PORT=${STUDIO_TTS_PORT:-8192}
+    volumes:
+      - ${KOKORO_DIR:-/mnt/models/comfyui/models/tts/kokoro}:/models/kokoro:ro
+      - ${COMFYUI_OUTPUT_DIR:-/mnt/models/comfyui/output}:/output

--- a/services/studio/tts/tts.py
+++ b/services/studio/tts/tts.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Studio TTS + audio-mixdown service — integrated voices for video (Phase 3a).
+
+The Studio's video lanes (LTX/Sulphur) already render a clip *with* native ambient audio.
+This service adds a **voiceover/narration** layer on top, using **Kokoro-82M** (ONNX, CPU —
+never touches the GPUs), and a **layer-aware ffmpeg mixdown**: it ducks the clip's native
+audio under the voice (sidechain compression) and loudness-normalizes the master.
+
+The mixdown is structured around an ordered layer list (bed → … → voice) so that future
+layers (generated music / SFX from a dedicated audio-studio) slot in without a rewrite —
+only the voice layer is populated today. See docs/VIDEO_STUDIO.md "Integrated audio".
+
+Endpoints:
+  GET  /tts/health
+  POST /tts      {text, voice?, speed?}                 -> {wav: <file in OUTPUT_DIR>}
+  POST /narrate  {video, text, voice?, speed?, duck_db?} -> {filename, subfolder}  (muxed clip)
+
+Env:
+  KOKORO_MODEL   path to kokoro-v1.0.onnx     (default /models/kokoro/kokoro-v1.0.onnx)
+  KOKORO_VOICES  path to voices-v1.0.bin      (default /models/kokoro/voices-v1.0.bin)
+  OUTPUT_DIR     ComfyUI output dir (mounted) (default /output)
+  DEFAULT_VOICE  Kokoro voice id              (default af_heart)
+  TTS_PORT       listen port                  (default 8192)
+"""
+import os, json, time, uuid, asyncio, subprocess, tempfile, shutil
+from aiohttp import web
+import soundfile as sf
+from kokoro_onnx import Kokoro
+
+KOKORO_MODEL = os.environ.get("KOKORO_MODEL", "/models/kokoro/kokoro-v1.0.onnx")
+KOKORO_VOICES = os.environ.get("KOKORO_VOICES", "/models/kokoro/voices-v1.0.bin")
+OUTPUT_DIR = os.environ.get("OUTPUT_DIR", "/output").rstrip("/")
+DEFAULT_VOICE = os.environ.get("DEFAULT_VOICE", "af_heart")
+PORT = int(os.environ.get("TTS_PORT", "8192"))
+
+_kokoro = None
+def kokoro():
+    global _kokoro
+    if _kokoro is None:
+        _kokoro = Kokoro(KOKORO_MODEL, KOKORO_VOICES)
+    return _kokoro
+
+
+def _synth(text, voice, speed):
+    """Kokoro TTS -> a temp wav path (24 kHz mono float)."""
+    samples, sr = kokoro().create(text, voice=voice or DEFAULT_VOICE, speed=float(speed or 1.0), lang="en-us")
+    fd, path = tempfile.mkstemp(suffix=".wav", dir="/tmp")
+    os.close(fd)
+    sf.write(path, samples, sr)
+    return path
+
+
+def _has_audio(video_path):
+    try:
+        out = subprocess.run(["ffprobe", "-v", "error", "-select_streams", "a", "-show_entries",
+                              "stream=index", "-of", "csv=p=0", video_path],
+                             capture_output=True, text=True, timeout=30)
+        return bool(out.stdout.strip())
+    except Exception:
+        return False
+
+
+def _duration(video_path):
+    try:
+        out = subprocess.run(["ffprobe", "-v", "error", "-show_entries", "format=duration",
+                              "-of", "csv=p=0", video_path], capture_output=True, text=True, timeout=30)
+        return float(out.stdout.strip())
+    except Exception:
+        return None
+
+
+def _mixdown(video_path, voice_wav, out_path, duck_db=12):
+    """Layer-aware mixdown (Phase 3a = bed + voice).
+
+    bed   = the clip's native audio (LTX/Sulphur ambient). Ducked under the voice.
+    voice = the Kokoro narration, kept at full level.
+    master is loudness-normalized (EBU R128, -16 LUFS). Output audio is capped to the
+    video duration. Adding music/SFX later = more inputs into the same amix + their own
+    levels before the duck — the structure doesn't change.
+    """
+    dur = _duration(video_path)
+    common = ["-c:v", "copy", "-c:a", "aac", "-b:a", "192k", "-map", "0:v:0"]
+    if dur:
+        common += ["-t", f"{dur:.3f}"]
+    if _has_audio(video_path):
+        # ratio set from duck_db: a deeper duck = higher ratio. threshold low so quiet
+        # ambient still ducks; release ~250ms so the bed swells back between phrases.
+        ratio = max(2, min(20, round(duck_db / 1.5)))
+        # apad the voice so the sidechain key spans the whole clip (sidechaincompress otherwise
+        # ends when the shorter voice input runs out, truncating the bed). -t caps to video len.
+        fc = (
+            "[1:a]aresample=24000,apad,asplit=2[vk][vm];"
+            "[0:a]aresample=48000[bed];"
+            f"[bed][vk]sidechaincompress=threshold=0.03:ratio={ratio}:attack=5:release=250[duck];"
+            "[duck][vm]amix=inputs=2:normalize=0:dropout_transition=0[mix];"
+            "[mix]loudnorm=I=-16:TP=-1.5:LRA=11[a]"
+        )
+    else:
+        fc = "[1:a]aresample=48000,loudnorm=I=-16:TP=-1.5:LRA=11[a]"
+    cmd = ["ffmpeg", "-y", "-i", video_path, "-i", voice_wav, "-filter_complex", fc, "-map", "[a]"] + common + [out_path]
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+    if r.returncode != 0:
+        raise RuntimeError("ffmpeg mixdown failed: " + r.stderr[-600:])
+
+
+async def health(request):
+    return web.json_response({"ok": True, "model": os.path.basename(KOKORO_MODEL),
+                              "default_voice": DEFAULT_VOICE,
+                              "model_present": os.path.exists(KOKORO_MODEL)})
+
+
+async def tts(request):
+    b = await request.json()
+    text = (b.get("text") or "").strip()
+    if not text:
+        return web.json_response({"error": "no text"}, status=400)
+    loop = asyncio.get_event_loop()
+    wav = await loop.run_in_executor(None, _synth, text, b.get("voice"), b.get("speed"))
+    name = "studio_tts_" + uuid.uuid4().hex[:8] + ".wav"
+    dst = os.path.join(OUTPUT_DIR, name)
+    shutil.move(wav, dst)   # /tmp -> /output is cross-device; shutil.move copies+unlinks
+    return web.json_response({"wav": name})
+
+
+async def narrate(request):
+    b = await request.json()
+    text = (b.get("text") or "").strip()
+    video = b.get("video") or ""
+    if not text:
+        return web.json_response({"error": "no text"}, status=400)
+    sub = b.get("subfolder", "") or ""
+    video_path = os.path.join(OUTPUT_DIR, sub, os.path.basename(video))
+    if not os.path.exists(video_path):
+        return web.json_response({"error": "video not found: " + video}, status=404)
+    loop = asyncio.get_event_loop()
+    voice_wav = None
+    try:
+        voice_wav = await loop.run_in_executor(None, _synth, text, b.get("voice"), b.get("speed"))
+        out_name = "studio_narrated_" + uuid.uuid4().hex[:8] + ".mp4"
+        out_path = os.path.join(OUTPUT_DIR, out_name)
+        await loop.run_in_executor(None, _mixdown, video_path, voice_wav, out_path, int(b.get("duck_db", 12)))
+        return web.json_response({"filename": out_name, "subfolder": ""})
+    except Exception as e:
+        return web.json_response({"error": str(e)}, status=500)
+    finally:
+        if voice_wav and os.path.exists(voice_wav):
+            os.remove(voice_wav)
+
+
+def make_app():
+    app = web.Application(client_max_size=32 * 1024 * 1024)
+    app.router.add_get("/tts/health", health)
+    app.router.add_post("/tts", tts)
+    app.router.add_post("/narrate", narrate)
+    return app
+
+
+if __name__ == "__main__":
+    web.run_app(make_app(), host="0.0.0.0", port=PORT)


### PR DESCRIPTION
## What

Phase 3a of the Studio audio plan: a **voiceover layer for the video lanes** (not a dedicated audio mode). Add `voiceover: …` / `narration: "…"` / `say: …` to the message and the pipe generates a voice and mixes it over the rendered clip.

New service **`services/studio/tts/`** (`:8192`, aiohttp):
- **Kokoro-82M (ONNX) on CPU** — never touches the GPUs, ~1–2 s to synth a sentence, zero VRAM (better than the original "small TTS on GPU0" plan). Runs after the render.
- **Layer-aware ffmpeg mixdown, Path A**: keep LTX/Sulphur's native ambient as the **bed**, mix the voice over it, **duck the bed under the voice** (`sidechaincompress`), **loudness-normalize** (`loudnorm` −16 LUFS), cap audio to the clip length. Structured around an ordered layer list so generated music / SFX (the future audio-studio) slot in without a rewrite — only the voice layer is filled today. Honours the pro sound-design order (bed → SFX → voice → mix).

Pipe **v0.9.0**:
- `_narration()` parses the spoken line out of the message (and strips it from the video prompt / duration parse); `_narrate()` POSTs `/narrate` after the render (single-clip **and** long-clip paths); silent-clip fallback if the TTS service is down. Valves: `enable_narration`, `tts_url`, `narrate_voice`.
- `gpu-mode video-studio` starts `studio-tts`.

## Gotchas found + fixed
- `os.replace` `/tmp`→`/output` is cross-device → `shutil.move`.
- `sidechaincompress` ends when the **shorter** input (the voice) runs out, truncating the mux → `apad` the voice so the sidechain spans the clip, then `-t` caps to the video duration.
- Our video model already emits audio, so "silent video first" isn't free — we **duck the native bed** rather than build from silence (this is what the layered-ordering review concluded).

## Validation (on the rig)
- `/tts`: text → wav in **1.7 s** (CPU). `/narrate`: mixes the voice over a real LTX-audio clip — ducked, −16 LUFS, **duration-matched** (20.1 s audio / 20.08 s video). Narration regex unit-tested across phrasings. Gate 41/42 (the 1 red is the pre-existing untracked `nex-n2-mini` pollution).

> Model files (`kokoro-v1.0.onnx` + `voices-v1.0.bin`) obtained separately into `models/tts/kokoro/` — see `docs/VIDEO_STUDIO.md` "Integrated audio". Design: `club-3090-ai-studio-design.md` Phase 3a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)