### PR TITLE
c3/tui-core: [Y]-copy the visible live-log tail + pane-specific placeholders (F4+F8)

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -2485,7 +2485,12 @@ class OperateContainersPane(Container):
         yield ct
         with TabbedContent(id="drill-tabs"):
             with TabPane("Logs", id="drill-tab-logs"):
-                yield LivePane(id="drill-logs")
+                # F8 — pane-specific idle copy (the shared LivePane default once
+                # leaked test-runner wording into this docker-logs drill).
+                yield LivePane(
+                    id="drill-logs",
+                    placeholder="Select a running container — its docker logs stream here.",
+                )
             with TabPane("Top", id="drill-tab-stats"):
                 yield Static("[dim]highlight a container (move cursor) or press [t] — docker top loads[/dim]", id="drill-stats")
             with TabPane("Config", id="drill-tab-config"):
@@ -2778,7 +2783,10 @@ class ValidateRunPane(Container):
             id="run-step-preview",
         )
         yield Static(_TUNE_GOTCHAS, id="run-gotchas")
-        yield LivePane(id="run-output")
+        yield LivePane(
+            id="run-output",
+            placeholder="Ready. Launch a validation run (⏎ on a step) — output streams here.",
+        )
         yield Label(
             "[dim]\\[⏎] launch selected (heavy — confirm) · streams below[/dim]",
             id="run-hint",
@@ -5753,7 +5761,8 @@ class CockpitApp(App):
                     # the user can flip to Orchestration (SAME mode) to watch.
                     # Hidden until ⏎ on a Catalog row stages a serve and the
                     # reconcile-gated confirm commits.
-                    yield LivePane(id="serve-live")
+                    # Hidden until a serve streams — no idle placeholder.
+                    yield LivePane(id="serve-live", placeholder="")
 
                 # Mode 1 — Bring & Validate (producer lane).  Renumbered 2→1 in the
                 # 2-mode merge.  An ORDERED, numbered pipeline reusing the
@@ -7374,8 +7383,37 @@ class CockpitApp(App):
                 payload = ""
             if payload:
                 return payload, "details"
+        # 2.5 (F4) — the live-log pane the user is looking at (Containers Logs
+        # drill / ③ Gate output).  RichLog-family widgets don't implement text
+        # selection (Top/Config are selectable Statics), so [Y] copies the
+        # pane's streamed tail.  An idle pane has an empty tail (placeholders
+        # aren't buffered) → falls through to the row-primary copy below.
+        pane, label = self._visible_live_pane()
+        if pane is not None:
+            tail = pane.tail_text()
+            if tail:
+                return tail, label
         # 3. the highlighted row's primary id on the active table.
         return self._active_row_primary()
+
+    def _visible_live_pane(self) -> tuple[Optional[LivePane], str]:
+        """F4 — the LivePane the user is currently LOOKING at, if any: the
+        Containers Logs drill or the ③ Gate run output.  Main screen only (a
+        modal on top owns [Y] via its own binding / copyable_text).  The
+        transient #serve-live pane is deliberately NOT routed: it shares the
+        screen with the primary tables, whose [Y]-copies-the-slug semantics
+        are established."""
+        if len(self.screen_stack) > 1:
+            return None, ""
+        try:
+            tab = self._current_subtab()
+            if tab == "tab-containers" and self._active_drill_tab() == "drill-tab-logs":
+                return self.query_one("#drill-logs", LivePane), "log tail"
+            if tab == "tab-run":
+                return self.query_one("#run-output", LivePane), "run-output tail"
+        except Exception:
+            pass
+        return None, ""
 
     def _active_row_primary(self) -> tuple[str, str]:
         """The most-pasteable id of the highlighted row on the active primary
@@ -9023,7 +9061,9 @@ class CockpitApp(App):
         try:
             live = self.query_one("#drill-logs", LivePane)
             live.clear_log()
-            live.append_line(f"[dim]{placeholder}[/dim]")
+            # buffer=False: a display-only note — [Y] on an idle/stopped drill
+            # must fall through to the container name, not copy this line (F4).
+            live.append_line(f"[dim]{placeholder}[/dim]", buffer=False)
         except Exception:
             pass
         try:

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -7932,6 +7932,89 @@ class TestCopyAndHScroll:
             await _settle(pilot)
             assert app.check_action("copy_context", ()) is True
 
+
+class TestF4F8LiveLogCopy:
+    """F4 — [Y] copies the VISIBLE live-log tail: RichLog-family panes capture
+    the mouse and don't implement text selection (Top/Config are selectable
+    Statics), so the Logs drill / ③ Gate output get the copy affordance via
+    the pane's plain-text tail buffer.  F8 — pane-specific idle placeholders
+    (the shared LivePane default once leaked 'Select a test and press Enter'
+    test-runner wording into the docker-logs drill)."""
+
+    @pytest.mark.asyncio
+    async def test_f8_pane_placeholders_name_their_purpose(self):
+        app, _, _ = make_app(surface="producer")
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            drill = app.query_one("#drill-logs")
+            assert "container" in drill._placeholder
+            assert "test" not in drill._placeholder.lower()
+            assert "validation" in app.query_one("#run-output")._placeholder
+            # The transient serve pane is hidden until a serve — no idle copy.
+            assert app.query_one("#serve-live")._placeholder == ""
+
+    async def _open_logs_drill(self, app, pilot):
+        await _enter_operate(pilot)
+        app.query_one("#operate-tabs", TabbedContent).active = "tab-containers"
+        await _settle(pilot)
+        app.query_one("#drill-tabs", TabbedContent).active = "drill-tab-logs"
+        await _settle(pilot)
+        tbl = app.query_one("#containers-table", DataTable)
+        tbl.focus()
+        tbl.move_cursor(row=0)
+        await pilot.pause()
+        return app.query_one("#drill-logs")
+
+    @pytest.mark.asyncio
+    async def test_y_copies_logs_drill_tail(self):
+        responses = fake_responses(**{"docker ps": ok(DOCKER_PS_ENGINE)})
+        app, _, _ = make_app(responses=responses)
+        copied: dict = {}
+        async with app.run_test(size=(120, 40)) as pilot:
+            app.copy_to_clipboard = lambda t: copied.__setitem__("text", t)
+            drill = await self._open_logs_drill(app, pilot)
+            # Deterministic pane content (any auto-streamed fixture lines out).
+            drill.clear_log()
+            drill.append_line("[cyan]INFO[/cyan] engine ready")
+            drill.append_line("request 1 done")
+            await pilot.press("Y")
+            await _settle(pilot)
+            # The tail wins over the highlighted container name while the Logs
+            # drill is showing — plain text, markup stripped.
+            assert copied.get("text") == "INFO engine ready\nrequest 1 done"
+
+    @pytest.mark.asyncio
+    async def test_y_on_idle_logs_drill_falls_back_to_container_name(self):
+        responses = fake_responses(**{"docker ps": ok(DOCKER_PS_ENGINE)})
+        app, _, _ = make_app(responses=responses)
+        copied: dict = {}
+        async with app.run_test(size=(120, 40)) as pilot:
+            app.copy_to_clipboard = lambda t: copied.__setitem__("text", t)
+            drill = await self._open_logs_drill(app, pilot)
+            # Idle pane: placeholders/notes aren't buffered → empty tail.
+            drill.clear_log()
+            await pilot.press("Y")
+            await _settle(pilot)
+            assert copied.get("text") == "vllm-qwen36-27b-dual"
+
+    @pytest.mark.asyncio
+    async def test_y_copies_gate_run_output_tail(self):
+        app, _, _ = make_app(surface="producer")
+        copied: dict = {}
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            app.copy_to_clipboard = lambda t: copied.__setitem__("text", t)
+            await pilot.press("2")
+            await _settle(pilot)
+            app.query_one("#validate-tabs", TabbedContent).active = "tab-run"
+            await pilot.pause()
+            out = app.query_one("#run-output")
+            out.clear_log()
+            out.append_line("verify-full [3/8] tool call ✓")
+            await pilot.press("Y")
+            await _settle(pilot)
+            assert copied.get("text") == "verify-full [3/8] tool call ✓"
+
     @pytest.mark.asyncio
     async def test_shift_arrows_page_scroll_wide_table(self):
         app, _, _ = make_app()

--- a/tools/tui-core/club3090_tui_core/widgets/live_pane.py
+++ b/tools/tui-core/club3090_tui_core/widgets/live_pane.py
@@ -237,10 +237,21 @@ class LivePane(Static):
 
     current_test: reactive[Optional[TestType]] = reactive(None)
 
-    def __init__(self, **kwargs):
+    # [Y]-copy tail cap — plain-text lines retained for tail_text().
+    _RAW_LINES_MAX = 2000
+
+    def __init__(self, placeholder: str = "Ready.", **kwargs):
+        """``placeholder`` is the idle line written on mount — hosts should pass
+        copy that names THEIR pane's purpose (the old hardcoded test-runner
+        wording leaked into non-test-runner mounts); "" writes nothing."""
         super().__init__(**kwargs)
         self._follow = True
         self._run_start_time = None
+        self._placeholder = placeholder
+        # Plain-text tail for [Y]-copy: RichLog-family widgets don't implement
+        # text selection, so hosts copy tail_text() instead.  The placeholder
+        # and set_run_header banner are NOT buffered — the tail is the output.
+        self._raw_lines: list[str] = []
 
     def compose(self) -> ComposeResult:
         yield Label("Live", classes="live-title")
@@ -248,11 +259,22 @@ class LivePane(Static):
         yield RichLog(id="live-log", wrap=True, highlight=True, markup=True)
 
     def on_mount(self) -> None:
-        log = self.query_one("#live-log", RichLog)
-        log.write("[dim]Ready. Select a test and press Enter to run.[/dim]")
+        if self._placeholder:
+            log = self.query_one("#live-log", RichLog)
+            log.write(f"[dim]{self._placeholder}[/dim]")
 
-    def append_line(self, line: str) -> None:
-        """Append a raw log line."""
+    def append_line(self, line: str, buffer: bool = True) -> None:
+        """Append a raw log line.  ``buffer=False`` writes display-only lines
+        (idle/stopped notes) that must NOT appear in the [Y]-copy tail."""
+        if buffer:
+            try:
+                from rich.text import Text
+
+                self._raw_lines.append(Text.from_markup(line).plain)
+            except Exception:
+                self._raw_lines.append(str(line))
+            if len(self._raw_lines) > self._RAW_LINES_MAX:
+                del self._raw_lines[: self._RAW_LINES_MAX // 2]
         try:
             log = self.query_one("#live-log", RichLog)
             log.write(line)
@@ -260,6 +282,11 @@ class LivePane(Static):
                 log.scroll_end(animate=False)
         except Exception:
             pass
+
+    def tail_text(self, lines: int = 400) -> str:
+        """The last ``lines`` buffered output lines as plain text — the
+        [Y]-copy payload ('' when nothing has streamed yet)."""
+        return "\n".join(self._raw_lines[-lines:])
 
     def process_event(self, event: ParseEvent, test_type: TestType) -> None:
         """Process a parsed event and update the structured header."""
@@ -270,7 +297,8 @@ class LivePane(Static):
             pass
 
     def clear_log(self) -> None:
-        """Clear the log and structured header."""
+        """Clear the log, structured header, and the [Y]-copy tail buffer."""
+        self._raw_lines.clear()
         try:
             log = self.query_one("#live-log", RichLog)
             log.clear()

--- a/tools/tui-core/tests/test_live_pane.py
+++ b/tools/tui-core/tests/test_live_pane.py
@@ -1,0 +1,54 @@
+"""LivePane tail-buffer + placeholder contract (F4/F8).
+
+Pure widget-object tests — no app mount needed: append_line buffers plain
+text BEFORE touching the (unmounted) RichLog, so the [Y]-copy tail works
+standalone.
+"""
+
+from __future__ import annotations
+
+from club3090_tui_core.widgets.live_pane import LivePane
+
+
+class TestLivePaneTailBuffer:
+    def test_tail_collects_plain_text(self):
+        lp = LivePane()
+        lp.append_line("[green]✓[/green] step one")
+        lp.append_line("run 3/5 narrative…")
+        assert lp.tail_text() == "✓ step one\nrun 3/5 narrative…"
+        # Markup is stripped — the tail is paste-ready plain text.
+        assert "[green]" not in lp.tail_text()
+
+    def test_unbuffered_lines_stay_out_of_tail(self):
+        lp = LivePane()
+        lp.append_line("[dim]▸ stopped · no live logs[/dim]", buffer=False)
+        assert lp.tail_text() == ""
+        lp.append_line("real output")
+        assert lp.tail_text() == "real output"
+
+    def test_clear_log_clears_tail(self):
+        lp = LivePane()
+        lp.append_line("old run line")
+        lp.clear_log()
+        assert lp.tail_text() == ""
+
+    def test_tail_caps_line_count(self):
+        lp = LivePane()
+        for i in range(3000):
+            lp.append_line(f"line {i}")
+        # The buffer stays bounded and keeps the NEWEST lines.
+        assert len(lp._raw_lines) <= lp._RAW_LINES_MAX
+        assert lp.tail_text(lines=1) == "line 2999"
+
+    def test_tail_limit_parameter(self):
+        lp = LivePane()
+        for i in range(10):
+            lp.append_line(f"l{i}")
+        assert lp.tail_text(lines=3) == "l7\nl8\nl9"
+
+    def test_placeholder_is_constructor_owned(self):
+        # F8 — hosts pass pane-specific idle copy; default is neutral (the old
+        # hardcoded test-runner wording leaked into non-test-runner mounts).
+        assert LivePane()._placeholder == "Ready."
+        assert LivePane(placeholder="")._placeholder == ""
+        assert LivePane(placeholder="logs stream here")._placeholder == "logs stream here"


### PR DESCRIPTION
## What

T1-lite **F4** + **F8** (T1.1 audit, one batch as planned).

**F4 — no way to copy from the Logs drill.** `LivePane` is RichLog-family: it captures the mouse and implements no text selection (Top/Config drills are selectable `Static`s — the asymmetry the audit flagged).

- tui-core `LivePane` gains a plain-text tail buffer: `append_line` stores the markup-stripped line (capped at 2000, keeps newest); `tail_text(lines=400)` is the copy payload; `clear_log()` clears it. Buffering happens before the RichLog write, so it works for every consumer.
- c3 `[Y]` resolution gains step 2.5: when the user is looking at a live-log pane — Containers **Logs drill** or **③ Gate run output** — copy its tail. Priority details:
  - selection and modal `copyable_text` still win (steps 1–2 unchanged);
  - placeholders + display-only notes (`buffer=False`, e.g. the "stopped · no live logs" note) are never buffered → `[Y]` on an **idle** drill falls through to copying the highlighted container name, exactly as before;
  - the transient `#serve-live` pane is deliberately **not** routed — it shares the screen with the primary tables, whose established `[Y]`-copies-the-slug semantics stay.

**F8 — test-runner copy leaked into the containers drill.** The idle placeholder ("Ready. Select a test and press Enter to run.") was hardcoded in the shared widget. It's now constructor-owned with a neutral default; c3 mounts pass pane-specific wording ("Select a running container — its docker logs stream here." / "Ready. Launch a validation run (⏎ on a step) — output streams here." / `""` for the hidden serve pane). c3t keeps its own vendored pane — unaffected.

## Verification

- 6 new tui-core unit tests (tail collects plain text · unbuffered notes stay out · clear clears · cap keeps newest · limit param · placeholder contract) — **76/76**
- 4 new headless tests (placeholders name their purpose · drill tail wins over row-primary · idle drill falls back to container name · ③ Gate tail) — full c3 suite **762/762**
- test-console (own vendored pane) **83/83** unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm