### PR TITLE
Add nvidia-power-cap.service referenced by gpu-mode.sh

### DIFF
--- a/scripts/systemd/nvidia-power-cap.service
+++ b/scripts/systemd/nvidia-power-cap.service
@@ -1,0 +1,31 @@
+# nvidia-power-cap.service — club-3090 GPU power cap (both RTX 3090s @ 250W)
+# ---------------------------------------------------------------------------
+# The single source of truth for this rig's boot-time power cap, and the unit
+# that scripts/gpu-mode.sh `power-cap on` restarts. Install with:
+#
+#   sudo cp scripts/systemd/nvidia-power-cap.service /etc/systemd/system/
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now nvidia-power-cap.service   # --now skips on a hung GPU; reboot applies it
+#
+# Why 250W: the rtx-3090.yml `power_cap_w_prefill` operating point. Chosen
+# after GPU1 repeatedly fell off the bus (NVRM TLB-invalidate / full-chip
+# reset) under higher caps on this X670E rig. 250W stays under that envelope.
+#
+# Why After=gpu-tune.service: on this rig ai-setup's gpu-tune.service (also a
+# Type=oneshot that sets -pl at boot from its own thresholds.json = 260/280)
+# is enabled. Ordering this unit AFTER it makes club-3090 the LAST writer, so
+# 250W wins with no edit to ai-setup. (After= on an absent unit is a harmless
+# no-op, so this file is portable to rigs without gpu-tune.)
+[Unit]
+Description=club-3090 NVIDIA GPU power cap (250W both cards)
+After=nvidia-persistenced.service gpu-tune.service
+Wants=nvidia-persistenced.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/nvidia-smi -i 0 -pl 250
+ExecStart=/usr/bin/nvidia-smi -i 1 -pl 250
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Ships the `nvidia-power-cap.service` unit that `scripts/gpu-mode.sh power-cap on` already restarts as the single-source-of-truth enforcer but that the repo never provided — so the path silently fell back to a direct `nvidia-smi -pl 230` with no cap surviving reboot.

Type=oneshot, caps both 3090s to 250W (the `rtx-3090.yml` `power_cap_w_prefill` point). Ordered `After=gpu-tune.service` so it's the last writer where another oneshot also sets `-pl` at boot; `After=` on an absent unit is a no-op, so the file stays portable.

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)