### PR TITLE
c3/detect: grade slug matches — shape guesses never masquerade as identity (F9)

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -659,6 +659,8 @@ class CatalogPane(Container):
         # N3: the slug currently live-serving (from the estate's matched_slug),
         # so its Run-catalog row carries a "● serving" badge.  "" → none serving.
         self._serving_slug: str = ""
+        # F9: the match grade for _serving_slug ("identity" | "shape" | "").
+        self._serving_confidence: str = ""
         # A6: live per-GPU free-VRAM (GB) from the last estate poll, used to
         # DOWNGRADE a "● fits-clean" glyph that would actually OOM right now (e.g.
         # GPU0 holding ComfyUI).  None → unknown (the fit column is then labelled
@@ -739,7 +741,13 @@ class CatalogPane(Container):
             slug_cell = e.slug
             is_serving_row = bool(serving and e.slug == serving)
             if is_serving_row:
-                slug_cell = f"[green]●[/green] {e.slug} [green]serving[/green]"
+                if (self._serving_confidence or "") == "shape":
+                    # F9: port/substring match — what's serving merely has this
+                    # row's SHAPE (its port / a name fragment); it is NOT verified
+                    # to BE this slug.  Never claim "serving" for a guess.
+                    slug_cell = f"[yellow]👤[/yellow] {e.slug} [yellow]port in use[/yellow]"
+                else:
+                    slug_cell = f"[green]●[/green] {e.slug} [green]serving[/green]"
             else:
                 # Download UX — a glyph for the on-disk state: ⏳NN% downloading,
                 # ⬇ absent (not downloaded), ⚠ partial.  present/unknown → clean.
@@ -800,15 +808,22 @@ class CatalogPane(Container):
             except Exception:
                 pass
 
-    def set_serving_slug(self, slug: str) -> None:
+    def set_serving_slug(self, slug: str, confidence: str = "") -> None:
         """N3: set (or clear, with "") the live-serving slug + re-render so the
         Run-catalog row badge stays fresh.  Cheap: only re-renders when the slug
         actually changed (so the periodic Operate poll doesn't churn the Run
-        table on every tick).  Cursor + filter preserved via refresh_enriched."""
+        table on every tick).  Cursor + filter preserved via refresh_enriched.
+
+        F9: ``confidence`` is the match grade ("identity" | "shape" | "") — a
+        shape match renders the row badge as a guess, never as "serving"."""
         new = (slug or "").strip()
-        if new == (self._serving_slug or "").strip():
+        new_conf = (confidence or "").strip()
+        if new == (self._serving_slug or "").strip() and new_conf == (
+            self._serving_confidence or ""
+        ):
             return
         self._serving_slug = new
+        self._serving_confidence = new_conf
         # Re-render only if rows are present (mount-order safe).
         if self._entries:
             self.refresh_enriched()
@@ -2066,10 +2081,16 @@ class OperateOrchPane(Container):
             line.update("[dim]○ no model serving[/dim]")
             return
         parts: list[str] = []
+        conf = (getattr(tgt, "match_confidence", "") or "").strip()
         if model:
             parts.append(f"[green]{model}[/green]")
         if slug:
-            parts.append(f"[dim]{slug}[/dim]")
+            if conf == "shape":
+                # F9: port/substring match — the slug is the matched SHAPE, not
+                # the verified identity of what's serving.  Say so.
+                parts.append(f"[yellow]👤[/yellow] [dim]on {slug} shape[/dim]")
+            else:
+                parts.append(f"[dim]{slug}[/dim]")
         if port:
             # F3: the USABLE endpoint — full LAN URL + auth status, not a bare
             # port. Same derivation as switch.sh's ready-line (services.lan_ip).
@@ -2573,7 +2594,9 @@ class OperateContainersPane(Container):
                     c.kind,
                     c.engine or "—",
                     str(c.host_port) if c.host_port else "—",
-                    c.slug or "—",
+                    # F9: badge a port/substring (shape) match — the slug is a
+                    # guess for this container, not a verified identity.
+                    (f"👤 {c.slug}" if getattr(c, "match_confidence", "") == "shape" and c.slug else (c.slug or "—")),
                 )
         # FIX 1 — restore the cursor by key: if the selected container still
         # exists, move to its new index; if it's gone, clamp the OLD index; if the
@@ -2629,7 +2652,12 @@ class OperateContainersPane(Container):
             f"  [bold]Kind[/bold]       {con.kind}",
             f"  [bold]Port[/bold]       {con.host_port or '—'} → {con.internal_port or '—'}",
             f"  [bold]Engine[/bold]     {con.engine or '—'}",
-            f"  [bold]Slug[/bold]       {con.slug or '[dim]unmatched[/dim]'}",
+            f"  [bold]Slug[/bold]       "
+            + (
+                f"👤 {con.slug} [dim](shape match — port/substring, not an exact container)[/dim]"
+                if getattr(con, "match_confidence", "") == "shape" and con.slug
+                else (con.slug or "[dim]unmatched[/dim]")
+            ),
         ]
         if variant is not None:
             lines.append(f"  [bold]Compose[/bold]    [dim]{getattr(variant, 'compose_path', '') or '—'}[/dim]")
@@ -4478,7 +4506,19 @@ class RailStatus(Static):
             lines.append(f"{bar} GPU{i} {used:.0f}/{total:.0f}G")
         lines.append("")
         if state.matched_slug:
-            lines.append(f"model   {state.matched_slug}")
+            # F9: a port/substring registry match is a SHAPE guess, not a verified
+            # identity — a brought model on a sibling's port masquerades as the
+            # sibling otherwise.  Lead with the PROBED served id + 👤 badge and
+            # demote the slug to "shape"; only an exact-container match may claim
+            # the slug as the identity.
+            _conf = (getattr(state.target, "match_confidence", "") or "") if state.target is not None else ""
+            _served = (getattr(state.target, "model", "") or "").strip() if state.target is not None else ""
+            if _conf == "shape":
+                lines.append(f"model   {_served or state.matched_slug} 👤")
+                if _served:
+                    lines.append(f"[dim]shape   {state.matched_slug}[/dim]")
+            else:
+                lines.append(f"model   {state.matched_slug}")
         elif state.target is not None and getattr(state.target, "model", ""):
             lines.append(f"model   {state.target.model}")
         dr = state.doctor
@@ -5467,6 +5507,9 @@ class CockpitApp(App):
         self._target_slug: str = ""
         self._target_model: str = ""
         self._target_url: str = ""
+        # F9: the slug match GRADE ("identity" | "shape" | "") from the last
+        # estate poll — a shape match must never be presented as an identity.
+        self._target_confidence: str = ""
         # Phase 5: the SHARED ServingTarget OBJECT from the last estate poll —
         # held by identity so the c3t Evaluate hand-off passes the SAME dataclass
         # instance c3t speaks (design §4/§6.6), not a reconstructed copy.
@@ -6196,6 +6239,7 @@ class CockpitApp(App):
         tgt = state.target
         self._target_model = getattr(tgt, "model", "") or ""
         self._target_url = getattr(tgt, "url", "") or ""
+        self._target_confidence = getattr(tgt, "match_confidence", "") or ""
         # Hold the SHARED ServingTarget object (by identity) for the c3t Evaluate
         # hand-off — design §4/§6.6 requires passing the SAME dataclass instance.
         self._target_obj = tgt
@@ -6306,7 +6350,7 @@ class CockpitApp(App):
         # the Run marker fresh.
         try:
             cat = self.query_one("#catalog-pane", CatalogPane)
-            cat.set_serving_slug(self._target_slug)
+            cat.set_serving_slug(self._target_slug, self._target_confidence)
             # A6: feed the Run catalog the LIVE per-GPU free-VRAM so a
             # "fits-clean" row that would OOM right now (e.g. GPU0 holding
             # ComfyUI) is downgraded.  Derived from THIS poll's GpuInfo

--- a/tools/serve-cockpit/club3090_cockpit/data.py
+++ b/tools/serve-cockpit/club3090_cockpit/data.py
@@ -452,6 +452,7 @@ class ContainerInfo:
     internal_port: int = 0
     engine: str = ""                    # for engine containers
     slug: str = ""                      # registry slug if matched
+    match_confidence: str = ""          # "identity" | "shape" | "" (see core detect)
     gpus: str = ""                      # "0,1" if known, else ""
     status: str = "running"             # "running" | "stopped" (known-but-down service)
 

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -941,10 +941,12 @@ class CockpitData:
         infos: list[ContainerInfo] = []
         for name, host_port, internal_port, engine, kind in await self._docker_ps_stack_containers():
             slug = ""
+            confidence = ""
             if kind == "engine" and variants:
                 tmp = ServingTarget(container=name, host_port=host_port)
                 tmp = match_target_to_registry(tmp, variants)
                 slug = tmp.slug
+                confidence = tmp.match_confidence
             infos.append(
                 ContainerInfo(
                     name=name,
@@ -953,6 +955,7 @@ class CockpitData:
                     internal_port=internal_port,
                     engine=engine,
                     slug=slug,
+                    match_confidence=confidence,
                 )
             )
         return infos

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -1816,6 +1816,63 @@ class TestBatch1OperateServingPanel:
             assert "no model serving" in line.lower()
 
 
+class TestF9SlugMasquerade:
+    """F9 — a port/substring registry match is a SHAPE guess, not an identity:
+    the UI must lead with the PROBED served id + 👤 badge and demote the slug to
+    'shape'.  Regression source: the Agents-A1 bring (2026-07-03) served on a
+    sibling's port and was presented as vllm/qwen-35b-a3b-dual with no hint it
+    was a different model."""
+
+    def _shape_target(self) -> ServingTarget:
+        # A brought container UNKNOWN to the registry, serving on vllm/dual's
+        # port 8010 → slug matches by PORT only (shape); the model id is the
+        # probed served id.
+        return ServingTarget(
+            url="http://localhost:8010", model="agents-a1", host_port=8010,
+            container="vllm-agents-a1-dual",
+            gpus=[GpuInfo(index=0, mem_used_mib=1), GpuInfo(index=1, mem_used_mib=1)],
+        )
+
+    @pytest.mark.asyncio
+    async def test_serving_panel_shape_match_badges(self):
+        app, _, _ = make_app(target=self._shape_target())
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot)
+            line = str(app.query_one("#serving-line", Static).render())
+            # The probed served id leads; the slug is presented as the SHAPE.
+            assert "agents-a1" in line
+            assert "👤" in line
+            assert "on vllm/dual shape" in line
+
+    @pytest.mark.asyncio
+    async def test_serving_panel_identity_match_has_no_badge(self):
+        # EXACT container match (the registry row's container, "_"→"-"
+        # normalized) → identity → the slug renders plainly, no badge.
+        tgt = ServingTarget(
+            url="http://localhost:8010", model="qwen3.6-27b", host_port=8010,
+            container="vllm_qwen36_27b",
+            gpus=[GpuInfo(index=0, mem_used_mib=1), GpuInfo(index=1, mem_used_mib=1)],
+        )
+        app, _, _ = make_app(target=tgt)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot)
+            line = str(app.query_one("#serving-line", Static).render())
+            assert "vllm/dual" in line
+            assert "👤" not in line
+            assert "shape" not in line
+
+    @pytest.mark.asyncio
+    async def test_rail_shape_match_leads_with_served_id(self):
+        app, _, _ = make_app(target=self._shape_target())
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot)
+            rail = str(app.query_one("#rail-status", RailStatus).render())
+            # Served id + badge on the model line; the slug demoted to shape.
+            assert "agents-a1 👤" in rail
+            assert "shape" in rail
+            assert "vllm/dual" in rail
+
+
 class TestBatch1KnownServices:
     """#2 — the Containers view shows known-but-stopped supporting services."""
 
@@ -6056,9 +6113,12 @@ class TestBatch2N3CatalogServingMarker:
 
     @pytest.mark.asyncio
     async def test_catalog_marks_serving_slug(self):
-        # A target on port 8010 → matched_slug vllm/dual.
+        # The registry row's EXACT container + port 8010 → matched_slug vllm/dual
+        # as an IDENTITY match (F9: a container-less port match is only a shape
+        # guess and renders the 👤 badge instead — see the test below).
         tgt = ServingTarget(
             url="http://localhost:8010", model="qwen3.6-27b", host_port=8010,
+            container="vllm_qwen36_27b",
             gpus=[GpuInfo(index=0, mem_used_mib=1), GpuInfo(index=1, mem_used_mib=1)],
         )
         app, _, _ = make_app(target=tgt)
@@ -6070,6 +6130,29 @@ class TestBatch2N3CatalogServingMarker:
             tbl = app.query_one("#catalog-table", DataTable)
             blob = " ".join(str(tbl.get_row_at(r)) for r in range(tbl.row_count))
             assert "serving" in blob        # the ● serving badge
+            assert "👤" not in blob
+
+    @pytest.mark.asyncio
+    async def test_catalog_shape_match_never_claims_serving(self):
+        # F9 — a brought container UNKNOWN to the registry on vllm/dual's port:
+        # the row must NOT read "● serving" (the A1 masquerade); it reads the
+        # 👤 port-in-use guess instead.
+        tgt = ServingTarget(
+            url="http://localhost:8010", model="agents-a1", host_port=8010,
+            container="vllm-agents-a1-dual",
+            gpus=[GpuInfo(index=0, mem_used_mib=1), GpuInfo(index=1, mem_used_mib=1)],
+        )
+        app, _, _ = make_app(target=tgt)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            await _enter_operate(pilot)
+            pane = app.query_one("#catalog-pane", CatalogPane)
+            assert pane._serving_slug == "vllm/dual"
+            assert pane._serving_confidence == "shape"
+            tbl = app.query_one("#catalog-table", DataTable)
+            blob = " ".join(str(tbl.get_row_at(r)) for r in range(tbl.row_count))
+            assert "serving" not in blob
+            assert "👤" in blob and "port in use" in blob
 
     @pytest.mark.asyncio
     async def test_catalog_marker_clears_when_nothing_serving(self):

--- a/tools/tui-core/club3090_tui_core/detect.py
+++ b/tools/tui-core/club3090_tui_core/detect.py
@@ -57,6 +57,7 @@ class ServingTarget:
     tp: int = 0
     status: str = ""           # registry status
     status_note: str = ""
+    match_confidence: str = ""  # "identity" | "shape" | "" — see match_target_to_registry
     health: str = "unknown"    # serving | unreachable | multiple
     gpus: list[GpuInfo] = field(default_factory=list)
 
@@ -248,6 +249,16 @@ def match_target_to_registry(target: ServingTarget, variants: list) -> ServingTa
          docker project/scale suffix (``<name>-1``); longest-first so a prefix
          sibling can never shadow the real container.
 
+    Match GRADE is recorded on ``target.match_confidence``:
+      - ``"identity"`` — rule 1 (exact container).  The container IS this slug.
+      - ``"shape"``    — rule 2/3 (port / substring fallback).  The slug is the
+        best *shape* guess, NOT a verified identity: a brought model serving on
+        a sibling's port (or a copied compose) lands here while actually running
+        something else entirely — renderers must lead with the probed served-model
+        id and present the slug as the matched shape (the Agents-A1 bring,
+        2026-07-03, masqueraded as the 35B sibling through exactly this path).
+      - ``""``         — unmatched (target returned unchanged).
+
     Accepts list[VariantRow] (core) or list[dict] (compat).
     """
 
@@ -262,12 +273,13 @@ def match_target_to_registry(target: ServingTarget, variants: list) -> ServingTa
     def _norm(c: str) -> str:
         return (c or "").replace("_", "-")
 
-    def _apply(fields) -> ServingTarget:
+    def _apply(fields, confidence: str) -> ServingTarget:
         _container, _port, slug, kvcalc_key, status, status_note = fields
         target.slug = slug
         target.kv_format = kvcalc_key
         target.status = status
         target.status_note = status_note
+        target.match_confidence = confidence
         return target
 
     rows = [_fields(v) for v in variants]
@@ -277,17 +289,17 @@ def match_target_to_registry(target: ServingTarget, variants: list) -> ServingTa
     if tcont:
         for f in rows:
             if _norm(f[0]) == tcont:
-                return _apply(f)
-    # 2. EXACT host port.
+                return _apply(f, "identity")
+    # 2. EXACT host port — a SHAPE guess (ports are copied between composes).
     if target.host_port:
         for f in rows:
             if f[1] == target.host_port:
-                return _apply(f)
+                return _apply(f, "shape")
     # 3. SUBSTRING container, longest registry container first (never let a prefix
-    #    sibling shadow the real one).
+    #    sibling shadow the real one) — also a shape guess.
     if tcont:
         for f in sorted(rows, key=lambda r: len(_norm(r[0])), reverse=True):
             c = _norm(f[0])
             if c and c in tcont:
-                return _apply(f)
+                return _apply(f, "shape")
     return target

--- a/tools/tui-core/tests/test_core_detect.py
+++ b/tools/tui-core/tests/test_core_detect.py
@@ -225,3 +225,45 @@ class TestRegistryMatchExactNotPrefix:
             match_target_to_registry(target, self.VARIANTS).slug
             == "beellama/carnice-v2-dual-q8-mtp"
         )
+
+
+class TestMatchConfidence:
+    """F9 (slug masquerade): the match GRADE is recorded on ``match_confidence``
+    so renderers can distinguish a verified identity (exact container) from a
+    shape guess (port/substring fallback).  Regression source: the Agents-A1
+    bring (2026-07-03) served on a sibling's port and was PRESENTED as
+    ``vllm/qwen-35b-a3b-dual`` with no hint it was a different model."""
+
+    VARIANTS = [
+        _make_variant_row(container="vllm-qwen36-35b-a3b-dual", port=8051,
+                          slug="vllm/qwen-35b-a3b-dual"),
+        _make_variant_row(container="vllm-qwen36-27b-dual", port=8010, slug="vllm/dual"),
+    ]
+
+    def test_exact_container_is_identity(self):
+        target = ServingTarget(container="vllm-qwen36-27b-dual", host_port=8010)
+        result = match_target_to_registry(target, self.VARIANTS)
+        assert result.slug == "vllm/dual"
+        assert result.match_confidence == "identity"
+
+    def test_port_fallback_is_shape(self):
+        # The A1 masquerade: an unknown (brought) container on a sibling's port
+        # still slug-matches — but MUST be graded a shape guess, not an identity.
+        target = ServingTarget(
+            container="vllm-agents-a1-dual", host_port=8051, model="agents-a1"
+        )
+        result = match_target_to_registry(target, self.VARIANTS)
+        assert result.slug == "vllm/qwen-35b-a3b-dual"
+        assert result.match_confidence == "shape"
+
+    def test_substring_fallback_is_shape(self):
+        target = ServingTarget(container="vllm-qwen36-27b-dual-1", host_port=0)
+        result = match_target_to_registry(target, self.VARIANTS)
+        assert result.slug == "vllm/dual"
+        assert result.match_confidence == "shape"
+
+    def test_unmatched_is_empty(self):
+        target = ServingTarget(container="comfyui", host_port=7861)
+        result = match_target_to_registry(target, self.VARIANTS)
+        assert result.slug == ""
+        assert result.match_confidence == ""


### PR DESCRIPTION
## What

T1-lite fix queue **F9** — the slug-masquerade fix, witnessed live during the Agents-A1 dogfood: c3 presented `vllm/qwen-35b-a3b-dual` as serving while the rig actually ran the A1 swap compose (served id `agents-a1`) on the sibling's port.

**Root cause:** `match_target_to_registry` resolves exact-container → exact-port → substring, and every consumer treated any match as the running model's *identity*. Every route-C swap inherits the sibling's port → always mislabeled.

## Fix (layer rule: detect decides, c3 renders)

**Detect layer** (`tools/tui-core/club3090_tui_core/detect.py` — shared by c3, c3t, estate tooling):
- `ServingTarget.match_confidence` records the match grade: `"identity"` (rule 1, exact container) · `"shape"` (rules 2–3, port/substring fallback) · `""` (unmatched). Docstring documents the semantics + the A1 regression source.

**c3** renders the grade on all four masquerade surfaces:

| Surface | identity (unchanged) | shape |
|---|---|---|
| Estate rail | `model vllm/dual` | `model agents-a1 👤` + dim `shape vllm/qwen-35b-a3b-dual` |
| Serving card | `qwen3.6-27b · vllm/dual · http://…` | `agents-a1 · 👤 on vllm/qwen-35b-a3b-dual shape · http://…` |
| Run catalog row | `● <slug> serving` | `👤 <slug> port in use` — a guess never claims "serving" |
| Containers table + config drill | plain slug | `👤 <slug>` (+ "(shape match — port/substring, not an exact container)" in the drill) |

`ContainerInfo.match_confidence` threads the grade through the containers path; the app captures `_target_confidence` alongside `_target_slug` from each estate poll.

**Considered and left:** targeted stop/restart keys off the detected *container name*, so it already acts on the real container regardless of label; the serve-wait resolver sees the new container by exact name (identity) once `switch.sh` boots it.

## Tests

- 4 new tui-core matcher tests (`TestMatchConfidence`): identity / port-shape (the A1 replay) / substring-shape / unmatched → **tui-core 70/70**
- 4 new headless tests (`TestF9SlugMasquerade` + catalog shape-guard): serving-card badge, identity no-badge, rail served-id-first, catalog never-claims-serving → **serve-cockpit 748/748**
- N3 catalog fixture repaired: it was a container-less port match (honestly a shape guess under F9); it gains the registry container so its intent — the identity `● serving` badge — is what it asserts. **test-console 83/83** (CLI-parity consumer of the same matcher).

## Live controls on the rig

- Negative: serving `vllm-qwen36-27b-minimal` grades `identity` → zero visual change for the normal case.
- Positive: replaying the A1 port-8051 squat against the **real** registry (dict-compat path) grades `shape` on `vllm/qwen-35b-a3b-dual`.

Note: post-#546 A1 is itself a registry slug (exact container → identity), so the original incident no longer reproduces as-was — the live positive control uses an unknown container name, which is exactly the next bring's shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm