### PR TITLE
c3: scene-preview box auto-grows to fit all services

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -1726,6 +1726,10 @@ def _with_force(plan: ActionPlan) -> list[str]:
 
 # ── Operate · Orchestration ───────────────────────────────────────────────────────
 
+# Max service bullets shown in the scene preview before collapsing to "… +N more".
+# Keeps the busy ai-studio scene (~6-7 services) within the preview's max-height: 6.
+_SCENE_PREVIEW_MAX_SVCS = 4
+
 
 class OperateOrchPane(Container):
     """Operate / Orchestration tab: GPU cards, Doctor, scene table, services."""
@@ -2230,11 +2234,20 @@ class OperateOrchPane(Container):
         if scene.description:
             lines.append(f"  [dim]{escape(scene.description)}[/dim]")
         if states:
+            # ai-studio brings up ~6-7 services; on one line they wrap past the preview's
+            # max-height (6) and clip. Cap the list + show "+N more" so the box stays tidy
+            # (full per-service state lives in the Containers tab). Running services first
+            # so the active ones are always visible when a scene is partially up.
+            ordered = sorted(states, key=lambda s: not s.running)
+            shown = ordered[:_SCENE_PREVIEW_MAX_SVCS]
             svcs = "   ".join(
                 (f"[green]●[/green] {escape(s.name)}" if s.running
                  else f"[red]○[/red] {escape(s.name)}")
-                for s in states
+                for s in shown
             )
+            extra = len(states) - len(shown)
+            if extra:
+                svcs += f"   [dim]… +{extra} more[/dim]"
             lines.append(f"  [bold]services[/bold]  {svcs}")
         else:
             lines.append("  [bold]services[/bold]  [dim]— none (frees GPUs)[/dim]")

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -1726,10 +1726,6 @@ def _with_force(plan: ActionPlan) -> list[str]:
 
 # ── Operate · Orchestration ───────────────────────────────────────────────────────
 
-# Max service bullets shown in the scene preview before collapsing to "… +N more".
-# Keeps the busy ai-studio scene (~6-7 services) within the preview's max-height: 6.
-_SCENE_PREVIEW_MAX_SVCS = 4
-
 
 class OperateOrchPane(Container):
     """Operate / Orchestration tab: GPU cards, Doctor, scene table, services."""
@@ -1782,7 +1778,6 @@ class OperateOrchPane(Container):
     }
     OperateOrchPane #scene-preview {
         height: auto;
-        max-height: 6;
         border: solid $primary;
         padding: 0 1;
         margin: 0 1 1 1;
@@ -2234,20 +2229,15 @@ class OperateOrchPane(Container):
         if scene.description:
             lines.append(f"  [dim]{escape(scene.description)}[/dim]")
         if states:
-            # ai-studio brings up ~6-7 services; on one line they wrap past the preview's
-            # max-height (6) and clip. Cap the list + show "+N more" so the box stays tidy
-            # (full per-service state lives in the Containers tab). Running services first
-            # so the active ones are always visible when a scene is partially up.
+            # Show every service (running first so active ones lead). The preview box
+            # auto-grows (no max-height) — a busy scene like ai-studio (~7 services) wraps
+            # across rows without clipping; the pane scrolls if it ever needs to.
             ordered = sorted(states, key=lambda s: not s.running)
-            shown = ordered[:_SCENE_PREVIEW_MAX_SVCS]
             svcs = "   ".join(
                 (f"[green]●[/green] {escape(s.name)}" if s.running
                  else f"[red]○[/red] {escape(s.name)}")
-                for s in shown
+                for s in ordered
             )
-            extra = len(states) - len(shown)
-            if extra:
-                svcs += f"   [dim]… +{extra} more[/dim]"
             lines.append(f"  [bold]services[/bold]  {svcs}")
         else:
             lines.append("  [bold]services[/bold]  [dim]— none (frees GPUs)[/dim]")

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -1406,6 +1406,28 @@ class TestEstateWired:
 
 
 @pytest.mark.asyncio
+async def test_scene_preview_caps_services_with_overflow():
+    """A busy scene (ai-studio, ~7 services) caps the preview bullets to
+    _SCENE_PREVIEW_MAX_SVCS and collapses the rest to '+N more', so the services
+    line doesn't wrap past the preview box (max-height 6) and clip."""
+    from club3090_cockpit.app import _SCENE_PREVIEW_MAX_SVCS
+    busy = Scene(name="ai-studio", group="studio", description="creative studio",
+                 services=["comfyui", "studio-director", "studio-gallery", "studio-tts",
+                           "studio-image-shim", "studio-orchestrator", "step-voice"],
+                 ports=["8188"], gpus="both")
+    app, _, _ = make_app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _enter_operate(pilot)
+        orch = app.query_one("#operate-orch-pane", OperateOrchPane)
+        orch.render_scene_preview(busy)
+        await pilot.pause()
+        txt = str(app.query_one("#scene-preview", Static).render())
+        svc_line = next(l for l in txt.splitlines() if "services" in l)       # the services row only (header also has a ○ tag)
+        assert svc_line.count("○") == _SCENE_PREVIEW_MAX_SVCS                  # only the cap shown (none running → ○)
+        assert f"+{len(busy.services) - _SCENE_PREVIEW_MAX_SVCS} more" in svc_line  # "+3 more"
+
+
+@pytest.mark.asyncio
 class TestFix1CursorPreserveAcrossPoll:
     """FIX 1 — the B2 periodic refresh re-populates the scene + container tables
     every 4s.  The cursor must NOT snap back to row 0 on each tick: preserve it by

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -1406,11 +1406,10 @@ class TestEstateWired:
 
 
 @pytest.mark.asyncio
-async def test_scene_preview_caps_services_with_overflow():
-    """A busy scene (ai-studio, ~7 services) caps the preview bullets to
-    _SCENE_PREVIEW_MAX_SVCS and collapses the rest to '+N more', so the services
-    line doesn't wrap past the preview box (max-height 6) and clip."""
-    from club3090_cockpit.app import _SCENE_PREVIEW_MAX_SVCS
+async def test_scene_preview_shows_all_services_no_clip():
+    """A busy scene (ai-studio, ~7 services) renders EVERY service in the preview —
+    no cap, no "+N more". The box has no max-height so it auto-grows to fit instead
+    of clipping (the pane scrolls if needed)."""
     busy = Scene(name="ai-studio", group="studio", description="creative studio",
                  services=["comfyui", "studio-director", "studio-gallery", "studio-tts",
                            "studio-image-shim", "studio-orchestrator", "step-voice"],
@@ -1422,9 +1421,12 @@ async def test_scene_preview_caps_services_with_overflow():
         orch.render_scene_preview(busy)
         await pilot.pause()
         txt = str(app.query_one("#scene-preview", Static).render())
-        svc_line = next(l for l in txt.splitlines() if "services" in l)       # the services row only (header also has a ○ tag)
-        assert svc_line.count("○") == _SCENE_PREVIEW_MAX_SVCS                  # only the cap shown (none running → ○)
-        assert f"+{len(busy.services) - _SCENE_PREVIEW_MAX_SVCS} more" in svc_line  # "+3 more"
+        for svc in busy.services:                       # every service is present, none dropped
+            assert svc in txt
+        assert "more" not in txt                          # no "+N more" collapse
+        # the #scene-preview rule carries no max-height cap (box auto-grows to fit)
+        preview_rule = OperateOrchPane.DEFAULT_CSS.split("#scene-preview")[1].split("}")[0]
+        assert "max-height" not in preview_rule
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes the truncated services in the ai-studio scene preview reported in testing.

**Cause:** `#scene-preview` had `max-height: 6`, and `render_scene_preview` puts all of a scene's services on one line. ai-studio's ~7 services (comfyui + 5 studio-* + step-voice) wrap past 6 rows and the box **clips** them (+ ports).

**Fix (grow the box, don't cap):** remove the `max-height` so the preview **auto-grows to fit all the text** — every service renders (running-first); the pane scrolls if it ever needs to. (Only ai-studio is busy enough to matter; 27b/gemma/deckard have 1-2 services.)

**Test:** `test_scene_preview_shows_all_services_no_clip` — all 7 services present, no `+N more`, `#scene-preview` carries no `max-height`. Targeted suite 15/15 green.

> Note: an earlier commit on this branch tried *capping* to "+N more" — replaced with the box-grows approach per the request to accommodate all the text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
