### PR TITLE
Fix #512: portable LAN-IP detection (hostname -I → ip fallback) + persist to .env

### DIFF
--- a/scripts/setup-ai-studio.sh
+++ b/scripts/setup-ai-studio.sh
@@ -13,7 +13,8 @@
 #   SKIP_DISK_CHECK=1 bypass the free-space preflight (resume an idempotent download)
 #   SKIP_PIPE=1      skip installing the OWUI Studio pipe (do it later)
 #   ASSUME_YES=1     same as --yes (also auto-yes when not a TTY / under CI)
-#   LANIP=<ip>       host IP shown in the final URLs (auto-detected otherwise)
+#   LANIP=<ip>       host IP shown in the final URLs. Auto-detected + saved to .env on first run;
+#                    pin it in .env (or via this env var) if it picks the wrong NIC / can't detect.
 #   MODEL_DIR=<dir>  HF/GGUF cache root; the ComfyUI tree goes to a "comfyui" sibling
 #                    of it (override COMFYUI_ROOT / COMFYUI_MODELS_DIR to decouple).
 #
@@ -29,10 +30,10 @@ STUDIO_DIR="$REPO_DIR/services/studio"
 # alongside it instead of the rig's /mnt fallback). See services/comfyui/comfyui-paths.sh.
 # shellcheck disable=SC1091
 . "$COMFYUI_DIR/comfyui-paths.sh"
-# LAN IP for the final URLs — via the shared c3_lan_ip helper (sourced just above), so setup
-# and gpu-mode can't drift. Prefers a LAN address over docker bridges; override with LANIP=.
-LANIP="${LANIP:-$(c3_lan_ip 2>/dev/null || true)}"
-LANIP="${LANIP:-localhost}"
+# LAN IP for the final URLs. Resolve via the shared helper: env / .env win, else auto-detect and
+# PERSIST to .env (the source of truth) — or, if nothing detects, fall back to localhost and tell
+# the user to set LANIP in .env. Keeps setup + gpu-mode from drifting. (#504, #512)
+c3_resolve_lanip
 
 ASSUME_YES="${ASSUME_YES:-}"
 case "${1:-}" in

--- a/scripts/tests/test-studio-derig.sh
+++ b/scripts/tests/test-studio-derig.sh
@@ -38,11 +38,20 @@ for f in "$ROOT"/services/comfyui/download_*.sh; do
   fi
 done
 
-# 4. Both launchers detect the LAN IP via the SHARED c3_lan_ip helper (no inline drift).
+# 4. Both launchers detect the LAN IP via a SHARED helper (no inline drift) — c3_lan_ip or the
+#    persist-to-.env wrapper c3_resolve_lanip.
 for s in scripts/gpu-mode.sh scripts/setup-ai-studio.sh; do
-  if grep -q 'c3_lan_ip' "$ROOT/$s"; then chk ok "$s uses shared c3_lan_ip"
-  else chk fail "$s does not use the shared c3_lan_ip helper"; fi
+  if grep -qE 'c3_lan_ip|c3_resolve_lanip' "$ROOT/$s"; then chk ok "$s uses a shared LAN-IP helper"
+  else chk fail "$s does not use the shared LAN-IP helper"; fi
 done
+
+# 4b. c3_lan_ip must not rely SOLELY on `hostname -I` (net-tools only — missing on CachyOS /
+#     GNU inetutils, club-3090 #512). It needs the portable `ip` fallback.
+if grep -q 'ip -4' "$ROOT/services/comfyui/comfyui-paths.sh"; then
+  chk ok "c3_lan_ip has the portable 'ip' fallback (not hostname -I only)"
+else
+  chk fail "c3_lan_ip relies on hostname -I only — breaks on GNU inetutils / CachyOS (#512)"
+fi
 
 # 5. The production video-lane valve must not call a WIRED lane "not yet wired" / "roadmap"
 #    (Codex F11, 2026-06-29: ltx/sulphur/10eros render in the executor but the valve text lagged).

--- a/services/comfyui/comfyui-paths.sh
+++ b/services/comfyui/comfyui-paths.sh
@@ -19,13 +19,27 @@
 #    if the caller hasn't already exported it. Resolve this file's repo root from its own
 #    location so it works whether sourced by an in-repo script or a symlinked launcher.
 #    (C3_PATHS_NO_ENV=1 skips the .env read — for tests / fully-explicit callers.)
-if [ -z "${MODEL_DIR:-}" ] && [ -z "${C3_PATHS_NO_ENV:-}" ]; then
-  _c3_paths_root="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/../.." && pwd)"
-  if [ -f "$_c3_paths_root/.env" ]; then
-    MODEL_DIR="$(grep -E '^MODEL_DIR=' "$_c3_paths_root/.env" 2>/dev/null | tail -1 | cut -d= -f2-)"
-    MODEL_DIR="${MODEL_DIR%\"}"; MODEL_DIR="${MODEL_DIR#\"}"   # strip optional surrounding quotes
+# Repo root (this file is services/comfyui/comfyui-paths.sh → ../.. = repo root). Exposed so the
+# studio helpers below (c3_resolve_lanip) can find the repo-root .env to read/persist config.
+C3_REPO_ROOT="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/../.." 2>/dev/null && pwd || true)"
+if [ -z "${C3_PATHS_NO_ENV:-}" ] && [ -n "$C3_REPO_ROOT" ]; then
+  _c3_env="$C3_REPO_ROOT/.env"
+  if [ -f "$_c3_env" ]; then
+    # MODEL_DIR (the studio's one knob) — env wins over .env.
+    if [ -z "${MODEL_DIR:-}" ]; then
+      MODEL_DIR="$(grep -E '^MODEL_DIR=' "$_c3_env" 2>/dev/null | tail -1 | cut -d= -f2-)"
+      MODEL_DIR="${MODEL_DIR%\"}"; MODEL_DIR="${MODEL_DIR#\"}"   # strip optional surrounding quotes
+    fi
+    # LANIP for the printed URLs — pin it here when auto-detect can't pick the right NIC, or on
+    # hosts without `hostname -I` / `ip` (club-3090 #512). Env wins; auto-detect (c3_lan_ip) is the
+    # fallback when neither sets it.
+    if [ -z "${LANIP:-}" ]; then
+      LANIP="$(grep -E '^LANIP=' "$_c3_env" 2>/dev/null | tail -1 | cut -d= -f2-)"
+      LANIP="${LANIP%\"}"; LANIP="${LANIP#\"}"
+      [ -n "$LANIP" ] && export LANIP
+    fi
   fi
-  unset _c3_paths_root
+  unset _c3_env
 fi
 
 # 2. Default MODEL_DIR only when neither the env nor .env set it. Prefer a USER-OWNED location
@@ -49,10 +63,45 @@ export MODEL_DIR COMFYUI_ROOT COMFYUI_MODELS_DIR
 # networks live) so a docker host doesn't advertise a bridge IP instead of its LAN IP. Empty
 # when none is found; callers fall back to localhost. Override everything with LANIP=. (#504)
 c3_lan_ip() {
-  local ips; ips="$(hostname -I 2>/dev/null | tr ' ' '\n')"
-  { printf '%s\n' "$ips" | grep -E '^(192\.168|10)\.'                # routable LAN first
-    printf '%s\n' "$ips" | grep -E '^172\.(1[6-9]|2[0-9]|3[01])\.'   # then 172.16/12 (incl docker)
+  local ips=""
+  # `hostname -I` is net-tools only; CachyOS / GNU inetutils lack it (club-3090 #512), where it
+  # left LANIP empty → URLs fell back to localhost. Try it, then fall back to `ip` (portable).
+  command -v hostname >/dev/null 2>&1 && ips="$(hostname -I 2>/dev/null || true)"
+  if [ -z "${ips// /}" ] && command -v ip >/dev/null 2>&1; then
+    ips="$(ip -4 -o addr show scope global 2>/dev/null | awk '{print $4}' | cut -d/ -f1 || true)"
+  fi
+  # Prefer a routable LAN address, then a 172.16/12 (incl docker bridges); print at most one.
+  # Never return non-zero — callers must not have to guard this with `|| true`.
+  { printf '%s\n' $ips | grep -E '^(192\.168|10)\.' || true
+    printf '%s\n' $ips | grep -E '^172\.(1[6-9]|2[0-9]|3[01])\.' || true
   } 2>/dev/null | head -1
+  return 0
+}
+
+# Resolve LANIP for the printed URLs and PERSIST it to repo-root .env so it's stable + editable —
+# the .env is the source of truth (club-3090 #512). Precedence: shell-env / .env (loaded above) >
+# auto-detect. If auto-detected, write it to .env; if nothing can be detected, fall back to
+# localhost and tell the user to set LANIP in .env. Sets + exports the global LANIP. Always 0.
+c3_resolve_lanip() {
+  if [ -n "${LANIP:-}" ]; then export LANIP; return 0; fi   # already pinned (env or .env)
+  local ip env_file="${C3_REPO_ROOT:-.}/.env"
+  ip="$(c3_lan_ip)"
+  if [ -n "$ip" ]; then
+    LANIP="$ip"; export LANIP
+    if touch "$env_file" 2>/dev/null; then                  # materialize into .env (upsert)
+      if grep -qE '^LANIP=' "$env_file" 2>/dev/null; then
+        sed -i "s|^LANIP=.*|LANIP=$ip|" "$env_file" 2>/dev/null || true
+      else
+        printf 'LANIP=%s\n' "$ip" >> "$env_file" 2>/dev/null || true
+      fi
+      echo "  ✔ LAN IP $ip detected and saved to .env (edit it there if it picked the wrong NIC)." >&2
+    fi
+    return 0
+  fi
+  LANIP="localhost"; export LANIP                            # couldn't detect → ask the user
+  echo "  ⚠ Couldn't auto-detect your LAN IP — browser media links will use 'localhost'." >&2
+  echo "    Set it in $env_file so links open from other devices:   LANIP=<your-machine-ip>" >&2
+  return 0
 }
 
 # Ensure COMFYUI_MODELS_DIR exists + is writable, else exit with an ACTIONABLE message instead


### PR DESCRIPTION
Closes #512.

## Problem
`hostname -I` is **net-tools only**. CachyOS (and any **GNU inetutils** host) lacks it → `c3_lan_ip` returned empty → the studio URLs fell back to `localhost`. (The reporter also hit a setup abort they attributed to it; I couldn't reproduce a LAN-IP abort on bash 5.2 — `$(c3_lan_ip … || true)` disables `set -e` during the call — but the portability bug is real and this removes any fragility.)

## Fix — portable detection + `.env` as the source of truth
- **`c3_lan_ip`**: try `hostname -I`, then fall back to the portable `ip -4 -o addr show scope global`. Always returns 0 (no `|| true` needed by callers).
- **`.env` LANIP**, like `MODEL_DIR`: `comfyui-paths.sh` reads `LANIP` from repo-root `.env` at source time (env still wins), and a new **`c3_resolve_lanip()`** *persists* an auto-detected IP back to `.env` (user-editable). If nothing detects → `localhost` + a message telling the user to set `LANIP` in `.env`. Precedence: **shell-env > `.env` > auto-detect > localhost**.
- `setup-ai-studio.sh` calls `c3_resolve_lanip` (the persister); `gpu-mode` keeps reading (now portable + `.env`-aware, no write on a mode switch).
- Derig guard asserts the `ip` fallback exists (no hostname-only regression).

## Verified
| Case | Result |
|---|---|
| net-tools host | detects + saves `LANIP=…` to `.env` |
| CachyOS host (`hostname -I` rejected) | **`ip` fallback** detects + saves |
| `LANIP` pinned in `.env` / env | reused, **not** re-detected or overwritten |
| nothing detectable | `localhost` + "set LANIP in .env" |

Real repo `.env` untouched by the tests; derig guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)