### PR TITLE
Director Batch 3 (Codex): semantic plan critic before render

### DIFF
--- a/services/studio/production/critic.py
+++ b/services/studio/production/critic.py
@@ -1,0 +1,162 @@
+"""Semantic plan critic — 'is this a GOOD plan?', not just 'is it valid JSON?'.
+
+Runs AFTER schema.validate() and BEFORE render, inside the planner's repair loop (Codex F5).
+'Valid JSON' is not 'good film plan': the schema can't tell that a documentary wandered
+off-topic, that shots repeat, or that the narration won't fit. Two layers:
+
+  - DETERMINISTIC checks (no LLM, always run, reliable): narration that won't fit its shot
+    window, near-duplicate shots, a documentary that smuggled in fictional characters.
+  - an LLM SEMANTIC critique (conservative, thinking-ON, FAIL-OPEN): does every shot serve the
+    brief? does the plan drift off-topic partway through? — the general form of the "documentary
+    became a character drama about Arif" bug (the genre detector fixed one special case; this
+    catches the class). It judges with reasoning on, and is parsed defensively.
+
+critique() returns a list of blocking issue strings — empty = ship. It FAILS OPEN: a flaky or
+unreachable critic must NEVER block a render, so any LLM error degrades to deterministic-only.
+"""
+from __future__ import annotations
+
+import json
+
+from .util import strip_reasoning
+
+WORDS_PER_SEC = 2.5            # Kokoro ≈ 2.5 wps; matches the planner's narration budget
+NARRATION_SLACK_WORDS = 3     # a little headroom before we flag
+DUP_JACCARD = 0.85            # near-identical prompt_intent → a lazy duplicate shot
+
+
+def _tokens(s):
+    return {w for w in "".join(c.lower() if c.isalnum() else " " for c in (s or "")).split()
+            if len(w) > 2}
+
+
+def deterministic_issues(plan, fmt="narrative"):
+    """Cheap, reliable checks that need no model. Returns a list of issue strings."""
+    issues = []
+    shots = list(plan.shots)
+
+    # 1) narration that won't fit its shot window
+    for s in shots:
+        narr = (s.narration or "").strip()
+        if not narr:
+            continue
+        budget = max(1, int(s.target_seconds * WORDS_PER_SEC) + NARRATION_SLACK_WORDS)
+        wc = len(narr.split())
+        if wc > budget:
+            issues.append(f"shot {s.id}: narration is {wc} words but only ~{budget} fit in "
+                          f"{s.target_seconds:.0f}s — shorten it to one short sentence")
+
+    # 2) near-duplicate shots (lazy repetition)
+    for i in range(len(shots)):
+        ti = _tokens(shots[i].prompt_intent)
+        if not ti:
+            continue
+        for j in range(i + 1, len(shots)):
+            tj = _tokens(shots[j].prompt_intent)
+            if tj and len(ti & tj) / len(ti | tj) >= DUP_JACCARD:
+                issues.append(f"shots {shots[i].id} and {shots[j].id} are near-duplicates — "
+                              f"make each shot visually distinct")
+                break
+
+    # 3) a documentary must carry no invented characters (belt-and-suspenders; normalize strips them)
+    if fmt == "documentary" and getattr(plan, "characters", None):
+        names = ", ".join(c.name for c in plan.characters)
+        issues.append(f"this is a DOCUMENTARY but it invents characters ({names}) — "
+                      f"a documentary has no fictional protagonist")
+
+    return issues
+
+
+# Per-shot RELEVANCE framing — a live A/B (2026-06-29) showed the 4B is far better at the bounded
+# "is shot N about the brief's subject?" judgement than a holistic "is this a good plan?" verdict
+# (which it rubber-stamped, missing obvious drift). It also showed thinking-ON returns EMPTY output
+# on this model (the <think> budget eats the answer) — so the critic runs thinking-OFF.
+CRITIC_SYS = (
+    "You review a film's shot list against its BRIEF and FORMAT. Output ONLY JSON:\n"
+    '{"off_topic": [shot numbers that do NOT serve the brief], "issues": ["other clear problems"]}\n'
+    "Judge EACH numbered shot:\n"
+    "- off_topic: list a shot's number if it does NOT depict the BRIEF's real subject. For a "
+    "DOCUMENTARY / factual / historical brief, a generic modern person, an INVENTED character, or "
+    "an unrelated everyday scene (office, park, shopping, a person's daily life) is OFF-TOPIC. For a "
+    "NARRATIVE brief, a shot unrelated to the story is off-topic.\n"
+    "- issues: ONLY other clear, important problems — the plan repeats the same shot, or a "
+    "documentary uses vague poetic narration instead of factual narration (real names/places/dates).\n"
+    "Do NOT nitpick style, word choice, camera angles, or creative taste. If every shot serves the "
+    "brief and the plan is coherent, return {\"off_topic\": [], \"issues\": []}. Output ONLY the JSON."
+)
+
+
+def _plan_digest(plan, brief, fmt):
+    lines = [f"BRIEF: {brief}", f"FORMAT: {fmt}", "SHOTS:"]
+    for i, s in enumerate(plan.ordered_shots(), 1):
+        narr = (s.narration or "").strip()
+        lines.append(f"{i}. {s.prompt_intent.strip()}" + (f"  [narration: {narr}]" if narr else ""))
+    return "\n".join(lines)
+
+
+def parse_critique(raw):
+    """Parse the LLM critique into {ok, issues}, or None on failure (after stripping reasoning)."""
+    t = strip_reasoning(raw)
+    i = t.find("{")
+    if i < 0:
+        return None
+    depth = 0
+    for j in range(i, len(t)):
+        if t[j] == "{":
+            depth += 1
+        elif t[j] == "}":
+            depth -= 1
+            if depth == 0:
+                try:
+                    d = json.loads(t[i:j + 1])
+                    return d if isinstance(d, dict) else None
+                except Exception:
+                    return None
+    return None
+
+
+def normalize_critique(parsed):
+    """A parsed critique → a list of blocking issue strings ([] = on-topic / not actionable).
+
+    Accepts the per-shot relevance shape {"off_topic": [shot numbers], "issues": [...]}.
+    """
+    if not isinstance(parsed, dict):
+        return []
+    out = []
+    off = parsed.get("off_topic")
+    if isinstance(off, list):
+        for n in off:
+            n = str(n).strip()
+            if n:
+                out.append(f"shot {n} is off-topic — replace it with one that depicts the brief's subject")
+    issues = parsed.get("issues")
+    if isinstance(issues, list):
+        out += [str(x).strip() for x in issues if str(x).strip()]
+    return out
+
+
+def llm_issues(plan, brief, fmt, call, *, prov=None):
+    """The semantic critique. FAILS OPEN: any error → [] (deterministic checks still apply).
+
+    Runs thinking-OFF: a 2026-06-29 A/B showed thinking-on returns EMPTY output on the 4B
+    director (the <think> budget eats the JSON), while thinking-off + the per-shot framing
+    catches drift reliably. extract/parse still strip <think> defensively (F7)."""
+    if call is None:
+        return []
+    user = _plan_digest(plan, brief, fmt) + "\n\nReview this plan. Output ONLY the JSON."
+    try:
+        # temperature 0 (greedy): a 2026-06-29 A/B showed temp 0.2 was noisy run-to-run (it
+        # missed drift AND false-flagged a clean plan ~1/3 of the time); greedy decoding is
+        # reliable — drift → every off-topic shot flagged, a clean plan → no issues.
+        raw = call([{"role": "system", "content": CRITIC_SYS}, {"role": "user", "content": user}],
+                   max_tokens=400, temperature=0.0, enable_thinking=False)
+    except Exception:
+        return []
+    if prov is not None:
+        prov.append(("critic", CRITIC_SYS, user, raw))
+    return normalize_critique(parse_critique(raw))
+
+
+def critique(plan, brief, fmt="narrative", *, call=None, prov=None):
+    """All blocking issues (deterministic + LLM). Empty list = ship. Fails open on LLM error."""
+    return deterministic_issues(plan, fmt) + llm_issues(plan, brief, fmt, call, prov=prov)

--- a/services/studio/production/planner.py
+++ b/services/studio/production/planner.py
@@ -18,11 +18,12 @@ import os
 import re
 import urllib.request
 
-from . import config
+from . import config, critic
 from .manifest import Artifact
-from .prompts import build_plan_system, build_treatment_system, detect_format, repair_user
+from .prompts import (build_plan_system, build_treatment_system, critic_repair_user,
+                      detect_format, repair_user)
 from .schema import PlanError, ProductionPlanV1
-from .util import sha256_text
+from .util import sha256_text, strip_reasoning
 
 
 class PlannerError(RuntimeError):
@@ -62,14 +63,19 @@ def derive_shots(brief: str, *, default: int = DEFAULT_SHOTS):
 
 # -- director call (the injectable boundary) ----------------------------------
 def director_call(messages: list[dict], *, max_tokens: int, temperature: float,
-                  base: str | None = None, timeout: int = 120) -> str:
-    """One /v1/chat/completions call to the llama.cpp director. Returns content."""
+                  base: str | None = None, timeout: int = 120,
+                  enable_thinking: bool = False) -> str:
+    """One /v1/chat/completions call to the llama.cpp director. Returns content.
+
+    `enable_thinking` is off for the structured stages (treatment/plan/repair — a <think> block
+    would pollute JSON extraction) and ON for the semantic critic, where reasoning improves the
+    judgement; extract_json/parse_critique strip any <think> block defensively (F6/F7)."""
     payload = {
         "model": config.DIRECTOR_MODEL,
         "messages": messages,
         "max_tokens": max_tokens,
         "temperature": temperature,
-        "chat_template_kwargs": {"enable_thinking": False},
+        "chat_template_kwargs": {"enable_thinking": enable_thinking},
     }
     req = urllib.request.Request(
         (base or config.DIRECTOR_URL).rstrip("/") + "/chat/completions",
@@ -82,7 +88,7 @@ def director_call(messages: list[dict], *, max_tokens: int, temperature: float,
 # -- robust JSON extraction (director emits free-form) ------------------------
 def extract_json(text: str) -> dict:
     """Pull the first balanced {...} object out of the director's reply."""
-    t = (text or "").strip()
+    t = strip_reasoning(text)
     if t.startswith("```"):
         t = t.strip("`")
         t = t[4:] if t[:4].lower() == "json" else t
@@ -210,9 +216,12 @@ def apply_continuity(data: dict, mode: str, *, image_lane: str = "chroma") -> di
 
 
 # -- the planner --------------------------------------------------------------
+MAX_CRITIC_ROUNDS = 1   # one semantic-critic fix attempt, then ship the valid plan (fail-open)
+
+
 def plan_from_brief(brief: str, reg: dict, *, llm=None, max_repairs: int = 3,
                     n_shots: int = 3, continuity: str = "none", stack=None,
-                    prompts_dir: str | None = None):
+                    prompts_dir: str | None = None, use_critic: bool = False):
     """Brief -> (ProductionPlanV1, list[Artifact]). Raises PlannerError on failure.
 
     `llm(messages, *, max_tokens, temperature)` is the injectable director call.
@@ -263,26 +272,43 @@ def plan_from_brief(brief: str, reg: dict, *, llm=None, max_repairs: int = 3,
                 s["narration"] = ""
         return data
 
-    # validator-repair loop
+    # SCHEMA-repair → SEMANTIC-critic loop. Schema errors repair against max_repairs; once a plan
+    # is structurally valid, the critic (deterministic + LLM, fail-open) gets MAX_CRITIC_ROUNDS to
+    # fix CONTENT problems (off-topic drift, repetition, bad narration) before we ship. A critic
+    # that finds nothing — or errors — never blocks: 'valid JSON' degrades to shipping the plan.
     last_err = None
-    for attempt in range(max_repairs + 1):
+    schema_repairs = 0
+    critic_rounds = 0
+    while True:
         try:
-            data = _build(raw)
-            plan = ProductionPlanV1.from_dict(data)     # validates
-            return plan, _write_provenance(prov, prompts_dir)
+            plan = ProductionPlanV1.from_dict(_build(raw))   # parse + schema validate
         except (PlanError, ValueError, json.JSONDecodeError) as e:
             last_err = str(e)
-            if attempt == max_repairs:
-                break
+            if schema_repairs >= max_repairs:
+                _write_provenance(prov, prompts_dir)         # keep the failed trail for debugging
+                raise PlannerError(
+                    f"director could not produce a valid plan after {max_repairs} repairs: {last_err}"
+                )
+            schema_repairs += 1
             ru = repair_user(raw, last_err)
             raw = call([{"role": "system", "content": plan_sys}, {"role": "user", "content": ru}],
                        max_tokens=plan_tokens, temperature=0.2)
-            prov.append((f"repair_{attempt + 1}", plan_sys, ru, raw))
+            prov.append((f"repair_{schema_repairs}", plan_sys, ru, raw))
+            continue
 
-    _write_provenance(prov, prompts_dir)   # keep the failed trail for debugging
-    raise PlannerError(
-        f"director could not produce a valid plan after {max_repairs} repairs: {last_err}"
-    )
+        # structurally valid → critique CONTENT (only while budget remains, so we never re-critique
+        # a plan we're about to ship anyway).
+        issues = (critic.critique(plan, brief, fmt, call=call, prov=prov)
+                  if (use_critic and critic_rounds < MAX_CRITIC_ROUNDS) else [])
+        if issues:
+            critic_rounds += 1
+            ru = critic_repair_user(raw, issues)
+            raw = call([{"role": "system", "content": plan_sys}, {"role": "user", "content": ru}],
+                       max_tokens=plan_tokens, temperature=0.3)
+            prov.append((f"critic_repair_{critic_rounds}", plan_sys, ru, raw))
+            continue
+
+        return plan, _write_provenance(prov, prompts_dir)
 
 
 def _write_provenance(prov, prompts_dir) -> list[Artifact]:

--- a/services/studio/production/prompts.py
+++ b/services/studio/production/prompts.py
@@ -151,3 +151,15 @@ def repair_user(raw: str, error: str) -> str:
         f"PREVIOUS OUTPUT:\n{raw}\n\n"
         "Output a corrected ProductionPlanV1 JSON object ONLY (no prose, no fences) that fixes that error."
     )
+
+
+def critic_repair_user(raw: str, issues: list) -> str:
+    """Re-ask the plan model to fix CONTENT problems the critic found (the plan is valid JSON)."""
+    bullets = "\n".join(f"- {i}" for i in issues)
+    return (
+        "Your plan is valid JSON but has these CONTENT problems:\n"
+        f"{bullets}\n\n"
+        f"PREVIOUS PLAN:\n{raw}\n\n"
+        "Output a corrected ProductionPlanV1 JSON object ONLY (no prose, no fences) that fixes these "
+        "problems. Keep the SAME format, the SAME pinned video lane, and the SAME number of shots."
+    )

--- a/services/studio/production/server.py
+++ b/services/studio/production/server.py
@@ -84,6 +84,7 @@ def _run_job(job_id: str, brief: str, stack: ProductionStack, shots: int, backen
         plan, arts = planner.plan_from_brief(
             brief, registry.load(), n_shots=shots, stack=stack,
             prompts_dir=os.path.join(prod_dir, "prompts"),
+            use_critic=True,   # semantic critic gates content before the (minutes-long) render
         )
         _set(job_id, status="rendering", title=plan.project.title, phase="planned", frac=0.05)
         now_iso = datetime.datetime.now(datetime.timezone.utc).isoformat()

--- a/services/studio/production/tests/test_critic.py
+++ b/services/studio/production/tests/test_critic.py
@@ -1,0 +1,143 @@
+"""Offline tests for the semantic plan critic (services/studio/production/critic.py) and its
+integration into the planner's repair loop (Codex F5/F6/F7). No model/GPU — a stub LLM drives
+the LLM critique; the deterministic checks need nothing.
+
+Run:  python3 -m unittest services.studio.production.tests.test_critic -v
+"""
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+
+from .. import critic
+from ..planner import extract_json, plan_from_brief
+from ..registry import load
+from ..schema import ProductionPlanV1
+from ..util import strip_reasoning
+from .test_v0b import GOOD_PLAN, StubLLM
+
+_BASE = json.loads(GOOD_PLAN)
+
+
+def _plan(mutate=None):
+    d = copy.deepcopy(_BASE)
+    if mutate:
+        mutate(d)
+    return ProductionPlanV1.from_dict(d)
+
+
+class TestDeterministicIssues(unittest.TestCase):
+    def test_clean_plan_has_no_issues(self):
+        self.assertEqual(critic.deterministic_issues(_plan()), [])
+
+    def test_overlong_narration_flagged(self):
+        # 5 s shot → budget ~15 words; 25 words trips it.
+        long = " ".join(["word"] * 25)
+        p = _plan(lambda d: d["shots"][0].update(narration=long))
+        issues = critic.deterministic_issues(p)
+        self.assertTrue(any("narration" in i and "s1" in i for i in issues), issues)
+
+    def test_near_duplicate_shots_flagged(self):
+        same = "a lone detective walks through the rain-slick alley at night"
+        def dup(d):
+            d["shots"][0]["prompt_intent"] = same
+            d["shots"][1]["prompt_intent"] = same
+        issues = critic.deterministic_issues(_plan(dup))
+        self.assertTrue(any("near-duplicate" in i for i in issues), issues)
+
+    def test_documentary_character_leak_flagged(self):
+        def add_char(d):
+            d["characters"] = [{"id": "p", "name": "Arif", "role": "protagonist",
+                                "description": "young man", "seed": 9}]
+            d["shots"][0]["characters"] = ["p"]
+        p = _plan(add_char)
+        issues = critic.deterministic_issues(p, fmt="documentary")
+        self.assertTrue(any("DOCUMENTARY" in i and "Arif" in i for i in issues), issues)
+        # the same plan is fine as a narrative
+        self.assertEqual([i for i in critic.deterministic_issues(p, fmt="narrative")
+                          if "DOCUMENTARY" in i], [])
+
+
+class TestParseAndNormalizeCritique(unittest.TestCase):
+    def test_parse_plain(self):
+        self.assertEqual(critic.parse_critique('{"off_topic": [2], "issues": []}')["off_topic"], [2])
+
+    def test_parse_strips_thinking(self):
+        raw = '<think>let me consider {fake: 1} carefully</think>\n{"off_topic": [], "issues": []}'
+        self.assertEqual(critic.parse_critique(raw), {"off_topic": [], "issues": []})
+
+    def test_parse_garbage_is_none(self):
+        for bad in ["", "no json", "{unbalanced"]:
+            self.assertIsNone(critic.parse_critique(bad), bad)
+
+    def test_normalize(self):
+        # off_topic shot numbers → one issue each
+        out = critic.normalize_critique({"off_topic": [1, 3], "issues": []})
+        self.assertEqual(len(out), 2)
+        self.assertTrue(all("off-topic" in i for i in out), out)
+        # explicit issues pass through (blank dropped)
+        self.assertEqual(critic.normalize_critique({"off_topic": [], "issues": ["a", " ", "b"]}), ["a", "b"])
+        # clean / empty / non-dict → no blocking issues
+        self.assertEqual(critic.normalize_critique({"off_topic": [], "issues": []}), [])
+        self.assertEqual(critic.normalize_critique({}), [])
+        self.assertEqual(critic.normalize_critique(None), [])
+
+
+class TestCritiqueFailsOpen(unittest.TestCase):
+    def test_llm_error_degrades_to_deterministic_only(self):
+        def boom(*a, **k):
+            raise RuntimeError("director down")
+        # a plan with an overlong narration still surfaces the deterministic issue; the LLM error
+        # is swallowed (fail-open) rather than raising.
+        p = _plan(lambda d: d["shots"][0].update(narration=" ".join(["w"] * 30)))
+        issues = critic.critique(p, "brief", "narrative", call=boom)
+        self.assertTrue(issues and all("narration" in i for i in issues), issues)
+
+    def test_no_call_means_deterministic_only(self):
+        self.assertEqual(critic.critique(_plan(), "brief", "narrative", call=None), [])
+
+
+class TestExtractJsonStripsThinking(unittest.TestCase):
+    def test_thinking_block_with_decoy_json_is_ignored(self):
+        raw = '<think>maybe {"project": {"title": "WRONG"}}</think>\n' + GOOD_PLAN
+        self.assertEqual(extract_json(raw)["project"]["title"], "Test")
+
+    def test_strip_reasoning_unclosed(self):
+        # an unclosed <think> (truncated output) → drop the tag, keep what follows so the JSON
+        # remains findable by extract_json.
+        out = strip_reasoning('<think>reasoning... {"a":1}')
+        self.assertNotIn("<think>", out)
+        self.assertIn('{"a":1}', out)
+
+
+class TestPlannerCriticIntegration(unittest.TestCase):
+    def setUp(self):
+        self.reg = load()
+
+    def test_critic_off_by_default_no_extra_calls(self):
+        llm = StubLLM(["treatment", GOOD_PLAN])
+        plan, _ = plan_from_brief("a 10s calm clip", self.reg, llm=llm)   # use_critic defaults False
+        self.assertEqual(len(llm.calls), 2)                              # treatment + plan, no critique
+
+    def test_critic_passes_a_clean_plan(self):
+        llm = StubLLM(["treatment", GOOD_PLAN, '{"ok": true, "issues": []}'])
+        plan, arts = plan_from_brief("a 10s calm clip", self.reg, llm=llm, use_critic=True)
+        self.assertEqual(len(llm.calls), 3)                              # treatment + plan + critique
+        self.assertEqual(len(plan.shots), 2)
+        self.assertNotIn("critic_repair", [a.role for a in arts])
+
+    def test_critic_triggers_one_repair_then_ships(self):
+        # plan #1 is flagged by the critic → one repair → plan #2 ships (no second critique).
+        llm = StubLLM(["treatment", GOOD_PLAN,
+                       '{"ok": false, "issues": ["shot s1 is off-topic"]}', GOOD_PLAN])
+        plan, arts = plan_from_brief("a 10s calm clip", self.reg, llm=llm, use_critic=True)
+        roles = [a.role for a in arts]
+        self.assertIn("critic", roles)
+        self.assertIn("critic_repair_1", roles)
+        self.assertEqual(len(llm.calls), 4)        # treatment + plan + critique + critic-repair
+        self.assertEqual(len(plan.shots), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/studio/production/tests/test_v0b.py
+++ b/services/studio/production/tests/test_v0b.py
@@ -57,8 +57,8 @@ class StubLLM:
         self.responses = list(responses)
         self.calls = []
 
-    def __call__(self, messages, *, max_tokens, temperature):
-        self.calls.append(messages)
+    def __call__(self, messages, *, max_tokens, temperature, **kwargs):
+        self.calls.append(messages)   # **kwargs absorbs enable_thinking (critic stage)
         return self.responses.pop(0)
 
 

--- a/services/studio/production/util.py
+++ b/services/studio/production/util.py
@@ -3,7 +3,24 @@ from __future__ import annotations
 
 import hashlib
 import os
+import re
 import subprocess
+
+_THINK_RE = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
+
+
+def strip_reasoning(text: str) -> str:
+    """Drop <think>…</think> reasoning blocks so a thinking-on stage can't pollute JSON parsing.
+
+    Guardrail for F6/F7: with thinking enabled the model may emit a reasoning block that itself
+    contains JSON-looking text BEFORE the real answer — a balanced-brace scan would grab that.
+    Strip closed blocks; if a <think> opened but never closed, keep everything after the last one
+    (the answer follows the reasoning). Shared by planner.extract_json + critic.parse_critique."""
+    t = text or ""
+    t = _THINK_RE.sub("", t)
+    if "<think>" in t.lower():
+        t = t[t.lower().rfind("<think>") + len("<think>"):]
+    return t.strip()
 
 
 class FFError(RuntimeError):


### PR DESCRIPTION
*Valid JSON* is not *good film plan* — the schema can't tell that a documentary wandered off-topic, that shots repeat, or that the narration won't fit. This adds a **critic that runs after schema validation and before the (minutes-long) render** (Codex F5), feeding blocking issues back into the repair loop — capped and **fail-open**.

## `critic.py` — two layers

- **Deterministic** (no LLM, always on, reliable): narration that won't fit its shot window, near-duplicate shots, a documentary that smuggled in fictional characters.
- **LLM per-shot relevance critique**: *"for each numbered shot, is it about the brief's subject?"* — the general form of the *"documentary became a drama about Arif"* bug. **Fails open**: any LLM error/empty/garbage → deterministic-only, never blocks a render.

## Empirically tuned on the live 4B (the dry-run is the point)

| Question | Finding | Decision |
|---|---|---|
| Does a bigger thinking budget fix the empty output? | thinking-ON is **empty even at 16k** and takes **~100s** on this uncensored 4B | run **thinking-OFF** (extraction still strips `<think>` defensively, F7) |
| Holistic *"is this good?"* verdict? | **rubber-stamped** — missed obvious drift | **per-shot** `off_topic` framing |
| temperature 0.2? | noisy — missed drift **and** false-flagged a clean plan ~1/3 | **temperature 0** (greedy): drift → all off-topic shots flagged, clean → none (3/3 each) |

## Integration
`plan_from_brief(use_critic=...)` (server passes `True`; default `False` keeps offline tests model-free). One critic-repair round then ship the valid plan; `director_call` gains `enable_thinking`; provenance → `prompts/critic.json`. `strip_reasoning` moved to `util.py` (shared by planner + critic).

## Validation
- Deterministic catches the original **Arif character leak**.
- LLM critique flags the **drifted Arif shots [1-6]** and **passes a clean Pakistan-history plan** (no false positive at temp 0).
- A clean `plan_from_brief` run critiques without a spurious repair.
- **134 offline unittests green.**

## Follow-up
A 4B is a borderline critic (Codex foresaw this). The `call` is injectable → routing the critique to the **27B/35B** for stronger judgement is a clean future upgrade.

## Out of scope (Codex deferred)
Long-plan decomposition (F9), cross-lane Studio router (Q4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)