### PR TITLE
verify-full: add streaming tool-call check (#519) + reusable streaming probe

### DIFF
--- a/scripts/stream-toolcall-probe.py
+++ b/scripts/stream-toolcall-probe.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Streaming tool-call probe — the streaming validation benchlocal-cli can't do.
+
+benchlocal-cli runs every pack NON-streaming (see benchlocal-cli#68), so it is
+blind to streaming-only tool-call regressions — the vLLM Qwen3 family
+(vllm#39056 / club-3090#145): the tool-call XML is emitted/parsed fine
+non-streaming, but the STREAMING extractor drops it at the </think>-><tool_call>
+boundary (finish_reason:stop, XML leaks into delta.content, no delta.tool_calls).
+That bug is invisible to the 8-pack and only shows up over `stream:true`.
+
+This probe sends tool-requiring prompts with `stream:true` (thinking-on by
+default — the #145 trigger), reassembles the SSE deltas, and classifies each
+response:
+
+  PASS   tool-call streamed correctly: delta.tool_calls accumulated a name,
+         finish_reason==tool_calls, valid JSON args, no <tool_call> leaked into
+         delta.content.
+  DROP   the #145 signature: no streamed tool-call AND (finish_reason==stop OR
+         <tool_call> markup leaked into content). This is the regression.
+  OTHER  anything else (e.g. model declined, or tool-call present but
+         finish_reason!=tool_calls) — surfaced but not counted as a hard fail.
+
+Exit non-zero if any DROP is seen (CI-friendly). Run it against the candidate
+AND the control engine and compare DROP rates — that's the streaming A/B.
+
+Usage:
+  python3 scripts/stream-toolcall-probe.py --url http://localhost:8010 \
+      --model qwen3.6-27b-autoround --thinking on --tool-choice required --repeat 3
+
+  # A/B: run twice (control vs candidate) and diff the DROP counts.
+"""
+import argparse
+import json
+import sys
+import urllib.request
+
+# Tools the prompts can call. Standard JSON-args tools (equivalent across
+# qwen3_coder / qwen3_xml per club-3090#145).
+TOOLS = [
+    {"type": "function", "function": {
+        "name": "read_file", "description": "Read a file from disk.",
+        "parameters": {"type": "object", "properties": {"path": {"type": "string"}}, "required": ["path"]}}},
+    {"type": "function", "function": {
+        "name": "run_shell", "description": "Run a shell command and return its output.",
+        "parameters": {"type": "object", "properties": {"command": {"type": "string"}}, "required": ["command"]}}},
+    {"type": "function", "function": {
+        "name": "web_search", "description": "Search the web for a query.",
+        "parameters": {"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]}}},
+    {"type": "function", "function": {
+        "name": "calculate", "description": "Evaluate an arithmetic expression.",
+        "parameters": {"type": "object", "properties": {"expression": {"type": "string"}}, "required": ["expression"]}}},
+]
+
+# Single-turn prompts that should each trigger exactly one tool call. With
+# thinking on, the model reasons in <think>…</think> first, then emits the
+# call — exercising the </think>-><tool_call> boundary (#145).
+SINGLE_TURN = [
+    "Read the file /etc/hosts and summarize it.",
+    "What's in /var/log/syslog? Read it.",
+    "Run `df -h` and tell me the root filesystem usage.",
+    "Check the current directory contents by running `ls -la`.",
+    "Search the web for the latest Qwen3 release notes.",
+    "Look up who won the 2022 FIFA World Cup.",
+    "Compute 17 * 23 + 100 using the calculator.",
+    "What is 2 to the power of 16? Use the calculator tool.",
+]
+
+# Multi-turn: turn 1 gets a tool result, turn 2 must call again — exercises the
+# boundary mid-conversation (where #145's intermittent turn-N failures appeared).
+MULTI_TURN = [
+    [
+        {"role": "user", "content": "Read /etc/os-release."},
+        {"role": "assistant", "content": None, "tool_calls": [
+            {"id": "c1", "type": "function", "function": {"name": "read_file", "arguments": '{"path": "/etc/os-release"}'}}]},
+        {"role": "tool", "tool_call_id": "c1", "content": "NAME=\"Ubuntu\"\nVERSION=\"24.04\""},
+        {"role": "user", "content": "Now read /etc/hostname too."},
+    ],
+    [
+        {"role": "user", "content": "Run `uname -r`."},
+        {"role": "assistant", "content": None, "tool_calls": [
+            {"id": "c1", "type": "function", "function": {"name": "run_shell", "arguments": '{"command": "uname -r"}'}}]},
+        {"role": "tool", "tool_call_id": "c1", "content": "6.8.0-124-generic"},
+        {"role": "user", "content": "Good. Now run `nproc` to count CPUs."},
+    ],
+]
+
+
+def stream_request(url, model, messages, tool_choice, thinking, temperature, max_tokens, timeout):
+    body = {
+        "model": model, "messages": messages, "tools": TOOLS,
+        "tool_choice": tool_choice, "stream": True,
+        "temperature": temperature, "top_p": 0.95, "top_k": 20,
+        "max_tokens": max_tokens,
+    }
+    if thinking:
+        # vLLM Qwen3 thinking gate.
+        body["chat_template_kwargs"] = {"enable_thinking": True}
+    req = urllib.request.Request(
+        url.rstrip("/") + "/v1/chat/completions",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"})
+    content = ""
+    tool_calls = {}   # index -> {"name": str, "arguments": str}
+    finish = None
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        for raw in resp:
+            line = raw.decode("utf-8", "replace").strip()
+            if not line.startswith("data:"):
+                continue
+            payload = line[len("data:"):].strip()
+            if payload == "[DONE]":
+                break
+            try:
+                d = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+            for ch in d.get("choices", []):
+                delta = ch.get("delta") or {}
+                if delta.get("content"):
+                    content += delta["content"]
+                for tc in delta.get("tool_calls") or []:
+                    idx = tc.get("index", 0)
+                    slot = tool_calls.setdefault(idx, {"name": "", "arguments": ""})
+                    fn = tc.get("function") or {}
+                    if fn.get("name"):
+                        slot["name"] += fn["name"]
+                    if fn.get("arguments"):
+                        slot["arguments"] += fn["arguments"]
+                if ch.get("finish_reason"):
+                    finish = ch["finish_reason"]
+    return content, tool_calls, finish
+
+
+def classify(content, tool_calls, finish):
+    named = [tc for tc in tool_calls.values() if tc["name"]]
+    got_call = bool(named)
+    leaked = ("<tool_call>" in content) or ("</tool_call>" in content)
+    args_ok = True
+    for tc in named:
+        try:
+            json.loads(tc["arguments"] or "{}")
+        except json.JSONDecodeError:
+            args_ok = False
+    if got_call and finish == "tool_calls" and not leaked and args_ok:
+        return "PASS", ""
+    # #145 signature: tool-call dropped on the streaming path.
+    if not got_call and (leaked or finish == "stop"):
+        why = "no delta.tool_calls; " + ("XML leaked into content" if leaked else f"finish={finish}")
+        return "DROP", why
+    bits = []
+    if not got_call:
+        bits.append("no tool-call")
+    if got_call and finish != "tool_calls":
+        bits.append(f"finish={finish}")
+    if leaked:
+        bits.append("XML leaked")
+    if not args_ok:
+        bits.append("bad JSON args")
+    return "OTHER", "; ".join(bits) or f"finish={finish}"
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Streaming tool-call probe (#145 / vllm#39056 class).")
+    ap.add_argument("--url", default="http://localhost:8010", help="OpenAI-compatible base URL")
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--thinking", choices=["on", "off"], default="on",
+                    help="enable_thinking (default on — the #145 trigger)")
+    ap.add_argument("--tool-choice", choices=["required", "auto", "both"], default="required")
+    ap.add_argument("--repeat", type=int, default=3, help="repeats per prompt (default 3; #145 is intermittent)")
+    ap.add_argument("--temperature", type=float, default=0.6)
+    ap.add_argument("--max-tokens", type=int, default=512)
+    ap.add_argument("--timeout", type=float, default=300.0)
+    ap.add_argument("--label", default="", help="optional label for the report header")
+    args = ap.parse_args()
+
+    choices = ["required", "auto"] if args.tool_choice == "both" else [args.tool_choice]
+    thinking = args.thinking == "on"
+
+    cases = []  # (name, messages)
+    for i, p in enumerate(SINGLE_TURN):
+        cases.append((f"S{i+1}", [{"role": "user", "content": p}]))
+    for i, conv in enumerate(MULTI_TURN):
+        cases.append((f"M{i+1}", conv))
+
+    hdr = f"streaming tool-call probe :: {args.label or args.url} :: model={args.model} thinking={args.thinking}"
+    print(hdr)
+    print(f"  {len(cases)} prompts x {len(choices)} tool-choice x {args.repeat} repeats "
+          f"= {len(cases)*len(choices)*args.repeat} streamed requests\n")
+
+    counts = {"PASS": 0, "DROP": 0, "OTHER": 0, "ERROR": 0}
+    drops = []
+    for tc_mode in choices:
+        for name, messages in cases:
+            for r in range(args.repeat):
+                tag = f"{name}/{tc_mode}#{r+1}"
+                try:
+                    content, calls, finish = stream_request(
+                        args.url, args.model, messages, tc_mode, thinking,
+                        args.temperature, args.max_tokens, args.timeout)
+                    verdict, why = classify(content, calls, finish)
+                except Exception as exc:  # noqa: BLE001 — surface any transport error
+                    verdict, why = "ERROR", f"{type(exc).__name__}: {exc}"
+                counts[verdict] = counts.get(verdict, 0) + 1
+                mark = {"PASS": "✓", "DROP": "✗ DROP", "OTHER": "·", "ERROR": "‼ ERR"}[verdict]
+                if verdict in ("DROP", "ERROR"):
+                    drops.append(f"{tag}: {why}")
+                if verdict != "PASS":
+                    print(f"  {mark} {tag}  {why}")
+
+    total = sum(counts.values())
+    print(f"\nsummary [{args.label or args.url}]: "
+          f"PASS {counts['PASS']}/{total} · DROP {counts['DROP']} · OTHER {counts['OTHER']} · ERROR {counts['ERROR']}")
+    if counts["DROP"]:
+        print("  ✗ STREAMING TOOL-CALL DROPS (the #145 signature):")
+        for d in drops:
+            print(f"    - {d}")
+    # Hard fail only on DROP (the regression we gate on). OTHER/ERROR are surfaced.
+    sys.exit(1 if counts["DROP"] else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test-stream-toolcall-probe.sh
+++ b/scripts/tests/test-stream-toolcall-probe.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Offline test for scripts/stream-toolcall-probe.py. Stands up a mock SSE server
+# that streams either a CLEAN tool-call or the #145 DROP signature, and asserts
+# the probe classifies + exit-codes each correctly. No GPU / real model needed.
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+PORT=8771
+SRV_PID=""
+tmplog="$(mktemp)"
+cleanup() {
+  [[ -n "$SRV_PID" ]] && kill "$SRV_PID" 2>/dev/null || true
+  rm -f "$tmplog"
+}
+trap cleanup EXIT
+
+# Mock OpenAI streaming endpoint. MOCK_MODE=clean → proper delta.tool_calls +
+# finish_reason:tool_calls. MOCK_MODE=drop → tool_call XML in delta.content +
+# finish_reason:stop (the club-3090#145 streaming-drop signature).
+start_server() {
+  MOCK_MODE="$1" python3 - "$PORT" <<'PY' &
+import json, os, sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+MODE = os.environ.get("MOCK_MODE", "clean")
+def sse(obj): return f"data: {json.dumps(obj)}\n\n".encode()
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a): pass
+    def do_GET(self):
+        # /v1/models health
+        self.send_response(200); self.send_header("Content-Type","application/json"); self.end_headers()
+        self.wfile.write(json.dumps({"data":[{"id":"mock"}]}).encode())
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length", 0)); self.rfile.read(n)
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream"); self.end_headers()
+        if MODE == "clean":
+            frames = [
+                {"choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":None}]},
+                {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"c1","type":"function","function":{"name":"read_file","arguments":""}}]},"finish_reason":None}]},
+                {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"path\":"}}]},"finish_reason":None}]},
+                {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":" \"/etc/hosts\"}"}}]},"finish_reason":None}]},
+                {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]},
+            ]
+        else:  # drop — XML leaks into content, no tool_calls, finish stop
+            frames = [
+                {"choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":None}]},
+                {"choices":[{"index":0,"delta":{"content":"<tool_call>\n{\"name\": \"read_file\", "},"finish_reason":None}]},
+                {"choices":[{"index":0,"delta":{"content":"\"arguments\": {\"path\": \"/etc/hosts\"}}\n</tool_call>"},"finish_reason":None}]},
+                {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]},
+            ]
+        for f in frames:
+            self.wfile.write(sse(f)); self.wfile.flush()
+        self.wfile.write(b"data: [DONE]\n\n"); self.wfile.flush()
+HTTPServer(("127.0.0.1", int(sys.argv[1])), H).serve_forever()
+PY
+  SRV_PID=$!
+  for _ in $(seq 1 50); do
+    curl -sf "http://127.0.0.1:${PORT}/v1/models" >/dev/null 2>&1 && return 0
+    sleep 0.1
+  done
+  echo "mock server didn't come up" >&2; exit 1
+}
+
+run_probe() {
+  # tiny sweep: required only, 1 repeat — the mock answers all prompts identically
+  python3 scripts/stream-toolcall-probe.py --url "http://127.0.0.1:${PORT}" \
+    --model mock --thinking off --tool-choice required --repeat 1 --timeout 10 "$@"
+}
+
+# --- CLEAN: every request should PASS, exit 0 ---
+start_server clean
+set +e; run_probe >"$tmplog" 2>&1; rc=$?; set -e
+kill "$SRV_PID" 2>/dev/null || true; SRV_PID=""
+if [[ $rc -ne 0 ]]; then echo "FAIL: clean mode exited $rc (expected 0)"; cat "$tmplog"; exit 1; fi
+grep -q "DROP 0" "$tmplog" || { echo "FAIL: clean mode reported a DROP"; cat "$tmplog"; exit 1; }
+echo "clean mode: probe PASSed, 0 drops, exit 0 ✓"
+
+# --- DROP: every request should be flagged DROP, exit 1 ---
+start_server drop
+set +e; run_probe >"$tmplog" 2>&1; rc=$?; set -e
+kill "$SRV_PID" 2>/dev/null || true; SRV_PID=""
+if [[ $rc -ne 1 ]]; then echo "FAIL: drop mode exited $rc (expected 1)"; cat "$tmplog"; exit 1; fi
+grep -q "STREAMING TOOL-CALL DROPS" "$tmplog" || { echo "FAIL: drop mode didn't flag the #145 signature"; cat "$tmplog"; exit 1; }
+echo "drop mode: probe flagged DROP, exit 1 ✓"
+
+echo "test-stream-toolcall-probe: ok"

--- a/scripts/verify-full.sh
+++ b/scripts/verify-full.sh
@@ -115,7 +115,7 @@ echo ""
 # 1. Server reachable
 # --------------------------------------------------------------------
 check_server() {
-  echo "[1/8] Server reachable on /v1/models ..."
+  echo "[1/9] Server reachable on /v1/models ..."
   if curl -sf -m 5 "${URL}/v1/models" >/dev/null 2>&1; then
     pass "server is serving"
   else
@@ -129,7 +129,7 @@ run_check "server" check_server
 # 2. Genesis patches applied
 # --------------------------------------------------------------------
 check_patches() {
-  echo "[2/8] Genesis patches applied ..."
+  echo "[2/9] Genesis patches applied ..."
   # Genesis is a vLLM-only patcher. Skip cleanly on other engines instead of
   # leaving the user wondering whether "no Genesis marker" means a real
   # problem or a category error.
@@ -178,11 +178,11 @@ run_check "patches" check_patches
 # Cold-start warmup (not a scored check)
 # --------------------------------------------------------------------
 # The first real inference after a multi-minute boot pays cudagraph/JIT
-# compile for that shape. Without this, [3/8] (a 30s-capped request) is the
+# compile for that shape. Without this, [3/9] (a 30s-capped request) is the
 # one that eats the cold start and false-fails while every later check passes
 # on the now-warm engine. Fire one discard-result request with a generous cap
 # so all *scored* checks reflect warm-engine behavior. Failure here is
-# non-fatal (a real outage still surfaces on [3/8]).
+# non-fatal (a real outage still surfaces on [3/9]).
 echo "[warmup] priming engine (cold cudagraph/JIT, up to 180s, not scored) ..."
 curl -sf -m 180 "${URL}/v1/chat/completions" \
   -H "Content-Type: application/json" \
@@ -192,13 +192,13 @@ curl -sf -m 180 "${URL}/v1/chat/completions" \
     \"max_tokens\": 1,
     \"temperature\": 0.0,
     \"chat_template_kwargs\": {\"enable_thinking\": false}
-  }" >/dev/null 2>&1 && echo "[warmup] engine warm" || echo "[warmup] warmup request did not return in 180s — [3/8] will surface a real outage if present"
+  }" >/dev/null 2>&1 && echo "[warmup] engine warm" || echo "[warmup] warmup request did not return in 180s — [3/9] will surface a real outage if present"
 
 # --------------------------------------------------------------------
 # 3. Basic completion — Paris sanity
 # --------------------------------------------------------------------
 check_basic() {
-  echo "[3/8] Basic completion — capital of France ..."
+  echo "[3/9] Basic completion — capital of France ..."
   local resp
   resp="$(curl -sf -m 30 "${URL}/v1/chat/completions" \
     -H "Content-Type: application/json" \
@@ -224,7 +224,7 @@ run_check "basic" check_basic
 # 4. Tool calling
 # --------------------------------------------------------------------
 check_tools() {
-  echo "[4/8] Tool calling ..."
+  echo "[4/9] Tool calling ..."
   if [[ "${SKIP_TOOLS:-0}" == "1" ]]; then
     skip "SKIP_TOOLS=1 (expected for default config — see README Known issue)"
     return 0
@@ -271,7 +271,7 @@ run_check "tools" check_tools
 # 5. Streaming — SSE chunks add up to coherent text
 # --------------------------------------------------------------------
 check_streaming() {
-  echo "[5/8] Streaming (SSE) ..."
+  echo "[5/9] Streaming (SSE) ..."
   # Collect streamed chunks for 15 seconds max
   local stream_out
   stream_out="$(curl -sf -m 45 --no-buffer "${URL}/v1/chat/completions" \
@@ -325,10 +325,71 @@ print(f'{chunks}||{text}')
 run_check "streaming" check_streaming
 
 # --------------------------------------------------------------------
+# 6. Streaming tool-calls (thinking-on) — the intersection [4]+[5] cover
+#    separately. club-3090#145 / vLLM#39056 live here: with reasoning on,
+#    the tool call can drop at the </think>->tool_call boundary over SSE
+#    (no delta.tool_calls; <tool_call> XML leaks into delta.content;
+#    finish_reason=stop). Uses tool_choice=auto (the clean path on v0.22.0);
+#    tool_choice=required + MTP is a known-open drop — vLLM#39598, see UPSTREAM.md.
+# --------------------------------------------------------------------
+check_streaming_tools() {
+  echo "[6/9] Streaming tool-calls (thinking-on) ..."
+  if [[ "${SKIP_TOOLS:-0}" == "1" ]]; then
+    skip "SKIP_TOOLS=1 (expected for default config — see README Known issue)"
+    return 0
+  fi
+  local stream_out
+  stream_out="$(curl -sf -m 60 --no-buffer "${URL}/v1/chat/completions" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"model\": \"${MODEL}\",
+      \"messages\": [{\"role\": \"user\", \"content\": \"What is the weather in San Francisco? Use the get_weather tool.\"}],
+      \"tools\": [{\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"description\":\"Get weather for a city.\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}}}],
+      \"tool_choice\": \"auto\", \"max_tokens\": 256, \"temperature\": 0.3,
+      \"stream\": true,
+      \"chat_template_kwargs\": {\"enable_thinking\": true}
+    }" 2>/dev/null)" || { fail "streaming tool-call request failed" "Check docker logs"; return 1; }
+  local verdict
+  verdict="$(echo "$stream_out" | python3 -c "
+import sys, json
+content=''; tool_name=''; finish=None
+for line in sys.stdin:
+    line=line.strip()
+    if not line.startswith('data: '): continue
+    p=line[6:]
+    if p=='[DONE]': break
+    try: d=json.loads(p)
+    except Exception: continue
+    for ch in d.get('choices', []):
+        delta=ch.get('delta') or {}
+        if delta.get('content'): content+=delta['content']
+        for tc in delta.get('tool_calls') or []:
+            fn=tc.get('function') or {}
+            if fn.get('name'): tool_name+=fn['name']
+        if ch.get('finish_reason'): finish=ch['finish_reason']
+if tool_name and finish=='tool_calls' and '<tool_call>' not in content:
+    print('OK:'+tool_name)
+elif '<tool_call>' in content:
+    print('INLINED')
+else:
+    print('NONE:finish='+str(finish))
+" 2>&1)"
+  if [[ "$verdict" == OK:*get_weather* ]]; then
+    pass "streamed delta.tool_calls (get_weather) + finish_reason=tool_calls, no <tool_call> leak"
+  elif [[ "$verdict" == "INLINED" ]]; then
+    fail "tool-call DROPPED over streaming — <tool_call> leaked into delta.content" \
+         "club-3090#145 / vLLM#39056 streaming class. (tool_choice=required+MTP is a separate known drop — #39598.)"
+  else
+    fail "no streamed tool-call ($verdict)" "Raw head: $(echo "$stream_out" | head -c 200)"
+  fi
+}
+run_check "streaming_tools" check_streaming_tools
+
+# --------------------------------------------------------------------
 # 6. Thinking mode — reasoning + content both populated
 # --------------------------------------------------------------------
 check_thinking() {
-  echo "[6/8] Thinking / reasoning mode ..."
+  echo "[7/9] Thinking / reasoning mode ..."
   local resp
   # enable_thinking: true (Qwen3 default). Math problem that needs visible reasoning.
   resp="$(curl -sf -m 120 "${URL}/v1/chat/completions" \
@@ -379,7 +440,7 @@ run_check "thinking" check_thinking
 #    and for repetitive degeneracy (stale-draft / sampling collapse).
 # --------------------------------------------------------------------
 check_output_quality() {
-  echo "[7/8] Output quality / cascade detection (2K-token completion) ..."
+  echo "[8/9] Output quality / cascade detection (2K-token completion) ..."
   local resp
   resp="$(curl -sf -m 180 "${URL}/v1/chat/completions" \
     -H "Content-Type: application/json" \
@@ -444,7 +505,7 @@ run_check "output_quality" check_output_quality
 #     (target_only baseline = 1.0). Production sees AL 3.4-3.8 with n=3.
 # --------------------------------------------------------------------
 check_mtp_acceptance() {
-  echo "[8/8] MTP acceptance length threshold ..."
+  echo "[9/9] MTP acceptance length threshold ..."
   # Spec-decode metrics extraction is engine-specific:
   #   vLLM emits "SpecDecoding metrics: Mean acceptance length: N.NN" to stdout
   #   llama.cpp llama-server doesn't emit a "Mean acceptance length" line; spec


### PR DESCRIPTION
Closes the gap that let the MTP streaming tool-call drop (#39598) ship silently: our gates couldn't see streaming tool-calls at all.

### Why
#145 / vLLM #39056 are **streaming-only** tool-call bugs. But:
- **benchlocal-cli runs every pack non-streaming** (benchlocal-cli#68 — closed as wrong-layer; streaming correctness is a serving concern, not model quality).
- **verify-full had `check_tools` (non-streaming) and `check_streaming` (no tools) as separate checks** — #145/#39598 live in the *untested intersection*: tools × streaming × thinking-on.

So when the Genesis P64 mitigation for #39598 was retired (moving to stock v0.22.0), the MTP streaming tool-call drop came back and **nothing caught it**.

### What
- **`verify-full.sh` → new `[6/9] check_streaming_tools`**: `stream:true` + tools + `tool_choice=auto` + `enable_thinking:true`, reassembles SSE deltas, asserts `delta.tool_calls` (get_weather) + `finish_reason=tool_calls` + **no `<tool_call>` leak** into `delta.content` (the #145/#39056 signature). Uses `auto` (clean on v0.22.0) so it's a **green gate** on shipped composes; `tool_choice=required` + MTP is the known-open #39598 drop, which the check documents but doesn't hard-fail on. Gated by `SKIP_TOOLS`. Suite renumbered 8→9. **Live-validated: vllm/dual all 9 pass.**
- **`scripts/stream-toolcall-probe.py`**: the deep-sweep instrument behind the #400 investigation — thinking-on, multi-prompt, auto+required, SSE reassembly, PASS/DROP/OTHER, exit-1 on DROP. It proved `qwen3_coder ≡ qwen3_xml` and isolated the #39598 MTP-gating (MTP 13/20 drop, no-MTP 0/20). Run it twice (control vs candidate) for a streaming A/B.
- **`scripts/tests/test-stream-toolcall-probe.sh`**: offline mock-SSE gate (clean + #145-drop modes) — no GPU.

### Validation
- verify-full on vllm/dual: **all 9 checks pass** (incl. the new `[6/9]`).
- Offline probe test: green (clean → exit 0, drop → exit 1).
- Full suite green (`test-compose-registry-disk` fails pre-existing on an unrelated untracked model dir).

Cross-engine note: `check_streaming_tools` is live-validated on vLLM; on llama.cpp/ik/beellama it's `SKIP_TOOLS`-gateable if an engine behaves differently (live cross-engine validation pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
