### PR TITLE
fix(launcher): read YAML as UTF-8 in registry-emit — switch broke on non-UTF-8 locales (#584)

### DIFF
--- a/scripts/lib/registry-emit.sh
+++ b/scripts/lib/registry-emit.sh
@@ -38,7 +38,7 @@ def switch_engine(key: str) -> str:
 def container_name(compose_path: str) -> str:
     path = root / compose_path
     try:
-        data = yaml.safe_load(path.read_text()) or {}
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     except Exception as exc:
         raise RuntimeError(f"could not parse compose yaml: {exc}") from exc
     services = data.get("services") or {}
@@ -59,7 +59,7 @@ _CTX_FLAG = re.compile(r"(?:--max-model-len|--ctx-size|--n-ctx|(?<!\w)-c)\s*\n?\
 def compose_default_ctx(compose_path: str):
     """The ctx the compose serves by DEFAULT (its ${VAR:-N} fallback or flag literal)."""
     try:
-        txt = (root / compose_path).read_text()
+        txt = (root / compose_path).read_text(encoding="utf-8")
     except Exception:
         return None
     m = _CTX_ENV.search(txt) or _CTX_FLAG.search(txt)
@@ -132,10 +132,14 @@ derive_switch_variant_tables() {
   # proper assoc arrays without each having to declare them. VARIANT_CONTAINER
   # (slug -> container name) drives switch.sh's registry-derived orphan teardown.
   declare -gA VARIANT_CTX VARIANT_CONTAINER
-  if ! emit="$(registry_variant_rows "$root" 2>/dev/null)"; then
+  local _emit_err; _emit_err="$(mktemp)"
+  if ! emit="$(registry_variant_rows "$root" 2>"$_emit_err")"; then
     echo "[switch] ERROR: could not derive variant tables from compose_registry.py" >&2
+    [[ -s "$_emit_err" ]] && sed 's/^/[switch]   /' "$_emit_err" >&2
+    rm -f "$_emit_err"
     exit 2
   fi
+  rm -f "$_emit_err"
   while IFS=$'\t' read -r kind key switch_engine _launch_engine cdir cfile port _model _profile_engine _kvcalc container _compose_path status max_ctx status_note; do
     [[ -n "${kind:-}" ]] || continue
     case "$kind" in
@@ -161,10 +165,14 @@ derive_switch_variant_tables() {
 
 derive_launch_variant_tables() {
   local root="$1" emit key _switch_engine launch_engine cdir cfile port model profile_engine kvcalc container _compose_path status _max_ctx status_note
-  if ! emit="$(registry_variant_rows "$root" 2>/dev/null)"; then
+  local _emit_err; _emit_err="$(mktemp)"
+  if ! emit="$(registry_variant_rows "$root" 2>"$_emit_err")"; then
     echo "[launch] ERROR: could not derive variant tables from compose_registry.py" >&2
+    [[ -s "$_emit_err" ]] && sed 's/^/[launch]   /' "$_emit_err" >&2
+    rm -f "$_emit_err"
     exit 2
   fi
+  rm -f "$_emit_err"
   while IFS=$'\t' read -r kind key _switch_engine launch_engine cdir cfile port model profile_engine kvcalc container _compose_path status _max_ctx status_note; do
     [[ -n "${kind:-}" ]] || continue
     case "$kind" in
@@ -418,7 +426,7 @@ import yaml as _yaml  # noqa: E402
 _bl_path = root / "scripts" / "lib" / "profiles" / "baselines.yml"
 _baselines = {}
 if _bl_path.exists():
-    _baselines = (_yaml.safe_load(_bl_path.read_text()) or {}).get("baselines") or {}
+    _baselines = (_yaml.safe_load(_bl_path.read_text(encoding="utf-8")) or {}).get("baselines") or {}
 
 # First `image:` default in the compose (handles both a bare literal and the
 # ${ENGINE_IMAGE:-literal} env-fallback form) — the pin truth for engines with


### PR DESCRIPTION
**Regression fix.** @ryanmpelletier hit `could not derive variant tables from compose_registry.py` from `switch.sh` after pulling #595 (#584).

**Root cause:** `registry_variant_rows` reads compose YAMLs + `baselines.yml` via `Path.read_text()` with **no encoding** → the locale default. On a non-UTF-8 locale (a minimal Proxmox VM is `ANSI_X3.4-1968` ASCII), reading a compose header with unicode (`— × → ⚠` — the em-dashes are long-standing; #594/#595 added more) throws `UnicodeDecodeError`, which `container_name()` re-raises → the whole emit dies → the error above (which `switch.sh` then swallowed with `2>/dev/null`, hiding the real cause).

**Fix:** `encoding="utf-8"` on all three reads + surface the previously-swallowed python traceback in the two derive functions.

**Verified:** default `read_text()` crashes under `LC_ALL=C` ASCII on the unicode compose (byte 0xe2); `encoding="utf-8"` reads clean. Emit (69 rows) + `test-switch-registry-parity` + `test-launch-registry-parity` + `test-compose-status-drift` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)