### PR TITLE
estate_cli: probe per-instance liveness so a leftover plan can't fake conflicts (F7)

### DIFF
--- a/scripts/lib/profiles/estate_cli.py
+++ b/scripts/lib/profiles/estate_cli.py
@@ -951,21 +951,38 @@ def report_state_payload(args: argparse.Namespace) -> tuple[dict[str, Any], int]
         payload["active_estate"] = {"present": True, "valid": False, "path": str(path), "error": str(exc)}
         return payload, 0
     claimed = sorted({gpu for inst in instances for gpu in inst.gpu_indices})
-    payload["active_estate"] = {
-        "present": True,
-        "valid": bool(result.valid),
-        "path": str(path),
-        "instance_count": len(instances),
-        "gpu_coverage": {"claimed_count": len(claimed), "total": len(hardware), "claimed": claimed},
-        "instances": [
+
+    # F7 (c3 T1.1 audit): estate.yml is a desired-state PLAN — reporting its
+    # instances without probing liveness made consumers (the c3 reconcile gate)
+    # treat a leftover plan file as live GPU claims on an empty rig.  Probe
+    # docker per instance: true/false when the probe answers, null when docker
+    # itself is unavailable (consumers must fail CLOSED on null/missing).
+    def _probe_running(name: str):
+        try:
+            return container_running(name)
+        except Exception:
+            return None
+
+    inst_rows = []
+    for inst in instances:
+        inst_rows.append(
             {
                 "name": inst.name,
                 "compose": inst.compose_name,
                 "gpus": list(inst.gpu_indices),
                 "port": inst.port,
+                "container": container_name(inst.name),
+                "running": _probe_running(inst.name),
             }
-            for inst in instances
-        ],
+        )
+    payload["active_estate"] = {
+        "present": True,
+        "valid": bool(result.valid),
+        "path": str(path),
+        "instance_count": len(instances),
+        "running_count": sum(1 for r in inst_rows if r["running"] is True),
+        "gpu_coverage": {"claimed_count": len(claimed), "total": len(hardware), "claimed": claimed},
+        "instances": inst_rows,
     }
     return payload, 0
 
@@ -1007,7 +1024,16 @@ def command_report_state(args: argparse.Namespace) -> int:
     print(f"  - Validation: {'PASS' if result.valid else 'FAIL'}")
     print(f"  - GPU coverage: {len(claimed)}/{len(hardware)} cards claimed ({claimed})")
     for inst in instances:
-        print(f"  - {inst.name}: {inst.compose_name}, GPUs {list(inst.gpu_indices)}, port {inst.port}")
+        # F7 — estate.yml is a PLAN: say per instance whether it is actually up
+        # (same probe the --json payload carries as `running`).
+        try:
+            live = "running" if container_running(inst.name) else "down (plan only)"
+        except Exception:
+            live = "liveness unknown (docker unavailable)"
+        print(
+            f"  - {inst.name}: {inst.compose_name}, GPUs {list(inst.gpu_indices)}, "
+            f"port {inst.port} — {live}"
+        )
     return 0
 
 

--- a/scripts/tests/test-estate-json.sh
+++ b/scripts/tests/test-estate-json.sh
@@ -73,6 +73,13 @@ assert_json_keys "$out" "d['active_estate']['instance_count']" "2"
 assert_json_keys "$out" "d['active_estate']['instances'][0]['name']" "qwen-left"
 assert_json_keys "$out" "d['active_estate']['instances'][0]['compose']" "llamacpp/default"
 assert_json_keys "$out" "d['active_estate']['instances'][0]['gpus']==[0]" "True"
+# F7 — per-instance LIVENESS: estate.yml is a plan; report-state probes docker
+# per instance. The test instances are never booted → running is False (probed,
+# down) or None (docker unavailable in this env) — NEVER True. Consumers treat
+# only running==False as "not a claim" (fail closed on None/missing).
+assert_json_keys "$out" "d['active_estate']['instances'][0]['running'] in (False, None)" "True"
+assert_json_keys "$out" "d['active_estate']['instances'][0]['container']" "club3090-qwen-left"
+assert_json_keys "$out" "d['active_estate']['running_count']" "0"
 assert_json_keys "$out" "sorted(d['profile_counts'].keys())==['drafters','engines','hardware','models','workloads']" "True"
 
 # report-state --json with a missing estate file

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -1860,6 +1860,14 @@ class CockpitData:
         active = (report or {}).get("active_estate") or {}
         if active.get("present") and active.get("instances"):
             for inst in active["instances"]:
+                # F7: estate.yml is a desired-state PLAN — only a LIVE instance
+                # is a claim.  running == False means estate_cli probed docker
+                # and the instance's container is NOT up (a leftover plan file
+                # must not fake a stop-conflict on an empty rig).  True / null /
+                # missing (older CLI, or docker unavailable) stay claims — the
+                # gate fails CLOSED on unknown liveness.
+                if inst.get("running", None) is False:
+                    continue
                 inst_gpus = set(inst.get("gpus", []) or [])
                 if inst_gpus & wanted:
                     result.estate_claims.append(inst)

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -1562,6 +1562,83 @@ class TestReconcileGate:
         assert rec.estate_claims == []
         assert rec.safe is True
 
+    # ── F7 — estate.yml is a PLAN: only LIVE instances are claims ────────────────
+    # (T1.1 audit: an EMPTY rig warned "⚠ Starting this will STOP estate
+    # llama-gpu0, llama-gpu1" off a leftover ~/.club3090/estate.yml.  estate_cli
+    # report-state now probes docker per instance; running==False → not a claim;
+    # True / null / missing → claim, the gate fails CLOSED on unknown liveness.
+    # The missing-key case is the legacy fixtures above, which must stay claims.)
+
+    def _estate_report(self, running):
+        return json.dumps(
+            {
+                "active_estate": {
+                    "present": True,
+                    "valid": True,
+                    "instances": [
+                        {"name": "llama-gpu0", "compose": "llamacpp/default",
+                         "gpus": [0], "port": 8010, "container": "club3090-llama-gpu0",
+                         "running": running},
+                        {"name": "llama-gpu1", "compose": "llamacpp/default",
+                         "gpus": [1], "port": 8020, "container": "club3090-llama-gpu1",
+                         "running": running},
+                    ],
+                }
+            }
+        )
+
+    def _empty_rig_data(self, runner):
+        gpus = [GpuInfo(index=0, mem_used_mib=3), GpuInfo(index=1, mem_used_mib=3)]
+        return CockpitData(
+            ROOT, runner=runner,
+            detect_endpoint_fn=make_detect(ServingTarget(gpus=gpus)),
+            get_gpu_info_fn=make_gpu_info(gpus),
+        )
+
+    @pytest.mark.asyncio
+    async def test_stale_estate_plan_is_not_a_claim(self):
+        """The audit repro: empty rig + leftover estate.yml (instances probed
+        DOWN) → the gate is SAFE; no scary stop-conflict for a fresh user."""
+        runner = full_runner(
+            **{
+                "docker ps": ok(DOCKER_PS_EMPTY),
+                "estate_cli.py report-state --json": ok(self._estate_report(False)),
+            }
+        )
+        cd = self._empty_rig_data(runner)
+        rec = await cd.reconcile_before_write("serve:dual", pending_gpus=[0, 1])
+        assert rec.estate_claims == []
+        assert rec.safe is True
+
+    @pytest.mark.asyncio
+    async def test_live_estate_instance_still_claims(self):
+        """running == True stays a conflict even when nvidia-smi shows the cards
+        idle (the instance may be mid-boot, VRAM not allocated yet)."""
+        runner = full_runner(
+            **{
+                "docker ps": ok(DOCKER_PS_EMPTY),
+                "estate_cli.py report-state --json": ok(self._estate_report(True)),
+            }
+        )
+        cd = self._empty_rig_data(runner)
+        rec = await cd.reconcile_before_write("serve:dual", pending_gpus=[0, 1])
+        assert len(rec.estate_claims) == 2
+        assert rec.safe is False
+
+    @pytest.mark.asyncio
+    async def test_unknown_estate_liveness_fails_closed(self):
+        """running == null (docker unavailable to estate_cli) → still a claim."""
+        runner = full_runner(
+            **{
+                "docker ps": ok(DOCKER_PS_EMPTY),
+                "estate_cli.py report-state --json": ok(self._estate_report(None)),
+            }
+        )
+        cd = self._empty_rig_data(runner)
+        rec = await cd.reconcile_before_write("serve:dual", pending_gpus=[0, 1])
+        assert len(rec.estate_claims) == 2
+        assert rec.safe is False
+
     @pytest.mark.asyncio
     async def test_pending_gpus_none_is_conservative_both_cards(self):
         """pending_gpus=None means 'wants both cards' → any GPU1 use conflicts."""


### PR DESCRIPTION
## What

T1-lite **F7** (T1.1 audit): on an **empty rig**, the c3 serve confirm warned *"⚠ Starting this will STOP estate llama-gpu0 (GPU [0]), estate llama-gpu1 (GPU [1])"* — a leftover `~/.club3090/estate.yml` rendered as live stop-conflicts. Scary and wrong for a fresh user.

**Root cause:** `estate.yml` is a desired-state *plan*, but `estate_cli report-state` reported its instances as "active" without probing docker — so the reconcile gate treated plan entries as live GPU claims.

## Fix — at the layer that owns estate liveness (not a c3 filter)

**`estate_cli.py`** (additive JSON contract):
- `report-state --json`: each instance gains `container` (its `club3090-<name>`) and `running` — `true` / `false` / `null` (docker itself unreachable); payload gains `running_count`. Reuses the existing `container_running()` probe.
- Text view parity: per instance `— running` / `— down (plan only)` / `— liveness unknown`.

**c3 reconcile gate** (consumer): an estate instance is a claim **unless `running == false`**. `true` / `null` / **missing** (older CLI output) all remain claims — the dual-writer gate fails **closed** on unknown liveness, and a mid-boot instance (container up, VRAM not yet allocated) still conflicts, so no safety regression.

## Verification

- Estate JSON contract test extended (`running` asserted `in (False, None)` so it passes with or without docker in the env; `container`, `running_count: 0`).
- 3 new c3 gate tests: stale plan on empty rig → **SAFE** (the audit repro) · `running: true` with idle GPUs → still a claim · `running: null` → fail closed. The pre-existing no-`running`-key fixtures double as the missing-key fail-closed case and pass unchanged.
- Full scripts gate green (all `scripts/tests/*.sh`); c3 suite **758/758**.
- **Live repro on this rig** (which has the exact stale `estate.yml` from the audit): `running_count: 0`; the reconcile gate now returns `estate_claims=[]` while correctly keeping the true conflict — the actually-serving `vllm-qwen36-27b-minimal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm