### PR TITLE
fix(studio): pin COMFYUI_ROOT to .env so ComfyUI mounts the models tree (#510, #530)

### DIFF
--- a/scripts/gpu-mode.sh
+++ b/scripts/gpu-mode.sh
@@ -184,6 +184,9 @@ stop_gemma_12b() {
 # GPU-bound — mutex with all vLLM / SGLang / llama-server LLM serving.
 start_comfyui() {
     printf "  ${GREEN}▲${NC} Starting comfyui..."
+    # Pin COMFYUI_ROOT into repo-root .env so the compose's `--env-file` mounts the SAME tree the
+    # downloads went into (not the /mnt default) on any rig whose MODEL_DIR isn't /mnt — #510/#530.
+    type c3_persist_comfy_root >/dev/null 2>&1 && c3_persist_comfy_root || true
     compose_at "$COMPOSE_BASE/comfyui" "up -d" && echo "done" || echo "failed"
 }
 stop_comfyui() {

--- a/scripts/tests/test-comfyui-paths.sh
+++ b/scripts/tests/test-comfyui-paths.sh
@@ -52,4 +52,20 @@ chk "HOME-less models → /mnt legacy" "/mnt/models/comfyui/models" "${got#*|}"
 lan="$(hostname() { echo '172.17.0.1 192.168.1.50 10.0.0.2'; }; . "$HELPER"; c3_lan_ip)"
 chk "lan_ip prefers LAN over 172.x bridge" "192.168.1.50" "$lan"
 
+# H — c3_persist_comfy_root pins the derived COMFYUI_ROOT into .env when absent (club-3090
+#     #510/#530: the comfyui compose mounts ${COMFYUI_ROOT}/models via --env-file, so without this
+#     the container falls back to the /mnt default and mounts an EMPTY tree on any non-/mnt rig).
+_tmpenv="$(mktemp)"; : > "$_tmpenv"
+env -u COMFYUI_ROOT -u COMFYUI_MODELS_DIR MODEL_DIR=/home/u/models C3_ENV_FILE="$_tmpenv" \
+  bash -c '. "'"$HELPER"'"; c3_persist_comfy_root' >/dev/null 2>&1
+chk "persist writes COMFYUI_ROOT when absent" "COMFYUI_ROOT=/home/u/comfyui" "$(grep '^COMFYUI_ROOT=' "$_tmpenv")"
+
+# I — never clobbers a hand-set COMFYUI_ROOT already in .env (exactly one line, value unchanged)
+printf 'COMFYUI_ROOT=/data/custom\n' > "$_tmpenv"
+env -u COMFYUI_ROOT -u COMFYUI_MODELS_DIR MODEL_DIR=/home/u/models C3_ENV_FILE="$_tmpenv" \
+  bash -c '. "'"$HELPER"'"; c3_persist_comfy_root' >/dev/null 2>&1
+chk "persist respects an existing COMFYUI_ROOT" "/data/custom|1" \
+  "$(grep '^COMFYUI_ROOT=' "$_tmpenv" | cut -d= -f2-)|$(grep -c '^COMFYUI_ROOT=' "$_tmpenv")"
+rm -f "$_tmpenv"
+
 if [ "$fails" -eq 0 ]; then echo "PASS: comfyui-paths derivation"; exit 0; else echo "FAIL: $fails assertion(s)"; exit 1; fi

--- a/services/comfyui/comfyui-paths.sh
+++ b/services/comfyui/comfyui-paths.sh
@@ -104,10 +104,28 @@ c3_resolve_lanip() {
   return 0
 }
 
+# Persist the resolved COMFYUI_ROOT to repo-root .env so the comfyui compose — launched as
+# `sudo docker compose --env-file .env` — mounts the SAME tree the downloader writes into.
+# Without this, COMFYUI_ROOT is derived in-shell but stripped by sudo AND absent from .env, so the
+# compose's `${COMFYUI_ROOT:-/mnt/models/comfyui}/models` falls back to the /mnt default and mounts
+# an EMPTY tree on any rig whose MODEL_DIR isn't the /mnt layout → ComfyUI's model dropdowns come up
+# empty (loaders 400 with "not in []"; the HiDream node says "not installed"). club-3090 #510 + #530.
+# Write-if-absent: never clobbers a hand-set COMFYUI_ROOT. No-op under C3_PATHS_NO_ENV / unwritable .env.
+c3_persist_comfy_root() {
+  [ -n "${C3_PATHS_NO_ENV:-}" ] && return 0
+  local env_file="${C3_ENV_FILE:-${C3_REPO_ROOT:-.}/.env}"
+  grep -qE '^COMFYUI_ROOT=' "$env_file" 2>/dev/null && return 0   # already pinned — respect it
+  touch "$env_file" 2>/dev/null && printf 'COMFYUI_ROOT=%s\n' "$COMFYUI_ROOT" >> "$env_file" 2>/dev/null || true
+  return 0
+}
+
 # Ensure COMFYUI_MODELS_DIR exists + is writable, else exit with an ACTIONABLE message instead
 # of letting hf/mkdir cascade into a traceback. Call from download entry points. (#503)
 c3_ensure_comfy_models_dir() {
-  if mkdir -p "$COMFYUI_MODELS_DIR" 2>/dev/null && [ -w "$COMFYUI_MODELS_DIR" ]; then return 0; fi
+  if mkdir -p "$COMFYUI_MODELS_DIR" 2>/dev/null && [ -w "$COMFYUI_MODELS_DIR" ]; then
+    c3_persist_comfy_root   # pin COMFYUI_ROOT so the container mounts this same tree (#510/#530)
+    return 0
+  fi
   echo "ERROR: ComfyUI models dir is not writable: $COMFYUI_MODELS_DIR" >&2
   echo "       Set MODEL_DIR to a writable location and retry, e.g.:" >&2
   echo "         MODEL_DIR=\"\$HOME/models\" $(basename "${0:-this script}")" >&2


### PR DESCRIPTION
## The bug (#510 + #530, same root cause)

On the reporter's rig, **every** image lane fails — ComfyUI's model dropdowns are empty:

```
Value not in list: unet_name: 'ideogram4_fp8_scaled.safetensors' not in []   ← diffusion_models is EMPTY
                   unet_name: 'z-image-turbo-fp8-e4m3fn.safetensors' not in []
                   unet_name: 'krea2_turbo_fp8_scaled.safetensors' not in []
```

(The HiDream custom node phrases the same "empty models tree" as a runtime *"not installed"* → #510; the standard loaders reject at submit → **HTTP 400** → #530.)

**Why:** the comfyui compose mounts `${COMFYUI_ROOT:-/mnt/models/comfyui}/models → /workspace/ComfyUI/models`. `gpu-mode` derives `COMFYUI_ROOT` in-shell (via `comfyui-paths.sh`) but launches the compose with `sudo docker compose --env-file .env` — **`sudo` strips the exported var, and `.env` carries only `MODEL_DIR`, not `COMFYUI_ROOT`** — so the compose falls back to the `/mnt` default. The downloads, meanwhile, key off the `MODEL_DIR`-derived `COMFYUI_ROOT` (fresh installs default `MODEL_DIR=$HOME/models` → `$HOME/comfyui/models`). The two diverge → the container mounts an empty tree.

It's invisible on the maintainer rig because its `/mnt/models` layout makes the derived `COMFYUI_ROOT` *equal* the compose default. It bites any rig with a non-`/mnt` `MODEL_DIR` — i.e. essentially every fresh install.

(The earlier #529 roster fix — adding HiDream/Chroma to `download_studio_models.sh` — was real but **orthogonal**: even with HiDream in the roster, it downloads to a tree the container can't see.)

## The fix

Persist the resolved `COMFYUI_ROOT` into repo-root `.env` so the `--env-file`'d compose mounts the **same** tree the downloads went into — the same mechanism already used for `LANIP`.

- `comfyui-paths.sh`: new `c3_persist_comfy_root()` — **write-if-absent** (never clobbers a hand-set value), no-op under `C3_PATHS_NO_ENV` / unwritable `.env`. Called from `c3_ensure_comfy_models_dir()` (every downloader).
- `gpu-mode.sh`: `start_comfyui` pins it before `compose up` (covers a launch without a fresh download).
- `test-comfyui-paths.sh`: + case **H** (writes when absent) / **I** (respects existing).

## Validation

- `test-comfyui-paths.sh` 13/13 green (incl. H/I); `test-studio-derig.sh` green; `bash -n` clean; the real repo `.env` is **not** polluted by the tests (a `C3_ENV_FILE` override isolates them).
- ⚠️ **Not live-validated on a non-`/mnt` rig here** (the maintainer rig uses `/mnt`, where the bug doesn't manifest). The unit tests cover the persist + derivation logic and the mechanism is confirmed from the compose/launch code paths; a fresh-install / custom-`MODEL_DIR` rig is the real end-to-end check.

Immediate workaround for affected users (no fix needed): add `COMFYUI_ROOT=<dirname of MODEL_DIR>/comfyui` to repo-root `.env` and relaunch `gpu-mode ai-studio`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)