### PR TITLE
Add llamacpp/qwen27b-pi-reasoning-single (Qwen3.6-27B reasoning fine-tune, mainline llama.cpp + MTP)

### DIFF
--- a/models/qwen3.6-27b/llama-cpp/compose/single/pi-reasoning-q4km/mtp.yml
+++ b/models/qwen3.6-27b/llama-cpp/compose/single/pi-reasoning-q4km/mtp.yml
@@ -1,0 +1,127 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-27B-MTP-pi-reasoning (bytkim Q4_K_M GGUF — "Pi-style" reasoning-supervised
+#              CODING / terminal-agent fine-tune of Qwen3.6-27B, full model + embedded MTP head)
+#   Engine:    llama.cpp (mainline ggml-org build, server-cuda-b9246, PR #22673 MTP)
+#   Topology:  Single 3090 (TP=1)
+#   Drafter:   MTP n=2 (--spec-type draft-mtp; our on-rig A/B peak. Card recommends n=3 — within
+#              noise of 2 here; MTP_DRAFT_N_MAX=3 matches the card exactly)
+#   KV:        q4_0 K + q4_0 V (per card; densest mainline, Ampere-fast)
+#   Vision:    no (text-only; repo ships no mmproj)
+#   Template:  native (GGUF-embedded) via --jinja
+#   Sampling:  temp 1.0 · top-p 0.95 · top-k 0 · min-p 0 (PER MODEL CARD — NOT the stack's 0.6/20)
+#   Max ctx:   200000-alloc default → ~188K USABLE (MEASURED 2026-06-17: 200K-alloc fills a
+#              ~188K prefill with correct needle recall, 22.7 GB / ~1.8 GB free). Do NOT raise
+#              to 262K-alloc — counterproductive: the FA scratch grows with the allocation, so
+#              262K OOMs at ~176K (LESS usable than 200K). The author only TESTED 128K, so
+#              128-188K is engine-proven but past the card's validated window. Full 262K usable
+#              needs beellama's unified KV (slower). CTX_SIZE=131072 for strict card-compliance.
+#   Genesis:   N/A — llama.cpp engine; Genesis is vLLM/Qwen3-Next-specific
+#   Status:    🧪 EXPERIMENTAL — boot + bench validated 2026-06-17 on mainline b9246: loads the
+#              fine-tune's EMBEDDED MTP head clean (draft-mtp, n_max=2, spec context initialized),
+#              q4_0/q4_0 KV, serves coherent output. Canonical bench.sh (n=3, thinking-off):
+#              NARRATIVE 28.5 wall / 28.7 decode TPS · CODE 32.9 wall / 33.4 decode · PP 743 tok/s.
+#              ~45% BELOW the base-model llamacpp/default (50.3/58.9 narr/code, same engine/KV/MTP)
+#              — identical setup, so the gap is this fine-tune's WEAKER embedded MTP head (lower
+#              draft acceptance on prose), not the engine. Still ~25% faster than the beellama
+#              q4_0/q4_1 path on identical weights → mainline chosen. verify-stress / soak ladder
+#              PENDING before promotion.
+#   Caveats:   (1) ~45% slower than the base llamacpp/default — the fine-tune's MTP head is weak;
+#                  pays off only if its reasoning quality (NOT yet benched) justifies the speed cost.
+#                  verify-stress / soak / quality ladder pending. Launch requires --force.
+#              (2) ships 200K-alloc → ~188K usable (MEASURED, needle-recalled), but that is past
+#                  the author's 128K tested window — retrieval works to ~188K, full generative
+#                  quality >128K is unverified (CTX_SIZE=131072 for the strict card window). The
+#                  full 262K usable is beellama-only (unified KV, ~25% slower); mainline OOMs
+#                  at ~176K if you alloc 262K — keep CTX_SIZE<=200000.
+#              (3) Defaults to reasoning ON (this is a reasoning fine-tune); flip REASONING=off
+#                  for plain/agentic use. Decode is ~identical thinking on vs off.
+#   Engine-profile: llama-cpp-local
+#   Best for:  single-card Pi-style coding / terminal agents (repo work, debugging, tool-heavy) —
+#              ~29 prose / ~33 code decode TPS (short-prompt) + MTP, ~188K usable context
+#              (~23 t/s decode at ~188K depth — slows with context, as expected for llama.cpp).
+# ---------------------------------------------------------------------------
+# Qwen3.6-27B-MTP-pi-reasoning on mainline llama.cpp — single 3090, MTP, 200K-alloc (~188K usable), no vision.
+# Weights: bytkim/Qwen3.6-27B-MTP-pi-reasoning-GGUF (Q4_K_M, ~15.7 GiB, embedded MTP head).
+#
+# Near-clone of the base-model llamacpp/default (unsloth-q4km/mtp.yml) — same engine pin, KV,
+# spec flags and Cliff-survival -ub — pointed at the pi-reasoning weights, reasoning-ON, and
+# MTP n=2 (A/B'd 2026-06-17: n=2 peak on draft acceptance > n=1/3/4). Chosen over a
+# beellama/q4_0/q4_1 path because mainline decodes ~25%
+# faster on identical weights; the trade is the context ceiling (200K here vs beellama's 262K).
+#
+# Quick start:
+#   1. Get the GGUF (Q4_K_M, embedded MTP head):
+#        hf download bytkim/Qwen3.6-27B-MTP-pi-reasoning-GGUF Qwen3.6-27B-MTP-pi-reasoning-Q4_K_M.gguf \
+#          --local-dir $MODEL_DIR/qwen3.6-27b-mtp-pi-reasoning-gguf/q4km
+#   2. From this directory:
+#        MODEL_DIR=/your/models/dir docker compose -f mtp.yml up -d
+#   3. curl http://localhost:8063/v1/models  → should list the model.
+#
+# Defaults follow the MODEL CARD (huggingface.co/bytkim/Qwen3.6-27B-MTP-pi-reasoning-GGUF):
+# temp 1.0, top-p 0.95, top-k 0, min-p 0, reasoning ON, q4_0/q4_0 KV, --jinja -ngl 99 -fa.
+# Override defaults via .env or shell:
+#   MODEL_DIR              host dir to mount as /models  (default: ../../../../../../models-cache)
+#   GGUF_FILE              path under /models
+#                          (default: qwen3.6-27b-mtp-pi-reasoning-gguf/q4km/Qwen3.6-27B-MTP-pi-reasoning-Q4_K_M.gguf)
+#   CTX_SIZE              KV pool size        (default: 200000-alloc → ~188K usable, MEASURED.
+#                          Keep <=200000: 262K-alloc OOMs at ~176K (bigger FA scratch = LESS usable).
+#                          131072 = the author's strict 128K tested window)
+#   BATCH_SIZE            llama.cpp -b        (default: 4096 — on mainline -b does NOT drive VRAM)
+#   UBATCH_SIZE          llama.cpp -ub       (default: 512)
+#   KV_TYPE              K and V quant type  (default: q4_0 — per card)
+#   NP                   parallel slots      (default: 1 — single card is compute-bound; -np>1 disables MTP)
+#   MTP_DRAFT_N_MAX      MTP draft tokens    (default: 2 — our on-rig A/B peak; the card recommends
+#                          3, within noise of 2 here — set =3 to match the card exactly)
+#   TEMP / TOP_K         sampling            (default: temp 1.0, top-k 0 — per card; NOT the stack's 0.6/20)
+#   PRESENCE_PENALTY     presence penalty    (default: 0; the card recommends 1.5 for DIRECT/instruct
+#                          mode i.e. REASONING=off — set it there, leave 0 for the thinking default)
+#   REASONING            thinking gate       (default: on — per card; pi-reasoning plans before acting)
+#   REASONING_FORMAT     reasoning routing   (default: deepseek — hygiene)
+#   PORT                 host port           (default: 8063)
+#   CUDA_VISIBLE_DEVICES which GPU to use    (default: 0)
+
+services:
+  llama-cpp-pi-reasoning:
+    # Pinned to b9246 (the validated mainline MTP build; rolling :server-cuda regressed at
+    # b9282, #187). Bump via env once a newer build is validated:
+    #   LLAMACPP_IMAGE=ghcr.io/ggml-org/llama.cpp:server-cuda-bXXXX
+    image: ${LLAMACPP_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda-b9246}
+    container_name: "${ESTATE_CONTAINER:-llama-cpp-pi-reasoning}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8063}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+    # -np 1 is intentional on a single 24 GB card — extra slots divide a compute-bound GPU
+    # and -np>1 auto-disables MTP + can OOM the spec-context buffer.
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      -m /models/${GGUF_FILE:-qwen3.6-27b-mtp-pi-reasoning-gguf/q4km/Qwen3.6-27B-MTP-pi-reasoning-Q4_K_M.gguf}
+      -c ${CTX_SIZE:-200000}
+      -b ${BATCH_SIZE:-4096}
+      -ub ${UBATCH_SIZE:-512}
+      -ngl 99
+      -fa on
+      --cache-type-k ${KV_TYPE:-q4_0}
+      --cache-type-v ${KV_TYPE:-q4_0}
+      -np ${NP:-1}
+      --spec-type draft-mtp
+      --spec-draft-n-max ${MTP_DRAFT_N_MAX:-2}
+      --jinja
+      --reasoning ${REASONING:-on}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-1.0}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-0}
+      --min-p ${MIN_P:-0.0}
+      --presence-penalty ${PRESENCE_PENALTY:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}"]
+              capabilities: [compute, utility]

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -352,6 +352,20 @@ COMPOSE_REGISTRY = {
         status="experimental",
         status_note="Carnice-V2-27B Q8_0 + EMBEDDED MTP head (--spec-type draft-mtp, n=1) + q8_0/q8_0 KV, DUAL 3090 (layer-split -ts 0.55,0.45). The dual / higher-quant follow-through requested in #403 (Q5_K_M single = beellama/carnice-v2-single-q5km-mtp). FULLY VALIDATED 2026-06-16 (rebench-full): verify-full ALL-PASS, bench n=5 narr 40.7/code 44.0 decode TPS, verify-stress 8/8 (NIAH->240K), soak fresh 20x5 PASS (0 growth, 0/100 silent-empty, p50 42.2, 100% retention), 8-pack think-OFF 103/150 / think-ON 105/150 (in-band, q8_0 KV held quality). MTP accept ~81%, full 262K fits @ -ts 0.55,0.45 (21.9/21.2 GB/card, ~2.5GB free). KV A/B: chose q8_0 over the originally-spec'd kvarn6 — q8_0 prefills +17% (1003 vs 860 t/s; kvarn6's software-compression compute throttled prefill), higher-fidelity (q8 > q6-class), reference path (kvarn6 = Anbeeld 'experimental'), fits 262K on dual. -b/-ub/--no-mmap A/B'd FLAT; n=2 = +13% validated-stable opt-in (DRAFT_N_MAX=2). DFlash A/B RULED OUT (base-27B drafter ~10% accept on the fine-tune; no Carnice-matched drafter exists) → MTP-only. Launch --force. beellama v0.3.2 rolling pre-release → experimental (#455).",
     ),
+    # Qwen3.6-27B-MTP-pi-reasoning (bytkim) — reasoning fine-tune, Q4_K_M GGUF + embedded
+    # MTP head + q4_0/q4_0 KV, single 3090, reasoning-ON, mainline llama.cpp. Chosen over a
+    # beellama/q4_0-q4_1 path: mainline decodes ~25% faster on identical weights (~41 vs ~33
+    # t/s), trading beellama's 262K unified-KV ceiling for speed at a ~200K mainline ceiling.
+    "llamacpp/qwen27b-pi-reasoning-single": _entry(
+        model="qwen3.6-27b", weights_variant="pi-reasoning-q4km", workload="fast-chat",
+        engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q4_0",
+        tp=1, max_ctx=200000, max_num_seqs=1, mem_util=None,
+        compose_path="models/qwen3.6-27b/llama-cpp/compose/single/pi-reasoning-q4km/mtp.yml",
+        default_port=8063,
+        kvcalc_key="SKIP",
+        status="experimental",
+        status_note="Qwen3.6-27B-MTP-pi-reasoning (bytkim — 'Pi-style' reasoning-supervised CODING/terminal-agent fine-tune of Qwen3.6-27B) Q4_K_M GGUF + EMBEDDED MTP head (--spec-type draft-mtp, n=2) + q4_0/q4_0 KV, single 3090, reasoning-ON, on MAINLINE llama.cpp (server-cuda-b9246, PR #22673). Launch with --force (experimental). CONFIG FOLLOWS THE MODEL CARD: temp 1.0 / top-p 0.95 / top-k 0 / min-p 0 (NOT the stack's 0.6/20), reasoning ON, q4_0/q4_0 KV. Card recommends MTP n=3; on-rig A/B found n=2 marginally faster (within noise) — kept n=2, MTP_DRAFT_N_MAX=3 matches the card. Card notes presence-penalty 1.5 for DIRECT/instruct (REASONING=off) mode. CONTEXT (measured 2026-06-17): 200K-alloc fills ~188K usable with correct needle recall (22.7 GB / ~1.8 GB free); decode ~23 t/s at ~188K depth. Do NOT alloc 262K — FA scratch grows with alloc, so 262K OOMs at ~176K (LESS usable than 200K); full 262K usable is beellama-only. Author TESTED only 128K, so 128-188K is engine-proven but past the card's validated window (CTX_SIZE=131072 for strict compliance). BENCH VALIDATED (canonical bench.sh n=3, thinking-off, short-prompt): NARRATIVE 28.5 wall / 28.7 decode TPS, CODE 32.9 / 33.4, PP 743 tok/s — ~45% BELOW base llamacpp/default (50.3/58.9) on the SAME engine/KV/MTP (this fine-tune's embedded MTP head is weaker, not the engine). PENDING before promotion: verify-stress/soak/quality ladder + a call on whether the (un-benched) coding quality justifies being ~45% slower than the base model. Mainline llama.cpp = no patches, follows upstream.",
+    ),
 
     # Qwen3.6-27B PRISM-PRO-DQ (Ex0bit dynamic-quant GGUF) — community-experimental, ik-llama.
     "ik-llama/prism-pro-dq-mtp": _entry(

--- a/scripts/lib/profiles/models/qwen3.6-27b.yml
+++ b/scripts/lib/profiles/models/qwen3.6-27b.yml
@@ -204,6 +204,19 @@ weights:
     kind: gguf
     verify_glob: "*.gguf"
     manual_note: "Carnice-V2-27B Q8_0 GGUF (embedded MTP head) — the higher-quant DUAL-card variant (#403). Drives beellama/carnice-v2-dual-q8-mtp (embedded MTP, q8_0/q8_0 KV, full 262K). KV A/B chose q8_0 over the originally-spec'd kvarn6 (q8_0 +17% prefill, higher fidelity, reference path, fits 262K on dual — kvarn's compression only pays off on a tight single card). DFlash A/B ruled out (base-27B drafter ~10% accept on the fine-tune; no Carnice-matched drafter exists) → MTP-only. 2026-06-15."
+  pi-reasoning-q4km:
+    path: qwen3.6-27b-mtp-pi-reasoning-gguf/q4km
+    local_subdir: qwen3.6-27b-mtp-pi-reasoning-gguf/q4km
+    size_gb: 15.7
+    format: gguf
+    status: experimental
+    hf_repo: bytkim/Qwen3.6-27B-MTP-pi-reasoning-GGUF
+    files:
+      - Qwen3.6-27B-MTP-pi-reasoning-Q4_K_M.gguf
+    engine: beellama
+    kind: gguf
+    verify_glob: "*.gguf"
+    manual_note: "bytkim 'Pi-style' reasoning-supervised CODING/terminal-agent fine-tune of Qwen3.6-27B — Q4_K_M GGUF (~15.7 GiB) with EMBEDDED MTP head (--spec-type draft-mtp; no separate draft download). Drives llamacpp/qwen27b-pi-reasoning-single (MAINLINE llama.cpp b9246, single 3090, q4_0/q4_0 KV @ 200K-alloc/~188K usable + MTP n=2, reasoning-ON). CONFIG PER MODEL CARD: temp 1.0/top-p 0.95/top-k 0/min-p 0 (not the stack 0.6/20), card recommends n=3 (we kept on-rig-faster n=2, within noise). Context measured 2026-06-17: 200K-alloc fills ~188K with needle recall (~1.8GB free, ~23 t/s @188K); 262K-alloc OOMs ~176K (don't); author tested only 128K so >128K is engine-proven but card-unvalidated. Boot+bench-validated 2026-06-17: mainline loads the embedded MTP head clean. Canonical bench.sh (n=3, thinking-off): narrative 28.5/28.7 wall/decode, code 32.9/33.4, PP 743 tok/s — ~45% BELOW base llamacpp/default (50/59) on identical engine/KV/MTP, i.e. this fine-tune's MTP head is weak. Engine A/B: mainline ~25% faster than a beellama q4_0/q4_1 path → chose mainline. verify-stress/soak/quality ladder pending. 2026-06-17."
   beellama-q8kxl-dflash:
     path: qwen3.6-27b-gguf/unsloth-mtp-q8kxl
     local_subdir: qwen3.6-27b-gguf/unsloth-mtp-q8kxl

--- a/scripts/tests/test-compose-registry-disk.sh
+++ b/scripts/tests/test-compose-registry-disk.sh
@@ -25,8 +25,8 @@ def check(cond, msg):
         print(f"FAIL: {msg}")
         failures.append(msg)
 
-check(len(COMPOSE_REGISTRY) == 52, f"registry has 52 entries (got {len(COMPOSE_REGISTRY)})")
-check(len(disk_paths) == 53, f"disk has 53 compose files (got {len(disk_paths)})")
+check(len(COMPOSE_REGISTRY) == 53, f"registry has 53 entries (got {len(COMPOSE_REGISTRY)})")
+check(len(disk_paths) == 54, f"disk has 54 compose files (got {len(disk_paths)})")
 check(registry_paths <= disk_paths, "all registry compose_path values exist on disk")
 parked_disk_only = disk_paths - registry_paths
 # Disk-only (non-registry) composes allowed: parked SGLang archives, plus the experimental


### PR DESCRIPTION
## What

Adds **`llamacpp/qwen27b-pi-reasoning-single`** — bytkim's `Qwen3.6-27B-MTP-pi-reasoning` (Q4_K_M GGUF, embedded MTP head), a **"Pi-style" coding / terminal-agent** fine-tune — on **mainline llama.cpp** (b9246, PR #22673), single-3090, q4_0/q4_0 KV + MTP, reasoning-ON. Near-clone of `llamacpp/default` pointed at the pi-reasoning weights.

- **Compose** `models/qwen3.6-27b/llama-cpp/compose/single/pi-reasoning-q4km/mtp.yml`
- **Registry** `llamacpp/qwen27b-pi-reasoning-single` (experimental, port 8063)
- **Catalog** weights `pi-reasoning-q4km`; drafter `qwen-mtp-builtin` (`spec_method mtp`)

## Config follows the model card

temp **1.0** · top-p 0.95 · top-k **0** · min-p 0 (the author's values — NOT the stack's 0.6/20) · reasoning ON · q4_0/q4_0 KV · `--jinja -ngl 99 -fa`. Card recommends MTP **n=3**; our on-rig A/B found **n=2** marginally faster (within noise) — kept n=2 (`MTP_DRAFT_N_MAX=3` matches the card). presence-penalty 1.5 is a documented knob for the card's direct/instruct (`REASONING=off`) mode.

## Context — fully measured on one 3090

| Alloc | Usable fill | |
|---|---|---|
| 131K | 131K | the author's strictly-tested window |
| **200K (default)** | **~188K, needle recalled** | sweet spot — 22.7 GB / ~1.8 GB free |
| 262K | OOMs ~176K | counterproductive (FA scratch grows with alloc) |

So mainline tops out at **~188K usable** — full 262K is **beellama-only** (unified KV, ~25% slower). Author tested only 128K, so 128–188K is engine-proven but past the card's validated window (`CTX_SIZE=131072` for strict compliance). Decode slows with depth: ~33/41 short-prompt → ~23 t/s at ~188K (expected for llama.cpp KV scan).

## Bench (canonical `bench.sh` n=3, thinking-off, short-prompt)

Narrative **28.5 wall / 28.7 decode**, Code **32.9 / 33.4**, PP **743 tok/s**. That's **~45% below** base `llamacpp/default` (50/59) on the *same* engine/KV/MTP — the gap is this fine-tune's **weaker embedded MTP head**, not the engine. (Engine A/B: mainline ~25% faster than a beellama q4_0/q4_1 path on identical weights → mainline chosen.)

Stays **🧪 Experimental** (`--force`). Pending: verify-stress / soak / quality ladder + a call on whether the (un-benched) coding quality justifies being ~45% slower than the base model.

`for t in scripts/tests/*.sh; do bash "$t"; done` → **47/47**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)