### PR TITLE
Promote vllm/qwen-27b-dual-max → Production (soak completes the gate)

### DIFF
--- a/models/qwen3.6-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/fp8/mtp.yml
@@ -10,7 +10,7 @@
 #              constrained on 2 cards, comfortable on the 4-card multi-max). Validation proxy for
 #              the TP=4 multi-max (vllm/qwen-27b-multi-max, same config).
 #   Genesis:   none — intentionally Genesis-free
-#   Status:    🧪 Experimental
+#   Status:    ✅ Production
 #   Quality:   110/150 (det 65/75 · sandbox 45/75) (--full, same harness 2026-06-07). 8-pack A/B
 #                same day: fast 109 · balanced 105 · max 110 — a TIE (det 64/64/65; within ±5-7
 #                noise). FP8 (8-bit) + int8-PTH KV are NOT a behavioral-quality win over the

--- a/scripts/lib/profiles/baselines.yml
+++ b/scripts/lib/profiles/baselines.yml
@@ -323,6 +323,9 @@ baselines:
     # wall 82.0/104.6, TTFT 158/167 ms, KV pool 295K/1.13×, ~21.4 GB/card,
     # NIAH clean@240K, 8-pack --full 107/150 (thinking-off). Measured ON the
     # current v0.24.0 pin → FRESH. Corrects the stale "~56 TPS" probe.
+    # Promoted to ✅ Production 2026-07-06: soak-continuous PASS re-run on the
+    # v0.24.0 pin (0 err / 0 growth / 100% retention, p50 decode 85) + verify-
+    # full 9/9 + verify-stress fillable to 240,636 tok — completes the gate.
     narr_tps: 83.1
     code_tps: 108.2
     ttft_ms: 158

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -187,8 +187,8 @@ COMPOSE_REGISTRY = {
         compose_path="models/qwen3.6-27b/vllm/compose/dual/fp8/mtp.yml",
         default_port=8013,
         kvcalc_key="SKIP",
-        status="experimental",
-        status_note="Qwen3.6-27B 'max accuracy' tier, 2-card: official FP8 weights (e4m3, embedded MTP head) + int8-PTH KV + MTP n=3, TP=2 @262K. 🧪 Experimental — live-validated 2026-06-07 (boots + serves @262K, KV pool 295K tok / 1.13x concurrency via int8-PTH, MarlinFP8 W8A16 on Ampere, coherent + MTP active; ~56 TPS decode). 8-pack A/B (--full, same harness 2026-06-07): 110/150 vs fast 109 vs balanced 105 — a TIE (det 65/64/64; spread within noise). The 8-pack (short-ctx) does NOT separate the quants; FP8 + int8-PTH differentiate on KV fidelity, not behavioral quality — a long-ctx NIAH A/B (where int8-PTH should matter) is the open follow-up. Slowest of the three (~56 vs fast ~89 code) with the smallest KV pool (1.13x). Also the validation proxy for vllm/qwen-27b-multi-max (same config @ TP=4).",
+        status="production",
+        status_note="Qwen3.6-27B 'max accuracy' tier, 2-card: official FP8 weights (e4m3, embedded MTP head) + int8-PTH KV + MTP n=3, TP=2 @262K. Promoted to ✅ Production 2026-07-06 on a full gate (v0.24.0): verify-full 9/9, verify-stress fillable to 240,636 tok, soak-continuous PASS (0 err / 0 growth / 100% retention, p50 decode 85), bench decode 83.1/108.2, 8-pack --full 107/150. KV pool 295K tok / 1.13x concurrency (int8-PTH — smallest pool of the tiers, the fidelity trade; slowest PREFILL/TTFT of the three since FP8 uses MarlinFP8 W8A16 on Ampere, not decode). The highest-fidelity weight tier; consumer Blackwell (5090+) gets native FP8 GEMM via the launcher's DeepGEMM-disable. Also the validation proxy for vllm/qwen-27b-multi-max (same config @ TP=4).",
     ),
     "vllm/qwen-27b-dual-lmcache": _entry(
         model="qwen3.6-27b", weights_variant="fp8", workload="long-ctx-single",


### PR DESCRIPTION
## What

The FP8 max-accuracy tier had bench (**83.1/108.2**) + quality (**107/150**) on the 2×3090 reference rig, but **no soak-continuous run** — the one missing gate item. Ran the full operational gate fresh on the **v0.24.0** pin:

- **verify-full** 9/9
- **verify-stress** — all 6 rungs, **fillable to 240,636 tok** clean (91%)
- **soak-continuous PASS** — 0 err / 0 growth / **100% retention**, p50 decode 85

That clears the ✅ Production bar.

## Changes
- **status experimental → production** (registry + compose header; drift guard green).
- **De-staled the registry `status_note`** (still carried the old "~56 TPS" probe / "slowest of the three" — fixed in the header + DUAL_CARD in #586 but missed the registry). Corrected to decode 83/108; the slow axis is **prefill/TTFT** (MarlinFP8 W8A16 on Ampere), not decode.
- **baselines.yml**: row comment records the soak PASS completing the gate.
- **No `DEFAULTS[(qwen,vllm,dual)]` change** → `vllm/dual` (fast) stays the dual default; dual-max joins the actionable list as the max-fidelity tier.

## Bonus
dual-max is now non-experimental → the launch command **drops `--force`**: `bash scripts/switch.sh vllm/qwen-27b-dual-max` (the clean command for the 5090 fp8 tweet).

## Validation
Full serial gate green (drift · baselines · registry parity · profiles-compat · deepgemm-parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
