### PR TITLE
Launcher arch-aware KV dtype injection for pilot slugs (#246 Phase 1)

### DIFF
--- a/docs/DTYPE_MATRIX.md
+++ b/docs/DTYPE_MATRIX.md
@@ -110,9 +110,11 @@ KV cache is a separate concern from weights — vLLM ships several KV-quant sche
 
 **Ada / Hopper / Blackwell get a real win on FP8 KV** because the Tensor Cores can multiply FP8 directly without an upcast. On Ampere, FP8 KV is just smaller storage — the matmul still happens in FP16, so you save VRAM but not compute time. That's why the 3090's fp8 KV gives lower per-stream TPS than INT8 PTH (which *can* multiply in INT8 on the Tensor Core directly).
 
+**The launchers act on this automatically since [#246](https://github.com/noonghunna/club-3090/issues/246) Phase 1**: `launch.sh` / `switch.sh` detect the GPU arch and, for the pilot slugs (`vllm/dual`, `vllm/minimal`), export `KV_CACHE_DTYPE=fp8_e4m3` on sm_89+ cards (the hardware profiles' `balanced` default). Ampere emits no override at all — compose defaults apply, byte-for-byte pre-#246 behavior. An explicit `KV_CACHE_DTYPE=` in your environment always wins, quant-specific KV slugs (int8-PTH / TQ) are never touched, and direct `docker compose up` keeps the Ampere-safe compose defaults. Expansion beyond the pilot slugs is gated on the cross-rig A/B in #246.
+
 **Emerging KV recipes** (worth watching, not yet defaults):
 - **Block-scaled FP8 KV** — per-block scales like MXFP8 but applied to KV cache rather than weights. Recovers accuracy at long-context where flat FP8 can lose precision in deep layers. Lands on Hopper / Blackwell first.
-- **NVFP4 KV** — Blackwell-native, ~4× smaller than FP16 KV at NVFP4 weight accuracy levels. Kernels still maturing in vLLM nightlies.
+- **NVFP4 KV** — Blackwell-native, ~4× smaller than FP16 KV at NVFP4 weight accuracy levels. **A valid `--kv-cache-dtype nvfp4` literal in our v0.24.0 pin** (declared as a *candidate* on the Blackwell hardware profiles; SM-gated ≥10.0). Unvalidated on this stack — it's arm 3 of the #246 cross-rig A/B; a literal existing ≠ working kernels + clean recall (see the int8-PTH-on-Gemma and mainline-TQ precedents).
 - **TensorRT-LLM W4A8 / W4A4** — Hopper/Blackwell weight+activation quant recipes that pair INT4/NVFP4 weights with FP8/FP4 activations. Out of scope for the vLLM-first composes here but worth knowing if you cross-shop.
 
 ### KV-quant × checkpoint compatibility — the two Ampere traps
@@ -318,9 +320,9 @@ What to ship as the default for each GPU class, given the matrix above:
 | **Turing (T4, 20-series)** | INT8 native; GPTQ INT4 via Marlin works | FP16 / INT8 | n-gram only | not a primary target |
 | **Ampere consumer (3090/3080/3060)** ⭐ | **AutoRound INT4** | **TQ3 (Genesis) / INT8 PTH / fp8** | **MTP n=3** + Genesis P67 | `dual/autoround-int4/turbo.yml`, `dual/autoround-int4/tq3-mtp-genesis.yml`, `single/autoround-int4/long-text.yml` — primary target of this stack |
 | **Ampere DC (A100)** | AutoRound INT4 or FP16 | TQ3 / fp8 | MTP n=3 | Same composes as 3090, more VRAM headroom |
-| **Ada (4090 / L40)** | AutoRound INT4 (preserve INT4 path) **OR** FP8 weights for full TC use | **fp8 (HW)** / TQ3 / INT8 PTH | MTP n=3 / DFlash | Same composes work; FP8 KV is now a real perf win |
+| **Ada (4090 / L40)** | AutoRound INT4 (preserve INT4 path) **OR** FP8 weights for full TC use | **fp8_e4m3 (HW — launcher-injected for pilot slugs, #246)** / TQ3 / INT8 PTH | MTP n=3 / DFlash | Same composes work; FP8 KV is now a real perf win |
 | **Hopper (H100/H200)** | FP8 weights (FBGEMM/INC) | **fp8 (HW transformer engine)** | MTP / DFlash | Not a primary target — these cards are usually already running their own optimised stacks |
-| **Blackwell consumer (5090/5080/5070)** | AutoRound INT4 today; NVFP4 when vLLM kernels mature | fp8_e5m2 advisory (e4m3 path undertuned per #51) | MTP n=3 | Genesis treats Blackwell consumer as a separate regime — some Hopper-targeted patches don't apply |
+| **Blackwell consumer (5090/5080/5070)** | AutoRound INT4 today; NVFP4 when vLLM kernels mature | **fp8_e4m3 (launcher-injected for pilot slugs, #246 — A/B pending)** · nvfp4 = candidate arm 3 | MTP n=3 | The old "e4m3 path undertuned per #51" advisory was **Genesis-nightly-era** — stock v0.24.0 is what the #246 A/B measures. Genesis treats Blackwell consumer as a separate regime — some Hopper-targeted patches don't apply |
 | **Blackwell DC (B100/B200/GB200)** | NVFP4 / FP8 weights | NVFP4 / fp8 | MTP / DFlash | Out of scope for club-3090 |
 
 The starred row (Ampere consumer) is the actual target of this stack; everything else is "should work, here's the data point we have".

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -65,6 +65,29 @@ Same `MAX_MODEL_LEN` / `GPU_MEMORY_UTILIZATION` env overrides apply for any setu
 
 ---
 
+## Arch-aware launcher defaults (#246 Phase 1)
+
+The shipped composes carry **Ampere-safe defaults** (fp8_e5m2 KV etc.). Since [#246](https://github.com/noonghunna/club-3090/issues/246) Phase 1, `launch.sh` / `switch.sh` detect your GPU's compute capability and export the better flag for newer silicon so you don't hand-tune:
+
+| Detected class | What the launchers do |
+|---|---|
+| **ampere** (sm_8.6/8.7) | Nothing — compose defaults apply, byte-for-byte pre-#246 behavior |
+| **ada** (sm_8.9) / **hopper** (sm_9.x) / **blackwell** (sm_10+) | Export `KV_CACHE_DTYPE=fp8_e4m3` (native FP8 Tensor-Core compute) for the **pilot slugs** |
+| unknown / heterogeneous mix / no nvidia-smi | Nothing — compose defaults apply |
+
+Mechanics and boundaries:
+
+- **Pilot slugs only**: `vllm/dual`, `vllm/minimal` — the two Qwen fp8-KV reference configs. Expansion to the rest of the catalog is gated on the cross-rig A/B in #246 (≥15% on either canonical prompt on a volunteer 4090/5090; within CV → the injection framework gets closed out instead).
+- **The injected value comes from the hardware profiles** (`scripts/lib/profiles/hardware/<card>.yml` → `kv_format_default.balanced`) — one source of truth shared with the pull gates and c3. 3090-class profiles declare `fp8_e5m2` there, which equals the compose default: the Ampere no-op is data, not a code branch.
+- **Your env wins**: an explicit `KV_CACHE_DTYPE=…` before `launch.sh`/`switch.sh` suppresses the injection entirely.
+- **Quant-specific KV slugs are never touched** — int8-PTH (compressed-tensors weights *reject* fp8 KV), TurboQuant, and bf16 configs keep their registry KV format.
+- **Direct `docker compose -f … up` bypasses all of this** and keeps the Ampere-safe compose defaults on any card.
+- The preflight banner names the detected class: `[preflight] arch: ada (sm_8.9) — arch-aware KV defaults active for pilot slugs (#246)`.
+- `VLLM_ATTENTION_BACKEND` is plumbed through the same channel but **ships no value** — vLLM's backend auto-detect is the default until someone measures a better per-arch choice.
+- **Blackwell + `nvfp4` KV**: a valid dtype literal in our v0.24.0 pin and declared as a *candidate* on the Blackwell hardware profiles, but unvalidated (no NIAH/quality data on any rig we've seen) — it's arm 3 of the #246 A/B, opt-in via `KV_CACHE_DTYPE=nvfp4`, not a default.
+
+---
+
 ## NVLink
 
 **Not required.** Dual-card composes auto-detect NVLink and configure themselves accordingly.

--- a/docs/KV_MATH.md
+++ b/docs/KV_MATH.md
@@ -107,8 +107,9 @@ For hybrid architectures (DeltaNet, SWA), only the **growing** attention layers 
 | `k8v4` | 0.75 | Mixed precision |
 | `q4_0` | ~0.56 | Includes packed-quant overhead |
 | `turboquant_3bit_nc` (TQ3) | ~0.425 | Genesis-supplied; cheapest KV format on this stack |
+| `nvfp4` | ~0.56 (**projected**) | 4-bit elements + fp8 block scale per 16 (9/16 B). Blackwell-only (sm ≥ 10.0); vLLM v0.24.0 literal, **no measured boot on this stack** — #246 A/B arm 3. kv-calc carries mirrored-fp8 activation coefs until a real boot calibrates them |
 
-**Note on Ampere**: `fp8_e4m3` is NOT supported by the Triton kernel on sm_86 (3090/3090-Ti/A5000). Use `fp8_e5m2` (engine-level fallback) or `int8_per_token_head` (vendored via PR #42102). See [DTYPE_MATRIX.md](DTYPE_MATRIX.md).
+**Note on Ampere**: `fp8_e4m3` is NOT supported by the Triton kernel on sm_86 (3090/3090-Ti/A5000). Use `fp8_e5m2` (engine-level fallback) or `int8_per_token_head` (vendored via PR #42102). On sm_89+ the launchers inject `fp8_e4m3` automatically for the #246 pilot slugs. See [DTYPE_MATRIX.md](DTYPE_MATRIX.md).
 
 ### Per-card budget composition (all models)
 

--- a/docs/QUANTIZATION.md
+++ b/docs/QUANTIZATION.md
@@ -161,7 +161,9 @@ Independent of the weight quant, you can quantize the **KV cache** — this is w
 | `f16` | 16 | all | Lossless, biggest. Rarely needed. |
 | `q8_0` | 8 | llama.cpp / ik | Near-lossless; good default when context is moderate. |
 | `q4_0` | 4 | llama.cpp / ik | Halves KV vs q8_0 → enables **262K on one 3090** (ik IQ4_KS). Tiny quality cost. |
-| `fp8_e5m2` | 8 | vLLM | Our `vllm/dual` default (AutoRound weights). |
+| `fp8_e5m2` | 8 | vLLM | Our `vllm/dual` default (AutoRound weights) — the Ampere-safe storage-only fp8. |
+| `fp8_e4m3` | 8 | vLLM | Same bytes as e5m2 but **native FP8 Tensor-Core compute on sm_89+** (Ada/Hopper/Blackwell; hard-rejected on Ampere). Since [#246](https://github.com/noonghunna/club-3090/issues/246) the launchers inject it automatically on those cards for the pilot slugs — you don't hand-pick it; `KV_CACHE_DTYPE=` in your env overrides. |
+| `nvfp4` | 4 | vLLM ≥ v0.24.0 | Blackwell-only (sm ≥ 10.0) FP4 KV — a valid dtype literal in our pin, **unvalidated on this stack** (candidate on the Blackwell hardware profiles; #246 A/B arm 3). Needs a NIAH-clean cross-rig gate before it's anyone's default. |
 | **`int8_per_token_head`** | 8 | vLLM | ~1 byte/tok like fp8; **native in stock v0.22.0** for standard models (Gemma-4 needs the #40391 overlay). The KV path for **compressed-tensors weights (AWQ/FP8/INT8) at long context** — those can't use fp8 KV. |
 | **TQ3 (TurboQuant)** | 3 | vLLM (Genesis) | 3-bit KV — beats fp8 on long-context memory; powers our `dual-turbo`. See [TQ3_MTP_GENESIS.md](TQ3_MTP_GENESIS.md) + [CLIFFS.md](CLIFFS.md). |
 | `-khad` (modifier) | — | **ik only** | Hadamard transform on the K-cache → recovers accuracy lost to KV quantization, so you keep quality at q4_0/q8_0. |

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -1156,9 +1156,12 @@ validate_selected_variant() {
 }
 
 export_variant_engine_pin() {
-  local variant="$1" output line key value
+  local variant="$1" output line key value gpu_spec
   [[ "$variant" == vllm/* || "$variant" == beellama/* ]] || return 0
-  if ! output="$(python3 "$LAUNCH_PROFILE" resolve-variant-pin --variant "$variant" --format shell 2>&1)"; then
+  # detected-GPU spec enables the #246 arch-aware env for pilot variants;
+  # empty (no selection yet / no nvidia-smi) -> pin exports only.
+  gpu_spec="$(selected_gpu_profile_spec 2>/dev/null || true)"
+  if ! output="$(python3 "$LAUNCH_PROFILE" resolve-variant-pin --variant "$variant" --format shell --gpu-spec "$gpu_spec" 2>&1)"; then
     echo "$output" >&2
     exit 2
   fi
@@ -1168,6 +1171,11 @@ export_variant_engine_pin() {
       VLLM_NIGHTLY_SHA) export VLLM_NIGHTLY_SHA="$value" ;;
       VLLM_IMAGE) export VLLM_IMAGE="$value" ;;
       BEELLAMA_IMAGE) export BEELLAMA_IMAGE="$value" ;;
+      # #246 arch-aware env (pilot slugs; hardware-profile balanced default)
+      KV_CACHE_DTYPE)
+        export KV_CACHE_DTYPE="$value"
+        echo "[launch] arch-aware KV dtype: ${value} (hardware-profile default for detected GPUs — #246)" ;;
+      VLLM_ATTENTION_BACKEND) export VLLM_ATTENTION_BACKEND="$value" ;;
       *) echo "[launch] ERROR: unexpected engine pin export: $key" >&2; exit 2 ;;
     esac
   done <<< "$output"

--- a/scripts/lib/profiles/gates.py
+++ b/scripts/lib/profiles/gates.py
@@ -68,14 +68,21 @@ from typing import Any, Callable, Optional
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
-# Arch-kernel SM rule (locked design [C0] / brief): these KV formats require
-# an SM-9.0-class kernel and are NOT loadable on Ampere sm_86 (RTX 3090).
-# (fp8_e4m3 native compute + Gemma-TQ3 are the §1 confidently-wrong-on-3090
-# risks Codex-r5 High-1 closes; mirrors compose_registry required_sm:9.0 +
-# arch_patches Gemma kernel_constraints "fp8_e4m3 is not supported on sm_86".)
+# Arch-kernel SM rule (locked design [C0] / brief): per-KV-format SM floors —
+# none loadable on Ampere sm_86 (RTX 3090). Floors are the vLLM kernel truth:
+#   fp8_e4m3            8.9  — vLLM "FP8 KV cache … requires SM89+" (Ada+;
+#                              was 9.0 here — corrected for #246, since the
+#                              launcher now injects e4m3 on 4090s. The gemma
+#                              fp8 slug keeps its explicit required_sm 9.0.)
+#   turboquant_3bit_nc  9.0  — MAINLINE TQ3 kernels (Genesis-Ampere TQ3 is a
+#                              different path; mirrors arch_patches Gemma
+#                              kernel_constraints)
+#   nvfp4               10.0 — Blackwell FP4 tensor cores; v0.24.0 literal,
+#                              unvalidated on this stack (#246 A/B arm 3)
 _ARCH_KERNEL_SM = {
-    "fp8_e4m3": 9.0,
+    "fp8_e4m3": 8.9,
     "turboquant_3bit_nc": 9.0,
+    "nvfp4": 10.0,
 }
 
 
@@ -502,7 +509,8 @@ def c0_engine_support(
             f"registry.required_sm={entry.get('required_sm')}, "
             f"arch-kernel[{kv_format}]="
             f"{_ARCH_KERNEL_SM.get(kv_format, 0.0):g}); "
-            f"e.g. fp8_e4m3 / Gemma-TQ3 need SM 9.0 — NOT loadable on sm_86"
+            f"e.g. fp8_e4m3 needs SM 8.9+, Gemma-TQ3 SM 9.0+, nvfp4 SM 10.0+ "
+            f"— NOT loadable on sm_86"
         )
 
     # --- 4. supported -----------------------------------------------------

--- a/scripts/lib/profiles/hardware/rtx-5090.yml
+++ b/scripts/lib/profiles/hardware/rtx-5090.yml
@@ -10,6 +10,9 @@ supported_kv_formats:
   - fp16
   - fp8_e5m2
   - fp8_e4m3
+  - nvfp4                 # Blackwell FP4 KV — vLLM v0.24.0 literal; CANDIDATE, unvalidated
+                          # on this stack (#246 A/B arm 3). Promote to kv_format_default
+                          # only after a NIAH-clean cross-rig gate.
   - turboquant_3bit_nc
   - int8_per_token_head
   - q4_0

--- a/scripts/lib/profiles/hardware/rtx-6000-pro-blackwell.yml
+++ b/scripts/lib/profiles/hardware/rtx-6000-pro-blackwell.yml
@@ -10,6 +10,9 @@ supported_kv_formats:
   - fp16
   - fp8_e5m2
   - fp8_e4m3
+  - nvfp4                 # Blackwell FP4 KV — vLLM v0.24.0 literal; CANDIDATE, unvalidated
+                          # on this stack (#246 A/B arm 3). Promote to kv_format_default
+                          # only after a NIAH-clean cross-rig gate.
   - turboquant_3bit_nc
   - int8_per_token_head
   - q4_0

--- a/scripts/lib/profiles/launch_compat.py
+++ b/scripts/lib/profiles/launch_compat.py
@@ -151,6 +151,49 @@ def _entry_objects(entry: dict, profiles):
 _ENGINE_IMAGE_ENV = {"beellama-local": "BEELLAMA_IMAGE"}
 
 
+# --- #246 Phase 1: arch-aware KV dtype injection (pilot) ---------------------
+# The launchers export KV_CACHE_DTYPE for these slugs when the detected cards'
+# hardware profiles declare a different `kv_format_default.balanced` than the
+# variant's registry kv_format. Expand this set only after the cross-rig A/B
+# (issue #246 acceptance: >=15% on a volunteer 4090/5090, else close-with-data).
+ARCH_KV_PILOT_VARIANTS = frozenset({"vllm/dual", "vllm/minimal"})
+
+# The ONLY substitutions Phase 1 may make. Keyed by the variant's registry
+# kv_format; values are the hardware-profile targets allowed to replace it.
+# fp8_e5m2 -> fp8_e4m3 is the native-FP8-compute swap for sm_89+ cards.
+# Nothing else is injectable: 3090-class profiles declare balanced=fp8_e5m2
+# (the Ampere no-op is data equality), and their long_context default (TQ3)
+# is a Genesis-era format that must never reach stock composes.
+_ARCH_KV_ALLOWED = {"fp8_e5m2": frozenset({"fp8_e4m3"})}
+
+
+def _arch_aware_env(profiles, variant: str, entry: dict, gpu_spec: str,
+                    pin_exports: dict) -> dict[str, str]:
+    """Arch-aware env for a variant (#246 Phase 1). Empty dict = no injection
+    (compose ${VAR:-default} fallbacks apply, i.e. pre-#246 behavior)."""
+    if not gpu_spec or variant not in ARCH_KV_PILOT_VARIANTS:
+        return {}
+    allowed = _ARCH_KV_ALLOWED.get(entry.get("kv_format") or "")
+    if not allowed:
+        return {}  # quant-specific KV (int8-PTH, turbo, bf16, ...) — never override
+    if not ({"VLLM_IMAGE", "VLLM_NIGHTLY_SHA"} & set(pin_exports)):
+        return {}  # vLLM-family variants only; KV_CACHE_DTYPE is a vLLM knob
+    if os.environ.get("KV_CACHE_DTYPE"):
+        return {}  # an explicit user pin always wins
+    try:
+        hardware = _parse_gpu_specs(gpu_spec, profiles)
+    except LaunchCompatError:
+        return {}  # unmapped card -> compose defaults (today's behavior)
+    balanced = {hw.kv_format_default.get("balanced") for hw in hardware}
+    if len(balanced) != 1:
+        return {}  # heterogeneous rig -> no single right answer; don't guess
+    target = balanced.pop()
+    if (not target or target == entry["kv_format"] or target not in allowed
+            or not all(target in hw.supported_kv_formats for hw in hardware)):
+        return {}
+    return {"KV_CACHE_DTYPE": target}
+
+
 def resolve_engine_pin(profiles, engine_id: str) -> dict[str, str]:
     """Resolve EngineProfile.install into compose environment exports."""
     try:
@@ -181,11 +224,16 @@ def resolve_engine_pin(profiles, engine_id: str) -> dict[str, str]:
     return {env_key: spec}
 
 
-def resolve_variant_pin(profiles, variant: str) -> dict[str, str]:
+def resolve_variant_pin(profiles, variant: str, gpu_spec: str = "") -> dict[str, str]:
     entry = COMPOSE_REGISTRY.get(variant)
     if not entry:
         raise ProfileError(f"unknown compose variant `{variant}`")
-    return resolve_engine_pin(profiles, entry["engine"])
+    exports = resolve_engine_pin(profiles, entry["engine"])
+    # #246: arch-aware env rides the same export channel as the image pin.
+    # Only emitted when a gpu_spec is passed (launchers do; the registry-emit
+    # baselines join calls without one and sees pins only).
+    exports.update(_arch_aware_env(profiles, variant, entry, gpu_spec, exports))
+    return exports
 
 
 def _print_env(exports: dict[str, str], fmt: str) -> None:
@@ -405,7 +453,7 @@ def command_resolve_engine_pin(args: argparse.Namespace) -> int:
 def command_resolve_variant_pin(args: argparse.Namespace) -> int:
     _quiet_compat_logger()
     profiles = load_profiles()
-    _print_env(resolve_variant_pin(profiles, args.variant), args.format)
+    _print_env(resolve_variant_pin(profiles, args.variant, args.gpu_spec), args.format)
     return 0
 
 
@@ -531,6 +579,9 @@ def build_parser() -> argparse.ArgumentParser:
     variant_pin = sub.add_parser("resolve-variant-pin")
     variant_pin.add_argument("--variant", required=True)
     variant_pin.add_argument("--format", choices=("shell", "json", "value"), default="shell")
+    # optional: detected GPUs (idx|name|mem_mib|sm;...) — enables the #246
+    # arch-aware env for pilot variants; omitted -> pin exports only.
+    variant_pin.add_argument("--gpu-spec", dest="gpu_spec", default="")
     variant_pin.set_defaults(func=command_resolve_variant_pin)
 
     topology = sub.add_parser("topology")

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -70,6 +70,24 @@ preflight_gpu() {
   fi
   echo "[preflight] gpu:     ${gpu_count}× detected"
   echo "$gpu_lines" | sed 's/^/[preflight]            /'
+  # GPU arch class (display-only, #246). The launchers inject arch-aware env
+  # (KV dtype) from the hardware profiles; this banner just names the class.
+  local _cap _arch_class
+  _cap="$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader,nounits 2>/dev/null | head -1 | tr -d '[:space:]')"
+  if [[ -n "$_cap" ]]; then
+    case "$_cap" in
+      8.6|8.7)      _arch_class="ampere" ;;
+      8.9)          _arch_class="ada" ;;
+      9.*)          _arch_class="hopper" ;;
+      1[0-9].*)     _arch_class="blackwell" ;;
+      *)            _arch_class="unknown" ;;
+    esac
+    if [[ "$_arch_class" == "ampere" || "$_arch_class" == "unknown" ]]; then
+      echo "[preflight] arch:    ${_arch_class} (sm_${_cap}) — compose defaults apply (no arch-aware override)"
+    else
+      echo "[preflight] arch:    ${_arch_class} (sm_${_cap}) — arch-aware KV defaults active for pilot slugs (#246)"
+    fi
+  fi
   # Cross-rig friendliness: surface a hint when 4090 / 5090 cards are
   # detected. Composes run cross-rig but per-class gotchas (ctx derate,
   # VRAM envelope, SM-gated kernels) live in the FAQ — easier to catch

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -135,6 +135,21 @@ declare -A VARIANT_CONTAINER=()
 # shellcheck source=lib/registry-emit.sh
 source "${ROOT_DIR}/scripts/lib/registry-emit.sh"
 derive_switch_variant_tables "${ROOT_DIR}"
+# shellcheck source=lib/compose-meta.sh
+source "${ROOT_DIR}/scripts/lib/compose-meta.sh"
+
+# Detected GPUs as an idx|name|mem_mib|sm;... spec (the launch_compat format).
+# Empty when detection fails -> the #246 arch-aware env simply stays off.
+switch_gpu_profile_spec() {
+  local lines idx name mem sm parts=()
+  lines="$(compose_hw_detect_gpus 2>/dev/null || true)"
+  [[ -n "$lines" ]] || { printf ''; return 0; }
+  while IFS=$'\t' read -r idx name mem sm; do
+    [[ -z "$idx" ]] && continue
+    parts+=("${idx}|${name}|${mem}|${sm}")
+  done <<< "$lines"
+  (IFS=';'; printf '%s' "${parts[*]}")
+}
 
 # Teardown is registry-derived from VARIANT_CONTAINER (see down_running()). This
 # replaced a fixed `^(vllm-|llama-cpp-)` regex that missed beellama-/ik-llama-/
@@ -894,9 +909,10 @@ gpu_preflight() {
 }
 
 export_variant_engine_pin() {
-  local variant="$1" output line key value
+  local variant="$1" output line key value gpu_spec
   [[ "$variant" == vllm/* || "$variant" == beellama/* ]] || return 0
-  if ! output="$(python3 "$LAUNCH_PROFILE" resolve-variant-pin --variant "$variant" --format shell 2>&1)"; then
+  gpu_spec="$(switch_gpu_profile_spec 2>/dev/null || true)"
+  if ! output="$(python3 "$LAUNCH_PROFILE" resolve-variant-pin --variant "$variant" --format shell --gpu-spec "$gpu_spec" 2>&1)"; then
     echo "$output" >&2
     exit 2
   fi
@@ -906,6 +922,11 @@ export_variant_engine_pin() {
       VLLM_NIGHTLY_SHA) export VLLM_NIGHTLY_SHA="$value" ;;
       VLLM_IMAGE) export VLLM_IMAGE="$value" ;;
       BEELLAMA_IMAGE) export BEELLAMA_IMAGE="$value" ;;
+      # #246 arch-aware env (pilot slugs; hardware-profile balanced default)
+      KV_CACHE_DTYPE)
+        export KV_CACHE_DTYPE="$value"
+        echo "[switch] arch-aware KV dtype: ${value} (hardware-profile default for detected GPUs — #246)" ;;
+      VLLM_ATTENTION_BACKEND) export VLLM_ATTENTION_BACKEND="$value" ;;
       *) echo "[switch] ERROR: unexpected engine pin export: $key" >&2; exit 2 ;;
     esac
   done <<< "$output"

--- a/scripts/tests/test-launch-compat.sh
+++ b/scripts/tests/test-launch-compat.sh
@@ -92,6 +92,36 @@ assert_contains "$out" "VLLM_IMAGE=vllm/vllm-openai:v0.24.0"
 out="$(python3 "$HELPER" resolve-variant-pin --variant vllm/gemma-int8-mtp --format shell)"
 assert_contains "$out" "VLLM_IMAGE=vllm/vllm-openai:v0.22.0"
 
+# --- #246 arch-aware KV injection matrix (resolve-variant-pin --gpu-spec) ----
+GPU_4090='0|NVIDIA GeForce RTX 4090|24564|8.9'
+GPU_5090X2='0|NVIDIA GeForce RTX 5090|32607|12.0;1|NVIDIA GeForce RTX 5090|32607|12.0'
+
+# ampere -> NOTHING injected (compose defaults; the no-op is data equality)
+out="$(python3 "$HELPER" resolve-variant-pin --variant vllm/dual --format shell --gpu-spec "$GPU_3090")"
+assert_not_contains "$out" "KV_CACHE_DTYPE"
+# ada / blackwell pilot slugs -> native-fp8 swap
+out="$(python3 "$HELPER" resolve-variant-pin --variant vllm/dual --format shell --gpu-spec "$GPU_4090")"
+assert_contains "$out" "KV_CACHE_DTYPE=fp8_e4m3"
+out="$(python3 "$HELPER" resolve-variant-pin --variant vllm/minimal --format shell --gpu-spec "$GPU_5090X2")"
+assert_contains "$out" "KV_CACHE_DTYPE=fp8_e4m3"
+# non-pilot slug (same kv_format) -> no injection until the #246 A/B expands the pilot
+out="$(python3 "$HELPER" resolve-variant-pin --variant vllm/qwen-27b-dual-fast --format shell --gpu-spec "$GPU_4090")"
+assert_not_contains "$out" "KV_CACHE_DTYPE"
+# quant-specific KV slug -> never overridden (compressed-tensors reject fp8 KV)
+out="$(python3 "$HELPER" resolve-variant-pin --variant vllm/gemma-int8-mtp --format shell --gpu-spec "$GPU_4090")"
+assert_not_contains "$out" "KV_CACHE_DTYPE"
+# explicit user env pin wins
+out="$(KV_CACHE_DTYPE=fp8_e5m2 python3 "$HELPER" resolve-variant-pin --variant vllm/dual --format shell --gpu-spec "$GPU_4090")"
+assert_not_contains "$out" "KV_CACHE_DTYPE"
+# heterogeneous rig -> no single right answer -> no injection
+out="$(python3 "$HELPER" resolve-variant-pin --variant vllm/dual --format shell --gpu-spec "${GPU_3090};1|NVIDIA GeForce RTX 4090|24564|8.9")"
+assert_not_contains "$out" "KV_CACHE_DTYPE"
+# unmapped card -> degrade to compose defaults, never an error
+out="$(python3 "$HELPER" resolve-variant-pin --variant vllm/dual --format shell --gpu-spec "0|Weird GPU|8192|7.0")"
+assert_contains "$out" "VLLM_IMAGE=vllm/vllm-openai:v0.24.0"
+assert_not_contains "$out" "KV_CACHE_DTYPE"
+echo "  ok: #246 arch-aware KV injection matrix (8 cases)"
+
 if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
   out="$(VLLM_NIGHTLY_SHA="$CLEAN_SHA" docker compose -f "$ROOT_DIR/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml" config 2>/dev/null)"
   assert_contains "$out" "image: vllm/vllm-openai:v0.24.0"

--- a/tools/kv-calc.py
+++ b/tools/kv-calc.py
@@ -167,6 +167,9 @@ KV_FORMAT_BYTES = {
     "q4_0":                  0.5 + 0.0625, # 4-bit + per-group scale
     "k8v4":                  0.75,         # avg of K=int8 V=int4
     "turboquant_3bit_nc":    0.375 + 0.05, # 3 bits + small QJL overhead
+    "nvfp4":                 0.5 + 0.0625, # 4-bit elements + fp8 block scale per 16
+                                           # (PROJECTED — Blackwell-only, no measured
+                                           # boot on this stack yet; #246 A/B arm 3)
 }
 
 INDEXER_FORMAT_BYTES = {
@@ -197,6 +200,7 @@ QWEN_GDN_ACTIVATION_COEF = {
     "q4_0":               155,
     "k8v4":               155,
     "turboquant_3bit_nc": 165,
+    "nvfp4":              130,  # PROJECTED — mirror fp8 until a Blackwell boot calibrates it (#246)
 }
 
 # ---- Qwen MoE activation + built-in MTP workspace ----
@@ -217,6 +221,7 @@ QWEN_MOE_ACTIVATION_COEF = {
     "q4_0":               130,
     "k8v4":               130,
     "turboquant_3bit_nc": 140,
+    "nvfp4":              105,  # PROJECTED — mirror fp8 until a Blackwell boot calibrates it (#246)
 }
 QWEN_MOE_EXPERT_DISPATCH_GB = 0.20
 QWEN_MOE_BUILTIN_MTP_WORKSPACE_GB = 0.10


### PR DESCRIPTION
Implements Phase 1 of #246 — the first of slice 3's two gates (design §"#246 must be scheduled before slice 3 opens"). A 4090/5090 user running `launch.sh`/`switch.sh` on the pilot slugs now gets `KV_CACHE_DTYPE=fp8_e4m3` (native FP8 Tensor-Core compute) exported automatically; a 3090 user gets **byte-for-byte today's behavior**.

## Design (differs from the issue sketch in two evidence-driven ways)

1. **No per-class env file.** The per-arch defaults already existed, dormant, in the hardware profiles — `rtx-4090.yml`/`rtx-5090.yml` have carried `kv_format_default: {balanced: fp8_e4m3}` all along while `rtx-3090.yml` says `balanced: fp8_e5m2`. The launchers now read that via the existing GPU→profile mapper, so there's **one source of truth** shared with the pull gates, and the Ampere no-op is *data equality*, not a code branch.
2. **No pilot-compose edit needed.** Every live Qwen vLLM compose already parametrizes `${KV_CACHE_DTYPE:-…}` — the pilot boundary moved into an explicit slug allowlist (`vllm/dual`, `vllm/minimal`) in `launch_compat.py`.

## Injection guards (each one prevents a real failure)

| Guard | Prevents |
|---|---|
| per-variant `kv_format == fp8_e5m2` | env leaking into `${KV_CACHE_DTYPE:-int8_per_token_head}` composes — compressed-tensors weights **reject** fp8 KV with a boot ValueError |
| e4m3-only substitution allowlist | the 3090 profile's `long_context: turboquant_3bit_nc` (Genesis-era) ever reaching a stock compose |
| pilot slug allowlist | fleet-wide behavior change before the cross-rig A/B |
| user `KV_CACHE_DTYPE=` wins · unmapped card / heterogeneous rig / no nvidia-smi → nothing | surprise overrides; direct `docker compose up` is untouched on any card |

`VLLM_ATTENTION_BACKEND` is whitelisted through the same channel but **ships no value** — auto-detect stays until someone measures better (empirical-first per the issue).

## Consistency fixes the work exposed

- `gates.py` `_ARCH_KERNEL_SM`: **fp8_e4m3 9.0 → 8.9** (vLLM's real floor is SM89+ — we'd otherwise inject e4m3 on 4090s our own pull-gate calls unloadable; the gemma fp8 slug keeps its explicit `required_sm: 9.0`), and **`nvfp4: 10.0` added** — the v0.24.0 literal previously had *no* SM gate, so an nvfp4 config wouldn't have been rejected on a 3090.
- Blackwell hardware profiles declare `nvfp4` as a **candidate capability** (engine list deliberately unchanged — gates take the intersection, so nothing becomes loadable until a validation gate adds it engine-side).
- `kv-calc`: projected `nvfp4` rows (~0.5625 B/elem + mirrored-fp8 activation coefs, clearly commented); `--calibration` unchanged.

## Docs

`HARDWARE.md` (new section: detection table, mechanics, boundaries) · `KV_MATH.md` (nvfp4 bytes row) · `QUANTIZATION.md` §5 (e4m3 + nvfp4 rows) · `DTYPE_MATRIX.md` (launcher note, per-arch rec cells, and retiring the Genesis-era "e4m3 undertuned per #51" advisory in favor of the A/B).

## Validation

- 8-case injection matrix added to `test-launch-compat` (ampere no-op · ada/blackwell inject · non-pilot · quant-KV slug · user-env wins · heterogeneous · unmapped card · back-compat no-spec)
- Live on the real 2×3090: spec builds, **nothing injected**, banner reads `arch: ampere (sm_8.6) — compose defaults apply`
- Faked 4090 through the real bash detection path (`CLUB3090_FAKE_GPUS`) → `KV_CACHE_DTYPE=fp8_e4m3` emitted
- Compose interpolation verified both ways (env set → e4m3; unset → fp8_e5m2)
- `kv-calc --calibration` green · full serial scripts gate **64/64**

## After merge

Volunteer A/B on the issue (@laurimyllari 4090 · @yundddd 5090 · @guybrush01 2×5090): `fp8_e5m2` control vs `fp8_e4m3` arch default (+ opt-in `nvfp4` arm 3 on Blackwell), n≥3 per arm on the pilot slugs. **≥15%** on either canonical prompt → expand the pilot list; within CV → close #246 with the measurement per its own acceptance criteria. I'll draft the instructions comment for review — the ask doubles as the producer-beta lane run (slice 3's gate b).

Closes nothing yet — #246 stays open for the A/B verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm