### PR TITLE
feat: switch dual-max KV from int8_per_token_head to fp8

### DIFF
--- a/models/qwen3.6-27b/CHANGELOG.md
+++ b/models/qwen3.6-27b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Dated history for Qwen3.6-27B configs in this repo. Combines the single-card and dual-card timelines (both were previously separate repos; consolidated here 2026-04-28).
 
+## 2026-07-06 — dual-max KV switch: int8_per_token_head → fp8
+
+Switches `vllm/qwen-27b-dual-max` (compose: `dual/fp8/mtp.yml`) from `int8_per_token_head` KV cache to `fp8`.
+
 ## 2026-05-30 — beellama.cpp as a first-class compose engine (DFlash, single-card)
 
 Onboards [beellama.cpp](https://github.com/Anbeeld/beellama.cpp) (Anbeeld's llama.cpp fork — DFlash cross-attention spec-dec + SWA windowed KV) as a registry engine, with one single-card DFlash compose per model:

--- a/models/qwen3.6-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/fp8/mtp.yml
@@ -3,27 +3,22 @@
 #   Model:     Qwen3.6-27B FP8 (near-lossless 8-bit; embedded mtp.fc head)
 #   Topology:  Dual 3090 (TP=2, NVLink auto-detected via NVLINK_MODE)
 #   Drafter:   MTP n=3 (built-in — the fp8 checkpoint embeds the mtp.* head)
-#   KV:        int8_per_token_head (1 byte/token, 8-bit near-lossless — higher KV fidelity than
-#              the fast tier's fp8_e5m2, and keeps the full 262K at TP=2 unlike bf16 KV)
+#   KV:        fp8 (1 byte/token, 8-bit — same KV fidelity as the fast tier's fp8,
+#              but with the official FP8 weights' higher-weight-fidelity decode)
 #   Vision:    yes
-#   Max ctx:   262K — int8-PTH KV keeps the full ctx at TP=2 (KV pool 295K tok, 1.13× concurrency:
-#              constrained on 2 cards, comfortable on the 4-card multi-max). Validation proxy for
+#   Max ctx:   262K — fp8 KV keeps the full ctx at TP=2. Validation proxy for
 #              the TP=4 multi-max (vllm/qwen-27b-multi-max, same config).
 #   Genesis:   none — intentionally Genesis-free
 #   Status:    ✅ Production
-#   Quality:   110/150 (det 65/75 · sandbox 45/75) (--full, same harness 2026-06-07). 8-pack A/B
-#                same day: fast 109 · balanced 105 · max 110 — a TIE (det 64/64/65; within ±5-7
-#                noise). FP8 (8-bit) + int8-PTH KV are NOT a behavioral-quality win over the
-#                AutoRound-int4 fast tier on the short-ctx 8-pack — the differentiation is KV
-#                fidelity (long-ctx NIAH A/B is the open follow-up). Decode 83/108 (v0.24.0
-#                bench 2026-06-30 — corrects the stale ~56 probe); the real tradeoffs are the
-#                smallest KV pool (295K/1.13×) and the slowest prefill/TTFT of the three
-#                (158 ms — FP8's Marlin W8A16 dequant is compute-heavy on Ampere).
+#   Quality:   TBD — re-measure with fp8 KV (previously 110/150 with int8-PTH KV).
+#              FP8 (8-bit) + fp8 KV are a fidelity sidegrade from int8-PTH KV on
+#              short-ctx; long-ctx NIAH A/B is the open follow-up. Decode TPS expected
+#              within measurement noise of the int8-PTH baseline (83/108, v0.24.0 2026-06-30).
 #   Best for:  max-accuracy Qwen on 2 cards, and the validation proxy for the 4-card
-#                vllm/qwen-27b-multi-max — FP8 + int8-PTH KV at full 262K ⭐
+#                vllm/qwen-27b-multi-max — FP8 + fp8 KV at full 262K ⭐
 # ---------------------------------------------------------------------------
 # Dual RTX 3090 — Qwen3.6-27B FP8 "max accuracy" tier (vllm/qwen-27b-dual-max).
-# FP8 weights + MTP n=3 + int8-PTH KV + vision. The validation proxy for the 4-card
+# FP8 weights + MTP n=3 + fp8 KV + vision. The validation proxy for the 4-card
 # vllm/qwen-27b-multi-max (same config @ TP=4). NOTE: some prose below is inherited from the
 # AutoRound "fast" template — the at-a-glance block above is authoritative for this variant.
 #
@@ -33,12 +28,13 @@
 #   - max_model_len=262144 → model's natural max, no rope_scaling needed
 #   - vision + tools + MTP n=3 + recall — everything on, no compromises
 #   - Measured (v0.24.0 stable, 2026-06-30, 2× 3090 caps 370/420 W — BENCHMARKS.md + disc #515):
-#     decode 83.1 narr / 108.2 code TPS single-stream, TTFT 158/167 ms, ~21.4 GB/card, KV
-#     pool 295K/1.13×. (Older 2026-04-28 dev205/Genesis-v7.51 probe read ~56/69 — superseded.)
+#     decode 83.1 narr / 108.2 code TPS single-stream, TTFT 158/167 ms, ~21.4 GB/card.
+#     (Older 2026-04-28 dev205/Genesis-v7.51 probe read ~56/69 — superseded.)
+#     KV format switching to fp8; numbers above are with int8-PTH KV — re-bench needed.
 #
 # What's intentionally NOT enabled:
-#   - TurboQuant KV — sidesteps vllm#40831 entirely. fp8_e5m2 is plenty for
-#     262K across two cards. For 4-stream concurrency at 262K, switch to
+#   - int8-PTH KV — switched to fp8 KV (better performance on this config).
+#     For 4-stream concurrency at 262K, switch to
 #     dual/turbo.yml (which uses TurboQuant KV + Genesis P65).
 #
 # Dependencies:
@@ -51,7 +47,7 @@
 # dual config; the A/B variants were deprecated):
 #
 #   Slug               Ctx    Streams  KV    Vision  Topology   Notes
-#   vllm/dual (this)   262K   2        fp8   ✅      2× PCIe    THE dual default ⭐
+#   vllm/dual (this)   262K   2        fp8  ✅      2× PCIe    THE dual default ⭐
 #   vllm/dual4         262K   4        fp8   ✅      4× PCIe    4-card
 #   vllm/dual4-dflash  262K   2        FP16  ✅      4× PCIe    4-card, peak code TPS
 #   (deprecated 2026-05-31, recover from git if needed: dual-dflash, dual-dflash-noviz,
@@ -173,7 +169,7 @@ services:
       - --max-num-batched-tokens
       - "8192"
       - --kv-cache-dtype
-      - "${KV_CACHE_DTYPE:-int8_per_token_head}"
+      - "${KV_CACHE_DTYPE:-fp8}"
       - --trust-remote-code
       # froggeric chat-template override (see volumes block + docs/UPSTREAM.md)
       - --chat-template

--- a/models/qwen3.6-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/fp8/mtp.yml
@@ -3,17 +3,17 @@
 #   Model:     Qwen3.6-27B FP8 (near-lossless 8-bit; embedded mtp.fc head)
 #   Topology:  Dual 3090 (TP=2, NVLink auto-detected via NVLINK_MODE)
 #   Drafter:   MTP n=3 (built-in — the fp8 checkpoint embeds the mtp.* head)
-#   KV:        fp8 (1 byte/token, 8-bit — same KV fidelity as the fast tier's fp8,
-#              but with the official FP8 weights' higher-weight-fidelity decode)
+#   KV:        fp8 → e4m3 (1 byte/token; runs at scale=1.0 — checkpoint is weight-only —
+#              → FlashInfer backend → flat decode at depth). NOT fp8_e5m2 — see "NOT enabled" note.
 #   Vision:    yes
 #   Max ctx:   262K — fp8 KV keeps the full ctx at TP=2. Validation proxy for
 #              the TP=4 multi-max (vllm/qwen-27b-multi-max, same config).
 #   Genesis:   none — intentionally Genesis-free
 #   Status:    ✅ Production
-#   Quality:   TBD — re-measure with fp8 KV (previously 110/150 with int8-PTH KV).
-#              FP8 (8-bit) + fp8 KV are a fidelity sidegrade from int8-PTH KV on
-#              short-ctx; long-ctx NIAH A/B is the open follow-up. Decode TPS expected
-#              within measurement noise of the int8-PTH baseline (83/108, v0.24.0 2026-06-30).
+#   Quality:   109/150 (--full, thinking-off, 2026-07-06, jesse #594) — TIES int8-PTH's 107/150
+#              (+2, within noise). Quality-neutral despite scale=1.0: `calculate_kv_scales` is
+#              disabled on Qwen3-Next hybrid (GDN recurrent state → unreliable warmup scales),
+#              so 1.0 is the only fp8 KV; e4m3's exponent range tolerates it. NIAH also ties → 240K.
 #   Best for:  max-accuracy Qwen on 2 cards, and the validation proxy for the 4-card
 #                vllm/qwen-27b-multi-max — FP8 + fp8 KV at full 262K ⭐
 # ---------------------------------------------------------------------------
@@ -33,7 +33,16 @@
 #     KV format switching to fp8; numbers above are with int8-PTH KV — re-bench needed.
 #
 # What's intentionally NOT enabled:
-#   - int8-PTH KV — switched to fp8 KV (better performance on this config).
+#   - int8-PTH KV — switched to fp8 (e4m3) KV. Why: int8-PTH is confined to the TRITON_ATTN
+#     backend, whose single-stream decode craters with context (measured 130.8 → 50.7 TPS @ 35K);
+#     fp8/e4m3 KV routes to FlashInfer → decode stays flat (~114 → 115 @ 35K, ≈2.3×) at ~2× prefill
+#     and equal NIAH recall to 240K + 8-pack quality tie (109 vs 107) (jesse, #594). ⚠️ Must be `fp8`
+#     (= e4m3, runs at scale=1.0 — the checkpoint is weight-only, and `calculate_kv_scales` is disabled
+#     on Qwen3-Next hybrid: GDN recurrent state → unreliable warmup scales, so 1.0 is the only fp8 KV).
+#     NOT `fp8_e5m2` — scale-free and hard-rejected with FP8 checkpoints
+#     (`ValueError: fp8_e5m2 kv-cache is not supported with fp8 checkpoints`). Don't "simplify" to e5m2.
+#     Trade vs int8-PTH: ~14% slower short-ctx (<5K) + tighter VRAM margin (509 MB free @ deepest soak
+#     fill, 0 MiB growth / 100% retention / p50 125.5 — soak-continuous PASS 2026-07-06).
 #     For 4-stream concurrency at 262K, switch to
 #     dual/turbo.yml (which uses TurboQuant KV + Genesis P65).
 #
@@ -47,7 +56,7 @@
 # dual config; the A/B variants were deprecated):
 #
 #   Slug               Ctx    Streams  KV    Vision  Topology   Notes
-#   vllm/dual (this)   262K   2        fp8  ✅      2× PCIe    THE dual default ⭐
+#   vllm/dual (this)   262K   2        fp8   ✅      2× PCIe    THE dual default ⭐
 #   vllm/dual4         262K   4        fp8   ✅      4× PCIe    4-card
 #   vllm/dual4-dflash  262K   2        FP16  ✅      4× PCIe    4-card, peak code TPS
 #   (deprecated 2026-05-31, recover from git if needed: dual-dflash, dual-dflash-noviz,


### PR DESCRIPTION
Switches `llm/qwen-27b-dual-max`) KV cache dtype from `int8_per_token_head` to  `fp8` KV performs significantly better on this config.

`verify-full.sh` ✅
```
[autodetect] served model='qwen3.6-27b' (from http://localhost:8010/v1/models; set MODEL= to override)
Running FULL functional test against http://localhost:8010
  model=qwen3.6-27b  container=vllm-qwen36-27b-dual-max  engine=vllm

[1/9] Server reachable on /v1/models ...
  ✓ server is serving
[2/9] Genesis patches applied ...
  ⊘ no Genesis marker in logs (container restarted, or Genesis not loaded) (skipped)
[warmup] priming engine (cold cudagraph/JIT, up to 180s, not scored) ...
[warmup] engine warm
[3/9] Basic completion — capital of France ...
  ✓ reply contains 'Paris'
[4/9] Tool calling ...
  ✓ tool_calls[] populated with get_weather
[5/9] Streaming (SSE) ...
  ✓ streamed 12 chunks, 116 chars:  Here is a three-sentence haiku about debugging:  One missing semicolon. Hours lo...
[6/9] Streaming tool-calls (thinking-on) ...
  ✓ streamed delta.tool_calls (get_weather) + finish_reason=tool_calls, no <tool_call> leak
[7/9] Thinking / reasoning mode ...
  ✓ reasoning 2347 chars, content 4 chars (finish=stop)
    reasoning: Here's a thinking process:  1.  **Analyze User Input:**    -...
    content:     4....
[8/9] Output quality / cascade detection (2K-token completion) ...
  ✓ output OK — 9374 chars, variety=0.640, max_line_repeat=0, finish=length
[9/9] MTP acceptance length threshold ...
  ✓ MTP acceptance length = 3.24 (>=2.0 — spec-decode contributing)

All checks passed. Stack is ready for full-functionality use.
```

`verify-stress.sh` ❌ all tests passed but little vram margin
```
[autodetect] using running container=vllm-qwen36-27b-dual-max url=http://localhost:8010  (skip: PREFLIGHT_NO_AUTODETECT=1)
[autodetect] served model='qwen3.6-27b' (from http://localhost:8010/v1/models; set MODEL= to override)
Running STRESS / boundary test against http://localhost:8010
  model=qwen3.6-27b  container=vllm-qwen36-27b-dual-max  engine=vllm
  This script does the heavy stuff (longctx needle ladder + ~25K-token tool prefill).
  For the fast functional smoke (~2 min), use verify-full.sh instead.

[1/8] Long-context needle small rungs (10K / 30K) ...
    ✓   9820 tokens: recalled 'sapphire narwhal 47' (got: sapphire narwhal 47 )  prefill=1256.5 t/s (8s)
    ✓  29319 tokens: recalled 'amber chinchilla 75' (got: amber chinchilla 75 )  prefill=1191.7 t/s (25s)
  ✓ all long-ctx depths recalled secret correctly
[2/8] Tool response prefill OOM (~25K-token mock tool response) ...
  ✓ tool prefill OK — text response (455 chars, finish=stop)
[3/8] IDE-agent one-shot prompt (sys + tool schemas + user request) ...
  ✓ IDE-agent one-shot OK — 47 completion tokens (202 chars), finish=stop
[4/8] Multi-turn agent prompt (sys + tools + 4-turn history) ...
  ✓ multi-turn agent OK
[5/8] LCB-coding shape (LeetCode-style problem + structured plan) ...
  ✓ LCB-coding shape OK
[6/8] Reasoning-heavy (math problem + max_tokens=8192) ...
  ✓ reasoning-heavy OK — 6279 completion tokens
[7/8] Long-context needle large rungs (60K / 90K — Cliff 2 territory) ...
    ✓  58569 tokens: recalled 'turquoise otter 35' (got: turquoise otter 35 )  prefill=1295.7 t/s (45s)
    ✓  91069 tokens: recalled 'silver narwhal 62' (got: silver narwhal 62 )  prefill=1342.8 t/s (68s)
  ✓ all long-ctx depths recalled secret correctly
[8/8] Context ceiling ladder (staggered NIAH from ~95000 → ~0.92 × n_ctx) ...
    n_ctx=262144  ladder: 95000 → 125000 → 155000 → 185000 → 215000 → 241172 (6 rungs)
    calibrated: scale=100 → 6515 tokens (tok/scale_unit=65.15)
    VRAM free (ladder start): 486 MB
    ✓ rung 1/6: target=95K  actual=94K tok (36%)  recalled 'sapphire falcon 84'  prefill=1659.1 t/s (57s)  VRAM_free=486MB
    ✓ rung 2/6: target=125K  actual=124K tok (47%)  recalled 'emerald platypus 90'  prefill=1276.7 t/s (98s)  VRAM_free=486MB
    ✓ rung 3/6: target=155K  actual=154K tok (59%)  recalled 'turquoise axolotl 88'  prefill=1222.8 t/s (127s)  VRAM_free=486MB
    ✓ rung 4/6: target=185K  actual=184K tok (70%)  recalled 'crimson capybara 38'  prefill=1163.2 t/s (159s)  VRAM_free=486MB
    ✓ rung 5/6: target=215K  actual=214K tok (81%)  recalled 'amber otter 92'  prefill=1048.8 t/s (205s)  VRAM_free=486MB
    ✓ rung 6/6: target=241K  actual=240K tok (91%)  recalled 'golden iguana 28'  prefill=1045.5 t/s (230s)  VRAM_free=486MB

  ✓ ceiling ladder: all 6 rungs passed — fillable to 240634 tok (91% of n_ctx=262144)
    \033[33m⚠\033[0m VRAM margin thin at ceiling: 486 MB free < 1024 MB threshold
      Recall succeeded at 91% fill, but sustained agent load also carries
      prompt-cache + context-checkpoint overhead (~292 MiB, see #197).
      Agent users should target a CTX_SIZE where margin ≥ 1024 MB at this depth.

1 stress check(s) failed. See hints above.
```

`soak-test.sh` ✅
```

[soak] running soak test against http://localhost:8010 (model=qwen3.6-27b, container=vllm-qwen36-27b-dual-max)
[soak] mode=continuous sessions=5 turns=5 max_growth=200MiB timeout=1800s
[soak] output=results/soak-20260706-113439
[soak] session 1/5
[soak]   turn 1/5: status=200 wall=882ms ttft=690ms decode_tps=151.184 vram=47224MiB
[soak]   turn 2/5: status=200 wall=4784ms ttft=4590ms decode_tps=144.704 vram=47224MiB
[soak]   turn 3/5: status=200 wall=7474ms ttft=7162ms decode_tps=125.099 vram=47224MiB
[soak]   turn 4/5: status=200 wall=8932ms ttft=8540ms decode_tps=114.549 vram=47224MiB
[soak]   turn 5/5: status=200 wall=8865ms ttft=8274ms decode_tps=91.371 vram=47224MiB
[soak] warm baseline after session 1: 47224 MiB
[soak] session 2/5
[soak]   turn 1/5: status=200 wall=832ms ttft=640ms decode_tps=151.352 vram=47224MiB
[soak]   turn 2/5: status=200 wall=2365ms ttft=2171ms decode_tps=144.449 vram=47224MiB
[soak]   turn 3/5: status=200 wall=2419ms ttft=2107ms decode_tps=125.067 vram=47224MiB
[soak]   turn 4/5: status=200 wall=2292ms ttft=1898ms decode_tps=114.39 vram=47224MiB
[soak]   turn 5/5: status=200 wall=3294ms ttft=2741ms decode_tps=97.611 vram=47224MiB
[soak] session 3/5
[soak]   turn 1/5: status=200 wall=832ms ttft=640ms decode_tps=151.309 vram=47224MiB
[soak]   turn 2/5: status=200 wall=2375ms ttft=2181ms decode_tps=144.617 vram=47224MiB
[soak]   turn 3/5: status=200 wall=2421ms ttft=2107ms decode_tps=124.539 vram=47224MiB
[soak]   turn 4/5: status=200 wall=2298ms ttft=1902ms decode_tps=113.578 vram=47224MiB
[soak]   turn 5/5: status=200 wall=3665ms ttft=2755ms decode_tps=82.428 vram=47224MiB
[soak] session 4/5
[soak]   turn 1/5: status=200 wall=831ms ttft=639ms decode_tps=151.415 vram=47224MiB
[soak]   turn 2/5: status=200 wall=2376ms ttft=2182ms decode_tps=144.297 vram=47224MiB
[soak]   turn 3/5: status=200 wall=2418ms ttft=2104ms decode_tps=124.104 vram=47224MiB
[soak]   turn 4/5: status=200 wall=2292ms ttft=1897ms decode_tps=113.999 vram=47224MiB
[soak]   turn 5/5: status=200 wall=3293ms ttft=2741ms decode_tps=92.388 vram=47224MiB
[soak] session 5/5
[soak]   turn 1/5: status=200 wall=832ms ttft=640ms decode_tps=150.882 vram=47224MiB
[soak]   turn 2/5: status=200 wall=2374ms ttft=2180ms decode_tps=144.473 vram=47224MiB
[soak]   turn 3/5: status=200 wall=2416ms ttft=2104ms decode_tps=124.951 vram=47224MiB
[soak]   turn 4/5: status=200 wall=2291ms ttft=1896ms decode_tps=114.019 vram=47224MiB
[soak]   turn 5/5: status=200 wall=8480ms ttft=2744ms decode_tps=70.952 vram=47224MiB

[soak] summary
[soak]   verdict              PASS
[soak]   boot_vram_mib        47224
[soak]   max_vram_mib         47224
[soak]   max_growth_mib       0 / 200
[soak]   errors               0
[soak]   silent_empty         0 / 25 (0.0%)
[soak]   p50_decode_tps       124.95
[soak]   p95_ttft_ms          8052
[soak]   tps_retention        100.0%
[soak]   note                 PASS = no failure signal on this sample;
[soak]                        not patch validation (topology alone can
[soak]                        sidestep what overlays target). See
[soak]                        scripts/soak-test.sh --help and docs/CLIFFS.md.
[soak] artifacts: results/soak-20260706-113439
```

`bench.sh`✅
```
[autodetect] using running container=vllm-qwen36-27b-dual-max url=http://localhost:8010  (skip: PREFLIGHT_NO_AUTODETECT=1)
[autodetect] served model='qwen3.6-27b' (from http://localhost:8010/v1/models; set MODEL= to override)

========== NARRATIVE (prompt=65 chars, max_tokens=1000) ==========
=== warmups (3) ===
  warm-1     wall= 14.69s  ttft=   132ms  toks=1000  wall_TPS= 68.07  decode_TPS= 68.68
  warm-2     wall= 14.05s  ttft=   129ms  toks=1000  wall_TPS= 71.19  decode_TPS= 71.85
  warm-3     wall= 13.90s  ttft=   131ms  toks=1000  wall_TPS= 71.94  decode_TPS= 72.62

=== measured (5) ===
  run-1      wall= 14.99s  ttft=   129ms  toks=1000  wall_TPS= 66.72  decode_TPS= 67.30
  run-2      wall= 13.99s  ttft=   132ms  toks=1000  wall_TPS= 71.49  decode_TPS= 72.17
  run-3      wall= 14.45s  ttft=   129ms  toks=1000  wall_TPS= 69.21  decode_TPS= 69.83
  run-4      wall= 14.37s  ttft=   129ms  toks=1000  wall_TPS= 69.60  decode_TPS= 70.23
  run-5      wall= 14.96s  ttft=    95ms  toks=1000  wall_TPS= 66.87  decode_TPS= 67.29

=== summary [narrative] (n=5) ===
  wall_TPS       mean=  68.78   std=  2.01   CV= 2.9%   min=66.72   max=71.49
  decode_TPS     mean=  69.36   std=  2.09   CV= 3.0%   min=67.29   max=72.17
  TTFT          mean=   123ms  std=   16ms  min=95ms  max=132ms
  PP tok/s       mean=   1.50   std=  1.37   CV=91.3%   min=0.00   max=2.50

========== CODE (prompt=78 chars, max_tokens=800) ==========
=== warmups (3) ===
  warm-1     wall=  7.20s  ttft=    95ms  toks= 645  wall_TPS= 89.59  decode_TPS= 90.79
  warm-2     wall=  4.23s  ttft=   128ms  toks= 380  wall_TPS= 89.92  decode_TPS= 92.74
  warm-3     wall=  7.61s  ttft=   128ms  toks= 703  wall_TPS= 92.41  decode_TPS= 93.99

=== measured (5) ===
  run-1      wall=  6.87s  ttft=   128ms  toks= 613  wall_TPS= 89.18  decode_TPS= 90.87
  run-2      wall=  8.61s  ttft=   129ms  toks= 757  wall_TPS= 87.96  decode_TPS= 89.30
  run-3      wall=  3.31s  ttft=   129ms  toks= 290  wall_TPS= 87.70  decode_TPS= 91.27
  run-4      wall=  9.71s  ttft=   129ms  toks= 800  wall_TPS= 82.39  decode_TPS= 83.50
  run-5      wall=  8.53s  ttft=   129ms  toks= 766  wall_TPS= 89.76  decode_TPS= 91.14

=== summary [code] (n=5) ===
  wall_TPS       mean=  87.40   std=  2.93   CV= 3.3%   min=82.39   max=89.76
  decode_TPS     mean=  89.22   std=  3.29   CV= 3.7%   min=83.50   max=91.27
  TTFT          mean=   129ms  std=    1ms  min=128ms  max=129ms
  PP tok/s       mean=   3.50   std=  1.37   CV=39.1%   min=2.50   max=5.00

========== PREFILL-10K (target=10000 prompt tokens, max_tokens=16, cache-busted: fresh haystack per run) ==========
=== warmups (1) ===
  warm-1     wall= 10.36s  ttft= 10323ms  prompt_toks= 12886  PP_tok/s=1248.34
  [calibrated: 12886 tok at request=10000 → measured runs request 7760]

=== measured (3) ===
  run-1      wall=  8.33s  ttft=  8293ms  prompt_toks= 10367  PP_tok/s=1250.02
  run-2      wall=  8.33s  ttft=  8290ms  prompt_toks= 10367  PP_tok/s=1250.55
  run-3      wall=  8.33s  ttft=  8289ms  prompt_toks= 10367  PP_tok/s=1250.63

=== summary [prefill-10k] (n=3) ===
  prefill tok/s  mean=1250.40   std=  0.33   CV= 0.0%   min=1250.02   max=1250.63
  TTFT          mean=  8291ms  std=    2ms  min=8289ms  max=8293ms
  PP tok/s (engine log, windowed) mean= 775.93   std=681.55   CV=87.8%   min=2.50   max=1288.60

========== PREFILL-90K (target=90000 prompt tokens, max_tokens=16, cache-busted: fresh haystack per run) ==========
=== warmups (1) ===
  warm-1     wall=118.99s  ttft=118975ms  prompt_toks=111443  PP_tok/s= 936.69
  [calibrated: 111443 tok at request=90000 → measured runs request 72682]

=== measured (3) ===
  run-1      wall= 95.21s  ttft= 95204ms  prompt_toks= 93481  PP_tok/s= 981.91
  run-2      wall= 99.31s  ttft= 99288ms  prompt_toks= 96943  PP_tok/s= 976.38
  run-3      wall= 95.17s  ttft= 95158ms  prompt_toks= 93481  PP_tok/s= 982.37

=== summary [prefill-90k] (n=3) ===
  prefill tok/s  mean= 980.22   std=  3.33   CV= 0.3%   min=976.38   max=982.37
  TTFT          mean= 96550ms  std= 2371ms  min=95158ms  max=99288ms
  PP tok/s (engine log, windowed) mean=10062.03   std=952.97   CV= 9.5%   min=9347.80   max=11144.10

=== GPU state ===
0, 100 %, 23588 MiB, 24576 MiB, 247.63 W, 60
1, 98 %, 23636 MiB, 24576 MiB, 247.16 W, 74

=== Last 3 SpecDecoding metrics ===
(APIServer pid=1) INFO 07-06 11:42:30 [metrics.py:120] SpecDecoding metrics: Mean acceptance length: 4.00, Accepted throughput: 0.02 tokens/s, Drafted throughput: 0.02 tokens/s, Accepted: 3 tokens, Drafted: 3 tokens, Per-position acceptance rate: 1.000, 1.000, 1.000, Avg Draft acceptance rate: 100.0%
(APIServer pid=1) INFO 07-06 11:44:10 [metrics.py:120] SpecDecoding metrics: Mean acceptance length: 4.00, Accepted throughput: 0.03 tokens/s, Drafted throughput: 0.03 tokens/s, Accepted: 3 tokens, Drafted: 3 tokens, Per-position acceptance rate: 1.000, 1.000, 1.000, Avg Draft acceptance rate: 100.0%
(APIServer pid=1) INFO 07-06 11:45:50 [metrics.py:120] SpecDecoding metrics: Mean acceptance length: 4.00, Accepted throughput: 0.03 tokens/s, Drafted throughput: 0.03 tokens/s, Accepted: 3 tokens, Drafted: 3 tokens, Per-position acceptance rate: 1.000, 1.000, 1.000, Avg Draft acceptance rate: 100.0%
```

`report.sh` 
```

## System

- **OS:** Ubuntu 24.04.4 LTS
- **Kernel:** 6.8.0-134-generic
- **Environment:** bare metal
- **Locale:** en_US.UTF-8
- **Timezone:** UTC
- **Uptime:** up 5 hours, 12 minutes

## CPU + RAM

- **CPU:** AMD Ryzen 5 5600X 6-Core Processor (12 threads)
- **RAM:** 31Gi total, 22Gi available
- **Swap:** 8.0Gi

## Disk

- **<MODEL_DIR>:** 1.5T available, ext4 filesystem
- **/var/lib/docker:** 1.5T available, ext4 filesystem

## GPU hardware

- **GPU 0:** NVIDIA GeForce RTX 3090 | 24576 MiB | driver 610.43.02 | VBIOS 94.02.42.80.88 | persistence=Enabled
  - **Power:** limit=250.00 W (default=370.00 W, max=390.00 W) | current_draw=27.96 W ⚠ user-capped below default
  - **PCIe:** x4 lanes negotiated (GPU max x16, Gen up to 4) | bus 00000000:05:00.0 ⚠ slot is narrower than GPU capability — affects load + all-reduce bandwidth
- **GPU 1:** NVIDIA GeForce RTX 3090 | 24576 MiB | driver 610.43.02 | VBIOS 94.02.42.40.B7 | persistence=Enabled
  - **Power:** limit=250.00 W (default=370.00 W, max=390.00 W) | current_draw=34.34 W ⚠ user-capped below default
  - **PCIe:** x16 lanes negotiated (GPU max x16, Gen up to 4) | bus 00000000:0A:00.0
- **ECC mode:** [N/A] (3090s don't have ECC; expect N/A)

### NVLink

_No NVLink detected (PCIe-only)_

### Topology

<details><summary>PCIe / GPU topology matrix</summary>

```
	GPU0	GPU1	CPU Affinity	NUMA Affinity	GPU NUMA ID
GPU0	 X 	PHB	0-11	0		N/A
GPU1	PHB	 X 	0-11	0		N/A

Legend:

  X    = Self
  SYS  = Connection traversing PCIe as well as the SMP interconnect between NUMA nodes (e.g., QPI/UPI)
  NODE = Connection traversing PCIe as well as the interconnect between PCIe Host Bridges within a NUMA node
  PHB  = Connection traversing PCIe as well as a PCIe Host Bridge (typically the CPU)
  PXB  = Connection traversing multiple PCIe bridges (without traversing the PCIe Host Bridge)
  PIX  = Connection traversing at most a single PCIe bridge
  NV#  = Connection traversing a bonded set of # NVLinks
```

</details>

### PCIe / P2P detail (lspci)

<details><summary>lspci PCIe/P2P detail (LnkSta / ACS / topology)</summary>

```
_Note: sudo unavailable/non-interactive — running lspci without root; ACS capability lines may be incomplete (LnkSta still accurate)._

# lspci -t  (PCIe topology tree)
-[0000:00]-+-00.0
           +-00.2
           +-01.0
           +-01.1-[01]----00.0
           +-01.2-[02-09]----00.0-[03-09]--+-01.0-[04]----00.0
           |                               +-02.0-[05]--+-00.0
           |                               |            \-00.1
           |                               +-04.0-[06]----00.0
           |                               +-08.0-[07]--+-00.0
           |                               |            +-00.1
           |                               |            \-00.3
           |                               +-09.0-[08]----00.0
           |                               \-0a.0-[09]----00.0
           +-02.0
           +-03.0
           +-03.1-[0a]--+-00.0
           |            \-00.1
           +-04.0
           +-05.0
           +-07.0
           +-07.1-[0b]----00.0
           +-08.0
           +-08.1-[0c]--+-00.0
           |            +-00.1
           |            +-00.3
           |            \-00.4
           +-14.0
           +-14.3
           +-18.0
           +-18.1
           +-18.2
           +-18.3
           +-18.4
           +-18.5
           +-18.6
           \-18.7

# lspci -vvv -s 0000:05:00.0  (GPU function: LnkCap/LnkSta/ACSCap/ACSCtl)
  (no matching LnkCap/LnkSta/ACSCap/ACSCtl lines)

# lspci -vvv -s 0000:03:02.0  (upstream bridge of 0000:05:00.0: LnkCap/LnkSta/ACSCap/ACSCtl)
  (no matching LnkCap/LnkSta/ACSCap/ACSCtl lines)

# lspci -vvv -s 0000:0a:00.0  (GPU function: LnkCap/LnkSta/ACSCap/ACSCtl)
  (no matching LnkCap/LnkSta/ACSCap/ACSCtl lines)

# lspci -vvv -s 0000:00:03.1  (upstream bridge of 0000:0a:00.0: LnkCap/LnkSta/ACSCap/ACSCtl)
  (no matching LnkCap/LnkSta/ACSCap/ACSCtl lines)

# lspci -nnk | grep -A3 -i nvidia  (driver binding + device IDs)
05:00.0 VGA compatible controller [0300]: NVIDIA Corporation GA102 [GeForce RTX 3090] [10de:2204] (rev a1)
	Subsystem: Gigabyte Technology Co., Ltd GA102 [GeForce RTX 3090] [1458:4043]
	Kernel driver in use: nvidia
	Kernel modules: nvidiafb, nouveau, nvidia_drm, nvidia
05:00.1 Audio device [0403]: NVIDIA Corporation GA102 High Definition Audio Controller [10de:1aef] (rev a1)
	Subsystem: Gigabyte Technology Co., Ltd GA102 High Definition Audio Controller [1458:4043]
	Kernel driver in use: snd_hda_intel
	Kernel modules: snd_hda_intel
--
0a:00.0 VGA compatible controller [0300]: NVIDIA Corporation GA102 [GeForce RTX 3090] [10de:2204] (rev a1)
	Subsystem: Gigabyte Technology Co., Ltd GA102 [GeForce RTX 3090] [1458:4043]
	Kernel driver in use: nvidia
	Kernel modules: nvidiafb, nouveau, nvidia_drm, nvidia
0a:00.1 Audio device [0403]: NVIDIA Corporation GA102 High Definition Audio Controller [10de:1aef] (rev a1)
	Subsystem: Gigabyte Technology Co., Ltd GA102 High Definition Audio Controller [1458:4043]
	Kernel driver in use: snd_hda_intel
	Kernel modules: snd_hda_intel
```

</details>

### Full nvidia-smi

<details><summary>Full nvidia-smi output</summary>

```
Mon Jul  6 11:49:06 2026
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 610.43.02              KMD Version: 610.43.02     CUDA UMD Version: 13.3     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA GeForce RTX 3090        On  |   00000000:05:00.0 Off |                  N/A |
|  0%   42C    P8             27W /  250W |   23588MiB /  24576MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+
|   1  NVIDIA GeForce RTX 3090        On  |   00000000:0A:00.0 Off |                  N/A |
| 62%   46C    P8             34W /  250W |   23636MiB /  24576MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|    0   N/A  N/A           55277      C   VLLM::Worker_TP0                      23578MiB |
|    1   N/A  N/A           55289      C   VLLM::Worker_TP1                      23618MiB |
+-----------------------------------------------------------------------------------------+
```

</details>

## Display / desktop state

- **$DISPLAY:** unset (headless)
- **Display processes running:** none detected
- **GPU 0 idle VRAM:** 23588 MiB (held by running `vllm-qwen36-27b-dual-max`)
- **GPU 1 idle VRAM:** 23636 MiB (held by running `vllm-qwen36-27b-dual-max`)

## Container runtime

- **Docker:** 29.6.1
- **docker compose (v2):** 5.3.0
- **NVIDIA Container Toolkit:** 1.19.1

## Stack version

- **club-3090:** `v0.10.1-97-g087d094-dirty` (branch: `master`, SHA `087d094`)
- **Working tree:** ⚠ has uncommitted changes (run `git status` to inspect)
- **GENESIS_PIN default:** `7b9fd319` (per scripts/setup.sh)
- **Cached vLLM images:**
  - tag `v0.24.0` digest `sha256:251eba5cc7c12fed0b75da22a9240e582b1c9e39f6fbc064f86781b963bd814f` (7 days ago)
  - tag `v0.23.0` digest `sha256:6d8429e38e3747723ca07ee1b17972e09bb9c51c4032b266f24fb1cc3b22ed8f` (3 weeks ago)
  - tag `v0.22.0` digest `sha256:0fec7ec5f3e6bc168e54899935fb0557da908a4832a1dbc88e2debcf2f889416` (5 weeks ago)
## Profile state

- **Profile schema version:** 1
- **Profile counts:** 10 hardware, 11 models, 5 workloads, 13 engines, 11 drafters
- **Compose registry:** 57 entries
- **Canonical scenarios:** 9
- **Calibration:**
  - gemma-4-12b: 1 rows
  - gemma-4-26b-a4b: 0 rows
  - gemma-4-31b: 3 rows
  - qwen3.6-27b: 2 rows
  - qwen3.6-35b-a3b: 1 rows
- **Active estate:** none (`~/.club3090/estate.yml` not found)

## KV math calibration

- _Scoped to the running model `qwen3.6-27b` — pass `--full-calibration` for all calibrated models._
- Overall: 7/7 (100%)
- No FAIL rows. kv-calc projections should agree with measured VRAM within the ±1.5 GB error band.
<details><summary>Full kv-calc --calibration output</summary>

```
========================================================================================
Calibration — predicted per-card VRAM vs measured BENCHMARKS rows
========================================================================================

  Predicted = weights + activation + overhead + drafter + (KV capped at available).
  Budget = mem_util × VRAM. Measured = nvidia-smi peak during bench (target ≈ budget).
  Verdict ✓ iff PASS/TIGHT and measured < VRAM (boot OK).

== qwen3.6-27b ==
  compose                     predicted    budget   measured  verdict
  ─────────────────────────   ─────────  ────────  ─────────  ───────
  dual                          19.91 GB   22.80 GB    23.60 GB    PASS ✓
  minimal@64K                   21.60 GB   21.60 GB    22.40 GB   TIGHT ✓

  Verdict accuracy: 2/2 (100%)

Overall: 7/7 (100%)
```

</details>

## Active container

- **Name:** `vllm-qwen36-27b-dual-max`
- **Engine:** `vllm`
- **Status:** Up 55 minutes
- **Ports:** 0.0.0.0:8010->8000/tcp
- **Image:** `vllm/vllm-openai:v0.24.0`
- **Image digest:** `sha256:251eba5cc7c12fed0b75da22a9240e582b1c9e39f6fbc064f86781b963bd814f`
- **Build tag (OCI version):** `vllm/vllm-openai:v0.24.0`
- **Upstream commit (OCI revision):** `ee0da84ab9e04ac7610e28580af62c365e898389`
- **Upstream source:** https://github.com/vllm-project/vllm

### Container Python / CUDA versions

- **PyTorch:** `torch=2.11.0+cu130 torch_cuda_build=13.0 cudnn=91900`
- **vLLM:** `0.24.0`
- **nvidia-smi inside container:**
  ```
  0, NVIDIA GeForce RTX 3090, 610.43.02
  1, NVIDIA GeForce RTX 3090, 610.43.02
  ```

### Boot log highlights

**Interconnect / P2P engagement:**
```
[nvlink] PCIe topology (PHB), P2P not available (topo -p2p: no OK) — using PCIe mode (no P2P; for a patched driver on a P2P-capable layout this auto-enables, or set NVLINK_MODE=pcie_p2p to force)
[nvlink] P2P DISABLED — NCCL_P2P_DISABLE=1, custom all-reduce OFF, expandable_segments ON
[nvlink] PCIe topology (PHB), P2P not available (topo -p2p: no OK) — using PCIe mode (no P2P; for a patched driver on a P2P-capable layout this auto-enables, or set NVLINK_MODE=pcie_p2p to force)
[nvlink] P2P DISABLED — NCCL_P2P_DISABLE=1, custom all-reduce OFF, expandable_segments ON
# resolved container env:
NVLINK_MODE=auto
```

**KV pool sizing:**
```
(Worker_TP0 pid=89) INFO 07-06 10:54:37 [gpu_worker.py:508] Available KV cache memory: 5.33 GiB
(EngineCore pid=80) INFO 07-06 10:54:37 [kv_cache_utils.py:2146] GPU KV cache size: 300,220 tokens
(EngineCore pid=80) INFO 07-06 10:54:37 [kv_cache_utils.py:2147] Maximum concurrency for 262,144 tokens per request: 1.15x
```

**Engine config (CLI flags + engine init):**
```
(APIServer pid=1) INFO 07-06 10:43:59 [api_utils.py:273] non-default args: {'model_tag': '~/.cache/huggingface/qwen3.6-27b-fp8', 'chat_template': '/etc/qwen-froggeric-chat-template.jinja', 'default_chat_template_kwargs': {'enable_thinking': False}, 'enable_auto_tool_choice': True, 'tool_call_parser': 'qwen3_coder', 'host': '0.0.0.0', 'model': '~/.cache/huggingface/qwen3.6-27b-fp8', 'trust_remote_code': True, 'dtype': 'bfloat16', 'max_model_len': 262144, 'quantization': 'fp8', 'served_model_name': ['qwen3.6-27b', 'qwen3.6-27b-autoround'], 'override_generation_config': {'temperature': 0.6, 'top_p': 0.95, 'top_k': 20, 'min_p': 0.0, 'repetition_penalty': 1.0}, 'reasoning_parser': 'qwen3', 'tensor_parallel_size': 2, 'disable_custom_all_reduce': True, 'kv_cache_dtype': 'fp8', 'enable_prefix_caching': True, 'max_num_batched_tokens': 8192, 'max_num_seqs': 2, 'enable_chunked_prefill': True, 'speculative_config': {'method': 'mtp', 'num_speculative_tokens': 3}}
(EngineCore pid=92) INFO 07-06 10:44:23 [core.py:114] Initializing a V1 LLM engine (v0.24.0) with config: model='~/.cache/huggingface/qwen3.6-27b-fp8', speculative_config=SpeculativeConfig(method='mtp', model='~/.cache/huggingface/qwen3.6-27b-fp8', num_spec_tokens=3), tokenizer='~/.cache/huggingface/qwen3.6-27b-fp8', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=262144, download_dir=None, load_format=auto, tensor_parallel_size=2, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=True, quantization=fp8, quantization_config=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=fp8, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='qwen3', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False, jit_monitor_verbose=False), seed=0, served_model_name=qwen3.6-27b, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['+quant_fp8', 'none', '+quant_fp8'], 'ir_enable_torch_wrap': True, 'splitting_ops': ['vllm::unified_attention_with_output', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::qwen_gdn_attention_core', 'vllm::gdn_attention_core_xpu', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::deepseek_v4_attention', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': [], 'compile_ranges_endpoints': [8192], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'size_asserts': False, 'alignment_asserts': False, 'scalar_asserts': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': True, 'fuse_act_quant': True, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_rope_kvcache_cat_mla': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 16, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': False, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']), enable_flashinfer_autotune=True, moe_backend='auto', linear_backend='auto')
```

**Recent warnings/errors (last 5):**
```
WARNING 07-06 10:43:59 [argparse_utils.py:257] With `vllm serve`, you should provide the model as a positional argument or in a config file instead of via the `--model` option. The `--model` option will be removed in a future version.
WARNING 07-06 10:53:15 [argparse_utils.py:257] With `vllm serve`, you should provide the model as a positional argument or in a config file instead of via the `--model` option. The `--model` option will be removed in a future version.
```

### Full boot log (first 200 lines)

<details><summary>First 200 lines of docker logs</summary>

```
[nvlink] PCIe topology (PHB), P2P not available (topo -p2p: no OK) — using PCIe mode (no P2P; for a patched driver on a P2P-capable layout this auto-enables, or set NVLINK_MODE=pcie_p2p to force)
[nvlink] P2P DISABLED — NCCL_P2P_DISABLE=1, custom all-reduce OFF, expandable_segments ON
WARNING 07-06 10:43:59 [argparse_utils.py:257] With `vllm serve`, you should provide the model as a positional argument or in a config file instead of via the `--model` option. The `--model` option will be removed in a future version.
(APIServer pid=1) INFO 07-06 10:43:59 [api_utils.py:339]
(APIServer pid=1) INFO 07-06 10:43:59 [api_utils.py:339]        █     █     █▄   ▄█
(APIServer pid=1) INFO 07-06 10:43:59 [api_utils.py:339]  ▄▄ ▄█ █     █     █ ▀▄▀ █  version 0.24.0
(APIServer pid=1) INFO 07-06 10:43:59 [api_utils.py:339]   █▄█▀ █     █     █     █  model   ~/.cache/huggingface/qwen3.6-27b-fp8
(APIServer pid=1) INFO 07-06 10:43:59 [api_utils.py:339]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀
(APIServer pid=1) INFO 07-06 10:43:59 [api_utils.py:339]
(APIServer pid=1) INFO 07-06 10:43:59 [api_utils.py:273] non-default args: {'model_tag': '~/.cache/huggingface/qwen3.6-27b-fp8', 'chat_template': '/etc/qwen-froggeric-chat-template.jinja', 'default_chat_template_kwargs': {'enable_thinking': False}, 'enable_auto_tool_choice': True, 'tool_call_parser': 'qwen3_coder', 'host': '0.0.0.0', 'model': '~/.cache/huggingface/qwen3.6-27b-fp8', 'trust_remote_code': True, 'dtype': 'bfloat16', 'max_model_len': 262144, 'quantization': 'fp8', 'served_model_name': ['qwen3.6-27b', 'qwen3.6-27b-autoround'], 'override_generation_config': {'temperature': 0.6, 'top_p': 0.95, 'top_k': 20, 'min_p': 0.0, 'repetition_penalty': 1.0}, 'reasoning_parser': 'qwen3', 'tensor_parallel_size': 2, 'disable_custom_all_reduce': True, 'kv_cache_dtype': 'fp8', 'enable_prefix_caching': True, 'max_num_batched_tokens': 8192, 'max_num_seqs': 2, 'enable_chunked_prefill': True, 'speculative_config': {'method': 'mtp', 'num_speculative_tokens': 3}}
(APIServer pid=1) WARNING 07-06 10:43:59 [envs.py:2004] Unknown vLLM environment variable detected: VLLM_BUILD_URL
(APIServer pid=1) WARNING 07-06 10:43:59 [envs.py:2004] Unknown vLLM environment variable detected: VLLM_IMAGE_TAG
(APIServer pid=1) WARNING 07-06 10:43:59 [envs.py:2004] Unknown vLLM environment variable detected: VLLM_BUILD_PIPELINE
(APIServer pid=1) WARNING 07-06 10:43:59 [envs.py:2004] Unknown vLLM environment variable detected: VLLM_BUILD_COMMIT
(APIServer pid=1) INFO 07-06 10:44:05 [model.py:598] Resolved architecture: Qwen3_5ForConditionalGeneration
(APIServer pid=1) INFO 07-06 10:44:05 [model.py:1725] Using max model len 262144
(APIServer pid=1) INFO 07-06 10:44:05 [cache.py:279] Using fp8 data type to store kv cache. It reduces the GPU memory footprint and boosts the performance. Meanwhile, it may cause accuracy drop without a proper scaling factor
(APIServer pid=1) INFO 07-06 10:44:11 [model.py:598] Resolved architecture: Qwen3_5MTP
(APIServer pid=1) INFO 07-06 10:44:11 [model.py:1725] Using max model len 262144
(APIServer pid=1) WARNING 07-06 10:44:11 [speculative.py:761] Enabling num_speculative_tokens > 1 will run multiple times of forward on same MTP layer,which may result in lower acceptance rate
(APIServer pid=1) INFO 07-06 10:44:11 [scheduler.py:252] Chunked prefill is enabled with max_num_batched_tokens=8192.
(APIServer pid=1) WARNING 07-06 10:44:11 [config.py:422] Mamba cache mode is set to 'align' for Qwen3_5ForConditionalGeneration by default when prefix caching is enabled
(APIServer pid=1) INFO 07-06 10:44:11 [config.py:442] Warning: Prefix caching in Mamba cache 'align' mode is currently enabled. Its support for Mamba layers is experimental. Please report any issues you may observe.
(APIServer pid=1) INFO 07-06 10:44:11 [vllm.py:1006] Asynchronous scheduling is enabled.
(APIServer pid=1) INFO 07-06 10:44:11 [kernel.py:276] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
(APIServer pid=1) INFO 07-06 10:44:12 [compilation.py:310] Enabled custom fusions: norm_quant, act_quant
(APIServer pid=1) [transformers] The `use_fast` parameter is deprecated and will be removed in a future version. Use `backend="torchvision"` instead of `use_fast=True`, or `backend="pil"` instead of `use_fast=False`.
(EngineCore pid=92) INFO 07-06 10:44:23 [core.py:114] Initializing a V1 LLM engine (v0.24.0) with config: model='~/.cache/huggingface/qwen3.6-27b-fp8', speculative_config=SpeculativeConfig(method='mtp', model='~/.cache/huggingface/qwen3.6-27b-fp8', num_spec_tokens=3), tokenizer='~/.cache/huggingface/qwen3.6-27b-fp8', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=262144, download_dir=None, load_format=auto, tensor_parallel_size=2, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=True, quantization=fp8, quantization_config=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=fp8, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='qwen3', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False, jit_monitor_verbose=False), seed=0, served_model_name=qwen3.6-27b, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['+quant_fp8', 'none', '+quant_fp8'], 'ir_enable_torch_wrap': True, 'splitting_ops': ['vllm::unified_attention_with_output', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::qwen_gdn_attention_core', 'vllm::gdn_attention_core_xpu', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::deepseek_v4_attention', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': [], 'compile_ranges_endpoints': [8192], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'size_asserts': False, 'alignment_asserts': False, 'scalar_asserts': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': True, 'fuse_act_quant': True, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'fuse_rope_kvcache_cat_mla': False, 'fuse_act_padding': False}, 'max_cudagraph_capture_size': 16, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': False, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']), enable_flashinfer_autotune=True, moe_backend='auto', linear_backend='auto')
(EngineCore pid=92) INFO 07-06 10:44:23 [multiproc_executor.py:140] DP group leader: node_rank=0, node_rank_within_dp=0, master_addr=127.0.0.1, mq_connect_ip=172.18.0.2 (local), world_size=2, local_world_size=2
(Worker pid=101) INFO 07-06 10:44:28 [parallel_state.py:1588] world_size=2 rank=0 local_rank=0 distributed_init_method=tcp://127.0.0.1:40801 backend=nccl
(Worker pid=106) INFO 07-06 10:44:33 [parallel_state.py:1588] world_size=2 rank=1 local_rank=1 distributed_init_method=tcp://127.0.0.1:40801 backend=nccl
(Worker pid=101) INFO 07-06 10:44:34 [pynccl.py:113] vLLM is using nccl==2.28.9
(Worker pid=101) WARNING 07-06 10:44:35 [symm_mem.py:66] SymmMemCommunicator: Device capability 8.6 not supported, communicator is not available.
(Worker pid=101) INFO 07-06 10:44:35 [cuda_communicator.py:245] Using ['PYNCCL'] all-reduce backends (in dispatch order) for group 'tp:0' out of potential backends: ['NCCL_SYMM_MEM', 'QUICK_REDUCE', 'FLASHINFER', 'CUSTOM', 'SYMM_MEM', 'PYNCCL'].
(Worker pid=106) WARNING 07-06 10:44:35 [symm_mem.py:66] SymmMemCommunicator: Device capability 8.6 not supported, communicator is not available.
(Worker pid=101) INFO 07-06 10:44:35 [parallel_state.py:1923] rank 0 in world size 2 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
(Worker pid=101) INFO 07-06 10:44:35 [topk_topp_sampler.py:55] Using FlashInfer for top-p & top-k sampling.
(Worker pid=101) WARNING 07-06 10:44:35 [__init__.py:204] min_p and logit_bias parameters won't work with speculative decoding.
(Worker pid=106) WARNING 07-06 10:44:35 [__init__.py:204] min_p and logit_bias parameters won't work with speculative decoding.
(Worker pid=106) [transformers] The `use_fast` parameter is deprecated and will be removed in a future version. Use `backend="torchvision"` instead of `use_fast=True`, or `backend="pil"` instead of `use_fast=False`.
(Worker pid=101) [transformers] The `use_fast` parameter is deprecated and will be removed in a future version. Use `backend="torchvision"` instead of `use_fast=True`, or `backend="pil"` instead of `use_fast=False`.
(Worker_TP0 pid=101) INFO 07-06 10:44:39 [gpu_model_runner.py:5160] Starting to load model ~/.cache/huggingface/qwen3.6-27b-fp8...
(Worker_TP0 pid=101) INFO 07-06 10:44:39 [cuda.py:539] Using backend AttentionBackendEnum.FLASH_ATTN for vit attention
(Worker_TP0 pid=101) INFO 07-06 10:44:39 [mm_encoder_attention.py:373] Using AttentionBackendEnum.FLASH_ATTN for MMEncoderAttention.
(Worker_TP0 pid=101) INFO 07-06 10:44:39 [__init__.py:563] Selected MarlinFP8ScaledMMLinearKernel for Fp8LinearMethod
(Worker_TP0 pid=101) INFO 07-06 10:44:39 [qwen_gdn_linear_attn.py:228] Using Triton/FLA GDN prefill kernel (requested=auto, head_k_dim=128).
(Worker_TP0 pid=101) INFO 07-06 10:44:39 [cuda.py:480] Using FLASHINFER attention backend out of potential backends: ['FLASHINFER', 'TRITON_ATTN'].
(Worker_TP0 pid=101) INFO 07-06 10:44:40 [weight_utils.py:849] Filesystem type for checkpoints: EXT4. Checkpoint size: 28.75 GiB. Available RAM: 23.20 GiB.
(Worker_TP0 pid=101) INFO 07-06 10:44:40 [weight_utils.py:879] Auto-prefetch is disabled because the filesystem (EXT4) is not a recognized network FS (NFS/Lustre) and the checkpoint size (28.75 GiB) exceeds 90% of available RAM (23.20 GiB).
Loading safetensors checkpoint shards:   0% Completed | 0/66 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:   2% Completed | 1/66 [00:00<00:16,  3.85it/s]
Loading safetensors checkpoint shards:   3% Completed | 2/66 [00:00<00:16,  3.92it/s]
Loading safetensors checkpoint shards:   5% Completed | 3/66 [00:00<00:15,  3.97it/s]
Loading safetensors checkpoint shards:   6% Completed | 4/66 [00:01<00:15,  3.93it/s]
Loading safetensors checkpoint shards:   8% Completed | 5/66 [00:01<00:15,  3.94it/s]
Loading safetensors checkpoint shards:   9% Completed | 6/66 [00:01<00:15,  3.96it/s]
Loading safetensors checkpoint shards:  11% Completed | 7/66 [00:01<00:14,  4.03it/s]
Loading safetensors checkpoint shards:  12% Completed | 8/66 [00:02<00:14,  4.03it/s]
Loading safetensors checkpoint shards:  14% Completed | 9/66 [00:02<00:14,  3.99it/s]
Loading safetensors checkpoint shards:  15% Completed | 10/66 [00:02<00:13,  4.09it/s]
Loading safetensors checkpoint shards:  17% Completed | 11/66 [00:02<00:13,  4.15it/s]
Loading safetensors checkpoint shards:  18% Completed | 12/66 [00:02<00:12,  4.17it/s]
Loading safetensors checkpoint shards:  20% Completed | 13/66 [00:03<00:13,  4.03it/s]
Loading safetensors checkpoint shards:  21% Completed | 14/66 [00:03<00:12,  4.04it/s]
Loading safetensors checkpoint shards:  23% Completed | 15/66 [00:03<00:12,  4.04it/s]
Loading safetensors checkpoint shards:  24% Completed | 16/66 [00:03<00:12,  4.05it/s]
Loading safetensors checkpoint shards:  26% Completed | 17/66 [00:04<00:12,  4.00it/s]
Loading safetensors checkpoint shards:  27% Completed | 18/66 [00:04<00:12,  3.97it/s]
Loading safetensors checkpoint shards:  29% Completed | 19/66 [00:04<00:11,  3.97it/s]
Loading safetensors checkpoint shards:  30% Completed | 20/66 [00:04<00:11,  4.07it/s]
Loading safetensors checkpoint shards:  32% Completed | 21/66 [00:05<00:11,  4.06it/s]
Loading safetensors checkpoint shards:  33% Completed | 22/66 [00:05<00:10,  4.06it/s]
Loading safetensors checkpoint shards:  35% Completed | 23/66 [00:05<00:10,  4.09it/s]
Loading safetensors checkpoint shards:  36% Completed | 24/66 [00:05<00:10,  4.12it/s]
Loading safetensors checkpoint shards:  38% Completed | 25/66 [00:06<00:10,  4.07it/s]
Loading safetensors checkpoint shards:  39% Completed | 26/66 [00:06<00:10,  3.98it/s]
Loading safetensors checkpoint shards:  41% Completed | 27/66 [00:06<00:09,  4.02it/s]
Loading safetensors checkpoint shards:  42% Completed | 28/66 [00:06<00:09,  4.03it/s]
Loading safetensors checkpoint shards:  44% Completed | 29/66 [00:07<00:09,  4.03it/s]
Loading safetensors checkpoint shards:  45% Completed | 30/66 [00:07<00:08,  4.02it/s]
Loading safetensors checkpoint shards:  47% Completed | 31/66 [00:07<00:08,  4.05it/s]
Loading safetensors checkpoint shards:  48% Completed | 32/66 [00:07<00:08,  4.07it/s]
Loading safetensors checkpoint shards:  50% Completed | 33/66 [00:08<00:08,  4.06it/s]
Loading safetensors checkpoint shards:  52% Completed | 34/66 [00:08<00:07,  4.09it/s]
Loading safetensors checkpoint shards:  53% Completed | 35/66 [00:08<00:07,  4.09it/s]
Loading safetensors checkpoint shards:  55% Completed | 36/66 [00:08<00:07,  4.09it/s]
Loading safetensors checkpoint shards:  56% Completed | 37/66 [00:09<00:07,  4.04it/s]
Loading safetensors checkpoint shards:  58% Completed | 38/66 [00:09<00:07,  3.98it/s]
Loading safetensors checkpoint shards:  59% Completed | 39/66 [00:09<00:06,  3.88it/s]
Loading safetensors checkpoint shards:  61% Completed | 40/66 [00:09<00:06,  4.01it/s]
Loading safetensors checkpoint shards:  62% Completed | 41/66 [00:10<00:06,  3.93it/s]
Loading safetensors checkpoint shards:  64% Completed | 42/66 [00:10<00:06,  3.98it/s]
Loading safetensors checkpoint shards:  65% Completed | 43/66 [00:10<00:05,  3.99it/s]
Loading safetensors checkpoint shards:  67% Completed | 44/66 [00:10<00:05,  3.95it/s]
Loading safetensors checkpoint shards:  68% Completed | 45/66 [00:11<00:05,  4.01it/s]
Loading safetensors checkpoint shards:  70% Completed | 46/66 [00:11<00:04,  4.04it/s]
Loading safetensors checkpoint shards:  71% Completed | 47/66 [00:11<00:04,  4.02it/s]
Loading safetensors checkpoint shards:  73% Completed | 48/66 [00:11<00:04,  4.10it/s]
Loading safetensors checkpoint shards:  74% Completed | 49/66 [00:12<00:04,  4.00it/s]
Loading safetensors checkpoint shards:  76% Completed | 50/66 [00:12<00:04,  3.98it/s]
Loading safetensors checkpoint shards:  77% Completed | 51/66 [00:12<00:03,  3.93it/s]
Loading safetensors checkpoint shards:  79% Completed | 52/66 [00:12<00:03,  4.02it/s]
Loading safetensors checkpoint shards:  80% Completed | 53/66 [00:13<00:03,  4.01it/s]
Loading safetensors checkpoint shards:  82% Completed | 54/66 [00:13<00:03,  3.94it/s]
Loading safetensors checkpoint shards:  83% Completed | 55/66 [00:13<00:02,  3.99it/s]
Loading safetensors checkpoint shards:  85% Completed | 56/66 [00:13<00:02,  3.99it/s]
Loading safetensors checkpoint shards:  86% Completed | 57/66 [00:14<00:02,  3.99it/s]
Loading safetensors checkpoint shards:  88% Completed | 58/66 [00:14<00:01,  4.01it/s]
Loading safetensors checkpoint shards:  89% Completed | 59/66 [00:14<00:01,  4.00it/s]
Loading safetensors checkpoint shards:  91% Completed | 60/66 [00:14<00:01,  4.12it/s]
Loading safetensors checkpoint shards:  92% Completed | 61/66 [00:15<00:01,  4.02it/s]
Loading safetensors checkpoint shards:  94% Completed | 62/66 [00:15<00:00,  4.02it/s]
Loading safetensors checkpoint shards:  95% Completed | 63/66 [00:15<00:00,  3.98it/s]
Loading safetensors checkpoint shards:  97% Completed | 64/66 [00:15<00:00,  4.09it/s]
Loading safetensors checkpoint shards: 100% Completed | 66/66 [00:20<00:00,  1.29s/it]
Loading safetensors checkpoint shards: 100% Completed | 66/66 [00:20<00:00,  3.15it/s]
(Worker_TP0 pid=101)
(Worker_TP0 pid=101) INFO 07-06 10:45:01 [default_loader.py:430] Loading weights took 21.02 seconds
(Worker_TP0 pid=101) WARNING 07-06 10:45:01 [marlin_utils_fp8.py:111] Your GPU does not have native support for FP8 computation but FP8 quantization is being used. Weight-only FP8 compression will be used leveraging the Marlin kernel. This may degrade performance for compute-heavy workloads.
(Worker_TP0 pid=101) WARNING 07-06 10:45:01 [kv_cache.py:134] Checkpoint does not provide a q scaling factor. Setting it to k_scale. This only matters for FP8 Attention backends (flash-attn or flashinfer).
(Worker_TP0 pid=101) WARNING 07-06 10:45:01 [kv_cache.py:148] Using KV cache scaling factor 1.0 for fp8_e4m3. If this is unintended, verify that k/v_scale scaling factors are properly set in the checkpoint.
(Worker_TP0 pid=101) WARNING 07-06 10:45:01 [kv_cache.py:187] Using uncalibrated q_scale 1.0 and/or prob_scale 1.0 with fp8 attention. This may cause accuracy issues. Please make sure q/prob scaling factors are available in the fp8 checkpoint.
(Worker_TP1 pid=106) INFO 07-06 10:45:01 [kernel.py:276] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
(Worker_TP0 pid=101) INFO 07-06 10:45:01 [gpu_model_runner.py:5184] Loading drafter model...
(Worker_TP0 pid=101) INFO 07-06 10:45:01 [vllm.py:1006] Asynchronous scheduling is enabled.
(Worker_TP0 pid=101) INFO 07-06 10:45:01 [kernel.py:276] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
(Worker_TP0 pid=101) INFO 07-06 10:45:01 [compilation.py:310] Enabled custom fusions: norm_quant, act_quant
(Worker_TP0 pid=101) INFO 07-06 10:45:02 [weight_utils.py:849] Filesystem type for checkpoints: EXT4. Checkpoint size: 28.75 GiB. Available RAM: 26.90 GiB.
(Worker_TP0 pid=101) INFO 07-06 10:45:02 [weight_utils.py:879] Auto-prefetch is disabled because the filesystem (EXT4) is not a recognized network FS (NFS/Lustre) and the checkpoint size (28.75 GiB) exceeds 90% of available RAM (26.90 GiB).
Loading safetensors checkpoint shards:   0% Completed | 0/66 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  98% Completed | 65/66 [00:00<00:00, 187.75it/s]
Loading safetensors checkpoint shards: 100% Completed | 66/66 [00:00<00:00, 82.16it/s]
(Worker_TP0 pid=101)
(Worker_TP0 pid=101) INFO 07-06 10:45:02 [default_loader.py:430] Loading weights took 0.92 seconds
(Worker_TP0 pid=101) INFO 07-06 10:45:06 [llm_base_proposer.py:1379] Detected MTP model. Sharing target model embedding weights with the draft model.
(Worker_TP0 pid=101) INFO 07-06 10:45:06 [llm_base_proposer.py:1435] Detected MTP model. Sharing target model lm_head weights with the draft model.
(Worker_TP1 pid=106) INFO 07-06 10:45:06 [llm_base_proposer.py:1379] Detected MTP model. Sharing target model embedding weights with the draft model.
(Worker_TP1 pid=106) INFO 07-06 10:45:06 [llm_base_proposer.py:1435] Detected MTP model. Sharing target model lm_head weights with the draft model.
(Worker_TP0 pid=101) INFO 07-06 10:45:10 [gpu_model_runner.py:5255] Model loading took 14.68 GiB memory and 27.095672 seconds
(Worker_TP0 pid=101) INFO 07-06 10:45:10 [interface.py:773] Setting attention block size to 1600 tokens to ensure that attention page size is >= mamba page size.
(Worker_TP0 pid=101) INFO 07-06 10:45:10 [interface.py:797] Padding mamba page size by 0.25% to ensure that mamba page size and attention page size are exactly equal.
(Worker_TP1 pid=106) INFO 07-06 10:45:10 [interface.py:773] Setting attention block size to 1600 tokens to ensure that attention page size is >= mamba page size.
(Worker_TP1 pid=106) INFO 07-06 10:45:10 [interface.py:797] Padding mamba page size by 0.25% to ensure that mamba page size and attention page size are exactly equal.
(Worker_TP0 pid=101) INFO 07-06 10:45:10 [gpu_model_runner.py:6271] Encoder cache will be initialized with a budget of 16384 tokens, and profiled with 1 image items of the maximum feature size.
(Worker_TP0 pid=101) INFO 07-06 10:45:15 [backends.py:1089] Using cache directory: ~/.cache/vllm/torch_compile_cache/5c1b2270cd/rank_0_0/backbone for vLLM's torch.compile
(Worker_TP0 pid=101) INFO 07-06 10:45:15 [backends.py:1148] Dynamo bytecode transform time: 2.61 s
(Worker_TP0 pid=101) INFO 07-06 10:45:23 [backends.py:292] Directly load the compiled graph(s) for compile range (1, 8192) from the cache, took 6.304 s
(Worker_TP0 pid=101) INFO 07-06 10:45:23 [decorators.py:311] Directly load AOT compilation from path ~/.cache/vllm/torch_compile_cache/torch_aot_compile/12b4a80c210acc686826cd3268b962a20d0d40667899da2c2d3f6597d9df0fc2/rank_0_0/model
(Worker_TP0 pid=101) INFO 07-06 10:45:23 [monitor.py:53] torch.compile took 10.09 s in total
(Worker_TP1 pid=106) INFO 07-06 10:45:23 [decorators.py:311] Directly load AOT compilation from path ~/.cache/vllm/torch_compile_cache/torch_aot_compile/12b4a80c210acc686826cd3268b962a20d0d40667899da2c2d3f6597d9df0fc2/rank_1_0/model
(EngineCore pid=92) INFO 07-06 10:46:11 [shm_broadcast.py:705] No available shared memory broadcast block found in 60 seconds. This typically happens when some processes are hanging or doing some time-consuming work (e.g. compilation, weight/kv cache quantization).
(Worker_TP0 pid=101) INFO 07-06 10:46:16 [monitor.py:81] Initial profiling/warmup run took 52.93 s
(Worker_TP0 pid=101) INFO 07-06 10:46:16 [backends.py:1089] Using cache directory: ~/.cache/vllm/torch_compile_cache/5c1b2270cd/rank_0_0/eagle_head for vLLM's torch.compile
(Worker_TP0 pid=101) INFO 07-06 10:46:16 [backends.py:1148] Dynamo bytecode transform time: 0.10 s
(Worker_TP0 pid=101) INFO 07-06 10:46:17 [backends.py:292] Directly load the compiled graph(s) for compile range (1, 8192) from the cache, took 0.115 s
(Worker_TP0 pid=101) INFO 07-06 10:46:17 [decorators.py:311] Directly load AOT compilation from path ~/.cache/vllm/torch_compile_cache/torch_aot_compile/764c2a7cc727e9eeaa8710f12a83eb4dba9a851eca7df420db7d458efa3ee5b1/rank_0_0/model
(Worker_TP0 pid=101) INFO 07-06 10:46:17 [monitor.py:53] torch.compile took 0.87 s in total
(Worker_TP1 pid=106) INFO 07-06 10:46:17 [decorators.py:311] Directly load AOT compilation from path ~/.cache/vllm/torch_compile_cache/torch_aot_compile/764c2a7cc727e9eeaa8710f12a83eb4dba9a851eca7df420db7d458efa3ee5b1/rank_1_0/model
(Worker_TP0 pid=101) INFO 07-06 10:46:17 [monitor.py:81] Initial profiling/warmup run took 0.43 s
(Worker_TP1 pid=106) WARNING 07-06 10:46:19 [kv_cache_utils.py:1208] Add 3 padding layers, may waste at most 6.25% KV cache memory
(Worker_TP0 pid=101) WARNING 07-06 10:46:19 [kv_cache_utils.py:1208] Add 3 padding layers, may waste at most 6.25% KV cache memory
(Worker_TP1 pid=106) WARNING 07-06 10:46:19 [compilation.py:1405] CUDAGraphMode.FULL_AND_PIECEWISE is not supported with spec-decode for attention backend FlashInferBackend (support: AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE); setting cudagraph_mode=PIECEWISE
(Worker_TP0 pid=101) WARNING 07-06 10:46:19 [compilation.py:1405] CUDAGraphMode.FULL_AND_PIECEWISE is not supported with spec-decode for attention backend FlashInferBackend (support: AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE); setting cudagraph_mode=PIECEWISE
(Worker_TP1 pid=106) INFO 07-06 10:46:19 [gpu_model_runner.py:6483] Profiling CUDA graph memory: PIECEWISE=5 (largest=16)
(Worker_TP0 pid=101) INFO 07-06 10:46:19 [gpu_model_runner.py:6483] Profiling CUDA graph memory: PIECEWISE=5 (largest=16)
(Worker_TP0 pid=101) INFO 07-06 10:46:20 [gpu_model_runner.py:6588] Estimated CUDA graph memory: 0.13 GiB total
(Worker_TP1 pid=106) INFO 07-06 10:46:20 [gpu_model_runner.py:6588] Estimated CUDA graph memory: 0.13 GiB total
(Worker_TP0 pid=101) INFO 07-06 10:46:21 [gpu_worker.py:508] Available KV cache memory: 5.32 GiB
(Worker_TP0 pid=101) INFO 07-06 10:46:21 [gpu_worker.py:523] CUDA graph memory profiling is enabled (default since v0.21.0). The current --gpu-memory-utilization=0.9200 is equivalent to --gpu-memory-utilization=0.9143 without CUDA graph memory profiling. To maintain the same effective KV cache size as before, increase --gpu-memory-utilization to 0.9257. To disable, set VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0.
(Worker_TP1 pid=106) INFO 07-06 10:46:21 [gpu_worker.py:523] CUDA graph memory profiling is enabled (default since v0.21.0). The current --gpu-memory-utilization=0.9200 is equivalent to --gpu-memory-utilization=0.9143 without CUDA graph memory profiling. To maintain the same effective KV cache size as before, increase --gpu-memory-utilization to 0.9257. To disable, set VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0.
(EngineCore pid=92) WARNING 07-06 10:46:21 [kv_cache_utils.py:1208] Add 3 padding layers, may waste at most 6.25% KV cache memory
(EngineCore pid=92) INFO 07-06 10:46:21 [kv_cache_utils.py:2146] GPU KV cache size: 300,220 tokens
(EngineCore pid=92) INFO 07-06 10:46:21 [kv_cache_utils.py:2147] Maximum concurrency for 262,144 tokens per request: 1.15x
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|██████████| 5/5 [00:00<00:00,  9.16it/s]
(Worker_TP0 pid=101) INFO 07-06 10:46:22 [gpu_model_runner.py:6656] Graph capturing finished in 1 secs, took 0.10 GiB
(Worker_TP0 pid=101) INFO 07-06 10:46:22 [gpu_worker.py:667] CUDA graph pool memory: 0.1 GiB (actual), 0.13 GiB (estimated), difference: 0.04 GiB (38.0%).
(Worker_TP1 pid=106) INFO 07-06 10:46:22 [gpu_worker.py:667] CUDA graph pool memory: 0.1 GiB (actual), 0.13 GiB (estimated), difference: 0.04 GiB (38.0%).
(Worker_TP1 pid=106) INFO 07-06 10:46:22 [jit_monitor.py:60] Kernel JIT monitor activated — Triton JIT compilations during inference will be logged as warnings.
(Worker_TP0 pid=101) INFO 07-06 10:46:22 [jit_monitor.py:60] Kernel JIT monitor activated — Triton JIT compilations during inference will be logged as warnings.
(EngineCore pid=92) INFO 07-06 10:46:22 [core.py:337] init engine (profile, create kv cache, warmup model) took 72.29 s (compilation: 11.33 s)
(EngineCore pid=92) [transformers] The `use_fast` parameter is deprecated and will be removed in a future version. Use `backend="torchvision"` instead of `use_fast=True`, or `backend="pil"` instead of `use_fast=False`.
(EngineCore pid=92) INFO 07-06 10:46:31 [vllm.py:1006] Asynchronous scheduling is enabled.
(EngineCore pid=92) INFO 07-06 10:46:31 [kernel.py:276] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
(EngineCore pid=92) INFO 07-06 10:46:31 [compilation.py:310] Enabled custom fusions: norm_quant, act_quant
(APIServer pid=1) INFO 07-06 10:46:34 [api_server.py:577] Supported tasks: ['generate']
(APIServer pid=1) INFO 07-06 10:46:35 [parser_manager.py:37] "auto" tool choice has been enabled.
(APIServer pid=1) WARNING 07-06 10:46:35 [model.py:1477] Default vLLM sampling parameters have been overridden by the model's `generation_config.json`: `{'repetition_penalty': 1.0, 'temperature': 0.6, 'top_k': 20, 'top_p': 0.95, 'min_p': 0.0}`. If this is not intended, please relaunch vLLM instance with `--generation-config vllm`.
(APIServer pid=1) INFO 07-06 10:46:35 [hf.py:548] Detected the chat template content format to be 'openai'. You can set `--chat-template-content-format` to override this.
(APIServer pid=1) INFO 07-06 10:46:50 [base.py:223] Multi-modal warmup completed in 14.403s
(APIServer pid=1) INFO 07-06 10:46:52 [base.py:223] Readonly multi-modal warmup completed in 1.885s
(APIServer pid=1) INFO 07-06 10:46:52 [api_server.py:581] Starting vLLM server on http://0.0.0.0:8000
(APIServer pid=1) INFO 07-06 10:46:52 [launcher.py:37] Available routes are:
(APIServer pid=1) INFO 07-06 10:46:52 [launcher.py:46] Route: /openapi.json, Methods: HEAD, GET
(APIServer pid=1) INFO 07-06 10:46:52 [launcher.py:46] Route: /docs, Methods: HEAD, GET
(APIServer pid=1) INFO 07-06 10:46:52 [launcher.py:46] Route: /docs/oauth2-redirect, Methods: HEAD, GET
(APIServer pid=1) INFO 07-06 10:46:52 [launcher.py:46] Route: /redoc, Methods: HEAD, GET
(APIServer pid=1) INFO 07-06 10:46:52 [launcher.py:46] Route: /load, Methods: GET
(APIServer pid=1) INFO 07-06 10:46:52 [launcher.py:46] Route: /version, Methods: GET
(APIServer pid=1) INFO 07-06 10:46:52 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=1) INFO 07-06 10:46:52 [launcher.py:46] Route: /metrics, Methods: GET
```

</details>

## Recent failed boot attempts

_Exited vLLM/llama.cpp containers exist but all >24h old — likely not relevant to current investigation._

---

_Generated by `bash scripts/report.sh`. Flags: `--verify` (verify-full), `--stress` (verify-stress 7/7 incl. Cliff 2 needles), `--soak` (SOAK_MODE=continuous, catches Cliff 2b), `--bench` (canonical TPS), `--agentic` (multi-turn TTFT/decode curve-shape, ~8 min estimate), `--studio` (AI Studio / ComfyUI container log tails — for generation bugs), `--full` (all five, ~43 min estimate). Use `--no-redact` to disable redaction (internal sharing only)._
```