### PR TITLE
Phase 2: GPU_MEMORY_UTILIZATION floor for unified-memory cards (DGX Spark)

### DIFF
--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -1178,6 +1178,9 @@ export_variant_engine_pin() {
       MAX_NUM_SEQS)
         export MAX_NUM_SEQS="$value"
         echo "[launch] memory-envelope concurrency: MAX_NUM_SEQS=${value} (measured for this card class — #246 Phase 2)" ;;
+      GPU_MEMORY_UTILIZATION)
+        export GPU_MEMORY_UTILIZATION="$value"
+        echo "[launch] memory-fraction floor: GPU_MEMORY_UTILIZATION=${value} (unified-memory card can't safely give the default — #246 Phase 2)" ;;
       VLLM_ATTENTION_BACKEND) export VLLM_ATTENTION_BACKEND="$value" ;;
       *) echo "[launch] ERROR: unexpected engine pin export: $key" >&2; exit 2 ;;
     esac

--- a/scripts/lib/profiles/launch_compat.py
+++ b/scripts/lib/profiles/launch_compat.py
@@ -261,6 +261,40 @@ def _envelope_env(profiles, variant: str, gpu_spec: str) -> dict[str, str]:
     return {"MAX_NUM_SEQS": str(seqs)}
 
 
+def _mem_util_env(profiles, variant: str, gpu_spec: str) -> dict[str, str]:
+    """Phase 2 memory-fraction safety floor. Injects GPU_MEMORY_UTILIZATION
+    DOWNWARD only — when a detected card cannot safely give the compose's default
+    fraction. Today that means unified-memory cards (DGX Spark: its LPDDR5X is
+    shared with the Grace CPU/OS, so mem_util_safe=0.85 < the 0.92 default — boot
+    at 0.92 would starve the OS). It NEVER raises above the tested compose
+    default: a bigger discrete card *could* give more, but that touches Cliff-2b
+    margin + boot-OOM, so the upward move stays a validated opt-in, not an
+    automatic bump. Empty dict = no injection (compose default stands)."""
+    if not gpu_spec:
+        return {}
+    if os.environ.get("GPU_MEMORY_UTILIZATION"):
+        return {}  # explicit user pin always wins
+    entry = COMPOSE_REGISTRY.get(variant)
+    if not entry:
+        return {}
+    compose_gmu = entry.get("mem_util")  # the compose's default --gpu-memory-utilization
+    if not isinstance(compose_gmu, (int, float)):
+        return {}
+    try:
+        hardware = _parse_gpu_specs(gpu_spec, profiles)
+    except LaunchCompatError:
+        return {}  # unmapped card -> compose default
+    # One GMU applies across every rank, so the safe fraction is the LOWEST card's
+    # ceiling — a unified-memory card in a mixed rig forces the whole rig down.
+    ceilings = [hw.mem_util_safe for hw in hardware if hw.mem_util_safe is not None]
+    if not ceilings:
+        return {}
+    safe = min(ceilings)
+    if safe < compose_gmu:  # downward only — never raise above the tested default
+        return {"GPU_MEMORY_UTILIZATION": f"{safe:g}"}
+    return {}
+
+
 def resolve_engine_pin(profiles, engine_id: str) -> dict[str, str]:
     """Resolve EngineProfile.install into compose environment exports."""
     try:
@@ -300,7 +334,8 @@ def resolve_variant_pin(profiles, variant: str, gpu_spec: str = "") -> dict[str,
     # Only emitted when a gpu_spec is passed (launchers do; the registry-emit
     # baselines join calls without one and sees pins only).
     exports.update(_arch_aware_env(profiles, variant, entry, gpu_spec, exports))
-    exports.update(_envelope_env(profiles, variant, gpu_spec))  # Phase 2 concurrency
+    exports.update(_envelope_env(profiles, variant, gpu_spec))   # Phase 2 concurrency
+    exports.update(_mem_util_env(profiles, variant, gpu_spec))   # Phase 2 mem-fraction floor
     return exports
 
 

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -929,6 +929,9 @@ export_variant_engine_pin() {
       MAX_NUM_SEQS)
         export MAX_NUM_SEQS="$value"
         echo "[switch] memory-envelope concurrency: MAX_NUM_SEQS=${value} (measured for this card class — #246 Phase 2)" ;;
+      GPU_MEMORY_UTILIZATION)
+        export GPU_MEMORY_UTILIZATION="$value"
+        echo "[switch] memory-fraction floor: GPU_MEMORY_UTILIZATION=${value} (unified-memory card can't safely give the default — #246 Phase 2)" ;;
       VLLM_ATTENTION_BACKEND) export VLLM_ATTENTION_BACKEND="$value" ;;
       *) echo "[switch] ERROR: unexpected engine pin export: $key" >&2; exit 2 ;;
     esac

--- a/scripts/tests/test-launch-compat.sh
+++ b/scripts/tests/test-launch-compat.sh
@@ -142,6 +142,23 @@ PY
 [[ "$det" == "OK" ]] || { echo "  FAIL: detector: $det"; exit 1; }
 echo "  ok: Blackwell detector split (PRO 6000 / GB10 / 5090 / Ada — 5 cases)"
 
+# --- #246 Phase 2 mem-fraction floor (DOWNWARD only) --------------------------
+# A unified-memory card (Spark, mem_util_safe 0.85) can't safely give the 0.92
+# compose default -> inject the floor. Discrete cards (0.95/0.96 > 0.92) are
+# never raised (that touches Cliff margin -> validated opt-in, not automatic).
+GPU_SPARK='0|NVIDIA GB10|131072|12.1'
+out="$(python3 "$HELPER" resolve-variant-pin --variant vllm/dual --format shell --gpu-spec "$GPU_SPARK")"
+assert_contains "$out" "GPU_MEMORY_UTILIZATION=0.85"
+out="$(python3 "$HELPER" resolve-variant-pin --variant vllm/dual --format shell --gpu-spec "$GPU_5090X2")"
+assert_not_contains "$out" "GPU_MEMORY_UTILIZATION"
+# heterogeneous: the lowest ceiling (Spark 0.85) forces the whole rig down
+out="$(python3 "$HELPER" resolve-variant-pin --variant vllm/dual --format shell --gpu-spec "${GPU_SPARK};1|NVIDIA GeForce RTX 5090|32607|12.0")"
+assert_contains "$out" "GPU_MEMORY_UTILIZATION=0.85"
+# explicit user pin wins
+out="$(GPU_MEMORY_UTILIZATION=0.7 python3 "$HELPER" resolve-variant-pin --variant vllm/dual --format shell --gpu-spec "$GPU_SPARK")"
+assert_not_contains "$out" "GPU_MEMORY_UTILIZATION=0.85"
+echo "  ok: #246 mem-fraction floor (Spark down · discrete no-raise · het-min · user-pin — 4 cases)"
+
 if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
   out="$(VLLM_NIGHTLY_SHA="$CLEAN_SHA" docker compose -f "$ROOT_DIR/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml" config 2>/dev/null)"
   assert_contains "$out" "image: vllm/vllm-openai:v0.24.0"


### PR DESCRIPTION
The concurrency envelope spends the KV pool, but nothing sized the *pool* per card — the composes default to `--gpu-memory-utilization 0.92` and the launcher never adjusted it. For most cards that's fine; for DGX Spark it's a real safety hole.

## The gap

`mem_util_safe` per hardware profile vs the 0.92 compose default:

| Card | `mem_util_safe` | vs 0.92 |
|---|---|---|
| 3090 / 4090 / A5000 | 0.95 | above |
| 5090 / PRO 6000 / H100 | 0.96 | above |
| **DGX Spark** | **0.85** | **below** ⚠️ |

Spark's 128 GB is **unified LPDDR5X** shared with the Grace CPU/OS. Booting at 0.92 hands ~118 GB to vLLM and starves the OS → instability. The seeded Spark envelope row already assumes 0.85; the launch would wrongly use 0.92.

## The fix — `_mem_util_env` (same seam as the concurrency injection)

Inject `GPU_MEMORY_UTILIZATION` **downward only** — when a detected card's `mem_util_safe` is below the compose's registry `mem_util`. Heterogeneous rigs clamp to the lowest ceiling (one GMU spans all ranks). Today this fires for exactly one card:

| Rig | injected |
|---|---|
| 1×/2× DGX Spark | **0.85** |
| 2× 5090 · 2× 3090 · PRO 6000 | none (0.95–0.96 > 0.92 — never raise) |
| Spark + 5090 (het) | 0.85 (lowest wins) |
| user `GPU_MEMORY_UTILIZATION` set | untouched |

## Why downward-only

A discrete card *could* give 0.95–0.96, but raising 0.92→0.95 on a 3090/5090 changes the **tested Cliff-2b margin** and risks boot-OOM if the profile value is optimistic. So the upward move is a **validated opt-in** on the soak protocol, not an automatic bump — and it's low-value anyway (big-card concurrency is bandwidth-bound, so extra pool mostly buys context headroom).

## Validation

- Both launchers whitelist the new export; `test-launch-compat` locks Spark-down / discrete-no-raise / het-min / user-pin-wins (4 cases).
- Full serial gate **67/67 green.**

Independent of the probe PR (#578) — no file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)