### PR TITLE
fix(lmcache): forward env tuning knobs

### DIFF
--- a/models/qwen3.6-27b/INTERNALS.md
+++ b/models/qwen3.6-27b/INTERNALS.md
@@ -222,12 +222,15 @@ How many sessions fit per tier:
 
 ⚠️ **RAM sizing is preflight-gated.** `scripts/preflight.sh::preflight_lmcache_ram` hard-fails launch if available RAM < `l1-size-gb` + 28 GB reserve, **even under `--force`** (a 100 GB cache on this 94 GB rig once OOM'd the host and forced a reboot — the incident that motivated the guard); it also soft-warns on low L2 disk space. Cap L1 at ~50 GB here.
 
+**Operational gotcha fixed 2026-06-21:** LMCache's tunables are read by the in-container `bash -c` entrypoint (`$${LMCACHE_L1_GB:-30}`, `$${LMCACHE_L2:-0}`, etc.). Docker Compose only forwards host env into that process when the names are declared in `environment:`. The compose now declares `LMCACHE_L1_GB`, `LMCACHE_L2`, `LMCACHE_L2_ADAPTER`, and `LMCACHE_CHUNK_SIZE` with empty defaults, so bash still owns the fallback values. Regression guard: `scripts/tests/test-lmcache-env-passthrough.sh`. Verify a live launch with `docker exec <container> env | grep LMCACHE` and the `lmcache server` command line.
+
 ### Disk (the optional L2 tier — `LMCACHE_L2_ADAPTER`, off by default)
-Set `LMCACHE_L2_ADAPTER` to a JSON adapter spec to spill evicted (older) sessions from RAM to disk instead of dropping them, and to **survive container restarts**:
+Set `LMCACHE_L2=1` to use the gitignored repo-root `lmcache-kv/` mount (`/lmcache-kv` in-container), or set `LMCACHE_L2_ADAPTER` to a JSON adapter spec to spill evicted (older) sessions from RAM to disk instead of dropping them, and to **survive container restarts**:
 ```
+LMCACHE_L2=1
 LMCACHE_L2_ADAPTER='{"type":"fs","base_path":"/mnt/ssd/lmcache-kv"}'
 ```
-Use the **`fs`** adapter (`base_path`), **not `nixl_store`** — this image's NIXL backend is broken (`libcudart.so.13` ImportError); `fs` is a plain filesystem store with no NIXL dependency. Disk footprint is **~125 KB/token measured** (4.6 GB for a 37K session → ~33 GB per full 262K session — LMCache's L2 stores ~7× lower-density than the int8-PTH GPU cache, so size disk accordingly), still effectively unbounded; LRU auto-evicts within the cap. Point `base_path` at an SSD dir — **not `/tmp`** (tmpfs, wiped on reboot, competes for RAM).
+Use the **`fs`** adapter (`base_path`), **not `nixl_store`** — this image's NIXL backend is broken (`libcudart.so.13` ImportError); `fs` is a plain filesystem store with no NIXL dependency. Disk footprint is **~125 KB/token measured** (4.6 GB for a 37K session → ~33 GB per full 262K session — LMCache's L2 stores ~7× lower-density than the int8-PTH GPU cache, so size disk accordingly), still effectively unbounded; LRU auto-evicts within the cap. Point custom `base_path` at an SSD dir — **not `/tmp`** (tmpfs, wiped on reboot, competes for RAM).
 
 **Measured on-rig (2026-06-17, 36,807-token session, ~1.9 GB/s disk):**
 
@@ -237,7 +240,7 @@ Use the **`fs`** adapter (`base_path`), **not `nixl_store`** — this image's NI
 | **L2 rehydrate** (from disk, after container restart) | **4.8 s** | **~9× faster** |
 | L1 hit (warm RAM) | 1.4 s | ~31× faster |
 
-**Cross-restart persistence confirmed**: after a full container restart (L1 RAM cleared), the log shows `46/46 retained keys (0 L1, 46 L2)` — the session rehydrated entirely from L2 disk.
+**Cross-restart persistence confirmed**: after a full container restart (L1 RAM cleared), the log shows `46/46 retained keys (0 L1, 46 L2)` — the session rehydrated entirely from L2 disk. For restart tests, prefer a clean `docker compose down && docker compose up -d`; cross-rig #423 found `docker restart` can race GPU-memory release and crash-loop TP worker init on PCIe 3090 rigs.
 
 **No reduced-size L2 on this model (measured 2026-06-17).** LMCache's only built-in MP-mode compressor — the **fp8 serde** (`"serde":{"type":"fp8","fp8_dtype":"float8_e4m3fn"}` on the adapter) — **shape-errors on this model's KV**: `RuntimeError: shape '[2, 16, 1584, 260]' is invalid for input of size 53539200` (the serializer assumes a layout that doesn't match the hybrid GDN / head_dim-256 / int8-PTH source). Result: **60 serialize fails / 30 store fails, L2 stays empty (0 files)** — serving is unaffected (L1 works), but nothing reaches disk. **CacheGen** (the larger ~3–4× compressor) is "not implemented for MP mode yet — coming soon." So **don't add an fp8 serde** here; L2 is uncompressed (~131 KB/token) until one of those is fixed (re-test trigger). The plain `fs` adapter (no serde) is the working path.
 

--- a/models/qwen3.6-27b/vllm-lmcache/compose/dual/fp8/lmcache.yml
+++ b/models/qwen3.6-27b/vllm-lmcache/compose/dual/fp8/lmcache.yml
@@ -103,6 +103,13 @@ services:
       - VLLM_NO_USAGE_STATS=1
       - VLLM_USE_FLASHINFER_SAMPLER=1
       - LMCACHE_DISABLE_BANNER=1
+      # Forward host-tunable LMCache knobs into the in-container entrypoint.
+      # Keep empty defaults here so bash's own $${VAR:-fallback} logic below
+      # remains the single source of default values when the host env is unset.
+      - LMCACHE_L1_GB=${LMCACHE_L1_GB:-}
+      - LMCACHE_L2=${LMCACHE_L2:-}
+      - LMCACHE_L2_ADAPTER=${LMCACHE_L2_ADAPTER:-}
+      - LMCACHE_CHUNK_SIZE=${LMCACHE_CHUNK_SIZE:-}
       # NOTE: PYTORCH_CUDA_ALLOC_CONF=expandable_segments is intentionally OMITTED —
       # it is incompatible with the LMCacheMPConnector (raises at engine config validation).
     entrypoint:

--- a/scripts/tests/test-lmcache-env-passthrough.sh
+++ b/scripts/tests/test-lmcache-env-passthrough.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# CONTRACT — LMCache entrypoint knobs must be forwarded through compose env.
+#
+# The LMCache compose starts `lmcache server` from an in-container `bash -c`
+# entrypoint and intentionally uses escaped `$${LMCACHE_*:-...}` tokens so bash,
+# not Docker Compose, chooses defaults at runtime. Docker Compose will not pass
+# host-shell values into that bash process unless each knob is declared in the
+# service `environment:` block. Missing declarations silently force defaults
+# (e.g. L1=30, L2 off) even when the user launches with LMCACHE_L1_GB/LMCACHE_L2.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+python3 - <<'PY'
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+compose_files = sorted(Path("models").glob("*/*/compose/*/*/*.yml"))
+runtime_lmcache_var = re.compile(r"\$\$\{?(LMCACHE_[A-Za-z0-9_]+)")
+
+
+def env_keys(service):
+    env = service.get("environment") or {}
+    if isinstance(env, dict):
+        return set(env)
+    keys = set()
+    if isinstance(env, list):
+        for item in env:
+            if not isinstance(item, str):
+                continue
+            keys.add(item.split("=", 1)[0])
+    return keys
+
+
+def entrypoint_script(service):
+    ep = service.get("entrypoint")
+    if not isinstance(ep, list) or len(ep) < 3:
+        return ""
+    if ep[0] in {"bash", "sh", "/bin/bash", "/bin/sh"} and ep[1] == "-c":
+        return ep[2] or ""
+    return ""
+
+
+failures = []
+checked = 0
+for compose in compose_files:
+    data = yaml.safe_load(compose.read_text()) or {}
+    for service_name, service in sorted((data.get("services") or {}).items()):
+        service = service or {}
+        script = entrypoint_script(service)
+        if "lmcache server" not in script:
+            continue
+        checked += 1
+        used = set(runtime_lmcache_var.findall(script))
+        # LMCACHE_DISABLE_BANNER is consumed by the image, not by the entrypoint
+        # command construction, but it is still declared in environment.
+        used.discard("LMCACHE_DISABLE_BANNER")
+        declared = env_keys(service)
+        missing = sorted(used - declared)
+        if missing:
+            failures.append(
+                f"{compose} [{service_name}]: entrypoint uses {', '.join(missing)} "
+                "but compose does not forward them in environment:"
+            )
+
+print(f"[lmcache-env] scanned {len(compose_files)} composes; {checked} LMCache entrypoint(s)")
+if failures:
+    print("FAIL:", file=sys.stderr)
+    for failure in failures:
+        print(f"  - {failure}", file=sys.stderr)
+    sys.exit(1)
+print("[lmcache-env] PASS: LMCache runtime knobs are declared in compose environment")
+PY


### PR DESCRIPTION
## Summary
- forward LMCACHE_L1_GB, LMCACHE_L2, LMCACHE_L2_ADAPTER, and LMCACHE_CHUNK_SIZE into the LMCache compose environment so the in-container entrypoint sees host tuning values
- add a guard test that fails when an LMCache entrypoint references a runtime LMCACHE_* knob missing from environment
- document live verification, LMCACHE_L2=1 default storage, and the compose down/up restart-test caveat from discussion #423

## Tests
- `bash scripts/tests/test-lmcache-env-passthrough.sh`
- `bash scripts/tests/test-submit-bench.sh` after copying ignored local rebench fixtures into this clean worktree
- `set -e; for t in scripts/tests/*.sh; do bash "$t"; done` after the same ignored fixture copy