### PR TITLE
feat(lmcache): NVLink auto-detect + Compose v5 entrypoint fix

### DIFF
--- a/models/qwen3.6-27b/vllm-lmcache/compose/dual/fp8/lmcache.yml
+++ b/models/qwen3.6-27b/vllm-lmcache/compose/dual/fp8/lmcache.yml
@@ -109,15 +109,17 @@ services:
         #   LMCACHE_L2=1                -> enable L2 at the in-repo default /lmcache-kv (fs adapter)
         #   LMCACHE_L2_ADAPTER='{...}'  -> full override (custom path/backend); wins over LMCACHE_L2
         # chunk-size MUST be a multiple of vLLM's unified block (1584 for int8-PTH KV).
-        LM_ARGS=(--chunk-size "${LMCACHE_CHUNK_SIZE:-1584}" --l1-size-gb "${LMCACHE_L1_GB:-30}" --eviction-policy LRU)
-        if [ -n "${LMCACHE_L2_ADAPTER:-}" ]; then
-          LM_ARGS+=(--l2-adapter "${LMCACHE_L2_ADAPTER}")
-        elif [ "${LMCACHE_L2:-0}" = "1" ]; then
+        # $$ escapes $ so Docker Compose passes bash syntax through (v5.1+ interpolates
+        # entrypoint strings; $${VAR[@]} without escape → "invalid interpolation format").
+        LM_ARGS=(--chunk-size "$${LMCACHE_CHUNK_SIZE:-1584}" --l1-size-gb "$${LMCACHE_L1_GB:-30}" --eviction-policy LRU)
+        if [ -n "$${LMCACHE_L2_ADAPTER:-}" ]; then
+          LM_ARGS+=(--l2-adapter "$${LMCACHE_L2_ADAPTER}")
+        elif [ "$${LMCACHE_L2:-0}" = "1" ]; then
           LM_ARGS+=(--l2-adapter '{"type":"fs","base_path":"/lmcache-kv"}')
         fi
-        lmcache server "${LM_ARGS[@]}" &
+        lmcache server "$${LM_ARGS[@]}" &
         sleep 6
-        exec vllm serve --disable-custom-all-reduce "$@"
+        exec vllm serve --disable-custom-all-reduce "$$@"
       - --
     command:
       - --model

--- a/models/qwen3.6-27b/vllm-lmcache/compose/dual/fp8/lmcache.yml
+++ b/models/qwen3.6-27b/vllm-lmcache/compose/dual/fp8/lmcache.yml
@@ -1,7 +1,7 @@
 # ===========================================================================
 # Profile (at-a-glance):
 #   Model:     Qwen3.6-27B FP8 (official e4m3, embedded mtp head)
-#   Topology:  Dual 3090 (TP=2, PCIe — custom all-reduce disabled)
+#   Topology:  Dual 3090 (TP=2, NVLink auto-detected via NVLINK_MODE)
 #   Drafter:   MTP n=3 (built-in) — survives LMCache, acceptance ~83%
 #   KV:        int8_per_token_head (1 byte/token) + LMCache tiered prefix cache
 #                (GPU → L1 CPU RAM → optional L2 disk)
@@ -79,6 +79,7 @@ services:
     mem_limit: ${CLUB3090_MEM_LIMIT:-70g}
     memswap_limit: ${CLUB3090_MEM_LIMIT:-70g}
     shm_size: "32gb"   # MUST be >= LMCACHE_L1_GB (default 30). Raise if you raise the cache.
+    ipc: host
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
       # froggeric chat template is shared from the vllm engine dir (model-scoped) —
@@ -88,12 +89,15 @@ services:
       # works with zero setup. Override the host path with LMCACHE_KV_DIR, or bypass entirely with
       # LMCACHE_L2_ADAPTER (point at a faster/larger SSD). Mount is harmless when L2 is off.
       - ${LMCACHE_KV_DIR:-../../../../../../lmcache-kv}:/lmcache-kv
+      # NVLink auto-detection — runs inside container at boot (same path as dual-max).
+      - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}
       - VLLM_WORKER_MULTIPROC_METHOD=spawn
+      - NVLINK_MODE=${NVLINK_MODE:-auto}
       - NCCL_CUMEM_ENABLE=0
       - NCCL_P2P_DISABLE=1
       - VLLM_NO_USAGE_STATS=1
@@ -105,6 +109,12 @@ services:
       - bash
       - -c
       - |
+        # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
+        source /etc/club3090/detect_nvlink.sh
+        if [ "$${_NVLINK_ENABLED:-0}" = "0" ]; then
+          # detect_nvlink sets expandable_segments on PCIe — incompatible with LMCacheMPConnector.
+          unset PYTORCH_CUDA_ALLOC_CONF
+        fi
         # LMCache MP server. L1 = CPU RAM (--l1-size-gb). L2 = optional disk, OFF by default:
         #   LMCACHE_L2=1                -> enable L2 at the in-repo default /lmcache-kv (fs adapter)
         #   LMCACHE_L2_ADAPTER='{...}'  -> full override (custom path/backend); wins over LMCACHE_L2
@@ -119,7 +129,11 @@ services:
         fi
         lmcache server "$${LM_ARGS[@]}" &
         sleep 6
-        exec vllm serve --disable-custom-all-reduce "$$@"
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve "$$@"
+        else
+          exec vllm serve --disable-custom-all-reduce "$$@"
+        fi
       - --
     command:
       - --model


### PR DESCRIPTION
## Summary

- Port **NVLink auto-detection** from `vllm/qwen-27b-dual-max` (`dual/fp8/mtp.yml`) onto the incubating LMCache compose (`vllm/qwen-27b-dual-lmcache`)
- On NVLink rigs: enable NCCL P2P (`NCCL_P2P_LEVEL=NVL`) and **omit** `--disable-custom-all-reduce` so TP=2 all-reduce uses the GPU–GPU NVLink path instead of PCIe
- On PCIe rigs: unchanged behavior (`NCCL_P2P_DISABLE=1`, `--disable-custom-all-reduce`)

**Includes #429** (Compose v5 `$$` entrypoint escape — required for this compose to parse on Docker Compose v5.1+). If #429 lands first, this PR can be rebased to a single-commit NVLink-only diff.

## Why this was needed

The LMCache compose shipped as **PCIe-forced** even though every other dual vLLM compose in this repo auto-detects NVLink at boot via `scripts/detect_nvlink.sh` + `NVLINK_MODE` (see `docs/DUAL_CARD.md`).

Observed on an NVLink bridge rig running LMCache stress tests:

- High sustained **PCIe TX/RX** on both 3090s
- **Flat NVLink counters** during TP traffic
- Container env showed `NCCL_P2P_DISABLE=1` and entrypoint always passed `--disable-custom-all-reduce`

Root cause: `lmcache.yml` omitted the `detect_nvlink.sh` mount, `NVLINK_MODE` env, and conditional entrypoint that `dual/fp8/mtp.yml` uses. That was likely an oversight when authoring the third-party `lmcache/vllm-openai` image path (#133), not an LMCache requirement — the controlled A/B in #133 toggled only the connector, not NCCL topology.

**Note:** LMCache KV offload (GPU ↔ host DRAM) still uses PCIe per GPU; NVLink does not remove that. This change fixes **tensor-parallel GPU↔GPU** traffic only.

## Implementation notes

| Change | Purpose |
|--------|---------|
| Mount `scripts/detect_nvlink.sh` | Same boot-time topology probe as dual-max |
| `NVLINK_MODE=${NVLINK_MODE:-auto}` | `auto` / `force_on` / `force_off` override (see `docs/HARDWARE.md`) |
| `ipc: host` | Matches other dual composes (NCCL) |
| Conditional `vllm serve` | NVLink → custom all-reduce on; PCIe → `--disable-custom-all-reduce` |
| `unset PYTORCH_CUDA_ALLOC_CONF` on PCIe path | `detect_nvlink.sh` sets `expandable_segments:True` on PCIe, which **breaks LMCacheMPConnector** (documented boot constraint in compose header). NVLink path keeps `detect_nvlink`'s `max_split_size_mb:512` only — compatible. |

## Test plan

- [ ] `docker compose -f models/qwen3.6-27b/vllm-lmcache/compose/dual/fp8/lmcache.yml config` — exit 0 (Compose v5 `$$` escaping from #429)
- [ ] **NVLink rig:** `docker logs … \| grep '\[nvlink\]'` → `detected NVLink … P2P ENABLED`; `nvidia-smi nvlink --getthroughput` shows traffic under TP load
- [ ] **PCIe rig (or `NVLINK_MODE=force_off`):** logs show PCIe mode; boot + serve unchanged
- [ ] LMCache still boots with connector enabled (no `expandable_segments` validation error on PCIe)
- [ ] Optional: `bash scripts/switch.sh --force vllm/qwen-27b-dual-lmcache` end-to-end on NVLink hardware
