### PR TITLE
Studio Production Agent v0b-images — continuity (chain + hero, live A/B)

### DIFF
--- a/services/studio/production/README.md
+++ b/services/studio/production/README.md
@@ -1,20 +1,22 @@
-# Studio Production Agent — v0a
+# Studio Production Agent — v0a + v0b-core
 
-One static brief → a finished MP4, by driving the **existing** AI-Studio lanes
-serially (Wan video · Kokoro narration · ACE-Step bed → ffmpeg mix). This is the
-**v0a executor spike** from
-[`/opt/ai/docs/ai-studio-production-agent-design.md`](../../../../docs/ai-studio-production-agent-design.md):
-prove the executor + assembly can drive the lanes, collect + validate artifacts,
-and assemble something watchable **without manual babysitting**.
+Brief → a finished MP4, by driving the **existing** AI-Studio lanes serially (Wan
+video · Kokoro narration · ACE-Step bed → ffmpeg mix). From
+[`/opt/ai/docs/ai-studio-production-agent-design.md`](../../../../docs/ai-studio-production-agent-design.md).
 
-**v0a scope (deliberately tight):** CLI/admin only · no OWUI lane · single-flight
-(host file-lock) · **static** hand-authored `ProductionPlanV1` · one pinned video
-lane (`wan`, t2v) · ffprobe validators · final ffmpeg mix at the delivery profile ·
-typed/extensible manifest with run-level provenance.
+- **v0a** — a *static* hand-authored `ProductionPlanV1` → MP4 (the executor + assembly).
+- **v0b-core** — the **4B director** (`qwen3.5-4b-uncensored` @ `:8090`) *plans* a
+  one-line brief into a valid `ProductionPlanV1` — against the capability registry
+  (`capabilities.yaml`) + a prompt pack, with a **validator-repair loop** (parse →
+  `schema.validate()` → feed errors back) — then the v0a executor renders it.
+  Prompt provenance is stored as `llm_prompt` manifest records under `prompts/`.
 
-**Deferred to v0b/v1:** the 4B planner, skills, image lanes / asset-DAG, takes +
-rerender, Qdrant/SearXNG, durable queue, OWUI lane. (The manifest is already typed
-so v0b prompt-provenance records slot in with no redesign.)
+**Scope (deliberately tight):** CLI/admin only · single-flight (host file-lock) · one
+pinned video lane (`wan`, t2v) · ffprobe validators · ffmpeg mix at the delivery
+profile · typed manifest with run-level provenance.
+
+**Deferred to v0b-images / v1:** image lanes + `image_policy` roles + asset-DAG
+(continuity), skills, takes + rerender, Qdrant/SearXNG, durable queue, OWUI lane.
 
 ## Run
 
@@ -25,7 +27,12 @@ so v0b prompt-provenance records slot in with no redesign.)
 python3 -m services.studio.production.run \
     services/studio/production/plans/lighthouse_3shot.json --backend synthetic
 
-# live — drives ComfyUI (:8188) + Kokoro TTS (:8192); needs the ai-studio scene up:
+# v0b — the 4B director PLANS a brief, then renders it (needs the ai-studio scene up):
+gpu-mode ai-studio
+python3 -m services.studio.production.run \
+    --brief "a 15-second calm documentary about lighthouses" --backend live --shots 3
+
+# v0a live — a static plan; drives ComfyUI (:8188) + Kokoro TTS (:8192):
 gpu-mode ai-studio        # bring the scene up first
 python3 -m services.studio.production.run \
     services/studio/production/plans/lighthouse_3shot.json --backend live
@@ -42,12 +49,14 @@ question: *is this better than picking lanes by hand?*
 ## Tests (offline, stdlib only — no pydantic/pytest/GPU)
 
 ```bash
-python3 -m unittest services.studio.production.tests.test_v0a -v
+python3 -m unittest services.studio.production.tests.test_v0a \
+                     services.studio.production.tests.test_v0b -v
 ```
 
-The end-to-end test runs the **whole** pipeline on the synthetic backend and
-asserts a real MP4 with an audio track + a well-formed manifest — so the logic is
-verified before it ever touches the rig.
+`test_v0a` runs the **whole** render pipeline on the synthetic backend (real MP4 +
+manifest). `test_v0b` drives the planner with a **stub LLM** — prompt construction,
+JSON extraction, normalization, and the validator-repair loop — so both the executor
+and the planner are verified before touching the rig.
 
 ## Layout
 
@@ -62,5 +71,9 @@ verified before it ever touches the rig.
 | `manifest.py` | typed, extensible manifest + run-level provenance |
 | `lock.py` | single-flight host file-lock |
 | `executor.py` | the four-phase loop (video → audio → post) |
-| `run.py` | CLI + exit-criteria summary |
-| `plans/` | static `ProductionPlanV1` JSON |
+| `capabilities.yaml` | lane capability registry — the planner's menu (wan/kokoro/ace) |
+| `registry.py` | load the registry + compress it into the planner's prompt slice |
+| `prompts.py` | the planner prompt pack (treatment + plan + repair) |
+| `planner.py` | the 4B director: brief → plan, with the validator-repair loop |
+| `run.py` | CLI (`PLAN.json` for v0a, `--brief "…"` for v0b) + exit-criteria summary |
+| `plans/` | static `ProductionPlanV1` JSON (v0a) |

--- a/services/studio/production/README.md
+++ b/services/studio/production/README.md
@@ -1,0 +1,66 @@
+# Studio Production Agent — v0a
+
+One static brief → a finished MP4, by driving the **existing** AI-Studio lanes
+serially (Wan video · Kokoro narration · ACE-Step bed → ffmpeg mix). This is the
+**v0a executor spike** from
+[`/opt/ai/docs/ai-studio-production-agent-design.md`](../../../../docs/ai-studio-production-agent-design.md):
+prove the executor + assembly can drive the lanes, collect + validate artifacts,
+and assemble something watchable **without manual babysitting**.
+
+**v0a scope (deliberately tight):** CLI/admin only · no OWUI lane · single-flight
+(host file-lock) · **static** hand-authored `ProductionPlanV1` · one pinned video
+lane (`wan`, t2v) · ffprobe validators · final ffmpeg mix at the delivery profile ·
+typed/extensible manifest with run-level provenance.
+
+**Deferred to v0b/v1:** the 4B planner, skills, image lanes / asset-DAG, takes +
+rerender, Qdrant/SearXNG, durable queue, OWUI lane. (The manifest is already typed
+so v0b prompt-provenance records slot in with no redesign.)
+
+## Run
+
+```bash
+# from the repo root (/opt/ai/github/club-3090)
+
+# offline — ffmpeg lavfi stand-ins, no GPU/ComfyUI/TTS (good for dev + CI):
+python3 -m services.studio.production.run \
+    services/studio/production/plans/lighthouse_3shot.json --backend synthetic
+
+# live — drives ComfyUI (:8188) + Kokoro TTS (:8192); needs the ai-studio scene up:
+gpu-mode ai-studio        # bring the scene up first
+python3 -m services.studio.production.run \
+    services/studio/production/plans/lighthouse_3shot.json --backend live
+```
+
+Output lands in `/mnt/models/comfyui/output/productions/<job_id>/`
+(`shots/ audio/ assembly/final.mp4 manifest.json`). Override the base with
+`--productions-dir`, endpoints with `COMFYUI_URL` / `TTS_URL` / `VOICE_URL`.
+
+The run prints a summary against the **exit criteria** — all validators pass,
+VO-within-tolerance, final-has-audio, durations — and ends on the decisive human
+question: *is this better than picking lanes by hand?*
+
+## Tests (offline, stdlib only — no pydantic/pytest/GPU)
+
+```bash
+python3 -m unittest services.studio.production.tests.test_v0a -v
+```
+
+The end-to-end test runs the **whole** pipeline on the synthetic backend and
+asserts a real MP4 with an audio track + a well-formed manifest — so the logic is
+verified before it ever touches the rig.
+
+## Layout
+
+| File | Role |
+|---|---|
+| `schema.py` | `ProductionPlanV1` (dataclasses + `validate()`) |
+| `comfy.py` | minimal ComfyUI client (`submit` / `await_output` / `alive`) |
+| `lanes.py` | `LiveBackend` (ComfyUI+Kokoro) · `SyntheticBackend` (ffmpeg lavfi) |
+| `ensure.py` | `ensure_lane` — services-up + Step-Voice `/unload` before video |
+| `validators.py` | ffprobe checks (duration / audio / dims / non-empty) |
+| `assemble.py` | pure `build_mix_command` + `assemble` (concat + duck + loudnorm) |
+| `manifest.py` | typed, extensible manifest + run-level provenance |
+| `lock.py` | single-flight host file-lock |
+| `executor.py` | the four-phase loop (video → audio → post) |
+| `run.py` | CLI + exit-criteria summary |
+| `plans/` | static `ProductionPlanV1` JSON |

--- a/services/studio/production/README.md
+++ b/services/studio/production/README.md
@@ -1,4 +1,4 @@
-# Studio Production Agent — v0a + v0b-core
+# Studio Production Agent — v0a + v0b-core + v0b-images
 
 Brief → a finished MP4, by driving the **existing** AI-Studio lanes serially (Wan
 video · Kokoro narration · ACE-Step bed → ffmpeg mix). From
@@ -10,13 +10,18 @@ video · Kokoro narration · ACE-Step bed → ffmpeg mix). From
   (`capabilities.yaml`) + a prompt pack, with a **validator-repair loop** (parse →
   `schema.validate()` → feed errors back) — then the v0a executor renders it.
   Prompt provenance is stored as `llm_prompt` manifest records under `prompts/`.
+- **v0b-images** — **continuity** (the slideshow fix). Two modes via `--continuity`:
+  **chain** (each shot Wan-i2v from the previous shot's last frame) and **hero** (all
+  shots i2v from one generated **hero keyframe**, chroma image lane). Asset-DAG:
+  `asset_tasks[]` (generated images) + `shot.start_from` (`prev_last_frame` | `<asset id>`),
+  resolved in an executor **pre-production phase**; the 4B stays creative, the planner
+  wires continuity deterministically (`apply_continuity`).
 
-**Scope (deliberately tight):** CLI/admin only · single-flight (host file-lock) · one
-pinned video lane (`wan`, t2v) · ffprobe validators · ffmpeg mix at the delivery
-profile · typed manifest with run-level provenance.
+**Scope (deliberately tight):** CLI/admin only · single-flight · one pinned video
+lane · ffprobe validators · ffmpeg mix at the delivery profile · typed manifest.
 
-**Deferred to v0b-images / v1:** image lanes + `image_policy` roles + asset-DAG
-(continuity), skills, takes + rerender, Qdrant/SearXNG, durable queue, OWUI lane.
+**Deferred to v1:** skills, takes + rerender, Qdrant/SearXNG, durable queue, OWUI
+lane, the remaining image roles (reference / storyboard / title-card).
 
 ## Run
 
@@ -31,6 +36,13 @@ python3 -m services.studio.production.run \
 gpu-mode ai-studio
 python3 -m services.studio.production.run \
     --brief "a 15-second calm documentary about lighthouses" --backend live --shots 3
+
+# v0b-images — same, with CONTINUITY (chain = i2v from prev frame; hero = shared keyframe):
+python3 -m services.studio.production.run \
+    --brief "a 15-second calm documentary about lighthouses" --backend live --continuity chain
+# or the static continuity experiment plans:
+python3 -m services.studio.production.run \
+    services/studio/production/plans/lighthouse_hero.json --backend live
 
 # v0a live — a static plan; drives ComfyUI (:8188) + Kokoro TTS (:8192):
 gpu-mode ai-studio        # bring the scene up first

--- a/services/studio/production/__init__.py
+++ b/services/studio/production/__init__.py
@@ -1,0 +1,13 @@
+"""AI Studio — Production Agent (v0a).
+
+A CLI/admin, single-flight executor that drives the EXISTING AI-Studio lanes from a
+static `ProductionPlanV1` and assembles one MP4. No 4B planner, no OWUI lane, no
+Qdrant/SearXNG, no durable queue — those are v0b/v1 (see
+/opt/ai/docs/ai-studio-production-agent-design.md).
+
+stdlib-only on purpose (host python has no pydantic/pytest) so the spike runs +
+self-tests with zero installs. A `synthetic` backend (ffmpeg lavfi) exercises the
+whole path offline; the `live` backend hits ComfyUI (:8188) + Kokoro TTS (:8192).
+"""
+
+__version__ = "0a"

--- a/services/studio/production/assemble.py
+++ b/services/studio/production/assemble.py
@@ -1,0 +1,94 @@
+"""Post-production: the final ffmpeg mix.
+
+`build_mix_command` is PURE (inputs -> argv) so it's unit-testable without running
+ffmpeg; `assemble` runs it. One pass: concat the silent clips, lay each narration
+WAV at its timeline offset (adelay), duck the music bed under the narration
+(sidechaincompress), loudnorm to the delivery target, mux to one MP4. The exact
+argv is recorded in the manifest for reproducibility.
+
+Reuses the studio ffmpeg idioms (loudnorm I=…:TP=-1.5:LRA=11, sidechaincompress)
+from tts/tts.py `_mixdown`.
+"""
+from __future__ import annotations
+
+from .util import sh
+
+
+def db_to_linear(db: float) -> float:
+    return 10.0 ** (db / 20.0)
+
+
+def build_mix_command(
+    final_path: str,
+    clips: list[str],
+    narrations: list[tuple[str, int]],   # (wav_path, start_ms)
+    bed: str | None,
+    *,
+    fps: int,
+    lufs: float,
+    bed_level_db: float,
+    duck_ratio: int = 8,
+) -> list[str]:
+    """Build the single-pass ffmpeg argv. Pure — no side effects."""
+    n = len(clips)
+    m = len(narrations)
+    if n == 0:
+        raise ValueError("no clips to assemble")
+
+    inputs: list[str] = []
+    for c in clips:
+        inputs += ["-i", c]
+    for (p, _) in narrations:
+        inputs += ["-i", p]
+    if bed:
+        inputs += ["-i", bed]
+
+    fc: list[str] = []
+    # 1) video concat
+    fc.append("".join(f"[{i}:v]" for i in range(n)) + f"concat=n={n}:v=1:a=0[vid]")
+
+    # 2) narration timeline (delay each VO to its start, mix together)
+    narr_label = None
+    if m:
+        for j, (_, start) in enumerate(narrations):
+            fc.append(f"[{n + j}:a]adelay={start}|{start}[n{j}]")
+        if m == 1:
+            narr_label = "[n0]"
+        else:
+            fc.append("".join(f"[n{j}]" for j in range(m)) + f"amix=inputs={m}:normalize=0[narr]")
+            narr_label = "[narr]"
+
+    # 3) bed + duck + final audio
+    bidx = n + m
+    if bed and m:
+        # split narration: one copy keys the sidechain, one is mixed back in
+        fc.append(f"{narr_label}asplit=2[nkey][nmix]")
+        fc.append(f"[{bidx}:a]volume={db_to_linear(bed_level_db):.4f}[bedv]")
+        fc.append(f"[bedv][nkey]sidechaincompress=threshold=0.03:ratio={duck_ratio}:attack=5:release=250[bedduck]")
+        fc.append(f"[bedduck][nmix]amix=inputs=2:normalize=0[premix]")
+        pre = "[premix]"
+    elif bed:
+        fc.append(f"[{bidx}:a]volume={db_to_linear(bed_level_db):.4f}[premix]")
+        pre = "[premix]"
+    elif m:
+        pre = narr_label
+    else:
+        raise ValueError("nothing to put on the audio track (no narration, no bed)")
+
+    fc.append(f"{pre}loudnorm=I={lufs}:TP=-1.5:LRA=11[a]")
+
+    return (
+        ["ffmpeg", "-y", "-v", "error", *inputs,
+         "-filter_complex", ";".join(fc),
+         "-map", "[vid]", "-map", "[a]",
+         "-r", str(fps), "-c:v", "libx264", "-pix_fmt", "yuv420p",
+         "-c:a", "aac", "-b:a", "192k", "-shortest", final_path]
+    )
+
+
+def assemble(final_path, clips, narrations, bed, *, fps, lufs, bed_level_db) -> list[str]:
+    """Build + run the mix. Returns the exact argv used (for the manifest)."""
+    cmd = build_mix_command(final_path, clips, narrations, bed,
+                            fps=fps, lufs=lufs, bed_level_db=bed_level_db)
+    sh(cmd, timeout=900)
+    return cmd

--- a/services/studio/production/assemble.py
+++ b/services/studio/production/assemble.py
@@ -1,70 +1,119 @@
 """Post-production: the final ffmpeg mix.
 
 `build_mix_command` is PURE (inputs -> argv) so it's unit-testable without running
-ffmpeg; `assemble` runs it. One pass: concat the silent clips, lay each narration
-WAV at its timeline offset (adelay), duck the music bed under the narration
-(sidechaincompress), loudnorm to the delivery target, mux to one MP4. The exact
-argv is recorded in the manifest for reproducibility.
+ffmpeg; `assemble` runs it.
 
-Reuses the studio ffmpeg idioms (loudnorm I=…:TP=-1.5:LRA=11, sidechaincompress)
-from tts/tts.py `_mixdown`.
+Video: clips are joined with per-seam transitions — `dissolve` (xfade crossfade,
+the default) or `cut`. A dissolve overlaps two clips by `transition_seconds`, so it
+shortens the timeline; clip start times are computed crossfade-aware and the
+narration is delayed to those (shifted) starts.
+
+Audio: each narration WAV is laid at its shot's start (+ intra-shot offset), the
+music bed is ducked under the narration (sidechaincompress, gentle defaults so it
+glides instead of pumping), then loudnorm to the delivery target, one MP4. The exact
+argv is recorded in the manifest. Reuses the studio ffmpeg idioms from tts.py.
 """
 from __future__ import annotations
 
 from .util import sh
+
+_CUT_XFADE = 1.0 / 30.0   # a "cut" seam inside an xfade chain: ~1 frame (no visible blend)
 
 
 def db_to_linear(db: float) -> float:
     return 10.0 ** (db / 20.0)
 
 
+def duck_ratio(duck_db: int) -> int:
+    """Map a duck depth (dB) to a sidechaincompress ratio (gentle floor)."""
+    return max(2, min(20, round(duck_db / 1.5)))
+
+
+def _clip_starts(durations: list[float], xfades: list[float]) -> list[float]:
+    """Output start time of each clip, given per-seam crossfade overlaps.
+
+    xfades[k] is the crossfade seconds for the seam between clip k and k+1.
+    """
+    starts = [0.0]
+    for k in range(1, len(durations)):
+        starts.append(starts[-1] + durations[k - 1] - xfades[k - 1])
+    return starts
+
+
 def build_mix_command(
     final_path: str,
     clips: list[str],
-    narrations: list[tuple[str, int]],   # (wav_path, start_ms)
+    durations: list[float],
+    transitions: list[tuple[str, float]],     # per seam (len = len(clips)-1): (type, seconds)
+    narrations: list[tuple[str, int, float]],  # (wav_path, shot_index, intra_offset_s)
     bed: str | None,
     *,
     fps: int,
     lufs: float,
     bed_level_db: float,
-    duck_ratio: int = 8,
+    duck_db: int = 6,
 ) -> list[str]:
     """Build the single-pass ffmpeg argv. Pure — no side effects."""
     n = len(clips)
-    m = len(narrations)
     if n == 0:
         raise ValueError("no clips to assemble")
+    if len(durations) != n:
+        raise ValueError("durations must match clips")
+    if len(transitions) != max(0, n - 1):
+        raise ValueError("transitions must have one entry per seam (clips-1)")
+
+    # effective crossfade per seam: dissolve -> its seconds; cut -> ~1 frame
+    xf = [secs if typ == "dissolve" else _CUT_XFADE for (typ, secs) in transitions]
+    all_cut = all(typ == "cut" for (typ, _s) in transitions)
+    starts = (
+        [sum(durations[:k]) for k in range(n)] if (all_cut or n == 1)
+        else _clip_starts(durations, xf)
+    )
 
     inputs: list[str] = []
     for c in clips:
         inputs += ["-i", c]
-    for (p, _) in narrations:
+    for (p, _i, _o) in narrations:
         inputs += ["-i", p]
     if bed:
         inputs += ["-i", bed]
 
     fc: list[str] = []
-    # 1) video concat
-    fc.append("".join(f"[{i}:v]" for i in range(n)) + f"concat=n={n}:v=1:a=0[vid]")
+    # 1) video — concat (all hard cuts) or an xfade dissolve chain
+    if all_cut or n == 1:
+        fc.append("".join(f"[{i}:v]" for i in range(n)) + f"concat=n={n}:v=1:a=0[vid]")
+    else:
+        prev = "[0:v]"
+        for k in range(1, n):
+            out = "[vid]" if k == n - 1 else f"[vx{k}]"
+            fc.append(
+                f"{prev}[{k}:v]xfade=transition=dissolve:"
+                f"duration={xf[k - 1]:.3f}:offset={starts[k]:.3f}{out}"
+            )
+            prev = out
 
-    # 2) narration timeline (delay each VO to its start, mix together)
+    # 2) narration timeline — delay each VO to its (crossfade-aware) shot start
+    m = len(narrations)
     narr_label = None
     if m:
-        for j, (_, start) in enumerate(narrations):
-            fc.append(f"[{n + j}:a]adelay={start}|{start}[n{j}]")
+        for j, (_p, shot_idx, intra) in enumerate(narrations):
+            start_ms = max(0, int((starts[shot_idx] + intra) * 1000))
+            fc.append(f"[{n + j}:a]adelay={start_ms}|{start_ms}[n{j}]")
         if m == 1:
             narr_label = "[n0]"
         else:
             fc.append("".join(f"[n{j}]" for j in range(m)) + f"amix=inputs={m}:normalize=0[narr]")
             narr_label = "[narr]"
 
-    # 3) bed + duck + final audio
+    # 3) bed + (gentle) duck + final audio
     bidx = n + m
     if bed and m:
-        # split narration: one copy keys the sidechain, one is mixed back in
         fc.append(f"{narr_label}asplit=2[nkey][nmix]")
         fc.append(f"[{bidx}:a]volume={db_to_linear(bed_level_db):.4f}[bedv]")
-        fc.append(f"[bedv][nkey]sidechaincompress=threshold=0.03:ratio={duck_ratio}:attack=5:release=250[bedduck]")
+        fc.append(
+            f"[bedv][nkey]sidechaincompress=threshold=0.05:ratio={duck_ratio(duck_db)}:"
+            f"attack=20:release=600[bedduck]"
+        )
         fc.append(f"[bedduck][nmix]amix=inputs=2:normalize=0[premix]")
         pre = "[premix]"
     elif bed:
@@ -86,9 +135,10 @@ def build_mix_command(
     )
 
 
-def assemble(final_path, clips, narrations, bed, *, fps, lufs, bed_level_db) -> list[str]:
+def assemble(final_path, clips, durations, transitions, narrations, bed, *,
+             fps, lufs, bed_level_db, duck_db=6) -> list[str]:
     """Build + run the mix. Returns the exact argv used (for the manifest)."""
-    cmd = build_mix_command(final_path, clips, narrations, bed,
-                            fps=fps, lufs=lufs, bed_level_db=bed_level_db)
+    cmd = build_mix_command(final_path, clips, durations, transitions, narrations, bed,
+                            fps=fps, lufs=lufs, bed_level_db=bed_level_db, duck_db=duck_db)
     sh(cmd, timeout=900)
     return cmd

--- a/services/studio/production/capabilities.yaml
+++ b/services/studio/production/capabilities.yaml
@@ -1,0 +1,67 @@
+# Lane capability registry — "what the machine can do."
+#
+# The planner chooses lanes ONLY from here (for video, only the production's pinned
+# `project.video_lane`). The executor + validators are AUTHORITATIVE: a plan that
+# violates a contract is repaired (validator-repair loop) or rejected — never
+# executed as-is. A skill/plan may guide creativity, but it never overrides this.
+#
+# v0b-core lanes: wan (video) · kokoro (narration) · ace-step (music).
+# Image lanes (hidream/chroma/krea/ideogram) + `image_policy` roles + asset
+# dependencies land in v0b-images — NOT available to the planner yet.
+
+version: 1
+
+video_lanes:
+  wan:
+    kind: video
+    supports: [t2v, i2v]            # i2v exists but v0b-core plans t2v only
+    inputs:
+      t2v: [prompt]
+      i2v: [prompt, start_image]
+    outputs: [mp4]
+    audio_behavior: none           # Wan clips are SILENT (no synced audio)
+    native_fps: 16
+    native_window_seconds: 5.06    # 81 frames @ 16 fps — one window
+    duration_limits:
+      min_seconds: 1
+      max_seconds: 5.1             # one native window; longer needs chaining (v1)
+    prompt_format: prose
+    resource_class: dual_card_dit  # DisTorch DiT across both 3090s
+    validators: [non_empty, duration, no_audio_expected]
+    when_to_use: "the one pinned video lane for a whole production"
+    avoid_when: "you need synced native audio in the clip, or a single shot > ~5 s"
+
+audio_lanes:
+  kokoro:
+    kind: narration
+    inputs: [text]
+    outputs: [wav]
+    audio_behavior: voice
+    prompt_format: plain_text      # narration sentences, NOT a generation prompt
+    words_per_second: 2.5          # rough, for VO-length budgeting (v0b VO-first)
+    resource_class: cpu
+    validators: [non_empty, audio_present]
+    when_to_use: "spoken narration / voiceover"
+    avoid_when: "you need a specific cloned voice (that is step-voice, premium, on-demand)"
+
+  ace-step:
+    kind: music
+    inputs: [tags, lyrics, seconds]
+    outputs: [mp3]
+    audio_behavior: music
+    prompt_format: tags_plus_lyrics  # comma-tags + [verse]/[chorus] structure, or [instrumental]
+    duration_limits:
+      min_seconds: 5
+      max_seconds: 240
+    resource_class: gpu0
+    validators: [non_empty, audio_present]
+    when_to_use: "one music bed under the whole piece"
+    avoid_when: "you need a specific licensed track"
+
+# Production-level rules the planner MUST honor (enforced by schema.validate()).
+rules:
+  - "Pin ONE video_lane for the whole production (project.video_lane); EVERY shot uses it."
+  - "Each shot: id, mode=t2v, target_seconds (<= the lane's native window), prompt_intent, optional narration."
+  - "Image lanes / asset dependencies are NOT available in v0b-core."
+  - "The timeline lists every shot exactly once, in play order, each with transition_in (dissolve|cut)."
+  - "If an idea exceeds a lane limit, ADAPT the idea (shorter shot, split into two) — never break the limit."

--- a/services/studio/production/comfy.py
+++ b/services/studio/production/comfy.py
@@ -1,0 +1,91 @@
+"""Minimal ComfyUI client — replicated from studio_pipe.py (no OWUI deps).
+
+studio_pipe.py is a standalone OWUI pipe that can't be imported (it relies on the
+OWUI async/event context), so we re-implement the three calls we need against the
+HTTP API: submit a workflow graph, poll /history for completion, and a liveness
+ping. Same patterns as studio_pipe `_submit` / `_await_output` / `_alive`.
+"""
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.request
+
+from . import config
+
+
+class ComfyError(RuntimeError):
+    pass
+
+
+def alive(base: str = config.COMFYUI_URL, path: str = "/system_stats", timeout: float = 0.6) -> bool:
+    """True if the backend answers at all (an HTTP error still means 'up')."""
+    try:
+        urllib.request.urlopen(base.rstrip("/") + path, timeout=timeout)
+        return True
+    except urllib.error.HTTPError:
+        return True
+    except Exception:
+        return False
+
+
+def submit(wf: dict, base: str = config.COMFYUI_URL, client_id: str = "studio-production") -> str:
+    """POST a workflow graph to /prompt, return its prompt_id."""
+    req = urllib.request.Request(
+        base.rstrip("/") + "/prompt",
+        data=json.dumps({"prompt": wf, "client_id": client_id}).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    r = json.load(urllib.request.urlopen(req, timeout=config.SUBMIT_TIMEOUT))
+    if r.get("node_errors"):
+        raise ComfyError("ComfyUI node_errors: " + json.dumps(r["node_errors"])[:400])
+    pid = r.get("prompt_id")
+    if not pid:
+        raise ComfyError("ComfyUI returned no prompt_id")
+    return pid
+
+
+def await_output(
+    pid: str,
+    want: str,
+    base: str = config.COMFYUI_URL,
+    timeout: float = config.RENDER_TIMEOUT,
+    poll: float = config.POLL_INTERVAL,
+) -> tuple[str, str]:
+    """Poll /history/{pid} until complete; return (filename, subfolder).
+
+    `want` is 'video' | 'image' | 'audio'. Mirrors studio_pipe._await_output's
+    output-node walk.
+    """
+    exts = {
+        "video": (".mp4", ".webm", ".mkv"),
+        "image": (".png", ".jpg", ".jpeg", ".webp"),
+        "audio": (".mp3", ".flac", ".wav", ".opus"),
+    }[want]
+    keys = {"video": ("gifs", "videos", "images"),
+            "image": ("images",),
+            "audio": ("audio", "images")}[want]
+
+    t0 = time.time()
+    while time.time() - t0 < timeout:
+        time.sleep(poll)
+        try:
+            h = json.load(urllib.request.urlopen(base.rstrip("/") + "/history/" + pid, timeout=30))
+        except Exception:
+            continue
+        if pid not in h:
+            continue
+        st = h[pid].get("status", {})
+        if st.get("status_str") == "error":
+            raise ComfyError(f"ComfyUI generation error for prompt {pid}")
+        if not st.get("completed"):
+            continue
+        for node in h[pid].get("outputs", {}).values():
+            for k in keys:
+                for v in node.get(k, []) or []:
+                    fn = str(v.get("filename", ""))
+                    if fn.endswith(exts) or str(v.get("format", "")).startswith(want):
+                        return fn, v.get("subfolder", "")
+        raise ComfyError(f"prompt {pid} completed but produced no {want} output")
+    raise TimeoutError(f"ComfyUI timed out after {timeout:.0f}s for prompt {pid}")

--- a/services/studio/production/config.py
+++ b/services/studio/production/config.py
@@ -12,6 +12,9 @@ import os
 COMFYUI_URL = os.environ.get("COMFYUI_URL", "http://localhost:8188").rstrip("/")
 TTS_URL = os.environ.get("TTS_URL", "http://localhost:8192").rstrip("/")
 VOICE_URL = os.environ.get("VOICE_URL", "http://localhost:8193").rstrip("/")
+# The director LLM (qwen3.5-4b-uncensored on llama.cpp) — the v0b planner.
+DIRECTOR_URL = os.environ.get("DIRECTOR_URL", "http://localhost:8090/v1").rstrip("/")
+DIRECTOR_MODEL = os.environ.get("DIRECTOR_MODEL", "qwen3.5-4b-uncensored")
 
 # ComfyUI's host output root (mounted at /output in the studio containers). All
 # lanes write here; we scope productions under `<root>/productions/<job_id>/`.

--- a/services/studio/production/config.py
+++ b/services/studio/production/config.py
@@ -24,6 +24,12 @@ WORKFLOW_DIR = os.environ.get(
     os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "workflows"),
 )
 
+# Container names — used to pull artifacts a service wrote root-only (e.g. Kokoro
+# TTS writes its WAV mode 0600, which the host CLI user can't read; `docker cp`
+# from the container works because the docker daemon reads as root).
+COMFY_CONTAINER = os.environ.get("STUDIO_COMFY_CONTAINER", "comfyui")
+TTS_CONTAINER = os.environ.get("STUDIO_TTS_CONTAINER", "studio-tts")
+
 # Network timeouts (seconds).
 SUBMIT_TIMEOUT = int(os.environ.get("STUDIO_SUBMIT_TIMEOUT", "60"))
 RENDER_TIMEOUT = int(os.environ.get("STUDIO_RENDER_TIMEOUT", "1800"))  # 30 min/clip ceiling

--- a/services/studio/production/config.py
+++ b/services/studio/production/config.py
@@ -1,0 +1,30 @@
+"""Runtime config — env-driven, host-side defaults.
+
+The production CLI runs on the HOST (not inside the OWUI container), so the studio
+backends are reached on `localhost` (studio_pipe.py uses host.docker.internal
+because it runs in-container — do not copy that here).
+"""
+from __future__ import annotations
+
+import os
+
+# Studio service endpoints (host-side).
+COMFYUI_URL = os.environ.get("COMFYUI_URL", "http://localhost:8188").rstrip("/")
+TTS_URL = os.environ.get("TTS_URL", "http://localhost:8192").rstrip("/")
+VOICE_URL = os.environ.get("VOICE_URL", "http://localhost:8193").rstrip("/")
+
+# ComfyUI's host output root (mounted at /output in the studio containers). All
+# lanes write here; we scope productions under `<root>/productions/<job_id>/`.
+OUTPUT_ROOT = os.environ.get("COMFYUI_OUTPUT_DIR", "/mnt/models/comfyui/output")
+PRODUCTIONS_DIR = os.path.join(OUTPUT_ROOT, "productions")
+
+# The canonical (friendly-keyed) ComfyUI workflow graphs — shared with studio_pipe.
+WORKFLOW_DIR = os.environ.get(
+    "STUDIO_WORKFLOW_DIR",
+    os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "workflows"),
+)
+
+# Network timeouts (seconds).
+SUBMIT_TIMEOUT = int(os.environ.get("STUDIO_SUBMIT_TIMEOUT", "60"))
+RENDER_TIMEOUT = int(os.environ.get("STUDIO_RENDER_TIMEOUT", "1800"))  # 30 min/clip ceiling
+POLL_INTERVAL = float(os.environ.get("STUDIO_POLL_INTERVAL", "2.0"))

--- a/services/studio/production/ensure.py
+++ b/services/studio/production/ensure.py
@@ -1,0 +1,50 @@
+"""ensure_lane — concrete admission checks per lane (NOT c3's UI-side guard).
+
+The contract (design doc): verify services up → Step-Voice /unload before any video
+lane → ComfyUI health → (the job-level lock is held by the caller). On the synthetic
+backend everything is a no-op (no services to gate). The job-wide single-flight lock
+lives in lock.py and is acquired once in run.py.
+"""
+from __future__ import annotations
+
+import urllib.request
+
+from . import comfy, config
+
+
+class EnsureError(RuntimeError):
+    pass
+
+
+VIDEO_LANES = {"wan", "ltx", "sulphur", "10eros"}
+COMFY_LANES = VIDEO_LANES | {"ace-step", "image"}
+
+
+def _evict_voice() -> None:
+    """Best-effort Step-Voice /unload before a video render (GPU1 mutex)."""
+    try:
+        req = urllib.request.Request(config.VOICE_URL + "/unload", data=b"",
+                                     headers={"Content-Type": "application/json"})
+        urllib.request.urlopen(req, timeout=5)
+    except Exception:
+        pass  # best-effort: the lazy service idle-unloads anyway
+
+
+def ensure_lane(lane: str, *, backend: str) -> None:
+    """Prepare for a render on `lane`. Raises EnsureError if a needed service is down."""
+    if backend == "synthetic":
+        return  # nothing to gate offline
+    if lane in VIDEO_LANES:
+        _evict_voice()
+    if lane in COMFY_LANES:
+        if not comfy.alive():
+            raise EnsureError(
+                f"ComfyUI not reachable at {config.COMFYUI_URL} — is the ai-studio scene up?"
+            )
+
+
+def ensure_tts(*, backend: str) -> None:
+    if backend == "synthetic":
+        return
+    if not comfy.alive(config.TTS_URL, "/tts/health"):
+        raise EnsureError(f"Kokoro TTS not reachable at {config.TTS_URL}")

--- a/services/studio/production/ensure.py
+++ b/services/studio/production/ensure.py
@@ -17,7 +17,8 @@ class EnsureError(RuntimeError):
 
 
 VIDEO_LANES = {"wan", "ltx", "sulphur", "10eros"}
-COMFY_LANES = VIDEO_LANES | {"ace-step", "image"}
+IMAGE_LANES = {"chroma", "hidream", "krea", "ideogram", "z-image"}
+COMFY_LANES = VIDEO_LANES | IMAGE_LANES | {"ace-step", "image"}
 
 
 def _evict_voice() -> None:

--- a/services/studio/production/executor.py
+++ b/services/studio/production/executor.py
@@ -1,0 +1,152 @@
+"""The deterministic executor — the four production phases for v0a.
+
+v0a has no pre-production (no image lanes), so the loop is: video → audio → post.
+The LLM proposes (here: a static plan); the executor validates, renders, stores
+artifacts, and assembles. No retries/takes in v0a — a failure raises (and that
+shows up as `zero_manual_restarts=False` in the summary).
+"""
+from __future__ import annotations
+
+import os
+
+from . import assemble as _assemble
+from . import config, ensure, validators
+from .lanes import get_backend
+from .manifest import Artifact, Manifest
+from .schema import ProductionPlanV1
+from .util import sha256_file, sha256_text
+
+WAN_STEPS = 4          # distilled AllInOne schedule (studio_pipe default)
+MUSIC_STEPS = 50
+MUSIC_CFG = 5.0
+VO_TOLERANCE_S = 1.0   # a shot's narration may run up to its length + this
+
+
+def _workflow_versions() -> dict:
+    out = {}
+    for lane, fn in (("wan", "wan22_rapid.json"), ("ace-step", "ace_step_music.json")):
+        p = os.path.join(config.WORKFLOW_DIR, fn)
+        if os.path.isfile(p):
+            out[lane] = sha256_file(p)
+    return out
+
+
+def run_production(
+    plan: ProductionPlanV1,
+    *,
+    backend_name: str,
+    job_id: str,
+    now_iso: str,
+    productions_dir: str = config.PRODUCTIONS_DIR,
+) -> dict:
+    backend = get_backend(backend_name)
+    d = plan.delivery
+    prod_dir = os.path.join(productions_dir, job_id)
+    for sub in ("shots", "audio", "assembly", "logs"):
+        os.makedirs(os.path.join(prod_dir, sub), exist_ok=True)
+
+    def rel(p: str) -> str:
+        return os.path.relpath(p, prod_dir)
+
+    pairs = [(plan.shot_by_id(t.clip), t) for t in plan.timeline]   # (shot, timeline) in play order
+    man = Manifest(
+        job_id=job_id, title=plan.project.title, created_utc=now_iso, backend=backend.name,
+        delivery={"aspect": d.aspect, "width": d.width, "height": d.height, "fps": d.fps,
+                  "codec": d.codec, "loudness_lufs": d.loudness_lufs},
+        workflow_versions=_workflow_versions(),
+        seeds=[s.seed for s, _ in pairs] + ([plan.music.seed] if plan.music else []),
+    )
+
+    # -- Phase 1: video production ----------------------------------------
+    clip_paths: dict[str, str] = {}
+    for shot, _t in pairs:
+        ensure.ensure_lane("wan", backend=backend.name)
+        frames = max(1, round(shot.target_seconds * d.fps))
+        path = backend.render_video(
+            prompt=shot.prompt_intent, width=d.width, height=d.height, frames=frames,
+            steps=WAN_STEPS, seed=shot.seed, fps=d.fps,
+            out_stem=os.path.join(prod_dir, "shots", shot.id),
+        )
+        clip_paths[shot.id] = path
+        pr = validators.ffprobe(path)
+        man.add(Artifact(
+            id=f"shot.{shot.id}", type="media", role="shot", path=rel(path), lane="wan",
+            seed=shot.seed, prompt_hash=sha256_text(shot.prompt_intent),
+            width=pr.width, height=pr.height, duration=pr.duration,
+            validation=validators.run_all(shot.validators, path, target_seconds=shot.target_seconds),
+        ))
+
+    durations = [validators.ffprobe(clip_paths[s.id]).duration for s, _ in pairs]
+    total = sum(durations)
+    starts = [sum(durations[:i]) for i in range(len(durations))]
+
+    # -- Phase 2: audio production ----------------------------------------
+    ensure.ensure_tts(backend=backend.name)
+    narration: dict[str, str] = {}
+    for shot, _t in pairs:
+        if shot.narration.strip():
+            wav = backend.tts(text=shot.narration, voice="", speed=1.0,
+                              out_stem=os.path.join(prod_dir, "audio", f"{shot.id}_vo"))
+            narration[shot.id] = wav
+            man.add(Artifact(
+                id=f"narration.{shot.id}", type="media", role="narration", path=rel(wav),
+                prompt_hash=sha256_text(shot.narration),
+                duration=validators.ffprobe(wav).duration,
+                validation=validators.run_all(["non_empty", "audio_present"], wav),
+            ))
+
+    bed = None
+    if plan.music:
+        ensure.ensure_lane("ace-step", backend=backend.name)
+        secs = plan.music.seconds or total
+        bed = backend.make_music(
+            tags=plan.music.tags, lyrics=plan.music.lyrics, seconds=secs,
+            steps=MUSIC_STEPS, cfg=MUSIC_CFG, seed=plan.music.seed,
+            out_stem=os.path.join(prod_dir, "audio", "bed"),
+        )
+        man.add(Artifact(
+            id="music.bed", type="media", role="music_bed", path=rel(bed), lane="ace-step",
+            seed=plan.music.seed, duration=validators.ffprobe(bed).duration,
+            validation=validators.run_all(["non_empty", "audio_present"], bed),
+        ))
+
+    # -- Phase 3: post-production (assemble) ------------------------------
+    narr_inputs: list[tuple[str, int]] = []
+    for i, (shot, t) in enumerate(pairs):
+        if shot.id in narration:
+            start_ms = max(0, int((starts[i] + t.narration_offset) * 1000))
+            narr_inputs.append((narration[shot.id], start_ms))
+    bed_level_db = pairs[0][1].music_level_db if pairs else -18.0
+
+    final_path = os.path.join(prod_dir, "assembly", "final.mp4")
+    cmd = _assemble.assemble(
+        final_path, [clip_paths[s.id] for s, _ in pairs], narr_inputs, bed,
+        fps=d.fps, lufs=d.loudness_lufs, bed_level_db=bed_level_db,
+    )
+    man.ffmpeg_cmds.append(cmd)
+    fpr = validators.ffprobe(final_path)
+    man.add(Artifact(
+        id="final.mp4", type="media", role="final", path=rel(final_path),
+        width=fpr.width, height=fpr.height, duration=fpr.duration,
+        validation=validators.run_all(["non_empty", "audio_present", "duration"], final_path),
+    ))
+    man.final = rel(final_path)
+
+    # -- exit criteria -----------------------------------------------------
+    vo_ok = []
+    for i, (shot, _t) in enumerate(pairs):
+        if shot.id in narration:
+            vo_dur = validators.ffprobe(narration[shot.id]).duration
+            vo_ok.append({"shot": shot.id, "vo_s": round(vo_dur, 2), "shot_s": round(durations[i], 2),
+                          "ok": vo_dur <= durations[i] + VO_TOLERANCE_S})
+    man.exit_criteria = {
+        "all_validators_pass": all(a.validation.get("ok") for a in man.artifacts),
+        "vo_within_tolerance": all(v["ok"] for v in vo_ok),
+        "vo_detail": vo_ok,
+        "final_has_audio": fpr.has_audio,
+        "final_duration_s": round(fpr.duration, 2),
+        "total_clip_s": round(total, 2),
+        "better_than_lane_by_lane": None,   # human judgment — printed as a prompt
+    }
+    man.write(prod_dir)
+    return {"prod_dir": prod_dir, "final": final_path, "manifest": man.to_dict()}

--- a/services/studio/production/executor.py
+++ b/services/studio/production/executor.py
@@ -16,7 +16,7 @@ from . import config, ensure, validators
 from .lanes import get_backend
 from .manifest import Artifact, Manifest
 from .schema import ProductionPlanV1
-from .util import sha256_file, sha256_text
+from .util import last_frame, sha256_file, sha256_text
 
 WAN_STEPS = 4          # distilled AllInOne schedule (studio_pipe default)
 MUSIC_STEPS = 50
@@ -64,20 +64,53 @@ def run_production(
     with open(os.path.join(prod_dir, "production.json"), "w") as f:
         json.dump(dataclasses.asdict(plan), f, indent=2)
 
+    # -- Phase 0: pre-production (generate image assets, v0b-images) -------
+    # The asset-DAG resolves here: anything a shot's start_from references must be
+    # produced BEFORE the video that consumes it.
+    asset_paths: dict[str, str] = {}
+    for at in plan.asset_tasks:
+        ensure.ensure_lane(at.lane, backend=backend.name)
+        img = backend.generate_image(
+            prompt=at.prompt, width=at.width, height=at.height, seed=at.seed,
+            lane=at.lane, out_stem=os.path.join(prod_dir, "assets", at.id),
+        )
+        asset_paths[at.id] = img
+        ipr = validators.ffprobe(img)
+        man.add(Artifact(
+            id=f"asset.{at.id}", type="media", role=at.role, path=rel(img), lane=at.lane,
+            seed=at.seed, prompt_hash=sha256_text(at.prompt),
+            width=ipr.width, height=ipr.height,
+            validation=validators.run_all(["non_empty", "has_video"], img),
+        ))
+
     # -- Phase 1: video production ----------------------------------------
+    vlane = plan.project.video_lane
     clip_paths: dict[str, str] = {}
-    for shot, _t in pairs:
-        ensure.ensure_lane("wan", backend=backend.name)
+    prev_clip = None
+    for shot, _t in pairs:        # pairs is in play (timeline) order — prev_last_frame relies on it
+        mode, start_image = "t2v", None
+        if shot.start_from == "prev_last_frame":
+            if prev_clip is None:
+                raise RuntimeError(f"shot {shot.id}: start_from 'prev_last_frame' but no previous clip")
+            start_image = last_frame(prev_clip, os.path.join(prod_dir, "assets", f"{shot.id}_start.png"))
+            mode = "i2v"
+        elif shot.start_from:
+            start_image = asset_paths.get(shot.start_from)
+            if not start_image:
+                raise RuntimeError(f"shot {shot.id}: start_from {shot.start_from!r} was not generated")
+            mode = "i2v"
+        ensure.ensure_lane(vlane, backend=backend.name)
         frames = max(1, round(shot.target_seconds * d.fps))
         path = backend.render_video(
             prompt=shot.prompt_intent, width=d.width, height=d.height, frames=frames,
-            steps=WAN_STEPS, seed=shot.seed, fps=d.fps,
+            steps=WAN_STEPS, seed=shot.seed, fps=d.fps, mode=mode, start_image=start_image,
             out_stem=os.path.join(prod_dir, "shots", shot.id),
         )
         clip_paths[shot.id] = path
+        prev_clip = path
         pr = validators.ffprobe(path)
         man.add(Artifact(
-            id=f"shot.{shot.id}", type="media", role="shot", path=rel(path), lane="wan",
+            id=f"shot.{shot.id}", type="media", role="shot", path=rel(path), lane=vlane,
             seed=shot.seed, prompt_hash=sha256_text(shot.prompt_intent),
             width=pr.width, height=pr.height, duration=pr.duration,
             validation=validators.run_all(shot.validators, path, target_seconds=shot.target_seconds),

--- a/services/studio/production/executor.py
+++ b/services/studio/production/executor.py
@@ -78,7 +78,6 @@ def run_production(
 
     durations = [validators.ffprobe(clip_paths[s.id]).duration for s, _ in pairs]
     total = sum(durations)
-    starts = [sum(durations[:i]) for i in range(len(durations))]
 
     # -- Phase 2: audio production ----------------------------------------
     ensure.ensure_tts(backend=backend.name)
@@ -111,17 +110,21 @@ def run_production(
         ))
 
     # -- Phase 3: post-production (assemble) ------------------------------
-    narr_inputs: list[tuple[str, int]] = []
-    for i, (shot, t) in enumerate(pairs):
-        if shot.id in narration:
-            start_ms = max(0, int((starts[i] + t.narration_offset) * 1000))
-            narr_inputs.append((narration[shot.id], start_ms))
+    # narration as (path, shot_index, intra_offset) — assemble computes the
+    # crossfade-aware absolute start from the shot index.
+    narr_inputs = [
+        (narration[shot.id], i, t.narration_offset)
+        for i, (shot, t) in enumerate(pairs) if shot.id in narration
+    ]
+    # per-seam transitions — each governed by the transition_in of the clip the
+    # seam leads INTO (dissolve default, cut available).
+    transitions = [(t.transition_in, plan.assembly.transition_seconds) for (_s, t) in pairs[1:]]
     bed_level_db = pairs[0][1].music_level_db if pairs else -18.0
 
     final_path = os.path.join(prod_dir, "assembly", "final.mp4")
     cmd = _assemble.assemble(
-        final_path, [clip_paths[s.id] for s, _ in pairs], narr_inputs, bed,
-        fps=d.fps, lufs=d.loudness_lufs, bed_level_db=bed_level_db,
+        final_path, [clip_paths[s.id] for s, _ in pairs], durations, transitions, narr_inputs, bed,
+        fps=d.fps, lufs=d.loudness_lufs, bed_level_db=bed_level_db, duck_db=plan.assembly.duck_db,
     )
     man.ffmpeg_cmds.append(cmd)
     fpr = validators.ffprobe(final_path)

--- a/services/studio/production/executor.py
+++ b/services/studio/production/executor.py
@@ -7,6 +7,8 @@ shows up as `zero_manual_restarts=False` in the summary).
 """
 from __future__ import annotations
 
+import dataclasses
+import json
 import os
 
 from . import assemble as _assemble
@@ -38,6 +40,7 @@ def run_production(
     job_id: str,
     now_iso: str,
     productions_dir: str = config.PRODUCTIONS_DIR,
+    extra_artifacts: list = (),
 ) -> dict:
     backend = get_backend(backend_name)
     d = plan.delivery
@@ -56,6 +59,10 @@ def run_production(
         workflow_versions=_workflow_versions(),
         seeds=[s.seed for s, _ in pairs] + ([plan.music.seed] if plan.music else []),
     )
+    for a in (extra_artifacts or []):   # planner llm_prompt provenance (v0b)
+        man.add(a)
+    with open(os.path.join(prod_dir, "production.json"), "w") as f:
+        json.dump(dataclasses.asdict(plan), f, indent=2)
 
     # -- Phase 1: video production ----------------------------------------
     clip_paths: dict[str, str] = {}

--- a/services/studio/production/executor.py
+++ b/services/studio/production/executor.py
@@ -150,7 +150,10 @@ def run_production(
             vo_ok.append({"shot": shot.id, "vo_s": round(vo_dur, 2), "shot_s": round(durations[i], 2),
                           "ok": vo_dur <= durations[i] + VO_TOLERANCE_S})
     man.exit_criteria = {
-        "all_validators_pass": all(a.validation.get("ok") for a in man.artifacts),
+        # only MEDIA artifacts carry validators; llm_prompt provenance is excluded.
+        "all_validators_pass": all(
+            a.validation.get("ok", False) for a in man.artifacts if a.type == "media"
+        ),
         "vo_within_tolerance": all(v["ok"] for v in vo_ok),
         "vo_detail": vo_ok,
         "final_has_audio": fpr.has_audio,

--- a/services/studio/production/lanes.py
+++ b/services/studio/production/lanes.py
@@ -1,0 +1,141 @@
+"""Lane backends — `live` (real studio services) and `synthetic` (ffmpeg lavfi).
+
+Backend methods take an `out_stem` (no extension) and return the ACTUAL path
+written (extension chosen by the lane), so the executor stays agnostic to whether
+a clip came from ComfyUI (.mp4), ACE (.mp3), Kokoro (.wav), or a synthetic source.
+
+The synthetic backend exists so the WHOLE executor → validators → assemble →
+manifest path runs offline (no GPU / ComfyUI / TTS) with real, ffprobe-able media —
+that's how v0a is verified before it ever touches the rig.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import urllib.request
+from abc import ABC, abstractmethod
+
+from . import comfy, config
+from .util import sh
+
+
+def _load_workflow(name: str) -> dict:
+    path = os.path.join(config.WORKFLOW_DIR, name)
+    with open(path) as f:
+        return json.load(f)
+
+
+class StudioBackend(ABC):
+    name = "abstract"
+
+    @abstractmethod
+    def render_video(self, *, prompt: str, width: int, height: int, frames: int,
+                     steps: int, seed: int, fps: int, out_stem: str) -> str: ...
+
+    @abstractmethod
+    def make_music(self, *, tags: str, lyrics: str, seconds: float, steps: int,
+                   cfg: float, seed: int, out_stem: str) -> str: ...
+
+    @abstractmethod
+    def tts(self, *, text: str, voice: str, speed: float, out_stem: str) -> str: ...
+
+
+# --------------------------------------------------------------------------- live
+class LiveBackend(StudioBackend):
+    """Drives the real ComfyUI (:8188) + Kokoro TTS (:8192)."""
+    name = "live"
+
+    def _comfy_to(self, fn: str, sub: str, out_stem: str) -> str:
+        src = os.path.join(config.OUTPUT_ROOT, sub, fn)
+        ext = os.path.splitext(fn)[1] or ".bin"
+        dst = out_stem + ext
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        shutil.copyfile(src, dst)
+        return dst
+
+    def render_video(self, *, prompt, width, height, frames, steps, seed, fps, out_stem) -> str:
+        wf = _load_workflow("wan22_rapid.json")
+        wf["pos"]["inputs"]["text"] = prompt
+        wf["latent"]["inputs"]["width"] = width
+        wf["latent"]["inputs"]["height"] = height
+        wf["latent"]["inputs"]["length"] = frames
+        wf["ksampler"]["inputs"]["steps"] = steps
+        wf["ksampler"]["inputs"]["seed"] = seed
+        wf["video"]["inputs"]["fps"] = float(fps)
+        fn, sub = comfy.await_output(comfy.submit(wf), "video")
+        return self._comfy_to(fn, sub, out_stem)
+
+    def make_music(self, *, tags, lyrics, seconds, steps, cfg, seed, out_stem) -> str:
+        wf = _load_workflow("ace_step_music.json")
+        wf["pos"]["inputs"]["tags"] = tags
+        wf["pos"]["inputs"]["lyrics"] = lyrics or "[instrumental]"
+        wf["latent"]["inputs"]["seconds"] = float(seconds)
+        wf["ksampler"]["inputs"]["steps"] = steps
+        wf["ksampler"]["inputs"]["cfg"] = cfg
+        wf["ksampler"]["inputs"]["seed"] = seed
+        fn, sub = comfy.await_output(comfy.submit(wf), "audio")
+        return self._comfy_to(fn, sub, out_stem)
+
+    def tts(self, *, text, voice, speed, out_stem) -> str:
+        body = {"text": text}
+        if voice:
+            body["voice"] = voice
+        if speed:
+            body["speed"] = speed
+        req = urllib.request.Request(
+            config.TTS_URL + "/tts", data=json.dumps(body).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        r = json.load(urllib.request.urlopen(req, timeout=config.RENDER_TIMEOUT))
+        name = r.get("wav")
+        if not name:
+            raise RuntimeError(f"TTS returned no wav: {r}")
+        src = os.path.join(config.OUTPUT_ROOT, name)
+        dst = out_stem + ".wav"
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        shutil.copyfile(src, dst)
+        return dst
+
+
+# ---------------------------------------------------------------------- synthetic
+class SyntheticBackend(StudioBackend):
+    """ffmpeg-lavfi stand-ins: real media, real durations — no GPU/services.
+
+    Clips are silent solid-colour video (so `no_audio_expected` holds), narration is
+    a sine WAV sized to word-count (so VO-timing logic is exercised), music is a low
+    sine bed. Lets the full pipeline run + self-test offline.
+    """
+    name = "synthetic"
+
+    def render_video(self, *, prompt, width, height, frames, steps, seed, fps, out_stem) -> str:
+        dur = max(0.1, frames / float(fps or 16))
+        colour = "0x%06x" % (abs(hash((prompt, seed))) % 0xFFFFFF)
+        dst = out_stem + ".mp4"
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        sh(["ffmpeg", "-y", "-v", "error",
+            "-f", "lavfi", "-i", f"color=c={colour}:s={width}x{height}:r={fps}",
+            "-t", f"{dur:.3f}", "-c:v", "libx264", "-pix_fmt", "yuv420p", "-an", dst])
+        return dst
+
+    def make_music(self, *, tags, lyrics, seconds, steps, cfg, seed, out_stem) -> str:
+        dst = out_stem + ".wav"
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        sh(["ffmpeg", "-y", "-v", "error",
+            "-f", "lavfi", "-i", f"sine=frequency=180:duration={max(0.5, seconds):.3f}",
+            "-c:a", "pcm_s16le", dst])
+        return dst
+
+    def tts(self, *, text, voice, speed, out_stem) -> str:
+        words = max(1, len(text.split()))
+        dur = max(0.6, words * 0.4 / float(speed or 1.0))
+        dst = out_stem + ".wav"
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        sh(["ffmpeg", "-y", "-v", "error",
+            "-f", "lavfi", "-i", f"sine=frequency=440:duration={dur:.3f}",
+            "-c:a", "pcm_s16le", dst])
+        return dst
+
+
+def get_backend(name: str) -> StudioBackend:
+    return {"live": LiveBackend, "synthetic": SyntheticBackend}[name]()

--- a/services/studio/production/lanes.py
+++ b/services/studio/production/lanes.py
@@ -27,6 +27,10 @@ def _load_workflow(name: str) -> dict:
         return json.load(f)
 
 
+# image lane -> ComfyUI workflow (hero keyframes / reference stills, v0b-images)
+_IMAGE_WORKFLOWS = {"chroma": "chroma1_hd.json"}
+
+
 def _pull(src_host: str, dst: str, *, container: str, container_path: str) -> str:
     """Copy a service-written artifact into the production tree.
 
@@ -54,7 +58,12 @@ class StudioBackend(ABC):
 
     @abstractmethod
     def render_video(self, *, prompt: str, width: int, height: int, frames: int,
-                     steps: int, seed: int, fps: int, out_stem: str) -> str: ...
+                     steps: int, seed: int, fps: int, out_stem: str,
+                     mode: str = "t2v", start_image: str | None = None) -> str: ...
+
+    @abstractmethod
+    def generate_image(self, *, prompt: str, width: int, height: int, seed: int,
+                       lane: str, out_stem: str) -> str: ...
 
     @abstractmethod
     def make_music(self, *, tags: str, lyrics: str, seconds: float, steps: int,
@@ -75,16 +84,61 @@ class LiveBackend(StudioBackend):
         cpath = "/output/" + (f"{sub}/{fn}" if sub else fn)
         return _pull(src, out_stem + ext, container=config.COMFY_CONTAINER, container_path=cpath)
 
-    def render_video(self, *, prompt, width, height, frames, steps, seed, fps, out_stem) -> str:
-        wf = _load_workflow("wan22_rapid.json")
+    def _upload_image(self, path: str) -> str:
+        """Upload a host image to ComfyUI (/upload/image); return its name."""
+        with open(path, "rb") as f:
+            raw = f.read()
+        ext = (os.path.splitext(path)[1].lstrip(".") or "png")
+        fname = "studio_prod_input." + ext
+        bnd = "----studioprodboundary7e3"
+        body = (b"--" + bnd.encode() + b"\r\n"
+                b'Content-Disposition: form-data; name="image"; filename="' + fname.encode() + b'"\r\n'
+                b"Content-Type: image/" + ext.encode() + b"\r\n\r\n" + raw + b"\r\n"
+                b"--" + bnd.encode() + b"\r\n"
+                b'Content-Disposition: form-data; name="overwrite"\r\n\r\ntrue\r\n'
+                b"--" + bnd.encode() + b"--\r\n")
+        req = urllib.request.Request(config.COMFYUI_URL + "/upload/image", data=body,
+                                     headers={"Content-Type": "multipart/form-data; boundary=" + bnd})
+        return json.load(urllib.request.urlopen(req, timeout=60)).get("name", fname)
+
+    def render_video(self, *, prompt, width, height, frames, steps, seed, fps, out_stem,
+                     mode="t2v", start_image=None) -> str:
+        if mode == "i2v":
+            if not start_image:
+                raise RuntimeError("i2v render requires a start_image")
+            wf = _load_workflow("wan22_rapid_i2v.json")
+            wf["loadimage"]["inputs"]["image"] = self._upload_image(start_image)
+            wf["resize"]["inputs"]["width"] = width
+            wf["resize"]["inputs"]["height"] = height
+            wf["pos"]["inputs"]["text"] = prompt
+            wf["i2v"]["inputs"]["width"] = width
+            wf["i2v"]["inputs"]["height"] = height
+            wf["i2v"]["inputs"]["length"] = frames
+            wf["ksampler"]["inputs"]["steps"] = steps
+            wf["ksampler"]["inputs"]["seed"] = seed
+            wf["video"]["inputs"]["fps"] = float(fps)
+        else:
+            wf = _load_workflow("wan22_rapid.json")
+            wf["pos"]["inputs"]["text"] = prompt
+            wf["latent"]["inputs"]["width"] = width
+            wf["latent"]["inputs"]["height"] = height
+            wf["latent"]["inputs"]["length"] = frames
+            wf["ksampler"]["inputs"]["steps"] = steps
+            wf["ksampler"]["inputs"]["seed"] = seed
+            wf["video"]["inputs"]["fps"] = float(fps)
+        fn, sub = comfy.await_output(comfy.submit(wf), "video")
+        return self._comfy_to(fn, sub, out_stem)
+
+    def generate_image(self, *, prompt, width, height, seed, lane, out_stem) -> str:
+        wf_name = _IMAGE_WORKFLOWS.get(lane)
+        if not wf_name:
+            raise RuntimeError(f"no image workflow for lane {lane!r} (have {list(_IMAGE_WORKFLOWS)})")
+        wf = _load_workflow(wf_name)
         wf["pos"]["inputs"]["text"] = prompt
         wf["latent"]["inputs"]["width"] = width
         wf["latent"]["inputs"]["height"] = height
-        wf["latent"]["inputs"]["length"] = frames
-        wf["ksampler"]["inputs"]["steps"] = steps
-        wf["ksampler"]["inputs"]["seed"] = seed
-        wf["video"]["inputs"]["fps"] = float(fps)
-        fn, sub = comfy.await_output(comfy.submit(wf), "video")
+        wf["noise"]["inputs"]["noise_seed"] = seed   # chroma sampler graph
+        fn, sub = comfy.await_output(comfy.submit(wf), "image")
         return self._comfy_to(fn, sub, out_stem)
 
     def make_music(self, *, tags, lyrics, seconds, steps, cfg, seed, out_stem) -> str:
@@ -127,14 +181,32 @@ class SyntheticBackend(StudioBackend):
     """
     name = "synthetic"
 
-    def render_video(self, *, prompt, width, height, frames, steps, seed, fps, out_stem) -> str:
+    def render_video(self, *, prompt, width, height, frames, steps, seed, fps, out_stem,
+                     mode="t2v", start_image=None) -> str:
         dur = max(0.1, frames / float(fps or 16))
-        colour = "0x%06x" % (abs(hash((prompt, seed))) % 0xFFFFFF)
         dst = out_stem + ".mp4"
         os.makedirs(os.path.dirname(dst), exist_ok=True)
+        if mode == "i2v" and start_image:
+            # synthetic i2v: a clip that literally BEGINS from the start frame (a
+            # static hold), so chaining/hero continuity is visibly continuous offline
+            # too — and the asset-DAG ordering is exercised for real.
+            sh(["ffmpeg", "-y", "-v", "error", "-loop", "1", "-i", start_image,
+                "-t", f"{dur:.3f}", "-r", str(fps),
+                "-vf", f"scale={width}:{height},format=yuv420p",
+                "-c:v", "libx264", "-an", dst])
+        else:
+            colour = "0x%06x" % (abs(hash((prompt, seed))) % 0xFFFFFF)
+            sh(["ffmpeg", "-y", "-v", "error",
+                "-f", "lavfi", "-i", f"color=c={colour}:s={width}x{height}:r={fps}",
+                "-t", f"{dur:.3f}", "-c:v", "libx264", "-pix_fmt", "yuv420p", "-an", dst])
+        return dst
+
+    def generate_image(self, *, prompt, width, height, seed, lane, out_stem) -> str:
+        colour = "0x%06x" % (abs(hash((prompt, seed, "img"))) % 0xFFFFFF)
+        dst = out_stem + ".png"
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
         sh(["ffmpeg", "-y", "-v", "error",
-            "-f", "lavfi", "-i", f"color=c={colour}:s={width}x{height}:r={fps}",
-            "-t", f"{dur:.3f}", "-c:v", "libx264", "-pix_fmt", "yuv420p", "-an", dst])
+            "-f", "lavfi", "-i", f"color=c={colour}:s={width}x{height}", "-frames:v", "1", dst])
         return dst
 
     def make_music(self, *, tags, lyrics, seconds, steps, cfg, seed, out_stem) -> str:

--- a/services/studio/production/lanes.py
+++ b/services/studio/production/lanes.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import subprocess
 import urllib.request
 from abc import ABC, abstractmethod
 
@@ -24,6 +25,28 @@ def _load_workflow(name: str) -> dict:
     path = os.path.join(config.WORKFLOW_DIR, name)
     with open(path) as f:
         return json.load(f)
+
+
+def _pull(src_host: str, dst: str, *, container: str, container_path: str) -> str:
+    """Copy a service-written artifact into the production tree.
+
+    Tries a plain host copy first (ComfyUI writes 0666). If the service wrote the
+    file root-only (Kokoro TTS writes mode 0600), fall back to `docker cp` from the
+    owning container — the docker daemon reads it as root. Either way the result is
+    host-owned + 0644 so downstream ffmpeg can read it. Surfaced live on 2026-06-28;
+    the cleaner systemic fix is for the TTS service to write 0644 (a v0b follow-up).
+    """
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
+    try:
+        shutil.copyfile(src_host, dst)
+    except PermissionError:
+        subprocess.run(["docker", "cp", f"{container}:{container_path}", dst],
+                       check=True, capture_output=True, text=True)
+    try:
+        os.chmod(dst, 0o644)
+    except OSError:
+        pass
+    return dst
 
 
 class StudioBackend(ABC):
@@ -49,10 +72,8 @@ class LiveBackend(StudioBackend):
     def _comfy_to(self, fn: str, sub: str, out_stem: str) -> str:
         src = os.path.join(config.OUTPUT_ROOT, sub, fn)
         ext = os.path.splitext(fn)[1] or ".bin"
-        dst = out_stem + ext
-        os.makedirs(os.path.dirname(dst), exist_ok=True)
-        shutil.copyfile(src, dst)
-        return dst
+        cpath = "/output/" + (f"{sub}/{fn}" if sub else fn)
+        return _pull(src, out_stem + ext, container=config.COMFY_CONTAINER, container_path=cpath)
 
     def render_video(self, *, prompt, width, height, frames, steps, seed, fps, out_stem) -> str:
         wf = _load_workflow("wan22_rapid.json")
@@ -92,10 +113,8 @@ class LiveBackend(StudioBackend):
         if not name:
             raise RuntimeError(f"TTS returned no wav: {r}")
         src = os.path.join(config.OUTPUT_ROOT, name)
-        dst = out_stem + ".wav"
-        os.makedirs(os.path.dirname(dst), exist_ok=True)
-        shutil.copyfile(src, dst)
-        return dst
+        return _pull(src, out_stem + ".wav",
+                     container=config.TTS_CONTAINER, container_path="/output/" + name)
 
 
 # ---------------------------------------------------------------------- synthetic

--- a/services/studio/production/lock.py
+++ b/services/studio/production/lock.py
@@ -1,0 +1,64 @@
+"""Process-local single-flight lock for v0a (CLI/admin).
+
+v0a is CLI/admin-only, so a host file-lock is enough to guarantee one production
+job at a time (two `run`s can't render into the same ComfyUI queue concurrently).
+The durable queue + OWUI-exposed job lock are v0b/v1.
+"""
+from __future__ import annotations
+
+import errno
+import fcntl
+import os
+
+from . import config
+
+
+class ProductionLockHeld(RuntimeError):
+    pass
+
+
+class ProductionLock:
+    """Non-blocking flock on `<productions>/.run.lock`.
+
+    Usage:
+        with ProductionLock():
+            ...   # raises ProductionLockHeld immediately if another run holds it
+    """
+
+    def __init__(self, path: str | None = None):
+        self.path = path or os.path.join(config.PRODUCTIONS_DIR, ".run.lock")
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
+        self._fd = None
+
+    def acquire(self) -> "ProductionLock":
+        self._fd = os.open(self.path, os.O_CREAT | os.O_RDWR, 0o644)
+        try:
+            fcntl.flock(self._fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as e:
+            os.close(self._fd)
+            self._fd = None
+            if e.errno in (errno.EAGAIN, errno.EACCES):
+                raise ProductionLockHeld(
+                    f"another production run holds {self.path} — v0a is single-flight"
+                ) from e
+            raise
+        os.ftruncate(self._fd, 0)
+        os.write(self._fd, str(os.getpid()).encode())
+        return self
+
+    def release(self) -> None:
+        if self._fd is not None:
+            try:
+                fcntl.flock(self._fd, fcntl.LOCK_UN)
+            finally:
+                os.close(self._fd)
+                self._fd = None
+
+    def held(self) -> bool:
+        return self._fd is not None
+
+    def __enter__(self) -> "ProductionLock":
+        return self.acquire()
+
+    def __exit__(self, *exc) -> None:
+        self.release()

--- a/services/studio/production/manifest.py
+++ b/services/studio/production/manifest.py
@@ -1,0 +1,64 @@
+"""Typed, extensible production manifest.
+
+Records (a) run-level provenance — registry/workflow versions, seeds, the exact
+ffmpeg command, delivery profile — so a whole run reproduces, and (b) per-artifact
+records discriminated by `type`. v0a only writes `type="media"` records, but the
+shape already admits `type="llm_prompt"` so v0b prompt-provenance slots in with no
+redesign.
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+
+
+@dataclass
+class Artifact:
+    id: str
+    type: str            # "media" | "llm_prompt"  (v0a writes only "media")
+    role: str            # "shot" | "narration" | "music_bed" | "final"
+    path: str            # relative to the production dir
+    lane: str = ""
+    seed: int = 0
+    prompt_hash: str = ""
+    width: int = 0
+    height: int = 0
+    duration: float = 0.0
+    validation: dict = field(default_factory=dict)
+
+
+@dataclass
+class Manifest:
+    job_id: str
+    title: str
+    created_utc: str
+    backend: str                          # "live" | "synthetic"
+    schema_version: str = "ProductionPlanV1"
+    delivery: dict = field(default_factory=dict)
+    workflow_versions: dict = field(default_factory=dict)   # {"wan": sha, "ace-step": sha}
+    seeds: list = field(default_factory=list)
+    ffmpeg_cmds: list = field(default_factory=list)         # exact assemble commands
+    artifacts: list = field(default_factory=list)           # list[Artifact]
+    final: str = ""
+    exit_criteria: dict = field(default_factory=dict)
+
+    def add(self, art: Artifact) -> Artifact:
+        self.artifacts.append(art)
+        return art
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["artifacts"] = [asdict(a) if isinstance(a, Artifact) else a for a in self.artifacts]
+        return d
+
+    def write(self, prod_dir: str) -> str:
+        path = os.path.join(prod_dir, "manifest.json")
+        with open(path, "w") as f:
+            json.dump(self.to_dict(), f, indent=2)
+        return path
+
+    @staticmethod
+    def read(prod_dir: str) -> dict:
+        with open(os.path.join(prod_dir, "manifest.json")) as f:
+            return json.load(f)

--- a/services/studio/production/planner.py
+++ b/services/studio/production/planner.py
@@ -1,0 +1,159 @@
+"""The 4B planner — brief -> validated ProductionPlanV1.
+
+Two-stage, creative-within-bounds: (1) a free-form creative treatment, then
+(2) a structured plan, then a **validator-repair loop** — parse the director's JSON,
+`schema.validate()` it, and on any failure feed the exact error back asking for a
+corrected JSON (up to `max_repairs`). The repair loop is the backbone (we do NOT
+rely on server-side constrained output, which is flaky on this build).
+
+The director call is injectable (`llm=`) so the whole planner — prompt construction,
+normalization, and the repair loop — is unit-testable offline with a stub LLM, no
+model required (mirrors the synthetic lane backend).
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+
+from . import config
+from .manifest import Artifact
+from .prompts import TREATMENT_SYS, build_plan_system, repair_user
+from .schema import PlanError, ProductionPlanV1
+from .util import sha256_text
+
+
+class PlannerError(RuntimeError):
+    pass
+
+
+# -- director call (the injectable boundary) ----------------------------------
+def director_call(messages: list[dict], *, max_tokens: int, temperature: float,
+                  base: str | None = None, timeout: int = 120) -> str:
+    """One /v1/chat/completions call to the llama.cpp director. Returns content."""
+    payload = {
+        "model": config.DIRECTOR_MODEL,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    req = urllib.request.Request(
+        (base or config.DIRECTOR_URL).rstrip("/") + "/chat/completions",
+        data=json.dumps(payload).encode(), headers={"Content-Type": "application/json"},
+    )
+    r = json.load(urllib.request.urlopen(req, timeout=timeout))
+    return r["choices"][0]["message"]["content"].strip()
+
+
+# -- robust JSON extraction (director emits free-form) ------------------------
+def extract_json(text: str) -> dict:
+    """Pull the first balanced {...} object out of the director's reply."""
+    t = (text or "").strip()
+    if t.startswith("```"):
+        t = t.strip("`")
+        t = t[4:] if t[:4].lower() == "json" else t
+        t = t.strip()
+    i = t.find("{")
+    if i < 0:
+        raise ValueError("no JSON object in director output")
+    depth = 0
+    for j in range(i, len(t)):
+        if t[j] == "{":
+            depth += 1
+        elif t[j] == "}":
+            depth -= 1
+            if depth == 0:
+                return json.loads(t[i:j + 1])
+    raise ValueError("unbalanced JSON in director output")
+
+
+# -- lenient normalization (fill obvious defaults so the 4B can be terse) -----
+def normalize(data: dict, video_lane: str = "wan") -> dict:
+    data.setdefault("schema_version", "ProductionPlanV1")
+    proj = data.setdefault("project", {})
+    proj.setdefault("video_lane", video_lane)
+    proj.setdefault("title", "Untitled")
+    vl = proj.get("video_lane", video_lane)
+    shots = data.get("shots") or []
+    for i, s in enumerate(shots):
+        s.setdefault("id", f"s{i + 1}")
+        s.setdefault("lane", vl)
+        s.setdefault("mode", "t2v")
+        s.setdefault("prompt_intent", "")
+    data.setdefault("delivery", {"aspect": "16:9", "width": 832, "height": 480,
+                                 "fps": 16, "loudness_lufs": -14.0})
+    data.setdefault("assembly", {"transition_seconds": 0.6, "duck_db": 6})
+    if not data.get("music"):
+        data["music"] = {"lane": "ace-step", "tags": "ambient, cinematic, instrumental",
+                         "lyrics": "[instrumental]", "seed": 7}
+    if not data.get("timeline"):
+        data["timeline"] = [
+            {"clip": s["id"], "narration_offset": 0.0, "music_level_db": -18,
+             "transition_in": "dissolve"} for s in shots
+        ]
+    return data
+
+
+# -- the planner --------------------------------------------------------------
+def plan_from_brief(brief: str, reg: dict, *, llm=None, max_repairs: int = 3,
+                    n_shots: int = 3, prompts_dir: str | None = None):
+    """Brief -> (ProductionPlanV1, list[Artifact]). Raises PlannerError on failure.
+
+    `llm(messages, *, max_tokens, temperature)` is the injectable director call.
+    """
+    call = llm or director_call
+    prov: list[tuple[str, str, str, str]] = []   # (role, system, user, response)
+
+    # stage 1 — creative treatment (free-form)
+    treatment = call([{"role": "system", "content": TREATMENT_SYS},
+                      {"role": "user", "content": brief}],
+                     max_tokens=400, temperature=0.8)
+    prov.append(("treatment", TREATMENT_SYS, brief, treatment))
+
+    # stage 2 — structured plan
+    plan_sys = build_plan_system(reg, n_shots=n_shots)
+    plan_user = f"BRIEF: {brief}\n\nTREATMENT:\n{treatment}\n\nNow output the ProductionPlanV1 JSON only."
+    raw = call([{"role": "system", "content": plan_sys}, {"role": "user", "content": plan_user}],
+               max_tokens=900, temperature=0.4)
+    prov.append(("plan", plan_sys, plan_user, raw))
+
+    # validator-repair loop
+    last_err = None
+    for attempt in range(max_repairs + 1):
+        try:
+            data = normalize(extract_json(raw))
+            plan = ProductionPlanV1.from_dict(data)     # validates
+            return plan, _write_provenance(prov, prompts_dir)
+        except (PlanError, ValueError, json.JSONDecodeError) as e:
+            last_err = str(e)
+            if attempt == max_repairs:
+                break
+            ru = repair_user(raw, last_err)
+            raw = call([{"role": "system", "content": plan_sys}, {"role": "user", "content": ru}],
+                       max_tokens=900, temperature=0.2)
+            prov.append((f"repair_{attempt + 1}", plan_sys, ru, raw))
+
+    _write_provenance(prov, prompts_dir)   # keep the failed trail for debugging
+    raise PlannerError(
+        f"director could not produce a valid plan after {max_repairs} repairs: {last_err}"
+    )
+
+
+def _write_provenance(prov, prompts_dir) -> list[Artifact]:
+    """Write each LLM step to prompts/<role>.json and return llm_prompt records."""
+    arts: list[Artifact] = []
+    if prompts_dir:
+        os.makedirs(prompts_dir, exist_ok=True)
+    for (role, system, user, resp) in prov:
+        rel = f"prompts/{role}.json"
+        if prompts_dir:
+            with open(os.path.join(prompts_dir, f"{role}.json"), "w") as f:
+                json.dump({"model": config.DIRECTOR_MODEL, "role": role,
+                           "system": system, "user": user, "response": resp}, f, indent=2)
+        arts.append(Artifact(
+            id=f"prompt.{role}", type="llm_prompt", role=role, path=rel,
+            lane="director", prompt_hash=sha256_text(system + "" + user),
+            validation={"response_hash": sha256_text(resp)},
+        ))
+    return arts

--- a/services/studio/production/planner.py
+++ b/services/studio/production/planner.py
@@ -95,9 +95,46 @@ def normalize(data: dict, video_lane: str = "wan") -> dict:
     return data
 
 
+# -- continuity (control-plane: the planner wires it, the 4B stays creative) ---
+def apply_continuity(data: dict, mode: str, *, image_lane: str = "chroma") -> dict:
+    """Deterministically rewrite a plan into a continuity mode (v0b-images).
+
+    The 4B produces creative shots; THIS wires the asset-DAG so consecutive clips
+    flow. `chain` = each shot i2v from the previous last frame; `hero` = all shots
+    i2v from one generated hero keyframe; `none` = leave as authored (t2v).
+    """
+    if mode not in ("none", "chain", "hero"):
+        raise ValueError(f"unknown continuity {mode!r}")
+    if mode == "none":
+        return data
+    shots = data.get("shots") or []
+    data.setdefault("project", {})["continuity"] = mode
+    if mode == "chain":
+        for i, s in enumerate(shots):
+            if i == 0:
+                s["mode"] = "t2v"
+                s.pop("start_from", None)
+            else:
+                s["mode"] = "i2v"
+                s["start_from"] = "prev_last_frame"
+    elif mode == "hero":
+        deliv = data.get("delivery", {})
+        anchor = (shots[0].get("prompt_intent") if shots else "") \
+            or data["project"].get("title", "establishing shot")
+        data["project"]["image_policy"] = {"hero_keyframe_lane": image_lane}
+        data["asset_tasks"] = [{
+            "id": "hero", "role": "hero_keyframe", "lane": image_lane, "prompt": anchor,
+            "seed": 7, "width": deliv.get("width", 832), "height": deliv.get("height", 480),
+        }]
+        for s in shots:
+            s["mode"] = "i2v"
+            s["start_from"] = "hero"
+    return data
+
+
 # -- the planner --------------------------------------------------------------
 def plan_from_brief(brief: str, reg: dict, *, llm=None, max_repairs: int = 3,
-                    n_shots: int = 3, prompts_dir: str | None = None):
+                    n_shots: int = 3, continuity: str = "none", prompts_dir: str | None = None):
     """Brief -> (ProductionPlanV1, list[Artifact]). Raises PlannerError on failure.
 
     `llm(messages, *, max_tokens, temperature)` is the injectable director call.
@@ -122,7 +159,7 @@ def plan_from_brief(brief: str, reg: dict, *, llm=None, max_repairs: int = 3,
     last_err = None
     for attempt in range(max_repairs + 1):
         try:
-            data = normalize(extract_json(raw))
+            data = apply_continuity(normalize(extract_json(raw)), continuity)
             plan = ProductionPlanV1.from_dict(data)     # validates
             return plan, _write_provenance(prov, prompts_dir)
         except (PlanError, ValueError, json.JSONDecodeError) as e:

--- a/services/studio/production/planner.py
+++ b/services/studio/production/planner.py
@@ -103,12 +103,38 @@ def apply_continuity(data: dict, mode: str, *, image_lane: str = "chroma") -> di
     flow. `chain` = each shot i2v from the previous last frame; `hero` = all shots
     i2v from one generated hero keyframe; `none` = leave as authored (t2v).
     """
-    if mode not in ("none", "chain", "hero"):
+    if mode not in ("none", "chain", "hero", "storyboard"):
         raise ValueError(f"unknown continuity {mode!r}")
     if mode == "none":
         return data
     shots = data.get("shots") or []
-    data.setdefault("project", {})["continuity"] = mode
+    proj = data.setdefault("project", {})
+    proj["continuity"] = mode
+    deliv = data.get("delivery", {})
+    iw, ih = deliv.get("width", 832), deliv.get("height", 480)
+    if mode == "storyboard":
+        # a shared style bible + ONE deliberate keyframe per shot (each shot i2v from
+        # its OWN keyframe). Shared style/palette across keyframes -> coherence; the
+        # per-shot prompt -> deliberate per-shot subject. Threads between hero
+        # (every shot orbits one image) and chain (drifts).
+        tone = (proj.get("tone") or "").strip()
+        bible = ", ".join(filter(None, [
+            "cohesive cinematic style", "consistent palette and lighting",
+            "soft film grade", tone]))
+        proj["image_policy"] = {"storyboard_keyframe_lane": image_lane}
+        tasks = []
+        for s in shots:
+            kf = f"kf_{s.get('id', 'x')}"
+            tasks.append({
+                "id": kf, "role": "storyboard_keyframe", "lane": image_lane,
+                "prompt": f"{bible}. {s.get('prompt_intent', '')}".strip(),
+                "seed": 7,            # shared seed across keyframes -> stronger style coherence
+                "width": iw, "height": ih,
+            })
+            s["mode"] = "i2v"
+            s["start_from"] = kf
+        data["asset_tasks"] = tasks
+        return data
     if mode == "chain":
         for i, s in enumerate(shots):
             if i == 0:

--- a/services/studio/production/plans/lighthouse_3shot.json
+++ b/services/studio/production/plans/lighthouse_3shot.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "ProductionPlanV1",
+  "project": {
+    "title": "A Short History of Lighthouses",
+    "tone": "calm",
+    "target_seconds": 15,
+    "video_lane": "wan"
+  },
+  "delivery": {
+    "aspect": "16:9",
+    "width": 832,
+    "height": 480,
+    "fps": 16,
+    "codec": "h264",
+    "loudness_lufs": -14.0,
+    "subtitles": false
+  },
+  "shots": [
+    {
+      "id": "s1",
+      "lane": "wan",
+      "mode": "t2v",
+      "target_seconds": 5,
+      "prompt_intent": "dawn over a rocky New England cape, a white lighthouse silhouette, gentle swell, archival film grade",
+      "narration": "In 1716, the first American lighthouse rose over Boston Harbor.",
+      "seed": 12345
+    },
+    {
+      "id": "s2",
+      "lane": "wan",
+      "mode": "t2v",
+      "target_seconds": 5,
+      "prompt_intent": "slow reveal of a rotating Fresnel lens glowing amber inside the lamp room, warm light",
+      "narration": "Its rotating Fresnel lens could throw a beam for twenty miles.",
+      "seed": 23456
+    },
+    {
+      "id": "s3",
+      "lane": "wan",
+      "mode": "t2v",
+      "target_seconds": 5,
+      "prompt_intent": "a lighthouse at dusk in light fog, the beam sweeping across a calm sea, contemplative",
+      "narration": "Today most stand automated, quiet keepers of a fading craft.",
+      "seed": 34567
+    }
+  ],
+  "audio_layers": {
+    "narration": { "engine": "kokoro" },
+    "music": { "lane": "ace-step" }
+  },
+  "music": {
+    "lane": "ace-step",
+    "tags": "ambient, reflective, cinematic, soft piano, instrumental",
+    "lyrics": "[instrumental]",
+    "seed": 99
+  },
+  "timeline": [
+    { "clip": "s1", "narration_offset": 0.2, "music_level_db": -18 },
+    { "clip": "s2", "narration_offset": 0.0, "music_level_db": -18 },
+    { "clip": "s3", "narration_offset": 0.0, "music_level_db": -18 }
+  ]
+}

--- a/services/studio/production/plans/lighthouse_3shot.json
+++ b/services/studio/production/plans/lighthouse_3shot.json
@@ -54,9 +54,13 @@
     "lyrics": "[instrumental]",
     "seed": 99
   },
+  "assembly": {
+    "transition_seconds": 0.6,
+    "duck_db": 6
+  },
   "timeline": [
-    { "clip": "s1", "narration_offset": 0.2, "music_level_db": -18 },
-    { "clip": "s2", "narration_offset": 0.0, "music_level_db": -18 },
-    { "clip": "s3", "narration_offset": 0.0, "music_level_db": -18 }
+    { "clip": "s1", "narration_offset": 0.2, "music_level_db": -18, "transition_in": "dissolve" },
+    { "clip": "s2", "narration_offset": 0.0, "music_level_db": -18, "transition_in": "dissolve" },
+    { "clip": "s3", "narration_offset": 0.0, "music_level_db": -18, "transition_in": "dissolve" }
   ]
 }

--- a/services/studio/production/plans/lighthouse_chain.json
+++ b/services/studio/production/plans/lighthouse_chain.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "ProductionPlanV1",
+  "project": {
+    "title": "Lighthouses — Chain",
+    "tone": "calm",
+    "target_seconds": 15,
+    "video_lane": "wan",
+    "continuity": "chain"
+  },
+  "delivery": { "aspect": "16:9", "width": 832, "height": 480, "fps": 16, "loudness_lufs": -14.0 },
+  "shots": [
+    { "id": "s1", "lane": "wan", "mode": "t2v", "target_seconds": 5,
+      "prompt_intent": "dawn over a rocky cape, a white lighthouse silhouette, gentle swell, archival film grade, muted maritime palette",
+      "narration": "In 1716 the first American lighthouse rose.", "seed": 12345 },
+    { "id": "s2", "lane": "wan", "mode": "i2v", "start_from": "prev_last_frame", "target_seconds": 5,
+      "prompt_intent": "the camera drifts inward toward a rotating Fresnel lens glowing amber",
+      "narration": "Its lens threw a beam for twenty miles.", "seed": 23456 },
+    { "id": "s3", "lane": "wan", "mode": "i2v", "start_from": "prev_last_frame", "target_seconds": 5,
+      "prompt_intent": "the beam sweeps out across a calm sea at dusk in light fog",
+      "narration": "Today they stand automated and quiet.", "seed": 34567 }
+  ],
+  "music": { "lane": "ace-step", "tags": "ambient, reflective, cinematic, soft piano, instrumental", "lyrics": "[instrumental]", "seed": 99 },
+  "assembly": { "transition_seconds": 0.6, "duck_db": 6 },
+  "timeline": [
+    { "clip": "s1", "narration_offset": 0.2, "music_level_db": -18, "transition_in": "dissolve" },
+    { "clip": "s2", "narration_offset": 0.0, "music_level_db": -18, "transition_in": "dissolve" },
+    { "clip": "s3", "narration_offset": 0.0, "music_level_db": -18, "transition_in": "dissolve" }
+  ]
+}

--- a/services/studio/production/plans/lighthouse_hero.json
+++ b/services/studio/production/plans/lighthouse_hero.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": "ProductionPlanV1",
+  "project": {
+    "title": "Lighthouses — Hero",
+    "tone": "calm",
+    "target_seconds": 15,
+    "video_lane": "wan",
+    "continuity": "hero",
+    "image_policy": { "hero_keyframe_lane": "chroma" }
+  },
+  "delivery": { "aspect": "16:9", "width": 832, "height": 480, "fps": 16, "loudness_lufs": -14.0 },
+  "asset_tasks": [
+    { "id": "hero", "role": "hero_keyframe", "lane": "chroma",
+      "prompt": "a white lighthouse on a rocky cape at dawn, muted maritime palette, archival film grade, cinematic, soft fog",
+      "seed": 7, "width": 832, "height": 480 }
+  ],
+  "shots": [
+    { "id": "s1", "lane": "wan", "mode": "i2v", "start_from": "hero", "target_seconds": 5,
+      "prompt_intent": "slow push toward the lighthouse at dawn, gentle swell",
+      "narration": "In 1716 the first American lighthouse rose.", "seed": 12345 },
+    { "id": "s2", "lane": "wan", "mode": "i2v", "start_from": "hero", "target_seconds": 5,
+      "prompt_intent": "the rotating Fresnel lens glows amber inside the lamp room",
+      "narration": "Its lens threw a beam for twenty miles.", "seed": 23456 },
+    { "id": "s3", "lane": "wan", "mode": "i2v", "start_from": "hero", "target_seconds": 5,
+      "prompt_intent": "the beam sweeps across a calm sea at dusk in light fog",
+      "narration": "Today they stand automated and quiet.", "seed": 34567 }
+  ],
+  "music": { "lane": "ace-step", "tags": "ambient, reflective, cinematic, soft piano, instrumental", "lyrics": "[instrumental]", "seed": 99 },
+  "assembly": { "transition_seconds": 0.6, "duck_db": 6 },
+  "timeline": [
+    { "clip": "s1", "narration_offset": 0.2, "music_level_db": -18, "transition_in": "dissolve" },
+    { "clip": "s2", "narration_offset": 0.0, "music_level_db": -18, "transition_in": "dissolve" },
+    { "clip": "s3", "narration_offset": 0.0, "music_level_db": -18, "transition_in": "dissolve" }
+  ]
+}

--- a/services/studio/production/plans/lighthouse_storyboard.json
+++ b/services/studio/production/plans/lighthouse_storyboard.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "ProductionPlanV1",
+  "project": {
+    "title": "Lighthouses — Storyboard",
+    "tone": "calm",
+    "target_seconds": 15,
+    "video_lane": "wan",
+    "continuity": "storyboard",
+    "image_policy": { "storyboard_keyframe_lane": "chroma" }
+  },
+  "delivery": { "aspect": "16:9", "width": 832, "height": 480, "fps": 16, "loudness_lufs": -14.0 },
+  "asset_tasks": [
+    { "id": "kf_s1", "role": "storyboard_keyframe", "lane": "chroma",
+      "prompt": "cohesive cinematic style, consistent muted maritime palette, soft archival film grade, calm. a white lighthouse on a rocky cape at dawn, gentle swell",
+      "seed": 7, "width": 832, "height": 480 },
+    { "id": "kf_s2", "role": "storyboard_keyframe", "lane": "chroma",
+      "prompt": "cohesive cinematic style, consistent muted maritime palette, soft archival film grade, calm. inside the lamp room, a rotating Fresnel lens glowing amber",
+      "seed": 7, "width": 832, "height": 480 },
+    { "id": "kf_s3", "role": "storyboard_keyframe", "lane": "chroma",
+      "prompt": "cohesive cinematic style, consistent muted maritime palette, soft archival film grade, calm. the lighthouse beam sweeping across a calm sea at dusk in light fog",
+      "seed": 7, "width": 832, "height": 480 }
+  ],
+  "shots": [
+    { "id": "s1", "lane": "wan", "mode": "i2v", "start_from": "kf_s1", "target_seconds": 5,
+      "prompt_intent": "slow push toward the lighthouse at dawn, gentle swell",
+      "narration": "In 1716 the first American lighthouse rose.", "seed": 12345 },
+    { "id": "s2", "lane": "wan", "mode": "i2v", "start_from": "kf_s2", "target_seconds": 5,
+      "prompt_intent": "the Fresnel lens turns, throwing amber light around the lamp room",
+      "narration": "Its lens threw a beam for twenty miles.", "seed": 23456 },
+    { "id": "s3", "lane": "wan", "mode": "i2v", "start_from": "kf_s3", "target_seconds": 5,
+      "prompt_intent": "the beam sweeps across the dark sea at dusk",
+      "narration": "Today they stand automated and quiet.", "seed": 34567 }
+  ],
+  "music": { "lane": "ace-step", "tags": "ambient, reflective, cinematic, soft piano, instrumental", "lyrics": "[instrumental]", "seed": 99 },
+  "assembly": { "transition_seconds": 0.6, "duck_db": 6 },
+  "timeline": [
+    { "clip": "s1", "narration_offset": 0.2, "music_level_db": -18, "transition_in": "dissolve" },
+    { "clip": "s2", "narration_offset": 0.0, "music_level_db": -18, "transition_in": "dissolve" },
+    { "clip": "s3", "narration_offset": 0.0, "music_level_db": -18, "transition_in": "dissolve" }
+  ]
+}

--- a/services/studio/production/prompts.py
+++ b/services/studio/production/prompts.py
@@ -39,7 +39,7 @@ ProductionPlanV1 shape:
 Guidance (be inventive WITHIN these bounds):
 - Aim for {n_shots} shots. Each shot is ONE Wan window (<= 5 s), so keep target_seconds 4-5.
 - prompt_intent: vivid, cinematic prose for the video model (one shot's worth of imagery).
-- narration: ONE spoken sentence the viewer hears over that shot. Keep it short enough to fit (~2.5 words per second), so a 5 s shot is ~12 words max.
+- narration: ONE spoken sentence the viewer hears over that shot, in ENGLISH ONLY (no other-language words). Keep it short enough to fit (~2.5 words per second), so a 5 s shot is AT MOST 10 words.
 - If an idea needs more than ~5 s, SPLIT it into two shots — never exceed the limit.
 - Every shot needs a UNIQUE id. The timeline lists EVERY shot exactly once, in play order.
 - OUTPUT ONLY THE JSON OBJECT."""

--- a/services/studio/production/prompts.py
+++ b/services/studio/production/prompts.py
@@ -1,0 +1,54 @@
+"""The planner prompt pack — the 4B director's 'tight operating manual.'
+
+Creative-within-bounds: the director is free in the film-making layer (angle, tone,
+shot concepts, narration, mood) but the OUTPUT must be a valid ProductionPlanV1, and
+if an idea exceeds a lane limit it must ADAPT the idea, never break the limit. The
+executor/validator wins (the validator-repair loop enforces this).
+"""
+from __future__ import annotations
+
+from .registry import prompt_slice
+
+TREATMENT_SYS = (
+    "You are a production director. Given a brief, write a SHORT creative treatment "
+    "(4-6 sentences): the angle, the tone, the structure, and 3 concrete visual beats "
+    "— each something that could be ONE ~5-second shot. Be specific and cinematic. "
+    "Plain prose only — no JSON, no markdown, no preamble."
+)
+
+
+def build_plan_system(reg: dict, n_shots: int = 3) -> str:
+    return f"""You are the production director for an automated video studio. Turn the brief and treatment into ONE valid ProductionPlanV1 JSON object. OUTPUT ONLY THE JSON — no prose, no markdown fences, no comments.
+
+{prompt_slice(reg)}
+
+ProductionPlanV1 shape:
+{{
+  "project": {{"title": str, "tone": str, "target_seconds": int, "video_lane": "wan"}},
+  "shots": [
+    {{"id": "s1", "lane": "wan", "mode": "t2v", "target_seconds": 5,
+      "prompt_intent": "<vivid cinematic prose describing the shot>",
+      "narration": "<ONE short spoken sentence heard over this shot>", "seed": 12345}}
+  ],
+  "music": {{"lane": "ace-step", "tags": "<comma-separated mood tags>", "lyrics": "[instrumental]", "seed": 7}},
+  "timeline": [
+    {{"clip": "s1", "narration_offset": 0.0, "music_level_db": -18, "transition_in": "dissolve"}}
+  ]
+}}
+
+Guidance (be inventive WITHIN these bounds):
+- Aim for {n_shots} shots. Each shot is ONE Wan window (<= 5 s), so keep target_seconds 4-5.
+- prompt_intent: vivid, cinematic prose for the video model (one shot's worth of imagery).
+- narration: ONE spoken sentence the viewer hears over that shot. Keep it short enough to fit (~2.5 words per second), so a 5 s shot is ~12 words max.
+- If an idea needs more than ~5 s, SPLIT it into two shots — never exceed the limit.
+- Every shot needs a UNIQUE id. The timeline lists EVERY shot exactly once, in play order.
+- OUTPUT ONLY THE JSON OBJECT."""
+
+
+def repair_user(raw: str, error: str) -> str:
+    return (
+        "Your previous output was not a valid plan.\n"
+        f"ERROR: {error}\n\n"
+        f"PREVIOUS OUTPUT:\n{raw}\n\n"
+        "Output a corrected ProductionPlanV1 JSON object ONLY (no prose, no fences) that fixes that error."
+    )

--- a/services/studio/production/registry.py
+++ b/services/studio/production/registry.py
@@ -1,0 +1,47 @@
+"""Lane capability registry loader — 'what the machine can do.'
+
+Loads `capabilities.yaml` and compresses it into the compact text the planner is
+given (the planner may choose lanes ONLY from here). The executor + schema remain
+authoritative; this is the planner's menu, not the enforcement.
+"""
+from __future__ import annotations
+
+import os
+
+import yaml
+
+REGISTRY_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "capabilities.yaml")
+
+
+def load(path: str = REGISTRY_PATH) -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def video_lanes(reg: dict) -> list[str]:
+    return list((reg.get("video_lanes") or {}).keys())
+
+
+def audio_lanes(reg: dict) -> list[str]:
+    return list((reg.get("audio_lanes") or {}).keys())
+
+
+def prompt_slice(reg: dict) -> str:
+    """The compact lane menu + rules handed to the planner."""
+    lines = ["LANES YOU MAY USE (choose ONLY from these):"]
+    for name, c in (reg.get("video_lanes") or {}).items():
+        win = c.get("native_window_seconds", 5.0)
+        fps = c.get("native_fps", 16)
+        lines.append(
+            f"- VIDEO lane '{name}': mode t2v, vivid PROSE prompt, each shot <= {win:.1f}s "
+            f"@ {fps}fps, SILENT (no audio in the clip). {c.get('when_to_use', '')}"
+        )
+    for name, c in (reg.get("audio_lanes") or {}).items():
+        lines.append(
+            f"- AUDIO lane '{name}': {c.get('kind')}, format {c.get('prompt_format')}. "
+            f"{c.get('when_to_use', '')}"
+        )
+    lines.append("RULES:")
+    for r in reg.get("rules", []):
+        lines.append(f"- {r}")
+    return "\n".join(lines)

--- a/services/studio/production/run.py
+++ b/services/studio/production/run.py
@@ -59,8 +59,9 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--brief", default=None,
                     help='a one-line brief; the 4B director plans it (v0b), e.g. --brief "60s doc on lighthouses"')
     ap.add_argument("--shots", type=int, default=3, help="target shot count for --brief planning")
-    ap.add_argument("--continuity", choices=["none", "chain", "hero"], default="hero",
+    ap.add_argument("--continuity", choices=["none", "chain", "hero", "storyboard"], default="hero",
                     help="v0b-images continuity for --brief: hero (shared keyframe, DEFAULT) · "
+                         "storyboard (per-shot keyframes, shared style bible) · "
                          "chain (i2v from prev frame) · none (independent t2v)")
     ap.add_argument("--backend", choices=["live", "synthetic"], default="live",
                     help="live = ComfyUI+Kokoro on the rig; synthetic = offline ffmpeg stand-ins")

--- a/services/studio/production/run.py
+++ b/services/studio/production/run.py
@@ -1,0 +1,91 @@
+"""v0a CLI: brief plan -> finished MP4.
+
+    python -m services.studio.production.run PLAN.json [--backend live|synthetic]
+
+CLI/admin only, single-flight (a host file-lock). `live` drives ComfyUI + Kokoro on
+the rig; `synthetic` uses ffmpeg lavfi stand-ins so the whole pipeline runs offline.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import re
+import sys
+
+from . import config
+from .executor import run_production
+from .lock import ProductionLock, ProductionLockHeld
+from .schema import PlanError, ProductionPlanV1
+
+
+def _slug(s: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", s.lower()).strip("-")[:40] or "production"
+
+
+def _job_id(title: str) -> str:
+    stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d-%H%M%S")
+    return f"{_slug(title)}-{stamp}-{os.urandom(2).hex()}"
+
+
+def _print_summary(summary: dict) -> bool:
+    man = summary["manifest"]
+    ec = man["exit_criteria"]
+    print("\n" + "=" * 64)
+    print(f"  PRODUCTION COMPLETE — {man['title']}  [{man['backend']}]")
+    print("=" * 64)
+    print(f"  final:      {summary['final']}")
+    print(f"  artifacts:  {len(man['artifacts'])}   dir: {summary['prod_dir']}")
+    print("  --- exit criteria " + "-" * 45)
+    print(f"  all validators pass : {ec['all_validators_pass']}")
+    print(f"  VO within tolerance : {ec['vo_within_tolerance']}   {ec['vo_detail']}")
+    print(f"  final has audio     : {ec['final_has_audio']}")
+    print(f"  final duration      : {ec['final_duration_s']}s  (clips {ec['total_clip_s']}s)")
+    print("  --- the decisive (human) question " + "-" * 29)
+    print("  > is this assembled MP4 better than picking lanes by hand?  [you decide]")
+    print("=" * 64)
+    failed = [a["id"] for a in man["artifacts"] if not a["validation"].get("ok")]
+    if failed:
+        print(f"  ⚠ validators FAILED on: {failed}")
+    return bool(ec["all_validators_pass"] and ec["vo_within_tolerance"] and ec["final_has_audio"])
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="studio-production", description="v0a: static plan -> MP4")
+    ap.add_argument("plan", help="path to a ProductionPlanV1 JSON")
+    ap.add_argument("--backend", choices=["live", "synthetic"], default="live",
+                    help="live = ComfyUI+Kokoro on the rig; synthetic = offline ffmpeg stand-ins")
+    ap.add_argument("--job-id", default=None, help="override the generated job id")
+    ap.add_argument("--productions-dir", default=config.PRODUCTIONS_DIR,
+                    help=f"base dir (default {config.PRODUCTIONS_DIR})")
+    args = ap.parse_args(argv)
+
+    try:
+        with open(args.plan) as f:
+            plan = ProductionPlanV1.from_dict(json.load(f))
+    except (OSError, json.JSONDecodeError, PlanError) as e:
+        print(f"[plan error] {e}", file=sys.stderr)
+        return 2
+
+    job_id = args.job_id or _job_id(plan.project.title)
+    now_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+    lock = ProductionLock(os.path.join(args.productions_dir, ".run.lock"))
+    try:
+        lock.acquire()
+    except ProductionLockHeld as e:
+        print(f"[locked] {e}", file=sys.stderr)
+        return 3
+    try:
+        summary = run_production(plan, backend_name=args.backend, job_id=job_id,
+                                 now_iso=now_iso, productions_dir=args.productions_dir)
+    finally:
+        lock.release()
+
+    ok = _print_summary(summary)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/studio/production/run.py
+++ b/services/studio/production/run.py
@@ -59,8 +59,9 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--brief", default=None,
                     help='a one-line brief; the 4B director plans it (v0b), e.g. --brief "60s doc on lighthouses"')
     ap.add_argument("--shots", type=int, default=3, help="target shot count for --brief planning")
-    ap.add_argument("--continuity", choices=["none", "chain", "hero"], default="none",
-                    help="v0b-images continuity for --brief: chain (i2v from prev frame) or hero (shared keyframe)")
+    ap.add_argument("--continuity", choices=["none", "chain", "hero"], default="hero",
+                    help="v0b-images continuity for --brief: hero (shared keyframe, DEFAULT) · "
+                         "chain (i2v from prev frame) · none (independent t2v)")
     ap.add_argument("--backend", choices=["live", "synthetic"], default="live",
                     help="live = ComfyUI+Kokoro on the rig; synthetic = offline ffmpeg stand-ins")
     ap.add_argument("--job-id", default=None, help="override the generated job id")

--- a/services/studio/production/run.py
+++ b/services/studio/production/run.py
@@ -45,7 +45,8 @@ def _print_summary(summary: dict) -> bool:
     print("  --- the decisive (human) question " + "-" * 29)
     print("  > is this assembled MP4 better than picking lanes by hand?  [you decide]")
     print("=" * 64)
-    failed = [a["id"] for a in man["artifacts"] if not a["validation"].get("ok")]
+    failed = [a["id"] for a in man["artifacts"]
+              if a["type"] == "media" and not a["validation"].get("ok")]
     if failed:
         print(f"  ⚠ validators FAILED on: {failed}")
     return bool(ec["all_validators_pass"] and ec["vo_within_tolerance"] and ec["final_has_audio"])

--- a/services/studio/production/run.py
+++ b/services/studio/production/run.py
@@ -52,8 +52,12 @@ def _print_summary(summary: dict) -> bool:
 
 
 def main(argv: list[str] | None = None) -> int:
-    ap = argparse.ArgumentParser(prog="studio-production", description="v0a: static plan -> MP4")
-    ap.add_argument("plan", help="path to a ProductionPlanV1 JSON")
+    ap = argparse.ArgumentParser(prog="studio-production",
+                                 description="static plan (v0a) or a brief the 4B plans (v0b) -> MP4")
+    ap.add_argument("plan", nargs="?", help="path to a ProductionPlanV1 JSON (v0a path)")
+    ap.add_argument("--brief", default=None,
+                    help='a one-line brief; the 4B director plans it (v0b), e.g. --brief "60s doc on lighthouses"')
+    ap.add_argument("--shots", type=int, default=3, help="target shot count for --brief planning")
     ap.add_argument("--backend", choices=["live", "synthetic"], default="live",
                     help="live = ComfyUI+Kokoro on the rig; synthetic = offline ffmpeg stand-ins")
     ap.add_argument("--job-id", default=None, help="override the generated job id")
@@ -61,15 +65,12 @@ def main(argv: list[str] | None = None) -> int:
                     help=f"base dir (default {config.PRODUCTIONS_DIR})")
     args = ap.parse_args(argv)
 
-    try:
-        with open(args.plan) as f:
-            plan = ProductionPlanV1.from_dict(json.load(f))
-    except (OSError, json.JSONDecodeError, PlanError) as e:
-        print(f"[plan error] {e}", file=sys.stderr)
+    if bool(args.plan) == bool(args.brief):
+        print('[args] give exactly one of: a plan file, or --brief "..."', file=sys.stderr)
         return 2
 
-    job_id = args.job_id or _job_id(plan.project.title)
     now_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    extra_artifacts: list = []
 
     lock = ProductionLock(os.path.join(args.productions_dir, ".run.lock"))
     try:
@@ -78,8 +79,35 @@ def main(argv: list[str] | None = None) -> int:
         print(f"[locked] {e}", file=sys.stderr)
         return 3
     try:
+        if args.brief:
+            from . import planner, registry
+            job_id = args.job_id or _job_id(args.brief)
+            prod_dir = os.path.join(args.productions_dir, job_id)
+            os.makedirs(prod_dir, exist_ok=True)
+            try:
+                reg = registry.load()
+                print(f"[plan] director planning the brief into ~{args.shots} shots…", file=sys.stderr)
+                plan, extra_artifacts = planner.plan_from_brief(
+                    args.brief, reg, n_shots=args.shots,
+                    prompts_dir=os.path.join(prod_dir, "prompts"),
+                )
+            except planner.PlannerError as e:
+                print(f"[plan error] {e}", file=sys.stderr)
+                return 2
+            print(f"[plan] director produced {len(plan.shots)} shots: "
+                  f"{plan.project.title!r}", file=sys.stderr)
+        else:
+            try:
+                with open(args.plan) as f:
+                    plan = ProductionPlanV1.from_dict(json.load(f))
+            except (OSError, json.JSONDecodeError, PlanError) as e:
+                print(f"[plan error] {e}", file=sys.stderr)
+                return 2
+            job_id = args.job_id or _job_id(plan.project.title)
+
         summary = run_production(plan, backend_name=args.backend, job_id=job_id,
-                                 now_iso=now_iso, productions_dir=args.productions_dir)
+                                 now_iso=now_iso, productions_dir=args.productions_dir,
+                                 extra_artifacts=extra_artifacts)
     finally:
         lock.release()
 

--- a/services/studio/production/run.py
+++ b/services/studio/production/run.py
@@ -59,6 +59,8 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--brief", default=None,
                     help='a one-line brief; the 4B director plans it (v0b), e.g. --brief "60s doc on lighthouses"')
     ap.add_argument("--shots", type=int, default=3, help="target shot count for --brief planning")
+    ap.add_argument("--continuity", choices=["none", "chain", "hero"], default="none",
+                    help="v0b-images continuity for --brief: chain (i2v from prev frame) or hero (shared keyframe)")
     ap.add_argument("--backend", choices=["live", "synthetic"], default="live",
                     help="live = ComfyUI+Kokoro on the rig; synthetic = offline ffmpeg stand-ins")
     ap.add_argument("--job-id", default=None, help="override the generated job id")
@@ -89,7 +91,7 @@ def main(argv: list[str] | None = None) -> int:
                 reg = registry.load()
                 print(f"[plan] director planning the brief into ~{args.shots} shots…", file=sys.stderr)
                 plan, extra_artifacts = planner.plan_from_brief(
-                    args.brief, reg, n_shots=args.shots,
+                    args.brief, reg, n_shots=args.shots, continuity=args.continuity,
                     prompts_dir=os.path.join(prod_dir, "prompts"),
                 )
             except planner.PlannerError as e:

--- a/services/studio/production/run.py
+++ b/services/studio/production/run.py
@@ -59,10 +59,10 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--brief", default=None,
                     help='a one-line brief; the 4B director plans it (v0b), e.g. --brief "60s doc on lighthouses"')
     ap.add_argument("--shots", type=int, default=3, help="target shot count for --brief planning")
-    ap.add_argument("--continuity", choices=["none", "chain", "hero", "storyboard"], default="hero",
-                    help="v0b-images continuity for --brief: hero (shared keyframe, DEFAULT) · "
-                         "storyboard (per-shot keyframes, shared style bible) · "
-                         "chain (i2v from prev frame) · none (independent t2v)")
+    ap.add_argument("--continuity", choices=["none", "chain", "hero", "storyboard"], default="storyboard",
+                    help="v0b-images continuity for --brief: storyboard (per-shot keyframes + shared "
+                         "style bible, DEFAULT) · hero (one shared keyframe) · chain (i2v from prev "
+                         "frame) · none (independent t2v)")
     ap.add_argument("--backend", choices=["live", "synthetic"], default="live",
                     help="live = ComfyUI+Kokoro on the rig; synthetic = offline ffmpeg stand-ins")
     ap.add_argument("--job-id", default=None, help="override the generated job id")

--- a/services/studio/production/schema.py
+++ b/services/studio/production/schema.py
@@ -142,9 +142,10 @@ class ProductionPlanV1:
         if len(ids) != len(set(ids)):
             raise PlanError(f"duplicate shot ids: {ids}")
 
-        if self.project.continuity not in ("none", "chain", "hero"):
+        if self.project.continuity not in ("none", "chain", "hero", "storyboard"):
             raise PlanError(
-                f"project.continuity must be none|chain|hero (got {self.project.continuity!r})"
+                f"project.continuity must be none|chain|hero|storyboard "
+                f"(got {self.project.continuity!r})"
             )
         asset_ids = {a.id for a in self.asset_tasks}
         if len(asset_ids) != len(self.asset_tasks):

--- a/services/studio/production/schema.py
+++ b/services/studio/production/schema.py
@@ -36,6 +36,7 @@ class Shot:
     prompt_intent: str
     narration: str = ""
     seed: int = 0
+    start_from: Optional[str] = None   # None=t2v · "prev_last_frame"=chain · "<asset id>"=hero/keyframe
     validators: list = field(
         default_factory=lambda: ["non_empty", "duration", "no_audio_expected"]
     )
@@ -59,11 +60,25 @@ class Assembly:
 
 
 @dataclass
+class AssetTask:
+    """A generated image asset produced in pre-production (v0b-images)."""
+    id: str
+    role: str            # hero_keyframe | reference | storyboard | title_card
+    lane: str            # an image lane (e.g. "chroma")
+    prompt: str
+    seed: int = 0
+    width: int = 832
+    height: int = 480
+
+
+@dataclass
 class Project:
     title: str
     tone: str = ""
     target_seconds: float = 0.0
     video_lane: str = "wan"
+    continuity: str = "none"          # none | chain | hero  (v0b-images continuity mode)
+    image_policy: dict = field(default_factory=dict)   # role -> image lane
 
 
 @dataclass
@@ -82,6 +97,7 @@ class ProductionPlanV1:
     timeline: list                    # list[TimelineEntry]
     music: Optional[Music] = None
     assembly: Assembly = field(default_factory=Assembly)
+    asset_tasks: list = field(default_factory=list)   # list[AssetTask] (v0b-images)
     schema_version: str = "ProductionPlanV1"
 
     # -- construction -------------------------------------------------------
@@ -99,11 +115,13 @@ class ProductionPlanV1:
                 duck_db=int(_a.get("duck_db", 6)),
                 normalize=bool(_a.get("normalize", True)),
             )
+            asset_tasks = [AssetTask(**a) for a in (d.get("asset_tasks") or [])]
         except (KeyError, TypeError, ValueError) as e:
             raise PlanError(f"malformed plan: {e}") from e
         plan = ProductionPlanV1(
             project=project, shots=shots, delivery=delivery,
             timeline=timeline, music=music, assembly=assembly,
+            asset_tasks=asset_tasks,
             schema_version=d.get("schema_version", "ProductionPlanV1"),
         )
         plan.validate()
@@ -124,16 +142,32 @@ class ProductionPlanV1:
         if len(ids) != len(set(ids)):
             raise PlanError(f"duplicate shot ids: {ids}")
 
+        if self.project.continuity not in ("none", "chain", "hero"):
+            raise PlanError(
+                f"project.continuity must be none|chain|hero (got {self.project.continuity!r})"
+            )
+        asset_ids = {a.id for a in self.asset_tasks}
+        if len(asset_ids) != len(self.asset_tasks):
+            raise PlanError("duplicate asset_task ids")
+
         for s in self.shots:
             if s.lane != self.project.video_lane:
                 raise PlanError(
                     f"shot {s.id}: lane {s.lane!r} != pinned video_lane "
-                    f"{self.project.video_lane!r} (v0a pins one video lane)"
+                    f"{self.project.video_lane!r} (one pinned video lane per job)"
                 )
-            if s.mode != "t2v":
-                raise PlanError(f"shot {s.id}: v0a supports only mode='t2v' (got {s.mode!r})")
+            if s.mode not in ("t2v", "i2v"):
+                raise PlanError(f"shot {s.id}: mode must be 't2v' or 'i2v' (got {s.mode!r})")
             if s.target_seconds <= 0:
                 raise PlanError(f"shot {s.id}: target_seconds must be > 0")
+            if s.mode == "i2v" and not s.start_from:
+                raise PlanError(f"shot {s.id}: mode 'i2v' requires start_from")
+            # missing-dependency rejection: start_from must resolve.
+            if s.start_from and s.start_from != "prev_last_frame" and s.start_from not in asset_ids:
+                raise PlanError(
+                    f"shot {s.id}: start_from {s.start_from!r} is neither 'prev_last_frame' "
+                    f"nor a declared asset_task id {sorted(asset_ids)}"
+                )
 
         # Timeline: one entry per shot, all references valid, order = play order.
         known = set(ids)
@@ -153,6 +187,13 @@ class ProductionPlanV1:
             missing = known - seen
             raise PlanError(f"timeline missing shots: {sorted(missing)}")
 
+        # asset-DAG ordering: the FIRST shot (play order) can't chain from a previous clip.
+        ordered = self.ordered_shots()
+        if ordered and ordered[0].start_from == "prev_last_frame":
+            raise PlanError(
+                f"first shot {ordered[0].id!r} cannot start_from 'prev_last_frame' (no previous clip)"
+            )
+
         if self.delivery.fps <= 0 or self.delivery.width <= 0 or self.delivery.height <= 0:
             raise PlanError("delivery fps/width/height must be > 0")
 
@@ -161,6 +202,12 @@ class ProductionPlanV1:
             if s.id == sid:
                 return s
         raise PlanError(f"no shot {sid!r}")
+
+    def asset_task_by_id(self, aid: str):
+        for a in self.asset_tasks:
+            if a.id == aid:
+                return a
+        raise PlanError(f"no asset_task {aid!r}")
 
     def ordered_shots(self) -> list:
         """Shots in timeline (play) order."""

--- a/services/studio/production/schema.py
+++ b/services/studio/production/schema.py
@@ -1,0 +1,147 @@
+"""ProductionPlanV1 — the validatable plan contract (v0a subset).
+
+stdlib dataclasses + an explicit `validate()` (host has no pydantic). The shape is
+forward-compatible with the full schema in the design doc; v0a only *enforces* the
+slice it executes (single pinned video lane = wan, t2v shots, one timeline entry
+per shot). Fields the design reserves but v0a ignores (creative_intent, style_bible,
+asset_dependencies, image_policy, takes, ...) are simply not modelled here yet.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+class PlanError(ValueError):
+    """Raised when a plan is structurally invalid (clear, actionable message)."""
+
+
+@dataclass
+class Delivery:
+    aspect: str = "16:9"
+    width: int = 832          # Wan native lo-res; v0a renders at delivery dims (no rescale)
+    height: int = 480
+    fps: int = 16             # Wan native rate
+    codec: str = "h264"
+    loudness_lufs: float = -14.0
+    subtitles: bool = False
+
+
+@dataclass
+class Shot:
+    id: str
+    lane: str                 # v0a: must equal project.video_lane ("wan")
+    mode: str                 # v0a: "t2v"
+    target_seconds: float
+    prompt_intent: str
+    narration: str = ""
+    seed: int = 0
+    validators: list = field(
+        default_factory=lambda: ["non_empty", "duration", "no_audio_expected"]
+    )
+
+
+@dataclass
+class Music:
+    lane: str = "ace-step"
+    tags: str = "ambient, reflective, cinematic, instrumental"
+    lyrics: str = "[instrumental]"
+    seconds: float = 0.0      # 0 => derived from total timeline duration at run time
+    seed: int = 0
+
+
+@dataclass
+class Project:
+    title: str
+    tone: str = ""
+    target_seconds: float = 0.0
+    video_lane: str = "wan"
+
+
+@dataclass
+class TimelineEntry:
+    clip: str                 # references Shot.id
+    narration_offset: float = 0.0
+    music_level_db: float = -18.0
+    transition_in: str = "cut"
+
+
+@dataclass
+class ProductionPlanV1:
+    project: Project
+    shots: list                       # list[Shot]
+    delivery: Delivery
+    timeline: list                    # list[TimelineEntry]
+    music: Optional[Music] = None
+    schema_version: str = "ProductionPlanV1"
+
+    # -- construction -------------------------------------------------------
+    @staticmethod
+    def from_dict(d: dict[str, Any]) -> "ProductionPlanV1":
+        try:
+            project = Project(**d["project"])
+            shots = [Shot(**s) for s in d["shots"]]
+            delivery = Delivery(**d.get("delivery", {}))
+            timeline = [TimelineEntry(**t) for t in d.get("timeline", [])]
+            music = Music(**d["music"]) if d.get("music") else None
+        except (KeyError, TypeError) as e:
+            raise PlanError(f"malformed plan: {e}") from e
+        plan = ProductionPlanV1(
+            project=project, shots=shots, delivery=delivery,
+            timeline=timeline, music=music,
+            schema_version=d.get("schema_version", "ProductionPlanV1"),
+        )
+        plan.validate()
+        return plan
+
+    # -- v0a validation -----------------------------------------------------
+    def validate(self) -> None:
+        if self.schema_version != "ProductionPlanV1":
+            raise PlanError(f"unsupported schema_version {self.schema_version!r}")
+        if self.project.video_lane != "wan":
+            raise PlanError(
+                f"v0a supports only video_lane='wan' (got {self.project.video_lane!r})"
+            )
+        if not self.shots:
+            raise PlanError("plan has no shots")
+
+        ids = [s.id for s in self.shots]
+        if len(ids) != len(set(ids)):
+            raise PlanError(f"duplicate shot ids: {ids}")
+
+        for s in self.shots:
+            if s.lane != self.project.video_lane:
+                raise PlanError(
+                    f"shot {s.id}: lane {s.lane!r} != pinned video_lane "
+                    f"{self.project.video_lane!r} (v0a pins one video lane)"
+                )
+            if s.mode != "t2v":
+                raise PlanError(f"shot {s.id}: v0a supports only mode='t2v' (got {s.mode!r})")
+            if s.target_seconds <= 0:
+                raise PlanError(f"shot {s.id}: target_seconds must be > 0")
+
+        # Timeline: one entry per shot, all references valid, order = play order.
+        known = set(ids)
+        seen: set[str] = set()
+        for t in self.timeline:
+            if t.clip not in known:
+                raise PlanError(f"timeline references unknown clip {t.clip!r}")
+            if t.clip in seen:
+                raise PlanError(f"timeline references clip {t.clip!r} twice")
+            seen.add(t.clip)
+        if seen != known:
+            missing = known - seen
+            raise PlanError(f"timeline missing shots: {sorted(missing)}")
+
+        if self.delivery.fps <= 0 or self.delivery.width <= 0 or self.delivery.height <= 0:
+            raise PlanError("delivery fps/width/height must be > 0")
+
+    def shot_by_id(self, sid: str) -> Shot:
+        for s in self.shots:
+            if s.id == sid:
+                return s
+        raise PlanError(f"no shot {sid!r}")
+
+    def ordered_shots(self) -> list:
+        """Shots in timeline (play) order."""
+        return [self.shot_by_id(t.clip) for t in self.timeline]

--- a/services/studio/production/schema.py
+++ b/services/studio/production/schema.py
@@ -51,6 +51,14 @@ class Music:
 
 
 @dataclass
+class Assembly:
+    """Deterministic post-production knobs (not 'brain' work)."""
+    transition_seconds: float = 0.6   # dissolve length between clips
+    duck_db: int = 6                  # bed duck depth under narration (gentler than the old ~12)
+    normalize: bool = True
+
+
+@dataclass
 class Project:
     title: str
     tone: str = ""
@@ -63,7 +71,7 @@ class TimelineEntry:
     clip: str                 # references Shot.id
     narration_offset: float = 0.0
     music_level_db: float = -18.0
-    transition_in: str = "cut"
+    transition_in: str = "dissolve"   # "dissolve" (default) | "cut" — transition INTO this clip
 
 
 @dataclass
@@ -73,6 +81,7 @@ class ProductionPlanV1:
     delivery: Delivery
     timeline: list                    # list[TimelineEntry]
     music: Optional[Music] = None
+    assembly: Assembly = field(default_factory=Assembly)
     schema_version: str = "ProductionPlanV1"
 
     # -- construction -------------------------------------------------------
@@ -84,11 +93,17 @@ class ProductionPlanV1:
             delivery = Delivery(**d.get("delivery", {}))
             timeline = [TimelineEntry(**t) for t in d.get("timeline", [])]
             music = Music(**d["music"]) if d.get("music") else None
-        except (KeyError, TypeError) as e:
+            _a = d.get("assembly", {}) or {}
+            assembly = Assembly(
+                transition_seconds=float(_a.get("transition_seconds", 0.6)),
+                duck_db=int(_a.get("duck_db", 6)),
+                normalize=bool(_a.get("normalize", True)),
+            )
+        except (KeyError, TypeError, ValueError) as e:
             raise PlanError(f"malformed plan: {e}") from e
         plan = ProductionPlanV1(
             project=project, shots=shots, delivery=delivery,
-            timeline=timeline, music=music,
+            timeline=timeline, music=music, assembly=assembly,
             schema_version=d.get("schema_version", "ProductionPlanV1"),
         )
         plan.validate()
@@ -128,6 +143,11 @@ class ProductionPlanV1:
                 raise PlanError(f"timeline references unknown clip {t.clip!r}")
             if t.clip in seen:
                 raise PlanError(f"timeline references clip {t.clip!r} twice")
+            if t.transition_in not in ("cut", "dissolve"):
+                raise PlanError(
+                    f"timeline {t.clip}: transition_in must be 'cut' or 'dissolve' "
+                    f"(got {t.transition_in!r})"
+                )
             seen.add(t.clip)
         if seen != known:
             missing = known - seen

--- a/services/studio/production/tests/test_v0a.py
+++ b/services/studio/production/tests/test_v0a.py
@@ -62,28 +62,54 @@ class TestSchema(unittest.TestCase):
         with self.assertRaises(PlanError):
             ProductionPlanV1.from_dict(_load(lambda d: d["shots"][0].update(mode="i2v")))
 
+    def test_transition_default_and_assembly_knobs(self):
+        plan = ProductionPlanV1.from_dict(_load())
+        self.assertTrue(all(t.transition_in == "dissolve" for t in plan.timeline))
+        self.assertEqual(plan.assembly.transition_seconds, 0.6)
+        self.assertEqual(plan.assembly.duck_db, 6)
+
+    def test_rejects_bad_transition(self):
+        with self.assertRaises(PlanError):
+            ProductionPlanV1.from_dict(_load(lambda d: d["timeline"][1].update(transition_in="wipe")))
+
 
 class TestAssembleCommand(unittest.TestCase):
-    def test_full_mix_graph(self):
+    def test_dissolve_mix_graph(self):
         cmd = assemble.build_mix_command(
             "/tmp/final.mp4",
             clips=["a.mp4", "b.mp4", "c.mp4"],
-            narrations=[("v1.wav", 200), ("v2.wav", 5000)],
-            bed="bed.wav", fps=16, lufs=-14.0, bed_level_db=-18,
+            durations=[5.0, 5.0, 5.0],
+            transitions=[("dissolve", 0.6), ("dissolve", 0.6)],
+            narrations=[("v1.wav", 0, 0.2), ("v2.wav", 1, 0.0)],
+            bed="bed.wav", fps=16, lufs=-14.0, bed_level_db=-18, duck_db=6,
         )
         fc = cmd[cmd.index("-filter_complex") + 1]
-        self.assertIn("concat=n=3:v=1:a=0[vid]", fc)
+        # dissolves -> xfade chain, not a hard concat
+        self.assertIn("xfade=transition=dissolve:duration=0.600", fc)
+        self.assertNotIn("concat=n=3", fc)
+        # narration delayed to crossfade-aware starts: shot0 @0.2s; shot1 @ (5-0.6)+0=4.4s
         self.assertIn("adelay=200|200", fc)
-        self.assertIn("sidechaincompress", fc)        # bed ducked under narration
+        self.assertIn("adelay=4400|4400", fc)
+        self.assertIn("sidechaincompress", fc)         # bed ducked under narration
+        self.assertIn("ratio=4", fc)                   # duck_db 6 -> ratio 4 (gentle)
         self.assertIn("asplit=2[nkey][nmix]", fc)      # narration split, used once each
         self.assertIn("loudnorm=I=-14.0", fc)
         self.assertIn("-shortest", cmd)
         self.assertEqual(cmd[-1], "/tmp/final.mp4")
 
+    def test_all_cut_uses_concat(self):
+        cmd = assemble.build_mix_command(
+            "/tmp/f.mp4", clips=["a.mp4", "b.mp4"], durations=[5.0, 5.0],
+            transitions=[("cut", 0.6)], narrations=[("v.wav", 0, 0.0)],
+            bed=None, fps=16, lufs=-14.0, bed_level_db=-18)
+        fc = cmd[cmd.index("-filter_complex") + 1]
+        self.assertIn("concat=n=2:v=1:a=0[vid]", fc)   # hard cuts -> concat, no xfade
+        self.assertNotIn("xfade", fc)
+
     def test_bed_only_no_narration(self):
         cmd = assemble.build_mix_command(
-            "/tmp/f.mp4", clips=["a.mp4"], narrations=[], bed="bed.wav",
-            fps=16, lufs=-14.0, bed_level_db=-18)
+            "/tmp/f.mp4", clips=["a.mp4"], durations=[5.0], transitions=[],
+            narrations=[], bed="bed.wav", fps=16, lufs=-14.0, bed_level_db=-18)
         fc = cmd[cmd.index("-filter_complex") + 1]
         self.assertNotIn("sidechaincompress", fc)
         self.assertIn("loudnorm", fc)

--- a/services/studio/production/tests/test_v0a.py
+++ b/services/studio/production/tests/test_v0a.py
@@ -1,0 +1,157 @@
+"""Offline v0a tests (stdlib unittest, no pydantic/pytest, no GPU/services).
+
+Run:  python3 -m unittest services.studio.production.tests.test_v0a -v
+      (from the repo root)
+
+The end-to-end test uses the `synthetic` backend (ffmpeg lavfi) so it exercises the
+WHOLE pipeline — render -> validate -> tts -> bed -> assemble -> manifest -> a real
+MP4 with an audio track — without ComfyUI, TTS, or a GPU.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+from .. import assemble, validators
+from ..lock import ProductionLock, ProductionLockHeld
+from ..schema import PlanError, ProductionPlanV1
+
+HERE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PLAN = os.path.join(HERE, "plans", "lighthouse_3shot.json")
+HAVE_FFMPEG = shutil.which("ffmpeg") and shutil.which("ffprobe")
+
+
+def _load(extra=None):
+    with open(PLAN) as f:
+        d = json.load(f)
+    if extra:
+        extra(d)
+    return d
+
+
+class TestSchema(unittest.TestCase):
+    def test_valid_plan_loads(self):
+        plan = ProductionPlanV1.from_dict(_load())
+        self.assertEqual(plan.project.video_lane, "wan")
+        self.assertEqual(len(plan.shots), 3)
+        self.assertEqual([s.id for s in plan.ordered_shots()], ["s1", "s2", "s3"])
+
+    def test_rejects_non_wan_video_lane(self):
+        with self.assertRaises(PlanError):
+            ProductionPlanV1.from_dict(_load(lambda d: d["project"].update(video_lane="ltx")))
+
+    def test_rejects_shot_lane_mismatch(self):
+        with self.assertRaises(PlanError):
+            ProductionPlanV1.from_dict(_load(lambda d: d["shots"][0].update(lane="sulphur")))
+
+    def test_rejects_duplicate_shot_ids(self):
+        def dup(d):
+            d["shots"][1]["id"] = "s1"
+            d["timeline"][1]["clip"] = "s1"
+        with self.assertRaises(PlanError):
+            ProductionPlanV1.from_dict(_load(dup))
+
+    def test_rejects_timeline_missing_shot(self):
+        with self.assertRaises(PlanError):
+            ProductionPlanV1.from_dict(_load(lambda d: d["timeline"].pop()))
+
+    def test_rejects_non_t2v_mode(self):
+        with self.assertRaises(PlanError):
+            ProductionPlanV1.from_dict(_load(lambda d: d["shots"][0].update(mode="i2v")))
+
+
+class TestAssembleCommand(unittest.TestCase):
+    def test_full_mix_graph(self):
+        cmd = assemble.build_mix_command(
+            "/tmp/final.mp4",
+            clips=["a.mp4", "b.mp4", "c.mp4"],
+            narrations=[("v1.wav", 200), ("v2.wav", 5000)],
+            bed="bed.wav", fps=16, lufs=-14.0, bed_level_db=-18,
+        )
+        fc = cmd[cmd.index("-filter_complex") + 1]
+        self.assertIn("concat=n=3:v=1:a=0[vid]", fc)
+        self.assertIn("adelay=200|200", fc)
+        self.assertIn("sidechaincompress", fc)        # bed ducked under narration
+        self.assertIn("asplit=2[nkey][nmix]", fc)      # narration split, used once each
+        self.assertIn("loudnorm=I=-14.0", fc)
+        self.assertIn("-shortest", cmd)
+        self.assertEqual(cmd[-1], "/tmp/final.mp4")
+
+    def test_bed_only_no_narration(self):
+        cmd = assemble.build_mix_command(
+            "/tmp/f.mp4", clips=["a.mp4"], narrations=[], bed="bed.wav",
+            fps=16, lufs=-14.0, bed_level_db=-18)
+        fc = cmd[cmd.index("-filter_complex") + 1]
+        self.assertNotIn("sidechaincompress", fc)
+        self.assertIn("loudnorm", fc)
+
+    def test_db_to_linear(self):
+        self.assertAlmostEqual(assemble.db_to_linear(0), 1.0)
+        self.assertAlmostEqual(assemble.db_to_linear(-6), 0.501, places=2)
+
+
+class TestValidators(unittest.TestCase):
+    @unittest.skipUnless(HAVE_FFMPEG, "ffmpeg/ffprobe required")
+    def test_silent_clip_and_audio(self):
+        with tempfile.TemporaryDirectory() as td:
+            vid = os.path.join(td, "v.mp4")
+            wav = os.path.join(td, "a.wav")
+            from ..util import sh
+            sh(["ffmpeg", "-y", "-v", "error", "-f", "lavfi", "-i",
+                "color=c=0x102030:s=320x240:r=16", "-t", "2", "-c:v", "libx264",
+                "-pix_fmt", "yuv420p", "-an", vid])
+            sh(["ffmpeg", "-y", "-v", "error", "-f", "lavfi", "-i",
+                "sine=frequency=440:duration=2", "-c:a", "pcm_s16le", wav])
+            self.assertTrue(validators.run_all(["non_empty", "no_audio_expected", "duration"],
+                                               vid, target_seconds=2)["ok"])
+            self.assertTrue(validators.run_all(["non_empty", "audio_present"], wav)["ok"])
+            # a silent clip must FAIL audio_present
+            self.assertFalse(validators.check("audio_present", vid)[0])
+
+
+class TestLock(unittest.TestCase):
+    def test_single_flight(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = os.path.join(td, ".run.lock")
+            a = ProductionLock(p).acquire()
+            try:
+                with self.assertRaises(ProductionLockHeld):
+                    ProductionLock(p).acquire()
+            finally:
+                a.release()
+            ProductionLock(p).acquire().release()   # free again
+
+
+class TestEndToEndSynthetic(unittest.TestCase):
+    @unittest.skipUnless(HAVE_FFMPEG, "ffmpeg/ffprobe required")
+    def test_full_pipeline_offline(self):
+        from ..executor import run_production
+        with tempfile.TemporaryDirectory() as td:
+            plan = ProductionPlanV1.from_dict(_load())
+            summary = run_production(plan, backend_name="synthetic", job_id="test-job",
+                                     now_iso="2026-01-01T00:00:00Z", productions_dir=td)
+            man = summary["manifest"]
+            # a real final MP4 with an audio track exists
+            self.assertTrue(os.path.isfile(summary["final"]))
+            fpr = validators.ffprobe(summary["final"])
+            self.assertGreater(fpr.duration, 10)        # ~15s of clips
+            self.assertTrue(fpr.has_audio)
+            # manifest: typed records, run-level provenance, exit criteria
+            self.assertEqual({a["type"] for a in man["artifacts"]}, {"media"})
+            roles = sorted({a["role"] for a in man["artifacts"]})
+            self.assertEqual(roles, ["final", "music_bed", "narration", "shot"])
+            self.assertEqual(len(man["ffmpeg_cmds"]), 1)
+            self.assertIn("wan", man["workflow_versions"])
+            self.assertTrue(man["exit_criteria"]["all_validators_pass"])
+            self.assertTrue(man["exit_criteria"]["final_has_audio"])
+            # manifest.json was written + reloads
+            with open(os.path.join(summary["prod_dir"], "manifest.json")) as f:
+                reloaded = json.load(f)
+            self.assertEqual(reloaded["job_id"], "test-job")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/studio/production/tests/test_v0b.py
+++ b/services/studio/production/tests/test_v0b.py
@@ -1,0 +1,101 @@
+"""Offline v0b planner tests (stdlib unittest, no model/GPU).
+
+A stub LLM returns canned director replies so the full planner — prompt
+construction, JSON extraction, lenient normalization, and the validator-repair
+loop — is exercised without the 4B (mirrors v0a's synthetic backend).
+
+Run:  python3 -m unittest services.studio.production.tests.test_v0b -v
+"""
+from __future__ import annotations
+
+import unittest
+
+from ..planner import PlannerError, extract_json, normalize, plan_from_brief
+from ..registry import audio_lanes, load, prompt_slice, video_lanes
+
+GOOD_PLAN = """{
+  "project": {"title": "Test", "tone": "calm", "target_seconds": 10, "video_lane": "wan"},
+  "shots": [
+    {"id": "s1", "lane": "wan", "mode": "t2v", "target_seconds": 5, "prompt_intent": "a", "narration": "one", "seed": 1},
+    {"id": "s2", "lane": "wan", "mode": "t2v", "target_seconds": 5, "prompt_intent": "b", "narration": "two", "seed": 2}
+  ],
+  "music": {"lane": "ace-step", "tags": "calm, ambient", "lyrics": "[instrumental]", "seed": 3},
+  "timeline": [
+    {"clip": "s1", "transition_in": "dissolve"},
+    {"clip": "s2", "transition_in": "dissolve"}
+  ]
+}"""
+
+
+class StubLLM:
+    """Returns a queue of canned director responses; records the calls."""
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def __call__(self, messages, *, max_tokens, temperature):
+        self.calls.append(messages)
+        return self.responses.pop(0)
+
+
+class TestRegistry(unittest.TestCase):
+    def test_load_and_slice(self):
+        reg = load()
+        self.assertIn("wan", video_lanes(reg))
+        self.assertIn("kokoro", audio_lanes(reg))
+        self.assertIn("ace-step", audio_lanes(reg))
+        s = prompt_slice(reg)
+        self.assertIn("wan", s)
+        self.assertIn("RULES", s)
+        self.assertIn("Pin ONE video_lane", s)   # the pinning rule is handed to the planner
+
+
+class TestPlanner(unittest.TestCase):
+    def setUp(self):
+        self.reg = load()
+
+    def test_happy_path(self):
+        llm = StubLLM(["a short treatment", GOOD_PLAN])
+        plan, arts = plan_from_brief("a 10s calm clip", self.reg, llm=llm)
+        self.assertEqual([s.id for s in plan.shots], ["s1", "s2"])
+        self.assertEqual(plan.project.video_lane, "wan")
+        self.assertEqual(len(llm.calls), 2)                 # treatment + plan, no repair
+        self.assertEqual([a.type for a in arts], ["llm_prompt", "llm_prompt"])
+        self.assertEqual([a.role for a in arts], ["treatment", "plan"])
+
+    def test_fenced_and_trailing_chatter(self):
+        llm = StubLLM(["t", "```json\n" + GOOD_PLAN + "\n```\nhope that helps!"])
+        plan, _ = plan_from_brief("b", self.reg, llm=llm)
+        self.assertEqual(len(plan.shots), 2)
+
+    def test_repair_loop_recovers(self):
+        bad = '{"project": {"video_lane": "ltx"}, "shots": []}'   # invalid: not wan, no shots
+        llm = StubLLM(["t", bad, GOOD_PLAN])
+        plan, arts = plan_from_brief("b", self.reg, llm=llm)
+        self.assertEqual(len(plan.shots), 2)
+        self.assertEqual(len(llm.calls), 3)                 # treatment + plan + 1 repair
+        self.assertEqual(arts[-1].role, "repair_1")
+
+    def test_repair_exhausted_raises(self):
+        llm = StubLLM(["t", "nonsense", "still no json", "nope", "still nope"])
+        with self.assertRaises(PlannerError):
+            plan_from_brief("b", self.reg, llm=llm, max_repairs=3)
+
+    def test_normalize_fills_defaults(self):
+        data = normalize({"project": {"video_lane": "wan"},
+                          "shots": [{"prompt_intent": "x", "narration": "n"}]})
+        self.assertEqual(data["shots"][0]["id"], "s1")
+        self.assertEqual(data["shots"][0]["lane"], "wan")
+        self.assertEqual(data["shots"][0]["mode"], "t2v")
+        self.assertTrue(data["timeline"])                   # auto-built from shots
+        self.assertIn("music", data)
+        self.assertEqual(data["delivery"]["width"], 832)
+
+    def test_extract_json_balanced(self):
+        self.assertEqual(extract_json('prefix {"a": {"b": 1}} suffix')["a"]["b"], 1)
+        with self.assertRaises(ValueError):
+            extract_json("no json here")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/studio/production/tests/test_v0b.py
+++ b/services/studio/production/tests/test_v0b.py
@@ -8,10 +8,18 @@ Run:  python3 -m unittest services.studio.production.tests.test_v0b -v
 """
 from __future__ import annotations
 
+import json
+import os
+import shutil
+import tempfile
 import unittest
 
 from ..planner import PlannerError, extract_json, normalize, plan_from_brief
 from ..registry import audio_lanes, load, prompt_slice, video_lanes
+
+_PROD = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_PLAN = os.path.join(_PROD, "plans", "lighthouse_3shot.json")
+_HAVE_FFMPEG = shutil.which("ffmpeg") and shutil.which("ffprobe")
 
 GOOD_PLAN = """{
   "project": {"title": "Test", "tone": "calm", "target_seconds": 10, "video_lane": "wan"},
@@ -95,6 +103,32 @@ class TestPlanner(unittest.TestCase):
         self.assertEqual(extract_json('prefix {"a": {"b": 1}} suffix')["a"]["b"], 1)
         with self.assertRaises(ValueError):
             extract_json("no json here")
+
+
+class TestProvenanceNotCountedAsValidator(unittest.TestCase):
+    """Regression: llm_prompt provenance must NOT fail all_validators_pass.
+
+    (Live v0b run #1 reported rc=1 because the planner's prompt records — which carry
+    no media 'ok' — were counted as failed validators.)
+    """
+    @unittest.skipUnless(_HAVE_FFMPEG, "ffmpeg/ffprobe required")
+    def test_llm_prompt_excluded_from_exit_criteria(self):
+        from ..executor import run_production
+        from ..manifest import Artifact
+        from ..schema import ProductionPlanV1
+        with open(_PLAN) as f:
+            plan = ProductionPlanV1.from_dict(json.load(f))
+        prov = [Artifact(id="prompt.plan", type="llm_prompt", role="plan",
+                         path="prompts/plan.json", validation={"response_hash": "x"})]
+        with tempfile.TemporaryDirectory() as td:
+            s = run_production(plan, backend_name="synthetic", job_id="prov",
+                               now_iso="2026-01-01T00:00:00Z", productions_dir=td,
+                               extra_artifacts=prov)
+            ec = s["manifest"]["exit_criteria"]
+            self.assertTrue(ec["all_validators_pass"])   # media all pass; provenance excluded
+            types = {a["type"] for a in s["manifest"]["artifacts"]}
+            self.assertIn("llm_prompt", types)           # provenance still carried
+            self.assertIn("media", types)
 
 
 if __name__ == "__main__":

--- a/services/studio/production/tests/test_v0b_images.py
+++ b/services/studio/production/tests/test_v0b_images.py
@@ -93,6 +93,41 @@ class TestContinuityE2E(unittest.TestCase):
             self.assertIn("hero_keyframe", roles)
 
 
+class TestStoryboardMode(unittest.TestCase):
+    def test_storyboard_plan_valid(self):
+        p = ProductionPlanV1.from_dict(_load("lighthouse_storyboard.json"))
+        self.assertEqual(p.project.continuity, "storyboard")
+        # one keyframe per shot, each shot i2v from ITS OWN keyframe
+        self.assertEqual([a.id for a in p.asset_tasks], ["kf_s1", "kf_s2", "kf_s3"])
+        self.assertEqual([s.start_from for s in p.shots], ["kf_s1", "kf_s2", "kf_s3"])
+        self.assertTrue(all(s.mode == "i2v" for s in p.shots))
+
+    def test_planner_authors_storyboard(self):
+        from ..planner import plan_from_brief
+        from ..registry import load
+        from .test_v0b import GOOD_PLAN, StubLLM
+        plan, _ = plan_from_brief("b", load(), llm=StubLLM(["t", GOOD_PLAN]), continuity="storyboard")
+        self.assertEqual(plan.project.continuity, "storyboard")
+        # GOOD_PLAN has 2 shots -> 2 per-shot keyframes; each shot starts from its own
+        self.assertEqual(len(plan.asset_tasks), len(plan.shots))
+        for s in plan.shots:
+            self.assertEqual(s.start_from, f"kf_{s.id}")
+            self.assertEqual(s.mode, "i2v")
+        # shared style bible prefixes every keyframe prompt
+        self.assertTrue(all("cohesive cinematic style" in a.prompt for a in plan.asset_tasks))
+
+    @unittest.skipUnless(_HAVE_FFMPEG, "ffmpeg/ffprobe required")
+    def test_storyboard_renders_per_shot_keyframes(self):
+        from ..executor import run_production
+        plan = ProductionPlanV1.from_dict(_load("lighthouse_storyboard.json"))
+        with tempfile.TemporaryDirectory() as td:
+            s = run_production(plan, backend_name="synthetic", job_id="sb",
+                               now_iso="2026-01-01T00:00:00Z", productions_dir=td)
+            self.assertTrue(s["manifest"]["exit_criteria"]["all_validators_pass"])
+            for kf in ("kf_s1", "kf_s2", "kf_s3"):
+                self.assertTrue(os.path.isfile(os.path.join(td, "sb", "assets", kf + ".png")))
+
+
 class TestPlannerContinuity(unittest.TestCase):
     """The planner deterministically wires continuity (4B stays creative)."""
     def setUp(self):

--- a/services/studio/production/tests/test_v0b_images.py
+++ b/services/studio/production/tests/test_v0b_images.py
@@ -93,5 +93,30 @@ class TestContinuityE2E(unittest.TestCase):
             self.assertIn("hero_keyframe", roles)
 
 
+class TestPlannerContinuity(unittest.TestCase):
+    """The planner deterministically wires continuity (4B stays creative)."""
+    def setUp(self):
+        from ..registry import load
+        self.reg = load()
+
+    def test_planner_applies_chain(self):
+        from ..planner import plan_from_brief
+        from .test_v0b import GOOD_PLAN, StubLLM
+        plan, _ = plan_from_brief("b", self.reg, llm=StubLLM(["t", GOOD_PLAN]), continuity="chain")
+        self.assertEqual(plan.project.continuity, "chain")
+        self.assertEqual(plan.shots[0].mode, "t2v")
+        self.assertTrue(all(s.mode == "i2v" and s.start_from == "prev_last_frame"
+                            for s in plan.shots[1:]))
+
+    def test_planner_applies_hero(self):
+        from ..planner import plan_from_brief
+        from .test_v0b import GOOD_PLAN, StubLLM
+        plan, _ = plan_from_brief("b", self.reg, llm=StubLLM(["t", GOOD_PLAN]), continuity="hero")
+        self.assertEqual(plan.project.continuity, "hero")
+        self.assertEqual([a.id for a in plan.asset_tasks], ["hero"])
+        self.assertTrue(all(s.mode == "i2v" and s.start_from == "hero" for s in plan.shots))
+        self.assertEqual(plan.project.image_policy.get("hero_keyframe_lane"), "chroma")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/services/studio/production/tests/test_v0b_images.py
+++ b/services/studio/production/tests/test_v0b_images.py
@@ -1,0 +1,97 @@
+"""Offline v0b-images tests — the asset-DAG + both continuity modes (synthetic).
+
+Covers the user's asks: asset-DAG ordering (hero generated before the shots that
+consume it) and missing-dependency rejection. The synthetic backend renders i2v as
+a clip that literally begins from the start frame, so chain/hero continuity is
+exercised end-to-end offline (no GPU).
+
+Run:  python3 -m unittest services.studio.production.tests.test_v0b_images -v
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+from ..schema import PlanError, ProductionPlanV1
+
+_PROD = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_HAVE_FFMPEG = shutil.which("ffmpeg") and shutil.which("ffprobe")
+
+
+def _load(name, mut=None):
+    with open(os.path.join(_PROD, "plans", name)) as f:
+        d = json.load(f)
+    if mut:
+        mut(d)
+    return d
+
+
+class TestAssetDAGSchema(unittest.TestCase):
+    def test_chain_plan_valid(self):
+        p = ProductionPlanV1.from_dict(_load("lighthouse_chain.json"))
+        self.assertEqual(p.project.continuity, "chain")
+        self.assertEqual([s.mode for s in p.ordered_shots()], ["t2v", "i2v", "i2v"])
+        self.assertEqual(p.ordered_shots()[1].start_from, "prev_last_frame")
+
+    def test_hero_plan_valid(self):
+        p = ProductionPlanV1.from_dict(_load("lighthouse_hero.json"))
+        self.assertEqual(p.project.continuity, "hero")
+        self.assertEqual([a.id for a in p.asset_tasks], ["hero"])
+        self.assertTrue(all(s.start_from == "hero" for s in p.shots))
+
+    def test_missing_asset_dependency_rejected(self):
+        with self.assertRaises(PlanError):
+            ProductionPlanV1.from_dict(_load(
+                "lighthouse_hero.json", lambda d: d["shots"][0].update(start_from="nope")))
+
+    def test_i2v_without_start_from_rejected(self):
+        with self.assertRaises(PlanError):
+            ProductionPlanV1.from_dict(_load(
+                "lighthouse_chain.json", lambda d: d["shots"][1].pop("start_from")))
+
+    def test_first_shot_cannot_chain(self):
+        with self.assertRaises(PlanError):
+            ProductionPlanV1.from_dict(_load(
+                "lighthouse_chain.json",
+                lambda d: d["shots"][0].update(mode="i2v", start_from="prev_last_frame")))
+
+    def test_bad_continuity_rejected(self):
+        with self.assertRaises(PlanError):
+            ProductionPlanV1.from_dict(_load(
+                "lighthouse_chain.json", lambda d: d["project"].update(continuity="morph")))
+
+
+class TestContinuityE2E(unittest.TestCase):
+    @unittest.skipUnless(_HAVE_FFMPEG, "ffmpeg/ffprobe required")
+    def test_chain_mode_renders_with_handoff_frames(self):
+        from ..executor import run_production
+        from ..validators import ffprobe
+        plan = ProductionPlanV1.from_dict(_load("lighthouse_chain.json"))
+        with tempfile.TemporaryDirectory() as td:
+            s = run_production(plan, backend_name="synthetic", job_id="chain",
+                               now_iso="2026-01-01T00:00:00Z", productions_dir=td)
+            self.assertTrue(s["manifest"]["exit_criteria"]["all_validators_pass"])
+            self.assertTrue(ffprobe(s["final"]).has_audio)
+            # the i2v hand-off frames were extracted for the chained shots
+            self.assertTrue(os.path.isfile(os.path.join(td, "chain", "assets", "s2_start.png")))
+            self.assertTrue(os.path.isfile(os.path.join(td, "chain", "assets", "s3_start.png")))
+
+    @unittest.skipUnless(_HAVE_FFMPEG, "ffmpeg/ffprobe required")
+    def test_hero_mode_asset_dag_orders(self):
+        from ..executor import run_production
+        plan = ProductionPlanV1.from_dict(_load("lighthouse_hero.json"))
+        with tempfile.TemporaryDirectory() as td:
+            s = run_production(plan, backend_name="synthetic", job_id="hero",
+                               now_iso="2026-01-01T00:00:00Z", productions_dir=td)
+            self.assertTrue(s["manifest"]["exit_criteria"]["all_validators_pass"])
+            # pre-production generated the hero BEFORE the shots that consume it
+            self.assertTrue(os.path.isfile(os.path.join(td, "hero", "assets", "hero.png")))
+            roles = {a["role"] for a in s["manifest"]["artifacts"]}
+            self.assertIn("hero_keyframe", roles)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/studio/production/util.py
+++ b/services/studio/production/util.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import subprocess
 
 
@@ -15,6 +16,21 @@ def sh(cmd: list[str], timeout: int = 600) -> str:
     if r.returncode != 0:
         raise FFError(f"{cmd[0]} failed ({r.returncode}): {(r.stderr or '')[-600:]}")
     return r.stdout
+
+
+def last_frame(clip_path: str, out_png: str) -> str:
+    """Extract a video's final frame to a PNG (the i2v-chain hand-off)."""
+    os.makedirs(os.path.dirname(out_png), exist_ok=True)
+    n = sh(["ffprobe", "-v", "error", "-select_streams", "v:0", "-count_frames",
+            "-show_entries", "stream=nb_read_frames", "-of",
+            "default=nokey=1:noprint_wrappers=1", clip_path]).strip()
+    try:
+        idx = max(0, int(n) - 1)
+    except ValueError:
+        idx = 0
+    sh(["ffmpeg", "-y", "-v", "error", "-i", clip_path,
+        "-vf", f"select=eq(n\\,{idx})", "-vframes", "1", out_png])
+    return out_png
 
 
 def sha256_file(path: str) -> str:

--- a/services/studio/production/util.py
+++ b/services/studio/production/util.py
@@ -1,0 +1,29 @@
+"""Small shared helpers."""
+from __future__ import annotations
+
+import hashlib
+import subprocess
+
+
+class FFError(RuntimeError):
+    pass
+
+
+def sh(cmd: list[str], timeout: int = 600) -> str:
+    """Run a subprocess, raise FFError with tail of stderr on failure. Returns stdout."""
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    if r.returncode != 0:
+        raise FFError(f"{cmd[0]} failed ({r.returncode}): {(r.stderr or '')[-600:]}")
+    return r.stdout
+
+
+def sha256_file(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return "sha256:" + h.hexdigest()
+
+
+def sha256_text(text: str) -> str:
+    return "sha256:" + hashlib.sha256(text.encode()).hexdigest()

--- a/services/studio/production/validators.py
+++ b/services/studio/production/validators.py
@@ -1,0 +1,84 @@
+"""ffprobe-backed validators — transport-success != real success.
+
+A rendered file existing is not enough (Ideogram placeholders, LTX collapse, audio
+truncation all "succeed" at the file layer). These check the actual media: duration,
+audio presence, dimensions, non-emptiness. v0a wires the cheap subset; richer checks
+(placeholder / near-uniform-frame detection) are v1.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+
+
+@dataclass
+class ProbeResult:
+    duration: float = 0.0
+    has_audio: bool = False
+    width: int = 0
+    height: int = 0
+    size_bytes: int = 0
+
+
+def ffprobe(path: str) -> ProbeResult:
+    """Probe a media file. Returns zeros if the file is missing/unreadable."""
+    r = ProbeResult()
+    if not (path and os.path.isfile(path)):
+        return r
+    r.size_bytes = os.path.getsize(path)
+    try:
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-show_entries",
+             "format=duration:stream=codec_type,width,height",
+             "-of", "json", path],
+            capture_output=True, text=True, timeout=30,
+        ).stdout
+        data = json.loads(out or "{}")
+    except Exception:
+        return r
+    try:
+        r.duration = float(data.get("format", {}).get("duration") or 0.0)
+    except (TypeError, ValueError):
+        r.duration = 0.0
+    for s in data.get("streams", []):
+        if s.get("codec_type") == "audio":
+            r.has_audio = True
+        if s.get("codec_type") == "video":
+            r.width = int(s.get("width") or 0)
+            r.height = int(s.get("height") or 0)
+    return r
+
+
+# -- individual checks: (name) -> (ok: bool, detail: str) ---------------------
+
+def check(name: str, path: str, *, target_seconds: float = 0.0, tol: float = 1.5) -> tuple[bool, str]:
+    p = ffprobe(path)
+    if name == "non_empty":
+        ok = p.size_bytes > 0
+        return ok, f"{p.size_bytes} bytes"
+    if name == "duration":
+        if target_seconds <= 0:
+            return p.duration > 0, f"{p.duration:.2f}s"
+        ok = abs(p.duration - target_seconds) <= tol
+        return ok, f"{p.duration:.2f}s vs target {target_seconds:.2f}s (±{tol})"
+    if name == "no_audio_expected":
+        return (not p.has_audio), ("has audio!" if p.has_audio else "silent (ok)")
+    if name == "audio_present":
+        return p.has_audio, ("audio present" if p.has_audio else "NO audio track")
+    if name == "has_video":
+        ok = p.width > 0 and p.height > 0
+        return ok, f"{p.width}x{p.height}"
+    return False, f"unknown validator {name!r}"
+
+
+def run_all(names: list[str], path: str, *, target_seconds: float = 0.0) -> dict:
+    """Run a list of validators against one artifact. Returns a result dict."""
+    results = {}
+    ok_all = True
+    for n in names:
+        ok, detail = check(n, path, target_seconds=target_seconds)
+        results[n] = {"ok": ok, "detail": detail}
+        ok_all = ok_all and ok
+    return {"ok": ok_all, "checks": results}


### PR DESCRIPTION
> **Stacked on #497 (v0b-core), which is stacked on #496 (v0a).** Base is `feat/studio-production-v0b`. Merge order: #496 → #497 → this. (Stack is 3 deep — worth collapsing.)

## What

**v0b-images**: **continuity** — the lever for the "three unrelated clips" / slideshow problem. Two modes, both live-validated:

- **chain** — each shot is Wan **i2v** from the *previous shot's last frame*, so the motion flows shot-to-shot.
- **hero** — all shots i2v from one generated **hero keyframe** (chroma image lane) — a shared visual anchor.

## How

- **Asset-DAG schema**: `project.continuity` (none/chain/hero) + `image_policy`, `asset_tasks[]` (generated images), `shot.start_from` (`prev_last_frame` | `<asset id>`), `mode` now `t2v`/`i2v`. Validation does **missing-dependency rejection**, first-shot-can't-chain, and i2v-requires-start_from. `continuity:none` preserves v0a/v0b-core.
- **Backends**: Wan i2v (upload start image + `wan22_rapid_i2v`) + chroma `generate_image` (`chroma1_hd`), live + synthetic. Synthetic i2v *begins from the start frame* so continuity is exercised offline.
- **Executor**: Phase 0 pre-production generates `asset_tasks` → Phase 1 resolves `start_from` (extracting the prev clip's last frame via ffmpeg for chain).
- **Planner**: the 4B stays creative; `apply_continuity()` wires the mode deterministically. `--brief --continuity chain|hero`.

## Results

| Check | Result |
|---|---|
| offline | ✅ **33/33** (asset-DAG ordering, missing-dep rejection, both modes synthetic e2e, planner-continuity) |
| **live chain** | ✅ rc=0, i2v from extracted `s2_start.png`/`s3_start.png`, MP4 + audio, VO in tolerance |
| **live hero** | ✅ rc=0, chroma `hero.png` generated → all shots i2v from it, MP4 + audio |

## The open question (the live test's purpose)

*Does chain or hero stop it feeling like three unrelated clips?* — a **human visual judgment** on the A/B/C (baseline t2v vs chain vs hero), in progress. The mechanism is proven; whether it *reads* as continuous is the call that decides where continuity work goes next.

## Scope / deferred

Isolated under `services/studio/production/`, stdlib + PyYAML. Deferred to v1: skills, takes/rerender, Qdrant/SearXNG, durable queue, OWUI lane, the remaining image roles (reference/storyboard/title-card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
