### PR TITLE
c3/gpu-mode: preview-clip fix + scene-boundary hardening (F2+F5, T1-lite tail)

### DIFF
--- a/scripts/gpu-mode.sh
+++ b/scripts/gpu-mode.sh
@@ -531,6 +531,7 @@ mode_27b() {
     stop_27b_dual_dflash
     stop_27b_dual_dflash_noviz
     stop_27b_dual_turbo
+    wait_gpu_vram_settle     # let the torn-down scene's VRAM release before TP=2 boots (#535 follow-up)
     start_27b_dual_mtp
     start_service litellm
     start_service qdrant
@@ -557,6 +558,7 @@ mode_35b_a3b() {
     stop_step_voice
     _director_evict_if_gpu
     stop_diffusiongemma
+    wait_gpu_vram_settle     # let the torn-down scene's VRAM release before TP=2 boots (#535 follow-up)
     start_35b_a3b_dual
     start_service litellm
     start_service qdrant
@@ -582,6 +584,7 @@ mode_gemma_12b() {
     stop_step_voice
     _director_evict_if_gpu
     stop_diffusiongemma
+    wait_gpu_vram_settle     # single-card boot can still land in another scene's residue (#535 follow-up)
     start_gemma_12b
     start_service litellm
     start_service qdrant
@@ -631,6 +634,7 @@ mode_deckard() {
     stop_comfyui
     stop_step_voice
     _director_evict_if_gpu
+    wait_gpu_vram_settle     # 31 GB GGUF layer-splits both cards — don't boot into residue (#535 follow-up)
     start_deckard
     start_service litellm
     start_service qdrant
@@ -713,6 +717,7 @@ mode_ai_studio() {
     stop_35b_a3b_dual
     stop_all_gemma
     stop_diffusiongemma
+    wait_gpu_vram_settle     # ComfyUI checkpoints load into the just-freed cards (#535 follow-up)
     start_comfyui
     start_studio_director
     start_studio_gallery
@@ -908,6 +913,18 @@ mode_off() {
     stop_step_voice
     stop_studio_director     # full off stops even a CPU/always-on director
     stop_estate
+    # CATCH-ALL: the enumerated stop_* lists above cover the gpu-mode SCENES,
+    # but a catalog-launched engine (switch.sh <slug>, e.g. vllm/minimal) isn't
+    # in any of them — and 'off' promises "ALL services".  Stop every remaining
+    # engine-prefixed container so the next scene never boots into held VRAM
+    # (#535 class; caught live 2026-07-04 when off left vllm-qwen36-27b-minimal
+    # serving and the 27b TP=2 scene booted into its residue).
+    _stragglers=$(docker ps --format '{{.Names}}' 2>/dev/null \
+        | grep -E '^(vllm-|llama-cpp-|ik-llama-|sglang-|beellama-)' || true)
+    if [ -n "$_stragglers" ]; then
+        echo -e "  ${YELLOW}▼${NC} Stopping catalog-launched engine(s): $(echo "$_stragglers" | tr '\n' ' ')"
+        echo "$_stragglers" | xargs -r docker stop >/dev/null 2>&1 || true
+    fi
     for svc in "${SERVICES[@]}"; do
         stop_service "$svc"
     done

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -592,7 +592,12 @@ class CatalogPane(Container):
     }
     CatalogPane #catalog-preview {
         height: auto;
-        max-height: 6;
+        /* F2 — the border eats 2 rows, so max-height 6 capped content at 4
+           lines and a WRAPPING caveat line clipped (the dual-fast case).
+           8 fits the 3 base lines + a caveat wrapped to 2-3; anything
+           pathological scrolls instead of silently clipping. */
+        max-height: 8;
+        overflow-y: auto;
         border: solid $primary;
         padding: 0 1;
         margin: 0 1;

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -9258,6 +9258,36 @@ class TestCatalogPreview:
             assert "Cliff-2b" not in second  # the caveat is row-0's, not row-1's
 
     @pytest.mark.asyncio
+    async def test_f2_wrapping_caveat_not_clipped(self):
+        """F2 — a long (wrapping) caveat line must GROW the preview strip, not
+        clip below the old max-height 6 (border eats 2 rows → 4 content lines;
+        the dual-fast caveat wrapped past that and lost its tail)."""
+        responses = fake_responses(**{"registry-emit.sh --json": ok(REGISTRY_JSON_CAVEAT)})
+        app, _, _ = make_app(responses=responses)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            pane = app.query_one("#catalog-pane", CatalogPane)
+            t = app.query_one("#catalog-table", DataTable)
+            t.move_cursor(row=0)
+            await pilot.pause()
+            entry = pane.selected_entry()
+            # A ~240-char caveat wraps to 3 display lines at 120 cols → content
+            # = 3 base + 3 caveat = 6 → 8 with the border.  (status_note is a
+            # property over the registry row — mutate the row.)
+            entry.row.status_note = (
+                "prose regression on DFlash v0.3.0 above 50K ctx — code packs OK; "
+                "promote only on a stable upstream tag; see UPSTREAM.md row and "
+                "the beellama pin-bump helper before changing anything here; "
+                "workaround: run the q8 dual instead for long prose"
+            )
+            pane.render_preview(entry)
+            await pilot.pause()
+            preview = app.query_one("#catalog-preview", Static)
+            assert preview.region.height >= 7, preview.region
+            # The caveat's TAIL is inside the rendered region (not clipped).
+            assert "long prose" in str(preview.render())
+
+    @pytest.mark.asyncio
     async def test_vs_empty_card_not_doubled_when_free_unknown(self):
         # N3 — with live free-VRAM UNKNOWN, the fit line must show "vs empty card"
         # exactly ONCE (the trailing "({fit_basis})"), not doubled by also


### PR DESCRIPTION
## What

The last two T1-lite queue items in one small PR.

**F2 — Catalog preview strip clips wrapping caveats.** The strip's border eats 2 of its `max-height: 6` rows → 4 content lines; a long caveat that wraps (the `dual-fast` case from the audit) silently lost its tail. Now `max-height: 8` + `overflow-y: auto` (`height: auto` unchanged — short previews don't grow). Regression test renders a ~240-char caveat and asserts full height + visible tail.

**F5 — the #544 deliberate deferrals:**
- `wait_gpu_vram_settle` wired into **all** model/studio scene handlers (27b · 35b-a3b · gemma-12b · deckard · ai-studio) — previously gemma-int8 only. Every scene switch now waits for the torn-down scene's VRAM to actually release before booting (#535 class). The wait is a ~2s no-op when VRAM is already stable.
- **`mode_off` catch-all** (found live during this PR's validation): the enumerated `stop_*` lists cover gpu-mode *scenes*, but a catalog-launched engine (`switch.sh <slug>`) survived `off` — the rig's `vllm/minimal` kept serving and the 27b TP=2 scene booted straight into its held VRAM, reproducing #535 exactly. `off` now stops any remaining `vllm-`/`llama-cpp-`/`ik-llama-`/`sglang-`/`beellama-` container, with a named notice.
- c3 preflight-error visibility (third residual): **verified already-plumbed, no change** — #544's refusal exits fast, its `[preflight] ERROR` lines stream into the serve pane, and `serve_failed` stamps ✗ + the `[!]` report capture (pinned by existing tests).

Per-scene stop-lists remain hand-enumerated (they intentionally name sibling scenes); the catch-all lives in `off` where "stop ALL" is the contract. A registry-derived stop-list for scenes is a possible future refactor, noted in the tracker.

## Verification

- `bash -n` + full scripts gate green (asserted by **exit code**); c3 suite **763/763**.
- **Live scene cycle on the rig**: `off` → `27b` → `off`. Boot reached ready (`qwen3.6-27b`, 21.5 GiB/card); the fixed `off` left **zero** engine containers — validated with a non-enumerated probe container (`vllm-catchall-probe`) that the catch-all stopped; both GPUs at 1 MiB after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm