### PR TITLE
Studio Production Agent v0b-core — 4B director plans a brief (offline + live PASS)

### DIFF
--- a/services/studio/production/README.md
+++ b/services/studio/production/README.md
@@ -1,20 +1,22 @@
-# Studio Production Agent — v0a
+# Studio Production Agent — v0a + v0b-core
 
-One static brief → a finished MP4, by driving the **existing** AI-Studio lanes
-serially (Wan video · Kokoro narration · ACE-Step bed → ffmpeg mix). This is the
-**v0a executor spike** from
-[`/opt/ai/docs/ai-studio-production-agent-design.md`](../../../../docs/ai-studio-production-agent-design.md):
-prove the executor + assembly can drive the lanes, collect + validate artifacts,
-and assemble something watchable **without manual babysitting**.
+Brief → a finished MP4, by driving the **existing** AI-Studio lanes serially (Wan
+video · Kokoro narration · ACE-Step bed → ffmpeg mix). From
+[`/opt/ai/docs/ai-studio-production-agent-design.md`](../../../../docs/ai-studio-production-agent-design.md).
 
-**v0a scope (deliberately tight):** CLI/admin only · no OWUI lane · single-flight
-(host file-lock) · **static** hand-authored `ProductionPlanV1` · one pinned video
-lane (`wan`, t2v) · ffprobe validators · final ffmpeg mix at the delivery profile ·
-typed/extensible manifest with run-level provenance.
+- **v0a** — a *static* hand-authored `ProductionPlanV1` → MP4 (the executor + assembly).
+- **v0b-core** — the **4B director** (`qwen3.5-4b-uncensored` @ `:8090`) *plans* a
+  one-line brief into a valid `ProductionPlanV1` — against the capability registry
+  (`capabilities.yaml`) + a prompt pack, with a **validator-repair loop** (parse →
+  `schema.validate()` → feed errors back) — then the v0a executor renders it.
+  Prompt provenance is stored as `llm_prompt` manifest records under `prompts/`.
 
-**Deferred to v0b/v1:** the 4B planner, skills, image lanes / asset-DAG, takes +
-rerender, Qdrant/SearXNG, durable queue, OWUI lane. (The manifest is already typed
-so v0b prompt-provenance records slot in with no redesign.)
+**Scope (deliberately tight):** CLI/admin only · single-flight (host file-lock) · one
+pinned video lane (`wan`, t2v) · ffprobe validators · ffmpeg mix at the delivery
+profile · typed manifest with run-level provenance.
+
+**Deferred to v0b-images / v1:** image lanes + `image_policy` roles + asset-DAG
+(continuity), skills, takes + rerender, Qdrant/SearXNG, durable queue, OWUI lane.
 
 ## Run
 
@@ -25,7 +27,12 @@ so v0b prompt-provenance records slot in with no redesign.)
 python3 -m services.studio.production.run \
     services/studio/production/plans/lighthouse_3shot.json --backend synthetic
 
-# live — drives ComfyUI (:8188) + Kokoro TTS (:8192); needs the ai-studio scene up:
+# v0b — the 4B director PLANS a brief, then renders it (needs the ai-studio scene up):
+gpu-mode ai-studio
+python3 -m services.studio.production.run \
+    --brief "a 15-second calm documentary about lighthouses" --backend live --shots 3
+
+# v0a live — a static plan; drives ComfyUI (:8188) + Kokoro TTS (:8192):
 gpu-mode ai-studio        # bring the scene up first
 python3 -m services.studio.production.run \
     services/studio/production/plans/lighthouse_3shot.json --backend live
@@ -42,12 +49,14 @@ question: *is this better than picking lanes by hand?*
 ## Tests (offline, stdlib only — no pydantic/pytest/GPU)
 
 ```bash
-python3 -m unittest services.studio.production.tests.test_v0a -v
+python3 -m unittest services.studio.production.tests.test_v0a \
+                     services.studio.production.tests.test_v0b -v
 ```
 
-The end-to-end test runs the **whole** pipeline on the synthetic backend and
-asserts a real MP4 with an audio track + a well-formed manifest — so the logic is
-verified before it ever touches the rig.
+`test_v0a` runs the **whole** render pipeline on the synthetic backend (real MP4 +
+manifest). `test_v0b` drives the planner with a **stub LLM** — prompt construction,
+JSON extraction, normalization, and the validator-repair loop — so both the executor
+and the planner are verified before touching the rig.
 
 ## Layout
 
@@ -62,5 +71,9 @@ verified before it ever touches the rig.
 | `manifest.py` | typed, extensible manifest + run-level provenance |
 | `lock.py` | single-flight host file-lock |
 | `executor.py` | the four-phase loop (video → audio → post) |
-| `run.py` | CLI + exit-criteria summary |
-| `plans/` | static `ProductionPlanV1` JSON |
+| `capabilities.yaml` | lane capability registry — the planner's menu (wan/kokoro/ace) |
+| `registry.py` | load the registry + compress it into the planner's prompt slice |
+| `prompts.py` | the planner prompt pack (treatment + plan + repair) |
+| `planner.py` | the 4B director: brief → plan, with the validator-repair loop |
+| `run.py` | CLI (`PLAN.json` for v0a, `--brief "…"` for v0b) + exit-criteria summary |
+| `plans/` | static `ProductionPlanV1` JSON (v0a) |

--- a/services/studio/production/capabilities.yaml
+++ b/services/studio/production/capabilities.yaml
@@ -1,0 +1,67 @@
+# Lane capability registry — "what the machine can do."
+#
+# The planner chooses lanes ONLY from here (for video, only the production's pinned
+# `project.video_lane`). The executor + validators are AUTHORITATIVE: a plan that
+# violates a contract is repaired (validator-repair loop) or rejected — never
+# executed as-is. A skill/plan may guide creativity, but it never overrides this.
+#
+# v0b-core lanes: wan (video) · kokoro (narration) · ace-step (music).
+# Image lanes (hidream/chroma/krea/ideogram) + `image_policy` roles + asset
+# dependencies land in v0b-images — NOT available to the planner yet.
+
+version: 1
+
+video_lanes:
+  wan:
+    kind: video
+    supports: [t2v, i2v]            # i2v exists but v0b-core plans t2v only
+    inputs:
+      t2v: [prompt]
+      i2v: [prompt, start_image]
+    outputs: [mp4]
+    audio_behavior: none           # Wan clips are SILENT (no synced audio)
+    native_fps: 16
+    native_window_seconds: 5.06    # 81 frames @ 16 fps — one window
+    duration_limits:
+      min_seconds: 1
+      max_seconds: 5.1             # one native window; longer needs chaining (v1)
+    prompt_format: prose
+    resource_class: dual_card_dit  # DisTorch DiT across both 3090s
+    validators: [non_empty, duration, no_audio_expected]
+    when_to_use: "the one pinned video lane for a whole production"
+    avoid_when: "you need synced native audio in the clip, or a single shot > ~5 s"
+
+audio_lanes:
+  kokoro:
+    kind: narration
+    inputs: [text]
+    outputs: [wav]
+    audio_behavior: voice
+    prompt_format: plain_text      # narration sentences, NOT a generation prompt
+    words_per_second: 2.5          # rough, for VO-length budgeting (v0b VO-first)
+    resource_class: cpu
+    validators: [non_empty, audio_present]
+    when_to_use: "spoken narration / voiceover"
+    avoid_when: "you need a specific cloned voice (that is step-voice, premium, on-demand)"
+
+  ace-step:
+    kind: music
+    inputs: [tags, lyrics, seconds]
+    outputs: [mp3]
+    audio_behavior: music
+    prompt_format: tags_plus_lyrics  # comma-tags + [verse]/[chorus] structure, or [instrumental]
+    duration_limits:
+      min_seconds: 5
+      max_seconds: 240
+    resource_class: gpu0
+    validators: [non_empty, audio_present]
+    when_to_use: "one music bed under the whole piece"
+    avoid_when: "you need a specific licensed track"
+
+# Production-level rules the planner MUST honor (enforced by schema.validate()).
+rules:
+  - "Pin ONE video_lane for the whole production (project.video_lane); EVERY shot uses it."
+  - "Each shot: id, mode=t2v, target_seconds (<= the lane's native window), prompt_intent, optional narration."
+  - "Image lanes / asset dependencies are NOT available in v0b-core."
+  - "The timeline lists every shot exactly once, in play order, each with transition_in (dissolve|cut)."
+  - "If an idea exceeds a lane limit, ADAPT the idea (shorter shot, split into two) — never break the limit."

--- a/services/studio/production/config.py
+++ b/services/studio/production/config.py
@@ -12,6 +12,9 @@ import os
 COMFYUI_URL = os.environ.get("COMFYUI_URL", "http://localhost:8188").rstrip("/")
 TTS_URL = os.environ.get("TTS_URL", "http://localhost:8192").rstrip("/")
 VOICE_URL = os.environ.get("VOICE_URL", "http://localhost:8193").rstrip("/")
+# The director LLM (qwen3.5-4b-uncensored on llama.cpp) — the v0b planner.
+DIRECTOR_URL = os.environ.get("DIRECTOR_URL", "http://localhost:8090/v1").rstrip("/")
+DIRECTOR_MODEL = os.environ.get("DIRECTOR_MODEL", "qwen3.5-4b-uncensored")
 
 # ComfyUI's host output root (mounted at /output in the studio containers). All
 # lanes write here; we scope productions under `<root>/productions/<job_id>/`.

--- a/services/studio/production/executor.py
+++ b/services/studio/production/executor.py
@@ -7,6 +7,8 @@ shows up as `zero_manual_restarts=False` in the summary).
 """
 from __future__ import annotations
 
+import dataclasses
+import json
 import os
 
 from . import assemble as _assemble
@@ -38,6 +40,7 @@ def run_production(
     job_id: str,
     now_iso: str,
     productions_dir: str = config.PRODUCTIONS_DIR,
+    extra_artifacts: list = (),
 ) -> dict:
     backend = get_backend(backend_name)
     d = plan.delivery
@@ -56,6 +59,10 @@ def run_production(
         workflow_versions=_workflow_versions(),
         seeds=[s.seed for s, _ in pairs] + ([plan.music.seed] if plan.music else []),
     )
+    for a in (extra_artifacts or []):   # planner llm_prompt provenance (v0b)
+        man.add(a)
+    with open(os.path.join(prod_dir, "production.json"), "w") as f:
+        json.dump(dataclasses.asdict(plan), f, indent=2)
 
     # -- Phase 1: video production ----------------------------------------
     clip_paths: dict[str, str] = {}

--- a/services/studio/production/executor.py
+++ b/services/studio/production/executor.py
@@ -150,7 +150,10 @@ def run_production(
             vo_ok.append({"shot": shot.id, "vo_s": round(vo_dur, 2), "shot_s": round(durations[i], 2),
                           "ok": vo_dur <= durations[i] + VO_TOLERANCE_S})
     man.exit_criteria = {
-        "all_validators_pass": all(a.validation.get("ok") for a in man.artifacts),
+        # only MEDIA artifacts carry validators; llm_prompt provenance is excluded.
+        "all_validators_pass": all(
+            a.validation.get("ok", False) for a in man.artifacts if a.type == "media"
+        ),
         "vo_within_tolerance": all(v["ok"] for v in vo_ok),
         "vo_detail": vo_ok,
         "final_has_audio": fpr.has_audio,

--- a/services/studio/production/planner.py
+++ b/services/studio/production/planner.py
@@ -1,0 +1,159 @@
+"""The 4B planner — brief -> validated ProductionPlanV1.
+
+Two-stage, creative-within-bounds: (1) a free-form creative treatment, then
+(2) a structured plan, then a **validator-repair loop** — parse the director's JSON,
+`schema.validate()` it, and on any failure feed the exact error back asking for a
+corrected JSON (up to `max_repairs`). The repair loop is the backbone (we do NOT
+rely on server-side constrained output, which is flaky on this build).
+
+The director call is injectable (`llm=`) so the whole planner — prompt construction,
+normalization, and the repair loop — is unit-testable offline with a stub LLM, no
+model required (mirrors the synthetic lane backend).
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+
+from . import config
+from .manifest import Artifact
+from .prompts import TREATMENT_SYS, build_plan_system, repair_user
+from .schema import PlanError, ProductionPlanV1
+from .util import sha256_text
+
+
+class PlannerError(RuntimeError):
+    pass
+
+
+# -- director call (the injectable boundary) ----------------------------------
+def director_call(messages: list[dict], *, max_tokens: int, temperature: float,
+                  base: str | None = None, timeout: int = 120) -> str:
+    """One /v1/chat/completions call to the llama.cpp director. Returns content."""
+    payload = {
+        "model": config.DIRECTOR_MODEL,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    req = urllib.request.Request(
+        (base or config.DIRECTOR_URL).rstrip("/") + "/chat/completions",
+        data=json.dumps(payload).encode(), headers={"Content-Type": "application/json"},
+    )
+    r = json.load(urllib.request.urlopen(req, timeout=timeout))
+    return r["choices"][0]["message"]["content"].strip()
+
+
+# -- robust JSON extraction (director emits free-form) ------------------------
+def extract_json(text: str) -> dict:
+    """Pull the first balanced {...} object out of the director's reply."""
+    t = (text or "").strip()
+    if t.startswith("```"):
+        t = t.strip("`")
+        t = t[4:] if t[:4].lower() == "json" else t
+        t = t.strip()
+    i = t.find("{")
+    if i < 0:
+        raise ValueError("no JSON object in director output")
+    depth = 0
+    for j in range(i, len(t)):
+        if t[j] == "{":
+            depth += 1
+        elif t[j] == "}":
+            depth -= 1
+            if depth == 0:
+                return json.loads(t[i:j + 1])
+    raise ValueError("unbalanced JSON in director output")
+
+
+# -- lenient normalization (fill obvious defaults so the 4B can be terse) -----
+def normalize(data: dict, video_lane: str = "wan") -> dict:
+    data.setdefault("schema_version", "ProductionPlanV1")
+    proj = data.setdefault("project", {})
+    proj.setdefault("video_lane", video_lane)
+    proj.setdefault("title", "Untitled")
+    vl = proj.get("video_lane", video_lane)
+    shots = data.get("shots") or []
+    for i, s in enumerate(shots):
+        s.setdefault("id", f"s{i + 1}")
+        s.setdefault("lane", vl)
+        s.setdefault("mode", "t2v")
+        s.setdefault("prompt_intent", "")
+    data.setdefault("delivery", {"aspect": "16:9", "width": 832, "height": 480,
+                                 "fps": 16, "loudness_lufs": -14.0})
+    data.setdefault("assembly", {"transition_seconds": 0.6, "duck_db": 6})
+    if not data.get("music"):
+        data["music"] = {"lane": "ace-step", "tags": "ambient, cinematic, instrumental",
+                         "lyrics": "[instrumental]", "seed": 7}
+    if not data.get("timeline"):
+        data["timeline"] = [
+            {"clip": s["id"], "narration_offset": 0.0, "music_level_db": -18,
+             "transition_in": "dissolve"} for s in shots
+        ]
+    return data
+
+
+# -- the planner --------------------------------------------------------------
+def plan_from_brief(brief: str, reg: dict, *, llm=None, max_repairs: int = 3,
+                    n_shots: int = 3, prompts_dir: str | None = None):
+    """Brief -> (ProductionPlanV1, list[Artifact]). Raises PlannerError on failure.
+
+    `llm(messages, *, max_tokens, temperature)` is the injectable director call.
+    """
+    call = llm or director_call
+    prov: list[tuple[str, str, str, str]] = []   # (role, system, user, response)
+
+    # stage 1 — creative treatment (free-form)
+    treatment = call([{"role": "system", "content": TREATMENT_SYS},
+                      {"role": "user", "content": brief}],
+                     max_tokens=400, temperature=0.8)
+    prov.append(("treatment", TREATMENT_SYS, brief, treatment))
+
+    # stage 2 — structured plan
+    plan_sys = build_plan_system(reg, n_shots=n_shots)
+    plan_user = f"BRIEF: {brief}\n\nTREATMENT:\n{treatment}\n\nNow output the ProductionPlanV1 JSON only."
+    raw = call([{"role": "system", "content": plan_sys}, {"role": "user", "content": plan_user}],
+               max_tokens=900, temperature=0.4)
+    prov.append(("plan", plan_sys, plan_user, raw))
+
+    # validator-repair loop
+    last_err = None
+    for attempt in range(max_repairs + 1):
+        try:
+            data = normalize(extract_json(raw))
+            plan = ProductionPlanV1.from_dict(data)     # validates
+            return plan, _write_provenance(prov, prompts_dir)
+        except (PlanError, ValueError, json.JSONDecodeError) as e:
+            last_err = str(e)
+            if attempt == max_repairs:
+                break
+            ru = repair_user(raw, last_err)
+            raw = call([{"role": "system", "content": plan_sys}, {"role": "user", "content": ru}],
+                       max_tokens=900, temperature=0.2)
+            prov.append((f"repair_{attempt + 1}", plan_sys, ru, raw))
+
+    _write_provenance(prov, prompts_dir)   # keep the failed trail for debugging
+    raise PlannerError(
+        f"director could not produce a valid plan after {max_repairs} repairs: {last_err}"
+    )
+
+
+def _write_provenance(prov, prompts_dir) -> list[Artifact]:
+    """Write each LLM step to prompts/<role>.json and return llm_prompt records."""
+    arts: list[Artifact] = []
+    if prompts_dir:
+        os.makedirs(prompts_dir, exist_ok=True)
+    for (role, system, user, resp) in prov:
+        rel = f"prompts/{role}.json"
+        if prompts_dir:
+            with open(os.path.join(prompts_dir, f"{role}.json"), "w") as f:
+                json.dump({"model": config.DIRECTOR_MODEL, "role": role,
+                           "system": system, "user": user, "response": resp}, f, indent=2)
+        arts.append(Artifact(
+            id=f"prompt.{role}", type="llm_prompt", role=role, path=rel,
+            lane="director", prompt_hash=sha256_text(system + "" + user),
+            validation={"response_hash": sha256_text(resp)},
+        ))
+    return arts

--- a/services/studio/production/prompts.py
+++ b/services/studio/production/prompts.py
@@ -39,7 +39,7 @@ ProductionPlanV1 shape:
 Guidance (be inventive WITHIN these bounds):
 - Aim for {n_shots} shots. Each shot is ONE Wan window (<= 5 s), so keep target_seconds 4-5.
 - prompt_intent: vivid, cinematic prose for the video model (one shot's worth of imagery).
-- narration: ONE spoken sentence the viewer hears over that shot. Keep it short enough to fit (~2.5 words per second), so a 5 s shot is ~12 words max.
+- narration: ONE spoken sentence the viewer hears over that shot, in ENGLISH ONLY (no other-language words). Keep it short enough to fit (~2.5 words per second), so a 5 s shot is AT MOST 10 words.
 - If an idea needs more than ~5 s, SPLIT it into two shots — never exceed the limit.
 - Every shot needs a UNIQUE id. The timeline lists EVERY shot exactly once, in play order.
 - OUTPUT ONLY THE JSON OBJECT."""

--- a/services/studio/production/prompts.py
+++ b/services/studio/production/prompts.py
@@ -1,0 +1,54 @@
+"""The planner prompt pack — the 4B director's 'tight operating manual.'
+
+Creative-within-bounds: the director is free in the film-making layer (angle, tone,
+shot concepts, narration, mood) but the OUTPUT must be a valid ProductionPlanV1, and
+if an idea exceeds a lane limit it must ADAPT the idea, never break the limit. The
+executor/validator wins (the validator-repair loop enforces this).
+"""
+from __future__ import annotations
+
+from .registry import prompt_slice
+
+TREATMENT_SYS = (
+    "You are a production director. Given a brief, write a SHORT creative treatment "
+    "(4-6 sentences): the angle, the tone, the structure, and 3 concrete visual beats "
+    "— each something that could be ONE ~5-second shot. Be specific and cinematic. "
+    "Plain prose only — no JSON, no markdown, no preamble."
+)
+
+
+def build_plan_system(reg: dict, n_shots: int = 3) -> str:
+    return f"""You are the production director for an automated video studio. Turn the brief and treatment into ONE valid ProductionPlanV1 JSON object. OUTPUT ONLY THE JSON — no prose, no markdown fences, no comments.
+
+{prompt_slice(reg)}
+
+ProductionPlanV1 shape:
+{{
+  "project": {{"title": str, "tone": str, "target_seconds": int, "video_lane": "wan"}},
+  "shots": [
+    {{"id": "s1", "lane": "wan", "mode": "t2v", "target_seconds": 5,
+      "prompt_intent": "<vivid cinematic prose describing the shot>",
+      "narration": "<ONE short spoken sentence heard over this shot>", "seed": 12345}}
+  ],
+  "music": {{"lane": "ace-step", "tags": "<comma-separated mood tags>", "lyrics": "[instrumental]", "seed": 7}},
+  "timeline": [
+    {{"clip": "s1", "narration_offset": 0.0, "music_level_db": -18, "transition_in": "dissolve"}}
+  ]
+}}
+
+Guidance (be inventive WITHIN these bounds):
+- Aim for {n_shots} shots. Each shot is ONE Wan window (<= 5 s), so keep target_seconds 4-5.
+- prompt_intent: vivid, cinematic prose for the video model (one shot's worth of imagery).
+- narration: ONE spoken sentence the viewer hears over that shot. Keep it short enough to fit (~2.5 words per second), so a 5 s shot is ~12 words max.
+- If an idea needs more than ~5 s, SPLIT it into two shots — never exceed the limit.
+- Every shot needs a UNIQUE id. The timeline lists EVERY shot exactly once, in play order.
+- OUTPUT ONLY THE JSON OBJECT."""
+
+
+def repair_user(raw: str, error: str) -> str:
+    return (
+        "Your previous output was not a valid plan.\n"
+        f"ERROR: {error}\n\n"
+        f"PREVIOUS OUTPUT:\n{raw}\n\n"
+        "Output a corrected ProductionPlanV1 JSON object ONLY (no prose, no fences) that fixes that error."
+    )

--- a/services/studio/production/registry.py
+++ b/services/studio/production/registry.py
@@ -1,0 +1,47 @@
+"""Lane capability registry loader — 'what the machine can do.'
+
+Loads `capabilities.yaml` and compresses it into the compact text the planner is
+given (the planner may choose lanes ONLY from here). The executor + schema remain
+authoritative; this is the planner's menu, not the enforcement.
+"""
+from __future__ import annotations
+
+import os
+
+import yaml
+
+REGISTRY_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "capabilities.yaml")
+
+
+def load(path: str = REGISTRY_PATH) -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def video_lanes(reg: dict) -> list[str]:
+    return list((reg.get("video_lanes") or {}).keys())
+
+
+def audio_lanes(reg: dict) -> list[str]:
+    return list((reg.get("audio_lanes") or {}).keys())
+
+
+def prompt_slice(reg: dict) -> str:
+    """The compact lane menu + rules handed to the planner."""
+    lines = ["LANES YOU MAY USE (choose ONLY from these):"]
+    for name, c in (reg.get("video_lanes") or {}).items():
+        win = c.get("native_window_seconds", 5.0)
+        fps = c.get("native_fps", 16)
+        lines.append(
+            f"- VIDEO lane '{name}': mode t2v, vivid PROSE prompt, each shot <= {win:.1f}s "
+            f"@ {fps}fps, SILENT (no audio in the clip). {c.get('when_to_use', '')}"
+        )
+    for name, c in (reg.get("audio_lanes") or {}).items():
+        lines.append(
+            f"- AUDIO lane '{name}': {c.get('kind')}, format {c.get('prompt_format')}. "
+            f"{c.get('when_to_use', '')}"
+        )
+    lines.append("RULES:")
+    for r in reg.get("rules", []):
+        lines.append(f"- {r}")
+    return "\n".join(lines)

--- a/services/studio/production/run.py
+++ b/services/studio/production/run.py
@@ -45,7 +45,8 @@ def _print_summary(summary: dict) -> bool:
     print("  --- the decisive (human) question " + "-" * 29)
     print("  > is this assembled MP4 better than picking lanes by hand?  [you decide]")
     print("=" * 64)
-    failed = [a["id"] for a in man["artifacts"] if not a["validation"].get("ok")]
+    failed = [a["id"] for a in man["artifacts"]
+              if a["type"] == "media" and not a["validation"].get("ok")]
     if failed:
         print(f"  ⚠ validators FAILED on: {failed}")
     return bool(ec["all_validators_pass"] and ec["vo_within_tolerance"] and ec["final_has_audio"])

--- a/services/studio/production/run.py
+++ b/services/studio/production/run.py
@@ -52,8 +52,12 @@ def _print_summary(summary: dict) -> bool:
 
 
 def main(argv: list[str] | None = None) -> int:
-    ap = argparse.ArgumentParser(prog="studio-production", description="v0a: static plan -> MP4")
-    ap.add_argument("plan", help="path to a ProductionPlanV1 JSON")
+    ap = argparse.ArgumentParser(prog="studio-production",
+                                 description="static plan (v0a) or a brief the 4B plans (v0b) -> MP4")
+    ap.add_argument("plan", nargs="?", help="path to a ProductionPlanV1 JSON (v0a path)")
+    ap.add_argument("--brief", default=None,
+                    help='a one-line brief; the 4B director plans it (v0b), e.g. --brief "60s doc on lighthouses"')
+    ap.add_argument("--shots", type=int, default=3, help="target shot count for --brief planning")
     ap.add_argument("--backend", choices=["live", "synthetic"], default="live",
                     help="live = ComfyUI+Kokoro on the rig; synthetic = offline ffmpeg stand-ins")
     ap.add_argument("--job-id", default=None, help="override the generated job id")
@@ -61,15 +65,12 @@ def main(argv: list[str] | None = None) -> int:
                     help=f"base dir (default {config.PRODUCTIONS_DIR})")
     args = ap.parse_args(argv)
 
-    try:
-        with open(args.plan) as f:
-            plan = ProductionPlanV1.from_dict(json.load(f))
-    except (OSError, json.JSONDecodeError, PlanError) as e:
-        print(f"[plan error] {e}", file=sys.stderr)
+    if bool(args.plan) == bool(args.brief):
+        print('[args] give exactly one of: a plan file, or --brief "..."', file=sys.stderr)
         return 2
 
-    job_id = args.job_id or _job_id(plan.project.title)
     now_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    extra_artifacts: list = []
 
     lock = ProductionLock(os.path.join(args.productions_dir, ".run.lock"))
     try:
@@ -78,8 +79,35 @@ def main(argv: list[str] | None = None) -> int:
         print(f"[locked] {e}", file=sys.stderr)
         return 3
     try:
+        if args.brief:
+            from . import planner, registry
+            job_id = args.job_id or _job_id(args.brief)
+            prod_dir = os.path.join(args.productions_dir, job_id)
+            os.makedirs(prod_dir, exist_ok=True)
+            try:
+                reg = registry.load()
+                print(f"[plan] director planning the brief into ~{args.shots} shots…", file=sys.stderr)
+                plan, extra_artifacts = planner.plan_from_brief(
+                    args.brief, reg, n_shots=args.shots,
+                    prompts_dir=os.path.join(prod_dir, "prompts"),
+                )
+            except planner.PlannerError as e:
+                print(f"[plan error] {e}", file=sys.stderr)
+                return 2
+            print(f"[plan] director produced {len(plan.shots)} shots: "
+                  f"{plan.project.title!r}", file=sys.stderr)
+        else:
+            try:
+                with open(args.plan) as f:
+                    plan = ProductionPlanV1.from_dict(json.load(f))
+            except (OSError, json.JSONDecodeError, PlanError) as e:
+                print(f"[plan error] {e}", file=sys.stderr)
+                return 2
+            job_id = args.job_id or _job_id(plan.project.title)
+
         summary = run_production(plan, backend_name=args.backend, job_id=job_id,
-                                 now_iso=now_iso, productions_dir=args.productions_dir)
+                                 now_iso=now_iso, productions_dir=args.productions_dir,
+                                 extra_artifacts=extra_artifacts)
     finally:
         lock.release()
 

--- a/services/studio/production/tests/test_v0b.py
+++ b/services/studio/production/tests/test_v0b.py
@@ -1,0 +1,101 @@
+"""Offline v0b planner tests (stdlib unittest, no model/GPU).
+
+A stub LLM returns canned director replies so the full planner — prompt
+construction, JSON extraction, lenient normalization, and the validator-repair
+loop — is exercised without the 4B (mirrors v0a's synthetic backend).
+
+Run:  python3 -m unittest services.studio.production.tests.test_v0b -v
+"""
+from __future__ import annotations
+
+import unittest
+
+from ..planner import PlannerError, extract_json, normalize, plan_from_brief
+from ..registry import audio_lanes, load, prompt_slice, video_lanes
+
+GOOD_PLAN = """{
+  "project": {"title": "Test", "tone": "calm", "target_seconds": 10, "video_lane": "wan"},
+  "shots": [
+    {"id": "s1", "lane": "wan", "mode": "t2v", "target_seconds": 5, "prompt_intent": "a", "narration": "one", "seed": 1},
+    {"id": "s2", "lane": "wan", "mode": "t2v", "target_seconds": 5, "prompt_intent": "b", "narration": "two", "seed": 2}
+  ],
+  "music": {"lane": "ace-step", "tags": "calm, ambient", "lyrics": "[instrumental]", "seed": 3},
+  "timeline": [
+    {"clip": "s1", "transition_in": "dissolve"},
+    {"clip": "s2", "transition_in": "dissolve"}
+  ]
+}"""
+
+
+class StubLLM:
+    """Returns a queue of canned director responses; records the calls."""
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def __call__(self, messages, *, max_tokens, temperature):
+        self.calls.append(messages)
+        return self.responses.pop(0)
+
+
+class TestRegistry(unittest.TestCase):
+    def test_load_and_slice(self):
+        reg = load()
+        self.assertIn("wan", video_lanes(reg))
+        self.assertIn("kokoro", audio_lanes(reg))
+        self.assertIn("ace-step", audio_lanes(reg))
+        s = prompt_slice(reg)
+        self.assertIn("wan", s)
+        self.assertIn("RULES", s)
+        self.assertIn("Pin ONE video_lane", s)   # the pinning rule is handed to the planner
+
+
+class TestPlanner(unittest.TestCase):
+    def setUp(self):
+        self.reg = load()
+
+    def test_happy_path(self):
+        llm = StubLLM(["a short treatment", GOOD_PLAN])
+        plan, arts = plan_from_brief("a 10s calm clip", self.reg, llm=llm)
+        self.assertEqual([s.id for s in plan.shots], ["s1", "s2"])
+        self.assertEqual(plan.project.video_lane, "wan")
+        self.assertEqual(len(llm.calls), 2)                 # treatment + plan, no repair
+        self.assertEqual([a.type for a in arts], ["llm_prompt", "llm_prompt"])
+        self.assertEqual([a.role for a in arts], ["treatment", "plan"])
+
+    def test_fenced_and_trailing_chatter(self):
+        llm = StubLLM(["t", "```json\n" + GOOD_PLAN + "\n```\nhope that helps!"])
+        plan, _ = plan_from_brief("b", self.reg, llm=llm)
+        self.assertEqual(len(plan.shots), 2)
+
+    def test_repair_loop_recovers(self):
+        bad = '{"project": {"video_lane": "ltx"}, "shots": []}'   # invalid: not wan, no shots
+        llm = StubLLM(["t", bad, GOOD_PLAN])
+        plan, arts = plan_from_brief("b", self.reg, llm=llm)
+        self.assertEqual(len(plan.shots), 2)
+        self.assertEqual(len(llm.calls), 3)                 # treatment + plan + 1 repair
+        self.assertEqual(arts[-1].role, "repair_1")
+
+    def test_repair_exhausted_raises(self):
+        llm = StubLLM(["t", "nonsense", "still no json", "nope", "still nope"])
+        with self.assertRaises(PlannerError):
+            plan_from_brief("b", self.reg, llm=llm, max_repairs=3)
+
+    def test_normalize_fills_defaults(self):
+        data = normalize({"project": {"video_lane": "wan"},
+                          "shots": [{"prompt_intent": "x", "narration": "n"}]})
+        self.assertEqual(data["shots"][0]["id"], "s1")
+        self.assertEqual(data["shots"][0]["lane"], "wan")
+        self.assertEqual(data["shots"][0]["mode"], "t2v")
+        self.assertTrue(data["timeline"])                   # auto-built from shots
+        self.assertIn("music", data)
+        self.assertEqual(data["delivery"]["width"], 832)
+
+    def test_extract_json_balanced(self):
+        self.assertEqual(extract_json('prefix {"a": {"b": 1}} suffix')["a"]["b"], 1)
+        with self.assertRaises(ValueError):
+            extract_json("no json here")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/studio/production/tests/test_v0b.py
+++ b/services/studio/production/tests/test_v0b.py
@@ -8,10 +8,18 @@ Run:  python3 -m unittest services.studio.production.tests.test_v0b -v
 """
 from __future__ import annotations
 
+import json
+import os
+import shutil
+import tempfile
 import unittest
 
 from ..planner import PlannerError, extract_json, normalize, plan_from_brief
 from ..registry import audio_lanes, load, prompt_slice, video_lanes
+
+_PROD = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_PLAN = os.path.join(_PROD, "plans", "lighthouse_3shot.json")
+_HAVE_FFMPEG = shutil.which("ffmpeg") and shutil.which("ffprobe")
 
 GOOD_PLAN = """{
   "project": {"title": "Test", "tone": "calm", "target_seconds": 10, "video_lane": "wan"},
@@ -95,6 +103,32 @@ class TestPlanner(unittest.TestCase):
         self.assertEqual(extract_json('prefix {"a": {"b": 1}} suffix')["a"]["b"], 1)
         with self.assertRaises(ValueError):
             extract_json("no json here")
+
+
+class TestProvenanceNotCountedAsValidator(unittest.TestCase):
+    """Regression: llm_prompt provenance must NOT fail all_validators_pass.
+
+    (Live v0b run #1 reported rc=1 because the planner's prompt records — which carry
+    no media 'ok' — were counted as failed validators.)
+    """
+    @unittest.skipUnless(_HAVE_FFMPEG, "ffmpeg/ffprobe required")
+    def test_llm_prompt_excluded_from_exit_criteria(self):
+        from ..executor import run_production
+        from ..manifest import Artifact
+        from ..schema import ProductionPlanV1
+        with open(_PLAN) as f:
+            plan = ProductionPlanV1.from_dict(json.load(f))
+        prov = [Artifact(id="prompt.plan", type="llm_prompt", role="plan",
+                         path="prompts/plan.json", validation={"response_hash": "x"})]
+        with tempfile.TemporaryDirectory() as td:
+            s = run_production(plan, backend_name="synthetic", job_id="prov",
+                               now_iso="2026-01-01T00:00:00Z", productions_dir=td,
+                               extra_artifacts=prov)
+            ec = s["manifest"]["exit_criteria"]
+            self.assertTrue(ec["all_validators_pass"])   # media all pass; provenance excluded
+            types = {a["type"] for a in s["manifest"]["artifacts"]}
+            self.assertIn("llm_prompt", types)           # provenance still carried
+            self.assertIn("media", types)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> **Stacked on #496 (v0a).** Base is `feat/studio-production-v0a` so the diff is *just v0b*. Merge #496 first; this then retargets to master.

## What

**v0b-core**: the **4B director** (`qwen3.5-4b-uncensored` @ `:8090`, llama.cpp) turns a one-line **brief** into a valid `ProductionPlanV1`, then the v0a executor renders it. `--brief "…"`.

This proves the v0b thesis: *can a small model with a tight operating manual emit an executable plan?*

- **`capabilities.yaml` + `registry.py`** — machine-readable lane contracts (wan/kokoro/ace) = the planner's menu; the schema/executor stay authoritative.
- **`prompts.py`** — the prompt pack (creative treatment → structured plan → repair), creative-within-bounds.
- **`planner.py`** — two-stage planner with a **validator-repair loop** (parse → `schema.validate()` → feed the error back, up to N) + lenient normalization. The director call is **injectable**, so the planner is offline-testable with a stub LLM (no model).
- Prompt provenance stored as typed `llm_prompt` manifest records under `prompts/`.

## Results

| Check | Result |
|---|---|
| offline (planner stub-LLM + executor synthetic) | ✅ **23/23** |
| **planner live** (real 4B) | ✅ **valid plan first-try, 0 repairs, 5.9s** |
| **full live `--brief`** (4B plans → executor renders) | ✅ end-to-end → 832×480 h264+aac MP4, ~7 min |
| media validators (clips/VO/bed/final) | ✅ all pass |
| `llm_prompt` provenance | ✅ written under `prompts/`, in manifest |

The 4B planned *"The Enduring Light"* (planner test) and *"The Keeper's Vigil"* (full run) — genuinely creative titles, shot prompts, narration, and music tags from one line.

## Two findings the live run earned

1. **Bug (fixed here):** exit-criteria counted the `llm_prompt` provenance records as failed validators (they carry no media `ok`) → a false `rc=1`. Now only `type=="media"` artifacts are validated. + regression test.
2. **Finding (model):** the 4B leaked a non-English word into a narration line (`守望`), which stretched the Kokoro VO past its ~4.8s shot. Prompt pack now requires **English-only** narration + a firmer ≤10-word cap. Full **VO-length budgeting / VO-first** is the next v0b refinement.

## Scope / deferred

Still CLI/admin, single-flight, one pinned video lane, isolated under `services/studio/production/`, stdlib + PyYAML (registry). **Deferred to v0b-images:** image lanes + `image_policy` roles + asset-DAG (the **continuity** lever), skills, takes/rerender, Qdrant/SearXNG, durable queue, OWUI lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
