### PR TITLE
Add curated quality-baseline corpus + auto-diff (#252 Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ results/*
 !results/grammar-full-*/
 !results/lucebox-*/
 !results/v0.20-migration/
+# #252: curated quality-baseline corpus (committed; the trusted n>=3 aggregates
+# `quality-baseline.sh` diffs fresh runs against). Run output elsewhere stays ignored.
+!results/baselines/

--- a/docs/QUALITY_TEST.md
+++ b/docs/QUALITY_TEST.md
@@ -263,6 +263,27 @@ Suggested gates (informal, not enforced):
 
 For comparing a new pin / quant / config A/B against the previous version: a >10pp drop on any pack vs the previous baseline is a signal worth investigating before promoting `Status: ✅ Production`.
 
+### Regression baselines (the curated corpus)
+
+Rather than hunt down "the previous baseline" by hand each time, the curated corpus in
+[`results/baselines/`](../results/baselines/README.md) holds committed `n≥3` aggregates per
+`(registry-slug, thinking-mode)`. [`scripts/quality-baseline.sh`](../scripts/quality-baseline.sh)
+captures and diffs against them:
+
+```bash
+# capture / refresh a baseline (n=3 aggregate; needs a live endpoint)
+bash scripts/quality-baseline.sh --slug vllm/qwen-35b-a3b-dual --capture
+# diff a fresh run vs the committed baseline — the regression check
+bash scripts/quality-baseline.sh --slug vllm/qwen-35b-a3b-dual
+# thinking-on companion baseline
+bash scripts/quality-baseline.sh --slug vllm/qwen-35b-a3b-dual --mode enable-thinking
+```
+
+`no-thinking` is canonical (temp-0, reproducible — diff against this for a CI-style gate);
+`enable-thinking` is the reasoning-on companion. It's a thin wrapper over `quality-test.sh --full`
+(`--repeat` → `--save-json`/`--previous-result`); extra args pass through (e.g.
+`--exit-on-regression` for a hard CI gate). `--dry-run` prints the resolved command.
+
 ## What it doesn't replace
 
 - **`bench.sh`** measures throughput, not quality. They're complementary.

--- a/results/baselines/README.md
+++ b/results/baselines/README.md
@@ -1,0 +1,56 @@
+# Quality baseline corpus (#252)
+
+Curated, **committed** quality 8-pack baselines — the trusted `n≥3` aggregates that
+[`scripts/quality-baseline.sh`](../../scripts/quality-baseline.sh) diffs a fresh run
+against to catch quality regressions on a config change (quant swap, pin bump, Genesis
+env-flip, KV change).
+
+This is distinct from the runtime **measurement-record** TPS corpus
+(`scripts/lib/profiles/measurement_record.py`) — that tracks throughput; this tracks
+*behavioral quality* (ToolCall / InstructFollow / StructOutput / DataExtract / …).
+
+## What lives here
+
+One JSON per `(registry-slug, thinking-mode)`, named:
+
+```
+<slug-with-slashes-as-dashes>__<mode>.json
+```
+
+- `<mode>` ∈ `no-thinking` | `enable-thinking`.
+- `no-thinking` is **canonical** — temp-0, reproducible, the one a CI-style regression
+  gate should diff against. `enable-thinking` is the non-canonical companion for
+  reasoning-on configs.
+- e.g. `vllm-qwen-35b-a3b-dual__no-thinking.json` ← slug `vllm/qwen-35b-a3b-dual`.
+
+Each file is a benchlocal-cli `RunResult` JSON written with `--repeat N` (N≥3), so a
+baseline is an **aggregate**, not a single run — run-to-run noise (~±5–7 / 150 on the
+8-pack) doesn't read as a regression.
+
+## How to use
+
+```bash
+# capture / refresh a baseline (needs a live endpoint for the slug)
+bash scripts/quality-baseline.sh --slug vllm/qwen-35b-a3b-dual --capture
+
+# diff a fresh run vs the committed baseline (the regression check)
+bash scripts/quality-baseline.sh --slug vllm/qwen-35b-a3b-dual
+
+# thinking-on variant
+bash scripts/quality-baseline.sh --slug vllm/qwen-35b-a3b-dual --mode enable-thinking --capture
+```
+
+Endpoint/model are inherited by `quality-test.sh` (auto-detect, or `MODEL=`/`URL=`).
+Extra args pass through to `quality-test.sh` → benchlocal-cli (e.g.
+`--exit-on-regression` for a CI gate, `--sampling-from-server`). `--dry-run` prints the
+resolved command without running.
+
+**Refresh a baseline only deliberately** — a baseline that drifts upward silently to
+track a regression defeats the purpose. Re-capture when the config legitimately changes
+(new quant, intentional sampling change) and note why in the commit.
+
+## Index
+
+| Baseline file | Slug | Mode | Score (/150) | Captured | Notes |
+|---|---|---|---|---|---|
+| _(none yet — Phase 2 curates these against the live `RECOMMENDED_DEFAULT_MODELS` configs)_ | | | | | |

--- a/scripts/quality-baseline.sh
+++ b/scripts/quality-baseline.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# quality-baseline.sh (#252) — diff a fresh quality 8-pack run against the
+# curated baseline for a (registry-slug, thinking-mode), or capture/refresh that
+# baseline. Thin wrapper over quality-test.sh.
+#
+# Baselines live in results/baselines/<slug>__<mode>.json (committed — the
+# trusted n>=3 aggregates). Canonical = no-thinking (temp-0 reproducible);
+# non-canonical = enable-thinking. A baseline is an n>=3 aggregate (--repeat) so
+# run-to-run noise (~+-5-7 / 150 on the 8-pack) isn't flagged as a regression.
+#
+# Usage:
+#   # diff a fresh run vs the canonical (no-thinking) baseline for a slug
+#   bash scripts/quality-baseline.sh --slug vllm/qwen-35b-a3b-dual
+#   # ...vs the thinking-on baseline
+#   bash scripts/quality-baseline.sh --slug vllm/qwen-35b-a3b-dual --mode enable-thinking
+#   # capture / refresh a baseline (n=3 aggregate) — needs a live endpoint
+#   bash scripts/quality-baseline.sh --slug vllm/qwen-35b-a3b-dual --capture
+#   # print the resolved quality-test.sh command without running
+#   bash scripts/quality-baseline.sh --slug X --dry-run
+#
+# Endpoint/model are inherited by quality-test.sh (auto-detect, or MODEL=/URL=).
+# Any unrecognized args pass through to quality-test.sh (e.g.
+# --sampling-from-server, --thinking-max-tokens, --model NAME).
+#
+# Flags:
+#   --slug <registry-slug>   REQUIRED. e.g. vllm/qwen-35b-a3b-dual ('/' -> '-' in the filename)
+#   --mode no-thinking|enable-thinking   default: no-thinking (canonical)
+#   --capture                write/refresh the baseline instead of diffing against it
+#   --repeat N               runs per scenario (default 3; applies to both capture and diff)
+#   --dry-run                print the command, don't run
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+BASELINE_DIR="${ROOT_DIR}/results/baselines"
+
+SLUG=""
+MODE="no-thinking"
+CAPTURE=0
+DRY=0
+REPEAT="${REPEAT:-3}"
+PASSTHROUGH=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --slug)    SLUG="${2:-}"; shift 2 ;;
+    --mode)    MODE="${2:-}"; shift 2 ;;
+    --capture) CAPTURE=1; shift ;;
+    --repeat)  REPEAT="${2:-}"; shift 2 ;;
+    --dry-run) DRY=1; shift ;;
+    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    *)         PASSTHROUGH+=("$1"); shift ;;
+  esac
+done
+
+if [[ -z "$SLUG" ]]; then
+  echo "✗ --slug <registry-slug> is required (e.g. vllm/qwen-35b-a3b-dual)" >&2; exit 2
+fi
+case "$MODE" in
+  no-thinking)     MODE_FLAG="--no-thinking" ;;
+  enable-thinking) MODE_FLAG="--enable-thinking" ;;
+  *) echo "✗ --mode must be no-thinking | enable-thinking (got: '${MODE}')" >&2; exit 2 ;;
+esac
+if ! [[ "$REPEAT" =~ ^[0-9]+$ ]] || [[ "$REPEAT" -lt 1 ]]; then
+  echo "✗ --repeat must be a positive integer (got: '${REPEAT}')" >&2; exit 2
+fi
+
+# registry slugs contain '/'; make the baseline filename safe.
+SLUG_SAFE="${SLUG//\//-}"
+BASELINE_FILE="${BASELINE_DIR}/${SLUG_SAFE}__${MODE}.json"
+QT="${ROOT_DIR}/scripts/quality-test.sh"
+
+CMD=(bash "$QT" --full "$MODE_FLAG" --repeat "$REPEAT")
+if [[ "$CAPTURE" == "1" ]]; then
+  CMD+=(--save-json "$BASELINE_FILE")
+  echo "[quality-baseline] CAPTURE → ${BASELINE_FILE}  (n=${REPEAT}, mode=${MODE})"
+else
+  if [[ ! -f "$BASELINE_FILE" ]]; then
+    echo "✗ no baseline for slug='${SLUG}' mode='${MODE}':" >&2
+    echo "    ${BASELINE_FILE}" >&2
+    echo "  Capture one first:  bash scripts/quality-baseline.sh --slug '${SLUG}' --mode ${MODE} --capture" >&2
+    exit 1
+  fi
+  CMD+=(--previous-result "$BASELINE_FILE")
+  echo "[quality-baseline] DIFF vs ${BASELINE_FILE}  (mode=${MODE})"
+fi
+[[ ${#PASSTHROUGH[@]} -gt 0 ]] && CMD+=("${PASSTHROUGH[@]}")
+
+if [[ "$DRY" == "1" ]]; then
+  printf '[quality-baseline] (dry-run) would run:\n  %s\n' "${CMD[*]}"
+  exit 0
+fi
+exec "${CMD[@]}"

--- a/scripts/quality-test.sh
+++ b/scripts/quality-test.sh
@@ -199,6 +199,12 @@ SAMPLING_FROM_SERVER="${SAMPLING_FROM_SERVER:-0}"
 ENABLE_THINKING="${ENABLE_THINKING:-0}"
 NO_THINKING="${NO_THINKING:-0}"
 THINKING_MAX_TOKENS="${THINKING_MAX_TOKENS:-}"
+# #252: passthroughs to benchlocal-cli for the quality-baseline corpus —
+# --repeat (n>=3 aggregate), --previous-result (diff vs a baseline), and a
+# --save-json override (write the run to an explicit path, e.g. a baseline file).
+REPEAT=""
+PREVIOUS_RESULT=""
+SAVE_JSON_OVERRIDE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -268,6 +274,30 @@ while [[ $# -gt 0 ]]; do
       THINKING_MAX_TOKENS="${2:-}"
       if [[ -z "$THINKING_MAX_TOKENS" ]] || ! [[ "$THINKING_MAX_TOKENS" =~ ^[0-9]+$ ]]; then
         echo "✗ --thinking-max-tokens requires a positive integer" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    --repeat)
+      REPEAT="${2:-}"
+      if [[ -z "$REPEAT" ]] || ! [[ "$REPEAT" =~ ^[0-9]+$ ]]; then
+        echo "✗ --repeat requires a positive integer" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    --previous-result)
+      PREVIOUS_RESULT="${2:-}"
+      if [[ -z "$PREVIOUS_RESULT" ]]; then
+        echo "✗ --previous-result requires a path to a saved RunResult JSON" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    --save-json)
+      SAVE_JSON_OVERRIDE="${2:-}"
+      if [[ -z "$SAVE_JSON_OVERRIDE" ]]; then
+        echo "✗ --save-json requires a path" >&2
         exit 2
       fi
       shift 2
@@ -403,6 +433,11 @@ RESULTS_DIR="${ROOT_DIR}/results/quality"
 mkdir -p "$RESULTS_DIR"
 TS=$(date +%Y-%m-%dT%H-%M-%S)
 JSON_OUT="${RESULTS_DIR}/quality-${TS}.json"
+# #252: --save-json overrides the default per-run path (e.g. write to a baseline file).
+if [[ -n "$SAVE_JSON_OVERRIDE" ]]; then
+  JSON_OUT="$SAVE_JSON_OVERRIDE"
+  mkdir -p "$(dirname "$JSON_OUT")"
+fi
 
 if [[ "$TIMEOUT_PER_CASE_SET" == "1" ]]; then
   TIMEOUT_DISPLAY="${TIMEOUT_PER_CASE}s"
@@ -427,6 +462,12 @@ CLI_ARGS=(
 )
 if [[ "$TIMEOUT_PER_CASE_SET" == "1" ]]; then
   CLI_ARGS+=(--timeout-per-case "${TIMEOUT_PER_CASE}")
+fi
+if [[ -n "$REPEAT" ]]; then
+  CLI_ARGS+=(--repeat "$REPEAT")
+fi
+if [[ -n "$PREVIOUS_RESULT" ]]; then
+  CLI_ARGS+=(--previous-result "$PREVIOUS_RESULT")
 fi
 if [[ "$PROGRESS" == "1" ]]; then
   CLI_ARGS+=(--progress)

--- a/scripts/tests/test-quality-baseline.sh
+++ b/scripts/tests/test-quality-baseline.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Offline test for scripts/quality-baseline.sh (#252). Uses --dry-run so it never
+# needs a live endpoint or benchlocal-cli — it only asserts that the wrapper resolves
+# the correct quality-test.sh command + baseline path for each mode, and that the
+# guard rails (required slug, valid mode, positive --repeat, missing-baseline) fire.
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+QB="scripts/quality-baseline.sh"
+# A throwaway slug that can never collide with a real (Phase-2) baseline filename.
+FAKE_SLUG="test/fake-slug-252"
+FAKE_FILE="results/baselines/test-fake-slug-252__no-thinking.json"
+
+LAST_OUT=""
+# rm -f never errors on a missing file and always returns 0, so the EXIT trap
+# can't poison the script's exit code (the FAKE_FILE slug is unique to this test).
+cleanup() { rm -f "$FAKE_FILE"; }
+trap cleanup EXIT
+
+assert_contains() {
+  local haystack="$1" needle="$2"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "ASSERTION FAILED: expected output to contain: $needle" >&2
+    echo "--- output ---" >&2
+    echo "$haystack" >&2
+    exit 1
+  fi
+}
+assert_not_contains() {
+  local haystack="$1" needle="$2"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "ASSERTION FAILED: expected output NOT to contain: $needle" >&2
+    echo "--- output ---" >&2
+    echo "$haystack" >&2
+    exit 1
+  fi
+}
+# run the wrapper, capture combined output, assert on the exit code.
+expect_rc() {
+  local want="$1"; shift
+  local rc
+  set +e
+  LAST_OUT="$("$@" 2>&1)"
+  rc=$?
+  set -e
+  if [[ "$rc" != "$want" ]]; then
+    echo "ASSERTION FAILED: expected exit $want, got $rc for: $*" >&2
+    echo "--- output ---" >&2
+    echo "$LAST_OUT" >&2
+    exit 1
+  fi
+}
+
+# 1. capture, no-thinking (default mode) — dry-run resolves the canonical command.
+expect_rc 0 bash "$QB" --slug "$FAKE_SLUG" --capture --dry-run
+assert_contains "$LAST_OUT" "--full --no-thinking --repeat 3"
+assert_contains "$LAST_OUT" "--save-json"
+assert_contains "$LAST_OUT" "$FAKE_FILE"
+assert_not_contains "$LAST_OUT" "--previous-result"
+
+# 2. capture, enable-thinking — mode flag + filename both flip.
+expect_rc 0 bash "$QB" --slug "$FAKE_SLUG" --mode enable-thinking --capture --dry-run
+assert_contains "$LAST_OUT" "--full --enable-thinking --repeat 3"
+assert_contains "$LAST_OUT" "results/baselines/test-fake-slug-252__enable-thinking.json"
+
+# 3. --repeat override flows into the command.
+expect_rc 0 bash "$QB" --slug "$FAKE_SLUG" --capture --repeat 5 --dry-run
+assert_contains "$LAST_OUT" "--repeat 5"
+
+# 4. passthrough args land after the resolved command.
+expect_rc 0 bash "$QB" --slug "$FAKE_SLUG" --capture --dry-run --sampling-from-server
+assert_contains "$LAST_OUT" "--sampling-from-server"
+
+# 5. diff mode with NO baseline on disk → hard error (exit 1), even under --dry-run.
+rm -f "$FAKE_FILE"
+expect_rc 1 bash "$QB" --slug "$FAKE_SLUG" --dry-run
+assert_contains "$LAST_OUT" "no baseline"
+
+# 6. diff mode with a baseline present → resolves --previous-result, not --save-json.
+mkdir -p results/baselines
+echo '{}' > "$FAKE_FILE"
+expect_rc 0 bash "$QB" --slug "$FAKE_SLUG" --dry-run
+assert_contains "$LAST_OUT" "--previous-result"
+assert_contains "$LAST_OUT" "$FAKE_FILE"
+assert_not_contains "$LAST_OUT" "--save-json"
+rm -f "$FAKE_FILE"
+
+# 7. missing --slug → usage error (exit 2).
+expect_rc 2 bash "$QB" --capture --dry-run
+assert_contains "$LAST_OUT" "--slug"
+
+# 8. invalid --mode → usage error (exit 2).
+expect_rc 2 bash "$QB" --slug "$FAKE_SLUG" --mode sideways --dry-run
+assert_contains "$LAST_OUT" "--mode must be"
+
+# 9. non-numeric --repeat → usage error (exit 2).
+expect_rc 2 bash "$QB" --slug "$FAKE_SLUG" --repeat zero --dry-run
+assert_contains "$LAST_OUT" "--repeat must be"
+
+echo "test-quality-baseline: ok"


### PR DESCRIPTION
Phase 1 of #252 — the **offline scaffolding** for a curated quality-baseline corpus. Phase 2 (curating the actual baselines) is GPU-gated and lands separately.

### What this adds

A committed corpus of trusted quality 8-pack aggregates + a wrapper to capture and diff against them, so a config change (quant swap, pin bump, Genesis env-flip, KV change) can be regression-checked against a known-good reference instead of "the previous baseline" hunted down by hand each time.

- **`scripts/quality-baseline.sh`** — thin wrapper over `quality-test.sh --full`:
  - `--capture` → `--save-json results/baselines/<slug>__<mode>.json` (writes/refreshes the baseline)
  - default (diff) → `--previous-result <baseline>` (the regression check; errors if no baseline exists yet)
  - `--mode no-thinking|enable-thinking` — `no-thinking` is **canonical** (temp-0, reproducible; diff against this for a CI-style gate), `enable-thinking` is the reasoning-on companion
  - `--repeat N` (default 3) so a baseline is an `n≥3` aggregate — run-to-run noise (~±5–7 / 150 on the 8-pack) doesn't read as a regression
  - `--dry-run` prints the resolved command; unrecognized args pass through (e.g. `--exit-on-regression` for a hard CI gate)
- **`scripts/quality-test.sh`** — forwards `--repeat` / `--previous-result` and honors a `--save-json` path override, so the wrapper's layout works (previously `*)` errored on these).
- **`results/baselines/`** — committed corpus home (whitelisted in `.gitignore`) + a `README.md` documenting the convention, usage, and an empty index table.
- **`scripts/tests/test-quality-baseline.sh`** — offline gate (`--dry-run`, no endpoint/Docker): asserts command + path resolution per mode and the required-slug / valid-mode / positive-`--repeat` / missing-baseline guards.
- **`docs/QUALITY_TEST.md`** — a "Regression baselines" subsection under *What "passing" means* pointing at the corpus.

### This is distinct from the measurement-record TPS corpus

`measurement_record.py` tracks **throughput**; this tracks **behavioral quality** (ToolCall / InstructFollow / StructOutput / DataExtract / …). Different axis, different corpus.

### Test

```
$ bash scripts/tests/test-quality-baseline.sh
test-quality-baseline: ok
$ bash scripts/tests/test-quality-thinking.sh   # no regression from the quality-test.sh passthroughs
test-quality-thinking: ok
```

Full suite green except `test-compose-registry-disk` (pre-existing — an unrelated in-progress local model dir adds disk composes not yet in the registry; this branch touches zero composes).

### Phase 2 (follow-up, GPU-gated)

Curate the actual baselines against the live `RECOMMENDED_DEFAULT_MODELS` configs and fill the index table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
