### PR TITLE
Production planner: scale director token budget by shot count (fix unbalanced-JSON on longer films)

### DIFF
--- a/services/studio/production/planner.py
+++ b/services/studio/production/planner.py
@@ -224,11 +224,15 @@ def plan_from_brief(brief: str, reg: dict, *, llm=None, max_repairs: int = 3,
                      max_tokens=400, temperature=0.8)
     prov.append(("treatment", TREATMENT_SYS, brief, treatment))
 
-    # stage 2 — structured plan (the video lane is PINNED to the operator's choice)
+    # stage 2 — structured plan (the video lane is PINNED to the operator's choice).
+    # Size the token budget to the shot count — a ProductionPlanV1 is ~150 tokens/shot
+    # (prompt_intent + narration + timeline + characters); a fixed 900 truncated longer
+    # films (e.g. a 30 s / 6-shot brief) into unbalanced JSON.
+    plan_tokens = min(4096, 700 + n_shots * 180)
     plan_sys = build_plan_system(reg, n_shots=n_shots, video_lane=st.video_lane)
     plan_user = f"BRIEF: {brief}\n\nTREATMENT:\n{treatment}\n\nNow output the ProductionPlanV1 JSON only."
     raw = call([{"role": "system", "content": plan_sys}, {"role": "user", "content": plan_user}],
-               max_tokens=900, temperature=0.4)
+               max_tokens=plan_tokens, temperature=0.4)
     prov.append(("plan", plan_sys, plan_user, raw))
 
     def _build(raw_json: str) -> dict:
@@ -254,7 +258,7 @@ def plan_from_brief(brief: str, reg: dict, *, llm=None, max_repairs: int = 3,
                 break
             ru = repair_user(raw, last_err)
             raw = call([{"role": "system", "content": plan_sys}, {"role": "user", "content": ru}],
-                       max_tokens=900, temperature=0.2)
+                       max_tokens=plan_tokens, temperature=0.2)
             prov.append((f"repair_{attempt + 1}", plan_sys, ru, raw))
 
     _write_provenance(prov, prompts_dir)   # keep the failed trail for debugging


### PR DESCRIPTION
Surfaced testing the Sulphur lane with **"make a 30s noir short"**: a 30s film = **6 shots**, and `plan_from_brief` capped the director at a fixed `max_tokens=900`. The 6-shot `ProductionPlanV1` JSON overflowed → **"unbalanced JSON"** → 3 failed repairs → planner error (no render).

**Fix:** size the budget to the shot count — `plan_tokens = min(4096, 700 + n_shots*180)` (a plan is ~150 tokens/shot: prompt_intent + narration + timeline + characters), applied to both the plan call and the repair calls. 6→1780, 12→2860, capped for the 24-shot ceiling.

**Verified live:** the same brief now plans 6 shots ("Neon Noir: The Shattered Umbrella") and proceeds to render on Sulphur. Suite 84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)