### PR TITLE
Baselines slice 3: cross-rig submissions — schema, --from-bundle ingest, first external row

### DIFF
--- a/scripts/catalog-baseline.sh
+++ b/scripts/catalog-baseline.sh
@@ -186,25 +186,50 @@ if bench_log and n_runs < 5:
 
 
 def _quality_from(path: Path):
+    """(score, provenance) from a benchlocal results JSON.  Provenance is the
+    friction-#8 hook: a quality number without its harness fingerprint is
+    unreproducible (the half-deployed-sandbox incident).  runner_version is in
+    every results JSON; sandbox_digest rides along when benchlocal starts
+    emitting it (upstream candidate — no warn until then)."""
     if not path.is_file():
-        return None
+        return None, None
     try:
         q = json.loads(path.read_text())
         packs = q.get("packs") or []
         p = sum(int(x.get("passed") or 0) for x in packs)
         t = sum(int(x.get("total") or 0) for x in packs)
-        return f"{p}/{t}" if t else None
+        prov = {
+            "runner_version": q.get("runner_version") or None,
+            "sandbox_digest": q.get("sandbox_digest") or None,
+        }
+        return (f"{p}/{t}" if t else None), prov
     except (ValueError, TypeError):
-        return None
+        return None, None
 
 
-q_off = _quality_from(tag_dir / "quality-full.json")
-q_on = _quality_from(tag_dir / "quality-full-thinking.json")
+q_off, prov_off = _quality_from(tag_dir / "quality-full.json")
+q_on, prov_on = _quality_from(tag_dir / "quality-full-thinking.json")
 if not q_off and not q_on:
     if not tps_only:
         die("quality gate not covered: no quality-full*.json in the tag dir "
             "(re-run with --tps-only to induct a TPS-only row, WARNED)")
     warn("inducting WITHOUT a quality run (--tps-only) — 8pk stays empty")
+
+# quality_env (friction #8 / design §2.1.4): the harness fingerprint the
+# quality numbers were produced ON.  Both arms must agree — a version split
+# means the arms aren't comparable, so the field is omitted LOUDLY.
+quality_env = None
+_provs = [p for p in (prov_off, prov_on) if p and p.get("runner_version")]
+if _provs:
+    _vers = sorted({p["runner_version"] for p in _provs})
+    if len(_vers) > 1:
+        warn(f"quality arms ran on DIFFERENT harness versions {_vers} — "
+             "quality_env omitted; investigate before trusting the arm delta")
+    else:
+        quality_env = f'harness: "benchlocal-cli {_vers[0]}"'
+        _digs = sorted({p["sandbox_digest"] for p in _provs if p.get("sandbox_digest")})
+        if len(_digs) == 1:
+            quality_env += f', sandbox_digest: "{_digs[0]}"'
 
 # ── ctx_validated: the verify-stress ceiling ladder verdict ──────────────────
 ctx_tokens = None
@@ -360,6 +385,8 @@ if q_off:
     fields.append(f'quality_8pk: "{q_off}"')
 if q_on:
     fields.append(f'quality_8pk_think_on: "{q_on}"')
+if (q_off or q_on) and quality_env:
+    fields.append(f"quality_env: {{ {quality_env} }}")
 if ctx_tokens:
     fields.append(f'ctx_validated: {{ tokens: {ctx_tokens}, niah: "{niah}" }}')
 fields.append(f"date: {row_date}")

--- a/scripts/catalog-baseline.sh
+++ b/scripts/catalog-baseline.sh
@@ -3,9 +3,17 @@
 # baseline row in scripts/lib/profiles/baselines.yml (catalog-baselines §2.3).
 #
 #   bash scripts/catalog-baseline.sh <slug> --from-tag <rebench-tag> [options]
+#   bash scripts/catalog-baseline.sh <slug> --from-bundle <tgz|dir> \
+#        --source <disc/PR link> --submitted-by <handle> [options]
 #
 # One mechanism, three entry points: ⑤ Promote (c3 producer lane) · maintainer
 # CLI · the rebench-full completion prompt (re-validation after pin bumps).
+# PLUS the slice-3 cross-rig path: --from-bundle ingests a VOLUNTEER's rebench
+# bundle into the slug's `submissions:` map (keyed by rig_class, tier:
+# submitted). In bundle mode provenance comes FROM THE BUNDLE — rig/power from
+# rig.txt, engine pin from container-config.json — NEVER from this rig
+# (nvidia-smi / resolve_variant_pin would stamp OUR fingerprint onto foreign
+# numbers). --source and --submitted-by are REQUIRED (no $USER default).
 #
 # It VALIDATES the tag dir covers the gates (verify-full pass · bench n>=3,
 # n<5 warned · quality run present), extracts the display projection (decode
@@ -20,16 +28,24 @@
 # saved results".
 #
 # Options:
-#   --from-tag <tag>     rebench tag under results/rebench/ (required)
+#   --from-tag <tag>     rebench tag under results/rebench/ (required unless
+#                        --from-bundle; WITH --from-bundle it selects the tag
+#                        when the bundle carries more than one)
 #   --tag-dir <dir>      explicit tag dir (overrides --from-tag lookup; for
 #                        tags living in another checkout/worktree)
+#   --from-bundle <p>    a volunteer's rebench bundle (.tgz or an extracted
+#                        dir) → ingest into the slug's submissions: map
+#   --source <url>      (bundle mode, REQUIRED) provenance link — the
+#                        discussion comment / PR the bundle was submitted in
 #   --engine-pin <spec>  override the measured pin (default: the slug's CURRENT
-#                        resolved pin — correct when inducting right after the
-#                        gate ran on it)
+#                        resolved pin; bundle mode: container-config.json)
 #   --rig <class>        hardware fingerprint class (default: derived from
-#                        nvidia-smi, e.g. 2x3090-pcie)
-#   --power-cap-w <csv>  per-card caps, e.g. "370,420" (default: nvidia-smi)
-#   --submitted-by <who> provenance (default: $USER)
+#                        nvidia-smi, e.g. 2x3090-pcie; bundle mode: rig.txt.
+#                        In bundle mode this is also the submissions map key)
+#   --power-cap-w <csv>  per-card caps, e.g. "370,420" (default: nvidia-smi;
+#                        bundle mode: rig.txt)
+#   --submitted-by <who> provenance (default: $USER; bundle mode: REQUIRED —
+#                        the volunteer's handle, never defaulted)
 #   --tps-only           induct without a quality run (WARNS; the 8-pack gate
 #                        is normally required)
 #   --dry-run            print the diff, do not write
@@ -47,12 +63,15 @@ SLUG="${1:-}"
 }
 shift
 
-TAG="" TAG_DIR="" ENGINE_PIN="" RIG="" POWER="" SUBMITTED_BY="${USER:-unknown}"
-TPS_ONLY=0 DRY_RUN=0 BASELINES_FILE="scripts/lib/profiles/baselines.yml"
+TAG="" TAG_DIR="" BUNDLE="" SOURCE="" ENGINE_PIN="" RIG="" POWER=""
+SUBMITTED_BY="" TPS_ONLY=0 DRY_RUN=0
+BASELINES_FILE="scripts/lib/profiles/baselines.yml"
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --from-tag)     TAG="$2"; shift 2 ;;
     --tag-dir)      TAG_DIR="$2"; shift 2 ;;
+    --from-bundle)  BUNDLE="$2"; shift 2 ;;
+    --source)       SOURCE="$2"; shift 2 ;;
     --engine-pin)   ENGINE_PIN="$2"; shift 2 ;;
     --rig)          RIG="$2"; shift 2 ;;
     --power-cap-w)  POWER="$2"; shift 2 ;;
@@ -63,12 +82,46 @@ while [[ $# -gt 0 ]]; do
     *) echo "[catalog-baseline] unknown option: $1" >&2; exit 2 ;;
   esac
 done
-[[ -n "$TAG" || -n "$TAG_DIR" ]] || { echo "[catalog-baseline] --from-tag (or --tag-dir) is required" >&2; exit 2; }
-TAG_DIR="${TAG_DIR:-$ROOT_DIR/results/rebench/$TAG}"
-TAG="${TAG:-$(basename "$TAG_DIR")}"
+
+FROM_BUNDLE=0
+if [[ -n "$BUNDLE" ]]; then
+  # ── bundle mode (slice 3): extract + locate the tag dir INSIDE the bundle ──
+  FROM_BUNDLE=1
+  [[ -n "$SOURCE" ]] || { echo "[catalog-baseline] bundle mode: --source <disc/PR link> is required" >&2; exit 2; }
+  [[ -n "$SUBMITTED_BY" ]] || { echo "[catalog-baseline] bundle mode: --submitted-by <handle> is required (never defaulted to \$USER)" >&2; exit 2; }
+  [[ -z "$TAG_DIR" ]] || { echo "[catalog-baseline] --tag-dir and --from-bundle are mutually exclusive" >&2; exit 2; }
+  if [[ -d "$BUNDLE" ]]; then
+    BUNDLE_DIR="$BUNDLE"
+  else
+    [[ -f "$BUNDLE" ]] || { echo "[catalog-baseline] bundle not found: $BUNDLE" >&2; exit 2; }
+    BUNDLE_DIR="$(mktemp -d)"
+    trap 'rm -rf "$BUNDLE_DIR"' EXIT
+    tar xzf "$BUNDLE" -C "$BUNDLE_DIR"
+  fi
+  # a tag dir is any dir carrying _internal.json (the rebench-report record)
+  mapfile -t _tag_dirs < <(find "$BUNDLE_DIR" -name _internal.json -printf '%h\n' | sort)
+  if [[ ${#_tag_dirs[@]} -eq 0 ]]; then
+    echo "[catalog-baseline] no tag dir (_internal.json) inside the bundle" >&2; exit 1
+  elif [[ ${#_tag_dirs[@]} -eq 1 ]]; then
+    TAG_DIR="${_tag_dirs[0]}"
+  else
+    [[ -n "$TAG" ]] || { echo "[catalog-baseline] bundle carries ${#_tag_dirs[@]} tags — select one with --from-tag:" >&2
+                         printf '  %s\n' "${_tag_dirs[@]##*/}" >&2; exit 2; }
+    TAG_DIR=""
+    for d in "${_tag_dirs[@]}"; do [[ "$(basename "$d")" == "$TAG" ]] && TAG_DIR="$d"; done
+    [[ -n "$TAG_DIR" ]] || { echo "[catalog-baseline] tag $TAG not in the bundle" >&2; exit 2; }
+  fi
+  TAG="${TAG:-$(basename "$TAG_DIR")}"
+else
+  [[ -n "$TAG" || -n "$TAG_DIR" ]] || { echo "[catalog-baseline] --from-tag (or --tag-dir / --from-bundle) is required" >&2; exit 2; }
+  SUBMITTED_BY="${SUBMITTED_BY:-${USER:-unknown}}"
+  TAG_DIR="${TAG_DIR:-$ROOT_DIR/results/rebench/$TAG}"
+  TAG="${TAG:-$(basename "$TAG_DIR")}"
+fi
 
 SLUG="$SLUG" TAG="$TAG" TAG_DIR="$TAG_DIR" ENGINE_PIN="$ENGINE_PIN" RIG="$RIG" \
 POWER="$POWER" SUBMITTED_BY="$SUBMITTED_BY" TPS_ONLY="$TPS_ONLY" DRY_RUN="$DRY_RUN" \
+FROM_BUNDLE="$FROM_BUNDLE" SOURCE="$SOURCE" \
 BASELINES_FILE="$BASELINES_FILE" \
 python3 - <<'PY'
 import difflib
@@ -204,39 +257,74 @@ if bench_log:
                          "warm-vs-cold or config drift; investigate before trusting the depth curve")
 
 # ── provenance ────────────────────────────────────────────────────────────────
-engine_pin = os.environ["ENGINE_PIN"]
-if not engine_pin:
-    try:
-        exports = resolve_variant_pin(load_profiles(), slug)
-        if "VLLM_NIGHTLY_SHA" not in exports:
-            engine_pin = next(iter(exports.values()))
-    except ProfileError:
-        pass
-    if not engine_pin:
-        # compose-image default (ik/llama.cpp class) — same rule as the emit join
-        txt = (Path(COMPOSE_REGISTRY[slug]["compose_path"])).read_text(errors="replace")
-        m = re.search(r"^\s*image:\s*[\"']?(?:\$\{[A-Z_0-9]+:-)?([^\s}\"']+)\}?", txt, re.M)
-        engine_pin = m.group(1) if m else ""
-if not engine_pin:
-    die("could not resolve the engine pin — pass --engine-pin explicitly")
+# Two regimes: local induction reads THIS rig (nvidia-smi + resolved pin);
+# bundle mode reads THE BUNDLE (rig.txt + container-config.json) and NEVER
+# falls back to local state — that would stamp our fingerprint onto foreign
+# numbers (the slice-3 trust boundary).
+from_bundle = os.environ["FROM_BUNDLE"] == "1"
+source = os.environ["SOURCE"]
 
+engine_pin = os.environ["ENGINE_PIN"]
 rig = os.environ["RIG"]
 power = os.environ["POWER"]
-if not rig or not power:
-    try:
-        out = subprocess.run(
-            ["nvidia-smi", "--query-gpu=name,power.limit", "--format=csv,noheader,nounits"],
-            capture_output=True, text=True, timeout=10,
-        ).stdout.strip().splitlines()
-        names = [l.split(",")[0].strip() for l in out]
-        caps = [str(round(float(l.split(",")[1]))) for l in out]
-        if not rig and names:
-            short = re.sub(r"NVIDIA GeForce RTX\s*", "", names[0]).strip().replace(" ", "").lower()
-            rig = f"{len(names)}x{short}-pcie"
-        if not power and caps:
-            power = ",".join(caps)
-    except Exception:
-        pass
+
+if from_bundle:
+    if not engine_pin:
+        cc = tag_dir / "container-config.json"
+        if cc.is_file():
+            try:
+                data = json.loads(cc.read_text(errors="replace"))
+                engine_pin = ((data[0].get("Config") or {}).get("Image") or "").strip()
+            except (ValueError, IndexError, AttributeError, TypeError):
+                pass
+        if not engine_pin:
+            die("bundle mode: no readable Config.Image in container-config.json — pass --engine-pin")
+    rig_txt = (tag_dir / "rig.txt").read_text(errors="replace") if (tag_dir / "rig.txt").is_file() else ""
+    names = re.findall(r"^GPU \d+: (.+?) \(UUID", rig_txt, re.M)
+    if not rig:
+        if not names:
+            die("bundle mode: no GPU lines in rig.txt — pass --rig")
+        short = re.sub(r"NVIDIA\s+(GeForce\s+)?(RTX\s+)?", "", names[0]).strip().replace(" ", "").lower()
+        rig = f"{len(names)}x{short}-pcie"
+    if not power:
+        caps = re.findall(r"^power_cap_w:\s*([\d.]+)", rig_txt, re.M)
+        if not caps:
+            die("bundle mode: no power_cap_w in rig.txt — pass --power-cap-w")
+        vals = [str(round(float(c))) for c in caps]
+        if len(vals) == 1 and len(names) > 1:
+            vals = vals * len(names)  # one global cap line → replicate per card
+        power = ",".join(vals)
+else:
+    if not engine_pin:
+        try:
+            exports = resolve_variant_pin(load_profiles(), slug)
+            if "VLLM_NIGHTLY_SHA" not in exports:
+                engine_pin = next(iter(exports.values()))
+        except ProfileError:
+            pass
+        if not engine_pin:
+            # compose-image default (ik/llama.cpp class) — same rule as the emit join
+            txt = (Path(COMPOSE_REGISTRY[slug]["compose_path"])).read_text(errors="replace")
+            m = re.search(r"^\s*image:\s*[\"']?(?:\$\{[A-Z_0-9]+:-)?([^\s}\"']+)\}?", txt, re.M)
+            engine_pin = m.group(1) if m else ""
+    if not engine_pin:
+        die("could not resolve the engine pin — pass --engine-pin explicitly")
+
+    if not rig or not power:
+        try:
+            out = subprocess.run(
+                ["nvidia-smi", "--query-gpu=name,power.limit", "--format=csv,noheader,nounits"],
+                capture_output=True, text=True, timeout=10,
+            ).stdout.strip().splitlines()
+            names = [l.split(",")[0].strip() for l in out]
+            caps = [str(round(float(l.split(",")[1]))) for l in out]
+            if not rig and names:
+                short = re.sub(r"NVIDIA GeForce RTX\s*", "", names[0]).strip().replace(" ", "").lower()
+                rig = f"{len(names)}x{short}-pcie"
+            if not power and caps:
+                power = ",".join(caps)
+        except Exception:
+            pass
 if not rig:
     die("could not derive --rig (nvidia-smi unavailable) — pass it explicitly")
 if not power:
@@ -249,34 +337,45 @@ row_date = date.fromtimestamp(
 ).isoformat()
 
 # ── build the row text (matches the file's hand-written shape) ───────────────
-lines = [f"  {slug}:"]
-lines.append(f"    # inducted by catalog-baseline.sh from rebench tag {tag} ({datetime.now().date().isoformat()});")
-lines.append(f"    # evidence: verify-full pass · bench n={n_runs or '?'} · "
-             + ("quality both arms" if (q_off and q_on) else ("quality one arm" if (q_off or q_on) else "TPS-ONLY (no quality)"))
-             + (" · NIAH ladder" if ctx_tokens else ""))
-lines.append(f"    narr_tps: {round(float(narr['decode_tps_mean']), 2)}")
-lines.append(f"    code_tps: {round(float(code['decode_tps_mean']), 2)}")
+# The SAME fields serve both shapes; only indent + head + tier/source differ:
+#   local:  "  <slug>:"        + 4-space fields + tier: local
+#   bundle: "      <rig>:"     + 8-space fields + source: + tier: submitted
+#           (spliced under the slug's "    submissions:" map)
+tool = "catalog-baseline.sh --from-bundle" if from_bundle else "catalog-baseline.sh"
+fields = [f"# inducted by {tool} from rebench tag {tag} ({datetime.now().date().isoformat()});"]
+fields.append(f"# evidence: verify-full pass · bench n={n_runs or '?'} · "
+              + ("quality both arms" if (q_off and q_on) else ("quality one arm" if (q_off or q_on) else "TPS-ONLY (no quality)"))
+              + (" · NIAH ladder" if ctx_tokens else ""))
+fields.append(f"narr_tps: {round(float(narr['decode_tps_mean']), 2)}")
+fields.append(f"code_tps: {round(float(code['decode_tps_mean']), 2)}")
 if ttft is not None:
-    lines.append(f"    ttft_ms: {round(float(ttft))}")
+    fields.append(f"ttft_ms: {round(float(ttft))}")
 if prefill_by_ctx:
     inner = ", ".join(
         f"{int(k) // 1000}k: {v:.0f}"
         for k, v in sorted(prefill_by_ctx.items(), key=lambda x: int(x[0]))
     )
-    lines.append(f"    prefill_tps: {{ {inner} }}")
+    fields.append(f"prefill_tps: {{ {inner} }}")
 if q_off:
-    lines.append(f'    quality_8pk: "{q_off}"')
+    fields.append(f'quality_8pk: "{q_off}"')
 if q_on:
-    lines.append(f'    quality_8pk_think_on: "{q_on}"')
+    fields.append(f'quality_8pk_think_on: "{q_on}"')
 if ctx_tokens:
-    lines.append(f'    ctx_validated: {{ tokens: {ctx_tokens}, niah: "{niah}" }}')
-lines.append(f"    date: {row_date}")
-lines.append(f'    engine_pin: "{engine_pin}"')
-lines.append(f'    rig: "{rig}"')
-lines.append(f"    power_cap_w: {power_list}")
-lines.append(f'    source_tag: "{tag}"')
-lines.append(f'    submitted_by: "{os.environ["SUBMITTED_BY"]}"')
-row_text = "\n".join(lines) + "\n"
+    fields.append(f'ctx_validated: {{ tokens: {ctx_tokens}, niah: "{niah}" }}')
+fields.append(f"date: {row_date}")
+fields.append(f'engine_pin: "{engine_pin}"')
+fields.append(f'rig: "{rig}"')
+fields.append(f"power_cap_w: {power_list}")
+if from_bundle:
+    fields.append(f'source: "{source}"')
+fields.append(f'source_tag: "{tag}"')
+fields.append(f'submitted_by: "{os.environ["SUBMITTED_BY"]}"')
+fields.append("tier: submitted" if from_bundle else "tier: local")
+
+if from_bundle:
+    row_text = f"      {rig}:\n" + "".join(f"        {f}\n" for f in fields)
+else:
+    row_text = f"  {slug}:\n" + "".join(f"    {f}\n" for f in fields)
 
 # ── upsert (textual splice — comments elsewhere in the file preserved) ────────
 bl_path = Path(os.environ["BASELINES_FILE"])
@@ -284,22 +383,74 @@ old = bl_path.read_text()
 block_re = re.compile(
     rf"^  {re.escape(slug)}:\n(?:^(?:    .*|\s*)\n)*?(?=^  \S|^#|^\S|\Z)", re.M
 )
-if block_re.search(old):
-    new = block_re.sub(row_text + "\n", old, count=1)
-    action = "replaced"
+# an existing submissions: sub-map inside a slug block (6+-space content lines)
+SUBMAP_RE = re.compile(
+    r"^    submissions:\n(?:^(?:      .*|\s*)\n)*?(?=^    \S|^  \S|^#|^\S|\Z)", re.M
+)
+m_block = block_re.search(old)
+
+if from_bundle:
+    # bundle mode touches ONLY the submissions map — the primary row (if any)
+    # is the local bar and stays byte-identical.
+    if m_block:
+        block = m_block.group(0)
+        body = block.rstrip("\n") + "\n"          # block content
+        trail = block[len(body):]                 # blank-line row separator(s)
+        sub_re = re.compile(
+            rf"^      {re.escape(rig)}:\n(?:^(?:        .*|\s*)\n)*?(?=^      \S|^    \S|^  \S|^#|^\S|\Z)",
+            re.M,
+        )
+        m_hdr = re.search(r"^    submissions:\n", body, re.M)
+        if m_hdr:
+            m_sub = sub_re.search(body)
+            if m_sub:
+                # ONE row per rig_class — newest replaces; older stays in git
+                new_body = body[:m_sub.start()] + row_text + body[m_sub.end():]
+                action = f"replaced submission [{rig}] in"
+            else:
+                new_body = body[:m_hdr.end()] + row_text + body[m_hdr.end():]
+                action = f"added submission [{rig}] to"
+        else:
+            new_body = body + "    submissions:\n" + row_text
+            action = f"added submissions map [{rig}] to"
+        new = old[:m_block.start()] + new_body + trail + old[m_block.end():]
+    else:
+        # submission-only entry: a slug measured on hardware we don't have
+        entry_text = (
+            f"  {slug}:\n"
+            "    # cross-rig submissions only — no local baseline row yet\n"
+            "    submissions:\n" + row_text
+        )
+        m = re.search(r"^# ─+\n# (?:KNOWN GAPS|SEED WAVE 2)", old, re.M)
+        ins = m.start() if m else len(old)
+        new = old[:ins] + entry_text + "\n" + old[ins:]
+        action = f"added submission-only entry [{rig}] as"
 else:
-    # append before the top-level gap-list footer comment block (or at EOF)
-    m = re.search(r"^# ─+\n# (?:KNOWN GAPS|SEED WAVE 2)", old, re.M)
-    ins = m.start() if m else len(old)
-    new = old[:ins] + row_text + "\n" + old[ins:]
-    action = "added"
+    if m_block:
+        # preserve an existing submissions: sub-map across the primary-row
+        # replace (the block regex would otherwise swallow it)
+        m_sub = SUBMAP_RE.search(m_block.group(0))
+        keep = (m_sub.group(0).rstrip("\n") + "\n") if m_sub else ""
+        new = old[:m_block.start()] + row_text + keep + "\n" + old[m_block.end():]
+        action = "replaced"
+    else:
+        # append before the top-level gap-list footer comment block (or at EOF)
+        m = re.search(r"^# ─+\n# (?:KNOWN GAPS|SEED WAVE 2)", old, re.M)
+        ins = m.start() if m else len(old)
+        new = old[:ins] + row_text + "\n" + old[ins:]
+        action = "added"
 
 # self-check: the produced file must still parse + the row must round-trip
 import yaml  # noqa: E402
 
 parsed = yaml.safe_load(new)
 got = (parsed.get("baselines") or {}).get(slug)
-assert got and isinstance(got.get("narr_tps"), (int, float)), "upsert self-check failed"
+if from_bundle:
+    sub_got = (got or {}).get("submissions", {}).get(rig)
+    assert sub_got and isinstance(sub_got.get("narr_tps"), (int, float)), "upsert self-check failed (submission)"
+    assert sub_got.get("tier") == "submitted" and sub_got.get("source"), "upsert self-check failed (provenance)"
+else:
+    assert got and isinstance(got.get("narr_tps"), (int, float)), "upsert self-check failed"
 
 diff = "".join(
     difflib.unified_diff(

--- a/scripts/lib/profiles/baselines.yml
+++ b/scripts/lib/profiles/baselines.yml
@@ -14,6 +14,12 @@
 #   quality_8pk           thinking-OFF arm "P/150"; _think_on = thinking-ON.
 #                         8-pack noise band is ±5–7 — separates classes, not
 #                         fine rankings (badge semantics, design §2.1.4).
+#   quality_env           the harness fingerprint the quality numbers were
+#                         produced ON: { harness: "benchlocal-cli X.Y.Z",
+#                         sandbox_digest?: "sha256:…" } — §2.1.4 provenance
+#                         (the half-deployed-sandbox lesson). Written by
+#                         catalog-baseline.sh from the results JSON; digest
+#                         rides along once benchlocal emits it.
 #   ctx_validated         highest ctx EXERCISED by the gate, with the recall
 #                         verdict: {tokens: N, niah: "clean@XK" | "allocation-
 #                         only"} — allocation alone is NOT validation (§2.1.2).

--- a/scripts/lib/profiles/baselines.yml
+++ b/scripts/lib/profiles/baselines.yml
@@ -311,6 +311,26 @@ baselines:
     submitted_by: "noonghunna"
     tier: local
 
+  vllm/qwen-27b-dual-max:
+    # cross-rig submissions only — no local baseline row yet
+    submissions:
+      2x5090-pcie:
+        # inducted by catalog-baseline.sh --from-bundle from rebench tag 246-ab-fp8w (2026-07-05);
+        # evidence: verify-full pass · bench n=5 · TPS-ONLY (no quality) · NIAH ladder
+        narr_tps: 134.52
+        code_tps: 165.11
+        ttft_ms: 56
+        prefill_tps: { 10k: 3693, 90k: 1906 }
+        ctx_validated: { tokens: 240635, niah: "clean@241K" }
+        date: 2026-07-05
+        engine_pin: "vllm/vllm-openai:v0.24.0"
+        rig: "2x5090-pcie"
+        power_cap_w: [575, 575]
+        source: "https://github.com/noonghunna/club-3090/discussions/571#discussioncomment-17536412"
+        source_tag: "246-ab-fp8w"
+        submitted_by: "guybrush01"
+        tier: submitted
+
 # ───────────────────────────────────────────────────────────────────────────
 # KNOWN GAPS — wave-2 dispositions (2026-07-04): each slug below has NO row
 # on purpose; the disposition says what unlocks one. Do NOT guess numbers in.

--- a/scripts/lib/profiles/baselines.yml
+++ b/scripts/lib/profiles/baselines.yml
@@ -24,6 +24,26 @@
 #   source_tag            results/rebench/<tag>/ when a tag dir exists;
 #                         omitted for rows reviewed from a BENCHMARKS.md entry
 #                         (the row comment names the source).
+#   tier                  provenance trust tier (slice 3):
+#                           local      — measured on the maintainer reference
+#                                        rig via the full gate (primary rows
+#                                        are ALWAYS tier: local)
+#                           submitted  — foreign bundle, ingested via
+#                                        catalog-baseline.sh --from-bundle;
+#                                        NOT independently verified
+#                           reproduced — a submission independently re-run
+#                                        (second submitter on the same
+#                                        rig-class, or maintainer on matching
+#                                        hardware)
+#   submissions           OPTIONAL map keyed by rig_class (e.g. 2x5090-pcie):
+#                         cross-rig rows ingested from volunteer bundles.
+#                         Same fields as a primary row PLUS required `source:`
+#                         (the disc/PR link) and tier ∈ {submitted,reproduced}.
+#                         ONE row per rig_class — newest-by-date wins, older
+#                         stays in git history. Submissions NEVER become the
+#                         slug's default bar (consumers show them rig-labeled);
+#                         a slug MAY carry submissions with no primary row
+#                         (measured on hardware we don't have).
 #
 # SEED WAVE 1 (2026-07-04): rows with airtight traceability only — a rebench
 # tag on disk or an unambiguous decode-class BENCHMARKS.md row. Slugs still
@@ -52,6 +72,7 @@ baselines:
     rig: "2x3090-pcie"
     power_cap_w: [370, 420]
     submitted_by: "noonghunna"
+    tier: local
 
   vllm/qwen-27b-dual-fast:
     # alias of vllm/dual (same compose_path dual/autoround-int4/fp8-mtp.yml,
@@ -65,6 +86,7 @@ baselines:
     rig: "2x3090-pcie"
     power_cap_w: [370, 420]
     submitted_by: "noonghunna"
+    tier: local
 
   llamacpp/default:
     # BENCHMARKS.md 2026-05-23 row (decode, n=3, CV 0.6%/1.4%).
@@ -77,6 +99,7 @@ baselines:
     rig: "1x3090-pcie"
     power_cap_w: [370]
     submitted_by: "noonghunna"
+    tier: local
 
   llamacpp/mtp:
     # BENCHMARKS.md 2026-06-18 row (decode, n=5, CV <2%, thinking-off).
@@ -87,6 +110,7 @@ baselines:
     rig: "1x3090-pcie"
     power_cap_w: [370]
     submitted_by: "noonghunna"
+    tier: local
 
   llamacpp/mtp-vision:
     # BENCHMARKS.md 2026-05-20 row (decode, n=5, CV 1.6%/1.7%).
@@ -98,6 +122,7 @@ baselines:
     rig: "1x3090-pcie"
     power_cap_w: [370]
     submitted_by: "noonghunna"
+    tier: local
 
   ik-llama/iq4ks-mtp:
     # BENCHMARKS.md 2026-05-23 row (decode 60.39/72.40, n=3; set+readback 370 W).
@@ -110,6 +135,7 @@ baselines:
     rig: "1x3090-pcie"
     power_cap_w: [370]
     submitted_by: "noonghunna"
+    tier: local
 
   ik-llama/iq4ks-two-stage:
     # BENCHMARKS.md 2026-05-24 row (decode, n=3, CV 1.9%/5.3%).
@@ -120,6 +146,7 @@ baselines:
     rig: "1x3090-pcie"
     power_cap_w: [370]
     submitted_by: "noonghunna"
+    tier: local
 
   beellama/dflash:
     # BENCHMARKS.md 2026-05-30 row (decode 50.4/101.3, n=5, CV 5.6%/7.4%).
@@ -133,6 +160,7 @@ baselines:
     rig: "1x3090-pcie"
     power_cap_w: [370]
     submitted_by: "noonghunna"
+    tier: local
 
   ik-llama/iq4ks-mtp-vision:
     # BENCHMARKS.md 2026-05-25 vision re-tune row (PR #227/#437): decode
@@ -148,6 +176,7 @@ baselines:
     rig: "1x3090-pcie"
     power_cap_w: [370]
     submitted_by: "noonghunna"
+    tier: local
 
   ik-llama/byteshape-iq4xs-mtp:
     # BENCHMARKS.md row (decode 115.60/137.07, n=5) + 8-pack 110/150 off —
@@ -160,6 +189,7 @@ baselines:
     rig: "1x3090-pcie"
     power_cap_w: [370]
     submitted_by: "noonghunna"
+    tier: local
 
   # ── Qwen3.6-35B-A3B ──────────────────────────────────────────────────────
   ik-llama/apex-fit-q8q5:
@@ -176,6 +206,7 @@ baselines:
     rig: "1x3090-pcie"
     power_cap_w: [370]
     submitted_by: "noonghunna"
+    tier: local
 
   vllm/qwen-35b-a3b-dual:
     # BENCHMARKS.md promotion row (#259, decode 182.3/182.3; NIAH-clean 240K).
@@ -192,6 +223,7 @@ baselines:
     rig: "2x3090-pcie"
     power_cap_w: [370, 420]
     submitted_by: "noonghunna"
+    tier: local
 
   # ── Agents-A1 ────────────────────────────────────────────────────────────
   vllm/agents-a1-dual:
@@ -221,6 +253,7 @@ baselines:
     power_cap_w: [370, 420]
     source_tag: "agents-a1-fp8-dual"
     submitted_by: "noonghunna"
+    tier: local
 
   # ── Gemma-4-31B ──────────────────────────────────────────────────────────
   vllm/gemma-31b-dual:
@@ -237,6 +270,7 @@ baselines:
     power_cap_w: [370, 420]
     source_tag: "gemma-31b-dual-bf16"
     submitted_by: "noonghunna"
+    tier: local
 
   # ── Gemma-4-26B-A4B ──────────────────────────────────────────────────────
   vllm/gemma-26ba4b-single:
@@ -257,6 +291,7 @@ baselines:
     power_cap_w: [370]
     source_tag: "gemma-26ba4b-int8r"
     submitted_by: "noonghunna"
+    tier: local
 
   beellama/gemma-dflash:
     # inducted by catalog-baseline.sh from rebench tag gemma-dflash-regate (2026-07-04);
@@ -274,6 +309,7 @@ baselines:
     power_cap_w: [370]
     source_tag: "gemma-dflash-regate"
     submitted_by: "noonghunna"
+    tier: local
 
 # ───────────────────────────────────────────────────────────────────────────
 # KNOWN GAPS — wave-2 dispositions (2026-07-04): each slug below has NO row

--- a/scripts/lib/registry-emit.sh
+++ b/scripts/lib/registry-emit.sh
@@ -461,6 +461,20 @@ def _baseline_for(slug: str, compose_path: str):
     # (unpinned engine or unreadable compose) — badge only on TRUE.
     out["stale"] = (cur != measured) if (cur and measured) else None
     out["current_pin"] = cur
+    # slice 3: cross-rig submissions ride the join with the SAME per-row
+    # staleness verdict (an image pin is rig-independent, so the comparison
+    # holds for foreign rigs).  A submission-only entry (no primary row) has
+    # out["stale"] = None and carries only this map.
+    subs = row.get("submissions")
+    if isinstance(subs, dict):
+        out["submissions"] = {
+            rc: {
+                **s,
+                "stale": (cur != s.get("engine_pin"))
+                if (cur and s.get("engine_pin")) else None,
+            }
+            for rc, s in subs.items()
+        }
     return out
 
 # --- variants: exactly the fields parse_variant_rows produces from the tab form,

--- a/scripts/tests/test-baselines.sh
+++ b/scripts/tests/test-baselines.sh
@@ -30,11 +30,16 @@ rows = doc.get("baselines") or {}
 assert rows, "baselines.yml has no rows"
 
 QUALITY_RE = re.compile(r"^\d{1,3}/150$")
+# rig_class key format (slice 3): <count>x<card-token>-<interconnect-ish tail>,
+# e.g. 2x3090-pcie / 2x5090-pcie / 1xdgx-spark. Format check, NOT a fixed set —
+# a new GPU model must not require a guard edit.
+RIG_CLASS_RE = re.compile(r"^\d+x[a-z0-9][a-z0-9-]*$")
 errors = []
-for slug, row in rows.items():
-    where = f"baselines[{slug}]"
-    if slug not in COMPOSE_REGISTRY:
-        errors.append(f"{where}: unknown registry slug"); continue
+
+
+def check_row(where, row, submission=False):
+    """Shared field validation — primary rows and submission rows carry the
+    same measurement fields; submissions ADD required source/tier semantics."""
     for k in ("narr_tps", "code_tps"):
         if not isinstance(row.get(k), (int, float)):
             errors.append(f"{where}.{k}: required numeric")
@@ -46,6 +51,16 @@ for slug, row in rows.items():
     pw = row.get("power_cap_w")
     if not (isinstance(pw, list) and pw and all(isinstance(x, int) for x in pw)):
         errors.append(f"{where}.power_cap_w: required list of ints")
+    # tier (slice 3): primary rows are ALWAYS the local bar; submissions carry
+    # the trust verdict (submitted = unverified, reproduced = independently re-run)
+    tier = row.get("tier")
+    if submission:
+        if tier not in ("submitted", "reproduced"):
+            errors.append(f"{where}.tier: must be submitted|reproduced")
+        if not (isinstance(row.get("source"), str) and row["source"].strip()):
+            errors.append(f"{where}.source: required non-empty string (disc/PR link)")
+    elif tier != "local":
+        errors.append(f"{where}.tier: primary rows must be tier: local")
     # optional, typed when present
     if "ttft_ms" in row and not isinstance(row["ttft_ms"], (int, float)):
         errors.append(f"{where}.ttft_ms: numeric")
@@ -66,6 +81,32 @@ for slug, row in rows.items():
             errors.append(f"{where}.prefill_tps: dict of numeric depth points (e.g. {{10k: N, 90k: M}})")
     if "source_tag" in row and not isinstance(row["source_tag"], str):
         errors.append(f"{where}.source_tag: string")
+
+
+for slug, row in rows.items():
+    where = f"baselines[{slug}]"
+    if slug not in COMPOSE_REGISTRY:
+        errors.append(f"{where}: unknown registry slug"); continue
+    subs = row.get("submissions")
+    has_primary = any(k in row for k in ("narr_tps", "code_tps"))
+    if not has_primary and subs is None:
+        errors.append(f"{where}: empty entry (needs a primary row and/or submissions)")
+        continue
+    if has_primary:
+        check_row(where, row)
+    if subs is not None:
+        if not (isinstance(subs, dict) and subs):
+            errors.append(f"{where}.submissions: must be a non-empty map keyed by rig_class")
+        else:
+            for rc, srow in subs.items():
+                swhere = f"{where}.submissions[{rc}]"
+                if not RIG_CLASS_RE.match(str(rc)):
+                    errors.append(f"{swhere}: rig_class key must look like '2x5090-pcie'")
+                if not isinstance(srow, dict):
+                    errors.append(f"{swhere}: must be a row map"); continue
+                check_row(swhere, srow, submission=True)
+                if srow.get("rig") != rc:
+                    errors.append(f"{swhere}.rig: must equal the rig_class key ({srow.get('rig')!r} != {rc!r})")
 
 # ctx parity (functional slugs): compose ctx-env default == registry max_ctx.
 CTX_RE = re.compile(r"\$\{(?:MAX_MODEL_LEN|CTX_SIZE|MAX_CTX)[^:}]*:-(\d+)\}")
@@ -119,6 +160,19 @@ if missing:
 bad = [s for s in rows if "stale" not in by_slug[s]["baseline"]]
 if bad:
     print(f"test-baselines: FAIL — joined rows missing 'stale': {bad}", file=sys.stderr)
+    sys.exit(1)
+
+# slice 3: submissions must ride the join with a per-submission staleness
+# verdict (same mechanism as the primary row — the pin comparison is
+# rig-independent)
+sub_bad = []
+for s in rows:
+    for rc, srow in (by_slug[s]["baseline"].get("submissions") or {}).items():
+        if "stale" not in srow:
+            sub_bad.append(f"{s}[{rc}]")
+if sub_bad:
+    print(f"test-baselines: FAIL — joined submissions missing 'stale': {sub_bad}",
+          file=sys.stderr)
     sys.exit(1)
 
 stale = [s for s in rows if by_slug[s]["baseline"]["stale"] is True]

--- a/scripts/tests/test-baselines.sh
+++ b/scripts/tests/test-baselines.sh
@@ -67,6 +67,16 @@ def check_row(where, row, submission=False):
     for k in ("quality_8pk", "quality_8pk_think_on"):
         if k in row and not QUALITY_RE.match(str(row[k])):
             errors.append(f"{where}.{k}: must look like 'P/150'")
+    # quality_env (friction #8 / §2.1.4): the harness fingerprint the quality
+    # numbers were produced on — harness required, sandbox_digest optional
+    # (rides along once benchlocal emits it)
+    if "quality_env" in row:
+        qe = row["quality_env"]
+        ok = (isinstance(qe, dict)
+              and isinstance(qe.get("harness"), str) and qe["harness"].strip()
+              and ("sandbox_digest" not in qe or isinstance(qe["sandbox_digest"], str)))
+        if not ok:
+            errors.append(f"{where}.quality_env: {{harness: str, sandbox_digest?: str}}")
     if "ctx_validated" in row:
         cv = row["ctx_validated"]
         ok = (isinstance(cv, dict) and isinstance(cv.get("tokens"), int)

--- a/scripts/tests/test-catalog-baseline.sh
+++ b/scripts/tests/test-catalog-baseline.sh
@@ -69,10 +69,12 @@ cat > "$TAGD/_internal.json" <<'EOF'
            "code": {"decode_tps_mean": 154.0, "ttft_ms_mean": 128.0}}}
 EOF
 cat > "$TAGD/quality-full.json" <<'EOF'
-{"packs": [{"passed": 55, "total": 75}, {"passed": 50, "total": 75}]}
+{"runner_version": "0.9.9",
+ "packs": [{"passed": 55, "total": 75}, {"passed": 50, "total": 75}]}
 EOF
 cat > "$TAGD/quality-full-thinking.json" <<'EOF'
-{"packs": [{"passed": 60, "total": 75}, {"passed": 50, "total": 75}]}
+{"runner_version": "0.9.9",
+ "packs": [{"passed": 60, "total": 75}, {"passed": 50, "total": 75}]}
 EOF
 cat > "$TAGD/verify-stress.log" <<'EOF'
     ✓ rung 1/6: target=95K  actual=94K tok (36%)  recalled 'violet chinchilla 79'  prefill=7402.9 t/s (13s)  VRAM_free=1403MB
@@ -90,6 +92,9 @@ grep -q "narr_tps: 153.9" <<<"$out" || fail "narr_tps not extracted: $out"
 grep -q "code_tps: 154.0" <<<"$out" || fail "code_tps not extracted"
 grep -q 'quality_8pk: "105/150"' <<<"$out" || fail "quality_8pk not extracted"
 grep -q 'quality_8pk_think_on: "110/150"' <<<"$out" || fail "think-on not extracted"
+# friction #8: the harness fingerprint rides the row (§2.1.4 provenance)
+grep -q 'quality_env: { harness: "benchlocal-cli 0.9.9" }' <<<"$out" \
+  || fail "quality_env not extracted from runner_version: $out"
 grep -q 'tokens: 240635' <<<"$out" || fail "ctx_validated not extracted"
 # 2c: prefill depth points land; the canonical ttft_ms stays the SHORT-prompt
 # value (the 90K block's 17s TTFT must not bleed into it).

--- a/scripts/tests/test-catalog-baseline.sh
+++ b/scripts/tests/test-catalog-baseline.sh
@@ -18,17 +18,20 @@ mkdir -p "$TAGD"
 BL="$TMP/baselines.yml"
 cp scripts/lib/profiles/baselines.yml "$BL"
 REAL_SUM_BEFORE="$(sha256sum scripts/lib/profiles/baselines.yml | cut -d' ' -f1)"
-# guarantee the ADD path below: strip any real vllm/dual row from the copy
-# (the real file seeds one since wave-2)
+# guarantee the ADD paths below: strip any real vllm/dual row (the real file
+# seeds one since wave-2) AND any real vllm/qwen-27b-dual-max entry (the real
+# file carries a submission-only entry since slice 3 — section 5's
+# submission-only case needs the slug absent)
 python3 - "$BL" <<'PY'
 import re
 import sys
 
 p = sys.argv[1]
 old = open(p).read()
-new = re.sub(r"^  vllm/dual:\n(?:^(?:    .*|\s*)\n)*?(?=^  \S|^#|^\S|\Z)",
-             "", old, count=1, flags=re.M)
-open(p, "w").write(new)
+for slug in ("vllm/dual", "vllm/qwen-27b-dual-max"):
+    old = re.sub(rf"^  {re.escape(slug)}:\n(?:^(?:    .*|\s*)\n)*?(?=^  \S|^#|^\S|\Z)",
+                 "", old, count=1, flags=re.M)
+open(p, "w").write(old)
 PY
 
 fail() { echo "FAIL: $1" >&2; exit 1; }
@@ -147,6 +150,125 @@ grep -q "WITHOUT a quality run" <<<"$out" || fail "--tps-only must WARN"
 if bash scripts/catalog-baseline.sh vllm/__nope__ "${ARGS[@]}" --dry-run >/dev/null 2>&1; then
   fail "unknown slug must refuse"
 fi
+
+# ── 5. bundle mode (slice 3): provenance FROM the bundle → submissions map ───
+# Synthetic volunteer bundle: the same gate artifacts + rig.txt +
+# container-config.json (a 2×5090 rig, one global power line, a pin that is
+# NOT this rig's resolved pin — so any local-fallback leak fails loudly).
+BSRC="$TMP/bundle-src/results/rebench/synth-fp8w"
+mkdir -p "$BSRC"
+cp "$TAGD"/verify-full.log "$TAGD"/bench.log "$TAGD"/_internal.json \
+   "$TAGD"/verify-stress.log "$BSRC"/
+cat > "$BSRC/rig.txt" <<'EOF'
+hostname: volunteer-box
+GPU 0: NVIDIA GeForce RTX 5090 (UUID: GPU-aaa)
+GPU 1: NVIDIA GeForce RTX 5090 (UUID: GPU-bbb)
+power_cap_w: 575.00
+EOF
+cat > "$BSRC/container-config.json" <<'EOF'
+[{"Config": {"Image": "vllm/test-pin:v9"}}]
+EOF
+tar czf "$TMP/bundle.tgz" -C "$TMP/bundle-src" results
+
+BARGS=(--from-bundle "$TMP/bundle.tgz" --source "https://example.test/disc#42"
+       --submitted-by volunteer1 --tps-only --baselines-file "$BL")
+
+# refusals: --source and --submitted-by are the trust boundary — REQUIRED
+if bash scripts/catalog-baseline.sh vllm/dual --from-bundle "$TMP/bundle.tgz" \
+     --submitted-by v --tps-only --baselines-file "$BL" --dry-run >/dev/null 2>&1; then
+  fail "bundle mode without --source must refuse"
+fi
+if bash scripts/catalog-baseline.sh vllm/dual --from-bundle "$TMP/bundle.tgz" \
+     --source x --tps-only --baselines-file "$BL" --dry-run >/dev/null 2>&1; then
+  fail "bundle mode without --submitted-by must refuse (no \$USER default)"
+fi
+
+# dry-run: every provenance field derived FROM the bundle, none from this rig
+sum_before="$(sha256sum "$BL" | cut -d' ' -f1)"
+out="$(bash scripts/catalog-baseline.sh vllm/dual "${BARGS[@]}" --dry-run 2>&1)"
+grep -q 'rig: "2x5090-pcie"' <<<"$out" || fail "rig not derived from rig.txt: $out"
+grep -q 'power_cap_w: \[575, 575\]' <<<"$out" || fail "one global cap line not replicated per card"
+grep -q 'engine_pin: "vllm/test-pin:v9"' <<<"$out" || fail "pin not read from container-config.json"
+grep -q 'tier: submitted' <<<"$out" || fail "tier: submitted missing"
+[[ "$(sha256sum "$BL" | cut -d' ' -f1)" == "$sum_before" ]] || fail "bundle dry-run WROTE the file"
+
+# write: the submissions map lands; the primary row is untouched
+out="$(bash scripts/catalog-baseline.sh vllm/dual "${BARGS[@]}" 2>&1)" || fail "bundle add failed"
+grep -q "added submissions map" <<<"$out" || fail "first bundle induction did not add the map"
+python3 - "$BL" <<'PY'
+import sys
+
+import yaml
+
+d = yaml.safe_load(open(sys.argv[1]))
+row = d["baselines"]["vllm/dual"]
+assert row["narr_tps"] == 153.9 and row["engine_pin"] == "test/pin:v2", \
+    "primary row disturbed by a bundle induction"
+s = row["submissions"]["2x5090-pcie"]
+assert s["narr_tps"] == 153.9 and s["tier"] == "submitted"
+assert s["source"] == "https://example.test/disc#42" and s["submitted_by"] == "volunteer1"
+assert s["power_cap_w"] == [575, 575] and s["engine_pin"] == "vllm/test-pin:v9"
+assert s["rig"] == "2x5090-pcie"
+PY
+
+# same rig_class re-induction REPLACES (one row per rig_class, newest wins)
+out="$(bash scripts/catalog-baseline.sh vllm/dual "${BARGS[@]}" 2>&1)" || fail "bundle replace failed"
+grep -q "replaced submission" <<<"$out" || fail "same-rig_class re-induction did not replace"
+python3 - "$BL" <<'PY'
+import sys
+
+import yaml
+
+d = yaml.safe_load(open(sys.argv[1]))
+assert len(d["baselines"]["vllm/dual"]["submissions"]) == 1
+PY
+
+# primary re-induction PRESERVES the submissions map (the block regex would
+# otherwise swallow it — the slice-3 splice-safety guard)
+out="$(bash scripts/catalog-baseline.sh vllm/dual "${ARGS[@]}" --tps-only 2>&1)" \
+  || fail "primary re-induction over a row with submissions failed"
+python3 - "$BL" <<'PY'
+import sys
+
+import yaml
+
+d = yaml.safe_load(open(sys.argv[1]))
+row = d["baselines"]["vllm/dual"]
+assert row.get("tier") == "local", "primary induction must stamp tier: local"
+assert row["submissions"]["2x5090-pcie"]["tier"] == "submitted", \
+    "primary re-induction dropped the submissions map"
+PY
+
+# submission-only entry: a slug measured on hardware we don't have
+out="$(bash scripts/catalog-baseline.sh vllm/qwen-27b-dual-max "${BARGS[@]}" 2>&1)" \
+  || fail "submission-only add failed"
+grep -q "submission-only" <<<"$out" || fail "did not create a submission-only entry"
+python3 - "$BL" <<'PY'
+import sys
+
+import yaml
+
+d = yaml.safe_load(open(sys.argv[1]))
+row = d["baselines"]["vllm/qwen-27b-dual-max"]
+assert "narr_tps" not in row, "submission-only entry must carry no primary fields"
+assert row["submissions"]["2x5090-pcie"]["tier"] == "submitted"
+txt = open(sys.argv[1]).read()
+assert txt.index("  vllm/qwen-27b-dual-max:") < txt.index("KNOWN GAPS"), \
+    "submission-only entry landed after the gap-list footer"
+PY
+
+# multi-tag bundle: refuse without --from-tag, select with it
+mkdir -p "$TMP/bundle-src/results/rebench/synth-second"
+cp "$BSRC"/* "$TMP/bundle-src/results/rebench/synth-second/"
+tar czf "$TMP/bundle2.tgz" -C "$TMP/bundle-src" results
+if bash scripts/catalog-baseline.sh vllm/dual --from-bundle "$TMP/bundle2.tgz" \
+     --source x --submitted-by v --tps-only --baselines-file "$BL" --dry-run >/dev/null 2>&1; then
+  fail "multi-tag bundle without --from-tag must refuse"
+fi
+out="$(bash scripts/catalog-baseline.sh vllm/dual --from-bundle "$TMP/bundle2.tgz" \
+     --from-tag synth-second --source x --submitted-by v --tps-only \
+     --baselines-file "$BL" --dry-run 2>&1)" || fail "multi-tag --from-tag selection failed"
+grep -q 'source_tag: "synth-second"' <<<"$out" || fail "--from-tag did not select the tag in the bundle"
 
 # real file untouched throughout (checksum across the run — git state may
 # legitimately be dirty in a working checkout)

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -1038,6 +1038,21 @@ class CatalogPane(Container):
                 yours += f"  [dim]· on {lm.quality_8pk_think_on}[/dim]"
             yours += f"  [dim]({lm.date} · this rig)[/dim]"
             lines.append(yours)
+        # Slice 3 — cross-rig submissions: rig-labeled, tier-badged, NEVER
+        # merged into the bar (a 5090 number is not this rig's bar). A
+        # submission-only entry shows bar "—" with only these lines.
+        for rc, s in sorted((b.get("submissions") or {}).items()):
+            n = s.get("narr_tps")
+            c = s.get("code_tps")
+            tps = (f"{n:.0f}" if n is not None else "—") + "/" + (
+                f"{c:.0f}" if c is not None else "—")
+            sub = (
+                f"  [bold]⑂ {rc}[/bold]  {tps} TPS"
+                f"  [dim]({s.get('tier')} · {s.get('date')} · {s.get('submitted_by')})[/dim]"
+            )
+            if s.get("stale") is True:
+                sub += "  [yellow]†[/yellow]"
+            lines.append(sub)
         note = (entry.status_note or "").strip()
         if note:
             lines.append(f"  [bold]caveat[/bold]  [yellow]{note}[/yellow]")

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -8206,8 +8206,18 @@ class CockpitApp(App):
     async def run_measure_vs_bar(self, screen: "MeasureVsBarScreen", tag: str) -> None:
         """Compute the measured-vs-bar comparison for a tag (READ) + push it to
         the modal.  No GPU / network / write — pure filesystem reads + the
-        benchmarks explorer."""
-        vsbar = await self._data.measure_vs_bar(tag, variants=self._variants or None)
+        benchmarks explorer.
+
+        Friction #9: when a ① Bring fit-check ran this session, its swap_path
+        sibling rides along as the CLASS-bar fallback — a NEW model has no
+        same-model bar by definition."""
+        byo = self._last_byo
+        class_hint = ""
+        if byo is not None and not getattr(byo, "error", ""):
+            class_hint = getattr(byo, "sibling_slug", "") or ""
+        vsbar = await self._data.measure_vs_bar(
+            tag, variants=self._variants or None, class_hint=class_hint
+        )
         try:
             screen.set_result(vsbar)
         except Exception:

--- a/tools/serve-cockpit/club3090_cockpit/data.py
+++ b/tools/serve-cockpit/club3090_cockpit/data.py
@@ -969,6 +969,11 @@ class MeasureVsBar:
     # was picked deterministically on model alone (surfaced as a caveat).
     run_engine: str = ""
     engine_resolved: bool = False       # True when run_engine drove bar selection
+    # Friction #9 (T2): the bar is the SIBLING-CLASS bar (①'s swap_path
+    # sibling) because no same-model bar exists — a NEW model's primary case.
+    # Labeled, never silent: the verdict reads class-relative.
+    bar_is_class: bool = False
+    class_model: str = ""
     # Per-metric measured−bar deltas (None when either side is missing).
     narr_tps_delta: Optional[float] = None
     code_tps_delta: Optional[float] = None

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -2936,7 +2936,11 @@ class CockpitData:
     # ── Validate / ④ Measure: producer-measured vs the curated catalog bar (READ) ─
 
     async def measure_vs_bar(
-        self, tag: str, *, variants: Optional[list[VariantRow]] = None
+        self,
+        tag: str,
+        *,
+        variants: Optional[list[VariantRow]] = None,
+        class_hint: str = "",
     ) -> MeasureVsBar:
         """Compare a rebench tag's MEASURED numbers against the curated catalog's
         published bar for the SAME class — "did this config earn catalog-grade?"
@@ -3030,6 +3034,35 @@ class CockpitData:
             model_rows.sort(key=lambda r: 0 if r.source == "corpus" else 1)
             bar = model_rows[0] if model_rows else None
 
+        # Friction #9 (T2): a NEW model has no same-model rows BY DEFINITION —
+        # the lane's primary case.  Fall back to the CLASS bar when the caller
+        # carries ①'s swap_path sibling (a registry slug or a model id).
+        # Labeled, never silent: bar_is_class rides the struct + a caveat.
+        bar_is_class = False
+        class_model = ""
+        if bar is None and measured.model and class_hint and rows:
+            class_model = class_hint
+            for v in variants or []:
+                if getattr(v, "slug", "") == class_hint:
+                    class_model = getattr(v, "model", "") or class_hint
+                    break
+            ckey = _canon_model_key(class_model)
+            crows = [r for r in rows if _bench_row_matches(r, class_model, "")]
+            if not crows and ckey:
+                crows = [r for r in rows if _canon_model_key(r.model) == ckey]
+            if run_engine:
+                eng_rows = [
+                    r for r in crows
+                    if _canon_engine_family(r.engine) == run_engine
+                ]
+                if eng_rows:
+                    crows = eng_rows
+                    engine_resolved = True
+            crows.sort(key=lambda r: 0 if r.source == "corpus" else 1)
+            if crows:
+                bar = crows[0]
+                bar_is_class = True
+
         vsbar = MeasureVsBar(
             tag=tag,
             measured=measured,
@@ -3037,6 +3070,8 @@ class CockpitData:
             bar_source=(bar.source if bar else ""),
             run_engine=run_engine,
             engine_resolved=engine_resolved,
+            bar_is_class=bar_is_class,
+            class_model=class_model if bar_is_class else "",
         )
         if bar is not None:
             # Fix 2 (corpus metric mismatch): a corpus bar's narr_tps is WALL TPS
@@ -3103,9 +3138,19 @@ class CockpitData:
                 )
             else:
                 caveats.append(
-                    f"No curated catalog bar found for model '{vsbar.measured.model}'."
+                    f"No curated catalog bar found for model '{vsbar.measured.model}' "
+                    "— and no sibling class to fall back to. A ① Bring fit-check "
+                    "computes the sibling (swap_path) that enables the class-bar "
+                    "comparison for a NEW model."
                 )
             return caveats
+        # Friction #9: the CLASS bar is a labeled fallback, never a silent swap.
+        if vsbar.bar_is_class:
+            caveats.append(
+                f"CLASS bar: no published bar exists for '{vsbar.measured.model}' — "
+                f"compared against its sibling class '{vsbar.class_model}' "
+                "(①'s swap_path). Read deltas as class-relative, not same-model."
+            )
         # We have a bar — surface WHICH bar was used (engine + topology) so the
         # comparison is legible, then flag every protocol dimension we can't
         # confirm.

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -820,6 +820,11 @@ class CockpitData:
             b = getattr(e.row, "baseline", None)
             if not b:
                 continue
+            # Slice 3: a submission-only entry (cross-rig rows, no primary
+            # local row) is NOT the bar — the TPS column stays "—" and the
+            # cross-rig rows surface rig-labeled in the detail panel only.
+            if b.get("narr_tps") is None and b.get("code_tps") is None:
+                continue
             e.measurement = Measurement(
                 narr_tps=b.get("narr_tps"),
                 code_tps=b.get("code_tps"),

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -3123,6 +3123,39 @@ class TestMeasureVsBarData:
             assert "could not resolve" in joined or "no curated catalog bar" in joined
 
     @pytest.mark.asyncio
+    async def test_measure_vs_bar_class_fallback_for_new_model(self, tmp_path):
+        """Friction #9 (T2): a NEW model has no same-model bar BY DEFINITION —
+        with ①'s swap_path sibling as class_hint the comparison falls back to
+        the labeled CLASS bar (engine-matched, bar_is_class + caveat); without
+        a hint the no-bar caveat says how to get one (run ① fit-check)."""
+        app, _, _ = make_app(repo_root=tmp_path, surface="producer")
+        d = tmp_path / "results" / "rebench" / "new-model-tag"
+        d.mkdir(parents=True)
+        (d / "REPORT.md").write_text(
+            MEASURE_REPORT_MD.replace("`qwen3.6-27b`", "`brandnew-40b`")
+        )
+        (d / "_internal.json").write_text(MEASURE_INTERNAL_JSON)
+        (tmp_path / "BENCHMARKS.md").write_text(BENCHMARKS_MD)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            # No hint → honest no-bar + the actionable pointer to ① fit-check.
+            vsbar = await app._data.measure_vs_bar("new-model-tag")
+            assert vsbar.bar is None
+            assert vsbar.bar_is_class is False
+            joined = " ".join(vsbar.protocol_caveats).lower()
+            assert "sibling class" in joined and "fit-check" in joined
+            # With the sibling hint → the labeled CLASS bar, engine-matched.
+            vsbar = await app._data.measure_vs_bar(
+                "new-model-tag", class_hint="qwen3.6-27b"
+            )
+            assert vsbar.bar is not None
+            assert vsbar.bar_is_class is True
+            assert vsbar.class_model == "qwen3.6-27b"
+            assert vsbar.bar.model == "qwen3.6-27b"
+            assert vsbar.bar.engine == "vllm"  # engine-matched within the class
+            assert any("CLASS bar" in c for c in vsbar.protocol_caveats)
+
+    @pytest.mark.asyncio
     async def test_measure_vs_bar_missing_tag_dir_errors(self, tmp_path):
         app, _, _ = make_app(repo_root=tmp_path, surface="producer")
         (tmp_path / "BENCHMARKS.md").write_text(BENCHMARKS_MD)

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -520,6 +520,48 @@ class TestLoadCatalog:
         assert ik.measurement.stale is True
 
     @pytest.mark.asyncio
+    async def test_submission_only_baseline_is_not_the_bar(self):
+        """Slice 3 — cross-rig submissions: a submission-only baseline (no
+        primary local row) must NOT become the slug's bar — the TPS column
+        stays "—"; the rows surface rig-labeled in the detail panel only.  A
+        primary row WITH submissions keeps its bar untouched."""
+        import copy
+
+        emit = json.loads(REGISTRY_JSON)
+        # vllm/dual: primary row + a cross-rig submission riding along
+        emit["variants"][0]["baseline"]["submissions"] = {
+            "2x5090-pcie": {
+                "narr_tps": 134.5, "code_tps": 165.1, "date": "2026-07-05",
+                "engine_pin": "vllm/vllm-openai:v0.24.0", "rig": "2x5090-pcie",
+                "power_cap_w": [575, 575], "tier": "submitted",
+                "source": "https://example.test/disc#42",
+                "submitted_by": "guybrush01", "stale": False,
+            }
+        }
+        # ik slug: submission-only (no primary fields at all)
+        sub_only = copy.deepcopy(emit["variants"][1])
+        emit["variants"][1]["baseline"] = {
+            "stale": None, "current_pin": "ghcr.io/ik-new@sha256:bbb",
+            "submissions": emit["variants"][0]["baseline"]["submissions"],
+        }
+        del sub_only  # (structure reuse above is enough)
+        cd = CockpitData(ROOT, runner=full_runner(**{
+            "registry-emit.sh --json": ok(json.dumps(emit)),
+        }))
+        entries, _ = await cd.load_catalog(enrich_fit=False, enrich_measurement=True)
+        vllm = next(e for e in entries if e.slug == "vllm/dual")
+        # primary bar unchanged by the riding submission
+        assert vllm.measurement.source == "baseline"
+        assert vllm.measurement.tps_label == "174/42"
+        ik = next(e for e in entries if e.slug == "ik-llama/iq4ks-mtp")
+        # submission-only: NOT enriched as the bar
+        assert ik.measurement.source == ""
+        assert ik.measurement.tps_label == "—"
+        # ...but the submissions ride the row for the detail panel
+        subs = (getattr(ik.row, "baseline", None) or {}).get("submissions") or {}
+        assert subs["2x5090-pcie"]["tier"] == "submitted"
+
+    @pytest.mark.asyncio
     async def test_local_measurements_overlay(self, tmp_path):
         """Slice 2b — the per-rig corpus overlay: newest record per slug wins
         (by _recorded_at), malformed lines are skipped, and the overlay joins


### PR DESCRIPTION
## What

The slice-3 **trust-boundary layer** for catalog baselines: cross-rig volunteer numbers can now land in `baselines.yml` without masquerading as this rig's bar.

### 3a — schema (`slug × rig_class` + tier)
- Every primary row gains `tier: local` (16 rows migrated); optional `submissions:` map keyed by rig_class (e.g. `2x5090-pcie`) with required `source:` + `tier: submitted|reproduced`. Submission-only entries are legal (hardware we don't have).
- `test-baselines`: shared validator across both row shapes, rig_class format + rig-field parity, tier enums.
- `registry-emit` join: submissions ride through with **per-submission staleness** (pin comparison is rig-independent).
- c3: a submission-only baseline is **not** the bar (TPS column stays —); detail panel renders `⑂ <rig_class>` lines, tier-badged, never merged into the local bar.

### 3b — `catalog-baseline.sh --from-bundle <tgz|dir>`
- Provenance **from the bundle**: rig/power ← `rig.txt`, engine pin ← `container-config.json` `Config.Image` — never from this rig (no nvidia-smi / resolve_variant_pin fallback in bundle mode).
- `--source` + `--submitted-by` required (no `$USER` default) — the trust boundary.
- Splice safety both directions: primary re-induction preserves an existing submissions map; bundle mode never touches the primary row. One row per rig_class, newest replaces.
- Multi-tag bundles refuse without `--from-tag` selection.

### Dogfood — first external row
guybrush01's #571 fp8w bundle ingested by the tool itself: `vllm/qwen-27b-dual-max → submissions[2x5090-pcie]` = **134.52/165.11 decode, NIAH-clean 240,635 tok, v0.24.0 (pin-fresh), tier: submitted** — TPS-only pending his quality run (the row upgrades in place when it arrives).

## Validation
- Full serial gate green (`scripts/tests/*.sh`, includes the new synthetic-bundle fixture: refusals · bundle-derived provenance · add/replace · submission-only · splice preservation · multi-tag)
- c3 suite **767/767** (new slice-3 test: submission-only ≠ bar; primary bar untouched by riding submissions)
- Real ingest exercised twice (dry-run + write) against guybrush's actual bundle

## Not in this PR (by scope)
3c intake automation (issue template + validating Action) + 3d reviewer/docs/dedup docs — after this hand-run path proves out, per the dogfood-before-automation rule. 3e quality-corpus ingest (will carry sandbox-image digest provenance per the T2 friction-log §2.1.4 note) + 3f redaction deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm

---

## Folded in (maintainer go, 2026-07-05): the two T2 friction-log gaps

### ④ sibling-class bar fallback (friction #9)
`measure_vs_bar` no longer dead-ends on a NEW model ("No curated catalog bar found") — the lane's primary case. It accepts `class_hint` (①'s swap_path sibling, wired from the session's fit-check) and falls back to the **labeled CLASS bar**: `bar_is_class` + `class_model` ride the struct, a caveat marks deltas class-relative, engine-matching still applies. No hint → the caveat points at ① fit-check instead of a dead end.

### quality_env harness provenance (friction #8, design §2.1.4)
`catalog-baseline.sh` stamps `quality_env: { harness: "benchlocal-cli X.Y.Z" }` (from the results JSON's `runner_version`) next to any quality number it inducts — the half-deployed-sandbox lesson. `sandbox_digest` rides along once benchlocal emits it. Arms on different harness versions → loud warn + field omitted. Guard validates the shape.

**Validation after folds:** full serial shell gate green · c3 768/768 (new class-fallback headless test + slice-3 tests).
