### PR TITLE
Pull gate: actionable messages for uncurated derives of curated models

### DIFF
--- a/docs/BRING_YOUR_OWN.md
+++ b/docs/BRING_YOUR_OWN.md
@@ -79,6 +79,52 @@ engines you copy a `single/` or `dual/` compose (dual splits layers / `-ts` acro
 cards). Custom all-reduce stays disabled on PCIe (no NVLink). See
 [`SINGLE_CARD.md`](SINGLE_CARD.md) / [`DUAL_CARD.md`](DUAL_CARD.md).
 
+### C — Swap a curated model for a fine-tune / abliterated variant  →  reuse its compose
+
+If your model is the **same architecture** as one we already ship (e.g. an
+abliterated or fine-tuned Qwen3.6-27B — config arch `Qwen3_5ForConditionalGeneration`),
+`pull.sh --profile-like` will **refuse** it:
+
+> `not generic-dense eligible (arch 'Qwen3_5ForConditionalGeneration') … NOTE: this arch is the curated 'qwen3.6-27b' …`
+
+That's expected, not a bug — the generic deriver only fit-prices **generic-dense**
+transformers, and Qwen3-Next / Gemma-4 are **hybrid / MoE** that need the curated
+hand-tuned flags (mamba-cache-mode, MTP spec-config, the quant kernel). So **don't
+derive — reuse the curated compose and swap the weights.** Three things to get right:
+
+- **Artifact ↔ engine:** match the weights *format* to the engine. **GGUF goes to a
+  `llama-cpp` / `ik-llama` / `beellama` compose, never a vLLM one** (vLLM serves
+  safetensors — AutoRound / AWQ / GPTQ / fp8 — not GGUF). Pointing a vLLM compose at a
+  `.gguf` is rejected at the `pull.sh` gate (`weight_format 'gguf' not loadable by
+  engine … — serve GGUF with a llama.cpp/ik-llama/beellama compose`); the rows below
+  already pair them correctly.
+- **Quant:** the curated composes load a *quantized* checkpoint (AutoRound-int4 / AWQ
+  / fp8). A **bf16 full-weight** repo won't fit 2×24 GB (~54 GB) — grab a pre-quantized
+  variant whose format matches a compose's `--quantization`.
+- **MTP:** the dual / "max" configs use a built-in MTP head for spec-dec. Use a
+  **`-MTP` variant** (the head is embedded in the checkpoint), or drop
+  `--speculative-config`.
+
+Example — abliterated Qwen3.6-27B:
+
+| You have | Reuse this curated compose | Notes |
+|---|---|---|
+| an **AWQ + MTP** variant (vLLM) | `models/qwen3.6-27b/vllm/compose/dual/awq-bf16-int4/int8.yml` | match `--quantization` (`awq` / `compressed-tensors`) to the repo |
+| a **GGUF + MTP** variant (llama.cpp) | a `llama-cpp` compose (path **B** above) | self-contained — simplest |
+
+```bash
+# 1. download the quantized + MTP variant
+hf download <org/Model-AWQ-MTP> --local-dir /mnt/models/huggingface/<your-name>
+# 2. copy the matching curated compose; change --model to your weights path
+#    (+ match --quantization; drop --speculative-config if there's no MTP head)
+# 3. boot directly:
+docker compose -f models/qwen3.6-27b/vllm/compose/dual/awq-bf16-int4/int8.yml up -d
+```
+
+It inherits everything from the curated config — TP, KV dtype, chat template, tool
+parser, MTP, context — you only swap the weights. (Claude/Codex on the repo can do
+the swap + quant-flag match for you.)
+
 ## 2. Tune it
 
 Bring-up rarely lands on the best config first. Tune with the **fast loops** and

--- a/scripts/lib/generate_compose.py
+++ b/scripts/lib/generate_compose.py
@@ -167,6 +167,27 @@ def resolve_arch(root: Path, runtime: dict, arches: list[dict], model: str) -> t
     return matched_arch, arch_row
 
 
+def resolve_arch_from_config(runtime: dict, arches: list[dict], config_arch: str):
+    """Map a config.json architectures[0] string -> (canonical_arch, arch_row)
+    via arch_model_xref. Matches either the canonical (inner) arch key itself or
+    any `config_architectures` alias (the OUTER multimodal wrapper class a weights
+    repo reports — e.g. Qwen3_5ForConditionalGeneration -> Qwen3NextForCausalLM).
+    Used by the [C0] pull gate so an uncurated derive (abliterated / fine-tune) of
+    an already-supported arch is not false-aborted with "no arch_patches matrix row".
+    arch_patches.yml stays a closed key-set; the alias lives in the editable xref.
+    Returns (None, None) when the config arch maps to no row."""
+    if not config_arch:
+        return None, None
+    xref = runtime.get("arch_model_xref") or {}
+    for canonical, meta in xref.items():
+        aliases = (meta or {}).get("config_architectures") or []
+        if config_arch == canonical or config_arch in aliases:
+            row = next((r for r in arches if r.get("arch") == canonical), None)
+            if row is not None:
+                return canonical, row
+    return None, None
+
+
 # --------------------------------------------------------------------------
 # Step 3 — engine-pin validation (validation ONLY; never rewrites image).
 # --------------------------------------------------------------------------

--- a/scripts/lib/profiles/gates.py
+++ b/scripts/lib/profiles/gates.py
@@ -382,7 +382,19 @@ def c0_engine_support(
         arch_row = next(
             (r for r in arches if r.get("arch") == arch_from_config), None
         )
-        arch_name = arch_from_config if arch_row is not None else arch_name
+        if arch_row is not None:
+            arch_name = arch_from_config
+        else:
+            # Resolve the config-reported OUTER wrapper arch to its canonical
+            # matrix arch via arch_model_xref config_architectures (e.g.
+            # Qwen3_5ForConditionalGeneration -> Qwen3NextForCausalLM), so an
+            # uncurated derive (abliterated / fine-tune) of an already-supported
+            # arch is not false-aborted with NO_ARCH_ROW.
+            canon, arch_row = gc.resolve_arch_from_config(
+                runtime, arches, arch_from_config
+            )
+            if arch_row is not None:
+                arch_name = canon
 
     has_auto_map = bool(profile.get("auto_map"))
 
@@ -457,6 +469,28 @@ def c0_engine_support(
         return _incompat(
             f"kv_format {kv_format!r} not in engine {engine_id} "
             f"supported_kv_formats {engine.get('supported_kv_formats')}"
+        )
+
+    # 3c-bis. weight ARTIFACT vs engine — the GGUF axis (structural & mutually
+    # exclusive). GGUF-serving engines (llama.cpp / ik-llama / beellama) and
+    # safetensors-serving engines (vLLM / SGLang) cannot load each other's
+    # artifact. The deriver already rejects GGUF on the --profile-like *derive*
+    # path (safetensors-only header probe), but the curated registry / the
+    # curated-swap path (clone a vLLM compose, point --model at your weights)
+    # have no such probe — so enforce it here too, off the engine's declared
+    # `supported_weight_formats`. Match the unambiguous `gguf` token only (NOT
+    # full membership: the dtype-derived weight_format is raw-spelled
+    # "bfloat16"/"float16", which a naive `in` test would false-reject).
+    weight_format = str(profile.get("weight_format") or "").lower()
+    _eng_wfmts = [
+        str(f).lower() for f in (engine.get("supported_weight_formats") or [])
+    ]
+    if weight_format == "gguf" and "gguf" not in _eng_wfmts:
+        return _incompat(
+            f"weight_format 'gguf' not loadable by engine {engine_id} "
+            f"(safetensors-only; supported_weight_formats="
+            f"{engine.get('supported_weight_formats')}) — serve GGUF with a "
+            f"llama.cpp / ik-llama / beellama compose, not a vLLM one"
         )
 
     # 3d. hardware SM ≥ max(engine.min_sm, registry required_sm, arch-kernel)

--- a/scripts/lib/profiles/profile_runtime.yml
+++ b/scripts/lib/profiles/profile_runtime.yml
@@ -762,6 +762,14 @@ arch_model_xref:
   Qwen3NextForCausalLM:
     family: qwen3-next-hybrid
     model_slugs: [qwen3.6-27b]
+    # config.json architectures[] strings that map to this canonical (inner) arch.
+    # The Qwen3-Next weights report the OUTER multimodal wrapper class
+    # `Qwen3_5ForConditionalGeneration`; the patch matrix is keyed on the inner
+    # `Qwen3NextForCausalLM`. An uncurated derive (e.g. an abliterated/fine-tune
+    # repo) only knows the wrapper string, so without this alias the pull gate
+    # false-aborts with "no arch_patches matrix row" on a model we fully support.
+    # (arch_patches.yml is a closed key-set; the alias lives here, the editable xref.)
+    config_architectures: [Qwen3_5ForConditionalGeneration]
     trust_remote_code: false
     trust_remote_code_evidence: "qwen3.6-27b weights config.json (qwen3.6-27b-autoround-int4) has architectures=[Qwen3_5ForConditionalGeneration], auto_map absent, no *modeling*.py modeling file shipped with weights -> loads built-in transformers/vLLM class, no remote code execution"
     golden_triple_profiles: [vllm/minimal, vllm/dual]

--- a/scripts/lib/profiles/pull.py
+++ b/scripts/lib/profiles/pull.py
@@ -423,6 +423,37 @@ def _topology_summary_canonical(names: list[str], vram_mib: list[int]) -> str:
     return "[" + ", ".join(f"({n}, {v})" for n, v in tuples) + "]"
 
 
+def _weights_oversize_advisory(weights_total_gb, gpu_topology) -> str:
+    """If the raw weights ALONE exceed the detected topology's total VRAM,
+    return a one-line advisory explaining the won't-fit. Used to enrich the
+    eligibility `no-fit-model` abort for an uncurated derive — e.g. a bf16
+    full-weight abliterated repo of a model we serve only quantized — so the
+    user sees WHY their specific repo can't run, not just a generic stop.
+
+    Pure / total: empty string when it fits, when size or topology is unknown
+    (headless / injected None), or on any malformed input — never raises."""
+    try:
+        wgb = float(weights_total_gb)
+    except (TypeError, ValueError):
+        return ""
+    if wgb <= 0 or not gpu_topology:
+        return ""
+    try:
+        gcount, vram_mib, gnames = gpu_topology
+        total_vram_gb = sum(float(v) for v in vram_mib) / 1024.0
+    except (TypeError, ValueError):
+        return ""
+    if total_vram_gb <= 0 or wgb <= total_vram_gb:
+        return ""
+    gpu_label = gnames[0] if gnames else "GPU"
+    return (
+        f" SIZE: the weights are ~{wgb:.0f} GB but the detected topology has "
+        f"~{total_vram_gb:.0f} GB total VRAM ({gcount}× {gpu_label}) — they "
+        f"won't fit even before KV cache. A bf16 full-weight repo is too large "
+        f"for this rig; use an int4 (AWQ / AutoRound, ~1/4 the size) or GGUF variant."
+    )
+
+
 # ===========================================================================
 # v0.8.2 CONTRACT-1.1 — capture-on-hard-block PASS-THROUGH.
 #
@@ -755,11 +786,53 @@ def run_pull(
             res.ok = False
             res.stratum = Stratum.ELIGIBILITY
             res.abort_reason = "no-fit-model"
+            _arch = (der.profile or {}).get("arch")
+            # If the (uncurated) arch resolves via the xref alias to a family we
+            # serve CURATED (hybrid/MoE — not generic-dense, so unfit-priceable
+            # here), point at the curated-swap path instead of dead-ending. The
+            # generic derive genuinely can't fit these; the curated compose can.
+            _hint = ""
+            try:
+                # `gc` (the generate_compose module) is already loaded above via
+                # `gc = _gc()`; reuse it — do NOT re-import as a local (that
+                # shadows the module-level `_gc` loader -> UnboundLocalError).
+                _rt = gc._load_yaml(
+                    root, "scripts/lib/profiles/profile_runtime.yml"
+                )
+                _canon, _row = gc.resolve_arch_from_config(
+                    _rt, gc.load_arches(root), _arch
+                )
+                if _row is not None:
+                    _slugs = (
+                        ((_rt.get("arch_model_xref") or {}).get(_canon) or {})
+                        .get("model_slugs") or []
+                    )
+                    if _slugs:
+                        _hint = (
+                            f" NOTE: this arch is the curated '{_slugs[0]}' "
+                            f"({_row.get('family')}) — generic derive can't fit it, "
+                            f"but the curated path can: clone that model's compose and "
+                            f"point --model at your weights (use a quantized + MTP "
+                            f"variant; the bf16 base won't fit and lacks the MTP head). "
+                            f"See docs/BRING_YOUR_OWN.md → 'Swap a curated model for a "
+                            f"fine-tune / abliterated variant'."
+                        )
+            except Exception:
+                _hint = ""
+            # Coarse weights-only VRAM verdict: even when we can't kv-calc-price
+            # a hybrid/MoE, if the raw weights exceed total VRAM it won't fit at
+            # ANY KV — surface that concretely (the huihui abliterated bf16 ~54GB
+            # vs 2×24GB case). Empty when it fits / size unknown / headless.
+            _size_hint = _weights_oversize_advisory(
+                (der.profile or {}).get("weights_total_gb"), gpu_topology
+            )
             res.detail = (
                 f"{slug}: not Tier-1 curated and not generic-dense eligible "
-                f"(arch {(der.profile or {}).get('arch')!r}); no fit model "
+                f"(arch {_arch!r}); no fit model "
                 f"to price — pre-[B] hard-stop (non-bypassable; "
-                f"--experimental-arch does NOT apply — there is no model)"
+                f"--experimental-arch does NOT apply — there is no model)."
+                + _size_hint
+                + _hint
             )
             return _gate_capture_passthrough(
                 res, slug=slug, profile_like=profile_like, der=der,

--- a/scripts/tests/test-pullgate-gates.sh
+++ b/scripts/tests/test-pullgate-gates.sh
@@ -40,6 +40,7 @@ sys.path.insert(0, str(root))
 
 from scripts.lib.profiles import gates as G  # noqa: E402
 from scripts.lib.profiles import deriver as D  # noqa: E402
+from scripts.lib.profiles import pull as P  # noqa: E402
 from scripts.lib.profiles.compat import load_profiles  # noqa: E402
 from scripts.lib.profiles.compose_registry import COMPOSE_REGISTRY  # noqa: E402
 
@@ -242,6 +243,99 @@ check(
     and c0_norow.bypassable_by == (G.BYPASS_EXPERIMENTAL_ARCH,),
     f"[C0]: no arch row -> no-arch-row, bypassable by --experimental-arch "
     f"(got {c0_norow.state}/{c0_norow.sub_reason}/{c0_norow.bypassable_by})",
+)
+
+# config OUTER wrapper arch (Qwen3_5ForConditionalGeneration) resolves via the
+# arch_model_xref config_architectures alias to the canonical inner row
+# (Qwen3NextForCausalLM, qwen3-next-hybrid) -> NOT a false no-arch-row. The
+# abliterated / fine-tune same-arch case (the pull-gate arch-alias fix).
+ALIAS = mk_result(
+    "huihui-ai/Huihui-Qwen3.6-27B-abliterated",
+    profile={"arch": "Qwen3_5ForConditionalGeneration", "auto_map": False},
+)
+c0_alias = G.c0_engine_support(
+    "vllm/minimal", ALIAS, path="B", hardware_sm=SM_86
+)
+check(
+    c0_alias.sub_reason != G.C0SubReason.NO_ARCH_ROW,
+    f"[C0]: config wrapper arch Qwen3_5ForConditionalGeneration resolves via "
+    f"xref alias (not a false no-arch-row) "
+    f"(got state={c0_alias.state}/sub={c0_alias.sub_reason})",
+)
+
+# resolver unit: the config-arch alias maps to the canonical row; a genuinely
+# unknown arch still maps to nothing.
+import scripts.lib.generate_compose as _gcmod  # noqa: E402
+_rt_x = _gcmod._load_yaml(root, "scripts/lib/profiles/profile_runtime.yml")
+_arches_x = _gcmod.load_arches(root)
+_canon_x, _row_x = _gcmod.resolve_arch_from_config(
+    _rt_x, _arches_x, "Qwen3_5ForConditionalGeneration"
+)
+check(
+    _canon_x == "Qwen3NextForCausalLM"
+    and (_row_x or {}).get("family") == "qwen3-next-hybrid",
+    f"resolve_arch_from_config: wrapper arch -> canonical hybrid row "
+    f"(got {_canon_x})",
+)
+_un_c, _un_r = _gcmod.resolve_arch_from_config(_rt_x, _arches_x, "NopeForCausalLM")
+check(
+    _un_c is None and _un_r is None,
+    "resolve_arch_from_config: genuinely-unknown arch -> (None, None)",
+)
+
+# 3c-bis: a GGUF weight artifact aligned to a vLLM (safetensors-only) engine ->
+# runtime-incompatible. vLLM engines don't list `gguf` in
+# supported_weight_formats. The deriver blocks GGUF on the --profile-like derive
+# path, but a curated entry / the curated-swap path could still mispair one, so
+# the [C0] gate enforces the GGUF axis off supported_weight_formats.
+GGUF_MISPAIR = mk_result(
+    "fixtures/qwen-gguf-on-vllm",
+    tier1=D.Tier1Match(
+        model_id="qwen3.6-27b",
+        weights_variant="autoround-int4",
+        slug="fixtures/qwen-gguf-on-vllm",
+    ),
+    profile={
+        "model_id": "qwen3.6-27b",
+        "weights_variant": "autoround-int4",
+        "weight_format": "gguf",
+        "weights_variant_size_gb": 17.5,
+    },
+)
+c0_gguf = G.c0_engine_support(
+    "vllm/minimal", GGUF_MISPAIR, path="A", hardware_sm=SM_86
+)
+check(
+    c0_gguf.state == G.C0State.ENGINE_SUPPORT_UNKNOWN
+    and c0_gguf.sub_reason == G.C0SubReason.RUNTIME_INCOMPATIBLE
+    and "gguf" in (c0_gguf.detail or "").lower(),
+    f"[C0]: GGUF weight on a vLLM (safetensors-only) engine -> "
+    f"runtime-incompatible (got {c0_gguf.state}/{c0_gguf.sub_reason})",
+)
+# no false-positive: the curated autoround (safetensors) weight on the SAME
+# engine stays ENGINE_SUPPORTED — the 3c-bis guard matches the `gguf` token
+# only, never the raw dtype/quant spelling.
+check(
+    c0_ok.state == G.C0State.ENGINE_SUPPORTED,
+    f"[C0]: non-GGUF (autoround) weight on vLLM still supported — gguf guard "
+    f"is not over-broad (got {c0_ok.state})",
+)
+
+# Eligibility no-fit-model SIZE advisory: raw weights > total VRAM -> a concrete
+# won't-fit line (the huihui abliterated bf16 ~54GB vs 2×24GB case). Pure helper,
+# total: fits / unknown-size / headless-topology -> empty, never raises.
+_TOPO_DUAL = (2, [24576, 24576], ["NVIDIA GeForce RTX 3090", "NVIDIA GeForce RTX 3090"])
+_adv_big = P._weights_oversize_advisory(54.0, _TOPO_DUAL)
+check(
+    "won't fit" in _adv_big and "~54 GB" in _adv_big and "~48 GB" in _adv_big,
+    f"no-fit SIZE advisory: bf16 ~54GB > 2×24GB -> won't-fit line (got {_adv_big!r})",
+)
+check(
+    P._weights_oversize_advisory(17.0, _TOPO_DUAL) == ""
+    and P._weights_oversize_advisory(54.0, None) == ""
+    and P._weights_oversize_advisory(None, _TOPO_DUAL) == ""
+    and P._weights_oversize_advisory(54.0, ("malformed",)) == "",
+    "no-fit SIZE advisory: fits / headless / unknown-size / malformed -> empty (total)",
 )
 
 # tp ∉ valid-TP -> runtime-incompatible. The MoE arch valid_tp.tp_divisors


### PR DESCRIPTION
## Why

mog (Discord) wanted to swap Qwen3.6-27B for `huihui-ai/Huihui-Qwen3.6-27B-abliterated`, reusing all the club-3090 config. `pull.sh --profile-like vllm/dual` aborted with **"no arch_patches matrix row for `Qwen3_5ForConditionalGeneration`"** — a dead-end on a model we fully support. Digging in surfaced three gaps on the uncurated-derive / curated-swap surface, all fixed here.

## What

**1. Wrapper-arch alias resolution.** `Qwen3_5ForConditionalGeneration` is the *outer* multimodal wrapper class the weights report; the patch matrix is keyed on the *inner* canonical `Qwen3NextForCausalLM`. `arch_patches.yml` is a closed key-set, so the alias lives in the editable `arch_model_xref` (`config_architectures:`). New shared resolver `resolve_arch_from_config()`; C0 uses it before declaring `NO_ARCH_ROW`. The hybrid now reports `ENGINE_SUPPORTED`.

**2. GGUF-axis guard.** `supported_weight_formats` was declared on every engine but never enforced (only `kv_format` was). C0 now rejects a `gguf` weight on a vLLM (safetensors-only) engine → `runtime-incompatible`, steering to a llama.cpp/ik-llama/beellama compose. Token-matched on `gguf` only, so a derive's raw `bfloat16`/`float16` dtype spelling is never false-rejected.

**3. Won't-fit size advisory.** The eligibility `no-fit-model` abort for a hybrid/MoE derive now appends (a) an actionable NOTE → the curated-swap path + `docs/BRING_YOUR_OWN.md`, and (b) a coarse weights-only VRAM verdict when raw weights exceed total VRAM — concretely, for the abliterated bf16 repo:

> `SIZE: the weights are ~54 GB but the detected topology has ~48 GB total VRAM (2× NVIDIA GeForce RTX 3090) — they won't fit even before KV cache. A bf16 full-weight repo is too large for this rig; use an int4 (AWQ / AutoRound, ~1/4 the size) or GGUF variant.`

`_weights_oversize_advisory()` is pure/total (empty when it fits / size unknown / headless).

## Net effect for the mog case

`pull.sh --profile-like` still (correctly) refuses to *derive* a hybrid — generic-dense fit-pricing can't price it — but instead of a cryptic dead-end the user now gets: arch recognized → why it can't derive → the curated-swap recipe → and, for a bf16 repo, the concrete "won't fit, use int4/GGUF" verdict. New `docs/BRING_YOUR_OWN.md` section C documents the swap (artifact↔engine + quant + MTP caveats, worked example).

## Tests

`for t in scripts/tests/*.sh; do bash "$t"; done` → **47/47**. New `test-pullgate-gates.sh` cases: wrapper-arch ALIAS C0 + `resolve_arch_from_config()` unit + GGUF-on-vLLM runtime-incompatible + no-false-positive control + `_weights_oversize_advisory()` unit (oversize / fits / headless / malformed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)