### PR TITLE
fp8w on Blackwell: auto-disable DeepGEMM + --force the arch-ab arm

### DIFF
--- a/models/qwen3.6-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/fp8/mtp.yml
@@ -110,6 +110,14 @@ services:
       - VLLM_NO_USAGE_STATS=1
       - VLLM_USE_FLASHINFER_SAMPLER=1
       - OMP_NUM_THREADS=1
+      # DeepGEMM (vLLM's fp8-GEMM path) is built for Hopper (sm_90) + datacenter
+      # Blackwell (sm_100/103). Consumer Blackwell (5090 / PRO 6000 / GB10,
+      # sm_120/121) has no recipe and hard-fails "recipe not found" at boot
+      # (disc #571). Pass-through: switch.sh/launch.sh auto-inject
+      # VLLM_USE_DEEP_GEMM=0 on those cards; if you run raw `docker compose` on a
+      # consumer Blackwell card, set it yourself (VLLM_USE_DEEP_GEMM=0). Unset =
+      # vLLM's arch default (DeepGEMM stays on where it works).
+      - VLLM_USE_DEEP_GEMM
       # expandable_segments:True crashes boot on some setups (likely cuMemMap path).
       # Known: JusefPol on NVLink (PR #31), WSL2 single-card 3090 Ti.
       # Override via .env: PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False

--- a/scripts/arch-ab.sh
+++ b/scripts/arch-ab.sh
@@ -147,11 +147,13 @@ for arm in "${ARM_LIST[@]}"; do
   echo "[arch-ab] ===== arm ${arm}: ${arm_variant}$( [[ -n "$dtype" ]] && echo " KV_CACHE_DTYPE=${dtype}" || echo " (stock)") -> tag ${tag} ====="
   # Fresh symmetric boot per arm (same settle path for every arm). KV arms use
   # an explicit env pin so what ran is unambiguous on any launcher version;
-  # the fp8w arm runs stock (its checkpoint REJECTS fp8 KV — see header).
+  # the fp8w arm runs stock (its checkpoint REJECTS fp8 KV — see header) and
+  # needs --force: vllm/qwen-27b-dual-max is status=experimental, so switch.sh
+  # gates it without --force (disc #571 guybrush01).
   if [[ -n "$dtype" ]]; then
     KV_CACHE_DTYPE="$dtype" bash scripts/switch.sh "$arm_variant"
   else
-    bash scripts/switch.sh "$arm_variant"
+    bash scripts/switch.sh --force "$arm_variant"
   fi
   # Assert the expected dtype is actually live before spending bench time on it.
   running_cmd="$(docker inspect "$container" --format '{{join .Config.Cmd " "}}' 2>/dev/null || true)"

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -1181,6 +1181,9 @@ export_variant_engine_pin() {
       GPU_MEMORY_UTILIZATION)
         export GPU_MEMORY_UTILIZATION="$value"
         echo "[launch] memory-fraction floor: GPU_MEMORY_UTILIZATION=${value} (unified-memory card can't safely give the default — #246 Phase 2)" ;;
+      VLLM_USE_DEEP_GEMM)
+        export VLLM_USE_DEEP_GEMM="$value"
+        echo "[launch] fp8 weights: VLLM_USE_DEEP_GEMM=${value} (consumer card has no DeepGEMM recipe — disc #571)" ;;
       VLLM_ATTENTION_BACKEND) export VLLM_ATTENTION_BACKEND="$value" ;;
       *) echo "[launch] ERROR: unexpected engine pin export: $key" >&2; exit 2 ;;
     esac

--- a/scripts/lib/profiles/launch_compat.py
+++ b/scripts/lib/profiles/launch_compat.py
@@ -295,6 +295,33 @@ def _mem_util_env(profiles, variant: str, gpu_spec: str) -> dict[str, str]:
     return {}
 
 
+_DEEPGEMM_DISABLE_SM = {8.9, 12.0, 12.1}
+
+
+def _deepgemm_env(profiles, variant: str, entry: dict, gpu_spec: str) -> dict[str, str]:
+    """Disable vLLM's DeepGEMM fp8-GEMM path on CONSUMER cards that serve fp8
+    weights. DeepGEMM is built for Hopper (sm_90) + datacenter Blackwell
+    (sm_100/103). Consumer Blackwell (sm_120/121) hard-fails with 'recipe not
+    found' (confirmed on a 5090 — disc #571 guybrush01); Ada (sm_89) never routes
+    fp8 through DeepGEMM at all (Marlin/CUTLASS), so injecting 0 there is a
+    harmless no-op that pre-empts the same wall for 4090 owners. Hopper/datacenter
+    (where DeepGEMM is the fast path) are left untouched. Only fires for fp8-weights
+    slugs. Empty dict = no injection."""
+    if not gpu_spec:
+        return {}
+    if os.environ.get("VLLM_USE_DEEP_GEMM"):
+        return {}  # explicit user pin always wins
+    if (entry or {}).get("weights_variant") != "fp8":
+        return {}  # only native fp8-weights slugs touch the DeepGEMM path
+    try:
+        hardware = _parse_gpu_specs(gpu_spec, profiles)
+    except LaunchCompatError:
+        return {}
+    if any(float(hw.sm) in _DEEPGEMM_DISABLE_SM for hw in hardware):
+        return {"VLLM_USE_DEEP_GEMM": "0"}
+    return {}
+
+
 def resolve_engine_pin(profiles, engine_id: str) -> dict[str, str]:
     """Resolve EngineProfile.install into compose environment exports."""
     try:
@@ -336,6 +363,7 @@ def resolve_variant_pin(profiles, variant: str, gpu_spec: str = "") -> dict[str,
     exports.update(_arch_aware_env(profiles, variant, entry, gpu_spec, exports))
     exports.update(_envelope_env(profiles, variant, gpu_spec))   # Phase 2 concurrency
     exports.update(_mem_util_env(profiles, variant, gpu_spec))   # Phase 2 mem-fraction floor
+    exports.update(_deepgemm_env(profiles, variant, entry, gpu_spec))  # fp8w consumer-Blackwell fix
     return exports
 
 

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -932,6 +932,9 @@ export_variant_engine_pin() {
       GPU_MEMORY_UTILIZATION)
         export GPU_MEMORY_UTILIZATION="$value"
         echo "[switch] memory-fraction floor: GPU_MEMORY_UTILIZATION=${value} (unified-memory card can't safely give the default — #246 Phase 2)" ;;
+      VLLM_USE_DEEP_GEMM)
+        export VLLM_USE_DEEP_GEMM="$value"
+        echo "[switch] fp8 weights: VLLM_USE_DEEP_GEMM=${value} (consumer card has no DeepGEMM recipe — disc #571)" ;;
       VLLM_ATTENTION_BACKEND) export VLLM_ATTENTION_BACKEND="$value" ;;
       *) echo "[switch] ERROR: unexpected engine pin export: $key" >&2; exit 2 ;;
     esac

--- a/scripts/tests/test-launch-compat.sh
+++ b/scripts/tests/test-launch-compat.sh
@@ -159,6 +159,24 @@ out="$(GPU_MEMORY_UTILIZATION=0.7 python3 "$HELPER" resolve-variant-pin --varian
 assert_not_contains "$out" "GPU_MEMORY_UTILIZATION=0.85"
 echo "  ok: #246 mem-fraction floor (Spark down · discrete no-raise · het-min · user-pin — 4 cases)"
 
+# --- fp8-weights DeepGEMM disable on consumer cards (disc #571) ----------------
+# DeepGEMM has no recipe on consumer Blackwell (sm_120/121, hard-fails) and is
+# unused on Ada (sm_89, harmless no-op) -> disable for fp8-weights slugs. Hopper
+# (sm_90) keeps it; non-fp8 slugs are untouched.
+DMAX=vllm/qwen-27b-dual-max
+GPU_H100X2='0|NVIDIA H100|81920|9.0;1|NVIDIA H100|81920|9.0'
+out="$(python3 "$HELPER" resolve-variant-pin --variant "$DMAX" --format shell --gpu-spec "$GPU_5090X2")"
+assert_contains "$out" "VLLM_USE_DEEP_GEMM=0"
+out="$(python3 "$HELPER" resolve-variant-pin --variant "$DMAX" --format shell --gpu-spec "${GPU_4090};1|NVIDIA GeForce RTX 4090|24564|8.9")"
+assert_contains "$out" "VLLM_USE_DEEP_GEMM=0"          # Ada proactively covered
+out="$(python3 "$HELPER" resolve-variant-pin --variant "$DMAX" --format shell --gpu-spec "$GPU_H100X2")"
+assert_not_contains "$out" "VLLM_USE_DEEP_GEMM"        # Hopper keeps the fast path
+out="$(python3 "$HELPER" resolve-variant-pin --variant vllm/dual --format shell --gpu-spec "$GPU_5090X2")"
+assert_not_contains "$out" "VLLM_USE_DEEP_GEMM"        # int4-weights slug: not the DeepGEMM path
+out="$(VLLM_USE_DEEP_GEMM=1 python3 "$HELPER" resolve-variant-pin --variant "$DMAX" --format shell --gpu-spec "$GPU_5090X2")"
+assert_not_contains "$out" "VLLM_USE_DEEP_GEMM=0"      # explicit user pin wins
+echo "  ok: fp8w DeepGEMM disable (5090/Ada down · Hopper keep · non-fp8 skip · user-pin — 5 cases)"
+
 if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
   out="$(VLLM_NIGHTLY_SHA="$CLEAN_SHA" docker compose -f "$ROOT_DIR/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml" config 2>/dev/null)"
   assert_contains "$out" "image: vllm/vllm-openai:v0.24.0"


### PR DESCRIPTION
Two fixes from **@guybrush01's fp8-weights 5090 run** (disc #571) — both were needed to boot the `fp8w` arm on consumer Blackwell.

## 1. Auto-disable DeepGEMM on consumer Blackwell (fp8-weights slugs)

vLLM's DeepGEMM fp8-GEMM path is built for **Hopper (sm_90) + datacenter Blackwell (sm_100/103)**. Consumer Blackwell (5090 / PRO 6000 / GB10, sm_120/121) has **no recipe** and hard-fails `recipe not found` at boot.

`_deepgemm_env` (same seam as the other arch-aware injections) injects `VLLM_USE_DEEP_GEMM=0` for **fp8-weights slugs** when a detected card is a consumer SM:

| Card | SM | result |
|---|---|---|
| 5090 / PRO 6000 / GB10 | 12.0 / 12.1 | **inject 0** (confirmed-broken) |
| 4090 (Ada) | 8.9 | **inject 0** (proactive — Ada routes fp8 via Marlin/CUTLASS, so it's a harmless no-op that pre-empts the same wall) |
| H100 (Hopper) | 9.0 | none (keeps the fast path) |
| `vllm/dual` (int4 weights) | any | none (not the DeepGEMM path) |

`dual/fp8/mtp.yml` gets a pass-through env; both launchers whitelist the export. Raw `docker compose` on a consumer Blackwell card still needs the env set by hand (documented in the compose).

## 2. `--force` the arch-ab fp8w arm

`vllm/qwen-27b-dual-max` is `status=experimental`, so `switch.sh` gates it. The `fp8w` arm now passes `--force` (the KV arms, which run production `vllm/dual`, are untouched).

## Validation

- `test-launch-compat`: 5 new cases (5090/Ada down · Hopper keep · non-fp8 skip · user-pin wins). Full serial gate **68/68 green.**
- Live-verified the full arch matrix.

Independent of the concurrency/mem-util work; touches the fp8-weights path only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)