### PR TITLE
Promote vllm/qwen-27b-multi-max → Production w/ caveats (@Whamp #446)

### DIFF
--- a/models/qwen3.6-27b/vllm/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/multi4/fp8/mtp.yml
@@ -10,7 +10,12 @@
 #              proxy (vllm/qwen-27b-dual-max, TP=2): KV pool 295K tok, 1.13× concurrency —
 #              tight on 2 cards, comfortable on 4.
 #   Genesis:   none — intentionally Genesis-free
-#   Status:    🧪 Experimental (TP=4 cross-rig — config = vllm/qwen-27b-dual-max validated @TP=2)
+#   Status:    ⚠️ Production w/ caveats
+#   Caveats:   Cross-rig validation only (this dev rig has 2 cards). Promoted on @Whamp's 4× 3090
+#                full chain — #446: verify-full + verify-stress 7/7 + soak-continuous PASS (85/102) —
+#                BUT on an OLDER engine (pre-v0.24.0 pin) + a non-standard rig (aikitoria P2P kernel,
+#                mixed x4/x16/x8/x16 lanes), single report. No clean v0.24.0 4-card datapoint yet →
+#                a fresh one upgrades this to ✅. Byte-identical to the production dual-max @TP=4.
 #   Quality:   = the dual-max proxy (vllm/qwen-27b-dual-max): 8-pack 110/150 (--full, current
 #                harness 2026-06-07); 3-way A/B fast 109 · balanced 105 · max 110 = TIE — FP8 +
 #                int8-PTH is NOT an 8-pack quality win over the fast tier (the differentiation is
@@ -23,8 +28,9 @@
 # 2-card vllm/qwen-27b-dual-max (dual/fp8/mtp.yml) — only the tensor-parallel size and
 # the required gpu-count bump to 4. The dual-max at TP=2 is the on-rig validation proxy
 # (boots/serves @262K, KV pool 295K tok, 1.13× concurrency — tight on 2 cards,
-# comfortable on 4); this 4-card variant is 🧪 Experimental until a real ≥4× 3090 host
-# validates it (this dev rig has 2 cards).
+# comfortable on 4). Promoted to ⚠️ Production w/ caveats 2026-07-06 on @Whamp's 4× 3090
+# cross-rig full chain (#446); see the Caveats line above for the validation's limits
+# (older engine + non-standard rig, single report) — a clean v0.24.0 4-card report upgrades to ✅.
 #
 # Why "max accuracy": FP8 weights (8-bit, near-lossless per our KLD findings) + int8-PTH
 # KV (8-bit, higher fidelity than the fast tier's fp8_e5m2), vs the AutoRound-INT4 fast

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -227,8 +227,8 @@ COMPOSE_REGISTRY = {
         compose_path="models/qwen3.6-27b/vllm/compose/multi4/fp8/mtp.yml",
         default_port=8015,
         kvcalc_key="SKIP",
-        status="experimental",
-        status_note="Qwen3.6-27B 'max accuracy' tier, 4-card (TP=4): official FP8 weights + int8-PTH KV + MTP n=3 @262K. 🧪 Experimental (cross-rig) — byte-identical to vllm/qwen-27b-dual-max apart from TP=4 + gpu-count; the dual-max @TP=2 is the on-rig validation proxy. FP8 + int8-PTH = the highest-fidelity Qwen path at full 262K, with TP=4 relieving the dual-max's tight (1.13x) KV pool. Validate on a real ≥4× 3090 host before promotion.",
+        status="caveats",
+        status_note="Qwen3.6-27B 'max accuracy' tier, 4-card (TP=4): official FP8 weights + int8-PTH KV + MTP n=3 @262K. ⚠️ Production w/ caveats — byte-identical to the now-production vllm/qwen-27b-dual-max apart from TP=4 + gpu-count (dual-max @TP=2 is the on-rig proxy; this dev rig has 2 cards). Promoted 2026-07-06 on @Whamp's cross-rig full chain (#446, 4× 3090: verify-full + verify-stress 7/7 + soak-continuous PASS, 85/102). CAVEAT: that validation was on an OLDER engine (pre-v0.24.0-pin) + a non-standard rig (aikitoria P2P kernel, mixed x4/x16/x8/x16 lanes), single report — no clean v0.24.0 4-card datapoint yet; a fresh one upgrades this to ✅ Production. TP=4 relieves dual-max's tight 1.13x KV pool (→ 6.77x). Value is concurrency/fidelity, single-stream decode ~flat vs 2-card.",
     ),
 
     # Qwen 3.6 27B, llama.cpp single-card.


### PR DESCRIPTION
## What

Promoting the 4-card FP8 max tier `vllm/qwen-27b-multi-max` — **⚠️ Production w/ caveats** (not bare ✅, per the discussion). It's byte-identical to the now-production `vllm/qwen-27b-dual-max` apart from TP=4 + gpu-count. We can't self-validate (2-card dev rig), so it rides **@Whamp's cross-rig full chain** ([#446](https://github.com/noonghunna/club-3090/issues/446), 4× 3090: verify-full + verify-stress 7/7 + soak-continuous PASS, 85/102).

## The caveat (stated honestly, in the required Caveats line)
@Whamp's validation was on an **older engine** (pre-v0.24.0 pin) + a **non-standard rig** (aikitoria P2P kernel, mixed x4/x16/x8/x16 lanes), **single report**. There's no clean v0.24.0 4-card datapoint yet. A fresh one (like @ryanmpelletier's for multi-fast) **upgrades this to bare ✅**.

## Changes
- **status experimental → caveats** (registry) + `Status: ⚠️ Production w/ caveats` + a required `Caveats:` line (drift guard green).
- **No baseline row inducted** — @Whamp's number is under-specified (engine version unstated, non-standard rig); inducting it as *the* bar would mislead. The `status_note` carries the provenance + caveats instead. (c3 shows "—" for the bar until a clean report lands, which is honest.)
- Removed the now-contradictory "🧪 Experimental until a ≥4× host validates it" prose from the header.
- **No `DEFAULTS` change** → the fast tiers stay the defaults; multi-max joins the actionable list as the 4-card max-fidelity option.

## Validation
Full serial gate green (status-drift confirms ⚠️ header ↔ registry `caveats`; parity · profiles-compat · deepgemm-parity all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
