### PR TITLE
quality-test/rebench-full: forward --max-tokens to benchlocal-cli

### DIFF
--- a/scripts/quality-test.sh
+++ b/scripts/quality-test.sh
@@ -106,6 +106,12 @@ OPTIONS (extra)
                    budget applies only to packs whose thinking gate resolves on
                    (pack default or --enable-thinking). Also settable via
                    THINKING_MAX_TOKENS env.
+  --max-tokens N   Forward to benchlocal-cli --max-tokens N — overrides the
+                   per-pack completion budget (~1024 default) for BOTH arms.
+                   Use when a verbose model truncates the deterministic packs
+                   (finish_reason=length) before emitting its final answer; the
+                   thinking arm still uses --thinking-max-tokens if that is set.
+                   Also settable via MAX_TOKENS env.
 
 ENV VARS
   URL              Endpoint base URL (default: auto-detected via preflight,
@@ -127,6 +133,10 @@ ENV VARS
   THINKING_MAX_TOKENS
                    Optional thinking budget passed through to benchlocal-cli.
                    Applies only to packs whose thinking gate resolves on.
+  MAX_TOKENS       Optional completion budget passed through to benchlocal-cli
+                   (--max-tokens) for BOTH arms — overrides the per-pack ~1024
+                   default. Raise for verbose models that self-truncate the
+                   deterministic packs. --max-tokens is equivalent.
 
 EXAMPLES
   bash scripts/quality-test.sh                          # --medium against running compose
@@ -199,6 +209,7 @@ SAMPLING_FROM_SERVER="${SAMPLING_FROM_SERVER:-0}"
 ENABLE_THINKING="${ENABLE_THINKING:-0}"
 NO_THINKING="${NO_THINKING:-0}"
 THINKING_MAX_TOKENS="${THINKING_MAX_TOKENS:-}"
+MAX_TOKENS="${MAX_TOKENS:-}"
 # #252: passthroughs to benchlocal-cli for the quality-baseline corpus —
 # --repeat (n>=3 aggregate), --previous-result (diff vs a baseline), and a
 # --save-json override (write the run to an explicit path, e.g. a baseline file).
@@ -274,6 +285,14 @@ while [[ $# -gt 0 ]]; do
       THINKING_MAX_TOKENS="${2:-}"
       if [[ -z "$THINKING_MAX_TOKENS" ]] || ! [[ "$THINKING_MAX_TOKENS" =~ ^[0-9]+$ ]]; then
         echo "✗ --thinking-max-tokens requires a positive integer" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    --max-tokens)
+      MAX_TOKENS="${2:-}"
+      if [[ -z "$MAX_TOKENS" ]] || ! [[ "$MAX_TOKENS" =~ ^[0-9]+$ ]]; then
+        echo "✗ --max-tokens requires a positive integer" >&2
         exit 2
       fi
       shift 2
@@ -503,6 +522,10 @@ fi
 if [[ -n "$THINKING_MAX_TOKENS" ]]; then
   CLI_ARGS+=(--thinking-max-tokens "$THINKING_MAX_TOKENS")
   echo "[quality-test] thinking max tokens: $THINKING_MAX_TOKENS (applies to thinking-enabled packs)"
+fi
+if [[ -n "$MAX_TOKENS" ]]; then
+  CLI_ARGS+=(--max-tokens "$MAX_TOKENS")
+  echo "[quality-test] max tokens: $MAX_TOKENS (overrides the per-pack completion budget for both arms)"
 fi
 
 # Run; capture exit code so we can also try to emit the compact one-liner

--- a/scripts/rebench-full.sh
+++ b/scripts/rebench-full.sh
@@ -86,6 +86,11 @@
 #   THINKING_MAX_TOKENS
 #                       Optional thinking budget forwarded to the 8-pack
 #                       reasoning-ON pass (--with-8pack-thinking=on|both).
+#   MAX_TOKENS          Optional completion budget forwarded to BOTH 8-pack
+#                       passes (off + on) as quality-test.sh --max-tokens —
+#                       overrides the per-pack ~1024 default. Raise for verbose
+#                       models that self-truncate the deterministic packs
+#                       (finish_reason=length before the final answer).
 #
 
 set -euo pipefail
@@ -334,6 +339,7 @@ URL="$URL" MODEL="$MODEL" \
 if [[ "$RUN_8PACK_OFF" == "1" ]]; then
   URL="$URL" MODEL="$MODEL" \
     SAMPLING_FROM_SERVER="${SAMPLING_FROM_SERVER:-0}" \
+    MAX_TOKENS="${MAX_TOKENS:-}" \
     NO_THINKING=1 \
     run_step quality-full "$OUT_DIR/quality-full.log" \
       bash "$ROOT_DIR/scripts/quality-test.sh" --full --no-thinking --sandbox-log-dir "$OUT_DIR"
@@ -350,6 +356,7 @@ if [[ "$RUN_8PACK_ON" == "1" ]]; then
   URL="$URL" MODEL="$MODEL" \
     SAMPLING_FROM_SERVER="${SAMPLING_FROM_SERVER:-0}" \
     THINKING_MAX_TOKENS="${THINKING_MAX_TOKENS:-}" \
+    MAX_TOKENS="${MAX_TOKENS:-}" \
     ENABLE_THINKING=1 \
     run_step quality-thinking "$OUT_DIR/quality-full-thinking.log" \
       bash "$ROOT_DIR/scripts/quality-test.sh" --full --enable-thinking --sandbox-log-dir "$OUT_DIR"

--- a/scripts/tests/test-quality-thinking.sh
+++ b/scripts/tests/test-quality-thinking.sh
@@ -105,4 +105,26 @@ if [[ "$args" == *"--enable-thinking"* ]]; then
   exit 1
 fi
 
+# --- --max-tokens / MAX_TOKENS passthrough (overrides per-pack budget for BOTH arms) ---
+# Lets a verbose model that self-truncates the deterministic packs be benched at a
+# higher completion budget (benchlocal-cli already supports --max-tokens; this wires
+# the club-3090 wrapper to forward it).
+: > "$tmp_log"
+out="$(PATH="${tmp_bin}:$PATH" BENCHLOCAL_MOCK_LOG="$tmp_log" PREFLIGHT_NO_AUTODETECT=1 URL=http://mock MODEL=mock-model MAX_TOKENS=4096 bash scripts/quality-test.sh --quick 2>&1)"
+assert_contains "$out" "[quality-test] max tokens: 4096 (overrides the per-pack completion budget for both arms)"
+args="$(cat "$tmp_log")"
+assert_contains "$args" "--max-tokens 4096"
+
+# the --max-tokens flag form is equivalent to the MAX_TOKENS env var
+: > "$tmp_log"
+out="$(PATH="${tmp_bin}:$PATH" BENCHLOCAL_MOCK_LOG="$tmp_log" PREFLIGHT_NO_AUTODETECT=1 URL=http://mock MODEL=mock-model bash scripts/quality-test.sh --quick --max-tokens 2048 2>&1)"
+args="$(cat "$tmp_log")"
+assert_contains "$args" "--max-tokens 2048"
+
+# a non-integer --max-tokens is rejected (exit 2), like --thinking-max-tokens
+if PATH="${tmp_bin}:$PATH" PREFLIGHT_NO_AUTODETECT=1 URL=http://mock MODEL=mock-model bash scripts/quality-test.sh --quick --max-tokens abc >/dev/null 2>&1; then
+  echo "ASSERTION FAILED: --max-tokens accepted a non-integer" >&2
+  exit 1
+fi
+
 echo "test-quality-thinking: ok"


### PR DESCRIPTION
## Why

`benchlocal-cli` already supports `--max-tokens` (overrides the per-pack ~1024 completion budget for **both** arms, #28), but club-3090's `quality-test.sh` only forwarded `--thinking-max-tokens`. So a **verbose model that self-truncates the deterministic packs** — `finish_reason=length` before it emits the final `ANSWER:`/`</solution>` line — couldn't be benched at a higher budget through our wrapper.

Surfaced on **`llamacpp/qwen27b-pi-reasoning`** (a reasoning fine-tune that reasons in *visible* content even thinking-off): ~5–10 ReasonMath/BugFind/CLI misses in the thinking-OFF 8-pack were **truncations, not wrong answers** (e.g. RM-05 had 4/5 checkpoints correct but ran out of tokens). The thinking-ON pass (16384 budget) didn't truncate — so the gap was purely the deterministic budget, which had no knob.

## What

- **`quality-test.sh`**: add `--max-tokens N` + `MAX_TOKENS` env passthrough — mirrors `--thinking-max-tokens` exactly (same positive-int validation, `--help` + `ENV VARS` docs, forward to benchlocal-cli + echo).
- **`rebench-full.sh`**: plumb `MAX_TOKENS` into **both** 8-pack passes (off + on) + document the env var.
- **`test-quality-thinking.sh`**: assert the env form and the flag form both forward `--max-tokens N`, and that a non-integer is rejected (mock-benchlocal harness — hermetic, no endpoint).

Usage for a verbose model: `MAX_TOKENS=4096 bash scripts/rebench-full.sh --with-8pack-thinking=both`.

## Tests

`test-quality-thinking.sh` ✓ and the full guard suite **47/47**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
