### PR TITLE
① Bring: staged artifact-first funnel — inspect → quant pick → filtered slugs → fit → download → handoff

### DIFF
--- a/scripts/lib/profiles/deriver.py
+++ b/scripts/lib/profiles/deriver.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import re
 import struct
 import sys
 import urllib.error
@@ -512,6 +513,124 @@ def sized_download_gb(api: dict) -> float:
 
 
 # ---------------------------------------------------------------------------
+# Bring-funnel stage-1 INSPECT — artifact inventory (design §2 / §2b)
+# ---------------------------------------------------------------------------
+# GGUF quant token in a basename (Q4_K_M / IQ4_XS / UD-Q5_K_XL / Q8_0 / TQ1_0 /
+# BF16 / F16), tolerant of multi-part suffixes which are stripped first.
+_GGUF_PART_RE = re.compile(r"-(\d{5})-of-(\d{5})$", re.I)
+_GGUF_QUANT_RE = re.compile(
+    r"(?:^|[-_.])((?:UD-)?(?:I?Q\d|TQ\d|BF16|F16|F32)[A-Z0-9_]*)$", re.I
+)
+
+
+def _blob_sizes(api: dict) -> dict[str, int]:
+    by_name: dict[str, int] = {}
+    for s in _siblings(api or {}):
+        size = s.get("size")
+        if size is None and isinstance(s.get("lfs"), dict):
+            size = s["lfs"].get("size")
+        if size is not None:
+            by_name[s["rfilename"]] = int(size)
+    return by_name
+
+
+def artifact_inventory(api: dict) -> dict:
+    """What servable artifacts does this repo carry? — WITHOUT gating on
+    format.  A GGUF-only repo is a first-class bring here (design §2b-1/2:
+    the staged Bring UI reveals nothing template-side until this says the
+    repo is supported, and presents ALL discovered GGUF variants for the
+    user to pick BEFORE any engine/slug appears).  `select_weight_files`
+    stays the vLLM/safetensors gate — this never replaces it.
+
+    Returns (all sizes GiB, from the ?blobs=true siblings):
+      formats          ["safetensors", "gguf"] — whichever are present
+      safetensors      {weight_files, size_gb} | None (top-level, non-adapter)
+      gguf_variants    [{quant, size_gb, parts, files}] sorted by size —
+                       multi-part files grouped under one quant token; a file
+                       with no parseable token keys by its stem (never dropped)
+      gguf_mmproj      vision-projector *.gguf names (NOT variants)
+      lineage_base_model  cardData.base_model when the API carries it
+                          (friction #11 — ⑤'s taxonomy default + credits)"""
+    sizes = _blob_sizes(api)
+    names = [s["rfilename"] for s in _siblings(api or {})]
+
+    safet = [
+        n for n in names
+        if n.endswith(".safetensors") and "/" not in n and not _is_adapter(n)
+    ]
+    st = None
+    if safet:
+        st = {
+            "weight_files": sorted(safet),
+            "size_gb": round(sum(sizes.get(n, 0) for n in safet) / (1024 ** 3), 4),
+        }
+
+    # GGUF: any depth (quant subdirs are common), mmproj split out.
+    variants: dict[str, dict] = {}
+    mmproj: list[str] = []
+    for n in names:
+        if not n.lower().endswith(".gguf"):
+            continue
+        base = n.rsplit("/", 1)[-1][: -len(".gguf")]
+        if base.lower().startswith("mmproj"):
+            mmproj.append(n)
+            continue
+        stem = _GGUF_PART_RE.sub("", base)
+        m = _GGUF_QUANT_RE.search(stem)
+        key = m.group(1).upper() if m else stem
+        v = variants.setdefault(key, {"quant": key, "size_gb": 0.0, "parts": 0, "files": []})
+        v["size_gb"] += sizes.get(n, 0) / (1024 ** 3)
+        v["parts"] += 1
+        v["files"].append(n)
+    gguf_variants = sorted(
+        ({**v, "size_gb": round(v["size_gb"], 4), "files": sorted(v["files"])}
+         for v in variants.values()),
+        key=lambda v: (v["size_gb"], v["quant"]),
+    )
+
+    formats = []
+    if st:
+        formats.append("safetensors")
+    if gguf_variants or mmproj:
+        formats.append("gguf")
+
+    card = api.get("cardData") if isinstance(api, dict) else None
+    base_model = (card or {}).get("base_model") if isinstance(card, dict) else None
+
+    return {
+        "formats": formats,
+        "safetensors": st,
+        "gguf_variants": gguf_variants,
+        "gguf_mmproj": sorted(mmproj),
+        "lineage_base_model": base_model,
+    }
+
+
+def inspect_repo(
+    slug: str,
+    *,
+    hf_token: Optional[str] = None,
+    fetcher: Optional[HttpFetcher] = None,
+) -> dict:
+    """Stage-1 INSPECT entry: fetch the model API + return the inventory.
+    Structured errors, never a traceback (same discipline as derive())."""
+    if fetcher is None:
+        fetcher = HttpFetcher()
+    hf_token = hf_token or os.environ.get("HF_TOKEN") or None
+    try:
+        api, err = _fetch_model_api(slug, fetcher, hf_token)
+    except NetworkError as exc:
+        return {"repo": slug, "error": f"network error: {exc}"}
+    if err is not None:
+        return {"repo": slug, "error": str(err)}
+    inv = artifact_inventory(api or {})
+    inv["repo"] = slug
+    if not inv["formats"]:
+        inv["error"] = "no servable artifacts (no safetensors weight set, no *.gguf)"
+    return inv
+
+
+# ---------------------------------------------------------------------------
 # Bounded safetensors-header probe (pre-download, range-bounded)
 # ---------------------------------------------------------------------------
 def probe_safetensors_dtype(
@@ -873,3 +992,42 @@ def derive(
         res.confidence = Confidence.NOT_ELIGIBLE  # P4 wires stratum-5 abort
 
     return res
+
+
+# ---------------------------------------------------------------------------
+# CLI — stage-1 INSPECT for the Bring funnel (c3 subprocess + standalone use)
+#   python3 scripts/lib/profiles/deriver.py --inventory <org/Model> [--json]
+# ---------------------------------------------------------------------------
+def _cli(argv: list[str]) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(
+        prog="deriver", description="Bring-funnel stage-1 INSPECT (artifact inventory)"
+    )
+    ap.add_argument("repo", help="HF repo slug, e.g. org/Model")
+    ap.add_argument("--inventory", action="store_true", required=True,
+                    help="emit the artifact inventory (the only CLI mode)")
+    ap.add_argument("--json", action="store_true", help="JSON output (default: pretty)")
+    ns = ap.parse_args(argv)
+    inv = inspect_repo(ns.repo)
+    if ns.json:
+        print(json.dumps(inv))
+    else:
+        if inv.get("error"):
+            print(f"error: {inv['error']}")
+        else:
+            print(f"repo: {inv['repo']}  formats: {', '.join(inv['formats'])}")
+            if inv.get("safetensors"):
+                st = inv["safetensors"]
+                print(f"  safetensors: {len(st['weight_files'])} file(s), {st['size_gb']:.1f} GiB")
+            for v in inv.get("gguf_variants") or []:
+                print(f"  gguf {v['quant']}: {v['size_gb']:.1f} GiB ({v['parts']} file(s))")
+            for m in inv.get("gguf_mmproj") or []:
+                print(f"  mmproj: {m}")
+            if inv.get("lineage_base_model"):
+                print(f"  base_model: {inv['lineage_base_model']}")
+    return 1 if inv.get("error") else 0
+
+
+if __name__ == "__main__":  # pragma: no cover - thin CLI shim
+    raise SystemExit(_cli(sys.argv[1:]))

--- a/scripts/tests/test-artifact-inventory.sh
+++ b/scripts/tests/test-artifact-inventory.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# test-artifact-inventory — the deriver's stage-1 INSPECT for the Bring funnel
+# (bring-funnel design §2/§2b: artifact_inventory + inspect_repo).
+#
+# Offline: fixture API dicts only — NO network, NO weights. Guards the funnel's
+# trust surface: a GGUF-only repo must be a first-class bring (not
+# unsupported-format), variants must group multi-part files, mmproj must never
+# masquerade as a servable variant, and lineage must ride along.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+python3 - <<'PY'
+import sys
+
+sys.path.insert(0, ".")
+from scripts.lib.profiles.deriver import artifact_inventory  # noqa: E402
+
+GB = 1024 ** 3
+
+
+def api(siblings, card=None):
+    d = {"siblings": [{"rfilename": n, "size": s} for n, s in siblings]}
+    if card:
+        d["cardData"] = card
+    return d
+
+
+# ── 1. GGUF-only repo: first-class, grouped, sorted by size ─────────────────
+inv = artifact_inventory(api([
+    ("Qwen-27B-Q4_K_M.gguf", 17 * GB),
+    ("Qwen-27B-Q8_0-00001-of-00002.gguf", 15 * GB),
+    ("Qwen-27B-Q8_0-00002-of-00002.gguf", 14 * GB),
+    ("UD-Q5_K_XL/Qwen-27B-UD-Q5_K_XL.gguf", 20 * GB),   # subdir layout
+    ("mmproj-F16.gguf", 1 * GB),
+    ("README.md", 100),
+], card={"base_model": "Qwen/Qwen3.6-27B"}))
+assert inv["formats"] == ["gguf"], inv["formats"]
+assert inv["safetensors"] is None
+quants = [v["quant"] for v in inv["gguf_variants"]]
+assert quants == ["Q4_K_M", "UD-Q5_K_XL", "Q8_0"], quants   # size-sorted
+q8 = inv["gguf_variants"][2]
+assert q8["parts"] == 2 and abs(q8["size_gb"] - 29.0) < 0.01, q8
+assert inv["gguf_mmproj"] == ["mmproj-F16.gguf"]            # NOT a variant
+assert inv["lineage_base_model"] == "Qwen/Qwen3.6-27B"
+print("  ✓ gguf-only: grouped, multi-part summed, mmproj split, lineage rides")
+
+# ── 2. safetensors-only repo (adapters excluded) ─────────────────────────────
+inv = artifact_inventory(api([
+    ("model-00001-of-00002.safetensors", 15 * GB),
+    ("model-00002-of-00002.safetensors", 14 * GB),
+    ("adapter_model.safetensors", 1 * GB),               # adapter — excluded
+    ("model.safetensors.index.json", 90_000),
+    ("config.json", 900),
+]))
+assert inv["formats"] == ["safetensors"], inv["formats"]
+assert len(inv["safetensors"]["weight_files"]) == 2
+assert abs(inv["safetensors"]["size_gb"] - 29.0) < 0.01
+assert inv["gguf_variants"] == []
+print("  ✓ safetensors-only: adapter excluded, sharded set sized")
+
+# ── 3. both formats in one repo ──────────────────────────────────────────────
+inv = artifact_inventory(api([
+    ("model.safetensors", 30 * GB),
+    ("model-Q4_K_M.gguf", 17 * GB),
+]))
+assert inv["formats"] == ["safetensors", "gguf"], inv["formats"]
+print("  ✓ mixed repo carries both formats")
+
+# ── 4. empty / unservable repo ───────────────────────────────────────────────
+inv = artifact_inventory(api([("README.md", 100)]))
+assert inv["formats"] == [] and inv["safetensors"] is None and inv["gguf_variants"] == []
+print("  ✓ unservable repo → empty formats (inspect_repo maps this to error)")
+
+# ── 5. tokenless gguf never dropped (keys by stem) ───────────────────────────
+inv = artifact_inventory(api([("weird-model.gguf", 5 * GB)]))
+assert len(inv["gguf_variants"]) == 1 and inv["gguf_variants"][0]["quant"] == "weird-model"
+print("  ✓ unparseable quant token keys by stem (never silently dropped)")
+PY
+
+# CLI shim: --inventory is required; bad usage exits 2 without network
+if python3 scripts/lib/profiles/deriver.py some/repo >/dev/null 2>&1; then
+  echo "FAIL: CLI without --inventory must refuse" >&2; exit 1
+fi
+echo "  ✓ CLI refuses without --inventory (no accidental network mode)"
+
+echo "test-artifact-inventory: ok"

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -78,6 +78,7 @@ from club3090_tui_core.widgets.live_pane import LivePane
 
 from .data import (
     ActionPlan,
+    ArtifactInventory,
     BenchRow,
     ByoResult,
     CatalogEntry,
@@ -106,6 +107,7 @@ from .data import (
     downgrade_fit_glyph,
     measurement_from_explain_columns,
     parse_ctx_label,
+    variant_quant,
 )
 from .services import CockpitData
 
@@ -222,6 +224,87 @@ def profile_select_options(
     pairs = [(o.label, o.slug) for o in options]
     pairs.append(("✎ custom slug…", PROFILE_CUSTOM_SENTINEL))
     return pairs
+
+
+# ── Bring funnel (design §2b, maintainer UX decisions 2026-07-05) ─────────────
+# §2b-3 — artifact→engine compat is ABSOLUTE: a GGUF pick never sees a vLLM
+# slug; a safetensors repo never sees the llama.cpp family.  Tokens are the
+# _canon_engine_family space (which collapses ik-llama + llamacpp to ONE
+# "llama-cpp" family — both are GGUF engines, so the filter doesn't care;
+# the display label uses the precise switch_engine / slug prefix instead).
+_GGUF_ENGINE_FAMILIES = frozenset({"llama-cpp", "beellama"})
+_SAFETENSORS_ENGINE_FAMILIES = frozenset({"vllm", "sglang"})
+_TOPO_CARDS = {"single": 1, "dual": 2, "multi3": 3, "multi4": 4, "multi8": 8}
+# The weights may claim at most this fraction of a topology's TOTAL VRAM in
+# the DISPLAY filter — KV + runtime overhead need the rest.  Deliberately
+# generous: the funnel only HIDES what clearly cannot fit; borderline stays
+# visible and the real fit-check adjudicates.
+_FUNNEL_WEIGHTS_VRAM_FRAC = 0.90
+
+
+def funnel_slug_options(
+    variants: list["VariantRow"],
+    artifact_format: str,
+    *,
+    artifact_gb: Optional[float] = None,
+    vram_gb: Optional[float] = None,
+    gpu_count: Optional[int] = None,
+) -> list["ProfileOption"]:
+    """§2b-4/5 — the staged Bring funnel's slug options: EVERY catalog variant
+    that passes the artifact→engine compat filter (the filter already shrinks
+    the list, so no representative-collapsing here — distinct from
+    :func:`profile_templates`, which stays the pre-inspect short list), labeled
+    topology-FIRST (``topology/engine/model-quant · serving``) and sorted so
+    all models under the same topology/engine appear together.
+
+    Topology floor (maintainer rule, 2026-07-05): when the selected artifact's
+    size is known, HIDE topologies whose total VRAM can't hold the weights
+    (``artifact_gb > cards × vram_gb × 0.90``) — a 34G Q8 never shows single-
+    card slugs on a 24G card.  One-directional by design: larger topologies
+    are NEVER hidden (running a small quant across more GPUs for KV/concurrency
+    is legitimate).  Topologies needing more cards than the rig has are hidden
+    too.  Unknown sizes/rig → no floor (never guess-hide)."""
+    fams = (
+        _GGUF_ENGINE_FAMILIES if artifact_format == "gguf"
+        else _SAFETENSORS_ENGINE_FAMILIES
+    )
+    out: list[ProfileOption] = []
+    seen: set[str] = set()
+    for row in variants:
+        slug = (getattr(row, "slug", "") or "").strip()
+        if not slug or slug in seen:
+            continue
+        family = _canon_engine_family(getattr(row, "engine", "") or "")
+        if family not in fams:
+            continue
+        topo = _variant_topology(row) or ""
+        cards = _TOPO_CARDS.get(topo)
+        if cards is not None:
+            if gpu_count is not None and cards > gpu_count:
+                continue  # the rig can't host this topology at all
+            if (
+                artifact_gb is not None
+                and vram_gb is not None
+                and artifact_gb > cards * vram_gb * _FUNNEL_WEIGHTS_VRAM_FRAC
+            ):
+                continue  # weights alone exceed the topology's VRAM — floor
+        seen.add(slug)
+        model = (getattr(row, "model", "") or "").strip() or "—"
+        quant = variant_quant(row) or ""
+        stem = ((getattr(row, "file", "") or "").rsplit(".", 1)[0]) or ""
+        # Display engine = the PRECISE token (switch_engine, else the slug's
+        # own prefix) — the canon family is filter-only (it can't tell
+        # ik-llama from llamacpp, which the label must).
+        eng = (
+            (getattr(row, "switch_engine", "") or "").strip()
+            or slug.split("/", 1)[0]
+        )
+        tail = f"{model}-{quant}" if quant else model
+        label = f"{topo or '—'}/{eng}/{tail}" + (f"  ·  {stem}" if stem else "")
+        status = (getattr(row, "status", "") or "").strip().lower()
+        out.append(ProfileOption(label=label, slug=slug, topology=topo or "—", status=status))
+    out.sort(key=lambda o: (_TOPO_ORDER.get(o.topology, 99), o.label))
+    return out
 
 
 def _curated_default_map(
@@ -4297,15 +4380,21 @@ class UntestedComposePreviewScreen(ModalScreen):
 
 
 class LaneBringPane(Container):
-    """① Bring — the producer lane's fit-check entry, and (since the 2-mode merge)
-    the SINGLE bring-an-arbitrary-repo entry point in the app.
+    """① Bring — the producer lane's STAGED artifact-first funnel (design §2b,
+    maintainer UX 2026-07-05), and (since the 2-mode merge) the SINGLE
+    bring-an-arbitrary-repo entry point in the app.
 
-    REUSES ``byo_check`` (pull.sh --dry-run --json → ByoResult: supported? fits?
-    the swap_path route) as the lane's first stage: paste an HF repo / slug,
-    Fit-check, read the route + sibling_slug + quant_match.  (The standalone
-    Run · Bring-your-own tab + its ByoPane were removed in the merge — this pane's
-    widget IDs are the only fit-check widgets now.)  The cached ``_last_byo`` it
-    produces feeds ② Serve and ⑤ Promote."""
+    Staged reveal — nothing template-side shows until the artifact is known:
+      1. repo input + [Inspect] → deriver artifact inventory (READ; a
+         GGUF-only repo is a first-class bring, never unsupported-format);
+      2. GGUF discovered → ALL quant variants presented for the pick FIRST;
+      3. only then the slug Select appears — every catalog option passing the
+         artifact→engine compat filter (GGUF never sees vLLM; safetensors
+         never sees the llama.cpp family), labeled topology-first
+         (``topology/engine/model-quant · serving``), topology-floored by the
+         picked artifact's size vs the rig's VRAM;
+      4. Fit-check (the existing ``byo_check``) → ② Serve / ⑤ Promote arm.
+    The cached ``_last_byo`` it produces feeds ② Serve and ⑤ Promote."""
 
     DEFAULT_CSS = """
     LaneBringPane {
@@ -4320,11 +4409,22 @@ class LaneBringPane(Container):
         height: 3;
         margin-bottom: 1;
     }
+    LaneBringPane #lane-bring-stage2-row {
+        height: 3;
+        margin-bottom: 1;
+    }
     LaneBringPane #lane-bring-url-input {
         width: 1fr;
     }
+    LaneBringPane #lane-bring-inspect-btn {
+        width: 13;
+        margin-left: 1;
+    }
+    LaneBringPane #lane-bring-gguf-select {
+        width: 36;
+    }
     LaneBringPane #lane-bring-profile-input {
-        width: 40;
+        width: 1fr;
         margin-left: 1;
     }
     LaneBringPane #lane-bring-profile-custom {
@@ -4332,6 +4432,9 @@ class LaneBringPane(Container):
         margin-left: 1;
     }
     LaneBringPane .profile-custom-hidden {
+        display: none;
+    }
+    LaneBringPane .funnel-hidden {
         display: none;
     }
     LaneBringPane #lane-bring-fit-btn {
@@ -4344,6 +4447,11 @@ class LaneBringPane(Container):
         margin-top: 1;
         height: auto;
     }
+    LaneBringPane #lane-bring-weights-line {
+        padding: 0 2;
+        margin-top: 1;
+        height: auto;
+    }
     LaneBringPane #lane-bring-hint {
         color: $text-muted;
         margin-top: 1;
@@ -4351,19 +4459,33 @@ class LaneBringPane(Container):
     """
 
     def compose(self) -> ComposeResult:
-        yield Label("① Bring — fit-check an HF model", id="lane-bring-heading")
+        yield Label("① Bring — inspect an HF model", id="lane-bring-heading")
         with Horizontal(id="lane-bring-input-row"):
             yield Input(
                 placeholder="org/Model  (e.g. unsloth/Qwen3-27B-abliterated-GGUF)",
                 id="lane-bring-url-input",
             )
-            # #6/A12 — same registry-derived (engine, topology) template Select as
-            # Run · BYO (populated by set_profile_options after the catalog loads).
+            yield Button("Inspect", id="lane-bring-inspect-btn", variant="primary")
+        # Stage 2/3 — HIDDEN until Inspect identifies a supported artifact
+        # (§2b-1: no engine/topology/template before the artifact is known).
+        with Horizontal(id="lane-bring-stage2-row", classes="funnel-hidden"):
+            # §2b-2 — the GGUF quant pick comes BEFORE any slug appears.
+            yield Select(
+                [],
+                prompt="— pick a GGUF quant —",
+                allow_blank=True,
+                id="lane-bring-gguf-select",
+                classes="funnel-hidden",
+            )
+            # §2b-4/5 — the artifact-filtered, topology-first catalog options
+            # (repopulated per inventory/pick by the app; the pre-inspect
+            # template fill is harmless — the row is hidden).
             yield Select(
                 [("vllm/dual  ·  loading templates…", "vllm/dual")],
                 value="vllm/dual",
                 allow_blank=False,
                 id="lane-bring-profile-input",
+                classes="funnel-hidden",
             )
             # FIX 2 (escape hatch) — companion free-text override, hidden until the
             # "✎ custom slug…" sentinel is chosen (same idiom as Run · BYO).
@@ -4372,14 +4494,23 @@ class LaneBringPane(Container):
                 id="lane-bring-profile-custom",
                 classes="profile-custom-hidden",
             )
-            yield Button("Fit-check", id="lane-bring-fit-btn", variant="primary")
+            yield Button(
+                "Fit-check",
+                id="lane-bring-fit-btn",
+                variant="primary",
+                classes="funnel-hidden",
+            )
         yield Static(
-            "[dim]Stage ① of the Bring & Validate pipeline.  Enter an HF repo + a\n"
-            "profile-like slug, then Fit-check — pull.sh --dry-run (Path B, never\n"
-            "downloads).  A successful fit-check unlocks ② Serve (generate + serve\n"
-            "the untested compose) and ⑤ Promote.[/dim]",
+            "[dim]Stage ① of the Bring & Validate pipeline.  Enter an HF repo and\n"
+            "Inspect — the deriver enumerates its artifacts (safetensors / GGUF\n"
+            "quants) from HF metadata, never downloading a weight.  The matching\n"
+            "engine/topology slugs appear once the artifact is known; a successful\n"
+            "Fit-check then unlocks ② Serve and ⑤ Promote.[/dim]",
             id="lane-bring-result-card",
         )
+        # §2b-6/7 — the weights state + download/handoff affordance line
+        # (hidden until a fit-check succeeds).
+        yield Static("", id="lane-bring-weights-line", classes="funnel-hidden")
         yield Label(
             "[dim]Routes:  A = new curated profile   ·   B = serve-locally   ·   "
             "C = reuse a sibling compose + swap weights\n"
@@ -4393,6 +4524,12 @@ class LaneBringPane(Container):
             f"[dim]Checking[/dim] [cyan]{repo}[/cyan] [dim](pull.sh --dry-run --json)…[/dim]"
         )
 
+    def set_inspecting(self, repo: str) -> None:
+        self.query_one("#lane-bring-result-card", Static).update(
+            f"[dim]Inspecting[/dim] [cyan]{repo}[/cyan] "
+            "[dim](deriver --inventory — HF metadata only, no download)…[/dim]"
+        )
+
     def set_profile_options(
         self, options: list[tuple[str, str]], default: Optional[str]
     ) -> None:
@@ -4401,6 +4538,76 @@ class LaneBringPane(Container):
         _set_select_options(
             self.query_one("#lane-bring-profile-input", Select), options, default
         )
+
+    def show_inventory(self, inv: "ArtifactInventory") -> None:
+        """Stage-1 verdict: render the inventory + reveal the matching stage-2
+        widgets.  GGUF → the quant Select (slugs stay hidden until the pick);
+        safetensors → straight to the slug stage (the app repopulates it)."""
+        card = self.query_one("#lane-bring-result-card", Static)
+        row = self.query_one("#lane-bring-stage2-row", Horizontal)
+        gsel = self.query_one("#lane-bring-gguf-select", Select)
+        if inv.error:
+            card.update(f"[red]Inspect failed:[/red] {inv.error}")
+            row.add_class("funnel-hidden")
+            return
+        lines = [f"  [bold]{inv.repo}[/bold]   formats: [cyan]{', '.join(inv.formats) or '—'}[/cyan]"]
+        if inv.has_safetensors:
+            lines.append(
+                f"  [bold]safetensors[/bold]  {inv.safetensors_files} file(s), "
+                f"{inv.safetensors_size_gb:.1f} GiB"
+            )
+        if inv.has_gguf:
+            lines.append(
+                f"  [bold]gguf[/bold]  {len(inv.gguf_variants)} quant(s) discovered — "
+                "pick one below to see the matching slugs"
+            )
+        if inv.gguf_mmproj:
+            lines.append(f"  [dim]mmproj (vision projector): {', '.join(inv.gguf_mmproj)}[/dim]")
+        if inv.lineage_base_model:
+            lines.append(f"  [dim]base_model: {inv.lineage_base_model}[/dim]")
+        card.update("\n".join(lines))
+        row.remove_class("funnel-hidden")
+        if inv.has_gguf:
+            opts = [
+                (f"{v.quant}  ·  {v.size_gb:.1f} GiB" + (f" ({v.parts} parts)" if v.parts > 1 else ""), v.quant)
+                for v in inv.gguf_variants
+            ]
+            # Start BLANK — the pick is the USER's stage-2 decision (§2b-2);
+            # pre-selecting would fire the slug reveal without a genuine pick.
+            try:
+                with gsel.prevent(Select.Changed):
+                    gsel.set_options(opts)
+                    gsel.value = Select.BLANK
+            except Exception:
+                gsel.set_options(opts)
+            gsel.remove_class("funnel-hidden")
+        else:
+            gsel.add_class("funnel-hidden")
+
+    def reveal_slug_stage(
+        self, options: list[tuple[str, str]], default: Optional[str]
+    ) -> None:
+        """Stage-3: populate + reveal the artifact-filtered slug Select and the
+        Fit-check button (§2b-3/4/5 — only now do engine/topology slugs show)."""
+        sel = self.query_one("#lane-bring-profile-input", Select)
+        _set_select_options(sel, options, default)
+        sel.remove_class("funnel-hidden")
+        self.query_one("#lane-bring-fit-btn", Button).remove_class("funnel-hidden")
+
+    def hide_slug_stage(self) -> None:
+        self.query_one("#lane-bring-profile-input", Select).add_class("funnel-hidden")
+        self.query_one("#lane-bring-fit-btn", Button).add_class("funnel-hidden")
+
+    def set_weights_line(self, markup: str) -> None:
+        """§2b-6/7 — the weights-state / download / handoff line under the
+        verdict card.  Empty markup hides it."""
+        line = self.query_one("#lane-bring-weights-line", Static)
+        if markup:
+            line.update(markup)
+            line.remove_class("funnel-hidden")
+        else:
+            line.update("")
+            line.add_class("funnel-hidden")
 
     def populate(self, res: ByoResult) -> None:
         card = self.query_one("#lane-bring-result-card", Static)
@@ -5223,6 +5430,9 @@ class CockpitApp(App):
         # R3b-2 — producer lane ④ Measure: compare the selected tag's measured
         # numbers to the curated catalog bar (READ · producer-only).
         Binding("m", "measure_vs_bar", "vs catalog bar", show=False),
+        # Funnel §2b-6 — ① Bring: download the fit-checked repo's weights
+        # (pull.sh real run — DISK write, no GPU claim; streams into the pane).
+        Binding("D", "bring_download", "Download weights", show=False),
         # R3b-2 — producer lane: the ~43-min FULL validation battery
         # (report.sh --full) — confirm-gated, bg-streamed, producer-only, uses the
         # serving model (claims no GPU); NEVER auto-fired.
@@ -5704,6 +5914,10 @@ class CockpitApp(App):
         # Phase 5: the last BYO fit-check result (Run · BYO) — the arch facts
         # the Promote-to-catalog scaffold computes from.
         self._last_byo: Optional[ByoResult] = None
+        # Bring funnel (§2b): the last stage-1 inventory + the user's GGUF pick
+        # — drive the staged reveal + the artifact→engine/topology filters.
+        self._last_inventory: Optional[ArtifactInventory] = None
+        self._funnel_gguf_pick: str = ""
         # Phase R / R2b: failure context for the [!] problem report — captured AT
         # a failed serve in dispatch_action (the slug + the boot-log lines that
         # were streamed into the serve-live pane) so problem_report can assemble
@@ -6648,6 +6862,88 @@ class CockpitApp(App):
 
     # ── BYO fit-check ────────────────────────────────────────────────────────────────
 
+    def _trigger_lane_inspect(self) -> None:
+        """[Inspect] / ⏎ on the ① Bring repo input: stage-1 of the funnel —
+        the deriver artifact inventory (§2b-1).  Nothing template-side shows
+        until this succeeds."""
+        try:
+            repo = self.query_one("#lane-bring-url-input", Input).value.strip()
+        except Exception:
+            return
+        if not repo:
+            self.notify("Enter an HF repo (org/Model).", title="① Bring", severity="warning", timeout=3)
+            return
+        self.run_bring_inspect(repo)
+
+    def _known_gpu_vram_gb(self) -> Optional[float]:
+        """Best-known per-card VRAM (GiB) from the last estate poll — the MIN
+        across cards (heterogeneous rigs: the smallest card dictates the pool,
+        mirroring the launcher's het-clamp).  None before the first poll —
+        the funnel then applies NO size floor (never guess-hide)."""
+        st = self._last_estate_state
+        gpus = getattr(st, "gpus", None) if st is not None else None
+        if not gpus:
+            return None
+        totals = [g.mem_total_mib for g in gpus if getattr(g, "mem_total_mib", 0) > 0]
+        return (min(totals) / 1024.0) if totals else None
+
+    def _funnel_options_for(
+        self, artifact_format: str, artifact_gb: Optional[float]
+    ) -> list[tuple[str, str]]:
+        """The stage-3 slug options for the current artifact (§2b-3/4/5):
+        compat-filtered, topology-floored by size vs the rig, topology-first
+        labels, sentinel appended."""
+        opts = funnel_slug_options(
+            self._variants or [],
+            artifact_format,
+            artifact_gb=artifact_gb,
+            vram_gb=self._known_gpu_vram_gb(),
+            gpu_count=self._known_gpu_count(),
+        )
+        return profile_select_options(opts)
+
+    def _reveal_funnel_slugs(
+        self, artifact_format: str, artifact_gb: Optional[float]
+    ) -> None:
+        pairs = self._funnel_options_for(artifact_format, artifact_gb)
+        opts = funnel_slug_options(
+            self._variants or [],
+            artifact_format,
+            artifact_gb=artifact_gb,
+            vram_gb=self._known_gpu_vram_gb(),
+            gpu_count=self._known_gpu_count(),
+        )
+        default = default_profile_template(opts, self._known_gpu_count() or 2)
+        try:
+            self.query_one("#lane-bring-pane", LaneBringPane).reveal_slug_stage(pairs, default)
+        except Exception:
+            pass
+
+    @work(exclusive=True, group="byo")
+    async def run_bring_inspect(self, repo: str) -> None:
+        """Stage-1 INSPECT worker: deriver artifact inventory → staged reveal.
+        GGUF present → quant pick first (slugs stay hidden); safetensors →
+        straight to the compat-filtered slug stage."""
+        lane_pane = None
+        try:
+            lane_pane = self.query_one("#lane-bring-pane", LaneBringPane)
+            lane_pane.set_inspecting(repo)
+        except Exception:
+            lane_pane = None
+        inv = await self._data.bring_inspect(repo)
+        self._last_inventory = inv
+        self._funnel_gguf_pick = ""
+        if lane_pane is not None:
+            lane_pane.show_inventory(inv)
+        if inv.error:
+            return
+        if inv.has_safetensors:
+            # §2b-1: the safetensors set is the artifact — slugs reveal now.
+            self._reveal_funnel_slugs("safetensors", inv.safetensors_size_gb or None)
+        elif lane_pane is not None:
+            # GGUF-only: slugs stay hidden until the quant pick (§2b-2).
+            lane_pane.hide_slug_stage()
+
     @work(exclusive=True, group="byo")
     async def run_byo_check(self, repo: str, profile_like: str) -> None:
         # The fit-check is the producer lane's ① Bring stage (the standalone Run ·
@@ -6696,6 +6992,82 @@ class CockpitApp(App):
             )
         except Exception:
             pass
+        # §2b-6/7 — weights state after a successful fit-check: on disk → the
+        # ② Serve handoff is explicit; absent → the [D] download affordance.
+        if lane_pane is not None:
+            if getattr(res, "error", ""):
+                lane_pane.set_weights_line("")
+            elif self._data.bring_weights_present(repo):
+                lane_pane.set_weights_line(
+                    "  [green]✓ weights on disk[/green] — "
+                    "[green]→ ② Serve[/green] [dim](\\[2/]] next stage)[/dim]"
+                )
+            else:
+                lane_pane.set_weights_line(
+                    "  [yellow]weights not on disk[/yellow] — press [bold]\\[D][/bold] "
+                    "to download via pull.sh [dim](SHA-verified, streams here; "
+                    "disk write only, no GPU claim)[/dim]"
+                )
+
+    def action_bring_download(self) -> None:
+        """[D] — §2b-6: download the fit-checked repo's weights (the REAL
+        pull.sh run — Path B fetch into the pull dir).  Guarded on a successful
+        fit-check; a disk write with no GPU claim, so the key press is the
+        confirm (same discipline as the catalog Download)."""
+        if self._active_mode != 1:
+            return
+        byo = self._last_byo
+        if byo is None or getattr(byo, "error", ""):
+            self.notify(
+                "Run ① Bring fit-check first — nothing to download.",
+                title="Download", severity="warning", timeout=4,
+            )
+            return
+        repo = getattr(byo, "repo", "")
+        if self._data.bring_weights_present(repo):
+            self.notify("Weights already on disk.", title="Download", timeout=3)
+            return
+        self.run_bring_download_worker(repo, getattr(byo, "profile_like", ""))
+
+    @work(exclusive=True, group="bring-download")
+    async def run_bring_download_worker(self, repo: str, profile_like: str) -> None:
+        """§2b-6/7 — stream the pull.sh download into the weights line, then
+        re-probe and hand off to ② Serve."""
+        lane_pane = None
+        try:
+            lane_pane = self.query_one("#lane-bring-pane", LaneBringPane)
+        except Exception:
+            pass
+
+        from rich.markup import escape
+
+        def _on_line(line: str) -> None:
+            if lane_pane is not None:
+                clipped = line.strip()[-100:]
+                try:
+                    lane_pane.set_weights_line(
+                        f"  [cyan]downloading[/cyan] [dim]{escape(clipped)}[/dim]"
+                    )
+                except Exception:
+                    pass
+
+        handle = await self._data.run_bring_download(repo, profile_like, on_line=_on_line)
+        try:
+            await handle.done.wait()
+        except Exception:
+            pass
+        if lane_pane is None:
+            return
+        if self._data.bring_weights_present(repo):
+            lane_pane.set_weights_line(
+                "  [green]✓ weights downloaded[/green] — "
+                "[green]→ ② Serve[/green] [dim](\\[2/]] next stage)[/dim]"
+            )
+        else:
+            lane_pane.set_weights_line(
+                "  [red]download did not complete[/red] — check the pull.sh output "
+                "[dim](re-press \\[D] to retry)[/dim]"
+            )
 
     # ── Explain ──────────────────────────────────────────────────────────────────────
 
@@ -8945,6 +9317,24 @@ class CockpitApp(App):
             except Exception:
                 pass
             return
+        if sel_id == "lane-bring-gguf-select":
+            # §2b-2 — the GGUF quant pick: only NOW do the matching slugs
+            # appear, topology-floored by THIS variant's size (§2b size rule:
+            # hide topologies whose VRAM can't hold the weights; never hide
+            # larger ones — small-quant-on-many-GPUs is legitimate).
+            val = event.value
+            if val is None or val is Select.BLANK:
+                return
+            self._funnel_gguf_pick = str(val)
+            inv = self._last_inventory
+            size = None
+            if inv is not None:
+                for v in inv.gguf_variants:
+                    if v.quant == self._funnel_gguf_pick:
+                        size = v.size_gb or None
+                        break
+            self._reveal_funnel_slugs("gguf", size)
+            return
         if sel_id != "lane-bring-profile-input":
             return
         new_val = event.value
@@ -9167,6 +9557,8 @@ class CockpitApp(App):
         bid = event.button.id
         if bid == "lane-bring-fit-btn":
             self._trigger_lane_bring()
+        elif bid == "lane-bring-inspect-btn":
+            self._trigger_lane_inspect()
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         if event.input.id == "catalog-filter":
@@ -9178,7 +9570,9 @@ class CockpitApp(App):
             except Exception:
                 pass
         elif event.input.id == "lane-bring-url-input":
-            self._trigger_lane_bring()
+            # §2b-1 — ⏎ on the repo input runs stage-1 INSPECT (the funnel's
+            # entry), not the fit-check (which needs a slug pick first).
+            self._trigger_lane_inspect()
 
     def on_input_changed(self, event: Input.Changed) -> None:
         if event.input.id == "catalog-filter":

--- a/tools/serve-cockpit/club3090_cockpit/data.py
+++ b/tools/serve-cockpit/club3090_cockpit/data.py
@@ -607,6 +607,65 @@ class ReconcileResult:
 
 
 @dataclass
+class GgufVariant:
+    """One GGUF quant discovered in an HF repo (deriver artifact inventory)."""
+
+    quant: str = ""
+    size_gb: float = 0.0
+    parts: int = 1
+    files: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ArtifactInventory:
+    """Bring-funnel stage-1 INSPECT (design §2b): what servable artifacts an
+    HF repo carries — BEFORE any engine/template is shown.  From
+    ``deriver.py --inventory <repo> --json`` (offline-testable; a GGUF-only
+    repo is a first-class bring here, never ``unsupported-format``)."""
+
+    repo: str = ""
+    error: str = ""
+    formats: list[str] = field(default_factory=list)
+    safetensors_files: int = 0
+    safetensors_size_gb: float = 0.0
+    gguf_variants: list[GgufVariant] = field(default_factory=list)
+    gguf_mmproj: list[str] = field(default_factory=list)
+    lineage_base_model: Any = None
+
+    @property
+    def has_safetensors(self) -> bool:
+        return "safetensors" in self.formats
+
+    @property
+    def has_gguf(self) -> bool:
+        return bool(self.gguf_variants)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any] | None) -> "ArtifactInventory":
+        if not d:
+            return cls(error="no output")
+        st = d.get("safetensors") or {}
+        return cls(
+            repo=str(d.get("repo", "")),
+            error=str(d.get("error", "") or ""),
+            formats=list(d.get("formats") or []),
+            safetensors_files=len(st.get("weight_files") or []),
+            safetensors_size_gb=float(st.get("size_gb") or 0.0),
+            gguf_variants=[
+                GgufVariant(
+                    quant=str(v.get("quant", "")),
+                    size_gb=float(v.get("size_gb") or 0.0),
+                    parts=int(v.get("parts") or 1),
+                    files=list(v.get("files") or []),
+                )
+                for v in (d.get("gguf_variants") or [])
+            ],
+            gguf_mmproj=list(d.get("gguf_mmproj") or []),
+            lineage_base_model=d.get("lineage_base_model"),
+        )
+
+
+@dataclass
 class ByoResult:
     """Result of pull.sh --profile-like <repo> --dry-run --json."""
 

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -48,6 +48,7 @@ from club3090_tui_core.runner import SubprocessRunner
 
 from .data import (
     ActionPlan,
+    ArtifactInventory,
     BenchRow,
     ByoResult,
     CatalogEntry,
@@ -949,6 +950,83 @@ class CockpitData:
         return FitVerdict.from_dict(data, card=card)
 
     # ── READ: BYO check ──────────────────────────────────────────────────────────────
+
+    def _bring_hf_home(self) -> Path:
+        """The HF_HOME the lane's pull.sh runs under: env HF_HOME when set,
+        else the models-disk cache (same convention as run_weights_download —
+        multi-GB staging stays off the root disk).  run_bring_download PINS
+        the child to this value, so probe and download can't diverge."""
+        return Path(
+            os.environ.get("HF_HOME")
+            or (Path(self.weights_model_dir()) / ".cache" / "huggingface")
+        )
+
+    def bring_pull_dir(self, repo: str) -> Path:
+        """The CONTRACT-2 pull dir a brought repo's weights land in
+        (``<hf_home>/club3090/pulls/<sanitized>``).  Mirrors
+        scripts/lib/profiles/downloader.py pull_dir/sanitize_slug — a path
+        COMPUTATION only, no I/O."""
+        s = re.sub(r"[^a-z0-9._-]+", "-", repo.strip().lower())
+        s = re.sub(r"-{2,}", "-", s).strip("-._") or "model"
+        return self._bring_hf_home() / "club3090" / "pulls" / s
+
+    def bring_weights_present(self, repo: str) -> bool:
+        """§2b-6/7 — weights-on-disk probe for a brought repo: the pull dir
+        holds at least one weight blob and no ``.incomplete`` staging tree
+        remains (downloader deletes it on success, leaves none on failure)."""
+        d = self.bring_pull_dir(repo)
+        if not d.is_dir() or (d / ".incomplete").exists():
+            return False
+        try:
+            return any(d.glob("*.safetensors")) or any(d.glob("*.gguf"))
+        except OSError:
+            return False
+
+    async def run_bring_download(
+        self,
+        repo: str,
+        profile_like: str,
+        *,
+        on_line: Optional[Callable[[str], None]] = None,
+    ) -> Any:
+        """§2b-6 — the lane's weights download: the REAL ``pull.sh`` run
+        (Path B: SHA-verified fetch into the pull dir + serve-locally compose
+        emission).  A DISK write, NO GPU claim — the pane's [D] press is the
+        confirm, same discipline as the catalog Download.  Shares the single
+        download runner (one download at a time).  HF_HOME is pinned to the
+        SAME value the presence probe reads.  WIRED-BUT-MOCK-ONLY in tests
+        (conftest blocks the real spawn)."""
+        env = dict(os.environ)
+        env.setdefault("HF_HOME", str(self._bring_hf_home()))
+        if on_line is not None:
+            self._download_runner.set_callbacks(on_line=on_line)
+        return await self._download_runner.start_raw(
+            ["bash", "scripts/pull.sh", repo, "--profile-like", profile_like],
+            env=env,
+            run_type="download",
+            parser=None,
+        )
+
+    async def bring_inspect(self, repo: str) -> ArtifactInventory:
+        """Bring-funnel stage-1 INSPECT (design §2b-1): the deriver's artifact
+        inventory for an HF repo — what formats/quants it carries, BEFORE any
+        engine/template is shown.  READ-only (HF API metadata; never downloads
+        a weight).  A GGUF-only repo comes back as a first-class bring with
+        its variants enumerated; the staged Bring UI reveals nothing
+        template-side until this succeeds."""
+        data, err = await self._run_json(
+            [
+                "python3",
+                "scripts/lib/profiles/deriver.py",
+                "--inventory",
+                repo,
+                "--json",
+            ],
+            timeout=60.0,
+        )
+        if data is None:
+            return ArtifactInventory(repo=repo, error=err or "no output")
+        return ArtifactInventory.from_dict(data)
 
     async def byo_check(self, repo: str, profile_like: str) -> ByoResult:
         """pull.sh <repo> --profile-like <key> --dry-run --json.

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -319,6 +319,32 @@ PULL_JSON = json.dumps(
     }
 )
 
+# Bring funnel (§2b) — deriver --inventory canned responses (stage-1 INSPECT).
+INVENTORY_SAFETENSORS_JSON = json.dumps(
+    {
+        "repo": "org/Model",
+        "formats": ["safetensors"],
+        "safetensors": {"weight_files": ["model.safetensors"], "size_gb": 16.2},
+        "gguf_variants": [],
+        "gguf_mmproj": [],
+        "lineage_base_model": "Qwen/Qwen3.6-27B",
+    }
+)
+INVENTORY_GGUF_JSON = json.dumps(
+    {
+        "repo": "org/Model-GGUF",
+        "formats": ["gguf"],
+        "safetensors": None,
+        "gguf_variants": [
+            {"quant": "Q4_K_M", "size_gb": 17.0, "parts": 1, "files": ["m-Q4_K_M.gguf"]},
+            {"quant": "Q8_0", "size_gb": 29.0, "parts": 2,
+             "files": ["m-Q8_0-00001-of-00002.gguf", "m-Q8_0-00002-of-00002.gguf"]},
+        ],
+        "gguf_mmproj": ["mmproj-F16.gguf"],
+        "lineage_base_model": None,
+    }
+)
+
 ESTATE_REPORT_FREE = json.dumps({"active_estate": {"present": False, "instances": []}})
 ESTATE_REPORT_BUSY = json.dumps(
     {
@@ -579,6 +605,8 @@ def fake_responses(**overrides) -> dict[str, RunResult]:
         "--explain ik-llama/iq4ks-mtp --json": ok(EXPLAIN_NO_BENCH_JSON),
         "gpu-mode.sh --list-modes --json": ok(SCENES_JSON),
         "pull.sh": ok(PULL_JSON),
+        # Bring funnel §2b stage-1 (safetensors default; gguf tests override)
+        "deriver.py --inventory": ok(INVENTORY_SAFETENSORS_JSON),
         "estate_cli.py report-state --json": ok(ESTATE_REPORT_FREE),
         "health.sh": ok(HEALTH_SERVING),
         "docker ps": ok(DOCKER_PS_EMPTY),
@@ -1344,10 +1372,15 @@ class TestByoWired:
 
     @pytest.mark.asyncio
     async def test_lane_bring_fit_check_renders_route(self):
+        # Funnel §2b: the fit-check is stage 4 — Inspect must run first (the
+        # fit button is HIDDEN until the artifact is known; press() on a
+        # hidden button is a Textual no-op, which IS the staged-reveal guard).
         app, runner, _ = make_app()
         async with app.run_test(size=(120, 40)) as pilot:
             await _enter_bring(pilot)
             app.query_one("#lane-bring-url-input", Input).value = "org/Model"
+            app.query_one("#lane-bring-inspect-btn", Button).press()
+            await _settle(pilot)
             app.query_one("#lane-bring-fit-btn", Button).press()
             await _settle(pilot)
             card = app.query_one("#lane-bring-result-card", Static)
@@ -1369,6 +1402,9 @@ class TestByoWired:
         async with app.run_test(size=(120, 40)) as pilot:
             await _enter_bring(pilot)
             app.query_one("#lane-bring-url-input", Input).value = "org/Model"
+            # Funnel §2b: the slug Select is hidden until Inspect resolves.
+            app.query_one("#lane-bring-inspect-btn", Button).press()
+            await _settle(pilot)
             sel = app.query_one("#lane-bring-profile-input", Select)
             custom = app.query_one("#lane-bring-profile-custom", Input)
             # Reveal the companion Input by selecting the sentinel.
@@ -1387,6 +1423,185 @@ class TestByoWired:
             joined = " ".join(pull)
             assert "--profile-like ik-llama/iq4ks-mtp" in joined
             assert PROFILE_CUSTOM_SENTINEL not in joined   # sentinel never leaks
+
+
+class TestBringFunnelStagedReveal:
+    """Bring funnel §2b (maintainer UX 2026-07-05): staged reveal, GGUF pick
+    before slugs, artifact→engine compat filtering, topology-first labels."""
+
+    @pytest.mark.asyncio
+    async def test_nothing_template_side_before_inspect(self):
+        app, _, _ = make_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_bring(pilot)
+            row = app.query_one("#lane-bring-stage2-row")
+            assert row.has_class("funnel-hidden")          # §2b-1
+            assert not app.query_one("#lane-bring-fit-btn", Button).display
+
+    @pytest.mark.asyncio
+    async def test_safetensors_inspect_reveals_filtered_sorted_slugs(self):
+        from club3090_cockpit.app import PROFILE_CUSTOM_SENTINEL
+
+        app, runner, _ = make_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_bring(pilot)
+            app.query_one("#lane-bring-url-input", Input).value = "org/Model"
+            app.query_one("#lane-bring-inspect-btn", Button).press()
+            await _settle(pilot)
+            # deriver --inventory ran (READ-only, --json)
+            inv_call = next(c for c in runner.calls if "--inventory" in " ".join(c))
+            assert "--json" in inv_call
+            # card renders the inventory verdict + lineage
+            text = str(app.query_one("#lane-bring-result-card", Static).render())
+            assert "safetensors" in text and "16.2" in text
+            assert "Qwen/Qwen3.6-27B" in text              # lineage rides (friction #11)
+            # slug stage revealed; gguf pick NOT shown for a safetensors repo
+            sel = app.query_one("#lane-bring-profile-input", Select)
+            assert sel.display
+            assert not app.query_one("#lane-bring-gguf-select", Select).display
+            assert app.query_one("#lane-bring-fit-btn", Button).display
+            # §2b-3/4: only safetensors engines; topology-FIRST labels
+            labels = [l for (l, v) in sel._options if v != PROFILE_CUSTOM_SENTINEL]
+            assert labels == ["dual/vllm/qwen3.6-27b-autoround-int4  ·  fp8-mtp"]
+
+    @pytest.mark.asyncio
+    async def test_gguf_inspect_requires_quant_pick_before_slugs(self):
+        from club3090_cockpit.app import PROFILE_CUSTOM_SENTINEL
+
+        responses = fake_responses(
+            **{"deriver.py --inventory": ok(INVENTORY_GGUF_JSON)}
+        )
+        app, _, _ = make_app(responses=responses)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_bring(pilot)
+            app.query_one("#lane-bring-url-input", Input).value = "org/Model-GGUF"
+            app.query_one("#lane-bring-inspect-btn", Button).press()
+            await _settle(pilot)
+            gsel = app.query_one("#lane-bring-gguf-select", Select)
+            sel = app.query_one("#lane-bring-profile-input", Select)
+            # §2b-2: ALL gguf quants presented; slugs stay hidden until the pick
+            assert gsel.display
+            assert not sel.display
+            glabels = [l for (l, _v) in gsel._options]
+            assert any("Q4_K_M" in l and "17.0" in l for l in glabels)
+            assert any("Q8_0" in l and "29.0" in l and "2 parts" in l for l in glabels)
+            # mmproj is informational, never a variant
+            assert not any("mmproj" in l for l in glabels)
+            # the pick reveals the gguf-engine slugs (§2b-3: never vLLM)
+            gsel.value = "Q4_K_M"
+            await _settle(pilot)
+            assert sel.display
+            labels = [l for (l, v) in sel._options if v != PROFILE_CUSTOM_SENTINEL]
+            assert labels == ["single/ik-llama/qwen3.6-27b-ubergarm-iq4ks  ·  mtp"]
+
+    @pytest.mark.asyncio
+    async def test_fit_check_surfaces_weights_state_and_handoff(self, monkeypatch, tmp_path):
+        # §2b-6/7 — after a successful fit-check: weights absent → the [D]
+        # download affordance; weights on disk → the explicit ② Serve handoff.
+        monkeypatch.setenv("HF_HOME", str(tmp_path))
+        app, _, _ = make_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_bring(pilot)
+            app.query_one("#lane-bring-url-input", Input).value = "org/Model"
+            app.query_one("#lane-bring-inspect-btn", Button).press()
+            await _settle(pilot)
+            app.query_one("#lane-bring-fit-btn", Button).press()
+            await _settle(pilot)
+            line = app.query_one("#lane-bring-weights-line", Static)
+            assert line.display
+            text = str(line.render())
+            assert "not on disk" in text and "[D]" in text
+            # weights land on disk → a re-fit-check flips the line to handoff
+            d = app._data.bring_pull_dir("org/Model")
+            d.mkdir(parents=True)
+            (d / "model.safetensors").write_bytes(b"x")
+            app.query_one("#lane-bring-fit-btn", Button).press()
+            await _settle(pilot)
+            text = str(line.render())
+            assert "on disk" in text and "② Serve" in text
+
+    @pytest.mark.asyncio
+    async def test_inspect_error_reveals_nothing(self):
+        responses = fake_responses(
+            **{"deriver.py --inventory": ok(json.dumps(
+                {"repo": "org/Nope", "error": "repo-not-found: org/Nope",
+                 "formats": [], "gguf_variants": [], "gguf_mmproj": []}))}
+        )
+        app, _, _ = make_app(responses=responses)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_bring(pilot)
+            app.query_one("#lane-bring-url-input", Input).value = "org/Nope"
+            app.query_one("#lane-bring-inspect-btn", Button).press()
+            await _settle(pilot)
+            text = str(app.query_one("#lane-bring-result-card", Static).render())
+            assert "repo-not-found" in text
+            assert app.query_one("#lane-bring-stage2-row").has_class("funnel-hidden")
+
+
+class TestFunnelSlugOptionsPure:
+    """funnel_slug_options — the §2b filters as a pure function."""
+
+    def _rows(self):
+        from types import SimpleNamespace as NS
+
+        return [
+            NS(slug="vllm/dual", engine="vllm-stable", model="qwen3.6-27b",
+               file="fp8-mtp.yml", status="production",
+               compose_path="models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml",
+               compose_dir=""),
+            NS(slug="vllm/minimal", engine="vllm-stable", model="qwen3.6-27b",
+               file="minimal.yml", status="production",
+               compose_path="models/qwen3.6-27b/vllm/compose/single/autoround-int4/minimal.yml",
+               compose_dir=""),
+            NS(slug="ik-llama/iq4ks-mtp", engine="ik-llama", model="qwen3.6-27b",
+               file="mtp.yml", status="production",
+               compose_path="models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/mtp.yml",
+               compose_dir=""),
+        ]
+
+    def test_compat_filter_is_absolute(self):
+        from club3090_cockpit.app import funnel_slug_options
+
+        st = funnel_slug_options(self._rows(), "safetensors")
+        assert {o.slug for o in st} == {"vllm/dual", "vllm/minimal"}   # never llama-family
+        gg = funnel_slug_options(self._rows(), "gguf")
+        assert {o.slug for o in gg} == {"ik-llama/iq4ks-mtp"}          # never vLLM
+
+    def test_topology_first_labels_and_grouped_sort(self):
+        from club3090_cockpit.app import funnel_slug_options
+
+        st = funnel_slug_options(self._rows(), "safetensors")
+        # single before dual; label = topology/engine/model-quant · serving
+        assert [o.label for o in st] == [
+            "single/vllm/qwen3.6-27b-autoround-int4  ·  minimal",
+            "dual/vllm/qwen3.6-27b-autoround-int4  ·  fp8-mtp",
+        ]
+
+    def test_size_floor_hides_too_small_topologies_only(self):
+        from club3090_cockpit.app import funnel_slug_options
+
+        # 34G weights on 24G cards: single (24×0.9=21.6) hidden, dual kept.
+        st = funnel_slug_options(
+            self._rows(), "safetensors", artifact_gb=34.0, vram_gb=24.0, gpu_count=2
+        )
+        assert {o.slug for o in st} == {"vllm/dual"}
+        # Small artifact: NOTHING hidden — running a small quant on more GPUs
+        # is legitimate (the floor is one-directional).
+        st = funnel_slug_options(
+            self._rows(), "safetensors", artifact_gb=5.0, vram_gb=24.0, gpu_count=2
+        )
+        assert {o.slug for o in st} == {"vllm/dual", "vllm/minimal"}
+        # Unknown rig → no floor (never guess-hide).
+        st = funnel_slug_options(self._rows(), "safetensors", artifact_gb=34.0)
+        assert {o.slug for o in st} == {"vllm/dual", "vllm/minimal"}
+
+    def test_rig_card_count_hides_unhostable_topologies(self):
+        from club3090_cockpit.app import funnel_slug_options
+
+        st = funnel_slug_options(
+            self._rows(), "safetensors", artifact_gb=5.0, vram_gb=24.0, gpu_count=1
+        )
+        assert {o.slug for o in st} == {"vllm/minimal"}   # dual unhostable on 1 card
 
 
 # ===========================================================================

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -2133,6 +2133,40 @@ class TestContainerLogs:
         assert "No such container" in out["error"]
 
 
+class TestBringDownloadSeam:
+    """§2b-6/7 — the lane download's presence probe + path contract."""
+
+    def test_pull_dir_mirrors_downloader_sanitizer(self, monkeypatch, tmp_path):
+        # The c3-side path computation must equal the SoT sanitizer in
+        # scripts/lib/profiles/downloader.py (drift guard — the probe reads
+        # where pull.sh actually writes).
+        import sys
+        from pathlib import Path as _P
+
+        monkeypatch.setenv("HF_HOME", str(tmp_path))
+        cd = CockpitData(ROOT, runner=full_runner())
+        repo_root = str(_P(__file__).resolve().parents[3])
+        if repo_root not in sys.path:
+            sys.path.insert(0, repo_root)
+        from scripts.lib.profiles.downloader import pull_dir as sot_pull_dir
+
+        for repo in ("Org/Some Model-7B", "unsloth/Qwen3-27B-GGUF", "a/B__c"):
+            assert cd.bring_pull_dir(repo) == sot_pull_dir(tmp_path, repo), repo
+
+    def test_weights_present_probe(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HF_HOME", str(tmp_path))
+        cd = CockpitData(ROOT, runner=full_runner())
+        repo = "org/Model"
+        assert cd.bring_weights_present(repo) is False          # no dir
+        d = cd.bring_pull_dir(repo)
+        d.mkdir(parents=True)
+        assert cd.bring_weights_present(repo) is False          # dir, no blobs
+        (d / "model.safetensors").write_bytes(b"x")
+        assert cd.bring_weights_present(repo) is True           # blob present
+        (d / ".incomplete").mkdir()
+        assert cd.bring_weights_present(repo) is False          # staging = not done
+
+
 class TestRealRunnerNotInvokedInTests:
     """Sanity: a CockpitData built with a FakeRunner never constructs a
     RealRunner, and the default RealRunner is only the production fallback."""


### PR DESCRIPTION
## What

The Bring-funnel redesign (T2 friction #5, design §2b — maintainer UX decisions 2026-07-05), stacked on #581 (shares the c3 measure_vs_bar changes; retarget to master after #581 merges).

### The staged flow (nothing template-side before the artifact is known)
1. **`[Inspect]`** → NEW `deriver.py --inventory <repo> --json` (F1-1): enumerates safetensors sets + **GGUF quants at any depth** (grouped by quant token, multi-part summed, mmproj split out) + lineage (`base_model`, friction #11). **A GGUF-only repo is a first-class bring** — no longer `unsupported-format`. HF metadata only, never downloads.
2. **GGUF → the quant pick comes first**: all variants with sizes; slugs stay hidden until a genuine pick.
3. **Slug Select**: every catalog option passing the **absolute artifact→engine filter** (GGUF never sees vLLM; safetensors never sees llama.cpp/ik-llama/beellama), labeled **`topology/engine/model-quant · serving`**, sorted so models group under topology/engine. Custom-slug escape hatch kept.
4. **Topology floor by quant size** (maintainer rule): hide topologies whose total VRAM can't hold the weights — **rig-relative** (`cards × min-card-VRAM × 0.90`), not fixed 20/40 GB. **One-directional**: larger topologies never hidden (small-quant-on-more-GPUs is legitimate). Unknown size/rig → no floor.
5. **Fit-check → weights state**: on disk → explicit **→ ② Serve** handoff; absent → **`[D]`** streams the real `pull.sh` fetch into the pane (disk write, no GPU claim), re-probes on completion.

### Trust seams
- Presence probe mirrors `downloader.py pull_dir/sanitize_slug` with a **parity drift-guard test**; `HF_HOME` pinned identically for probe + download (can't diverge).
- GGUF pick Select starts BLANK — only a user pick reveals stage 3.
- `press()` on hidden widgets is a Textual no-op — the staged reveal is enforced, not cosmetic (the old direct-fit tests had to walk the funnel).

## Validation
- c3 suite **779/779** (11 new tests: staged reveal · gguf pick flow · compat filter · label format+sort · size floor pure-fn · presence probe · weights line/handoff)
- `test-artifact-inventory.sh` (new offline guard: grouping, multipart, mmproj, adapter exclusion, stem fallback, CLI refusal)
- Serial shell gate green (shell surface unchanged since the last full-green run on this tree)

## Not in this PR
- ② Serve still reproduces the catalog sibling's compose verbatim (the weights-swap `generate-compose --repo` extension stays the deferred follow-up — friction #3, funnel stage 5)
- Optimizer socket (§3) — this PR builds the surface that will host it, per the design's discipline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm