### PR TITLE
c3: keep the catalog's money columns on-screen at 120-140 cols (F6)

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -647,7 +647,12 @@ class CatalogPane(Container):
         # fit verdict is a pick-the-serve decision input, shown when you ⏎ a row).
         # Fit is STILL computed (it feeds the pop-up + the serving-row exemption);
         # it just no longer occupies a Catalog column.
-        table.add_columns("model", "slug", "topology", "engine", "ctx", "TPS (our rig)", "8pk (our rig)", "status")
+        # F6 — column budget: the money columns (ctx · TPS · 8pk · status) come
+        # RIGHT after the identity (model · slug); topology/engine — largely
+        # redundant with the slug, which encodes both — moved to the tail so a
+        # 120-140-col terminal folds THEM, not the numbers a user picks by.
+        # "(rig)" keeps the our-rig provenance at 4 chars ("our rig" cost 8 more).
+        table.add_columns("model", "slug", "ctx", "TPS (rig)", "8pk (rig)", "status", "topo", "engine")
         # Full enriched catalog, and the current filter substring.
         self._entries: list[CatalogEntry] = []
         self._filter: str = ""
@@ -767,12 +772,12 @@ class CatalogPane(Container):
             table.add_row(
                 model_cell,
                 slug_cell,
-                e.topology,
-                e.engine,
                 e.ctx_label or "—",
                 tps,
                 e.measurement.quality_label,
                 _status_glyph(e.status),
+                e.topology,
+                e.engine,
             )
 
         banner = f"[yellow]{self._model_dir_note}[/yellow]  ·  " if self._model_dir_note else ""

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -895,13 +895,16 @@ class TestNavNodesExist:
         async with app.run_test(size=(120, 40)) as pilot:
             table = app.query_one("#catalog-table", DataTable)
             col_labels = [str(c.label) for c in table.columns.values()]
-            # Fold 3: TPS / 8pk columns are explicitly labelled as our-rig.
-            # Round-4: "source" column dropped; "topology" added BEFORE "engine".
+            # Fold 3: TPS / 8pk columns are explicitly labelled as this-rig
+            # (F6 shortened "our rig" → "rig" for column budget).
             # Serve-confirm rework: the "fit" column moved into the serve pop-up.
             # Model-filter: a "model" column leads the table (group-by-model view).
+            # F6: money columns (ctx · TPS · 8pk · status) directly after the
+            # identity; topology/engine (slug-redundant) at the tail so a
+            # 120-140-col terminal folds them, not the numbers.
             for expected in (
-                "model", "slug", "topology", "engine", "ctx",
-                "TPS (our rig)", "8pk (our rig)", "status",
+                "model", "slug", "ctx", "TPS (rig)", "8pk (rig)",
+                "status", "topo", "engine",
             ):
                 assert expected in col_labels, f"missing {expected!r}: {col_labels}"
             # "source" is gone.
@@ -910,8 +913,10 @@ class TestNavNodesExist:
             assert "fit" not in col_labels, col_labels
             # "model" is the FIRST column (mirrors switch.sh --list's grouping).
             assert col_labels[0] == "model", col_labels
-            # topology sits immediately before engine.
-            assert col_labels.index("topology") < col_labels.index("engine"), col_labels
+            # F6 — every money column sits LEFT of topo/engine.
+            fold = col_labels.index("topo")
+            for money in ("ctx", "TPS (rig)", "8pk (rig)", "status"):
+                assert col_labels.index(money) < fold, col_labels
 
     @pytest.mark.asyncio
     async def test_mode_switcher_exists(self):


### PR DESCRIPTION
## What

T1-lite **F6** (T1.1 audit): at 140 cols the catalog's decision-driving columns — `TPS (our rig)` / `8pk (our rig)` / `status` — sat past the horizontal fold; a fresh user may never discover them.

## Why it folded

Two compounding causes, both cheap to fix:

1. The `(our rig)` header qualifiers cost 8 columns by themselves — with the real registry's content widths the table's right edge was 141+, just past a 140-col viewport.
2. `topology` and `engine` sat **before** the numbers despite being largely redundant with the slug (which encodes both: `vllm/qwen-35b-a3b-dual`).

## Fix

- **Reorder**: `model · slug · ctx · TPS (rig) · 8pk (rig) · status · topo · engine` — a narrow terminal now folds the slug-redundant tail, not the numbers a user picks by.
- **Headers**: `(our rig)` → `(rig)` keeps the this-rig provenance on the column at 4 chars; `topology` → `topo`.

No index-sensitive consumers exist (no header-click sort, no positional cell reads beyond `[0]`/blob joins); the one layout-pinning test now asserts the fold order (every money column LEFT of `topo`/`engine`).

## Verification

Headless Pilot against the **real registry** (53 rows) at 140 cols:

| column | right edge | |
|---|---|---|
| slug | 62 | |
| **status** (last money col) | **103** | visible down to ~110-col terminals |
| engine (tail) | 133 | fits at 140; first to fold on narrower |

(previously: `status` right edge 141+ → past fold at exactly the audit's width)

Suite **755/755**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm