### PR TITLE
Director Batch 2 (Codex): structured LLM intent controller — natural multi-turn chat

### DIFF
--- a/services/studio/build_studio_pipe.py
+++ b/services/studio/build_studio_pipe.py
@@ -483,6 +483,28 @@ class Pipe:
                                      headers={"Content-Type": "application/json"})
         return json.load(urllib.request.urlopen(req, timeout=120))["choices"][0]["message"]["content"].strip()
 
+    def _classify(self, turns, plan_ctx=""):
+        """Batch-2 LLM intent controller (blocking; call via run_in_executor).
+
+        Reads the whole conversation and returns a validated decision dict
+        {intent, brief, stack_patch, confirm, reply}, or None on any failure (→ the caller
+        falls back to the Batch-1 keyword heuristics). build_controller_system /
+        parse_controller_json / normalize_decision are injected from director_intent.py."""
+        convo = "\n".join("User: " + t for t in turns[-10:])
+        u = (("Current plan: " + plan_ctx + "\n\n") if plan_ctx else "") + "Conversation:\n" + convo
+        body = json.dumps({"model": self.valves.chat_model,
+                           "messages": [{"role": "system", "content": build_controller_system()},
+                                        {"role": "user", "content": u}],
+                           "max_tokens": 320, "temperature": 0.2,
+                           "chat_template_kwargs": {"enable_thinking": False}}).encode()
+        try:
+            req = urllib.request.Request(self.valves.chat_url + "/chat/completions", data=body,
+                                         headers={"Content-Type": "application/json"})
+            raw = json.load(urllib.request.urlopen(req, timeout=45))["choices"][0]["message"]["content"]
+            return normalize_decision(parse_controller_json(raw))
+        except Exception:
+            return None   # director unreachable / bad JSON → caller uses the keyword floor
+
     # ── long-clip (>15s) via the orchestrator: chain ~10s segments → one combined video ──
     def _target_seconds(self, text):
         """Parse a requested duration from the user's text. 0 = none (single clip)."""
@@ -821,14 +843,42 @@ class Pipe:
             def _pure_override(t):
                 return bool(_overrides(t)) and len(t.split()) <= 5
 
-            # effective brief = the first turn that reads as a film brief. A GENERATION REQUEST
-            # ("can you make a 30s noir short?", "do a 1-min documentary on Pakistan") counts even
-            # though it's question-shaped — the old gate dropped those as questions and never
-            # captured a brief, so it dove into chit-chat (Codex F1, 2026-06-29).
-            brief = pick_brief(users, _pure_override)
+            # ── FLOOR (Batch 1): deterministic keyword heuristics — the fallback when the LLM is down.
+            # A GENERATION REQUEST ("can you make a 30s noir short?") counts as a brief even though
+            # it's question-shaped (Codex F1, 2026-06-29).
+            brief_kw = pick_brief(users, _pure_override)
             ov = {}
             for t in users:
-                ov.update(_overrides(t))         # accumulate tweaks across the convo (later wins)
+                ov.update(_overrides(t))         # accumulate explicit tweaks across the convo (later wins)
+            confirm_kw = _is_confirm(last)
+
+            # ── CONTROLLER (Batch 2): the 4B reads the WHOLE conversation and returns a structured
+            # decision {intent, brief, stack_patch(lanes), confirm, reply}. It REFINES the floor —
+            # a mid-chat brief change ("actually make it a bookstore promo"), a compound confirm
+            # ("go with ltx"), a natural question — and FALLS BACK to the floor on any failure. A
+            # render starts only when the decision says confirm AND the latest turn carries a real
+            # confirm word (has_confirm_word) — never on the LLM's say-so alone (Codex F1/F2/F3).
+            _pshots = max(1, math.ceil(ov["seconds"] / 5.0)) if ov.get("seconds") else 0
+            _prelim_ctx = "film so far: %s; video=%s%s" % (
+                brief_kw or "(none described yet)",
+                ov.get("video_lane") or (self.valves.production_video_lane or "auto"),
+                (", ~%d shots" % _pshots) if _pshots else "")
+            _decision = await loop.run_in_executor(None, self._classify, users, _prelim_ctx)
+            if _decision:
+                brief = _decision["brief"] or brief_kw
+                for _k, _v in _decision["stack_patch"].items():
+                    ov.setdefault(_k, _v)        # keyword floor wins; the LLM only fills a lane it left blank
+                confirmed = (_decision["confirm"] or confirm_kw) and has_confirm_word(last)
+                intent = _decision["intent"]
+                llm_reply = _decision["reply"]
+            else:
+                brief = brief_kw
+                confirmed = confirm_kw
+                intent = ("confirm" if confirm_kw
+                          else "question" if (_is_question(last) and last != brief_kw and not _overrides(last))
+                          else "stack" if (last == brief_kw or _overrides(last)) else "smalltalk")
+                llm_reply = None
+
             video = ov.get("video_lane") or (self.valves.production_video_lane or "auto")
             keyf = ov.get("keyframe_lane") or (self.valves.production_keyframe_lane or "auto")
             cont = ov.get("continuity") or (self.valves.production_continuity or "auto")
@@ -878,20 +928,20 @@ class Pipe:
                 except Exception:
                     return None   # director unreachable
 
-            # no brief yet → converse NATURALLY (greeting / question), never a render
-            if not brief:
-                if _is_confirm(last):
-                    return ("Nothing to start yet — give me a one-line brief first, e.g. "
-                            "“a 1-minute documentary on the history of Pakistan”.")
-                return (await _chat(last, "")) or _help
-
-            # have a brief, not confirming → show the plan when it's new/changed, else just chat
-            if not _is_confirm(last):
-                if last == brief or _overrides(last):   # the brief itself, or a settings tweak → plan card
-                    await status("", True)
-                    return _proposal()
-                # a question / chit-chat about the plan → answer naturally (NOT a canned re-dump)
-                return (await _chat(last, _plan_ctx)) or _proposal()
+            # route the resolved turn → ONE action (tested: director_intent.decide_action).
+            action = decide_action(brief, confirmed, intent)
+            if action == "need_brief":
+                return ("Nothing to start yet — give me a one-line brief first, e.g. "
+                        "“a 1-minute documentary on the history of Pakistan”.")
+            if action == "chat":
+                # the LLM's own reply when it has one, else a fresh director chat call; the static
+                # fallback is the plan card (if we have a brief) or the help line.
+                return llm_reply or (await _chat(last, _plan_ctx if brief else "")) or \
+                    (_proposal() if brief else _help)
+            if action == "proposal":
+                await status("", True)
+                return _proposal()
+            # action == "build" → fall through to the resolved-plan build below
 
             # CONFIRMED + have a brief → build with the resolved plan
             await status("\U0001F3AC Starting “" + brief + "” — " + str(shots) + " shots, ~" +

--- a/services/studio/director_intent.py
+++ b/services/studio/director_intent.py
@@ -14,6 +14,7 @@ The bug this fixes (Codex F1, 2026-06-29): the old gate classified "can you make
 short?" as a question and dropped it, so no brief was ever captured. A GENERATION REQUEST now
 takes precedence over question-shape, so a creation ask phrased as a question is still a brief.
 """
+import json
 import re
 
 # Exact-match small-talk + confirmation vocabularies (matched on a normalized turn).
@@ -81,3 +82,153 @@ def pick_brief(turns, pure_override_of=None):
         if is_brief_candidate(t, po(t)):
             return t
     return ""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Batch 2 — the structured LLM intent controller (Codex F1/F2/F3).
+#
+# The keyword classifiers above are the deterministic FLOOR/FALLBACK. The controller
+# asks the 4B to read the whole conversation and emit ONE small JSON decision —
+# {intent, brief, stack_patch, confirm, reply} — which the pipe merges ON TOP of the
+# floor (LLM brief/stack win when present; the floor fills the gaps). The pure parse +
+# validation below is table-tested; the HTTP call + fallback orchestration live in the
+# pipe (`_classify`). A render only starts when the decision says confirm AND the latest
+# turn carries a real confirm word (has_confirm_word) — the irreversible action is never
+# triggered on the LLM's say-so alone.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Valid slot values — MUST mirror the wired lanes in production/stack.py (guarded by
+# test_controller_lane_constants_match_stack). The pipe can't import stack.py (it runs
+# in the OWUI container), so these are duplicated here, same as the pipe's own lane maps.
+VIDEO_LANES_VALID = ("wan", "ltx", "sulphur", "10eros")
+KEYFRAME_LANES_VALID = ("chroma", "zimage", "krea", "hidream")
+CONTINUITY_VALID = ("storyboard", "hero", "chain", "none")
+INTENTS = ("brief", "revise", "stack", "question", "confirm", "smalltalk", "cancel")
+
+# A turn that signals "start rendering NOW" — used to CORROBORATE the LLM's confirm flag
+# so an expensive render never fires on a hallucinated confirm. Looser than is_confirm
+# (exact-match) so compound asks like "go with LTX" still count.
+_CONFIRM_WORD_RE = re.compile(r"\b(go|yes|yeah|yep|sure|start|render|build|proceed|confirm|okay?)\b", re.I)
+_CONFIRM_PHRASES = ("do it", "go ahead", "let's go", "lets go", "ok go", "render it",
+                    "build it", "make it", "ship it", "send it")
+
+
+def has_confirm_word(t):
+    """Does this turn carry an explicit 'start now' signal? (corroborates the LLM confirm)."""
+    tl = (t or "").lower()
+    return bool(_CONFIRM_WORD_RE.search(tl)) or any(p in tl for p in _CONFIRM_PHRASES)
+
+
+def build_controller_system():
+    """The 4B's intent-parser system prompt — read the conversation, emit ONE JSON decision."""
+    return (
+        "You are the intent parser for a film studio's chat assistant. Read the conversation and "
+        "output ONE JSON object describing what the user wants RIGHT NOW. OUTPUT ONLY THE JSON — no "
+        "prose, no markdown fences.\n\n"
+        "{\n"
+        '  "intent": "brief|revise|stack|question|confirm|smalltalk|cancel",\n'
+        '  "brief": "<the ONE-LINE film the user currently wants, or empty string>",\n'
+        '  "stack_patch": {"video_lane": "", "keyframe_lane": "", "continuity": "", "music": true, "narration": true, "seconds": 0},\n'
+        '  "confirm": false,\n'
+        '  "reply": "<a warm, concise 1-2 sentence reply to the user>"\n'
+        "}\n\n"
+        "Rules:\n"
+        "- brief: the film the user wants, using their LATEST description. If they CHANGED the subject "
+        "(\"actually make it a bookstore promo\"), use the NEW one. Empty if they haven't described a film yet.\n"
+        "- stack_patch: include ONLY settings the user explicitly asked for; OMIT keys they didn't mention. "
+        "video_lane ∈ {wan, ltx, sulphur, 10eros}; keyframe_lane ∈ {chroma, zimage, krea, hidream}; "
+        "continuity ∈ {storyboard, hero, chain, none}; music/narration are booleans; seconds is the requested length.\n"
+        "- confirm: true ONLY if the user is telling you to START rendering now (\"go\", \"yes do it\", "
+        "\"go with ltx\", \"render it\"). A change request like \"make it 30 seconds\" is NOT a confirm.\n"
+        "- intent: brief = first/main film description; revise = changing the film; stack = changing a "
+        "setting/model; question = asking something; confirm = start now; smalltalk = greeting/chit-chat; "
+        "cancel = stop/never mind.\n"
+        "- reply: what to say back, warm and concise. For a question, ANSWER it. Never claim rendering "
+        "has started (only the word \"go\" starts it).\n"
+        "Output ONLY the JSON object."
+    )
+
+
+def _extract_json(text):
+    """First balanced {...} object out of the model's reply, or None."""
+    t = (text or "").strip()
+    if t.startswith("```"):
+        t = t.strip("`")
+        t = t[4:] if t[:4].lower() == "json" else t
+    i = t.find("{")
+    if i < 0:
+        return None
+    depth = 0
+    for j in range(i, len(t)):
+        if t[j] == "{":
+            depth += 1
+        elif t[j] == "}":
+            depth -= 1
+            if depth == 0:
+                try:
+                    return json.loads(t[i:j + 1])
+                except Exception:
+                    return None
+    return None
+
+
+def parse_controller_json(raw):
+    """Parse the controller's reply into a dict, or None (→ caller falls back to heuristics)."""
+    d = _extract_json(raw)
+    return d if isinstance(d, dict) else None
+
+
+def normalize_decision(parsed):
+    """Validate + clean a parsed controller dict → a usable decision, or None.
+
+    Drops unknown lanes (never silently coerced — the heuristic floor fills them), coerces
+    types, and clamps `seconds`. None only when there's nothing usable to act on.
+    """
+    if not isinstance(parsed, dict):
+        return None
+    brief = str(parsed.get("brief") or "").strip()
+
+    # The controller owns ONLY the explicit MODEL/continuity picks. music/narration/seconds are
+    # deliberately NOT taken from the LLM — the 4B over-reaches on them (e.g. it stripped music +
+    # narration from a "bookstore promo" nobody asked to silence). Those stay keyword-driven in the
+    # pipe (`_overrides`: "no music" / "30 seconds" are reliable + explicit). Unknown lanes are
+    # DROPPED, never coerced — the keyword floor fills the gap.
+    raw_patch = parsed.get("stack_patch") or {}
+    patch = {}
+    if isinstance(raw_patch, dict):
+        v = str(raw_patch.get("video_lane") or "").strip().lower()
+        if v in VIDEO_LANES_VALID:
+            patch["video_lane"] = v
+        k = str(raw_patch.get("keyframe_lane") or "").strip().lower()
+        if k in KEYFRAME_LANES_VALID:
+            patch["keyframe_lane"] = k
+        c = str(raw_patch.get("continuity") or "").strip().lower()
+        if c in CONTINUITY_VALID:
+            patch["continuity"] = c
+
+    intent = str(parsed.get("intent") or "").strip().lower()
+    if intent not in INTENTS:
+        intent = "brief" if brief else "smalltalk"
+    reply = str(parsed.get("reply") or "").strip() or None
+    return {
+        "brief": brief,
+        "stack_patch": patch,
+        "confirm": bool(parsed.get("confirm")),
+        "intent": intent,
+        "reply": reply,
+    }
+
+
+def decide_action(brief, confirmed, intent):
+    """Route a resolved turn to ONE pipe action. Pure — the pipe handles the rendering.
+
+      build      → a brief is set AND the user confirmed (corroborated) → start the render
+      need_brief → the user confirmed but there's nothing to build yet
+      proposal   → a brief is set and the plan is new/changed (brief/revise/stack) → show the card
+      chat       → answer the user naturally (no brief yet, or a question/smalltalk/cancel)
+    """
+    if confirmed:
+        return "build" if brief else "need_brief"
+    if not brief:
+        return "chat"
+    return "chat" if intent in ("question", "smalltalk", "cancel") else "proposal"

--- a/services/studio/production/tests/test_director_intent.py
+++ b/services/studio/production/tests/test_director_intent.py
@@ -88,5 +88,92 @@ class TestPickBrief(unittest.TestCase):
         self.assertEqual(di.pick_brief(["hi", "hello", "what can you do?"]), "")
 
 
+class TestConfirmWord(unittest.TestCase):
+    """has_confirm_word corroborates the LLM confirm so a render never fires on a hallucination."""
+
+    def test_start_signals(self):
+        for t in ["go", "go with ltx", "yes do it", "render it", "let's go", "ok go", "build it now"]:
+            self.assertTrue(di.has_confirm_word(t), t)
+
+    def test_non_starts(self):
+        for t in ["use ltx", "what about hidream?", "a noir short", "30 seconds"]:
+            self.assertFalse(di.has_confirm_word(t), t)
+
+
+class TestParseControllerJson(unittest.TestCase):
+    def test_plain_and_fenced(self):
+        self.assertEqual(di.parse_controller_json('{"intent": "confirm", "confirm": true}')["confirm"], True)
+        self.assertEqual(di.parse_controller_json('```json\n{"a": 1}\n```')["a"], 1)
+        # leading chatter + trailing text → still pulls the object
+        self.assertEqual(di.parse_controller_json('sure! {"a": {"b": 2}} hope that helps')["a"]["b"], 2)
+
+    def test_garbage_is_none(self):
+        for bad in ["", "no json here", "{unbalanced", "[1,2,3]"]:
+            self.assertIsNone(di.parse_controller_json(bad), bad)
+
+
+class TestNormalizeDecision(unittest.TestCase):
+    def test_valid_decision_keeps_only_lane_picks(self):
+        d = di.normalize_decision({
+            "intent": "stack", "brief": "a noir short",
+            "stack_patch": {"video_lane": "ltx", "keyframe_lane": "hidream", "music": False, "seconds": 30},
+            "confirm": False, "reply": "Switching to LTX."})
+        self.assertEqual(d["brief"], "a noir short")
+        # music/seconds are NOT taken from the LLM (keyword floor owns them) — lanes only
+        self.assertEqual(d["stack_patch"], {"video_lane": "ltx", "keyframe_lane": "hidream"})
+        self.assertNotIn("music", d["stack_patch"])
+        self.assertNotIn("seconds", d["stack_patch"])
+        self.assertEqual(d["intent"], "stack")
+        self.assertEqual(d["reply"], "Switching to LTX.")
+
+    def test_drops_unknown_lanes_and_bad_types(self):
+        d = di.normalize_decision({
+            "intent": "stack",
+            "stack_patch": {"video_lane": "veo", "keyframe_lane": "dalle", "continuity": "morph",
+                            "music": "yes", "seconds": 99999}})
+        self.assertEqual(d["stack_patch"], {})   # every invalid value dropped, none coerced
+
+    def test_intent_defaulted_and_confirm_coerced(self):
+        self.assertEqual(di.normalize_decision({"brief": "x"})["intent"], "brief")
+        self.assertEqual(di.normalize_decision({"brief": ""})["intent"], "smalltalk")
+        self.assertEqual(di.normalize_decision({"confirm": 1, "brief": "x"})["confirm"], True)
+
+    def test_none_on_non_dict(self):
+        self.assertIsNone(di.normalize_decision(None))
+        self.assertIsNone(di.normalize_decision("nope"))
+
+    def test_controller_system_lists_the_valid_slots(self):
+        s = di.build_controller_system()
+        for tok in ("wan", "ltx", "sulphur", "10eros", "chroma", "hidream", "storyboard", "confirm"):
+            self.assertIn(tok, s)
+
+
+class TestDecideAction(unittest.TestCase):
+    """The pipe routes a resolved turn through decide_action — the core branch logic."""
+
+    def test_build_only_when_brief_and_confirmed(self):
+        self.assertEqual(di.decide_action("a noir short", True, "confirm"), "build")
+
+    def test_confirm_without_brief_needs_a_brief(self):
+        self.assertEqual(di.decide_action("", True, "confirm"), "need_brief")
+
+    def test_no_brief_is_chat(self):
+        self.assertEqual(di.decide_action("", False, "smalltalk"), "chat")
+        self.assertEqual(di.decide_action("", False, "question"), "chat")
+
+    def test_brief_with_question_or_smalltalk_is_chat(self):
+        self.assertEqual(di.decide_action("a noir short", False, "question"), "chat")
+        self.assertEqual(di.decide_action("a noir short", False, "smalltalk"), "chat")
+        self.assertEqual(di.decide_action("a noir short", False, "cancel"), "chat")
+
+    def test_brief_with_plan_change_shows_proposal(self):
+        for intent in ("brief", "revise", "stack"):
+            self.assertEqual(di.decide_action("a noir short", False, intent), "proposal", intent)
+
+    def test_confirmed_wins_over_intent(self):
+        # a corroborated confirm builds even if the LLM labeled the intent "stack" ("go with ltx")
+        self.assertEqual(di.decide_action("a noir short", True, "stack"), "build")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/services/studio/production/tests/test_stack.py
+++ b/services/studio/production/tests/test_stack.py
@@ -54,6 +54,18 @@ class TestResolveStack(unittest.TestCase):
             self.assertEqual(S.resolve_stack(video_lane=lane).video_lane, lane)
         self.assertEqual(sorted(S.wired_video_lanes()), ["10eros", "ltx", "sulphur", "wan"])
 
+    def test_controller_lane_constants_match_stack(self):
+        # The injected intent controller duplicates the lane menus (it can't import stack.py —
+        # it runs in the OWUI container). Guard the duplication against drift.
+        import os as _os
+        import sys as _sys
+        # services/studio/production/tests/ -> services/studio (where director_intent.py lives)
+        _sys.path.insert(0, _os.path.dirname(_os.path.dirname(_os.path.dirname(
+            _os.path.abspath(__file__)))))
+        import director_intent as di
+        self.assertEqual(sorted(di.VIDEO_LANES_VALID), sorted(S.wired_video_lanes()))
+        self.assertEqual(sorted(di.KEYFRAME_LANES_VALID), sorted(S.wired_keyframe_lanes()))
+
     def test_capabilities_match_wired_video_lanes(self):
         # F8 drift guard: every wired video lane (stack.py) must have a capability contract
         # the planner is shown, else the 4B plans against the wrong lane's physics.

--- a/services/studio/studio_pipe.py
+++ b/services/studio/studio_pipe.py
@@ -57,6 +57,7 @@ The bug this fixes (Codex F1, 2026-06-29): the old gate classified "can you make
 short?" as a question and dropped it, so no brief was ever captured. A GENERATION REQUEST now
 takes precedence over question-shape, so a creation ask phrased as a question is still a brief.
 """
+import json
 import re
 
 # Exact-match small-talk + confirmation vocabularies (matched on a normalized turn).
@@ -124,6 +125,156 @@ def pick_brief(turns, pure_override_of=None):
         if is_brief_candidate(t, po(t)):
             return t
     return ""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Batch 2 — the structured LLM intent controller (Codex F1/F2/F3).
+#
+# The keyword classifiers above are the deterministic FLOOR/FALLBACK. The controller
+# asks the 4B to read the whole conversation and emit ONE small JSON decision —
+# {intent, brief, stack_patch, confirm, reply} — which the pipe merges ON TOP of the
+# floor (LLM brief/stack win when present; the floor fills the gaps). The pure parse +
+# validation below is table-tested; the HTTP call + fallback orchestration live in the
+# pipe (`_classify`). A render only starts when the decision says confirm AND the latest
+# turn carries a real confirm word (has_confirm_word) — the irreversible action is never
+# triggered on the LLM's say-so alone.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Valid slot values — MUST mirror the wired lanes in production/stack.py (guarded by
+# test_controller_lane_constants_match_stack). The pipe can't import stack.py (it runs
+# in the OWUI container), so these are duplicated here, same as the pipe's own lane maps.
+VIDEO_LANES_VALID = ("wan", "ltx", "sulphur", "10eros")
+KEYFRAME_LANES_VALID = ("chroma", "zimage", "krea", "hidream")
+CONTINUITY_VALID = ("storyboard", "hero", "chain", "none")
+INTENTS = ("brief", "revise", "stack", "question", "confirm", "smalltalk", "cancel")
+
+# A turn that signals "start rendering NOW" — used to CORROBORATE the LLM's confirm flag
+# so an expensive render never fires on a hallucinated confirm. Looser than is_confirm
+# (exact-match) so compound asks like "go with LTX" still count.
+_CONFIRM_WORD_RE = re.compile(r"\b(go|yes|yeah|yep|sure|start|render|build|proceed|confirm|okay?)\b", re.I)
+_CONFIRM_PHRASES = ("do it", "go ahead", "let's go", "lets go", "ok go", "render it",
+                    "build it", "make it", "ship it", "send it")
+
+
+def has_confirm_word(t):
+    """Does this turn carry an explicit 'start now' signal? (corroborates the LLM confirm)."""
+    tl = (t or "").lower()
+    return bool(_CONFIRM_WORD_RE.search(tl)) or any(p in tl for p in _CONFIRM_PHRASES)
+
+
+def build_controller_system():
+    """The 4B's intent-parser system prompt — read the conversation, emit ONE JSON decision."""
+    return (
+        "You are the intent parser for a film studio's chat assistant. Read the conversation and "
+        "output ONE JSON object describing what the user wants RIGHT NOW. OUTPUT ONLY THE JSON — no "
+        "prose, no markdown fences.\n\n"
+        "{\n"
+        '  "intent": "brief|revise|stack|question|confirm|smalltalk|cancel",\n'
+        '  "brief": "<the ONE-LINE film the user currently wants, or empty string>",\n'
+        '  "stack_patch": {"video_lane": "", "keyframe_lane": "", "continuity": "", "music": true, "narration": true, "seconds": 0},\n'
+        '  "confirm": false,\n'
+        '  "reply": "<a warm, concise 1-2 sentence reply to the user>"\n'
+        "}\n\n"
+        "Rules:\n"
+        "- brief: the film the user wants, using their LATEST description. If they CHANGED the subject "
+        "(\"actually make it a bookstore promo\"), use the NEW one. Empty if they haven't described a film yet.\n"
+        "- stack_patch: include ONLY settings the user explicitly asked for; OMIT keys they didn't mention. "
+        "video_lane ∈ {wan, ltx, sulphur, 10eros}; keyframe_lane ∈ {chroma, zimage, krea, hidream}; "
+        "continuity ∈ {storyboard, hero, chain, none}; music/narration are booleans; seconds is the requested length.\n"
+        "- confirm: true ONLY if the user is telling you to START rendering now (\"go\", \"yes do it\", "
+        "\"go with ltx\", \"render it\"). A change request like \"make it 30 seconds\" is NOT a confirm.\n"
+        "- intent: brief = first/main film description; revise = changing the film; stack = changing a "
+        "setting/model; question = asking something; confirm = start now; smalltalk = greeting/chit-chat; "
+        "cancel = stop/never mind.\n"
+        "- reply: what to say back, warm and concise. For a question, ANSWER it. Never claim rendering "
+        "has started (only the word \"go\" starts it).\n"
+        "Output ONLY the JSON object."
+    )
+
+
+def _extract_json(text):
+    """First balanced {...} object out of the model's reply, or None."""
+    t = (text or "").strip()
+    if t.startswith("```"):
+        t = t.strip("`")
+        t = t[4:] if t[:4].lower() == "json" else t
+    i = t.find("{")
+    if i < 0:
+        return None
+    depth = 0
+    for j in range(i, len(t)):
+        if t[j] == "{":
+            depth += 1
+        elif t[j] == "}":
+            depth -= 1
+            if depth == 0:
+                try:
+                    return json.loads(t[i:j + 1])
+                except Exception:
+                    return None
+    return None
+
+
+def parse_controller_json(raw):
+    """Parse the controller's reply into a dict, or None (→ caller falls back to heuristics)."""
+    d = _extract_json(raw)
+    return d if isinstance(d, dict) else None
+
+
+def normalize_decision(parsed):
+    """Validate + clean a parsed controller dict → a usable decision, or None.
+
+    Drops unknown lanes (never silently coerced — the heuristic floor fills them), coerces
+    types, and clamps `seconds`. None only when there's nothing usable to act on.
+    """
+    if not isinstance(parsed, dict):
+        return None
+    brief = str(parsed.get("brief") or "").strip()
+
+    # The controller owns ONLY the explicit MODEL/continuity picks. music/narration/seconds are
+    # deliberately NOT taken from the LLM — the 4B over-reaches on them (e.g. it stripped music +
+    # narration from a "bookstore promo" nobody asked to silence). Those stay keyword-driven in the
+    # pipe (`_overrides`: "no music" / "30 seconds" are reliable + explicit). Unknown lanes are
+    # DROPPED, never coerced — the keyword floor fills the gap.
+    raw_patch = parsed.get("stack_patch") or {}
+    patch = {}
+    if isinstance(raw_patch, dict):
+        v = str(raw_patch.get("video_lane") or "").strip().lower()
+        if v in VIDEO_LANES_VALID:
+            patch["video_lane"] = v
+        k = str(raw_patch.get("keyframe_lane") or "").strip().lower()
+        if k in KEYFRAME_LANES_VALID:
+            patch["keyframe_lane"] = k
+        c = str(raw_patch.get("continuity") or "").strip().lower()
+        if c in CONTINUITY_VALID:
+            patch["continuity"] = c
+
+    intent = str(parsed.get("intent") or "").strip().lower()
+    if intent not in INTENTS:
+        intent = "brief" if brief else "smalltalk"
+    reply = str(parsed.get("reply") or "").strip() or None
+    return {
+        "brief": brief,
+        "stack_patch": patch,
+        "confirm": bool(parsed.get("confirm")),
+        "intent": intent,
+        "reply": reply,
+    }
+
+
+def decide_action(brief, confirmed, intent):
+    """Route a resolved turn to ONE pipe action. Pure — the pipe handles the rendering.
+
+      build      → a brief is set AND the user confirmed (corroborated) → start the render
+      need_brief → the user confirmed but there's nothing to build yet
+      proposal   → a brief is set and the plan is new/changed (brief/revise/stack) → show the card
+      chat       → answer the user naturally (no brief yet, or a question/smalltalk/cancel)
+    """
+    if confirmed:
+        return "build" if brief else "need_brief"
+    if not brief:
+        return "chat"
+    return "chat" if intent in ("question", "smalltalk", "cancel") else "proposal"
 
 # ── end injected intent classifiers ──
 
@@ -483,6 +634,28 @@ class Pipe:
                                      headers={"Content-Type": "application/json"})
         return json.load(urllib.request.urlopen(req, timeout=120))["choices"][0]["message"]["content"].strip()
 
+    def _classify(self, turns, plan_ctx=""):
+        """Batch-2 LLM intent controller (blocking; call via run_in_executor).
+
+        Reads the whole conversation and returns a validated decision dict
+        {intent, brief, stack_patch, confirm, reply}, or None on any failure (→ the caller
+        falls back to the Batch-1 keyword heuristics). build_controller_system /
+        parse_controller_json / normalize_decision are injected from director_intent.py."""
+        convo = "\n".join("User: " + t for t in turns[-10:])
+        u = (("Current plan: " + plan_ctx + "\n\n") if plan_ctx else "") + "Conversation:\n" + convo
+        body = json.dumps({"model": self.valves.chat_model,
+                           "messages": [{"role": "system", "content": build_controller_system()},
+                                        {"role": "user", "content": u}],
+                           "max_tokens": 320, "temperature": 0.2,
+                           "chat_template_kwargs": {"enable_thinking": False}}).encode()
+        try:
+            req = urllib.request.Request(self.valves.chat_url + "/chat/completions", data=body,
+                                         headers={"Content-Type": "application/json"})
+            raw = json.load(urllib.request.urlopen(req, timeout=45))["choices"][0]["message"]["content"]
+            return normalize_decision(parse_controller_json(raw))
+        except Exception:
+            return None   # director unreachable / bad JSON → caller uses the keyword floor
+
     # ── long-clip (>15s) via the orchestrator: chain ~10s segments → one combined video ──
     def _target_seconds(self, text):
         """Parse a requested duration from the user's text. 0 = none (single clip)."""
@@ -821,14 +994,42 @@ class Pipe:
             def _pure_override(t):
                 return bool(_overrides(t)) and len(t.split()) <= 5
 
-            # effective brief = the first turn that reads as a film brief. A GENERATION REQUEST
-            # ("can you make a 30s noir short?", "do a 1-min documentary on Pakistan") counts even
-            # though it's question-shaped — the old gate dropped those as questions and never
-            # captured a brief, so it dove into chit-chat (Codex F1, 2026-06-29).
-            brief = pick_brief(users, _pure_override)
+            # ── FLOOR (Batch 1): deterministic keyword heuristics — the fallback when the LLM is down.
+            # A GENERATION REQUEST ("can you make a 30s noir short?") counts as a brief even though
+            # it's question-shaped (Codex F1, 2026-06-29).
+            brief_kw = pick_brief(users, _pure_override)
             ov = {}
             for t in users:
-                ov.update(_overrides(t))         # accumulate tweaks across the convo (later wins)
+                ov.update(_overrides(t))         # accumulate explicit tweaks across the convo (later wins)
+            confirm_kw = _is_confirm(last)
+
+            # ── CONTROLLER (Batch 2): the 4B reads the WHOLE conversation and returns a structured
+            # decision {intent, brief, stack_patch(lanes), confirm, reply}. It REFINES the floor —
+            # a mid-chat brief change ("actually make it a bookstore promo"), a compound confirm
+            # ("go with ltx"), a natural question — and FALLS BACK to the floor on any failure. A
+            # render starts only when the decision says confirm AND the latest turn carries a real
+            # confirm word (has_confirm_word) — never on the LLM's say-so alone (Codex F1/F2/F3).
+            _pshots = max(1, math.ceil(ov["seconds"] / 5.0)) if ov.get("seconds") else 0
+            _prelim_ctx = "film so far: %s; video=%s%s" % (
+                brief_kw or "(none described yet)",
+                ov.get("video_lane") or (self.valves.production_video_lane or "auto"),
+                (", ~%d shots" % _pshots) if _pshots else "")
+            _decision = await loop.run_in_executor(None, self._classify, users, _prelim_ctx)
+            if _decision:
+                brief = _decision["brief"] or brief_kw
+                for _k, _v in _decision["stack_patch"].items():
+                    ov.setdefault(_k, _v)        # keyword floor wins; the LLM only fills a lane it left blank
+                confirmed = (_decision["confirm"] or confirm_kw) and has_confirm_word(last)
+                intent = _decision["intent"]
+                llm_reply = _decision["reply"]
+            else:
+                brief = brief_kw
+                confirmed = confirm_kw
+                intent = ("confirm" if confirm_kw
+                          else "question" if (_is_question(last) and last != brief_kw and not _overrides(last))
+                          else "stack" if (last == brief_kw or _overrides(last)) else "smalltalk")
+                llm_reply = None
+
             video = ov.get("video_lane") or (self.valves.production_video_lane or "auto")
             keyf = ov.get("keyframe_lane") or (self.valves.production_keyframe_lane or "auto")
             cont = ov.get("continuity") or (self.valves.production_continuity or "auto")
@@ -878,20 +1079,20 @@ class Pipe:
                 except Exception:
                     return None   # director unreachable
 
-            # no brief yet → converse NATURALLY (greeting / question), never a render
-            if not brief:
-                if _is_confirm(last):
-                    return ("Nothing to start yet — give me a one-line brief first, e.g. "
-                            "“a 1-minute documentary on the history of Pakistan”.")
-                return (await _chat(last, "")) or _help
-
-            # have a brief, not confirming → show the plan when it's new/changed, else just chat
-            if not _is_confirm(last):
-                if last == brief or _overrides(last):   # the brief itself, or a settings tweak → plan card
-                    await status("", True)
-                    return _proposal()
-                # a question / chit-chat about the plan → answer naturally (NOT a canned re-dump)
-                return (await _chat(last, _plan_ctx)) or _proposal()
+            # route the resolved turn → ONE action (tested: director_intent.decide_action).
+            action = decide_action(brief, confirmed, intent)
+            if action == "need_brief":
+                return ("Nothing to start yet — give me a one-line brief first, e.g. "
+                        "“a 1-minute documentary on the history of Pakistan”.")
+            if action == "chat":
+                # the LLM's own reply when it has one, else a fresh director chat call; the static
+                # fallback is the plan card (if we have a brief) or the help line.
+                return llm_reply or (await _chat(last, _plan_ctx if brief else "")) or \
+                    (_proposal() if brief else _help)
+            if action == "proposal":
+                await status("", True)
+                return _proposal()
+            # action == "build" → fall through to the resolved-plan build below
 
             # CONFIRMED + have a brief → build with the resolved plan
             await status("\U0001F3AC Starting “" + brief + "” — " + str(shots) + " shots, ~" +


### PR DESCRIPTION
The Production lane was a keyword state machine — the 4B only wrote reply prose *after* Python had decided intent, so it felt natural only when phrasing matched the regexes (Codex Q1). It also latched the brief to the first turn (couldn't change the film mid-chat, **F2**) and couldn't parse a compound *"go with ltx"* (**F3**).

## What changed

A **structured intent controller**: the 4B reads the whole conversation and returns ONE JSON decision `{intent, brief, stack_patch, confirm, reply}`. The **Batch-1 keyword heuristics stay as the deterministic floor + fallback**, so this is strictly ≥ before.

- **brief** — the LLM's *current* desired film (so the user can change the subject mid-chat) or the floor brief.
- **stack_patch** — explicit **model/continuity picks only**. The LLM does *not* own `music`/`narration`/`seconds` (it over-reached — stripped music from a "bookstore promo" nobody asked to silence); those stay keyword-driven. Unknown lanes dropped, never coerced; the keyword floor wins on conflict.
- **confirmed** = `(LLM.confirm OR floor.confirm) AND has_confirm_word(last)` — a render **never** fires on the LLM's say-so alone; the latest turn must carry a real confirm word. So *"go with ltx"* builds (F3) but *"make it 30 seconds"* never does.
- **reply** — the LLM's contextual answer, reused for chat (no second call).
- **`decide_action(brief, confirmed, intent)`** → `build | proposal | chat | need_brief` (pure, tested).

On any LLM failure (timeout / bad JSON) it falls back to the Batch-1 floor. All new logic is stdlib-only in `director_intent.py`, **injected** into the pipe and table-tested.

## Validation

End-to-end against the **live 4B** (classifier + merge + `decide_action`) — **8/8 actions correct**:

| Turn(s) | Action | Note |
|---|---|---|
| "can you make a 30s noir short?" | proposal | F1 — brief captured |
| "make a noir short" → "actually make it a bookstore promo" | proposal | **F2 — new brief** |
| "make a noir short" → "go with ltx" | **build + ltx** | **F3 — compound confirm** |
| the real failing transcript | proposal | brief captured |
| "what other options do we have?" | chat | answered |
| "hi" | chat | greeting |
| "go" (after brief) | build | |
| "go" (no brief) | need_brief | |

**119 offline unittests green**; pipe rebuilt + `py_compile`-clean.

## Out of scope (Codex Batch 3)
Semantic critic before render, selective thinking-on, cross-lane Studio router.

🤖 Generated with [Claude Code](https://claude.com/claude-code)