### PR TITLE
c3 catalog: instant first-paint + batched fit (kv-calc --fit-all)

### DIFF
--- a/scripts/tests/test-kv-calc-fit.sh
+++ b/scripts/tests/test-kv-calc-fit.sh
@@ -140,10 +140,41 @@ for label, fit_arg, card_arg in (
         check(False, f"(d) {label}: output is valid JSON (got {exc}; out={out_u!r})")
     check(rc_u != 0, f"(d) {label}: exits non-zero (got {rc_u})")
 
+# ---------------------------------------------------------------------------
+# (e) --fit-all: ONE process emits a verdict for EVERY registry slug, shaped
+#     {card, card_vram_gb, variants:{slug: <fit_verdict>}}. vLLM slugs get a
+#     real verdict identical to the per-slug --fit; non-vLLM (kvcalc SKIP) get
+#     {"verdict":"skip"}. This is the cockpit catalog's batched fit path —
+#     one subprocess instead of N.
+# ---------------------------------------------------------------------------
+rc_a, out_a, err_a = run_fit("--fit-all", "--card", "rtx3090", "--json")
+check(rc_a == 0, f"(e) --fit-all exits 0 (got {rc_a}; stderr={err_a.strip()!r})")
+try:
+    da = json.loads(out_a)
+    parsed_a = True
+except Exception as exc:  # noqa: BLE001
+    da, parsed_a = {}, False
+    check(False, f"(e) --fit-all output is valid JSON (got {exc}; out={out_a!r})")
+if parsed_a:
+    check(set(da.keys()) >= {"card", "card_vram_gb", "variants"},
+          f"(e) top-level keys include card/card_vram_gb/variants (got {sorted(da.keys())})")
+    variants = da.get("variants", {})
+    check(isinstance(variants, dict) and len(variants) > 10,
+          f"(e) variants is a non-trivial dict (got {len(variants) if isinstance(variants, dict) else variants!r})")
+    check("vllm/dual" in variants and variants["vllm/dual"].get("verdict") in VERDICTS_OK,
+          f"(e) vllm/dual has a real verdict in the batch (got {variants.get('vllm/dual')!r})")
+    check(variants.get("vllm/dual") == json.loads(out),
+          "(e) batch vllm/dual == per-slug --fit (one pricing path)")
+    check(variants.get("beellama/dflash", {}).get("verdict") == "skip",
+          f"(e) non-vLLM beellama/dflash → skip (got {variants.get('beellama/dflash')!r})")
+    check(all(isinstance(v, dict) and isinstance(v.get("verdict"), str)
+              for v in variants.values()),
+          "(e) every variant value carries a verdict string")
+
 if failures:
     print(f"\n{len(failures)} assertion(s) failed.", file=sys.stderr)
     sys.exit(1)
-print("\nAll --fit JSON shape assertions passed (a-d).")
+print("\nAll --fit / --fit-all JSON shape assertions passed (a-e).")
 PY
 
 echo "test-kv-calc-fit.sh OK"

--- a/tools/kv-calc.py
+++ b/tools/kv-calc.py
@@ -1445,6 +1445,37 @@ def fit_verdict(target: str, card: Optional[str], vram_default: float) -> dict:
     }
 
 
+def fit_all_verdicts(card: Optional[str], vram_default: float) -> dict:
+    """Batch fit verdicts for EVERY registry slug on one card, in a SINGLE
+    process — one registry/profile load instead of N subprocesses.
+
+    Mirrors `--fit` per slug (same verdict shape); non-vLLM slugs
+    (kvcalc_key SKIP) get ``{"verdict": "skip"}``. Shaped:
+      {"card": <str|None>, "card_vram_gb": <float>,
+       "variants": {<slug>: <fit_verdict dict>, ...}}
+    The cockpit catalog consumes this instead of fanning out N `--fit` calls.
+    """
+    from scripts.lib.profiles.compose_registry import COMPOSE_REGISTRY
+
+    vram = _resolve_card_vram_gb(card)
+    if card is not None and vram is None:
+        return {
+            "card": card,
+            "error": f"unrecognized --card {card!r} (pass a known card name or a GB number)",
+            "variants": {},
+        }
+    if vram is None:
+        vram = float(vram_default)
+
+    variants: dict = {}
+    for slug, entry in COMPOSE_REGISTRY.items():
+        if entry.get("kvcalc_key") in (None, "SKIP"):
+            variants[slug] = {"verdict": "skip"}
+            continue
+        variants[slug] = fit_verdict(slug, card, vram_default)
+    return {"card": card, "card_vram_gb": round(float(vram), 4), "variants": variants}
+
+
 # =============================================================================
 # CLI
 # =============================================================================
@@ -1497,6 +1528,10 @@ def main():
     p.add_argument("--fit", metavar="SLUG|MODEL",
                    help="Structured fit verdict for a registry compose slug (e.g. vllm/dual) or a bare "
                         "catalogued model (resolved to its curated vLLM default). Use with --card and --json.")
+    p.add_argument("--fit-all", action="store_true",
+                   help="Batch --fit for EVERY registry slug on --card, as one JSON object "
+                        "{card, card_vram_gb, variants:{slug: verdict}}. One process, no per-slug fan-out "
+                        "(the cockpit catalog's fit column). Always emits JSON.")
     p.add_argument("--card", metavar="GPU",
                    help="Per-card GPU for --fit: a known card name (e.g. rtx3090, a6000) or a GB number. "
                         "Default: --vram.")
@@ -1550,6 +1585,11 @@ def main():
                 print(f"  VRAM est:     {result['vram_est_gb']:.2f} GB / card (±{result['band_gb']:.1f} GB band)")
                 print(f"  Max ctx fit:  {result['max_ctx']:,} tokens")
         return 0 if result["verdict"] != "unknown" else 2
+
+    if args.fit_all:
+        result = fit_all_verdicts(args.card, args.vram)
+        print(json.dumps(result, indent=2))
+        return 0 if "error" not in result else 2
 
     # Resolve model: explicit --model > inferred from --compose > qwen3.6-27b
     model_key = _resolve_compose_model(args.compose, args.model) if args.compose else (args.model or "qwen3.6-27b")

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -281,6 +281,18 @@ class CatalogPane(Container):
             star = "  ([dim]*[/dim] = BENCHMARKS.md scrape)" if self._has_md_scrape() else ""
             status_label.update(f"{len(self._entries)} variants loaded from registry{star}")
 
+    def refresh_enriched(self) -> None:
+        """Re-render after background enrichment mutated the shared entries in
+        place (fit / measurement), preserving the cursor row + active filter."""
+        table = self.query_one("#catalog-table", DataTable)
+        saved = table.cursor_row
+        self._render_rows()
+        if table.row_count:
+            try:
+                table.move_cursor(row=max(0, min(saved, table.row_count - 1)))
+            except Exception:
+                pass
+
     def _has_md_scrape(self) -> bool:
         return any(e.measurement.source == "benchmarks.md" for e in self._entries)
 
@@ -2207,14 +2219,28 @@ class CockpitApp(App):
 
     @work(exclusive=True, group="catalog")
     async def load_catalog(self) -> None:
-        """Load the enriched catalog from the service layer (real read)."""
-        entries, error = await self._data.load_catalog()
+        """Load the catalog (real read): paint the registry rows immediately,
+        then enrich fit + TPS in the background so the table appears in ~1s
+        instead of blocking on the full enrichment."""
+        rows, error = await self._data.load_catalog_rows()
+        if not error and not rows:
+            error = "No variants returned — registry may be empty"
         # Cache variants for detect/match + container slug-matching.
-        self._variants = [e.row for e in entries]
+        self._variants = [e.row for e in rows]
         try:
-            self.query_one("#catalog-pane", CatalogPane).populate(entries, error)
+            pane = self.query_one("#catalog-pane", CatalogPane)
         except Exception:
-            pass
+            return
+        pane.populate(rows, error)          # instant first paint (stub fit/TPS)
+        if error or not rows:
+            return
+        # Progressive enrichment — re-render after each phase (cursor preserved).
+        # rows are the SAME CatalogEntry objects the pane holds, so in-place
+        # mutation of e.fit / e.measurement is visible to refresh_enriched().
+        await self._data.enrich_fits(rows)
+        pane.refresh_enriched()
+        await self._data.enrich_measurements(rows)
+        pane.refresh_enriched()
 
     # ── Estate polling ───────────────────────────────────────────────────────────────
 

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -219,16 +219,31 @@ class CockpitData:
     async def load_catalog(
         self, *, enrich_fit: bool = True, enrich_measurement: bool = True
     ) -> tuple[list[CatalogEntry], Optional[str]]:
-        """Enriched variant rows.
+        """Fully-enriched variant rows: load_catalog_rows() + optional fit
+        (batched kv-calc --fit-all) + measurement (parallel) enrichment.
 
-        1. registry-emit.sh --json → VariantRow list (variants block).
-        2. per-slug fit verdict for the locally-detected card (via kv-calc).
-        3. per-slug measurement (TPS / 8pk) from the structured explain corpus,
-           fallback to a coarse BENCHMARKS.md parse.
-
-        Fit + measurement enrichment is best-effort: a failed join leaves the
-        stub glyph rather than failing the whole catalog load.
+        Enrichment is best-effort: a failed join leaves the stub glyph rather
+        than failing the whole load. The cockpit paints load_catalog_rows()
+        first and enriches in the background; this combined entry point is kept
+        for callers/tests that want a fully-enriched result in one await.
         """
+        entries, err = await self.load_catalog_rows()
+        if err and not entries:
+            return [], err
+
+        if enrich_fit:
+            await self.enrich_fits(entries)
+        if enrich_measurement:
+            await self.enrich_measurements(entries)
+
+        if not entries:
+            return [], "No variants returned — registry may be empty"
+        return entries, None
+
+    async def load_catalog_rows(self) -> tuple[list[CatalogEntry], Optional[str]]:
+        """Registry rows ONLY — the fast first paint (no fit/measurement
+        enrichment). One read of compose_registry.py via registry-emit.sh
+        --json, with the raw-tab fallback if the --json wrapper regresses."""
         data, err = await self._run_json(
             ["bash", "scripts/lib/registry-emit.sh", "--json"], timeout=30.0
         )
@@ -241,16 +256,7 @@ class CockpitData:
         else:
             rows = [_variant_row_from_dict(d) for d in (data or {}).get("variants", [])]
 
-        entries = [CatalogEntry(row=r) for r in rows]
-
-        if enrich_fit:
-            await self._enrich_fits(entries)
-        if enrich_measurement:
-            await self._enrich_measurements(entries)
-
-        if not entries:
-            return [], "No variants returned — registry may be empty"
-        return entries, None
+        return [CatalogEntry(row=r) for r in rows], None
 
     async def _load_catalog_rows_fallback(self) -> tuple[list[VariantRow], Optional[str]]:
         cmd = [
@@ -265,26 +271,36 @@ class CockpitData:
             return [], res.stderr.strip()[:200] or "no rows"
         return parse_variant_rows(res.stdout), None
 
-    # Catalog enrichment fans out one subprocess per slug (kv-calc --fit, then
-    # switch --explain). Serially awaited over ~50 variants that is ~45 s (the
-    # explain leg alone is ~0.7 s × N). A cap-bounded asyncio.gather cuts it to a
-    # few seconds without flooding the box with N concurrent bash+python procs.
+    # enrich_measurements still fans out one switch --explain per slug; a
+    # cap-bounded asyncio.gather keeps that to a few seconds without flooding
+    # the box. enrich_fits no longer fans out — it uses the single kv-calc
+    # --fit-all batch (one process for the whole catalog).
     _ENRICH_CONCURRENCY = 12
 
-    async def _enrich_fits(self, entries: list[CatalogEntry]) -> None:
-        sem = asyncio.Semaphore(self._ENRICH_CONCURRENCY)
+    async def fit_all(self, card: Optional[str] = None) -> dict:
+        """kv-calc.py --fit-all --card <card> --json — fit verdict for EVERY
+        registry slug in ONE process. Returns {slug: verdict_dict}, or {} on
+        error (catalog still renders, fit column shows the stub glyph)."""
+        cmd = ["python3", "tools/kv-calc.py", "--fit-all", "--json"]
+        c = card or self.card
+        if c:
+            cmd += ["--card", c]
+        data, _err = await self._run_json(cmd, timeout=30.0)
+        return (data or {}).get("variants", {}) or {}
 
-        async def _one(e: CatalogEntry) -> None:
-            # ik/llama composes use kvcalc_key "SKIP" → no vLLM kv-calc fit.
-            if (e.row.kvcalc_key or "").upper() == "SKIP":
+    async def enrich_fits(self, entries: list[CatalogEntry]) -> None:
+        """Fit column for the whole catalog via ONE kv-calc --fit-all call
+        (the batch replaces the former per-slug fan-out)."""
+        variants = await self.fit_all(self.card)
+        for e in entries:
+            vd = variants.get(e.slug)
+            if vd is not None:
+                e.fit = FitVerdict.from_dict(vd, card=self.card)
+            elif (e.row.kvcalc_key or "").upper() == "SKIP":
+                # ik/llama composes (kvcalc_key SKIP) — no vLLM kv-calc fit.
                 e.fit = FitVerdict(verdict="skip", card=self.card)
-                return
-            async with sem:
-                e.fit = await self.fit(e.slug, self.card)
 
-        await asyncio.gather(*(_one(e) for e in entries))
-
-    async def _enrich_measurements(self, entries: list[CatalogEntry]) -> None:
+    async def enrich_measurements(self, entries: list[CatalogEntry]) -> None:
         # Read BENCHMARKS.md once up front — the per-slug md fallback below is
         # then a pure in-memory parse (no I/O per slug).
         bench_md = self._read_benchmarks_md()

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -166,6 +166,18 @@ FIT_JSON = json.dumps(
     {"verdict": "fits-clean", "vram_est_gb": 19.881, "band_gb": 1.5, "max_ctx": 262144}
 )
 
+# kv-calc --fit-all batch (one call enriches the whole catalog's fit column).
+FIT_ALL_JSON = json.dumps(
+    {
+        "card": "rtx-3090",
+        "card_vram_gb": 24.0,
+        "variants": {
+            "vllm/dual": {"verdict": "fits-clean", "vram_est_gb": 19.881, "band_gb": 1.5, "max_ctx": 262144},
+            "ik-llama/iq4ks-mtp": {"verdict": "skip"},
+        },
+    }
+)
+
 # REAL switch.sh --explain --json benchmarks shape: [{"row","columns"}].
 # TPS lives in columns[4] ("Narr / Code TPS"); 8-pack is scraped from the row.
 EXPLAIN_BENCH_ROW = {
@@ -341,6 +353,9 @@ REBENCH_REPORT_MD = (
 def fake_responses(**overrides) -> dict[str, RunResult]:
     responses = {
         "registry-emit.sh --json": ok(REGISTRY_JSON),
+        # --fit-all MUST precede --fit (the batch cmd contains "kv-calc.py --fit"
+        # as a substring; FakeRunner returns the first match).
+        "kv-calc.py --fit-all": ok(FIT_ALL_JSON),
         "kv-calc.py --fit": ok(FIT_JSON),
         "--explain vllm/dual --json": ok(EXPLAIN_JSON),
         "--explain ik-llama/iq4ks-mtp --json": ok(EXPLAIN_NO_BENCH_JSON),

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -167,6 +167,20 @@ FIT_JSON = json.dumps(
     {"verdict": "fits-clean", "vram_est_gb": 19.881, "band_gb": 1.5, "max_ctx": 262144}
 )
 
+# kv-calc --fit-all --json shape: {card, card_vram_gb, variants:{slug: verdict}}.
+# The catalog fit column is enriched from ONE --fit-all call (not N --fit calls);
+# non-vLLM (kvcalc_key SKIP) slugs come back as {"verdict": "skip"}.
+FIT_ALL_JSON = json.dumps(
+    {
+        "card": "rtx-3090",
+        "card_vram_gb": 24.0,
+        "variants": {
+            "vllm/dual": {"verdict": "fits-clean", "vram_est_gb": 19.881, "band_gb": 1.5, "max_ctx": 262144},
+            "ik-llama/iq4ks-mtp": {"verdict": "skip"},
+        },
+    }
+)
+
 # REAL switch.sh --explain --json benchmarks shape (verified live):
 #   [{"row": "<markdown row>", "columns": [<cell>, …]}]
 # Canonical bench layout: Compose|Rig|KV|Max ctx|Narr/Code TPS|PP|VRAM|Date|Notes
@@ -262,6 +276,9 @@ def full_runner(**overrides) -> FakeRunner:
     """A FakeRunner wired for the common read contracts; override per-test."""
     responses = {
         "registry-emit.sh --json": ok(REGISTRY_JSON),
+        # --fit-all MUST precede --fit: the batch command contains the substring
+        # "kv-calc.py --fit" too, and FakeRunner returns the first match.
+        "kv-calc.py --fit-all": ok(FIT_ALL_JSON),
         "kv-calc.py --fit": ok(FIT_JSON),
         "--explain vllm/dual --json": ok(EXPLAIN_JSON),
         "--explain ik-llama/iq4ks-mtp --json": ok(EXPLAIN_NO_BENCH_JSON),
@@ -459,7 +476,8 @@ class TestLoadCatalog:
 
     @pytest.mark.asyncio
     async def test_catalog_skip_fit_for_ik_llama(self):
-        """ik/llama kvcalc_key=SKIP → fit verdict 'skip', no kv-calc call."""
+        """ik/llama kvcalc_key=SKIP → fit verdict 'skip' (the --fit-all batch
+        emits skip for non-vLLM slugs; no per-slug fan-out)."""
         cd = CockpitData(ROOT, runner=full_runner())
         entries, _ = await cd.load_catalog(enrich_fit=True, enrich_measurement=False)
         ik = next(e for e in entries if e.slug == "ik-llama/iq4ks-mtp")


### PR DESCRIPTION
Follow-up to #438. Takes the Discover catalog from "~5s to appear" to **~0.5s to appear**, and replaces the per-slug fit fan-out with one batched call — the "load from the registry in one read, one pass per enrichment" architecture (the same single registry read `switch.sh --list` uses).

## Two changes

**1. `kv-calc --fit-all` (new contract).** One process walks `COMPOSE_REGISTRY` and emits `{card, card_vram_gb, variants:{slug: verdict}}` — the same per-slug verdict as `--fit`, with `skip` for non-vLLM (kvcalc_key SKIP). Replaces 53 `kv-calc --fit` subprocesses with 1. `test-kv-calc-fit.sh` §(e) covers shape + per-slug equivalence + skip.

**2. Cockpit render-now + batch fit.** `load_catalog` now paints the registry rows *immediately* (one `registry-emit.sh --json` read), then enriches fit (one `--fit-all` call) and TPS (parallel, from #438) in the background, re-rendering after each phase with the cursor preserved (`CatalogPane.refresh_enriched`).

## Measured (this rig, 53 variants)

| phase | wall |
|---|---|
| **first paint** (`load_catalog_rows`) | **0.53s** |
| + fit fill (`--fit-all` batch) | +0.22s |
| + TPS fill (`enrich_measurements`) | +4.13s |

The table is **interactive at ~0.5s** (was ~5s after #438, ~48s originally); fit fully in ~0.75s. The `switch --explain` measurement leg still dominates the *full* background fill (~4s) — that's the registry-side TPS join (option 3), left as a follow-up.

## Tests

283 passed. Fit enrichment now goes through one `--fit-all` call, so both `FakeRunner` fixtures gained a `FIT_ALL_JSON` response, ordered **before** the `--fit` key (the batch command contains `--fit` as a substring and `FakeRunner` returns the first match). No assertions were weakened — the fit-glyph / skip / TPS-via-explain checks are unchanged, and the single-slug `fit()` + `--fit` contract stay (still used by the detail view).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
