### PR TITLE
serve-cockpit: declare PyYAML dep (fixes c3 diagnose-estate crash)

### DIFF
--- a/tools/serve-cockpit/pyproject.toml
+++ b/tools/serve-cockpit/pyproject.toml
@@ -12,6 +12,13 @@ dependencies = [
     "club3090-tui-core>=0.1.0",
     "textual>=0.60",
     "rich>=13.0",
+    # The cockpit shells out to the repo's profile scripts (estate_cli.py,
+    # weights.py, compat.py, classifier.py, patch_attribution.py) which
+    # `import yaml`. Declaring PyYAML here means a `uv pip install -e` /
+    # `pip install` venv has it — otherwise `c3`'s python3 subprocess (the
+    # venv interpreter) hits `ModuleNotFoundError: No module named 'yaml'`
+    # on Doctor → diagnose-estate (works only if SYSTEM python3 has it).
+    "pyyaml>=6.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Problem
@alexpolo1 hit this on Doctor → `diagnose-estate` ([discussions/459](https://github.com/noonghunna/club-3090/discussions/459#discussioncomment-17424010)):

```
File ".../scripts/lib/profiles/estate_cli.py", line 26, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```

## Root cause
c3 shells out to the repo's profile scripts (`estate_cli.py`, `weights.py`, `compat.py`, `classifier.py`, `patch_attribution.py`) which `import yaml`. **PyYAML was never declared as a cockpit dependency.** A `uv pip install -e tools/serve-cockpit` venv therefore lacks it, and since `c3`'s `python3` subprocess resolves to that venv interpreter, the import dies. It only worked on the maintainer rig because *system* `python3` happened to have PyYAML.

## Fix
Add `pyyaml>=6.0` to `tools/serve-cockpit` dependencies. PyYAML is the **only** third-party module across every script c3 shells out to (verified — the rest is stdlib).

## Validation
Reproduced in a clean venv and confirmed fixed:
```
BEFORE: import yaml → ModuleNotFoundError       # clean venv
AFTER:  import yaml OK, PyYAML 6.0.3            # after `uv pip install -e tools/serve-cockpit`
        estate_cli.py report-state --json → runs clean (the exact failing path)
```

Existing users just need to **re-run** `uv pip install -e tools/serve-cockpit` (or `pip install pyyaml`) to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
