### PR TITLE
feat(weights): optional revision: pin in weights-fetch schema (#319)

### DIFF
--- a/docs/ADDING_MODELS.md
+++ b/docs/ADDING_MODELS.md
@@ -195,6 +195,10 @@ weights:
     format: autoround                      # autoround | awq | gguf | …
     status: production                     # production | experimental | community-experimental
     hf_repo: <Org/Repo>
+    revision: <sha-or-tag>                 # OPTIONAL (#319): pin the fetch to an exact
+                                           #   commit/tag. Unset = track HEAD (default).
+                                           #   Set it to reproduce the bytes a BENCHMARKS
+                                           #   row was measured against (guards re-quants).
     files: ["*.safetensors"]               # or explicit GGUF filenames
     engine: vllm                           # vllm | ik-llama | llama-cpp | beellama (filesystem dir name)
     kind: main                             # main | draft | mmproj | gguf

--- a/scripts/lib/profiles/weights.py
+++ b/scripts/lib/profiles/weights.py
@@ -118,6 +118,7 @@ def _recipe(model_id: str, variant: str) -> dict[str, str]:
         "WEIGHT_ENGINE": str(meta.get("engine") or ""),
         "WEIGHT_KIND": str(meta.get("kind") or ""),
         "WEIGHT_REPO": str(meta.get("hf_repo") or ""),
+        "WEIGHT_REVISION": str(meta.get("revision") or ""),
         "WEIGHT_SUBDIR": str(meta.get("local_subdir") or meta.get("path") or ""),
         "WEIGHT_FILES": " ".join(str(f) for f in files),
         "WEIGHT_VERIFY_GLOB": str(meta.get("verify_glob") or "*.safetensors"),

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -708,12 +708,16 @@ _preflight_weight_recipe_for_key() {
 _preflight_weight_hf_command() {
   local model_dir_expr="${1:-\$MODEL_DIR}"
   [[ -n "${WEIGHT_REPO:-}" ]] || return 1
+  # Mirror an optional revision pin (#319) so the manual fallback fetches the
+  # same bytes setup.sh would. Unset -> no flag (track HEAD).
+  local rev=""
+  [[ -n "${WEIGHT_REVISION:-}" ]] && rev=" --revision ${WEIGHT_REVISION}"
   if [[ -n "${WEIGHT_FILES:-}" ]]; then
-    printf 'hf download %s %s --local-dir %s/%s' \
-      "$WEIGHT_REPO" "$WEIGHT_FILES" "$model_dir_expr" "$WEIGHT_SUBDIR"
+    printf 'hf download %s %s%s --local-dir %s/%s' \
+      "$WEIGHT_REPO" "$WEIGHT_FILES" "$rev" "$model_dir_expr" "$WEIGHT_SUBDIR"
   else
-    printf 'hf download %s --local-dir %s/%s' \
-      "$WEIGHT_REPO" "$model_dir_expr" "$WEIGHT_SUBDIR"
+    printf 'hf download %s%s --local-dir %s/%s' \
+      "$WEIGHT_REPO" "$rev" "$model_dir_expr" "$WEIGHT_SUBDIR"
   fi
 }
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -94,6 +94,7 @@ load_weight_recipe() {
     exit 1
   fi
   MODEL_REPO="${WEIGHT_REPO}"
+  MODEL_REVISION="${WEIGHT_REVISION:-}"
   MODEL_SUBDIR="${WEIGHT_SUBDIR}"
   GGUF_FILES="${WEIGHT_FILES}"
   VERIFY_GLOB="${WEIGHT_VERIFY_GLOB:-*.safetensors}"
@@ -524,16 +525,20 @@ _hf_download_repo() {
   local repo="$1"
   local subdir="$2"
   local files="${3:-}"
+  local revision="${4:-}"
+  # Optional commit-SHA / tag pin (#319). Empty -> track HEAD (today's behavior).
+  local rev_args=()
+  [[ -n "$revision" ]] && rev_args=(--revision "$revision")
   mkdir -p "${MODEL_DIR}/${subdir}"
   if command -v hf >/dev/null 2>&1; then
     echo "[model]   Using 'hf download' (hf_transfer if available) ..."
     # files is intentionally word-split: empty -> whole repo; non-empty -> selected files.
     HF_HUB_ENABLE_HF_TRANSFER=1 HF_HUB_DISABLE_XET=1 \
-      hf download "$repo" ${files} --local-dir "${MODEL_DIR}/${subdir}"
+      hf download "$repo" ${files} "${rev_args[@]}" --local-dir "${MODEL_DIR}/${subdir}"
   elif command -v huggingface-cli >/dev/null 2>&1; then
     echo "[model]   Using 'huggingface-cli download' ..."
     HF_HUB_ENABLE_HF_TRANSFER=1 HF_HUB_DISABLE_XET=1 \
-      huggingface-cli download "$repo" ${files} --local-dir "${MODEL_DIR}/${subdir}"
+      huggingface-cli download "$repo" ${files} "${rev_args[@]}" --local-dir "${MODEL_DIR}/${subdir}"
   else
     echo "ERROR: neither 'hf' nor 'huggingface-cli' found. Install with:" >&2
     echo "  pip install 'huggingface-hub[hf_transfer]'" >&2
@@ -547,14 +552,17 @@ _verify_downloaded_files() {
   local repo="$1"
   local subdir="$2"
   local verify_glob="$3"
+  # Pin the etag lookup to the same revision we downloaded (#319). Empty -> main
+  # HEAD; a stale pin would otherwise etag-check against a newer HEAD and FAIL.
+  local revision="${4:-main}"
   local fail=0 count=0 f expected actual
 
-  echo "[verify]  Checking SHA256 of every ${verify_glob} against HF x-linked-etag ..."
+  echo "[verify]  Checking SHA256 of every ${verify_glob} against HF x-linked-etag (rev: ${revision}) ..."
   cd "${MODEL_DIR}/${subdir}"
   for f in ${verify_glob}; do
     [[ -f "$f" ]] || continue
     count=$((count + 1))
-    expected="$(curl -sfI "https://huggingface.co/${repo}/resolve/main/$f" \
+    expected="$(curl -sfI "https://huggingface.co/${repo}/resolve/${revision}/$f" \
       | grep -i '^x-linked-etag:' | tr -d '"\r' | awk '{print $NF}' || true)"
     actual="$(sha256sum "$f" | awk '{print $1}')"
     if [[ -z "$expected" ]]; then
@@ -584,13 +592,13 @@ download_weight_key() {
   local key="$1"
   load_weight_recipe "$key"
   echo "[model]   Downloading ${WEIGHT_LABEL:-$key} ..."
-  _hf_download_repo "$WEIGHT_REPO" "$WEIGHT_SUBDIR" "$WEIGHT_FILES"
-  _verify_downloaded_files "$WEIGHT_REPO" "$WEIGHT_SUBDIR" "$WEIGHT_VERIFY_GLOB"
+  _hf_download_repo "$WEIGHT_REPO" "$WEIGHT_SUBDIR" "$WEIGHT_FILES" "${WEIGHT_REVISION:-}"
+  _verify_downloaded_files "$WEIGHT_REPO" "$WEIGHT_SUBDIR" "$WEIGHT_VERIFY_GLOB" "${WEIGHT_REVISION:-main}"
 }
 
 VERIFY_GLOB="${VERIFY_GLOB_OVERRIDE:-*.safetensors}"
-_hf_download_repo "${MODEL_REPO}" "${MODEL_SUBDIR}" "${GGUF_FILES}"
-_verify_downloaded_files "${MODEL_REPO}" "${MODEL_SUBDIR}" "${VERIFY_GLOB}"
+_hf_download_repo "${MODEL_REPO}" "${MODEL_SUBDIR}" "${GGUF_FILES}" "${MODEL_REVISION:-}"
+_verify_downloaded_files "${MODEL_REPO}" "${MODEL_SUBDIR}" "${VERIFY_GLOB}" "${MODEL_REVISION:-main}"
 
 for extra_key in "${EXTRA_WEIGHT_KEYS[@]}"; do
   download_weight_key "$extra_key"

--- a/scripts/tests/test-weights-revision.sh
+++ b/scripts/tests/test-weights-revision.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# #319: weights-fetch schema should support an optional `revision:` pin
+# (commit SHA / tag) per weights variant, round-tripping through weights.py as
+# WEIGHT_REVISION. Unset must stay empty (track HEAD = today's behavior).
+#
+# In-process: imports weights.py and points PROFILE_ROOT at a throwaway fixture
+# tree, so no real model entry is touched and the tracked models/ dir is never
+# written to.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+python3 - "$ROOT_DIR" <<'PY'
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+
+root = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location(
+    "weights", root / "scripts" / "lib" / "profiles" / "weights.py"
+)
+weights = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(weights)
+
+FIXTURE = """\
+schema_version: 1
+id: revfixture
+display_name: Revision Fixture
+weights:
+  pinned:
+    local_subdir: revfixture-pinned
+    hf_repo: example/Repo
+    revision: 65f69c7abc1234
+    engine: vllm
+    kind: main
+  floating:
+    local_subdir: revfixture-floating
+    hf_repo: example/Repo
+    engine: vllm
+    kind: main
+"""
+
+failures = []
+with tempfile.TemporaryDirectory() as tmp:
+    models = Path(tmp) / "models"
+    models.mkdir()
+    (models / "revfixture.yml").write_text(FIXTURE, encoding="utf-8")
+    weights.PROFILE_ROOT = Path(tmp)
+
+    pinned = weights._recipe("revfixture", "pinned")
+    if pinned.get("WEIGHT_REVISION") != "65f69c7abc1234":
+        failures.append(
+            f"pinned: WEIGHT_REVISION got {pinned.get('WEIGHT_REVISION')!r} "
+            f"expected '65f69c7abc1234'"
+        )
+
+    floating = weights._recipe("revfixture", "floating")
+    if floating.get("WEIGHT_REVISION") != "":
+        failures.append(
+            f"floating: WEIGHT_REVISION got {floating.get('WEIGHT_REVISION')!r} "
+            f"expected '' (unset = track HEAD)"
+        )
+
+if failures:
+    print("ASSERTION FAILED:", file=sys.stderr)
+    for f in failures:
+        print(f"  {f}", file=sys.stderr)
+    sys.exit(1)
+
+print("OK: weights.py round-trips optional revision: as WEIGHT_REVISION")
+PY


### PR DESCRIPTION
## summary

adds an optional `revision:` key per weights variant so a fetch can be pinned to an exact commit or tag, the same way we already pin engine images. unset keeps today's behavior (track HEAD), so nothing changes for any current entry.

the chain:
- `weights.py` emits `WEIGHT_REVISION` from the variant's optional `revision:` (empty when unset)
- `setup.sh` `_hf_download_repo` adds `--revision <sha>` only when one is set
- `setup.sh` `_verify_downloaded_files` pins the post-download sha-verify etag lookup to that same revision. without this, a pin to an older commit would etag-check against current HEAD and false-fail
- `preflight.sh` manual-fetch hint mirrors the flag so the copy-paste fallback grabs the same bytes
- `docs/ADDING_MODELS.md` documents the field
- new guard `scripts/tests/test-weights-revision.sh` asserts the round-trip (set -> `WEIGHT_REVISION`, unset -> empty)

## what problem this solves

#316: upstream quant repos re-quant silently. `Intel/Qwen3.6-35B-A3B-int4-mixed-AutoRound` was renamed and re-quantized after we benched it, so a fresh `setup.sh` pulls different bytes than our published numbers were measured against. engine images already have a pin lever, weights had none. this adds it.

## measured impact

no perf impact, it's a fetch-schema lever. the impact is reproducibility: a pinned variant fetches exact bytes, and the sha-verify checks against that same revision instead of HEAD.

## compared against

current behavior (no pin). confirmed at HEAD that `weights.py` emitted no `WEIGHT_REVISION` and the fetch path passed no `--revision`. on this branch, unset behaves identically (no flag, `/resolve/main/`); set adds `--revision` and switches verify to `/resolve/<sha>/`.

## trade-off

none for existing configs. the field is optional and no entry sets it in this PR.

## verification

this doesn't change what the server does, only what `setup.sh` downloads, and only when a `revision:` is present (none are yet), so it isn't a verify-full change. checked three ways:

- round-trip: the new guard passes; real entries emit empty (not absent); sha and tag values pass through verbatim
- no regression: full `scripts/tests/*.sh` sweep green except the pre-existing `test-submit-bench` fixture failure, which fails identically on master and touches none of these files
- command construction: stubbed `hf` / `curl`, ran the real `_hf_download_repo` and `_verify_downloaded_files`. unset -> `hf download <repo> --local-dir ...` + `/resolve/main/`; pinned -> `hf download <repo> --revision <sha> ...` + `/resolve/<sha>/`. `bash -n` clean on both scripts.

## left to your side

mechanism only. i deliberately didn't pin any real entry: which variant to pin, and to which validated sha, is a per-entry rig call that's yours to make. the #316 qwen moe's good revision is gone from the repo history anyway, so that one can't be pinned retroactively. once #316 re-validation lands, wiring `revision: <sha>` into an entry is a one-line follow-up.

happy to also pick up the #320 sibling (the hf-repo-resolve guard) so the two halves of #316 land together.

refs #319, #316
