### PR TITLE
Fix NVLink auto-detect across dual/multi vLLM composes (Compose v5.1)

### DIFF
--- a/models/diffusiongemma-26b-a4b/vllm/compose/dual/fp8/base.yml
+++ b/models/diffusiongemma-26b-a4b/vllm/compose/dual/fp8/base.yml
@@ -2,7 +2,7 @@
 # Profile (at-a-glance):
 #   Model:     DiffusionGemma 26B-A4B — discrete-diffusion LM / dLLM (RedHatAI
 #              FP8-dynamic, compressed-tensors float-quantized)
-#   Topology:  Dual 3090 PCIe (TP=2, no NVLink)
+#   Topology:  Dual 3090 (TP=2, NVLink auto-detected via NVLINK_MODE — PCIe by default on this rig)
 #   Drafter:   none — diffusion LM (block-parallel denoising; AR spec-dec N/A)
 #   KV:        bf16 (pool ~408K tok @ util 0.82, 262K-len)
 #   Vision:    no (text diffusion)
@@ -71,6 +71,8 @@ services:
       - ../../../patches/gemma-image-fixes/marlin.py:/usr/local/lib/python3.12/dist-packages/vllm/model_executor/kernels/linear/scaled_mm/marlin.py:ro
       - ../../../patches/gemma-image-fixes/marlin_utils_fp8.py:/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/utils/marlin_utils_fp8.py:ro
       - ../../../patches/gemma-image-fixes/diffusion_gemma.py:/usr/local/lib/python3.12/dist-packages/vllm/model_executor/models/diffusion_gemma.py:ro
+      # NVLink auto-detection — runs inside container at boot (same path as dual-max).
+      - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
@@ -80,9 +82,12 @@ services:
       - TORCHDYNAMO_DISABLE=1
       - TORCH_COMPILE_DISABLE=1
       - VLLM_WORKER_MULTIPROC_METHOD=spawn
+      - NVLINK_MODE=${NVLINK_MODE:-auto}
       - NCCL_CUMEM_ENABLE=0
       - NCCL_P2P_DISABLE=1
-      - VLLM_DISABLE_CUSTOM_ALL_REDUCE=1
+      # custom all-reduce is now toggled by the entrypoint (OFF on PCIe via
+      # --disable-custom-all-reduce, ON when detect_nvlink finds NVLink/P2P) —
+      # replaces the former static VLLM_DISABLE_CUSTOM_ALL_REDUCE=1.
       - VLLM_NO_USAGE_STATS=1
       - OMP_NUM_THREADS=1
       - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True,max_split_size_mb:512}
@@ -98,7 +103,23 @@ services:
             - driver: nvidia
               count: all
               capabilities: [gpu]
-    # The :gemma image ENTRYPOINT is ["vllm","serve"]; command supplies the model + flags.
+    # Custom entrypoint overrides the :gemma image's ["vllm","serve"] so detect_nvlink
+    # can toggle custom all-reduce; command (the model + flags) is passed through as "$@".
+    entrypoint:
+      - bash
+      - -c
+      - |
+        # NVLink auto-detect: detect_nvlink.sh sets the NCCL env + _NVLINK_ENABLED;
+        # vLLM custom all-reduce is ON for NVLink/P2P, OFF (--disable-custom-all-reduce)
+        # for PCIe. $$ escapes $ so Compose v5.1+ passes the bash through verbatim — an
+        # un-escaped _NVLINK_ENABLED ref would be interpolated at parse time → forced to 0.
+        source /etc/club3090/detect_nvlink.sh
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve "$$@"
+        else
+          exec vllm serve --disable-custom-all-reduce "$$@"
+        fi
+      - --
     command:
       - /root/.cache/huggingface/diffusiongemma-26b-a4b-it-fp8-dynamic
       - --served-model-name

--- a/models/gemma-4-12b/vllm/compose/dual/bf16/mtp.yml
+++ b/models/gemma-4-12b/vllm/compose/dual/bf16/mtp.yml
@@ -79,10 +79,10 @@ services:
       - |
         # PCIe (no NVLink) → inject --disable-custom-all-reduce; NVLink rigs skip it.
         source /etc/club3090/detect_nvlink.sh
-        if [ "${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve "$@"
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve "$$@"
         else
-          exec vllm serve --disable-custom-all-reduce "$@"
+          exec vllm serve --disable-custom-all-reduce "$$@"
         fi
       - --
     command:

--- a/models/gemma-4-26b-a4b/vllm/compose/dual/awq/mtp.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/dual/awq/mtp.yml
@@ -1,7 +1,7 @@
 # ===========================================================================
 # Profile (at-a-glance):
 #   Model:     Gemma 4 26B-A4B MoE (cyankiwi AWQ-4bit, compressed-tensors)
-#   Topology:  Dual 3090 (TP=2)
+#   Topology:  Dual 3090 (TP=2, NVLink auto-detected via NVLINK_MODE)
 #   Drafter:   MTP n=4 — google/gemma-4-26B-A4B-it-assistant (external)
 #   KV:        bfloat16 (sidesteps Ampere fp8 dispatch issues)
 #   Vision:    off (limit-mm-per-prompt image=0 audio=0)
@@ -51,12 +51,15 @@ services:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
+      # NVLink auto-detection — runs inside container at boot (same path as dual-max).
+      - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}
       - VLLM_WORKER_MULTIPROC_METHOD=spawn
+      - NVLINK_MODE=${NVLINK_MODE:-auto}
       - NCCL_CUMEM_ENABLE=0
       - NCCL_P2P_DISABLE=1
       - VLLM_NO_USAGE_STATS=1
@@ -73,6 +76,21 @@ services:
             - driver: nvidia
               count: all
               capabilities: [gpu]
+    entrypoint:
+      - bash
+      - -c
+      - |
+        # NVLink auto-detect: detect_nvlink.sh sets the NCCL env + _NVLINK_ENABLED;
+        # vLLM custom all-reduce is ON for NVLink/P2P, OFF (--disable-custom-all-reduce)
+        # for PCIe. $$ escapes $ so Compose v5.1+ passes the bash through verbatim — an
+        # un-escaped _NVLINK_ENABLED ref would be interpolated at parse time → forced to 0.
+        source /etc/club3090/detect_nvlink.sh
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve "$$@"
+        else
+          exec vllm serve --disable-custom-all-reduce "$$@"
+        fi
+      - --
     command:
       - --override-generation-config
       - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-64},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'

--- a/models/gemma-4-31b/vllm/compose/dual/autoround-int4/bf16-mtp.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/autoround-int4/bf16-mtp.yml
@@ -116,10 +116,10 @@ services:
         bash /etc/club3090/pr42006/install.sh
         # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
         source /etc/club3090/detect_nvlink.sh
-        if [ "${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve "$@"
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve "$$@"
         else
-          exec vllm serve --disable-custom-all-reduce "$@"
+          exec vllm serve --disable-custom-all-reduce "$$@"
         fi
       - --
     command:

--- a/models/gemma-4-31b/vllm/compose/dual/autoround-int4/int8.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/autoround-int4/int8.yml
@@ -178,10 +178,10 @@ services:
         bash /etc/club3090/pr42006/install.sh
         # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
         source /etc/club3090/detect_nvlink.sh
-        if [ "${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve "$@"
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve "$$@"
         else
-          exec vllm serve --disable-custom-all-reduce "$@"
+          exec vllm serve --disable-custom-all-reduce "$$@"
         fi
       - --
     command:

--- a/models/gemma-4-31b/vllm/compose/dual/qat-w4a16/int8.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/qat-w4a16/int8.yml
@@ -183,10 +183,10 @@ services:
         bash /etc/club3090/pr42006/install.sh
         # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
         source /etc/club3090/detect_nvlink.sh
-        if [ "${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve "$@"
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve "$$@"
         else
-          exec vllm serve --disable-custom-all-reduce "$@"
+          exec vllm serve --disable-custom-all-reduce "$$@"
         fi
       - --
     command:

--- a/models/qwen3-omni-30b-a3b/vllm-omni/compose/dual/autoround-int4/omni.yml
+++ b/models/qwen3-omni-30b-a3b/vllm-omni/compose/dual/autoround-int4/omni.yml
@@ -24,6 +24,10 @@
 #       routes through the Talker (audio) stage, which has a prefill shape bug and kills the engine.
 #     • fp8 KV (default) → full ctx for TEXT, but breaks Code2Wav (audio). Speech out → KV_CACHE_DTYPE=auto.
 #     • Uses BOTH cards (stage-parallel). Don't co-run another GPU-heavy service.
+#     • NVLink auto-config (the detect_nvlink/NVLINK_MODE custom-all-reduce toggle the other vLLM
+#       duals carry) is deliberately N/A here: stage-parallel (thinker→GPU0, talker+code2wav→GPU1)
+#       has no TP all-reduce to toggle, and the cross-stage connector uses host shared memory — so
+#       NCCL_P2P stays disabled by design (re-enabling P2P would regress, not help). Not missing.
 #   Best for:  Qwen3-Omni text + multimodal *understanding* on 2x 3090 (RAG/long-doc, vision/audio in).
 # ---------------------------------------------------------------------------
 # See ../../../README.md (engine folder) for the full setup walk-through (weights download,

--- a/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml
@@ -125,10 +125,10 @@ services:
         # stability. See docs/HARDWARE.md "Note for WSL2 / Windows users".
         # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
         source /etc/club3090/detect_nvlink.sh
-        if [ "${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} "$@"
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@"
         else
-          exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$@"
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@"
         fi
       - --
     command:

--- a/models/qwen3.6-27b/vllm/compose/dual/awq-bf16-int4/int8.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/awq-bf16-int4/int8.yml
@@ -120,10 +120,10 @@ services:
         # stability. See docs/HARDWARE.md "Note for WSL2 / Windows users".
         # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
         source /etc/club3090/detect_nvlink.sh
-        if [ "${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} "$@"
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@"
         else
-          exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$@"
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@"
         fi
       - --
     command:

--- a/models/qwen3.6-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/fp8/mtp.yml
@@ -133,10 +133,10 @@ services:
         # stability. See docs/HARDWARE.md "Note for WSL2 / Windows users".
         # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
         source /etc/club3090/detect_nvlink.sh
-        if [ "${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} "$@"
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@"
         else
-          exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$@"
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@"
         fi
       - --
     command:

--- a/models/qwen3.6-27b/vllm/compose/multi4/autoround-int4/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/multi4/autoround-int4/mtp.yml
@@ -109,10 +109,10 @@ services:
         # stability. See docs/HARDWARE.md "Note for WSL2 / Windows users".
         # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
         source /etc/club3090/detect_nvlink.sh
-        if [ "${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} "$@"
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@"
         else
-          exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$@"
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@"
         fi
       - --
     command:

--- a/models/qwen3.6-27b/vllm/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/multi4/fp8/mtp.yml
@@ -115,10 +115,10 @@ services:
         # stability. See docs/HARDWARE.md "Note for WSL2 / Windows users".
         # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
         source /etc/club3090/detect_nvlink.sh
-        if [ "${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} "$@"
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@"
         else
-          exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$@"
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@"
         fi
       - --
     command:

--- a/models/qwen3.6-35b-a3b/vllm/compose/dual/autoround-int4/fp8.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/dual/autoround-int4/fp8.yml
@@ -1,7 +1,7 @@
 # ===========================================================================
 # Profile (at-a-glance):
 #   Model:     Qwen 3.6 35B-A3B MoE (AutoRound INT4 experts + BF16 routers, ~20 GB weights)
-#   Topology:  Dual 3090 (TP=2, PCIe — no NVLink)
+#   Topology:  Dual 3090 (TP=2, NVLink auto-detected via NVLINK_MODE — PCIe by default on this rig)
 #   Drafter:   none — built-in MTP REJECTED (n=2 AND n=3 both ≈ −45/−51% TPS on
 #              this MoE under vLLM TP=2: the draft forward incurs inter-GPU sync
 #              the acceptance gain can't amortize). MTP head is present in the
@@ -68,12 +68,15 @@ services:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
+      # NVLink auto-detection — runs inside container at boot (same path as dual-max).
+      - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}
       - VLLM_WORKER_MULTIPROC_METHOD=spawn
+      - NVLINK_MODE=${NVLINK_MODE:-auto}
       - NCCL_CUMEM_ENABLE=0
       - NCCL_P2P_DISABLE=1
       - VLLM_NO_USAGE_STATS=1
@@ -88,6 +91,21 @@ services:
             - driver: nvidia
               count: all
               capabilities: [gpu]
+    entrypoint:
+      - bash
+      - -c
+      - |
+        # NVLink auto-detect: detect_nvlink.sh sets the NCCL env + _NVLINK_ENABLED;
+        # vLLM custom all-reduce is ON for NVLink/P2P, OFF (--disable-custom-all-reduce)
+        # for PCIe. $$ escapes $ so Compose v5.1+ passes the bash through verbatim — an
+        # un-escaped _NVLINK_ENABLED ref would be interpolated at parse time → forced to 0.
+        source /etc/club3090/detect_nvlink.sh
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve "$$@"
+        else
+          exec vllm serve --disable-custom-all-reduce "$$@"
+        fi
+      - --
     command:
       - --override-generation-config
       - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'


### PR DESCRIPTION
## Summary

Auditing NVLink auto-detection across all 25 live dual/multi composes (prompted by reviewing #433) surfaced **two problems**, both fixed here:

1. **9 vLLM composes had NVLink detection, but it was silently DEAD on Docker Compose v5.1+.** The un-escaped `${_NVLINK_ENABLED:-0}` in their boot scripts was interpolated to `0` *at parse time* (the host env lacks the var), so `if [ "0" = "1" ]` was always false → always the PCIe branch, regardless of hardware. `detect_nvlink.sh` still ran, but its result was ignored. On an NVLink rig running Compose v5.1+, NVLink never engaged. **Same root cause as the lmcache fix in #429/#433 — applied repo-wide.**
2. **3 dual composes were missing the auto-config entirely** — now ported.

`qwen3-omni` is documented as *exempt* (stage-parallel, not TP — no all-reduce to toggle; the cross-stage connector uses host shared memory).

## The bug (finding #1)

On Compose v5.1.4 (verified on this rig), the on-master entrypoints resolve like this:

```
# before (un-escaped) — `docker compose config` shows:
if [ "0" = "1" ]; then ...        # _NVLINK_ENABLED baked to 0 at parse time → NVLink branch dead

# after ($$-escaped) — resolves to:
if [ "${_NVLINK_ENABLED:-0}" = "1" ]; then ...   # bash evaluates it at runtime
```

The fix escapes the three entrypoint-bash tokens (`$${_NVLINK_ENABLED:-0}`, `$${VLLM_ENFORCE_EAGER:+...}`, `"$$@"`) so Compose passes them through verbatim. It is **PCIe-behaviour-neutral** — on a PCIe rig both the broken and fixed forms resolve to the PCIe branch, so there is no behaviour change on this rig; the fix only *restores* the NVLink path on NVLink rigs.

## What changed (13 composes, 3 commits)

| Commit | Composes | Note |
|---|---|---|
| **1 — escape-fix** | qwen3.6-27b dual default (`dual/fp8/mtp`) + `dual/autoround-int4/fp8-mtp` + `dual/awq-bf16-int4/int8` + both `multi4`; gemma-4-31b ×3; gemma-4-12b | restores dead detection; PCIe-neutral |
| **2 — add missing** | gemma-4-26b-a4b (🧪) · diffusiongemma (🧪) + document omni exemption | new ports, escaped form |
| **3 — add missing (gated)** | qwen3.6-35b-a3b (✅ Production) | **rebench-gated — see below** |

## ⚠️ Merge-readiness is per-commit

- **Commits 1 & 2 (11 composes)** are merge-ready: PCIe-behaviour-neutral (the escape-fixes) or experimental (the two ports).
- **Commit 3 (qwen3.6-35b-a3b, ✅ Production)** is the only one that changes a *validated* PCIe path — it adds an explicit `--disable-custom-all-reduce` where there was none before (the compose relied on the image default + `NCCL_P2P_DISABLE=1`). Almost certainly a no-op on PCIe (vLLM auto-disables custom all-reduce without P2P on consumer 3090s), but it warrants a `rebench-full` confirm on a free rig before merge (rig currently busy). **This PR is a draft for that reason** — hold/rebench commit 3, then mark ready.

## Validation (Compose v5.1.4; this rig is 2× RTX 3090, PCIe)

- `docker compose config` parses clean on all 13; the 9 fixed + 3 ported all resolve to a **live** `${_NVLINK_ENABLED}` (not a baked `0`).
- The 3 ports are warning-free (no `variable is not set`).
- Guard suite **47/47** (`for t in scripts/tests/*.sh; do bash "$t"; done`).
- The NVLink branch itself is **untested here** (PCIe rig) — cross-rig NVLink validation welcome (cf. #405/#433 for the qwen / diffusion paths). The diffusiongemma `:gemma`-image entrypoint override in particular wants an NVLink boot-check.

## Relationship to #429 / #433

#429/#433 fix the same Compose-v5.1 escape bug for the lmcache compose; this PR fixes it everywhere else and adds the 3 missing composes. No file overlap (lmcache untouched here). Suggest landing #433 for lmcache + this for the rest. A follow-up guard test asserting no shipped compose carries the un-escaped form would prevent this regressing again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
