### PR TITLE
deckard-40b: anti-loop sampling defaults (rep 1.1 + repeat-last-n 256) + DRY opt-in

### DIFF
--- a/models/qwen3.6-40b-deckard/llama-cpp/compose/dual/piehsoft-q6k/mtp.yml
+++ b/models/qwen3.6-40b-deckard/llama-cpp/compose/dual/piehsoft-q6k/mtp.yml
@@ -61,6 +61,12 @@
 #   SERVED_NAME            --alias value       (default: deckard-40b)
 #   REASONING              thinking gate       (default: off — stack-wide policy)
 #   REASONING_FORMAT       reasoning routing   (default: deepseek — hygiene)
+#   REPEAT_PENALTY         repetition penalty  (default: 1.1 — anti-loop; was 1.0)
+#   REPEAT_LAST_N          repeat window       (default: 256 — anti-loop; llama.cpp default 64)
+#   DRY_MULTIPLIER         DRY sampler strength (default: 0.0 = OFF). For severe long-ctx
+#                          loops (e.g. ~262K), set 0.8 — strongest loop-breaker, but it can
+#                          over-suppress legitimate repetition in CODE, so it's opt-in (#517).
+#   DRY_BASE / DRY_ALLOWED_LENGTH  DRY tuning   (defaults: 1.75 / 2; only active when DRY_MULTIPLIER>0)
 #   PORT                   host port           (default: 8199)
 #   CUDA_VISIBLE_DEVICES   which GPUs to use   (default: 0,1)
 #
@@ -106,7 +112,11 @@ services:
       --top-p ${TOP_P:-0.95}
       --top-k ${TOP_K:-20}
       --min-p ${MIN_P:-0.0}
-      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.1}
+      --repeat-last-n ${REPEAT_LAST_N:-256}
+      --dry-multiplier ${DRY_MULTIPLIER:-0.0}
+      --dry-base ${DRY_BASE:-1.75}
+      --dry-allowed-length ${DRY_ALLOWED_LENGTH:-2}
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
Fixes the long-context looping milano reported on Discord (deckard-40b @ 262K).

### Problem
The compose shipped `--repeat-penalty 1.0` (no penalty) + llama.cpp's default `repeat-last-n 64` → degenerate loops (a 10-word phrase repeating up to **~46×** in a 2500-token generation, intermittent at temp 0.6). milano's `rep 1.05 + presence 0.05` only got that to ~18 ("helps then loops again" — presence penalty is a weak loop-breaker).

### Change
- `--repeat-penalty 1.0 → 1.1` (env `REPEAT_PENALTY`)
- add `--repeat-last-n 256` (env `REPEAT_LAST_N`; was the llama.cpp default 64)
- wire **DRY** env knobs, **default OFF** (`--dry-multiplier 0.0`): DRY is the strongest loop-breaker but over-suppresses legitimate repetition in **code**, so it's opt-in (`DRY_MULTIPLIER=0.8`) for severe long-ctx loops. Header env-docs updated.

Per-request sweep: `rep 1.1 + repeat-last-n 256` cuts looping **~5× (max 46 → 9)**, and is gentle on code (unlike DRY).

### Quality — same-session symmetric 8-pack A/B (2026-06-13, think-off, MTP n=2)
| | OLD rep1.0 | NEW rep1.1 | Δ |
|---|---|---|---|
| Total /150 | 99 | 100 | **+1** |

Quality-neutral (+1 = noise; per-pack deltas bidirectional). NB: OLD measured **99 today vs the #350 Results Card's historical 105** — that 6-pt gap is harness drift since 2026-06-10, **not** this change (a non-symmetric new-vs-#350 comparison would have falsely flagged −5; the symmetric arm shows +1).

### Note
Reasoning is **off** by default on this compose, so `--reasoning-budget` (a common anti-loop suggestion) is a no-op here unless reasoning is enabled.

Full suite green (`test-compose-registry-disk` fails pre-existing on an unrelated untracked model dir).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
