### PR TITLE
c3+switch: show/copy the serving API URL; fast-flip booting→ready (F3/F3b)

### DIFF
--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -1062,6 +1062,22 @@ wait_ready() {
     fi
   done
   echo "[switch] ✓ ready (${elapsed}s)"
+  # F3 (CLI parity with c3's serving card): print the USABLE endpoint — the LAN
+  # URL an agent/client should point at, the served model id, and the auth
+  # status. LANIP's source of truth is the repo .env (#512, loaded above; shell
+  # env wins); fall back to the shared c3_lan_ip helper in a SUBSHELL
+  # (comfyui-paths.sh sets studio paths at source time — keep that contained),
+  # then localhost.
+  local _lanip _served _port
+  _lanip="${LANIP:-}"
+  if [[ -z "$_lanip" && -f "${ROOT_DIR}/services/comfyui/comfyui-paths.sh" ]]; then
+    _lanip="$(bash -c ". '${ROOT_DIR}/services/comfyui/comfyui-paths.sh' >/dev/null 2>&1; c3_lan_ip" 2>/dev/null || true)"
+  fi
+  _lanip="${_lanip:-localhost}"
+  _port="${READY_URL#*://}"; _port="${_port#*:}"; _port="${_port%%/*}"
+  _served="$(curl -sf --max-time 3 "${READY_URL}" \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["data"][0]["id"])' 2>/dev/null || true)"
+  echo "[switch] ▶ API:  http://${_lanip}:${_port}/v1   (model: ${_served:-?} · OpenAI-compatible · no auth)"
 }
 
 # --- arg parsing ---

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -2071,7 +2071,13 @@ class OperateOrchPane(Container):
         if slug:
             parts.append(f"[dim]{slug}[/dim]")
         if port:
-            parts.append(f"[dim]:{port}[/dim]")
+            # F3: the USABLE endpoint — full LAN URL + auth status, not a bare
+            # port. Same derivation as switch.sh's ready-line (services.lan_ip).
+            try:
+                lan = self.app._data.lan_ip()
+            except Exception:
+                lan = "localhost"
+            parts.append(f"http://{lan}:{port}/v1 [dim]· no auth · \\[u] copy[/dim]")
         elif url:
             parts.append(f"[dim]{url}[/dim]")
         head = "[green]▶[/green] Serving: " + "  ·  ".join(parts)
@@ -4479,6 +4485,11 @@ class RailStatus(Static):
         if dr.reachable:
             glyph = "[green]●[/green]" if dr.serving else "[yellow]○[/yellow]"
             lines.append(f"{glyph} {dr.summary}")
+            # F3: the endpoint, compactly (the rail is ~30 cols — the FULL URL
+            # lives on the Orchestration serving card; [u] copies it anywhere).
+            _port = getattr(state.target, "host_port", 0) or 0
+            if _port:
+                lines.append(f"[dim]api :{_port}/v1 · \\[u] copy[/dim]")
         elif dr.booting:
             lines.append("[yellow]⏳[/yellow] booting…")
         else:
@@ -4821,6 +4832,7 @@ _PALETTE_COMMANDS: tuple[tuple[str, str, str], ...] = (
     ("explain", "Explain selected slug", "Catalog — detail + cross-rig benchmarks"),
     ("filter_catalog", "Filter catalog", "Catalog — filter by slug / engine / status"),
     ("toggle_catalog_deprecated", "Show/hide deprecated", "Catalog — reveal 🗑️ deprecated slugs (hidden by default)"),
+    ("copy_endpoint", "Copy the serving API URL", "Run & Operate — copy http://<lan>:<port>/v1 for your agent/client (no auth by default)"),
     ("set_default", "Set default", "Catalog — pin the selected slug as model default"),
     ("clear_default", "Clear default", "Catalog — clear the model default pin"),
     ("optimize_card", "Optimize for my card", "Catalog — v0.10.0 seam (not available yet)"),
@@ -4972,6 +4984,7 @@ class CockpitApp(App):
         Binding("slash", "filter_catalog", "Filter", show=False),
         Binding("backslash", "toggle_catalog_model", "Model", show=False),
         Binding("h", "toggle_catalog_deprecated", "Deprecated", show=False),
+        Binding("u", "copy_endpoint", "API URL", show=False),
         Binding("e", "explain", "Explain", show=False),
         # 2-mode merge: [1] = merged Run & Operate, [2] = Bring & Validate lane.
         Binding("1", "mode_run", "Run & Operate", show=True),
@@ -5164,6 +5177,10 @@ class CockpitApp(App):
         # Merged mode 0 · Catalog tab
         "filter_catalog":   ({0}, {"tab-catalog"}),  # Catalog
         "toggle_catalog_deprecated": ({0}, {"tab-catalog"}),  # Catalog — [h] hide/show deprecated
+        # [u] copy the serving API URL — the endpoint is rig-global, so it's
+        # live on EVERY merged-mode tab (F3; guards inside the action when
+        # nothing is serving).
+        "copy_endpoint":    ({0}, {"tab-catalog", "tab-orchestration", "tab-containers", "tab-doctor"}),
         "explain":          ({0}, {"tab-catalog"}),  # Catalog (guards inside action)
         "set_default":      ({0}, {"tab-catalog"}),  # Catalog
         "clear_default":    ({0}, {"tab-catalog"}),  # Catalog
@@ -5769,6 +5786,28 @@ class CockpitApp(App):
             self.query_one("#operate-orch-pane", OperateOrchPane).refresh_gpu_cards(gpus)
         except Exception:
             pass
+        # F3b: readiness fast-flip. api_booting only clears when the HEAVY
+        # docker+health batch re-runs — so "⏳ booting" outlived actual readiness
+        # by a poll cycle (audit: ≥25s stale). While booting, piggyback a CHEAP
+        # direct /v1/models probe on this fast tick; on 200, pull the next heavy
+        # poll forward (burst regime) so every "booting" surface flips promptly.
+        # Bounded: fires ONLY in the booting state, 1.5s timeout, best-effort.
+        state = getattr(self, "_last_estate_state", None)
+        if state is not None and getattr(state.doctor, "booting", False):
+            url = (getattr(state.target, "url", "") or "").strip()
+            if not url:
+                port = getattr(state.target, "host_port", 0) or 0
+                url = f"http://localhost:{port}" if port else ""
+            if url:
+                try:
+                    import httpx
+                    async with httpx.AsyncClient(timeout=1.5) as client:
+                        r = await client.get(f"{url.rstrip('/')}/v1/models")
+                    if r.status_code == 200:
+                        import time as _t
+                        self._docker_burst_until = _t.monotonic() + 6.0
+                except Exception:
+                    pass
 
     def _docker_poll_due(self) -> bool:
         """Whether THIS tick runs the heavy docker+host batch, by regime: burst (within
@@ -7064,6 +7103,36 @@ class CockpitApp(App):
             rail.remove_class("rail-hidden")
 
     # ── Batch 4 · copy-to-clipboard + horizontal scroll ──────────────────────────
+
+    def _serving_endpoint_url(self) -> str:
+        """F3: the serving endpoint URL (``http://<lan>:<port>/v1``) from the
+        CACHED estate state — '' when nothing is serving / port unknown. Same
+        LAN-IP derivation as switch.sh's ready-line (services.lan_ip)."""
+        state = getattr(self, "_last_estate_state", None)
+        port = getattr(getattr(state, "target", None), "host_port", 0) or 0
+        if not port:
+            return ""
+        try:
+            lan = self._data.lan_ip()
+        except Exception:
+            lan = "localhost"
+        return f"http://{lan}:{port}/v1"
+
+    def action_copy_endpoint(self) -> None:
+        """[u] — copy the serving API URL (the "point your agent here" string).
+        No-ops with a notify when nothing is serving."""
+        url = self._serving_endpoint_url()
+        if not url:
+            self.notify(
+                "No model serving — nothing to point an agent at yet.",
+                title="API URL", severity="warning", timeout=3,
+            )
+            return
+        self.copy_to_clipboard(url)
+        self.notify(
+            f"Copied API URL: {url}  (OpenAI-compatible · no auth)",
+            title="API URL", severity="information", timeout=4,
+        )
 
     def action_copy_context(self) -> None:
         """[Y] — yank the contextually-relevant text to the system clipboard.

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -836,6 +836,41 @@ class CockpitData:
         except OSError:
             return ""
 
+    def lan_ip(self) -> str:
+        """The rig's LAN IP for user-facing endpoint URLs (F3) — the SAME
+        derivation as the launchers (layer rule, #512 precedence): env LANIP →
+        repo .env `LANIP=` → the shared `c3_lan_ip` helper (subshell-contained;
+        comfyui-paths.sh sets studio paths at source time) → localhost.
+        Cached for the session (the LAN IP doesn't move under a running TUI)."""
+        cached = getattr(self, "_lan_ip_cache", "")
+        if cached:
+            return cached
+        import os
+        import re
+        import subprocess
+        ip = (os.environ.get("LANIP") or "").strip()
+        if not ip:
+            try:
+                m = re.search(
+                    r"^LANIP=(.+)$", (self.repo_root / ".env").read_text(), re.M
+                )
+                if m:
+                    ip = m.group(1).strip()
+            except OSError:
+                pass
+        if not ip:
+            helper = self.repo_root / "services" / "comfyui" / "comfyui-paths.sh"
+            if helper.is_file():
+                try:
+                    ip = subprocess.run(
+                        ["bash", "-c", f". '{helper}' >/dev/null 2>&1; c3_lan_ip"],
+                        capture_output=True, text=True, timeout=5,
+                    ).stdout.strip()
+                except Exception:
+                    ip = ""
+        self._lan_ip_cache = ip or "localhost"
+        return self._lan_ip_cache
+
     # ── READ: explain (Tier-3 detail) ────────────────────────────────────────────
 
     async def explain(self, slug: str) -> tuple[Optional[dict[str, Any]], Optional[str]]:


### PR DESCRIPTION
## The gap (T1 audit, findings F3 + F3b)

Even while a model **serves**, the best endpoint info anywhere in the stack was a bare port (`ports 8010, 8080, 4000` in a scene card) — no scheme, no host, no `/v1`, no auth note, no way to copy. And three surfaces (estate rail, serving card, doctor-line) kept saying "⏳ API booting" **≥25s after the API was returning 200**, because the booting flag only clears on the heavy docker+health poll.

## The fix — one derivation, four surfaces (layer rule)

LAN-IP derivation per #512 precedence (`env`/`.env` → shared `c3_lan_ip` in a contained subshell → `localhost`), consumed identically by CLI and TUI:

- **`switch.sh`** now ends a successful boot with the line that was always missing:
  ```
  [switch] ✓ ready (152s)
  [switch] ▶ API:  http://192.168.86.33:8020/v1   (model: qwen3.6-27b · OpenAI-compatible · no auth)
  ```
  (served id probed live from `/v1/models` — note the neutral name from #543 showing up correctly)
- **`services.lan_ip()`** — c3 reads the same derivation, cached per session.
- **Orchestration serving card**: bare `:8020` → `http://<lan>:8020/v1 · no auth · [u] copy`.
- **Estate rail**: compact `api :8020/v1 · [u] copy` (rail is ~30 cols; full URL on the card).
- **New `[u]` key — copy the API URL** — on every Run & Operate tab (the endpoint is rig-global). Deliberately *not* folded into `[Y]`: row-copy (slug/scene/container) semantics untouched. Honest notify no-op when nothing serves.

## F3b — readiness fast-flip

While `api_booting`, the fast (docker-free) GPU tick piggybacks a **1.5s `/v1/models` probe**; on 200 it pulls the next heavy poll forward via the existing burst regime. Every "booting" surface now flips within a tick or two of the API actually answering. Bounded: fires **only** in the booting state — zero extra load idle or serving.

## Verification

- **c3 pytest suite: 516 passed.**
- **Live end-to-end**: served `vllm/minimal` via `switch.sh` — the ready-line printed with the real LAN IP + probed served id (output above).
- `bash -n` + `py_compile` clean; `lan_ip()` resolves the real rig address (192.168.86.33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)