### PR TITLE
setup-ai-studio.sh: surface the pipe-install step when OWUI has no admin yet (#510)

### DIFF
--- a/scripts/setup-ai-studio.sh
+++ b/scripts/setup-ai-studio.sh
@@ -113,14 +113,18 @@ say "── [3/4] Starting the studio (gpu-mode ai-studio) ──"
 bash "$REPO_DIR/scripts/gpu-mode.sh" ai-studio
 
 # --- 4. Install the OWUI Studio pipe (install-if-absent; needs an OWUI admin) ---
+# PIPE_OK drives the onboarding below: a fresh install has no OWUI admin yet (you create it by
+# signing up), so the pipe install is EXPECTED to be skipped here — we then make "sign up THEN
+# install the pipe" a prominent numbered step instead of a warning that scrolls past (#510).
+PIPE_OK=0
 if [ -z "${SKIP_PIPE:-}" ]; then
     say "── [4/4] Installing the Open WebUI Studio pipe ──"
     if bash "$STUDIO_DIR/push-pipe-to-owui.sh"; then
         ok "  Studio pipe installed/updated."
+        PIPE_OK=1
     else
-        warn "  Pipe install skipped — Open WebUI likely has no admin account yet."
-        warn "  Sign up at http://$LANIP:8080 (first account = admin), then run:"
-        warn "    bash services/studio/push-pipe-to-owui.sh"
+        warn "  Pipe install skipped — Open WebUI has no admin account yet (expected on a fresh install)."
+        warn "  → see the highlighted step below: sign up first, then install the pipe."
     fi
 else
     echo "  (SKIP_PIPE set — install later: bash services/studio/push-pipe-to-owui.sh)"
@@ -152,12 +156,23 @@ echo "  ComfyUI:     http://$LANIP:8188   ← optional: full node-graph control"
 echo "  Gallery:     http://$LANIP:8189   ← your renders (survive ComfyUI restarts)"
 echo ""
 say  "  Get started:"
-echo "    1. Open the Open WebUI URL and SIGN UP — the FIRST account becomes the admin."
-echo "       (If you signed up after this ran, install the pipe now:"
-echo "        bash services/studio/push-pipe-to-owui.sh )"
-echo "    2. On the 'Studio' function (gear icon), set the 'browser_base' valve to"
-echo "       http://$LANIP:8189 so returned media links open from your browser."
-echo "    3. Pick a lane in the model selector (🎬 Video · 🖼️ Image · 🎵 Audio), type an idea,"
+_n=1
+echo "    $_n. Open the Open WebUI URL and SIGN UP — the FIRST account becomes the admin."; _n=$((_n + 1))
+# The pipe couldn't install without an admin → make installing it a LOUD, unmissable step.
+if [ "$PIPE_OK" != "1" ] && [ -z "${SKIP_PIPE:-}" ]; then
+    echo ""
+    warn "    $_n. ⚠ INSTALL THE STUDIO LANES — they were skipped because Open WebUI had no admin"
+    warn "       account yet. After you sign up (step 1), run this ONE command:"
+    warn ""
+    warn "           bash services/studio/push-pipe-to-owui.sh"
+    warn ""
+    warn "       Then reload Open WebUI — the 🎬 Studio lanes appear in the model selector."
+    echo ""
+    _n=$((_n + 1))
+fi
+echo "    $_n. On the 'Studio' function (Admin → Functions → Studio), set the 'browser_base'"
+echo "       valve to http://$LANIP:8189 so returned media links open from your browser."; _n=$((_n + 1))
+echo "    $_n. Pick a lane in the model selector (🎬 Video · 🖼️ Image · 🎵 Audio), type an idea,"
 echo "       and refine by just replying. Full guide: docs/ai-studio/README.md"
 echo ""
 warn "  Notes:"


### PR DESCRIPTION
Part of #510 (the "no Studio function / no valves" half).

## Problem
On a **fresh** install, Open WebUI has no admin account yet — and `push-pipe-to-owui.sh` (step 4) **requires an admin** to write the function. So the pipe install is *expected* to be skipped, and the user must: sign up at OWUI (first account = admin) → run push-pipe. The old guidance was a yellow warning mid-run + a parenthetical buried in onboarding step 1, which the reporter scrolled past → "no Studio function, no valves."

## Fix
Track `PIPE_OK` from the install result. When the pipe was **skipped**, surface installing it as a **loud, renumbered onboarding step**:

```
  Get started:
    1. Open the Open WebUI URL and SIGN UP — the FIRST account becomes the admin.

    2. ⚠ INSTALL THE STUDIO LANES — they were skipped because Open WebUI had no admin
       account yet. After you sign up (step 1), run this ONE command:

           bash services/studio/push-pipe-to-owui.sh

       Then reload Open WebUI — the 🎬 Studio lanes appear in the model selector.

    3. On the 'Studio' function (Admin → Functions → Studio), set the 'browser_base' valve …
    4. Pick a lane …
```

When the pipe **did** install, that step disappears and the flow stays a clean 3 steps. Also points the `browser_base` step at the real location (Admin → Functions → Studio).

Verified both renders + `bash -n` + derig guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)