### PR TITLE
scripts: support VLLM_API_KEY-secured composes end-to-end

### DIFF
--- a/models/gemma-4-31b/vllm/compose/dual/qat-awq-int4/base.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/qat-awq-int4/base.yml
@@ -70,7 +70,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-vllm-gemma-4-31b-qat-awq-int4}"
     restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
-      - "${ESTATE_PORT:-${PORT:-8032}}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8032}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
       # torch.compile + Triton kernel caches — first boot warms (~5-7 min);
@@ -83,6 +83,9 @@ services:
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
+      # Optional bearer-token auth. Set VLLM_API_KEY in the repo-root .env to require
+      # `Authorization: Bearer <key>` on every request. Empty = open (no auth).
+      - VLLM_API_KEY=${VLLM_API_KEY:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}
       - VLLM_WORKER_MULTIPROC_METHOD=spawn

--- a/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml
@@ -93,6 +93,9 @@ services:
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
+      # Optional bearer-token auth. Set VLLM_API_KEY in compose/.env to require
+      # `Authorization: Bearer <key>` on every request. Empty = open (no auth).
+      - VLLM_API_KEY=${VLLM_API_KEY:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}
       - VLLM_WORKER_MULTIPROC_METHOD=spawn

--- a/scripts/bench-agentic.sh
+++ b/scripts/bench-agentic.sh
@@ -66,6 +66,13 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Bearer auth for VLLM_API_KEY-secured composes (before autodetect's /v1/models
+# probe). No key set → no-op. See scripts/lib/curl-auth.sh.
+# shellcheck source=lib/curl-auth.sh
+source "${ROOT_DIR}/scripts/lib/curl-auth.sh"
+club3090_curl_auth_setup "${ROOT_DIR}"
+
 if [[ -f "${ROOT_DIR}/scripts/preflight.sh" ]]; then
   # shellcheck source=preflight.sh
   source "${ROOT_DIR}/scripts/preflight.sh"

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -64,6 +64,13 @@ set -euo pipefail
 # Auto-detect running container + port (URL/CONTAINER env vars still win).
 # See scripts/preflight.sh::preflight_autodetect_endpoint.
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Bearer auth for VLLM_API_KEY-secured composes (before autodetect's /v1/models
+# probe). No key set → no-op. See scripts/lib/curl-auth.sh.
+# shellcheck source=lib/curl-auth.sh
+source "${ROOT_DIR}/scripts/lib/curl-auth.sh"
+club3090_curl_auth_setup "${ROOT_DIR}"
+
 if [[ -f "${ROOT_DIR}/scripts/preflight.sh" ]]; then
   # shellcheck source=preflight.sh
   source "${ROOT_DIR}/scripts/preflight.sh"

--- a/scripts/health.sh
+++ b/scripts/health.sh
@@ -30,6 +30,13 @@ CONTAINER="${CONTAINER:-}"
 LOG_LINES="${LOG_LINES:-200}"
 WATCH_INTERVAL="${WATCH_INTERVAL:-5}"
 
+# Bearer auth for VLLM_API_KEY-secured composes (the /v1/models probe below
+# 401s without it). No key set → no-op. See scripts/lib/curl-auth.sh.
+_HEALTH_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=lib/curl-auth.sh
+source "${_HEALTH_ROOT}/scripts/lib/curl-auth.sh"
+club3090_curl_auth_setup "${_HEALTH_ROOT}"
+
 # Engine-prefix regex used when CONTAINER= is unset: any recognized inference
 # engine, not just qwen36-27b. (qwen36-27b containers — vllm-qwen36-27b /
 # llama-cpp-qwen36-27b — still match the first two alternatives, so a running

--- a/scripts/lib/curl-auth.sh
+++ b/scripts/lib/curl-auth.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# curl-auth.sh — authenticate curl against a VLLM_API_KEY-secured endpoint.
+#
+# Source this (don't execute it) near the top of any script that curls the
+# model's /v1/* endpoints, then call `club3090_curl_auth_setup "$ROOT_DIR"`.
+#
+# What it does:
+#   1. Resolves the bearer token from $VLLM_API_KEY / $CLUB3090_API_TOKEN, and
+#      if neither is set in the environment, from the repo-root .env. This is
+#      the fix for the direct-invocation case: `bash scripts/verify-full.sh`
+#      when the key lives ONLY in .env — switch.sh loads .env into its child
+#      `docker compose`, not into a sibling verify/bench/soak run, so those
+#      scripts otherwise see no key and 401.
+#   2. If a token is found, points curl's default config at a private temp
+#      .curlrc (0700 dir, 0600 file) that adds `Authorization: Bearer <token>`
+#      to EVERY curl in the sourcing process via $CURL_HOME — no per-curl edits.
+#   3. Installs an EXIT trap to delete the temp file — UNLESS the caller already
+#      has an EXIT trap (we don't clobber it). A caller with its own EXIT trap
+#      MUST call `club3090_curl_auth_cleanup` from its handler (see soak-test.sh).
+#
+# No token found → no-op: nothing written, no header sent, behaviour is
+# byte-identical to an unauthenticated run. The header is harmless on endpoints
+# that don't require it (/health and llama.cpp /props ignore it).
+#
+# Why a shared lib: a secured compose (VLLM_API_KEY set) breaks EVERY /v1/*
+# consumer — verify-full, verify-stress, bench, soak, health — not just one.
+# Threading a token through dozens of inline curls is error-prone; one $CURL_HOME
+# seam authenticates them all.
+
+club3090_curl_auth_cleanup() {
+  [[ -n "${CLUB3090_CURL_AUTH_DIR:-}" ]] && rm -rf "${CLUB3090_CURL_AUTH_DIR}"
+  CLUB3090_CURL_AUTH_DIR=""
+}
+
+# club3090_curl_auth_setup [repo_root]
+#   repo_root (optional): where to look for .env when the key isn't in the env.
+club3090_curl_auth_setup() {
+  local root="${1:-}"
+  local key="${VLLM_API_KEY:-${CLUB3090_API_TOKEN:-}}"
+  if [[ -z "$key" && -n "$root" && -f "${root}/.env" ]]; then
+    # Source .env in a subshell (like launch.sh's loader) so its quoting is
+    # honoured and its side effects don't leak into the calling script.
+    key="$(set -a; . "${root}/.env" >/dev/null 2>&1; printf '%s' "${VLLM_API_KEY:-${CLUB3090_API_TOKEN:-}}")"
+  fi
+  [[ -z "$key" ]] && return 0
+
+  # Expose the resolved token for consumers that authenticate a CHILD PROCESS
+  # rather than curl — e.g. quality-test.sh handing $BENCHLOCAL_API_KEY to
+  # benchlocal-cli. CURL_HOME only covers this process's own curls.
+  export CLUB3090_RESOLVED_API_KEY="$key"
+
+  CLUB3090_CURL_AUTH_DIR="$(mktemp -d)"                 # mktemp -d is 0700
+  ( umask 077; printf 'header = "Authorization: Bearer %s"\n' "$key" \
+      > "${CLUB3090_CURL_AUTH_DIR}/.curlrc" )
+  export CURL_HOME="${CLUB3090_CURL_AUTH_DIR}"          # curl reads $CURL_HOME/.curlrc first
+  # Auto-install cleanup only when the caller has no EXIT trap of its own.
+  if [[ -z "$(trap -p EXIT)" ]]; then
+    trap club3090_curl_auth_cleanup EXIT
+  fi
+}

--- a/scripts/lib/owui-register.sh
+++ b/scripts/lib/owui-register.sh
@@ -26,9 +26,20 @@ fi
 SECRET="$(docker exec "$OWUI" cat /app/backend/.webui_secret_key 2>/dev/null || true)"
 if [[ -z "$SECRET" ]]; then log "couldn't read OWUI secret key — skipping."; exit 0; fi
 
-docker exec -i "$OWUI" python3 - "$SECRET" "$PORT" <<'PY'
+# The OpenAI API key OWUI stores for this endpoint. On a VLLM_API_KEY-secured
+# compose the picker's calls 401 unless OWUI presents the real bearer token, so
+# register that (not a placeholder). switch.sh --owui exports .env into our env;
+# fall back to reading .env directly, then to "sk-noauth" for an open endpoint.
+API_KEY="${VLLM_API_KEY:-${CLUB3090_API_TOKEN:-}}"
+if [[ -z "$API_KEY" ]]; then
+  _owui_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+  [[ -f "${_owui_root}/.env" ]] && API_KEY="$(set -a; . "${_owui_root}/.env" >/dev/null 2>&1; printf '%s' "${VLLM_API_KEY:-${CLUB3090_API_TOKEN:-}}")"
+fi
+API_KEY="${API_KEY:-sk-noauth}"
+
+docker exec -i "$OWUI" python3 - "$SECRET" "$PORT" "$API_KEY" <<'PY'
 import sys, sqlite3, hmac, hashlib, base64, json, urllib.request
-secret = sys.argv[1].encode(); port = sys.argv[2]
+secret = sys.argv[1].encode(); port = sys.argv[2]; api_key = sys.argv[3]
 db = "/app/backend/data/webui.db"
 try:
     admins = [r[0] for r in sqlite3.connect(db).execute(
@@ -55,7 +66,7 @@ except Exception as e:
 urls = cfg.get("OPENAI_API_BASE_URLS") or []; keys = cfg.get("OPENAI_API_KEYS") or []
 if url in urls:
     print("[owui-register] already registered: %s" % url); sys.exit(0)
-urls.append(url); keys.append("sk-noauth")
+urls.append(url); keys.append(api_key)
 new = dict(cfg); new.update({"ENABLE_OPENAI_API": True, "OPENAI_API_BASE_URLS": urls, "OPENAI_API_KEYS": keys})
 try:
     call("/openai/config/update", new)

--- a/scripts/power-cap-sweep.sh
+++ b/scripts/power-cap-sweep.sh
@@ -356,6 +356,14 @@ fi
 
 # Determine paths — script may be invoked from anywhere
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Bearer auth for VLLM_API_KEY-secured composes (its /v1/models detection + the
+# bench.sh child it drives 401 without it). No key set → no-op. This script owns
+# an EXIT trap (cleanup), which chains club3090_curl_auth_cleanup — see curl-auth.sh.
+# shellcheck source=lib/curl-auth.sh
+source "${REPO_ROOT}/scripts/lib/curl-auth.sh"
+club3090_curl_auth_setup "${REPO_ROOT}"
+
 BENCH="$REPO_ROOT/scripts/bench.sh"
 if [ ! -x "$BENCH" ]; then
   echo "[error] expected $BENCH" >&2; exit 1
@@ -436,6 +444,9 @@ cleanup() {
   if [ -n "${GPU_LIST_CSV:-}" ]; then
     restore_gpus
   fi
+
+  # Remove curl-auth's temp .curlrc (this EXIT trap supersedes its auto-cleanup).
+  declare -F club3090_curl_auth_cleanup >/dev/null && club3090_curl_auth_cleanup
 }
 trap cleanup EXIT INT TERM
 

--- a/scripts/quality-test.sh
+++ b/scripts/quality-test.sh
@@ -397,6 +397,19 @@ if [[ -n "$DETECTED_MODEL" && "$DETECTED_MODEL" != "$MODEL" ]]; then
   fi
 fi
 
+# Bearer auth for VLLM_API_KEY-secured composes. benchlocal-cli sends its
+# --api-key as `Authorization: Bearer`, defaulting to $BENCHLOCAL_API_KEY; the
+# wrapper's own /props probe goes through curl-auth's $CURL_HOME. Resolve the key
+# (env, else repo-root .env) and hand it to benchlocal-cli unless already set.
+# No key set → no-op. See scripts/lib/curl-auth.sh.
+# shellcheck source=lib/curl-auth.sh
+source "${ROOT_DIR}/scripts/lib/curl-auth.sh"
+club3090_curl_auth_setup "${ROOT_DIR}"
+if [[ -z "${BENCHLOCAL_API_KEY:-}" && -n "${CLUB3090_RESOLVED_API_KEY:-}" ]]; then
+  export BENCHLOCAL_API_KEY="$CLUB3090_RESOLVED_API_KEY"
+  echo "[quality-test] VLLM_API_KEY detected — set BENCHLOCAL_API_KEY so benchlocal-cli authenticates to the secured endpoint" >&2
+fi
+
 # hermesagent-20 runs its agent inside a Docker sandbox container. Localhost-style
 # URLs (localhost/127.x/[::1]) inside the container resolve to the container itself,
 # not the host's vLLM. Auto-set BENCHLOCAL_HERMES_RESOLVE_LOCALHOST=1 so benchlocal-cli

--- a/scripts/rebench-full.sh
+++ b/scripts/rebench-full.sh
@@ -102,6 +102,13 @@ set -euo pipefail
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+# Bearer auth for VLLM_API_KEY-secured composes (its /v1/models detection + the
+# verify-full/bench children it drives all 401 without it). No key set → no-op.
+# See scripts/lib/curl-auth.sh.
+# shellcheck source=lib/curl-auth.sh
+source "${ROOT_DIR}/scripts/lib/curl-auth.sh"
+club3090_curl_auth_setup "${ROOT_DIR}"
+
 # --- args -------------------------------------------------------------------
 SKIP_CSV=""
 RESUME=0

--- a/scripts/soak-test.sh
+++ b/scripts/soak-test.sh
@@ -279,6 +279,9 @@ finish() {
   local rc=$?
   capture_state "final"
   log "artifacts: ${SOAK_OUTPUT}"
+  # curl-auth.sh sees this EXIT trap and skips its own auto-cleanup, so remove
+  # its temp .curlrc here. Guarded — die() can exit before curl-auth is sourced.
+  declare -F club3090_curl_auth_cleanup >/dev/null && club3090_curl_auth_cleanup
   exit "$rc"
 }
 trap finish EXIT
@@ -303,6 +306,13 @@ else
   ENDPOINT="${ENDPOINT:-${URL:-$(endpoint_from_container "$CONTAINER")}}"
 fi
 mkdir -p "$SOAK_OUTPUT"
+
+# Bearer auth for VLLM_API_KEY-secured composes (the /v1/models probe below and
+# every soak turn 401 without it). No key set → no-op. This script owns an EXIT
+# trap (finish), which chains club3090_curl_auth_cleanup — see curl-auth.sh.
+# shellcheck source=lib/curl-auth.sh
+source "${REPO_ROOT}/scripts/lib/curl-auth.sh"
+club3090_curl_auth_setup "${REPO_ROOT}"
 
 MODELS_JSON="${SOAK_OUTPUT}/models.json"
 curl -sf -m 10 "${ENDPOINT}/v1/models" -o "$MODELS_JSON" \

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -3,7 +3,7 @@
 # Switch between club-3090 compose variants.
 #
 # Brings down whatever's currently running, brings up the new variant,
-# and (optionally) waits for the server to report ready on /v1/models.
+# and (optionally) waits for the server to report ready on /health.
 # Stateless — re-run any time you want a different config.
 #
 # Usage:
@@ -65,7 +65,8 @@
 #   COMPOSE_BIN     Default: "docker compose" (set to e.g. "podman compose" if needed)
 #   CLUB3090_GPU    Single-card GPU index override, e.g. "1" on a hetero rig
 #   FORCE           Set to 1 to skip hardware/free-VRAM preflight
-#   READY_URL       Default: http://localhost:8020/v1/models
+#   READY_URL       Default: http://localhost:8020/health  (unauthenticated —
+#                   works whether or not the compose sets VLLM_API_KEY)
 #   READY_TIMEOUT   Default: 600 (seconds — longer for cold cudagraph capture)
 
 set -euo pipefail
@@ -1000,12 +1001,19 @@ up_variant() {
 resolve_ready_url() {
   # Precedence: $READY_URL (full override) → $PORT (port only, host=localhost)
   # → per-variant default port from VARIANT_DEFAULT_PORT.
+  #
+  # Default probe is /health, NOT /v1/models. /health is unauthenticated and
+  # only returns 200 once the engine has finished loading, so readiness works
+  # whether or not the compose sets VLLM_API_KEY. An auth-gated /v1/models probe
+  # returns 401 forever when a key is set → the server never looks "ready" and
+  # we burn the full READY_TIMEOUT on a healthy model (the false-timeout we hit
+  # on the secured rig). Override READY_URL to probe a different path.
   local variant="$1"
   if [[ -n "${READY_URL:-}" ]]; then
     return 0
   fi
   local port="${PORT:-${VARIANT_DEFAULT_PORT[$variant]:-8020}}"
-  READY_URL="http://localhost:${port}/v1/models"
+  READY_URL="http://localhost:${port}/health"
 }
 
 wait_ready() {
@@ -1167,4 +1175,8 @@ if [[ "$OWUI_REGISTER" -eq 1 && "$WAIT" -eq 1 ]]; then
   _owui_port="${READY_URL##*:}"; _owui_port="${_owui_port%%/*}"
   bash "$(dirname "$0")/lib/owui-register.sh" "$_owui_port" || true
 fi
-echo "[switch] done. Try:  curl -s ${READY_URL%/v1/models}/v1/models | jq ."
+# Derive scheme://host:port from READY_URL (whatever its path) so the hint is
+# correct regardless of whether the probe path is /health or an override.
+_ready_rest="${READY_URL#*://}"                       # strip scheme
+_ready_origin="${READY_URL%%://*}://${_ready_rest%%/*}" # scheme + host:port
+echo "[switch] done. Try:  curl -s ${_ready_origin}/v1/models | jq ."

--- a/scripts/verify-full.sh
+++ b/scripts/verify-full.sh
@@ -53,6 +53,15 @@ done
 # Auto-detect running container + port (URL/CONTAINER env vars still win).
 # See scripts/preflight.sh::preflight_autodetect_endpoint.
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Bearer auth for VLLM_API_KEY-secured composes. MUST run before the preflight
+# autodetect below, which probes /v1/models over HTTP — if that 401s, model
+# detection silently falls back to the wrong default and every completion POSTs
+# a bad model name. No key set → no-op. (See scripts/lib/curl-auth.sh.)
+# shellcheck source=lib/curl-auth.sh
+source "${ROOT_DIR}/scripts/lib/curl-auth.sh"
+club3090_curl_auth_setup "${ROOT_DIR}"
+
 if [[ -f "${ROOT_DIR}/scripts/preflight.sh" ]]; then
   # shellcheck source=preflight.sh
   source "${ROOT_DIR}/scripts/preflight.sh"

--- a/scripts/verify-stress.sh
+++ b/scripts/verify-stress.sh
@@ -85,6 +85,13 @@ set -euo pipefail
 # Auto-detect running container + port (URL/CONTAINER env vars still win).
 # See scripts/preflight.sh::preflight_autodetect_endpoint.
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Bearer auth for VLLM_API_KEY-secured composes (before autodetect's /v1/models
+# probe). No key set → no-op. See scripts/lib/curl-auth.sh.
+# shellcheck source=lib/curl-auth.sh
+source "${ROOT_DIR}/scripts/lib/curl-auth.sh"
+club3090_curl_auth_setup "${ROOT_DIR}"
+
 if [[ -f "${ROOT_DIR}/scripts/preflight.sh" ]]; then
   # shellcheck source=preflight.sh
   source "${ROOT_DIR}/scripts/preflight.sh"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -22,6 +22,13 @@ set -euo pipefail
 # Auto-detect running container + port + served model (env vars still win).
 # See scripts/preflight.sh::preflight_autodetect_endpoint / _model.
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Bearer auth for VLLM_API_KEY-secured composes (before autodetect's /v1/models
+# probe). No key set → no-op. See scripts/lib/curl-auth.sh.
+# shellcheck source=lib/curl-auth.sh
+source "${ROOT_DIR}/scripts/lib/curl-auth.sh"
+club3090_curl_auth_setup "${ROOT_DIR}"
+
 if [[ -f "${ROOT_DIR}/scripts/preflight.sh" ]]; then
   # shellcheck source=preflight.sh
   source "${ROOT_DIR}/scripts/preflight.sh"


### PR DESCRIPTION
## Problem
A compose that sets `VLLM_API_KEY` rejects unauthenticated `/v1/*` requests. Today that breaks the *required validation workflow* on a secured rig: `verify-*`, `bench*`, `quality-test`, `soak-test`, `health` all 401, `switch.sh --owui` registers `sk-noauth`, and `switch.sh`'s readiness probe hangs forever on the auth-gated `/v1/models`.

## Fix — one shared seam
`scripts/lib/curl-auth.sh`: resolves the token from the env, else repo-root `.env` (so a direct `bash scripts/verify-full.sh` works — `switch.sh` only loads `.env` into its child compose), then points curl's default config at a private temp `.curlrc` via `$CURL_HOME`. Every curl in the process authenticates; **no per-curl edits**. No key set → **no-op, byte-identical to today.**

Wired into: verify-full, verify, verify-stress, bench, health, soak-test, quality-test (`BENCHLOCAL_API_KEY`), bench-agentic, rebench-full, power-cap-sweep.

Also:
- `switch.sh`: readiness probe defaults to `/health` (unauthenticated) instead of `/v1/models` — fixes the secured-compose false-timeout; `READY_URL` override still honored.
- `owui-register.sh`: registers the real key, not `sk-noauth`.
- `fp8-mtp.yml` / gemma `base.yml`: pass `VLLM_API_KEY` through (empty default = unchanged behaviour).

## Verified (live, key only in `.env`)
`verify-full`, `verify.sh`, `health.sh` all pass against a `VLLM_API_KEY`-secured endpoint; helper unit-tested (no-op path, cleanup, no `/tmp` leaks).

## Notes for review
- Only the two current default composes carry the passthrough; extending to sibling composes is a mechanical follow-up.
- `soak-test`/`power-cap-sweep` own an EXIT trap → cleanup is chained, not auto-installed.

Draft for review.