### PR TITLE
studio: add 🎙️ Voice lane — Step-Audio-EditX premium clone (isolated service)

### DIFF
--- a/docs/VIDEO_STUDIO.md
+++ b/docs/VIDEO_STUDIO.md
@@ -156,7 +156,7 @@ moment; use a longer duration (more segments) for a scene that needs to evolve.
 | **Audio** | yes — LTX-2.3 generates synced ambient audio |
 | **Resolution** | Sulphur 1280×720 · LTX 768×512 (set in the workflow) |
 | **Length** | default ~10 s; see the ceiling below |
-| **Lanes** | `🎬 LTX-2.3` · `🔓 Sulphur` (video) · `✨ Image` (HiDream-O1) · `🖼️ Image` (Ideogram-4) · `🔓 Image` (Chroma) · `🎵 Music` (ACE-Step) · `🔊 SFX` (Stable Audio) — see *Image lanes* / *Music lane* / *SFX lane* |
+| **Lanes** | `🎬 LTX-2.3` · `🔓 Sulphur` (video) · `✨ Image` (HiDream-O1) · `🖼️ Image` (Ideogram-4) · `🔓 Image` (Chroma) · `🎵 Music` (ACE-Step) · `🔊 SFX` (Stable Audio) · `🎙️ Voice` (Step-Audio-EditX — premium clone) — see *Image lanes* / *Music lane* / *SFX lane* |
 
 ### Length ceiling (measured on 2× 3090, 1280×720, frames = 24·seconds + 1)
 

--- a/services/studio/README.md
+++ b/services/studio/README.md
@@ -23,6 +23,7 @@ architecture, capabilities and the measured length limits live in **[../../docs/
 | `orchestrator/` | `docker compose` + Dockerfile for the long-clip engine (`:8190`): chains ~10 s segments into one combined video for requests >15 s. The pipe POSTs here when you ask for a length. |
 | `image-shim/` | `docker compose` + Dockerfile for the native-button image shim (`:8191`): a transparent ComfyUI reverse-proxy that crafts an Ideogram-4 JSON caption (via the director) on `POST /prompt`, so OWUI's built-in 🖼️ image button renders instead of the "blocked by safety filter" placeholder. Point OWUI's `COMFYUI_BASE_URL` at it. See VIDEO_STUDIO.md "Native image button". |
 | `tts/` | `docker compose` + Dockerfile for integrated voices (`:8192`): **Kokoro-82M** (ONNX, CPU) generates a voiceover and a **layer-aware ffmpeg mixdown** ducks it over the clip's native audio + loudness-normalizes. The pipe POSTs `/narrate` when the message has a `voiceover:`/`narration:` directive. No GPU. See VIDEO_STUDIO.md "Integrated audio". |
+| `step-voice/` | `docker compose` + Dockerfile for the **premium voice** service (`:8193`): **Step-Audio-EditX** (3B, Apache) — zero-shot voice cloning + emotion/style/paralinguistic **editing**. **ISOLATED container** pinned to `transformers==4.53.3` (the version the model needs; conflicts with ComfyUI's 5.x), GPU (~14 GB bf16, pinned to a free card). The pipe POSTs `/clone`. On-demand (not always-on). Weights: `Step-Audio-EditX` + `Step-Audio-Tokenizer` under `models/Step-Audio/`. |
 | `extend_chain.py` | The same chaining as a standalone host CLI (handy for scripted long renders). |
 
 ## Install the pipe into Open WebUI
@@ -32,7 +33,7 @@ python3 build_studio_pipe.py            # writes studio_pipe.py
 ```
 
 Then in Open WebUI: **Admin → Functions → +**, paste the contents of `studio_pipe.py`,
-save, enable. Seven models appear in the picker:
+save, enable. Eight models appear in the picker:
 
 - `🎬 Studio · LTX-2.3` — video + audio (stock model)
 - `🔓 Studio · Sulphur` — uncensored video lane
@@ -41,6 +42,7 @@ save, enable. Seven models appear in the picker:
 - `🔓 Studio · Image (Chroma)` — uncensored stills (natural-language prompt)
 - `🎵 Studio · Music` — ACE-Step (songs + instrumentals)
 - `🔊 Studio · SFX` — Stable Audio (sound effects + ambient)
+- `🎙️ Studio · Voice` — Step-Audio-EditX premium voice (zero-shot clone + emotion/style)
 
 Set the pipe's **Valves** (gear icon on the function):
 - `comfyui_url` → your ComfyUI (`http://host.docker.internal:8188` from the OWUI container)

--- a/services/studio/build_studio_pipe.py
+++ b/services/studio/build_studio_pipe.py
@@ -85,9 +85,9 @@ PIPE = r'''
 """
 title: Studio (text/image -> video · image · music)
 author: club-3090
-description: Type a rough idea — the studio director (qwen) crafts it and generates. Video: LTX (video+audio) or Sulphur (uncensored), text->video or attach an image, with optional voiceover. Image: HiDream-O1 (top quality), Ideogram-4 (design/logo/photo/text), or Chroma (uncensored). Music: ACE-Step (songs + instrumentals). SFX: Stable Audio (sound effects + ambient). Refine anytime by just saying what to change.
+description: Type a rough idea — the studio director (qwen) crafts it and generates. Video: LTX (video+audio) or Sulphur (uncensored), text->video or attach an image, with optional voiceover. Image: HiDream-O1 (top quality), Ideogram-4 (design/logo/photo/text), or Chroma (uncensored). Music: ACE-Step (songs + instrumentals). SFX: Stable Audio (sound effects + ambient). Voice: Step-Audio-EditX (premium cloned voice + emotion/style). Refine anytime by just saying what to change.
 required_open_webui_version: 0.5.0
-version: 0.12.0
+version: 0.13.0
 """
 # ── Pipeline defaults (this rig, 2x 3090, measured 2026-06-11) ──────────────────
 #  Video lanes: ltx = LTX-2.3-distilled (video+audio) · sulphur = uncensored dev fine-tune
@@ -144,6 +144,8 @@ class Pipe:
         music_cfg: float = Field(default=5.0, description="ACE-Step CFG scale.")
         sfx_seconds: float = Field(default=10.0, description="SFX lane (Stable Audio) default length in seconds (hard-capped at 47 — the model's max).")
         sfx_steps: int = Field(default=50, description="Stable Audio sampler steps.")
+        voice_url: str = Field(default="http://host.docker.internal:8193", description="Studio premium-voice service (Step-Audio-EditX, isolated container, transformers 4.53.3). Zero-shot clone + emotion/style editing. GPU — bring up on demand (docker compose -f services/studio/step-voice/docker-compose.yml up -d). If unreachable, the voice lane errors.")
+        voice_reference: str = Field(default="Narrator.wav", description="Default reference voice the lane clones — a bundled sample name (Narrator.wav / Narrator-UK.wav / Pirates.wav) or an absolute path inside the service. Replace with your own 10–30 s clean clip to clone your voice.")
 
     def __init__(self):
         self.valves = self.Valves()
@@ -157,6 +159,7 @@ class Pipe:
             {"id": "chroma", "name": "\U0001F513 Studio · Image (Chroma · uncensored)"},
             {"id": "music", "name": "\U0001F3B5 Studio · Music (ACE-Step · songs + instrumentals)"},
             {"id": "sfx", "name": "\U0001F50A Studio · SFX (Stable Audio · sound effects + ambient)"},
+            {"id": "voice", "name": "\U0001F399️ Studio · Voice (Step-Audio-EditX · premium clone)"},
         ]
 
     def _extract_image(self, body):
@@ -415,6 +418,16 @@ class Pipe:
             return r["filename"], r.get("subfolder", "")
         raise RuntimeError(r.get("error", "narration failed"))
 
+    def _voice(self, text, reference):
+        # Premium voice via the isolated Step-Audio-EditX service (zero-shot clone). Returns (filename, subfolder).
+        body = json.dumps({"text": text, "reference": reference}).encode()
+        req = urllib.request.Request(self.valves.voice_url.rstrip("/") + "/clone", data=body,
+                                     headers={"Content-Type": "application/json"})
+        r = json.load(urllib.request.urlopen(req, timeout=self.valves.timeout_s))
+        if r.get("filename"):
+            return r["filename"], r.get("subfolder", "")
+        raise RuntimeError(r.get("error", "voice generation failed"))
+
     def _submit(self, wf):
         req = urllib.request.Request(self.valves.comfyui_url + "/prompt",
                                      data=json.dumps({"prompt": wf, "client_id": "owui-studio"}).encode(),
@@ -518,6 +531,8 @@ class Pipe:
             lane = "music"
         elif "sfx" in model:
             lane = "sfx"
+        elif "voice" in model:
+            lane = "voice"
         elif "hidream" in model:
             lane = "hidream"
         elif "chroma" in model:
@@ -530,7 +545,7 @@ class Pipe:
             lane = "ltx"
         label = {"image": "Image (Ideogram-4)", "chroma": "Image · Chroma (uncensored)",
                  "hidream": "Image (HiDream-O1)",
-                 "music": "Music (ACE-Step)", "sfx": "SFX (Stable Audio)",
+                 "music": "Music (ACE-Step)", "sfx": "SFX (Stable Audio)", "voice": "Voice (Step-Audio-EditX)",
                  "sulphur": "Sulphur (uncensored)", "ltx": "LTX-2.3 (video+audio)"}[lane]
         loop = asyncio.get_event_loop()
 
@@ -574,6 +589,34 @@ class Pipe:
                     "_Want changes? Just say what to tweak — e.g. “more distant”, “add reverb”, "
                     "“heavier rain” — and I’ll re-craft and regenerate._ "
                     "_(Browse all media: " + base + "/ )_" + marker)
+
+        # ── VOICE LANE (Step-Audio-EditX premium clone, via the isolated step-voice service :8193) ──
+        if lane == "voice":
+            up = ""
+            for m in reversed(body.get("messages", [])):
+                if m.get("role") == "user":
+                    c = m.get("content")
+                    up = (" ".join(p.get("text", "") for p in c if isinstance(p, dict) and p.get("type") == "text").strip()
+                          if isinstance(c, list) else (c or "").strip())
+                    break
+            if not up:
+                return "Type what you want spoken — e.g. “Welcome to the show.” It's cloned in the **" + self.valves.voice_reference + "** voice (set `voice_reference` to your own clip to clone your voice)."
+            await status("\U0001F399️ Speaking on Step-Audio-EditX (premium voice)…")
+            try:
+                fn, sub = await loop.run_in_executor(None, self._voice, up, self.valves.voice_reference)
+            except Exception as e:
+                await status("Failed", True)
+                return ("⚠️ Voice generation failed — is the step-voice service up? "
+                        "`docker compose -f services/studio/step-voice/docker-compose.yml up -d`\n\n" + str(e))
+            await status("Done", True)
+            if not fn:
+                return "Generation finished but no audio output was found."
+            base = self.valves.browser_base.rstrip("/")
+            url = base + "/" + ((sub + "/") if sub else "") + fn
+            return ("**\U0001F399️ " + label + "**\n\n"
+                    "**Spoken:** " + up + "\n\n"
+                    "\U0001F3A7 **[Open / download the voice clip](" + url + ")**\n\n"
+                    "_Cloned from **" + self.valves.voice_reference + "**. (Browse all media: " + base + "/ )_")
 
         # ── MUSIC LANE (ACE-Step · tags + lyrics/[instrumental] · seconds-duration) ───────────────
         if lane == "music":
@@ -798,4 +841,4 @@ class Pipe:
 '''.replace('__WF_JSON__', WF_JSON)
 
 open(OUT_PATH, 'w').write(PIPE)
-print("wrote %s (%d bytes; 9 workflows (video x2 + image x3 + music + sfx) + narration)" % (OUT_PATH, len(PIPE)))
+print("wrote %s (%d bytes; 9 workflows (video x2 + image x3 + music + sfx) + narration + voice service)" % (OUT_PATH, len(PIPE)))

--- a/services/studio/step-voice/Dockerfile
+++ b/services/studio/step-voice/Dockerfile
@@ -1,0 +1,38 @@
+# Step-Audio-EditX premium voice service — ISOLATED from ComfyUI.
+# Step-Audio-EditX hard-pins transformers==4.53.3 (4.54+ = silent audio, per the model authors),
+# which conflicts with ComfyUI's transformers 5.x (HiDream needs 5.x). So it runs in its OWN
+# container with the exact transformers it was validated against — zero conflict, guaranteed-correct.
+# Mirrors the Kokoro studio-tts service shape (HTTP server, writes to the shared gallery output dir).
+FROM pytorch/pytorch:2.7.0-cuda12.8-cudnn9-runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git ffmpeg libsndfile1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Vendor the reviewed Step-Audio-EditX inference (bundled step_audio_impl: tokenizer + TTS +
+# CosyVoice2 vocoder + funasr_detach). Pinned to the commit we source-reviewed.
+ARG NODE_REF=d8eddc6618fdbe14a10cc99d13360a64a2b03657
+RUN git clone https://github.com/Saganaki22/ComfyUI-Step_Audio_EditX_TTS.git /opt/step \
+    && git -C /opt/step checkout ${NODE_REF}
+
+# The repo's requirements.txt pins transformers==4.53.3 + the audio/whisper/onnx deps. torch +
+# torchaudio come from the base image (satisfy the >= floors). gradio is unused by the server but
+# harmless. + aiohttp for the HTTP layer.
+RUN pip install --no-cache-dir -r /opt/step/requirements.txt
+# Deps the repo's requirements.txt omits but the CosyVoice2 vocoder needs (found at model-load):
+# einops (decoder_dit), ffmpeg-python (audio I/O), rotary_embedding_torch (mossformer path). + aiohttp.
+RUN pip install --no-cache-dir aiohttp einops ffmpeg-python rotary_embedding_torch
+
+COPY server.py /opt/server.py
+
+ENV STEP_IMPL=/opt/step/step_audio_impl \
+    STEP_MODELS_DIR=/models \
+    OUTPUT_DIR=/output \
+    VOICE_SAMPLES_DIR=/opt/step/voice_samples \
+    STEP_VOICE_PORT=8193 \
+    STEP_DEFAULT_VOICE=Narrator.wav \
+    STEP_TORCH_DTYPE=bfloat16 \
+    WHISPER_MODEL=base
+WORKDIR /opt
+EXPOSE 8193
+CMD ["python3", "/opt/server.py"]

--- a/services/studio/step-voice/docker-compose.yml
+++ b/services/studio/step-voice/docker-compose.yml
@@ -1,0 +1,31 @@
+# Studio Step-Voice — premium voice (zero-shot clone + emotion/style editing) via Step-Audio-EditX.
+# ISOLATED container: runs transformers==4.53.3 (the version the model needs; 4.54+ = silent audio),
+# so it never conflicts with ComfyUI's transformers 5.x. HTTP server on :8193; writes WAVs into the
+# shared gallery output dir. The OWUI Studio pipe's premium voice lane POSTs /clone (and /edit).
+#
+# GPU-heavy (~14 GB bf16 / ~3-4 GB if switched to the AWQ-4bit weights) — NOT always-on; bring it up
+# when you want the premium voice (gpu-mode-gated), pinned to a free card via STEP_VOICE_CUDA.
+#   docker compose -f services/studio/step-voice/docker-compose.yml up -d --build
+services:
+  studio-step-voice:
+    build: .
+    image: studio-step-voice:latest
+    container_name: studio-step-voice
+    restart: "no"               # on-demand, not always-on (holds ~14 GB VRAM)
+    network_mode: host          # reachable at host:8193; writes the mounted gallery output dir
+    environment:
+      - STEP_MODELS_DIR=/models
+      - OUTPUT_DIR=/output
+      - STEP_VOICE_PORT=${STEP_VOICE_PORT:-8193}
+      - STEP_DEFAULT_VOICE=${STEP_DEFAULT_VOICE:-Narrator.wav}
+      - WHISPER_MODEL=${STEP_WHISPER_MODEL:-base}
+      - CUDA_VISIBLE_DEVICES=${STEP_VOICE_CUDA:-1}   # pin to a free card (GPU1 by default; GPU0 has ComfyUI+director)
+    volumes:
+      - ${STEP_AUDIO_DIR:-/mnt/models/comfyui/models/Step-Audio}:/models:ro
+      - ${COMFYUI_OUTPUT_DIR:-/mnt/models/comfyui/output}:/output
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: [gpu]

--- a/services/studio/step-voice/server.py
+++ b/services/studio/step-voice/server.py
@@ -1,0 +1,126 @@
+"""Studio Step-Voice service — premium voice (clone + emotion/style editing) via Step-Audio-EditX.
+
+Isolated from ComfyUI: runs the model on its required transformers==4.53.3 in its own container.
+Mirrors the Kokoro studio-tts service — an HTTP server that writes WAVs into the shared gallery
+output dir, called by the OWUI Studio pipe's premium voice lane.
+
+Endpoints:
+  GET  /health                                              -> {ok, ready}
+  POST /clone  {text|target_text, reference?, prompt_text?}  -> {filename, subfolder}
+       zero-shot clone: speak `text` in the reference voice. `reference` = a bundled sample name
+       (e.g. "Narrator.wav"), an absolute path, or a data: URI (user-attached voice). `prompt_text`
+       is the transcript of the reference; if omitted, Whisper transcribes it automatically.
+  POST /edit   {audio, source_text, edit_type, edit_info, generated_text?} -> {filename, subfolder}
+       re-emote / restyle existing audio (edit_type: emotion|style|speed|paralinguistic|denoise|vad).
+"""
+import os, sys, time, base64, tempfile, traceback
+import numpy as np
+import soundfile as sf
+import torch
+from aiohttp import web
+
+STEP_IMPL   = os.environ.get("STEP_IMPL", "/opt/step/step_audio_impl")
+MODELS_DIR  = os.environ.get("STEP_MODELS_DIR", "/models")          # contains Step-Audio-EditX/ + Step-Audio-Tokenizer/
+OUTPUT_DIR  = os.environ.get("OUTPUT_DIR", "/output")
+VOICE_DIR   = os.environ.get("VOICE_SAMPLES_DIR", "/opt/step/voice_samples")
+PORT        = int(os.environ.get("STEP_VOICE_PORT", "8193"))
+DEFAULT_REF = os.environ.get("STEP_DEFAULT_VOICE", "Narrator.wav")
+TOKENIZER_ID = os.environ.get("STEP_TOKENIZER_ID",
+                              "dengcunqin/speech_paraformer-large_asr_nat-zh-cantonese-en-16k-vocab8501-online")
+
+sys.path.insert(0, STEP_IMPL)
+from tokenizer import StepAudioTokenizer          # noqa: E402
+from tts import StepAudioTTS                       # noqa: E402
+from model_loader import ModelSource               # noqa: E402
+
+print("[step-voice] loading tokenizer (funasr paraformer)…", flush=True)
+_encoder = StepAudioTokenizer(os.path.join(MODELS_DIR, "Step-Audio-Tokenizer"),
+                              model_source=ModelSource.LOCAL, funasr_model_id=TOKENIZER_ID)
+print("[step-voice] loading Step-Audio-EditX (3B, transformers 4.53.3)…", flush=True)
+_engine = StepAudioTTS(os.path.join(MODELS_DIR, "Step-Audio-EditX"), _encoder, model_source=ModelSource.LOCAL)
+print("[step-voice] ready", flush=True)
+
+_whisper = None
+def _transcribe(path):
+    """Auto-transcribe a reference clip when no prompt_text is supplied (clone needs the transcript)."""
+    global _whisper
+    if _whisper is None:
+        import whisper
+        _whisper = whisper.load_model(os.environ.get("WHISPER_MODEL", "base"))
+    return (_whisper.transcribe(path).get("text") or "").strip()
+
+def _materialize(ref):
+    """Resolve a reference to a filesystem path: bundled sample name | absolute path | data: URI."""
+    if not ref:
+        ref = DEFAULT_REF
+    if isinstance(ref, str) and ref.startswith("data:"):
+        raw = base64.b64decode(ref.split(",", 1)[1])
+        fd, p = tempfile.mkstemp(suffix=".wav"); os.write(fd, raw); os.close(fd)
+        return p, True
+    if os.path.isabs(ref) and os.path.isfile(ref):
+        return ref, False
+    return os.path.join(VOICE_DIR, ref), False
+
+def _save(audio, sr, prefix):
+    if isinstance(audio, torch.Tensor):
+        audio = audio.detach().cpu().numpy()
+    audio = np.squeeze(np.asarray(audio))
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    fn = "%s_%08d.wav" % (prefix, int(time.time() * 1000) % 100000000)
+    sf.write(os.path.join(OUTPUT_DIR, fn), audio, int(sr))
+    return fn
+
+async def health(_req):
+    return web.json_response({"ok": True, "ready": _engine is not None})
+
+async def clone(req):
+    d = await req.json()
+    target = (d.get("target_text") or d.get("text") or "").strip()
+    if not target:
+        return web.json_response({"error": "target_text (text to speak) is required"}, status=400)
+    ref_path, tmp = _materialize(d.get("reference"))
+    try:
+        if not os.path.isfile(ref_path):
+            return web.json_response({"error": "reference voice not found: %s" % ref_path}, status=400)
+        prompt_text = (d.get("prompt_text") or "").strip() or _transcribe(ref_path)
+        audio, sr = await _run(_engine.clone, ref_path, prompt_text, target)
+        fn = _save(audio, sr, "step_voice")
+        return web.json_response({"filename": fn, "subfolder": "", "prompt_text": prompt_text})
+    except Exception as e:
+        traceback.print_exc()
+        return web.json_response({"error": str(e)}, status=500)
+    finally:
+        if tmp:
+            try: os.unlink(ref_path)
+            except Exception: pass
+
+async def edit(req):
+    d = await req.json()
+    ref_path, tmp = _materialize(d.get("audio"))
+    try:
+        if not os.path.isfile(ref_path):
+            return web.json_response({"error": "audio to edit not found: %s" % ref_path}, status=400)
+        src_text = (d.get("source_text") or "").strip() or _transcribe(ref_path)
+        edit_type = d.get("edit_type", "emotion")
+        edit_info = d.get("edit_info", "")
+        generated_text = d.get("generated_text", src_text)
+        audio, sr = await _run(_engine.edit, ref_path, src_text, edit_type, edit_info, generated_text)
+        fn = _save(audio, sr, "step_voice_edit")
+        return web.json_response({"filename": fn, "subfolder": ""})
+    except Exception as e:
+        traceback.print_exc()
+        return web.json_response({"error": str(e)}, status=500)
+    finally:
+        if tmp:
+            try: os.unlink(ref_path)
+            except Exception: pass
+
+async def _run(fn, *args):
+    # Step inference is blocking/CPU-GPU heavy — run off the event loop.
+    import asyncio
+    return await asyncio.get_event_loop().run_in_executor(None, fn, *args)
+
+app = web.Application(client_max_size=64 * 1024 * 1024)
+app.add_routes([web.get("/health", health), web.post("/clone", clone), web.post("/edit", edit)])
+if __name__ == "__main__":
+    web.run_app(app, host="0.0.0.0", port=PORT)

--- a/services/studio/studio_pipe.py
+++ b/services/studio/studio_pipe.py
@@ -2,9 +2,9 @@
 """
 title: Studio (text/image -> video · image · music)
 author: club-3090
-description: Type a rough idea — the studio director (qwen) crafts it and generates. Video: LTX (video+audio) or Sulphur (uncensored), text->video or attach an image, with optional voiceover. Image: HiDream-O1 (top quality), Ideogram-4 (design/logo/photo/text), or Chroma (uncensored). Music: ACE-Step (songs + instrumentals). SFX: Stable Audio (sound effects + ambient). Refine anytime by just saying what to change.
+description: Type a rough idea — the studio director (qwen) crafts it and generates. Video: LTX (video+audio) or Sulphur (uncensored), text->video or attach an image, with optional voiceover. Image: HiDream-O1 (top quality), Ideogram-4 (design/logo/photo/text), or Chroma (uncensored). Music: ACE-Step (songs + instrumentals). SFX: Stable Audio (sound effects + ambient). Voice: Step-Audio-EditX (premium cloned voice + emotion/style). Refine anytime by just saying what to change.
 required_open_webui_version: 0.5.0
-version: 0.12.0
+version: 0.13.0
 """
 # ── Pipeline defaults (this rig, 2x 3090, measured 2026-06-11) ──────────────────
 #  Video lanes: ltx = LTX-2.3-distilled (video+audio) · sulphur = uncensored dev fine-tune
@@ -61,6 +61,8 @@ class Pipe:
         music_cfg: float = Field(default=5.0, description="ACE-Step CFG scale.")
         sfx_seconds: float = Field(default=10.0, description="SFX lane (Stable Audio) default length in seconds (hard-capped at 47 — the model's max).")
         sfx_steps: int = Field(default=50, description="Stable Audio sampler steps.")
+        voice_url: str = Field(default="http://host.docker.internal:8193", description="Studio premium-voice service (Step-Audio-EditX, isolated container, transformers 4.53.3). Zero-shot clone + emotion/style editing. GPU — bring up on demand (docker compose -f services/studio/step-voice/docker-compose.yml up -d). If unreachable, the voice lane errors.")
+        voice_reference: str = Field(default="Narrator.wav", description="Default reference voice the lane clones — a bundled sample name (Narrator.wav / Narrator-UK.wav / Pirates.wav) or an absolute path inside the service. Replace with your own 10–30 s clean clip to clone your voice.")
 
     def __init__(self):
         self.valves = self.Valves()
@@ -74,6 +76,7 @@ class Pipe:
             {"id": "chroma", "name": "\U0001F513 Studio · Image (Chroma · uncensored)"},
             {"id": "music", "name": "\U0001F3B5 Studio · Music (ACE-Step · songs + instrumentals)"},
             {"id": "sfx", "name": "\U0001F50A Studio · SFX (Stable Audio · sound effects + ambient)"},
+            {"id": "voice", "name": "\U0001F399️ Studio · Voice (Step-Audio-EditX · premium clone)"},
         ]
 
     def _extract_image(self, body):
@@ -332,6 +335,16 @@ class Pipe:
             return r["filename"], r.get("subfolder", "")
         raise RuntimeError(r.get("error", "narration failed"))
 
+    def _voice(self, text, reference):
+        # Premium voice via the isolated Step-Audio-EditX service (zero-shot clone). Returns (filename, subfolder).
+        body = json.dumps({"text": text, "reference": reference}).encode()
+        req = urllib.request.Request(self.valves.voice_url.rstrip("/") + "/clone", data=body,
+                                     headers={"Content-Type": "application/json"})
+        r = json.load(urllib.request.urlopen(req, timeout=self.valves.timeout_s))
+        if r.get("filename"):
+            return r["filename"], r.get("subfolder", "")
+        raise RuntimeError(r.get("error", "voice generation failed"))
+
     def _submit(self, wf):
         req = urllib.request.Request(self.valves.comfyui_url + "/prompt",
                                      data=json.dumps({"prompt": wf, "client_id": "owui-studio"}).encode(),
@@ -435,6 +448,8 @@ class Pipe:
             lane = "music"
         elif "sfx" in model:
             lane = "sfx"
+        elif "voice" in model:
+            lane = "voice"
         elif "hidream" in model:
             lane = "hidream"
         elif "chroma" in model:
@@ -447,7 +462,7 @@ class Pipe:
             lane = "ltx"
         label = {"image": "Image (Ideogram-4)", "chroma": "Image · Chroma (uncensored)",
                  "hidream": "Image (HiDream-O1)",
-                 "music": "Music (ACE-Step)", "sfx": "SFX (Stable Audio)",
+                 "music": "Music (ACE-Step)", "sfx": "SFX (Stable Audio)", "voice": "Voice (Step-Audio-EditX)",
                  "sulphur": "Sulphur (uncensored)", "ltx": "LTX-2.3 (video+audio)"}[lane]
         loop = asyncio.get_event_loop()
 
@@ -491,6 +506,34 @@ class Pipe:
                     "_Want changes? Just say what to tweak — e.g. “more distant”, “add reverb”, "
                     "“heavier rain” — and I’ll re-craft and regenerate._ "
                     "_(Browse all media: " + base + "/ )_" + marker)
+
+        # ── VOICE LANE (Step-Audio-EditX premium clone, via the isolated step-voice service :8193) ──
+        if lane == "voice":
+            up = ""
+            for m in reversed(body.get("messages", [])):
+                if m.get("role") == "user":
+                    c = m.get("content")
+                    up = (" ".join(p.get("text", "") for p in c if isinstance(p, dict) and p.get("type") == "text").strip()
+                          if isinstance(c, list) else (c or "").strip())
+                    break
+            if not up:
+                return "Type what you want spoken — e.g. “Welcome to the show.” It's cloned in the **" + self.valves.voice_reference + "** voice (set `voice_reference` to your own clip to clone your voice)."
+            await status("\U0001F399️ Speaking on Step-Audio-EditX (premium voice)…")
+            try:
+                fn, sub = await loop.run_in_executor(None, self._voice, up, self.valves.voice_reference)
+            except Exception as e:
+                await status("Failed", True)
+                return ("⚠️ Voice generation failed — is the step-voice service up? "
+                        "`docker compose -f services/studio/step-voice/docker-compose.yml up -d`\n\n" + str(e))
+            await status("Done", True)
+            if not fn:
+                return "Generation finished but no audio output was found."
+            base = self.valves.browser_base.rstrip("/")
+            url = base + "/" + ((sub + "/") if sub else "") + fn
+            return ("**\U0001F399️ " + label + "**\n\n"
+                    "**Spoken:** " + up + "\n\n"
+                    "\U0001F3A7 **[Open / download the voice clip](" + url + ")**\n\n"
+                    "_Cloned from **" + self.valves.voice_reference + "**. (Browse all media: " + base + "/ )_")
 
         # ── MUSIC LANE (ACE-Step · tags + lyrics/[instrumental] · seconds-duration) ───────────────
         if lane == "music":


### PR DESCRIPTION
Adds the **premium voice tier** — zero-shot voice cloning + emotion/style/paralinguistic **editing** via **Step-Audio-EditX** (3B, **Apache-2.0** — the only commercially-licensed one of the top open TTS; Fish S2-Pro / Higgs v3 are research/non-commercial).

## Why a service, not a ComfyUI lane
Step-Audio-EditX hard-pins **`transformers==4.53.3`** (4.54+ = *silent audio*, per the authors), which conflicts with ComfyUI's transformers **5.x** (HiDream needs 5.x). So it runs in its **own isolated container** with the exact version it was validated against → guaranteed-correct, zero conflict. Same shape as the Kokoro `studio-tts` service.

## Changes
- **`services/studio/step-voice/`** — Dockerfile (PyTorch cu12.8 base + the source-reviewed `Saganaki22/ComfyUI-Step_Audio_EditX_TTS` `step_audio_impl`, pinned commit + `transformers==4.53.3` + whisper/CosyVoice deps), aiohttp `server.py` (`/clone` + `/edit`, auto-Whisper-transcribe of references, writes WAVs to the shared gallery output dir), compose (GPU1-pinned, on-demand, `:8193`).
- **`build_studio_pipe.py` (v0.13.0)** — `🎙️ voice` lane: `_voice()` POSTs the service `/clone`; valves `voice_url`/`voice_reference`; routing + label. Mirrors how `_narrate` calls the Kokoro TTS service.
- **Missing-dep fix** the node's `requirements.txt` omits: `einops` (CosyVoice2 `decoder_dit`) + `ffmpeg-python` + `rotary_embedding_torch`.
- **Docs**: README picker (8 models) + `step-voice/` pieces row + VIDEO_STUDIO lanes table. (Full Voice prose lands in the upcoming `docs/ai-studio/` restructure.)

## Validation (live, transformers 4.53.3, GPU1)
- Service healthy ~30 s; zero-shot clone of a bundled reference → **7.44 s, 24 kHz, RMS 0.156, peak 0.95 → REAL AUDIO** (not silent — the 4.53.3 pin does its job). bf16 ~14 GB.

## Notes
- On-demand (not always-on — holds ~14 GB). AWQ-4bit (~3-4 GB) is a future light-deploy option (needs autoawq).
- Premium **batch** voice; the realtime voice-agent (calling/bookings) is a separate streaming pipeline (Kokoro for that leg), tracked privately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)