### PR TITLE
c3: auto-load container drill detail on select + consistent Esc

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -329,6 +329,18 @@ class CatalogPane(Container):
             inp.add_class("visible")
             inp.focus()
 
+    def close_filter_if_open(self) -> bool:
+        """Esc/cancel: hide + clear the filter and refocus the table. Returns
+        True if a filter was actually open (so the app can swallow the Esc)."""
+        inp = self.query_one("#catalog-filter", Input)
+        if "visible" in inp.classes:
+            inp.remove_class("visible")
+            inp.value = ""
+            self.set_filter("")
+            self.query_one("#catalog-table", DataTable).focus()
+            return True
+        return False
+
 
 # ── Explain detail modal ────────────────────────────────────────────────────────
 
@@ -1045,11 +1057,11 @@ class EstateContainersPane(Container):
             with TabPane("Logs", id="drill-tab-logs"):
                 yield LivePane(id="drill-logs")
             with TabPane("Top", id="drill-tab-stats"):
-                yield Static("[dim]select a container and press \\[t] to read docker top[/dim]", id="drill-stats")
+                yield Static("[dim]select a container — docker top loads automatically[/dim]", id="drill-stats")
             with TabPane("Config", id="drill-tab-config"):
-                yield Static("[dim]select a container and press \\[t] to read its config[/dim]", id="drill-config")
+                yield Static("[dim]select a container — config loads automatically[/dim]", id="drill-config")
         yield Label(
-            "[dim]\\[l] logs   \\[t] top (read)   \\[s] restart (gated)   "
+            "[dim]detail auto-loads on select · \\[l] logs   \\[t] top   \\[s] restart (gated)   "
             "\\[x] stop (gated)   \\[X] rm (reconcile-gated)[/dim]",
             id="containers-hint",
         )
@@ -1490,6 +1502,17 @@ class ValidateBenchmarksPane(Container):
         inp = Input(placeholder="filter model / engine / topology…", id="bmk-filter")
         self.mount(inp, before=self.query_one("#bmk-table", DataTable))
         inp.focus()
+
+    def close_filter_if_open(self) -> bool:
+        """Esc/cancel: unmount + clear the filter and refocus the table. Returns
+        True if a filter was actually open (so the app can swallow the Esc)."""
+        existing = self.query("#bmk-filter")
+        if existing:
+            existing.first(Input).remove()
+            self.set_filter("")
+            self.query_one("#bmk-table", DataTable).focus()
+            return True
+        return False
 
 
 class ValidateEvidencePane(Container):
@@ -2756,7 +2779,7 @@ class CockpitApp(App):
         except Exception:
             return None
 
-    @work(group="container-logs")
+    @work(group="container-logs", exclusive=True)
     async def stream_container_logs(self, name: str) -> None:
         """Read `docker logs --tail <N> <name>` and push lines into the drill
         Logs LivePane.  READ-only; goes through the injected read runner so
@@ -2816,7 +2839,7 @@ class CockpitApp(App):
             pass
         self.read_container_top(con.name)
 
-    @work(group="container-top")
+    @work(group="container-top", exclusive=True)
     async def read_container_top(self, name: str) -> None:
         """docker top <name> (READ) → the Top drill tab.  Also fills the Config
         tab from the cached registry row matched to the selected container."""
@@ -3131,6 +3154,15 @@ class CockpitApp(App):
         panel.  Events from mode panels that are currently hidden (display:none) are
         ignored so startup/background activations don't steal focus."""
         self.refresh_bindings()
+        # Nested Estate·Containers drill-tabs (Logs/Top/Config): load the newly
+        # active tab's content for the selected container, then stop — these are
+        # NOT mode-level tabs and must not run the mode focus logic below.
+        try:
+            if event.tabbed_content.id == "drill-tabs":
+                self._load_active_drill_tab()
+                return
+        except Exception:
+            pass
         raw_tab_id = event.tab.id if event.tab else ""
         # Strip the Textual internal prefix if present.
         _PREFIX = "--content-tab-"
@@ -3159,6 +3191,13 @@ class CockpitApp(App):
                     self.query_one(widget_id, DataTable).focus()
                 except Exception:
                     pass
+                # Entering Estate·Containers auto-loads the detail for the
+                # already-highlighted container — switching tabs doesn't re-fire
+                # RowHighlighted (the cursor was set when the table populated),
+                # so trigger the load here.
+                if tab_id == "tab-containers":
+                    self._refresh_container_config()
+                    self._load_active_drill_tab()
             self.call_after_refresh(_do_focus)
 
     # ── Widget event handlers ─────────────────────────────────────────────────────────
@@ -3169,6 +3208,83 @@ class CockpitApp(App):
         the ⏎ → primary_action contract that the tests (and help text) document."""
         event.stop()
         self.action_primary_action()
+
+    def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        """Estate · Containers: auto-load the drill detail for the highlighted
+        container (lazydocker-style). Config is a local read → immediate; the
+        active live tab (Logs / Top) is a docker read → debounced ~250ms so
+        arrowing through the list doesn't spawn a subprocess per row."""
+        try:
+            if event.data_table.id != "containers-table":
+                return
+        except Exception:
+            return
+        if self._active_mode != 2 or self._active_estate_tab() != "tab-containers":
+            return
+        self._refresh_container_config()
+        timer = getattr(self, "_drill_timer", None)
+        if timer is not None:
+            try:
+                timer.stop()
+            except Exception:
+                pass
+        self._drill_timer = self.set_timer(0.25, self._load_active_drill_tab)
+
+    def _active_drill_tab(self) -> str:
+        try:
+            return self.query_one("#drill-tabs", TabbedContent).active
+        except Exception:
+            return ""
+
+    def _refresh_container_config(self) -> None:
+        """Render the selected container's config tab from the cached registry
+        (a local read — safe to run on every highlight)."""
+        con = self._selected_container()
+        variant = None
+        if con is not None and con.slug:
+            variant = next((v for v in self._variants if getattr(v, "slug", "") == con.slug), None)
+        try:
+            self.query_one("#estate-containers-pane", EstateContainersPane).populate_config(con, variant)
+        except Exception:
+            pass
+
+    def _load_active_drill_tab(self) -> None:
+        """Load the live content for whichever drill tab is active + the selected
+        container. Logs/Top are docker reads (workers); Config is local (already
+        refreshed on highlight)."""
+        con = self._selected_container()
+        if con is None:
+            return
+        tab = self._active_drill_tab()
+        if tab == "drill-tab-logs":
+            self.stream_container_logs(con.name)
+        elif tab == "drill-tab-stats":
+            self.read_container_top(con.name)
+
+    def on_key(self, event) -> None:
+        """App-level Esc: close an open filter (Discover·Catalog / Validate·
+        Benchmarks) and refocus the table. Modal screens capture their own Esc
+        (they have escape→dismiss bindings), so this only runs on the main
+        screen — Esc otherwise no-ops and NEVER quits."""
+        if event.key != "escape":
+            return
+        if isinstance(self.screen, ModalScreen):
+            return
+        if self._close_open_filter():
+            event.stop()
+            event.prevent_default()
+
+    def _close_open_filter(self) -> bool:
+        if self._active_mode == 0:
+            pane_id, cls = "#catalog-pane", CatalogPane
+        elif self._active_mode == 3:
+            pane_id, cls = "#validate-benchmarks-pane", ValidateBenchmarksPane
+        else:
+            return False
+        try:
+            return self.query_one(pane_id, cls).close_filter_if_open()
+        except Exception:
+            return False
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         bid = event.button.id

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -263,6 +263,12 @@ DOCKER_PS_ENGINE = (
     "vllm-qwen36-27b-dual|0.0.0.0:8010->8000/tcp, [::]:8010->8000/tcp\n"
     "open-webui|0.0.0.0:3000->8080/tcp\n"
 )
+# Two recognized engine containers → a 2-row containers table (open-webui above
+# is filtered out as an unrecognized service, so it can't test a row CHANGE).
+DOCKER_PS_TWO = (
+    "vllm-qwen36-27b-dual|0.0.0.0:8010->8000/tcp\n"
+    "vllm-gemma-4-31b-dual|0.0.0.0:8011->8000/tcp\n"
+)
 DOCKER_PS_EMPTY = ""
 
 # REAL diagnose-estate.sh --json shape (verified live 2026-06-18).
@@ -323,6 +329,12 @@ DOCKER_TOP = (
     "root   1234   1200   9   10:01   ?     00:12:30   python3 -m vllm.entrypoints.openai.api_server\n"
 )
 
+# docker logs --tail N <name> (READ).
+DOCKER_LOGS = (
+    "INFO 06-18 boot: starting vLLM engine\n"
+    "INFO 06-18 ready: serving on :8000\n"
+)
+
 # Minimal BENCHMARKS.md the explorer can scrape (model + topo headers + a row).
 BENCHMARKS_MD = (
     "# BENCHMARKS\n"
@@ -369,6 +381,7 @@ def fake_responses(**overrides) -> dict[str, RunResult]:
         "diagnose-profile.sh": ok(DIAGNOSE_PROFILE_TEXT),
         "power-cap status": ok(POWER_CAP_STATUS),
         "docker top": ok(DOCKER_TOP),
+        "docker logs": ok(DOCKER_LOGS),
     }
     responses.update(overrides)
     return responses
@@ -2251,3 +2264,116 @@ class TestModeSwitchFocus:
             assert tc.active == "tab-benchmarks"
             assert isinstance(app.focused, DataTable)
             assert app.focused.id == "bmk-table"
+
+
+class TestContainerAutoLoad:
+    """Estate·Containers drill detail auto-loads on selection (lazydocker-style)
+    — no [l]/[t] keypress needed."""
+
+    @pytest.mark.asyncio
+    async def test_entering_containers_autoloads_config(self):
+        """Switching to the Containers tab auto-fills the Config drill tab for the
+        highlighted container — no keypress."""
+        responses = fake_responses(**{"docker ps": ok(DOCKER_PS_ENGINE)})
+        app, _, _ = make_app(responses=responses)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.press("3")
+            await _settle(pilot)
+            app.query_one("#estate-tabs", TabbedContent).active = "tab-containers"
+            await _settle(pilot)
+            cfg = str(app.query_one("#drill-config", Static).render())
+            assert "vllm-qwen36-27b-dual" in cfg  # config loaded with no [t]
+
+    @pytest.mark.asyncio
+    async def test_entering_containers_autoloads_logs(self):
+        """Default drill tab is Logs — entering Containers auto-reads docker logs
+        for the selected container (no [l])."""
+        responses = fake_responses(**{"docker ps": ok(DOCKER_PS_ENGINE)})
+        app, runner, _ = make_app(responses=responses)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.press("3")
+            await _settle(pilot)
+            app.query_one("#estate-tabs", TabbedContent).active = "tab-containers"
+            await _settle(pilot)
+            assert any("docker logs" in " ".join(c) for c in runner.calls)
+
+    @pytest.mark.asyncio
+    async def test_drill_tab_switch_to_top_reads_top(self):
+        """Switching the drill tab Logs→Top reads docker top for the selected
+        container (no [t])."""
+        responses = fake_responses(**{"docker ps": ok(DOCKER_PS_ENGINE)})
+        app, runner, _ = make_app(responses=responses)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.press("3")
+            await _settle(pilot)
+            app.query_one("#estate-tabs", TabbedContent).active = "tab-containers"
+            await _settle(pilot)
+            app.query_one("#drill-tabs", TabbedContent).active = "drill-tab-stats"
+            await _settle(pilot)
+            assert any("docker top" in " ".join(c) for c in runner.calls)
+            assert "PID" in str(app.query_one("#drill-stats", Static).render())
+
+    @pytest.mark.asyncio
+    async def test_highlight_change_updates_config(self):
+        """Highlighting a different container updates Config immediately (the
+        local read is not debounced)."""
+        responses = fake_responses(**{"docker ps": ok(DOCKER_PS_TWO)})
+        app, _, _ = make_app(responses=responses)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.press("3")
+            await _settle(pilot)
+            app.query_one("#estate-tabs", TabbedContent).active = "tab-containers"
+            await _settle(pilot)
+            tbl = app.query_one("#containers-table", DataTable)
+            tbl.focus()
+            await pilot.pause()
+            await pilot.press("down")  # row 0 (qwen) → row 1 (gemma) — fires RowHighlighted
+            await pilot.pause()
+            assert tbl.cursor_row == 1, f"cursor did not move (row={tbl.cursor_row})"
+            cfg = str(app.query_one("#drill-config", Static).render())
+            assert "vllm-gemma-4-31b-dual" in cfg
+
+
+class TestEscClosesFilter:
+    """Esc closes an open filter Input + refocuses the table (it was a dead key
+    inside the filter before) — and never quits the app."""
+
+    @pytest.mark.asyncio
+    async def test_esc_closes_catalog_filter(self):
+        app, _, _ = make_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            await pilot.press("slash")
+            await pilot.pause()
+            inp = app.query_one("#catalog-filter", Input)
+            assert "visible" in inp.classes and app.focused is inp
+            await pilot.press("escape")
+            await pilot.pause()
+            assert "visible" not in inp.classes
+            assert app.focused is app.query_one("#catalog-table", DataTable)
+
+    @pytest.mark.asyncio
+    async def test_esc_closes_bmk_filter(self):
+        app, _, _ = make_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.press("4")
+            await _settle(pilot)
+            app.query_one("#validate-tabs", TabbedContent).active = "tab-benchmarks"
+            await _settle(pilot)
+            await pilot.press("slash")
+            await pilot.pause()
+            assert app.query("#bmk-filter")
+            await pilot.press("escape")
+            await pilot.pause()
+            assert not app.query("#bmk-filter")
+            assert app.focused is app.query_one("#bmk-table", DataTable)
+
+    @pytest.mark.asyncio
+    async def test_esc_on_main_screen_does_not_quit(self):
+        """Esc with no filter + no modal is a harmless no-op (never quits)."""
+        app, _, _ = make_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            await pilot.press("escape")
+            await pilot.pause()
+            assert app.is_running


### PR DESCRIPTION
Two Estate·Containers / Esc UX fixes from user feedback.

## 1. Container drill detail auto-loads on selection (lazydocker-style)
The Containers pane was already a master-detail (table + Logs / Top / Config drill tabs), but the detail only filled on `[l]`/`[t]`. Now it auto-loads for the highlighted container:
- `on_data_table_row_highlighted` (scoped to `containers-table` + Estate·Containers): **Config** refreshes immediately (local read); the active live tab (**Logs**/**Top**) is **debounced ~250ms** so arrowing through the list doesn't spawn a docker read per row.
- `drill-tabs` `TabActivated` loads the newly-active tab; entering the Containers tab loads the detail for the already-highlighted row.
- `stream_container_logs` / `read_container_top` → `@work(exclusive=True)` so a re-select replaces the prior read instead of leaking it.
- `[l]`/`[t]` kept as instant-refresh shortcuts.

## 2. Esc consistency
App-level `on_key`: Esc closes an open filter (Discover·Catalog / Validate·Benchmarks) and refocuses the table — only on the main screen (the 6 modals keep their own `escape→dismiss`), and **Esc never quits** (no-op when nothing's open).

## Verification
- **290 tests** (+7: `TestContainerAutoLoad`, `TestEscClosesFilter`) — real Pilot assertions (`str(Static.render())` content + `runner.calls` for the docker reads).
- Independently re-ran the suite + drove 16 of my own Pilot probes: auto-load on entry, highlight-change updates Config, drill-tab→Top runs `docker top`, Esc closes both filters + dismisses the modal + doesn't quit — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
