### PR TITLE
Studio setup: de-rig standalone scripts (fix #503 model path, #504 LAN IP)

### DIFF
--- a/scripts/gpu-mode.sh
+++ b/scripts/gpu-mode.sh
@@ -48,6 +48,12 @@ RED='\033[0;31m'
 CYAN='\033[0;36m'
 NC='\033[0m' # No Color
 
+# LAN IP for the URLs printed by the mode banners below — auto-detected (override with
+# LANIP=...), matching setup-ai-studio.sh. Falls back to 'localhost' so a fresh clone never
+# prints the dev rig's hardcoded address (issue #504). `|| true` keeps set -e happy on no match.
+LANIP="${LANIP:-$(hostname -I 2>/dev/null | tr ' ' '\n' | grep -E '^(192\.168|10\.|172\.)' | head -1 || true)}"
+LANIP="${LANIP:-localhost}"
+
 # Standard supporting services living under $CLUB3090_DIR/services.
 # Ollama removed 2026-06-22 (dropped from serving 2026-05-10 — Qwen/Gemma route
 # through LiteLLM directly; the unused services/ollama/ compose dir was deleted).
@@ -481,7 +487,7 @@ mode_chat() {
     start_service searxng
     start_studio_director
     echo ""
-    echo -e "${GREEN}Chat mode active.${NC} Open WebUI: http://192.168.86.33:8080"
+    echo -e "${GREEN}Chat mode active.${NC} Open WebUI: http://$LANIP:8080"
     echo -e "${YELLOW}Director placement: $(_director_device) (change in c3 Settings · Director placement).${NC}"
     echo -e "${YELLOW}Plug in catalog models: bash scripts/switch.sh --owui <variant>  (registers it into OWUI here).${NC}"
 }
@@ -507,7 +513,7 @@ mode_27b() {
     start_service openwebui
     start_service searxng
     echo ""
-    echo -e "${GREEN}27B dual-card MTP mode active.${NC} API: http://192.168.86.33:8010"
+    echo -e "${GREEN}27B dual-card MTP mode active.${NC} API: http://$LANIP:8010"
     echo -e "${YELLOW}Per-stream: 68 narr / 89 code TPS short, 36 TPS @ 100K, 28 TPS @ 200K warm.${NC}"
     echo -e "${YELLOW}2 concurrent streams. KV pool 168K, max concurrency 2.36× at full 262K.${NC}"
     echo -e "${YELLOW}Vision + tools + thinking + 262K ctx all working. Boot ~3-4 min.${NC}"
@@ -533,7 +539,7 @@ mode_35b_a3b() {
     start_service openwebui
     start_service searxng
     echo ""
-    echo -e "${GREEN}35B-A3B dual-card mode active.${NC} API: http://192.168.86.33:8051"
+    echo -e "${GREEN}35B-A3B dual-card mode active.${NC} API: http://$LANIP:8051"
     echo -e "${YELLOW}MoE: 3B active / 35B total — ~178/174 TPS, 262K ctx, vision. Boot ~3-4 min.${NC}"
     echo -e "${YELLOW}Tail: sudo docker logs -f vllm-qwen36-35b-a3b-dual${NC}"
 }
@@ -558,7 +564,7 @@ mode_gemma_12b() {
     start_service openwebui
     start_service searxng
     echo ""
-    echo -e "${GREEN}Gemma 4 12B mode active.${NC} API: http://192.168.86.33:8038"
+    echo -e "${GREEN}Gemma 4 12B mode active.${NC} API: http://$LANIP:8038"
     echo -e "${YELLOW}gemma4_unified arch-preview image (EPHEMERAL tag — pin a digest before prod). Single card; the other GPU is free.${NC}"
     echo -e "${YELLOW}Tail: sudo docker logs -f vllm-gemma-4-12b-int8-mtp${NC}"
 }
@@ -586,7 +592,7 @@ mode_gemma_int8() {
     start_service openwebui
     start_service searxng
     echo ""
-    echo -e "${GREEN}Gemma 4 31B INT8 PTH mode active.${NC} API: http://192.168.86.33:8032"
+    echo -e "${GREEN}Gemma 4 31B INT8 PTH mode active.${NC} API: http://$LANIP:8032"
     echo -e "${YELLOW}Tail: sudo docker logs -f vllm-gemma-4-31b-mtp-int8${NC}"
 }
 mode_deckard() {
@@ -612,7 +618,7 @@ mode_deckard() {
         bash "$CLUB3090_DIR/scripts/lib/owui-register.sh" 8199 || true
     fi
     echo ""
-    echo -e "${GREEN}Deckard-40B mode active.${NC} API: http://192.168.86.33:8199  (model: deckard-40b)"
+    echo -e "${GREEN}Deckard-40B mode active.${NC} API: http://$LANIP:8199  (model: deckard-40b)"
     echo -e "${YELLOW}MTP n=2: ~36 narr / 46 code TPS · 128K ctx @ q8_0 KV · uncensored, text-only.${NC}"
     echo -e "${YELLOW}First boot ~1-2 min (31 GB GGUF load + 128K KV alloc across both cards).${NC}"
     echo -e "${YELLOW}Tail: sudo docker logs -f llama-cpp-deckard-40b${NC}"
@@ -695,9 +701,9 @@ mode_ai_studio() {
     start_service searxng
     echo ""
     echo -e "${GREEN}AI-studio mode active.${NC} — one scene; pick the lane in Open WebUI."
-    echo -e "  Open WebUI:  http://192.168.86.33:8080   (image · video · music · SFX · voice lanes)"
-    echo -e "  Gallery:     http://192.168.86.33:8189   (all generated media; survives ComfyUI down)"
-    echo -e "  ComfyUI:     http://192.168.86.33:8188   (full node graph / control)"
+    echo -e "  Open WebUI:  http://$LANIP:8080   (image · video · music · SFX · voice lanes)"
+    echo -e "  Gallery:     http://$LANIP:8189   (all generated media; survives ComfyUI down)"
+    echo -e "  ComfyUI:     http://$LANIP:8188   (full node graph / control)"
     echo -e "${YELLOW}First ComfyUI boot can take a few min (clones + node deps). Video DiT splits across both 3090s (DisTorch); image/audio lanes run on GPU0 beside the director.${NC}"
     echo -e "${YELLOW}GPU-mutex with the dual-card LLMs. Premium voice (step-audio-editx) is on-demand on GPU1 — mutually exclusive with an active video render.${NC}"
     echo -e "${YELLOW}Tail: sudo docker logs -f comfyui${NC}"

--- a/scripts/tests/test-studio-derig.sh
+++ b/scripts/tests/test-studio-derig.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Guards against dev-rig defaults leaking into the studio setup scripts.
+# Regression guard for club-3090 #503 + #504 (sumo-dandan, 2026-06-28):
+#   #503 — standalone services/comfyui/download_*.sh fell back to the rig path
+#          /mnt/models/comfyui/models instead of deriving COMFYUI_MODELS_DIR from
+#          MODEL_DIR → "mkdir: Permission denied" on a clean machine. Fix: each
+#          download_*.sh sources comfyui-paths.sh before its ROOT= line.
+#   #504 — gpu-mode.sh hard-coded the rig LAN IP 192.168.86.33 in its URL banners.
+#          Fix: auto-detect LANIP (LANIP-overridable), like setup-ai-studio.sh.
+set -uo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+fails=0
+chk() { if [ "$1" = ok ]; then echo "  ok: $2"; else echo "  FAIL: $2"; fails=$((fails+1)); fi; }
+
+# 1. No script anywhere may hard-code the dev rig's LAN IP (this guard file excepted —
+#    it names the IP in its own comment + grep pattern).
+hits="$(grep -rl '192\.168\.86\.33' "$ROOT/scripts" "$ROOT/services" \
+        --exclude="$(basename "$0")" 2>/dev/null || true)"
+[ -z "$hits" ] && chk ok "no hardcoded rig IP 192.168.86.33" \
+  || { chk fail "hardcoded rig IP still present in: $hits"; }
+
+# 2. gpu-mode.sh derives LANIP (override + localhost fallback), no rig IP.
+if grep -q 'LANIP="${LANIP:-' "$ROOT/scripts/gpu-mode.sh" \
+   && grep -q 'LANIP:-localhost' "$ROOT/scripts/gpu-mode.sh"; then
+  chk ok "gpu-mode.sh auto-detects LANIP with localhost fallback"
+else
+  chk fail "gpu-mode.sh missing LANIP auto-detect / localhost fallback"
+fi
+
+# 3. Every standalone download_*.sh that references the rig fallback also sources
+#    comfyui-paths.sh (so a direct run derives COMFYUI_MODELS_DIR from MODEL_DIR).
+for f in "$ROOT"/services/comfyui/download_*.sh; do
+  grep -q 'COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models' "$f" || continue   # not a comfy-models downloader
+  if grep -q 'comfyui-paths.sh' "$f"; then
+    chk ok "sources comfyui-paths.sh: $(basename "$f")"
+  else
+    chk fail "$(basename "$f") uses the rig fallback but never sources comfyui-paths.sh"
+  fi
+done
+
+if [ "$fails" -eq 0 ]; then echo "PASS: studio scripts carry no dev-rig defaults"; exit 0
+else echo "FAIL: $fails assertion(s)"; exit 1; fi

--- a/services/comfyui/download_ace_step.sh
+++ b/services/comfyui/download_ace_step.sh
@@ -8,6 +8,9 @@
 # Idempotent: skips if already on disk.  Run:  ./download_ace_step.sh
 set -uo pipefail
 
+# Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
+# setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
+. "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
 ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 log() { echo "[$(date +%H:%M:%S)] $*"; }
 command -v hf >/dev/null 2>&1 || { echo "ERROR: 'hf' (huggingface_hub CLI) not found. pip install -U huggingface_hub" >&2; exit 1; }

--- a/services/comfyui/download_flux2.sh
+++ b/services/comfyui/download_flux2.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -uo pipefail
+# Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
+# setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
+. "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
 ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 
 ts() { date +%H:%M:%S; }

--- a/services/comfyui/download_hidream_o1.sh
+++ b/services/comfyui/download_hidream_o1.sh
@@ -16,6 +16,9 @@
 #   models/diffusion_models/HiDream-O1-Image-Dev-2604-FP8/{model.safetensors,config.json,...}
 set -uo pipefail
 
+# Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
+# setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
+. "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
 ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 DEST="$ROOT/diffusion_models/HiDream-O1-Image-Dev-2604-FP8"   # folder name must match the loader's canonical choice
 REPO="drbaph/HiDream-O1-Image-Dev-2604-FP8"

--- a/services/comfyui/download_hunyuan_llava.sh
+++ b/services/comfyui/download_hunyuan_llava.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -uo pipefail
+# Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
+# setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
+. "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
 ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 echo "[$(date +%H:%M:%S)] Downloading llava_llama3_fp8_scaled.safetensors (~9 GB)..."
 hf download Comfy-Org/HunyuanVideo_repackaged \

--- a/services/comfyui/download_ideogram4.sh
+++ b/services/comfyui/download_ideogram4.sh
@@ -16,6 +16,9 @@
 #   models/vae/flux2-vae.safetensors
 set -uo pipefail
 
+# Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
+# setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
+. "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
 ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 LOG_TS() { date +%H:%M:%S; }
 log()  { echo "[$(LOG_TS)] $*"; }

--- a/services/comfyui/download_kokoro.sh
+++ b/services/comfyui/download_kokoro.sh
@@ -16,6 +16,9 @@
 set -uo pipefail
 
 # Mirrors the studio-tts compose default (${KOKORO_DIR:-/mnt/models/comfyui/models/tts/kokoro}).
+# Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
+# setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
+. "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
 ROOT="${KOKORO_DIR:-${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}/tts/kokoro}"
 REL="https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0"
 LOG_TS() { date +%H:%M:%S; }

--- a/services/comfyui/download_krea.sh
+++ b/services/comfyui/download_krea.sh
@@ -19,6 +19,9 @@
 #   models/vae/qwen_image_vae.safetensors
 set -uo pipefail
 
+# Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
+# setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
+. "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
 ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 export HF_HUB_DISABLE_XET=1
 LOG_TS() { date +%H:%M:%S; }

--- a/services/comfyui/download_models.sh
+++ b/services/comfyui/download_models.sh
@@ -4,6 +4,9 @@
 # Run in background:  nohup ./download_models.sh > /tmp/comfyui-downloads.log 2>&1 &
 set -uo pipefail
 
+# Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
+# setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
+. "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
 ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 LOG_TS() { date +%H:%M:%S; }
 log()  { echo "[$(LOG_TS)] $*"; }

--- a/services/comfyui/download_stable_audio.sh
+++ b/services/comfyui/download_stable_audio.sh
@@ -12,6 +12,9 @@
 # and symlinked to the name the workflow expects (keeps hf's resume/idempotency intact).
 set -uo pipefail
 
+# Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
+# setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
+. "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
 ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 log() { echo "[$(date +%H:%M:%S)] $*"; }
 command -v hf >/dev/null 2>&1 || { echo "ERROR: 'hf' (huggingface_hub CLI) not found. pip install -U huggingface_hub" >&2; exit 1; }

--- a/services/comfyui/download_step_audio.sh
+++ b/services/comfyui/download_step_audio.sh
@@ -12,6 +12,9 @@
 set -uo pipefail
 
 # Mirrors the step-voice compose default (${STEP_AUDIO_DIR:-/mnt/models/comfyui/models/Step-Audio}).
+# Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
+# setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
+. "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
 ROOT="${STEP_AUDIO_DIR:-${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}/Step-Audio}"
 LOG_TS() { date +%H:%M:%S; }
 log()  { echo "[$(LOG_TS)] $*"; }

--- a/services/comfyui/download_video_models.sh
+++ b/services/comfyui/download_video_models.sh
@@ -20,6 +20,9 @@
 # repo (Comfy-Org/ltx-2) is gated. Run:  ./download_video_models.sh  (or nohup … & for bg)
 set -uo pipefail
 
+# Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
+# setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
+. "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
 ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 LOG_TS() { date +%H:%M:%S; }
 log()  { echo "[$(LOG_TS)] $*"; }

--- a/services/comfyui/download_wan.sh
+++ b/services/comfyui/download_wan.sh
@@ -16,6 +16,9 @@
 #   models/vae/wan_2.1_vae.safetensors
 set -uo pipefail
 
+# Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
+# setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
+. "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
 ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 export HF_HUB_DISABLE_XET=1
 LOG_TS() { date +%H:%M:%S; }

--- a/services/comfyui/download_zimage.sh
+++ b/services/comfyui/download_zimage.sh
@@ -15,6 +15,9 @@
 #   models/vae/ae.safetensors
 set -uo pipefail
 
+# Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
+# setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
+. "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
 ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 export HF_HUB_DISABLE_XET=1
 LOG_TS() { date +%H:%M:%S; }


### PR DESCRIPTION
Two dev-rig defaults leaked into code paths a fresh clone hits (both reported by @sumo-dandan).

## Fixes #503 — standalone `download_*.sh` ignored `MODEL_DIR`
`setup-ai-studio.sh` derives + exports `COMFYUI_MODELS_DIR` from `MODEL_DIR` (via `comfyui-paths.sh`), so the orchestrated download lands in the user's models dir. But each `services/comfyui/download_*.sh` hard-coded `ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"` — run **standalone** (as setup prompts on a gated/missing-token retry), `COMFYUI_MODELS_DIR` is unset → it fell back to the **rig path**, which isn't writable on a clean machine → the `mkdir … Permission denied` cascade.

**Fix:** each `download_*.sh` now sources `comfyui-paths.sh` before its `ROOT=` line, so a direct run derives `COMFYUI_MODELS_DIR` from `MODEL_DIR`/`.env` exactly like the orchestrated path. Idempotent and backward-compatible — explicit `COMFYUI_MODELS_DIR` still respected; no `MODEL_DIR`/`.env` still yields the `/mnt` rig default. Verified: `MODEL_DIR=/home/sumo/models` → `/home/sumo/comfyui/models`.

## Fixes #504 — `gpu-mode.sh` printed a hard-coded rig IP
`gpu-mode.sh` hard-coded `192.168.86.33` in every "mode active" URL banner, so `setup-ai-studio.sh` Phase 3 (which calls `gpu-mode ai-studio`) printed the wrong URLs while Phase 4 used the auto-detected `$LANIP`.

**Fix:** `gpu-mode.sh` now derives `LANIP` the same way as setup (`hostname -I`, `LANIP`-overridable, `localhost` fallback) and uses it in all banners.

## Guard
`scripts/tests/test-studio-derig.sh` asserts: no hard-coded rig IP anywhere under `scripts/`+`services/`, `gpu-mode.sh` has the `LANIP` auto-detect + localhost fallback, and every rig-fallback `download_*.sh` sources the helper. `test-comfyui-paths.sh` still green; all touched scripts `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
