### PR TITLE
Auto-detect served model from /v1/models in verify/bench scripts (#372)

### DIFF
--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -26,7 +26,8 @@
 #
 # Env vars:
 #   URL                Endpoint. Default: http://localhost:8020
-#   MODEL              Served model name. Default: qwen3.6-27b-autoround
+#   MODEL              Served model name. Default: auto-detected from
+#                      /v1/models, else qwen3.6-27b-autoround
 #   CONTAINER          Container for log scraping. Default: vllm-qwen36-27b
 #   RUNS               Measured runs per prompt. Default: 5
 #   WARMUPS            Warm-up runs (shared across both). Default: 3
@@ -69,6 +70,9 @@ if [[ -f "${ROOT_DIR}/scripts/preflight.sh" ]]; then
   preflight_autodetect_endpoint || true
 fi
 URL="${URL:-http://localhost:8020}"
+# Resolve the served model from /v1/models when MODEL is unset (#372). The qwen
+# literal below is only a last resort if detection no-ops (endpoint unreachable).
+declare -F preflight_autodetect_model >/dev/null && preflight_autodetect_model
 MODEL="${MODEL:-qwen3.6-27b-autoround}"
 CONTAINER="${CONTAINER:-vllm-qwen36-27b}"
 RUNS="${RUNS:-5}"

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1102,3 +1102,43 @@ preflight_autodetect_endpoint() {
   fi
   return 0
 }
+
+# ---------------------------------------------------------------------------
+# Resolve the SERVED model name from the running endpoint's /v1/models when the
+# caller hasn't set MODEL explicitly. Mirrors what soak-test.sh / bench-agentic.sh
+# / quality-test.sh already do — so verify-full / verify-stress / bench / verify
+# send the model the server actually serves instead of a hardcoded qwen default.
+#
+# Why this exists (#372): report.sh autodetects container + URL + engine but NOT
+# the served model, so the verify/bench scripts fell back to MODEL=qwen3.6-27b-
+# autoround. Against a non-qwen vLLM endpoint (e.g. gemma-4-26b-a4b-awq) every
+# request 404'd ("The model `qwen3.6-27b-autoround` does not exist"). llama.cpp
+# ignores the request's model field, so the same wrong default silently "worked"
+# there (#371) — which is exactly what masked the bug.
+#
+# Sets MODEL in the caller's scope. No-op when MODEL is already set (an explicit
+# env/flag value always wins — critical for llama-swap / multi-model endpoints
+# where /v1/models returns the first, often wrong, registered model), when there
+# is no URL to query, or when the endpoint isn't reachable (the caller's own
+# reachability check then surfaces the real outage). Callers keep their own
+# last-resort literal after this, so behaviour is unchanged when detection no-ops.
+preflight_autodetect_model() {
+  [[ -n "${MODEL:-}" ]] && return 0
+  local url="${1:-${URL:-}}"
+  [[ -n "$url" ]] || return 0
+  command -v curl >/dev/null 2>&1 || return 0
+  command -v python3 >/dev/null 2>&1 || return 0
+  local detected
+  detected="$(curl -sf -m 5 "${url%/}/v1/models" 2>/dev/null \
+    | python3 -c "import json,sys
+try:
+    d = json.load(sys.stdin).get('data', [])
+    print(d[0]['id'] if d else '')
+except Exception:
+    print('')" 2>/dev/null || true)"
+  if [[ -n "$detected" ]]; then
+    MODEL="$detected"
+    echo "[autodetect] served model='${MODEL}' (from ${url%/}/v1/models; set MODEL= to override)" >&2
+  fi
+  return 0
+}

--- a/scripts/verify-full.sh
+++ b/scripts/verify-full.sh
@@ -29,7 +29,8 @@
 #
 # Env (optional):
 #   URL          Default: http://localhost:8020
-#   MODEL        Default: qwen3.6-27b-autoround
+#   MODEL        Default: auto-detected from the endpoint's /v1/models, else
+#                qwen3.6-27b-autoround
 #   CONTAINER    Default: vllm-qwen36-27b
 #   SKIP_TOOLS   Set to 1 to skip the tool-call test entirely (useful when
 #                running against the default config which is known to fail
@@ -58,6 +59,9 @@ if [[ -f "${ROOT_DIR}/scripts/preflight.sh" ]]; then
   preflight_autodetect_endpoint
 fi
 URL="${URL:-http://localhost:8020}"
+# Resolve the served model from /v1/models when MODEL is unset (#372). The qwen
+# literal below is only a last resort if detection no-ops (endpoint unreachable).
+declare -F preflight_autodetect_model >/dev/null && preflight_autodetect_model
 MODEL="${MODEL:-qwen3.6-27b-autoround}"
 CONTAINER="${CONTAINER:-vllm-qwen36-27b}"
 

--- a/scripts/verify-stress.sh
+++ b/scripts/verify-stress.sh
@@ -49,7 +49,8 @@
 #
 # Env (optional):
 #   URL                    Default: http://localhost:8020
-#   MODEL                  Default: qwen3.6-27b-autoround
+#   MODEL                  Default: auto-detected from /v1/models, else
+#                          qwen3.6-27b-autoround
 #   CONTAINER              Default: vllm-qwen36-27b
 #   SKIP_LONGCTX           Set to 1 to skip the long-context needle ladder.
 #   SKIP_TOOL_PREFILL      Set to 1 to skip the tool-response prefill test.
@@ -90,6 +91,9 @@ if [[ -f "${ROOT_DIR}/scripts/preflight.sh" ]]; then
   preflight_autodetect_endpoint
 fi
 URL="${URL:-http://localhost:8020}"
+# Resolve the served model from /v1/models when MODEL is unset (#372). The qwen
+# literal below is only a last resort if detection no-ops (endpoint unreachable).
+declare -F preflight_autodetect_model >/dev/null && preflight_autodetect_model
 MODEL="${MODEL:-qwen3.6-27b-autoround}"
 CONTAINER="${CONTAINER:-vllm-qwen36-27b}"
 

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -19,7 +19,18 @@
 
 set -euo pipefail
 
+# Auto-detect running container + port + served model (env vars still win).
+# See scripts/preflight.sh::preflight_autodetect_endpoint / _model.
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ -f "${ROOT_DIR}/scripts/preflight.sh" ]]; then
+  # shellcheck source=preflight.sh
+  source "${ROOT_DIR}/scripts/preflight.sh"
+  preflight_autodetect_endpoint
+fi
 URL="${URL:-http://localhost:8020}"
+# Resolve the served model from /v1/models when MODEL is unset (#372). The qwen
+# literal below is only a last resort if detection no-ops (endpoint unreachable).
+declare -F preflight_autodetect_model >/dev/null && preflight_autodetect_model
 MODEL="${MODEL:-qwen3.6-27b-autoround}"
 CONTAINER="${CONTAINER:-vllm-qwen36-27b}"
 


### PR DESCRIPTION
## Problem (#372)

`report.sh` autodetects the running container + URL + engine, but **not the served model name**. So `verify.sh` / `verify-full.sh` / `verify-stress.sh` / `bench.sh` fell back to a hardcoded `MODEL=qwen3.6-27b-autoround`. Against a non-qwen vLLM endpoint (e.g. `vllm/gemma-26ba4b-single`, served name `gemma-4-26b-a4b-awq`) every request 404'd:

```
{"error":{"message":"The model `qwen3.6-27b-autoround` does not exist.","code":404}}
```

→ all of verify-full / verify-stress / bench fail. llama.cpp ignores the request's `model` field and serves whatever is loaded, so the same wrong default silently "worked" in #371 (beellama gemma-31b) — which is what masked the bug.

## Fix

Add a shared `preflight_autodetect_model` helper that resolves the served name from the endpoint's `/v1/models` (first `data[].id`) when `MODEL` is unset, and call it in the four affected scripts before their qwen fallback. This mirrors what `soak-test.sh` / `bench-agentic.sh` / `quality-test.sh` already do (and is why soak/agentic resolved the model correctly in both reports while verify/bench didn't).

- An explicit `MODEL=` always wins (important for llama-swap / multi-model endpoints where `/v1/models` returns the first, often wrong, registered model).
- The `qwen3.6-27b-autoround` literal stays as a last resort if detection no-ops (endpoint unreachable → the caller's own reachability check surfaces the real outage).

## Validation

- **Unit:** resolve-from-`/v1/models` / respect-explicit-`MODEL` / unreachable-fallback (under `set -euo pipefail`).
- **End-to-end** against a mock `/v1/models`: `verify.sh` + `bench.sh` surface the resolved id.
- **Live, on the actual #372 endpoint** (`vllm/gemma-26ba4b-single`, single 3090):
  - OLD hardcoded `MODEL=qwen3.6-27b-autoround` → **HTTP 404** (reproduces #372).
  - FIXED → resolves `gemma-4-26b-a4b-awq` → **HTTP 200**, and `verify-full.sh` (MODEL unset) goes **8/8 "All checks passed"** (vs 6 failed in the report).
- **`scripts/tests/*.sh`** stays green; the one pre-existing `test-compose-registry-disk` failure is unrelated (untracked `models/nex-n2-mini/` WIP composes).

Closes #372.
