### PR TITLE
Production: wire LTX-2.3 / Sulphur / 10Eros video lanes into the executor

### DIFF
--- a/services/studio/build_studio_pipe.py
+++ b/services/studio/build_studio_pipe.py
@@ -34,56 +34,17 @@ with open(DIRECTOR_AGENTS) as _f:
     DIRECTOR_MD = json.dumps([_f.read().split('\n---\n', 1)[-1].strip()])
 OUT_PATH = os.path.join(_HERE, 'studio_pipe.py')
 
-def build(dit, audio_vae, video_vae, connectors, width, height, frames=121, lora=None):
-    wf = json.load(open(TEMPLATE))
-    wf['3']['inputs']['unet_name'] = dit
-    wf['1']['inputs']['vae_name'] = audio_vae
-    wf['2']['inputs']['vae_name'] = video_vae
-    wf['47']['inputs']['clip_name2'] = connectors
-    wf['7']['inputs']['width'] = width; wf['7']['inputs']['height'] = height
-    wf['8']['inputs']['scale_by'] = 1.0          # output res == base res (no upscaler stage)
-    wf['10']['inputs']['value'] = frames
-    if lora:                                     # distill LoRA -> dev DiT runs single-stage 8-step cfg=1
-        wf['50'] = {"class_type": "LoraLoaderModelOnly",
-                    "inputs": {"model": ["3", 0], "lora_name": lora, "strength_model": 1.0}}
-        wf['18']['inputs']['model'] = ["50", 0]  # CFGGuider reads the LoRA'd model
-    return wf
+# LTX-family video graphs (LTX-2.3 · Sulphur · 10Eros, t2v + i2v) are built from the SHARED
+# recipe in production/ltx_workflows.py, which the Production executor also uses at render time
+# (one source of truth — the interactive lanes + the production executor can't drift). The
+# script's own dir (services/studio) is on sys.path, so `production` is importable.
+import sys as _sys
+if _HERE not in _sys.path:
+    _sys.path.insert(0, _HERE)
+from production import ltx_workflows   # noqa: E402
 
-def i2v_insert(wf, base_longer_edge):
-    """Insert LoadImage->resize->preprocess->ImgToVideoInplace, conditioning the base video latent (node 14) on an image."""
-    wf = json.loads(json.dumps(wf))
-    wf['100'] = {"class_type": "LoadImage", "inputs": {"image": "__STUDIO_IMAGE__"}}
-    wf['101'] = {"class_type": "ResizeImagesByLongerEdge", "inputs": {"images": ["100", 0], "longer_edge": base_longer_edge}}
-    wf['102'] = {"class_type": "LTXVPreprocess", "inputs": {"image": ["101", 0], "img_compression": 35}}
-    wf['103'] = {"class_type": "LTXVImgToVideoInplace",
-                 "inputs": {"vae": ["2", 0], "image": ["102", 0], "latent": ["14", 0], "strength": 1.0, "bypass": False}}
-    wf['15']['inputs']['video_latent'] = ["103", 0]   # rewire concat: empty latent -> image-conditioned latent
-    return wf
-
-LTX_DIT      = 'ltx2.3/distilled-1.1/ltx-2.3-22b-distilled-1.1-Q8_0.gguf'
-SUL_DIT      = 'sulphur-2/sulphur_dev-Q8_0.gguf'
-EROS_DIT     = '10eros/10Eros_v1-Q8_0.gguf'
-DISTILL_LORA = 'ltx-2.3-22b-distilled-lora-384-1.1.safetensors'   # 22B distilled LoRA — shared by both dev lanes
-
-# LTX: pre-distilled checkpoint, distilled VAEs/connectors, no LoRA (already single-stage). 768x512 proven (00016).
-ltx_t2v = build(LTX_DIT,
-                'ltx-2.3-22b-distilled_audio_vae.safetensors', 'ltx-2.3-22b-distilled_video_vae.safetensors',
-                'ltx-2.3-22b-distilled_embeddings_connectors.safetensors', 768, 512)
-# Uncensored dev lanes (both LTX-2.3-22B-dev) -> dev VAEs/connectors + the shared distill LoRA,
-# single-stage 8-step cfg=1, 1280x720. Two lanes so Sulphur and 10Eros can be compared directly.
-sul_t2v  = build(SUL_DIT,
-                 'ltx-2.3-22b-dev_audio_vae.safetensors', 'ltx-2.3-22b-dev_video_vae.safetensors',
-                 'ltx-2.3-22b-dev_embeddings_connectors.safetensors', 1280, 720, lora=DISTILL_LORA)
-eros_t2v = build(EROS_DIT,
-                 'ltx-2.3-22b-dev_audio_vae.safetensors', 'ltx-2.3-22b-dev_video_vae.safetensors',
-                 'ltx-2.3-22b-dev_embeddings_connectors.safetensors', 1280, 720, lora=DISTILL_LORA)
 WF = {
-    "ltx-t2v": ltx_t2v,
-    "ltx-i2v": i2v_insert(ltx_t2v, 768),
-    "sulphur-t2v": sul_t2v,
-    "sulphur-i2v": i2v_insert(sul_t2v, 1280),
-    "10eros-t2v": eros_t2v,
-    "10eros-i2v": i2v_insert(eros_t2v, 1280),
+    **ltx_workflows.build_workflows(),   # ltx/sulphur/10eros × t2v+i2v
     # Image lane: Ideogram-4 fp8 (DualModelGuider, native nodes). Single-device GPU0,
     # coexists with the director on GPU0 at <=1024^2 (2048^2 would OOM — capped in pipe).
     "image": json.load(open(IMAGE_TEMPLATE)),
@@ -888,9 +849,7 @@ class Pipe:
                          % (video, keyf, cont, _audio_txt, shots))
             def _proposal():
                 _vl = {"auto": "Wan2.2 (auto)", "wan": "Wan2.2", "ltx": "LTX-2.3",
-                       "sulphur": "Sulphur", "10eros": "10Eros"}.get(video, video)
-                if video not in ("auto", "wan"):
-                    _vl += " ⚠️ roadmap — only Wan renders today"
+                       "sulphur": "Sulphur (uncensored)", "10eros": "10Eros (uncensored)"}.get(video, video)
                 _kl = {"auto": "Chroma (auto)", "chroma": "Chroma", "zimage": "Z-Image",
                        "krea": "Krea 2", "hidream": "HiDream-O1"}.get(keyf, keyf)
                 _audio = ("narration" if narr else "no narration") + " + " + ("music" if music else "no music")
@@ -904,9 +863,10 @@ class Pipe:
                     "| \U0001F39E️ continuity | **" + str(cont) + "**  ·  \U0001F50A audio **" + _audio + "** |\n"
                     "| ⏱️ length | **" + _len + "** |\n"
                     "| ⚙️ est. render | **~" + str(est_lo) + "–" + str(est_hi) + " min** on 1× 3090 |\n\n"
-                    "Reply **go** to start — or tell me what to change: _“use LTX” · “30 seconds” · "
-                    "“no music” · “hidream keyframes” · “hero continuity”_.\n\n"
-                    "_(Video renders on **Wan** today; LTX/Sulphur/10Eros are roadmap.)_"
+                    "Reply **go** to start — or tell me what to change: _“use LTX” · “sulphur” · "
+                    "“30 seconds” · “no music” · “hidream keyframes” · “hero continuity”_.\n\n"
+                    "_(Video: Wan2.2 · LTX-2.3 · Sulphur · 10Eros — all render. LTX-family lanes "
+                    "use their own resolution; the film's audio is the narration + music layer.)_"
                 )
 
             async def _chat(msg, ctx):

--- a/services/studio/director/AGENTS.md
+++ b/services/studio/director/AGENTS.md
@@ -21,7 +21,7 @@ You are the Studio Production Director — a warm, concise assistant that plans 
 
 What you can make, and the options the user can pick:
 - Length: any — roughly 5 seconds per shot (e.g. a 1-minute film ≈ 12 shots).
-- Video model: Wan2.2 is the only one that RENDERS TODAY; LTX-2.3, Sulphur and 10Eros are on the roadmap (not renderable yet).
+- Video model (all render): Wan2.2 (default, 832×480, uncensored), LTX-2.3 (768×512, the distilled base), Sulphur (uncensored LTX dev, 1280×720), or 10Eros (uncensored LTX dev, 1280×720). The LTX-family lanes can generate their own audio, but in a multi-shot film the soundtrack comes from the narration + music layer, so their native audio isn't used.
 - Keyframe / image model (drives the look + character consistency): Chroma (default), Z-Image (fast), Krea 2 (aesthetic), or HiDream-O1 (top quality, slower).
 - Continuity: storyboard (default), hero, chain, or none.
 - Audio: narration (Kokoro) and/or background music (ACE-Step) — either can be turned off.

--- a/services/studio/production/README.md
+++ b/services/studio/production/README.md
@@ -46,14 +46,16 @@ actually render, and **recorded in the manifest** (`stack` field). The lane pin 
 
 | Dimension | Default | Options (render **today**) | Roadmap (declared, not yet wired) |
 |---|---|---|---|
-| video lane | `wan` | `wan` | `ltx` · `sulphur` · `10eros` (LTX-family checkpoint-swap graph not yet ported to the executor) |
+| video lane | `wan` | `wan` (832×480) · `ltx` (768×512) · `sulphur` (1280×720) · `10eros` (1280×720) | — |
 | keyframe lane | `chroma` | `chroma` ✅ · `zimage` ✅ · `krea` ✅ · `hidream` ✅ | `ideogram` (needs structured JSON, not prose → a title-card lane, not a continuity keyframe lane) |
 | continuity | `storyboard` | `storyboard` · `hero` · `chain` · `none` | — |
 | audio | narration + music | `--no-music` · `--no-narration` · `--voice <id>` | — |
 
-✅ = all four keyframe lanes live-validated end-to-end (noir/candle A/B, 2026-06-28).
-HiDream renders at native 2560×1440 (16:9, snapped up from a /32 clamp); chroma/zimage/krea
-render at the requested 832×480. The Wan i2v resize downsizes each keyframe to the clip dims.
+All four **video** lanes render via the executor (shared `ltx_workflows.py` recipe — the same
+graph the interactive Studio lanes use). The LTX family runs at its own native res + 24 fps
+and can emit synced audio, but in a multi-shot film the soundtrack is the narration+music
+layer (the assembler ignores the clip's own audio). The four **keyframe** lanes are live-A/B
+validated; HiDream renders native 2560×1440 (snapped from a /32 clamp), the others at 832×480.
 
 A choice the executor can't honour (unknown or roadmap lane) **fails fast** with a clear
 message + the renderable set — an operator is never handed a choice that errors at render.

--- a/services/studio/production/executor.py
+++ b/services/studio/production/executor.py
@@ -134,7 +134,7 @@ def run_production(
         path = backend.render_video(
             prompt=_inject(shot.prompt_intent, spos), width=d.width, height=d.height, frames=frames,
             steps=WAN_STEPS, seed=shot.seed, fps=d.fps, mode=mode, start_image=start_image,
-            out_stem=os.path.join(prod_dir, "shots", shot.id), negative=sneg,
+            out_stem=os.path.join(prod_dir, "shots", shot.id), negative=sneg, lane=vlane,
         )
         clip_paths[shot.id] = path
         prev_clip = path

--- a/services/studio/production/lanes.py
+++ b/services/studio/production/lanes.py
@@ -17,7 +17,7 @@ import subprocess
 import urllib.request
 from abc import ABC, abstractmethod
 
-from . import comfy, config
+from . import comfy, config, ltx_workflows
 from .util import sh
 
 
@@ -125,7 +125,7 @@ class StudioBackend(ABC):
     def render_video(self, *, prompt: str, width: int, height: int, frames: int,
                      steps: int, seed: int, fps: int, out_stem: str,
                      mode: str = "t2v", start_image: str | None = None,
-                     negative: str = "") -> str: ...
+                     negative: str = "", lane: str = "wan") -> str: ...
 
     @abstractmethod
     def generate_image(self, *, prompt: str, width: int, height: int, seed: int,
@@ -168,7 +168,22 @@ class LiveBackend(StudioBackend):
         return json.load(urllib.request.urlopen(req, timeout=60)).get("name", fname)
 
     def render_video(self, *, prompt, width, height, frames, steps, seed, fps, out_stem,
-                     mode="t2v", start_image=None, negative="") -> str:
+                     mode="t2v", start_image=None, negative="", lane="wan") -> str:
+        # LTX family (LTX-2.3 / Sulphur / 10Eros): built from the shared recipe at the lane's
+        # OWN native res + 24 fps (NOT the Wan delivery dims). frames were sized Wan-shaped by the
+        # executor → recover the seconds and let LTX re-size at 24 fps.
+        if ltx_workflows.is_ltx_family(lane):
+            img_name = None
+            if mode == "i2v":
+                if not start_image:
+                    raise RuntimeError("i2v render requires a start_image")
+                img_name = self._upload_image(start_image)
+            seconds = frames / float(fps or 16)
+            wf, _w, _h = ltx_workflows.render_graph(
+                lane, prompt=prompt, seconds=seconds, seed=seed, mode=mode,
+                image_name=img_name, negative=negative)
+            fn, sub = comfy.await_output(comfy.submit(wf), "video")
+            return self._comfy_to(fn, sub, out_stem)
         if mode == "i2v":
             if not start_image:
                 raise RuntimeError("i2v render requires a start_image")
@@ -252,7 +267,7 @@ class SyntheticBackend(StudioBackend):
     name = "synthetic"
 
     def render_video(self, *, prompt, width, height, frames, steps, seed, fps, out_stem,
-                     mode="t2v", start_image=None, negative="") -> str:
+                     mode="t2v", start_image=None, negative="", lane="wan") -> str:
         dur = max(0.1, frames / float(fps or 16))
         dst = out_stem + ".mp4"
         os.makedirs(os.path.dirname(dst), exist_ok=True)

--- a/services/studio/production/ltx_workflows.py
+++ b/services/studio/production/ltx_workflows.py
@@ -1,0 +1,110 @@
+"""LTX-family (LTX-2.3 · Sulphur · 10Eros) video workflow builder — ONE recipe, two callers.
+
+Both the interactive Studio pipe (build_studio_pipe.py, at build time) and the Production
+executor (lanes.py, at render time) build these ComfyUI graphs from the same recipe: a
+DiT-GGUF swap on the proven LTX-distilled template + dev VAEs/connectors + the shared
+distill LoRA for the uncensored dev lanes, plus i2v node-surgery. Single source of truth so
+the interactive lanes and the production executor can't drift.
+
+Lane traits (this rig, single-stage 8-step cfg=1):
+  ltx      LTX-2.3-distilled — 768×512, native synced audio, no LoRA (already distilled)
+  sulphur  LTX-2.3-22B dev fine-tune (uncensored) — 1280×720, + distill LoRA
+  10eros   LTX-2.3-22B dev fine-tune (uncensored) — 1280×720, + distill LoRA
+All are 24 fps. (In the multi-shot production pipeline the clip's own audio is unused — the
+assembler builds the track from narration + music; see assemble.py.)
+"""
+from __future__ import annotations
+
+import json
+import os
+
+from . import config
+
+TEMPLATE = os.path.join(config.WORKFLOW_DIR, "ltx_distilled_distorch.json")
+LTX_FPS = 24.0
+_DISTILL_LORA = "ltx-2.3-22b-distilled-lora-384-1.1.safetensors"
+
+# lane -> (dit, audio_vae, video_vae, connectors, width, height, lora, i2v_longer_edge)
+LANES: dict[str, tuple] = {
+    "ltx": ("ltx2.3/distilled-1.1/ltx-2.3-22b-distilled-1.1-Q8_0.gguf",
+            "ltx-2.3-22b-distilled_audio_vae.safetensors",
+            "ltx-2.3-22b-distilled_video_vae.safetensors",
+            "ltx-2.3-22b-distilled_embeddings_connectors.safetensors", 768, 512, None, 768),
+    "sulphur": ("sulphur-2/sulphur_dev-Q8_0.gguf",
+                "ltx-2.3-22b-dev_audio_vae.safetensors",
+                "ltx-2.3-22b-dev_video_vae.safetensors",
+                "ltx-2.3-22b-dev_embeddings_connectors.safetensors", 1280, 720, _DISTILL_LORA, 1280),
+    "10eros": ("10eros/10Eros_v1-Q8_0.gguf",
+               "ltx-2.3-22b-dev_audio_vae.safetensors",
+               "ltx-2.3-22b-dev_video_vae.safetensors",
+               "ltx-2.3-22b-dev_embeddings_connectors.safetensors", 1280, 720, _DISTILL_LORA, 1280),
+}
+
+
+def is_ltx_family(lane: str) -> bool:
+    return lane in LANES
+
+
+def _build(dit, audio_vae, video_vae, connectors, width, height, frames=121, lora=None) -> dict:
+    wf = json.load(open(TEMPLATE))
+    wf["3"]["inputs"]["unet_name"] = dit
+    wf["1"]["inputs"]["vae_name"] = audio_vae
+    wf["2"]["inputs"]["vae_name"] = video_vae
+    wf["47"]["inputs"]["clip_name2"] = connectors
+    wf["7"]["inputs"]["width"] = width
+    wf["7"]["inputs"]["height"] = height
+    wf["8"]["inputs"]["scale_by"] = 1.0          # output res == base res (no upscaler stage)
+    wf["10"]["inputs"]["value"] = frames
+    if lora:                                     # distill LoRA -> dev DiT runs single-stage 8-step cfg=1
+        wf["50"] = {"class_type": "LoraLoaderModelOnly",
+                    "inputs": {"model": ["3", 0], "lora_name": lora, "strength_model": 1.0}}
+        wf["18"]["inputs"]["model"] = ["50", 0]  # CFGGuider reads the LoRA'd model
+    return wf
+
+
+def _i2v_insert(wf: dict, base_longer_edge: int) -> dict:
+    """LoadImage -> resize -> LTXVPreprocess -> LTXVImgToVideoInplace, conditioning the base
+    video latent (node 14) on the start image (the keyframe/continuity anchor)."""
+    wf = json.loads(json.dumps(wf))
+    wf["100"] = {"class_type": "LoadImage", "inputs": {"image": "__STUDIO_IMAGE__"}}
+    wf["101"] = {"class_type": "ResizeImagesByLongerEdge",
+                 "inputs": {"images": ["100", 0], "longer_edge": base_longer_edge}}
+    wf["102"] = {"class_type": "LTXVPreprocess", "inputs": {"image": ["101", 0], "img_compression": 35}}
+    wf["103"] = {"class_type": "LTXVImgToVideoInplace",
+                 "inputs": {"vae": ["2", 0], "image": ["102", 0], "latent": ["14", 0],
+                            "strength": 1.0, "bypass": False}}
+    wf["15"]["inputs"]["video_latent"] = ["103", 0]   # rewire concat: empty -> image-conditioned latent
+    return wf
+
+
+def build_workflows() -> dict:
+    """Every LTX-family t2v + i2v graph, keyed '<lane>-<mode>' — for the interactive pipe's WF map."""
+    out = {}
+    for lane, (dit, avae, vvae, conn, w, h, lora, edge) in LANES.items():
+        t2v = _build(dit, avae, vvae, conn, w, h, lora=lora)
+        out[lane + "-t2v"] = t2v
+        out[lane + "-i2v"] = _i2v_insert(t2v, edge)
+    return out
+
+
+def render_graph(lane: str, *, prompt: str, seconds: float, seed: int,
+                 mode: str = "t2v", image_name: str | None = None,
+                 negative: str = "") -> tuple[dict, int, int]:
+    """A ready-to-submit LTX-family graph for the production executor + its (width, height).
+
+    LTX renders at its OWN native res + 24 fps (NOT the Wan delivery dims) — frame count is
+    sized from the requested seconds. seed makes the shot reproducible. i2v conditions on
+    `image_name` (an already-uploaded ComfyUI input).
+    """
+    dit, avae, vvae, conn, w, h, lora, edge = LANES[lane]
+    frames = max(1, round(seconds * LTX_FPS))
+    wf = _build(dit, avae, vvae, conn, w, h, frames=frames, lora=lora)
+    if mode == "i2v":
+        wf = _i2v_insert(wf, edge)
+        if image_name:
+            wf["100"]["inputs"]["image"] = image_name
+    wf["5"]["inputs"]["text"] = prompt          # node 5 = positive prompt encoder
+    if negative:
+        wf["6"]["inputs"]["text"] = negative     # node 6 = negative prompt encoder
+    wf["16"]["inputs"]["noise_seed"] = int(seed) % 2147483647
+    return wf, w, h

--- a/services/studio/production/stack.py
+++ b/services/studio/production/stack.py
@@ -33,20 +33,20 @@ class StackError(ValueError):
 #   i2v   = the lane has an image->video workflow (every continuity mode needs i2v).
 VIDEO_LANES: dict[str, dict] = {
     "wan": {
-        "label": "Wan2.2 (uncensored · i2v/storyboard flow · no native audio)",
+        "label": "Wan2.2 (uncensored · 832×480 · no native audio)",
         "wired": True, "i2v": True,
     },
     "ltx": {
-        "label": "LTX-2.3 (native synced audio · text→video)",
-        "wired": False, "i2v": True,
+        "label": "LTX-2.3 (768×512 · the distilled base)",
+        "wired": True, "i2v": True,
     },
     "sulphur": {
-        "label": "Sulphur (uncensored LTX-2.3 dev fine-tune)",
-        "wired": False, "i2v": True,
+        "label": "Sulphur (uncensored LTX-2.3 dev fine-tune · 1280×720)",
+        "wired": True, "i2v": True,
     },
     "10eros": {
-        "label": "10Eros (uncensored LTX-2.3 dev fine-tune)",
-        "wired": False, "i2v": True,
+        "label": "10Eros (uncensored LTX-2.3 dev fine-tune · 1280×720)",
+        "wired": True, "i2v": True,
     },
 }
 

--- a/services/studio/production/tests/test_stack.py
+++ b/services/studio/production/tests/test_stack.py
@@ -48,12 +48,11 @@ class TestResolveStack(unittest.TestCase):
         with self.assertRaises(S.StackError):
             S.resolve_stack(video_lane="nope")
 
-    def test_unwired_video_lane_rejected_with_renderable_set(self):
-        # ltx/sulphur/10eros are known studio lanes but not yet wired in the executor.
-        for lane in ("ltx", "sulphur", "10eros"):
-            with self.assertRaises(S.StackError) as cm:
-                S.resolve_stack(video_lane=lane)
-            self.assertIn("wan", str(cm.exception))   # points the operator at what renders
+    def test_all_video_lanes_wired_and_resolve(self):
+        # wan + the LTX family (ltx/sulphur/10eros) all render via the executor now.
+        for lane in ("wan", "ltx", "sulphur", "10eros"):
+            self.assertEqual(S.resolve_stack(video_lane=lane).video_lane, lane)
+        self.assertEqual(sorted(S.wired_video_lanes()), ["10eros", "ltx", "sulphur", "wan"])
 
     def test_unknown_keyframe_and_continuity_rejected(self):
         with self.assertRaises(S.StackError):
@@ -103,13 +102,12 @@ class TestSchemaLaneValidation(unittest.TestCase):
             "timeline": [{"clip": "s1", "transition_in": "dissolve"}],
         }
 
-    def test_unwired_video_lane_rejected(self):
-        d = self._good()
-        d["project"]["video_lane"] = "ltx"
-        d["shots"][0]["lane"] = "ltx"
-        with self.assertRaises(PlanError) as cm:
-            ProductionPlanV1.from_dict(d)
-        self.assertIn("not yet wired", str(cm.exception))
+    def test_ltx_family_video_lanes_accepted(self):
+        for lane in ("ltx", "sulphur", "10eros"):
+            d = self._good()
+            d["project"]["video_lane"] = lane
+            d["shots"][0]["lane"] = lane
+            ProductionPlanV1.from_dict(d)   # wired now → must not raise
 
     def test_unknown_video_lane_rejected(self):
         d = self._good()
@@ -256,6 +254,36 @@ class TestStackInManifest(unittest.TestCase):
         self.assertEqual(st.video_lane, "wan")
         self.assertEqual(st.continuity, "hero")
         self.assertEqual(st.keyframe_lane, "chroma")   # from image_policy / asset lane
+
+
+class TestLtxWorkflows(unittest.TestCase):
+    """The shared LTX-family builder used by both the interactive pipe and the executor."""
+
+    def test_family_membership(self):
+        from .. import ltx_workflows as L
+        self.assertTrue(all(L.is_ltx_family(x) for x in ("ltx", "sulphur", "10eros")))
+        self.assertFalse(L.is_ltx_family("wan"))
+
+    def test_render_graph_sizes_at_24fps_native_res(self):
+        from .. import ltx_workflows as L
+        wf, w, h = L.render_graph("sulphur", prompt="noir alley", seconds=5, seed=7)
+        self.assertEqual((w, h), (1280, 720))                 # native dev res (not Wan 832×480)
+        self.assertEqual(wf["5"]["inputs"]["text"], "noir alley")
+        self.assertEqual(wf["16"]["inputs"]["noise_seed"], 7)
+        self.assertEqual(wf["10"]["inputs"]["value"], 120)    # 5 s × 24 fps
+
+    def test_i2v_conditions_on_image(self):
+        from .. import ltx_workflows as L
+        wf, w, h = L.render_graph("ltx", prompt="x", seconds=4, seed=1, mode="i2v", image_name="kf.png")
+        self.assertEqual((w, h), (768, 512))
+        self.assertEqual(wf["100"]["inputs"]["image"], "kf.png")
+        self.assertEqual(wf["10"]["inputs"]["value"], 96)     # 4 s × 24 fps
+
+    def test_build_workflows_has_all_six(self):
+        from .. import ltx_workflows as L
+        self.assertEqual(sorted(L.build_workflows()),
+                         sorted(["ltx-t2v", "ltx-i2v", "sulphur-t2v", "sulphur-i2v",
+                                 "10eros-t2v", "10eros-i2v"]))
 
 
 if __name__ == "__main__":

--- a/services/studio/studio_pipe.py
+++ b/services/studio/studio_pipe.py
@@ -262,7 +262,7 @@ class Pipe:
     # The 🎬 Production lane's conversational voice (greetings, "what options?", nudging toward a
     # brief). The behavioral spec is the editable source of truth in director/AGENTS.md — the build
     # bakes its body in here (the pipe runs in-container and can't read the repo at runtime).
-    DIRECTOR_PRODUCER_SYS = json.loads(r"""["You are the Studio Production Director \u2014 a warm, concise assistant that plans and renders SHORT AI films from a one-line brief. Chat naturally; keep replies to 1\u20134 sentences, plain prose (NO JSON, NO markdown tables).\n\nWhat you can make, and the options the user can pick:\n- Length: any \u2014 roughly 5 seconds per shot (e.g. a 1-minute film \u2248 12 shots).\n- Video model: Wan2.2 is the only one that RENDERS TODAY; LTX-2.3, Sulphur and 10Eros are on the roadmap (not renderable yet).\n- Keyframe / image model (drives the look + character consistency): Chroma (default), Z-Image (fast), Krea 2 (aesthetic), or HiDream-O1 (top quality, slower).\n- Continuity: storyboard (default), hero, chain, or none.\n- Audio: narration (Kokoro) and/or background music (ACE-Step) \u2014 either can be turned off.\n\nThe user changes anything by just saying so (\"use HiDream\", \"30 seconds\", \"no music\"). When they're happy they say \"go\" and the build starts \u2014 only \"go\" renders; never claim you've already started rendering. If they haven't described a film yet, warmly invite a one-line brief. Answer the user's actual message; when useful, end with a light nudge to say \"go\" or tell you what to change."]""")[0]
+    DIRECTOR_PRODUCER_SYS = json.loads(r"""["You are the Studio Production Director \u2014 a warm, concise assistant that plans and renders SHORT AI films from a one-line brief. Chat naturally; keep replies to 1\u20134 sentences, plain prose (NO JSON, NO markdown tables).\n\nWhat you can make, and the options the user can pick:\n- Length: any \u2014 roughly 5 seconds per shot (e.g. a 1-minute film \u2248 12 shots).\n- Video model (all render): Wan2.2 (default, 832\u00d7480, uncensored), LTX-2.3 (768\u00d7512, the distilled base), Sulphur (uncensored LTX dev, 1280\u00d7720), or 10Eros (uncensored LTX dev, 1280\u00d7720). The LTX-family lanes can generate their own audio, but in a multi-shot film the soundtrack comes from the narration + music layer, so their native audio isn't used.\n- Keyframe / image model (drives the look + character consistency): Chroma (default), Z-Image (fast), Krea 2 (aesthetic), or HiDream-O1 (top quality, slower).\n- Continuity: storyboard (default), hero, chain, or none.\n- Audio: narration (Kokoro) and/or background music (ACE-Step) \u2014 either can be turned off.\n\nThe user changes anything by just saying so (\"use HiDream\", \"30 seconds\", \"no music\"). When they're happy they say \"go\" and the build starts \u2014 only \"go\" renders; never claim you've already started rendering. If they haven't described a film yet, warmly invite a one-line brief. Answer the user's actual message; when useful, end with a light nudge to say \"go\" or tell you what to change."]""")[0]
 
     # HiDream-O1 takes rich NATURAL-LANGUAGE prompts (Qwen3-VL text understanding). The Dev-2604
     # build runs CFG-off (no negative prompt), so everything must live in the positive description.
@@ -773,9 +773,7 @@ class Pipe:
                          % (video, keyf, cont, _audio_txt, shots))
             def _proposal():
                 _vl = {"auto": "Wan2.2 (auto)", "wan": "Wan2.2", "ltx": "LTX-2.3",
-                       "sulphur": "Sulphur", "10eros": "10Eros"}.get(video, video)
-                if video not in ("auto", "wan"):
-                    _vl += " ⚠️ roadmap — only Wan renders today"
+                       "sulphur": "Sulphur (uncensored)", "10eros": "10Eros (uncensored)"}.get(video, video)
                 _kl = {"auto": "Chroma (auto)", "chroma": "Chroma", "zimage": "Z-Image",
                        "krea": "Krea 2", "hidream": "HiDream-O1"}.get(keyf, keyf)
                 _audio = ("narration" if narr else "no narration") + " + " + ("music" if music else "no music")
@@ -789,9 +787,10 @@ class Pipe:
                     "| \U0001F39E️ continuity | **" + str(cont) + "**  ·  \U0001F50A audio **" + _audio + "** |\n"
                     "| ⏱️ length | **" + _len + "** |\n"
                     "| ⚙️ est. render | **~" + str(est_lo) + "–" + str(est_hi) + " min** on 1× 3090 |\n\n"
-                    "Reply **go** to start — or tell me what to change: _“use LTX” · “30 seconds” · "
-                    "“no music” · “hidream keyframes” · “hero continuity”_.\n\n"
-                    "_(Video renders on **Wan** today; LTX/Sulphur/10Eros are roadmap.)_"
+                    "Reply **go** to start — or tell me what to change: _“use LTX” · “sulphur” · "
+                    "“30 seconds” · “no music” · “hidream keyframes” · “hero continuity”_.\n\n"
+                    "_(Video: Wan2.2 · LTX-2.3 · Sulphur · 10Eros — all render. LTX-family lanes "
+                    "use their own resolution; the film's audio is the narration + music layer.)_"
                 )
 
             async def _chat(msg, ctx):


### PR DESCRIPTION
Closes the gap behind "I thought we tested LTX/Sulphur/10Eros?": they **were** tested + working in the **interactive** Studio video lanes, but the **Production agent's executor** was Wan-only — because the LTX-family graphs are *generated* (DiT-GGUF swap on the LTX template + i2v node-surgery), not flat JSONs the executor loads.

## One recipe, two callers
Extracted the builder into **`production/ltx_workflows.py`** — the single source of truth used by both `build_studio_pipe.py` (build time, interactive lanes) and `production/lanes.py` (render time, executor). Verified **byte-identical** to the old inline builder, so the interactive lanes are unchanged.

## Executor wiring
- `render_video` gains a `lane` arg + an LTX branch: native res (LTX **768×512**, Sulphur/10Eros **1280×720**), **24 fps** (frame count re-sized from the requested seconds — the executor's Wan-shaped frames are converted), seed → RandomNoise, i2v keyframe → LoadImage, negative-drift → neg encoder. `executor` passes `lane=vlane`.
- `stack.py`: `ltx`/`sulphur`/`10eros` → `wired=True` (all four video lanes render now).
- **Audio:** the multi-shot soundtrack stays the narration+music layer; the assembler never maps the clip's own audio, so LTX's synced audio is simply unused (no double-audio). Noted in `AGENTS.md` + the README.

## Validation
- shared `build_workflows()` **== inline builder** (byte-identical) → interactive lanes safe.
- All three LTX graphs **accepted live by ComfyUI** (`200`, no `node_errors`) via the executor's `render_graph`.
- Offline suite **84** (+4 LTX). Real multi-shot renders are the live test — pick the model in chat ("use sulphur" → go).

🤖 Generated with [Claude Code](https://claude.com/claude-code)