### PR TITLE
Studio Production Agent v0a — executor spike (offline + live PASS)

### DIFF
--- a/services/studio/production/README.md
+++ b/services/studio/production/README.md
@@ -1,0 +1,66 @@
+# Studio Production Agent — v0a
+
+One static brief → a finished MP4, by driving the **existing** AI-Studio lanes
+serially (Wan video · Kokoro narration · ACE-Step bed → ffmpeg mix). This is the
+**v0a executor spike** from
+[`/opt/ai/docs/ai-studio-production-agent-design.md`](../../../../docs/ai-studio-production-agent-design.md):
+prove the executor + assembly can drive the lanes, collect + validate artifacts,
+and assemble something watchable **without manual babysitting**.
+
+**v0a scope (deliberately tight):** CLI/admin only · no OWUI lane · single-flight
+(host file-lock) · **static** hand-authored `ProductionPlanV1` · one pinned video
+lane (`wan`, t2v) · ffprobe validators · final ffmpeg mix at the delivery profile ·
+typed/extensible manifest with run-level provenance.
+
+**Deferred to v0b/v1:** the 4B planner, skills, image lanes / asset-DAG, takes +
+rerender, Qdrant/SearXNG, durable queue, OWUI lane. (The manifest is already typed
+so v0b prompt-provenance records slot in with no redesign.)
+
+## Run
+
+```bash
+# from the repo root (/opt/ai/github/club-3090)
+
+# offline — ffmpeg lavfi stand-ins, no GPU/ComfyUI/TTS (good for dev + CI):
+python3 -m services.studio.production.run \
+    services/studio/production/plans/lighthouse_3shot.json --backend synthetic
+
+# live — drives ComfyUI (:8188) + Kokoro TTS (:8192); needs the ai-studio scene up:
+gpu-mode ai-studio        # bring the scene up first
+python3 -m services.studio.production.run \
+    services/studio/production/plans/lighthouse_3shot.json --backend live
+```
+
+Output lands in `/mnt/models/comfyui/output/productions/<job_id>/`
+(`shots/ audio/ assembly/final.mp4 manifest.json`). Override the base with
+`--productions-dir`, endpoints with `COMFYUI_URL` / `TTS_URL` / `VOICE_URL`.
+
+The run prints a summary against the **exit criteria** — all validators pass,
+VO-within-tolerance, final-has-audio, durations — and ends on the decisive human
+question: *is this better than picking lanes by hand?*
+
+## Tests (offline, stdlib only — no pydantic/pytest/GPU)
+
+```bash
+python3 -m unittest services.studio.production.tests.test_v0a -v
+```
+
+The end-to-end test runs the **whole** pipeline on the synthetic backend and
+asserts a real MP4 with an audio track + a well-formed manifest — so the logic is
+verified before it ever touches the rig.
+
+## Layout
+
+| File | Role |
+|---|---|
+| `schema.py` | `ProductionPlanV1` (dataclasses + `validate()`) |
+| `comfy.py` | minimal ComfyUI client (`submit` / `await_output` / `alive`) |
+| `lanes.py` | `LiveBackend` (ComfyUI+Kokoro) · `SyntheticBackend` (ffmpeg lavfi) |
+| `ensure.py` | `ensure_lane` — services-up + Step-Voice `/unload` before video |
+| `validators.py` | ffprobe checks (duration / audio / dims / non-empty) |
+| `assemble.py` | pure `build_mix_command` + `assemble` (concat + duck + loudnorm) |
+| `manifest.py` | typed, extensible manifest + run-level provenance |
+| `lock.py` | single-flight host file-lock |
+| `executor.py` | the four-phase loop (video → audio → post) |
+| `run.py` | CLI + exit-criteria summary |
+| `plans/` | static `ProductionPlanV1` JSON |

--- a/services/studio/production/__init__.py
+++ b/services/studio/production/__init__.py
@@ -1,0 +1,13 @@
+"""AI Studio — Production Agent (v0a).
+
+A CLI/admin, single-flight executor that drives the EXISTING AI-Studio lanes from a
+static `ProductionPlanV1` and assembles one MP4. No 4B planner, no OWUI lane, no
+Qdrant/SearXNG, no durable queue — those are v0b/v1 (see
+/opt/ai/docs/ai-studio-production-agent-design.md).
+
+stdlib-only on purpose (host python has no pydantic/pytest) so the spike runs +
+self-tests with zero installs. A `synthetic` backend (ffmpeg lavfi) exercises the
+whole path offline; the `live` backend hits ComfyUI (:8188) + Kokoro TTS (:8192).
+"""
+
+__version__ = "0a"

--- a/services/studio/production/assemble.py
+++ b/services/studio/production/assemble.py
@@ -1,0 +1,94 @@
+"""Post-production: the final ffmpeg mix.
+
+`build_mix_command` is PURE (inputs -> argv) so it's unit-testable without running
+ffmpeg; `assemble` runs it. One pass: concat the silent clips, lay each narration
+WAV at its timeline offset (adelay), duck the music bed under the narration
+(sidechaincompress), loudnorm to the delivery target, mux to one MP4. The exact
+argv is recorded in the manifest for reproducibility.
+
+Reuses the studio ffmpeg idioms (loudnorm I=…:TP=-1.5:LRA=11, sidechaincompress)
+from tts/tts.py `_mixdown`.
+"""
+from __future__ import annotations
+
+from .util import sh
+
+
+def db_to_linear(db: float) -> float:
+    return 10.0 ** (db / 20.0)
+
+
+def build_mix_command(
+    final_path: str,
+    clips: list[str],
+    narrations: list[tuple[str, int]],   # (wav_path, start_ms)
+    bed: str | None,
+    *,
+    fps: int,
+    lufs: float,
+    bed_level_db: float,
+    duck_ratio: int = 8,
+) -> list[str]:
+    """Build the single-pass ffmpeg argv. Pure — no side effects."""
+    n = len(clips)
+    m = len(narrations)
+    if n == 0:
+        raise ValueError("no clips to assemble")
+
+    inputs: list[str] = []
+    for c in clips:
+        inputs += ["-i", c]
+    for (p, _) in narrations:
+        inputs += ["-i", p]
+    if bed:
+        inputs += ["-i", bed]
+
+    fc: list[str] = []
+    # 1) video concat
+    fc.append("".join(f"[{i}:v]" for i in range(n)) + f"concat=n={n}:v=1:a=0[vid]")
+
+    # 2) narration timeline (delay each VO to its start, mix together)
+    narr_label = None
+    if m:
+        for j, (_, start) in enumerate(narrations):
+            fc.append(f"[{n + j}:a]adelay={start}|{start}[n{j}]")
+        if m == 1:
+            narr_label = "[n0]"
+        else:
+            fc.append("".join(f"[n{j}]" for j in range(m)) + f"amix=inputs={m}:normalize=0[narr]")
+            narr_label = "[narr]"
+
+    # 3) bed + duck + final audio
+    bidx = n + m
+    if bed and m:
+        # split narration: one copy keys the sidechain, one is mixed back in
+        fc.append(f"{narr_label}asplit=2[nkey][nmix]")
+        fc.append(f"[{bidx}:a]volume={db_to_linear(bed_level_db):.4f}[bedv]")
+        fc.append(f"[bedv][nkey]sidechaincompress=threshold=0.03:ratio={duck_ratio}:attack=5:release=250[bedduck]")
+        fc.append(f"[bedduck][nmix]amix=inputs=2:normalize=0[premix]")
+        pre = "[premix]"
+    elif bed:
+        fc.append(f"[{bidx}:a]volume={db_to_linear(bed_level_db):.4f}[premix]")
+        pre = "[premix]"
+    elif m:
+        pre = narr_label
+    else:
+        raise ValueError("nothing to put on the audio track (no narration, no bed)")
+
+    fc.append(f"{pre}loudnorm=I={lufs}:TP=-1.5:LRA=11[a]")
+
+    return (
+        ["ffmpeg", "-y", "-v", "error", *inputs,
+         "-filter_complex", ";".join(fc),
+         "-map", "[vid]", "-map", "[a]",
+         "-r", str(fps), "-c:v", "libx264", "-pix_fmt", "yuv420p",
+         "-c:a", "aac", "-b:a", "192k", "-shortest", final_path]
+    )
+
+
+def assemble(final_path, clips, narrations, bed, *, fps, lufs, bed_level_db) -> list[str]:
+    """Build + run the mix. Returns the exact argv used (for the manifest)."""
+    cmd = build_mix_command(final_path, clips, narrations, bed,
+                            fps=fps, lufs=lufs, bed_level_db=bed_level_db)
+    sh(cmd, timeout=900)
+    return cmd

--- a/services/studio/production/assemble.py
+++ b/services/studio/production/assemble.py
@@ -1,70 +1,119 @@
 """Post-production: the final ffmpeg mix.
 
 `build_mix_command` is PURE (inputs -> argv) so it's unit-testable without running
-ffmpeg; `assemble` runs it. One pass: concat the silent clips, lay each narration
-WAV at its timeline offset (adelay), duck the music bed under the narration
-(sidechaincompress), loudnorm to the delivery target, mux to one MP4. The exact
-argv is recorded in the manifest for reproducibility.
+ffmpeg; `assemble` runs it.
 
-Reuses the studio ffmpeg idioms (loudnorm I=…:TP=-1.5:LRA=11, sidechaincompress)
-from tts/tts.py `_mixdown`.
+Video: clips are joined with per-seam transitions — `dissolve` (xfade crossfade,
+the default) or `cut`. A dissolve overlaps two clips by `transition_seconds`, so it
+shortens the timeline; clip start times are computed crossfade-aware and the
+narration is delayed to those (shifted) starts.
+
+Audio: each narration WAV is laid at its shot's start (+ intra-shot offset), the
+music bed is ducked under the narration (sidechaincompress, gentle defaults so it
+glides instead of pumping), then loudnorm to the delivery target, one MP4. The exact
+argv is recorded in the manifest. Reuses the studio ffmpeg idioms from tts.py.
 """
 from __future__ import annotations
 
 from .util import sh
+
+_CUT_XFADE = 1.0 / 30.0   # a "cut" seam inside an xfade chain: ~1 frame (no visible blend)
 
 
 def db_to_linear(db: float) -> float:
     return 10.0 ** (db / 20.0)
 
 
+def duck_ratio(duck_db: int) -> int:
+    """Map a duck depth (dB) to a sidechaincompress ratio (gentle floor)."""
+    return max(2, min(20, round(duck_db / 1.5)))
+
+
+def _clip_starts(durations: list[float], xfades: list[float]) -> list[float]:
+    """Output start time of each clip, given per-seam crossfade overlaps.
+
+    xfades[k] is the crossfade seconds for the seam between clip k and k+1.
+    """
+    starts = [0.0]
+    for k in range(1, len(durations)):
+        starts.append(starts[-1] + durations[k - 1] - xfades[k - 1])
+    return starts
+
+
 def build_mix_command(
     final_path: str,
     clips: list[str],
-    narrations: list[tuple[str, int]],   # (wav_path, start_ms)
+    durations: list[float],
+    transitions: list[tuple[str, float]],     # per seam (len = len(clips)-1): (type, seconds)
+    narrations: list[tuple[str, int, float]],  # (wav_path, shot_index, intra_offset_s)
     bed: str | None,
     *,
     fps: int,
     lufs: float,
     bed_level_db: float,
-    duck_ratio: int = 8,
+    duck_db: int = 6,
 ) -> list[str]:
     """Build the single-pass ffmpeg argv. Pure — no side effects."""
     n = len(clips)
-    m = len(narrations)
     if n == 0:
         raise ValueError("no clips to assemble")
+    if len(durations) != n:
+        raise ValueError("durations must match clips")
+    if len(transitions) != max(0, n - 1):
+        raise ValueError("transitions must have one entry per seam (clips-1)")
+
+    # effective crossfade per seam: dissolve -> its seconds; cut -> ~1 frame
+    xf = [secs if typ == "dissolve" else _CUT_XFADE for (typ, secs) in transitions]
+    all_cut = all(typ == "cut" for (typ, _s) in transitions)
+    starts = (
+        [sum(durations[:k]) for k in range(n)] if (all_cut or n == 1)
+        else _clip_starts(durations, xf)
+    )
 
     inputs: list[str] = []
     for c in clips:
         inputs += ["-i", c]
-    for (p, _) in narrations:
+    for (p, _i, _o) in narrations:
         inputs += ["-i", p]
     if bed:
         inputs += ["-i", bed]
 
     fc: list[str] = []
-    # 1) video concat
-    fc.append("".join(f"[{i}:v]" for i in range(n)) + f"concat=n={n}:v=1:a=0[vid]")
+    # 1) video — concat (all hard cuts) or an xfade dissolve chain
+    if all_cut or n == 1:
+        fc.append("".join(f"[{i}:v]" for i in range(n)) + f"concat=n={n}:v=1:a=0[vid]")
+    else:
+        prev = "[0:v]"
+        for k in range(1, n):
+            out = "[vid]" if k == n - 1 else f"[vx{k}]"
+            fc.append(
+                f"{prev}[{k}:v]xfade=transition=dissolve:"
+                f"duration={xf[k - 1]:.3f}:offset={starts[k]:.3f}{out}"
+            )
+            prev = out
 
-    # 2) narration timeline (delay each VO to its start, mix together)
+    # 2) narration timeline — delay each VO to its (crossfade-aware) shot start
+    m = len(narrations)
     narr_label = None
     if m:
-        for j, (_, start) in enumerate(narrations):
-            fc.append(f"[{n + j}:a]adelay={start}|{start}[n{j}]")
+        for j, (_p, shot_idx, intra) in enumerate(narrations):
+            start_ms = max(0, int((starts[shot_idx] + intra) * 1000))
+            fc.append(f"[{n + j}:a]adelay={start_ms}|{start_ms}[n{j}]")
         if m == 1:
             narr_label = "[n0]"
         else:
             fc.append("".join(f"[n{j}]" for j in range(m)) + f"amix=inputs={m}:normalize=0[narr]")
             narr_label = "[narr]"
 
-    # 3) bed + duck + final audio
+    # 3) bed + (gentle) duck + final audio
     bidx = n + m
     if bed and m:
-        # split narration: one copy keys the sidechain, one is mixed back in
         fc.append(f"{narr_label}asplit=2[nkey][nmix]")
         fc.append(f"[{bidx}:a]volume={db_to_linear(bed_level_db):.4f}[bedv]")
-        fc.append(f"[bedv][nkey]sidechaincompress=threshold=0.03:ratio={duck_ratio}:attack=5:release=250[bedduck]")
+        fc.append(
+            f"[bedv][nkey]sidechaincompress=threshold=0.05:ratio={duck_ratio(duck_db)}:"
+            f"attack=20:release=600[bedduck]"
+        )
         fc.append(f"[bedduck][nmix]amix=inputs=2:normalize=0[premix]")
         pre = "[premix]"
     elif bed:
@@ -86,9 +135,10 @@ def build_mix_command(
     )
 
 
-def assemble(final_path, clips, narrations, bed, *, fps, lufs, bed_level_db) -> list[str]:
+def assemble(final_path, clips, durations, transitions, narrations, bed, *,
+             fps, lufs, bed_level_db, duck_db=6) -> list[str]:
     """Build + run the mix. Returns the exact argv used (for the manifest)."""
-    cmd = build_mix_command(final_path, clips, narrations, bed,
-                            fps=fps, lufs=lufs, bed_level_db=bed_level_db)
+    cmd = build_mix_command(final_path, clips, durations, transitions, narrations, bed,
+                            fps=fps, lufs=lufs, bed_level_db=bed_level_db, duck_db=duck_db)
     sh(cmd, timeout=900)
     return cmd

--- a/services/studio/production/comfy.py
+++ b/services/studio/production/comfy.py
@@ -1,0 +1,91 @@
+"""Minimal ComfyUI client — replicated from studio_pipe.py (no OWUI deps).
+
+studio_pipe.py is a standalone OWUI pipe that can't be imported (it relies on the
+OWUI async/event context), so we re-implement the three calls we need against the
+HTTP API: submit a workflow graph, poll /history for completion, and a liveness
+ping. Same patterns as studio_pipe `_submit` / `_await_output` / `_alive`.
+"""
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.request
+
+from . import config
+
+
+class ComfyError(RuntimeError):
+    pass
+
+
+def alive(base: str = config.COMFYUI_URL, path: str = "/system_stats", timeout: float = 0.6) -> bool:
+    """True if the backend answers at all (an HTTP error still means 'up')."""
+    try:
+        urllib.request.urlopen(base.rstrip("/") + path, timeout=timeout)
+        return True
+    except urllib.error.HTTPError:
+        return True
+    except Exception:
+        return False
+
+
+def submit(wf: dict, base: str = config.COMFYUI_URL, client_id: str = "studio-production") -> str:
+    """POST a workflow graph to /prompt, return its prompt_id."""
+    req = urllib.request.Request(
+        base.rstrip("/") + "/prompt",
+        data=json.dumps({"prompt": wf, "client_id": client_id}).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    r = json.load(urllib.request.urlopen(req, timeout=config.SUBMIT_TIMEOUT))
+    if r.get("node_errors"):
+        raise ComfyError("ComfyUI node_errors: " + json.dumps(r["node_errors"])[:400])
+    pid = r.get("prompt_id")
+    if not pid:
+        raise ComfyError("ComfyUI returned no prompt_id")
+    return pid
+
+
+def await_output(
+    pid: str,
+    want: str,
+    base: str = config.COMFYUI_URL,
+    timeout: float = config.RENDER_TIMEOUT,
+    poll: float = config.POLL_INTERVAL,
+) -> tuple[str, str]:
+    """Poll /history/{pid} until complete; return (filename, subfolder).
+
+    `want` is 'video' | 'image' | 'audio'. Mirrors studio_pipe._await_output's
+    output-node walk.
+    """
+    exts = {
+        "video": (".mp4", ".webm", ".mkv"),
+        "image": (".png", ".jpg", ".jpeg", ".webp"),
+        "audio": (".mp3", ".flac", ".wav", ".opus"),
+    }[want]
+    keys = {"video": ("gifs", "videos", "images"),
+            "image": ("images",),
+            "audio": ("audio", "images")}[want]
+
+    t0 = time.time()
+    while time.time() - t0 < timeout:
+        time.sleep(poll)
+        try:
+            h = json.load(urllib.request.urlopen(base.rstrip("/") + "/history/" + pid, timeout=30))
+        except Exception:
+            continue
+        if pid not in h:
+            continue
+        st = h[pid].get("status", {})
+        if st.get("status_str") == "error":
+            raise ComfyError(f"ComfyUI generation error for prompt {pid}")
+        if not st.get("completed"):
+            continue
+        for node in h[pid].get("outputs", {}).values():
+            for k in keys:
+                for v in node.get(k, []) or []:
+                    fn = str(v.get("filename", ""))
+                    if fn.endswith(exts) or str(v.get("format", "")).startswith(want):
+                        return fn, v.get("subfolder", "")
+        raise ComfyError(f"prompt {pid} completed but produced no {want} output")
+    raise TimeoutError(f"ComfyUI timed out after {timeout:.0f}s for prompt {pid}")

--- a/services/studio/production/config.py
+++ b/services/studio/production/config.py
@@ -24,6 +24,12 @@ WORKFLOW_DIR = os.environ.get(
     os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "workflows"),
 )
 
+# Container names — used to pull artifacts a service wrote root-only (e.g. Kokoro
+# TTS writes its WAV mode 0600, which the host CLI user can't read; `docker cp`
+# from the container works because the docker daemon reads as root).
+COMFY_CONTAINER = os.environ.get("STUDIO_COMFY_CONTAINER", "comfyui")
+TTS_CONTAINER = os.environ.get("STUDIO_TTS_CONTAINER", "studio-tts")
+
 # Network timeouts (seconds).
 SUBMIT_TIMEOUT = int(os.environ.get("STUDIO_SUBMIT_TIMEOUT", "60"))
 RENDER_TIMEOUT = int(os.environ.get("STUDIO_RENDER_TIMEOUT", "1800"))  # 30 min/clip ceiling

--- a/services/studio/production/config.py
+++ b/services/studio/production/config.py
@@ -1,0 +1,30 @@
+"""Runtime config — env-driven, host-side defaults.
+
+The production CLI runs on the HOST (not inside the OWUI container), so the studio
+backends are reached on `localhost` (studio_pipe.py uses host.docker.internal
+because it runs in-container — do not copy that here).
+"""
+from __future__ import annotations
+
+import os
+
+# Studio service endpoints (host-side).
+COMFYUI_URL = os.environ.get("COMFYUI_URL", "http://localhost:8188").rstrip("/")
+TTS_URL = os.environ.get("TTS_URL", "http://localhost:8192").rstrip("/")
+VOICE_URL = os.environ.get("VOICE_URL", "http://localhost:8193").rstrip("/")
+
+# ComfyUI's host output root (mounted at /output in the studio containers). All
+# lanes write here; we scope productions under `<root>/productions/<job_id>/`.
+OUTPUT_ROOT = os.environ.get("COMFYUI_OUTPUT_DIR", "/mnt/models/comfyui/output")
+PRODUCTIONS_DIR = os.path.join(OUTPUT_ROOT, "productions")
+
+# The canonical (friendly-keyed) ComfyUI workflow graphs — shared with studio_pipe.
+WORKFLOW_DIR = os.environ.get(
+    "STUDIO_WORKFLOW_DIR",
+    os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "workflows"),
+)
+
+# Network timeouts (seconds).
+SUBMIT_TIMEOUT = int(os.environ.get("STUDIO_SUBMIT_TIMEOUT", "60"))
+RENDER_TIMEOUT = int(os.environ.get("STUDIO_RENDER_TIMEOUT", "1800"))  # 30 min/clip ceiling
+POLL_INTERVAL = float(os.environ.get("STUDIO_POLL_INTERVAL", "2.0"))

--- a/services/studio/production/ensure.py
+++ b/services/studio/production/ensure.py
@@ -1,0 +1,50 @@
+"""ensure_lane — concrete admission checks per lane (NOT c3's UI-side guard).
+
+The contract (design doc): verify services up → Step-Voice /unload before any video
+lane → ComfyUI health → (the job-level lock is held by the caller). On the synthetic
+backend everything is a no-op (no services to gate). The job-wide single-flight lock
+lives in lock.py and is acquired once in run.py.
+"""
+from __future__ import annotations
+
+import urllib.request
+
+from . import comfy, config
+
+
+class EnsureError(RuntimeError):
+    pass
+
+
+VIDEO_LANES = {"wan", "ltx", "sulphur", "10eros"}
+COMFY_LANES = VIDEO_LANES | {"ace-step", "image"}
+
+
+def _evict_voice() -> None:
+    """Best-effort Step-Voice /unload before a video render (GPU1 mutex)."""
+    try:
+        req = urllib.request.Request(config.VOICE_URL + "/unload", data=b"",
+                                     headers={"Content-Type": "application/json"})
+        urllib.request.urlopen(req, timeout=5)
+    except Exception:
+        pass  # best-effort: the lazy service idle-unloads anyway
+
+
+def ensure_lane(lane: str, *, backend: str) -> None:
+    """Prepare for a render on `lane`. Raises EnsureError if a needed service is down."""
+    if backend == "synthetic":
+        return  # nothing to gate offline
+    if lane in VIDEO_LANES:
+        _evict_voice()
+    if lane in COMFY_LANES:
+        if not comfy.alive():
+            raise EnsureError(
+                f"ComfyUI not reachable at {config.COMFYUI_URL} — is the ai-studio scene up?"
+            )
+
+
+def ensure_tts(*, backend: str) -> None:
+    if backend == "synthetic":
+        return
+    if not comfy.alive(config.TTS_URL, "/tts/health"):
+        raise EnsureError(f"Kokoro TTS not reachable at {config.TTS_URL}")

--- a/services/studio/production/executor.py
+++ b/services/studio/production/executor.py
@@ -1,0 +1,152 @@
+"""The deterministic executor — the four production phases for v0a.
+
+v0a has no pre-production (no image lanes), so the loop is: video → audio → post.
+The LLM proposes (here: a static plan); the executor validates, renders, stores
+artifacts, and assembles. No retries/takes in v0a — a failure raises (and that
+shows up as `zero_manual_restarts=False` in the summary).
+"""
+from __future__ import annotations
+
+import os
+
+from . import assemble as _assemble
+from . import config, ensure, validators
+from .lanes import get_backend
+from .manifest import Artifact, Manifest
+from .schema import ProductionPlanV1
+from .util import sha256_file, sha256_text
+
+WAN_STEPS = 4          # distilled AllInOne schedule (studio_pipe default)
+MUSIC_STEPS = 50
+MUSIC_CFG = 5.0
+VO_TOLERANCE_S = 1.0   # a shot's narration may run up to its length + this
+
+
+def _workflow_versions() -> dict:
+    out = {}
+    for lane, fn in (("wan", "wan22_rapid.json"), ("ace-step", "ace_step_music.json")):
+        p = os.path.join(config.WORKFLOW_DIR, fn)
+        if os.path.isfile(p):
+            out[lane] = sha256_file(p)
+    return out
+
+
+def run_production(
+    plan: ProductionPlanV1,
+    *,
+    backend_name: str,
+    job_id: str,
+    now_iso: str,
+    productions_dir: str = config.PRODUCTIONS_DIR,
+) -> dict:
+    backend = get_backend(backend_name)
+    d = plan.delivery
+    prod_dir = os.path.join(productions_dir, job_id)
+    for sub in ("shots", "audio", "assembly", "logs"):
+        os.makedirs(os.path.join(prod_dir, sub), exist_ok=True)
+
+    def rel(p: str) -> str:
+        return os.path.relpath(p, prod_dir)
+
+    pairs = [(plan.shot_by_id(t.clip), t) for t in plan.timeline]   # (shot, timeline) in play order
+    man = Manifest(
+        job_id=job_id, title=plan.project.title, created_utc=now_iso, backend=backend.name,
+        delivery={"aspect": d.aspect, "width": d.width, "height": d.height, "fps": d.fps,
+                  "codec": d.codec, "loudness_lufs": d.loudness_lufs},
+        workflow_versions=_workflow_versions(),
+        seeds=[s.seed for s, _ in pairs] + ([plan.music.seed] if plan.music else []),
+    )
+
+    # -- Phase 1: video production ----------------------------------------
+    clip_paths: dict[str, str] = {}
+    for shot, _t in pairs:
+        ensure.ensure_lane("wan", backend=backend.name)
+        frames = max(1, round(shot.target_seconds * d.fps))
+        path = backend.render_video(
+            prompt=shot.prompt_intent, width=d.width, height=d.height, frames=frames,
+            steps=WAN_STEPS, seed=shot.seed, fps=d.fps,
+            out_stem=os.path.join(prod_dir, "shots", shot.id),
+        )
+        clip_paths[shot.id] = path
+        pr = validators.ffprobe(path)
+        man.add(Artifact(
+            id=f"shot.{shot.id}", type="media", role="shot", path=rel(path), lane="wan",
+            seed=shot.seed, prompt_hash=sha256_text(shot.prompt_intent),
+            width=pr.width, height=pr.height, duration=pr.duration,
+            validation=validators.run_all(shot.validators, path, target_seconds=shot.target_seconds),
+        ))
+
+    durations = [validators.ffprobe(clip_paths[s.id]).duration for s, _ in pairs]
+    total = sum(durations)
+    starts = [sum(durations[:i]) for i in range(len(durations))]
+
+    # -- Phase 2: audio production ----------------------------------------
+    ensure.ensure_tts(backend=backend.name)
+    narration: dict[str, str] = {}
+    for shot, _t in pairs:
+        if shot.narration.strip():
+            wav = backend.tts(text=shot.narration, voice="", speed=1.0,
+                              out_stem=os.path.join(prod_dir, "audio", f"{shot.id}_vo"))
+            narration[shot.id] = wav
+            man.add(Artifact(
+                id=f"narration.{shot.id}", type="media", role="narration", path=rel(wav),
+                prompt_hash=sha256_text(shot.narration),
+                duration=validators.ffprobe(wav).duration,
+                validation=validators.run_all(["non_empty", "audio_present"], wav),
+            ))
+
+    bed = None
+    if plan.music:
+        ensure.ensure_lane("ace-step", backend=backend.name)
+        secs = plan.music.seconds or total
+        bed = backend.make_music(
+            tags=plan.music.tags, lyrics=plan.music.lyrics, seconds=secs,
+            steps=MUSIC_STEPS, cfg=MUSIC_CFG, seed=plan.music.seed,
+            out_stem=os.path.join(prod_dir, "audio", "bed"),
+        )
+        man.add(Artifact(
+            id="music.bed", type="media", role="music_bed", path=rel(bed), lane="ace-step",
+            seed=plan.music.seed, duration=validators.ffprobe(bed).duration,
+            validation=validators.run_all(["non_empty", "audio_present"], bed),
+        ))
+
+    # -- Phase 3: post-production (assemble) ------------------------------
+    narr_inputs: list[tuple[str, int]] = []
+    for i, (shot, t) in enumerate(pairs):
+        if shot.id in narration:
+            start_ms = max(0, int((starts[i] + t.narration_offset) * 1000))
+            narr_inputs.append((narration[shot.id], start_ms))
+    bed_level_db = pairs[0][1].music_level_db if pairs else -18.0
+
+    final_path = os.path.join(prod_dir, "assembly", "final.mp4")
+    cmd = _assemble.assemble(
+        final_path, [clip_paths[s.id] for s, _ in pairs], narr_inputs, bed,
+        fps=d.fps, lufs=d.loudness_lufs, bed_level_db=bed_level_db,
+    )
+    man.ffmpeg_cmds.append(cmd)
+    fpr = validators.ffprobe(final_path)
+    man.add(Artifact(
+        id="final.mp4", type="media", role="final", path=rel(final_path),
+        width=fpr.width, height=fpr.height, duration=fpr.duration,
+        validation=validators.run_all(["non_empty", "audio_present", "duration"], final_path),
+    ))
+    man.final = rel(final_path)
+
+    # -- exit criteria -----------------------------------------------------
+    vo_ok = []
+    for i, (shot, _t) in enumerate(pairs):
+        if shot.id in narration:
+            vo_dur = validators.ffprobe(narration[shot.id]).duration
+            vo_ok.append({"shot": shot.id, "vo_s": round(vo_dur, 2), "shot_s": round(durations[i], 2),
+                          "ok": vo_dur <= durations[i] + VO_TOLERANCE_S})
+    man.exit_criteria = {
+        "all_validators_pass": all(a.validation.get("ok") for a in man.artifacts),
+        "vo_within_tolerance": all(v["ok"] for v in vo_ok),
+        "vo_detail": vo_ok,
+        "final_has_audio": fpr.has_audio,
+        "final_duration_s": round(fpr.duration, 2),
+        "total_clip_s": round(total, 2),
+        "better_than_lane_by_lane": None,   # human judgment — printed as a prompt
+    }
+    man.write(prod_dir)
+    return {"prod_dir": prod_dir, "final": final_path, "manifest": man.to_dict()}

--- a/services/studio/production/executor.py
+++ b/services/studio/production/executor.py
@@ -78,7 +78,6 @@ def run_production(
 
     durations = [validators.ffprobe(clip_paths[s.id]).duration for s, _ in pairs]
     total = sum(durations)
-    starts = [sum(durations[:i]) for i in range(len(durations))]
 
     # -- Phase 2: audio production ----------------------------------------
     ensure.ensure_tts(backend=backend.name)
@@ -111,17 +110,21 @@ def run_production(
         ))
 
     # -- Phase 3: post-production (assemble) ------------------------------
-    narr_inputs: list[tuple[str, int]] = []
-    for i, (shot, t) in enumerate(pairs):
-        if shot.id in narration:
-            start_ms = max(0, int((starts[i] + t.narration_offset) * 1000))
-            narr_inputs.append((narration[shot.id], start_ms))
+    # narration as (path, shot_index, intra_offset) — assemble computes the
+    # crossfade-aware absolute start from the shot index.
+    narr_inputs = [
+        (narration[shot.id], i, t.narration_offset)
+        for i, (shot, t) in enumerate(pairs) if shot.id in narration
+    ]
+    # per-seam transitions — each governed by the transition_in of the clip the
+    # seam leads INTO (dissolve default, cut available).
+    transitions = [(t.transition_in, plan.assembly.transition_seconds) for (_s, t) in pairs[1:]]
     bed_level_db = pairs[0][1].music_level_db if pairs else -18.0
 
     final_path = os.path.join(prod_dir, "assembly", "final.mp4")
     cmd = _assemble.assemble(
-        final_path, [clip_paths[s.id] for s, _ in pairs], narr_inputs, bed,
-        fps=d.fps, lufs=d.loudness_lufs, bed_level_db=bed_level_db,
+        final_path, [clip_paths[s.id] for s, _ in pairs], durations, transitions, narr_inputs, bed,
+        fps=d.fps, lufs=d.loudness_lufs, bed_level_db=bed_level_db, duck_db=plan.assembly.duck_db,
     )
     man.ffmpeg_cmds.append(cmd)
     fpr = validators.ffprobe(final_path)

--- a/services/studio/production/lanes.py
+++ b/services/studio/production/lanes.py
@@ -1,0 +1,141 @@
+"""Lane backends — `live` (real studio services) and `synthetic` (ffmpeg lavfi).
+
+Backend methods take an `out_stem` (no extension) and return the ACTUAL path
+written (extension chosen by the lane), so the executor stays agnostic to whether
+a clip came from ComfyUI (.mp4), ACE (.mp3), Kokoro (.wav), or a synthetic source.
+
+The synthetic backend exists so the WHOLE executor → validators → assemble →
+manifest path runs offline (no GPU / ComfyUI / TTS) with real, ffprobe-able media —
+that's how v0a is verified before it ever touches the rig.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import urllib.request
+from abc import ABC, abstractmethod
+
+from . import comfy, config
+from .util import sh
+
+
+def _load_workflow(name: str) -> dict:
+    path = os.path.join(config.WORKFLOW_DIR, name)
+    with open(path) as f:
+        return json.load(f)
+
+
+class StudioBackend(ABC):
+    name = "abstract"
+
+    @abstractmethod
+    def render_video(self, *, prompt: str, width: int, height: int, frames: int,
+                     steps: int, seed: int, fps: int, out_stem: str) -> str: ...
+
+    @abstractmethod
+    def make_music(self, *, tags: str, lyrics: str, seconds: float, steps: int,
+                   cfg: float, seed: int, out_stem: str) -> str: ...
+
+    @abstractmethod
+    def tts(self, *, text: str, voice: str, speed: float, out_stem: str) -> str: ...
+
+
+# --------------------------------------------------------------------------- live
+class LiveBackend(StudioBackend):
+    """Drives the real ComfyUI (:8188) + Kokoro TTS (:8192)."""
+    name = "live"
+
+    def _comfy_to(self, fn: str, sub: str, out_stem: str) -> str:
+        src = os.path.join(config.OUTPUT_ROOT, sub, fn)
+        ext = os.path.splitext(fn)[1] or ".bin"
+        dst = out_stem + ext
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        shutil.copyfile(src, dst)
+        return dst
+
+    def render_video(self, *, prompt, width, height, frames, steps, seed, fps, out_stem) -> str:
+        wf = _load_workflow("wan22_rapid.json")
+        wf["pos"]["inputs"]["text"] = prompt
+        wf["latent"]["inputs"]["width"] = width
+        wf["latent"]["inputs"]["height"] = height
+        wf["latent"]["inputs"]["length"] = frames
+        wf["ksampler"]["inputs"]["steps"] = steps
+        wf["ksampler"]["inputs"]["seed"] = seed
+        wf["video"]["inputs"]["fps"] = float(fps)
+        fn, sub = comfy.await_output(comfy.submit(wf), "video")
+        return self._comfy_to(fn, sub, out_stem)
+
+    def make_music(self, *, tags, lyrics, seconds, steps, cfg, seed, out_stem) -> str:
+        wf = _load_workflow("ace_step_music.json")
+        wf["pos"]["inputs"]["tags"] = tags
+        wf["pos"]["inputs"]["lyrics"] = lyrics or "[instrumental]"
+        wf["latent"]["inputs"]["seconds"] = float(seconds)
+        wf["ksampler"]["inputs"]["steps"] = steps
+        wf["ksampler"]["inputs"]["cfg"] = cfg
+        wf["ksampler"]["inputs"]["seed"] = seed
+        fn, sub = comfy.await_output(comfy.submit(wf), "audio")
+        return self._comfy_to(fn, sub, out_stem)
+
+    def tts(self, *, text, voice, speed, out_stem) -> str:
+        body = {"text": text}
+        if voice:
+            body["voice"] = voice
+        if speed:
+            body["speed"] = speed
+        req = urllib.request.Request(
+            config.TTS_URL + "/tts", data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        r = json.load(urllib.request.urlopen(req, timeout=config.RENDER_TIMEOUT))
+        name = r.get("wav")
+        if not name:
+            raise RuntimeError(f"TTS returned no wav: {r}")
+        src = os.path.join(config.OUTPUT_ROOT, name)
+        dst = out_stem + ".wav"
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        shutil.copyfile(src, dst)
+        return dst
+
+
+# ---------------------------------------------------------------------- synthetic
+class SyntheticBackend(StudioBackend):
+    """ffmpeg-lavfi stand-ins: real media, real durations — no GPU/services.
+
+    Clips are silent solid-colour video (so `no_audio_expected` holds), narration is
+    a sine WAV sized to word-count (so VO-timing logic is exercised), music is a low
+    sine bed. Lets the full pipeline run + self-test offline.
+    """
+    name = "synthetic"
+
+    def render_video(self, *, prompt, width, height, frames, steps, seed, fps, out_stem) -> str:
+        dur = max(0.1, frames / float(fps or 16))
+        colour = "0x%06x" % (abs(hash((prompt, seed))) % 0xFFFFFF)
+        dst = out_stem + ".mp4"
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        sh(["ffmpeg", "-y", "-v", "error",
+            "-f", "lavfi", "-i", f"color=c={colour}:s={width}x{height}:r={fps}",
+            "-t", f"{dur:.3f}", "-c:v", "libx264", "-pix_fmt", "yuv420p", "-an", dst])
+        return dst
+
+    def make_music(self, *, tags, lyrics, seconds, steps, cfg, seed, out_stem) -> str:
+        dst = out_stem + ".wav"
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        sh(["ffmpeg", "-y", "-v", "error",
+            "-f", "lavfi", "-i", f"sine=frequency=180:duration={max(0.5, seconds):.3f}",
+            "-c:a", "pcm_s16le", dst])
+        return dst
+
+    def tts(self, *, text, voice, speed, out_stem) -> str:
+        words = max(1, len(text.split()))
+        dur = max(0.6, words * 0.4 / float(speed or 1.0))
+        dst = out_stem + ".wav"
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        sh(["ffmpeg", "-y", "-v", "error",
+            "-f", "lavfi", "-i", f"sine=frequency=440:duration={dur:.3f}",
+            "-c:a", "pcm_s16le", dst])
+        return dst
+
+
+def get_backend(name: str) -> StudioBackend:
+    return {"live": LiveBackend, "synthetic": SyntheticBackend}[name]()

--- a/services/studio/production/lanes.py
+++ b/services/studio/production/lanes.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import subprocess
 import urllib.request
 from abc import ABC, abstractmethod
 
@@ -24,6 +25,28 @@ def _load_workflow(name: str) -> dict:
     path = os.path.join(config.WORKFLOW_DIR, name)
     with open(path) as f:
         return json.load(f)
+
+
+def _pull(src_host: str, dst: str, *, container: str, container_path: str) -> str:
+    """Copy a service-written artifact into the production tree.
+
+    Tries a plain host copy first (ComfyUI writes 0666). If the service wrote the
+    file root-only (Kokoro TTS writes mode 0600), fall back to `docker cp` from the
+    owning container — the docker daemon reads it as root. Either way the result is
+    host-owned + 0644 so downstream ffmpeg can read it. Surfaced live on 2026-06-28;
+    the cleaner systemic fix is for the TTS service to write 0644 (a v0b follow-up).
+    """
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
+    try:
+        shutil.copyfile(src_host, dst)
+    except PermissionError:
+        subprocess.run(["docker", "cp", f"{container}:{container_path}", dst],
+                       check=True, capture_output=True, text=True)
+    try:
+        os.chmod(dst, 0o644)
+    except OSError:
+        pass
+    return dst
 
 
 class StudioBackend(ABC):
@@ -49,10 +72,8 @@ class LiveBackend(StudioBackend):
     def _comfy_to(self, fn: str, sub: str, out_stem: str) -> str:
         src = os.path.join(config.OUTPUT_ROOT, sub, fn)
         ext = os.path.splitext(fn)[1] or ".bin"
-        dst = out_stem + ext
-        os.makedirs(os.path.dirname(dst), exist_ok=True)
-        shutil.copyfile(src, dst)
-        return dst
+        cpath = "/output/" + (f"{sub}/{fn}" if sub else fn)
+        return _pull(src, out_stem + ext, container=config.COMFY_CONTAINER, container_path=cpath)
 
     def render_video(self, *, prompt, width, height, frames, steps, seed, fps, out_stem) -> str:
         wf = _load_workflow("wan22_rapid.json")
@@ -92,10 +113,8 @@ class LiveBackend(StudioBackend):
         if not name:
             raise RuntimeError(f"TTS returned no wav: {r}")
         src = os.path.join(config.OUTPUT_ROOT, name)
-        dst = out_stem + ".wav"
-        os.makedirs(os.path.dirname(dst), exist_ok=True)
-        shutil.copyfile(src, dst)
-        return dst
+        return _pull(src, out_stem + ".wav",
+                     container=config.TTS_CONTAINER, container_path="/output/" + name)
 
 
 # ---------------------------------------------------------------------- synthetic

--- a/services/studio/production/lock.py
+++ b/services/studio/production/lock.py
@@ -1,0 +1,64 @@
+"""Process-local single-flight lock for v0a (CLI/admin).
+
+v0a is CLI/admin-only, so a host file-lock is enough to guarantee one production
+job at a time (two `run`s can't render into the same ComfyUI queue concurrently).
+The durable queue + OWUI-exposed job lock are v0b/v1.
+"""
+from __future__ import annotations
+
+import errno
+import fcntl
+import os
+
+from . import config
+
+
+class ProductionLockHeld(RuntimeError):
+    pass
+
+
+class ProductionLock:
+    """Non-blocking flock on `<productions>/.run.lock`.
+
+    Usage:
+        with ProductionLock():
+            ...   # raises ProductionLockHeld immediately if another run holds it
+    """
+
+    def __init__(self, path: str | None = None):
+        self.path = path or os.path.join(config.PRODUCTIONS_DIR, ".run.lock")
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
+        self._fd = None
+
+    def acquire(self) -> "ProductionLock":
+        self._fd = os.open(self.path, os.O_CREAT | os.O_RDWR, 0o644)
+        try:
+            fcntl.flock(self._fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as e:
+            os.close(self._fd)
+            self._fd = None
+            if e.errno in (errno.EAGAIN, errno.EACCES):
+                raise ProductionLockHeld(
+                    f"another production run holds {self.path} — v0a is single-flight"
+                ) from e
+            raise
+        os.ftruncate(self._fd, 0)
+        os.write(self._fd, str(os.getpid()).encode())
+        return self
+
+    def release(self) -> None:
+        if self._fd is not None:
+            try:
+                fcntl.flock(self._fd, fcntl.LOCK_UN)
+            finally:
+                os.close(self._fd)
+                self._fd = None
+
+    def held(self) -> bool:
+        return self._fd is not None
+
+    def __enter__(self) -> "ProductionLock":
+        return self.acquire()
+
+    def __exit__(self, *exc) -> None:
+        self.release()

--- a/services/studio/production/manifest.py
+++ b/services/studio/production/manifest.py
@@ -1,0 +1,64 @@
+"""Typed, extensible production manifest.
+
+Records (a) run-level provenance — registry/workflow versions, seeds, the exact
+ffmpeg command, delivery profile — so a whole run reproduces, and (b) per-artifact
+records discriminated by `type`. v0a only writes `type="media"` records, but the
+shape already admits `type="llm_prompt"` so v0b prompt-provenance slots in with no
+redesign.
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+
+
+@dataclass
+class Artifact:
+    id: str
+    type: str            # "media" | "llm_prompt"  (v0a writes only "media")
+    role: str            # "shot" | "narration" | "music_bed" | "final"
+    path: str            # relative to the production dir
+    lane: str = ""
+    seed: int = 0
+    prompt_hash: str = ""
+    width: int = 0
+    height: int = 0
+    duration: float = 0.0
+    validation: dict = field(default_factory=dict)
+
+
+@dataclass
+class Manifest:
+    job_id: str
+    title: str
+    created_utc: str
+    backend: str                          # "live" | "synthetic"
+    schema_version: str = "ProductionPlanV1"
+    delivery: dict = field(default_factory=dict)
+    workflow_versions: dict = field(default_factory=dict)   # {"wan": sha, "ace-step": sha}
+    seeds: list = field(default_factory=list)
+    ffmpeg_cmds: list = field(default_factory=list)         # exact assemble commands
+    artifacts: list = field(default_factory=list)           # list[Artifact]
+    final: str = ""
+    exit_criteria: dict = field(default_factory=dict)
+
+    def add(self, art: Artifact) -> Artifact:
+        self.artifacts.append(art)
+        return art
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["artifacts"] = [asdict(a) if isinstance(a, Artifact) else a for a in self.artifacts]
+        return d
+
+    def write(self, prod_dir: str) -> str:
+        path = os.path.join(prod_dir, "manifest.json")
+        with open(path, "w") as f:
+            json.dump(self.to_dict(), f, indent=2)
+        return path
+
+    @staticmethod
+    def read(prod_dir: str) -> dict:
+        with open(os.path.join(prod_dir, "manifest.json")) as f:
+            return json.load(f)

--- a/services/studio/production/plans/lighthouse_3shot.json
+++ b/services/studio/production/plans/lighthouse_3shot.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "ProductionPlanV1",
+  "project": {
+    "title": "A Short History of Lighthouses",
+    "tone": "calm",
+    "target_seconds": 15,
+    "video_lane": "wan"
+  },
+  "delivery": {
+    "aspect": "16:9",
+    "width": 832,
+    "height": 480,
+    "fps": 16,
+    "codec": "h264",
+    "loudness_lufs": -14.0,
+    "subtitles": false
+  },
+  "shots": [
+    {
+      "id": "s1",
+      "lane": "wan",
+      "mode": "t2v",
+      "target_seconds": 5,
+      "prompt_intent": "dawn over a rocky New England cape, a white lighthouse silhouette, gentle swell, archival film grade",
+      "narration": "In 1716, the first American lighthouse rose over Boston Harbor.",
+      "seed": 12345
+    },
+    {
+      "id": "s2",
+      "lane": "wan",
+      "mode": "t2v",
+      "target_seconds": 5,
+      "prompt_intent": "slow reveal of a rotating Fresnel lens glowing amber inside the lamp room, warm light",
+      "narration": "Its rotating Fresnel lens could throw a beam for twenty miles.",
+      "seed": 23456
+    },
+    {
+      "id": "s3",
+      "lane": "wan",
+      "mode": "t2v",
+      "target_seconds": 5,
+      "prompt_intent": "a lighthouse at dusk in light fog, the beam sweeping across a calm sea, contemplative",
+      "narration": "Today most stand automated, quiet keepers of a fading craft.",
+      "seed": 34567
+    }
+  ],
+  "audio_layers": {
+    "narration": { "engine": "kokoro" },
+    "music": { "lane": "ace-step" }
+  },
+  "music": {
+    "lane": "ace-step",
+    "tags": "ambient, reflective, cinematic, soft piano, instrumental",
+    "lyrics": "[instrumental]",
+    "seed": 99
+  },
+  "timeline": [
+    { "clip": "s1", "narration_offset": 0.2, "music_level_db": -18 },
+    { "clip": "s2", "narration_offset": 0.0, "music_level_db": -18 },
+    { "clip": "s3", "narration_offset": 0.0, "music_level_db": -18 }
+  ]
+}

--- a/services/studio/production/plans/lighthouse_3shot.json
+++ b/services/studio/production/plans/lighthouse_3shot.json
@@ -54,9 +54,13 @@
     "lyrics": "[instrumental]",
     "seed": 99
   },
+  "assembly": {
+    "transition_seconds": 0.6,
+    "duck_db": 6
+  },
   "timeline": [
-    { "clip": "s1", "narration_offset": 0.2, "music_level_db": -18 },
-    { "clip": "s2", "narration_offset": 0.0, "music_level_db": -18 },
-    { "clip": "s3", "narration_offset": 0.0, "music_level_db": -18 }
+    { "clip": "s1", "narration_offset": 0.2, "music_level_db": -18, "transition_in": "dissolve" },
+    { "clip": "s2", "narration_offset": 0.0, "music_level_db": -18, "transition_in": "dissolve" },
+    { "clip": "s3", "narration_offset": 0.0, "music_level_db": -18, "transition_in": "dissolve" }
   ]
 }

--- a/services/studio/production/run.py
+++ b/services/studio/production/run.py
@@ -1,0 +1,91 @@
+"""v0a CLI: brief plan -> finished MP4.
+
+    python -m services.studio.production.run PLAN.json [--backend live|synthetic]
+
+CLI/admin only, single-flight (a host file-lock). `live` drives ComfyUI + Kokoro on
+the rig; `synthetic` uses ffmpeg lavfi stand-ins so the whole pipeline runs offline.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import re
+import sys
+
+from . import config
+from .executor import run_production
+from .lock import ProductionLock, ProductionLockHeld
+from .schema import PlanError, ProductionPlanV1
+
+
+def _slug(s: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", s.lower()).strip("-")[:40] or "production"
+
+
+def _job_id(title: str) -> str:
+    stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d-%H%M%S")
+    return f"{_slug(title)}-{stamp}-{os.urandom(2).hex()}"
+
+
+def _print_summary(summary: dict) -> bool:
+    man = summary["manifest"]
+    ec = man["exit_criteria"]
+    print("\n" + "=" * 64)
+    print(f"  PRODUCTION COMPLETE — {man['title']}  [{man['backend']}]")
+    print("=" * 64)
+    print(f"  final:      {summary['final']}")
+    print(f"  artifacts:  {len(man['artifacts'])}   dir: {summary['prod_dir']}")
+    print("  --- exit criteria " + "-" * 45)
+    print(f"  all validators pass : {ec['all_validators_pass']}")
+    print(f"  VO within tolerance : {ec['vo_within_tolerance']}   {ec['vo_detail']}")
+    print(f"  final has audio     : {ec['final_has_audio']}")
+    print(f"  final duration      : {ec['final_duration_s']}s  (clips {ec['total_clip_s']}s)")
+    print("  --- the decisive (human) question " + "-" * 29)
+    print("  > is this assembled MP4 better than picking lanes by hand?  [you decide]")
+    print("=" * 64)
+    failed = [a["id"] for a in man["artifacts"] if not a["validation"].get("ok")]
+    if failed:
+        print(f"  ⚠ validators FAILED on: {failed}")
+    return bool(ec["all_validators_pass"] and ec["vo_within_tolerance"] and ec["final_has_audio"])
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="studio-production", description="v0a: static plan -> MP4")
+    ap.add_argument("plan", help="path to a ProductionPlanV1 JSON")
+    ap.add_argument("--backend", choices=["live", "synthetic"], default="live",
+                    help="live = ComfyUI+Kokoro on the rig; synthetic = offline ffmpeg stand-ins")
+    ap.add_argument("--job-id", default=None, help="override the generated job id")
+    ap.add_argument("--productions-dir", default=config.PRODUCTIONS_DIR,
+                    help=f"base dir (default {config.PRODUCTIONS_DIR})")
+    args = ap.parse_args(argv)
+
+    try:
+        with open(args.plan) as f:
+            plan = ProductionPlanV1.from_dict(json.load(f))
+    except (OSError, json.JSONDecodeError, PlanError) as e:
+        print(f"[plan error] {e}", file=sys.stderr)
+        return 2
+
+    job_id = args.job_id or _job_id(plan.project.title)
+    now_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+    lock = ProductionLock(os.path.join(args.productions_dir, ".run.lock"))
+    try:
+        lock.acquire()
+    except ProductionLockHeld as e:
+        print(f"[locked] {e}", file=sys.stderr)
+        return 3
+    try:
+        summary = run_production(plan, backend_name=args.backend, job_id=job_id,
+                                 now_iso=now_iso, productions_dir=args.productions_dir)
+    finally:
+        lock.release()
+
+    ok = _print_summary(summary)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/studio/production/schema.py
+++ b/services/studio/production/schema.py
@@ -1,0 +1,147 @@
+"""ProductionPlanV1 — the validatable plan contract (v0a subset).
+
+stdlib dataclasses + an explicit `validate()` (host has no pydantic). The shape is
+forward-compatible with the full schema in the design doc; v0a only *enforces* the
+slice it executes (single pinned video lane = wan, t2v shots, one timeline entry
+per shot). Fields the design reserves but v0a ignores (creative_intent, style_bible,
+asset_dependencies, image_policy, takes, ...) are simply not modelled here yet.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+class PlanError(ValueError):
+    """Raised when a plan is structurally invalid (clear, actionable message)."""
+
+
+@dataclass
+class Delivery:
+    aspect: str = "16:9"
+    width: int = 832          # Wan native lo-res; v0a renders at delivery dims (no rescale)
+    height: int = 480
+    fps: int = 16             # Wan native rate
+    codec: str = "h264"
+    loudness_lufs: float = -14.0
+    subtitles: bool = False
+
+
+@dataclass
+class Shot:
+    id: str
+    lane: str                 # v0a: must equal project.video_lane ("wan")
+    mode: str                 # v0a: "t2v"
+    target_seconds: float
+    prompt_intent: str
+    narration: str = ""
+    seed: int = 0
+    validators: list = field(
+        default_factory=lambda: ["non_empty", "duration", "no_audio_expected"]
+    )
+
+
+@dataclass
+class Music:
+    lane: str = "ace-step"
+    tags: str = "ambient, reflective, cinematic, instrumental"
+    lyrics: str = "[instrumental]"
+    seconds: float = 0.0      # 0 => derived from total timeline duration at run time
+    seed: int = 0
+
+
+@dataclass
+class Project:
+    title: str
+    tone: str = ""
+    target_seconds: float = 0.0
+    video_lane: str = "wan"
+
+
+@dataclass
+class TimelineEntry:
+    clip: str                 # references Shot.id
+    narration_offset: float = 0.0
+    music_level_db: float = -18.0
+    transition_in: str = "cut"
+
+
+@dataclass
+class ProductionPlanV1:
+    project: Project
+    shots: list                       # list[Shot]
+    delivery: Delivery
+    timeline: list                    # list[TimelineEntry]
+    music: Optional[Music] = None
+    schema_version: str = "ProductionPlanV1"
+
+    # -- construction -------------------------------------------------------
+    @staticmethod
+    def from_dict(d: dict[str, Any]) -> "ProductionPlanV1":
+        try:
+            project = Project(**d["project"])
+            shots = [Shot(**s) for s in d["shots"]]
+            delivery = Delivery(**d.get("delivery", {}))
+            timeline = [TimelineEntry(**t) for t in d.get("timeline", [])]
+            music = Music(**d["music"]) if d.get("music") else None
+        except (KeyError, TypeError) as e:
+            raise PlanError(f"malformed plan: {e}") from e
+        plan = ProductionPlanV1(
+            project=project, shots=shots, delivery=delivery,
+            timeline=timeline, music=music,
+            schema_version=d.get("schema_version", "ProductionPlanV1"),
+        )
+        plan.validate()
+        return plan
+
+    # -- v0a validation -----------------------------------------------------
+    def validate(self) -> None:
+        if self.schema_version != "ProductionPlanV1":
+            raise PlanError(f"unsupported schema_version {self.schema_version!r}")
+        if self.project.video_lane != "wan":
+            raise PlanError(
+                f"v0a supports only video_lane='wan' (got {self.project.video_lane!r})"
+            )
+        if not self.shots:
+            raise PlanError("plan has no shots")
+
+        ids = [s.id for s in self.shots]
+        if len(ids) != len(set(ids)):
+            raise PlanError(f"duplicate shot ids: {ids}")
+
+        for s in self.shots:
+            if s.lane != self.project.video_lane:
+                raise PlanError(
+                    f"shot {s.id}: lane {s.lane!r} != pinned video_lane "
+                    f"{self.project.video_lane!r} (v0a pins one video lane)"
+                )
+            if s.mode != "t2v":
+                raise PlanError(f"shot {s.id}: v0a supports only mode='t2v' (got {s.mode!r})")
+            if s.target_seconds <= 0:
+                raise PlanError(f"shot {s.id}: target_seconds must be > 0")
+
+        # Timeline: one entry per shot, all references valid, order = play order.
+        known = set(ids)
+        seen: set[str] = set()
+        for t in self.timeline:
+            if t.clip not in known:
+                raise PlanError(f"timeline references unknown clip {t.clip!r}")
+            if t.clip in seen:
+                raise PlanError(f"timeline references clip {t.clip!r} twice")
+            seen.add(t.clip)
+        if seen != known:
+            missing = known - seen
+            raise PlanError(f"timeline missing shots: {sorted(missing)}")
+
+        if self.delivery.fps <= 0 or self.delivery.width <= 0 or self.delivery.height <= 0:
+            raise PlanError("delivery fps/width/height must be > 0")
+
+    def shot_by_id(self, sid: str) -> Shot:
+        for s in self.shots:
+            if s.id == sid:
+                return s
+        raise PlanError(f"no shot {sid!r}")
+
+    def ordered_shots(self) -> list:
+        """Shots in timeline (play) order."""
+        return [self.shot_by_id(t.clip) for t in self.timeline]

--- a/services/studio/production/schema.py
+++ b/services/studio/production/schema.py
@@ -51,6 +51,14 @@ class Music:
 
 
 @dataclass
+class Assembly:
+    """Deterministic post-production knobs (not 'brain' work)."""
+    transition_seconds: float = 0.6   # dissolve length between clips
+    duck_db: int = 6                  # bed duck depth under narration (gentler than the old ~12)
+    normalize: bool = True
+
+
+@dataclass
 class Project:
     title: str
     tone: str = ""
@@ -63,7 +71,7 @@ class TimelineEntry:
     clip: str                 # references Shot.id
     narration_offset: float = 0.0
     music_level_db: float = -18.0
-    transition_in: str = "cut"
+    transition_in: str = "dissolve"   # "dissolve" (default) | "cut" — transition INTO this clip
 
 
 @dataclass
@@ -73,6 +81,7 @@ class ProductionPlanV1:
     delivery: Delivery
     timeline: list                    # list[TimelineEntry]
     music: Optional[Music] = None
+    assembly: Assembly = field(default_factory=Assembly)
     schema_version: str = "ProductionPlanV1"
 
     # -- construction -------------------------------------------------------
@@ -84,11 +93,17 @@ class ProductionPlanV1:
             delivery = Delivery(**d.get("delivery", {}))
             timeline = [TimelineEntry(**t) for t in d.get("timeline", [])]
             music = Music(**d["music"]) if d.get("music") else None
-        except (KeyError, TypeError) as e:
+            _a = d.get("assembly", {}) or {}
+            assembly = Assembly(
+                transition_seconds=float(_a.get("transition_seconds", 0.6)),
+                duck_db=int(_a.get("duck_db", 6)),
+                normalize=bool(_a.get("normalize", True)),
+            )
+        except (KeyError, TypeError, ValueError) as e:
             raise PlanError(f"malformed plan: {e}") from e
         plan = ProductionPlanV1(
             project=project, shots=shots, delivery=delivery,
-            timeline=timeline, music=music,
+            timeline=timeline, music=music, assembly=assembly,
             schema_version=d.get("schema_version", "ProductionPlanV1"),
         )
         plan.validate()
@@ -128,6 +143,11 @@ class ProductionPlanV1:
                 raise PlanError(f"timeline references unknown clip {t.clip!r}")
             if t.clip in seen:
                 raise PlanError(f"timeline references clip {t.clip!r} twice")
+            if t.transition_in not in ("cut", "dissolve"):
+                raise PlanError(
+                    f"timeline {t.clip}: transition_in must be 'cut' or 'dissolve' "
+                    f"(got {t.transition_in!r})"
+                )
             seen.add(t.clip)
         if seen != known:
             missing = known - seen

--- a/services/studio/production/tests/test_v0a.py
+++ b/services/studio/production/tests/test_v0a.py
@@ -62,28 +62,54 @@ class TestSchema(unittest.TestCase):
         with self.assertRaises(PlanError):
             ProductionPlanV1.from_dict(_load(lambda d: d["shots"][0].update(mode="i2v")))
 
+    def test_transition_default_and_assembly_knobs(self):
+        plan = ProductionPlanV1.from_dict(_load())
+        self.assertTrue(all(t.transition_in == "dissolve" for t in plan.timeline))
+        self.assertEqual(plan.assembly.transition_seconds, 0.6)
+        self.assertEqual(plan.assembly.duck_db, 6)
+
+    def test_rejects_bad_transition(self):
+        with self.assertRaises(PlanError):
+            ProductionPlanV1.from_dict(_load(lambda d: d["timeline"][1].update(transition_in="wipe")))
+
 
 class TestAssembleCommand(unittest.TestCase):
-    def test_full_mix_graph(self):
+    def test_dissolve_mix_graph(self):
         cmd = assemble.build_mix_command(
             "/tmp/final.mp4",
             clips=["a.mp4", "b.mp4", "c.mp4"],
-            narrations=[("v1.wav", 200), ("v2.wav", 5000)],
-            bed="bed.wav", fps=16, lufs=-14.0, bed_level_db=-18,
+            durations=[5.0, 5.0, 5.0],
+            transitions=[("dissolve", 0.6), ("dissolve", 0.6)],
+            narrations=[("v1.wav", 0, 0.2), ("v2.wav", 1, 0.0)],
+            bed="bed.wav", fps=16, lufs=-14.0, bed_level_db=-18, duck_db=6,
         )
         fc = cmd[cmd.index("-filter_complex") + 1]
-        self.assertIn("concat=n=3:v=1:a=0[vid]", fc)
+        # dissolves -> xfade chain, not a hard concat
+        self.assertIn("xfade=transition=dissolve:duration=0.600", fc)
+        self.assertNotIn("concat=n=3", fc)
+        # narration delayed to crossfade-aware starts: shot0 @0.2s; shot1 @ (5-0.6)+0=4.4s
         self.assertIn("adelay=200|200", fc)
-        self.assertIn("sidechaincompress", fc)        # bed ducked under narration
+        self.assertIn("adelay=4400|4400", fc)
+        self.assertIn("sidechaincompress", fc)         # bed ducked under narration
+        self.assertIn("ratio=4", fc)                   # duck_db 6 -> ratio 4 (gentle)
         self.assertIn("asplit=2[nkey][nmix]", fc)      # narration split, used once each
         self.assertIn("loudnorm=I=-14.0", fc)
         self.assertIn("-shortest", cmd)
         self.assertEqual(cmd[-1], "/tmp/final.mp4")
 
+    def test_all_cut_uses_concat(self):
+        cmd = assemble.build_mix_command(
+            "/tmp/f.mp4", clips=["a.mp4", "b.mp4"], durations=[5.0, 5.0],
+            transitions=[("cut", 0.6)], narrations=[("v.wav", 0, 0.0)],
+            bed=None, fps=16, lufs=-14.0, bed_level_db=-18)
+        fc = cmd[cmd.index("-filter_complex") + 1]
+        self.assertIn("concat=n=2:v=1:a=0[vid]", fc)   # hard cuts -> concat, no xfade
+        self.assertNotIn("xfade", fc)
+
     def test_bed_only_no_narration(self):
         cmd = assemble.build_mix_command(
-            "/tmp/f.mp4", clips=["a.mp4"], narrations=[], bed="bed.wav",
-            fps=16, lufs=-14.0, bed_level_db=-18)
+            "/tmp/f.mp4", clips=["a.mp4"], durations=[5.0], transitions=[],
+            narrations=[], bed="bed.wav", fps=16, lufs=-14.0, bed_level_db=-18)
         fc = cmd[cmd.index("-filter_complex") + 1]
         self.assertNotIn("sidechaincompress", fc)
         self.assertIn("loudnorm", fc)

--- a/services/studio/production/tests/test_v0a.py
+++ b/services/studio/production/tests/test_v0a.py
@@ -1,0 +1,157 @@
+"""Offline v0a tests (stdlib unittest, no pydantic/pytest, no GPU/services).
+
+Run:  python3 -m unittest services.studio.production.tests.test_v0a -v
+      (from the repo root)
+
+The end-to-end test uses the `synthetic` backend (ffmpeg lavfi) so it exercises the
+WHOLE pipeline — render -> validate -> tts -> bed -> assemble -> manifest -> a real
+MP4 with an audio track — without ComfyUI, TTS, or a GPU.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+from .. import assemble, validators
+from ..lock import ProductionLock, ProductionLockHeld
+from ..schema import PlanError, ProductionPlanV1
+
+HERE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PLAN = os.path.join(HERE, "plans", "lighthouse_3shot.json")
+HAVE_FFMPEG = shutil.which("ffmpeg") and shutil.which("ffprobe")
+
+
+def _load(extra=None):
+    with open(PLAN) as f:
+        d = json.load(f)
+    if extra:
+        extra(d)
+    return d
+
+
+class TestSchema(unittest.TestCase):
+    def test_valid_plan_loads(self):
+        plan = ProductionPlanV1.from_dict(_load())
+        self.assertEqual(plan.project.video_lane, "wan")
+        self.assertEqual(len(plan.shots), 3)
+        self.assertEqual([s.id for s in plan.ordered_shots()], ["s1", "s2", "s3"])
+
+    def test_rejects_non_wan_video_lane(self):
+        with self.assertRaises(PlanError):
+            ProductionPlanV1.from_dict(_load(lambda d: d["project"].update(video_lane="ltx")))
+
+    def test_rejects_shot_lane_mismatch(self):
+        with self.assertRaises(PlanError):
+            ProductionPlanV1.from_dict(_load(lambda d: d["shots"][0].update(lane="sulphur")))
+
+    def test_rejects_duplicate_shot_ids(self):
+        def dup(d):
+            d["shots"][1]["id"] = "s1"
+            d["timeline"][1]["clip"] = "s1"
+        with self.assertRaises(PlanError):
+            ProductionPlanV1.from_dict(_load(dup))
+
+    def test_rejects_timeline_missing_shot(self):
+        with self.assertRaises(PlanError):
+            ProductionPlanV1.from_dict(_load(lambda d: d["timeline"].pop()))
+
+    def test_rejects_non_t2v_mode(self):
+        with self.assertRaises(PlanError):
+            ProductionPlanV1.from_dict(_load(lambda d: d["shots"][0].update(mode="i2v")))
+
+
+class TestAssembleCommand(unittest.TestCase):
+    def test_full_mix_graph(self):
+        cmd = assemble.build_mix_command(
+            "/tmp/final.mp4",
+            clips=["a.mp4", "b.mp4", "c.mp4"],
+            narrations=[("v1.wav", 200), ("v2.wav", 5000)],
+            bed="bed.wav", fps=16, lufs=-14.0, bed_level_db=-18,
+        )
+        fc = cmd[cmd.index("-filter_complex") + 1]
+        self.assertIn("concat=n=3:v=1:a=0[vid]", fc)
+        self.assertIn("adelay=200|200", fc)
+        self.assertIn("sidechaincompress", fc)        # bed ducked under narration
+        self.assertIn("asplit=2[nkey][nmix]", fc)      # narration split, used once each
+        self.assertIn("loudnorm=I=-14.0", fc)
+        self.assertIn("-shortest", cmd)
+        self.assertEqual(cmd[-1], "/tmp/final.mp4")
+
+    def test_bed_only_no_narration(self):
+        cmd = assemble.build_mix_command(
+            "/tmp/f.mp4", clips=["a.mp4"], narrations=[], bed="bed.wav",
+            fps=16, lufs=-14.0, bed_level_db=-18)
+        fc = cmd[cmd.index("-filter_complex") + 1]
+        self.assertNotIn("sidechaincompress", fc)
+        self.assertIn("loudnorm", fc)
+
+    def test_db_to_linear(self):
+        self.assertAlmostEqual(assemble.db_to_linear(0), 1.0)
+        self.assertAlmostEqual(assemble.db_to_linear(-6), 0.501, places=2)
+
+
+class TestValidators(unittest.TestCase):
+    @unittest.skipUnless(HAVE_FFMPEG, "ffmpeg/ffprobe required")
+    def test_silent_clip_and_audio(self):
+        with tempfile.TemporaryDirectory() as td:
+            vid = os.path.join(td, "v.mp4")
+            wav = os.path.join(td, "a.wav")
+            from ..util import sh
+            sh(["ffmpeg", "-y", "-v", "error", "-f", "lavfi", "-i",
+                "color=c=0x102030:s=320x240:r=16", "-t", "2", "-c:v", "libx264",
+                "-pix_fmt", "yuv420p", "-an", vid])
+            sh(["ffmpeg", "-y", "-v", "error", "-f", "lavfi", "-i",
+                "sine=frequency=440:duration=2", "-c:a", "pcm_s16le", wav])
+            self.assertTrue(validators.run_all(["non_empty", "no_audio_expected", "duration"],
+                                               vid, target_seconds=2)["ok"])
+            self.assertTrue(validators.run_all(["non_empty", "audio_present"], wav)["ok"])
+            # a silent clip must FAIL audio_present
+            self.assertFalse(validators.check("audio_present", vid)[0])
+
+
+class TestLock(unittest.TestCase):
+    def test_single_flight(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = os.path.join(td, ".run.lock")
+            a = ProductionLock(p).acquire()
+            try:
+                with self.assertRaises(ProductionLockHeld):
+                    ProductionLock(p).acquire()
+            finally:
+                a.release()
+            ProductionLock(p).acquire().release()   # free again
+
+
+class TestEndToEndSynthetic(unittest.TestCase):
+    @unittest.skipUnless(HAVE_FFMPEG, "ffmpeg/ffprobe required")
+    def test_full_pipeline_offline(self):
+        from ..executor import run_production
+        with tempfile.TemporaryDirectory() as td:
+            plan = ProductionPlanV1.from_dict(_load())
+            summary = run_production(plan, backend_name="synthetic", job_id="test-job",
+                                     now_iso="2026-01-01T00:00:00Z", productions_dir=td)
+            man = summary["manifest"]
+            # a real final MP4 with an audio track exists
+            self.assertTrue(os.path.isfile(summary["final"]))
+            fpr = validators.ffprobe(summary["final"])
+            self.assertGreater(fpr.duration, 10)        # ~15s of clips
+            self.assertTrue(fpr.has_audio)
+            # manifest: typed records, run-level provenance, exit criteria
+            self.assertEqual({a["type"] for a in man["artifacts"]}, {"media"})
+            roles = sorted({a["role"] for a in man["artifacts"]})
+            self.assertEqual(roles, ["final", "music_bed", "narration", "shot"])
+            self.assertEqual(len(man["ffmpeg_cmds"]), 1)
+            self.assertIn("wan", man["workflow_versions"])
+            self.assertTrue(man["exit_criteria"]["all_validators_pass"])
+            self.assertTrue(man["exit_criteria"]["final_has_audio"])
+            # manifest.json was written + reloads
+            with open(os.path.join(summary["prod_dir"], "manifest.json")) as f:
+                reloaded = json.load(f)
+            self.assertEqual(reloaded["job_id"], "test-job")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/studio/production/util.py
+++ b/services/studio/production/util.py
@@ -1,0 +1,29 @@
+"""Small shared helpers."""
+from __future__ import annotations
+
+import hashlib
+import subprocess
+
+
+class FFError(RuntimeError):
+    pass
+
+
+def sh(cmd: list[str], timeout: int = 600) -> str:
+    """Run a subprocess, raise FFError with tail of stderr on failure. Returns stdout."""
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    if r.returncode != 0:
+        raise FFError(f"{cmd[0]} failed ({r.returncode}): {(r.stderr or '')[-600:]}")
+    return r.stdout
+
+
+def sha256_file(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return "sha256:" + h.hexdigest()
+
+
+def sha256_text(text: str) -> str:
+    return "sha256:" + hashlib.sha256(text.encode()).hexdigest()

--- a/services/studio/production/validators.py
+++ b/services/studio/production/validators.py
@@ -1,0 +1,84 @@
+"""ffprobe-backed validators — transport-success != real success.
+
+A rendered file existing is not enough (Ideogram placeholders, LTX collapse, audio
+truncation all "succeed" at the file layer). These check the actual media: duration,
+audio presence, dimensions, non-emptiness. v0a wires the cheap subset; richer checks
+(placeholder / near-uniform-frame detection) are v1.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+
+
+@dataclass
+class ProbeResult:
+    duration: float = 0.0
+    has_audio: bool = False
+    width: int = 0
+    height: int = 0
+    size_bytes: int = 0
+
+
+def ffprobe(path: str) -> ProbeResult:
+    """Probe a media file. Returns zeros if the file is missing/unreadable."""
+    r = ProbeResult()
+    if not (path and os.path.isfile(path)):
+        return r
+    r.size_bytes = os.path.getsize(path)
+    try:
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-show_entries",
+             "format=duration:stream=codec_type,width,height",
+             "-of", "json", path],
+            capture_output=True, text=True, timeout=30,
+        ).stdout
+        data = json.loads(out or "{}")
+    except Exception:
+        return r
+    try:
+        r.duration = float(data.get("format", {}).get("duration") or 0.0)
+    except (TypeError, ValueError):
+        r.duration = 0.0
+    for s in data.get("streams", []):
+        if s.get("codec_type") == "audio":
+            r.has_audio = True
+        if s.get("codec_type") == "video":
+            r.width = int(s.get("width") or 0)
+            r.height = int(s.get("height") or 0)
+    return r
+
+
+# -- individual checks: (name) -> (ok: bool, detail: str) ---------------------
+
+def check(name: str, path: str, *, target_seconds: float = 0.0, tol: float = 1.5) -> tuple[bool, str]:
+    p = ffprobe(path)
+    if name == "non_empty":
+        ok = p.size_bytes > 0
+        return ok, f"{p.size_bytes} bytes"
+    if name == "duration":
+        if target_seconds <= 0:
+            return p.duration > 0, f"{p.duration:.2f}s"
+        ok = abs(p.duration - target_seconds) <= tol
+        return ok, f"{p.duration:.2f}s vs target {target_seconds:.2f}s (±{tol})"
+    if name == "no_audio_expected":
+        return (not p.has_audio), ("has audio!" if p.has_audio else "silent (ok)")
+    if name == "audio_present":
+        return p.has_audio, ("audio present" if p.has_audio else "NO audio track")
+    if name == "has_video":
+        ok = p.width > 0 and p.height > 0
+        return ok, f"{p.width}x{p.height}"
+    return False, f"unknown validator {name!r}"
+
+
+def run_all(names: list[str], path: str, *, target_seconds: float = 0.0) -> dict:
+    """Run a list of validators against one artifact. Returns a result dict."""
+    results = {}
+    ok_all = True
+    for n in names:
+        ok, detail = check(n, path, target_seconds=target_seconds)
+        results[n] = {"ok": ok, "detail": detail}
+        ok_all = ok_all and ok
+    return {"ok": ok_all, "checks": results}


### PR DESCRIPTION
## What

The **v0a executor spike** for the Production Agent (`docs/ai-studio-production-agent-design.md`): one static `ProductionPlanV1` → a finished MP4 by driving the existing AI-Studio lanes serially — **Wan t2v ×3 → Kokoro narration → ACE-Step bed → ffmpeg mix**. CLI/admin only, single-flight, one pinned video lane, ffprobe validators, final mix at the delivery profile, typed manifest with run-level provenance.

This proves the *runtime* question the design couldn't: **can the executor drive the real lanes, collect + validate artifacts, and assemble something watchable without babysitting?**

## Results

| Check | Result |
|---|---|
| **offline synthetic E2E** (ffmpeg-lavfi, no GPU) | ✅ 12/12 unittests, real MP4 with audio + manifest |
| **live ai-studio 3-shot** | ✅ **PASS** (rc=0) |
| final MP4 | **832×480 h264 + aac**, 13.4s, 928 KB |
| wall time | **432s** warm (453s cold) |
| all validators pass | ✅ 3 Wan clips · 3 Kokoro VO · ACE bed · final |
| manifest written | ✅ delivery · workflow sha256s · seeds · exact ffmpeg argv |
| **babysitting** | **none** on the clean run |

## What the spike surfaced (the real payoff)

1. **Permission integration bug** (fixed here): Kokoro TTS writes its WAV `0600 root:root`, so the host CLI (uid 1000) can't read it (ComfyUI writes `0666`, so video/music copied fine). `_pull()` now falls back to `docker cp` from the owning container. The cleaner systemic fix — TTS writing `0644` — is a noted v0b follow-up.
2. **VO overran its shot** — s1's narration (5.53s) is longer than its 4.81s Wan window (within tolerance, but real). This is concrete evidence for **VO-first mode** (v0b): lock narration, size clips to it.

## Scope / isolation

- Entirely under `services/studio/production/` — **zero edits elsewhere**.
- **stdlib-only** (host has no pydantic/pytest): dataclasses + `validate()`, `unittest`. A `synthetic` ffmpeg-lavfi backend runs the whole pipeline offline; `live` drives ComfyUI (:8188) + Kokoro (:8192) and **replicates** the studio_pipe calls (doesn't import the OWUI pipe).
- Generated MP4s/manifests land under `/mnt/models/comfyui/output/productions/` (outside the repo) — not committed.

## Deferred to v0b/v1 (per design)

4B planner · skills · image lanes / asset-DAG · takes + rerender · Qdrant/SearXNG · durable queue · OWUI lane + the systemic TTS-perm fix.

## Run it

```bash
python3 -m services.studio.production.run \
    services/studio/production/plans/lighthouse_3shot.json --backend synthetic   # offline
gpu-mode ai-studio && python3 -m services.studio.production.run \
    services/studio/production/plans/lighthouse_3shot.json --backend live         # on the rig
python3 -m unittest services.studio.production.tests.test_v0a -v                  # tests
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
