### PR TITLE
catalog-baselines slice 2b: c3 'yours vs the bar' overlay + bar provenance/staleness detail

### DIFF
--- a/scripts/rebench-full.sh
+++ b/scripts/rebench-full.sh
@@ -530,6 +530,8 @@ try:
     if q_on:
         rec["measured_extensions"]["quality_8pk_think_on"] = q_on
     rec["_rebench_tag"] = tag
+    from datetime import datetime, timezone
+    rec["_recorded_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     path = write_record(rec)
     print(f"  record:      corpus record appended -> {path}  (slug {slug})")
 except Exception as exc:

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -1006,10 +1006,38 @@ class CatalogPane(Container):
             f"  [bold]{entry.slug}[/bold]  [dim]·[/dim]  {entry.engine}"
             f"  [dim]·[/dim]  {_status_glyph(entry.status)} {entry.status or '—'}",
             f"  [bold]fit[/bold]  {fit_line}  [dim]({fit_basis})[/dim]",
-            f"  [bold]ctx[/bold]  {entry.ctx_label or '—'}"
-            f"   [bold]measured[/bold]  {entry.measurement.tps_label} TPS"
-            f"  ·  8pk {entry.measurement.quality_label}",
         ]
+        # Slice 2b — the measured line is the shipped BAR with its provenance;
+        # a stale bar gets an explicit detail line; THIS RIG's newest corpus
+        # record renders as "yours" for the at-a-glance rig-vs-bar read.
+        m = entry.measurement
+        bar_line = (
+            f"  [bold]ctx[/bold]  {entry.ctx_label or '—'}"
+            f"   [bold]bar[/bold]  {m.tps_label} TPS  ·  8pk {m.quality_label}"
+        )
+        b = getattr(entry.row, "baseline", None) or {}
+        if m.source == "baseline" and b:
+            prov = " · ".join(
+                str(x) for x in (b.get("date"), b.get("rig"), b.get("submitted_by")) if x
+            )
+            if prov:
+                bar_line += f"  [dim]({prov})[/dim]"
+        lines.append(bar_line)
+        if m.stale is True and b:
+            lines.append(
+                f"  [yellow]† bar measured on {b.get('engine_pin')} — "
+                f"current pin {b.get('current_pin')}; re-bench owed[/yellow]"
+            )
+        lm = entry.local_measurement
+        if lm is not None:
+            dec = f"{lm.decode_tps:.0f}" if lm.decode_tps is not None else "—"
+            yours = f"  [bold]yours[/bold]  ~{dec} decode"
+            if lm.quality_8pk:
+                yours += f"  ·  8pk {lm.quality_8pk}"
+            if lm.quality_8pk_think_on:
+                yours += f"  [dim]· on {lm.quality_8pk_think_on}[/dim]"
+            yours += f"  [dim]({lm.date} · this rig)[/dim]"
+            lines.append(yours)
         note = (entry.status_note or "").strip()
         if note:
             lines.append(f"  [bold]caveat[/bold]  [yellow]{note}[/yellow]")

--- a/tools/serve-cockpit/club3090_cockpit/data.py
+++ b/tools/serve-cockpit/club3090_cockpit/data.py
@@ -319,6 +319,10 @@ class CatalogEntry:
     weights_state: str = "unknown"
     weights: Optional["WeightsMeta"] = None
     download_pct: Optional[int] = None   # 0-99 while weights_state == "downloading"
+    # Catalog-baselines slice 2b: THIS RIG's newest corpus record for the slug
+    # (results/measurement-records/, written by rebench-full) — the "yours vs
+    # the bar" overlay.  None when this rig has never gated the slug.
+    local_measurement: Optional["LocalMeasured"] = None
 
     # Convenience pass-throughs (so panes can read entry.slug, not entry.row.slug)
     @property
@@ -400,6 +404,22 @@ class CatalogEntry:
         """Provenance string for the catalog 'source' column (registry source
         field, e.g. 'curated' / 'community' / 'local')."""
         return getattr(self.row, "source", "") or "·"
+
+
+@dataclass
+class LocalMeasured:
+    """The local "yours" overlay projection of one #249 corpus record
+    (catalog-baselines slice 2b) — THIS RIG's newest gate numbers for a slug.
+
+    The record's bench carries ONE canonical-short decode point (not the
+    narr/code pair — a parser limitation noted for slice 2c), plus the
+    quality extensions and the pin the run measured on."""
+
+    decode_tps: Optional[float] = None
+    quality_8pk: Optional[str] = None
+    quality_8pk_think_on: Optional[str] = None
+    engine_pin: Optional[str] = None
+    date: str = ""                       # _recorded_at date, else file-mtime date
 
 
 # ── Estate / Scene / Container / Doctor ─────────────────────────────────────────

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -66,6 +66,7 @@ from .data import (
     GATE_STEPS,
     GpuCompApp,
     GpuConflict,
+    LocalMeasured,
     Measurement,
     MeasuredNumbers,
     MeasureVsBar,
@@ -810,9 +811,12 @@ class CockpitData:
         BENCHMARKS.md is the public human/cross-rig ledger, never a machine
         source.  The baseline dict rides the variant row we already loaded, so
         this is a pure in-memory map (no I/O, no subprocess).  ``stale`` is the
-        emit-computed pin-staleness verdict (badged; slice 2 adds the local
-        measurement-record overlay)."""
+        emit-computed pin-staleness verdict (badged).  Slice 2b: the per-rig
+        corpus overlay joins here too — ``local_measurement`` carries THIS
+        RIG's newest gate numbers for the "yours vs the bar" preview line."""
+        local = self.local_measurements()
         for e in entries:
+            e.local_measurement = local.get(e.slug)
             b = getattr(e.row, "baseline", None)
             if not b:
                 continue
@@ -824,6 +828,54 @@ class CockpitData:
                 source="baseline",
                 stale=b.get("stale"),
             )
+
+    def local_measurements(self) -> dict[str, LocalMeasured]:
+        """The per-rig corpus overlay (slice 2b): THIS RIG's newest #249 record
+        per variant slug from results/measurement-records/*.jsonl (written by
+        rebench-full's completion block).  Pure filesystem read; {} when the
+        corpus is empty/absent.
+
+        Newest = the record's _recorded_at stamp when present, else the file's
+        mtime + line order (records append; later lines are later runs)."""
+        base = self.repo_root / "results" / "measurement-records"
+        if not base.is_dir():
+            return {}
+        import datetime as _dt
+
+        best: dict[str, tuple[float, LocalMeasured]] = {}
+        for f in sorted(base.glob("*.jsonl")):
+            try:
+                mtime = f.stat().st_mtime
+                lines = f.read_text(encoding="utf-8", errors="replace").splitlines()
+            except OSError:
+                continue
+            for i, ln in enumerate(lines):
+                try:
+                    r = json.loads(ln)
+                except ValueError:
+                    continue
+                slug = r.get("_tag")
+                if not slug:
+                    continue
+                stamp = r.get("_recorded_at") or ""
+                try:
+                    ts = _dt.datetime.fromisoformat(stamp.replace("Z", "+00:00")).timestamp()
+                except ValueError:
+                    ts = mtime + i * 1e-6
+                ext = r.get("measured_extensions") or {}
+                by_ctx = ext.get("decode_tps_by_ctx") or {}
+                decode = next(iter(by_ctx.values()), None)
+                lm = LocalMeasured(
+                    decode_tps=decode,
+                    quality_8pk=ext.get("quality_8pk"),
+                    quality_8pk_think_on=ext.get("quality_8pk_think_on"),
+                    engine_pin=r.get("engine_pin"),
+                    date=(stamp[:10] if stamp
+                          else _dt.date.fromtimestamp(mtime).isoformat()),
+                )
+                if slug not in best or ts > best[slug][0]:
+                    best[slug] = (ts, lm)
+        return {s: lm for s, (ts, lm) in best.items()}
 
     def _read_benchmarks_md(self) -> str:
         path = self.repo_root / "BENCHMARKS.md"

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -9321,6 +9321,43 @@ class TestCatalogPreview:
             assert "long prose" in str(preview.render())
 
     @pytest.mark.asyncio
+    async def test_preview_bar_provenance_stale_detail_and_yours(self, tmp_path):
+        """Slice 2b — the preview's measured line is the BAR with provenance;
+        a stale bar gets the explicit pin-detail line; a slug this rig has
+        gated shows the 'yours' corpus overlay line."""
+        seed_repo(tmp_path)
+        corpus = tmp_path / "results" / "measurement-records"
+        corpus.mkdir(parents=True)
+        (corpus / "vllm-dual__test.jsonl").write_text(json.dumps({
+            "_tag": "vllm/dual", "_recorded_at": "2026-07-04T12:00:00Z",
+            "engine_pin": "vllm/vllm-openai:v0.24.0",
+            "measured_extensions": {"decode_tps_by_ctx": {"canonical-short": 172.4},
+                                     "quality_8pk": "108/150"},
+        }) + "\n")
+        app, _, _ = make_app(repo_root=tmp_path)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            pane = app.query_one("#catalog-pane", CatalogPane)
+            t = app.query_one("#catalog-table", DataTable)
+            # vllm/dual: fresh bar + provenance + yours (this rig gated it).
+            t.move_cursor(row=0)
+            await pilot.pause()
+            prev = str(app.query_one("#catalog-preview", Static).render())
+            assert "bar" in prev and "174/42" in prev
+            assert "2026-07-01" in prev and "noonghunna" in prev   # provenance
+            assert "yours" in prev and "~172 decode" in prev and "108/150" in prev
+            assert "re-bench owed" not in prev                     # fresh bar
+            # ik row: stale bar → the explicit pin-detail line; no 'yours'.
+            ik_idx = next(i for i, e in enumerate(pane._filtered_entries())
+                          if e.slug == "ik-llama/iq4ks-mtp")
+            t.move_cursor(row=ik_idx)
+            await pilot.pause()
+            prev = str(app.query_one("#catalog-preview", Static).render())
+            assert "re-bench owed" in prev
+            assert "ghcr.io/ik-old@sha256:aaa" in prev and "ghcr.io/ik-new@sha256:bbb" in prev
+            assert "yours" not in prev
+
+    @pytest.mark.asyncio
     async def test_vs_empty_card_not_doubled_when_free_unknown(self):
         # N3 — with live free-VRAM UNKNOWN, the fit line must show "vs empty card"
         # exactly ONCE (the trailing "({fit_basis})"), not doubled by also

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -520,6 +520,39 @@ class TestLoadCatalog:
         assert ik.measurement.stale is True
 
     @pytest.mark.asyncio
+    async def test_local_measurements_overlay(self, tmp_path):
+        """Slice 2b — the per-rig corpus overlay: newest record per slug wins
+        (by _recorded_at), malformed lines are skipped, and the overlay joins
+        onto catalog entries as local_measurement."""
+        corpus = tmp_path / "results" / "measurement-records"
+        corpus.mkdir(parents=True)
+        older = {"_tag": "vllm/dual", "_recorded_at": "2026-07-01T10:00:00Z",
+                 "engine_pin": "vllm/vllm-openai:v0.22.0",
+                 "measured_extensions": {"decode_tps_by_ctx": {"canonical-short": 170.0},
+                                          "quality_8pk": "100/150"}}
+        newer = {"_tag": "vllm/dual", "_recorded_at": "2026-07-04T10:00:00Z",
+                 "engine_pin": "vllm/vllm-openai:v0.24.0",
+                 "measured_extensions": {"decode_tps_by_ctx": {"canonical-short": 174.5},
+                                          "quality_8pk": "109/150",
+                                          "quality_8pk_think_on": "111/150"}}
+        (corpus / "vllm-dual__aaaa.jsonl").write_text(
+            json.dumps(older) + "\nnot-json\n" + json.dumps(newer) + "\n"
+        )
+        cd = CockpitData(tmp_path, runner=full_runner())
+        local = cd.local_measurements()
+        lm = local["vllm/dual"]
+        assert lm.decode_tps == 174.5 and lm.quality_8pk == "109/150"
+        assert lm.quality_8pk_think_on == "111/150"
+        assert lm.engine_pin == "vllm/vllm-openai:v0.24.0"
+        assert lm.date == "2026-07-04"
+        # joins onto the catalog entry
+        entries, _ = await cd.load_catalog(enrich_fit=False, enrich_measurement=True)
+        vllm = next(e for e in entries if e.slug == "vllm/dual")
+        assert vllm.local_measurement == lm
+        ik = next(e for e in entries if e.slug == "ik-llama/iq4ks-mtp")
+        assert ik.local_measurement is None   # this rig never gated it
+
+    @pytest.mark.asyncio
     async def test_catalog_empty_registry_returns_error(self):
         runner = full_runner(**{"registry-emit.sh --json": ok(json.dumps({"variants": []}))})
         cd = CockpitData(ROOT, runner=runner)


### PR DESCRIPTION
## What

**Slice 2b — the consumer half of the producer wiring**: the per-rig corpus records that rebench-full now writes automatically (#562) render next to the shipped bar in the catalog preview.

## Pieces

1. **`LocalMeasured` + `CatalogEntry.local_measurement`** — this rig's newest corpus record per slug (decode point · both 8-pack arms · pin · date). Records carry one canonical-short decode point; the narr/code pair split is a 2c parser note.
2. **`local_measurements()`** — pure-filesystem corpus scan, newest-per-slug by the record's `_recorded_at` stamp (**new**: rebench-full stamps it at write; mtime+line-order fallback covers pre-stamp records), malformed lines skipped. Joins in the same enrichment pass — the catalog path stays zero-subprocess.
3. **Preview rework** (the pick-decision surface):
   - the measured line is now the **bar** with provenance: `bar 154/154 TPS · 8pk 105/150 (2026-07-03 · 2x3090-pcie · noonghunna)`
   - a stale bar gets the explicit detail: `† bar measured on <old-pin> — current pin <new-pin>; re-bench owed`
   - a slug this rig has gated adds: `yours ~154 decode · 8pk 105/150 (2026-07-04 · this rig)`

## Verification

- Live: the corpus's first record (A1, written by 2a's live validation) joins and renders.
- Tests: overlay semantics (newest-wins by stamp · malformed-skip · entry join · never-gated → None) + the three-state preview (fresh bar+provenance+yours · stale pin-detail · no-yours).
- c3 suite **766/766**; full scripts gate green (serial).

Remaining in slice 2: **2c** — the bench 10K/90K warm prefill/TTFT probe (cache-busting protocol; needs live GPU validation runs) + the rescore-materialization follow-up with benchlocal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm