### PR TITLE
fix(studio): derive + pin COMFYUI_OUTPUT_DIR from COMFYUI_ROOT (#510 render-mount)

### DIFF
--- a/scripts/tests/test-comfyui-paths.sh
+++ b/scripts/tests/test-comfyui-paths.sh
@@ -68,4 +68,45 @@ chk "persist respects an existing COMFYUI_ROOT" "/data/custom|1" \
   "$(grep '^COMFYUI_ROOT=' "$_tmpenv" | cut -d= -f2-)|$(grep -c '^COMFYUI_ROOT=' "$_tmpenv")"
 rm -f "$_tmpenv"
 
+# --- COMFYUI_OUTPUT_DIR (#510 follow-on): the gallery :8189 + orchestrator / tts / step-voice /
+#     production mount ${COMFYUI_OUTPUT_DIR}; it MUST derive from COMFYUI_ROOT or ComfyUI writes
+#     renders to $COMFYUI_ROOT/output while the gallery serves the empty /mnt default → 404.
+out() { env "$@" bash -c '. "'"$HELPER"'"; printf "%s" "$COMFYUI_OUTPUT_DIR"'; }
+
+# J — derives as $COMFYUI_ROOT/output (home case — where ComfyUI actually writes)
+chk "output dir → \$COMFYUI_ROOT/output" "/home/u/comfyui/output" \
+  "$(out -u COMFYUI_ROOT -u COMFYUI_OUTPUT_DIR MODEL_DIR=/home/u/models)"
+# K — follows an explicit COMFYUI_ROOT
+chk "output dir follows explicit root" "/data/cr/output" \
+  "$(out -u COMFYUI_OUTPUT_DIR COMFYUI_ROOT=/data/cr MODEL_DIR=/x)"
+# L — respects an explicit COMFYUI_OUTPUT_DIR
+chk "explicit output dir respected" "/data/out" \
+  "$(out -u COMFYUI_ROOT COMFYUI_OUTPUT_DIR=/data/out MODEL_DIR=/x)"
+
+_tmpenv="$(mktemp)"
+# M — c3_persist_comfy_root pins COMFYUI_OUTPUT_DIR when absent
+: > "$_tmpenv"
+env -u COMFYUI_ROOT -u COMFYUI_OUTPUT_DIR MODEL_DIR=/home/u/models C3_ENV_FILE="$_tmpenv" \
+  bash -c '. "'"$HELPER"'"; c3_persist_comfy_root' >/dev/null 2>&1
+chk "persist writes COMFYUI_OUTPUT_DIR when absent" "COMFYUI_OUTPUT_DIR=/home/u/comfyui/output" \
+  "$(grep '^COMFYUI_OUTPUT_DIR=' "$_tmpenv")"
+
+# N — THE migration case: COMFYUI_ROOT already pinned (from #531) but no OUTPUT_DIR → persist must
+#     ADD OUTPUT_DIR (not bail on ROOT presence) and leave ROOT untouched.
+printf 'COMFYUI_ROOT=/home/u/comfyui\n' > "$_tmpenv"
+env -u COMFYUI_ROOT -u COMFYUI_OUTPUT_DIR MODEL_DIR=/home/u/models C3_ENV_FILE="$_tmpenv" \
+  bash -c '. "'"$HELPER"'"; c3_persist_comfy_root' >/dev/null 2>&1
+chk "adds OUTPUT_DIR when only ROOT was pinned" "COMFYUI_OUTPUT_DIR=/home/u/comfyui/output" \
+  "$(grep '^COMFYUI_OUTPUT_DIR=' "$_tmpenv")"
+chk "ROOT untouched in the migration case" "/home/u/comfyui|1" \
+  "$(grep '^COMFYUI_ROOT=' "$_tmpenv" | cut -d= -f2-)|$(grep -c '^COMFYUI_ROOT=' "$_tmpenv")"
+
+# O — never clobbers a hand-set COMFYUI_OUTPUT_DIR (exactly one line, unchanged)
+printf 'COMFYUI_OUTPUT_DIR=/data/custom-out\n' > "$_tmpenv"
+env -u COMFYUI_ROOT -u COMFYUI_OUTPUT_DIR MODEL_DIR=/home/u/models C3_ENV_FILE="$_tmpenv" \
+  bash -c '. "'"$HELPER"'"; c3_persist_comfy_root' >/dev/null 2>&1
+chk "persist respects an existing COMFYUI_OUTPUT_DIR" "/data/custom-out|1" \
+  "$(grep '^COMFYUI_OUTPUT_DIR=' "$_tmpenv" | cut -d= -f2-)|$(grep -c '^COMFYUI_OUTPUT_DIR=' "$_tmpenv")"
+rm -f "$_tmpenv"
+
 if [ "$fails" -eq 0 ]; then echo "PASS: comfyui-paths derivation"; exit 0; else echo "FAIL: $fails assertion(s)"; exit 1; fi

--- a/services/comfyui/comfyui-paths.sh
+++ b/services/comfyui/comfyui-paths.sh
@@ -53,7 +53,13 @@ fi
 # 3. Derive (only when unset), then export so child processes + docker compose inherit them.
 : "${COMFYUI_ROOT:=$(dirname "$MODEL_DIR")/comfyui}"
 : "${COMFYUI_MODELS_DIR:=${COMFYUI_ROOT}/models}"
-export MODEL_DIR COMFYUI_ROOT COMFYUI_MODELS_DIR
+# COMFYUI_OUTPUT_DIR is where ComfyUI WRITES renders ($COMFYUI_ROOT/output) AND what every studio
+# output consumer mounts (gallery :8189, orchestrator, tts, step-voice, production). It MUST derive
+# from COMFYUI_ROOT — otherwise it falls back to the /mnt default and the gallery serves an EMPTY
+# tree while ComfyUI writes renders elsewhere → 404 on generated media on any non-/mnt rig
+# (club-3090 #510 follow-on; #531 pinned COMFYUI_ROOT for the *input* side but not the output side).
+: "${COMFYUI_OUTPUT_DIR:=${COMFYUI_ROOT}/output}"
+export MODEL_DIR COMFYUI_ROOT COMFYUI_MODELS_DIR COMFYUI_OUTPUT_DIR
 
 
 # --- shared studio host helpers (this is the lib every studio entry point sources) -----------
@@ -104,18 +110,23 @@ c3_resolve_lanip() {
   return 0
 }
 
-# Persist the resolved COMFYUI_ROOT to repo-root .env so the comfyui compose — launched as
-# `sudo docker compose --env-file .env` — mounts the SAME tree the downloader writes into.
-# Without this, COMFYUI_ROOT is derived in-shell but stripped by sudo AND absent from .env, so the
-# compose's `${COMFYUI_ROOT:-/mnt/models/comfyui}/models` falls back to the /mnt default and mounts
-# an EMPTY tree on any rig whose MODEL_DIR isn't the /mnt layout → ComfyUI's model dropdowns come up
-# empty (loaders 400 with "not in []"; the HiDream node says "not installed"). club-3090 #510 + #530.
-# Write-if-absent: never clobbers a hand-set COMFYUI_ROOT. No-op under C3_PATHS_NO_ENV / unwritable .env.
+# Persist the resolved COMFYUI_ROOT + COMFYUI_OUTPUT_DIR to repo-root .env so the studio composes —
+# launched as `sudo docker compose --env-file .env` — mount the SAME trees this shell derives.
+# Without this, the vars are derived in-shell but stripped by sudo AND absent from .env, so:
+#   • `${COMFYUI_ROOT:-/mnt/models/comfyui}/models` falls back to /mnt → ComfyUI model dropdowns come
+#     up EMPTY (loaders 400 "not in []"; HiDream node "not installed"). club-3090 #510 + #530.
+#   • `${COMFYUI_OUTPUT_DIR:-/mnt/models/comfyui/output}` (gallery :8189 + orchestrator / tts /
+#     step-voice / production) falls back to /mnt → generated renders 404 in the gallery / don't show
+#     in OWUI, while ComfyUI writes them to $COMFYUI_ROOT/output. club-3090 #510 follow-on.
+# Write-if-absent PER VAR: never clobbers a hand-set value, and — critically — adds COMFYUI_OUTPUT_DIR
+# for users who already have COMFYUI_ROOT pinned from #531 (don't gate on ROOT presence). No-op under
+# C3_PATHS_NO_ENV / unwritable .env.
 c3_persist_comfy_root() {
   [ -n "${C3_PATHS_NO_ENV:-}" ] && return 0
   local env_file="${C3_ENV_FILE:-${C3_REPO_ROOT:-.}/.env}"
-  grep -qE '^COMFYUI_ROOT=' "$env_file" 2>/dev/null && return 0   # already pinned — respect it
-  touch "$env_file" 2>/dev/null && printf 'COMFYUI_ROOT=%s\n' "$COMFYUI_ROOT" >> "$env_file" 2>/dev/null || true
+  touch "$env_file" 2>/dev/null || return 0
+  grep -qE '^COMFYUI_ROOT='       "$env_file" 2>/dev/null || printf 'COMFYUI_ROOT=%s\n'       "$COMFYUI_ROOT"       >> "$env_file" 2>/dev/null || true
+  grep -qE '^COMFYUI_OUTPUT_DIR=' "$env_file" 2>/dev/null || printf 'COMFYUI_OUTPUT_DIR=%s\n' "$COMFYUI_OUTPUT_DIR" >> "$env_file" 2>/dev/null || true
   return 0
 }
 


### PR DESCRIPTION
## What

Follow-on to #510 / #531. #531 pinned `COMFYUI_ROOT` so ComfyUI's **input/models** mount correctly, but the **output** side stayed broken: the gallery (`:8189`) and the other four output consumers (orchestrator, tts, step-voice, production) mount a *separate* `COMFYUI_OUTPUT_DIR` that was **never derived from `COMFYUI_ROOT`** — it fell back to the hardcoded `/mnt/models/comfyui/output`.

**Symptom (reported in #510):** on a non-`/mnt` rig, ComfyUI writes renders to `$COMFYUI_ROOT/output` (e.g. `~/comfyui/output`) while the gallery serves the empty `/mnt/models/comfyui/output` → **nginx 404 on the generated PNG** (`studio_hidream_00001_.png`), and the render never appears in the gallery / OWUI. The `_output_images_will_be_put_here` placeholder returning 200/0 is the tell — the mount is live but pointed at the wrong tree.

## Fix

- `comfyui-paths.sh`: derive + export **`COMFYUI_OUTPUT_DIR=$COMFYUI_ROOT/output`** (single source of truth, alongside `COMFYUI_ROOT` / `COMFYUI_MODELS_DIR`).
- `c3_persist_comfy_root`: pin it to `.env` **per-var** — so it **adds `COMFYUI_OUTPUT_DIR` even for users who already have `COMFYUI_ROOT` pinned from #531** (they self-heal on the next `gpu-mode ai-studio`), and never clobbers a hand-set value.
- `test-comfyui-paths.sh`: **+7 assertions** — derivation, explicit-override respect, and the ROOT-already-pinned **migration case**. Full file green (20/20).

No compose changes needed — the consumers already read `${COMFYUI_OUTPUT_DIR:-…}`; they just needed it derived + pinned. `start_comfyui` (which persists) runs before the gallery in the ai-studio scene, so the pin lands first.

Fixes #510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
