### PR TITLE
Add Carnice-V2-27B beellama single-card compose (beellama/carnice-v2-single-q5km-mtp)

### DIFF
--- a/models/qwen3.6-27b/beellama/compose/single/carnice-v2-q5km/mtp-kvarn4.yml
+++ b/models/qwen3.6-27b/beellama/compose/single/carnice-v2-q5km/mtp-kvarn4.yml
@@ -1,0 +1,164 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Carnice-V2-27B (stuchapin Q5_K_M MTP GGUF — kai-os/Carnice-V2-27b,
+#              a Hermes-style agentic SFT of Qwen3.6-27B; full model + embedded MTP head)
+#   Engine:    beellama.cpp v0.3.2-preview (Anbeeld fork — MTP spec-dec + KVarN KV-compression)
+#   Topology:  Single 3090 (TP=1)
+#   Drafter:   MTP (--spec-type draft-mtp, embedded head — NO separate draft model).
+#              n_max=1 (NOT 3 — see Caveats: this head is mtp_num_hidden_layers=1).
+#   KV:        kvarn4 K + kvarn4 V (KVarN — q5-class quality at ~28% bf16 memory; disc #329).
+#              Author's card ships q4_0/q4_0; we use kvarn4 (better quality, similar memory →
+#              bigger window) per the qwopus-coder KVarN result.
+#   Vision:    no (text-only fine-tune; no mmproj)
+#   Template:  native (GGUF-embedded) via --jinja
+#   Max ctx:   163840 (160K) default, MEASURED ceiling 176K (2026-06-14, single 3090, kvarn4+MTP
+#              n=1): 160K @ 23.49GB (1.09GB free), 176K @ 23.93GB (0.65GB free) = runtime ceiling,
+#              192K OOMs (compute-pp buffer). 160K is the safe default (~1GB margin); set
+#              CTX_SIZE=180224 for the tight 176K. This beats qwopus-coder's 160K ceiling exactly
+#              as predicted (n_max=1 frees draft VRAM vs its n_max=3). Card itself ran q4_0 KV @ 64K
+#              (CTX_SIZE=65536 = card-conservative fallback). Native max 262144 (MTP off — see "Big-context").
+#   Genesis:   N/A — beellama is a llama.cpp-family engine; Genesis is vLLM/Qwen3-Next-specific
+#   Status:    🧪 EXPERIMENTAL — authored + boot-validated 2026-06-14 (single 3090, KVarN digest
+#              858e7c…). Engine-compat PASS: beellama LOADS the PR#22673-fused GGUF (MTP head
+#              registers, "speculative decoding context initialized") — the card's "mainline
+#              fails to load" does NOT apply to beellama. Basic gen + tool-call clean; reasoning
+#              genuinely on (reasoning_content populated). MTP acceptance ~94% @ n=1 (card 81-84%).
+#              Measured single-card kvarn4+MTP ceilings: 160K @ 23.49GB (1.09GB free, default),
+#              176K @ 23.93GB (0.65GB free, RUNTIME CEILING), 192K OOMs (compute-pp buffer).
+#              FULLY VALIDATED 2026-06-14 (rebench-full, reasoning-on): bench 46.8/50.5 TPS, verify-
+#              stress 8/8 (NIAH clean to 150K), soak PASS (0 growth, 0/100 silent-empty, 100.5%
+#              retention, p50 49.54 TPS). Stays 🧪 ONLY because beellama v0.3.2 is a rolling pre-
+#              release (#455 gate), not for any quality reason. n_max=1 default (n=2 = +12% opt-in).
+#   Quality:   8-pack /150 reasoning-ON: 110/150 (73%) — beats qwopus-coder 103/150. Per-pack:
+#              toolcall 14 · instructfollow 15 · structoutput 14 · dataextract 10 · reasonmath 13 ·
+#              bugfind 12 · hermes 13 · cli 19 (rebench-full --with-8pack-thinking=on, kvarn4/kvarn4,
+#              n=1, 2026-06-14). Edge vs qwopus is agentic/instruct (hermes 13 vs 10, instructfollow
+#              15, reasonmath 13). dataextract 10 = Qwen-family number-format floor (string-vs-number,
+#              same as qwopus), not a KV artifact.
+#   Caveats:   (1) MTP n_max=1 is the card-faithful default — the author warns n=3 is "wrong by a
+#              wide margin" (mtp_num_hidden_layers=1) and reports n=2 CRASHED on his 2×3090.
+#              n_max FINDING (2026-06-14, our single-card kvarn4): n=2 does NOT crash here and is
+#              ~12% FASTER (55.6 vs 49.6 TPS) — spec-dec is lossless so the lower acceptance
+#              (82% vs 90%) costs speed only, NOT quality. n=2 is a measured opt-in (DRAFT_N_MAX=2)
+#              pending a soak; n=1 stays default until n=2 stability is confirmed. n≥3 not worth it.
+#              (2) Default ctx 160K is MEASURED safe (1GB free); 176K is the measured ceiling
+#              (CTX_SIZE=180224, 0.65GB free); 192K OOMs. Card-conservative fallback CTX_SIZE=65536.
+#              230K+ needs MTP off (see "Big-context").
+#              (3) Needs the KVarN build (v0.3.2 preview, digest-pinned). The older -317c65 tag
+#              has no kvarn* cache types; engines/beellama-local.yml install.spec carries the
+#              right digest (sha256:858e7c…).
+#              (4) beellama v0.3.2 is a rolling PRE-RELEASE, not a tagged stable — same upstream
+#              gate as the other beellama composes (Anbeeld #39/#48; un-park on a stable tag, #455).
+#   Best for:  single-card agentic reasoning + tool-use (reasoning ON by default) over a large
+#              KVarN-compressed window with embedded-MTP spec-dec. ⭐ Carnice's niche. Flip
+#              REASONING=off for fast no-think interactive use.
+# ---------------------------------------------------------------------------
+# Carnice-V2-27B on beellama.cpp v0.3.2-preview — SINGLE 3090, Q5_K_M + MTP (embedded
+# head), kvarn4/kvarn4 KV. Weights: stuchapin/Carnice-V2-27B-MTP-GGUF (Q5_K_M-mtp, ~19 GB).
+#
+# WHY n_max=1 (the one config that surprises people): the model card states the embedded
+# head is mtp_num_hidden_layers=1 and that the common --spec-draft-n-max 3 recommendation is
+# "wrong by a wide margin" here — each extra draft step compounds error off a single-layer
+# head, tanking acceptance. n_max=1 is the author's tested value (acceptance 81-84%). This
+# differs from the sibling qwopus-coder compose (n_max=3) — different MTP head depth.
+#
+# MTP (embedded) vs DFlash (external draft): the MTP head is baked into the -m GGUF, so there
+# is NO --spec-draft-model here; `--spec-type draft-mtp` activates the embedded head and
+# `--spec-draft-n-max` sets draft depth.
+#
+# beellama is a llama.cpp fork; server target ENTRYPOINT is /app/llama-server, so `command:`
+# below is just the server flags (same shape as ik-llama / llama-cpp / qwopus-coder composes).
+#
+# Quick start:
+#   1. Pull the KVarN image (Anbeeld official sm_86/89 = 3090/4090):
+#        docker pull ghcr.io/anbeeld/beellama.cpp@sha256:858e7cfbfb0d5d3d605723a82ace1474698de368b81bc310f4df4dadc6c1b7d2
+#   2. Get the GGUF (Q5_K_M, embedded MTP head):
+#        hf download stuchapin/Carnice-V2-27B-MTP-GGUF Carnice-V2-27B-Q5_K_M-mtp.gguf \
+#          --local-dir "$MODEL_DIR/carnice-v2-27b-gguf/stuchapin-q5km"
+#   3. From this directory:
+#        MODEL_DIR=/your/models/dir docker compose -f mtp-kvarn4.yml up -d
+#   4. curl http://localhost:8068/v1/models  → should list the model.
+#
+# Override defaults via .env or shell:
+#   MODEL_DIR             host dir mounted as /models (default: ../../../../../../models-cache)
+#   GGUF_FILE            MTP target GGUF under /models
+#                        (default: carnice-v2-27b-gguf/stuchapin-q5km/Carnice-V2-27B-Q5_K_M-mtp.gguf)
+#   CTX_SIZE             KV pool size                (default: 163840 / 160K — expected kvarn4+MTP ceiling, qwopus analog; 65536 = card-conservative fallback)
+#   DRAFT_N_MAX          --spec-draft-n-max          (default: 1 — model-mandated; do NOT raise blindly)
+#   BATCH_SIZE           llama.cpp -b                (default: 2048)
+#   UBATCH_SIZE          llama.cpp -ub               (default: 512 — qwopus 160K-safe; card uses 1024 @ 64K)
+#   KV_TYPE_K / KV_TYPE_V K / V cache quant          (default: kvarn4 / kvarn4 — q5-class, leaner)
+#   NP                   parallel slots              (default: 1 — single-slot on one card)
+#   REASONING            thinking gate               (default: ON — per model card; set 'off' for fast no-think)
+#   REASONING_FORMAT     thought-tag extraction      (default: deepseek — thoughts → message.reasoning_content)
+#   REASONING_BUDGET     thinking-token cap          (default: 4096 — card value; -1 unrestricted, 0 immediate end)
+#   TEMP TOP_K TOP_P MIN_P  sampling                 (defaults: 0.6 / 20 / 0.95 / 0.0 — author card)
+#   PORT                 host port                   (default: 8068)
+#   CUDA_VISIBLE_DEVICES which GPU to use            (default: 0)
+#
+# Thinking: we ship --reasoning ON by default (Carnice-V2 is a reasoning/agentic SFT; the card's
+# example invocation runs reasoning on). Set REASONING=off for a fast no-think pass. The card's
+# `--reasoning-format deepseek --reasoning-budget 4096` are BAKED IN — verified accepted on this
+# beellama tag (2026-06-14 `--help`): deepseek puts thoughts in message.reasoning_content, and
+# the 4096-token budget caps runaway thinking. The cap matters: at max_tokens=400 the model spent
+# ALL 400 on reasoning with zero visible answer (validation step 2) — the qwopus-v2 over-think
+# class. beellama also exposes --reasoning-loop-guard (off by default) if loops appear.
+#
+# Big-context mode (~230K-262K, MTP OFF): MTP costs VRAM that caps the MTP-on window. For a
+# bigger window drop MTP and raise ctx (kvarn4 fits the full 262K no-MTP on one 24 GB card per
+# engines/beellama-local.yml). Run plain instead of this compose:
+#   docker run --rm --gpus '"device=0"' -p 8068:8080 -v $MODEL_DIR:/models:ro \
+#     ghcr.io/anbeeld/beellama.cpp@sha256:858e7cfbfb0d5d3d605723a82ace1474698de368b81bc310f4df4dadc6c1b7d2 \
+#     --host 0.0.0.0 --port 8080 \
+#     -m /models/carnice-v2-27b-gguf/stuchapin-q5km/Carnice-V2-27B-Q5_K_M-mtp.gguf \
+#     -ngl all --ctx-size 262144 -np 1 --kv-unified --flash-attn on --no-context-shift \
+#     --cache-type-k kvarn4 --cache-type-v kvarn4 --jinja --reasoning off
+services:
+  beellama-carnice-v2:
+    # Fallback for direct `docker compose up` MUST be a KVarN build (the v0.3.0 multiarch
+    # image other beellama composes fall back to has no kvarn* cache types). Launchers
+    # inject BEELLAMA_IMAGE from engines/beellama-local.yml install.spec (same digest).
+    image: ${BEELLAMA_IMAGE:-ghcr.io/anbeeld/beellama.cpp@sha256:858e7cfbfb0d5d3d605723a82ace1474698de368b81bc310f4df4dadc6c1b7d2}
+    container_name: "${ESTATE_CONTAINER:-beellama-carnice-v2}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8068}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+    # server target ENTRYPOINT is /app/llama-server — args only below.
+    # -np 1 is intentional on a single 24 GB card (extra slots divide a compute-bound GPU).
+    # --no-context-shift: author-recommended — errors instead of silently shifting when the
+    # window fills (context-shift can corrupt MTP draft alignment at long ctx).
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      -m /models/${GGUF_FILE:-carnice-v2-27b-gguf/stuchapin-q5km/Carnice-V2-27B-Q5_K_M-mtp.gguf}
+      --spec-type draft-mtp
+      --spec-draft-n-max ${DRAFT_N_MAX:-1}
+      -ngl all
+      --ctx-size ${CTX_SIZE:-163840}
+      -b ${BATCH_SIZE:-2048}
+      -ub ${UBATCH_SIZE:-512}
+      -np ${NP:-1}
+      --kv-unified
+      --no-context-shift
+      --cache-type-k ${KV_TYPE_K:-kvarn4}
+      --cache-type-v ${KV_TYPE_V:-kvarn4}
+      --flash-attn on
+      --cache-ram 0
+      --no-host
+      --jinja
+      --reasoning ${REASONING:-on}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --reasoning-budget ${REASONING_BUDGET:-4096}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-k ${TOP_K:-20}
+      --top-p ${TOP_P:-0.95}
+      --min-p ${MIN_P:-0.0}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}"]
+              capabilities: [gpu]

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -315,6 +315,20 @@ COMPOSE_REGISTRY = {
         status_note="Qwopus3.6-27B-Coder (Jackrong) Q5_K_M GGUF + EMBEDDED MTP head (--spec-type draft-mtp) + KVarN-4 KV, single 3090. Launch with --force (experimental). REQUIRES the KVarN engine build (beellama v0.3.2 PREVIEW, digest-pinned) — the v0.3.0/earlier images reject --cache-type-k kvarn4. 2026-06-12 on sm_86: embedded MTP head loads, verify-full all-pass, NIAH needle @72K (= q5_0/q4_1 control), bench ~46/58 TPS narr/code (≈ q5_0/q4_1 — KVarN decode-neutral), 8-pack quality 104/103 think-off/on ≈ q5_0/q4_1 102/107 (quality-neutral; disc #329). Ships 160K (MTP-on ceiling; 230K via the no-MTP env opt-in in the compose). Launcher path (switch.sh --force) + soak-continuous PASS (0-growth, 0/25 silent-empty, 100% retention). beellama v0.3.2 is a rolling PRE-RELEASE → stays experimental (un-park on a stable Anbeeld tag; full verify-stress NIAH ladder pending for ⚠️ promotion).",
     ),
 
+    # Carnice-V2-27B (stuchapin — Hermes-style agentic SFT of Qwen3.6-27B) — single 3090,
+    # Q5_K_M GGUF + embedded MTP head + KVarN-4 KV. Sibling of beellama/qwopus-coder; the
+    # embedded head is mtp_num_hidden_layers=1 so DRAFT_N_MAX=1 (author warns n=3 is wrong).
+    "beellama/carnice-v2-single-q5km-mtp": _entry(
+        model="qwen3.6-27b", weights_variant="carnice-v2-q5km", workload="fast-chat",
+        engine="beellama-local", drafter="carnice-mtp-gguf", kv_format="kvarn4",
+        tp=1, max_ctx=163840, max_num_seqs=1, mem_util=None,
+        compose_path="models/qwen3.6-27b/beellama/compose/single/carnice-v2-q5km/mtp-kvarn4.yml",
+        default_port=8068,
+        kvcalc_key="SKIP",
+        status="experimental",
+        status_note="Carnice-V2-27B (stuchapin — kai-os/Carnice-V2-27b, Hermes-style agentic SFT of Qwen3.6-27B) Q5_K_M GGUF + EMBEDDED MTP head (--spec-type draft-mtp, n=1) + KVarN-4 KV, single 3090. Launch with --force (experimental). REQUIRES the KVarN engine build (beellama v0.3.2 PREVIEW, digest-pinned) — v0.3.0/earlier reject --cache-type-k kvarn4. FULLY VALIDATED 2026-06-14 (rebench-full, reasoning-on): engine-compat PASS (beellama LOADS the PR#22673-fused GGUF — the card's 'mainline fails to load' does NOT apply), verify-full all-pass, verify-stress 8/8 (NIAH clean to 150K), soak PASS (0-growth, 0/100 silent-empty, 100.5% retention, p50 49.5 TPS), bench 46.8/50.5 TPS narr/code, MTP accept ~94%. 8-pack reasoning-on 110/150 — BEATS sibling beellama/qwopus-coder 103/150 (edge is agentic/instruct: hermes 13 vs 10, instructfollow 15, reasonmath 13; dataextract 10 = Qwen-family number-format floor). Ships 160K (MTP-on default; 176K measured ceiling, 192K OOMs; 230K via the no-MTP env opt-in). n=1 default; n=2 is a +12%-TPS opt-in (DRAFT_N_MAX=2, doesn't crash on our single-card kvarn4 unlike the author's 2×3090) pending a dedicated soak. beellama v0.3.2 is a rolling PRE-RELEASE → stays experimental (un-park on a stable Anbeeld tag, #455).",
+    ),
+
     # Qwen3.6-27B PRISM-PRO-DQ (Ex0bit dynamic-quant GGUF) — community-experimental, ik-llama.
     "ik-llama/prism-pro-dq-mtp": _entry(
         model="qwen3.6-27b", weights_variant="ex0bit-prism-pro-dq", workload="fast-chat",

--- a/scripts/lib/profiles/drafters/carnice-mtp-gguf.yml
+++ b/scripts/lib/profiles/drafters/carnice-mtp-gguf.yml
@@ -1,0 +1,23 @@
+schema_version: 1
+id: carnice-mtp-gguf
+display_name: Carnice-V2-27B embedded MTP GGUF (stuchapin)
+spec_method: mtp_gguf
+model_compat:
+  - qwen3.6-27b
+engine_compat:
+  engine_type: llama.cpp
+n_default: 1
+n_max: 1
+download:
+  hf_repo: stuchapin/Carnice-V2-27B-MTP-GGUF
+  size_gb: variable
+vram_footprint_gb: variable
+status: experimental
+# Embedded MTP head — baked into the model GGUF (Carnice-V2-27B-Q5_K_M-mtp.gguf), activated
+# via beellama `--spec-type draft-mtp` (no separate draft download — the download.hf_repo is
+# the same file as the model weights). UNLIKE the qwopus/unsloth siblings, this head is
+# mtp_num_hidden_layers=1 → n_default/n_max=1: the author warns n=3 is "wrong by a wide
+# margin" (errors cascade off a single-layer head) and reports n=2 CRASHED on his 2×3090.
+# On club-3090's single-card kvarn4 n=2 does NOT crash and is ~12% faster (lossless), but
+# n=1 stays the shipped default (DRAFT_N_MAX=2 is the documented opt-in). Sibling of
+# qwopus-mtp-gguf / unsloth-mtp-gguf. llama.cpp-family (beellama) only — no vLLM form.

--- a/scripts/lib/profiles/models/qwen3.6-27b.yml
+++ b/scripts/lib/profiles/models/qwen3.6-27b.yml
@@ -178,6 +178,19 @@ weights:
     kind: gguf
     verify_glob: "*.gguf"
     manual_note: "Jackrong coder fine-tune of Qwen3.6-27B — Q5_K_M GGUF with EMBEDDED MTP head (beellama --spec-type draft-mtp; no separate draft download). Drives beellama/qwopus-coder (single 3090, kvarn4 KV @ 160K + MTP; 230K no-MTP opt-in). disc #329."
+  carnice-v2-q5km:
+    path: carnice-v2-27b-gguf/stuchapin-q5km
+    local_subdir: carnice-v2-27b-gguf/stuchapin-q5km
+    size_gb: 18.7
+    format: gguf
+    status: experimental
+    hf_repo: stuchapin/Carnice-V2-27B-MTP-GGUF
+    files:
+      - Carnice-V2-27B-Q5_K_M-mtp.gguf
+    engine: beellama
+    kind: gguf
+    verify_glob: "*.gguf"
+    manual_note: "stuchapin Carnice-V2-27B (kai-os/Carnice-V2-27b — Hermes-style agentic SFT of Qwen3.6-27B) — Q5_K_M GGUF with EMBEDDED MTP head (beellama --spec-type draft-mtp; no separate draft download). mtp_num_hidden_layers=1 → DRAFT_N_MAX=1 (author: n=3 'wrong by a wide margin'). Drives beellama/carnice-v2-single-q5km-mtp (single 3090, kvarn4 KV @ 160K + MTP; 176K ceiling). 8-pack reasoning-on 110/150 (beats qwopus-coder 103). 2026-06-14."
   beellama-q8kxl-dflash:
     path: qwen3.6-27b-gguf/unsloth-mtp-q8kxl
     local_subdir: qwen3.6-27b-gguf/unsloth-mtp-q8kxl

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -281,8 +281,19 @@ elif [[ "${WEIGHTS}" == "qwopus-coder" ]]; then
       echo "ERROR: WEIGHTS=qwopus-coder is only wired for qwen3.6-27b." >&2
       exit 1 ;;
   esac
+elif [[ "${WEIGHTS}" == "carnice-v2" ]]; then
+  # Carnice-V2-27B Q5_K_M GGUF (embedded MTP head) for beellama/carnice-v2-single-q5km-mtp.
+  case "${MODEL_NAME}" in
+    qwen3.6-27b)
+      PRIMARY_WEIGHT_KEY="qwen3.6-27b:carnice-v2-q5km"
+      NEEDS_GENESIS=0
+      ;;
+    *)
+      echo "ERROR: WEIGHTS=carnice-v2 is only wired for qwen3.6-27b." >&2
+      exit 1 ;;
+  esac
 elif [[ "${WEIGHTS}" != "autoround" ]]; then
-  echo "ERROR: WEIGHTS='${WEIGHTS}' not recognized (use 'autoround', 'awq', 'fp8', 'qwopus-coder', 'gguf', or 'iq4ks')." >&2
+  echo "ERROR: WEIGHTS='${WEIGHTS}' not recognized (use 'autoround', 'awq', 'fp8', 'qwopus-coder', 'carnice-v2', 'gguf', or 'iq4ks')." >&2
   exit 1
 fi
 

--- a/scripts/tests/test-compose-registry-disk.sh
+++ b/scripts/tests/test-compose-registry-disk.sh
@@ -25,8 +25,8 @@ def check(cond, msg):
         print(f"FAIL: {msg}")
         failures.append(msg)
 
-check(len(COMPOSE_REGISTRY) == 46, f"registry has 46 entries (got {len(COMPOSE_REGISTRY)})")
-check(len(disk_paths) == 47, f"disk has 47 compose files (got {len(disk_paths)})")
+check(len(COMPOSE_REGISTRY) == 47, f"registry has 47 entries (got {len(COMPOSE_REGISTRY)})")
+check(len(disk_paths) == 48, f"disk has 48 compose files (got {len(disk_paths)})")
 check(registry_paths <= disk_paths, "all registry compose_path values exist on disk")
 parked_disk_only = disk_paths - registry_paths
 # Disk-only (non-registry) composes allowed: parked SGLang archives, plus the experimental

--- a/scripts/tests/test-profiles-compat.sh
+++ b/scripts/tests/test-profiles-compat.sh
@@ -27,7 +27,7 @@ assert len(p.hardware) == 9
 assert len(p.models) == 7
 assert len(p.workloads) == 5
 assert len(p.engines) == 12
-assert len(p.drafters) == 10
+assert len(p.drafters) == 11
 assert len(p.calibration) == 5
 PY
 


### PR DESCRIPTION
## Summary

Adds **Carnice-V2-27B** as a single-3090 beellama compose — `beellama/carnice-v2-single-q5km-mtp`. stuchapin's Q5_K_M GGUF (kai-os/Carnice-V2-27b, a Hermes-style agentic SFT of Qwen3.6-27B) with an **embedded MTP head**, served on beellama v0.3.2-preview with **KVarN-4** KV.

Sibling of `beellama/qwopus-coder`; this is the *agentic-reasoning* single-card slot (reasoning-on by default).

## Config

| | |
|---|---|
| Quant / KV | Q5_K_M + embedded MTP head · kvarn4/kvarn4 |
| Drafter | MTP `--spec-type draft-mtp`, **n=1** (head is `mtp_num_hidden_layers=1`; author warns n=3 is wrong) |
| Sampling | temp 0.6 · top-p 0.95 · top-k 20 · min-p 0.0 · `--reasoning on` + deepseek format + 4096 budget |
| Max ctx | 160K default · 176K measured ceiling (192K OOMs) |
| Port | 8068 |
| Status | 🧪 Experimental (beellama v0.3.2 is a rolling pre-release — #455 gate; **not** a quality cap) |

## Validation (rebench-full, reasoning-on, single 3090)

- **Engine-compat PASS** — beellama loads the PR-22673-fused GGUF (MTP head registers). The model card's "mainline llama.cpp fails to load these" does **not** apply to beellama.
- **bench** 46.8 / 50.5 TPS (narrative / code), MTP acceptance ~94%
- **verify-stress 8/8** — NIAH clean to 150K (through Cliff-2 territory)
- **soak PASS** — 0 MiB growth, 0 errors, 0/100 silent-empty, 100.5% retention
- **8-pack reasoning-on: 110/150** — beats sibling `beellama/qwopus-coder` (103/150). Edge is agentic/instruct: HermesAgent 13 (vs 10), InstructFollow 15, ReasonMath 13. (DataExtract 10 is the Qwen-family number-format floor, same as qwopus — not a KV artifact.)

## n=2 note

The card reports n=2 **crashed** on the author's 2×3090. On our single-card kvarn4 it does **not** crash and is **~12% faster** (55.6 vs 49.6 TPS) — spec-dec is lossless, so the lower acceptance costs speed only, not quality. Shipped as a documented opt-in (`DRAFT_N_MAX=2`); n=1 stays the default pending a dedicated soak.

## Tests

Full `scripts/tests/*.sh` suite green (45/45) in a clean tree. Count assertions bumped: registry 47, disk 48, drafters 11.
