### PR TITLE
Fix LMCache compose entrypoint for Docker Compose v5 interpolation

### DIFF
--- a/models/qwen3.6-27b/vllm-lmcache/compose/dual/fp8/lmcache.yml
+++ b/models/qwen3.6-27b/vllm-lmcache/compose/dual/fp8/lmcache.yml
@@ -109,15 +109,17 @@ services:
         #   LMCACHE_L2=1                -> enable L2 at the in-repo default /lmcache-kv (fs adapter)
         #   LMCACHE_L2_ADAPTER='{...}'  -> full override (custom path/backend); wins over LMCACHE_L2
         # chunk-size MUST be a multiple of vLLM's unified block (1584 for int8-PTH KV).
-        LM_ARGS=(--chunk-size "${LMCACHE_CHUNK_SIZE:-1584}" --l1-size-gb "${LMCACHE_L1_GB:-30}" --eviction-policy LRU)
-        if [ -n "${LMCACHE_L2_ADAPTER:-}" ]; then
-          LM_ARGS+=(--l2-adapter "${LMCACHE_L2_ADAPTER}")
-        elif [ "${LMCACHE_L2:-0}" = "1" ]; then
+        # $$ escapes $ so Docker Compose passes bash syntax through (v5.1+ interpolates
+        # entrypoint strings; $${VAR[@]} without escape → "invalid interpolation format").
+        LM_ARGS=(--chunk-size "$${LMCACHE_CHUNK_SIZE:-1584}" --l1-size-gb "$${LMCACHE_L1_GB:-30}" --eviction-policy LRU)
+        if [ -n "$${LMCACHE_L2_ADAPTER:-}" ]; then
+          LM_ARGS+=(--l2-adapter "$${LMCACHE_L2_ADAPTER}")
+        elif [ "$${LMCACHE_L2:-0}" = "1" ]; then
           LM_ARGS+=(--l2-adapter '{"type":"fs","base_path":"/lmcache-kv"}')
         fi
-        lmcache server "${LM_ARGS[@]}" &
+        lmcache server "$${LM_ARGS[@]}" &
         sleep 6
-        exec vllm serve --disable-custom-all-reduce "$@"
+        exec vllm serve --disable-custom-all-reduce "$$@"
       - --
     command:
       - --model


### PR DESCRIPTION
## Summary

- Escape bash `$` as `$$` in the `vllm/qwen-27b-dual-lmcache` inline entrypoint so Docker Compose v5.1+ can parse the file
- Fixes `invalid interpolation format for services.vllm-qwen36-27b-lmcache.entrypoint.[]` when running `bash scripts/switch.sh --force vllm/qwen-27b-dual-lmcache`

## Root cause

Docker Compose interpolates variables in **all** YAML string values, including multiline `entrypoint` scripts. The LMCache bootstrap uses bash constructs that are not valid Compose interpolation:

- `${LM_ARGS[@]}` — array expansion; `[@]` triggers **invalid interpolation format**
- `${LMCACHE_L2_ADAPTER:-}` — eaten at compose-parse time (warning + wrong runtime branch)
- `"$@"` — same class of problem

Other dual composes only use simple `${VAR:-default}` patterns and do not use bash arrays in entrypoints.

Per [Docker Compose variable interpolation docs](https://docs.docker.com/compose/environment-variables/variable-interpolation/), literal `$` must be written as `$$` in compose files. Compose renders `$$` → `$` before the container starts.

## Reproducer (before)

```bash
docker compose -f models/qwen3.6-27b/vllm-lmcache/compose/dual/fp8/lmcache.yml config
# invalid interpolation format …
```

Minimal isolated repro on Compose v5.1.4:

```yaml
entrypoint: [sh, -c, "ARGS=(--foo); echo \"${ARGS[@]}\""]
```

## Verification (after)

- `docker compose -f …/lmcache.yml config` — exit 0
- `docker compose create && docker inspect vllm-qwen36-27b-lmcache --format '{{index .Config.Entrypoint 2}}'` — shows single-`$` bash (`${LM_ARGS[@]}`, `$@`)
- `bash scripts/switch.sh --force vllm/qwen-27b-dual-lmcache` — boots and serves (remote rig, 2×3090, Compose v5.1.4)

## Test plan

- [x] `docker compose config` on affected compose
- [x] `docker inspect` confirms runtime entrypoint script
- [x] `switch.sh --force vllm/qwen-27b-dual-lmcache` end-to-end boot on reporter rig
- [x] Maintainer spot-check: `docker compose config` on any machine with Compose ≥2.20
