### PR TITLE
fix(c3): surface submission-only baselines in funnel card + 8pk on ⑂ lines

### DIFF
--- a/scripts/lib/profiles/baselines.yml
+++ b/scripts/lib/profiles/baselines.yml
@@ -67,11 +67,15 @@ baselines:
     # BENCHMARKS.md 2026-06-30 row — the v0.22.0→v0.24.0 pin-bump validation
     # gate (decode 70.7/93.5; MTP n=3 accept 3.51, KV pool 622K/2.37×,
     # verify-full 8/8, verify-stress NIAH→240K, soak-continuous PASS).
-    # Measured ON the current vllm-stable pin → FRESH. Quality gate was
-    # `--quick` only (toolcall 11/15 · IF 15/15) — no 8-pack yet; add
-    # quality_8pk on the next full gate.
+    # Measured ON the current vllm-stable pin → FRESH. On-rig quality gate was
+    # `--quick` (toolcall 11/15 · IF 15/15); the 8-pack below is CARRIED from
+    # multi-fast #584 (ryan, 4×3090, same AutoRound-INT4 weights, current harness)
+    # — TP-invariant (4-card = 2-card; TP is not a quality lever, confirmed on #584).
+    # Replace with an on-rig 2-card --full number if/when one is run.
     narr_tps: 70.7
     code_tps: 93.5
+    quality_8pk: "108/150"
+    quality_env: { harness: "carried from multi-fast #584 (ryan 4×3090, TP-invariant); on-rig 2-card --full pending" }
     ctx_validated: { tokens: 245760, niah: "clean@240K" }
     date: 2026-06-30
     engine_pin: "vllm/vllm-openai:v0.24.0"
@@ -83,9 +87,11 @@ baselines:
   vllm/qwen-27b-dual-fast:
     # alias of vllm/dual (same compose_path dual/autoround-int4/fp8-mtp.yml,
     # same port — the #340 tier naming). Row mirrors vllm/dual verbatim;
-    # update both together.
+    # update both together. 8-pack carried from multi-fast #584 (TP-invariant).
     narr_tps: 70.7
     code_tps: 93.5
+    quality_8pk: "108/150"
+    quality_env: { harness: "carried from multi-fast #584 (ryan 4×3090, TP-invariant); on-rig 2-card --full pending" }
     ctx_validated: { tokens: 245760, niah: "clean@240K" }
     date: 2026-06-30
     engine_pin: "vllm/vllm-openai:v0.24.0"

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -1172,8 +1172,10 @@ class CatalogPane(Container):
             c = s.get("code_tps")
             tps = (f"{n:.0f}" if n is not None else "—") + "/" + (
                 f"{c:.0f}" if c is not None else "—")
-            sub = (
-                f"  [bold]⑂ {rc}[/bold]  {tps} TPS"
+            sub = f"  [bold]⑂ {rc}[/bold]  {tps} TPS"
+            if s.get("quality_8pk"):
+                sub += f"  ·  8pk {s['quality_8pk']}"
+            sub += (
                 f"  [dim]({s.get('tier')} · {s.get('date')} · {s.get('submitted_by')})[/dim]"
             )
             if s.get("stale") is True:
@@ -7074,6 +7076,20 @@ class CockpitApp(App):
             if b.get("stale") is True:
                 bar += "  [yellow]† re-bench owed[/yellow]"
             lines.append(bar)
+        # Cross-rig submissions — rig-labeled, NEVER merged into the bar (a 4-card /
+        # 5090 number isn't this rig's bar). This is what surfaces submission-only
+        # slugs (e.g. multi-fast: 4-card, no on-rig bar) in the detail card.
+        for rc, s in sorted((b.get("submissions") or {}).items()):
+            sn, sc = s.get("narr_tps"), s.get("code_tps")
+            stps = (f"{sn:.0f}" if sn is not None else "—") + "/" + (
+                f"{sc:.0f}" if sc is not None else "—")
+            sub = f"  [bold]⑂ {rc}[/bold]  {stps} TPS"
+            if s.get("quality_8pk"):
+                sub += f"  ·  8pk {s['quality_8pk']}"
+            sub += (
+                f"  [dim]({s.get('tier')} · {s.get('date')} · {s.get('submitted_by')})[/dim]"
+            )
+            lines.append(sub)
         note = (getattr(row, "status_note", "") or "").strip()
         if note:
             lines.append(f"  [yellow]caveat: {note}[/yellow]")


### PR DESCRIPTION
Fixes the c3 gap you spotted: multi-max/multi-fast (and dual/dual-fast's missing 8-pack) not showing numbers in the app. It was **three different causes**, not one bug:

| slug | cause | fix |
|---|---|---|
| **multi-fast** | in `baselines.yml` as a **submissions-only** entry (ryan #584: 75/91 · 8pk 108/150), but the Bring pane's slug-detail card (`_funnel_slug_details`) rendered *only* the primary "bar" — never the `⑂` submission lines | render `⑂` submissions in the funnel card (design-consistent: **never merged into the bar**) |
| **⑂ lines everywhere** | the existing `⑂` submission renderer **omitted `quality_8pk`** | add `quality_8pk` to the `⑂` line in both renderers |
| **vllm/dual + dual-fast** | TPS present, `quality_8pk` deferred ("on the next full gate") | fill `108/150`, **carried from multi-fast #584** (same AutoRound-INT4 weights, TP-invariant — you confirmed 4-card = 2-card on #584); provenance in `quality_env` |
| **multi-max** | **no row at all** — 4-card (can't run on our 2 cards), and @Whamp #446's numbers are int8-PTH (now stale post-fp8 flip) | *(intentionally left blank — fills from its pending 4-card fp8 re-test, #584)* |

**After:** multi-fast shows `⑂ 4x3090-pcie 75/91 TPS · 8pk 108/150 (submitted · 2026-07-05 · ryanmpelletier)`; the fast tier shows its 8-pack; dual-max's 5090 submission line now shows its 8pk too.

**Verified:** 239 c3 tests pass, `test-baselines` + `test-catalog-baseline` green, direct render-logic check confirms the multi-fast line. (The headless-app test is slow/hangs in CI-less local runs — ran the fast suite + render check instead.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
