### PR TITLE
feat(qwen): NVFP4 slugs for Hopper/Blackwell — community-validated (authored blind)

### DIFF
--- a/models/qwen3.6-27b/vllm/compose/dual/nvfp4/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/nvfp4/mtp.yml
@@ -1,0 +1,189 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-27B NVFP4 (nvidia modelopt v0.45 MIXED_PRECISION:
+#              NVFP4 gs16 FFN + FP8-static attention/linear_attn + FP8 KV scales
+#              baked + UNQUANTIZED mtp.* head — 21.9 GB)
+#   Topology:  Dual Hopper/Blackwell (TP=2) — 2× 5090 is the primary target;
+#              H100 / RTX 6000 Pro / GB10 pairs also qualify. required_sm=9.0:
+#              the launchers REFUSE this on Ampere (sm_86) — NVFP4 has no
+#              kernel there (NVIDIA supports Hopper + Blackwell only).
+#   Drafter:   MTP n=3 (built-in — the checkpoint keeps mtp.* unquantized)
+#   KV:        fp8 → e4m3 (this checkpoint BAKES FP8 KV scales — modelopt
+#              kv_cache_quant_algo=FP8 — unlike our weight-only fp8 tier which
+#              runs scale=1.0). NVFP4 *KV* is deliberately NOT used: consumer
+#              Blackwell (sm_120/121) has no FP4 FMHA build (see
+#              hardware/rtx-5090.yml + vllm#43562) — fp8/e4m3 is the FP4-era KV.
+#   Vision:    yes (full VLM — vision tower + preprocessors ship in the repo)
+#   Max ctx:   262K (kv-calc: ~22.1 GB/card on 2× 32 GB @ util 0.92 — 75% of
+#              budget, comfortable; ~11 GB/card weights vs dual-max's 14.5)
+#   Genesis:   none — intentionally Genesis-free
+#   Status:    🧪 Experimental
+#   Best for:  max-ctx Qwen on Blackwell/Hopper pairs at 2.5× less weight
+#              memory than bf16 — pending first community validation
+# ---------------------------------------------------------------------------
+# ⚠️ AUTHORED BLIND — READ THIS FIRST.
+# The maintainer rig is 2× RTX 3090 (Ampere sm_86) and CANNOT BOOT NVFP4: this
+# compose has never been started anywhere. It mirrors the production-validated
+# vllm/qwen-27b-dual-max shape (TP=2 + MTP n=3 + fp8/e4m3 KV + vision @262K)
+# with the weights swapped to nvidia/Qwen3.6-27B-NVFP4 per NVIDIA's own model
+# card recipe (--quantization modelopt). If you have 2× Hopper/Blackwell
+# cards, YOU are the validation:
+#   1. bash scripts/switch.sh vllm/qwen-27b-dual-nvfp4
+#   2. bash scripts/verify-full.sh            (MODEL=qwen3.6-27b if needed)
+#   3. bash scripts/rebench-full.sh           (full eval chain, resumable)
+#   4. Report numbers + any boot failure via the numbers-from-your-rig issue
+#      template (or the c3 cockpit funnel). Boot logs >>> silence — a clean
+#      "it crashed here" report is exactly what promotes/kills this slug.
+# Known-unknowns to watch for (report either way):
+#   - MTP: the head is unquantized in the checkpoint and SHOULD load; if
+#     spec-dec errors on the modelopt path, delete the --speculative-config
+#     flag below and report — the slug is still useful without it.
+#   - Cliff 2 (DeltaNet GDN activation spikes at >50K single-prompt) was
+#     measured on Ampere; unknown on Blackwell. VLLM_ENFORCE_EAGER=1 is the
+#     mitigation if you see mid-generation hangs at depth.
+#   - froggeric chat-template: fixes 7 upstream Qwen3.6 template bugs; the
+#     NVFP4 repo ships the same base template, so it applies — but it has only
+#     been exercised against the AutoRound/FP8 tiers.
+#
+# What this gives you (once validated):
+#   - Full 262K ctx, 2 concurrent streams, vision + tools + MTP
+#   - ~11 GB/card weights (vs 14.5 dual-max FP8) → bigger KV headroom on 32 GB
+#   - Native FP4 GEMM on Blackwell (NVIDIA claims near-FP8 throughput);
+#     Hopper runs the supported-but-emulated path
+#   - NVIDIA's own accuracy deltas vs bf16 are <1% on MMLU-Pro/GSM8K (model
+#     card) — our 8-pack verdict lands with the first community rebench
+#
+# Run (Blackwell/Hopper only):
+#   cd <repo>/models/qwen3.6-27b/vllm/compose
+#   docker compose -f dual/nvfp4/mtp.yml up -d
+# ===========================================================================
+# Hardware metadata (parsed by scripts/preflight.sh):
+# Requires-min-vram-gb: 24
+# Engine-profile: vllm-stable
+# Requires-min-gpu-count: 2
+# Tensor-parallel: 2
+services:
+  vllm-qwen36-27b-dual-nvfp4:
+    # Pinned to a vLLM STABLE release (immutable — never purged from Docker
+    # Hub, unlike nightlies; #407). The launchers inject the engine-profile
+    # image over this default (#254). Override with VLLM_IMAGE=... if needed.
+    image: ${VLLM_IMAGE:-vllm/vllm-openai:v0.24.0}
+    container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b-dual-nvfp4}"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
+    ports:
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8077}}:8000"
+    volumes:
+      - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
+      # torch.compile + Triton kernel caches — first boot warms (~60-90 sec);
+      # subsequent boots reuse cached graphs.
+      - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
+      - ../../../cache/triton:/root/.triton/cache
+      # froggeric/Qwen-Fixed-Chat-Templates qwen3.6 — fixes 7 default-template
+      # bugs (empty <think></think> spam, </thinking> hallucination, unclosed
+      # think before tool call, no-user-query crash, developer role, etc.).
+      # See docs/UPSTREAM.md "Community templates / model assets".
+      - ../../../patches/froggeric-chat-template/chat_template.jinja:/etc/qwen-froggeric-chat-template.jinja:ro
+      # NVLink auto-detection — runs inside container at boot.
+      - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
+      - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
+      - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}
+      - VLLM_WORKER_MULTIPROC_METHOD=spawn
+      - NVLINK_MODE=${NVLINK_MODE:-auto}
+      - NCCL_CUMEM_ENABLE=0
+      # Safe PCIe default (mirrors the validated dual composes). On a rig with
+      # working P2P (NVLink pairs, datacenter fabric) set NCCL_P2P_DISABLE=0.
+      - NCCL_P2P_DISABLE=${NCCL_P2P_DISABLE:-1}
+      - VLLM_NO_USAGE_STATS=1
+      - VLLM_USE_FLASHINFER_SAMPLER=1
+      - OMP_NUM_THREADS=1
+      # DeepGEMM (vLLM's fp8-GEMM path — this checkpoint's ATTENTION layers are
+      # FP8) is built for Hopper (sm_90) + datacenter Blackwell (sm_100/103).
+      # Consumer Blackwell (5090 / PRO 6000 / GB10, sm_120/121) hard-fails
+      # "recipe not found" at boot (disc #571). Pass-through: switch.sh /
+      # launch.sh auto-inject VLLM_USE_DEEP_GEMM=0 on those cards; raw
+      # `docker compose` users on consumer Blackwell set it themselves.
+      - VLLM_USE_DEEP_GEMM
+      # expandable_segments:True crashes boot on some setups (WSL2, some
+      # NVLink rigs). Override via .env if boot fails in cuMemMap.
+      - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True,max_split_size_mb:512}
+    shm_size: "16gb"
+    ipc: host
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    entrypoint:
+      - bash
+      - -c
+      - |
+        # VLLM_ENFORCE_EAGER=1 in compose/.env disables CUDA graphs — the
+        # Cliff 2 mitigation if you see mid-generation hangs at >50K depth
+        # (unverified on Blackwell — report either way).
+        # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
+        source /etc/club3090/detect_nvlink.sh
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@"
+        else
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@"
+        fi
+      - --
+    command:
+      - --model
+      - /root/.cache/huggingface/qwen3.6-27b-nvfp4
+      - --served-model-name
+      - qwen3.6-27b
+      - qwen3.6-27b-autoround
+      - qwen3.6-27b-nvfp4
+      # NVIDIA model-card recipe: modelopt quantization (MIXED_PRECISION
+      # NVFP4 + FP8 — vLLM reads hf_quant_config.json / quantization_config).
+      - --quantization
+      - modelopt
+      - --dtype
+      - bfloat16
+      - --tensor-parallel-size
+      - "${TP:-2}"
+      - --pipeline-parallel-size
+      - "${PP:-1}"
+      - --max-model-len
+      - "${MAX_MODEL_LEN:-262144}"
+      - --gpu-memory-utilization
+      - "${GPU_MEMORY_UTILIZATION:-0.92}"
+      - --max-num-seqs
+      - "2"
+      - --max-num-batched-tokens
+      - "8192"
+      # fp8 (= e4m3). This checkpoint bakes FP8 KV scales (modelopt
+      # kv_cache_quant_algo=FP8) — do NOT "simplify" to fp8_e5m2 (hard-rejected
+      # with fp8 checkpoints) and do NOT use nvfp4 KV (no FP4 FMHA on consumer
+      # Blackwell — vllm#43562).
+      - --kv-cache-dtype
+      - "${KV_CACHE_DTYPE:-fp8}"
+      - --trust-remote-code
+      # froggeric chat-template override (see volumes block + docs/UPSTREAM.md)
+      - --chat-template
+      - /etc/qwen-froggeric-chat-template.jinja
+      - --reasoning-parser
+      - qwen3
+      - --default-chat-template-kwargs
+      - '{"enable_thinking": false}'
+      - --enable-auto-tool-choice
+      - --tool-call-parser
+      - qwen3_coder
+      - --enable-prefix-caching
+      - --enable-chunked-prefill
+      # MTP n=3 — the checkpoint keeps mtp.* unquantized. If spec-dec fails on
+      # the modelopt path on your rig, delete these two lines and REPORT it.
+      - --speculative-config
+      - '{"method":"mtp","num_speculative_tokens":3}'
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8000"

--- a/models/qwen3.6-27b/vllm/compose/single/nvfp4/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/nvfp4/mtp.yml
@@ -1,0 +1,141 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-27B NVFP4 (nvidia modelopt v0.45 MIXED_PRECISION:
+#              NVFP4 gs16 FFN + FP8-static attention/linear_attn + FP8 KV scales
+#              baked + UNQUANTIZED mtp.* head — 21.9 GB)
+#   Topology:  Single Hopper/Blackwell card, 32 GB+ — 5090 is the primary
+#              target; H100 / RTX 6000 Pro / GB10 also qualify. required_sm=9.0:
+#              the launchers REFUSE this on Ampere (sm_86) — NVFP4 has no
+#              kernel there (NVIDIA supports Hopper + Blackwell only).
+#   Drafter:   MTP n=3 (built-in — the checkpoint keeps mtp.* unquantized)
+#   KV:        fp8 → e4m3 (checkpoint bakes FP8 KV scales — modelopt
+#              kv_cache_quant_algo=FP8). NVFP4 *KV* deliberately NOT used:
+#              consumer Blackwell has no FP4 FMHA (rtx-5090.yml, vllm#43562).
+#   Vision:    yes (full VLM)
+#   Max ctx:   131K default — sized for the SMALLEST target card (5090 32 GB:
+#              kv-calc 28.5/29.4 GB @ util 0.92 = PASS at 97%, inside the
+#              ±1.5 GB error band; if the boot pre-check OOMs →
+#              MAX_MODEL_LEN=98304). Bigger cards raise via env — kv-calc'd:
+#                GB10 (128 GB unified): MAX_MODEL_LEN=262144 → 33.7 GB (29% of
+#                  budget). Even 4 streams @ full 262K → 59.4 GB (50%) — the
+#                  GB10 is THE single-card home for this slug.
+#                H100 (80 GB): 262144 → 33.7 GB (46% of budget).
+#                RTX 6000 Pro (96 GB): 262144 fits similarly.
+#   Genesis:   none — intentionally Genesis-free
+#   Status:    🧪 Experimental
+#   Best for:  27B-class Qwen with vision+tools on ONE Blackwell/Hopper card —
+#              pending first community validation
+# ---------------------------------------------------------------------------
+# ⚠️ AUTHORED BLIND — READ THIS FIRST.
+# The maintainer rig is Ampere sm_86 and CANNOT BOOT NVFP4: this compose has
+# never been started anywhere. Shape mirrors the validated Qwen singles +
+# NVIDIA's own model-card recipe (--quantization modelopt). If you have a
+# 5090 / H100 / GB10, YOU are the validation:
+#   1. bash scripts/switch.sh vllm/qwen-27b-single-nvfp4
+#   2. bash scripts/verify-full.sh
+#   3. bash scripts/rebench-full.sh
+#   4. Report numbers or the boot failure via the numbers-from-your-rig
+#      template (or the c3 funnel). "It crashed here" is a useful result.
+# Known-unknowns (report either way): MTP-on-modelopt loading; Cliff 2
+# (DeltaNet GDN >50K single-prompt — measured on Ampere, unknown on
+# Blackwell; VLLM_ENFORCE_EAGER=1 is the mitigation); froggeric template on
+# this repo (same base template as the validated tiers, but unexercised here).
+#
+# Run (Blackwell/Hopper only):
+#   cd <repo>/models/qwen3.6-27b/vllm/compose
+#   docker compose -f single/nvfp4/mtp.yml up -d
+# ===========================================================================
+# Hardware metadata (parsed by scripts/preflight.sh):
+# Requires-min-vram-gb: 32
+# Engine-profile: vllm-stable
+# Requires-min-gpu-count: 1
+# Tensor-parallel: 1
+services:
+  vllm-qwen36-27b-single-nvfp4:
+    # Pinned to a vLLM STABLE release (immutable, #407); the launchers inject
+    # the engine-profile image over this default (#254).
+    image: ${VLLM_IMAGE:-vllm/vllm-openai:v0.24.0}
+    container_name: "${ESTATE_CONTAINER:-vllm-qwen36-27b-single-nvfp4}"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
+    ports:
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8076}}:8000"
+    volumes:
+      - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
+      # torch.compile + Triton kernel caches — warm-start across boots.
+      - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
+      - ../../../cache/triton:/root/.triton/cache
+      # froggeric/Qwen-Fixed-Chat-Templates qwen3.6 — fixes 7 default-template
+      # bugs. See docs/UPSTREAM.md "Community templates / model assets".
+      - ../../../patches/froggeric-chat-template/chat_template.jinja:/etc/qwen-froggeric-chat-template.jinja:ro
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # Pin to a specific GPU on multi-card rigs, e.g.: CUDA_VISIBLE_DEVICES=0
+      - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
+      - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
+      - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}
+      - VLLM_WORKER_MULTIPROC_METHOD=spawn
+      - VLLM_NO_USAGE_STATS=1
+      - VLLM_USE_FLASHINFER_SAMPLER=1
+      - OMP_NUM_THREADS=1
+      # DeepGEMM: no recipe on consumer Blackwell (5090/GB10 sm_120/121) —
+      # launchers auto-inject VLLM_USE_DEEP_GEMM=0 there (disc #571); raw
+      # `docker compose` users on those cards set it themselves.
+      - VLLM_USE_DEEP_GEMM
+      - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True,max_split_size_mb:512}
+    shm_size: "16gb"
+    ipc: host
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    command:
+      - --model
+      - /root/.cache/huggingface/qwen3.6-27b-nvfp4
+      - --served-model-name
+      - qwen3.6-27b
+      - qwen3.6-27b-autoround
+      - qwen3.6-27b-nvfp4
+      # NVIDIA model-card recipe: modelopt quantization.
+      - --quantization
+      - modelopt
+      - --dtype
+      - bfloat16
+      - --tensor-parallel-size
+      - "${TP:-1}"
+      - --max-model-len
+      - "${MAX_MODEL_LEN:-131072}"
+      - --gpu-memory-utilization
+      - "${GPU_MEMORY_UTILIZATION:-0.92}"
+      - --max-num-seqs
+      - "1"
+      - --max-num-batched-tokens
+      - "8192"
+      # fp8 (= e4m3) — checkpoint bakes FP8 KV scales. NOT fp8_e5m2 (rejected
+      # with fp8 checkpoints), NOT nvfp4 KV (no FP4 FMHA on consumer Blackwell).
+      - --kv-cache-dtype
+      - "${KV_CACHE_DTYPE:-fp8}"
+      - --trust-remote-code
+      - --chat-template
+      - /etc/qwen-froggeric-chat-template.jinja
+      - --reasoning-parser
+      - qwen3
+      - --default-chat-template-kwargs
+      - '{"enable_thinking": false}'
+      - --enable-auto-tool-choice
+      - --tool-call-parser
+      - qwen3_coder
+      - --enable-prefix-caching
+      - --enable-chunked-prefill
+      # MTP n=3 — mtp.* is unquantized in the checkpoint. If spec-dec fails on
+      # the modelopt path on your rig, delete these two lines and REPORT it.
+      - --speculative-config
+      - '{"method":"mtp","num_speculative_tokens":3}'
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8000"

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -231,6 +231,35 @@ COMPOSE_REGISTRY = {
         status_note="Qwen3.6-27B 'max accuracy' tier, 4-card (TP=4): official FP8 weights + fp8/e4m3 KV (flipped from int8-PTH alongside dual-max #594; follow-up multi-max PR) + MTP n=3 @262K. ⚠️ Production w/ caveats — byte-identical to the now-production vllm/qwen-27b-dual-max apart from TP=4 + gpu-count (dual-max @TP=2 is the on-rig proxy; this dev rig has 2 cards). Promoted 2026-07-06 on @Whamp's cross-rig full chain (#446, 4× 3090: verify-full + verify-stress 7/7 + soak-continuous PASS, 85/102). CAVEAT: that validation was on an OLDER engine (pre-v0.24.0-pin) + a non-standard rig (aikitoria P2P kernel, mixed x4/x16/x8/x16 lanes), single report — no clean v0.24.0 4-card datapoint yet; a fresh one upgrades this to ✅ Production. TP=4 relieves dual-max's tight 1.13x KV pool (→ 6.77x). Value is concurrency/fidelity, single-stream decode ~flat vs 2-card.",
     ),
 
+    # Qwen3.6-27B NVFP4 (nvidia modelopt) — the community-validated Hopper/
+    # Blackwell tier. AUTHORED BLIND on this sm_86 dev rig (NVFP4 cannot boot
+    # here): required_sm=9.0 gates launch to NVIDIA's supported set (Hopper
+    # sm_90 / Blackwell sm_100+ incl. 5090 sm_120, GB10 sm_121); the first
+    # community booter is the validation, not a confirmation. NVFP4 *KV* stays
+    # off everywhere (consumer Blackwell has no FP4 FMHA — see hardware
+    # rtx-5090.yml note); fp8_e4m3 KV is the FP4-era KV, and this checkpoint
+    # bakes FP8 KV scales (modelopt kv_cache_quant_algo=FP8).
+    "vllm/qwen-27b-single-nvfp4": _entry(
+        model="qwen3.6-27b", weights_variant="nvfp4", workload="long-ctx-single",
+        engine="vllm-stable", drafter="qwen-mtp-builtin", kv_format="fp8_e4m3",
+        tp=1, max_ctx=131072, max_num_seqs=1, mem_util=0.92,
+        compose_path="models/qwen3.6-27b/vllm/compose/single/nvfp4/mtp.yml",
+        default_port=8076, required_sm=9.0,
+        kvcalc_key="qwen3.6-27b:nvfp4-single",
+        status="experimental",
+        status_note="Qwen3.6-27B NVFP4 (nvidia modelopt MIXED_PRECISION: NVFP4 FFN + FP8 attention + FP8 KV scales + unquantized MTP head), single Hopper/Blackwell card (required_sm=9.0 — H100 / 5090 / RTX 6000 Pro / GB10; NOT Ampere). 🧪 AUTHORED BLIND — this dev rig is sm_86 and cannot boot NVFP4; ships untested pending first community boot + rebench-full via the funnel. Ships 131K (kv-calc-predicted fit on the smallest target card, 5090 32 GB: ~22 GB weights + fp8/e4m3 KV; 80 GB+ cards raise MAX_MODEL_LEN toward the model's 262K). MTP n=3 on (head is unquantized in the checkpoint) — if spec-dec fails on your rig, drop the --speculative-config flag and report. ~2.5x smaller than bf16, NVIDIA MMLU-Pro/GSM8K deltas <1% vs bf16 per the model card. No DEFAULTS row (opt-in only).",
+    ),
+    "vllm/qwen-27b-dual-nvfp4": _entry(
+        model="qwen3.6-27b", weights_variant="nvfp4", workload="long-ctx-single",
+        engine="vllm-stable", drafter="qwen-mtp-builtin", kv_format="fp8_e4m3",
+        tp=2, max_ctx=262144, max_num_seqs=2, mem_util=0.92,
+        compose_path="models/qwen3.6-27b/vllm/compose/dual/nvfp4/mtp.yml",
+        default_port=8077, required_sm=9.0,
+        kvcalc_key="qwen3.6-27b:nvfp4-dual",
+        status="experimental",
+        status_note="Qwen3.6-27B NVFP4 (nvidia modelopt MIXED_PRECISION — see single-nvfp4) at TP=2 @262K full ctx, 2x Hopper/Blackwell (required_sm=9.0; the 2x 5090 configuration is the primary community target). 🧪 AUTHORED BLIND on an sm_86 rig — cannot boot here; first community boot + rebench-full validates (funnel). Mirrors vllm/qwen-27b-dual-max's shape (TP=2 + MTP n=3 + fp8/e4m3 KV + vision @262K) with NVFP4 weights instead of FP8: ~11 GB/card weights vs dual-max's 14.5 — bigger KV pool headroom on 32 GB cards. On native-FP4 GEMM parts (Blackwell) NVIDIA claims near-fp8 throughput at 2.5x less weight memory. No DEFAULTS row (opt-in only).",
+    ),
+
     # Qwen 3.6 27B, llama.cpp single-card.
     # `llamacpp/default` is an alias for `llamacpp/mtp` (collapsed 2026-05-22):
     # the old Q3_K_XL vanilla compose was retired and `default` now points at

--- a/scripts/lib/profiles/engines/vllm-stable.yml
+++ b/scripts/lib/profiles/engines/vllm-stable.yml
@@ -46,6 +46,10 @@ supported_weight_formats:
   - compressed-tensors
   - fp8                   # qwen3.6-27b-fp8 (official e4m3 release) — Marlin W8A16 on Ampere sm_86
                           # (memory win, no FP8 compute speedup). Drives the qwen "max accuracy" tier.
+  - modelopt              # nvidia modelopt checkpoints (NVFP4 / MIXED_PRECISION) — stock vLLM
+                          # supports --quantization modelopt; the FP4 KERNELS need Hopper/Blackwell,
+                          # which is encoded per-slug via required_sm=9.0 (vllm/qwen-27b-*-nvfp4),
+                          # NOT here (the loader itself is arch-agnostic).
 required_overlays: []
 # OVERLAY-FREE BY DESIGN. This is the load-bearing distinction (#254, 2026-06-05):
 # `derived_emittable` (CONTRACT-5) refuses any engine with vendored_overlays != []

--- a/scripts/lib/profiles/models/qwen3.6-27b.yml
+++ b/scripts/lib/profiles/models/qwen3.6-27b.yml
@@ -51,6 +51,17 @@ weights:
     kind: main
     verify_glob: "*.safetensors"
     manual_note: "Official Qwen3.6-27B FP8 release (e4m3, dynamic act-scale): layer-split safetensors (layers-N.safetensors + outside.safetensors) with an embedded MTP head (mtp.safetensors) and the multimodal vision tower. Drives the 'max accuracy' tier (vllm/qwen-27b-dual-max + vllm/qwen-27b-multi-max). On Ampere sm_86 FP8 weights run via the Marlin W8A16 kernel (memory win, no FP8 compute speedup). Pull recipe wired (hf_repo above): WEIGHTS=fp8 bash scripts/setup.sh qwen3.6-27b (whole-repo fetch + per-file SHA verify). For a stall-resistant manual pull of this 29 GB layer-split repo, hf-download.sh also works."
+  nvfp4:
+    path: qwen3.6-27b-nvfp4
+    local_subdir: qwen3.6-27b-nvfp4
+    size_gb: 22
+    format: modelopt
+    status: experimental
+    hf_repo: nvidia/Qwen3.6-27B-NVFP4
+    engine: vllm
+    kind: main
+    verify_glob: "*.safetensors"
+    manual_note: "Official NVIDIA modelopt (v0.45) MIXED_PRECISION quant of Qwen/Qwen3.6-27B: NVFP4 (4-bit float, group_size 16) on the FFN linears + FP8 static on all self_attn/linear_attn projections + FP8 KV scales baked (kv_cache_quant_algo FP8) + the mtp.* head kept UNQUANTIZED (ignore: mtp*). Full VLM (vision tower + preprocessor configs). NVIDIA-supported runtimes: vLLM on Hopper + Blackwell (sm >= 9.0) — NOT runnable on this rig's Ampere sm_86; drives the community-validated vllm/qwen-27b-{single,dual}-nvfp4 slugs (authored blind, gated required_sm=9.0). Serving recipe per the model card: --quantization modelopt. 21.9 GB across 3 safetensors shards."
   awq-bf16-int4:
     path: qwen3.6-27b-awq-bf16-int4
     local_subdir: qwen3.6-27b-awq-bf16-int4

--- a/scripts/lib/profiles/weights.py
+++ b/scripts/lib/profiles/weights.py
@@ -27,6 +27,7 @@ PROFILE_ROOT = Path(__file__).resolve().parent
 
 ALIASES = {
     "qwen3.6-27b:autoround_int4": ("qwen3.6-27b", "autoround-int4"),
+    "qwen3.6-27b:nvfp4": ("qwen3.6-27b", "nvfp4"),
     "qwen3.6-27b:gguf_q4km": ("qwen3.6-27b", "unsloth-q4km"),
     "qwen3.6-27b:gguf_iq4ks": ("qwen3.6-27b", "ubergarm-iq4ks"),
     "qwen3.6-27b:carnice_bf16mtp": ("qwen3.6-27b", "carnice-bf16mtp"),
@@ -37,6 +38,8 @@ ALIASES = {
     "gemma-4-26b-a4b:autoround_int4_mixed": ("gemma-4-26b-a4b", "autoround-int4-mixed"),
     "gemma-4-26b-a4b:awq_compressed_tensors": ("gemma-4-26b-a4b", "awq"),
     "qwen3.6-27b-autoround-int4": ("qwen3.6-27b", "autoround-int4"),
+    "qwen3.6-27b-nvfp4": ("qwen3.6-27b", "nvfp4"),
+    "Qwen3.6-27B-NVFP4": ("qwen3.6-27b", "nvfp4"),
     "qwen3.6-27b-dflash": ("qwen3.6-27b", "dflash"),
     "qwen3.6-27b-prism-eagle3": ("qwen3.6-27b", "prism_eagle3"),
     "qwen3.6-27b-mtp-head": ("qwen3.6-27b", "mtp_head"),

--- a/scripts/tests/test-compose-registry-disk.sh
+++ b/scripts/tests/test-compose-registry-disk.sh
@@ -25,8 +25,8 @@ def check(cond, msg):
         print(f"FAIL: {msg}")
         failures.append(msg)
 
-check(len(COMPOSE_REGISTRY) == 57, f"registry has 57 entries (got {len(COMPOSE_REGISTRY)})")
-check(len(disk_paths) == 58, f"disk has 58 compose files (got {len(disk_paths)})")
+check(len(COMPOSE_REGISTRY) == 59, f"registry has 59 entries (got {len(COMPOSE_REGISTRY)})")
+check(len(disk_paths) == 60, f"disk has 60 compose files (got {len(disk_paths)})")
 check(registry_paths <= disk_paths, "all registry compose_path values exist on disk")
 parked_disk_only = disk_paths - registry_paths
 # Disk-only (non-registry) composes allowed: parked SGLang archives, plus the experimental

--- a/tools/kv-calc.py
+++ b/tools/kv-calc.py
@@ -98,7 +98,7 @@ def _load_model_specs_from_yaml(profiles):
     g_fields = ("hidden_size", "intermediate_size", "num_hidden_layers", "num_full_attn_layers", "num_sliding_attn_layers", "num_attn_heads", "num_kv_heads", "head_dim_sliding", "global_head_dim", "sliding_window", "max_ctx_supported", "attention_k_eq_v")
     gm_fields = (*g_fields, "num_global_kv_heads", "num_experts", "num_experts_per_tok", "moe_intermediate_size", "active_params_b", "mtp_num_hidden_layers")
     qm_fields = (*q_fields, "num_experts", "num_experts_per_tok", "moe_intermediate_size", "shared_expert_intermediate_size", "active_params_b", "mtp_num_hidden_layers")
-    qspec = {"model_id": qwen.id, "model_family": qwen.family, **{k: getattr(qwen, k) for k in q_fields}, "valid_tp": list(qwen.valid_tp), "weights_total_gb": _weight_size(qwen, qwen.default_weight_variant), "mamba_state_bytes": 4, "chunk_size": 256, "mtp_n_default": profiles.drafters["qwen-mtp-builtin"].n_default}
+    qspec = {"model_id": qwen.id, "model_family": qwen.family, **{k: getattr(qwen, k) for k in q_fields}, "valid_tp": list(qwen.valid_tp), "weights_total_gb": _weight_size(qwen, qwen.default_weight_variant), "weights_nvfp4_gb": _weight_size(qwen, "nvfp4"), "mamba_state_bytes": 4, "chunk_size": 256, "mtp_n_default": profiles.drafters["qwen-mtp-builtin"].n_default}
     qmspec = {"model_id": qwen_moe.id, "model_family": qwen_moe.family, **{k: getattr(qwen_moe, k) for k in qm_fields}, "valid_tp": list(qwen_moe.valid_tp), "weights_total_gb": _weight_size(qwen_moe, qwen_moe.default_weight_variant), "weights_gptq_gb": _weight_size(qwen_moe, "gptq_int4"), "mamba_state_bytes": 4, "chunk_size": 256, "mtp_n_default": profiles.drafters["qwen-mtp-builtin"].n_default}
     gspec = {"model_id": gemma.id, "model_family": gemma.family, **{k: getattr(gemma, k) for k in g_fields}, "valid_tp": list(gemma.valid_tp), "weights_int4_gb": _weight_size(gemma, "autoround-int4"), "weights_awq_gb": _weight_size(gemma, "awq"), "weights_bf16_gb": _weight_size(gemma, "bf16"), "drafter_mtp_gb": float(profiles.drafters["gemma-it-assistant"].vram_footprint_gb), "drafter_dflash_gb": float(profiles.drafters["gemma-dflash"].vram_footprint_gb), "mtp_n_default": profiles.drafters["gemma-it-assistant"].n_default}
     gmspec = {"model_id": gemma_moe.id, "model_family": gemma_moe.family, **{k: getattr(gemma_moe, k) for k in gm_fields}, "valid_tp": list(gemma_moe.valid_tp), "weights_int4_gb": _weight_size(gemma_moe, "autoround-int4-mixed"), "weights_awq_gb": _weight_size(gemma_moe, "awq"), "drafter_mtp_gb": float(profiles.drafters["gemma-26b-it-assistant"].vram_footprint_gb), "mtp_n_default": profiles.drafters["gemma-26b-it-assistant"].n_default}
@@ -266,7 +266,7 @@ GENERIC_DENSE_ACTIVATION_FLOOR_GB = 1.5         # ≥ Gemma dense constant activ
 # Compose presets (per-model)
 # =============================================================================
 COMPOSE_ALIAS_TEXT = {
-    "qwen3.6-27b": "minimal=vllm/minimal dual=vllm/dual",
+    "qwen3.6-27b": "minimal=vllm/minimal dual=vllm/dual nvfp4-single=vllm/qwen-27b-single-nvfp4 nvfp4-dual=vllm/qwen-27b-dual-nvfp4",
     "qwen3.6-35b-a3b": "qwen-a3b-preview-single=vllm/qwen-a3b-preview-single qwen-35b-a3b-dual=vllm/qwen-35b-a3b-dual",
     "agents-a1": "agents-a1-dual=vllm/agents-a1-dual",
     "gemma-4-31b": "gemma-dual=vllm/gemma-bf16-mtp gemma-dual-int8=vllm/gemma-int8-mtp gemma-single=vllm/gemma-mtp-tp1",
@@ -313,6 +313,8 @@ def _compose_cfg_from_registry(profiles, model_id, legacy_name, registry_name):
             cfg["drafter_gb"] = float(drafter.vram_footprint_gb)
     if model_id == "qwen3.6-35b-a3b":
         cfg["weights_variant"] = "gptq" if entry["weights_variant"] == "gptq_int4" else "default"
+    if model_id == "qwen3.6-27b":
+        cfg["weights_variant"] = "nvfp4" if entry["weights_variant"] == "nvfp4" else "default"
     cfg.update(COMPOSE_COMPAT_OVERRIDES.get((model_id, legacy_name), {}))
     return cfg
 
@@ -377,6 +379,10 @@ class CacheBreakdown:
 def _weights_per_card_gb(spec, tp, weights_variant="default"):
     """Return per-card weights footprint in GB after TP split."""
     if spec["model_family"] == "qwen3-next-hybrid":
+        # nvfp4 (nvidia modelopt, 21.9 GB) vs the default AutoRound INT4 —
+        # the community Hopper/Blackwell slugs (vllm/qwen-27b-*-nvfp4).
+        if weights_variant == "nvfp4":
+            return spec["weights_nvfp4_gb"] / tp
         return spec["weights_total_gb"] / tp
     elif spec["model_family"] == "qwen3-next-moe":
         # vLLM shards attention + MoE expert weights across TP ranks, so
@@ -1536,7 +1542,7 @@ def main():
                    help="Drafter model size in GB (MTP / DFlash). 0 if not using a drafter.")
     p.add_argument("--dflash-draft-gb", type=float, default=None,
                    help="(deprecated alias for --drafter-gb)")
-    p.add_argument("--weights-variant", choices=["default", "int4", "awq", "bf16", "int8"], default=None,
+    p.add_argument("--weights-variant", choices=["default", "int4", "awq", "bf16", "int8", "nvfp4"], default=None,
                    help="Gemma 4 only: which weight quant variant. Default: from --compose, or int4.")
     p.add_argument("--calibration", action="store_true", help="Print predicted vs measured for all calibrated models.")
     p.add_argument("--fit", metavar="SLUG|MODEL",


### PR DESCRIPTION
Adds **nvidia/Qwen3.6-27B-NVFP4** to the catalog as the first tier this dev rig *cannot* run — NVFP4 kernels need Hopper/Blackwell (`required_sm=9.0`). Both slugs are **🧪 authored blind**: the first community boot IS the validation.

**The checkpoint** (verified from `config.json` / `hf_quant_config.json`): modelopt v0.45 MIXED_PRECISION — NVFP4 (gs16) FFN + FP8-static attention/linear_attn + **FP8 KV scales baked** + the `mtp.*` head kept unquantized. 21.9 GB, full VLM. NVIDIA's card: vLLM, Hopper + Blackwell, `--quantization modelopt`.

| slug | topology | ctx | kv-calc fit |
|---|---|---|---|
| `vllm/qwen-27b-single-nvfp4` :8076 | 1× ≥32 GB | **131K** default | 5090 32 GB: 28.5/29.4 GB PASS @97% · **GB10 128 GB: full 262K @29%** (4 streams @262K = 50%) · H100: 262K @46% |
| `vllm/qwen-27b-dual-nvfp4` :8077 | TP=2 | **262K** | 2× 5090: 22.1 GB/card @75% (~11 GB/card weights vs dual-max's 14.5) |

**KV = fp8_e4m3, deliberately NOT nvfp4-KV** — consumer Blackwell has no FP4 FMHA (vllm#43562; the rtx-5090 hardware profile documents this); the checkpoint's baked FP8 KV scales make e4m3 the natural pair.

**Wiring**: weights entry + `weights.py` aliases · `vllm-stable` `supported_weight_formats += modelopt` (loader is arch-agnostic; kernels gated per-slug via `required_sm`) · **kv-calc fully wired** (weights size, variant pass-through, compose aliases — fit predictions on hardware we don't own is the point) · no `DEFAULTS` rows.

**Gates**: full `scripts/tests` suite + `kv-calc --calibration` green. Honest refusal verified on sm_86: `C3: requires sm >= 9` + `C5: fp8_e4m3 KV`; `switch.sh --list` shows `(NA: experimental)`.

**Compose headers carry the community ask**: switch → verify-full → rebench-full → report via the numbers-from-your-rig template, with known-unknowns spelled out (MTP-on-modelopt load, Cliff 2 behavior on Blackwell, template provenance). ⚠️ Cannot be boot-tested before merge — that's the design; a boot-failure report is a useful result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)