### PR TITLE
Planner: documentary vs narrative format detection (no invented protagonist)

### DIFF
--- a/services/studio/production/planner.py
+++ b/services/studio/production/planner.py
@@ -20,7 +20,7 @@ import urllib.request
 
 from . import config
 from .manifest import Artifact
-from .prompts import TREATMENT_SYS, build_plan_system, repair_user
+from .prompts import build_plan_system, build_treatment_system, detect_format, repair_user
 from .schema import PlanError, ProductionPlanV1
 from .util import sha256_text
 
@@ -102,20 +102,31 @@ def extract_json(text: str) -> dict:
 
 
 # -- lenient normalization (fill obvious defaults so the 4B can be terse) -----
-def normalize(data: dict, video_lane: str = "wan", *, music: bool = True) -> dict:
+def normalize(data: dict, video_lane: str = "wan", *, music: bool = True,
+              fmt: str = "narrative") -> dict:
     data.setdefault("schema_version", "ProductionPlanV1")
     proj = data.setdefault("project", {})
     # The video lane is an operator/stack decision — FORCE it (the planner authors
     # shot content, not the lane). Whatever the 4B emitted is overridden by the pin.
     proj["video_lane"] = video_lane
+    # Format is the planner's deterministic genre decision (documentary vs narrative) —
+    # FORCE it so the manifest records how the piece was planned (and a documentary
+    # can't carry an invented protagonist the model snuck in).
+    proj["format"] = fmt
     proj.setdefault("title", "Untitled")
+    documentary = fmt == "documentary"
+    if documentary:
+        # Hard guarantee: a documentary has NO recurring fictional person. Strip any
+        # Character Bible the 4B emitted anyway, so the executor never stamps an invented
+        # protagonist onto every shot of a factual piece (the "Arif" failure, 2026-06-29).
+        data["characters"] = []
     shots = data.get("shots") or []
     for i, s in enumerate(shots):
         s.setdefault("id", f"s{i + 1}")
         s["lane"] = video_lane          # every shot uses the pinned lane
         s.setdefault("mode", "t2v")
         s.setdefault("prompt_intent", "")
-        s.setdefault("characters", [])  # Character Bible cast (ids); [] = none
+        s["characters"] = [] if documentary else s.get("characters", [])  # Bible cast ids; [] = none
     data.setdefault("delivery", {"aspect": "16:9", "width": 832, "height": 480,
                                  "fps": 16, "loudness_lufs": -14.0})
     data.setdefault("assembly", {"transition_seconds": 0.6, "duck_db": 6})
@@ -218,18 +229,25 @@ def plan_from_brief(brief: str, reg: dict, *, llm=None, max_repairs: int = 3,
     call = llm or director_call
     prov: list[tuple[str, str, str, str]] = []   # (role, system, user, response)
 
+    # FORMAT first — documentary (non-fiction, no protagonist) vs narrative (fiction).
+    # Decided deterministically from the brief and threaded through BOTH stages so the
+    # 4B can't fictionalize a factual brief (it used to invent a protagonist for a
+    # "documentary on the history of Pakistan"; diagnosed 2026-06-29).
+    fmt = detect_format(brief)
+    treatment_sys = build_treatment_system(fmt)
+
     # stage 1 — creative treatment (free-form)
-    treatment = call([{"role": "system", "content": TREATMENT_SYS},
+    treatment = call([{"role": "system", "content": treatment_sys},
                       {"role": "user", "content": brief}],
                      max_tokens=400, temperature=0.8)
-    prov.append(("treatment", TREATMENT_SYS, brief, treatment))
+    prov.append(("treatment", treatment_sys, brief, treatment))
 
     # stage 2 — structured plan (the video lane is PINNED to the operator's choice).
     # Size the token budget to the shot count — a ProductionPlanV1 is ~150 tokens/shot
     # (prompt_intent + narration + timeline + characters); a fixed 900 truncated longer
     # films (e.g. a 30 s / 6-shot brief) into unbalanced JSON.
     plan_tokens = min(4096, 700 + n_shots * 180)
-    plan_sys = build_plan_system(reg, n_shots=n_shots, video_lane=st.video_lane)
+    plan_sys = build_plan_system(reg, n_shots=n_shots, video_lane=st.video_lane, fmt=fmt)
     plan_user = f"BRIEF: {brief}\n\nTREATMENT:\n{treatment}\n\nNow output the ProductionPlanV1 JSON only."
     raw = call([{"role": "system", "content": plan_sys}, {"role": "user", "content": plan_user}],
                max_tokens=plan_tokens, temperature=0.4)
@@ -237,7 +255,7 @@ def plan_from_brief(brief: str, reg: dict, *, llm=None, max_repairs: int = 3,
 
     def _build(raw_json: str) -> dict:
         data = apply_continuity(
-            normalize(extract_json(raw_json), video_lane=st.video_lane, music=st.music),
+            normalize(extract_json(raw_json), video_lane=st.video_lane, music=st.music, fmt=fmt),
             st.continuity, image_lane=st.keyframe_lane,
         )
         if not st.narration:                      # operator opted out of voiceover

--- a/services/studio/production/prompts.py
+++ b/services/studio/production/prompts.py
@@ -7,36 +7,125 @@ executor/validator wins (the validator-repair loop enforces this).
 """
 from __future__ import annotations
 
+import re
+
 from .registry import prompt_slice
 
-TREATMENT_SYS = (
-    "You are a production director. Given a brief, write a SHORT creative treatment "
-    "(4-6 sentences): the angle, the tone, the structure, and 3 concrete visual beats "
-    "— each something that could be ONE ~5-second shot. Be specific and cinematic. "
-    "Plain prose only — no JSON, no markdown, no preamble."
+# --- format detection: documentary/factual vs narrative/fiction --------------
+# The brief's FORMAT decides whether the director invents a protagonist (narrative)
+# or narrates a real subject with NO recurring person (documentary). Without this,
+# the 4B latches onto the dominant CHARACTER BIBLE instruction and fictionalizes
+# every brief — e.g. a "documentary on the history of Pakistan" became a character
+# drama about an invented young architect named "Arif" (diagnosed 2026-06-29). Keep
+# these signals tight: a false positive (a story mislabeled documentary) is cheap to
+# correct ("make it a story"), and the strong signals below rarely occur in fiction.
+_DOC_SIGNALS = re.compile(
+    r"document\w*"                                   # documentary / documentory / documentry / documenting
+    r"|\bhistory of\b|\bthe history\b|\bhistories of\b"
+    r"|\bexplainer\b|\bexplain(?:ed|s|ing)?\b"
+    r"|\beducational\b|\bbiograph\w*"
+    r"|\bguide to\b|\boverview of\b|\btimeline of\b|\bfacts? about\b"
+    r"|\btutorial\b|\bhow to\b|\bhow .{0,30}?works?\b|\bcase study\b",
+    re.I,
 )
 
 
-def build_plan_system(reg: dict, n_shots: int = 3, video_lane: str = "wan") -> str:
+def detect_format(brief: str) -> str:
+    """Classify a brief as 'documentary' (non-fiction/factual) or 'narrative' (fiction)."""
+    return "documentary" if _DOC_SIGNALS.search(brief or "") else "narrative"
+
+
+def build_treatment_system(fmt: str = "narrative") -> str:
+    """The stage-1 treatment system prompt, branched on format."""
+    if fmt == "documentary":
+        return (
+            "You are a documentary director. Given a factual brief, write a SHORT treatment "
+            "(4-6 sentences) for a NON-FICTION, observational/archival piece narrated by an "
+            "unseen narrator. Do NOT invent a protagonist, a main character, or a personal "
+            "story — there is no recurring person to follow. Cover the REAL subject faithfully "
+            "(real places, events, eras, artifacts, figures relevant to the brief) in a sensible "
+            "order. Give 3 concrete visual beats, each a real scene that could be ONE ~5-second "
+            "shot. Plain prose only — no JSON, no markdown, no preamble."
+        )
+    return (
+        "You are a production director. Given a brief, write a SHORT creative treatment "
+        "(4-6 sentences): the angle, the tone, the structure, and 3 concrete visual beats "
+        "— each something that could be ONE ~5-second shot. Be specific and cinematic. "
+        "Plain prose only — no JSON, no markdown, no preamble."
+    )
+
+
+# Back-compat: the narrative treatment system prompt as a module constant.
+TREATMENT_SYS = build_treatment_system("narrative")
+
+
+def build_plan_system(reg: dict, n_shots: int = 3, video_lane: str = "wan",
+                      fmt: str = "narrative") -> str:
+    documentary = fmt == "documentary"
+
+    if documentary:
+        format_banner = (
+            "FORMAT: This is a DOCUMENTARY — NON-FICTION, narrated by an unseen narrator.\n"
+            "- Do NOT invent a protagonist, a named character, or a personal story. `characters` MUST be an empty list [], and NO shot may list `characters`.\n"
+            "- Every shot is a real, ON-TOPIC observational or archival image of the ACTUAL subject (real places, events, eras, artifacts, or figures relevant to the brief). No recurring fictional person to follow.\n"
+            "- narration is FACTUAL: real names, places, dates, and events — NOT poetic mood lines.\n"
+            "- Stay ON TOPIC for the ENTIRE piece: every shot must clearly serve the brief's subject from first to last.\n\n"
+        )
+        characters_field = '  "characters": [],\n'
+        shot_characters = ""
+        char_guidance = (
+            "- NO CHARACTERS: this is a documentary, so `characters` MUST be [] and no shot lists `characters`. "
+            "Never invent a person to follow — depict the real subject."
+        )
+        intent_guidance = (
+            "- prompt_intent: vivid, cinematic prose for ONE real, ON-TOPIC shot (imagery + action + camera) — "
+            "a true place, event, era, or artifact relevant to the brief. Never a fictional protagonist."
+        )
+        narr_guidance = (
+            "- narration: ONE FACTUAL spoken sentence per shot — real names, places, dates, events — in ENGLISH "
+            "ONLY. Keep it short (~2.5 words/second, so a 5 s shot is AT MOST 10 words)."
+        )
+    else:
+        format_banner = ""
+        characters_field = (
+            '  "characters": [\n'
+            '    {"id": "det", "name": "Detective Marlowe", "role": "protagonist",\n'
+            '      "description": "<canonical, reusable visual appearance: build, age, face, hair>",\n'
+            '      "wardrobe": "<signature clothing>", "props": "<signature props>",\n'
+            '      "negative": "<what NOT to render — drift to avoid>", "seed": 111}\n'
+            "  ],\n"
+        )
+        shot_characters = '\n      "characters": ["det"],'
+        char_guidance = (
+            "- CHARACTER BIBLE: define every recurring on-screen character (a person/creature appearing in MORE "
+            "THAN ONE shot) ONCE in `characters`, with a CANONICAL, detailed, REUSABLE appearance — build, age, "
+            "face, hair, `wardrobe`, signature `props`, and a `negative` note of drift to avoid. Then in each shot, "
+            "list the ids of the characters present via `characters` — do NOT restate their looks in prompt_intent "
+            "(the executor injects the canonical block automatically, so the SAME character stays consistent). Give "
+            "each character a stable `seed`. If the piece has NO recurring character, leave `characters` empty and "
+            "omit the per-shot `characters`."
+        )
+        intent_guidance = (
+            "- prompt_intent: vivid, cinematic prose for the video model (one shot's worth of imagery + action + "
+            "camera), referring to characters by NAME but not re-describing their fixed appearance."
+        )
+        narr_guidance = (
+            "- narration: ONE spoken sentence the viewer hears over that shot, in ENGLISH ONLY (no other-language "
+            "words). Keep it short enough to fit (~2.5 words per second), so a 5 s shot is AT MOST 10 words."
+        )
+
     return f"""You are the production director for an automated video studio. Turn the brief and treatment into ONE valid ProductionPlanV1 JSON object. OUTPUT ONLY THE JSON — no prose, no markdown fences, no comments.
 
-{prompt_slice(reg)}
+{format_banner}{prompt_slice(reg)}
 
 The video lane is PINNED by the operator to '{video_lane}'. Output project.video_lane = "{video_lane}" and EVERY shot's lane = "{video_lane}". Do NOT choose a different video lane.
 
 ProductionPlanV1 shape:
 {{
   "project": {{"title": str, "tone": str, "target_seconds": int, "video_lane": "{video_lane}"}},
-  "characters": [
-    {{"id": "det", "name": "Detective Marlowe", "role": "protagonist",
-      "description": "<canonical, reusable visual appearance: build, age, face, hair>",
-      "wardrobe": "<signature clothing>", "props": "<signature props>",
-      "negative": "<what NOT to render — drift to avoid>", "seed": 111}}
-  ],
-  "shots": [
+{characters_field}  "shots": [
     {{"id": "s1", "lane": "{video_lane}", "mode": "t2v", "target_seconds": 5,
-      "prompt_intent": "<vivid cinematic prose describing the shot>",
-      "characters": ["det"],
+      "prompt_intent": "<vivid cinematic prose describing the shot>",{shot_characters}
       "narration": "<ONE short spoken sentence heard over this shot>", "seed": 12345}}
   ],
   "music": {{"lane": "ace-step", "tags": "<comma-separated mood tags>", "lyrics": "[instrumental]", "seed": 7}},
@@ -47,9 +136,9 @@ ProductionPlanV1 shape:
 
 Guidance (be inventive WITHIN these bounds):
 - Aim for {n_shots} shots. Each shot is ONE video window (<= 5 s), so keep target_seconds 4-5.
-- CHARACTER BIBLE: define every recurring on-screen character (a person/creature appearing in MORE THAN ONE shot) ONCE in `characters`, with a CANONICAL, detailed, REUSABLE appearance — build, age, face, hair, `wardrobe`, signature `props`, and a `negative` note of drift to avoid. Then in each shot, list the ids of the characters present via `characters` — do NOT restate their looks in prompt_intent (the executor injects the canonical block automatically, so the SAME character stays consistent). Give each character a stable `seed`. If the piece has NO recurring character (e.g. a landscape documentary), leave `characters` empty and omit the per-shot `characters`.
-- prompt_intent: vivid, cinematic prose for the video model (one shot's worth of imagery + action + camera), referring to characters by NAME but not re-describing their fixed appearance.
-- narration: ONE spoken sentence the viewer hears over that shot, in ENGLISH ONLY (no other-language words). Keep it short enough to fit (~2.5 words per second), so a 5 s shot is AT MOST 10 words.
+{char_guidance}
+{intent_guidance}
+{narr_guidance}
 - If an idea needs more than ~5 s, SPLIT it into two shots — never exceed the limit.
 - Every shot needs a UNIQUE id. The timeline lists EVERY shot exactly once, in play order.
 - OUTPUT ONLY THE JSON OBJECT."""

--- a/services/studio/production/schema.py
+++ b/services/studio/production/schema.py
@@ -105,6 +105,7 @@ class Project:
     video_lane: str = "wan"           # operator-pinned (stack.py); default wan
     continuity: str = "none"          # none | chain | hero | storyboard (v0b-images)
     image_policy: dict = field(default_factory=dict)   # role -> image lane
+    format: str = "narrative"         # narrative (fiction) | documentary (non-fiction) — set by planner
 
 
 @dataclass

--- a/services/studio/production/tests/test_v0b.py
+++ b/services/studio/production/tests/test_v0b.py
@@ -34,6 +34,22 @@ GOOD_PLAN = """{
   ]
 }"""
 
+# A documentary brief where the 4B disobeyed and snuck in a fictional protagonist
+# (the "Arif" failure, 2026-06-29) — the planner must strip it for a documentary.
+DOC_PLAN_WITH_SNEAKY_CHARACTER = """{
+  "project": {"title": "The Architect's Line", "tone": "reflective", "target_seconds": 10, "video_lane": "wan"},
+  "characters": [{"id": "p", "name": "Arif", "role": "protagonist", "description": "young man", "seed": 9}],
+  "shots": [
+    {"id": "s1", "lane": "wan", "mode": "t2v", "target_seconds": 5, "prompt_intent": "ancient ruins of Mohenjo-daro", "characters": ["p"], "narration": "The Indus Valley civilization thrived here.", "seed": 1},
+    {"id": "s2", "lane": "wan", "mode": "t2v", "target_seconds": 5, "prompt_intent": "1947 partition crowds", "characters": ["p"], "narration": "In 1947 the subcontinent was partitioned.", "seed": 2}
+  ],
+  "music": {"lane": "ace-step", "tags": "documentary", "lyrics": "[instrumental]", "seed": 3},
+  "timeline": [
+    {"clip": "s1", "transition_in": "dissolve"},
+    {"clip": "s2", "transition_in": "dissolve"}
+  ]
+}"""
+
 
 class StubLLM:
     """Returns a queue of canned director responses; records the calls."""
@@ -149,6 +165,69 @@ class TestDeriveShots(unittest.TestCase):
         shots, secs = derive_shots("a noir detective short")
         self.assertEqual(shots, 4)
         self.assertIsNone(secs)
+
+
+class TestDocumentaryFormat(unittest.TestCase):
+    """A documentary/factual brief must NOT become a character-driven fiction — the 4B
+    used to invent a protagonist ("Arif") for a documentary on Pakistan's history
+    (diagnosed 2026-06-29). Format is detected from the brief, steered in the prompts,
+    AND enforced deterministically in normalize so the failure can't recur."""
+
+    def setUp(self):
+        self.reg = load()
+
+    def test_detect_format(self):
+        from ..prompts import detect_format
+        for b in ["a documentary on the history of pakistan",
+                  "give me a 2 minute documentory on history of pakistan",   # user's typo
+                  "explain how vaccines work", "a guide to the solar system",
+                  "the biography of Tesla", "a tutorial on knife sharpening",
+                  "an overview of the Roman empire"]:
+            self.assertEqual(detect_format(b), "documentary", b)
+        for b in ["a 15s noir detective short", "make a 30s noir short, use sulphur",
+                  "a lone wanderer crosses a desert at dusk", "two robots fall in love"]:
+            self.assertEqual(detect_format(b), "narrative", b)
+
+    def test_documentary_prompt_suppresses_character_bible(self):
+        from ..prompts import build_plan_system
+        doc = build_plan_system(self.reg, n_shots=6, video_lane="ltx", fmt="documentary")
+        self.assertIn("DOCUMENTARY", doc)
+        self.assertIn('"characters": []', doc)            # empty cast in the shape
+        self.assertNotIn("Detective Marlowe", doc)        # no protagonist example
+        self.assertNotIn("CHARACTER BIBLE", doc)
+        nar = build_plan_system(self.reg, n_shots=6, video_lane="ltx", fmt="narrative")
+        self.assertIn("CHARACTER BIBLE", nar)             # narrative keeps the bible
+        self.assertIn("Detective Marlowe", nar)
+
+    def test_normalize_strips_characters_in_documentary(self):
+        data = normalize(
+            {"project": {"video_lane": "wan"},
+             "characters": [{"id": "p", "name": "Arif"}],
+             "shots": [{"prompt_intent": "ruins", "characters": ["p"], "narration": "n"}]},
+            fmt="documentary")
+        self.assertEqual(data["characters"], [])
+        self.assertEqual(data["shots"][0]["characters"], [])
+        self.assertEqual(data["project"]["format"], "documentary")
+
+    def test_normalize_keeps_characters_in_narrative(self):
+        data = normalize(
+            {"project": {"video_lane": "wan"},
+             "characters": [{"id": "p", "name": "Marlowe"}],
+             "shots": [{"prompt_intent": "alley", "characters": ["p"], "narration": "n"}]},
+            fmt="narrative")
+        self.assertEqual(data["characters"], [{"id": "p", "name": "Marlowe"}])
+        self.assertEqual(data["shots"][0]["characters"], ["p"])
+        self.assertEqual(data["project"]["format"], "narrative")
+
+    def test_planner_routes_documentary_brief_and_strips_protagonist(self):
+        # End-to-end: a doc brief + a disobedient 4B that emitted "Arif" → stripped.
+        llm = StubLLM(["a factual treatment", DOC_PLAN_WITH_SNEAKY_CHARACTER])
+        plan, _ = plan_from_brief("a documentary on the history of pakistan", self.reg, llm=llm)
+        self.assertEqual(plan.project.format, "documentary")
+        self.assertEqual(plan.characters, [])
+        self.assertTrue(all(s.characters == [] for s in plan.shots))
+        # narration stays factual content the model wrote (we don't rewrite it)
+        self.assertIn("1947", " ".join(s.narration for s in plan.shots))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

A brief like *"a 2 minute documentary on the history of Pakistan"* came back as a **fictional character drama** — title *"The Architect's Line"*, an invented protagonist **"Arif"** stamped onto all 24 shots, poetic mood narration (*"The dust remembers what we forgot"*), and by shot 7 it had drifted off-topic entirely (Arif laughing with friends in a park, working late in an office).

The brief reached the planner intact (it's the job title + `production.json`). The failure was **100% in the plan the 4B wrote**: the planner prompt is built for narrative fiction — its biggest section is **CHARACTER BIBLE** with a *"Detective Marlowe"* example — so a 4B fictionalizes every brief and ignores the one buried "if no recurring character, leave it empty" clause.

## Fix — make FORMAT a first-class, deterministic decision

- **`detect_format(brief)`** → `documentary` (non-fiction) vs `narrative` (fiction), from tight signals (`document*`, `history of`, `explainer`, `guide to`, `tutorial`, …). False positives are cheap to correct ("make it a story"); these signals rarely occur in fiction.
- **`build_treatment_system(fmt)` / `build_plan_system(…, fmt)`** — documentary mode front-loads a NON-FICTION banner, sets `characters: []` in the shape, **drops the Character Bible**, and asks for **factual narration** + on-topic archival/observational shots. Narrative mode keeps the existing Bible.
- **`normalize(…, fmt)`** FORCES `project.format` and, for documentary, **strips any characters the 4B emitted anyway** — a hard guarantee the "Arif" failure can't recur even if a future model ignores the prompt.
- **`schema.Project.format`** records the genre in the plan/manifest.

## Validation

Live dry-run on the 4B with the **exact** brief (plan only, no render):

| | Before | After |
|---|---|---|
| Title | *The Architect's Line* | **The Partition of the Subcontinent** |
| Characters | invented "Arif" ×24 | **`[]`** |
| Narration | *"The dust remembers…"* | **"The Radcliffe Line divides the subcontinent"** |
| Content | drifts to a park | **Lahore refugees · Faisal Mosque · border negotiations** |

Narrative noir brief still yields **Detective Marlowe** (no regression). **+5 offline tests; full production suite 90/90.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)