### PR TITLE
c3: Evidence pane doubles as the live gate-run observer (F10 MVP)

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -86,6 +86,7 @@ from .data import (
     EstateTelemetry,
     EvidenceReport,
     EvidenceTag,
+    GATE_STEPS,
     Measurement,
     MeasureVsBar,
     OptimizerReport,
@@ -3099,11 +3100,45 @@ class DoctorPane(Container):
         body.update("\n".join(lines))
 
 
+def _age_label(secs: int) -> str:
+    """Compact 'how long ago' label for the F10 live/stale evidence rows."""
+    if secs < 60:
+        return f"{secs}s"
+    if secs < 3600:
+        return f"{secs // 60}m"
+    return f"{secs // 3600}h{(secs % 3600) // 60:02d}m"
+
+
+def _gate_ladder(et: EvidenceTag) -> str:
+    """F10 — one-line gate ladder for a live/incomplete run.
+
+    ``✓`` done (with duration) · ``▶`` the step running now · ``·`` not yet
+    reached.  Steps rendered positionally from GATE_STEPS; a step that was
+    skipped (--skip/--resume) simply never turns ✓ — the ▶ marker carries the
+    truth of what is actually executing."""
+    done = {s: secs for s, secs in et.steps_done}
+    parts: list[str] = []
+    for s in GATE_STEPS:
+        if s in done:
+            parts.append(f"[green]✓[/green]{s} [dim]{_age_label(int(done[s]))}[/dim]")
+        elif s == et.live_step:
+            parts.append(f"[yellow]▶{s}[/yellow]")
+        else:
+            parts.append(f"[dim]·{s}[/dim]")
+    return "  ".join(parts)
+
+
 class ValidateEvidencePane(Container):
     """Validate / Evidence tab: real ``results/rebench/<tag>/`` run list from
     ``evidence_list()``; ``⏎`` opens the paste-ready report (``evidence_report``)
     in a modal (reuses the history_view pattern), ``s`` stages the gated
-    submit-to-localmaxxing for the selected tag (confirm modal; never auto)."""
+    submit-to-localmaxxing for the selected tag (confirm modal; never auto).
+
+    F10 — doubles as the live gate-run OBSERVER: a tag dir with no REPORT.md is
+    a run in flight (badged ▶, ladder + live tail in the preview, 4s self
+    refresh) or an aborted one (⚠ incomplete).  Renders script-owned artifacts
+    only (timings.json + step logs) — works for CLI-launched runs, never
+    executes anything."""
 
     DEFAULT_CSS = """
     ValidateEvidencePane {
@@ -3162,21 +3197,57 @@ class ValidateEvidencePane(Container):
         t = self.query_one("#evidence-table", DataTable)
         t.add_columns("tag", "date", "report", "internal", "soak", "TL;DR")
         self._tags: list[EvidenceTag] = []
+        # F10 — live gate-run observer: while a run is in flight the list
+        # re-reads itself so the ladder + tail stay fresh (a producer facing a
+        # silent 3-hr gate otherwise assumes a hang).  Paused whenever nothing
+        # is live — populate() resumes/pauses it from the data, so CLI-launched
+        # runs picked up by any refresh start the ticking too.
+        self._live_timer = self.set_interval(4.0, self._live_tick, pause=True)
+
+    def _live_tick(self) -> None:
+        """F10 — periodic re-read while a run is live (READ; observer only)."""
+        try:
+            self.app.load_evidence()  # type: ignore[attr-defined]
+        except Exception:
+            pass
 
     def populate(self, tags: list[EvidenceTag]) -> None:
         status = self.query_one("#evidence-status", Label)
         t = self.query_one("#evidence-table", DataTable)
+        saved_row = t.cursor_row  # F10: periodic refresh must not yank the cursor
         t.clear()
         self._tags = list(tags)
+        # F10 — tick only while a run is in flight.
+        try:
+            if any(et.live for et in tags):
+                self._live_timer.resume()
+            else:
+                self._live_timer.pause()
+        except Exception:
+            pass
         if not tags:
             status.update("[dim]no runs under results/rebench/[/dim]")
             t.add_row("[dim]—[/dim]", "—", "—", "—", "—", "—")
             return
         for et in tags:
             yn = lambda b: "[green]✓[/green]" if b else "[dim]·[/dim]"
+            tag_cell = et.tag
             tldr = (et.tldr[:48] + "…") if len(et.tldr) > 49 else (et.tldr or "—")
-            t.add_row(et.tag, et.date or "—", yn(et.has_report), yn(et.has_internal), yn(et.has_soak), tldr)
+            if et.live:
+                # F10 — a run in flight: badge the row + say what's running now.
+                tag_cell = f"[green]▶[/green] {et.tag}"
+                step = et.live_step or "starting"
+                tldr = f"[green]running[/green] — {step} · {len(et.steps_done)}/{len(GATE_STEPS)} steps done"
+            elif et.stale:
+                tag_cell = f"[yellow]⚠[/yellow] {et.tag}"
+                tldr = f"[yellow]incomplete[/yellow] [dim](no REPORT.md · quiet {_age_label(et.age_secs)})[/dim]"
+            t.add_row(tag_cell, et.date or "—", yn(et.has_report), yn(et.has_internal), yn(et.has_soak), tldr)
         status.update(f"{len(tags)} run tag(s) under results/rebench/")
+        try:
+            if t.row_count and saved_row > 0:
+                t.move_cursor(row=min(saved_row, t.row_count - 1), animate=False)
+        except Exception:
+            pass
         # N8 — keep the preview in sync with the cursor after a (re-)populate.
         try:
             self.render_preview(self.selected_tag())
@@ -3203,6 +3274,28 @@ class ValidateEvidencePane(Container):
             return
         from rich.markup import escape
 
+        if tag.live:
+            # F10 — a run in flight: the ladder + the active step's live tail.
+            lines = [
+                f"  [green]▶ RUNNING[/green]  [bold]{escape(tag.tag)}[/bold]"
+                f"  [dim]· last write {_age_label(tag.age_secs)} ago[/dim]",
+                f"  {_gate_ladder(tag)}",
+            ]
+            for tl in (tag.live_tail or "").splitlines()[-4:]:
+                lines.append(f"  [dim]│[/dim] {escape(tl)}")
+            if not tag.live_tail:
+                lines.append("  [dim]│ (no step output yet)[/dim]")
+            body.update("\n".join(lines))
+            return
+        if tag.stale:
+            lines = [
+                f"  [yellow]⚠ INCOMPLETE[/yellow]  [bold]{escape(tag.tag)}[/bold]"
+                f"  [dim]· no REPORT.md · quiet {_age_label(tag.age_secs)}[/dim]",
+                f"  {_gate_ladder(tag)}",
+                "  [dim]aborted or orphaned — re-run with --resume to continue from its artifacts[/dim]",
+            ]
+            body.update("\n".join(lines))
+            return
         yn = lambda b: "[green]✓[/green]" if b else "[dim]·[/dim]"
         lines = [
             f"  [bold]{escape(tag.tag)}[/bold]"
@@ -7540,6 +7633,18 @@ class CockpitApp(App):
         if tag is None:
             self.notify("No run tag selected.", title="Evidence", severity="warning", timeout=3)
             return
+        if tag.live:
+            # F10 — report generation WRITES REPORT.md into the tag dir; doing
+            # that mid-run would corrupt the observer's completed/live signal
+            # (and the observer never executes against a run in flight).
+            self.notify(
+                "Run in flight — REPORT.md generates when it completes. "
+                "Watch the ladder + live tail in the preview below the list.",
+                title="Evidence",
+                severity="information",
+                timeout=5,
+            )
+            return
         # The screen loads its own report on mount (run_evidence_report), so the
         # set_report query resolves against a fully-mounted modal.
         self.push_screen(EvidenceReportScreen(tag.tag))
@@ -8157,6 +8262,16 @@ class CockpitApp(App):
             tag = None
         if tag is None:
             self.notify("No run tag selected.", title="Evidence", severity="warning", timeout=3)
+            return
+        if tag.live or tag.stale:
+            # F10 — an in-flight run has incomplete artifacts; an aborted one
+            # has no REPORT.md.  Neither is submittable evidence.
+            self.notify(
+                "This run has no completed REPORT.md — submit when the gate finishes.",
+                title="Evidence",
+                severity="warning",
+                timeout=4,
+            )
             return
         plan = self._data.submit_bench(tag.tag)
         self.push_screen(ConfirmActionScreen(plan))

--- a/tools/serve-cockpit/club3090_cockpit/data.py
+++ b/tools/serve-cockpit/club3090_cockpit/data.py
@@ -832,6 +832,20 @@ class BenchRow:
 
 # ── Phase 4: Evidence (rebench run tags) ──────────────────────────────────────────
 
+# F10 — the rebench-full gate ladder, in run order.  MUST mirror the `run_step
+# <name>` call sites in scripts/rebench-full.sh (the script owns the sequence;
+# this is a render constant — test_gate_steps_match_rebench_script pins the two
+# together so they can't drift).  Steps may be absent from a given run
+# (--skip / --resume / --quick): the observer renders those positionally.
+GATE_STEPS: tuple[str, ...] = (
+    "verify-full",
+    "bench",
+    "verify-stress",
+    "quality-full",
+    "quality-thinking",
+    "soak",
+)
+
 
 @dataclass
 class EvidenceTag:
@@ -845,6 +859,17 @@ class EvidenceTag:
     date: str = ""                      # from REPORT.md Meta or dir mtime
     # A coarse one-line TL;DR scraped from REPORT.md if present.
     tldr: str = ""
+    # F10 — live gate-run observer.  A dir with NO REPORT.md is a run in
+    # flight (rebench-full synthesizes REPORT.md last): ``live`` while its
+    # artifacts are still being written, ``stale`` once it has gone quiet
+    # (aborted / orphaned).  Both derive purely from the dir's files — the
+    # observer works identically for CLI-launched (nohup) runs.
+    live: bool = False
+    stale: bool = False                 # incomplete AND no recent writes
+    live_step: str = ""                 # the step whose log is growing now
+    steps_done: list = field(default_factory=list)   # [(step, secs), …] from timings.json
+    live_tail: str = ""                 # last lines of the active step's log
+    age_secs: int = 0                   # since the newest artifact write
 
 
 @dataclass

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -63,6 +63,7 @@ from .data import (
     EvidenceReport,
     EvidenceTag,
     FitVerdict,
+    GATE_STEPS,
     GpuCompApp,
     GpuConflict,
     Measurement,
@@ -2723,6 +2724,10 @@ class CockpitData:
             )
             if has_report:
                 et.date, et.tldr = self._scrape_report_meta(report)
+            else:
+                # F10 — no REPORT.md (rebench-full writes it LAST) → the run is
+                # in flight or died mid-run.  Read the live state off the dir.
+                self._evidence_live_read(d, et)
             if not et.date:
                 # mtime fallback (YYYY-MM-DD).
                 import datetime as _dt
@@ -2730,6 +2735,84 @@ class CockpitData:
                 et.date = _dt.datetime.fromtimestamp(d.stat().st_mtime).strftime("%Y-%m-%d")
             tags.append(et)
         return tags
+
+    # F10 — a run with no writes for this long is treated as aborted/orphaned,
+    # not live.  Generous: gate steps stream tee output continuously, but a
+    # single long generation (quality-full at depth) can go quiet for minutes.
+    EVIDENCE_LIVE_AGE_SECS = 600
+
+    def _evidence_live_read(self, d: Path, et: EvidenceTag) -> None:
+        """F10 — fill an EvidenceTag's live-run fields from a report-less tag dir.
+
+        Pure filesystem READ (observer, never executor) so it works identically
+        for CLI-launched (nohup) runs: rebench-full's ``run_step`` tees each
+        step to ``<step>.log`` and records completed steps in ``timings.json``,
+        so the ACTIVE step is the newest step log with no timings entry.  A dir
+        that has gone quiet (> EVIDENCE_LIVE_AGE_SECS) is ``stale`` instead."""
+        try:
+            # Newest write across the dir's top-level artifacts = run liveness.
+            newest = d.stat().st_mtime
+            for f in d.iterdir():
+                try:
+                    m = f.stat().st_mtime
+                except OSError:
+                    continue
+                newest = max(newest, m)
+            et.age_secs = max(0, int(time.time() - newest))
+            # Completed steps ([(name, secs)…] in gate order) from timings.json;
+            # tolerate a mid-rewrite read (record_timing rewrites the file).
+            timings: dict = {}
+            try:
+                timings = json.loads((d / "timings.json").read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                timings = {}
+            et.steps_done = [
+                (s, int(timings[s])) for s in GATE_STEPS if s in timings
+            ] + [(k, int(v)) for k, v in timings.items() if k not in GATE_STEPS]
+            # Active step = the newest <step>.log NOT yet in timings.json.
+            cand: list[tuple[float, str]] = []
+            for s in GATE_STEPS:
+                if s in timings:
+                    continue
+                log = d / f"{s}.log"
+                try:
+                    cand.append((log.stat().st_mtime, s))
+                except OSError:
+                    continue
+            if cand:
+                et.live_step = max(cand)[1]
+            et.live = et.age_secs < self.EVIDENCE_LIVE_AGE_SECS
+            et.stale = not et.live
+            if et.live and et.live_step:
+                et.live_tail = self._evidence_log_tail(d / f"{et.live_step}.log")
+        except OSError:
+            # Unreadable dir — leave the tag as a plain incomplete entry.
+            et.stale = True
+
+    @staticmethod
+    def _evidence_log_tail(log_path: Path, lines: int = 6) -> str:
+        """Last non-empty lines of a step log, ANSI/CR-cleaned for display.
+
+        Step logs carry benchlocal/verify ANSI colors and ``\\r`` progress
+        overdraw; keep only what a terminal would show."""
+        try:
+            with open(log_path, "rb") as fh:
+                fh.seek(0, os.SEEK_END)
+                size = fh.tell()
+                fh.seek(max(0, size - 4096))
+                raw = fh.read().decode("utf-8", errors="replace")
+        except OSError:
+            return ""
+        raw = re.sub(r"\x1b\[[0-9;?]*[A-Za-z]", "", raw)
+        out: list[str] = []
+        # Split on \n ONLY (splitlines() would split on \r and resurrect the
+        # progress frames a terminal overdraws).
+        for line in raw.split("\n"):
+            # \r overdraw: a terminal shows only the text after the last CR.
+            line = line.rsplit("\r", 1)[-1].strip()
+            if line:
+                out.append(line)
+        return "\n".join(out[-lines:])
 
     def _scrape_report_meta(self, report_path: Path) -> tuple[str, str]:
         """Pull (date, tldr) from a REPORT.md without importing the generator.

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -2908,6 +2908,96 @@ class TestValidateEvidenceWired:
             assert "--auto-submit" in wr.started[0]["cmd"]
 
 
+def _seed_live_gate_run(root: Path, tag: str = "live-gate") -> Path:
+    """F10 — a mid-flight rebench dir: verify-full done (timings.json), bench's
+    log growing.  Fresh mtimes → the observer grades it live."""
+    d = root / "results" / "rebench" / tag
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "timings.json").write_text('{"verify-full": 132}', encoding="utf-8")
+    (d / "verify-full.log").write_text("8/8 PASS\n", encoding="utf-8")
+    (d / "bench.log").write_text("warmup done\nrun 3/5 narrative…\n", encoding="utf-8")
+    return d
+
+
+class TestF10LiveGateObserver:
+    """F10 — the Evidence pane doubles as the live gate-run observer: a run in
+    flight (no REPORT.md, fresh writes) is badged ▶ with a ladder + live tail;
+    an aborted one reads ⚠ incomplete; report/submit are guarded mid-run.
+    Regression source: rebench-full via nohup was invisible in c3 — a producer
+    facing a silent 3-hr gate assumes a hang (T2 friction #7)."""
+
+    async def _open_evidence(self, pilot):
+        await pilot.press("2")
+        await _settle(pilot)
+        pilot.app.query_one("#validate-tabs", TabbedContent).active = "tab-evidence"
+        await pilot.pause()
+
+    @pytest.mark.asyncio
+    async def test_live_run_badged_with_ladder_and_tail(self, tmp_path):
+        seed_repo(tmp_path)
+        _seed_live_gate_run(tmp_path)
+        app, _, _ = make_app(repo_root=tmp_path, surface="producer")
+        async with app.run_test(size=(120, 40)) as pilot:
+            await self._open_evidence(pilot)
+            pane = app.query_one("#validate-evidence-pane", ValidateEvidencePane)
+            live_idx = next(i for i, t in enumerate(pane._tags) if t.tag == "live-gate")
+            assert pane._tags[live_idx].live
+            t = app.query_one("#evidence-table", DataTable)
+            row = " ".join(str(c) for c in t.get_row_at(live_idx))
+            assert "▶" in row and "running" in row and "bench" in row
+            # Preview for the live row: ladder + the active step's tail.
+            t.move_cursor(row=live_idx)
+            pane.render_preview(pane.selected_tag())
+            prev = str(app.query_one("#evidence-preview", Static).render())
+            assert "RUNNING" in prev
+            assert "verify-full" in prev and "bench" in prev   # ✓ done + ▶ active
+            assert "run 3/5 narrative…" in prev                 # live tail line
+
+    @pytest.mark.asyncio
+    async def test_enter_and_submit_guarded_on_live_run(self, tmp_path):
+        seed_repo(tmp_path)
+        _seed_live_gate_run(tmp_path)
+        app, _, _ = make_app(repo_root=tmp_path, surface="producer")
+        async with app.run_test(size=(120, 40)) as pilot:
+            await self._open_evidence(pilot)
+            pane = app.query_one("#validate-evidence-pane", ValidateEvidencePane)
+            live_idx = next(i for i, t in enumerate(pane._tags) if t.tag == "live-gate")
+            app.query_one("#evidence-table", DataTable).move_cursor(row=live_idx)
+            # ⏎ must NOT generate a report mid-run (rebench-report WRITES
+            # REPORT.md into the dir → would corrupt the live/complete signal).
+            await pilot.press("enter")
+            await pilot.pause()
+            assert not isinstance(app.screen, EvidenceReportScreen)
+            # [s] must not stage a submit of incomplete artifacts.
+            await pilot.press("s")
+            await pilot.pause()
+            assert not isinstance(app.screen, ConfirmActionScreen)
+
+    @pytest.mark.asyncio
+    async def test_quiet_incomplete_run_reads_incomplete(self, tmp_path):
+        import os as _os
+        import time as _t
+
+        seed_repo(tmp_path)
+        d = _seed_live_gate_run(tmp_path, tag="dead-gate")
+        old = _t.time() - 7200
+        for f in [d, *d.iterdir()]:
+            _os.utime(f, (old, old))
+        app, _, _ = make_app(repo_root=tmp_path, surface="producer")
+        async with app.run_test(size=(120, 40)) as pilot:
+            await self._open_evidence(pilot)
+            pane = app.query_one("#validate-evidence-pane", ValidateEvidencePane)
+            idx = next(i for i, t in enumerate(pane._tags) if t.tag == "dead-gate")
+            assert pane._tags[idx].stale and not pane._tags[idx].live
+            t = app.query_one("#evidence-table", DataTable)
+            row = " ".join(str(c) for c in t.get_row_at(idx))
+            assert "⚠" in row and "incomplete" in row
+            # A completed tag (seed_repo's vllm-dual-test) keeps the plain look.
+            done_idx = next(i for i, t2 in enumerate(pane._tags) if t2.tag == "vllm-dual-test")
+            done_row = " ".join(str(c) for c in t.get_row_at(done_idx))
+            assert "▶" not in done_row and "incomplete" not in done_row
+
+
 # ===========================================================================
 # Phase R / R3b-2 — ④ Measure-vs-curated-bar (READ · producer-only)
 #

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -2778,6 +2778,99 @@ class TestPhase4Evidence:
 
 
 # ===========================================================================
+# F10 — Evidence live gate-run OBSERVER (pure filesystem READ of the
+# rebench-full artifacts: timings.json + <step>.log; REPORT.md is written LAST
+# so its absence == run in flight / aborted)
+# ===========================================================================
+
+
+def _seed_live_run(base: Path, tag: str = "live-run") -> Path:
+    """A mid-flight rebench dir: 2 steps done (timings.json), the 3rd step's
+    log growing with ANSI + \\r-overdraw progress lines."""
+    d = base / "results" / "rebench" / tag
+    d.mkdir(parents=True)
+    (d / "timings.json").write_text(
+        json.dumps({"verify-full": 132, "bench": 241}), encoding="utf-8"
+    )
+    (d / "verify-full.log").write_text("8/8 PASS\n", encoding="utf-8")
+    (d / "bench.log").write_text("narrative 153.9 TPS\n", encoding="utf-8")
+    (d / "verify-stress.log").write_text(
+        "ladder 32K ok\n\x1b[32mladder 91K ok\x1b[0m\n"
+        "run [1/7]…\rrun [2/7]…\rrun [3/7] longctx probe\n",
+        encoding="utf-8",
+    )
+    return d
+
+
+class TestF10EvidenceLiveObserver:
+    @pytest.mark.asyncio
+    async def test_live_run_detected_with_ladder_and_tail(self, tmp_path):
+        _seed_live_run(tmp_path)
+        # A completed sibling stays a plain completed row.
+        done = tmp_path / "results" / "rebench" / "done-run"
+        done.mkdir(parents=True)
+        (done / "REPORT.md").write_text("# Rebench report\n", encoding="utf-8")
+        cd = CockpitData(tmp_path, runner=full_runner())
+        tags = {t.tag: t for t in await cd.evidence_list()}
+        live = tags["live-run"]
+        assert live.live and not live.stale
+        assert live.steps_done == [("verify-full", 132), ("bench", 241)]
+        # Active step = the newest step log with no timings entry.
+        assert live.live_step == "verify-stress"
+        # Tail is ANSI-stripped and \r-overdraw-resolved (a terminal's view).
+        assert "\x1b" not in live.live_tail
+        assert "run [3/7] longctx probe" in live.live_tail
+        assert "run [1/7]" not in live.live_tail
+        assert "ladder 91K ok" in live.live_tail
+        comp = tags["done-run"]
+        assert not comp.live and not comp.stale
+
+    @pytest.mark.asyncio
+    async def test_quiet_incomplete_run_is_stale_not_live(self, tmp_path):
+        import os as _os
+
+        d = _seed_live_run(tmp_path, tag="dead-run")
+        old = time.time() - 7200
+        for f in [d, *d.iterdir()]:
+            _os.utime(f, (old, old))
+        cd = CockpitData(tmp_path, runner=full_runner())
+        t = next(t for t in await cd.evidence_list() if t.tag == "dead-run")
+        assert t.stale and not t.live
+        assert t.age_secs >= 7000
+        # The ladder data is still read (what it finished before dying).
+        assert t.steps_done and t.live_step == "verify-stress"
+        # No tail read for a dead run.
+        assert t.live_tail == ""
+
+    @pytest.mark.asyncio
+    async def test_mid_rewrite_timings_tolerated(self, tmp_path):
+        # record_timing REWRITES timings.json — a torn read must not crash the
+        # observer; it degrades to "no steps recorded (yet)".
+        d = _seed_live_run(tmp_path, tag="torn-run")
+        (d / "timings.json").write_text('{"verify-full": 13', encoding="utf-8")
+        cd = CockpitData(tmp_path, runner=full_runner())
+        t = next(t for t in await cd.evidence_list() if t.tag == "torn-run")
+        assert t.live
+        assert t.steps_done == []
+        # With no timings, every present step log is a candidate → newest wins.
+        assert t.live_step == "verify-stress"
+
+    def test_gate_steps_match_rebench_script(self):
+        """Drift guard: GATE_STEPS is a render constant mirroring the run_step
+        call sites in scripts/rebench-full.sh — the script owns the sequence."""
+        import re as _re
+
+        from club3090_cockpit.data import GATE_STEPS
+
+        script = Path(__file__).resolve().parents[3] / "scripts" / "rebench-full.sh"
+        if not script.is_file():
+            pytest.skip("rebench-full.sh not present (standalone checkout)")
+        text = script.read_text(encoding="utf-8", errors="replace")
+        names = _re.findall(r"\brun_step\s+([a-z][a-z-]*)", text)
+        assert tuple(names) == GATE_STEPS
+
+
+# ===========================================================================
 # PHASE 4 — submit-bench (READ preview vs OUTWARD-FACING gated write)
 # ===========================================================================
 


### PR DESCRIPTION
## What

T1-lite **F10** (T2 friction #7, maintainer ask): rebench-full gate runs — including nohup/CLI-launched ones — were invisible in c3; a producer facing a silent 3-hr gate assumes a hang. The Evidence pane (Bring & Validate · ④ Measure) now doubles as a **live gate-run observer**.

## How it detects (observer, never executor)

Everything derives from artifacts the script already writes — no c3-side execution, works identically for CLI-launched runs (layer rule):

- `run_step` tees each step to `<step>.log` and records completed steps in `timings.json`; `REPORT.md` is synthesized **last**.
- ⇒ a report-less dir = a run **in flight** (fresh writes, < 10 min quiet) or an **aborted** one (gone quiet).
- Active step = the newest step log with no timings entry. Torn `timings.json` reads (mid-rewrite) degrade gracefully.

## UI

- Live row: `▶ <tag>` + `running — <step> · N/6 steps done`; preview shows the gate ladder (`✓verify-full 2m  ✓bench 4m  ▶verify-stress  ·quality-full …`) + an ANSI/CR-cleaned tail of the active step's log; the pane self-refreshes every 4s **only while a run is live** (cursor preserved).
- Aborted row: `⚠ <tag>` + `incomplete (no REPORT.md · quiet 3h12m)`; preview shows how far it got + a `--resume` hint.
- Guards: `⏎` (report) and `[s]` (submit) refuse on live/incomplete tags — `rebench-report.py` *writes* `REPORT.md` into the dir, so generating mid-run would corrupt the live/complete signal, and incomplete runs aren't submittable evidence.
- `GATE_STEPS` (verify-full → bench → verify-stress → quality-full → quality-thinking → soak) is a render constant pinned to `rebench-full.sh`'s `run_step` call sites by a drift-guard test.

## Scope note

The friction row named two further mounts — the ③ Gate pane and an Operate-side list. This MVP is the Evidence-pane mount per the plan's slot note; the others ride with F1 (post-T2) and will render from the same artifacts via the same reader.

## Verification

- 4 service tests (live ladder+tail, stale, torn timings, drift guard) + 3 headless tests (badge/ladder/tail render, mid-run ⏎/[s] guards, stale render); full suite **755/755**.
- Live against the rig's real `results/rebench/` (45 tags): three historical aborted runs surfaced honestly — `ornith-35b-q8-dual` died mid `quality-full` (3 steps done), `gemma-12b-coder-kvarn4` in `verify-stress`, `vibethinker-3b-single` between steps — and no false LIVE with nothing running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm