### PR TITLE
deriver: resolve bit-width from compressed-tensors config_groups

### DIFF
--- a/scripts/lib/profiles/deriver.py
+++ b/scripts/lib/profiles/deriver.py
@@ -600,6 +600,24 @@ def _quant_bpw(quant_cfg: dict) -> Optional[float]:
     )
     if isinstance(bits, (int, float)) and bits > 0:
         return float(bits)
+    # compressed-tensors (llm-compressor) checkpoints nest the bit-width per
+    # config-group instead of top-level: config_groups.<g>.weights =
+    # {num_bits: 8, type: "float"|"int", ...}. Take the widest weights
+    # num_bits across groups (mixed-precision groups exist; the widest
+    # dominates the VRAM footprint the fit-check cares about). Explicit
+    # structure beats the method-name heuristics below — "compressed-tensors"
+    # as a method name matches none of them (the Agents-A1-FP8-dynamic
+    # producer-zero dogfood finding, 2026-07-02).
+    groups = quant_cfg.get("config_groups")
+    if isinstance(groups, dict):
+        bits_seen = []
+        for g in groups.values():
+            w = g.get("weights") if isinstance(g, dict) else None
+            nb = w.get("num_bits") if isinstance(w, dict) else None
+            if isinstance(nb, (int, float)) and nb > 0:
+                bits_seen.append(float(nb))
+        if bits_seen:
+            return max(bits_seen)
     method = str(
         quant_cfg.get("quant_method")
         or quant_cfg.get("method")

--- a/scripts/tests/test-pullgate-deriver.sh
+++ b/scripts/tests/test-pullgate-deriver.sh
@@ -414,6 +414,53 @@ check(
 # (Real catalog has none, so this is covered by the gguf_with_repos check
 # above + the deriver's explicit guard.)
 
+# compressed-tensors config_groups bit-width resolution (the Agents-A1
+# FP8-dynamic producer-zero dogfood finding, 2026-07-02): bits live nested at
+# config_groups.<g>.weights.num_bits, NOT top-level — resolve_quant_dtype must
+# read them (previously -> quant-dtype-unknown for every llm-compressor
+# checkpoint: FP8-dynamic, INT8 W8A8, INT4 pack-quantized).
+CT_FP8_CFG = {
+    "quant_method": "compressed-tensors",
+    "format": "float-quantized",
+    "config_groups": {
+        "group_0": {
+            "weights": {"num_bits": 8, "type": "float", "strategy": "channel", "dynamic": False},
+            "input_activations": {"num_bits": 8, "type": "float", "dynamic": True},
+            "targets": ["Linear"],
+        }
+    },
+}
+wf, bpw, err = D.resolve_quant_dtype("fixtures/ct-fp8", {"quantization_config": CT_FP8_CFG}, [], None, None)
+check(
+    err is None and wf == "compressed-tensors" and bpw == 8.0,
+    f"compressed-tensors FP8-dynamic config_groups -> bpw 8.0 (got wf={wf} bpw={bpw} err={err})",
+)
+CT_INT4_CFG = {
+    "quant_method": "compressed-tensors",
+    "format": "pack-quantized",
+    "config_groups": {
+        "group_0": {"weights": {"num_bits": 4, "type": "int", "group_size": 128}}
+    },
+}
+wf4, bpw4, err4 = D.resolve_quant_dtype("fixtures/ct-int4", {"quantization_config": CT_INT4_CFG}, [], None, None)
+check(
+    err4 is None and bpw4 == 4.0,
+    f"compressed-tensors INT4 pack-quantized config_groups -> bpw 4.0 (got bpw={bpw4} err={err4})",
+)
+# mixed groups: the WIDEST weights num_bits wins (footprint-dominant).
+CT_MIXED_CFG = {
+    "quant_method": "compressed-tensors",
+    "config_groups": {
+        "g0": {"weights": {"num_bits": 4, "type": "int"}},
+        "g1": {"weights": {"num_bits": 8, "type": "float"}},
+    },
+}
+_, bpwm, errm = D.resolve_quant_dtype("fixtures/ct-mixed", {"quantization_config": CT_MIXED_CFG}, [], None, None)
+check(
+    errm is None and bpwm == 8.0,
+    f"compressed-tensors mixed groups -> widest bpw 8.0 (got bpw={bpwm} err={errm})",
+)
+
 if failures:
     print(f"\n{len(failures)} assertion(s) failed.", file=sys.stderr)
     sys.exit(1)


### PR DESCRIPTION
## Found by the T2 producer-zero dogfood (first friction of the run)

`pull.sh <slug> --profile-like … --dry-run` (and therefore c3's ① Bring pane) **rejected every llm-compressor checkpoint** — FP8-dynamic, INT8 W8A8, INT4 pack-quantized — with `quant-dtype-unknown (bits undeterminable)`, `arch: null`, `swap_path: null`. A producer bringing any modern compressed-tensors model hit a hard wall at step ①.

**Root cause:** `_quant_bpw` reads top-level `bits`/`w_bit` keys + method-name heuristics — and `"compressed-tensors"` as a method name matches none of them, while the actual bits live nested at `config_groups.<g>.weights.num_bits`.

**Fix (owning layer per the T1 layer rule):** parse `config_groups`, widest group wins (mixed-precision groups exist; the widest dominates the VRAM footprint the fit-check prices). pull.sh CLI and c3 inherit together.

**Validated live:** post-fix, `pull.sh InternScience/Agents-A1-FP8-dynamic --profile-like vllm/qwen-35b-a3b-dual --dry-run --json` resolves the arch (`Qwen3_5MoeForConditionalGeneration`) and emits the honest route-C verdict (sibling `qwen3.6-35b-a3b` + BRING_YOUR_OWN swap pointer + populated `swap_path`) — and the swapped compose **boots + serves** on stock v0.24.0 (Marlin weight-only FP8 MoE on sm_86, 262K, coherent, tool-calls clean).

+3 deriver test cases (FP8-dynamic = the A1 shape · INT4 pack-quantized · mixed-groups→widest). Gates: `test-pullgate-deriver` / `test-pull` / `test-pullgate-gates` / `test-pull-swap` all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)