### PR TITLE
Production assemble: fix sub-frame cut xfade collapsing multi-shot films to one clip

### DIFF
--- a/services/studio/production/assemble.py
+++ b/services/studio/production/assemble.py
@@ -17,7 +17,11 @@ from __future__ import annotations
 
 from .util import sh
 
-_CUT_XFADE = 1.0 / 30.0   # a "cut" seam inside an xfade chain: ~1 frame (no visible blend)
+# A "cut" seam inside an xfade chain is faked with a near-instant blend. It MUST be ≥ ~1 frame
+# at the output fps — a sub-frame xfade duration (the old 1/30 s = 0.033 s, < 1 frame at 24 fps)
+# silently produces a degenerate transition that collapses the whole chain to one clip's length
+# (surfaced on a 6-shot LTX/Sulphur noir with cut seams, 2026-06-29). fps-aware below.
+_CUT_FRAMES = 2.0   # 2 frames: imperceptible (reads as a cut) but valid for xfade
 
 
 def db_to_linear(db: float) -> float:
@@ -62,8 +66,11 @@ def build_mix_command(
     if len(transitions) != max(0, n - 1):
         raise ValueError("transitions must have one entry per seam (clips-1)")
 
-    # effective crossfade per seam: dissolve -> its seconds; cut -> ~1 frame
-    xf = [secs if typ == "dissolve" else _CUT_XFADE for (typ, secs) in transitions]
+    # effective crossfade per seam: dissolve -> its seconds; cut -> a 2-frame blend at the
+    # output fps (NOT sub-frame, which collapses the xfade chain). Never longer than the seam's
+    # own dissolve seconds would be, and clamped below each clip so the offset math stays valid.
+    cut_xf = _CUT_FRAMES / float(max(1, fps))
+    xf = [secs if typ == "dissolve" else cut_xf for (typ, secs) in transitions]
     all_cut = all(typ == "cut" for (typ, _s) in transitions)
     starts = (
         [sum(durations[:k]) for k in range(n)] if (all_cut or n == 1)

--- a/services/studio/production/executor.py
+++ b/services/studio/production/executor.py
@@ -12,7 +12,7 @@ import json
 import os
 
 from . import assemble as _assemble
-from . import config, ensure, validators
+from . import config, ensure, ltx_workflows, validators
 from .lanes import get_backend
 from .manifest import Artifact, Manifest
 from .schema import ProductionPlanV1
@@ -139,11 +139,15 @@ def run_production(
         clip_paths[shot.id] = path
         prev_clip = path
         pr = validators.ffprobe(path)
+        # LTX-family clips legitimately carry synced audio (Wan is silent) — so don't assert
+        # 'no_audio_expected' on them (their audio is unused; the soundtrack is narration+music).
+        svals = ([v for v in shot.validators if v != "no_audio_expected"]
+                 if ltx_workflows.is_ltx_family(vlane) else shot.validators)
         man.add(Artifact(
             id=f"shot.{shot.id}", type="media", role="shot", path=rel(path), lane=vlane,
             seed=shot.seed, prompt_hash=sha256_text(shot.prompt_intent),
             width=pr.width, height=pr.height, duration=pr.duration,
-            validation=validators.run_all(shot.validators, path, target_seconds=shot.target_seconds),
+            validation=validators.run_all(svals, path, target_seconds=shot.target_seconds),
         ))
 
     durations = [validators.ffprobe(clip_paths[s.id]).duration for s, _ in pairs]

--- a/services/studio/production/tests/test_v0a.py
+++ b/services/studio/production/tests/test_v0a.py
@@ -106,6 +106,22 @@ class TestAssembleCommand(unittest.TestCase):
         self.assertIn("concat=n=2:v=1:a=0[vid]", fc)   # hard cuts -> concat, no xfade
         self.assertNotIn("xfade", fc)
 
+    def test_mixed_cut_dissolve_cut_xfade_is_at_least_one_frame(self):
+        # Regression (2026-06-29): a MIXED chain takes the xfade path, where a "cut" seam was
+        # faked with a SUB-FRAME duration (0.033 s < 1 frame @24fps) → degenerate xfade collapsed
+        # the whole video to one clip's length. The cut blend must be ≥ 1 frame at the fps.
+        import re
+        for fps in (16, 24):
+            cmd = assemble.build_mix_command(
+                "/tmp/f.mp4", clips=["a.mp4", "b.mp4", "c.mp4"], durations=[5.0, 5.0, 5.0],
+                transitions=[("cut", 0.6), ("dissolve", 0.6)],   # mixed -> xfade chain
+                narrations=[("v.wav", 0, 0.0)], bed=None, fps=fps, lufs=-14.0, bed_level_db=-18)
+            fc = cmd[cmd.index("-filter_complex") + 1]
+            self.assertIn("xfade=transition=dissolve", fc)        # mixed uses the xfade chain
+            cut_durs = [float(d) for d in re.findall(r"xfade=transition=dissolve:duration=([0-9.]+)", fc)]
+            self.assertTrue(min(cut_durs) >= 1.0 / fps - 1e-6,    # no sub-frame xfade
+                            f"fps={fps}: a seam xfade {min(cut_durs)} is sub-frame")
+
     def test_bed_only_no_narration(self):
         cmd = assemble.build_mix_command(
             "/tmp/f.mp4", clips=["a.mp4"], durations=[5.0], transitions=[],


### PR DESCRIPTION
Surfaced on the live **"30s noir, sulphur"** test: all 6 Sulphur shots rendered fine (1280×704, ~4.7 s each, **28 s** total), but the assembled final was **4.99 s** — one clip.

**Root cause:** the timeline mixed `cut` and `dissolve` seams → the xfade path. A "cut" was faked with `_CUT_XFADE = 1/30 s = 0.033 s`, which is **sub-frame** (1 frame @24 fps = 0.042 s). A sub-frame xfade duration is degenerate and **collapses the whole chain to a single clip's length**. Latent for any lane (a Wan film with cut seams would hit it too); only surfaced now because the 4B chose cut seams *and* LTX runs at 24 fps. (All-dissolve and all-cut→concat paths were fine, hence the earlier green runs.)

**Fix:** cut blend = `2 / fps` s (2 frames — imperceptible, reads as a cut, valid for xfade). Re-assembling the same 6 clips: **4.99 s → 27.5 s**.

**Also:** LTX-family clips carry synced audio (Wan is silent), so the executor no longer asserts `no_audio_expected` on them (their audio is unused — the soundtrack is narration+music); that had been failing `all_validators_pass`.

**Tests:** +1 regression for the mixed cut/dissolve chain (no seam xfade may be sub-frame at 16/24 fps); 85 total. Verified live: the existing Sulphur noir re-assembles to 27.5 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)