### PR TITLE
Phase 2 (concurrency-only): memory-envelope MAX_NUM_SEQS injection + probe

### DIFF
--- a/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml
@@ -150,7 +150,7 @@ services:
       - --gpu-memory-utilization
       - "${GPU_MEMORY_UTILIZATION:-0.92}"
       - --max-num-seqs
-      - "2"
+      - "${MAX_NUM_SEQS:-2}"
       - --max-num-batched-tokens
       - "8192"
       - --kv-cache-dtype

--- a/models/qwen3.6-27b/vllm/compose/single/autoround-int4/minimal.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/autoround-int4/minimal.yml
@@ -112,7 +112,7 @@ services:
       - --gpu-memory-utilization
       - "${GPU_MEMORY_UTILIZATION:-0.92}"
       - --max-num-seqs
-      - "1"
+      - "${MAX_NUM_SEQS:-1}"
       - --kv-cache-dtype
       - "${KV_CACHE_DTYPE:-fp8_e5m2}"
       - --trust-remote-code

--- a/scripts/concurrency-probe.sh
+++ b/scripts/concurrency-probe.sh
@@ -83,9 +83,13 @@ def one(stream, rnd):
     try:
         r = json.load(urllib.request.urlopen(req, timeout=600))
         toks = (r.get("usage") or {}).get("completion_tokens", 0)
-        content = (r.get("choices") or [{}])[0].get("message",{}).get("content","") or ""
-        ok = toks > 0 and len(content.strip()) > 0
-        return {"ok": ok, "toks": toks, "silent": toks == 0 or not content.strip(),
+        # KV-pool stress semantics: a stream "ran" if it GENERATED tokens
+        # (held KV, decoded) — content-emptiness is irrelevant here (reasoning
+        # models legitimately return empty content when max_tokens truncates
+        # mid-<think>). silent-empty = HTTP 200 but ZERO tokens (the real
+        # failure soak-test flags).
+        ok = toks > 0
+        return {"ok": ok, "toks": toks, "silent": toks == 0,
                 "err": None, "dt": time.time()-t0}
     except Exception as e:
         return {"ok": False, "toks": 0, "silent": False, "err": str(e)[:80], "dt": time.time()-t0}

--- a/scripts/concurrency-probe.sh
+++ b/scripts/concurrency-probe.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# concurrency-probe.sh — the #246 Phase 2 measurement: how many concurrent
+# long-context streams a card's KV pool sustains cleanly.
+#
+# soak-test.sh is SINGLE-STREAM by design (no concurrency stress); this is its
+# concurrent sibling. It fires N concurrent long requests over R rounds and
+# checks completion + no-silent-empty + bounded VRAM growth — the validation
+# behind an envelopes.yml `max_num_seqs` row (born-from-measurement discipline).
+#
+# It VALIDATES a candidate N (does the server, booted at MAX_NUM_SEQS=N, hold
+# N concurrent long streams?), it does not search — kv-calc proposes N from the
+# pool, this confirms it. Boot the server at the candidate MAX_NUM_SEQS first.
+#
+# Usage:
+#   MAX_NUM_SEQS=4 bash scripts/switch.sh vllm/dual   # boot at the candidate
+#   bash scripts/concurrency-probe.sh                 # probe = server's cap
+#   CONCURRENCY=4 bash scripts/concurrency-probe.sh   # force N
+#
+# Env: URL (default http://localhost:8010) · MODEL (auto) · CONTAINER (auto for
+#   VRAM) · CONCURRENCY (default: detect served max-num-seqs, else 2) · ROUNDS
+#   (default 5) · PROMPT_TOKENS (default 16000) · GEN_TOKENS (default 256) ·
+#   VRAM_GROWTH_MB (default 200).
+set -euo pipefail
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+URL="${URL:-http://localhost:8010}"
+ROUNDS="${ROUNDS:-5}"
+PROMPT_TOKENS="${PROMPT_TOKENS:-16000}"
+GEN_TOKENS="${GEN_TOKENS:-256}"
+VRAM_GROWTH_MB="${VRAM_GROWTH_MB:-200}"
+
+MODEL="${MODEL:-$(curl -s -m 5 "${URL}/v1/models" 2>/dev/null \
+  | python3 -c 'import json,sys;print(json.load(sys.stdin)["data"][0]["id"])' 2>/dev/null || echo qwen3.6-27b)}"
+# best-effort container for VRAM (exact-match convention; port/name heuristic)
+CONTAINER="${CONTAINER:-$(docker ps --format '{{.Names}}' 2>/dev/null | grep -m1 -E 'vllm-qwen' || true)}"
+
+# CONCURRENCY defaults to the served max-num-seqs (the thing we're validating).
+if [[ -z "${CONCURRENCY:-}" ]]; then
+  CONCURRENCY="$(docker inspect "$CONTAINER" --format '{{join .Config.Cmd " "}}' 2>/dev/null \
+    | grep -oE 'max-num-seqs [0-9]+' | grep -oE '[0-9]+' | head -1 || true)"
+  CONCURRENCY="${CONCURRENCY:-2}"
+fi
+
+echo "[concurrency-probe] URL=$URL model=$MODEL N=$CONCURRENCY rounds=$ROUNDS prompt=${PROMPT_TOKENS}tok gen=${GEN_TOKENS}"
+
+URL="$URL" MODEL="$MODEL" CONTAINER="$CONTAINER" CONCURRENCY="$CONCURRENCY" \
+ROUNDS="$ROUNDS" PROMPT_TOKENS="$PROMPT_TOKENS" GEN_TOKENS="$GEN_TOKENS" \
+VRAM_GROWTH_MB="$VRAM_GROWTH_MB" python3 - <<'PY'
+import concurrent.futures as cf
+import json
+import os
+import subprocess
+import time
+import urllib.request
+
+URL = os.environ["URL"]; MODEL = os.environ["MODEL"]; N = int(os.environ["CONCURRENCY"])
+ROUNDS = int(os.environ["ROUNDS"]); PTOK = int(os.environ["PROMPT_TOKENS"])
+GTOK = int(os.environ["GEN_TOKENS"]); GROWTH = int(os.environ["VRAM_GROWTH_MB"])
+CONTAINER = os.environ.get("CONTAINER") or ""
+
+BLOCK = ("This section describes the history of computing in detail. Transistors "
+         "were invented in 1947 at Bell Labs. The integrated circuit came a decade "
+         "later. Microprocessors emerged in the 1970s and changed the world. ")
+# ~0.23 tok/char; build to ~PTOK, unique salt per stream so no prefix-cache free ride
+def prompt(stream, rnd):
+    reps = int(PTOK / (len(BLOCK) * 0.23)) + 1
+    return f"[probe s{stream} r{rnd}] " + BLOCK * reps + "\nSummarize in two sentences."
+
+def vram_used_mb():
+    try:
+        out = subprocess.run(["nvidia-smi","--query-gpu=memory.used","--format=csv,noheader,nounits"],
+                             capture_output=True, text=True, timeout=10).stdout
+        return sum(int(x) for x in out.split())
+    except Exception:
+        return -1
+
+def one(stream, rnd):
+    body = json.dumps({"model": MODEL, "max_tokens": GTOK, "temperature": 0.0,
+        "messages":[{"role":"user","content":prompt(stream,rnd)}]}).encode()
+    req = urllib.request.Request(URL+"/v1/chat/completions", data=body,
+        headers={"Content-Type":"application/json"})
+    t0 = time.time()
+    try:
+        r = json.load(urllib.request.urlopen(req, timeout=600))
+        toks = (r.get("usage") or {}).get("completion_tokens", 0)
+        content = (r.get("choices") or [{}])[0].get("message",{}).get("content","") or ""
+        ok = toks > 0 and len(content.strip()) > 0
+        return {"ok": ok, "toks": toks, "silent": toks == 0 or not content.strip(),
+                "err": None, "dt": time.time()-t0}
+    except Exception as e:
+        return {"ok": False, "toks": 0, "silent": False, "err": str(e)[:80], "dt": time.time()-t0}
+
+print(f"\n{'round':>5} {'done':>7} {'silent':>7} {'errors':>7} {'vram_MB':>8} {'agg_tok/s':>10}")
+vram0 = vram_used_mb()   # cold idle — empty KV pool
+vram_by_round = []
+bad = 0
+for rnd in range(1, ROUNDS+1):
+    t0 = time.time()
+    with cf.ThreadPoolExecutor(max_workers=N) as ex:
+        res = list(ex.map(lambda s: one(s, rnd), range(N)))
+    wall = time.time()-t0
+    done = sum(1 for r in res if r["ok"])
+    silent = sum(1 for r in res if r["silent"])
+    errs = sum(1 for r in res if r["err"])
+    v = vram_used_mb(); vram_by_round.append(v)
+    agg = sum(r["toks"] for r in res)/wall if wall else 0
+    print(f"{rnd:>5} {done:>4}/{N:<2} {silent:>7} {errs:>7} {v:>8} {agg:>10.1f}")
+    if done < N or silent or errs:
+        bad += 1
+
+# Leak signal = growth AFTER warm-up, not the cold->warm pool fill (which is
+# expected: N concurrent long contexts allocate KV blocks up to the working
+# set). warm baseline = after round 2 (the pool has filled); leak = final-warm.
+warm_i = 1 if ROUNDS >= 3 else 0
+warm = vram_by_round[warm_i]
+pool_fill = warm - vram0 if vram0 >= 0 else -1
+leak = vram_by_round[-1] - warm if vram0 >= 0 else -1
+print(f"\n=== verdict (N={N}) ===")
+print(f"  VRAM: cold {vram0} -> warm {warm} MB (pool fill {pool_fill} MB, expected) "
+      f"-> final {vram_by_round[-1]} MB  (post-warm growth {leak} MB / {GROWTH} threshold)")
+clean = (bad == 0) and (0 <= leak <= GROWTH)
+print(f"  concurrency {N} @ ~{PTOK} tok: {'PASS — sustained clean' if clean else 'FAIL — see rounds above'}")
+if clean:
+    print(f"  envelope row: max_num_seqs: {N}  "
+          f"validated: {{ concurrency_soak: '{N} @ ~{PTOK//1000}K, {leak} MB post-warm growth' }}")
+raise SystemExit(0 if clean else 1)
+PY

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -1175,6 +1175,9 @@ export_variant_engine_pin() {
       KV_CACHE_DTYPE)
         export KV_CACHE_DTYPE="$value"
         echo "[launch] arch-aware KV dtype: ${value} (hardware-profile default for detected GPUs — #246)" ;;
+      MAX_NUM_SEQS)
+        export MAX_NUM_SEQS="$value"
+        echo "[launch] memory-envelope concurrency: MAX_NUM_SEQS=${value} (measured for this card class — #246 Phase 2)" ;;
       VLLM_ATTENTION_BACKEND) export VLLM_ATTENTION_BACKEND="$value" ;;
       *) echo "[launch] ERROR: unexpected engine pin export: $key" >&2; exit 2 ;;
     esac

--- a/scripts/lib/profiles/envelopes.yml
+++ b/scripts/lib/profiles/envelopes.yml
@@ -1,0 +1,41 @@
+# envelopes.yml — the memory-envelope injection defaults (#246 Phase 2).
+# ===========================================================================
+# Weights-INVARIANT per-(slug, card-class) knobs the launcher injects to spend
+# a bigger card's KV pool. FIRST PASS = concurrency only: `max_num_seqs` (a
+# CAP, not a reservation — raising it is ~free until the pool fills). The
+# context lever (bigger max_model_len) is deferred (single-card vLLM only, and
+# Cliff-2b-capped) — see /opt/ai/docs/phase2-32gb-envelope-design.md §6.3.
+#
+# DISCIPLINE (identical to baselines.yml): a value here is a MEASURED, reviewed
+# ceiling from a validated concurrency-soak run — NEVER a raw projection. The
+# concurrency probe proposes; the soak validates (0 growth / 100% retention /
+# 0 silent-empty); this file stores the validated number. A row without a
+# `validated` block is a schema error (test-envelopes).
+#
+# HOW IT INJECTS: launch.sh/switch.sh detect the card class (hardware profile
+# id). If a row exists for (slug, card-class) with a value ABOVE the compose
+# default, the launcher exports `MAX_NUM_SEQS=<value>`; the compose consumes
+# `${MAX_NUM_SEQS:-<default>}`. 24 GB / no-row / heterogeneous / user-env-set
+# -> no injection (compose default stands). Consumers read the registry-emit
+# join, never this file directly.
+#
+# Conventions:
+#   max_num_seqs       measured concurrency cap the card's pool sustains.
+#   compose_default    the slug's shipped ${MAX_NUM_SEQS:-N} default (24 GB);
+#                      injection only fires when max_num_seqs > this.
+#   validated          { concurrency_soak: "N streams @ <ctx>, 0-growth",
+#                        vram_peak_gb: X, date: YYYY-MM-DD, source_tag: ... }
+#   rig / submitted_by hardware fingerprint class + who ran it.
+# ===========================================================================
+schema_version: 1
+envelopes:
+
+  # (empty — awaiting first validated 32 GB concurrency-soak runs)
+  #
+  # SEEDING PLAN (each needs a validated concurrency-soak on the card class):
+  #   vllm/dual  @ rtx-5090 (2x, 64 GB)  — HARVEST from guybrush's fp8w dual
+  #     ladder if it carries multi-stream, else a dedicated soak (disc #571).
+  #   vllm/minimal @ rtx-5090 (1x, 32 GB) — single-5090 concurrency soak
+  #     (the clean new ask, sequenced AFTER the fp8w round).
+  # 24 GB (rtx-3090) baseline is measured for REFERENCE (what the compose
+  # default should be) but carries NO row — the compose default already stands.

--- a/scripts/lib/profiles/launch_compat.py
+++ b/scripts/lib/profiles/launch_compat.py
@@ -194,6 +194,50 @@ def _arch_aware_env(profiles, variant: str, entry: dict, gpu_spec: str,
     return {"KV_CACHE_DTYPE": target}
 
 
+# --- #246 Phase 2: memory-envelope injection (concurrency-only first pass) ---
+# Weights-invariant. Injects MAX_NUM_SEQS from a MEASURED per-(slug, card-class)
+# ceiling in envelopes.yml, to spend a bigger card's KV pool on concurrency.
+# 24 GB / no-row / heterogeneous / user-env-set -> no injection.
+_ENVELOPES_PATH = Path(__file__).with_name("envelopes.yml")
+
+
+def _load_envelopes() -> dict:
+    try:
+        import yaml
+        doc = yaml.safe_load(_ENVELOPES_PATH.read_text()) or {}
+        return doc.get("envelopes") or {}
+    except (OSError, ImportError):
+        return {}
+
+
+def _envelope_env(profiles, variant: str, gpu_spec: str) -> dict[str, str]:
+    """Phase 2 concurrency injection. Empty dict = no injection (compose
+    ${MAX_NUM_SEQS:-default} stands)."""
+    if not gpu_spec:
+        return {}
+    if os.environ.get("MAX_NUM_SEQS"):
+        return {}  # explicit user pin always wins
+    row = _load_envelopes().get(variant)
+    if not row:
+        return {}
+    try:
+        hardware = _parse_gpu_specs(gpu_spec, profiles)
+    except LaunchCompatError:
+        return {}  # unmapped card -> compose default
+    card_ids = {hw.id for hw in hardware}
+    if len(card_ids) != 1:
+        return {}  # heterogeneous rig -> no single card-class row applies
+    card_row = row.get(card_ids.pop())
+    if not isinstance(card_row, dict):
+        return {}
+    seqs = card_row.get("max_num_seqs")
+    default = card_row.get("compose_default")
+    # only inject a validated value that actually raises the ceiling
+    if not isinstance(seqs, int) or (isinstance(default, int) and seqs <= default):
+        return {}
+    return {"MAX_NUM_SEQS": str(seqs)}
+
+
 def resolve_engine_pin(profiles, engine_id: str) -> dict[str, str]:
     """Resolve EngineProfile.install into compose environment exports."""
     try:
@@ -233,6 +277,7 @@ def resolve_variant_pin(profiles, variant: str, gpu_spec: str = "") -> dict[str,
     # Only emitted when a gpu_spec is passed (launchers do; the registry-emit
     # baselines join calls without one and sees pins only).
     exports.update(_arch_aware_env(profiles, variant, entry, gpu_spec, exports))
+    exports.update(_envelope_env(profiles, variant, gpu_spec))  # Phase 2 concurrency
     return exports
 
 

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -926,6 +926,9 @@ export_variant_engine_pin() {
       KV_CACHE_DTYPE)
         export KV_CACHE_DTYPE="$value"
         echo "[switch] arch-aware KV dtype: ${value} (hardware-profile default for detected GPUs — #246)" ;;
+      MAX_NUM_SEQS)
+        export MAX_NUM_SEQS="$value"
+        echo "[switch] memory-envelope concurrency: MAX_NUM_SEQS=${value} (measured for this card class — #246 Phase 2)" ;;
       VLLM_ATTENTION_BACKEND) export VLLM_ATTENTION_BACKEND="$value" ;;
       *) echo "[switch] ERROR: unexpected engine pin export: $key" >&2; exit 2 ;;
     esac

--- a/scripts/tests/test-envelopes.sh
+++ b/scripts/tests/test-envelopes.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# test-envelopes — guards for scripts/lib/profiles/envelopes.yml + its launcher
+# injection (#246 Phase 2, concurrency-only first pass).
+#
+# REDs on: schema violations · unknown slugs · unknown card-class ids · a row
+# missing its `validated` block (born-from-measurement discipline) · a broken
+# injection contract. An EMPTY envelopes file is valid (rows land from probes).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+HELPER="scripts/lib/profiles/launch_compat.py"
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# --- 1. schema (pure python) --------------------------------------------------
+python3 - <<'PY'
+import sys
+from pathlib import Path
+import yaml
+sys.path.insert(0, ".")
+from scripts.lib.profiles.compose_registry import COMPOSE_REGISTRY  # noqa: E402
+from scripts.lib.profiles.compat import load_profiles  # noqa: E402
+
+doc = yaml.safe_load(Path("scripts/lib/profiles/envelopes.yml").read_text())
+assert doc.get("schema_version") == 1, "schema_version must be 1"
+rows = doc.get("envelopes") or {}
+cards = set(load_profiles().hardware)
+errors = []
+for slug, byc in rows.items():
+    if slug not in COMPOSE_REGISTRY:
+        errors.append(f"envelopes[{slug}]: unknown registry slug"); continue
+    if not isinstance(byc, dict):
+        errors.append(f"envelopes[{slug}]: must be a card-class map"); continue
+    for card, row in byc.items():
+        w = f"envelopes[{slug}][{card}]"
+        if card not in cards:
+            errors.append(f"{w}: unknown hardware-profile id"); continue
+        if not isinstance(row.get("max_num_seqs"), int):
+            errors.append(f"{w}.max_num_seqs: required int")
+        if "compose_default" in row and not isinstance(row["compose_default"], int):
+            errors.append(f"{w}.compose_default: int")
+        # born-from-measurement: a value MUST cite a validated soak
+        if not isinstance(row.get("validated"), dict) or not row["validated"]:
+            errors.append(f"{w}.validated: required {{concurrency_soak, ...}} — no guessed rows")
+if errors:
+    print("test-envelopes: FAIL", file=sys.stderr)
+    for e in errors: print(f"  ✗ {e}", file=sys.stderr)
+    sys.exit(1)
+print(f"  ✓ schema ({len(rows)} slug rows; empty is valid)")
+PY
+
+# --- 2. injection contract (fixture: temp envelopes with a 5090 row) ----------
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+REAL="scripts/lib/profiles/envelopes.yml"
+BACKUP="$TMP/backup.yml"; cp "$REAL" "$BACKUP"
+REAL_SUM="$(sha256sum "$REAL" | cut -d' ' -f1)"
+
+cat > "$REAL" <<'EOF'
+schema_version: 1
+envelopes:
+  vllm/dual:
+    rtx-5090:
+      max_num_seqs: 4
+      compose_default: 2
+      validated: { concurrency_soak: "4 @262K, 0-growth" }
+EOF
+
+pin() { python3 "$HELPER" resolve-variant-pin --variant "$1" --format shell --gpu-spec "$2" 2>/dev/null; }
+S5090="0|RTX 5090|32607|12.0;1|RTX 5090|32607|12.0"
+S3090="0|RTX 3090|24576|8.6;1|RTX 3090|24576|8.6"
+HET="0|RTX 5090|32607|12.0;1|RTX 3090|24576|8.6"
+
+grep -q "MAX_NUM_SEQS=4" <(pin vllm/dual "$S5090") || fail "5090 with a row must inject MAX_NUM_SEQS=4"
+grep -q "MAX_NUM_SEQS" <(pin vllm/dual "$S3090") && fail "3090 (no row) must NOT inject"
+grep -q "MAX_NUM_SEQS" <(pin vllm/dual "$HET") && fail "heterogeneous rig must NOT inject"
+grep -q "MAX_NUM_SEQS" <(MAX_NUM_SEQS=9 pin vllm/dual "$S5090" | grep "MAX_NUM_SEQS=4") && fail "user env must win"
+# value at/below compose_default must not fire
+cat > "$REAL" <<'EOF'
+schema_version: 1
+envelopes:
+  vllm/dual:
+    rtx-5090: { max_num_seqs: 2, compose_default: 2, validated: { concurrency_soak: "x" } }
+EOF
+grep -q "MAX_NUM_SEQS" <(pin vllm/dual "$S5090") && fail "value == compose_default must NOT inject (no gain)"
+echo "  ✓ injection contract (inject · no-row · heterogeneous · user-env · no-gain)"
+
+cp "$BACKUP" "$REAL"
+[[ "$(sha256sum "$REAL" | cut -d' ' -f1)" == "$REAL_SUM" ]] || fail "real envelopes.yml not restored"
+
+echo "test-envelopes: ok"


### PR DESCRIPTION
The #246 **Phase 2** first pass — let a bigger card's KV pool serve **more concurrent streams**, weights-invariant. Ships the machinery + the measurement; the actual 32 GB envelope rows land from volunteer probe runs (plumbing-first, exactly like baselines slice 1).

## Why concurrency-only (agreed in design)

Most of our headline configs are **already at 262K model-max on 24 GB** (GGUF single-card, dual vLLM) — so the extra ~8 GB on a 5090 has no "more context" to unlock; it serves **more simultaneous streams**. The context lever (bigger `MAX_MODEL_LEN`) only helps the single-card vLLM path and is Cliff-2b-capped regardless of VRAM, so it's deferred. Full rationale: the Phase 2 design note.

## What's in this PR

- **Composes** — `--max-num-seqs` parametrized to `${MAX_NUM_SEQS:-N}` on the two pilot slugs (`vllm/dual`=2, `vllm/minimal`=1). Weights-invariant, default preserved, no behavior change without injection.
- **`envelopes.yml`** (empty) — measured per-`(slug, card-class)` `max_num_seqs`, **born-from-measurement**: a `validated` block is required, so no row can be a guess (same discipline as `baselines.yml`).
- **`_envelope_env`** in `launch_compat.py` — injects `MAX_NUM_SEQS` from a row only when it **exceeds** the compose default; **24 GB / no-row / heterogeneous rig / user-env-set → no-op**. Both launchers whitelist the export.
- **`test-envelopes`** — schema + injection contract (inject · no-row · heterogeneous · user-env-wins · no-gain-below-default).
- **`concurrency-probe.sh`** — the measurement keystone. `soak-test.sh` is single-stream by design; this fires N concurrent long streams × R rounds and — crucially — **separates the expected KV-pool fill from a real leak** (it measures *post-warm* growth, not cold→warm). Validates a candidate `max_num_seqs`; kv-calc proposes N, this confirms it.

## Validation

- **Live on the dual-3090:** the probe correctly PASSES the shipped N=2 default — VRAM flat at 46,944 MB, **0 MB post-warm growth**, all rounds clean (my first cut wrongly flagged the 4 GB pool-fill as a leak; fixed to measure post-warm growth). It even emits the exact envelope row it would produce.
- **Injection matrix** (test-envelopes + live): empty file → no-op everywhere; a temp 5090 row → `MAX_NUM_SEQS` injected; 3090/heterogeneous/user-env → no-op.
- Full serial scripts gate **67/67**.

## What ships empty, what lands later

The file has **no rows yet** — a 32 GB row needs a validated single-5090 (or dual) concurrency-soak, which is a volunteer run **sequenced after the fp8w round** (don't stack asks). We also harvest guybrush's `fp8w` dual ladder for the dual signal. The moment a validated row lands, adding it auto-enables the injection — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm