### PR TITLE
Standardize 27b served-model-name → qwen3.6-27b-autoround (#482)

### DIFF
--- a/models/qwen3.6-27b/vllm-lmcache/compose/dual/fp8/lmcache.yml
+++ b/models/qwen3.6-27b/vllm-lmcache/compose/dual/fp8/lmcache.yml
@@ -151,7 +151,7 @@ services:
       - --model
       - /root/.cache/huggingface/qwen3.6-27b-fp8
       - --served-model-name
-      - qwen3.6-27b-fp8
+      - qwen3.6-27b-autoround
       - --quantization
       - fp8
       - --dtype

--- a/models/qwen3.6-27b/vllm/compose/dual/awq-bf16-int4/int8.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/awq-bf16-int4/int8.yml
@@ -130,7 +130,7 @@ services:
       - --model
       - /root/.cache/huggingface/qwen3.6-27b-awq-bf16-int4
       - --served-model-name
-      - qwen3.6-27b-awq-bf16-int4
+      - qwen3.6-27b-autoround
       - --quantization
       - compressed-tensors
       - --dtype

--- a/models/qwen3.6-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/fp8/mtp.yml
@@ -143,7 +143,7 @@ services:
       - --model
       - /root/.cache/huggingface/qwen3.6-27b-fp8
       - --served-model-name
-      - qwen3.6-27b-fp8
+      - qwen3.6-27b-autoround
       - --quantization
       - fp8
       - --dtype

--- a/models/qwen3.6-27b/vllm/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/multi4/fp8/mtp.yml
@@ -125,7 +125,7 @@ services:
       - --model
       - /root/.cache/huggingface/qwen3.6-27b-fp8
       - --served-model-name
-      - qwen3.6-27b-fp8
+      - qwen3.6-27b-autoround
       - --quantization
       - fp8
       - --dtype

--- a/services/litellm/config.yaml
+++ b/services/litellm/config.yaml
@@ -4,6 +4,10 @@ model_list:
 
   # Qwen 3.6 27B (Lorbus AutoRound INT4) + MTP n=3 + fp8 KV + 262K + vision.
   # Started by `gpu-mode 27b` → vllm-qwen36-27b-dual at :8010. Stack default.
+  # NOTE: ALL 27b serving scenes (autoround / fp8 / awq / lmcache) serve under the
+  # canonical name `qwen3.6-27b-autoround` so this route matches whichever scene is
+  # brought up on :8010 — do NOT give a 27b compose a scene-specific --served-model-name
+  # (see #482). The quant differs by compose path/port, not by served name.
   - model_name: qwen3.6-27b-autoround
     litellm_params:
       model: openai/qwen3.6-27b-autoround


### PR DESCRIPTION
## Problem

The LiteLLM gateway routes `model_name: qwen3.6-27b-autoround` → the upstream vLLM served id `qwen3.6-27b-autoround` at `:8010`. But three 27b serving scenes set a **scene-specific** `--served-model-name`:

| Compose | Old served name |
|---|---|
| `vllm-lmcache/.../dual/fp8/lmcache.yml` | `qwen3.6-27b-fp8` |
| `vllm/.../dual/fp8/mtp.yml` | `qwen3.6-27b-fp8` |
| `vllm/.../multi4/fp8/mtp.yml` | `qwen3.6-27b-fp8` |
| `vllm/.../dual/awq-bf16-int4/int8.yml` | `qwen3.6-27b-awq-bf16-int4` |

Bring one of these up as the `:8010` primary (e.g. via a `gpu-mode` / `PORT` override, as in #482) and the gateway **404s** — the upstream serves a name LiteLLM never asks for.

## Fix (Option B — standardize the served-name)

Unify every 27b serving scene's `--served-model-name` to the canonical **`qwen3.6-27b-autoround`**, so the existing LiteLLM route matches whichever scene is on `:8010`. The quant still differs by **compose path + port** — only the *served name* is unified. The `--model` weights paths are untouched (fp8 weights still load from the fp8 dir).

Documented the invariant in `services/litellm/config.yaml` so a future compose doesn't reintroduce a scene-specific name.

## Verification

- Full test suite green: **58/58** (`for t in scripts/tests/*.sh; do bash "$t"; done`).
- Confirmed no registry/test fixture asserts the old served-names (only weights-path references, which are unchanged).
- All 4 composes still parse (`yaml.safe_load`).

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)