### PR TITLE
Add Ornith-1.0-9B experimental slug (ik-llama/ornith9b-single)

### DIFF
--- a/models/ornith-1.0-9b/ik-llama/compose/single/deepreinforce-q4km/ngram.yml
+++ b/models/ornith-1.0-9b/ik-llama/compose/single/deepreinforce-q4km/ngram.yml
@@ -1,0 +1,77 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Ornith-1.0-9B (DeepReinforce official Q4_K_M GGUF — agentic-coding RL)
+#   Engine:    ik_llama.cpp (cu13, digest-pinned below — the 2026-06-18 build that
+#              carries the `--spec-type` self-spec system incl. n-gram)
+#   Topology:  Single 3090 (TP=1)
+#   Drafter:   ngram K=64 — DRAFTER-FREE (no MTP head in this GGUF, no draft model).
+#              `--spec-type ngram-map-k:n_max=64,ngram_min_hits=1` (ik self-spec),
+#              baked default-on below. ~0.59 accept, +30% warm decode on copy-heavy
+#              gen, output-lossless. Works DESPITE the DeltaNet hybrid (DFlash/EAGLE
+#              are KV-rollback-blocked on Qwen3-Next; drafter-free ngram is not).
+#   KV:        q8_0 K + q8_0 V. Hybrid attention → only 8/32 layers carry GQA KV
+#              (full_attention_interval=4), so the full 262K fits at just 4.25 GiB KV.
+#   Vision:    no
+#   Max ctx:   262K (n_ctx_train=262144 — native). Whole estate ~13.4 GiB on one
+#              24 GiB 3090 (KV 4.25 + weights 5.23 + buffers), ~10 GiB headroom.
+#   Genesis:   N/A — Genesis is a vLLM patch system; this is ik_llama GGUF.
+#   Status:    🧪 Experimental
+#   Quality:   8-pack think-OFF 91/150 (toolcall 12 · instructfollow 12 · structoutput 14
+#              · dataextract 10 · reasonmath 10 · bugfind 14 · hermesagent 12/20 · cli 7/40)
+#              · think-ON 95/150 (--full, ik Q4_K_M + ngram, temp 0.6, 2026-06-25).
+#              cli-40 is partly a termination-protocol artifact: a hardened agent
+#              system prompt lifts it 7→13/40 (the model solves but mis-routes the
+#              `<solution>` sign-off via the bash tool). gemma-4-12b scores 16/40
+#              with the standard prompt.
+#   Best for:  lean single-card long-context small model that frees the 2nd GPU.
+#              NICHE ONLY — gemma-4-12b beats it on quality (105/150) AND speed
+#              (117/122 vs 102 TPS); pick Ornith only when the 13.4 GiB footprint /
+#              16 GB-card fit matters. NOT a default.
+# ---------------------------------------------------------------------------
+# Ornith-1.0-9B is a Qwen3-Next DENSE-FFN HYBRID (arch=qwen35): 8 full-attention
+# layers + 24 GDN/DeltaNet linear-attention layers, NON-MoE. The hybrid is why the
+# full 262K KV is only ~4.25 GiB (¾ of layers hold SSM state, not attention KV).
+#
+# Boot:   MODEL_DIR=/mnt/models/huggingface docker compose -f ngram.yml up -d
+# Tune:   NGRAM_NMAX / NGRAM_MIN_HITS env-override the ngram self-spec stage.
+# ===========================================================================
+services:
+  ik-llama-ornith-9b:
+    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp@sha256:b35e062cf032f1435b90387cfd9e9679006dd628d0999d86b6e7db2d4a43964d}
+    container_name: "${ESTATE_CONTAINER:-ik-llama-ornith-9b}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8070}}:8080"
+    volumes:
+      - "${MODEL_DIR:-/mnt/models/huggingface}:/models:ro"
+    # ENTRYPOINT is /app/llama-server — args only. The ngram self-spec stage is
+    # baked in (this is ngram.yml); tune via NGRAM_NMAX / NGRAM_MIN_HITS.
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      --model /models/${GGUF_FILE:-ornith-1.0-9b-gguf/q4_k_m/ornith-1.0-9b-Q4_K_M.gguf}
+      --alias ${MODEL_ALIAS:-ornith-1.0-9b}
+      -ngl 99
+      --ctx-size ${CTX_SIZE:-262144}
+      -b ${BATCH_SIZE:-4096}
+      -ub ${UBATCH_SIZE:-1024}
+      -np ${NP:-1}
+      -ctk ${KV_TYPE:-q8_0}
+      -ctv ${KV_TYPE:-q8_0}
+      -fa on
+      --jinja
+      --reasoning ${REASONING:-off}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+      --spec-type ngram-map-k:n_max=${NGRAM_NMAX:-64},ngram_min_hits=${NGRAM_MIN_HITS:-1}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}"]
+              capabilities: [gpu]

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -757,6 +757,21 @@ COMPOSE_REGISTRY = {
         category="uncensored",
     ),
 
+    # Ornith-1.0-9B — DeepReinforce agentic-coding RL fine-tune. Qwen3-Next DENSE-FFN
+    # HYBRID (arch=qwen35: 8 full-attn + 24 GDN/DeltaNet layers, NON-MoE) — only 8/32
+    # layers carry GQA KV so 262K fits at 4.25 GiB KV. No MTP head → drafter-free
+    # ngram self-spec on ik_llama. Lean single-card 9B. 🧪 niche (loses to gemma-12b).
+    "ik-llama/ornith9b-single": _entry(
+        model="ornith-1.0-9b", weights_variant="deepreinforce-q4km", workload="fast-chat",
+        engine="llama-cpp-local", drafter=None, kv_format="q8_0",
+        tp=1, max_ctx=262144, max_num_seqs=1, mem_util=None,
+        compose_path="models/ornith-1.0-9b/ik-llama/compose/single/deepreinforce-q4km/ngram.yml",
+        default_port=8070,
+        kvcalc_key="SKIP",
+        status="experimental",
+        status_note="Ornith-1.0-9B (DeepReinforce agentic-coding RL) on ik_llama single 3090, Q4_K_M + q8_0 KV, full 262K. Arch CONFIRMED qwen35 Qwen3-Next DENSE-FFN HYBRID (8 full-attn + 24 GDN/DeltaNet layers, NON-MoE) — only 8/32 layers carry GQA KV, so 262K fits at 4.25 GiB KV (13.4 GiB total, ~10 GiB headroom). No MTP head → drafter-free ngram self-spec (--spec-type ngram-map-k, ~0.59 accept, +30% warm on copy-heavy gen; works DESPITE the DeltaNet hybrid, where DFlash/EAGLE are KV-rollback-blocked). Full gate PASS 2026-06-25: bench ~102/103 TPS (TTFT 144ms, CV<1%), verify-stress 8/8 incl NIAH→0.92×262K, soak-continuous PASS (0 MiB growth, 0/100 silent-empty, p50 104 TPS, 98.1% retention). 8-pack think-OFF 91/150 / think-ON 95/150 (temp 0.6). cli-40 7/40 is partly a termination-protocol artifact (model solves but mis-routes the <solution> sign-off via the bash tool + loops → agent_loop_exhausted; a hardened agent prompt lifts it 7→13/40). NICHE ONLY — gemma-4-12b beats it on quality (105/150) AND speed (117/122 vs 102 TPS) at +7 GiB; pick Ornith only for the lean 13.4 GiB footprint / 16 GB-card fit. Self-grabbed official GGUF, ik digest-pinned → 🧪.",
+    ),
+
     # VibeThinker-3B — WeiboAI verifiable-reasoning fine-tune of Qwen2.5-Coder-3B
     # (Qwen2 dense). First dense-family + first sub-4B model in the catalog.
     "vllm/vibethinker-3b-single": _entry(

--- a/scripts/lib/profiles/models/ornith-1.0-9b.yml
+++ b/scripts/lib/profiles/models/ornith-1.0-9b.yml
@@ -1,0 +1,41 @@
+schema_version: 1
+id: ornith-1.0-9b
+display_name: Ornith 1.0 9B (DeepReinforce)
+family: qwen3-next-hybrid
+# DeepReinforce agentic-coding RL fine-tune. Arch CONFIRMED from the GGUF header
+# (general.architecture=qwen35): a Qwen3-Next DENSE-FFN HYBRID — NOT MoE, but NOT
+# plain GQA either. full_attention_interval=4 over 32 layers → 8 full-attention
+# layers (standard GQA KV) + 24 GDN/DeltaNet linear-attention layers (SSM state).
+# Distinct from Deckard-40B (qwen35-dense = standard GQA, no GDN). No MTP head in
+# the GGUF → spec-dec is drafter-free n-gram (ik_llama --spec-type ngram-map-k).
+hidden_size: 4096
+num_hidden_layers: 32
+num_attn_heads: 16
+num_kv_heads: 4
+head_dim_attn: 256          # key_length == value_length == 256
+intermediate_size: 12288    # feed_forward_length
+attention_k_eq_v: false     # standard GQA on the full-attn layers — K and V separate caches
+max_ctx_supported: 262144
+# Hybrid KV: only the 8 full-attention layers carry GQA KV; the 24 GDN layers hold
+# tiny SSM state (ssm.state_size=128, ssm.group_count=16). This is why KV @262K
+# q8_0 is ~4.25 GiB (8/32 layers full-attn), not 32/32 — read the boot-log
+# `KV self size`, do NOT extrapolate per-layer × all-layers (overshoots ~4×).
+vision_capable: false
+weights:
+  deepreinforce-q4km:
+    path: ornith-1.0-9b-gguf/q4_k_m
+    local_subdir: ornith-1.0-9b-gguf/q4_k_m
+    size_gb: 5.2                 # 5.232 GiB GGUF (5.02 BPW), official DeepReinforce Q4_K_M
+    format: gguf
+    status: experimental
+    hf_repo: deepreinforce-ai/Ornith-1.0-9B-GGUF
+    files:
+      - ornith-1.0-9b-Q4_K_M.gguf
+    engine: ik-llama
+    kind: gguf
+    verify_glob: "*.gguf"
+default_weight_variant: deepreinforce-q4km
+compatible_drafters: []        # no MTP head, no draft model — ngram is drafter-free
+valid_tp:
+  - 1
+requires_genesis: false

--- a/scripts/tests/test-compose-registry-disk.sh
+++ b/scripts/tests/test-compose-registry-disk.sh
@@ -25,8 +25,8 @@ def check(cond, msg):
         print(f"FAIL: {msg}")
         failures.append(msg)
 
-check(len(COMPOSE_REGISTRY) == 53, f"registry has 53 entries (got {len(COMPOSE_REGISTRY)})")
-check(len(disk_paths) == 54, f"disk has 54 compose files (got {len(disk_paths)})")
+check(len(COMPOSE_REGISTRY) == 54, f"registry has 54 entries (got {len(COMPOSE_REGISTRY)})")
+check(len(disk_paths) == 55, f"disk has 55 compose files (got {len(disk_paths)})")
 check(registry_paths <= disk_paths, "all registry compose_path values exist on disk")
 parked_disk_only = disk_paths - registry_paths
 # Disk-only (non-registry) composes allowed: parked SGLang archives, plus the experimental

--- a/scripts/tests/test-profiles-compat.sh
+++ b/scripts/tests/test-profiles-compat.sh
@@ -24,7 +24,7 @@ run_test "load_profiles parses all profile groups" <<'PY'
 from scripts.lib.profiles.compat import load_profiles
 p = load_profiles()
 assert len(p.hardware) == 9
-assert len(p.models) == 8
+assert len(p.models) == 9
 assert len(p.workloads) == 5
 assert len(p.engines) == 13
 assert len(p.drafters) == 11


### PR DESCRIPTION
## Ornith-1.0-9B → 🧪 experimental slug `ik-llama/ornith9b-single`

DeepReinforce agentic-coding RL fine-tune. **Qwen3-Next dense-FFN HYBRID** (arch `qwen35`: 8 full-attention + 24 GDN/DeltaNet layers, **non-MoE**) on a single 3090.

**Config:** ik_llama.cpp, Q4_K_M + q8_0 KV, full **262K**. The hybrid means only **8 of 32 layers** carry full-attention GQA KV → KV @262K is just **4.25 GiB** (13.4 GiB total, ~10 GiB headroom). Drafter-free **ngram** self-spec (`--spec-type ngram-map-k`, ~0.59 accept) — works *despite* the DeltaNet hybrid, where DFlash/EAGLE are KV-rollback-blocked.

**Gate (`rebench-full`, 2026-06-25):** bench ~102/103 TPS (TTFT 144 ms, CV <1%) · verify-stress **8/8** (NIAH → 0.92×262K) · soak-continuous **PASS** (0 growth, 0/100 silent-empty, p50 104 TPS) · 8-pack **91/150 off / 95 on**.

**Why 🧪 niche, not a default:** gemma-4-12B beats it on both quality (105/150) and speed (117/122 vs 102 TPS) at +7 GiB. Pick Ornith only for the lean 13.4 GiB footprint / 16 GB-card fit. `cli-40` (7/40) is partly a termination-protocol artifact — a hardened agent prompt lifts it 7→13/40 (the model solves the task but mis-routes the `<solution>` sign-off through the bash tool and loops).

Full catalog gate: **58/58 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
