### PR TITLE
Record multi-fast measured 4-card quality (108/150, @ryanmpelletier #584)

### DIFF
--- a/models/qwen3.6-27b/vllm/compose/multi4/autoround-int4/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/multi4/autoround-int4/mtp.yml
@@ -11,8 +11,9 @@
 #   Quality:   = the dual fast proxy (vllm/dual): 109/150 (--full, current harness 2026-06-07);
 #                3-way A/B fast 109 · balanced 105 · max 110 = TIE. (Earlier 129/150 on the
 #                2026-05-09 harness is not comparable — verifier fixes since.) Quality is
-#                TP-invariant (same weights/KV/sampling as vllm/dual, only TP differs); a
-#                4-card 8-pack confirmation is the open follow-up (report.sh runs no 8-pack).
+#                TP-invariant (same weights/KV/sampling as vllm/dual, only TP differs) — and
+#                now MEASURED on real 4-card hardware: @ryanmpelletier ran the full 8-pack
+#                thinking-off = 108/150 (#584, 2026-07-06), within ±1 of the 2-card carry.
 #   Best for:  4-card Qwen "fast" tier (vllm/qwen-27b-multi-fast) — AutoRound int4 + fp8 KV + MTP, TP=4 ⭐
 # ---------------------------------------------------------------------------
 # Quad RTX 3090 — Qwen3.6-27B "fast" tier at TP=4 (vllm/qwen-27b-multi-fast).

--- a/scripts/lib/profiles/baselines.yml
+++ b/scripts/lib/profiles/baselines.yml
@@ -368,13 +368,16 @@ baselines:
         # clean to 240K · soak-continuous PASS (0 err / 0 silent / <200 MiB) ·
         # bench n=5 CV 4.2%/3.0%. KV pool 1.77M tok / 6.77× @262K (vs 2-card
         # vllm/dual 622K/2.37×) — the 4-card win is concurrency, not single-stream
-        # speed (decode ~flat, TP=4 all-reduce over PCIe). TPS-only: report.sh
-        # runs no 8-pack; quality is TP-invariant, carried from the vllm/dual
-        # proxy (109/150). ⚠ ceiling margin thin (851 MB @240K on driver 595, #149).
+        # speed (decode ~flat, TP=4 all-reduce over PCIe). ⚠ ceiling margin thin
+        # (851 MB @240K on driver 595, #149). QUALITY confirmed 2026-07-06 (#584
+        # follow-up): full 8-pack thinking-off 108/150 — within ±1 of the carried
+        # vllm/dual proxy (109), so TP-invariance is now MEASURED, not assumed.
         narr_tps: 74.76
         code_tps: 90.83
         ttft_ms: 141
         prefill_tps: { 10k: 1288, 90k: 1175 }
+        quality_8pk: "108/150"
+        quality_env: { harness: "benchlocal-cli @ club-3090 087d094 (sandboxes rebuilt 2026-07-06)" }
         ctx_validated: { tokens: 240633, niah: "clean@240K" }
         date: 2026-07-05
         engine_pin: "vllm/vllm-openai:v0.24.0"


### PR DESCRIPTION
## What

@ryanmpelletier rebuilt the benchlocal sandboxes and ran the full 8-pack on his 4× 3090 (v0.24.0, thinking-off): **TOTAL 108/150** — within ±1 of the **109/150** we carry from the 2-card fast tier. So multi-fast's quality is now **measured TP-invariant on real 4-card hardware**, not assumed.

Per-pack: toolcall 13 · IF 13 · structout 14 · dataextract 13 · reasonmath 12 · bugfind 12 · hermes 10/20 · cli 21/40.

## Changes
- **baselines.yml**: ryan's `4x3090-pcie` submission gains `quality_8pk: "108/150"` + **`quality_env`** (harness provenance) — the **first quality ingest into a submission row**, exercising the friction-#8 / slice-3e hook (a quality number carries its harness fingerprint so it's reproducible). Guard validates it.
- **compose header `Quality:`** — "4-card 8-pack confirmation is the open follow-up" → the measured 108/150.

## Scope
- Closes the **last open item on the multi-fast promotion** — bench + soak + quality now all confirmed on 4-card.
- Does **not** touch multi-max's caveat — that needs an *fp8* 4-card report (ryan is INT4 multi-fast).

## Validation
Full serial gate green (`test-baselines` validates the new `quality_env` shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
