### PR TITLE
Add Ornith-1.0-35B experimental slug (ik-llama/ornith35b-dual)

### DIFF
--- a/models/ornith-1.0-35b/ik-llama/compose/dual/deepreinforce-q8/ngram.yml
+++ b/models/ornith-1.0-35b/ik-llama/compose/dual/deepreinforce-q8/ngram.yml
@@ -1,0 +1,67 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Ornith-1.0-35B (DeepReinforce official Q8_0 GGUF — agentic-coding RL)
+#   Engine:    ik_llama.cpp (cu13, digest-pinned — the --spec-type self-spec build)
+#   Topology:  Dual 3090 PCIe (layer-split via -ts, no NVLink)
+#   Drafter:   none by DEFAULT — Q8 weights nearly fill dual (~17.9/16.7 GB split), and
+#              the ngram per-step verify buffer is ~2 GB/card (256-expert MoE × the draft
+#              batch), tight at 262K. ngram is OPT-IN (drafter-free; no MTP head, verified):
+#              SPEC_TYPE_ARGS='--spec-type ngram-map-k:n_max=32,ngram_min_hits=1' + a
+#              balanced TENSOR_SPLIT=0.97,1.0 fits ~2.7 GB/card free at 262K. Output-lossless.
+#   KV:        q8_0 K + q8_0 V. qwen35moe is a hybrid MoE → only the full-attn layers
+#              (full_attention_interval) carry GQA KV, so 262K KV is cheap.
+#   Vision:    no
+#   Max ctx:   262K (native qwen35moe.context_length). Whole estate ~22 GB/card on dual
+#              (Q8 weights 17.9/16.7 split + KV 2.7 GB + buffers). Measured 2026-06-26.
+#   Genesis:   N/A — Genesis is a vLLM patch system; this is ik_llama GGUF.
+#   Status:    🧪 Experimental
+#   Quality:   8-pack think-OFF 105/150 / think-ON 105/150 (toolcall 13 · instructfollow 12
+#              · structoutput 14 · dataextract 10 · reasonmath 13 · bugfind 15 · hermes 12/20
+#              · cli 16/40) · aider-polyglot-30 15/30 (OFF==ON) (--full, temp 0.6, 2026-06-26).
+#              Ties the base qwen3.6-35b-a3b on the 8-pack (110); EDGES it on real coding
+#              (aider 15 vs the base's 12-13) — the agentic-coding fine-tune's actual value.
+#   Best for:  coding-leaning 35B-A3B on dual — full 262K, ~109 TPS, edges the base on aider.
+# ---------------------------------------------------------------------------
+# Ornith-1.0-35B = qwen35moe (MoE + DeltaNet hybrid), 35 GB Q8 → dual 3090.
+# Boot:  MODEL_DIR=/mnt/models/huggingface PORT=8071 docker compose -f ngram.yml -p ornith35b up -d
+# Tune:  TENSOR_SPLIT (default 1,1) rebalances cards; SPEC_TYPE_ARGS enables ngram (opt-in).
+# ===========================================================================
+services:
+  ik-llama-ornith-35b:
+    image: ${IK_LLAMA_IMAGE:-ghcr.io/ikawrakow/ik-llama-cpp@sha256:b35e062cf032f1435b90387cfd9e9679006dd628d0999d86b6e7db2d4a43964d}
+    container_name: "${ESTATE_CONTAINER:-ik-llama-ornith-35b}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8071}}:8080"
+    volumes:
+      - "${MODEL_DIR:-/mnt/models/huggingface}:/models:ro"
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      --model /models/${GGUF_FILE:-ornith-1.0-35b-gguf/q8_0/ornith-1.0-35b-Q8_0.gguf}
+      --alias ${MODEL_ALIAS:-ornith-1.0-35b}
+      -ngl 99
+      -ts ${TENSOR_SPLIT:-1,1}
+      --ctx-size ${CTX_SIZE:-262144}
+      -b ${BATCH_SIZE:-4096}
+      -ub ${UBATCH_SIZE:-1024}
+      -np ${NP:-1}
+      -ctk ${KV_TYPE:-q8_0}
+      -ctv ${KV_TYPE:-q8_0}
+      -fa on
+      --jinja
+      --reasoning ${REASONING:-off}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+      ${SPEC_TYPE_ARGS:-}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -772,6 +772,21 @@ COMPOSE_REGISTRY = {
         status_note="Ornith-1.0-9B (DeepReinforce agentic-coding RL) on ik_llama single 3090, Q4_K_M + q8_0 KV, full 262K. Arch CONFIRMED qwen35 Qwen3-Next DENSE-FFN HYBRID (8 full-attn + 24 GDN/DeltaNet layers, NON-MoE) — only 8/32 layers carry GQA KV, so 262K fits at 4.25 GiB KV (13.4 GiB total, ~10 GiB headroom). No MTP head → drafter-free ngram self-spec (--spec-type ngram-map-k, ~0.59 accept, +30% warm on copy-heavy gen; works DESPITE the DeltaNet hybrid, where DFlash/EAGLE are KV-rollback-blocked). Full gate PASS 2026-06-25: bench ~102/103 TPS (TTFT 144ms, CV<1%), verify-stress 8/8 incl NIAH→0.92×262K, soak-continuous PASS (0 MiB growth, 0/100 silent-empty, p50 104 TPS, 98.1% retention). 8-pack think-OFF 91/150 / think-ON 95/150 (temp 0.6). cli-40 7/40 is partly a termination-protocol artifact (model solves but mis-routes the <solution> sign-off via the bash tool + loops → agent_loop_exhausted; a hardened agent prompt lifts it 7→13/40). NICHE ONLY — gemma-4-12b beats it on quality (105/150) AND speed (117/122 vs 102 TPS) at +7 GiB; pick Ornith only for the lean 13.4 GiB footprint / 16 GB-card fit. Self-grabbed official GGUF, ik digest-pinned → 🧪.",
     ),
 
+    # Ornith-1.0-35B — DeepReinforce agentic-coding RL fine-tune of Qwen3.6-35B-A3B
+    # (qwen35moe MoE hybrid, 40L, 256 experts / 8 active ~3B, NO MTP head). Dual 3090,
+    # Q8_0 GGUF, full 262K, drafter-free ngram (opt-in; Q8 dual is tight). 🧪 — ties the
+    # base on the 8-pack, EDGES it on aider (15/30 vs 12-13) → coding-leaning lane.
+    "ik-llama/ornith35b-dual": _entry(
+        model="ornith-1.0-35b", weights_variant="deepreinforce-q8", workload="fast-chat",
+        engine="llama-cpp-local", drafter=None, kv_format="q8_0",
+        tp=2, max_ctx=262144, max_num_seqs=1, mem_util=None,
+        compose_path="models/ornith-1.0-35b/ik-llama/compose/dual/deepreinforce-q8/ngram.yml",
+        default_port=8071,
+        kvcalc_key="SKIP",
+        status="experimental",
+        status_note="Ornith-1.0-35B (DeepReinforce agentic-coding RL fine-tune of Qwen3.6-35B-A3B) on ik_llama dual 3090, Q8_0 GGUF, full 262K. Arch CONFIRMED qwen35moe (MoE hybrid, 40L: 10 full-attn + 30 GDN, 256 experts / 8 active, ~3B active of 34.66B) — only ~10 layers carry GQA KV so 262K KV is ~2.7 GB. NO MTP head → drafter-free ngram (--spec-type ngram-map-k, OPT-IN: Q8 weights nearly fill dual so ngram needs n_max=32 + a balanced -ts to fit 262K). Full gate PASS 2026-06-26: bench ~108.8/108.6 TPS, verify-stress 8/8 (NIAH→240K), soak-continuous PASS (0 growth, 0/100 silent-empty, p50 112). 8-pack think-OFF 105/150 / think-ON 105/150 — TIES the base qwen3.6-35b-a3b (byteshape 110) within noise; thinking adds nothing. EDGES the base on real coding: aider-polyglot-30 15/30 (OFF==ON) vs the base's 12-13/30, corroborated by bugfind 15/15. Coding-leaning 35B-A3B; the base stays the pick for general use. Self-grabbed official GGUF, ik digest-pinned → 🧪.",
+    ),
+
     # VibeThinker-3B — WeiboAI verifiable-reasoning fine-tune of Qwen2.5-Coder-3B
     # (Qwen2 dense). First dense-family + first sub-4B model in the catalog.
     "vllm/vibethinker-3b-single": _entry(

--- a/scripts/lib/profiles/models/ornith-1.0-35b.yml
+++ b/scripts/lib/profiles/models/ornith-1.0-35b.yml
@@ -1,0 +1,54 @@
+schema_version: 1
+id: ornith-1.0-35b
+display_name: Ornith 1.0 35B (DeepReinforce, MoE)
+family: qwen3-next-moe
+# DeepReinforce agentic-coding RL fine-tune of Qwen3.6-35B-A3B — SAME architecture
+# (arch=qwen35moe, confirmed from the GGUF header). Qwen3-Next MoE hybrid: 40 layers,
+# 10 full_attention (full_attention_interval=4) + 30 GDN/DeltaNet, 256 experts / 8
+# active (~3B active of 34.66B total). Distinct from the base only in two GGUF facts:
+# NO MTP head (verified) and text-only (no vision tower).
+hidden_size: 2048
+num_hidden_layers: 40
+# Hybrid: 10 full_attention layers at full_attention_interval=4; the other 30 are GDN.
+num_gdn_layers: 30
+num_attn_layers: 10
+num_attn_heads: 16
+num_kv_heads: 2
+head_dim_attn: 256
+linear_num_v_heads: 32
+linear_num_k_heads: 16
+linear_v_head_dim: 128
+linear_k_head_dim: 128
+linear_conv_kernel_dim: 4
+max_ctx_supported: 262144
+attention_k_eq_v: false
+# MoE (from the GGUF header)
+num_experts: 256
+num_experts_per_tok: 8
+moe_intermediate_size: 512
+shared_expert_intermediate_size: 512
+active_params_b: 3.0
+# NO MTP head in the DeepReinforce GGUF (verified) — unlike the base 35B-A3B; spec-dec
+# is drafter-free ngram (ik_llama --spec-type ngram-map-k), opt-in (Q8 dual is tight).
+mtp_num_hidden_layers: 0
+attn_output_gate: true
+vision_capable: false
+weights:
+  deepreinforce-q8:
+    path: ornith-1.0-35b-gguf/q8_0
+    local_subdir: ornith-1.0-35b-gguf/q8_0
+    size_gb: 35                 # 34.66 B params, Q8_0 GGUF (~35 GB) — dual-card only
+    format: gguf
+    status: experimental
+    hf_repo: deepreinforce-ai/Ornith-1.0-35B-GGUF
+    files:
+      - ornith-1.0-35b-Q8_0.gguf
+    engine: ik-llama
+    kind: gguf
+    verify_glob: "*.gguf"
+default_weight_variant: deepreinforce-q8
+compatible_drafters: []        # no MTP head, no draft model — ngram is drafter-free
+valid_tp:
+  - 1
+  - 2
+requires_genesis: false

--- a/scripts/tests/test-compose-registry-disk.sh
+++ b/scripts/tests/test-compose-registry-disk.sh
@@ -25,8 +25,8 @@ def check(cond, msg):
         print(f"FAIL: {msg}")
         failures.append(msg)
 
-check(len(COMPOSE_REGISTRY) == 54, f"registry has 54 entries (got {len(COMPOSE_REGISTRY)})")
-check(len(disk_paths) == 55, f"disk has 55 compose files (got {len(disk_paths)})")
+check(len(COMPOSE_REGISTRY) == 55, f"registry has 55 entries (got {len(COMPOSE_REGISTRY)})")
+check(len(disk_paths) == 56, f"disk has 56 compose files (got {len(disk_paths)})")
 check(registry_paths <= disk_paths, "all registry compose_path values exist on disk")
 parked_disk_only = disk_paths - registry_paths
 # Disk-only (non-registry) composes allowed: parked SGLang archives, plus the experimental

--- a/scripts/tests/test-profiles-compat.sh
+++ b/scripts/tests/test-profiles-compat.sh
@@ -24,7 +24,7 @@ run_test "load_profiles parses all profile groups" <<'PY'
 from scripts.lib.profiles.compat import load_profiles
 p = load_profiles()
 assert len(p.hardware) == 9
-assert len(p.models) == 9
+assert len(p.models) == 10
 assert len(p.workloads) == 5
 assert len(p.engines) == 13
 assert len(p.drafters) == 11


### PR DESCRIPTION
## Ornith-1.0-35B → 🧪 experimental slug `ik-llama/ornith35b-dual`

DeepReinforce agentic-coding RL fine-tune of **Qwen3.6-35B-A3B** (the base we already ship). Same architecture — `qwen35moe` MoE hybrid (40L: 10 full-attn + 30 GDN/DeltaNet, 256 experts / 8 active, ~3B of 34.66B) — minus an MTP head and the vision tower.

**Config:** ik_llama.cpp dual 3090, Q8_0 GGUF, q8_0 KV, full **262K** (KV ~2.7 GB — the hybrid MoE carries attention KV on only ~10/40 layers). Drafter-free **ngram** is opt-in: Q8 weights nearly fill dual, so it needs `n_max=32` + a balanced `-ts` to fit the verify buffer at 262K.

**Gate (rebench-full + aider, 2026-06-26):** bench ~108.8/108.6 TPS · verify-stress **8/8** (NIAH→240K) · soak-continuous **PASS** (0 growth, 0/100 silent-empty, p50 112) · 8-pack **105/150 OFF / 105 ON**.

**Why 🧪 coding-leaning, not a general default:** it **ties** the base qwen3.6-35b-a3b on the 8-pack (105 vs 110, within noise; thinking adds nothing) but **edges it on real coding** — aider-polyglot-30 **15/30 (OFF==ON) vs the base's 12–13**, corroborated by a perfect bugfind 15/15. So it's the coding-leaning 35B-A3B lane; the base stays the pick for general use. The aider edge is modest (+2 on n=1/30).

Catalog gate: **58/58 green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
