### PR TITLE
fix(ai-studio): honor MODEL_DIR for ComfyUI paths + portable gpu-mode + SKIP_DISK_CHECK

### DIFF
--- a/docs/ai-studio/README.md
+++ b/docs/ai-studio/README.md
@@ -141,8 +141,10 @@ gemma-4-12b — the uncensored DiTs still render, only the prompt-writing change
 (~120 GB), brings the scene up, and installs the OWUI Studio pipe:
 
 ```bash
-bash scripts/setup-ai-studio.sh        # add --yes to skip the confirm; SKIP_BUILD / SKIP_DOWNLOAD / SKIP_PIPE to trim
+bash scripts/setup-ai-studio.sh        # add --yes to skip the confirm; SKIP_BUILD / SKIP_DOWNLOAD / SKIP_DISK_CHECK / SKIP_PIPE to trim
 ```
+
+**Where the models land:** everything goes under your **`MODEL_DIR`** (set in repo-root `.env`, e.g. via c3 Settings) — the HF/GGUF weights at `$MODEL_DIR`, and the ComfyUI tree at a `comfyui` sibling of it (e.g. `MODEL_DIR=/home/me/models` → ComfyUI at `/home/me/comfyui`). Override `COMFYUI_ROOT` / `COMFYUI_MODELS_DIR` to decouple them. Resuming a download that already pushed you under the free-space threshold? `SKIP_DISK_CHECK=1` bypasses the preflight (the roster pull is idempotent and only fetches what's missing).
 
 **Already set up?** Just bring the scene up (or do it from c3 → Operate):
 

--- a/scripts/gpu-mode.sh
+++ b/scripts/gpu-mode.sh
@@ -5,10 +5,17 @@
 
 set -e
 
-# club-3090 is the canonical repo (qwen36-dual-3090 + /opt/ai/compose/<svc>
-# both deprecated 2026-05-10 — supporting services moved into services/).
-CLUB3090_DIR="/opt/ai/github/club-3090"
+# Repo root: auto-detected from this script's real location (resolving the
+# /usr/local/bin/gpu-mode symlink on the reference rig), so the script is portable to
+# any clone. Override with CLUB3090_DIR=... if needed.
+CLUB3090_DIR="${CLUB3090_DIR:-$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/.." && pwd)}"
 COMPOSE_BASE="$CLUB3090_DIR/services"
+# ComfyUI/studio paths derive from MODEL_DIR (see services/comfyui/comfyui-paths.sh) so the
+# ai-studio scene's compose mounts + missing-model check match wherever the user keeps models.
+if [ -f "$COMPOSE_BASE/comfyui/comfyui-paths.sh" ]; then
+    # shellcheck disable=SC1091
+    . "$COMPOSE_BASE/comfyui/comfyui-paths.sh"
+fi
 # Post-PR-A (<quant>/ layer): dual composes live under <topology>/<quant>/.
 # Point each var at the quant dir so `compose_at` cd's into it — mount-safe,
 # the same invocation switch.sh uses (project dir = compose-file dir).

--- a/scripts/setup-ai-studio.sh
+++ b/scripts/setup-ai-studio.sh
@@ -10,9 +10,12 @@
 # Env knobs:
 #   SKIP_BUILD=1     skip the ComfyUI image build (already built)
 #   SKIP_DOWNLOAD=1  skip the ~120 GB roster pull (already on disk)
+#   SKIP_DISK_CHECK=1 bypass the free-space preflight (resume an idempotent download)
 #   SKIP_PIPE=1      skip installing the OWUI Studio pipe (do it later)
 #   ASSUME_YES=1     same as --yes (also auto-yes when not a TTY / under CI)
 #   LANIP=<ip>       host IP shown in the final URLs (auto-detected otherwise)
+#   MODEL_DIR=<dir>  HF/GGUF cache root; the ComfyUI tree goes to a "comfyui" sibling
+#                    of it (override COMFYUI_ROOT / COMFYUI_MODELS_DIR to decouple).
 #
 # Idempotent: re-running rebuilds/re-pulls only what changed, installs-or-updates
 # the pipe, then brings the stack up via `gpu-mode ai-studio`.
@@ -21,13 +24,18 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 COMFYUI_DIR="$REPO_DIR/services/comfyui"
 STUDIO_DIR="$REPO_DIR/services/studio"
+# Derive COMFYUI_ROOT / COMFYUI_MODELS_DIR from MODEL_DIR so the download target, the disk
+# check, and the container mounts all agree (a user who set MODEL_DIR gets the ComfyUI tree
+# alongside it instead of the rig's /mnt fallback). See services/comfyui/comfyui-paths.sh.
+# shellcheck disable=SC1091
+. "$COMFYUI_DIR/comfyui-paths.sh"
 LANIP="${LANIP:-$(hostname -I 2>/dev/null | tr ' ' '\n' | grep -E '^(192\.168|10\.|172\.)' | head -1)}"
 LANIP="${LANIP:-<host-ip>}"
 
 ASSUME_YES="${ASSUME_YES:-}"
 case "${1:-}" in
   -y|--yes) ASSUME_YES=1 ;;
-  -h|--help) sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+  -h|--help) sed -n '2,21p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
 esac
 # Auto-yes when non-interactive (piped / nohup / CI) so we never hang on the prompt.
 [ -t 0 ] || ASSUME_YES=1
@@ -43,8 +51,8 @@ ok()   { echo -e "\033[0;32m$*\033[0m"; }
 if declare -f preflight_docker >/dev/null 2>&1; then
     preflight_docker || exit 1                                   # docker + compose v2 + daemon
     preflight_gpu 1  || exit 1                                   # 1 GPU runs image+audio; video wants 2 (warned below)
-    [ -z "${SKIP_BUILD:-}" ]    && { preflight_disk / 32 || exit 1; }                       # comfyui-local image + ~9 GB CUDA base
-    [ -z "${SKIP_DOWNLOAD:-}" ] && { preflight_disk /mnt/models/comfyui 130 || exit 1; }    # ~120 GB studio roster
+    [ -z "${SKIP_BUILD:-}${SKIP_DISK_CHECK:-}" ]    && { preflight_disk / 32 || exit 1; }                          # comfyui-local image + ~9 GB CUDA base
+    [ -z "${SKIP_DOWNLOAD:-}${SKIP_DISK_CHECK:-}" ] && { preflight_disk "$COMFYUI_MODELS_DIR" 130 || exit 1; }      # ~120 GB roster → MODEL_DIR-derived path
     preflight_gpu_idle || true                                   # soft warn if VRAM already in use
 else
     command -v docker >/dev/null 2>&1 || { echo "ERROR: docker not found." >&2; exit 1; }

--- a/scripts/tests/test-comfyui-paths.sh
+++ b/scripts/tests/test-comfyui-paths.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Guards services/comfyui/comfyui-paths.sh — the shared ComfyUI path derivation.
+# Regression guard for the sumo Discord report (2026-06-27): the ai-studio download
+# ignored MODEL_DIR and hard-failed creating /mnt/models/comfyui/... ("mkdir: Permission
+# denied") on any rig whose models don't live under /mnt.
+#
+# Asserts: COMFYUI_ROOT / COMFYUI_MODELS_DIR derive as a "comfyui" sibling of MODEL_DIR,
+# stay backward-compatible with the reference rig's /mnt layout, and respect explicit
+# overrides.
+set -uo pipefail
+HELPER="$(cd "$(dirname "$0")/../.." && pwd)/services/comfyui/comfyui-paths.sh"
+
+[ -f "$HELPER" ] || { echo "FAIL: helper not found: $HELPER"; exit 1; }
+
+fails=0
+chk() {  # chk <desc> <expected> <actual>
+  if [ "$2" = "$3" ]; then echo "  ok: $1"; else echo "  FAIL: $1 — expected '$2', got '$3'"; fails=$((fails+1)); fi
+}
+# Run the helper in a clean subshell (MODEL_DIR set so the .env lookup is skipped →
+# deterministic) and echo "COMFYUI_ROOT|COMFYUI_MODELS_DIR".
+derive() { env "$@" bash -c '. "'"$HELPER"'"; printf "%s|%s" "$COMFYUI_ROOT" "$COMFYUI_MODELS_DIR"'; }
+
+# A — reference rig default (backward-compatible): /mnt/models/huggingface -> /mnt/models/comfyui
+got="$(derive -u COMFYUI_ROOT -u COMFYUI_MODELS_DIR MODEL_DIR=/mnt/models/huggingface)"
+chk "rig default root"   "/mnt/models/comfyui"        "${got%|*}"
+chk "rig default models" "/mnt/models/comfyui/models" "${got#*|}"
+
+# B — custom home cache (the sumo case): /home/u/models -> /home/u/comfyui
+got="$(derive -u COMFYUI_ROOT -u COMFYUI_MODELS_DIR MODEL_DIR=/home/u/models)"
+chk "home root"   "/home/u/comfyui"        "${got%|*}"
+chk "home models" "/home/u/comfyui/models" "${got#*|}"
+
+# C — explicit COMFYUI_ROOT respected (models follows it)
+got="$(derive -u COMFYUI_MODELS_DIR COMFYUI_ROOT=/data/cr MODEL_DIR=/home/u/models)"
+chk "explicit root respected" "/data/cr"        "${got%|*}"
+chk "models follows root"     "/data/cr/models" "${got#*|}"
+
+# D — explicit COMFYUI_MODELS_DIR respected
+got="$(derive -u COMFYUI_ROOT COMFYUI_MODELS_DIR=/data/m MODEL_DIR=/x)"
+chk "explicit models respected" "/data/m" "${got#*|}"
+
+if [ "$fails" -eq 0 ]; then echo "PASS: comfyui-paths derivation"; exit 0; else echo "FAIL: $fails assertion(s)"; exit 1; fi

--- a/services/comfyui/comfyui-paths.sh
+++ b/services/comfyui/comfyui-paths.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Shared ComfyUI path derivation — ONE knob (MODEL_DIR) configures the whole studio.
+#
+# Source this from any studio entry point (setup-ai-studio.sh, download_studio_models.sh,
+# gpu-mode's ai-studio scene) so the download target, the disk-space check, and the
+# container mounts all agree on where the ComfyUI tree lives.
+#
+# Rule: COMFYUI_ROOT is a "comfyui" SIBLING of the HF cache (MODEL_DIR) — matching the
+# reference rig layout /mnt/models/{huggingface,comfyui}. A user who sets MODEL_DIR (e.g.
+# in repo-root .env via c3 Settings) gets the ComfyUI tree alongside it automatically,
+# instead of the download silently falling back to the rig's /mnt path and failing with
+# "mkdir: Permission denied" (club-3090 sumo report, 2026-06-27).
+#
+# Explicitly-set COMFYUI_ROOT / COMFYUI_MODELS_DIR are always respected.
+
+# 1. MODEL_DIR is configured in repo-root .env (c3 Settings writes it there). Pick it up
+#    if the caller hasn't already exported it. Resolve this file's repo root from its own
+#    location so it works whether sourced by an in-repo script or a symlinked launcher.
+if [ -z "${MODEL_DIR:-}" ]; then
+  _c3_paths_root="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/../.." && pwd)"
+  if [ -f "$_c3_paths_root/.env" ]; then
+    MODEL_DIR="$(grep -E '^MODEL_DIR=' "$_c3_paths_root/.env" 2>/dev/null | tail -1 | cut -d= -f2-)"
+    MODEL_DIR="${MODEL_DIR%\"}"; MODEL_DIR="${MODEL_DIR#\"}"   # strip optional surrounding quotes
+  fi
+  unset _c3_paths_root
+fi
+
+# 2. Derive (only when unset), then export so child processes + docker compose inherit them.
+: "${MODEL_DIR:=/mnt/models/huggingface}"
+: "${COMFYUI_ROOT:=$(dirname "$MODEL_DIR")/comfyui}"
+: "${COMFYUI_MODELS_DIR:=${COMFYUI_ROOT}/models}"
+export MODEL_DIR COMFYUI_ROOT COMFYUI_MODELS_DIR

--- a/services/comfyui/download_flux2.sh
+++ b/services/comfyui/download_flux2.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -uo pipefail
-ROOT="/mnt/models/comfyui/models"
+ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 
 ts() { date +%H:%M:%S; }
 log() { echo "[$(ts)] $*"; }

--- a/services/comfyui/download_hunyuan_llava.sh
+++ b/services/comfyui/download_hunyuan_llava.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -uo pipefail
-ROOT="/mnt/models/comfyui/models"
+ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 echo "[$(date +%H:%M:%S)] Downloading llava_llama3_fp8_scaled.safetensors (~9 GB)..."
 hf download Comfy-Org/HunyuanVideo_repackaged \
     split_files/text_encoders/llava_llama3_fp8_scaled.safetensors \

--- a/services/comfyui/download_models.sh
+++ b/services/comfyui/download_models.sh
@@ -4,7 +4,7 @@
 # Run in background:  nohup ./download_models.sh > /tmp/comfyui-downloads.log 2>&1 &
 set -uo pipefail
 
-ROOT="/mnt/models/comfyui/models"
+ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 LOG_TS() { date +%H:%M:%S; }
 log()  { echo "[$(LOG_TS)] $*"; }
 step() { log ""; log "=== $* ==="; }

--- a/services/comfyui/download_studio_models.sh
+++ b/services/comfyui/download_studio_models.sh
@@ -12,6 +12,12 @@
 set -uo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Derive COMFYUI_ROOT / COMFYUI_MODELS_DIR from MODEL_DIR so a direct CLI run (e.g. on a
+# rig where MODEL_DIR isn't /mnt/models) targets the right tree instead of failing on the
+# /mnt fallback. Each child download_*.sh inherits the exported COMFYUI_MODELS_DIR.
+# shellcheck disable=SC1091
+. "$HERE/comfyui-paths.sh"
+
 echo "════ ai-studio models — download all (idempotent; skips what's already present) ════"
 bash "$HERE/download_director.sh"
 bash "$HERE/download_ideogram4.sh"


### PR DESCRIPTION
## The report (Discord, sumo, Ubuntu)

`setup-ai-studio.sh` crashed mid-download:
```
[…] DONE — director           # → /home/sumo/models/...  (MODEL_DIR honored ✓)
mkdir: Permission denied
=== 1/4  Ideogram-4 fp8 transformer ===
FileNotFoundError: [Errno 2] No such file or directory: '/mnt/models/comfyui/models/.cache/huggingface'
```
Plus: a near-full disk that dropped under the threshold mid-run, after which re-running was blocked by the disk preflight with no way to override.

## Root cause — three walls, all "hardcoded rig path, doesn't honor `MODEL_DIR`"

1. **ComfyUI assets ignored `MODEL_DIR`.** The director GGUF honored `MODEL_DIR` (→ `/home/sumo/models`), but the ComfyUI image/video/audio downloads use a *separate* knob (`COMFYUI_MODELS_DIR`/`COMFYUI_ROOT`) that defaulted to `/mnt/models/comfyui/...` — root-owned/absent on his box → `mkdir: Permission denied`.
2. **Disk check hardcoded + no override.** `setup-ai-studio.sh` checked `preflight_disk /mnt/models/comfyui 130` (wrong filesystem) and `SKIP_DOWNLOAD=1` skips the check *and* the download, so an idempotent resume couldn't proceed.
3. **`gpu-mode.sh` hardcoded `CLUB3090_DIR=/opt/ai/github/club-3090`** — `setup-ai-studio.sh` calls it at step 3, so it would break on any non-rig clone even after the download succeeded.

## Fix

- **New `services/comfyui/comfyui-paths.sh`** — one knob (`MODEL_DIR`) configures the whole studio: `COMFYUI_ROOT`/`COMFYUI_MODELS_DIR` derive as a `comfyui` **sibling** of the HF cache (read from repo-root `.env` when unset). Backward-compatible on the rig (`/mnt/models/huggingface` → `/mnt/models/comfyui`); explicit overrides respected. Sourced by `setup-ai-studio.sh`, `download_studio_models.sh`, and `gpu-mode.sh` so the **download target, disk check, and container mounts all agree**.
- **`setup-ai-studio.sh`** — disk check uses the derived path; new **`SKIP_DISK_CHECK=1`** bypasses the preflight independently of `SKIP_DOWNLOAD`.
- **`gpu-mode.sh`** — `CLUB3090_DIR` auto-detects from the script's real location (resolving the `/usr/local/bin/gpu-mode` symlink), overridable via env. Removes the hardcoded `/opt/ai` path.
- 3 legacy hardcoded download scripts (`flux2`/`hunyuan_llava`/`models`) now honor `COMFYUI_MODELS_DIR`.
- New **`test-comfyui-paths.sh`** guards the derivation (rig default · custom home · explicit overrides) + a docs/ai-studio config note.

## Verification

- Full suite **59/59** green (incl. the new test).
- `bash -n` on every touched script; helper confirmed **set -e safe** when sourced (gpu-mode is `set -e`); `CLUB3090_DIR` auto-detect resolves to the repo root.
- Leak-clean.

## Workaround for users on the released v0.10.0 (pre-merge)

```bash
export COMFYUI_ROOT=/home/you/comfyui COMFYUI_MODELS_DIR=/home/you/comfyui/models
bash services/comfyui/download_studio_models.sh   # idempotent; bypasses the disk gate
bash scripts/gpu-mode.sh ai-studio
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)