### PR TITLE
catalog-baselines slice 2c: canonical two-depth prefill/TTFT probe + anchor calibration

### DIFF
--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -41,6 +41,17 @@
 #                      llama.cpp containers enable this automatically.
 #   PP_FALLBACK_TOKENS Approximate filler-token target for PP=1. Default: 10000
 #   PP_MAX_TOKENS      Completion cap for the PP fallback request. Default: 16
+#   PREFILL_PROBE      Set to 0 to skip the canonical two-depth prefill/TTFT
+#                      probe (catalog-baselines 2c). Default: 1. Each request
+#                      uses a FRESH salted haystack — composes serve
+#                      enable_prefix_caching, so identical prompts re-measure
+#                      the CACHE HIT, not prefill. Depths exceeding the served
+#                      context are skipped with a note.
+#   PREFILL_DEPTHS     CSV of prompt-token depths. Default: 10000,90000 (the
+#                      shallow/deep warm anchors; 90K sits inside the DeltaNet
+#                      degradation regime and pairs with the verify-stress
+#                      ladder's ~94K rung for anchor calibration).
+#   PREFILL_RUNS       Measured runs per depth. Default: 3
 #   ENABLE_THINKING    Set to 1 to send chat_template_kwargs.enable_thinking=true
 #                      in bench requests. Default: 0.
 #   FORCE_TOKENS       Force EXACTLY this many output tokens per run (sets
@@ -86,6 +97,12 @@ QUIET="${QUIET:-0}"
 PP="${PP:-0}"
 PP_FALLBACK_TOKENS="${PP_FALLBACK_TOKENS:-10000}"
 PP_MAX_TOKENS="${PP_MAX_TOKENS:-16}"
+PREFILL_PROBE="${PREFILL_PROBE:-1}"
+PREFILL_DEPTHS="${PREFILL_DEPTHS:-10000,90000}"
+PREFILL_RUNS="${PREFILL_RUNS:-3}"
+# The probe knobs reach the python heredoc via the environment (the argv tuple
+# is full); export them here.
+export PREFILL_PROBE PREFILL_DEPTHS PREFILL_RUNS
 ENABLE_THINKING="${ENABLE_THINKING:-0}"
 FORCE_TOKENS="${FORCE_TOKENS:-0}"
 
@@ -192,7 +209,7 @@ python3 - "$URL" "$MODEL" "$WARMUPS" "$RUNS" "$QUIET" "$ONLY" \
             "$ENABLE_THINKING" "$FORCE_TOKENS" \
             "$PROMPT_NARR" "$MAX_TOKENS_NARR" \
             "$PROMPT_CODE" "$MAX_TOKENS_CODE" << 'PYEOF'
-import json, re, shutil, subprocess, sys, time, urllib.request, statistics as s
+import json, os, random, re, shutil, string, subprocess, sys, time, urllib.request, statistics as s
 
 (URL, MODEL, WARMUPS, RUNS, QUIET, ONLY,
  CONTAINER, PP_MODE, PP_FALLBACK_TOKENS, PP_MAX_TOKENS,
@@ -365,12 +382,103 @@ def run_pp_fallback():
         print(stats("PP tok/s", pp_vals))
         print(f"  TTFT          mean={s.mean(ttfts)*1000:6.0f}ms  std=    0ms  min={min(ttfts)*1000:.0f}ms  max={max(ttfts)*1000:.0f}ms")
 
+def prefill_prompt(target_tokens, salt):
+    """Cache-busted long prompt (catalog-baselines 2c).
+
+    Composes serve ``enable_prefix_caching=True`` — an identical prompt
+    re-measures the PREFIX-CACHE HIT, not prefill.  vLLM's prefix cache is
+    block-chained, so a unique FIRST line breaks the whole chain; the salt is
+    also woven through the filler as belt-and-braces against block-aligned
+    partial hits."""
+    filler = (
+        f"calibration {salt} segment with stable token shape for the prefill probe. "
+        "This sentence is intentionally plain so tokenizer variance stays modest. "
+    )
+    words_per_chunk = max(len(filler.split()), 1)
+    chunks = max(1, target_tokens // words_per_chunk)
+    return (
+        f"[probe {salt}] Read the following calibration text. Reply with the single word DONE.\n\n"
+        + filler * chunks
+    )
+
+def run_prefill_probe():
+    """Canonical two-depth prefill/TTFT probe (catalog-baselines 2c): warm
+    engine, FRESH salted haystack per request, prefill tok/s = prompt_tokens/TTFT.
+    The deep anchor pairs with the verify-stress ladder's nearest rung for
+    anchor calibration (agreement certifies the ladder's whole depth curve).
+    A depth the served context can't hold is SKIPPED with a note."""
+    depths = [int(x) for x in os.environ.get("PREFILL_DEPTHS", "10000,90000").split(",") if x.strip()]
+    n = max(1, int(os.environ.get("PREFILL_RUNS", "3")))
+
+    def salt():
+        return "".join(random.choices(string.ascii_lowercase, k=8))
+
+    for target in depths:
+        label = f"prefill-{target // 1000}k"
+        print(
+            f"\n========== {label.upper()} (target={target} prompt tokens, "
+            f"max_tokens={PP_MAX_TOKENS}, cache-busted: fresh haystack per run) =========="
+        )
+        print("=== warmups (1) ===")
+        # The warmup doubles as the TOKEN CALIBRATOR: the word-count heuristic
+        # overshoots (salted filler tokenizes ~1.3 tok/word), so the measured
+        # runs scale their request by the warmup's actual/target ratio — the
+        # depth label stays honest to within a few percent.
+        request_tokens = target
+        try:
+            w, t, _k, ptoks = run_once(prefill_prompt(target, salt()), PP_MAX_TOKENS)
+            _pp, _t, line = fmt_pp("warm-1", w, t, ptoks)
+            if not QUIET:
+                print(line)
+            if ptoks > 0:
+                request_tokens = max(200, int(target * target / ptoks))
+                print(f"  [calibrated: {ptoks} tok at request={target} → measured runs request {request_tokens}]")
+        except Exception as e:
+            msg = str(e)
+            if any(x in msg for x in ("400", "maximum context", "max_model_len", "context length", "context window")):
+                print(f"  SKIP: {target} tokens exceeds the served context ({msg[:100]})")
+                continue
+            print(f"  warm-1     FAIL: {e}")
+        print(f"\n=== measured ({n}) ===")
+        pps, ttfts = [], []
+        for i in range(n):
+            try:
+                w, t, _k, ptoks = run_once(prefill_prompt(request_tokens, salt()), PP_MAX_TOKENS)
+                pp, ttft, line = fmt_pp(f"run-{i+1}", w, t, ptoks)
+                if not QUIET:
+                    print(line)
+                pps.append(pp)
+                ttfts.append(ttft)
+            except Exception as e:
+                print(f"  run-{i+1}    FAIL: {e}")
+        if pps:
+            print(f"\n=== summary [{label}] (n={len(pps)}) ===")
+            # prompt_tokens/TTFT = the CLIENT-OBSERVED rate (includes
+            # tokenization + transfer + scheduling) — the user-truth number.
+            print(stats("prefill tok/s", pps))
+            print(
+                f"  TTFT          mean={s.mean(ttfts)*1000:6.0f}ms  "
+                f"std={(s.stdev(ttfts)*1000 if len(ttfts) > 1 else 0):5.0f}ms  "
+                f"min={min(ttfts)*1000:.0f}ms  max={max(ttfts)*1000:.0f}ms"
+            )
+            # Engine-internal rate from the vLLM stats log — windowed (tokens
+            # per 10s stats window), so treat as approximate; the gap between
+            # this and the client-observed rate is tokenization/transfer/
+            # scheduling overhead, not prefill compute.
+            if PP_MODE == "log":
+                vals = scrape_prompt_throughput(CONTAINER, len(pps) * 2)
+                vals = [v for v in vals if v > 0][-len(pps):]
+                if vals:
+                    print(stats("PP tok/s (engine log, windowed)", vals))
+
 if ONLY in ("both", "narr"):
     run_set("narrative", PROMPT_NARR, MAX_NARR)
 if ONLY in ("both", "code"):
     run_set("code", PROMPT_CODE, MAX_CODE)
 if PP_MODE == "fallback":
     run_pp_fallback()
+if os.environ.get("PREFILL_PROBE", "1") == "1":
+    run_prefill_probe()
 PYEOF
 
 # GPU state

--- a/scripts/catalog-baseline.sh
+++ b/scripts/catalog-baseline.sh
@@ -146,17 +146,52 @@ if not q_off and not q_on:
 # ── ctx_validated: the verify-stress ceiling ladder verdict ──────────────────
 ctx_tokens = None
 niah = None
+stress_text = ""
 stress = tag_dir / "verify-stress.log"
 if stress.is_file():
-    st = stress.read_text(errors="replace")
-    m = re.search(r"all (\d+) rungs passed — fillable to (\d+) tok", st)
+    stress_text = stress.read_text(errors="replace")
+    m = re.search(r"all (\d+) rungs passed — fillable to (\d+) tok", stress_text)
     if m:
         ctx_tokens = int(m.group(2))
         niah = f"clean@{round(ctx_tokens / 1000)}K"
-    elif "All stress / boundary checks passed" in st:
+    elif "All stress / boundary checks passed" in stress_text:
         niah = "passed (no ceiling-ladder line parsed)"
 else:
     warn("no verify-stress.log — ctx_validated omitted")
+
+# ── prefill probe (catalog-baselines 2c) + anchor calibration ─────────────────
+# Reuse THE parser (measurement_record.parse_bench_output) — one grammar for
+# bench output, never a second regex set here.
+prefill_by_ctx = {}
+ttft_by_ctx = {}
+if bench_log:
+    from scripts.lib.profiles.measurement_record import parse_bench_output
+
+    bm = parse_bench_output(bench_log)
+    prefill_by_ctx = dict(bm.prefill_tps_by_ctx)
+    ttft_by_ctx = dict(bm.ttft_ms_by_ctx)
+    # Anchor calibration: the probe's DEEP warm anchor vs the NIAH ladder's
+    # nearest rung measure the same point — agreement certifies the ladder's
+    # whole depth curve; divergence is itself a finding (design §2.1.1).
+    if prefill_by_ctx and stress_text:
+        rungs = [
+            (int(a), float(p))
+            for a, p in re.findall(r"rung \d+/\d+: .*?actual=(\d+)K tok.*?prefill=([0-9.]+) t/s", stress_text)
+        ]
+        deep = max(((int(d), v) for d, v in prefill_by_ctx.items()), default=None)
+        if deep and rungs:
+            depth_k = deep[0] / 1000
+            nearest = min(rungs, key=lambda r: abs(r[0] - depth_k))
+            if abs(nearest[0] - depth_k) <= 20:  # comparable depths only
+                ratio = deep[1] / nearest[1] if nearest[1] else 0
+                if 0.7 <= ratio <= 1.3:
+                    print(f"[catalog-baseline] anchor calibration OK: probe {deep[1]:.0f} t/s @{depth_k:.0f}K "
+                          f"vs ladder {nearest[1]:.0f} t/s @{nearest[0]}K (ratio {ratio:.2f}) — depth curve certified",
+                          file=sys.stderr)
+                else:
+                    warn(f"anchor DIVERGENCE: probe {deep[1]:.0f} t/s @{depth_k:.0f}K vs ladder "
+                         f"{nearest[1]:.0f} t/s @{nearest[0]}K (ratio {ratio:.2f}, tolerance 0.7-1.3) — "
+                         "warm-vs-cold or config drift; investigate before trusting the depth curve")
 
 # ── provenance ────────────────────────────────────────────────────────────────
 engine_pin = os.environ["ENGINE_PIN"]
@@ -213,6 +248,12 @@ lines.append(f"    narr_tps: {round(float(narr['decode_tps_mean']), 2)}")
 lines.append(f"    code_tps: {round(float(code['decode_tps_mean']), 2)}")
 if ttft is not None:
     lines.append(f"    ttft_ms: {round(float(ttft))}")
+if prefill_by_ctx:
+    inner = ", ".join(
+        f"{int(k) // 1000}k: {v:.0f}"
+        for k, v in sorted(prefill_by_ctx.items(), key=lambda x: int(x[0]))
+    )
+    lines.append(f"    prefill_tps: {{ {inner} }}")
 if q_off:
     lines.append(f'    quality_8pk: "{q_off}"')
 if q_on:

--- a/scripts/lib/profiles/measurement_record.py
+++ b/scripts/lib/profiles/measurement_record.py
@@ -190,6 +190,12 @@ class BenchMetrics:
     power_cap_w: Optional[float] = None
     # Power draw in watts, per GPU index, if present.
     power_draw_w: dict[int, float] = field(default_factory=dict)
+    # Catalog-baselines 2c: the two-depth cache-busted prefill probe
+    # (``=== summary [prefill-<N>k] ===`` blocks). Keys = prompt-token depth
+    # as a string ("10000", "90000"); empty dicts when the probe didn't run
+    # (older bench captures / PREFILL_PROBE=0).
+    prefill_tps_by_ctx: dict[str, float] = field(default_factory=dict)
+    ttft_ms_by_ctx: dict[str, float] = field(default_factory=dict)
 
     # --- Parse provenance (drift / hollow-record detection) ----------------- #
     # How many ``=== summary [...] ===`` blocks carrying a ``decode_TPS mean=``
@@ -248,6 +254,29 @@ def parse_bench_output(text: str) -> BenchMetrics:
     if ttft:
         val = _f(ttft[-1])
         m.ttft_s = (val / 1000.0) if val is not None else None
+
+    # ── per-block pass (catalog-baselines 2c) ─────────────────────────────────
+    # The prefill probe appends ``=== summary [prefill-<N>k] ===`` blocks whose
+    # TTFT is a DEPTH measurement (seconds at 90K), not the canonical
+    # short-prompt TTFT — the naive last-occurrence rule above would swallow it.
+    # Parse per block: prefill blocks feed the by-depth dicts; the canonical
+    # ttft_s is re-anchored to the last NON-prefill block's TTFT.
+    parts = re.split(r"^=== summary \[([^\]]+)\] \(n=\d+\) ===$", text, flags=re.MULTILINE)
+    canonical_ttft_ms: Optional[float] = None
+    for label, body in zip(parts[1::2], parts[2::2]):
+        t_m = re.search(r"^\s*TTFT\s+mean=\s*([0-9.]+)ms", body, re.MULTILINE)
+        depth_m = re.fullmatch(r"prefill-(\d+)k", label.strip())
+        if depth_m:
+            depth = str(int(depth_m.group(1)) * 1000)
+            p_m = re.search(r"^\s*prefill tok/s\s+mean=\s*([0-9.]+)", body, re.MULTILINE)
+            if p_m:
+                m.prefill_tps_by_ctx[depth] = float(p_m.group(1))
+            if t_m:
+                m.ttft_ms_by_ctx[depth] = float(t_m.group(1))
+        elif t_m:
+            canonical_ttft_ms = float(t_m.group(1))
+    if canonical_ttft_ms is not None:
+        m.ttft_s = canonical_ttft_ms / 1000.0
 
     # nvidia-smi line (CSV, noheader):
     #   index, utilization.gpu, memory.used, memory.total, power.draw,
@@ -445,6 +474,10 @@ def build_record(
         "prefill_tps": bench_metrics.prefill_tps,
         "ttft_s": bench_metrics.ttft_s,
         "wall_tps": bench_metrics.wall_tps,
+        # Catalog-baselines 2c: the two-depth cache-busted prefill probe
+        # (empty dicts when the capture predates the probe / PREFILL_PROBE=0).
+        "prefill_tps_by_ctx": dict(bench_metrics.prefill_tps_by_ctx),
+        "ttft_ms_by_ctx": dict(bench_metrics.ttft_ms_by_ctx),
         "peak_vram_mib_by_gpu": {str(k): v for k, v in sorted(bench_metrics.vram_used_mib.items())},
         "power_draw_w_by_gpu": {str(k): v for k, v in sorted(bench_metrics.power_draw_w.items())},
         # power_cap_w is part of the conditions fingerprint AND an extension.

--- a/scripts/tests/test-baselines.sh
+++ b/scripts/tests/test-baselines.sh
@@ -58,6 +58,12 @@ for slug, row in rows.items():
               and isinstance(cv.get("niah"), str))
         if not ok:
             errors.append(f"{where}.ctx_validated: {{tokens: int, niah: str}}")
+    if "prefill_tps" in row:
+        pf = row["prefill_tps"]
+        ok = (isinstance(pf, dict) and pf
+              and all(isinstance(v, (int, float)) for v in pf.values()))
+        if not ok:
+            errors.append(f"{where}.prefill_tps: dict of numeric depth points (e.g. {{10k: N, 90k: M}})")
     if "source_tag" in row and not isinstance(row["source_tag"], str):
         errors.append(f"{where}.source_tag: string")
 

--- a/scripts/tests/test-catalog-baseline.sh
+++ b/scripts/tests/test-catalog-baseline.sh
@@ -31,9 +31,23 @@ EOF
   echo "========== NARRATIVE =========="
   echo "=== measured (5) ==="
   for i in 1 2 3 4 5; do echo "  run-$i  wall= 6.6s ttft= 130ms toks=1000 wall_TPS=150.0 decode_TPS=153.9"; done
+  echo "=== summary [narrative] (n=5) ==="
+  echo "  decode_TPS     mean= 153.90   std=  0.10   CV= 0.1%   min=153.80   max=154.00"
+  echo "  TTFT          mean=   130ms  std=    2ms  min=128ms  max=132ms"
   echo "========== CODE =========="
   echo "=== measured (5) ==="
   for i in 1 2 3 4 5; do echo "  run-$i  wall= 5.3s ttft= 128ms toks=800 wall_TPS=149.9 decode_TPS=154.0"; done
+  echo "=== summary [code] (n=5) ==="
+  echo "  decode_TPS     mean= 154.00   std=  0.10   CV= 0.1%   min=153.90   max=154.10"
+  echo "  TTFT          mean=   128ms  std=    2ms  min=126ms  max=130ms"
+  # 2c prefill-probe blocks: the 90K TTFT (17s!) must NOT bleed into the
+  # canonical short-prompt ttft_ms (per-block parser protection).
+  echo "=== summary [prefill-10k] (n=3) ==="
+  echo "  prefill tok/s  mean=7976.62   std= 87.19   CV= 1.1%   min=7902.43   max=8072.65"
+  echo "  TTFT          mean=  1254ms  std=   56ms  min=1193ms  max=1303ms"
+  echo "=== summary [prefill-90k] (n=3) ==="
+  echo "  prefill tok/s  mean=5459.14   std= 23.81   CV= 0.4%   min=5442.01   max=5486.33"
+  echo "  TTFT          mean= 17096ms  std=   74ms  min=17012ms  max=17150ms"
 } > "$TAGD/bench.log"
 cat > "$TAGD/_internal.json" <<'EOF'
 {"bench": {"narrative": {"decode_tps_mean": 153.9, "ttft_ms_mean": 130.0},
@@ -46,6 +60,7 @@ cat > "$TAGD/quality-full-thinking.json" <<'EOF'
 {"packs": [{"passed": 60, "total": 75}, {"passed": 50, "total": 75}]}
 EOF
 cat > "$TAGD/verify-stress.log" <<'EOF'
+    ✓ rung 1/6: target=95K  actual=94K tok (36%)  recalled 'violet chinchilla 79'  prefill=7402.9 t/s (13s)  VRAM_free=1403MB
   ✓ ceiling ladder: all 6 rungs passed — fillable to 240635 tok (91% of n_ctx=262144)
 All stress / boundary checks passed. KV-cache and prefill paths are sound.
 EOF
@@ -61,6 +76,12 @@ grep -q "code_tps: 154.0" <<<"$out" || fail "code_tps not extracted"
 grep -q 'quality_8pk: "105/150"' <<<"$out" || fail "quality_8pk not extracted"
 grep -q 'quality_8pk_think_on: "110/150"' <<<"$out" || fail "think-on not extracted"
 grep -q 'tokens: 240635' <<<"$out" || fail "ctx_validated not extracted"
+# 2c: prefill depth points land; the canonical ttft_ms stays the SHORT-prompt
+# value (the 90K block's 17s TTFT must not bleed into it).
+grep -q 'prefill_tps: { 10k: 7977, 90k: 5459 }' <<<"$out" || fail "prefill_tps not extracted: $out"
+grep -q 'ttft_ms: 130' <<<"$out" || fail "canonical ttft_ms polluted by probe blocks"
+# anchor calibration: probe 5459 @90K vs ladder 7403 @94K → ratio 0.74 → OK.
+grep -q "anchor calibration OK" <<<"$out" || fail "anchor calibration not reported"
 grep -q "DRY RUN" <<<"$out" || fail "dry-run not flagged"
 [[ "$(sha256sum "$BL" | cut -d' ' -f1)" == "$sum_before" ]] || fail "dry-run WROTE the file"
 


### PR DESCRIPTION
## What

**Slice 2c — the last piece of the producer wiring**: the canonical prefill/TTFT measurement (design §2.1.1's sourcing rule), with every protocol gotcha the design flagged now productized and live-validated.

## The probe (`bench.sh`, default-on)

- **Two warm anchors**: 10K (shallow) + 90K (deep — inside the DeltaNet degradation regime, paired with the NIAH ladder's ~94K rung). `PREFILL_PROBE=0` / `PREFILL_DEPTHS` / `PREFILL_RUNS` knobs.
- **Cache-busted**: fresh salted haystack per request — composes serve `enable_prefix_caching`, so an identical prompt re-measures the *cache hit* (vLLM's prefix cache is block-chained; a unique first line breaks the chain).
- **Self-calibrating**: word-count heuristics overshoot tokens ~1.3×; the warmup's reported `prompt_toks` scales the measured runs → within ~4% of the requested depth.
- **Dual metric, labeled** (a genuine finding from the live runs): `prompt_tokens/TTFT` = **client-observed** (user-truth — includes tokenization/transfer/scheduling) vs the vLLM stats-log windowed rate = **engine-internal** (compute-truth). At 93K on A1 they differ by ~7s of non-prefill overhead (5.5K vs ~10K t/s). Never cross-compare kinds — recorded as a stack LEARNINGS row.
- Depths exceeding the served context **skip with a note**.

## Downstream

- **Record parser**: per-block pass → `prefill_tps_by_ctx` + `ttft_ms_by_ctx` extensions; the canonical short-prompt `ttft_s` is *protected* (the old last-occurrence rule would have swallowed the 90K block's 17-second TTFT).
- **Induction tool**: rows gain `prefill_tps: { 10k: N, 90k: M }` (parsed via THE record parser — no second grammar) + **anchor calibration at induction**: the deep anchor vs the ladder's nearest rung; agreement (ratio 0.7–1.3) certifies the whole depth curve, divergence warns as a finding.
- Schema guard + hermetic fixtures updated (probe blocks · TTFT-pollution guard · anchor-OK).

## Live validation (serving A1, 262K, three runs)

| depth | client-observed | TTFT | CV |
|---|---|---|---|
| ~10K | **7,977 t/s** | 1.25 s | 1.1% |
| ~93K | **5,584 t/s** | 16.1 s | 0.5% |

Anchor: probe@93K vs ladder@94K (7,403 t/s) = **ratio 0.75 — inside tolerance** → A1's 6-point depth curve certified, exactly the design's calibrated-diagnostic mechanism working on its first outing.

Full scripts gate green. This completes slice 2 (2a #562 · 2b #563 · 2c here); the rescore-materialization follow-up rides with benchlocal upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm