### PR TITLE
Fix estate GPU visibility overrides

### DIFF
--- a/scripts/lib/profiles/estate_cli.py
+++ b/scripts/lib/profiles/estate_cli.py
@@ -368,6 +368,46 @@ def compose_cmd() -> list[str]:
     return shlex.split(os.environ.get("COMPOSE_BIN", "docker compose"))
 
 
+def compose_service_names(compose_name: str) -> list[str]:
+    """Return service names from a registry compose file."""
+    path = compose_abs_path(compose_name)
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    services = data.get("services")
+    if not isinstance(services, dict) or not services:
+        raise EstateCliError(f"compose file for `{compose_name}` has no services: {path}")
+    return [str(name) for name in services.keys()]
+
+
+def compose_override_doc(inst: InstanceSpec) -> dict[str, Any]:
+    """Per-estate compose override.
+
+    Some vLLM compose files expose all NVIDIA devices via the Docker device
+    reservation and only interpolate ESTATE_GPUS into NVIDIA_VISIBLE_DEVICES.
+    In that setup, CUDA may still enumerate physical GPU 0 first. Pass
+    CUDA_VISIBLE_DEVICES inside the container so each estate instance uses the
+    GPUs it claimed.
+    """
+    joined = ",".join(str(gpu) for gpu in inst.gpu_indices)
+    return {
+        "services": {
+            service: {
+                "environment": {
+                    "CUDA_VISIBLE_DEVICES": joined,
+                    "NVIDIA_VISIBLE_DEVICES": joined,
+                }
+            }
+            for service in compose_service_names(inst.compose_name)
+        }
+    }
+
+
+def write_compose_override(inst: InstanceSpec) -> Path:
+    boot_log_dir().mkdir(parents=True, exist_ok=True)
+    path = boot_log_dir() / f"{safe_name(inst.name)}.override.yml"
+    path.write_text(yaml.safe_dump(compose_override_doc(inst), sort_keys=False), encoding="utf-8")
+    return path
+
+
 def boot_log_dir() -> Path:
     return Path(os.environ.get("CLUB3090_ESTATE_BOOT_LOG_DIR", str(DEFAULT_BOOT_LOG_DIR))).expanduser()
 
@@ -407,7 +447,10 @@ def append_log(path: Path, message: str) -> None:
 
 
 def run_compose(inst: InstanceSpec, action: str, log_path: Path | None = None) -> None:
-    cmd = compose_cmd() + ["-p", project_name(inst.name), "-f", str(compose_abs_path(inst.compose_name)), action]
+    cmd = compose_cmd() + ["-p", project_name(inst.name), "-f", str(compose_abs_path(inst.compose_name))]
+    if action == "up":
+        cmd += ["-f", str(write_compose_override(inst))]
+    cmd.append(action)
     if action == "up":
         cmd.append("-d")
     if log_path is not None:

--- a/scripts/tests/test-diagnose-estate.sh
+++ b/scripts/tests/test-diagnose-estate.sh
@@ -91,6 +91,52 @@ assert_contains "$out" "default estate persisted"
 assert_contains "$out" "qwen-left"
 assert_contains "$out" "up:qwen-left,ready:qwen-left"
 
+out="$(
+  cd "$ROOT_DIR"
+  CLUB3090_ESTATE_BOOT_LOG_DIR="${TMP_DIR}/boot-logs" python3 - <<'PY'
+import yaml
+
+from scripts.lib.profiles import estate_cli as ec
+from scripts.lib.profiles.compat import InstanceSpec
+
+inst = InstanceSpec(name="gemma-dual", compose_name="vllm/gemma-int8-mtp", gpu_indices=(2, 3), port=8032)
+override_path = ec.write_compose_override(inst)
+data = yaml.safe_load(override_path.read_text(encoding="utf-8"))
+service = data["services"]["vllm-gemma-4-31b-mtp-int8"]
+print(override_path)
+print(service["environment"]["CUDA_VISIBLE_DEVICES"])
+print(service["environment"]["NVIDIA_VISIBLE_DEVICES"])
+PY
+)"
+assert_contains "$out" "gemma-dual.override.yml"
+assert_contains "$out" "2,3"
+
+out="$(
+  cd "$ROOT_DIR"
+  CLUB3090_ESTATE_BOOT_LOG_DIR="${TMP_DIR}/boot-logs" python3 - <<'PY'
+from scripts.lib.profiles import estate_cli as ec
+from scripts.lib.profiles.compat import InstanceSpec
+
+calls = []
+
+class Proc:
+    returncode = 0
+
+def fake_run(cmd, **kwargs):
+    calls.append(cmd)
+    return Proc()
+
+ec.subprocess.run = fake_run
+inst = InstanceSpec(name="gemma-dual", compose_name="vllm/gemma-int8-mtp", gpu_indices=(2, 3), port=8032)
+ec.run_compose(inst, "up")
+cmd = calls[0]
+print(" ".join(cmd))
+print(f"f_count={sum(1 for part in cmd if part == '-f')}")
+PY
+)"
+assert_contains "$out" "gemma-dual.override.yml"
+assert_contains "$out" "f_count=2"
+
 FAKE_BIN="${TMP_DIR}/fakebin"
 mkdir -p "$FAKE_BIN"
 cat > "${FAKE_BIN}/docker" <<'SH'


### PR DESCRIPTION
## Summary
- Generate a per-instance Compose override during estate `up` so each instance sets both `CUDA_VISIBLE_DEVICES` and `NVIDIA_VISIBLE_DEVICES` inside the container.
- Prevent parallel vLLM estate instances from both trying to use physical GPUs 0/1 when Docker exposes all reserved devices.
- Add regression coverage for the generated override and `docker compose -f base -f override up` wiring.

## Validation
- `python3 -m py_compile scripts/lib/profiles/estate_cli.py`
- `bash scripts/tests/test-diagnose-estate.sh`
- `bash scripts/tests/test-estate-json.sh`
- `bash scripts/tests/test-profiles-compat.sh`
- `bash scripts/tests/test-launch-compat.sh`
- Live 4×3090 estate boot: `qwen-dual` on GPUs 0,1 and `gemma-dual` on GPUs 2,3 both healthy in parallel.
