### PR TITLE
c3: adaptive estate poll — fast GPU, regime-gated docker (burst/steady/idle)

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -2028,6 +2028,20 @@ class OperateOrchPane(Container):
             except Exception:
                 pass
 
+    def refresh_gpu_cards(self, gpus) -> None:
+        """Fast GPU-only repaint: swap a fresh docker-free nvidia-smi read into the cached
+        estate state and re-render just the GPU cards (the App's _refresh_gpu_bars calls
+        this every poll tick). No-op until the first full estate poll has seeded _last_state
+        — and the 'held by: <container>' attribution stays on the slower estate batch."""
+        st = getattr(self, "_last_state", None)
+        if st is None or not gpus:
+            return
+        st.gpus = gpus
+        try:
+            self._populate_gpus(st)
+        except Exception:
+            pass
+
     def _populate_gpus(self, state: EstateState) -> None:
         # N2: when nvidia-smi returned NOTHING at all (no cards in the snapshot),
         # say so honestly on the first card rather than a calm "not present" per
@@ -5336,6 +5350,11 @@ class CockpitApp(App):
         # A3: monotonic timestamp of the last completed estate poll (for the
         # rail "as of <ago>" freshness stamp).  None until the first poll.
         self._last_estate_poll_mono: Optional[float] = None
+        # Adaptive estate-poll state (see _docker_poll_due). _last_activity_mono seeded
+        # "ancient" (0.0); on_mount stamps it to now so a fresh launch starts in steady.
+        self._last_activity_mono: float = 0.0
+        self._estate_tick: int = 0
+        self._docker_burst_until: float = 0.0   # monotonic deadline of the post-action burst
         # A3: the periodic-refresh interval handle (created once on mount, gated
         # at fire time to Operate + the main screen so it never churns elsewhere).
         self._estate_interval = None
@@ -5378,6 +5397,25 @@ class CockpitApp(App):
     # A1/A10 deferred-serve re-poll knobs.
     _SERVE_REPOLL_SECS = 3.0
     _SERVE_REPOLL_MAX_ATTEMPTS = 10               # ~30s before "still booting"
+
+    # Adaptive estate poll (perf: the docker `ps`/`inspect` batch is the daemon-CPU sink;
+    # nvidia-smi GPU reads are cheap + the only thing worth watching live). The timer fires
+    # at _POLL_TICK_SECS; every tick refreshes the GPU bars (docker-free), but the heavy
+    # docker+host batch runs only every Nth tick by REGIME (see _docker_poll_due):
+    #   • burst  — within _DOCKER_BURST_SECS of a docker-affecting action → every tick (live)
+    #   • steady — normal → _DOCKER_STEADY_STRIDE ticks (~20s)
+    #   • idle   — no input for _ESTATE_IDLE_AFTER_SECS → _DOCKER_IDLE_STRIDE ticks (~30s)
+    # Any input snaps idle→steady (_note_activity); a docker-affecting action snaps→burst.
+    _POLL_TICK_SECS = 3.0            # base tick = the live GPU cadence
+    _DOCKER_STEADY_STRIDE = 7       # 3s × 7 ≈ 21s
+    _DOCKER_IDLE_STRIDE = 10        # 3s × 10 = 30s
+    _ESTATE_IDLE_AFTER_SECS = 90.0  # no input this long → idle regime
+    _DOCKER_BURST_SECS = 90.0       # fast-docker window after a docker-affecting action
+    # ActionPlan kinds that change what's running (→ trigger the burst). NOT set_default /
+    # clear_default / download / power_cap (those don't start/stop containers).
+    _DOCKER_BURST_KINDS = frozenset(
+        {"serve", "scene", "estate_down", "container", "container_rm", "service-up"}
+    )
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
@@ -5447,6 +5485,9 @@ class CockpitApp(App):
     # ── Mount / startup ────────────────────────────────────────────────────────────
 
     def on_mount(self) -> None:
+        import time as _t
+        self._note_activity()                              # fresh launch = user present
+        self._docker_burst_until = _t.monotonic() + 15.0   # 15s startup burst → immediate + live
         self.load_catalog()
         # A3: ONE periodic refresh interval, created once.  It is GATED at fire
         # time (_periodic_estate_refresh) to the MERGED Run & Operate mode
@@ -5455,7 +5496,7 @@ class CockpitApp(App):
         # churns subprocesses behind the Bring & Validate lane or a confirm modal.
         # set_interval is the only timer.
         self._estate_interval = self.set_interval(
-            4.0, self._periodic_estate_refresh, pause=False
+            self._POLL_TICK_SECS, self._periodic_estate_refresh, pause=False
         )
         # A3: a lightweight as-of re-stamp timer.  The full poll (above) resets
         # the freshness clock every tick → the rail would always read "just now".
@@ -5559,7 +5600,50 @@ class CockpitApp(App):
                 return
         except Exception:
             pass
-        self.load_estate()
+        self._estate_tick += 1
+        # GPU bars refresh EVERY tick (cheap, docker-free) → live at _POLL_TICK_SECS.
+        self._refresh_gpu_bars()
+        # The heavy docker+host batch runs only on a due tick (burst/steady/idle).
+        if self._docker_poll_due():
+            self.load_estate()
+
+    def _note_activity(self) -> None:
+        """Reset the idle clock — any key/mouse/action keeps the docker poll out of the
+        idle regime (snaps idle→steady); it backs off when the cockpit is left idle."""
+        import time as _t
+        self._last_activity_mono = _t.monotonic()
+
+    @work(exclusive=True, group="gpu-rail")
+    async def _refresh_gpu_bars(self) -> None:
+        """Fast, docker-FREE GPU refresh (nvidia-smi only) — runs every tick so the GPU
+        cards stay live between the slower docker+host polls. The docker-dependent
+        'held by: <container>' attribution still rides the slow batch."""
+        try:
+            gpus = await self._data.gpu_info()
+        except Exception:
+            return
+        if not gpus:
+            return
+        try:
+            self.query_one("#operate-orch-pane", OperateOrchPane).refresh_gpu_cards(gpus)
+        except Exception:
+            pass
+
+    def _docker_poll_due(self) -> bool:
+        """Whether THIS tick runs the heavy docker+host batch, by regime: burst (within
+        _DOCKER_BURST_SECS of a docker-affecting action) → every tick; idle (no input for
+        _ESTATE_IDLE_AFTER_SECS) → _DOCKER_IDLE_STRIDE; else steady → _DOCKER_STEADY_STRIDE.
+        Pure (reads _estate_tick, no I/O) → unit-testable."""
+        import time as _t
+        now = _t.monotonic()
+        if now < self._docker_burst_until:
+            return True
+        stride = (
+            self._DOCKER_IDLE_STRIDE
+            if (now - self._last_activity_mono) > self._ESTATE_IDLE_AFTER_SECS
+            else self._DOCKER_STEADY_STRIDE
+        )
+        return (self._estate_tick % stride) == 0
 
     def _estate_as_of(self) -> str:
         """A3: a human "N s/m ago" string for the last estate poll, or "just now".
@@ -6291,6 +6375,10 @@ class CockpitApp(App):
         ``execute_action`` holds ``CockpitData._write_lock`` across the
         gate→write window so even direct concurrent calls can't TOCTOU the gate.
         """
+        self._note_activity()
+        if plan.kind in self._DOCKER_BURST_KINDS:
+            import time as _t
+            self._docker_burst_until = _t.monotonic() + self._DOCKER_BURST_SECS
         live = self._serve_live_pane()
         executed, rec, _state = await self._data.execute_action(
             plan, variants=self._variants or None
@@ -6911,6 +6999,7 @@ class CockpitApp(App):
         path for copying ARBITRARY on-screen text stays the terminal's own
         selection: hold Shift (or Option on macOS) while dragging to bypass the
         app's mouse capture, then the terminal's copy."""
+        self._note_activity()
         if getattr(event, "button", 0) != 3:   # 3 = right button
             return
         self.action_copy_context()
@@ -8550,6 +8639,7 @@ class CockpitApp(App):
         table. Modal screens capture their own Esc (they have escape→dismiss
         bindings), so this only runs on the main screen — Esc otherwise no-ops
         and NEVER quits."""
+        self._note_activity()
         if event.key != "escape":
             return
         if isinstance(self.screen, ModalScreen):

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -1213,6 +1213,15 @@ class CockpitData:
             return {"lines": [], "error": (res.stderr.strip()[:200] or f"rc={res.returncode}")}
         return {"lines": lines, "error": None}
 
+    async def gpu_info(self) -> "list[GpuInfo]":
+        """Docker-FREE per-card GPU read (nvidia-smi only) — for the cockpit's fast GPU
+        rail refresh, decoupled from the heavy docker+host estate batch (estate_state /
+        estate_telemetry). Returns [] on any read failure (the rail keeps its last bars)."""
+        try:
+            return await self._get_gpu_info()
+        except Exception:
+            return []
+
     # ── READ: estate state ────────────────────────────────────────────────────────
 
     async def estate_state(

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -9978,3 +9978,77 @@ class TestSettings:
         env = {"HF_TOKEN": "hf_shell"}
         M.apply_persisted_settings(app, env)
         assert env["HF_TOKEN"] == "hf_shell"
+
+
+class TestAdaptiveEstatePoll:
+    """Estate poll fires at _POLL_TICK_SECS; GPU bars refresh every tick (cheap, docker-free)
+    but the heavy docker+host batch runs only on a regime-gated tick — quiet while idle, live
+    during/after a docker-affecting action."""
+
+    @staticmethod
+    def _due(**kw):
+        import types, time
+        from club3090_cockpit.app import CockpitApp
+        s = types.SimpleNamespace(
+            _docker_burst_until=0.0, _last_activity_mono=time.monotonic(), _estate_tick=0,
+            _DOCKER_STEADY_STRIDE=CockpitApp._DOCKER_STEADY_STRIDE,
+            _DOCKER_IDLE_STRIDE=CockpitApp._DOCKER_IDLE_STRIDE,
+            _ESTATE_IDLE_AFTER_SECS=CockpitApp._ESTATE_IDLE_AFTER_SECS,
+        )
+        s.__dict__.update(kw)
+        return CockpitApp._docker_poll_due.__get__(s)()
+
+    def test_burst_polls_every_tick(self):
+        import time
+        for tick in (1, 2, 3, 5, 6):
+            assert self._due(_docker_burst_until=time.monotonic() + 100, _estate_tick=tick) is True
+
+    def test_steady_polls_on_stride(self):
+        from club3090_cockpit.app import CockpitApp
+        n = CockpitApp._DOCKER_STEADY_STRIDE
+        assert self._due(_estate_tick=n) is True
+        assert self._due(_estate_tick=n - 1) is False
+        assert self._due(_estate_tick=n * 2) is True
+
+    def test_idle_widens_stride(self):
+        from club3090_cockpit.app import CockpitApp
+        steady, idle = CockpitApp._DOCKER_STEADY_STRIDE, CockpitApp._DOCKER_IDLE_STRIDE
+        assert idle > steady
+        # ancient activity → idle regime: a steady-due tick is NOT idle-due (wider stride)
+        assert self._due(_last_activity_mono=0.0, _estate_tick=steady) is False
+        assert self._due(_last_activity_mono=0.0, _estate_tick=idle) is True
+
+    def test_burst_kinds_are_docker_affecting_only(self):
+        from club3090_cockpit.app import CockpitApp
+        k = CockpitApp._DOCKER_BURST_KINDS
+        assert {"serve", "scene", "container", "container_rm", "estate_down", "service-up"} <= k
+        for non in ("set_default", "clear_default", "power_cap", "submit_bench", "validation"):
+            assert non not in k
+
+    def test_gpu_info_is_docker_free_and_safe(self, tmp_path):
+        import asyncio
+        from club3090_cockpit.services import CockpitData
+        cd = CockpitData(tmp_path)
+        async def ok():
+            return ["g0", "g1"]
+        cd._get_gpu_info = ok
+        assert asyncio.run(cd.gpu_info()) == ["g0", "g1"]
+        async def boom():
+            raise RuntimeError("nvidia-smi gone")
+        cd._get_gpu_info = boom
+        assert asyncio.run(cd.gpu_info()) == []   # degrades, never raises
+
+    def test_refresh_gpu_cards_swaps_and_repaints(self):
+        import types
+        from club3090_cockpit.app import OperateOrchPane
+        calls = []
+        pane = types.SimpleNamespace(_last_state=None, _populate_gpus=lambda st: calls.append(st))
+        bound = OperateOrchPane.refresh_gpu_cards.__get__(pane)
+        bound(["g0"])                      # no _last_state yet → no-op
+        assert calls == []
+        st = types.SimpleNamespace(gpus=[])
+        pane._last_state = st
+        bound(["g0", "g1"])                # swaps fresh gpus + repaints
+        assert st.gpus == ["g0", "g1"] and calls == [st]
+        bound([])                          # empty read → keep last bars (no-op)
+        assert st.gpus == ["g0", "g1"]


### PR DESCRIPTION
## What
An open cockpit polled docker (`ps`/`inspect` × all containers) every **4s** regardless of whether anyone was watching — which kept **dockerd/containerd pegged** (observed ~47%/41% with the full ai-studio scene up for hours). This splits the one poll by what actually needs to be live.

## The split
- **GPU bars → every tick (3s).** New docker-free `CockpitData.gpu_info()` (nvidia-smi only) + `OperateOrchPane.refresh_gpu_cards()` repaint just the GPU cards each tick. GPU VRAM/util is the one live-worthy read and it's cheap. The docker-dependent **"held by: \<container\>"** attribution stays on the slow batch.
- **Docker + host batch → regime-gated tick** (`_docker_poll_due`):
  | Regime | Trigger | Effective docker cadence |
  |---|---|---|
  | **burst** | within 90s of a docker-affecting action | ~3s (watch it come up/go down) |
  | **steady** | normal | ~20s |
  | **idle** | no input for 90s | ~30s |
  A 15s **startup burst** makes the first poll immediate (no 21s blank).

## Burst triggers
Only **container-changing** `ActionPlan` kinds: `serve` / `scene` / `container` / `container_rm` / `estate_down` / `service-up`. **Not** `set_default` / `clear_default` / `download` / `power_cap` (they don't start/stop containers). Activity (idle↔steady) is tracked on `on_key` / `on_mouse_down` / `dispatch_action`.

## Effect
Steady docker churn drops ~5× (20s vs 4s) and idle ~10× (30s), while the GPU bars stay *more* live than before (3s) — and right after you act, you get ~3s feedback for 90s. Net: near-silent daemon when idle, instant feedback when you change something.

## Tests
+6 pure unit tests (`TestAdaptiveEstatePoll`): burst/steady/idle stride logic, burst-kind allowlist, `gpu_info` docker-free + fail-safe, GPU-card fast repaint. Estate/orch/gpu/services subset **97 passed**; full suite gating before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)