### PR TITLE
gpu-mode: fix gemma switch (undefined fn aborted start) + litellm :8032 route

### DIFF
--- a/scripts/gpu-mode.sh
+++ b/scripts/gpu-mode.sh
@@ -14,7 +14,6 @@ COMPOSE_BASE="$CLUB3090_DIR/services"
 # the same invocation switch.sh uses (project dir = compose-file dir).
 DUAL_27B_DIR="$CLUB3090_DIR/models/qwen3.6-27b/vllm/compose/dual/autoround-int4"
 GEMMA_DUAL_DIR="$CLUB3090_DIR/models/gemma-4-31b/vllm/compose/dual/autoround-int4"
-GEMMA_DUAL_AWQ_DIR="$CLUB3090_DIR/models/gemma-4-31b/vllm/compose/dual/awq"
 # Qwen3.6-40B-Deckard: uncensored dense 40B, Q6_K GGUF + embedded MTP head,
 # layer-split across both cards (llama.cpp). Dual-only — see `gpu-mode deckard`.
 DECKARD_DIR="$CLUB3090_DIR/models/qwen3.6-40b-deckard/llama-cpp/compose/dual/piehsoft-q6k"
@@ -414,26 +413,6 @@ mode_27b() {
 #  'gemma' scene (mode_gemma_int8) remains.  The bf16 compose is still serveable
 #  via its catalog slug if needed.)
 
-mode_gemma_dflash() {
-    echo -e "${CYAN}═══ Switching to Gemma 4 31B DFlash mode ═══${NC}"
-    echo "Starting: Gemma 4 31B + z-lab DFlash drafter (TP=2, :8032)"
-    echo ""
-    stop_all_27b
-    stop_deckard
-    stop_gemma_mtp
-    stop_gemma_int8
-    stop_gemma_dflash_int8
-    stop_gemma_awq
-    start_gemma_dflash
-    start_service litellm
-    start_service qdrant
-    start_service openwebui
-    start_service searxng
-    echo ""
-    echo -e "${GREEN}Gemma 4 31B DFlash mode active.${NC} API: http://192.168.86.33:8032"
-    echo -e "${YELLOW}Tail: sudo docker logs -f vllm-gemma-4-31b-dflash${NC}"
-}
-
 mode_gemma_int8() {
     echo -e "${CYAN}═══ Switching to Gemma 4 31B INT8-PTH mode (dual default, long ctx) ═══${NC}"
     echo "Starting: Gemma 4 31B + INT8 PTH KV + 262K ctx (TP=2, :8032)"
@@ -441,9 +420,7 @@ mode_gemma_int8() {
     stop_all_27b
     stop_deckard
     stop_gemma_mtp
-    stop_gemma_dflash
-    stop_gemma_dflash_int8
-    stop_gemma_awq
+    stop_gemma_int8          # clean re-switch; the dflash/awq gemma scenes were pruned
     start_gemma_int8
     start_service litellm
     start_service qdrant
@@ -477,46 +454,6 @@ mode_deckard() {
     echo -e "${YELLOW}MTP n=2: ~36 narr / 46 code TPS · 128K ctx @ q8_0 KV · uncensored, text-only.${NC}"
     echo -e "${YELLOW}First boot ~1-2 min (31 GB GGUF load + 128K KV alloc across both cards).${NC}"
     echo -e "${YELLOW}Tail: sudo docker logs -f llama-cpp-deckard-40b${NC}"
-}
-
-mode_gemma_dflash_int8() {
-    echo -e "${CYAN}═══ Switching to Gemma 4 31B DFlash + INT8 PTH mode ═══${NC}"
-    echo "Starting: Gemma 4 31B + DFlash + INT8 PTH KV (TP=2, :8032). Requires vllm#42102."
-    echo ""
-    stop_all_27b
-    stop_deckard
-    stop_gemma_mtp
-    stop_gemma_dflash
-    stop_gemma_int8
-    stop_gemma_awq
-    start_gemma_dflash_int8
-    start_service litellm
-    start_service qdrant
-    start_service openwebui
-    start_service searxng
-    echo ""
-    echo -e "${GREEN}Gemma 4 31B DFlash + INT8 mode active.${NC} API: http://192.168.86.33:8032"
-    echo -e "${YELLOW}Tail: sudo docker logs -f vllm-gemma-4-31b-dflash-int8${NC}"
-}
-
-mode_gemma_awq() {
-    echo -e "${CYAN}═══ Switching to Gemma 4 31B AWQ-4bit mode ═══${NC}"
-    echo "Starting: Gemma 4 31B AWQ-4bit (TP=2, :8033)"
-    echo ""
-    stop_all_27b
-    stop_deckard
-    stop_gemma_mtp
-    stop_gemma_dflash
-    stop_gemma_int8
-    stop_gemma_dflash_int8
-    start_gemma_awq
-    start_service litellm
-    start_service qdrant
-    start_service openwebui
-    start_service searxng
-    echo ""
-    echo -e "${GREEN}Gemma 4 31B AWQ mode active.${NC} API: http://192.168.86.33:8033"
-    echo -e "${YELLOW}Tail: sudo docker logs -f vllm-gemma-4-31b-awq${NC}"
 }
 
 # (mode_diffusiongemma removed — DiffusionGemma is a niche dLLM; its gpu-mode scene

--- a/services/litellm/config.yaml
+++ b/services/litellm/config.yaml
@@ -18,16 +18,17 @@ model_list:
       api_base: http://host.docker.internal:8051/v1
       api_key: EMPTY
 
-  # Gemma 4 31B (Intel AutoRound INT4) + Google MTP "assistant" drafter.
-  # Started by `gpu-mode gemma` → vllm-gemma-4-31b-mtp at :8030.
+  # Gemma 4 31B (Intel AutoRound INT4) + INT8-PTH KV @262K.
+  # Started by `gpu-mode gemma` → vllm-gemma-4-31b-mtp-int8 at :8032 (the old gemma-mtp
+  # :8030 scene was pruned; the live scene is mode_gemma_int8 on :8032).
   - model_name: gemma-4-31b-autoround
     litellm_params:
       model: openai/gemma-4-31b-autoround
-      api_base: http://host.docker.internal:8030/v1
+      api_base: http://host.docker.internal:8032/v1
       api_key: EMPTY
 
   # (gemma-4-12b :8069 route retired 2026-06-23 with the ai-studio consolidation — the
-  #  studio uses the qwen director only.  The gemma-4-31b :8030 route above is unaffected.)
+  #  studio uses the qwen director only. The gemma-4-31b :8032 route above is unaffected.)
 
   # NOTE: Gemma 4 26B-A4B is intentionally NOT routed — the registry default
   # (vllm/gemma-a4b, :8041) is the autoround-int4-mixed compose, which is


### PR DESCRIPTION
Fixes the reported **"switch to gemma → 27b unloads but gemma fails to load."**

## Root cause
`gpu-mode.sh` runs under `set -e`. `mode_gemma_int8` (what `gpu-mode gemma` dispatches to) called three functions that were **deleted** when the dflash/awq gemma scenes were pruned — `stop_gemma_dflash`, `stop_gemma_dflash_int8`, `stop_gemma_awq`. The first undefined call (`stop_gemma_dflash: command not found`) **aborts the function under `set -e` after the 27b teardown but before `start_gemma_int8`** → 27b stops, gemma never starts.

## Fix
- **`mode_gemma_int8`**: drop the 3 undefined calls; add the *defined* `stop_gemma_int8` for a clean re-switch. **Live-validated** — `gpu-mode gemma` now starts `vllm-gemma-4-31b-mtp-int8` on `:8032`, loads weights, and serves.
- **Finish the partial prune**: remove the 3 dead, unreachable gemma modes (`mode_gemma_dflash` / `_dflash_int8` / `_awq`, 0 dispatch refs) that referenced the same deleted functions, plus the orphaned `GEMMA_DUAL_AWQ_DIR`. No dangling refs remain; `bash -n` clean.
- **`litellm`**: the `gemma-4-31b-autoround` route was stale at `:8030` (the removed `gemma-mtp` scene) — repointed to **`:8032`** (the live int8 scene). **End-to-end OWUI → litellm → gemma now returns HTTP 200.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)