### PR TITLE
c3: hide deprecated slugs in catalog by default ([h] toggles)

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -652,6 +652,8 @@ class CatalogPane(Container):
         self._filter: str = ""
         # Model-scope dropdown selection ("" = all models); AND-combined with _filter.
         self._model_filter: str = ""
+        # [h] toggle: hide 🗑️ deprecated slugs by default (mirrors `switch.sh --list`).
+        self._show_deprecated: bool = False
         # Distinct model names (registry order) backing the dropdown — refreshed on load.
         self._models: list[str] = []
         # N3: the slug currently live-serving (from the estate's matched_slug),
@@ -767,14 +769,17 @@ class CatalogPane(Container):
         banner = f"[yellow]{self._model_dir_note}[/yellow]  ·  " if self._model_dir_note else ""
         # Surface an active model scope (dropdown) the same way the text filter is shown.
         scope = f"model: [cyan]{self._model_filter}[/cyan]  ·  " if self._model_filter else ""
+        # [h] hint: N 🗑️ deprecated slugs hidden (0 when revealed).
+        dep_n = self._deprecated_hidden_count()
+        dep_note = f"  ·  [dim]+{dep_n} deprecated hidden — h[/dim]" if dep_n else ""
         if self._filter or self._model_filter:
             tail = f"  ·  filter: {self._filter!r}" if self._filter else ""
             status_label.update(
-                f"{banner}{scope}{len(rows)} / {len(self._entries)} variants{tail}"
+                f"{banner}{scope}{len(rows)} / {len(self._entries)} variants{tail}{dep_note}"
             )
         else:
             star = "  ([dim]*[/dim] = BENCHMARKS.md scrape)" if self._has_md_scrape() else ""
-            status_label.update(f"{banner}{len(self._entries)} variants loaded from registry{star}")
+            status_label.update(f"{banner}{len(self._entries)} variants loaded from registry{star}{dep_note}")
 
         # #9/A8 — keep the preview strip in sync with the cursor after a (re-)render
         # (enrichment mutates fit/measurement in place; the preview must reflect it).
@@ -831,11 +836,17 @@ class CatalogPane(Container):
         return any(e.measurement.source == "benchmarks.md" for e in self._entries)
 
     def _filtered_entries(self) -> list[CatalogEntry]:
+        # Hide 🗑️ deprecated slugs by default (mirrors `switch.sh --list`); [h] reveals them.
+        pool = (
+            self._entries
+            if self._show_deprecated
+            else [e for e in self._entries if (e.status or "").strip().lower() != "deprecated"]
+        )
         # Model-scope dropdown first — AND-combined with the text filter below.
         base = (
-            [e for e in self._entries if e.model == self._model_filter]
+            [e for e in pool if e.model == self._model_filter]
             if self._model_filter
-            else self._entries
+            else pool
         )
         if not self._filter:
             return self._grouped_by_model(base)
@@ -878,6 +889,21 @@ class CatalogPane(Container):
             return
         self._model_filter = new
         self._render_rows()
+
+    def toggle_deprecated(self) -> None:
+        """[h] show/hide 🗑️ deprecated slugs (hidden by default, mirroring
+        `switch.sh --list`).  Re-renders (cursor resets to the top of the
+        now-widened / narrowed set)."""
+        self._show_deprecated = not self._show_deprecated
+        self._render_rows()
+
+    def _deprecated_hidden_count(self) -> int:
+        """How many 🗑️ deprecated slugs are currently hidden (0 once revealed)."""
+        if self._show_deprecated:
+            return 0
+        return sum(
+            1 for e in self._entries if (e.status or "").strip().lower() == "deprecated"
+        )
 
     def toggle_model_select(self) -> None:
         """[\\] toggle the model-scope dropdown (hidden by default, like the text
@@ -4794,6 +4820,7 @@ _PALETTE_COMMANDS: tuple[tuple[str, str, str], ...] = (
     ("primary_action", "Serve selected / primary action", "⏎ — serve the selected slug (reconcile-gated)"),
     ("explain", "Explain selected slug", "Catalog — detail + cross-rig benchmarks"),
     ("filter_catalog", "Filter catalog", "Catalog — filter by slug / engine / status"),
+    ("toggle_catalog_deprecated", "Show/hide deprecated", "Catalog — reveal 🗑️ deprecated slugs (hidden by default)"),
     ("set_default", "Set default", "Catalog — pin the selected slug as model default"),
     ("clear_default", "Clear default", "Catalog — clear the model default pin"),
     ("optimize_card", "Optimize for my card", "Catalog — v0.10.0 seam (not available yet)"),
@@ -4944,6 +4971,7 @@ class CockpitApp(App):
         # Context-sensitive — check_action enables/shows them only in the right mode.
         Binding("slash", "filter_catalog", "Filter", show=False),
         Binding("backslash", "toggle_catalog_model", "Model", show=False),
+        Binding("h", "toggle_catalog_deprecated", "Deprecated", show=False),
         Binding("e", "explain", "Explain", show=False),
         # 2-mode merge: [1] = merged Run & Operate, [2] = Bring & Validate lane.
         Binding("1", "mode_run", "Run & Operate", show=True),
@@ -5135,6 +5163,7 @@ class CockpitApp(App):
     _CONTEXT_KEYS: dict[str, tuple[set[int], Optional[set[str]]]] = {
         # Merged mode 0 · Catalog tab
         "filter_catalog":   ({0}, {"tab-catalog"}),  # Catalog
+        "toggle_catalog_deprecated": ({0}, {"tab-catalog"}),  # Catalog — [h] hide/show deprecated
         "explain":          ({0}, {"tab-catalog"}),  # Catalog (guards inside action)
         "set_default":      ({0}, {"tab-catalog"}),  # Catalog
         "clear_default":    ({0}, {"tab-catalog"}),  # Catalog
@@ -7225,6 +7254,14 @@ class CockpitApp(App):
         if self._active_mode == 0 and self._current_subtab() == "tab-catalog":
             try:
                 self.query_one("#catalog-pane", CatalogPane).toggle_model_select()
+            except Exception:
+                pass
+
+    def action_toggle_catalog_deprecated(self) -> None:
+        """[h] show/hide 🗑️ deprecated slugs (merged mode 0 · Catalog tab)."""
+        if self._active_mode == 0 and self._current_subtab() == "tab-catalog":
+            try:
+                self.query_one("#catalog-pane", CatalogPane).toggle_deprecated()
             except Exception:
                 pass
 

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -1056,6 +1056,68 @@ class TestCatalogWired:
             assert len(pane._filtered_entries()) == 2
 
     @pytest.mark.asyncio
+    async def test_catalog_hides_deprecated_by_default_and_h_reveals(self):
+        """🗑️ Deprecated slugs are HIDDEN from the catalog by default (mirrors
+        `switch.sh --list`); [h] / toggle_deprecated() reveals them, and the banner
+        surfaces the hidden count.  A deprecated slug stays filtered even when it
+        matches the active text filter — until revealed."""
+        from club3090_cockpit.data import CatalogEntry as _CE
+        from club3090_tui_core import VariantRow as _VR
+
+        def _entry(slug: str, status: str) -> _CE:
+            leaf = slug.split("/")[-1]
+            path = f"models/gemma-4-31b/vllm/compose/dual/autoround-int4/{leaf}.yml"
+            return _CE(
+                row=_VR(
+                    slug=slug, switch_engine="vllm", launch_engine="vllm",
+                    compose_dir=path.rsplit("/", 1)[0], file=path.rsplit("/", 1)[-1],
+                    port=8000, model="gemma-4-31b", engine="vllm-stable",
+                    kvcalc_key="gemma-4-31b:dual", container="c",
+                    compose_path=path, status=status, ctx_label="229K", status_note="",
+                )
+            )
+
+        live = _entry("vllm/gemma-dual", "caveats")
+        prod = _entry("vllm/gemma-prod", "production")
+        dead1 = _entry("vllm/gemma-int8-mtp", "deprecated")
+        dead2 = _entry("vllm/gemma-bf16-mtp", "deprecated")
+
+        app, _, _ = make_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            pane = app.query_one("#catalog-pane", CatalogPane)
+            pane.populate([live, prod, dead1, dead2], None)
+
+            # Default: 2 deprecated hidden; only the functional slugs show.
+            assert pane._show_deprecated is False
+            assert {e.slug for e in pane._filtered_entries()} == {
+                "vllm/gemma-dual", "vllm/gemma-prod",
+            }
+            assert pane._deprecated_hidden_count() == 2
+            assert app.query_one("#catalog-table", DataTable).row_count == 2
+
+            # A deprecated slug stays hidden even when it matches the text filter.
+            pane.set_filter("int8")
+            assert pane._filtered_entries() == []
+            pane.set_filter("")
+
+            # [h] reveals: all 4 rows show, hidden-count drops to 0.
+            pane.toggle_deprecated()
+            assert pane._show_deprecated is True
+            assert len(pane._filtered_entries()) == 4
+            assert pane._deprecated_hidden_count() == 0
+            assert app.query_one("#catalog-table", DataTable).row_count == 4
+            # Revealed → the deprecated slug is now findable by filter.
+            pane.set_filter("int8")
+            assert [e.slug for e in pane._filtered_entries()] == ["vllm/gemma-int8-mtp"]
+            pane.set_filter("")
+
+            # Toggling back hides them again.
+            pane.toggle_deprecated()
+            assert pane._show_deprecated is False
+            assert len(pane._filtered_entries()) == 2
+
+    @pytest.mark.asyncio
     async def test_catalog_model_dropdown_scopes_and_combines(self):
         """Model-scope dropdown: options are the DISTINCT model names in registry
         order (the switch.sh --list grouping the flat table drops); picking one
@@ -4345,6 +4407,7 @@ class TestCheckActionPerModeSubtab:
             # Catalog (default mode/tab): filter enabled.
             assert app._active_mode == 0
             assert app.check_action("filter_catalog", ()) is True
+            assert app.check_action("toggle_catalog_deprecated", ()) is True
             # Lane mode: no benchmarks tab → context_t (sort) disabled, and
             # filter_catalog is off (not a Catalog context).
             await pilot.press("2")
@@ -4352,6 +4415,7 @@ class TestCheckActionPerModeSubtab:
             assert app._active_mode == 1
             assert app.check_action("context_t", ()) is False
             assert app.check_action("filter_catalog", ()) is False
+            assert app.check_action("toggle_catalog_deprecated", ()) is False
 
     @pytest.mark.asyncio
     async def test_validate_evidence_enables_s_key(self):
@@ -4376,6 +4440,7 @@ class TestCheckActionPerModeSubtab:
             assert app._active_mode == 0
             assert app.check_action("explain", ()) is False
             assert app.check_action("filter_catalog", ()) is False
+            assert app.check_action("toggle_catalog_deprecated", ()) is False
 
     @pytest.mark.asyncio
     async def test_always_on_keys_active_in_every_mode(self):


### PR DESCRIPTION
## Why

The c3 **catalog** listed *every* registry slug — 🗑️ deprecated ones included — while `switch.sh --list` hides deprecated (and `--list --all` reveals them). So after the gemma-4 v0.24.0 consolidation deprecated a batch of old slugs (`gemma-int8-mtp`, `gemma-bf16-mtp`, `gemma-31b-qat-w4a16-dual`, …), they kept showing in c3, offering users dead configs.

This aligns c3 with `switch.sh`: **hide deprecated by default, `[h]` to reveal.**

## What

- **`CatalogPane`**: new `_show_deprecated` flag (default `False`) + `toggle_deprecated()` + a `_deprecated_hidden_count()` helper. `_filtered_entries()` drops deprecated from the pool **before** the model-scope and text filters — so a deprecated slug stays hidden even when it matches an active filter, until revealed.
- **Banner**: `+N deprecated hidden — h` note (0 when revealed) so the hidden count is always visible.
- **Binding**: `h → action_toggle_catalog_deprecated`, context-gated to **mode 0 · Catalog** in `_CONTEXT_KEYS` exactly like `[/] filter_catalog` (`show=False`; the printable letter is swallowed by the filter `Input` while it's focused, same mechanism as the existing `[e]` explain key — **no focus-chain change**, so the focus-test suite is unaffected).

Deprecated ≠ hidden-from-existence: the registry still carries the slug + hardware fields (launch-compat / pull-gate tests rely on them). This is purely a **default catalog view** change; `[h]` brings them back instantly.

## Scope

- **Deprecated only** — incubating/preview/experimental slugs still show (they're actionable-in-progress; deprecated is the only "don't pick this" status).

## Tests

- New `test_catalog_hides_deprecated_by_default_and_h_reveals`: hide-by-default, `[h]` reveals all rows, `_deprecated_hidden_count()`, banner-count, and the filter-interaction (deprecated stays hidden under an active text filter until revealed).
- `toggle_catalog_deprecated` gating assertions added alongside `filter_catalog` in the two existing catalog-key `check_action` tests (True on mode-0/Catalog, False on the lane + Doctor tabs).
- **Full headless suite green: 516 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)