### PR TITLE
Lazy-load step-voice + scene-wire it into ai-studio

### DIFF
--- a/scripts/gpu-mode.sh
+++ b/scripts/gpu-mode.sh
@@ -635,6 +635,7 @@ mode_ai_studio() {
     start_step_voice
     start_service openwebui
     start_service litellm
+    start_service qdrant
     start_service searxng
     echo ""
     echo -e "${GREEN}AI-studio mode active.${NC} — one scene; pick the lane in Open WebUI."
@@ -856,7 +857,7 @@ qwen35b-a3b	models	Qwen3.6-35B-A3B MoE (3B active / 35B total) AutoRound INT4 + 
 gemma-31b	models	Gemma 4 31B INT8 PTH KV + 262K + vision (TP=2) — dual default	vllm-gemma-4-31b-mtp-int8,litellm,qdrant,openwebui,searxng	8032,8080,4000	both
 gemma12b	models	Gemma 4 12B AutoRound INT8 + bf16 KV + MTP n=2 (gemma4_unified arch-preview, single-card)	vllm-gemma-4-12b-int8-mtp,litellm,qdrant,openwebui,searxng	8038,8080,4000	1
 deckard	models	Qwen3.6-40B-Deckard Q6_K + MTP n=2 + q8_0 KV + 128K (llama.cpp, dual)	llama-cpp-deckard-40b,litellm,qdrant,openwebui,searxng	8199,8080,4000	both
-ai-studio	studio	image · video · audio · voice — ComfyUI both GPUs + qwen director + sidecars + Open WebUI (pick the lane in OWUI)	comfyui,studio-director,studio-gallery,studio-orchestrator,studio-image-shim,studio-tts,studio-step-voice,openwebui,litellm,searxng	8188,8090,8189,8190,8191,8192,8193,8080,4000	both
+ai-studio	studio	image · video · audio · voice — ComfyUI both GPUs + qwen director + sidecars + Open WebUI (pick the lane in OWUI)	comfyui,studio-director,studio-gallery,studio-orchestrator,studio-image-shim,studio-tts,studio-step-voice,openwebui,litellm,qdrant,searxng	8188,8090,8189,8190,8191,8192,8193,8080,4000,6333	both
 off	ops	Stop all services	all-stopped		none
 power-cap	ops	GPU power-cap controls (on/off/status; both 3090s, 230W default cap)			both
 prune	ops	docker image prune -a (safe — only unreferenced images)			none

--- a/scripts/gpu-mode.sh
+++ b/scripts/gpu-mode.sh
@@ -205,6 +205,19 @@ start_studio_tts() {
     printf "  ${GREEN}▲${NC} Starting studio-tts (:8192, Kokoro voices + mixdown, CPU)..."
     compose_at "$COMPOSE_BASE/studio/tts" "up -d --build" && echo "done" || echo "failed"
 }
+# Premium voice (:8193, Step-Audio-EditX, GPU1, isolated transformers 4.53.3). LAZY: the container
+# comes up cheap (~0 GB) so the OWUI voice lane appears as soon as ai-studio starts it; the ~14 GB
+# model loads on the FIRST /clone and is freed again by idle-unload (300s) + the pipe's POST /unload
+# before a video render. Stopped wherever ComfyUI is (freeing GPU1 for a dual-card LLM scene).
+# `--build` picks up server.py edits (layer-cached → fast when unchanged).
+start_step_voice() {
+    printf "  ${GREEN}▲${NC} Starting step-voice (:8193, lazy — model loads on first use, GPU1)..."
+    compose_at "$COMPOSE_BASE/studio/step-voice" "up -d --build" && echo "done" || echo "failed"
+}
+stop_step_voice() {
+    printf "  ${RED}▼${NC} Stopping step-voice..."
+    compose_at "$COMPOSE_BASE/studio/step-voice" "down" && echo "done" || echo "skipped"
+}
 
 # (start_comfyui_gpu0 + the gemma-4-12b chat brain were retired with the
 #  image-studio→ai-studio consolidation 2026-06-23 — ComfyUI now always spans both GPUs.)
@@ -415,6 +428,7 @@ mode_chat() {
     stop_deckard
     stop_all_gemma
     stop_comfyui
+    stop_step_voice
     start_service openwebui
     start_service litellm
     start_service qdrant
@@ -433,6 +447,7 @@ mode_27b() {
     stop_deckard
     stop_35b_a3b_dual
     stop_comfyui
+    stop_step_voice
     stop_27b_dual_dflash
     stop_27b_dual_dflash_noviz
     stop_27b_dual_turbo
@@ -459,6 +474,7 @@ mode_35b_a3b() {
     stop_all_gemma
     stop_deckard
     stop_comfyui
+    stop_step_voice
     stop_diffusiongemma
     start_35b_a3b_dual
     start_service litellm
@@ -482,6 +498,7 @@ mode_gemma_12b() {
     stop_deckard
     stop_35b_a3b_dual
     stop_comfyui
+    stop_step_voice
     stop_diffusiongemma
     start_gemma_12b
     start_service litellm
@@ -526,6 +543,7 @@ mode_deckard() {
     stop_all_gemma
     stop_35b_a3b_dual
     stop_comfyui
+    stop_step_voice
     start_deckard
     start_service litellm
     start_service qdrant
@@ -614,6 +632,7 @@ mode_ai_studio() {
     start_studio_orchestrator
     start_studio_image_shim
     start_studio_tts
+    start_step_voice
     start_service openwebui
     start_service litellm
     start_service searxng
@@ -798,6 +817,7 @@ mode_off() {
     stop_diffusiongemma
     stop_all_gemma
     stop_comfyui
+    stop_step_voice
     stop_estate
     for svc in "${SERVICES[@]}"; do
         stop_service "$svc"
@@ -836,7 +856,7 @@ qwen35b-a3b	models	Qwen3.6-35B-A3B MoE (3B active / 35B total) AutoRound INT4 + 
 gemma-31b	models	Gemma 4 31B INT8 PTH KV + 262K + vision (TP=2) — dual default	vllm-gemma-4-31b-mtp-int8,litellm,qdrant,openwebui,searxng	8032,8080,4000	both
 gemma12b	models	Gemma 4 12B AutoRound INT8 + bf16 KV + MTP n=2 (gemma4_unified arch-preview, single-card)	vllm-gemma-4-12b-int8-mtp,litellm,qdrant,openwebui,searxng	8038,8080,4000	1
 deckard	models	Qwen3.6-40B-Deckard Q6_K + MTP n=2 + q8_0 KV + 128K (llama.cpp, dual)	llama-cpp-deckard-40b,litellm,qdrant,openwebui,searxng	8199,8080,4000	both
-ai-studio	studio	image · video · audio · voice — ComfyUI both GPUs + qwen director + sidecars + Open WebUI (pick the lane in OWUI)	comfyui,studio-director,studio-gallery,studio-orchestrator,studio-image-shim,studio-tts,openwebui,litellm,searxng	8188,8090,8189,8190,8191,8192,8080,4000	both
+ai-studio	studio	image · video · audio · voice — ComfyUI both GPUs + qwen director + sidecars + Open WebUI (pick the lane in OWUI)	comfyui,studio-director,studio-gallery,studio-orchestrator,studio-image-shim,studio-tts,studio-step-voice,openwebui,litellm,searxng	8188,8090,8189,8190,8191,8192,8193,8080,4000	both
 off	ops	Stop all services	all-stopped		none
 power-cap	ops	GPU power-cap controls (on/off/status; both 3090s, 230W default cap)			both
 prune	ops	docker image prune -a (safe — only unreferenced images)			none

--- a/services/studio/build_studio_pipe.py
+++ b/services/studio/build_studio_pipe.py
@@ -523,6 +523,17 @@ class Pipe:
             return r["filename"], r.get("subfolder", "")
         raise RuntimeError(r.get("error", "voice generation failed"))
 
+    def _evict_voice(self):
+        # Free the premium-voice model from GPU before a video render: the LTX/Wan DiT uses GPU1 as its
+        # DisTorch donor (~21.9 GB) and step-voice holds ~14 GB when loaded → co-resident = OOM. Best-effort
+        # + fast (the lazy service idle-unloads anyway; this just makes the voice⊕video mutex deterministic).
+        try:
+            req = urllib.request.Request(self.valves.voice_url.rstrip("/") + "/unload", data=b"",
+                                         headers={"Content-Type": "application/json"})
+            urllib.request.urlopen(req, timeout=5)
+        except Exception:
+            pass
+
     def _submit(self, wf):
         req = urllib.request.Request(self.valves.comfyui_url + "/prompt",
                                      data=json.dumps({"prompt": wf, "client_id": "owui-studio"}).encode(),
@@ -958,6 +969,10 @@ class Pipe:
                     "\U0001F5BC️ **[Open / download the image](" + url + ")**\n\n"
                     "_Want changes? Just say what to tweak — e.g. " + tweaks + " — and I’ll re-craft from this and regenerate._ "
                     "_(Browse all media: " + base + "/ )_")
+
+        # Past here, lane is a VIDEO lane (ltx/sulphur/10eros/wan) — all use GPU1 as the DisTorch
+        # donor. Free the premium-voice model first so the render can't OOM against it.
+        self._evict_voice()
 
         # ── WAN VIDEO LANE (Wan2.2-Rapid AllInOne · uncensored · t2v + i2v + long-clip chain · no synced audio) ──
         if lane == "wan":

--- a/services/studio/step-voice/docker-compose.yml
+++ b/services/studio/step-voice/docker-compose.yml
@@ -3,15 +3,18 @@
 # so it never conflicts with ComfyUI's transformers 5.x. HTTP server on :8193; writes WAVs into the
 # shared gallery output dir. The OWUI Studio pipe's premium voice lane POSTs /clone (and /edit).
 #
-# GPU-heavy (~14 GB bf16 / ~3-4 GB if switched to the AWQ-4bit weights) — NOT always-on; bring it up
-# when you want the premium voice (gpu-mode-gated), pinned to a free card via STEP_VOICE_CUDA.
+# LAZY (STEP_VOICE_LAZY=1, default): the ~14 GB model is NOT loaded at boot — the container comes up
+# cheap (~0 GB) so the OWUI voice lane appears as soon as `gpu-mode ai-studio` starts it, and the
+# weights load on the FIRST /clone. GPU1 is reclaimed by an idle-unload timer (STEP_VOICE_IDLE_UNLOAD_S,
+# default 300 s) + a POST /unload the Studio pipe's video lanes call before a render (voice⊕video mutex,
+# both want GPU1). Set STEP_VOICE_LAZY=0 to load eagerly at boot. Pinned to a free card via STEP_VOICE_CUDA.
 #   docker compose -f services/studio/step-voice/docker-compose.yml up -d --build
 services:
   studio-step-voice:
     build: .
     image: studio-step-voice:latest
     container_name: studio-step-voice
-    restart: "no"               # on-demand, not always-on (holds ~14 GB VRAM)
+    restart: "no"               # scene-managed (started/stopped by gpu-mode ai-studio); lazy → ~0 GB idle
     network_mode: host          # reachable at host:8193; writes the mounted gallery output dir
     environment:
       - STEP_MODELS_DIR=/models
@@ -19,6 +22,8 @@ services:
       - STEP_VOICE_PORT=${STEP_VOICE_PORT:-8193}
       - STEP_DEFAULT_VOICE=${STEP_DEFAULT_VOICE:-Narrator.wav}
       - WHISPER_MODEL=${STEP_WHISPER_MODEL:-base}
+      - STEP_VOICE_LAZY=${STEP_VOICE_LAZY:-1}                    # 1 = load model on first /clone (not at boot)
+      - STEP_VOICE_IDLE_UNLOAD_S=${STEP_VOICE_IDLE_UNLOAD_S:-300} # auto-free GPU after N s idle (0 = never)
       - CUDA_VISIBLE_DEVICES=${STEP_VOICE_CUDA:-1}   # pin to a free card (GPU1 by default; GPU0 has ComfyUI+director)
     volumes:
       - ${STEP_AUDIO_DIR:-/mnt/models/comfyui/models/Step-Audio}:/models:ro

--- a/services/studio/step-voice/server.py
+++ b/services/studio/step-voice/server.py
@@ -4,16 +4,25 @@ Isolated from ComfyUI: runs the model on its required transformers==4.53.3 in it
 Mirrors the Kokoro studio-tts service — an HTTP server that writes WAVs into the shared gallery
 output dir, called by the OWUI Studio pipe's premium voice lane.
 
+LAZY lifecycle (STEP_VOICE_LAZY=1, default): the model is ~14 GB on GPU and the ai-studio scene
+shares GPU1 with the video DiT donor (~21.9 GB). So we DON'T load at boot — the container comes up
+cheap (~0 GB), so the voice lane appears in OWUI as soon as ai-studio starts it, and the weights
+load on the FIRST /clone or /edit. GPU1 is reclaimed two ways: an idle-unload timer
+(STEP_VOICE_IDLE_UNLOAD_S, default 300 s) and an explicit POST /unload that the Studio pipe's video
+lanes call before a render (deterministic voice⊕video mutex). Set STEP_VOICE_LAZY=0 to load at boot.
+
 Endpoints:
-  GET  /health                                              -> {ok, ready}
+  GET  /health                                              -> {ok, ready, loaded, lazy}
   POST /clone  {text|target_text, reference?, prompt_text?}  -> {filename, subfolder}
        zero-shot clone: speak `text` in the reference voice. `reference` = a bundled sample name
        (e.g. "Narrator.wav"), an absolute path, or a data: URI (user-attached voice). `prompt_text`
        is the transcript of the reference; if omitted, Whisper transcribes it automatically.
   POST /edit   {audio, source_text, edit_type, edit_info, generated_text?} -> {filename, subfolder}
        re-emote / restyle existing audio (edit_type: emotion|style|speed|paralinguistic|denoise|vad).
+  POST /unload                                              -> {ok, unloaded}
+       free the model from GPU (no-op if not loaded). Called before a video render to free GPU1.
 """
-import os, sys, time, base64, tempfile, traceback
+import os, sys, time, base64, tempfile, traceback, threading
 import numpy as np
 import soundfile as sf
 import torch
@@ -27,18 +36,68 @@ PORT        = int(os.environ.get("STEP_VOICE_PORT", "8193"))
 DEFAULT_REF = os.environ.get("STEP_DEFAULT_VOICE", "Narrator.wav")
 TOKENIZER_ID = os.environ.get("STEP_TOKENIZER_ID",
                               "dengcunqin/speech_paraformer-large_asr_nat-zh-cantonese-en-16k-vocab8501-online")
+LAZY          = os.environ.get("STEP_VOICE_LAZY", "1") != "0"
+IDLE_UNLOAD_S = int(os.environ.get("STEP_VOICE_IDLE_UNLOAD_S", "300"))   # 0 = never idle-unload
 
 sys.path.insert(0, STEP_IMPL)
 from tokenizer import StepAudioTokenizer          # noqa: E402
 from tts import StepAudioTTS                       # noqa: E402
 from model_loader import ModelSource               # noqa: E402
 
-print("[step-voice] loading tokenizer (funasr paraformer)…", flush=True)
-_encoder = StepAudioTokenizer(os.path.join(MODELS_DIR, "Step-Audio-Tokenizer"),
-                              model_source=ModelSource.LOCAL, funasr_model_id=TOKENIZER_ID)
-print("[step-voice] loading Step-Audio-EditX (3B, transformers 4.53.3)…", flush=True)
-_engine = StepAudioTTS(os.path.join(MODELS_DIR, "Step-Audio-EditX"), _encoder, model_source=ModelSource.LOCAL)
-print("[step-voice] ready", flush=True)
+# ── Lazy model lifecycle ───────────────────────────────────────────────────
+_engine = None
+_encoder = None
+_load_lock = threading.Lock()      # serializes load/unload (both run in the request executor)
+_last_used = 0.0
+
+def _load():
+    """Load tokenizer + Step-Audio-EditX (idempotent). Caller holds _load_lock."""
+    global _engine, _encoder
+    if _engine is not None:
+        return _engine
+    print("[step-voice] loading tokenizer (funasr paraformer)…", flush=True)
+    _encoder = StepAudioTokenizer(os.path.join(MODELS_DIR, "Step-Audio-Tokenizer"),
+                                  model_source=ModelSource.LOCAL, funasr_model_id=TOKENIZER_ID)
+    print("[step-voice] loading Step-Audio-EditX (3B, transformers 4.53.3)…", flush=True)
+    _engine = StepAudioTTS(os.path.join(MODELS_DIR, "Step-Audio-EditX"), _encoder, model_source=ModelSource.LOCAL)
+    print("[step-voice] model ready", flush=True)
+    return _engine
+
+def _ensure_loaded():
+    """Load on first use; refresh the idle clock. Runs inside the request executor (blocking)."""
+    global _last_used
+    with _load_lock:
+        eng = _load()
+    _last_used = time.time()
+    return eng
+
+def _unload():
+    """Free the model from GPU. Returns True if something was freed."""
+    global _engine, _encoder
+    with _load_lock:
+        if _engine is None and _encoder is None:
+            return False
+        _engine = None
+        _encoder = None
+    import gc; gc.collect()
+    try:
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+    except Exception:
+        pass
+    print("[step-voice] model unloaded (GPU freed)", flush=True)
+    return True
+
+def _idle_watch():
+    """Background daemon: unload the model after IDLE_UNLOAD_S of inactivity to free GPU1."""
+    if IDLE_UNLOAD_S <= 0:
+        return
+    tick = min(60, IDLE_UNLOAD_S)
+    while True:
+        time.sleep(tick)
+        if _engine is not None and _last_used and (time.time() - _last_used) > IDLE_UNLOAD_S:
+            print("[step-voice] idle %ds → unloading" % IDLE_UNLOAD_S, flush=True)
+            _unload()
 
 _whisper = None
 def _transcribe(path):
@@ -70,8 +129,28 @@ def _save(audio, sr, prefix):
     sf.write(os.path.join(OUTPUT_DIR, fn), audio, int(sr))
     return fn
 
+# ── blocking workers (run off the event loop; lazy-load the model first) ──
+def _clone_sync(ref_path, prompt_text_in, target):
+    eng = _ensure_loaded()
+    prompt_text = prompt_text_in or _transcribe(ref_path)
+    audio, sr = eng.clone(ref_path, prompt_text, target)
+    return {"filename": _save(audio, sr, "step_voice"), "subfolder": "", "prompt_text": prompt_text}
+
+def _edit_sync(ref_path, src_text_in, edit_type, edit_info, generated_text_in):
+    eng = _ensure_loaded()
+    src_text = src_text_in or _transcribe(ref_path)
+    generated_text = generated_text_in or src_text
+    audio, sr = eng.edit(ref_path, src_text, edit_type, edit_info, generated_text)
+    return {"filename": _save(audio, sr, "step_voice_edit"), "subfolder": ""}
+
+async def _run(fn, *args):
+    # Step inference (and the lazy load) are blocking/CPU-GPU heavy — run off the event loop.
+    import asyncio
+    return await asyncio.get_event_loop().run_in_executor(None, fn, *args)
+
 async def health(_req):
-    return web.json_response({"ok": True, "ready": _engine is not None})
+    loaded = _engine is not None
+    return web.json_response({"ok": True, "ready": loaded, "loaded": loaded, "lazy": LAZY})
 
 async def clone(req):
     d = await req.json()
@@ -82,10 +161,7 @@ async def clone(req):
     try:
         if not os.path.isfile(ref_path):
             return web.json_response({"error": "reference voice not found: %s" % ref_path}, status=400)
-        prompt_text = (d.get("prompt_text") or "").strip() or _transcribe(ref_path)
-        audio, sr = await _run(_engine.clone, ref_path, prompt_text, target)
-        fn = _save(audio, sr, "step_voice")
-        return web.json_response({"filename": fn, "subfolder": "", "prompt_text": prompt_text})
+        return web.json_response(await _run(_clone_sync, ref_path, (d.get("prompt_text") or "").strip(), target))
     except Exception as e:
         traceback.print_exc()
         return web.json_response({"error": str(e)}, status=500)
@@ -100,13 +176,9 @@ async def edit(req):
     try:
         if not os.path.isfile(ref_path):
             return web.json_response({"error": "audio to edit not found: %s" % ref_path}, status=400)
-        src_text = (d.get("source_text") or "").strip() or _transcribe(ref_path)
-        edit_type = d.get("edit_type", "emotion")
-        edit_info = d.get("edit_info", "")
-        generated_text = d.get("generated_text", src_text)
-        audio, sr = await _run(_engine.edit, ref_path, src_text, edit_type, edit_info, generated_text)
-        fn = _save(audio, sr, "step_voice_edit")
-        return web.json_response({"filename": fn, "subfolder": ""})
+        return web.json_response(await _run(
+            _edit_sync, ref_path, (d.get("source_text") or "").strip(),
+            d.get("edit_type", "emotion"), d.get("edit_info", ""), d.get("generated_text", "")))
     except Exception as e:
         traceback.print_exc()
         return web.json_response({"error": str(e)}, status=500)
@@ -115,12 +187,19 @@ async def edit(req):
             try: os.unlink(ref_path)
             except Exception: pass
 
-async def _run(fn, *args):
-    # Step inference is blocking/CPU-GPU heavy — run off the event loop.
-    import asyncio
-    return await asyncio.get_event_loop().run_in_executor(None, fn, *args)
+async def unload(_req):
+    freed = await _run(_unload)
+    return web.json_response({"ok": True, "unloaded": freed})
 
 app = web.Application(client_max_size=64 * 1024 * 1024)
-app.add_routes([web.get("/health", health), web.post("/clone", clone), web.post("/edit", edit)])
+app.add_routes([web.get("/health", health), web.post("/clone", clone),
+                web.post("/edit", edit), web.post("/unload", unload)])
 if __name__ == "__main__":
+    if not LAZY:
+        print("[step-voice] STEP_VOICE_LAZY=0 → eager load at boot", flush=True)
+        _ensure_loaded()
+    else:
+        print("[step-voice] lazy mode — model loads on first /clone or /edit "
+              "(idle-unload %ss)" % (IDLE_UNLOAD_S or "off"), flush=True)
+    threading.Thread(target=_idle_watch, daemon=True).start()
     web.run_app(app, host="0.0.0.0", port=PORT)

--- a/services/studio/studio_pipe.py
+++ b/services/studio/studio_pipe.py
@@ -416,6 +416,17 @@ class Pipe:
             return r["filename"], r.get("subfolder", "")
         raise RuntimeError(r.get("error", "voice generation failed"))
 
+    def _evict_voice(self):
+        # Free the premium-voice model from GPU before a video render: the LTX/Wan DiT uses GPU1 as its
+        # DisTorch donor (~21.9 GB) and step-voice holds ~14 GB when loaded → co-resident = OOM. Best-effort
+        # + fast (the lazy service idle-unloads anyway; this just makes the voice⊕video mutex deterministic).
+        try:
+            req = urllib.request.Request(self.valves.voice_url.rstrip("/") + "/unload", data=b"",
+                                         headers={"Content-Type": "application/json"})
+            urllib.request.urlopen(req, timeout=5)
+        except Exception:
+            pass
+
     def _submit(self, wf):
         req = urllib.request.Request(self.valves.comfyui_url + "/prompt",
                                      data=json.dumps({"prompt": wf, "client_id": "owui-studio"}).encode(),
@@ -851,6 +862,10 @@ class Pipe:
                     "\U0001F5BC️ **[Open / download the image](" + url + ")**\n\n"
                     "_Want changes? Just say what to tweak — e.g. " + tweaks + " — and I’ll re-craft from this and regenerate._ "
                     "_(Browse all media: " + base + "/ )_")
+
+        # Past here, lane is a VIDEO lane (ltx/sulphur/10eros/wan) — all use GPU1 as the DisTorch
+        # donor. Free the premium-voice model first so the render can't OOM against it.
+        self._evict_voice()
 
         # ── WAN VIDEO LANE (Wan2.2-Rapid AllInOne · uncensored · t2v + i2v + long-clip chain · no synced audio) ──
         if lane == "wan":


### PR DESCRIPTION
## What

Makes the premium-voice lane "just work" in the studio without pre-pinning GPU1. The `step-voice` container is now part of the **ai-studio scene**, but the ~14 GB Step-Audio-EditX model **loads on first use** instead of at boot, and is **evicted before a video render** so it never OOMs against the LTX/Wan DiT (both want GPU1; the DisTorch donor is ~21.9 GB).

This is the "keep Step-Audio isolated (Apache, commercial, has the edit mode) + make it lazy" path, chosen after a spike proved Step-Audio can't fold into ComfyUI on transformers 5.x and the 5.x-native alternatives (Higgs v3, fishaudio/s2-pro) are non-commercial and no better quality.

## Changes

**`server.py` — lazy lifecycle (`STEP_VOICE_LAZY=1`, default)**
- Model loads on the first `/clone` or `/edit` (lock-guarded), not at import → container boots at **~0 GB GPU**, so the OWUI voice lane appears as soon as ai-studio starts it (the pipe gates the lane on `:8193` reachability — PR #470).
- New **`POST /unload`** frees the model from GPU; an **idle-unload timer** (`STEP_VOICE_IDLE_UNLOAD_S`, default 300 s) reclaims GPU1 automatically.
- `/health` now reports `{ready, loaded, lazy}`; transcribe+clone moved off the event loop. `STEP_VOICE_LAZY=0` restores eager boot.

**`build_studio_pipe.py` / `studio_pipe.py` — deterministic voice⊕video mutex**
- Video lanes (ltx/sulphur/10eros/wan) `POST /unload` before submitting the render.

**`gpu-mode.sh` — scene wiring**
- `start_step_voice` in `mode_ai_studio` (lazy → cheap); `stop_step_voice` wherever `stop_comfyui` is called (every LLM scene + `mode_off`) so GPU1 is freed for a dual-card model. ai-studio `--list-modes` row + helpers added.

**`docker-compose.yml`** — `STEP_VOICE_LAZY` + `STEP_VOICE_IDLE_UNLOAD_S` env, scene-managed restart note, header rewritten for lazy behaviour.

## Validation (live, real compose path)

`--build` bakes the new `server.py`:
- lazy boot → `{"loaded": false}` @ **~4 MiB** GPU1
- first `/clone` → loads (**~13 GB**) + clean audio (whisper-verified)
- `POST /unload` (the pipe's exact evict call) → freed back to **~0**
- reload after unload → clean
- gemma12b on GPU0 untouched throughout
- `bash -n` + undefined-helper sweep clean; `studio_pipe.py` regenerated + `py_compile` OK; #470's lane-gating intact.

## Deploy note

The voice lane goes live on the next `gpu-mode ai-studio` (starts the lazy container) + a pipe re-push (`push-pipe-to-owui.sh`, run by `setup-ai-studio.sh`) so the `/unload`-before-video hook is installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)