### PR TITLE
feat(gemma): v0.24.0 overlay-free Gemma-4-31B dual (cyankiwi, MTP-off)

### DIFF
--- a/models/gemma-4-31b/vllm/compose/dual/qat-awq-int4/int8.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/qat-awq-int4/int8.yml
@@ -1,0 +1,166 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Gemma 4 31B — cyankiwi QAT-AWQ INT4 (compressed-tensors, lm_head bf16)
+#   Topology:  Dual 3090 (TP=2, NVLink auto-detected via NVLINK_MODE)
+#   Drafter:   none — MTP DISABLED on v0.24.0 (see the ⏸️ MTP caveat block below)
+#   KV:        int8_per_token_head (1 byte/token — compressed-tensors can't do fp8 KV; TurboQuant is arch-blocked on Gemma-4)
+#   Vision:    yes
+#   Max ctx:   262K native default (dual-card max-ctx rule) @ 4-stream cap
+#   Genesis:   N/A — Genesis is Qwen3-Next-specific
+#   Status:    🧪 Experimental
+#   Caveats:   MTP (speculative decoding) is DISABLED on vLLM v0.24.0 — Gemma-4 MTP×tool-calling
+#              is broken upstream (vLLM #39043; MTP fix #42006 closed-unmerged). Plain chat + tools
+#              (without MTP) work perfectly. Re-enable when a stable vLLM ships the fix — see block below.
+#   Best for:  The Gemma-4-31B dual on v0.24.0 — overlay-free, vision + tools + 262K long-context. ⭐
+# ---------------------------------------------------------------------------
+# Gemma-4-31B (cyankiwi QAT-AWQ-INT4) on 2× RTX 3090 TP=2, stock vLLM v0.24.0.
+#
+# WHY cyankiwi qat-AWQ-int4 (not autoround-int4): on v0.24.0, gemma4.py ties the
+# lm_head through its quant method, and AutoRound (which quantizes the tied
+# lm_head) raises NotImplementedError at model init. cyankiwi's compressed-tensors
+# checkpoint keeps lm_head EXCLUDED from quant (bf16), so the tie dispatches to the
+# unquantized path → boots clean. QAT-int4 is also ≥ AutoRound-int4 fidelity (§4a).
+# The bf16 lm_head costs ~0.3 GiB, so util defaults to 0.965 to hold the full 262K.
+#
+# OVERLAY-FREE on v0.24.0 (this is the whole point of the migration):
+#   • #40391 (per-token-head KV page-align) — NATIVE in v0.24.0. int8-PTH allocates
+#     the full 262K pool with no page-size crash; the vendored overlay is GONE.
+#   • #42006 (MTP streaming multi-tool) — not needed here (MTP disabled, see below).
+#   • gemma4 tool + reasoning parsers — native ParserEngine (#45588). Streaming
+#     multi-tool validated clean (all args, no <|tool_call> leak) on stock v0.24.0.
+#
+# ──────────────────────────────────────────────────────────────────────────
+# ⏸️ MTP (speculative decoding) DISABLED on v0.24.0 — re-enable when upstream lands.
+#   Why: Gemma-4 MTP × tool-calling is broken on stock v0.24.0 — with spec-decode ON,
+#   tool calls emit <pad> / leak raw <|tool_call> tokens instead of parsed calls.
+#   (Plain chat is fine; tools WITHOUT MTP are fine — verified by A/B on this rig
+#   2026-07-01: MTP-off → tools PASS, MTP-on → tools FAIL.) Root cause = upstream
+#   vLLM #39043; the MTP fix (#42006) is closed-unmerged and NOT in v0.24.0.
+#   Re-enable trigger: a stable vLLM release carrying the #39043 / #42006 Gemma-4
+#   tool-call + MTP fixes. Check before re-enabling:
+#     gh api repos/vllm-project/vllm/issues/39043 --jq '.state, .state_reason'
+#     gh api repos/vllm-project/vllm/pulls/42006  --jq '.state, .merged_at'
+#   Then restore the two --speculative-config lines below + re-run a streaming
+#   multi-tool test (must return all args, no leak) before shipping:
+#     - --speculative-config
+#     - '{"model":"/root/.cache/huggingface/gemma-4-31b-it-assistant","num_speculative_tokens":${SPEC_N_MAX:-3}}'
+# ──────────────────────────────────────────────────────────────────────────
+#
+# Companion composes:
+#   single (TP=1) — Gemma-4-31B is DUAL-ONLY on 24 GB. Weights fit a single card but
+#                   int8-PTH KV leaves only a few-K ctx, and TurboQuant KV (the only
+#                   sub-byte option) is arch-blocked on Gemma-4 (heterogeneous head
+#                   dims force TRITON_ATTN, which rejects TQ dtypes). Needs ≥32 GB.
+#
+# Hardware metadata (parsed by scripts/preflight.sh):
+# Requires-min-vram-gb: 24
+# Engine-profile: vllm-stable
+# Requires-min-gpu-count: 2
+# Tensor-parallel: 2
+services:
+  vllm-gemma-4-31b-qat-awq-int4:
+    image: ${VLLM_IMAGE:-vllm/vllm-openai:v0.24.0}
+    container_name: "${ESTATE_CONTAINER:-vllm-gemma-4-31b-qat-awq-int4}"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8032}}:8000"
+    volumes:
+      - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
+      # torch.compile + Triton kernel caches — first boot warms (~5-7 min);
+      # subsequent boots reuse cached graphs (~3 min).
+      - ../../../cache/torch_compile_qatawq:/root/.cache/vllm/torch_compile_cache
+      - ../../../cache/triton_qatawq:/root/.triton/cache
+      # NVLink auto-detection — runs inside container at boot.
+      - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+      # NO overlay mounts — #40391 (KV) native in v0.24.0; #42006 (MTP tool) N/A (MTP off).
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
+      - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
+      - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}
+      - VLLM_WORKER_MULTIPROC_METHOD=spawn
+      - NVLINK_MODE=${NVLINK_MODE:-auto}
+      - NCCL_CUMEM_ENABLE=0
+      - NCCL_P2P_DISABLE=1
+      - VLLM_NO_USAGE_STATS=1
+      - OMP_NUM_THREADS=1
+      - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True,max_split_size_mb:512}
+      - VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
+      - TRITON_CACHE_DIR=/root/.triton/cache
+    shm_size: "16gb"
+    ipc: host
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # Overlay-free on v0.24.0 — no boot-time patch apply. Just NVLink autodetect + serve.
+        # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
+        source /etc/club3090/detect_nvlink.sh
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve "$$@"
+        else
+          exec vllm serve --disable-custom-all-reduce "$$@"
+        fi
+      - --
+    command:
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-64},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8000"
+      - --model
+      - /root/.cache/huggingface/gemma-4-31b-qat-awq-int4
+      - --served-model-name
+      - gemma-4-31b-qat-awq-int4
+      - --tensor-parallel-size
+      - "${TP:-2}"
+      - --pipeline-parallel-size
+      - "${PP:-1}"
+      # ---- KV format ----
+      # int8_per_token_head (1 byte/token) — the only sub-fp16 KV that works on Gemma-4:
+      #   • compressed-tensors weights can't take fp8 KV;
+      #   • fp8_e4m3/e5m2 PTH need Ada/Blackwell (sm_86 lacks the fp8e4nv Triton kernel);
+      #   • TurboQuant (turboquant_*_nc) is arch-blocked — Gemma-4's heterogeneous head
+      #     dims force TRITON_ATTN, which rejects TQ KV ("kv_cache_dtype not supported").
+      # #40391 page-align is NATIVE in v0.24.0 — no overlay needed.
+      - --kv-cache-dtype
+      - "${KV_DTYPE:-int8_per_token_head}"
+      # ---- max-model-len (TP=2, INT8 PTH KV) — DUAL-CARD RULE: prioritize max context
+      #      over concurrency (docs/DUAL_CARD.md). --max-num-seqs is a CAP, not a
+      #      reservation; the int8-PTH pool holds a single 262K request with room, so the
+      #      262144 native default is ~free for short-request concurrency.
+      - --max-model-len
+      - "${MAX_MODEL_LEN:-${CTX:-262144}}"
+      # 0.965 (not 0.95): cyankiwi's bf16 lm_head costs ~0.3 GiB; 0.965 holds the full
+      # 262K int8-PTH pool (measured GPU KV cache ~267K tok). Drop for vision-heavy 262K.
+      - --gpu-memory-utilization
+      - "${GPU_MEMORY_UTILIZATION:-0.965}"
+      # Lower --max-num-seqs only to GUARANTEE long requests are never preempted:
+      #   4 = native ctx, 4-wide for shorter reqs · 2 = two un-preempted long agents · 1 = one long request
+      # ⚠️ vision + near-max ctx: drop max-num-seqs/mem-util (thin headroom at 262K).
+      - --max-num-seqs
+      - "${MAX_NUM_SEQS:-4}"
+      # Vision tower: max_tokens_per_mm_item=2496 must fit in batched tokens.
+      - --max-num-batched-tokens
+      - "4096"
+      - --trust-remote-code
+      # Tool-call support — native gemma4 ParserEngine (#45588) on v0.24.0. Streaming
+      # multi-tool validated clean (all args, no <|tool_call> leak) 2026-07-01.
+      - --enable-auto-tool-choice
+      - --tool-call-parser
+      - gemma4
+      # Route Gemma-4's <|channel>thought…<channel|> reasoning into reasoning_content.
+      - --reasoning-parser
+      - gemma4
+      - --chat-template
+      - /vllm-workspace/examples/tool_chat_template_gemma4.jinja
+      # ⏸️ MTP disabled — see the caveat block in the header. Do NOT add --speculative-config
+      #    on v0.24.0 (breaks tool-calling); restore it only when vLLM #39043/#42006 land.

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -520,6 +520,23 @@ COMPOSE_REGISTRY = {
         kvcalc_key="gemma-4-31b:gemma-dual-int8",
     ),
 
+    # Gemma-4-31B cyankiwi QAT-AWQ-INT4 (compressed-tensors, lm_head bf16) — the v0.24.0
+    # OVERLAY-FREE dual on vllm-stable. On v0.24.0 the autoround/qat-w4a16 duals live on
+    # vllm-gemma-stable (autoround crashes tie_weights, qat-w4a16 carries #40391/#42006);
+    # cyankiwi's lm_head-excluded checkpoint dodges tie_weights, #40391 is native, and the
+    # native ParserEngine handles tools — so this folds onto vllm-stable, no overlays.
+    # MTP DISABLED (Gemma-4 MTP×tools broken on v0.24.0 — vLLM #39043/#42006; see compose caveat).
+    "vllm/gemma-31b-dual": _entry(
+        model="gemma-4-31b", weights_variant="qat-awq-int4", workload="multi-stream-tenant",
+        engine="vllm-stable", drafter=None, kv_format="int8_per_token_head",
+        tp=2, max_ctx=262144, max_num_seqs=4, mem_util=0.965,
+        compose_path="models/gemma-4-31b/vllm/compose/dual/qat-awq-int4/int8.yml",
+        default_port=8032, required_engine_features=["int8_per_token_head"],
+        kvcalc_key="gemma-4-31b:gemma-dual-int8",
+        status="experimental",
+        status_note="Gemma-4-31B cyankiwi QAT-AWQ-INT4 (compressed-tensors, lm_head bf16), dual TP=2 int8-PTH KV @262K, stock vLLM v0.24.0 OVERLAY-FREE. Live-validated 2026-07-01: serves 267K KV pool, coherent, streaming multi-tool 3/3 (all args, no <|tool_call> leak). tie_weights dodged (lm_head excluded; util 0.965 for the bf16 lm_head's ~0.3 GiB), #40391 KV page-align NATIVE in v0.24.0 (no overlay), gemma4 tool+reasoning parsers native (#45588). MTP DISABLED — Gemma-4 MTP×tool-calling is broken on v0.24.0 (upstream vLLM #39043; MTP fix #42006 closed-unmerged); re-enable when a stable vLLM ships the fix (see compose caveat). Supersedes the autoround/qat-w4a16 duals for v0.24.0. NIAH/soak/bench pending.",
+    ),
+
     # Gemma-4-31B unsloth QAT W4A16 (compressed-tensors int4) — QAT-int4 fidelity alt to
     # autoround-int4. Same dual / int8-PTH-KV(#40391) / assistant-MTP path as gemma-int8-mtp.
     "vllm/gemma-31b-qat-w4a16-dual": _entry(

--- a/scripts/lib/profiles/engines/vllm-stable.yml
+++ b/scripts/lib/profiles/engines/vllm-stable.yml
@@ -14,7 +14,9 @@ supported_model_families:
   - qwen3-next-hybrid
   - qwen3-next-moe
 features:
-  int8_per_token_head: false
+  int8_per_token_head: true    # v0.24.0: #40391 KV page-align is NATIVE (overlay-only on v0.22.0) →
+                               # gemma int8-PTH serves overlay-free. Validated 2026-07-01 (gemma-31b-dual
+                               # cyankiwi @262K, no overlay); qwen3-next was already native.
   turboquant_3bit_nc: false
   marlin_pad_sub_tile_n: false
   qwen3_coder_tool_parser: false
@@ -23,12 +25,10 @@ supported_kv_formats:
   - fp16
   - fp8_e4m3
   - fp8_e5m2
-  - int8_per_token_head   # NATIVE on stock v0.22.0 for uniform-head-dim models (qwen3-next):
-                          # no overlay needed (live-validated 2026-06-07, qwen fp8 dual-max @262K,
-                          # KV pool 295K tok). Distinct from the gemma path, where hetero head dims
-                          # require the #40391 overlay — hence features.int8_per_token_head stays
-                          # false here (no provenance-backed feature) and the overlay-carrying
-                          # vllm-gemma-stable owns Gemma's int8-PTH.
+  - int8_per_token_head   # NATIVE: uniform-head-dim models (qwen3-next) since v0.22.0; Gemma-4
+                          # (hetero head dims) needed the #40391 overlay on v0.22.0, but #40391 landed
+                          # NATIVE in v0.24.0 — so gemma int8-PTH now serves overlay-free on this engine
+                          # (validated 2026-07-01, gemma-31b-dual cyankiwi @262K). features flag = true.
 supported_drafters:
   - mtp
   - mtp_assistant

--- a/scripts/lib/profiles/models/gemma-4-31b.yml
+++ b/scripts/lib/profiles/models/gemma-4-31b.yml
@@ -52,6 +52,18 @@ weights:
     engine: vllm
     kind: main
     verify_glob: "*.safetensors"
+  qat-awq-int4:
+    path: gemma-4-31b-qat-awq-int4
+    local_subdir: gemma-4-31b-qat-awq-int4
+    size_gb: 20.0
+    format: compressed-tensors
+    status: experimental
+    hf_repo: cyankiwi/gemma-4-31B-it-qat-AWQ-INT4
+    hf_repos:
+      - cyankiwi/gemma-4-31B-it-qat-AWQ-INT4
+    engine: vllm
+    kind: main
+    verify_glob: "*.safetensors"
   assistant:
     path: gemma-4-31b-it-assistant
     local_subdir: gemma-4-31b-it-assistant

--- a/scripts/tests/test-compose-registry-disk.sh
+++ b/scripts/tests/test-compose-registry-disk.sh
@@ -25,8 +25,8 @@ def check(cond, msg):
         print(f"FAIL: {msg}")
         failures.append(msg)
 
-check(len(COMPOSE_REGISTRY) == 55, f"registry has 55 entries (got {len(COMPOSE_REGISTRY)})")
-check(len(disk_paths) == 56, f"disk has 56 compose files (got {len(disk_paths)})")
+check(len(COMPOSE_REGISTRY) == 56, f"registry has 56 entries (got {len(COMPOSE_REGISTRY)})")
+check(len(disk_paths) == 57, f"disk has 57 compose files (got {len(disk_paths)})")
 check(registry_paths <= disk_paths, "all registry compose_path values exist on disk")
 parked_disk_only = disk_paths - registry_paths
 # Disk-only (non-registry) composes allowed: parked SGLang archives, plus the experimental


### PR DESCRIPTION
## What

Adds **Gemma-4-31B serving overlay-free on stock vLLM v0.24.0** — a new `vllm/gemma-31b-dual` slug on the overlay-free `vllm-stable` engine.

- **`dual/qat-awq-int4/int8.yml`** — `cyankiwi/gemma-4-31B-it-qat-AWQ-INT4` weights, int8-PTH KV @ 262K, TP=2, native `gemma4` tool + reasoning parsers.
- **Overlay-free:** `#40391` (per-token-head KV page-align) is **native in v0.24.0** (was a vendored overlay on v0.22.0); the native ParserEngine (`#45588`) handles gemma4 tools. So this folds onto `vllm-stable` — no `vllm-gemma-stable` overlays.

## Why cyankiwi (weights swap)

On v0.24.0, `gemma4.py` ties the lm_head **through its quant method**. AutoRound-INT4 (which quantizes the tied lm_head) raises `NotImplementedError` at model init. cyankiwi's compressed-tensors checkpoint keeps **lm_head excluded from quant (bf16)**, so the tie dispatches to the unquantized path → boots clean. (`util=0.965` covers the bf16 lm_head's ~0.3 GiB; full 262K KV still fits.)

## MTP disabled — with a documented re-enable path

Gemma-4 **MTP × tool-calling is broken on v0.24.0** — with spec-decode on, tool calls emit `<pad>` / leak raw `<|tool_call>` tokens (upstream [vLLM #39043](https://github.com/vllm-project/vllm/issues/39043); the MTP fix #42006 is closed-unmerged). A/B-proven on-rig: **MTP-off → tools PASS, MTP-on → tools FAIL.** The compose carries a caveat block with the exact re-enable trigger (a stable vLLM shipping the fix) + `gh api` checks + the `--speculative-config` lines to restore.

## Validation

- **Live dual on stock v0.24.0:** 267K KV pool, coherent, **streaming multi-tool 3/3** (all args, no leak).
- Launcher resolves end-to-end (engine `vllm-stable`, int8-PTH, 262K, **fits-constrained ~23.2 GB**).
- **Suite green** (registry/compat/diagnose/mounts); the one fail is the pre-existing worktree-fixture `test-submit-bench` (green on a checkout with fixtures).
- `vllm-stable.features.int8_per_token_head → true` (native in v0.24.0, not overlay-provided).

## Scope / follow-up

Additive — the existing v0.22.0 gemma composes keep working; this **adds** the v0.24.0 path. The engine consolidation (retire `vllm-gemma-stable` + `vllm-gemma4-unified`, fold 12b + 26b, de-register the gemma overlays) + full verify/stress/NIAH/bench/soak lands as a **follow-up PR**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
