### PR TITLE
fix(#535): fail fast + actionable when gpu_memory_utilization doesn't fit free VRAM

### DIFF
--- a/scripts/gpu-mode.sh
+++ b/scripts/gpu-mode.sh
@@ -241,6 +241,27 @@ stop_studio_director() {
 _director_evict_if_gpu() {
     [ "$(_director_device)" != "cpu" ] && stop_studio_director
 }
+# `docker compose down` returns before CUDA actually releases the GPU memory, so the
+# next model scene can boot into not-yet-freed VRAM and hit vLLM's free-memory check
+# (club-3090 #535: ai-studio → gemma). Poll until total used-VRAM stops falling (or a
+# timeout) so the incoming model sees the freed memory.
+wait_gpu_vram_settle() {
+    command -v nvidia-smi >/dev/null 2>&1 || return 0
+    local timeout="${1:-20}" prev="" cur stable=0 waited=0 noted=0
+    while [ "$waited" -lt "$timeout" ]; do
+        cur=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null | awk '{s+=$1} END{print s+0}')
+        [ -z "$cur" ] && return 0
+        if [ -n "$prev" ] && [ "$cur" -ge "$prev" ]; then
+            stable=$((stable+1)); [ "$stable" -ge 2 ] && { [ "$noted" = 1 ] && echo "done"; return 0; }
+        else
+            if [ "$noted" = 0 ] && [ -n "$prev" ]; then printf "  ${YELLOW}◔${NC} waiting for the previous scene's GPU VRAM to release..."; noted=1; fi
+            stable=0
+        fi
+        prev="$cur"; sleep 1; waited=$((waited+1))
+    done
+    [ "$noted" = 1 ] && echo "timeout"
+    return 0
+}
 start_studio_orchestrator() {
     printf "  ${GREEN}▲${NC} Starting studio-orchestrator (:8190, long-clip chaining)..."
     compose_at "$COMPOSE_BASE/studio/orchestrator" "up -d --build" && echo "done" || echo "failed"
@@ -589,6 +610,7 @@ mode_gemma_int8() {
     stop_step_voice
     _director_evict_if_gpu
     stop_gemma_int8          # clean re-switch; the dflash/awq gemma scenes were pruned
+    wait_gpu_vram_settle     # let the torn-down scene's VRAM release before TP=2 gemma boots (#535)
     start_gemma_int8
     start_service litellm
     start_service qdrant

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -506,6 +506,66 @@ preflight_gpu_idle() {
   return 0
 }
 
+# preflight_compose_gpu_fit <compose_file> <force>
+#   HARD-fail (unless force=1) when the GPUs lack enough FREE VRAM for the compose's
+#   gpu_memory_utilization. vLLM aborts at boot if `free < util × total`; with
+#   restart:unless-stopped it then restart-loops, so `switch.sh` waits the full
+#   READY_TIMEOUT (600s) for an endpoint that never comes. This converts that silent
+#   timeout into an instant, actionable error — the failure @stage-chuk hit switching
+#   ai-studio → gemma on a desktop rig (club-3090 #535): GNOME on the GPUs (~1.3 GiB/card)
+#   leaves < the 0.95 budget free. We mirror vLLM's own check (util × total × 0.98 ≈ its
+#   mem_get_info total, i.e. nvidia-smi total minus ~2% driver-reserved) and briefly retry,
+#   because `docker compose down` returns before CUDA actually releases a torn-down scene.
+preflight_compose_gpu_fit() {
+  local compose="$1" force="${2:-0}"
+  command -v nvidia-smi >/dev/null 2>&1 || return 0
+  [[ -f "$compose" ]] || return 0
+
+  # Effective util: an env GPU_MEMORY_UTILIZATION override wins over the compose default
+  # (`${GPU_MEMORY_UTILIZATION:-<X>}`), so the gate matches what vLLM will actually use.
+  local util_default util
+  util_default=$(grep -oE 'GPU_MEMORY_UTILIZATION:-[0-9.]+' "$compose" | head -1 | sed 's/.*-//')
+  util="${GPU_MEMORY_UTILIZATION:-$util_default}"
+  case "$util" in ''|*[!0-9.]*) return 0 ;; esac   # unknown / non-numeric → can't gate
+
+  # Cards this compose uses (TP / min-gpu-count header; default 1).
+  local need_cards
+  need_cards=$(grep -oiE '#[[:space:]]*(Tensor-parallel|Requires-min-gpu-count):[[:space:]]*[0-9]+' "$compose" \
+               | grep -oE '[0-9]+' | sort -rn | head -1)
+  [[ -z "$need_cards" ]] && need_cards=1
+
+  # Settle window (~10s): a just-`down`ed scene's VRAM lags docker's return.
+  local attempt result idx fg ng fits
+  for attempt in 1 2 3 4 5; do
+    result=$(nvidia-smi --query-gpu=index,memory.total,memory.free --format=csv,noheader,nounits 2>/dev/null \
+      | awk -F, -v util="$util" -v n="$need_cards" '
+          { gi[NR]=$1+0; f[NR]=$3+0; d[NR]=util*$2*0.98 }
+          END {
+            if (NR==0) { print "-1 0 0 1"; exit }          # no cards visible → skip
+            for (i=1;i<=NR;i++) ord[i]=i                    # sort card rows by free desc
+            for (i=1;i<=NR;i++) for (j=i+1;j<=NR;j++) if (f[ord[j]]>f[ord[i]]) { t=ord[i]; ord[i]=ord[j]; ord[j]=t }
+            k=(n<NR ? n : NR); fits=1; wf=1e18; wn=0; wi=-1  # check the k best cards; report the worst
+            for (i=1;i<=k;i++){ c=ord[i]; if (f[c]<d[c]) fits=0; if (f[c]<wf){ wf=f[c]; wn=d[c]; wi=gi[c] } }
+            printf "%d %.1f %.1f %d", wi, wf/1024, wn/1024, fits
+          }')
+    read -r idx fg ng fits <<< "$result"
+    [[ "$fits" == "1" ]] && return 0
+    [[ "$attempt" -lt 5 ]] && sleep 2
+  done
+
+  echo "[preflight] ERROR: GPU ${idx} has ${fg} GiB free, but this config needs ~${ng} GiB/card" >&2
+  echo "[preflight]        (gpu_memory_utilization=${util}, ${need_cards} card(s) for TP). Something else is holding VRAM —" >&2
+  echo "[preflight]        a desktop on the GPU, another model, or a scene that isn't fully stopped (check: docker ps / nvidia-smi)." >&2
+  echo "[preflight]        Fix: free that VRAM, or lower the ceiling —" >&2
+  echo "[preflight]             GPU_MEMORY_UTILIZATION=0.90 bash scripts/switch.sh <variant>" >&2
+  echo "[preflight]        — then retry.  (Bypass this check with --force.)" >&2
+  if [[ "$force" == "1" ]]; then
+    echo "[preflight] WARN:  --force set — launching anyway; vLLM may still abort at the free-memory check." >&2
+    return 0
+  fi
+  return 1
+}
+
 preflight_running() {
   command -v docker >/dev/null 2>&1 || return 0
   local running

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -978,6 +978,11 @@ up_variant() {
     preflight_compose_deps "${full_dir}/${file}" || exit 1
     if [[ "$eng" == "vllm" ]]; then
       preflight_compose_hardware "${full_dir}/${file}" "$v" "${FORCE:-0}" || exit 1
+      # Free-VRAM gate: fail fast (not a 600s restart-loop) when the GPUs don't have
+      # room for this config's gpu_memory_utilization — e.g. a desktop/other scene
+      # still holding VRAM after a switch (club-3090 #535). Runs AFTER down_running(),
+      # so its settle-retry also covers the just-torn-down container's VRAM lag.
+      preflight_compose_gpu_fit "${full_dir}/${file}" "${FORCE:-0}" || exit 1
     fi
     # LMCache host-RAM guard — runs even under --force (incubating LMCache slugs
     # launch WITH --force, yet over-sizing --l1-size-gb can OOM the host; #133).

--- a/scripts/tests/test-preflight-gpu-fit.sh
+++ b/scripts/tests/test-preflight-gpu-fit.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Unit test for preflight_compose_gpu_fit — the free-VRAM-vs-util gate (club-3090 #535).
+# vLLM aborts at boot when `free < util × total`; with restart:unless-stopped that becomes
+# a silent 600s restart-loop. This gate must fail FAST + actionably instead. We mock
+# nvidia-smi (a shell function satisfies `command -v`) and no-op sleep so the settle-retry
+# doesn't actually wait.
+set -u
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=../preflight.sh
+source "${ROOT_DIR}/scripts/preflight.sh"
+
+FAILS=0
+pass() { echo "  ok:   $1"; }
+fail() { echo "  FAIL: $1"; FAILS=$((FAILS + 1)); }
+
+# Instant retries — don't sleep through the ~10s settle window in tests.
+sleep() { :; }
+# Mocked GPU state: set MOCK_SMI to the CSV rows nvidia-smi should emit.
+nvidia-smi() { printf '%s\n' "$MOCK_SMI"; }
+
+# gemma-like compose: TP=2, aggressive 0.95 util.
+tp2=$(mktemp)
+cat > "$tp2" <<'YAML'
+# Tensor-parallel: 2
+services:
+  x:
+    command:
+      - --gpu-memory-utilization
+      - "${GPU_MEMORY_UTILIZATION:-0.95}"
+YAML
+
+# single-card compose: no TP header (defaults to 1 card), 0.92 util.
+single=$(mktemp)
+cat > "$single" <<'YAML'
+services:
+  x:
+    command: ["--gpu-memory-utilization", "${GPU_MEMORY_UTILIZATION:-0.92}"]
+YAML
+
+# 1) FITS — both cards nearly empty (need ≈ 0.95×24576×0.98 = 22.9 GiB; 24000 free).
+MOCK_SMI=$'0, 24576, 24000\n1, 24576, 24000'
+if preflight_compose_gpu_fit "$tp2" 0 >/dev/null 2>&1; then pass "fits when both cards are free"; else fail "should fit when both cards free"; fi
+
+# 2) INSUFFICIENT — the exact #535 numbers (free 22350/22060 < 22.9 GiB need) → hard fail.
+MOCK_SMI=$'0, 24576, 22350\n1, 24576, 22060'
+err=$(preflight_compose_gpu_fit "$tp2" 0 2>&1); rc=$?
+[ "$rc" -ne 0 ] && pass "fails when a TP card is short (#535 repro)" || fail "should fail on the #535 numbers (rc=$rc)"
+echo "$err" | grep -q "GPU_MEMORY_UTILIZATION=0.90" && pass "emits the actionable lower-util hint" || fail "missing actionable hint"
+echo "$err" | grep -q "GPU 1 has" && pass "names the short card (GPU 1)" || fail "should name the worst card"
+
+# 3) --force bypasses the gate (rc 0, with a WARN).
+if preflight_compose_gpu_fit "$tp2" 1 >/dev/null 2>&1; then pass "--force bypasses"; else fail "--force should bypass"; fi
+
+# 4) env GPU_MEMORY_UTILIZATION override lowers the need so the same VRAM now fits.
+MOCK_SMI=$'0, 24576, 22350\n1, 24576, 22060'
+if GPU_MEMORY_UTILIZATION=0.88 preflight_compose_gpu_fit "$tp2" 0 >/dev/null 2>&1; then pass "env util override (0.88) fits"; else fail "env override should fit"; fi
+
+# 5) single-card only needs ONE good card — GPU0 busy, GPU1 free → OK.
+MOCK_SMI=$'0, 24576, 5000\n1, 24576, 24000'
+if preflight_compose_gpu_fit "$single" 0 >/dev/null 2>&1; then pass "single-card fits on the free card"; else fail "single-card should fit on the best card"; fi
+
+# 6) no nvidia-smi → skip (never blocks a rig without a GPU query).
+( unset -f nvidia-smi
+  command_v_backup() { command -v nvidia-smi; }
+  if ! command -v nvidia-smi >/dev/null 2>&1; then
+    preflight_compose_gpu_fit "$tp2" 0 >/dev/null 2>&1 && echo "  ok:   skips without nvidia-smi" || echo "  FAIL: should skip without nvidia-smi"
+  else
+    echo "  ok:   (nvidia-smi present on host — skip-case not exercised)"
+  fi )
+
+rm -f "$tp2" "$single"
+if [ "$FAILS" -eq 0 ]; then echo "PASS test-preflight-gpu-fit"; exit 0; else echo "FAIL test-preflight-gpu-fit ($FAILS)"; exit 1; fi


### PR DESCRIPTION
Fixes #535.

## Root cause

@stage-chuk's rig runs **GNOME on the 3090s** (~1.3 GiB/card). After ai-studio, free VRAM drops below gemma's **`gpu_memory_utilization: 0.95`** budget (needs ~22.4 GiB/card free). vLLM aborts at boot on its own free-memory check:

```
ValueError: Free memory on device cuda:1 (22.06/23.56 GiB) on startup is less than
desired GPU memory utilization (0.95, 22.38 GiB).
```

With `restart: unless-stopped` the container **restart-loops**, so `switch.sh` waits the full **600s** `READY_TIMEOUT` for an endpoint that never comes. The existing `gpu_preflight` only enforces a coarse **80%-free floor** — the reporter had ~90% free, so it sailed through. **qwen (`0.92`) fits** the same residue → step 8 worked, which is why *only gemma* broke.

## Fix

- **`preflight.sh` → `preflight_compose_gpu_fit`**: parses the *effective* `GPU_MEMORY_UTILIZATION` (env override or compose default) + TP card-count, compares each target card's **free** VRAM to `util × total × 0.98` (≈ vLLM's own `mem_get_info` total = nvidia-smi total minus ~2% driver-reserved), and **hard-fails** (unless `--force`) with an actionable message. A ~10s **settle-retry** covers teardown lag (`docker compose down` returns before CUDA frees).
- **`switch.sh`**: calls it in `up_variant` (vllm-only, after `down_running` so the retry also covers the just-torn-down container). `launch.sh` delegates to `switch.sh` → covered.
- **`gpu-mode.sh` → `wait_gpu_vram_settle`**: after the scene teardown in the gemma handler, so the incoming TP=2 model boots into freed VRAM instead of ai-studio's residue.
- **`test-preflight-gpu-fit.sh`**: mocks nvidia-smi + the #535 numbers — fit / short+message / `--force` / env-override / single-card.

## What the user now sees (instead of a 600s hang)

```
[preflight] ERROR: GPU 1 has 21.5 GiB free, but this config needs ~22.3 GiB/card
[preflight]        (gpu_memory_utilization=0.95, 2 card(s) for TP). Something else is holding VRAM …
[preflight]        Fix: free that VRAM, or lower the ceiling —
[preflight]             GPU_MEMORY_UTILIZATION=0.90 bash scripts/switch.sh <variant>
```

## Verification

- **Full shell gate 60/60** (only fail = known worktree-fixture-absent `test-submit-bench`).
- **End-to-end against the real gemma compose**: idle rig fits (rc 0); parses `0.95` + TP=2 correctly; simulated 22060 MiB free → instant fail with the message above (the 22.3 GiB need matches vLLM's own 22.38 threshold).

## Not in this PR (deliberate)

- The 0.95 → 0.92 util default for gemma (would give desktop rigs headroom but slightly trims KV on headless rigs) — that's a config-default call, left to the maintainer. The reporter's immediate workaround is `GPU_MEMORY_UTILIZATION=0.90`.
- Wiring the gate into gpu-mode's other model scenes (they're 0.92, less prone) — easy follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)