### PR TITLE
① Bring live-dogfood fixes: honest gguf variants · smallest-fit recommendation · clean labels · titled fields · slug detail card

### DIFF
--- a/scripts/lib/profiles/deriver.py
+++ b/scripts/lib/profiles/deriver.py
@@ -566,6 +566,12 @@ def artifact_inventory(api: dict) -> dict:
         }
 
     # GGUF: any depth (quant subdirs are common), mmproj split out.
+    # Grouping key = the STEM (basename minus the -NNNNN-of-NNNNN part
+    # suffix), NOT the quant token — a repo can ship DISTINCT artifacts
+    # sharing a token (live dogfood 2026-07-05: Qwythos ships
+    # `…-Q4_K_M.gguf` AND `…-MTP-Q4_K_M.gguf` per quant; token-keying
+    # merged them into one "2-part variant" with a summed, wrong size).
+    # True multi-part shards share a stem, so `parts` still counts them.
     variants: dict[str, dict] = {}
     mmproj: list[str] = []
     for n in names:
@@ -576,17 +582,26 @@ def artifact_inventory(api: dict) -> dict:
             mmproj.append(n)
             continue
         stem = _GGUF_PART_RE.sub("", base)
-        m = _GGUF_QUANT_RE.search(stem)
-        key = m.group(1).upper() if m else stem
-        v = variants.setdefault(key, {"quant": key, "size_gb": 0.0, "parts": 0, "files": []})
+        v = variants.setdefault(stem, {"size_gb": 0.0, "parts": 0, "files": []})
         v["size_gb"] += sizes.get(n, 0) / (1024 ** 3)
         v["parts"] += 1
         v["files"].append(n)
-    gguf_variants = sorted(
-        ({**v, "size_gb": round(v["size_gb"], 4), "files": sorted(v["files"])}
-         for v in variants.values()),
-        key=lambda v: (v["size_gb"], v["quant"]),
-    )
+    # Display label: the stem minus the repo-wide COMMON prefix — for
+    # standard repos that IS the quant token ("Q4_K_M"); for multi-artifact
+    # repos it keeps the distinguishing part ("MTP-Q4_K_M").  Falls back to
+    # the parsed token, then the full stem (labels stay unique: stems are).
+    common = os.path.commonprefix(list(variants)) if len(variants) > 1 else ""
+    out_variants = []
+    for stem, v in variants.items():
+        label = stem[len(common):].strip("-_. ")
+        if not label:
+            m = _GGUF_QUANT_RE.search(stem)
+            label = m.group(1).upper() if m else stem
+        out_variants.append(
+            {"quant": label, "size_gb": round(v["size_gb"], 4),
+             "parts": v["parts"], "files": sorted(v["files"])}
+        )
+    gguf_variants = sorted(out_variants, key=lambda v: (v["size_gb"], v["quant"]))
 
     formats = []
     if st:

--- a/scripts/tests/test-artifact-inventory.sh
+++ b/scripts/tests/test-artifact-inventory.sh
@@ -77,6 +77,21 @@ print("  ✓ unservable repo → empty formats (inspect_repo maps this to error)
 inv = artifact_inventory(api([("weird-model.gguf", 5 * GB)]))
 assert len(inv["gguf_variants"]) == 1 and inv["gguf_variants"][0]["quant"] == "weird-model"
 print("  ✓ unparseable quant token keys by stem (never silently dropped)")
+
+# ── 6. DISTINCT artifacts sharing a quant token stay separate ────────────────
+# (live dogfood 2026-07-05: Qwythos ships base + MTP builds per quant —
+# token-keyed grouping merged them into one "2-part" variant with a summed,
+# WRONG size and no way to pick just one)
+inv = artifact_inventory(api([
+    ("Qwythos-9B-Q4_K_M.gguf", 5 * GB),
+    ("Qwythos-9B-MTP-Q4_K_M.gguf", 6 * GB),
+    ("Qwythos-9B-Q8_0.gguf", 9 * GB),
+]))
+quants = {v["quant"]: v for v in inv["gguf_variants"]}
+assert set(quants) == {"Q4_K_M", "MTP-Q4_K_M", "Q8_0"}, quants
+assert quants["Q4_K_M"]["parts"] == 1 and abs(quants["Q4_K_M"]["size_gb"] - 5.0) < 0.01
+assert quants["MTP-Q4_K_M"]["parts"] == 1 and abs(quants["MTP-Q4_K_M"]["size_gb"] - 6.0) < 0.01
+print("  ✓ base vs MTP builds per quant = separate variants, honest sizes")
 PY
 
 # CLI shim: --inventory is required; bad usage exits 2 without network

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -307,6 +307,33 @@ def funnel_slug_options(
     return out
 
 
+def funnel_recommended(
+    options: list["ProfileOption"], defaults: Optional[list[dict]] = None
+) -> Optional[str]:
+    """§2b follow-up (live dogfood 2026-07-05): the funnel surfaces ONE
+    visible recommendation — the old rig-topology default picked a DUAL slug
+    for a 5 GiB gguf on a 2-card rig, which reads as 'the UI wants me on two
+    cards'.  Rule: the SMALLEST fitting topology wins (options are already
+    size-floored + topology-sorted, so that's the first group — the cheapest
+    config that holds the artifact); within it, prefer the registry's own
+    curated default for the (family, topology), else the first functional-
+    status option, else the group's first.  Pure."""
+    if not options:
+        return None
+    topo = options[0].topology
+    group = [o for o in options if o.topology == topo]
+    curated = _curated_default_map(defaults)
+    for o in group:
+        prefix = o.slug.split("/", 1)[0]
+        fam = _canon_engine_family(prefix) or prefix
+        if curated.get((fam, topo)) == o.slug:
+            return o.slug
+    for o in group:
+        if _status_is_functional(o.status):
+            return o.slug
+    return group[0].slug
+
+
 def _curated_default_map(
     defaults: Optional[list[dict]],
 ) -> dict[tuple[str, str], str]:
@@ -6905,7 +6932,6 @@ class CockpitApp(App):
     def _reveal_funnel_slugs(
         self, artifact_format: str, artifact_gb: Optional[float]
     ) -> None:
-        pairs = self._funnel_options_for(artifact_format, artifact_gb)
         opts = funnel_slug_options(
             self._variants or [],
             artifact_format,
@@ -6913,9 +6939,18 @@ class CockpitApp(App):
             vram_gb=self._known_gpu_vram_gb(),
             gpu_count=self._known_gpu_count(),
         )
-        default = default_profile_template(opts, self._known_gpu_count() or 2)
+        # ONE visible recommendation (§2b follow-up): smallest fitting
+        # topology + curated engine preference — starred AND pre-selected;
+        # the full filtered list stays reachable below it.
+        rec = funnel_recommended(
+            opts, list(getattr(self._data, "catalog_defaults", None) or [])
+        )
+        pairs = [
+            ((f"⭐ {label}" if value == rec else label), value)
+            for (label, value) in profile_select_options(opts)
+        ]
         try:
-            self.query_one("#lane-bring-pane", LaneBringPane).reveal_slug_stage(pairs, default)
+            self.query_one("#lane-bring-pane", LaneBringPane).reveal_slug_stage(pairs, rec)
         except Exception:
             pass
 

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -268,7 +268,7 @@ def funnel_slug_options(
         _GGUF_ENGINE_FAMILIES if artifact_format == "gguf"
         else _SAFETENSORS_ENGINE_FAMILIES
     )
-    out: list[ProfileOption] = []
+    raw: list[tuple[str, str, ProfileOption]] = []
     seen: set[str] = set()
     for row in variants:
         slug = (getattr(row, "slug", "") or "").strip()
@@ -291,7 +291,9 @@ def funnel_slug_options(
         seen.add(slug)
         model = (getattr(row, "model", "") or "").strip() or "—"
         quant = variant_quant(row) or ""
-        stem = ((getattr(row, "file", "") or "").rsplit(".", 1)[0]) or ""
+        # basename stem ONLY — some registry rows carry a subpath in `file`
+        # (dogfood r2: `dual/piehsoft-q6k/mtp.yml` rendered a duplicated tail)
+        stem = (getattr(row, "file", "") or "").rsplit("/", 1)[-1].rsplit(".", 1)[0]
         # Display engine = the PRECISE token (switch_engine, else the slug's
         # own prefix) — the canon family is filter-only (it can't tell
         # ik-llama from llamacpp, which the label must).
@@ -300,9 +302,23 @@ def funnel_slug_options(
             or slug.split("/", 1)[0]
         )
         tail = f"{model}-{quant}" if quant else model
-        label = f"{topo or '—'}/{eng}/{tail}" + (f"  ·  {stem}" if stem else "")
+        label = f"{topo or '—'}/{eng}/{tail}"
         status = (getattr(row, "status", "") or "").strip().lower()
-        out.append(ProfileOption(label=label, slug=slug, topology=topo or "—", status=status))
+        raw.append((label, stem, ProfileOption(label=label, slug=slug, topology=topo or "—", status=status)))
+    # §2b dogfood r2 (maintainer): the label is topology/engine/model-quant
+    # ONLY — a serving-stem tail duplicated the path axes and read as a
+    # second slug.  The stem is appended SOLELY to disambiguate genuine
+    # collisions (two slugs sharing all three axes, e.g. fp8-mtp vs turbo).
+    counts: dict[str, int] = {}
+    for label, _stem, _o in raw:
+        counts[label] = counts.get(label, 0) + 1
+    out = [
+        ProfileOption(
+            label=(f"{label}  ·  {stem}" if (counts[label] > 1 and stem) else label),
+            slug=o.slug, topology=o.topology, status=o.status,
+        )
+        for (label, stem, o) in raw
+    ]
     out.sort(key=lambda o: (_TOPO_ORDER.get(o.topology, 99), o.label))
     return out
 
@@ -4433,12 +4449,23 @@ class LaneBringPane(Container):
         margin-bottom: 1;
     }
     LaneBringPane #lane-bring-input-row {
-        height: 3;
+        height: 4;
         margin-bottom: 1;
     }
     LaneBringPane #lane-bring-stage2-row {
-        height: 3;
+        height: 4;
         margin-bottom: 1;
+    }
+    LaneBringPane .funnel-field {
+        width: auto;
+        height: auto;
+    }
+    LaneBringPane .funnel-field-grow {
+        width: 1fr;
+    }
+    LaneBringPane .funnel-field-title {
+        color: $text-muted;
+        height: 1;
     }
     LaneBringPane #lane-bring-url-input {
         width: 1fr;
@@ -4457,6 +4484,12 @@ class LaneBringPane(Container):
     LaneBringPane #lane-bring-profile-custom {
         width: 40;
         margin-left: 1;
+    }
+    LaneBringPane #lane-bring-slug-card {
+        border: solid $secondary;
+        padding: 0 2;
+        margin-top: 1;
+        height: auto;
     }
     LaneBringPane .profile-custom-hidden {
         display: none;
@@ -4487,46 +4520,69 @@ class LaneBringPane(Container):
 
     def compose(self) -> ComposeResult:
         yield Label("① Bring — inspect an HF model", id="lane-bring-heading")
+        # Dogfood r2 (maintainer): every input carries a TITLE — bare
+        # dropdowns read as anonymous fields.  Each field = a Vertical
+        # (title Label + widget); titles toggle WITH their widget.
         with Horizontal(id="lane-bring-input-row"):
-            yield Input(
-                placeholder="org/Model  (e.g. unsloth/Qwen3-27B-abliterated-GGUF)",
-                id="lane-bring-url-input",
-            )
-            yield Button("Inspect", id="lane-bring-inspect-btn", variant="primary")
+            with Vertical(classes="funnel-field funnel-field-grow"):
+                yield Label("HF repo", classes="funnel-field-title")
+                yield Input(
+                    placeholder="org/Model  (e.g. unsloth/Qwen3-27B-abliterated-GGUF)",
+                    id="lane-bring-url-input",
+                )
+            with Vertical(classes="funnel-field"):
+                yield Label(" ", classes="funnel-field-title")
+                yield Button("Inspect", id="lane-bring-inspect-btn", variant="primary")
         # Stage 2/3 — HIDDEN until Inspect identifies a supported artifact
         # (§2b-1: no engine/topology/template before the artifact is known).
         with Horizontal(id="lane-bring-stage2-row", classes="funnel-hidden"):
-            # §2b-2 — the GGUF quant pick comes BEFORE any slug appears.
-            yield Select(
-                [],
-                prompt="— pick a GGUF quant —",
-                allow_blank=True,
-                id="lane-bring-gguf-select",
-                classes="funnel-hidden",
-            )
-            # §2b-4/5 — the artifact-filtered, topology-first catalog options
-            # (repopulated per inventory/pick by the app; the pre-inspect
-            # template fill is harmless — the row is hidden).
-            yield Select(
-                [("vllm/dual  ·  loading templates…", "vllm/dual")],
-                value="vllm/dual",
-                allow_blank=False,
-                id="lane-bring-profile-input",
-                classes="funnel-hidden",
-            )
-            # FIX 2 (escape hatch) — companion free-text override, hidden until the
-            # "✎ custom slug…" sentinel is chosen (same idiom as Run · BYO).
+            with Vertical(classes="funnel-field"):
+                # §2b-2 — the GGUF quant pick comes BEFORE any slug appears.
+                yield Label(
+                    "GGUF quant",
+                    id="lane-bring-gguf-title",
+                    classes="funnel-field-title funnel-hidden",
+                )
+                yield Select(
+                    [],
+                    prompt="— pick a GGUF quant —",
+                    allow_blank=True,
+                    id="lane-bring-gguf-select",
+                    classes="funnel-hidden",
+                )
+            with Vertical(classes="funnel-field funnel-field-grow"):
+                # §2b-4/5 — the artifact-filtered, topology-first catalog options
+                # (repopulated per inventory/pick by the app; the pre-inspect
+                # template fill is harmless — the row is hidden).
+                yield Label(
+                    "catalog config  (topology/engine/model-quant · ⭐ recommended)",
+                    id="lane-bring-profile-title",
+                    classes="funnel-field-title funnel-hidden",
+                )
+                yield Select(
+                    [("vllm/dual  ·  loading templates…", "vllm/dual")],
+                    value="vllm/dual",
+                    allow_blank=False,
+                    id="lane-bring-profile-input",
+                    classes="funnel-hidden",
+                )
+            # FIX 2 (escape hatch) — companion free-text override, hidden until
+            # the "✎ custom slug…" sentinel is chosen (same idiom as Run · BYO;
+            # untitled — its placeholder is the title, and it must collapse
+            # fully when hidden).
             yield Input(
                 placeholder="profile-like slug — e.g. ik-llama/iq4ks-mtp",
                 id="lane-bring-profile-custom",
                 classes="profile-custom-hidden",
             )
-            yield Button(
-                "Fit-check",
-                id="lane-bring-fit-btn",
-                variant="primary",
-                classes="funnel-hidden",
-            )
+            with Vertical(classes="funnel-field"):
+                yield Label(" ", classes="funnel-field-title")
+                yield Button(
+                    "Fit-check",
+                    id="lane-bring-fit-btn",
+                    variant="primary",
+                    classes="funnel-hidden",
+                )
         yield Static(
             "[dim]Stage ① of the Bring & Validate pipeline.  Enter an HF repo and\n"
             "Inspect — the deriver enumerates its artifacts (safetensors / GGUF\n"
@@ -4535,6 +4591,9 @@ class LaneBringPane(Container):
             "Fit-check then unlocks ② Serve and ⑤ Promote.[/dim]",
             id="lane-bring-result-card",
         )
+        # Dogfood r2 — the SELECTED SLUG's detail card (ctx / status / port /
+        # drafter / the bar), beside the HF-repo inventory verdict above.
+        yield Static("", id="lane-bring-slug-card", classes="funnel-hidden")
         # §2b-6/7 — the weights state + download/handoff affordance line
         # (hidden until a fit-check succeeds).
         yield Static("", id="lane-bring-weights-line", classes="funnel-hidden")
@@ -4594,6 +4653,7 @@ class LaneBringPane(Container):
             lines.append(f"  [dim]base_model: {inv.lineage_base_model}[/dim]")
         card.update("\n".join(lines))
         row.remove_class("funnel-hidden")
+        gtitle = self.query_one("#lane-bring-gguf-title", Label)
         if inv.has_gguf:
             opts = [
                 (f"{v.quant}  ·  {v.size_gb:.1f} GiB" + (f" ({v.parts} parts)" if v.parts > 1 else ""), v.quant)
@@ -4608,8 +4668,10 @@ class LaneBringPane(Container):
             except Exception:
                 gsel.set_options(opts)
             gsel.remove_class("funnel-hidden")
+            gtitle.remove_class("funnel-hidden")
         else:
             gsel.add_class("funnel-hidden")
+            gtitle.add_class("funnel-hidden")
 
     def reveal_slug_stage(
         self, options: list[tuple[str, str]], default: Optional[str]
@@ -4619,11 +4681,25 @@ class LaneBringPane(Container):
         sel = self.query_one("#lane-bring-profile-input", Select)
         _set_select_options(sel, options, default)
         sel.remove_class("funnel-hidden")
+        self.query_one("#lane-bring-profile-title", Label).remove_class("funnel-hidden")
         self.query_one("#lane-bring-fit-btn", Button).remove_class("funnel-hidden")
 
     def hide_slug_stage(self) -> None:
         self.query_one("#lane-bring-profile-input", Select).add_class("funnel-hidden")
+        self.query_one("#lane-bring-profile-title", Label).add_class("funnel-hidden")
         self.query_one("#lane-bring-fit-btn", Button).add_class("funnel-hidden")
+        self.show_slug_details("")
+
+    def show_slug_details(self, markup: str) -> None:
+        """Dogfood r2 — the selected slug's detail card (ctx / status / port /
+        drafter / the bar).  Empty markup hides it."""
+        card = self.query_one("#lane-bring-slug-card", Static)
+        if markup:
+            card.update(markup)
+            card.remove_class("funnel-hidden")
+        else:
+            card.update("")
+            card.add_class("funnel-hidden")
 
     def set_weights_line(self, markup: str) -> None:
         """§2b-6/7 — the weights-state / download / handoff line under the
@@ -6950,9 +7026,58 @@ class CockpitApp(App):
             for (label, value) in profile_select_options(opts)
         ]
         try:
-            self.query_one("#lane-bring-pane", LaneBringPane).reveal_slug_stage(pairs, rec)
+            pane = self.query_one("#lane-bring-pane", LaneBringPane)
+            pane.reveal_slug_stage(pairs, rec)
+            # Dogfood r2 — the pre-selected recommendation's details show
+            # immediately (updates ride on_select_changed thereafter).
+            pane.show_slug_details(self._funnel_slug_details(rec) if rec else "")
         except Exception:
             pass
+
+    def _funnel_slug_details(self, slug: str) -> str:
+        """Dogfood r2 — the SELECTED catalog slug's key facts for the Bring
+        pane's detail card: status · ctx · port · drafter · vision · the
+        shipped bar (with the staleness dagger).  Pure read of the cached
+        variants (the baseline dict rides each row via the emit join)."""
+        row = next(
+            (v for v in (self._variants or []) if getattr(v, "slug", "") == slug),
+            None,
+        )
+        if row is None:
+            return ""
+        status = (getattr(row, "status", "") or "").strip()
+        lines = [
+            f"  [bold]{slug}[/bold]  [dim]·[/dim]  {_status_glyph(status)} {status or '—'}"
+            f"  [dim]·[/dim]  ctx {getattr(row, 'ctx_label', '') or '—'}"
+            f"  [dim]·[/dim]  port {getattr(row, 'port', '') or '—'}"
+        ]
+        drafter = str(getattr(row, "drafter", "") or "")
+        vision = bool(getattr(row, "vision", False))
+        facets = []
+        if drafter:
+            facets.append(f"drafter {drafter}")
+        if vision:
+            facets.append("vision")
+        if facets:
+            lines.append(f"  [dim]{' · '.join(facets)}[/dim]")
+        b = getattr(row, "baseline", None) or {}
+        n, c = b.get("narr_tps"), b.get("code_tps")
+        if n is not None or c is not None:
+            tps = (f"{n:.0f}" if n is not None else "—") + "/" + (
+                f"{c:.0f}" if c is not None else "—")
+            bar = f"  [bold]bar[/bold]  {tps} TPS"
+            if b.get("quality_8pk"):
+                bar += f"  ·  8pk {b['quality_8pk']}"
+            prov = " · ".join(str(x) for x in (b.get("date"), b.get("rig")) if x)
+            if prov:
+                bar += f"  [dim]({prov})[/dim]"
+            if b.get("stale") is True:
+                bar += "  [yellow]† re-bench owed[/yellow]"
+            lines.append(bar)
+        note = (getattr(row, "status_note", "") or "").strip()
+        if note:
+            lines.append(f"  [yellow]caveat: {note}[/yellow]")
+        return "\n".join(lines)
 
     @work(exclusive=True, group="byo")
     async def run_bring_inspect(self, repo: str) -> None:
@@ -9385,6 +9510,16 @@ class CockpitApp(App):
                 custom.focus()
             else:
                 custom.add_class("profile-custom-hidden")
+        except Exception:
+            pass
+        # Dogfood r2 — the detail card follows the selection (a custom-slug
+        # sentinel has no catalog row → hide).
+        try:
+            pane = self.query_one("#lane-bring-pane", LaneBringPane)
+            if new_val == PROFILE_CUSTOM_SENTINEL or new_val in (None, Select.BLANK):
+                pane.show_slug_details("")
+            else:
+                pane.show_slug_details(self._funnel_slug_details(str(new_val)))
         except Exception:
             pass
         # Before the registry-derived default has been applied, any Changed is the

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -1462,7 +1462,8 @@ class TestBringFunnelStagedReveal:
             assert app.query_one("#lane-bring-fit-btn", Button).display
             # §2b-3/4: only safetensors engines; topology-FIRST labels
             labels = [l for (l, v) in sel._options if v != PROFILE_CUSTOM_SENTINEL]
-            assert labels == ["dual/vllm/qwen3.6-27b-autoround-int4  ·  fp8-mtp"]
+            # the sole option IS the recommendation → starred + pre-selected
+            assert labels == ["⭐ dual/vllm/qwen3.6-27b-autoround-int4  ·  fp8-mtp"]
 
     @pytest.mark.asyncio
     async def test_gguf_inspect_requires_quant_pick_before_slugs(self):
@@ -1492,7 +1493,7 @@ class TestBringFunnelStagedReveal:
             await _settle(pilot)
             assert sel.display
             labels = [l for (l, v) in sel._options if v != PROFILE_CUSTOM_SENTINEL]
-            assert labels == ["single/ik-llama/qwen3.6-27b-ubergarm-iq4ks  ·  mtp"]
+            assert labels == ["⭐ single/ik-llama/qwen3.6-27b-ubergarm-iq4ks  ·  mtp"]
 
     @pytest.mark.asyncio
     async def test_fit_check_surfaces_weights_state_and_handoff(self, monkeypatch, tmp_path):
@@ -1602,6 +1603,27 @@ class TestFunnelSlugOptionsPure:
             self._rows(), "safetensors", artifact_gb=5.0, vram_gb=24.0, gpu_count=1
         )
         assert {o.slug for o in st} == {"vllm/minimal"}   # dual unhostable on 1 card
+
+    def test_recommendation_prefers_smallest_fitting_topology(self):
+        # Live dogfood 2026-07-05: a 5 GiB gguf on a 2-card rig defaulted to a
+        # DUAL slug (rig-topology rule) — the recommendation must be the
+        # SMALLEST fitting topology, curated default preferred within it.
+        from club3090_cockpit.app import funnel_recommended, funnel_slug_options
+
+        opts = funnel_slug_options(
+            self._rows(), "safetensors", artifact_gb=5.0, vram_gb=24.0, gpu_count=2
+        )
+        assert {o.slug for o in opts} == {"vllm/dual", "vllm/minimal"}
+        # no curated defaults → first functional option of the SINGLE group
+        assert funnel_recommended(opts) == "vllm/minimal"
+        # the registry's curated default for (vllm, single) wins within the group
+        defaults = [{"engine": "vllm-stable", "topology": "single", "slug": "vllm/minimal"}]
+        assert funnel_recommended(opts, defaults) == "vllm/minimal"
+        # big artifact → single floored away → the recommendation follows
+        opts = funnel_slug_options(
+            self._rows(), "safetensors", artifact_gb=34.0, vram_gb=24.0, gpu_count=2
+        )
+        assert funnel_recommended(opts) == "vllm/dual"
 
 
 # ===========================================================================

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -1463,7 +1463,18 @@ class TestBringFunnelStagedReveal:
             # §2b-3/4: only safetensors engines; topology-FIRST labels
             labels = [l for (l, v) in sel._options if v != PROFILE_CUSTOM_SENTINEL]
             # the sole option IS the recommendation → starred + pre-selected
-            assert labels == ["⭐ dual/vllm/qwen3.6-27b-autoround-int4  ·  fp8-mtp"]
+            assert labels == ["⭐ dual/vllm/qwen3.6-27b-autoround-int4"]
+            # dogfood r2 — titled field + the selected slug's detail card
+            assert app.query_one("#lane-bring-profile-title").display
+            card = app.query_one("#lane-bring-slug-card", Static)
+            assert card.display
+            ctext = str(card.render())
+            assert "vllm/dual" in ctext and "262K" in ctext
+            assert "174/42" in ctext          # the shipped bar rides the card
+            # sentinel pick hides the card (no catalog row to describe)
+            sel.value = PROFILE_CUSTOM_SENTINEL
+            await pilot.pause()
+            assert not card.display
 
     @pytest.mark.asyncio
     async def test_gguf_inspect_requires_quant_pick_before_slugs(self):
@@ -1493,7 +1504,7 @@ class TestBringFunnelStagedReveal:
             await _settle(pilot)
             assert sel.display
             labels = [l for (l, v) in sel._options if v != PROFILE_CUSTOM_SENTINEL]
-            assert labels == ["⭐ single/ik-llama/qwen3.6-27b-ubergarm-iq4ks  ·  mtp"]
+            assert labels == ["⭐ single/ik-llama/qwen3.6-27b-ubergarm-iq4ks"]
 
     @pytest.mark.asyncio
     async def test_fit_check_surfaces_weights_state_and_handoff(self, monkeypatch, tmp_path):
@@ -1572,11 +1583,32 @@ class TestFunnelSlugOptionsPure:
         from club3090_cockpit.app import funnel_slug_options
 
         st = funnel_slug_options(self._rows(), "safetensors")
-        # single before dual; label = topology/engine/model-quant · serving
+        # single before dual; label = topology/engine/model-quant (NO serving
+        # tail — dogfood r2: it duplicated the path axes)
         assert [o.label for o in st] == [
-            "single/vllm/qwen3.6-27b-autoround-int4  ·  minimal",
-            "dual/vllm/qwen3.6-27b-autoround-int4  ·  fp8-mtp",
+            "single/vllm/qwen3.6-27b-autoround-int4",
+            "dual/vllm/qwen3.6-27b-autoround-int4",
         ]
+
+    def test_serving_stem_disambiguates_collisions_only(self):
+        # Two slugs sharing (topology, engine, model, quant) differ only by
+        # serving stack → ONLY those two get the stem tail (basename, even
+        # when the registry file field carries a subpath).
+        from types import SimpleNamespace as NS
+
+        from club3090_cockpit.app import funnel_slug_options
+
+        rows = self._rows() + [
+            NS(slug="vllm/qwen-27b-dual-turbo", engine="vllm-stable",
+               model="qwen3.6-27b", file="dual/autoround-int4/turbo.yml",
+               status="production", compose_dir="",
+               compose_path="models/qwen3.6-27b/vllm/compose/dual/autoround-int4/turbo.yml"),
+        ]
+        st = funnel_slug_options(rows, "safetensors")
+        by_slug = {o.slug: o.label for o in st}
+        assert by_slug["vllm/minimal"] == "single/vllm/qwen3.6-27b-autoround-int4"
+        assert by_slug["vllm/dual"] == "dual/vllm/qwen3.6-27b-autoround-int4  ·  fp8-mtp"
+        assert by_slug["vllm/qwen-27b-dual-turbo"] == "dual/vllm/qwen3.6-27b-autoround-int4  ·  turbo"
 
     def test_size_floor_hides_too_small_topologies_only(self):
         from club3090_cockpit.app import funnel_slug_options


### PR DESCRIPTION
## What

Five maintainer frictions from the first two live rounds on the merged funnel (#582), fixed same-day.

### Round 1 (`empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF`)
1. **Distinct gguf artifacts sharing a quant token stay separate.** The repo ships base + MTP builds per quant; token-keyed grouping merged them into one "2-part" variant with a summed WRONG size (10.7 GiB shown for a 5.2 GiB pick). Now grouped by **stem** (true `-NNNNN-of-NNNNN` shards still merge), labeled by the common-prefix-stripped stem → `Q4_K_M` vs `MTP-Q4_K_M`, honest sizes. Live-verified: 10 selectable variants.
2. **ONE starred recommendation, smallest fitting topology.** The rig-topology default recommended a DUAL slug for a 5 GiB gguf. `funnel_recommended` = smallest fitting topology (options are size-floored + topo-sorted) + curated engine default within it — ⭐-starred AND pre-selected; the full list stays below.

### Round 2
3. **Label = `topology/engine/model-quant` ONLY.** The serving-stem tail duplicated the path axes and rendered subpaths (`· dual/piehsoft-q6k/mtp`) — dropped; the basename stem appends solely on genuine collisions (fp8-mtp vs turbo class).
4. **Titled fields.** Every input carries a title (`HF repo` · `GGUF quant` · `catalog config …`); titles toggle with their widgets so the staged reveal holds.
5. **Selected-slug detail card.** status · ctx · port · drafter/vision · the shipped bar (TPS/8pk, provenance, staleness †) · caveat — follows the selection, hides on the custom-slug sentinel.

## Validation
- c3 suite **781/781** (new: base-vs-MTP variant guard case · smallest-fit recommendation pure test · collision-only stem test · detail-card/titled-field headless asserts)
- `test-artifact-inventory.sh` green (Qwythos-shape regression case added)
- Deriver fix live-verified against the actual repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm