### PR TITLE
Studio setup: zero-config defaults (portable MODEL_DIR + fail-fast + shared LAN-IP)

### DIFF
--- a/scripts/gpu-mode.sh
+++ b/scripts/gpu-mode.sh
@@ -48,10 +48,10 @@ RED='\033[0;31m'
 CYAN='\033[0;36m'
 NC='\033[0m' # No Color
 
-# LAN IP for the URLs printed by the mode banners below — auto-detected (override with
-# LANIP=...), matching setup-ai-studio.sh. Falls back to 'localhost' so a fresh clone never
-# prints the dev rig's hardcoded address (issue #504). `|| true` keeps set -e happy on no match.
-LANIP="${LANIP:-$(hostname -I 2>/dev/null | tr ' ' '\n' | grep -E '^(192\.168|10\.|172\.)' | head -1 || true)}"
+# LAN IP for the URLs printed by the mode banners below — via the shared c3_lan_ip helper
+# (prefers LAN over docker bridges; LANIP=-overridable), so it can't drift from setup-ai-
+# studio.sh. Falls back to 'localhost' so a fresh clone never prints the rig's IP (#504).
+LANIP="${LANIP:-$(c3_lan_ip 2>/dev/null || true)}"
 LANIP="${LANIP:-localhost}"
 
 # Standard supporting services living under $CLUB3090_DIR/services.

--- a/scripts/setup-ai-studio.sh
+++ b/scripts/setup-ai-studio.sh
@@ -29,8 +29,10 @@ STUDIO_DIR="$REPO_DIR/services/studio"
 # alongside it instead of the rig's /mnt fallback). See services/comfyui/comfyui-paths.sh.
 # shellcheck disable=SC1091
 . "$COMFYUI_DIR/comfyui-paths.sh"
-LANIP="${LANIP:-$(hostname -I 2>/dev/null | tr ' ' '\n' | grep -E '^(192\.168|10\.|172\.)' | head -1)}"
-LANIP="${LANIP:-<host-ip>}"
+# LAN IP for the final URLs — via the shared c3_lan_ip helper (sourced just above), so setup
+# and gpu-mode can't drift. Prefers a LAN address over docker bridges; override with LANIP=.
+LANIP="${LANIP:-$(c3_lan_ip 2>/dev/null || true)}"
+LANIP="${LANIP:-localhost}"
 
 ASSUME_YES="${ASSUME_YES:-}"
 case "${1:-}" in

--- a/scripts/tests/test-comfyui-paths.sh
+++ b/scripts/tests/test-comfyui-paths.sh
@@ -39,4 +39,17 @@ chk "models follows root"     "/data/cr/models" "${got#*|}"
 got="$(derive -u COMFYUI_ROOT COMFYUI_MODELS_DIR=/data/m MODEL_DIR=/x)"
 chk "explicit models respected" "/data/m" "${got#*|}"
 
+# E — zero-config default (no MODEL_DIR, .env skipped): a USER-OWNED $HOME tree, NOT /mnt (#503)
+got="$(derive -u MODEL_DIR -u COMFYUI_ROOT -u COMFYUI_MODELS_DIR C3_PATHS_NO_ENV=1 HOME=/home/u)"
+chk "zero-config root → \$HOME"   "/home/u/comfyui"        "${got%|*}"
+chk "zero-config models → \$HOME" "/home/u/comfyui/models" "${got#*|}"
+
+# F — HOME-less (CI/root) keeps the legacy /mnt default
+got="$(derive -u MODEL_DIR -u COMFYUI_ROOT -u COMFYUI_MODELS_DIR -u HOME C3_PATHS_NO_ENV=1)"
+chk "HOME-less models → /mnt legacy" "/mnt/models/comfyui/models" "${got#*|}"
+
+# G — c3_lan_ip prefers a LAN address over a docker bridge, even when the bridge is listed first
+lan="$(hostname() { echo '172.17.0.1 192.168.1.50 10.0.0.2'; }; . "$HELPER"; c3_lan_ip)"
+chk "lan_ip prefers LAN over 172.x bridge" "192.168.1.50" "$lan"
+
 if [ "$fails" -eq 0 ]; then echo "PASS: comfyui-paths derivation"; exit 0; else echo "FAIL: $fails assertion(s)"; exit 1; fi

--- a/scripts/tests/test-studio-derig.sh
+++ b/scripts/tests/test-studio-derig.sh
@@ -38,5 +38,11 @@ for f in "$ROOT"/services/comfyui/download_*.sh; do
   fi
 done
 
+# 4. Both launchers detect the LAN IP via the SHARED c3_lan_ip helper (no inline drift).
+for s in scripts/gpu-mode.sh scripts/setup-ai-studio.sh; do
+  if grep -q 'c3_lan_ip' "$ROOT/$s"; then chk ok "$s uses shared c3_lan_ip"
+  else chk fail "$s does not use the shared c3_lan_ip helper"; fi
+done
+
 if [ "$fails" -eq 0 ]; then echo "PASS: studio scripts carry no dev-rig defaults"; exit 0
 else echo "FAIL: $fails assertion(s)"; exit 1; fi

--- a/services/comfyui/comfyui-paths.sh
+++ b/services/comfyui/comfyui-paths.sh
@@ -6,17 +6,20 @@
 # container mounts all agree on where the ComfyUI tree lives.
 #
 # Rule: COMFYUI_ROOT is a "comfyui" SIBLING of the HF cache (MODEL_DIR) — matching the
-# reference rig layout /mnt/models/{huggingface,comfyui}. A user who sets MODEL_DIR (e.g.
-# in repo-root .env via c3 Settings) gets the ComfyUI tree alongside it automatically,
-# instead of the download silently falling back to the rig's /mnt path and failing with
-# "mkdir: Permission denied" (club-3090 sumo report, 2026-06-27).
+# reference rig layout /mnt/models/{huggingface,comfyui}. Resolution order for MODEL_DIR:
+#   1. an explicit env / .env value (c3 Settings writes it to repo-root .env), else
+#   2. $HOME/models  → a USER-OWNED default, so a zero-config clone lands in a writable
+#      tree ($HOME/comfyui/models) instead of the rig's /mnt path → no "mkdir: Permission
+#      denied" (club-3090 #503; sumo report 2026-06-27). HOME-less shells keep /mnt.
 #
-# Explicitly-set COMFYUI_ROOT / COMFYUI_MODELS_DIR are always respected.
+# Explicitly-set COMFYUI_ROOT / COMFYUI_MODELS_DIR are always respected. This file is also
+# the shared home for studio host helpers — c3_lan_ip / c3_ensure_comfy_models_dir (below).
 
 # 1. MODEL_DIR is configured in repo-root .env (c3 Settings writes it there). Pick it up
 #    if the caller hasn't already exported it. Resolve this file's repo root from its own
 #    location so it works whether sourced by an in-repo script or a symlinked launcher.
-if [ -z "${MODEL_DIR:-}" ]; then
+#    (C3_PATHS_NO_ENV=1 skips the .env read — for tests / fully-explicit callers.)
+if [ -z "${MODEL_DIR:-}" ] && [ -z "${C3_PATHS_NO_ENV:-}" ]; then
   _c3_paths_root="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/../.." && pwd)"
   if [ -f "$_c3_paths_root/.env" ]; then
     MODEL_DIR="$(grep -E '^MODEL_DIR=' "$_c3_paths_root/.env" 2>/dev/null | tail -1 | cut -d= -f2-)"
@@ -25,8 +28,40 @@ if [ -z "${MODEL_DIR:-}" ]; then
   unset _c3_paths_root
 fi
 
-# 2. Derive (only when unset), then export so child processes + docker compose inherit them.
-: "${MODEL_DIR:=/mnt/models/huggingface}"
+# 2. Default MODEL_DIR only when neither the env nor .env set it. Prefer a USER-OWNED location
+#    so a zero-config clone never targets the reference rig's /mnt path (which a normal user
+#    can't write → "mkdir: Permission denied", club-3090 #503). HOME-less contexts (some
+#    CI/root shells) keep the legacy /mnt default. An explicit MODEL_DIR always wins.
+if [ -z "${MODEL_DIR:-}" ]; then
+  if [ -n "${HOME:-}" ]; then MODEL_DIR="$HOME/models"; else MODEL_DIR="/mnt/models/huggingface"; fi
+fi
+
+# 3. Derive (only when unset), then export so child processes + docker compose inherit them.
 : "${COMFYUI_ROOT:=$(dirname "$MODEL_DIR")/comfyui}"
 : "${COMFYUI_MODELS_DIR:=${COMFYUI_ROOT}/models}"
 export MODEL_DIR COMFYUI_ROOT COMFYUI_MODELS_DIR
+
+
+# --- shared studio host helpers (this is the lib every studio entry point sources) -----------
+
+# Best-effort LAN IP for the user-facing URLs the launchers print. Prefers a routable private
+# address (192.168/10) and DEPRIORITIZES docker bridges (172.16–31, where docker0 / compose
+# networks live) so a docker host doesn't advertise a bridge IP instead of its LAN IP. Empty
+# when none is found; callers fall back to localhost. Override everything with LANIP=. (#504)
+c3_lan_ip() {
+  local ips; ips="$(hostname -I 2>/dev/null | tr ' ' '\n')"
+  { printf '%s\n' "$ips" | grep -E '^(192\.168|10)\.'                # routable LAN first
+    printf '%s\n' "$ips" | grep -E '^172\.(1[6-9]|2[0-9]|3[01])\.'   # then 172.16/12 (incl docker)
+  } 2>/dev/null | head -1
+}
+
+# Ensure COMFYUI_MODELS_DIR exists + is writable, else exit with an ACTIONABLE message instead
+# of letting hf/mkdir cascade into a traceback. Call from download entry points. (#503)
+c3_ensure_comfy_models_dir() {
+  if mkdir -p "$COMFYUI_MODELS_DIR" 2>/dev/null && [ -w "$COMFYUI_MODELS_DIR" ]; then return 0; fi
+  echo "ERROR: ComfyUI models dir is not writable: $COMFYUI_MODELS_DIR" >&2
+  echo "       Set MODEL_DIR to a writable location and retry, e.g.:" >&2
+  echo "         MODEL_DIR=\"\$HOME/models\" $(basename "${0:-this script}")" >&2
+  echo "       (or set COMFYUI_MODELS_DIR directly; c3 Settings writes MODEL_DIR to repo .env)." >&2
+  exit 1
+}

--- a/services/comfyui/download_ace_step.sh
+++ b/services/comfyui/download_ace_step.sh
@@ -11,6 +11,7 @@ set -uo pipefail
 # Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
 # setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
 . "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
+c3_ensure_comfy_models_dir   # fail fast if the models dir isn't writable (#503)
 ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 log() { echo "[$(date +%H:%M:%S)] $*"; }
 command -v hf >/dev/null 2>&1 || { echo "ERROR: 'hf' (huggingface_hub CLI) not found. pip install -U huggingface_hub" >&2; exit 1; }

--- a/services/comfyui/download_flux2.sh
+++ b/services/comfyui/download_flux2.sh
@@ -3,6 +3,7 @@ set -uo pipefail
 # Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
 # setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
 . "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
+c3_ensure_comfy_models_dir   # fail fast if the models dir isn't writable (#503)
 ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 
 ts() { date +%H:%M:%S; }

--- a/services/comfyui/download_hidream_o1.sh
+++ b/services/comfyui/download_hidream_o1.sh
@@ -19,6 +19,7 @@ set -uo pipefail
 # Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
 # setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
 . "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
+c3_ensure_comfy_models_dir   # fail fast if the models dir isn't writable (#503)
 ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 DEST="$ROOT/diffusion_models/HiDream-O1-Image-Dev-2604-FP8"   # folder name must match the loader's canonical choice
 REPO="drbaph/HiDream-O1-Image-Dev-2604-FP8"

--- a/services/comfyui/download_hunyuan_llava.sh
+++ b/services/comfyui/download_hunyuan_llava.sh
@@ -3,6 +3,7 @@ set -uo pipefail
 # Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
 # setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
 . "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
+c3_ensure_comfy_models_dir   # fail fast if the models dir isn't writable (#503)
 ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 echo "[$(date +%H:%M:%S)] Downloading llava_llama3_fp8_scaled.safetensors (~9 GB)..."
 hf download Comfy-Org/HunyuanVideo_repackaged \

--- a/services/comfyui/download_ideogram4.sh
+++ b/services/comfyui/download_ideogram4.sh
@@ -19,6 +19,7 @@ set -uo pipefail
 # Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
 # setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
 . "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
+c3_ensure_comfy_models_dir   # fail fast if the models dir isn't writable (#503)
 ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 LOG_TS() { date +%H:%M:%S; }
 log()  { echo "[$(LOG_TS)] $*"; }

--- a/services/comfyui/download_kokoro.sh
+++ b/services/comfyui/download_kokoro.sh
@@ -19,6 +19,7 @@ set -uo pipefail
 # Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
 # setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
 . "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
+c3_ensure_comfy_models_dir   # fail fast if the models dir isn't writable (#503)
 ROOT="${KOKORO_DIR:-${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}/tts/kokoro}"
 REL="https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0"
 LOG_TS() { date +%H:%M:%S; }

--- a/services/comfyui/download_krea.sh
+++ b/services/comfyui/download_krea.sh
@@ -22,6 +22,7 @@ set -uo pipefail
 # Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
 # setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
 . "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
+c3_ensure_comfy_models_dir   # fail fast if the models dir isn't writable (#503)
 ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 export HF_HUB_DISABLE_XET=1
 LOG_TS() { date +%H:%M:%S; }

--- a/services/comfyui/download_models.sh
+++ b/services/comfyui/download_models.sh
@@ -7,6 +7,7 @@ set -uo pipefail
 # Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
 # setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
 . "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
+c3_ensure_comfy_models_dir   # fail fast if the models dir isn't writable (#503)
 ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 LOG_TS() { date +%H:%M:%S; }
 log()  { echo "[$(LOG_TS)] $*"; }

--- a/services/comfyui/download_stable_audio.sh
+++ b/services/comfyui/download_stable_audio.sh
@@ -15,6 +15,7 @@ set -uo pipefail
 # Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
 # setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
 . "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
+c3_ensure_comfy_models_dir   # fail fast if the models dir isn't writable (#503)
 ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 log() { echo "[$(date +%H:%M:%S)] $*"; }
 command -v hf >/dev/null 2>&1 || { echo "ERROR: 'hf' (huggingface_hub CLI) not found. pip install -U huggingface_hub" >&2; exit 1; }

--- a/services/comfyui/download_step_audio.sh
+++ b/services/comfyui/download_step_audio.sh
@@ -15,6 +15,7 @@ set -uo pipefail
 # Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
 # setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
 . "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
+c3_ensure_comfy_models_dir   # fail fast if the models dir isn't writable (#503)
 ROOT="${STEP_AUDIO_DIR:-${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}/Step-Audio}"
 LOG_TS() { date +%H:%M:%S; }
 log()  { echo "[$(LOG_TS)] $*"; }

--- a/services/comfyui/download_studio_models.sh
+++ b/services/comfyui/download_studio_models.sh
@@ -17,6 +17,7 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # /mnt fallback. Each child download_*.sh inherits the exported COMFYUI_MODELS_DIR.
 # shellcheck disable=SC1091
 . "$HERE/comfyui-paths.sh"
+c3_ensure_comfy_models_dir   # fail fast with an actionable message if the tree isn't writable (#503)
 
 echo "════ ai-studio models — download all (idempotent; skips what's already present) ════"
 bash "$HERE/download_director.sh"

--- a/services/comfyui/download_video_models.sh
+++ b/services/comfyui/download_video_models.sh
@@ -23,6 +23,7 @@ set -uo pipefail
 # Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
 # setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
 . "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
+c3_ensure_comfy_models_dir   # fail fast if the models dir isn't writable (#503)
 ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 LOG_TS() { date +%H:%M:%S; }
 log()  { echo "[$(LOG_TS)] $*"; }

--- a/services/comfyui/download_wan.sh
+++ b/services/comfyui/download_wan.sh
@@ -19,6 +19,7 @@ set -uo pipefail
 # Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
 # setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
 . "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
+c3_ensure_comfy_models_dir   # fail fast if the models dir isn't writable (#503)
 ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 export HF_HUB_DISABLE_XET=1
 LOG_TS() { date +%H:%M:%S; }

--- a/services/comfyui/download_zimage.sh
+++ b/services/comfyui/download_zimage.sh
@@ -18,6 +18,7 @@ set -uo pipefail
 # Resolve COMFYUI_MODELS_DIR from MODEL_DIR/.env so a standalone run matches
 # setup-ai-studio.sh instead of falling back to the dev-rig /mnt path (issue #503).
 . "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/comfyui-paths.sh"
+c3_ensure_comfy_models_dir   # fail fast if the models dir isn't writable (#503)
 ROOT="${COMFYUI_MODELS_DIR:-/mnt/models/comfyui/models}"
 export HF_HUB_DISABLE_XET=1
 LOG_TS() { date +%H:%M:%S; }


### PR DESCRIPTION
Follow-up to #505. That PR made standalone `download_*.sh` consistent with `setup-ai-studio.sh`, but left one gap (surfaced by a "will this work for *all* new users?" review): a user who set **no** `MODEL_DIR` still inherited the reference rig's `/mnt/models/huggingface` default — unwritable on a normal machine. This closes it with three de-rig hardenings, all centered on `comfyui-paths.sh` (the lib every studio entry point already sources).

## 1. Portable default (the real fix)
When neither env nor repo `.env` sets `MODEL_DIR`, default to a **user-owned** `$HOME/models` (→ `$HOME/comfyui/models`) instead of `/mnt/...`. So a zero-config clone lands in a writable tree.
- Explicit `MODEL_DIR` / repo `.env` **always win** → the reference rig (which pins `MODEL_DIR` in `.env`) is unaffected.
- HOME-less shells (some CI/root) keep the legacy `/mnt` default.

```
zero-config (HOME set)   → MODEL_DIR=$HOME/models       COMFYUI_MODELS_DIR=$HOME/comfyui/models
HOME-less (CI/root)      → MODEL_DIR=/mnt/models/huggingface   (legacy)
explicit MODEL_DIR / .env → respected
```

## 2. Fail-fast with an actionable message
`c3_ensure_comfy_models_dir()` exits with `set MODEL_DIR=<writable dir> …` instead of letting `hf`/`mkdir` cascade into a traceback. Called from `download_studio_models.sh` (the setup path) **and** every standalone `download_*.sh`.

## 3. Shared LAN-IP detection (no drift)
`c3_lan_ip()` — prefers a LAN address over docker bridges (`172.16–31`), `LANIP`-overridable, `localhost` fallback. Both `gpu-mode.sh` **and** `setup-ai-studio.sh` now use it, so the #504 IP can't diverge between them again.

## Tests
`test-comfyui-paths.sh` gains zero-config→`$HOME`, HOME-less→`/mnt`, and `lan_ip` LAN-over-bridge cases (via a `C3_PATHS_NO_ENV` test hook + a `hostname` stub). `test-studio-derig.sh` asserts both launchers use `c3_lan_ip`. **Full repo suite: 60/60.**

## Behavior-change note
A user who previously relied on the implicit `/mnt` default **with no `.env`** (rare — needs a writable `/mnt` and no config) will now default to `$HOME/models`; set `MODEL_DIR=/mnt/models/huggingface` (or add it to `.env`) to keep the old location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
