### PR TITLE
feat(c3): Weights + KV catalog columns · width-stable status glyphs

### DIFF
--- a/scripts/lib/profiles/models/qwen3.6-27b.yml
+++ b/scripts/lib/profiles/models/qwen3.6-27b.yml
@@ -247,6 +247,9 @@ weights:
     local_subdir: qwen3.6-27b-gguf/ex0bit-prism-pro-dq
     size_gb: variable
     format: gguf
+    # custom-named mixed-quant pack — quant_label read from the GGUF header
+    # (general.file_type=12 → Q3_K_M, verified 2026-07-06); catalog Weights column.
+    quant_label: q3km
     status: community-experimental
     hf_repo: Ex0bit/Qwen3.6-27B-PRISM-PRO-DQ
     files:

--- a/scripts/lib/profiles/models/qwen3.6-35b-a3b.yml
+++ b/scripts/lib/profiles/models/qwen3.6-35b-a3b.yml
@@ -91,6 +91,9 @@ weights:
     local_subdir: qwen3.6-35b-a3b-gguf/mudler-apex-mtp
     size_gb: variable
     format: gguf
+    # custom-named mixed-quant pack — quant_label read from the GGUF header
+    # (general.file_type=15 → Q4_K_M, verified 2026-07-06); catalog Weights column.
+    quant_label: q4km
     status: community-experimental
     hf_repo: mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF
     files:
@@ -115,6 +118,9 @@ weights:
     local_subdir: qwen3.6-35b-a3b-gguf/mudler-apex-mtp
     size_gb: variable
     format: gguf
+    # quant_label from the GGUF header via HTTP Range read of the HF artifact
+    # (general.file_type=18 → Q6_K, verified 2026-07-06); catalog Weights column.
+    quant_label: q6k
     status: community-experimental
     hf_repo: mudler/Qwen3.6-35B-A3B-APEX-MTP-GGUF
     files:

--- a/scripts/lib/registry-emit.sh
+++ b/scripts/lib/registry-emit.sh
@@ -511,6 +511,9 @@ for vr in _tui_registry.parse_variant_rows(tab):
             # probed running ctx against the slug's CONFIGURED ctx as an exact int,
             # never round-tripping through the colloquial ÷1000 label.
             "configured_ctx": (COMPOSE_REGISTRY.get(d["slug"], {}) or {}).get("max_ctx"),
+            # KV-cache format from the registry (for the catalog KV column) —
+            # int8_per_token_head / fp8_e4m3 / fp8_e5m2 / turboquant_3bit_nc / bf16 / q*.
+            "kv_format": (COMPOSE_REGISTRY.get(d["slug"], {}) or {}).get("kv_format"),
             # Per-slug download artifacts BEYOND the core weights_variant — the
             # extra weight-variant keys (a DFlash draft / an mmproj vision
             # projector) the slug's compose mounts from a separate subdir.  The

--- a/scripts/lib/registry-emit.sh
+++ b/scripts/lib/registry-emit.sh
@@ -492,7 +492,11 @@ def _baseline_for(slug: str, compose_path: str):
 # artifact slugs like mudler-apex-compact).  Built once from ALL model YAMLs,
 # keyed (model_id, variant); encoding= is load-bearing (#599).
 _WFMT = None
-def weights_format(model: str, variant: str):
+def _weights_meta(model: str, variant: str):
+    """(quant_label, format) for a weights entry — quant_label is the optional
+    explicit display quant for custom-named artifacts (mixed-quant packs like
+    PRISM-PRO-DQ whose token carries no quant segment; value read from the GGUF
+    header's general.file_type and baked into the model YAML)."""
     global _WFMT
     if _WFMT is None:
         _WFMT = {}
@@ -503,8 +507,11 @@ def weights_format(model: str, variant: str):
             _data = _yaml.safe_load(_p.read_text(encoding="utf-8")) or {}
             _mid = _data.get("id") or _p.stem
             for _wk, _wv in (_data.get("weights") or {}).items():
-                _WFMT[(_mid, _wk)] = (_wv or {}).get("format")
-    return _WFMT.get((model, variant))
+                _WFMT[(_mid, _wk)] = (
+                    (_wv or {}).get("quant_label"),
+                    (_wv or {}).get("format"),
+                )
+    return _WFMT.get((model, variant)) or (None, None)
 
 # --- variants: exactly the fields parse_variant_rows produces from the tab form,
 #     trimmed to the contract's variant schema (+ 'source' default "curated"). ---
@@ -535,12 +542,16 @@ for vr in _tui_registry.parse_variant_rows(tab):
             # KV-cache format from the registry (for the catalog KV column) —
             # int8_per_token_head / fp8_e4m3 / fp8_e5m2 / turboquant_3bit_nc / bf16 / q*.
             "kv_format": (COMPOSE_REGISTRY.get(d["slug"], {}) or {}).get("kv_format"),
-            # Weights FORMAT from the model profile (catalog Weights column
-            # fallback) — see weights_format() above.
-            "weights_format": weights_format(
+            # Weights quant_label + FORMAT from the model profile (catalog
+            # Weights column fallbacks) — see _weights_meta() above.
+            "weights_quant_label": _weights_meta(
                 (COMPOSE_REGISTRY.get(d["slug"], {}) or {}).get("model") or "",
                 (COMPOSE_REGISTRY.get(d["slug"], {}) or {}).get("weights_variant") or "",
-            ),
+            )[0],
+            "weights_format": _weights_meta(
+                (COMPOSE_REGISTRY.get(d["slug"], {}) or {}).get("model") or "",
+                (COMPOSE_REGISTRY.get(d["slug"], {}) or {}).get("weights_variant") or "",
+            )[1],
             # Per-slug download artifacts BEYOND the core weights_variant — the
             # extra weight-variant keys (a DFlash draft / an mmproj vision
             # projector) the slug's compose mounts from a separate subdir.  The

--- a/scripts/lib/registry-emit.sh
+++ b/scripts/lib/registry-emit.sh
@@ -485,6 +485,27 @@ def _baseline_for(slug: str, compose_path: str):
         }
     return out
 
+# --- weights-format join: models/<id>.yml weights[<variant>].format ----------
+# The honest quant FORMAT (autoround / awq / compressed-tensors / fp8 / bf16 /
+# gguf) behind a weights_variant token — the catalog Weights column falls back
+# to it when the token itself carries no recognisable quant segment (fine-tune
+# artifact slugs like mudler-apex-compact).  Built once from ALL model YAMLs,
+# keyed (model_id, variant); encoding= is load-bearing (#599).
+_WFMT = None
+def weights_format(model: str, variant: str):
+    global _WFMT
+    if _WFMT is None:
+        _WFMT = {}
+        for _p in sorted((root / "scripts/lib/profiles/models").glob("*.yml")):
+            # NOTE: _yaml (this block's alias), NOT yaml — a bare `yaml` here is
+            # a NameError that a blanket except would silently eat to an empty
+            # map (the exact swallowed-failure class #599 warned about).
+            _data = _yaml.safe_load(_p.read_text(encoding="utf-8")) or {}
+            _mid = _data.get("id") or _p.stem
+            for _wk, _wv in (_data.get("weights") or {}).items():
+                _WFMT[(_mid, _wk)] = (_wv or {}).get("format")
+    return _WFMT.get((model, variant))
+
 # --- variants: exactly the fields parse_variant_rows produces from the tab form,
 #     trimmed to the contract's variant schema (+ 'source' default "curated"). ---
 variants = []
@@ -514,6 +535,12 @@ for vr in _tui_registry.parse_variant_rows(tab):
             # KV-cache format from the registry (for the catalog KV column) —
             # int8_per_token_head / fp8_e4m3 / fp8_e5m2 / turboquant_3bit_nc / bf16 / q*.
             "kv_format": (COMPOSE_REGISTRY.get(d["slug"], {}) or {}).get("kv_format"),
+            # Weights FORMAT from the model profile (catalog Weights column
+            # fallback) — see weights_format() above.
+            "weights_format": weights_format(
+                (COMPOSE_REGISTRY.get(d["slug"], {}) or {}).get("model") or "",
+                (COMPOSE_REGISTRY.get(d["slug"], {}) or {}).get("weights_variant") or "",
+            ),
             # Per-slug download artifacts BEYOND the core weights_variant — the
             # extra weight-variant keys (a DFlash draft / an mmproj vision
             # projector) the slug's compose mounts from a separate subdir.  The

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -115,12 +115,17 @@ from .services import CockpitData
 
 _STATUS_GLYPH: dict[str, str] = {
     "production": "✅",
-    "caveats": "⚠️",
+    # ⚠️ 👁️ ⏸️ 🗑️ carry a U+FE0F variation selector — Rich's cell_len reserves
+    # 2 cols but many terminals render them 1-wide, shifting every column after
+    # the status cell.  These replacements are Emoji_Presentation=Yes (no VS16),
+    # so cell_len == terminal width == 2 everywhere.  (Status is also the LAST
+    # catalog column now, so any residual slop has nothing to misalign.)
+    "caveats": "❗",
     "experimental": "🧪",
     "incubating": "🐣",
-    "preview": "👁️",
-    "upstream-gated": "⏸️",
-    "deprecated": "🗑️",
+    "preview": "👀",
+    "upstream-gated": "🚧",
+    "deprecated": "🚫",
 }
 
 
@@ -682,8 +687,8 @@ class HelpScreen(ModalScreen):
             "",
             "[bold]Status glyphs[/bold]",
             "",
-            "  ✅ production   ⚠️  caveats   🧪 experimental",
-            "  🐣 incubating  👁️  preview   ⏸️  upstream-gated   🗑️  deprecated",
+            "  ✅ production   ❗ caveats   🧪 experimental",
+            "  🐣 incubating  👀 preview   🚧 upstream-gated   🚫 deprecated",
             "",
             "[bold]Fit glyphs (local card)[/bold]",
             "",
@@ -805,12 +810,14 @@ class CatalogPane(Container):
         # fit verdict is a pick-the-serve decision input, shown when you ⏎ a row).
         # Fit is STILL computed (it feeds the pop-up + the serving-row exemption);
         # it just no longer occupies a Catalog column.
-        # F6 — column budget: the money columns (ctx · TPS · 8pk · status) come
-        # RIGHT after the identity (model · slug); topology/engine — largely
-        # redundant with the slug, which encodes both — moved to the tail so a
-        # 120-140-col terminal folds THEM, not the numbers a user picks by.
+        # Column budget, left→right: identity (model · slug) → config the user
+        # picks by (weights · kv) → money (ctx · TPS · 8pk) → topology/engine
+        # (largely slug-redundant, fold first on a narrow terminal) → status.
+        # Status is deliberately LAST: its glyph is the one emoji-width column, so
+        # putting it at the tail means nothing follows it to misalign (belt +
+        # braces with the VS16-free glyphs in _STATUS_GLYPH).
         # "(rig)" keeps the our-rig provenance at 4 chars ("our rig" cost 8 more).
-        table.add_columns("model", "slug", "ctx", "TPS (rig)", "8pk (rig)", "status", "topo", "engine", "weights", "kv")
+        table.add_columns("model", "slug", "weights", "kv", "ctx", "TPS (rig)", "8pk (rig)", "topo", "engine", "status")
         # Full enriched catalog, and the current filter substring.
         self._entries: list[CatalogEntry] = []
         self._filter: str = ""
@@ -932,14 +939,14 @@ class CatalogPane(Container):
             table.add_row(
                 model_cell,
                 slug_cell,
+                _weights_label(e),
+                _kv_label(e),
                 e.ctx_label or "—",
                 tps,
                 e.measurement.quality_label,
-                _status_glyph(e.status),
                 e.topology,
                 e.engine,
-                _weights_label(e),
-                _kv_label(e),
+                _status_glyph(e.status),
             )
 
         banner = f"[yellow]{self._model_dir_note}[/yellow]  ·  " if self._model_dir_note else ""

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -139,6 +139,33 @@ def _status_glyph(status: str) -> str:
     return _STATUS_GLYPH.get(status.lower(), status)
 
 
+_WEIGHTS_LABELS = {
+    "fp8": "fp8", "autoround-int4": "int4·AR", "awq-bf16-int4": "awq4",
+    "qat-w4a16": "qat4", "bf16": "bf16", "bf16-mtp": "bf16",
+    "ubergarm-iq4ks": "iq4ks", "byteshape-iq4xs": "iq4xs",
+    "unsloth-q4km": "q4km", "unsloth-q5kxl": "q5kxl", "unsloth-q8": "q8",
+    "carnice-bf16mtp": "carnice", "qwopus-bf16mtp": "qwopus", "awq": "awq4",
+}
+_KV_LABELS = {
+    "int8_per_token_head": "int8-PTH", "fp8_e4m3": "fp8/e4m3",
+    "fp8_e5m2": "fp8/e5m2", "fp8": "fp8", "turboquant_3bit_nc": "tq3",
+    "turboquant_4bit_nc": "tq4", "bf16": "bf16", "fp16": "fp16",
+    "q4_0": "q4_0", "q4_1": "q4_1", "q5_0": "q5_0", "q8_0": "q8_0",
+}
+
+
+def _weights_label(e: "CatalogEntry") -> str:
+    """Compact weights-quant token for the catalog Weights column."""
+    wv = (e.weights_variant or "").lower()
+    return _WEIGHTS_LABELS.get(wv, wv.split("-")[0] if wv else "—")
+
+
+def _kv_label(e: "CatalogEntry") -> str:
+    """Compact KV-cache-format token for the catalog KV column (from the registry)."""
+    kv = (getattr(e.row, "kv_format", "") or "").lower()
+    return _KV_LABELS.get(kv, kv or "—")
+
+
 def _weights_glyph(e: CatalogEntry) -> str:
     """Download-state prefix for the catalog slug cell (Download UX).  ⏳NN%
     downloading · ⬇ absent (not on disk) · ⚠ partial (interrupted/wrong).
@@ -783,7 +810,7 @@ class CatalogPane(Container):
         # redundant with the slug, which encodes both — moved to the tail so a
         # 120-140-col terminal folds THEM, not the numbers a user picks by.
         # "(rig)" keeps the our-rig provenance at 4 chars ("our rig" cost 8 more).
-        table.add_columns("model", "slug", "ctx", "TPS (rig)", "8pk (rig)", "status", "topo", "engine")
+        table.add_columns("model", "slug", "ctx", "TPS (rig)", "8pk (rig)", "status", "topo", "engine", "weights", "kv")
         # Full enriched catalog, and the current filter substring.
         self._entries: list[CatalogEntry] = []
         self._filter: str = ""
@@ -829,7 +856,7 @@ class CatalogPane(Container):
             self._entries = []
             table.clear()
             status_label.update(f"[red]Catalog error:[/red] {error}")
-            table.add_row("—", "—", "—", "—", "—", "—", "—", "—")
+            table.add_row("—", "—", "—", "—", "—", "—", "—", "—", "—", "—")
             return
 
         self._entries = list(entries)
@@ -911,6 +938,8 @@ class CatalogPane(Container):
                 _status_glyph(e.status),
                 e.topology,
                 e.engine,
+                _weights_label(e),
+                _kv_label(e),
             )
 
         banner = f"[yellow]{self._model_dir_note}[/yellow]  ·  " if self._model_dir_note else ""

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -42,6 +42,7 @@ NEVER executed live — tests inject fakes and conftest blocks the real spawn.
 from __future__ import annotations
 
 import dataclasses
+import re
 from collections import OrderedDict
 from pathlib import Path
 from typing import NamedTuple, Optional
@@ -144,13 +145,6 @@ def _status_glyph(status: str) -> str:
     return _STATUS_GLYPH.get(status.lower(), status)
 
 
-_WEIGHTS_LABELS = {
-    "fp8": "fp8", "autoround-int4": "int4·AR", "awq-bf16-int4": "awq4",
-    "qat-w4a16": "qat4", "bf16": "bf16", "bf16-mtp": "bf16",
-    "ubergarm-iq4ks": "iq4ks", "byteshape-iq4xs": "iq4xs",
-    "unsloth-q4km": "q4km", "unsloth-q5kxl": "q5kxl", "unsloth-q8": "q8",
-    "carnice-bf16mtp": "carnice", "qwopus-bf16mtp": "qwopus", "awq": "awq4",
-}
 _KV_LABELS = {
     "int8_per_token_head": "int8-PTH", "fp8_e4m3": "fp8/e4m3",
     "fp8_e5m2": "fp8/e5m2", "fp8": "fp8", "turboquant_3bit_nc": "tq3",
@@ -159,10 +153,40 @@ _KV_LABELS = {
 }
 
 
+# Weights column — the label is DERIVED from the weights_variant token (the
+# compose <quant>/ dir name) by PATTERN, not by a hand-map keyed on full tokens:
+# the hand-map drifted immediately (18/30 catalog tokens fell to a naive
+# first-segment fallback that showed the PROVIDER prefix — "beellama",
+# "unsloth", "deepreinforce" — instead of the quant).  Precedence: an explicit
+# GGUF quant segment (q4km / q8kxl / iq4ks / q6kp …) wins; then the known
+# safetensors formats; else the model profile's `format:` (threaded through the
+# emit as row.weights_format) — the honest answer for fine-tune artifact slugs
+# whose token carries no quant segment (mudler-apex-compact → "gguf").
+_GGUF_SEG = re.compile(r"^i?q\d[a-z0-9_]*$")
+
+
 def _weights_label(e: "CatalogEntry") -> str:
     """Compact weights-quant token for the catalog Weights column."""
     wv = (e.weights_variant or "").lower()
-    return _WEIGHTS_LABELS.get(wv, wv.split("-")[0] if wv else "—")
+    if not wv:
+        return "—"
+    segs = wv.split("-")
+    for s in segs:
+        if _GGUF_SEG.match(s):
+            return s
+    if "nvfp4" in segs:
+        return "nvfp4"
+    if "w4a16" in segs:
+        return "w4a16"
+    if "awq" in segs:  # awq · awq-bf16-int4 · qat-awq-int4 — all int4 weights
+        return "awq4"
+    if "autoround" in segs:
+        return "int8·AR" if "int8" in segs else "int4·AR"
+    if "fp8" in segs:  # fp8 · fp8-dynamic
+        return "fp8"
+    if "bf16" in segs:
+        return "bf16"
+    return (getattr(e.row, "weights_format", "") or "") or wv
 
 
 def _kv_label(e: "CatalogEntry") -> str:
@@ -966,8 +990,16 @@ class CatalogPane(Container):
                 if self._has_stale_baseline()
                 else ""
             )
+            # ⑂ legend — shown whenever any row's numbers come from a COMMUNITY
+            # SUBMISSION (rig-labelled, never the local bar) so the marker on the
+            # TPS cell is decodable without opening the slug detail card.
+            sub_note = (
+                "  ([dim]⑂ = community-submitted numbers (other rig) — not a local baseline[/dim])"
+                if self._has_submission_measurement()
+                else ""
+            )
             status_label.update(
-                f"{banner}{len(self._entries)} variants loaded from registry{stale_note}{dep_note}"
+                f"{banner}{len(self._entries)} variants loaded from registry{stale_note}{sub_note}{dep_note}"
             )
 
         # #9/A8 — keep the preview strip in sync with the cursor after a (re-)render
@@ -1030,6 +1062,13 @@ class CatalogPane(Container):
 
     def _has_stale_baseline(self) -> bool:
         return any(e.measurement.stale is True for e in self._entries)
+
+    def _has_submission_measurement(self) -> bool:
+        """Any loaded row whose numbers came from a community submission (the
+        ⑂-marked cells) — drives the ⑂ legend in the status line."""
+        return any(
+            getattr(e.measurement, "submission_rig", None) for e in self._entries
+        )
 
     def _filtered_entries(self) -> list[CatalogEntry]:
         # Hide 🗑️ deprecated slugs by default (mirrors `switch.sh --list`); [h] reveals them.

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -186,7 +186,15 @@ def _weights_label(e: "CatalogEntry") -> str:
         return "fp8"
     if "bf16" in segs:
         return "bf16"
-    return (getattr(e.row, "weights_format", "") or "") or wv
+    # No quant segment in the token (custom-named mixed-quant packs like
+    # PRISM-PRO-DQ / APEX-MTP-I-*): prefer the entry's explicit quant_label
+    # (GGUF-header ground truth baked into the model YAML), then the coarse
+    # format ("gguf"), then the raw token.
+    return (
+        (getattr(e.row, "weights_quant_label", "") or "")
+        or (getattr(e.row, "weights_format", "") or "")
+        or wv
+    )
 
 
 def _kv_label(e: "CatalogEntry") -> str:

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -3914,6 +3914,9 @@ def _variant_row_from_dict(d: dict[str, Any]) -> VariantRow:
         object.__setattr__(row, "weights_companions", [str(c) for c in comp])
         object.__setattr__(row, "drafter", str(d.get("drafter") or ""))
         object.__setattr__(row, "vision", bool(d.get("vision")))
+        # KV-cache format from the registry (catalog KV column) — attached same
+        # as the facets above; "" when the contract didn't carry it.
+        object.__setattr__(row, "kv_format", str(d.get("kv_format") or ""))
         # Catalog-baselines slice 1: the shipped baseline row joined at
         # registry-emit (narr/code TPS · 8pk · ctx_validated · provenance ·
         # computed 'stale') — None when the slug has no accepted row.

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -3917,6 +3917,10 @@ def _variant_row_from_dict(d: dict[str, Any]) -> VariantRow:
         # KV-cache format from the registry (catalog KV column) — attached same
         # as the facets above; "" when the contract didn't carry it.
         object.__setattr__(row, "kv_format", str(d.get("kv_format") or ""))
+        # Weights FORMAT from the model profile (emit weights_format join) —
+        # the catalog Weights column's fallback for weights_variant tokens that
+        # carry no recognisable quant segment (fine-tune artifact slugs).
+        object.__setattr__(row, "weights_format", str(d.get("weights_format") or ""))
         # Catalog-baselines slice 1: the shipped baseline row joined at
         # registry-emit (narr/code TPS · 8pk · ctx_validated · provenance ·
         # computed 'stale') — None when the slug has no accepted row.

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -3917,9 +3917,14 @@ def _variant_row_from_dict(d: dict[str, Any]) -> VariantRow:
         # KV-cache format from the registry (catalog KV column) — attached same
         # as the facets above; "" when the contract didn't carry it.
         object.__setattr__(row, "kv_format", str(d.get("kv_format") or ""))
-        # Weights FORMAT from the model profile (emit weights_format join) —
-        # the catalog Weights column's fallback for weights_variant tokens that
-        # carry no recognisable quant segment (fine-tune artifact slugs).
+        # Weights quant_label + FORMAT from the model profile (emit join) —
+        # the catalog Weights column's fallbacks for weights_variant tokens that
+        # carry no recognisable quant segment: quant_label is the explicit
+        # per-artifact quant (GGUF header ground truth, baked into the model
+        # YAML for custom-named packs); format is the coarse last resort.
+        object.__setattr__(
+            row, "weights_quant_label", str(d.get("weights_quant_label") or "")
+        )
         object.__setattr__(row, "weights_format", str(d.get("weights_format") or ""))
         # Catalog-baselines slice 1: the shipped baseline row joined at
         # registry-emit (narr/code TPS · 8pk · ctx_validated · provenance ·

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -1127,9 +1127,10 @@ class TestCatalogWired:
             pane.set_filter("")
             assert len(pane._filtered_entries()) == 2
 
-    def _label_entry(self, quant: str, weights_format: str = ""):
+    def _label_entry(self, quant: str, weights_format: str = "", quant_label: str = ""):
         """Minimal CatalogEntry whose compose path carries the given <quant>/ dir
-        (weights_variant derives from the path) + an optional threaded format."""
+        (weights_variant derives from the path) + optional threaded format /
+        quant_label (the emit weights_quant_label / weights_format joins)."""
         from club3090_cockpit.data import CatalogEntry as _CE
         from club3090_tui_core import VariantRow as _VR
 
@@ -1143,6 +1144,8 @@ class TestCatalogWired:
         )
         if weights_format:
             object.__setattr__(row, "weights_format", weights_format)
+        if quant_label:
+            object.__setattr__(row, "weights_quant_label", quant_label)
         return _CE(row=row)
 
     def test_weights_label_quant_segment_beats_provider_prefix(self):
@@ -1172,11 +1175,19 @@ class TestCatalogWired:
         }.items():
             assert _weights_label(self._label_entry(tok)) == want, tok
 
-    def test_weights_label_no_quant_segment_falls_back_to_format(self):
-        """Fine-tune artifact tokens with no quant segment show the model
-        profile's format (emit weights_format join), else the raw token."""
+    def test_weights_label_no_quant_segment_fallback_chain(self):
+        """Custom-named pack tokens with no quant segment fall back, in order:
+        the entry's explicit quant_label (GGUF-header ground truth baked into
+        the model YAML — prism-pro-dq→q3km, apex-compact→q4km, apex-quality→q6k),
+        then the coarse format ("gguf"), then the raw token."""
         from club3090_cockpit.app import _weights_label
 
+        assert (
+            _weights_label(
+                self._label_entry("ex0bit-prism-pro-dq", "gguf", quant_label="q3km")
+            )
+            == "q3km"
+        )
         assert _weights_label(self._label_entry("mudler-apex-compact", "gguf")) == "gguf"
         assert (
             _weights_label(self._label_entry("mudler-apex-compact"))

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -1127,6 +1127,81 @@ class TestCatalogWired:
             pane.set_filter("")
             assert len(pane._filtered_entries()) == 2
 
+    def _label_entry(self, quant: str, weights_format: str = ""):
+        """Minimal CatalogEntry whose compose path carries the given <quant>/ dir
+        (weights_variant derives from the path) + an optional threaded format."""
+        from club3090_cockpit.data import CatalogEntry as _CE
+        from club3090_tui_core import VariantRow as _VR
+
+        row = _VR(
+            slug=f"x/{quant}", switch_engine="vllm", launch_engine="vllm",
+            compose_dir=f"models/m/vllm/compose/dual/{quant}",
+            file="base.yml", port=8000, model="m", engine="vllm-stable",
+            kvcalc_key="SKIP", container="c",
+            compose_path=f"models/m/vllm/compose/dual/{quant}/base.yml",
+            status="production", ctx_label="262K", status_note="",
+        )
+        if weights_format:
+            object.__setattr__(row, "weights_format", weights_format)
+        return _CE(row=row)
+
+    def test_weights_label_quant_segment_beats_provider_prefix(self):
+        """Regression: the Weights column labeller must extract the QUANT segment
+        from provider-prefixed tokens — the retired hand-map fell back to the
+        first '-'-segment and showed the PROVIDER ("beellama", "unsloth",
+        "deepreinforce") for 18/30 catalog tokens."""
+        from club3090_cockpit.app import _weights_label
+
+        for tok, want in {
+            "beellama-q4ks-dflash": "q4ks", "beellama-q8kxl-mtp": "q8kxl",
+            "unsloth-q8kxl": "q8kxl", "deepreinforce-q4km": "q4km",
+            "carnice-v2-q5km": "q5km", "ubergarm-iq4ks": "iq4ks",
+            "byteshape-iq4xs": "iq4xs", "morikomorizz-q6kp": "q6kp",
+            "qwopus-coder-mtp-q5km": "q5km", "prithivmlmods-q8": "q8",
+        }.items():
+            assert _weights_label(self._label_entry(tok)) == want, tok
+
+    def test_weights_label_safetensors_formats(self):
+        from club3090_cockpit.app import _weights_label
+
+        for tok, want in {
+            "autoround-int4": "int4·AR", "autoround-int8": "int8·AR",
+            "awq": "awq4", "awq-bf16-int4": "awq4", "qat-awq-int4": "awq4",
+            "qat-w4a16": "w4a16", "fp8": "fp8", "fp8-dynamic": "fp8",
+            "bf16": "bf16", "nvidia-nvfp4": "nvfp4",
+        }.items():
+            assert _weights_label(self._label_entry(tok)) == want, tok
+
+    def test_weights_label_no_quant_segment_falls_back_to_format(self):
+        """Fine-tune artifact tokens with no quant segment show the model
+        profile's format (emit weights_format join), else the raw token."""
+        from club3090_cockpit.app import _weights_label
+
+        assert _weights_label(self._label_entry("mudler-apex-compact", "gguf")) == "gguf"
+        assert (
+            _weights_label(self._label_entry("mudler-apex-compact"))
+            == "mudler-apex-compact"
+        )
+
+    @pytest.mark.asyncio
+    async def test_catalog_submission_legend_in_status_line(self):
+        """When any loaded row's numbers came from a community submission
+        (measurement.submission_rig set → ⑂-marked TPS cell), the catalog status
+        line carries the ⑂ legend so the marker is decodable in-place; without
+        one, no legend."""
+        entry = self._label_entry("autoround-int4")
+        app, _, _ = make_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            pane = app.query_one("#catalog-pane", CatalogPane)
+            pane.populate([entry], None)
+            status = str(app.query_one("#catalog-status", Label).render())
+            assert "⑂" not in status
+            object.__setattr__(entry.measurement, "submission_rig", "2x5090")
+            pane.populate([entry], None)
+            status = str(app.query_one("#catalog-status", Label).render())
+            assert "⑂" in status and "community-submitted" in status
+
     @pytest.mark.asyncio
     async def test_catalog_hides_deprecated_by_default_and_h_reveals(self):
         """🗑️ Deprecated slugs are HIDDEN from the catalog by default (mirrors

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -941,12 +941,13 @@ class TestNavNodesExist:
             # (F6 shortened "our rig" → "rig" for column budget).
             # Serve-confirm rework: the "fit" column moved into the serve pop-up.
             # Model-filter: a "model" column leads the table (group-by-model view).
-            # F6: money columns (ctx · TPS · 8pk · status) directly after the
-            # identity; topology/engine (slug-redundant) at the tail so a
-            # 120-140-col terminal folds them, not the numbers.
+            # Layout, left→right: identity (model · slug) → config (weights · kv)
+            # → money (ctx · TPS · 8pk) → topology/engine (slug-redundant, fold
+            # first) → status LAST (its emoji glyph is the one variable-width cell,
+            # so nothing follows it to misalign — see _STATUS_GLYPH note).
             for expected in (
-                "model", "slug", "ctx", "TPS (rig)", "8pk (rig)",
-                "status", "topo", "engine",
+                "model", "slug", "weights", "kv", "ctx", "TPS (rig)", "8pk (rig)",
+                "topo", "engine", "status",
             ):
                 assert expected in col_labels, f"missing {expected!r}: {col_labels}"
             # "source" is gone.
@@ -955,9 +956,14 @@ class TestNavNodesExist:
             assert "fit" not in col_labels, col_labels
             # "model" is the FIRST column (mirrors switch.sh --list's grouping).
             assert col_labels[0] == "model", col_labels
-            # F6 — every money column sits LEFT of topo/engine.
+            # status is the LAST column (emoji-width slop has nothing after it).
+            assert col_labels[-1] == "status", col_labels
+            # config (weights · kv) sits between the identity and the money columns.
+            assert col_labels.index("weights") < col_labels.index("ctx"), col_labels
+            assert col_labels.index("kv") < col_labels.index("ctx"), col_labels
+            # every money column sits LEFT of topo/engine.
             fold = col_labels.index("topo")
-            for money in ("ctx", "TPS (rig)", "8pk (rig)", "status"):
+            for money in ("ctx", "TPS (rig)", "8pk (rig)"):
                 assert col_labels.index(money) < fold, col_labels
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Adds two catalog columns, fixes the status-glyph alignment bug, fixes the Weights labeller, and adds the missing ⑂ legend.

### 1 — Weights + KV columns
`kv_format` + `weights_format` added to the registry-emit `--json` contract → threaded onto `VariantRow`. Column order: `model · slug · weights · kv · ctx · TPS · 8pk · topo · engine · status`.

### 2 — Width-stable status glyphs + status → last column
`⚠️ 👁️ ⏸️ 🗑️` carry U+FE0F (Rich reserves 2 cells, terminals draw 1 → every later cell shifts). Swapped for `Emoji_Presentation=Yes` glyphs (`❗ 👀 🚧 🚫`) + status moved last so nothing follows it.

### 3 — Weights labels derived by pattern, not hand-map
The hand-map covered 12/30 tokens; 18 fell to a first-segment fallback that showed the **provider prefix** ("beellama", "unsloth", "deepreinforce") instead of the quant — wrong on ~24/57 slugs. Now: GGUF quant segment wins (`q4km`/`q8kxl`/`iq4ks`/`q6kp`…) → known safetensors formats (`nvfp4`/`w4a16`/`awq4`/`int4·AR`/`int8·AR`/`fp8`/`bf16`) → model profile `format:` fallback (emit join) so no-quant-segment artifact tokens read `gguf`. Verified against the live emit: **all 57 slugs correct, zero provider-looking labels**.

### 4 — ⑂ legend
Catalog status line now explains the #598 marker whenever any row carries submission numbers: *"⑂ = community-submitted numbers (other rig) — not a local baseline"*.

**Verified:** all-57-slug label sweep · 8 catalog headless (4 new: labeller regression ×3, legend) · 239 fast c3 · switch/launch registry-parity guards green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)