### PR TITLE
hygiene: align stale vllm-nightly-clean Engine-profile headers → vllm-stable

### DIFF
--- a/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml
@@ -55,7 +55,7 @@
 # ===========================================================================
 # Hardware metadata (parsed by scripts/preflight.sh):
 # Requires-min-vram-gb: 24
-# Engine-profile: vllm-nightly-clean
+# Engine-profile: vllm-stable
 # Requires-min-gpu-count: 2
 # Tensor-parallel: 2
 services:

--- a/models/qwen3.6-27b/vllm/compose/single/autoround-int4/minimal.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/autoround-int4/minimal.yml
@@ -33,7 +33,7 @@
 # ===========================================================================
 # Hardware metadata (parsed by scripts/preflight.sh):
 # Requires-min-vram-gb: 20
-# Engine-profile: vllm-nightly-clean
+# Engine-profile: vllm-stable
 # Requires-min-gpu-count: 1
 # Tensor-parallel: 1
 services:

--- a/models/qwen3.6-35b-a3b/vllm/compose/dual/autoround-int4/fp8.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/dual/autoround-int4/fp8.yml
@@ -48,17 +48,17 @@
 # ===========================================================================
 # Hardware metadata (parsed by scripts/preflight.sh):
 # Requires-min-vram-gb: 24
-# Engine-profile: vllm-nightly-clean
+# Engine-profile: vllm-stable
 # Requires-min-gpu-count: 2
 # Tensor-parallel: 2
 # Requires-sm: 7.5+
 services:
   vllm-qwen36-35b-a3b-dual:
-    # Pinned to vLLM STABLE v0.22.0 (immutable — validated 2026-05-30; never
-    # purged from Docker Hub, unlike nightlies). No source overlays. Bump the tag
-    # after a verify-stress + soak gate. (Engine-profile metadata still reads
-    # vllm-nightly-clean for compat; aligning the profile to a stable engine is
-    # tracked in club-3090 #254.) Override with VLLM_IMAGE=... for a specific build.
+    # Pinned to vLLM STABLE v0.24.0 (immutable — never purged from Docker Hub,
+    # unlike nightlies). No source overlays. Bump the tag after a verify-stress +
+    # soak gate. (Engine-profile aligned to vllm-stable 2026-07-02 — the #254
+    # two-engine split shipped + the former vllm-nightly-clean tag was purged.)
+    # Override with VLLM_IMAGE=... for a specific build.
     image: ${VLLM_IMAGE:-vllm/vllm-openai:v0.24.0}
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-35b-a3b-dual}"
     restart: ${CLUB3090_RESTART:-unless-stopped}


### PR DESCRIPTION
3 active qwen composes (`qwen/minimal`, `qwen/dual/fp8-mtp`, `qwen-35b-a3b/dual/fp8`) carried a stale `# Engine-profile: vllm-nightly-clean` docstring — the registry moved them to `vllm-stable` (the nightly-clean successor, #254) but the header comments lagged. **Cosmetic only**: the launcher injects `VLLM_IMAGE` from the registry engine's `install.spec`, not from this header (launch/preflight don't parse `Engine-profile`). Also fixed the qwen-35b prose ("v0.22.0" → v0.24.0; dropped the "aligning tracked in #254" note — #254 shipped).

No functional change — the purged nightly images were never launched (registry routes everything to `vllm-stable` v0.24.0). Suite: header-relevant tests green (preflight-vram / profiles-compat / launch-compat / registry-disk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm