### PR TITLE
Director placement lever: CPU / GPU0 / GPU1 (c3 Settings)

### DIFF
--- a/docs/ai-studio/requirements.md
+++ b/docs/ai-studio/requirements.md
@@ -42,11 +42,14 @@ each fit one card.
 >   lane (18 GB donor + 4.5 GB = 22.5 GB fits). **NOT** the LTX / Sulphur / 10Eros lanes: they use GPU1
 >   as their ~22 GB DisTorch donor, so a director there OOMs them.
 > - **`cpu`** → universally safe, frees the GPU entirely (model mmaps into ~5 GB system RAM, SSD-backed),
->   at a craft-latency cost (single-digit tok/s for a 4B on CPU vs ~1.4 s on GPU — noticeable before a
->   fast image lane, invisible before a multi-minute video). Cap its cores with `DIRECTOR_THREADS`
->   (default 8). **A CPU director is the always-on path:** it uses no GPU, so it survives scene switches
->   and stays live as the uncensored model in Open WebUI — `gpu-mode` only evicts a *GPU*-placed director
->   when a dual-card LLM scene needs the cards.
+>   at a craft-latency cost (~14 tok/s for a 4B on CPU vs ~1.4 s on GPU — noticeable before a fast image
+>   lane, invisible before a multi-minute video). Cap its cores with `DIRECTOR_THREADS` (default 8).
+>   **Thinking is auto-disabled on CPU only** (`gpu-mode` sets `--reasoning off`): a full `<think>` trace
+>   would dominate the slow decode, so CPU craft is a direct one-pass answer. On GPU thinking stays on
+>   (fast there, and the trace lands in `reasoning_content`, leaving `content` clean either way).
+>   **A CPU director is the always-on path:** it uses no GPU, so it survives scene switches and stays
+>   live as the uncensored model in Open WebUI — `gpu-mode` only evicts a *GPU*-placed director when a
+>   dual-card LLM scene needs the cards.
 >
 > The `chat` scene also starts the director (honoring the same knob) as the **supporting-infra home for
 > Catalog models** — see [the chat scene + Catalog note](#chat-scene--the-catalog-support-layer) below.

--- a/docs/ai-studio/requirements.md
+++ b/docs/ai-studio/requirements.md
@@ -33,16 +33,26 @@ each fit one card.
 > **~1.4 s** to craft a prompt (measured, GPU), then idle. **Default: GPU0**, which coexists with every
 > shipped default lane. It's also the swing factor on the single-card Wan ceiling: its 4.5 GB on GPU0
 > caps the single-card 480p window at ~121 frames; **freeing it lifts that to 161** (measured).
-> Relocate it to reclaim GPU0:
-> - `STUDIO_DIRECTOR_GPU=1` → the second card. **Safe only when GPU1 has room** — the image lanes and
->   the Wan video lane (18 GB donor + 4.5 GB = 22.5 GB fits). **NOT** the LTX / Sulphur / 10Eros lanes:
->   they use GPU1 as their ~22 GB DisTorch donor, so a director there OOMs them.
-> - `-ngl 0` → **CPU**: universally safe, frees the GPU entirely (~5 GB RAM), at a craft-latency cost
->   (tens of seconds for a 4B on CPU vs ~1.4 s on GPU — noticeable before a fast image lane, invisible
->   before a multi-minute video).
 >
-> Keep it on GPU0 for the snappy refine-by-reply UX; move it only to unlock an edge case (Ideogram
-> 2048², single-window Wan >121 frames).
+> One knob drives it: **`STUDIO_DIRECTOR_DEVICE=gpu0|gpu1|cpu`** in the rig `.env` — set it from
+> **c3 → Settings → "Director placement"**, or edit the line directly. `gpu-mode` reads it on every
+> scene launch and translates it to the container's `CUDA_VISIBLE_DEVICES` + `-ngl`:
+> - **`gpu0`** (default) → GPU0, snappy refine-by-reply (~1.4 s craft).
+> - **`gpu1`** → the second card. **Safe only when GPU1 has room** — the image lanes and the Wan video
+>   lane (18 GB donor + 4.5 GB = 22.5 GB fits). **NOT** the LTX / Sulphur / 10Eros lanes: they use GPU1
+>   as their ~22 GB DisTorch donor, so a director there OOMs them.
+> - **`cpu`** → universally safe, frees the GPU entirely (model mmaps into ~5 GB system RAM, SSD-backed),
+>   at a craft-latency cost (single-digit tok/s for a 4B on CPU vs ~1.4 s on GPU — noticeable before a
+>   fast image lane, invisible before a multi-minute video). Cap its cores with `DIRECTOR_THREADS`
+>   (default 8). **A CPU director is the always-on path:** it uses no GPU, so it survives scene switches
+>   and stays live as the uncensored model in Open WebUI — `gpu-mode` only evicts a *GPU*-placed director
+>   when a dual-card LLM scene needs the cards.
+>
+> The `chat` scene also starts the director (honoring the same knob) as the **supporting-infra home for
+> Catalog models** — see [the chat scene + Catalog note](#chat-scene--the-catalog-support-layer) below.
+>
+> Keep it on GPU0 for the snappy refine-by-reply UX in AI-Studio; choose `cpu` for an always-on chat
+> companion, or `gpu1` to unlock a GPU0 edge case (Ideogram 2048², single-window Wan >121 frames).
 
 **Single-GPU (1× 24 GB):** image + music + SFX + the director run comfortably; **video is the
 constraint** — a 22B DiT won't fit one card at full resolution. Treat **dual-card as recommended**
@@ -94,3 +104,24 @@ gpu-mode ai-studio                                 # ComfyUI (both cards) + dire
 Then open Open WebUI and pick a lane. Full per-lane detail in [image.md](image.md) /
 [video.md](video.md) / [audio.md](audio.md); the service bundle is in
 [`services/studio/README.md`](../../services/studio/README.md).
+
+## Chat scene — the Catalog-support layer
+
+The studio's front-of-house services aren't studio-only. The **`chat` scene** (`gpu-mode chat`) brings
+up the same supporting infra — **Open WebUI** + **LiteLLM** + **Qdrant** (vector DB / document RAG) +
+**SearXNG** (web search) + the **uncensored director** (`:8090`) — *without* a scene GPU model. It's the
+home base for **Catalog models**: anything you launch ad-hoc outside a scene.
+
+```bash
+gpu-mode chat                                  # supporting infra + director, no scene LLM
+bash scripts/switch.sh --owui <variant>        # launch any catalog model AND register it into OWUI
+```
+
+`switch.sh --owui` (also reachable from **c3 → Catalog → Serve**) starts the chosen variant and wires it
+into Open WebUI as a direct connection, so it appears in the model picker alongside the director, with
+**web search and document RAG already attached**. You get a full chat workstation for any model in the
+catalog without authoring a scene for it.
+
+The director's placement here honors the same **`STUDIO_DIRECTOR_DEVICE`** knob (c3 → Settings → Director
+placement). Set it to **`cpu`** to keep the director **always-on**: it uses no GPU, so it persists across
+scene switches and stays available in OWUI even while a dual-card LLM scene owns both cards.

--- a/docs/ai-studio/video.md
+++ b/docs/ai-studio/video.md
@@ -257,8 +257,9 @@ holds the 22B DiT weights (~22 GB, DisTorch donor); GPU0 does compute (~7–14 G
 can also run a ≤1024² **image** lane in the same scene with no switch (it fits on GPU0 beside the
 director). Full per-lane VRAM in [image.md](image.md) / [audio.md](audio.md) / [README.md](README.md).
 
-> **Director placement is a VRAM lever** (default: GPU0; `STUDIO_DIRECTOR_GPU` / `-ngl 0` relocate it
-> — see [requirements.md](requirements.md)). Its 4.5 GB on GPU0 is exactly what caps the single-card
+> **Director placement is a VRAM lever** (default: GPU0; one knob — `STUDIO_DIRECTOR_DEVICE=gpu0|gpu1|cpu`,
+> set via c3 → Settings → Director placement — relocates it; see [requirements.md](requirements.md)).
+> Its 4.5 GB on GPU0 is exactly what caps the single-card
 > Wan window at ~121 frames; freeing it lifts that to 161. **GPU0 is the safe default** — it coexists
 > with every shipped default lane. **GPU1 is *not* a blanket-safe target:** the LTX/Sulphur/10Eros
 > lanes already use GPU1 as their ~22 GB donor, so a director there OOMs them. GPU1 is fine only for

--- a/scripts/gpu-mode.sh
+++ b/scripts/gpu-mode.sh
@@ -210,6 +210,15 @@ start_studio_director() {
         "DIRECTOR_NGL=$ngl" "STUDIO_DIRECTOR_CUDA=$cvd" "STUDIO_DIRECTOR_GPU=$gpu" \
         && echo "done" || echo "failed"
 }
+stop_studio_director() {
+    printf "  ${RED}▼${NC} Stopping studio-director..."
+    compose_at "$COMPOSE_BASE/studio/enhancer" "down" && echo "done" || echo "skipped"
+}
+# Free a GPU-resident director before a GPU-heavy LLM scene claims the cards. A CPU-placed
+# director uses no GPU, so it STAYS UP across scenes — the always-on uncensored model in OWUI.
+_director_evict_if_gpu() {
+    [ "$(_director_device)" != "cpu" ] && stop_studio_director
+}
 start_studio_orchestrator() {
     printf "  ${GREEN}▲${NC} Starting studio-orchestrator (:8190, long-clip chaining)..."
     compose_at "$COMPOSE_BASE/studio/orchestrator" "up -d --build" && echo "done" || echo "failed"
@@ -443,8 +452,10 @@ mode_prune_all() {
 
 mode_chat() {
     echo -e "${CYAN}═══ Switching to CHAT mode ═══${NC}"
-    echo "Starting: Open WebUI, LiteLLM, Qdrant, SearXNG"
-    echo "Stopping: all GPU-served model containers (Qwen + Gemma)"
+    echo "Starting: Open WebUI + LiteLLM + Qdrant + SearXNG + uncensored director (:8090)"
+    echo "The supporting-infra home: launch ANY catalog model with 'switch.sh --owui <variant>'"
+    echo "and it appears in OWUI here (web search + document RAG included)."
+    echo "Stopping: all GPU-served scene models (Qwen + Gemma)."
     echo ""
     stop_all_27b
     stop_deckard
@@ -455,8 +466,11 @@ mode_chat() {
     start_service litellm
     start_service qdrant
     start_service searxng
+    start_studio_director
     echo ""
     echo -e "${GREEN}Chat mode active.${NC} Open WebUI: http://192.168.86.33:8080"
+    echo -e "${YELLOW}Director placement: $(_director_device) (change in c3 Settings · Director placement).${NC}"
+    echo -e "${YELLOW}Plug in catalog models: bash scripts/switch.sh --owui <variant>  (registers it into OWUI here).${NC}"
 }
 
 mode_27b() {
@@ -470,6 +484,7 @@ mode_27b() {
     stop_35b_a3b_dual
     stop_comfyui
     stop_step_voice
+    _director_evict_if_gpu
     stop_27b_dual_dflash
     stop_27b_dual_dflash_noviz
     stop_27b_dual_turbo
@@ -497,6 +512,7 @@ mode_35b_a3b() {
     stop_deckard
     stop_comfyui
     stop_step_voice
+    _director_evict_if_gpu
     stop_diffusiongemma
     start_35b_a3b_dual
     start_service litellm
@@ -521,6 +537,7 @@ mode_gemma_12b() {
     stop_35b_a3b_dual
     stop_comfyui
     stop_step_voice
+    _director_evict_if_gpu
     stop_diffusiongemma
     start_gemma_12b
     start_service litellm
@@ -546,6 +563,9 @@ mode_gemma_int8() {
     stop_35b_a3b_dual
     stop_gemma_12b
     stop_gemma_mtp
+    stop_comfyui             # TP=2 needs both cards — clear the studio lanes too
+    stop_step_voice
+    _director_evict_if_gpu
     stop_gemma_int8          # clean re-switch; the dflash/awq gemma scenes were pruned
     start_gemma_int8
     start_service litellm
@@ -566,6 +586,7 @@ mode_deckard() {
     stop_35b_a3b_dual
     stop_comfyui
     stop_step_voice
+    _director_evict_if_gpu
     start_deckard
     start_service litellm
     start_service qdrant
@@ -841,6 +862,7 @@ mode_off() {
     stop_all_gemma
     stop_comfyui
     stop_step_voice
+    stop_studio_director     # full off stops even a CPU/always-on director
     stop_estate
     for svc in "${SERVICES[@]}"; do
         stop_service "$svc"
@@ -873,7 +895,7 @@ mode_off() {
 list_modes_data() {
     # name<TAB>group<TAB>description<TAB>services<TAB>ports<TAB>gpus
     cat <<'TSV'
-chat	ops	Open WebUI + LiteLLM + Qdrant + SearXNG (browser chat, no GPU model)	openwebui,litellm,qdrant,searxng	8080,4000	none
+chat	ops	Open WebUI + LiteLLM + Qdrant + SearXNG + uncensored director — supporting-infra home for catalog models	openwebui,litellm,qdrant,searxng,studio-director	8080,4000,8090	none
 qwen27b	models	Qwen3.6-27B MTP n=3 + fp8 KV + 262K + vision (TP=2) — default	vllm-qwen36-27b-dual,litellm,qdrant,openwebui,searxng	8010,8080,4000	both
 qwen35b-a3b	models	Qwen3.6-35B-A3B MoE (3B active / 35B total) AutoRound INT4 + fp8 KV + 262K + vision (TP=2)	vllm-qwen36-35b-a3b-dual,litellm,qdrant,openwebui,searxng	8051,8080,4000	both
 gemma-31b	models	Gemma 4 31B INT8 PTH KV + 262K + vision (TP=2) — dual default	vllm-gemma-4-31b-mtp-int8,litellm,qdrant,openwebui,searxng	8032,8080,4000	both
@@ -938,7 +960,7 @@ usage() {
     echo "Usage: gpu-mode <mode>"
     echo ""
     echo "Modes:"
-    echo "  chat               Open WebUI + LiteLLM + Qdrant + SearXNG (browser chat, no GPU model)"
+    echo "  chat               Open WebUI + LiteLLM + Qdrant + SearXNG + uncensored director (:8090) — catalog-model home"
     echo ""
     echo "  Qwen 3.6 27B (dual 3090, TP=2):"
     echo "  qwen27b            ⭐ DEFAULT — Qwen3.6-27B MTP + fp8 + 262K + vision + 2 streams (:8010) — alias: 27b"

--- a/scripts/gpu-mode.sh
+++ b/scripts/gpu-mode.sh
@@ -184,9 +184,31 @@ start_studio_gallery() {
     printf "  ${GREEN}▲${NC} Starting studio-gallery (:8189)..."
     compose_at "$COMPOSE_BASE/studio/gallery" "up -d" && echo "done" || echo "failed"
 }
+# Director placement lever — STUDIO_DIRECTOR_DEVICE (gpu0|gpu1|cpu) from the rig .env, set by
+# c3's Settings "Director placement" field (default gpu0). gpu0 = ~4.6 GB on GPU0 (fast craft,
+# coexists with the image lanes); gpu1 = GPU1 (NOT during a video render — GPU1 is the DiT donor);
+# cpu = frees GPU0 for long single-card video, but craft is ~single-digit tok/s. See video.md.
+_director_device() {
+    local d=gpu0
+    if [ -f "$CLUB3090_DIR/.env" ]; then
+        local v
+        v=$(grep -E '^STUDIO_DIRECTOR_DEVICE=' "$CLUB3090_DIR/.env" 2>/dev/null | tail -1 | cut -d= -f2- | tr -d "\"' ")
+        [ -n "$v" ] && d="$v"
+    fi
+    echo "$d"
+}
 start_studio_director() {
-    printf "  ${GREEN}▲${NC} Starting studio-director (:8090, GPU0)..."
-    compose_at "$COMPOSE_BASE/studio/enhancer" "up -d" && echo "done" || echo "failed"
+    local dev ngl cvd gpu label
+    dev=$(_director_device)
+    case "$dev" in
+        cpu)  ngl=0;  cvd="";  gpu=0; label="CPU — frees GPU0, craft ~single-digit tok/s" ;;
+        gpu1) ngl=99; cvd=1;   gpu=1; label=":8090, GPU1" ;;
+        *)    ngl=99; cvd=0;   gpu=0; label=":8090, GPU0" ;;
+    esac
+    printf "  ${GREEN}▲${NC} Starting studio-director ($label)..."
+    compose_at_env "$COMPOSE_BASE/studio/enhancer" "up -d" docker-compose.yml \
+        "DIRECTOR_NGL=$ngl" "STUDIO_DIRECTOR_CUDA=$cvd" "STUDIO_DIRECTOR_GPU=$gpu" \
+        && echo "done" || echo "failed"
 }
 start_studio_orchestrator() {
     printf "  ${GREEN}▲${NC} Starting studio-orchestrator (:8190, long-clip chaining)..."

--- a/scripts/gpu-mode.sh
+++ b/scripts/gpu-mode.sh
@@ -198,16 +198,22 @@ _director_device() {
     echo "$d"
 }
 start_studio_director() {
-    local dev ngl cvd gpu label
+    local dev ngl cvd gpu label think_args
     dev=$(_director_device)
+    # think_args empty on GPU: thinking stays ON (fast there, richer craft; the trace lands in
+    # reasoning_content so `content` is still clean). On CPU a full <think> trace dominates the
+    # ~14 tok/s latency, so disable it — '--reasoning off' sets the template's enable_thinking=false
+    # (this 'Aggressive' fine-tune ignores /no_think and --reasoning-budget 0, but honors this).
+    think_args=""
     case "$dev" in
-        cpu)  ngl=0;  cvd="";  gpu=0; label="CPU — frees GPU0, craft ~single-digit tok/s" ;;
+        cpu)  ngl=0;  cvd="";  gpu=0; think_args="--jinja --reasoning off"
+              label="CPU — thinking OFF for latency, ~14 tok/s craft" ;;
         gpu1) ngl=99; cvd=1;   gpu=1; label=":8090, GPU1" ;;
         *)    ngl=99; cvd=0;   gpu=0; label=":8090, GPU0" ;;
     esac
     printf "  ${GREEN}▲${NC} Starting studio-director ($label)..."
     compose_at_env "$COMPOSE_BASE/studio/enhancer" "up -d" docker-compose.yml \
-        "DIRECTOR_NGL=$ngl" "STUDIO_DIRECTOR_CUDA=$cvd" "STUDIO_DIRECTOR_GPU=$gpu" \
+        "DIRECTOR_NGL=$ngl" "STUDIO_DIRECTOR_CUDA=$cvd" "STUDIO_DIRECTOR_GPU=$gpu" "DIRECTOR_THINK_ARGS=$think_args" \
         && echo "done" || echo "failed"
 }
 stop_studio_director() {

--- a/scripts/tests/test-gpu-mode-list.sh
+++ b/scripts/tests/test-gpu-mode-list.sh
@@ -58,7 +58,7 @@ GROUPS = {"models", "studio", "ops"}
 #  diffusiongemma scenes were removed — bigmodel ≈ off, dgemma → catalog slug.  The
 #  standalone comfyui scene was removed — comfyui runs via ai-studio.)
 EXPECT = {
-    "27b": "models", "gemma": "models", "deckard": "models",
+    "qwen27b": "models", "gemma-31b": "models", "deckard": "models",
     "ai-studio": "studio",
     "chat": "ops", "off": "ops", "power-cap": "ops", "prune": "ops", "prune-all": "ops",
 }

--- a/services/studio/enhancer/docker-compose.yml
+++ b/services/studio/enhancer/docker-compose.yml
@@ -17,6 +17,9 @@
 #                   craft is ~single-digit tok/s — see docs/ai-studio/video.md director-placement lever)
 # On GPU0 the ~4.6 GB director coexists with ComfyUI's GPU0 compute; GPU1 is the video DiT donor
 # (don't put the director there during video). CPU is the universally-safe relocation.
+# CPU thread cap: DIRECTOR_THREADS (default 8 of 16) — bounds CPU use so it doesn't starve OWUI's
+# embedder/reranker. The ~2.6 GB GGUF loads into SYSTEM RAM (mmap'd → resident in page cache after
+# warm-up; the SSD is only the backing store, inference runs from RAM, not the disk).
 services:
   studio-director:
     image: ${LLAMACPP_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda}
@@ -32,7 +35,7 @@ services:
     command: >-
       -m /models/${DIRECTOR_GGUF:-qwen3.5-4b-gguf/hauhaucs-uncensored-q4km/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive-Q4_K_M.gguf}
       --mmproj /models/${DIRECTOR_MMPROJ:-qwen3.5-4b-gguf/hauhaucs-uncensored-q4km/mmproj-Qwen3.5-4B-Uncensored-HauhauCS-Aggressive-BF16.gguf}
-      -ngl ${DIRECTOR_NGL:-99} -c 16384 --host 0.0.0.0 --port ${STUDIO_DIRECTOR_PORT:-8090}
+      -ngl ${DIRECTOR_NGL:-99} -t ${DIRECTOR_THREADS:-8} -c 16384 --host 0.0.0.0 --port ${STUDIO_DIRECTOR_PORT:-8090}
       --alias qwen3.5-4b-uncensored
     deploy:
       resources:

--- a/services/studio/enhancer/docker-compose.yml
+++ b/services/studio/enhancer/docker-compose.yml
@@ -9,20 +9,30 @@
 # stock model (e.g. gemma-4-12b) if you'd rather craft through an aligned model; the
 # Sulphur DiT still renders uncensored. See docs/ai-studio/video.md.
 #
-# Pinned to GPU0 (default) — the ~4.6 GB director coexists there with ComfyUI's GPU0
-# compute (a video render donates its 22B DiT to GPU1 via DisTorch; image/music/SFX are GPU0).
+# Placement is a lever (default GPU0). `gpu-mode` derives these from STUDIO_DIRECTOR_DEVICE
+# (gpu0 | gpu1 | cpu) — or set them directly in the rig .env:
+#   GPU0 (default): DIRECTOR_NGL=99  STUDIO_DIRECTOR_CUDA=0  STUDIO_DIRECTOR_GPU=0
+#   GPU1:           DIRECTOR_NGL=99  STUDIO_DIRECTOR_CUDA=1  STUDIO_DIRECTOR_GPU=1
+#   CPU:            DIRECTOR_NGL=0   STUDIO_DIRECTOR_CUDA=""  (frees ~4.6 GB off GPU0 for long video;
+#                   craft is ~single-digit tok/s — see docs/ai-studio/video.md director-placement lever)
+# On GPU0 the ~4.6 GB director coexists with ComfyUI's GPU0 compute; GPU1 is the video DiT donor
+# (don't put the director there during video). CPU is the universally-safe relocation.
 services:
   studio-director:
     image: ${LLAMACPP_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda}
     container_name: studio-director
     restart: unless-stopped
     network_mode: host           # binds :8090 directly on the host
+    environment:
+      # "" → CPU-only (CUDA sees no device, llama.cpp falls back to CPU); 0/1 → that GPU.
+      # No-colon ${VAR-0}: an explicit empty value (CPU) is kept; only an UNSET var defaults to 0.
+      - CUDA_VISIBLE_DEVICES=${STUDIO_DIRECTOR_CUDA-0}
     volumes:
       - ${MODEL_DIR:-/mnt/models/huggingface}:/models:ro
     command: >-
       -m /models/${DIRECTOR_GGUF:-qwen3.5-4b-gguf/hauhaucs-uncensored-q4km/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive-Q4_K_M.gguf}
       --mmproj /models/${DIRECTOR_MMPROJ:-qwen3.5-4b-gguf/hauhaucs-uncensored-q4km/mmproj-Qwen3.5-4B-Uncensored-HauhauCS-Aggressive-BF16.gguf}
-      -ngl 99 -c 16384 --host 0.0.0.0 --port ${STUDIO_DIRECTOR_PORT:-8090}
+      -ngl ${DIRECTOR_NGL:-99} -c 16384 --host 0.0.0.0 --port ${STUDIO_DIRECTOR_PORT:-8090}
       --alias qwen3.5-4b-uncensored
     deploy:
       resources:

--- a/services/studio/enhancer/docker-compose.yml
+++ b/services/studio/enhancer/docker-compose.yml
@@ -20,6 +20,11 @@
 # CPU thread cap: DIRECTOR_THREADS (default 8 of 16) — bounds CPU use so it doesn't starve OWUI's
 # embedder/reranker. The ~2.6 GB GGUF loads into SYSTEM RAM (mmap'd → resident in page cache after
 # warm-up; the SSD is only the backing store, inference runs from RAM, not the disk).
+# Thinking: DIRECTOR_THINK_ARGS passes extra llama.cpp flags. `gpu-mode` leaves it empty on GPU
+# (thinking ON — fast, richer craft; the trace lands in reasoning_content so `content` stays clean)
+# and sets `--jinja --reasoning off` on CPU, where a full <think> trace would dominate the ~14 tok/s
+# latency. (This 'Aggressive' fine-tune ignores /no_think and --reasoning-budget 0 but honors
+# --reasoning off, which forces the template's enable_thinking=false.)
 services:
   studio-director:
     image: ${LLAMACPP_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda}
@@ -36,7 +41,7 @@ services:
       -m /models/${DIRECTOR_GGUF:-qwen3.5-4b-gguf/hauhaucs-uncensored-q4km/Qwen3.5-4B-Uncensored-HauhauCS-Aggressive-Q4_K_M.gguf}
       --mmproj /models/${DIRECTOR_MMPROJ:-qwen3.5-4b-gguf/hauhaucs-uncensored-q4km/mmproj-Qwen3.5-4B-Uncensored-HauhauCS-Aggressive-BF16.gguf}
       -ngl ${DIRECTOR_NGL:-99} -t ${DIRECTOR_THREADS:-8} -c 16384 --host 0.0.0.0 --port ${STUDIO_DIRECTOR_PORT:-8090}
-      --alias qwen3.5-4b-uncensored
+      --alias qwen3.5-4b-uncensored ${DIRECTOR_THINK_ARGS:-}
     deploy:
       resources:
         reservations:

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -3329,14 +3329,15 @@ class SettingsScreen(ModalScreen):
         Binding("escape", "cancel", "Cancel", show=True),
     ]
 
-    def __init__(self, model_dir: str, hf_token_set: bool, **kwargs):
+    def __init__(self, model_dir: str, hf_token_set: bool, director_device: str = "gpu0", **kwargs):
         super().__init__(**kwargs)
         self._model_dir = model_dir or ""
         self._hf_token_set = hf_token_set
+        self._director_device = director_device if director_device in ("gpu0", "gpu1", "cpu") else "gpu0"
 
     def compose(self) -> ComposeResult:
         with Vertical():
-            yield Label("Settings · weights download", classes="settings-title")
+            yield Label("Settings", classes="settings-title")
             yield Label("Model dir  [dim](weights live under <dir>/huggingface/)[/dim]",
                         classes="settings-field")
             yield Input(value=self._model_dir, placeholder="/mnt/models/huggingface", id="set-model-dir")
@@ -3344,9 +3345,17 @@ class SettingsScreen(ModalScreen):
                       if self._hf_token_set else "hf_…  (for gated / private repos)")
             yield Label("HuggingFace token", classes="settings-field")
             yield Input(value="", password=True, placeholder=tok_ph, id="set-hf-token")
+            yield Label("Director placement  [dim](ai-studio prompt-crafter · :8090)[/dim]",
+                        classes="settings-field")
+            yield Select(
+                [("GPU 0 — fast craft, ~4.6 GB (default)", "gpu0"),
+                 ("GPU 1 — only when free, not during video", "gpu1"),
+                 ("CPU — frees GPU0 for long video, slow craft", "cpu")],
+                value=self._director_device, allow_blank=False, id="set-director-device",
+            )
             yield Label(
-                "[dim]Ctrl+S save · Esc cancel · HF_HOME is auto-derived under the "
-                "model dir (off the root disk)[/dim]",
+                "[dim]Ctrl+S save · Esc cancel · HF_HOME auto-derived under the model dir · "
+                "director change applies on next ai-studio start[/dim]",
                 classes="settings-field",
             )
             yield Footer()
@@ -3354,8 +3363,9 @@ class SettingsScreen(ModalScreen):
     def action_save(self) -> None:
         mdir = self.query_one("#set-model-dir", Input).value.strip()
         tok = self.query_one("#set-hf-token", Input).value.strip()
+        dev = str(self.query_one("#set-director-device", Select).value)
         self.app.pop_screen()
-        self.app.apply_settings(model_dir=mdir, hf_token=tok)  # type: ignore[attr-defined]
+        self.app.apply_settings(model_dir=mdir, hf_token=tok, director_device=dev)  # type: ignore[attr-defined]
 
     def action_cancel(self) -> None:
         self.app.pop_screen()
@@ -6853,31 +6863,39 @@ class CockpitApp(App):
         )
 
     def action_settings(self) -> None:
-        """[S] — open the download Settings (MODEL_DIR + HF_TOKEN)."""
+        """[S] — open Settings (MODEL_DIR + HF_TOKEN + director placement)."""
         import os as _os
         self.push_screen(
-            SettingsScreen(self._data.weights_model_dir(), bool(_os.environ.get("HF_TOKEN")))
+            SettingsScreen(self._data.weights_model_dir(), bool(_os.environ.get("HF_TOKEN")),
+                           self._data.director_device())
         )
 
-    def apply_settings(self, *, model_dir: str, hf_token: str) -> None:
-        """Persist + apply Settings.  Empty fields are no-ops (a blank token keeps
-        the current one).  A model-dir change re-loads the catalog so the
-        weights-on-disk state re-stats against the new dir."""
+    def apply_settings(self, *, model_dir: str, hf_token: str, director_device: str = "gpu0") -> None:
+        """Persist + apply Settings.  MODEL_DIR / HF_TOKEN persist to c3-settings.json;
+        the director placement persists to the repo .env (STUDIO_DIRECTOR_DEVICE — what
+        gpu-mode reads, applied on the next ai-studio start).  Empty text fields are
+        no-ops; a model-dir change re-stats the catalog."""
         import os as _os
         from .__main__ import load_settings, save_settings
         s = load_settings()
-        changed = False
+        json_changed = False
         if model_dir and model_dir != self._data.weights_model_dir():
             self._data._model_dir = model_dir
             s["model_dir"] = model_dir
-            changed = True
+            json_changed = True
         if hf_token:
             _os.environ["HF_TOKEN"] = hf_token
             s["hf_token"] = hf_token
-            changed = True
-        if changed:
+            json_changed = True
+        if json_changed:
             save_settings(s)
-            self.notify("Settings saved.", title="Settings", timeout=3)
+        env_changed = False
+        if director_device and director_device != self._data.director_device():
+            env_changed = self._data.set_repo_env_var("STUDIO_DIRECTOR_DEVICE", director_device)
+        if json_changed or env_changed:
+            msg = (f"Saved · director → {director_device} (next ai-studio start)."
+                   if env_changed else "Settings saved.")
+            self.notify(msg, title="Settings", timeout=4)
         else:
             self.notify("No changes.", title="Settings", timeout=2)
         if model_dir:

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -178,6 +178,24 @@ STUDIO_MODELS = _load_studio_models()
 STUDIO_VOICE_CONTAINER = "studio-step-voice"
 STUDIO_VOICE_GPU_NEED_MIB = 14000
 
+# The director container — placement-aware (STUDIO_DIRECTOR_DEVICE); a Containers-pane
+# start must honor that knob, not the GPU0 compose default. See director_compose_env.
+STUDIO_DIRECTOR_CONTAINER = "studio-director"
+
+# Nested studio sidecars: container-name → services/studio/<subdir> basename. The
+# container suffix usually equals the subdir, EXCEPT the director (container
+# 'studio-director' lives in 'enhancer/'). Single SoT for BOTH resolving the nested
+# compose project AND enumerating a STOPPED sidecar in the Containers tab — gpu-mode
+# runs these from services/studio/<sub>/, so project == <sub> keeps the two in sync.
+STUDIO_SIDECARS = {
+    "studio-director": "enhancer",
+    "studio-gallery": "gallery",
+    "studio-image-shim": "image-shim",
+    "studio-orchestrator": "orchestrator",
+    "studio-step-voice": "step-voice",
+    "studio-tts": "tts",
+}
+
 
 # ── Subprocess runner protocol (dependency injection seam) ───────────────────────
 
@@ -593,6 +611,25 @@ class CockpitData:
             pass
         return "gpu0"
 
+    def director_compose_env(self) -> dict[str, str]:
+        """Translate the director placement (:meth:`director_device`) into the compose
+        env — NGL / CUDA / GPU / THINK_ARGS — EXACTLY as gpu-mode's ``start_studio_director``
+        does, so a Containers-pane start of ``studio-director`` honors STUDIO_DIRECTOR_DEVICE
+        (and disables thinking on CPU) instead of falling back to the GPU0 compose default.
+
+        Keep in lock-step with ``scripts/gpu-mode.sh`` ``start_studio_director``:
+          - cpu  → CPU (-ngl 0, no card), thinking OFF (a <think> trace dominates ~14 tok/s);
+          - gpu1 → second card; gpu0/default → first card; both keep thinking ON."""
+        dev = self.director_device()
+        if dev == "cpu":
+            return {"DIRECTOR_NGL": "0", "STUDIO_DIRECTOR_CUDA": "",
+                    "STUDIO_DIRECTOR_GPU": "0", "DIRECTOR_THINK_ARGS": "--jinja --reasoning off"}
+        if dev == "gpu1":
+            return {"DIRECTOR_NGL": "99", "STUDIO_DIRECTOR_CUDA": "1",
+                    "STUDIO_DIRECTOR_GPU": "1", "DIRECTOR_THINK_ARGS": ""}
+        return {"DIRECTOR_NGL": "99", "STUDIO_DIRECTOR_CUDA": "0",
+                "STUDIO_DIRECTOR_GPU": "0", "DIRECTOR_THINK_ARGS": ""}
+
     def set_repo_env_var(self, key: str, value: str) -> bool:
         """WRITE — upsert ``key=value`` in the repo ``.env`` (the SHARED config gpu-mode
         and the composes read), preserving every other line.  Updates the first
@@ -905,7 +942,14 @@ class CockpitData:
                     names.append(child.name)
         except (OSError, FileNotFoundError):
             return []
-        return names
+        # Nested studio sidecars (services/studio/<sub>/) aren't top-level dirs, so add
+        # them by CONTAINER name — otherwise a STOPPED director/gallery/orchestrator/…
+        # wouldn't enumerate as a startable row (only running ones show via docker-ps).
+        for cn, sub in STUDIO_SIDECARS.items():
+            d = base / "studio" / sub
+            if (d / "docker-compose.yml").is_file() or (d / "docker-compose.yaml").is_file():
+                names.append(cn)
+        return sorted(names)
 
     async def _running_container_ports(self) -> list[tuple[str, int]]:
         """READ — every running container as ``(name, first-published-host-port)``
@@ -1975,13 +2019,13 @@ class CockpitData:
         Two shapes:
           - **top-level** supporting service → ``services/<name>/docker-compose.yml``,
             project == ``name`` (matches gpu-mode running it from that dir).
-          - **nested studio sidecar** → the row carries the CONTAINER name
-            ``studio-<sub>`` while the compose lives at
-            ``services/studio/<sub>/docker-compose.yml`` (e.g. the on-demand
-            ``studio-step-voice`` → ``services/studio/step-voice/``).  Project ==
-            ``<sub>`` — the dir basename gpu-mode's ``compose_at`` uses, so the
-            cockpit and gpu-mode track the SAME compose project (avoids the
-            duplicate-``container_name`` collision the gallery hit).
+          - **nested studio sidecar** → the row carries the CONTAINER name, mapped via
+            ``STUDIO_SIDECARS`` to ``services/studio/<sub>/docker-compose.yml`` (the
+            suffix usually equals ``<sub>``, e.g. ``studio-step-voice`` →
+            ``step-voice/``, but NOT the director: ``studio-director`` →
+            ``enhancer/``).  Project == ``<sub>`` — the dir basename gpu-mode's
+            ``compose_at`` uses, so the cockpit and gpu-mode track the SAME compose
+            project (avoids the duplicate-``container_name`` collision the gallery hit).
 
         Returns ``None`` when no compose dir backs the name (caller then falls
         back to ``docker restart`` of an already-created container)."""
@@ -1994,8 +2038,8 @@ class CockpitData:
         top = _find(f"services/{name}")
         if top:
             return top, name
-        if name.startswith("studio-"):
-            sub = name[len("studio-"):]
+        sub = STUDIO_SIDECARS.get(name)
+        if sub is not None:
             nested = _find(f"services/studio/{sub}")
             if nested:
                 return nested, sub
@@ -2031,6 +2075,12 @@ class CockpitData:
         if (self.repo_root / ".env").is_file():
             cmd += ["--env-file", ".env"]
         cmd += ["-f", rel, "-p", project, "up", "-d"]
+        # The director is placement-aware: prefix the compose with the same env gpu-mode
+        # derives from STUDIO_DIRECTOR_DEVICE (NGL / CUDA / GPU / THINK_ARGS) so a Containers
+        # start honors the c3 Setting (and CPU no-think) instead of the GPU0 compose default.
+        # `env K=V …` (process env) wins over --env-file for compose interpolation.
+        if name == STUDIO_DIRECTOR_CONTAINER:
+            cmd = ["env", *(f"{k}={v}" for k, v in self.director_compose_env().items()), *cmd]
         return ActionPlan(
             kind="service-up",
             cmd=cmd,
@@ -2040,14 +2090,13 @@ class CockpitData:
 
     def service_start_or_restart(self, name: str) -> ActionPlan:
         """Bring a stopped service UP, picking the right mechanism:
-          - a compose dir backs the name (top-level ``services/<name>/`` OR a
-            nested studio sidecar ``services/studio/<sub>/`` for ``studio-<sub>``
-            — e.g. the on-demand ``studio-step-voice``) → ``compose up``
-            (``service_start`` — CREATES the container if it doesn't exist yet, so
-            it works on a fresh install, not just a re-start);
-          - otherwise it's a scene-managed container whose dir name doesn't match
-            (e.g. ``studio-director`` → ``services/studio/enhancer/``) → ``docker
-            restart`` STARTS the stopped-but-created container."""
+          - a compose dir backs the name (top-level ``services/<name>/`` OR a nested
+            studio sidecar via ``STUDIO_SIDECARS`` — incl. ``studio-director`` →
+            ``services/studio/enhancer/``) → ``compose up`` (``service_start`` —
+            CREATES the container if it doesn't exist yet, so it works on a fresh
+            install, and for the director injects the placement env);
+          - otherwise (no backing compose dir) → ``docker restart`` STARTS the
+            stopped-but-created container."""
         if self._resolve_service_compose(name) is not None:
             return self.service_start(name)
         return self.container_action(name, "restart")

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -576,6 +576,50 @@ class CockpitData:
             return ""
         return ""
 
+    def director_device(self) -> str:
+        """The studio director's placement — ``STUDIO_DIRECTOR_DEVICE`` from the repo
+        ``.env`` (``gpu0`` | ``gpu1`` | ``cpu``; default ``gpu0``).  Read by gpu-mode's
+        ``start_studio_director``; the Settings screen edits it via :meth:`set_repo_env_var`."""
+        try:
+            envf = self.repo_root / ".env"
+            if envf.is_file():
+                for raw in envf.read_text(encoding="utf-8", errors="replace").splitlines():
+                    s = raw.strip()
+                    if s.startswith("STUDIO_DIRECTOR_DEVICE=") and not s.startswith("#"):
+                        v = s.split("=", 1)[1].strip().strip('"').strip("'")
+                        if v in ("gpu0", "gpu1", "cpu"):
+                            return v
+        except OSError:
+            pass
+        return "gpu0"
+
+    def set_repo_env_var(self, key: str, value: str) -> bool:
+        """WRITE — upsert ``key=value`` in the repo ``.env`` (the SHARED config gpu-mode
+        and the composes read), preserving every other line.  Updates the first
+        uncommented ``key=`` line in place, else appends; creates the file if absent.
+        Returns True on a successful write."""
+        try:
+            envf = self.repo_root / ".env"
+            lines = (
+                envf.read_text(encoding="utf-8", errors="replace").splitlines()
+                if envf.is_file() else []
+            )
+            out: list[str] = []
+            done = False
+            for raw in lines:
+                st = raw.strip()
+                if st.startswith(f"{key}=") and not st.startswith("#"):
+                    out.append(f"{key}={value}")
+                    done = True
+                else:
+                    out.append(raw)
+            if not done:
+                out.append(f"{key}={value}")
+            envf.write_text("\n".join(out) + "\n", encoding="utf-8")
+            return True
+        except OSError:
+            return False
+
     def weights_model_dir(self) -> str:
         """The WEIGHTS ROOT — the dir that DIRECTLY holds the model subdirs
         (``<root>/<subdir>``), the SAME convention setup.sh uses (no extra

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -9891,6 +9891,24 @@ class TestSettings:
             assert os.environ.get("HF_TOKEN") == "hf_first"
 
     @pytest.mark.asyncio
+    async def test_director_placement_persists_to_repo_env(self, tmp_path):
+        """Director placement (CPU/GPU0/GPU1) persists to STUDIO_DIRECTOR_DEVICE in
+        the repo .env — what gpu-mode reads on the next ai-studio start."""
+        app, _, _ = make_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            app._data.repo_root = tmp_path                 # write the .env to a temp dir
+            assert app._data.director_device() == "gpu0"
+            app.apply_settings(model_dir="", hf_token="", director_device="cpu")
+            await _settle(pilot)
+            assert app._data.director_device() == "cpu"
+            assert "STUDIO_DIRECTOR_DEVICE=cpu" in (tmp_path / ".env").read_text()
+            # re-applying the same value is a no-op (no duplicate line)
+            app.apply_settings(model_dir="", hf_token="", director_device="cpu")
+            await _settle(pilot)
+            assert (tmp_path / ".env").read_text().count("STUDIO_DIRECTOR_DEVICE=") == 1
+
+    @pytest.mark.asyncio
     async def test_apply_persisted_settings_on_fresh_app(self):
         import os
         from club3090_cockpit import __main__ as M

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -3254,3 +3254,42 @@ def test_api_booting_false_when_no_engine_running():
     assert st.api_booting is False
     # nothing running at all → not booting (truly down)
     assert _booting_state(reachable=False, conts=[]).api_booting is False
+
+
+class TestDirectorPlacement:
+    """director_device() reads STUDIO_DIRECTOR_DEVICE from the repo .env (default
+    gpu0); set_repo_env_var() upserts a key IN PLACE, preserving the rest of the
+    file — the c3 Settings 'Director placement' lever (CPU / GPU0 / GPU1)."""
+
+    def test_default_gpu0_when_unset(self, tmp_path):
+        (tmp_path / ".env").write_text("MODEL_DIR=/mnt/models/huggingface\n")
+        cd = CockpitData(tmp_path, runner=full_runner())
+        assert cd.director_device() == "gpu0"
+
+    def test_no_env_file_defaults_gpu0(self, tmp_path):
+        assert CockpitData(tmp_path, runner=full_runner()).director_device() == "gpu0"
+
+    def test_set_and_read_roundtrip_preserves_file(self, tmp_path):
+        (tmp_path / ".env").write_text("MODEL_DIR=/x\n# comment\nFOO=bar\n")
+        cd = CockpitData(tmp_path, runner=full_runner())
+        assert cd.set_repo_env_var("STUDIO_DIRECTOR_DEVICE", "cpu") is True
+        assert cd.director_device() == "cpu"
+        cd.set_repo_env_var("STUDIO_DIRECTOR_DEVICE", "gpu1")   # update in place
+        assert cd.director_device() == "gpu1"
+        txt = (tmp_path / ".env").read_text()
+        assert txt.count("STUDIO_DIRECTOR_DEVICE=") == 1        # no duplicate
+        assert "MODEL_DIR=/x" in txt and "FOO=bar" in txt       # other lines kept
+
+    def test_invalid_value_falls_back_gpu0(self, tmp_path):
+        (tmp_path / ".env").write_text("STUDIO_DIRECTOR_DEVICE=bogus\n")
+        assert CockpitData(tmp_path, runner=full_runner()).director_device() == "gpu0"
+
+    def test_creates_env_when_absent(self, tmp_path):
+        cd = CockpitData(tmp_path, runner=full_runner())
+        assert cd.set_repo_env_var("STUDIO_DIRECTOR_DEVICE", "cpu") is True
+        assert (tmp_path / ".env").is_file()
+        assert cd.director_device() == "cpu"
+
+    def test_commented_line_ignored(self, tmp_path):
+        (tmp_path / ".env").write_text("# STUDIO_DIRECTOR_DEVICE=cpu\n")
+        assert CockpitData(tmp_path, runner=full_runner()).director_device() == "gpu0"

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -1143,7 +1143,7 @@ class TestStoppedStudioContainers:
 
 class TestServiceStartOrRestart:
     """service_start_or_restart: compose-up for a real service dir, docker restart
-    for an existing scene-managed container (studio-*) with no such dir."""
+    for an existing scene-managed container with no backing compose dir."""
 
     def test_dir_uses_compose_up(self, tmp_path):
         _seed_service_dirs(tmp_path, ["comfyui"])
@@ -1152,10 +1152,29 @@ class TestServiceStartOrRestart:
         assert plan.cmd[-4:] == ["-p", "comfyui", "up", "-d"]
 
     def test_no_dir_uses_docker_restart(self, tmp_path):
-        # studio-director's dir is services/studio/enhancer/ (name mismatch) — no
-        # resolvable compose → restart the scene-created container.
+        # An ad-hoc container with NO backing compose dir (not in STUDIO_SIDECARS,
+        # no services/<name>/) → restart the already-created container.
+        plan = CockpitData(tmp_path).service_start_or_restart("some-orphan-ctr")
+        assert plan.cmd == ["docker", "restart", "some-orphan-ctr"]
+
+    def test_director_resolves_to_enhancer_with_placement_env(self, tmp_path):
+        # studio-director's compose lives at services/studio/enhancer/ (name mismatch,
+        # mapped via STUDIO_SIDECARS) → compose-up, AND it carries the placement env
+        # gpu-mode derives from STUDIO_DIRECTOR_DEVICE (here cpu → -ngl 0 + no-think).
+        d = tmp_path / "services" / "studio" / "enhancer"
+        d.mkdir(parents=True)
+        (d / "docker-compose.yml").write_text("services: {}\n")
+        (tmp_path / ".env").write_text("STUDIO_DIRECTOR_DEVICE=cpu\n")
         plan = CockpitData(tmp_path).service_start_or_restart("studio-director")
-        assert plan.cmd == ["docker", "restart", "studio-director"]
+        assert plan.kind == "service-up"
+        assert plan.cmd[0] == "env"
+        # env prefix carries the cpu translation; compose targets the enhancer dir.
+        assert "DIRECTOR_NGL=0" in plan.cmd
+        assert "STUDIO_DIRECTOR_CUDA=" in plan.cmd
+        assert "DIRECTOR_THINK_ARGS=--jinja --reasoning off" in plan.cmd
+        assert plan.cmd[-6:] == [
+            "-f", "services/studio/enhancer/docker-compose.yml",
+            "-p", "enhancer", "up", "-d"]
 
     def test_nested_studio_sidecar_uses_compose_up(self, tmp_path):
         # step-voice lives at services/studio/step-voice/ (NOT services/<name>/) and
@@ -3293,3 +3312,42 @@ class TestDirectorPlacement:
     def test_commented_line_ignored(self, tmp_path):
         (tmp_path / ".env").write_text("# STUDIO_DIRECTOR_DEVICE=cpu\n")
         assert CockpitData(tmp_path, runner=full_runner()).director_device() == "gpu0"
+
+    def test_compose_env_cpu_disables_thinking(self, tmp_path):
+        (tmp_path / ".env").write_text("STUDIO_DIRECTOR_DEVICE=cpu\n")
+        env = CockpitData(tmp_path, runner=full_runner()).director_compose_env()
+        assert env == {"DIRECTOR_NGL": "0", "STUDIO_DIRECTOR_CUDA": "",
+                       "STUDIO_DIRECTOR_GPU": "0",
+                       "DIRECTOR_THINK_ARGS": "--jinja --reasoning off"}
+
+    def test_compose_env_gpu_keeps_thinking(self, tmp_path):
+        (tmp_path / ".env").write_text("STUDIO_DIRECTOR_DEVICE=gpu1\n")
+        env = CockpitData(tmp_path, runner=full_runner()).director_compose_env()
+        assert env["STUDIO_DIRECTOR_CUDA"] == "1" and env["DIRECTOR_NGL"] == "99"
+        assert env["DIRECTOR_THINK_ARGS"] == ""        # thinking ON on GPU
+
+    def test_compose_env_default_gpu0(self, tmp_path):
+        env = CockpitData(tmp_path, runner=full_runner()).director_compose_env()
+        assert env["STUDIO_DIRECTOR_CUDA"] == "0" and env["DIRECTOR_THINK_ARGS"] == ""
+
+
+class TestStudioSidecarEnumeration:
+    """_known_service_dirs surfaces NESTED studio sidecars by container-name so a
+    STOPPED director/gallery/… is a startable Containers row (not just running ones)."""
+
+    def test_nested_sidecars_enumerated_by_container_name(self, tmp_path):
+        _seed_service_dirs(tmp_path, ["litellm"])           # a top-level service
+        for sub in ("enhancer", "gallery"):                 # two nested sidecars
+            d = tmp_path / "services" / "studio" / sub
+            d.mkdir(parents=True)
+            (d / "docker-compose.yml").write_text("services: {}\n")
+        names = CockpitData(tmp_path, runner=full_runner())._known_service_dirs()
+        assert "litellm" in names                           # top-level still there
+        assert "studio-director" in names                   # enhancer → container name
+        assert "studio-gallery" in names
+        assert names == sorted(names)                       # stable order
+
+    def test_absent_sidecar_dir_not_enumerated(self, tmp_path):
+        # No services/studio/* present → no sidecar rows (only any top-level dirs).
+        names = CockpitData(tmp_path, runner=full_runner())._known_service_dirs()
+        assert not any(n.startswith("studio-") for n in names)


### PR DESCRIPTION
## What

Makes the studio director's GPU/CPU placement a **user lever** — pick it in c3's Settings instead of hand-editing the compose. Run it on GPU when you can (fast craft), CPU when you want GPU0 free for long single-card video.

## Backend (compose + gpu-mode)
- Single user-facing var **`STUDIO_DIRECTOR_DEVICE`** (`gpu0` | `gpu1` | `cpu`, default `gpu0`), read from the rig `.env` by `gpu-mode`'s `start_studio_director` and translated into the compose env (`-ngl` + `CUDA_VISIBLE_DEVICES` + `device_ids`).
- `cpu` → `-ngl 0`, `CUDA_VISIBLE_DEVICES=""` → **frees ~4.6 GB off GPU0** (lifts the single-card Wan window 121→161 frames) at ~single-digit tok/s craft. `gpu0`/`gpu1` → `-ngl 99` on that card. Default preserves current GPU0 behaviour exactly.
- **CPU thread cap**: `-t ${DIRECTOR_THREADS:-8}` so the director doesn't starve OWUI's CPU embedder/reranker. Model loads into **system RAM** (mmap'd; resident in page cache, not run from SSD).

## c3 Settings UI
- `SettingsScreen` gains a **Director placement** `Select` (CPU / GPU0 / GPU1).
- Persists to the repo `.env` (`STUDIO_DIRECTOR_DEVICE`) — the shared config gpu-mode reads — via a new `set_repo_env_var()` upsert helper (preserves other lines, no duplicates). Applies on the next ai-studio start.

## Validation
- **Live:** CPU director starts with GPU0 full (gemma12b), adds **0 MiB** to GPU0, serves on :8090, generates (~5 tok/s CPU). Compose resolves CPU→`CUDA_VISIBLE_DEVICES: ""`, default→`"0"`.
- **Tests:** +6 data-layer (`TestDirectorPlacement`) + 1 headless apply-settings round-trip. Full suite **728 passed**; settings/director subset 13/13.

## Follow-up (not in this PR)
Phase 2 — add the director to the **chat scene** (always-on when CPU) + frame the chat scene as the supporting-infra layer for ad-hoc Catalog models (`switch.sh --owui`). And a docs note pointing the existing `STUDIO_DIRECTOR_GPU`/`-ngl 0` lever at the new `STUDIO_DIRECTOR_DEVICE` + the c3 Setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)