### PR TITLE
fp8 composes: VLLM_USE_DEEP_GEMM pass-through parity + drift guard

### DIFF
--- a/models/diffusiongemma-26b-a4b/vllm/compose/dual/fp8/base.yml
+++ b/models/diffusiongemma-26b-a4b/vllm/compose/dual/fp8/base.yml
@@ -90,6 +90,14 @@ services:
       # replaces the former static VLLM_DISABLE_CUSTOM_ALL_REDUCE=1.
       - VLLM_NO_USAGE_STATS=1
       - OMP_NUM_THREADS=1
+      # DeepGEMM (vLLM's fp8-GEMM path) is built for Hopper (sm_90) + datacenter
+      # Blackwell (sm_100/103). Consumer Blackwell (5090 / PRO 6000 / GB10,
+      # sm_120/121) has no recipe and hard-fails "recipe not found" at boot
+      # (disc #571). Pass-through: switch.sh/launch.sh auto-inject
+      # VLLM_USE_DEEP_GEMM=0 on those cards; if you run raw `docker compose` on a
+      # consumer Blackwell card, set it yourself (VLLM_USE_DEEP_GEMM=0). Unset =
+      # vLLM's arch default (DeepGEMM stays on where it works).
+      - VLLM_USE_DEEP_GEMM
       - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True,max_split_size_mb:512}
       - VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
       - VLLM_ATTENTION_BACKEND=TRITON_ATTN

--- a/models/qwen3.6-27b/vllm-lmcache/compose/dual/fp8/lmcache.yml
+++ b/models/qwen3.6-27b/vllm-lmcache/compose/dual/fp8/lmcache.yml
@@ -111,6 +111,14 @@ services:
       - NCCL_P2P_DISABLE=1
       - VLLM_NO_USAGE_STATS=1
       - VLLM_USE_FLASHINFER_SAMPLER=1
+      # DeepGEMM (vLLM's fp8-GEMM path) is built for Hopper (sm_90) + datacenter
+      # Blackwell (sm_100/103). Consumer Blackwell (5090 / PRO 6000 / GB10,
+      # sm_120/121) has no recipe and hard-fails "recipe not found" at boot
+      # (disc #571). Pass-through: switch.sh/launch.sh auto-inject
+      # VLLM_USE_DEEP_GEMM=0 on those cards; if you run raw `docker compose` on a
+      # consumer Blackwell card, set it yourself (VLLM_USE_DEEP_GEMM=0). Unset =
+      # vLLM's arch default (DeepGEMM stays on where it works).
+      - VLLM_USE_DEEP_GEMM
       - LMCACHE_DISABLE_BANNER=1
       # Forward host-tunable LMCache knobs into the in-container entrypoint.
       # Keep empty defaults here so bash's own $${VAR:-fallback} logic below

--- a/models/qwen3.6-27b/vllm/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/multi4/fp8/mtp.yml
@@ -92,6 +92,14 @@ services:
       - VLLM_NO_USAGE_STATS=1
       - VLLM_USE_FLASHINFER_SAMPLER=1
       - OMP_NUM_THREADS=1
+      # DeepGEMM (vLLM's fp8-GEMM path) is built for Hopper (sm_90) + datacenter
+      # Blackwell (sm_100/103). Consumer Blackwell (5090 / PRO 6000 / GB10,
+      # sm_120/121) has no recipe and hard-fails "recipe not found" at boot
+      # (disc #571). Pass-through: switch.sh/launch.sh auto-inject
+      # VLLM_USE_DEEP_GEMM=0 on those cards; if you run raw `docker compose` on a
+      # consumer Blackwell card, set it yourself (VLLM_USE_DEEP_GEMM=0). Unset =
+      # vLLM's arch default (DeepGEMM stays on where it works).
+      - VLLM_USE_DEEP_GEMM
       # expandable_segments:True crashes boot on some setups (likely cuMemMap path).
       # Known: JusefPol on NVLink (PR #31), WSL2 single-card 3090 Ti.
       # Override via .env: PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False

--- a/scripts/tests/test-deepgemm-fp8-parity.sh
+++ b/scripts/tests/test-deepgemm-fp8-parity.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# test-deepgemm-fp8-parity — every fp8-weights vLLM compose MUST carry the
+# `- VLLM_USE_DEEP_GEMM` pass-through so the launcher's consumer-Blackwell
+# auto-disable (_deepgemm_env, sm {8.9, 12.0, 12.1}) actually reaches the
+# container. Without the receiving line, docker-compose drops the injected
+# VLLM_USE_DEEP_GEMM=0 and a 5090 / PRO 6000 / GB10 user hits the fp8-GEMM
+# "recipe not found" boot crash (disc #571 / #580).
+#
+# This guards the sibling-compose DRIFT class: dual-max carried the line
+# (added in #580) but multi-max / dual-lmcache / diffusiongemma-dual — the
+# same fp8-weights config — had silently drifted without it. These composes
+# are hand-maintained parallel copies (no extends/include), so nothing else
+# keeps them in sync.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+python3 - <<'PY'
+import re
+import sys
+
+sys.path.insert(0, ".")
+from scripts.lib.profiles.compose_registry import COMPOSE_REGISTRY  # noqa: E402
+
+LINE = re.compile(r"^\s*-\s*VLLM_USE_DEEP_GEMM\s*$", re.M)
+missing = []
+checked = 0
+for slug, e in COMPOSE_REGISTRY.items():
+    # The _deepgemm_env launcher injection gates on fp8 weights + a vLLM engine;
+    # match that exact set (INT4/AWQ/bf16/W8A8 never invoke DeepGEMM).
+    if e.get("weights_variant") != "fp8":
+        continue
+    if "vllm" not in (e.get("engine") or ""):
+        continue
+    checked += 1
+    try:
+        txt = open(e["compose_path"]).read()
+    except OSError:
+        missing.append(f"{slug}: compose unreadable ({e['compose_path']})")
+        continue
+    if not LINE.search(txt):
+        missing.append(f"{slug}: missing `- VLLM_USE_DEEP_GEMM` ({e['compose_path']})")
+
+if missing:
+    print("test-deepgemm-fp8-parity: FAIL", file=sys.stderr)
+    for m in missing:
+        print(f"  ✗ {m}", file=sys.stderr)
+    print("  fp8 weights on consumer Blackwell (sm_120/121) need the pass-through so the",
+          file=sys.stderr)
+    print("  launcher's VLLM_USE_DEEP_GEMM=0 reaches the container (disc #571 / #580).",
+          file=sys.stderr)
+    sys.exit(1)
+
+print(f"  ✓ all {checked} fp8-weights vLLM composes carry the VLLM_USE_DEEP_GEMM pass-through")
+PY
+
+echo "test-deepgemm-fp8-parity: ok"


### PR DESCRIPTION
## What

#580 added the consumer-Blackwell DeepGEMM auto-disable pass-through to `dual-max`, but the **other three fp8-weights vLLM composes had silently drifted** without it — they're hand-maintained parallel copies (no `extends`/`include`), so nothing kept them in sync. Surfaced while checking whether multi-max is derived from dual-max (it isn't).

**Impact:** on a 5090 / PRO 6000 / GB10 (sm_120/121), the launcher's `_deepgemm_env` injects `VLLM_USE_DEEP_GEMM=0`, but with no receiving line in the compose, docker-compose drops it → the fp8-GEMM **"recipe not found" boot crash** #580 fixed for dual-max ([disc #571](https://github.com/noonghunna/club-3090/discussions/571)).

## Changes
- Added the `- VLLM_USE_DEEP_GEMM` pass-through (+ shared comment) to the three drifted composes: **multi-max** (`multi4/fp8/mtp.yml`), **dual-lmcache** (`vllm-lmcache/dual/fp8/lmcache.yml`), **diffusiongemma-dual** (`diffusiongemma/dual/fp8/base.yml`). All 4 fp8-weights vLLM composes now carry it.
- **NEW `test-deepgemm-fp8-parity`** — asserts every fp8-weights vLLM compose has the pass-through, REDing on this exact drift class (verified it fails when a line is removed, passes when restored). Scope matches the `_deepgemm_env` gate: `weights_variant==fp8` + vLLM engine — INT4/AWQ/bf16/W8A8 never invoke DeepGEMM, so they're correctly excluded (the flag is a dead line on them).

## Scope note (from the review discussion)
This removes **one** 5090 blocker (the fp8 crash) — it is **not** a blanket "runs on 5090":
- **beellama composes stay broken** on sm_120 (Anbeeld#85 — CUDA 12.4 nvcc can't target sm_120)
- **llama.cpp / INT4-Marlin on sm_120 remain unvalidated** (no 5090 on the reference rig)

## Validation
- Full serial gate green; new guard passes on the fixed tree + REDs on the drift; launcher whitelist (switch.sh:935 / launch.sh:1184) confirmed to reach these slugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm