### PR TITLE
report.sh: surface P2P engagement as a labeled field

### DIFF
--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -694,6 +694,27 @@ else
 
   subsection "Boot log highlights"
   {
+    # Interconnect / P2P ENGAGEMENT — the runtime truth. The GPU "Topology" /
+    # "PCIe / P2P detail" sections above report P2P *capability* (can it?); this
+    # reports whether P2P is actually ON for the running serving container.
+    # detect_nvlink.sh emits an [nvlink] decision trail at boot stating the
+    # resolved NCCL_P2P_LEVEL + custom-all-reduce state. Grep the WHOLE log (not
+    # head -200) so a late line on a 3-4 GPU boot isn't missed, and fall back to
+    # the live container env. ALWAYS prints something so a reviewer never has to
+    # guess whether P2P was engaged (the gap that forced asks on #446 / #488).
+    nvlink_boot=$(docker logs "$CONTAINER" 2>&1 | grep -E '\[nvlink\]' | head -8)
+    p2p_env=$(docker exec "$CONTAINER" env 2>/dev/null | grep -E '^(NCCL_P2P|NVLINK_MODE|NCCL_CUMEM)=' | sort)
+    echo "**Interconnect / P2P engagement:**"
+    if [[ -n "$nvlink_boot" || -n "$p2p_env" ]]; then
+      echo '```'
+      [[ -n "$nvlink_boot" ]] && echo "$nvlink_boot"
+      [[ -n "$p2p_env" ]] && { echo "# resolved container env:"; echo "$p2p_env"; }
+      echo '```'
+    else
+      echo "_No \`[nvlink]\` boot line or NCCL_P2P/NVLINK_MODE env found — P2P engagement undetermined (single-GPU, a non-NCCL engine like llama.cpp, or an entrypoint predating detect_nvlink.sh)._"
+    fi
+    echo
+
     genesis_results=$(docker logs "$CONTAINER" 2>&1 | grep -E '\[INFO:genesis\.apply_all\] (Genesis|✅) Results' | tail -1)
     if [[ -n "$genesis_results" ]]; then
       echo "**Genesis patches applied:**"


### PR DESCRIPTION
## Problem

`report.sh` captured P2P **capability** thoroughly (`topo -m`, `topo -p2p rw`, lspci `LnkSta`/`ACS`/topology) — i.e. *can this rig do P2P*. But it never surfaced P2P **engagement** — *is P2P actually ON for the running serving container*.

The runtime truth lives in the `[nvlink]` boot line `detect_nvlink.sh` emits (e.g. `[nvlink] P2P ENABLED — NCCL_P2P_LEVEL=NVL, custom all-reduce ON` vs `… using PCIe mode (no P2P)`). That line was only present **implicitly** in the raw "first 200 lines of docker logs" dump — and **missing entirely** when (a) no serving container was up at report time, or (b) the line scrolled past line 200 (likelier on 3–4-GPU boots).

This is the exact gap that forced a round-trip on **#446** (@Whamp TP=4 — couldn't tell if P2P engaged) and **#488** (NVLink-vs-PHB A/B).

## Fix

Add an **"Interconnect / P2P engagement"** field to the *Boot log highlights* section. It:
- greps the **whole** boot log (not `head -200`) for the `[nvlink]` decision trail, so a late line isn't missed;
- adds the live container's resolved `NCCL_P2P` / `NVLINK_MODE` env (`docker exec … env`, best-effort);
- **always prints something** — an explicit "undetermined (single-GPU / non-NCCL engine / pre-detect_nvlink entrypoint)" note when neither is found — so a reviewer never has to guess.

Capability (above) and engagement (this) now sit side by side in the report.

## Verification
- `bash -n scripts/report.sh` — parses.
- Full test suite green: **58/58**.
- Leak-clean diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)