### PR TITLE
studio: TTS writes 0644 (systemic perm fix) + production-agent docs pointer

### DIFF
--- a/services/studio/tts/tts.py
+++ b/services/studio/tts/tts.py
@@ -119,6 +119,7 @@ async def tts(request):
     name = "studio_tts_" + uuid.uuid4().hex[:8] + ".wav"
     dst = os.path.join(OUTPUT_DIR, name)
     shutil.move(wav, dst)   # /tmp -> /output is cross-device; shutil.move copies+unlinks
+    os.chmod(dst, 0o644)    # world-readable so host-side consumers can read it (like ComfyUI's save nodes)
     return web.json_response({"wav": name})
 
 
@@ -139,6 +140,7 @@ async def narrate(request):
         out_name = "studio_narrated_" + uuid.uuid4().hex[:8] + ".mp4"
         out_path = os.path.join(OUTPUT_DIR, out_name)
         await loop.run_in_executor(None, _mixdown, video_path, voice_wav, out_path, int(b.get("duck_db", 12)))
+        os.chmod(out_path, 0o644)   # world-readable so host-side consumers can read it
         return web.json_response({"filename": out_name, "subfolder": ""})
     except Exception as e:
         return web.json_response({"error": str(e)}, status=500)


### PR DESCRIPTION
Housekeeping after the production-agent arc landed.

- **TTS 0600 → 0644**: the Kokoro TTS service now `chmod 0644`'s its `/tts` WAV + `/narrate` MP4 outputs (mirroring ComfyUI's save nodes), so host-side consumers can read them directly. This is the systemic fix for the issue the v0a live run surfaced; the production agent's `docker cp` fallback stays as defense-in-depth. ⚠️ `tts.py` is COPY'd into `studio-tts` — rebuild the container (`docker compose ... build studio-tts`) to deploy.
- **Docs**: a Production Agent pointer in `docs/ai-studio/README.md` → `services/studio/production/` (brief → MP4, storyboard continuity default).

Tiny + isolated. The design doc (private) already records the proof-path-built / v1-deferred status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm