### PR TITLE
DeepGEMM: cover fp8-dynamic weights (agents-a1) — all fp8 slugs 5090-safe via launcher

### DIFF
--- a/models/agents-a1/vllm/compose/dual/fp8-dynamic/fp8.yml
+++ b/models/agents-a1/vllm/compose/dual/fp8-dynamic/fp8.yml
@@ -154,6 +154,14 @@ services:
       - VLLM_NO_USAGE_STATS=1
       - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
       - OMP_NUM_THREADS=1
+      # DeepGEMM (vLLM's fp8-GEMM path) is built for Hopper (sm_90) + datacenter
+      # Blackwell (sm_100/103). This is FP8-dynamic (compressed-tensors) weights →
+      # it routes FP8 GEMM, so consumer Blackwell (5090 / PRO 6000 / GB10,
+      # sm_120/121) hard-fails "recipe not found" at boot (disc #571). Pass-through:
+      # switch.sh/launch.sh auto-inject VLLM_USE_DEEP_GEMM=0 on those cards; on raw
+      # `docker compose` on a consumer Blackwell card, set it yourself. Unset =
+      # vLLM's arch default (DeepGEMM stays on where it works).
+      - VLLM_USE_DEEP_GEMM
       # Blackwell (sm_120) on v0.24.0: uncomment to dodge the upstream
       # kernel-selection crash — forces the Marlin weight-only path this
       # compose's gate validated (see Caveats (4) + club-3090 #548).

--- a/scripts/lib/profiles/launch_compat.py
+++ b/scripts/lib/profiles/launch_compat.py
@@ -305,14 +305,18 @@ def _deepgemm_env(profiles, variant: str, entry: dict, gpu_spec: str) -> dict[st
     found' (confirmed on a 5090 — disc #571 guybrush01); Ada (sm_89) never routes
     fp8 through DeepGEMM at all (Marlin/CUTLASS), so injecting 0 there is a
     harmless no-op that pre-empts the same wall for 4090 owners. Hopper/datacenter
-    (where DeepGEMM is the fast path) are left untouched. Only fires for fp8-weights
-    slugs. Empty dict = no injection."""
+    (where DeepGEMM is the fast path) are left untouched. Fires for the whole
+    fp8-family weight set — "fp8" AND "fp8-dynamic" (compressed-tensors FP8, e.g.
+    agents-a1) — since both route FP8 GEMM. Empty dict = no injection."""
     if not gpu_spec:
         return {}
     if os.environ.get("VLLM_USE_DEEP_GEMM"):
         return {}  # explicit user pin always wins
-    if (entry or {}).get("weights_variant") != "fp8":
-        return {}  # only native fp8-weights slugs touch the DeepGEMM path
+    if not ((entry or {}).get("weights_variant") or "").startswith("fp8"):
+        return {}  # fp8-FAMILY weight formats only: "fp8" AND "fp8-dynamic"
+        # (compressed-tensors FP8, e.g. agents-a1) — both route FP8 GEMM →
+        # DeepGEMM. INT4/AWQ/W8A8/bf16 never do. New fp8 variants must be
+        # named fp8-* for this to catch them (test-deepgemm-fp8-parity guards).
     try:
         hardware = _parse_gpu_specs(gpu_spec, profiles)
     except LaunchCompatError:

--- a/scripts/tests/test-deepgemm-fp8-parity.sh
+++ b/scripts/tests/test-deepgemm-fp8-parity.sh
@@ -27,9 +27,10 @@ LINE = re.compile(r"^\s*-\s*VLLM_USE_DEEP_GEMM\s*$", re.M)
 missing = []
 checked = 0
 for slug, e in COMPOSE_REGISTRY.items():
-    # The _deepgemm_env launcher injection gates on fp8 weights + a vLLM engine;
-    # match that exact set (INT4/AWQ/bf16/W8A8 never invoke DeepGEMM).
-    if e.get("weights_variant") != "fp8":
+    # Mirror the _deepgemm_env gate EXACTLY: fp8-FAMILY weights (startswith
+    # "fp8" → "fp8" and "fp8-dynamic"/compressed-tensors, e.g. agents-a1) on a
+    # vLLM engine. INT4/AWQ/W8A8/bf16 never invoke DeepGEMM → correctly excluded.
+    if not (e.get("weights_variant") or "").startswith("fp8"):
         continue
     if "vllm" not in (e.get("engine") or ""):
         continue

--- a/scripts/tests/test-launch-compat.sh
+++ b/scripts/tests/test-launch-compat.sh
@@ -173,9 +173,12 @@ out="$(python3 "$HELPER" resolve-variant-pin --variant "$DMAX" --format shell --
 assert_not_contains "$out" "VLLM_USE_DEEP_GEMM"        # Hopper keeps the fast path
 out="$(python3 "$HELPER" resolve-variant-pin --variant vllm/dual --format shell --gpu-spec "$GPU_5090X2")"
 assert_not_contains "$out" "VLLM_USE_DEEP_GEMM"        # int4-weights slug: not the DeepGEMM path
+# fp8-DYNAMIC (compressed-tensors) is fp8-family too — agents-a1 must also disable
+out="$(python3 "$HELPER" resolve-variant-pin --variant vllm/agents-a1-dual --format shell --gpu-spec "$GPU_5090X2")"
+assert_contains "$out" "VLLM_USE_DEEP_GEMM=0"          # fp8-dynamic weights route FP8 GEMM
 out="$(VLLM_USE_DEEP_GEMM=1 python3 "$HELPER" resolve-variant-pin --variant "$DMAX" --format shell --gpu-spec "$GPU_5090X2")"
 assert_not_contains "$out" "VLLM_USE_DEEP_GEMM=0"      # explicit user pin wins
-echo "  ok: fp8w DeepGEMM disable (5090/Ada down · Hopper keep · non-fp8 skip · user-pin — 5 cases)"
+echo "  ok: fp8w DeepGEMM disable (5090/Ada down · Hopper keep · non-fp8 skip · fp8-dynamic · user-pin — 6 cases)"
 
 if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
   out="$(VLLM_NIGHTLY_SHA="$CLEAN_SHA" docker compose -f "$ROOT_DIR/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml" config 2>/dev/null)"


### PR DESCRIPTION
## What

Follow-up to #588. That PR made fp8-weights composes 5090-safe, but both the `_deepgemm_env` injection gate **and** the parity guard matched `weights_variant == "fp8"` **exactly** — which silently skipped **`vllm/agents-a1-dual`**, whose weights are `fp8-dynamic` (compressed-tensors FP8). Those are genuine FP8 weights that route FP8 GEMM, so a 5090 running agents-a1 would **still hit the "recipe not found" crash** the framework is meant to prevent.

(The other compressed-tensors slugs — qat-w4a16, awq-bf16-int4 — are INT4 weights, not fp8, so they correctly stay excluded.)

## Changes
- **`_deepgemm_env` gate**: `weights_variant == "fp8"` → `startswith("fp8")` — catches `fp8` **and** `fp8-dynamic`. INT4/AWQ/W8A8/bf16 never route FP8 GEMM, so they're still correctly untouched.
- **agents-a1 compose**: added the `- VLLM_USE_DEEP_GEMM` pass-through (so the injection reaches it).
- **`test-deepgemm-fp8-parity`**: broadened to `startswith("fp8")` — now covers all **5** fp8-family composes + any future `fp8-*` variant.
- **`test-launch-compat`**: new case — fp8-dynamic on 5090 injects `VLLM_USE_DEEP_GEMM=0`.

## Result
**All fp8-family vLLM slugs are now 5090-safe via the launcher**: dual-max, multi-max, dual-lmcache, diffusiongemma-dual, **+ agents-a1**. Convention documented: fp8 weight variants must be named `fp8-*` for the gate/guard to catch them.

## Validation
- Full serial gate green. Verified the injection now fires for agents-a1 on 5090 (`VLLM_USE_DEEP_GEMM=0`) while int4 `vllm/dual` still correctly skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm