### PR TITLE
Pin hauhaucs-35ba3b-dual weights to morikomorizz commit 49a080d (#319)

### DIFF
--- a/scripts/lib/profiles/models/qwen3.6-35b-a3b.yml
+++ b/scripts/lib/profiles/models/qwen3.6-35b-a3b.yml
@@ -128,6 +128,10 @@ weights:
     format: gguf
     status: community-experimental
     hf_repo: morikomorizz/Qwen3.6-35B-A3B-Uncensored-HauhauCS-MTP
+    # Pin the exact commit our BENCHMARKS row + #411 were measured against (#319).
+    # Repo last-modified 2026-06-10 (predates our 2026-06-14 download); etag at this
+    # sha == our local file's sha256 (verified). Guards a silent upstream re-quant.
+    revision: 49a080db7406cd98f94f0f2a18539bbcc1520444
     files:
       - Qwen3.6-35B-A3B-Uncensored-HauhauCS-MTP-Q6_K_P.gguf
     engine: llama-cpp


### PR DESCRIPTION
First use of the `revision:` lever from #408 (which closed half of #316).

Pins the `morikomorizz-q6kp` weights variant to commit **`49a080db7406cd98f94f0f2a18539bbcc1520444`** — the exact bytes the [BENCHMARKS row](../blob/master/BENCHMARKS.md) and [Results Card #411](https://github.com/noonghunna/club-3090/discussions/411) were measured against, so a fresh `setup.sh` can never silently pull a re-quant.

### Verification
- **Repo `lastModified` = 2026-06-10**, which *predates* our 2026-06-14 download → HEAD at this sha is unambiguously the commit our file came from.
- **Byte-exact:** the HF `x-linked-etag` at the pinned sha equals our local file's `sha256` (`76a0d4c2…`). This also exercises #408's new verify-revision path (`/resolve/<sha>/`) on real 30 GB.
- `weights.py` round-trips `revision:` → `WEIGHT_REVISION`; full `scripts/tests/*.sh` sweep green.

One-line profile change; no behavior change for any other entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)