### PR TITLE
detect_nvlink: auto-enable PCIe P2P when nvidia-smi reports it OK

### DIFF
--- a/scripts/detect_nvlink.sh
+++ b/scripts/detect_nvlink.sh
@@ -5,17 +5,38 @@
 # Handles 2-GPU setups (single NVLink bridge) and N-GPU setups (e.g. 2 bridges on 4 cards).
 #
 # NVLINK_MODE values:
-#   auto       — detect NVLink via nvidia-smi topo (default). No NVLink => P2P off.
+#   auto       — detect a fast P2P interconnect via nvidia-smi (default): NVLink (topo -m)
+#                OR, failing that, PCIe P2P that `nvidia-smi topo -p2p r` reports as OK
+#                between all pairs — i.e. a patched consumer-GPU driver (tinygrad/geohot/
+#                aikitoria) on a P2P-capable layout (shared root complex / switch). Neither
+#                => P2P off. NOTE: stock GeForce drivers software-disable P2P (report CNS),
+#                and cards on separate root complexes can't P2P — both correctly stay off.
 #   force_on   — assert NVLink present (NCCL_P2P_LEVEL=NVL).
 #   force_off  — no P2P at all (NCCL_P2P_DISABLE=1).
-#   pcie_p2p   — PCIe P2P WITHOUT NVLink (e.g. a patched consumer-GPU driver — the
-#                tinygrad/geohot P2P patch). Sets NCCL_P2P_LEVEL=PHB (or your own
-#                NCCL_P2P_LEVEL), leaves P2P ENABLED, and turns custom all-reduce ON.
-#                Explicit opt-in (like force_on) — auto can't tell the patch is loaded.
-#                See club-3090 #290.
+#   pcie_p2p   — FORCE PCIe P2P on (assert the patched driver is loaded + working),
+#                bypassing auto-detect. Sets NCCL_P2P_LEVEL=PHB (or your own NCCL_P2P_LEVEL),
+#                P2P ENABLED, custom all-reduce ON. Use when you trust the patch but auto's
+#                `topo -p2p r` probe doesn't report OK. See club-3090 #290.
 
 NVLINK_MODE="${NVLINK_MODE:-auto}"
 _P2P_LEVEL=NVL   # NCCL_P2P_LEVEL used when _NVLINK_ENABLED=1 (overridden by pcie_p2p)
+
+# True (0) when nvidia-smi reports working P2P between ALL GPU pairs — e.g. a patched
+# consumer-GPU driver (NVIDIA's stock driver software-disables P2P → reports "CNS") on a
+# P2P-capable PCIe layout. Parses `topo -p2p r`: a data row carries the self-"X" (header /
+# legend rows don't, so they're skipped); ANY off-diagonal cell that isn't OK => unavailable.
+_pcie_p2p_available() {
+  nvidia-smi topo -p2p r 2>/dev/null | awk '
+    $1 ~ /^GPU[0-9]+$/ {
+      hasX = 0
+      for (i = 2; i <= NF; i++) if ($i == "X") hasX = 1
+      if (!hasX) next                                  # header row (no self-X) — skip
+      rows++
+      for (i = 2; i <= NF; i++) if ($i != "X" && $i != "OK") bad = 1
+    }
+    END { exit (rows > 0 && !bad) ? 0 : 1 }
+  '
+}
 
 case "$NVLINK_MODE" in
   force_on)
@@ -39,18 +60,24 @@ case "$NVLINK_MODE" in
       if nvidia-smi topo -m 2>/dev/null | grep -qP '\bNV[0-9]+\b'; then
         _NVLINK_ENABLED=1
         echo "[nvlink] $GPU_COUNT GPUs detected — NVLink found, enabling NVLink mode"
+      elif _pcie_p2p_available; then
+        _NVLINK_ENABLED=1; _P2P_LEVEL="${NCCL_P2P_LEVEL:-PHB}"
+        echo "[nvlink] $GPU_COUNT GPUs — no NVLink, but nvidia-smi reports P2P=OK (patched driver / P2P-capable layout) — auto-enabling PCIe P2P (NCCL_P2P_LEVEL=$_P2P_LEVEL, custom all-reduce ON)"
       else
         _NVLINK_ENABLED=0
-        echo "[nvlink] $GPU_COUNT GPUs detected — no NVLink found, using PCIe mode"
+        echo "[nvlink] $GPU_COUNT GPUs detected — no NVLink, no P2P — using PCIe mode"
       fi
     elif [ "$GPU_COUNT" -eq 2 ]; then
       LINK=$(nvidia-smi topo -m 2>/dev/null | awk '/^GPU0/{print $3}')
       if [[ "$LINK" =~ ^NV[0-9]+$ ]]; then
         _NVLINK_ENABLED=1
         echo "[nvlink] detected NVLink ($LINK) between GPU0-GPU1 — enabling NVLink mode"
+      elif _pcie_p2p_available; then
+        _NVLINK_ENABLED=1; _P2P_LEVEL="${NCCL_P2P_LEVEL:-PHB}"
+        echo "[nvlink] PCIe topology ($LINK) but nvidia-smi reports P2P=OK (patched driver / shared root complex) — auto-enabling PCIe P2P (NCCL_P2P_LEVEL=$_P2P_LEVEL, custom all-reduce ON)"
       else
         _NVLINK_ENABLED=0
-        echo "[nvlink] PCIe topology ($LINK) — using PCIe mode (no NVLink; for patched-driver PCIe P2P set NVLINK_MODE=pcie_p2p)"
+        echo "[nvlink] PCIe topology ($LINK), P2P not available (topo -p2p: no OK) — using PCIe mode (no P2P; for a patched driver on a P2P-capable layout this auto-enables, or set NVLINK_MODE=pcie_p2p to force)"
       fi
     else
       _NVLINK_ENABLED=0
@@ -89,3 +116,5 @@ else
   export PYTORCH_CUDA_ALLOC_CONF="${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True,max_split_size_mb:512}"
   echo "[nvlink] P2P DISABLED — NCCL_P2P_DISABLE=1, custom all-reduce OFF, expandable_segments ON"
 fi
+
+unset -f _pcie_p2p_available 2>/dev/null || true   # don't leak the probe into the sourcing shell

--- a/scripts/tests/test-detect-nvlink-autop2p.sh
+++ b/scripts/tests/test-detect-nvlink-autop2p.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# detect_nvlink.sh `auto` mode must auto-enable PCIe P2P when nvidia-smi reports
+# P2P=OK between all pairs (a patched consumer-GPU driver on a P2P-capable layout),
+# and MUST stay off when P2P is unavailable (stock driver → CNS, or cards on
+# separate root complexes). NVLink detection still wins when present.
+#
+# nvidia-smi is mocked (no real GPUs); FAKE_GPUS / FAKE_LINK / FAKE_P2P drive it.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DETECT="${ROOT_DIR}/scripts/detect_nvlink.sh"
+MOCK_DIR="$(mktemp -d)"
+trap 'rm -rf "$MOCK_DIR"' EXIT
+
+cat > "$MOCK_DIR/nvidia-smi" <<'MOCK'
+#!/usr/bin/env bash
+n="${FAKE_GPUS:-2}"; args="$*"
+case "$args" in
+  "-L")
+    for ((i=0;i<n;i++)); do echo "GPU $i: NVIDIA GeForce RTX 3090 (UUID: GPU-$i)"; done ;;
+  "topo -m")
+    printf "\t"; for ((j=0;j<n;j++)); do printf "GPU%d\t" "$j"; done; printf "\n"
+    for ((i=0;i<n;i++)); do printf "GPU%d\t" "$i"
+      for ((j=0;j<n;j++)); do [ "$i" = "$j" ] && printf "X\t" || printf "%s\t" "${FAKE_LINK:-PHB}"; done
+      printf "\n"; done ;;
+  "topo -p2p r")
+    printf "\t"; for ((j=0;j<n;j++)); do printf "GPU%d\t" "$j"; done; printf "\n"
+    for ((i=0;i<n;i++)); do printf "GPU%d\t" "$i"
+      for ((j=0;j<n;j++)); do
+        if [ "$i" = "$j" ]; then printf "X\t"
+        elif [ "${FAKE_P2P:-CNS}" = "MIXED" ] && [ "$i" = 0 ] && [ "$j" = 1 ]; then printf "CNS\t"
+        else printf "%s\t" "${FAKE_P2P:-CNS}"; fi
+      done; printf "\n"; done ;;
+esac
+exit 0
+MOCK
+chmod +x "$MOCK_DIR/nvidia-smi"
+
+fail=0
+# $1=gpus $2=link $3=p2p -> "DISABLE=<>|LEVEL=<>"
+run() {
+  PATH="$MOCK_DIR:$PATH" FAKE_GPUS="$1" FAKE_LINK="$2" FAKE_P2P="$3" NVLINK_MODE=auto \
+    bash -c "source '$DETECT' >/dev/null 2>&1; printf 'DISABLE=%s|LEVEL=%s' \"\${NCCL_P2P_DISABLE:-}\" \"\${NCCL_P2P_LEVEL:-}\""
+}
+check() {
+  local desc="$1" gpus="$2" link="$3" p2p="$4" want="$5" got
+  got="$(run "$gpus" "$link" "$p2p")"
+  if [ "$got" != "$want" ]; then echo "[autop2p] FAIL: $desc — got '$got' want '$want'" >&2; fail=1
+  else echo "[autop2p] ok: $desc"; fi
+}
+
+# 2-GPU, no NVLink, P2P=OK (patched driver, shared root) -> AUTO-ENABLE PCIe P2P
+check "2gpu PHB + P2P OK -> enabled@PHB" 2 PHB OK  "DISABLE=|LEVEL=PHB"
+# 2-GPU, no NVLink, P2P=CNS (this rig: stock driver / separate root complex) -> OFF
+check "2gpu PHB + P2P CNS -> off"        2 PHB CNS "DISABLE=1|LEVEL="
+# 2-GPU NVLink present -> NVLink wins (NVL), regardless of P2P matrix
+check "2gpu NVLink -> enabled@NVL"       2 NV4 CNS "DISABLE=|LEVEL=NVL"
+# >2 GPUs, no NVLink, all pairs OK -> auto-enable
+check "4gpu PHB + all P2P OK -> enabled" 4 PHB OK  "DISABLE=|LEVEL=PHB"
+# >2 GPUs, one pair NOT OK -> stay off (custom all-reduce needs full P2P)
+check "4gpu PHB + mixed P2P -> off"      4 PHB MIXED "DISABLE=1|LEVEL="
+# >2 GPUs, no P2P at all -> off
+check "4gpu PHB + no P2P -> off"         4 PHB CNS "DISABLE=1|LEVEL="
+
+if [ "$fail" -ne 0 ]; then echo "[autop2p] FAILED" >&2; exit 1; fi
+echo "[autop2p] PASS: auto promotes to PCIe P2P only when topo -p2p reports OK on all pairs"


### PR DESCRIPTION
## Summary
`auto` mode now auto-enables **PCIe P2P** (not just NVLink). After the NVLink check, it probes `nvidia-smi topo -p2p r` and, if P2P is **OK across all pairs** (a patched consumer-GPU driver — tinygrad/geohot/aikitoria — on a P2P-capable layout: shared root complex / switch), promotes to PCIe P2P with **custom all-reduce ON** (`NCCL_P2P_LEVEL=PHB`). Previously this needed a manual `NVLINK_MODE=pcie_p2p`.

Motivated by the aikitoria `open-gpu-kernel-modules` P2P patch — users who run it on a shared-root-complex layout now get custom all-reduce automatically; `pcie_p2p` remains as a **force** override.

## Safe by construction
- **No-op for stock drivers / separate-root-complex rigs** — they report `CNS`/non-OK → stays off. Verified on the maintainer's 2× 3090 (cards on separate EPYC root complexes): `auto` still resolves **P2P DISABLED**.
- Requires **all** off-diagonal pairs == `OK` (partial P2P → off — custom all-reduce wants full P2P).
- `force_on` / `force_off` / `pcie_p2p` unchanged.

## Tests
- New `test-detect-nvlink-autop2p.sh` — 6 mocked cases (enable on OK · stay off on CNS · NVLink wins · 4-GPU all-OK vs mixed vs none).
- Existing `test-detect-nvlink-alloc-conf.sh` unchanged. Full `scripts/tests` gate: **58/58**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)