### PR TITLE
fix(quality-test): preflight sandbox images + document the build step (#492)

### DIFF
--- a/docs/QUALITY_TEST.md
+++ b/docs/QUALITY_TEST.md
@@ -59,6 +59,13 @@ The **reasoning suite** is also separate from `--full`; run it with `--reasoning
 
 `--full` runs the sandbox packs by default. `--no-sandboxed` drops `--full` back to the 5-pack deterministic scope (no Docker); `--sandboxed-only` runs just the 3 sandbox packs. `--reasoning` is independent of `--full`; use it for the four reasoning packs, with GPQA skipped until gated data is available.
 
+> ⚠️ **`--full` needs the sandbox images built first — "needs Docker" isn't enough.** The 3 sandboxed packs run inside pre-built `benchlocal-sandbox-*` Docker images that are **not auto-pulled**, and the build tooling is **not in the `pip install`** — it lives in a benchlocal-cli *checkout*. Build them once:
+> ```bash
+> git clone https://github.com/noonghunna/benchlocal-cli
+> bash benchlocal-cli/tools/build-sandboxes.sh        # ~30 GB free; the aider image is biggest — `docker system prune` if tight
+> ```
+> Then `--full` works. Without the images, `quality-test.sh` warns up front and runs the deterministic packs only; for a clean no-Docker run use **`--medium`** (or `--no-sandboxed`). (club-3090 #492 — benchlocal-cli's own mid-run hint pointed at a relative path that's wrong outside a checkout.)
+
 ## Install (one-time)
 
 ```bash

--- a/scripts/quality-test.sh
+++ b/scripts/quality-test.sh
@@ -446,6 +446,33 @@ if [[ "$ENABLE_THINKING" != "1" && "$NO_THINKING" != "1" ]] && server_reasoning_
   echo "[quality-test] WARN: server appears to have reasoning enabled, but --enable-thinking is not forced. Pack defaults still apply; use --enable-thinking or ENABLE_THINKING=1 to force thinking on for every pack (or --no-thinking / NO_THINKING=1 to force it off)." >&2
 fi
 
+# ---- sandbox-image preflight (--full / --sandboxed-only) --------------------
+# The sandboxed packs (BugFind / CLI / Hermes) need pre-built Docker images that
+# are NOT auto-pulled. benchlocal-cli's own mid-run hint points at a relative
+# `tools/build-sandboxes.sh` that only exists inside a benchlocal-cli *checkout*
+# (not a pip install, and not here) — so surface the correct steps UP FRONT
+# instead of letting users discover a dead path mid-run (club-3090 #492).
+if [[ -z "$PACK" ]] && { [[ "$MODE" == "--full" && "$NO_SANDBOX" != "1" ]] || [[ "$SANDBOXED_ONLY" == "1" ]]; }; then
+  _sb_missing=()
+  if ! command -v docker >/dev/null 2>&1; then
+    _sb_missing=("Docker not found on PATH")
+  else
+    for _img in benchlocal-sandbox-bugfind benchlocal-sandbox-cli benchlocal-sandbox-hermes; do
+      docker image inspect "${_img}:latest" >/dev/null 2>&1 || _sb_missing+=("${_img}:latest")
+    done
+  fi
+  if [[ ${#_sb_missing[@]} -gt 0 ]]; then
+    echo "[quality-test] ⚠  sandbox packs (BugFind / CLI / Hermes) will be SKIPPED — not available: ${_sb_missing[*]}" >&2
+    echo "               They need pre-built Docker images that aren't auto-pulled. Build them once from a" >&2
+    echo "               benchlocal-cli CHECKOUT (the build tooling isn't in the pip package):" >&2
+    echo "                 git clone https://github.com/noonghunna/benchlocal-cli" >&2
+    echo "                 bash benchlocal-cli/tools/build-sandboxes.sh        # ~30 GB free; prune if tight" >&2
+    echo "               then re-run --full. For a clean no-Docker run now:  bash scripts/quality-test.sh --medium" >&2
+    echo "               (Continuing with the deterministic packs.)" >&2
+    echo >&2
+  fi
+fi
+
 # ---- run benchlocal-cli ------------------------------------------------------
 
 RESULTS_DIR="${ROOT_DIR}/results/quality"


### PR DESCRIPTION
Closes #492.

## Problem

`quality-test.sh --full` (which we tell cross-rig contributors to run) needs the 3 sandboxed packs' Docker images (`benchlocal-sandbox-{bugfind,cli,hermes}`). They're **not auto-pulled**, and when they're missing benchlocal-cli emits a hint pointing at a relative `tools/build-sandboxes.sh` — which only resolves inside a benchlocal-cli *checkout* and is absent on a `pip install`. @guybrush01 (dual-5090) followed it into a dead path. Our `QUALITY_TEST.md` said "--full needs Docker" but never that the images must be built first.

## Fix

- **`quality-test.sh`** — on `--full` / `--sandboxed-only`, **preflight** the three sandbox images up front. If any are missing, print the *correct* steps (clone benchlocal-cli + `build-sandboxes.sh`, our context — not the broken relative path) plus the `--medium` no-Docker fallback, then continue with the deterministic packs rather than dying mid-run.
- **`QUALITY_TEST.md`** — document the sandbox-image build step for `--full` (the clone + build, ~30 GB), with `--medium` / `--no-sandboxed` as the no-Docker path.

## Verification

- Full suite **59/59** green; `bash -n` clean; leak-clean.
- Pairs with **benchlocal-cli#69** (fixes the upstream hint itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)