### PR TITLE
Add opt-in LMCache KV-offload compose (vllm/qwen-27b-dual-lmcache, 🐣 incubating)

### DIFF
--- a/models/qwen3.6-27b/INTERNALS.md
+++ b/models/qwen3.6-27b/INTERNALS.md
@@ -191,6 +191,35 @@ For Sandermage's documented numbers on his A5000 setup, see his [MODELS.md](http
 
 ---
 
+## LMCache KV-offload (opt-in, 🐣 incubating) — RAM & disk sizing
+
+`vllm/qwen-27b-dual-lmcache` (compose `vllm-lmcache/compose/dual/fp8/lmcache.yml`, club-3090 #133) layers an LMCache tiered persistent prefix-KV cache onto the dual-max fidelity profile (FP8 + int8-PTH KV + MTP n=3). It caches each session's prefix KV so long multi-turn / multi-session workloads reuse context instead of re-prefilling (cold→warm TTFT ~7–8×). **Zero decode penalty** — controlled A/B (toggle only the connector): 74 narr / 94 code TPS == without LMCache, MTP intact (~83% accept). The offload is async/overlapped.
+
+**KV size: ~18.9 KB/token (measured)** for int8-PTH on this model → a full 262K-token session ≈ **4.72 GB** of KV.
+
+### RAM (the L1 tier — `--l1-size-gb`, env `LMCACHE_L1_GB`)
+The L1 cache lives in CPU RAM (in shared memory; `shm_size` must be ≥ `l1-size-gb` or LMCache silently falls back to slow pickle).
+
+| `--l1-size-gb` | full 262K sessions | realistic 50K sessions | host RAM needed (l1 + ~28 GB vLLM+OS) |
+|--:|--:|--:|--:|
+| **30** (default) | ~6 | ~33 | ~58 GB |
+| 50 (max on 94 GB rig) | ~10 | ~55 | ~78 GB |
+| 100 | ~21 | ~110 | ~128 GB → **rejected** (> 94 GB → OOM) |
+
+⚠️ **Sizing is preflight-gated.** `scripts/preflight.sh::preflight_lmcache_ram` hard-fails launch if available RAM < `l1-size-gb` + 28 GB reserve — and it runs **even under `--force`** (incubating slugs launch with `--force`, but over-sizing the cache can OOM the host: a 100 GB cache on this 94 GB rig once forced a reboot, the incident that motivated this guard). Cap L1 at ~50 GB here; raise `shm_size` in the compose to match if you raise `LMCACHE_L1_GB`.
+
+### Disk (the optional L2 tier — `LMCACHE_L2_ADAPTER`, off by default)
+Set `LMCACHE_L2_ADAPTER` to a JSON adapter spec to spill evicted (older) sessions from RAM to disk instead of dropping them, and to **survive container restarts**:
+```
+LMCACHE_L2_ADAPTER='{"type":"nixl_store","backend":"POSIX","backend_params":{"file_path":"/mnt/ssd/lmcache-kv"}}'
+```
+Disk-sized (≈4.72 GB per full 262K session), so effectively unbounded; LRU auto-evicts within the configured cap. Point `file_path` at an SSD dir — **not `/tmp`** (tmpfs, wiped on reboot, competes for RAM). Rehydrating a 262K session from NVMe is ~1–2 s vs ~40 s to re-prefill. L2 spill/rehydrate latency is not yet measured on-rig (the open follow-up before promotion).
+
+### Why incubating, not production
+Runs LMCache's third-party image (`lmcache/vllm-openai`, **DIGEST-pinned** — the tag is mutable and bundles a newer vLLM 0.23.1-dev than our v0.22.0 pin); the L2 path is unmeasured on-rig; the 38 GB image is pulled on-demand. Promotion to ✅ wants LMCache installed into our own vLLM image. The earlier "LMCache halves decode" conclusion was an uncontrolled-measurement error, retracted — see [#133](https://github.com/noonghunna/club-3090/issues/133).
+
+---
+
 ## Upstream status
 
 | Issue | Status | Notes |

--- a/models/qwen3.6-27b/vllm-lmcache/compose/dual/fp8/lmcache.yml
+++ b/models/qwen3.6-27b/vllm-lmcache/compose/dual/fp8/lmcache.yml
@@ -1,0 +1,157 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-27B FP8 (official e4m3, embedded mtp head)
+#   Topology:  Dual 3090 (TP=2, PCIe — custom all-reduce disabled)
+#   Drafter:   MTP n=3 (built-in) — survives LMCache, acceptance ~83%
+#   KV:        int8_per_token_head (1 byte/token) + LMCache tiered prefix cache
+#                (GPU → L1 CPU RAM → optional L2 disk)
+#   Vision:    yes
+#   Max ctx:   262K (util 0.92 — KV pool ~279K tok, 1.07× — live-validated 2026-06-17)
+#   Genesis:   none
+#   Status:    🐣 Incubating
+#   Caveats:   OPT-IN KV-offload variant of vllm/qwen-27b-dual-max (#133). Three reasons it's
+#                incubating, not production: (1) runs LMCache's third-party image
+#                (lmcache/vllm-openai, DIGEST-pinned — the tag is mutable) bundling a NEWER vLLM
+#                (0.23.1-dev) than the stack's v0.22.0 pin; promotion to ✅ wants LMCache on our
+#                own image. (2) L2 disk tier (--l2-adapter) is wired but OFF by default + its
+#                spill/rehydrate latency is not yet measured on-rig. (3) 38 GB image pulled
+#                on-demand. RAM-gated: --l1-size-gb 30 needs ~58 GB free; preflight rejects
+#                over-allocation (the l1=100→reboot lesson). Hidden from `switch.sh --list`
+#                (see --list --all); `--force` to launch.
+#   Quality:   inherits dual-max fidelity (FP8 + int8-PTH + MTP); 8-pack not re-run (KV-cache
+#                layer, not a quant change). Decode 74 narr / 94 code TPS — ZERO penalty vs
+#                non-LMCache (controlled A/B 2026-06-17).
+#   Best for:  many concurrent long (50K–262K) sessions kept warm across turns/swaps — LMCache
+#                reuses cached prefix KV instead of re-prefilling (cold→warm TTFT ~7–8×) ⭐
+# ---------------------------------------------------------------------------
+# Dual RTX 3090 — Qwen3.6-27B "max accuracy + LMCache KV-offload" (vllm/qwen-27b-dual-lmcache).
+# Byte-identical serving fidelity to vllm/qwen-27b-dual-max (FP8 weights + int8-PTH KV + MTP n=3
+# @262K) with an LMCache tiered persistent prefix-KV cache bolted on. LMCache (MP/HMA connector,
+# new in 0.4.7) caches each session's prefix KV in CPU RAM (L1) and optionally on disk (L2), so
+# long multi-turn / multi-session workloads reuse context instead of re-prefilling it.
+#
+# Validated 2026-06-17 (club-3090 #133): boots + serves @262K, MTP active (~83% accept), and a
+# controlled A/B (toggle ONLY the connector) shows decode 74/94 TPS == without LMCache — the KV
+# offload is async/overlapped, ZERO decode penalty. (An earlier "halves decode" claim was an
+# uncontrolled-measurement error, retracted — see club-3090 #133.)
+#
+# LMCache boot recipe (the constraints that make the hybrid + connector load — each was a boot
+# assertion we hit and fixed):
+#   - LMCacheMPConnector (NOT the simple LMCacheConnectorV1, which crashes hybrids)
+#   - --mamba-cache-mode align  (mandatory for GDN; sets attention block = 1584 for int8-PTH KV)
+#   - --max-num-batched-tokens >= block (1584)   AND   lmcache --chunk-size a multiple of block
+#   - NO PYTORCH_CUDA_ALLOC_CONF=expandable_segments (INCOMPATIBLE with the MP connector)
+#   - shm_size >= --l1-size-gb (else SHM silently falls back to slow pickle)
+#
+# Capacity (int8-PTH ≈ 18.9 KB/token, measured → full 262K session ≈ 4.72 GB):
+#   --l1-size-gb 30 (default) → ~6 full 262K sessions, or ~33 realistic 50K sessions, in CPU RAM.
+#   Cap ~50 GB on a 94 GB rig (vLLM needs ~25 GB). Raising LMCACHE_L1_GB above ~34 also needs a
+#   bigger shm_size below. Add an L2 disk tier (LMCACHE_L2_ADAPTER) for unbounded + restart-survival.
+#
+# Run (direct docker — launchers inject VLLM_IMAGE from the engine profile):
+#   docker compose -f dual/fp8/lmcache.yml up -d
+#   # opt into disk L2:  LMCACHE_L2_ADAPTER='{"type":"nixl_store","backend":"POSIX","backend_params":{"file_path":"/mnt/ssd/lmcache-kv"}}' docker compose ...
+# ===========================================================================
+# Hardware metadata (parsed by scripts/preflight.sh):
+# Requires-min-vram-gb: 24
+# Engine-profile: vllm-lmcache
+# Requires-min-gpu-count: 2
+# Tensor-parallel: 2
+# LMCache-l1-gb: 30
+# Requires-min-ram-gb: 58
+services:
+  vllm-qwen36-27b-lmcache:
+    # Image resolved from the vllm-lmcache engine profile (install.spec, DIGEST-pinned —
+    # the lmcache tag is mutable). Launchers inject VLLM_IMAGE; this default mirrors it.
+    image: ${VLLM_IMAGE:-lmcache/vllm-openai@sha256:663f9b2f7528e34105c9b0428880b811616f9bc85133b6e2a577b2e7282be8de}
+    container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b-lmcache}"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
+    ports:
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8017}}:8000"
+    # Host-safety caps (defense-in-depth alongside preflight): the container cannot exceed
+    # mem_limit and cannot swap → it gets OOM-killed instead of choking the host (the l1=100
+    # incident). Raise these AND shm_size + LMCACHE_L1_GB together for a bigger cache.
+    mem_limit: ${CLUB3090_MEM_LIMIT:-70g}
+    memswap_limit: ${CLUB3090_MEM_LIMIT:-70g}
+    shm_size: "32gb"   # MUST be >= LMCACHE_L1_GB (default 30). Raise if you raise the cache.
+    volumes:
+      - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
+      # froggeric chat template is shared from the vllm engine dir (model-scoped) —
+      # one extra `../` vs dual-max because this compose lives under vllm-lmcache/.
+      - ../../../../vllm/patches/froggeric-chat-template/chat_template.jinja:/etc/qwen-froggeric-chat-template.jinja:ro
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
+      - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
+      - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}
+      - VLLM_WORKER_MULTIPROC_METHOD=spawn
+      - NCCL_CUMEM_ENABLE=0
+      - NCCL_P2P_DISABLE=1
+      - VLLM_NO_USAGE_STATS=1
+      - VLLM_USE_FLASHINFER_SAMPLER=1
+      - LMCACHE_DISABLE_BANNER=1
+      # NOTE: PYTORCH_CUDA_ALLOC_CONF=expandable_segments is intentionally OMITTED —
+      # it is incompatible with the LMCacheMPConnector (raises at engine config validation).
+    entrypoint:
+      - bash
+      - -c
+      - |
+        # LMCache MP server (L1 CPU-RAM cache; optional L2 disk via LMCACHE_L2_ADAPTER).
+        # chunk-size MUST be a multiple of vLLM's unified block (1584 for int8-PTH KV).
+        lmcache server \
+          --chunk-size "${LMCACHE_CHUNK_SIZE:-1584}" \
+          --l1-size-gb "${LMCACHE_L1_GB:-30}" \
+          --eviction-policy LRU \
+          ${LMCACHE_L2_ADAPTER:+--l2-adapter "${LMCACHE_L2_ADAPTER}"} &
+        sleep 6
+        exec vllm serve --disable-custom-all-reduce "$@"
+      - --
+    command:
+      - --model
+      - /root/.cache/huggingface/qwen3.6-27b-fp8
+      - --served-model-name
+      - qwen3.6-27b-fp8
+      - --quantization
+      - fp8
+      - --dtype
+      - bfloat16
+      - --tensor-parallel-size
+      - "${TP:-2}"
+      - --max-model-len
+      - "${MAX_MODEL_LEN:-262144}"
+      - --gpu-memory-utilization
+      - "${GPU_MEMORY_UTILIZATION:-0.92}"
+      - --max-num-seqs
+      - "${MAX_NUM_SEQS:-2}"
+      - --max-num-batched-tokens
+      - "${MAX_NUM_BATCHED_TOKENS:-1584}"
+      - --kv-cache-dtype
+      - "${KV_CACHE_DTYPE:-int8_per_token_head}"
+      - --mamba-cache-mode
+      - align
+      - --speculative-config
+      - '{"method":"mtp","num_speculative_tokens":3}'
+      - --enable-prefix-caching
+      - --kv-transfer-config
+      - '{"kv_connector":"LMCacheMPConnector","kv_role":"kv_both"}'
+      - --trust-remote-code
+      - --chat-template
+      - /etc/qwen-froggeric-chat-template.jinja
+      - --reasoning-parser
+      - qwen3
+      - --default-chat-template-kwargs
+      - '{"enable_thinking": false}'
+      - --enable-auto-tool-choice
+      - --tool-call-parser
+      - qwen3_coder
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8000"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -184,6 +184,16 @@ COMPOSE_REGISTRY = {
         status="experimental",
         status_note="Qwen3.6-27B 'max accuracy' tier, 2-card: official FP8 weights (e4m3, embedded MTP head) + int8-PTH KV + MTP n=3, TP=2 @262K. 🧪 Experimental — live-validated 2026-06-07 (boots + serves @262K, KV pool 295K tok / 1.13x concurrency via int8-PTH, MarlinFP8 W8A16 on Ampere, coherent + MTP active; ~56 TPS decode). 8-pack A/B (--full, same harness 2026-06-07): 110/150 vs fast 109 vs balanced 105 — a TIE (det 65/64/64; spread within noise). The 8-pack (short-ctx) does NOT separate the quants; FP8 + int8-PTH differentiate on KV fidelity, not behavioral quality — a long-ctx NIAH A/B (where int8-PTH should matter) is the open follow-up. Slowest of the three (~56 vs fast ~89 code) with the smallest KV pool (1.13x). Also the validation proxy for vllm/qwen-27b-multi-max (same config @ TP=4).",
     ),
+    "vllm/qwen-27b-dual-lmcache": _entry(
+        model="qwen3.6-27b", weights_variant="fp8", workload="long-ctx-single",
+        engine="vllm-lmcache", drafter="qwen-mtp-builtin", kv_format="int8_per_token_head",
+        tp=2, max_ctx=262144, max_num_seqs=2, mem_util=0.92,
+        compose_path="models/qwen3.6-27b/vllm-lmcache/compose/dual/fp8/lmcache.yml",
+        default_port=8017,
+        kvcalc_key="SKIP",
+        status="incubating",
+        status_note="Qwen3.6-27B 'max accuracy + LMCache KV-offload' tier, 2-card: byte-identical serving fidelity to vllm/qwen-27b-dual-max (FP8 weights + int8-PTH KV + MTP n=3 @262K, TP=2) PLUS an LMCache tiered persistent prefix-KV cache (MP/HMA connector, lmcache 0.4.7). 🐣 Incubating — OPT-IN, hidden from switch.sh --list (--force to launch). Live-validated 2026-06-17 (club-3090 #133): boots + serves @262K (util 0.92, KV pool 279K tok / 1.07x), MTP active (~83% accept), and a CONTROLLED A/B (toggle ONLY the connector, same image+config) shows decode 74 narr / 94 code TPS == WITHOUT LMCache → ZERO decode penalty (offload is async/overlapped; an earlier 'halves decode' claim was an uncontrolled-measurement error, retracted — see #133). LMCache caches each session's prefix KV in CPU RAM (L1, --l1-size-gb 30 default ≈ 6 full 262K or ~33 realistic 50K sessions @ 18.9 KB/token measured) + optional disk (L2, env-gated LMCACHE_L2_ADAPTER, off by default, survives restarts, unbounded). THREE reasons incubating not production: (1) runs LMCache's third-party image (lmcache/vllm-openai, DIGEST-pinned — the tag is MUTABLE, and it bundles a newer vLLM 0.23.1-dev than our v0.22.0 pin; ✅-promotion wants LMCache on our own image), (2) L2 spill/rehydrate latency not yet measured on-rig, (3) 38 GB image pulled on-demand. RAM-gated: preflight rejects --l1-size-gb over-allocation (the l1=100→reboot incident); needs ~58 GB free at l1=30, cap ~50 GB on a 94 GB rig; shm_size must track l1. Best for many concurrent long sessions kept warm (cold→warm TTFT ~7-8x) — efschu's high-context multi-session use case. Standard duals (vllm/dual, vllm/qwen-27b-dual-max) stay LMCache-free.",
+    ),
     "vllm/qwen-27b-dual-balanced": _entry(
         model="qwen3.6-27b", weights_variant="awq-bf16-int4", workload="long-ctx-single",
         engine="vllm-stable", drafter="qwen-mtp-builtin", kv_format="int8_per_token_head",

--- a/scripts/lib/profiles/engines/vllm-lmcache.yml
+++ b/scripts/lib/profiles/engines/vllm-lmcache.yml
@@ -1,0 +1,72 @@
+schema_version: 1
+id: vllm-lmcache
+display_name: vLLM + LMCache (KV offload, MP/HMA) — lmcache/vllm-openai pinned by digest
+type: vllm
+stability: experimental
+install:
+  method: docker_image
+  # PINNED BY DIGEST, not tag — the `lmcache/vllm-openai:v0.4.7-cu129` TAG IS MUTABLE:
+  # it bundled vLLM 0.22.1-dev on the first pull (2026-06-13) and 0.23.1-dev on a
+  # re-pull (2026-06-17) under the same tag. Freezing the digest is the only way to
+  # pin the bundled vLLM version (see club-3090 #133; tags drift → freeze the
+  # digest). Re-resolve the digest with:
+  #   docker buildx imagetools inspect lmcache/vllm-openai:v0.4.7-cu129
+  # This digest = vLLM 0.23.1rc1.dev88 + LMCache 0.4.7, the build the compose was
+  # live-validated against (262K @ util 0.92, MTP n=3 active, decode 74/94 TPS).
+  spec: lmcache/vllm-openai@sha256:663f9b2f7528e34105c9b0428880b811616f9bc85133b6e2a577b2e7282be8de
+min_sm: 8.0
+supported_model_families:
+  - dense
+  - qwen3-next-hybrid     # the validated target — Qwen3.6-27B GDN hybrid via LMCache's
+                          # HMA (Hybrid Memory Allocator), new in LMCache 0.4.7. The simple
+                          # LMCacheConnectorV1 crashes hybrids ("failed to convert KV cache
+                          # specs"); only LMCacheMPConnector (lmcache server sidecar + HMA)
+                          # handles GDN. Requires --mamba-cache-mode align (mandatory).
+features:
+  int8_per_token_head: true     # native on this vLLM 0.23.1 build (as on stock v0.22.0)
+  lmcache_kv_offload: true      # tiered GPU→L1(CPU RAM)→L2(disk) prefix-KV cache
+  turboquant_3bit_nc: false
+  marlin_pad_sub_tile_n: false
+  qwen3_coder_tool_parser: true
+supported_kv_formats:
+  - bf16
+  - fp8_e4m3              # works with LMCache HMA (fp8_e5m2 is REJECTED with fp8 weights)
+  - int8_per_token_head   # the dual-max KV — validated with LMCache HMA 2026-06-17
+                          # (block aligns to 1584 tokens; chunk-size + max-num-batched-tokens
+                          # must be >= 1584). NOTE: fp8_e5m2 is unsupported with fp8 checkpoints.
+supported_drafters:
+  - mtp                  # MTP n=3 survives the connector — acceptance ~83%, no TPS loss
+                          # (controlled A/B 2026-06-17: 74/94 TPS with LMCache == without)
+supported_weight_formats:
+  - bf16
+  - fp16
+  - fp8
+  - autoround
+  - awq
+  - gptq
+  - compressed-tensors
+required_overlays: []
+vendored_overlays: []
+required_genesis: false
+notes: >-
+  vLLM + LMCache engine for the OPT-IN, hidden (🐣 incubating) KV-offload compose
+  (slug vllm/qwen-27b-dual-lmcache, club-3090 #133). Third-party image
+  lmcache/vllm-openai (bundles vLLM + LMCache), DIGEST-pinned (the tag is mutable —
+  see install.spec comment). LMCache adds a tiered persistent prefix-KV cache:
+  GPU → L1 (CPU RAM, --l1-size-gb) → optional L2 (disk, --l2-adapter), so long
+  sessions reuse cached context instead of re-prefilling (cold→warm TTFT ~7-8x).
+  Live-validated 2026-06-17 on the dual-max fidelity profile (FP8 weights + int8-PTH
+  KV + MTP n=3, TP=2 @262K): boots, serves, MTP intact, ZERO decode penalty
+  (74 narr / 94 code TPS, == the same config without LMCache). KV ~18.9 KB/token
+  (measured) → a full 262K session ≈ 4.72 GB; --l1-size-gb 30 holds ~6 such sessions
+  (or ~33 realistic 50K ones). The KV offload is async/overlapped — it does NOT cost
+  decode (an earlier "halves decode" claim was an uncontrolled-measurement error,
+  retracted; see club-3090 #133). Boot requirements baked into the
+  compose recipe: --mamba-cache-mode align + --max-num-batched-tokens >= block (1584
+  for int8-PTH) + LMCache --chunk-size a multiple of the block + NO
+  expandable_segments (incompatible with the MP connector) + shm_size >= l1-size-gb.
+  Preflight (scripts/preflight.sh) gates launch on available RAM >= l1-size-gb + a
+  vLLM reserve — the guard that would have prevented the l1=100-on-94GB choke.
+  This engine is overlay-free but runs a DIFFERENT, newer vLLM than the stack's
+  v0.22.0 pin; promotion to ✅ would want LMCache installed into our own image. The
+  38 GB image is pulled on-demand (only when a user opts into the slug).

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -386,6 +386,60 @@ preflight_compose_hardware() {
   return 0
 }
 
+# preflight_lmcache_ram <compose_file>
+# Guards LMCache composes against over-allocating CPU RAM for the L1 KV cache.
+# Runs REGARDLESS of --force — host-choke prevention is NOT optional: an over-sized
+# --l1-size-gb (100 GB on a 94 GB rig) once exhausted RAM and forced a server reboot
+# (club-3090 #133). No-op for composes without an
+# `LMCache-l1-gb` metadata header, so it's safe to call on every launch.
+preflight_lmcache_ram() {
+  local compose_file="$1"
+  [[ -f "$compose_file" ]] || return 0
+  declare -F compose_meta_get >/dev/null 2>&1 || return 0
+
+  local l1_hdr
+  l1_hdr="$(compose_meta_get "$compose_file" lmcache-l1-gb || true)"
+  [[ -z "$l1_hdr" ]] && return 0   # not an LMCache compose
+
+  # Env override (LMCACHE_L1_GB) wins over the header default — the guard must track
+  # what the container will actually request.
+  local l1="${LMCACHE_L1_GB:-$l1_hdr}"
+  if ! [[ "$l1" =~ ^[0-9]+$ ]]; then
+    echo "[preflight] WARN:  LMCACHE_L1_GB='${l1}' is not an integer; skipping LMCache RAM check." >&2
+    return 0
+  fi
+
+  local reserve=28   # GB headroom for the vLLM process (27B @262K TP=2) + OS
+  local need=$(( l1 + reserve ))
+
+  if [[ ! -r /proc/meminfo ]]; then
+    echo "[preflight] WARN:  cannot read /proc/meminfo; skipping LMCache RAM check." >&2
+    return 0
+  fi
+  local kb avail_gb
+  kb="$(awk '/^MemAvailable:/{print $2}' /proc/meminfo)"
+  avail_gb=$(( kb / 1024 / 1024 ))
+
+  if (( avail_gb < need )); then
+    local suggest=$(( avail_gb > reserve ? avail_gb - reserve : 8 ))
+    echo "[preflight] ERROR: LMCache --l1-size-gb=${l1} needs ~${need} GB RAM (l1 ${l1} + ~${reserve} GB vLLM+OS), but only ${avail_gb} GB is available." >&2
+    echo "            (Guard against the l1-too-large host-OOM: a 100 GB cache on this 94 GB rig forced a reboot.)" >&2
+    echo "            Fix: lower the cache — LMCACHE_L1_GB=${suggest} bash scripts/switch.sh ... — or free RAM." >&2
+    return 1
+  fi
+
+  # Soft: SHM must be >= l1 or LMCache silently falls back to slow pickle serialization.
+  local shm_gb
+  shm_gb="$(grep -oE 'shm_size:[[:space:]]*"?[0-9]+' "$compose_file" | grep -oE '[0-9]+' | head -1 || true)"
+  if [[ -n "$shm_gb" ]] && (( shm_gb < l1 )); then
+    echo "[preflight] WARN:  shm_size (${shm_gb}g) < LMCACHE_L1_GB (${l1}) — LMCache SHM will fall back to slow pickle." >&2
+    echo "            Fix: raise shm_size in the compose to >= ${l1}g." >&2
+  fi
+
+  echo "[preflight] lmcache: RAM ok — l1=${l1} GB needs ~${need} GB, ${avail_gb} GB available"
+  return 0
+}
+
 preflight_disk() {
   local path="$1"
   local need_gb="$2"

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -693,6 +693,10 @@ up_variant() {
     if [[ "$eng" == "vllm" ]]; then
       preflight_compose_hardware "${full_dir}/${file}" "$v" "${FORCE:-0}" || exit 1
     fi
+    # LMCache host-RAM guard — runs even under --force (incubating LMCache slugs
+    # launch WITH --force, yet over-sizing --l1-size-gb can OOM the host; #133).
+    # No-op for composes without an LMCache-l1-gb metadata header.
+    preflight_lmcache_ram "${full_dir}/${file}" || exit 1
     preflight_kv_format_hint "${full_dir}/${file}" || true
   fi
   gpu_preflight

--- a/scripts/tests/test-compose-registry-disk.sh
+++ b/scripts/tests/test-compose-registry-disk.sh
@@ -25,8 +25,8 @@ def check(cond, msg):
         print(f"FAIL: {msg}")
         failures.append(msg)
 
-check(len(COMPOSE_REGISTRY) == 51, f"registry has 51 entries (got {len(COMPOSE_REGISTRY)})")
-check(len(disk_paths) == 52, f"disk has 52 compose files (got {len(disk_paths)})")
+check(len(COMPOSE_REGISTRY) == 52, f"registry has 52 entries (got {len(COMPOSE_REGISTRY)})")
+check(len(disk_paths) == 53, f"disk has 53 compose files (got {len(disk_paths)})")
 check(registry_paths <= disk_paths, "all registry compose_path values exist on disk")
 parked_disk_only = disk_paths - registry_paths
 # Disk-only (non-registry) composes allowed: parked SGLang archives, plus the experimental

--- a/scripts/tests/test-profiles-compat.sh
+++ b/scripts/tests/test-profiles-compat.sh
@@ -26,7 +26,7 @@ p = load_profiles()
 assert len(p.hardware) == 9
 assert len(p.models) == 8
 assert len(p.workloads) == 5
-assert len(p.engines) == 12
+assert len(p.engines) == 13
 assert len(p.drafters) == 11
 assert len(p.calibration) == 5
 PY


### PR DESCRIPTION
Closes the #133 investigation — ships LMCache as an opt-in, hidden (🐣 incubating) capability on the dual-max fidelity profile.

## What
`vllm/qwen-27b-dual-lmcache` — dual-max (FP8 + int8-PTH KV + MTP n=3 @262K) + an LMCache tiered persistent prefix-KV cache (GPU → L1 CPU RAM → optional L2 disk), reusing cached prefix KV across long / multi-session workloads instead of re-prefilling (cold→warm TTFT ~7–8×).

## Validated on-rig (2026-06-17)
- **Zero decode penalty** — controlled A/B (toggle ONLY the connector, same image+config): **74 narr / 94 code TPS == without LMCache**, MTP intact (~83% accept). Triple-confirmed (@efschu's cross-rig data → a no-MTP A/B → this dual-max+MTP A/B). The earlier "halves decode" read was an uncontrolled-measurement error — thanks @efschu for the persistence that caught it.
- Boots + serves full **262K** (util 0.92, KV pool 279K tok).
- KV **18.9 KB/token** measured → `--l1-size-gb 30` ≈ ~6 full 262K or ~33 realistic 50K sessions.

## Notable
- New `vllm-lmcache` engine profile — `lmcache/vllm-openai` **digest-pinned** (the tag is mutable: bundled vLLM 0.22.1-dev then 0.23.1-dev under the same tag).
- `preflight_lmcache_ram` — rejects `--l1-size-gb` over-allocation **even under `--force`** (the l1=100-on-94GB host-OOM that forced a reboot). No-op for non-LMCache composes.
- env-gated **L2 disk tier** hook (off by default; survives restarts; unbounded).
- INTERNALS.md RAM/disk sizing section; registry + count bumps; full guard suite green.

## Incubating, not production
Runs a third-party image with a newer vLLM than our v0.22.0 pin; L2 latency unmeasured on-rig; 38 GB image pulled on-demand. Promotion to ✅ wants LMCache installed into our own image. Hidden from `switch.sh --list` (`--list --all` to see), `--force` to launch.

## Follow-up
Unify via a standalone `lmcache-server` service (shared cache across instances) — revisit when we bump the stack's vLLM pin (the vLLM-side connector requires LMCache's newer vLLM, so the version gap, not packaging, is the real blocker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
