### PR TITLE
feat(c3): hide hardware-incompatible slugs by default + warn-before-download

### DIFF
--- a/scripts/tests/test-kv-calc-fit.sh
+++ b/scripts/tests/test-kv-calc-fit.sh
@@ -171,10 +171,45 @@ if parsed_a:
               for v in variants.values()),
           "(e) every variant value carries a verdict string")
 
+# (f) required_sm gate — the arch floor surfaced in the fit verdict (the
+# cockpit's hide/warn signal for hardware-incompatible slugs, e.g. NVFP4 on
+# Ampere). Three contract points: below-floor card → incompatible-hw with
+# required_sm/card_sm populated; at/above-floor card → a REAL priced verdict;
+# bare-number --card carries no arch info → gate skipped (permissive).
+rc_f, out_f, err_f = run_fit("--fit", "vllm/qwen-27b-dual-nvfp4", "--card", "rtx-3090", "--json")
+check(rc_f == 0, f"(f) nvfp4 --card rtx-3090 exits 0 (got {rc_f})")
+try:
+    df = json.loads(out_f)
+except Exception as exc:  # noqa: BLE001
+    df = {}
+    check(False, f"(f) nvfp4/3090 output is valid JSON (got {exc})")
+check(df.get("verdict") == "incompatible-hw",
+      f"(f) nvfp4 on rtx-3090 → incompatible-hw (got {df.get('verdict')!r})")
+check(df.get("required_sm") == 9.0 and df.get("card_sm") == 8.6,
+      f"(f) incompatible-hw carries required_sm=9.0/card_sm=8.6 (got {df!r})")
+check("sm" in str(df.get("error", "")),
+      f"(f) incompatible-hw error names the sm floor (got {df.get('error')!r})")
+
+rc_g, out_g, _err_g = run_fit("--fit", "vllm/qwen-27b-dual-nvfp4", "--card", "rtx-5090", "--json")
+dg = json.loads(out_g) if rc_g == 0 else {}
+check(dg.get("verdict") in VERDICTS_OK and dg.get("verdict") != "incompatible-hw",
+      f"(f) nvfp4 on rtx-5090 (sm 12.0) → real priced verdict (got {dg.get('verdict')!r})")
+
+rc_h, out_h, _err_h = run_fit("--fit", "vllm/qwen-27b-dual-nvfp4", "--card", "64", "--json")
+dh = json.loads(out_h) if rc_h == 0 else {}
+check(dh.get("verdict") != "incompatible-hw",
+      f"(f) bare-number --card 64 skips the sm gate — permissive (got {dh.get('verdict')!r})")
+
+# batch parity: --fit-all --card rtx-3090 marks nvfp4 incompatible-hw too
+rc_i, out_i, _err_i = run_fit("--fit-all", "--card", "rtx-3090", "--json")
+di = json.loads(out_i) if rc_i == 0 else {"variants": {}}
+check(di.get("variants", {}).get("vllm/qwen-27b-single-nvfp4", {}).get("verdict") == "incompatible-hw",
+      "(f) --fit-all on rtx-3090 marks single-nvfp4 incompatible-hw")
+
 if failures:
     print(f"\n{len(failures)} assertion(s) failed.", file=sys.stderr)
     sys.exit(1)
-print("\nAll --fit / --fit-all JSON shape assertions passed (a-e).")
+print("\nAll --fit / --fit-all JSON shape assertions passed (a-f).")
 PY
 
 echo "test-kv-calc-fit.sh OK"

--- a/scripts/tests/test-registry-json.sh
+++ b/scripts/tests/test-registry-json.sh
@@ -57,6 +57,9 @@ VARIANT_KEYS = {
     "model", "engine", "kvcalc_key", "container", "compose_path", "status",
     "ctx_label", "configured_ctx", "status_note", "source",
     "weights_companions", "drafter", "vision", "baseline",
+    # c3 catalog Weights/KV columns (#600): registry kv_format + the model
+    # profile's weights format / explicit quant_label joins.
+    "kv_format", "weights_format", "weights_quant_label",
 }
 v0 = d["variants"][0]
 need(set(v0.keys()) == VARIANT_KEYS,

--- a/tools/kv-calc.py
+++ b/tools/kv-calc.py
@@ -1346,6 +1346,29 @@ CARD_VRAM_GB = {
 # can compare vram_est to budget with the same tolerance the gate uses.
 FIT_BAND_GB = 1.5
 
+# Per-card SM (compute capability) for the required_sm gate — derived from the
+# hardware profiles (the SAME source compat.py's C3 floor uses), keyed like
+# CARD_VRAM_GB (canonical hyphenated id + dehyphenated alias). A bare-number
+# --card describes VRAM only, so it has no SM → the gate is skipped
+# (permissive by design: an uncatalogued card is not assumed incompatible).
+CARD_SM = {}
+for _hid, _h in PROFILES.hardware.items():
+    CARD_SM[_hid] = float(_h.sm)
+    CARD_SM[_hid.replace("-", "")] = float(_h.sm)
+
+
+def _resolve_card_sm(card: Optional[str]) -> Optional[float]:
+    if card is None:
+        return None
+    raw = str(card).strip()
+    try:
+        float(raw)
+        return None  # bare VRAM number — carries no arch info
+    except ValueError:
+        pass
+    key = raw.lower().replace(" ", "").replace("_", "").replace("/", "-")
+    return CARD_SM.get(key) or CARD_SM.get(key.replace("-", ""))
+
 
 def _resolve_card_vram_gb(card: Optional[str]) -> Optional[float]:
     """Map a `--card` value to per-card VRAM in GB. Accepts a known card key
@@ -1435,6 +1458,19 @@ def fit_verdict(target: str, card: Optional[str], vram_default: float) -> dict:
     if err is not None:
         return {"verdict": "unknown", "error": err}
 
+    # required_sm gate (compat C3's arch floor, surfaced in the FIT verdict so
+    # the cockpit can hide/warn hardware-incompatible slugs — e.g. NVFP4 on
+    # Ampere: the VRAM would "fit" but the kernels don't exist below sm 9.0).
+    _req_sm = COMPOSE_REGISTRY[slug].get("required_sm")
+    _card_sm = _resolve_card_sm(card)
+    if _req_sm is not None and _card_sm is not None and _card_sm < float(_req_sm):
+        return {
+            "verdict": "incompatible-hw",
+            "required_sm": float(_req_sm),
+            "card_sm": _card_sm,
+            "error": f"requires sm >= {float(_req_sm):g} (this card is sm_{_card_sm:g})",
+        }
+
     try:
         spec = MODEL_SPECS[model_id]
         cfg = _compose_cfg_from_registry(PROFILES, model_id, "__fit__", slug)
@@ -1488,7 +1524,19 @@ def fit_all_verdicts(card: Optional[str], vram_default: float) -> dict:
         vram = float(vram_default)
 
     variants: dict = {}
+    _card_sm = _resolve_card_sm(card)
     for slug, entry in COMPOSE_REGISTRY.items():
+        # required_sm gate first — applies to SKIP (non-vLLM) slugs too, and
+        # short-circuits the pricing for slugs whose kernels can't exist here.
+        _req_sm = entry.get("required_sm")
+        if _req_sm is not None and _card_sm is not None and _card_sm < float(_req_sm):
+            variants[slug] = {
+                "verdict": "incompatible-hw",
+                "required_sm": float(_req_sm),
+                "card_sm": _card_sm,
+                "error": f"requires sm >= {float(_req_sm):g} (this card is sm_{_card_sm:g})",
+            }
+            continue
         if entry.get("kvcalc_key") in (None, "SKIP"):
             variants[slug] = {"verdict": "skip"}
             continue

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -984,9 +984,19 @@ class CatalogPane(Container):
         banner = f"[yellow]{self._model_dir_note}[/yellow]  ·  " if self._model_dir_note else ""
         # Surface an active model scope (dropdown) the same way the text filter is shown.
         scope = f"model: [cyan]{self._model_filter}[/cyan]  ·  " if self._model_filter else ""
-        # [h] hint: N 🗑️ deprecated slugs hidden (0 when revealed).
+        # [h] hint: N 🗑️ deprecated + M hardware-incompatible slugs hidden
+        # (both 0 when revealed — one toggle, one bucket).
         dep_n = self._deprecated_hidden_count()
-        dep_note = f"  ·  [dim]+{dep_n} deprecated hidden — h[/dim]" if dep_n else ""
+        inc_n = self._incompatible_hidden_count()
+        _hidden_bits = []
+        if dep_n:
+            _hidden_bits.append(f"+{dep_n} deprecated")
+        if inc_n:
+            _hidden_bits.append(f"+{inc_n} incompatible-hw")
+        dep_note = (
+            f"  ·  [dim]{' · '.join(_hidden_bits)} hidden — h[/dim]"
+            if _hidden_bits else ""
+        )
         if self._filter or self._model_filter:
             tail = f"  ·  filter: {self._filter!r}" if self._filter else ""
             status_label.update(
@@ -1079,11 +1089,20 @@ class CatalogPane(Container):
         )
 
     def _filtered_entries(self) -> list[CatalogEntry]:
-        # Hide 🗑️ deprecated slugs by default (mirrors `switch.sh --list`); [h] reveals them.
+        # Hide 🗑️ deprecated slugs by default (mirrors `switch.sh --list`); [h]
+        # reveals them. Hardware-INCOMPATIBLE slugs (fit verdict incompatible-hw —
+        # the registry's required_sm exceeds this rig's card, e.g. NVFP4 on
+        # Ampere) share the SAME bucket: hidden by default, [h] reveals. The
+        # verdict lands with async fit enrichment, so such rows may be visible
+        # briefly on first paint, then fold away on refresh_enriched.
         pool = (
             self._entries
             if self._show_deprecated
-            else [e for e in self._entries if (e.status or "").strip().lower() != "deprecated"]
+            else [
+                e for e in self._entries
+                if (e.status or "").strip().lower() != "deprecated"
+                and not self._hw_incompatible(e)
+            ]
         )
         # Model-scope dropdown first — AND-combined with the text filter below.
         base = (
@@ -1139,6 +1158,27 @@ class CatalogPane(Container):
         now-widened / narrowed set)."""
         self._show_deprecated = not self._show_deprecated
         self._render_rows()
+
+    @staticmethod
+    def _hw_incompatible(e: CatalogEntry) -> bool:
+        """This rig's card can't run the slug's kernels (kv-calc fit verdict
+        incompatible-hw — required_sm above the local card's SM)."""
+        try:
+            return getattr(e.fit, "verdict", "") == "incompatible-hw"
+        except Exception:
+            return False
+
+    def _incompatible_hidden_count(self) -> int:
+        """How many hardware-incompatible slugs are currently hidden (0 once
+        revealed via [h]; deprecated slugs are counted by their own counter,
+        not double-counted here)."""
+        if self._show_deprecated:
+            return 0
+        return sum(
+            1 for e in self._entries
+            if self._hw_incompatible(e)
+            and (e.status or "").strip().lower() != "deprecated"
+        )
 
     def _deprecated_hidden_count(self) -> int:
         """How many 🗑️ deprecated slugs are currently hidden (0 once revealed)."""
@@ -1729,9 +1769,29 @@ class ConfirmActionScreen(ModalScreen):
                 "continues) · [cyan]k[/cyan] cancels the download[/dim]"
             )
         # mode "download"
+        # Hardware-incompatibility interstitial (still proceedable): the slug's
+        # kernels can't run on THIS rig's card (required_sm gate) — say so
+        # BEFORE the size/disk pitch so nobody downloads 20 GB expecting it to
+        # boot here. Download stays allowed (staging for another rig / a future
+        # GPU is legitimate).
+        _hw_warn = ""
+        fv = getattr(entry, "fit", None) if entry is not None else None
+        if fv is not None and getattr(fv, "verdict", "") == "incompatible-hw":
+            req = getattr(fv, "required_sm", None)
+            got = getattr(fv, "card_sm", None)
+            req_s = f"sm ≥ {req:g}" if req is not None else "a newer GPU architecture"
+            got_s = f" — this rig's card is sm_{got:g}" if got is not None else ""
+            _hw_warn = (
+                f"  [red]⊘ no compatible hardware detected[/red] — this slug requires "
+                f"[bold]{req_s}[/bold] (Hopper/Blackwell class){got_s}.\n"
+                "  [yellow]It will NOT boot on this machine.[/yellow] You can still "
+                "download the weights\n"
+                "  (e.g. to stage them for another rig), but serving here will be refused.\n\n"
+            )
         if w is None or not w.hf_repo:
             return (
                 f"  [bold]{slug}[/bold]\n\n"
+                f"{_hw_warn}"
                 "  [yellow]⚠ no direct download recipe[/yellow] — these weights are "
                 "manual (no HF repo wired).\n  See the model profile's manual_note."
             )
@@ -1747,6 +1807,7 @@ class ConfirmActionScreen(ModalScreen):
             warn = "  [yellow]⚠ partial download on disk — Download resumes it[/yellow]\n"
         return (
             f"  [bold]{slug}[/bold]   [dim]weights not on disk[/dim]\n"
+            f"{_hw_warn}"
             f"  repo   [dim]{w.hf_repo}[/dim]   ({size})\n"
             f"{disk}\n"
             f"{warn}\n"
@@ -1795,6 +1856,16 @@ class ConfirmActionScreen(ModalScreen):
                 if fv.band_gb is not None:
                     fit_line += f" / {float(fv.band_gb):.1f} GiB band"
             lines.append(f"  [bold]fit[/bold]    {fit_line}")
+            if fv.verdict == "incompatible-hw":
+                req = fv.required_sm
+                got = fv.card_sm
+                req_s = f"sm ≥ {req:g}" if req is not None else "a newer GPU architecture"
+                got_s = f" — this rig's card is sm_{got:g}" if got is not None else ""
+                lines.append(
+                    f"  [red]⊘ no compatible hardware detected[/red] — requires "
+                    f"{req_s} (Hopper/Blackwell class){got_s}. "
+                    "[yellow]Serving here will NOT boot.[/yellow]"
+                )
             note = (entry.status_note or "").strip()
             if note:
                 lines.append(f"  [bold]caveat[/bold] [yellow]{note}[/yellow]")

--- a/tools/serve-cockpit/club3090_cockpit/data.py
+++ b/tools/serve-cockpit/club3090_cockpit/data.py
@@ -163,14 +163,21 @@ class FitVerdict:
     """Result of kv-calc --fit / switch.sh --explain's fit block for one slug."""
 
     # Real kv-calc --fit verdict enum (verified live):
-    #   fits-clean | fits-constrained | wont-fit | unknown
+    #   fits-clean | fits-constrained | wont-fit | incompatible-hw | unknown
     # plus the cockpit-internal "skip" (ik/llama kvcalc_key=SKIP — no vLLM fit).
-    verdict: str = "unknown"          # fits-clean | fits-constrained | wont-fit | unknown | skip
+    # "incompatible-hw" = the registry's required_sm exceeds the local card's
+    # compute capability (e.g. NVFP4 on Ampere) — VRAM is irrelevant, the
+    # kernels don't exist here. Drives the catalog default-hide + the
+    # download/serve hardware warning.
+    verdict: str = "unknown"          # fits-clean | fits-constrained | wont-fit | incompatible-hw | unknown | skip
     vram_est_gb: Optional[float] = None
     band_gb: Optional[float] = None
     max_ctx: Optional[int] = None
     card: str = ""
     error: str = ""
+    # Populated only for verdict == "incompatible-hw".
+    required_sm: Optional[float] = None
+    card_sm: Optional[float] = None
 
     # Compact glyph for the Catalog "fit" column.
     @property
@@ -179,6 +186,7 @@ class FitVerdict:
             "fits-clean": "●",
             "fits-constrained": "◐",
             "wont-fit": "○",
+            "incompatible-hw": "⊘",
             "skip": "·",
             "unknown": "·",
         }.get(self.verdict, "·")
@@ -194,6 +202,8 @@ class FitVerdict:
             max_ctx=_as_int(d.get("max_ctx")),
             card=card,
             error=str(d.get("error", "")),
+            required_sm=_as_float(d.get("required_sm")),
+            card_sm=_as_float(d.get("card_sm")),
         )
 
 

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -1214,6 +1214,78 @@ class TestCatalogWired:
             assert "⑂" in status and "community-submitted" in status
 
     @pytest.mark.asyncio
+    async def test_catalog_hides_hw_incompatible_by_default_and_h_reveals(self):
+        """A slug whose fit verdict is incompatible-hw (registry required_sm
+        above the local card's SM — e.g. NVFP4 on Ampere) is HIDDEN from the
+        catalog by default, in the SAME [h] bucket as deprecated; the status
+        line counts it as incompatible-hw; [h] reveals it."""
+        from club3090_cockpit.data import FitVerdict
+
+        ok = self._label_entry("autoround-int4")
+        nv = self._label_entry("nvfp4")
+        nv.fit = FitVerdict(
+            verdict="incompatible-hw", required_sm=9.0, card_sm=8.6,
+            card="rtx-3090", error="requires sm >= 9 (this card is sm_8.6)",
+        )
+        app, _, _ = make_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            pane = app.query_one("#catalog-pane", CatalogPane)
+            pane.populate([ok, nv], None)
+
+            # Default: the incompatible slug is hidden + counted.
+            assert [e.slug for e in pane._filtered_entries()] == ["x/autoround-int4"]
+            assert pane._incompatible_hidden_count() == 1
+            status = str(app.query_one("#catalog-status", Label).render())
+            assert "incompatible-hw" in status and "h" in status
+
+            # [h] reveals it (same toggle as deprecated).
+            pane.toggle_deprecated()
+            assert {e.slug for e in pane._filtered_entries()} == {
+                "x/autoround-int4", "x/nvfp4",
+            }
+            assert pane._incompatible_hidden_count() == 0
+
+            # And a compatible-fit verdict is never hidden.
+            nv.fit = FitVerdict(verdict="fits-clean", card="rtx-5090")
+            pane.toggle_deprecated()  # back to default hide mode
+            assert {e.slug for e in pane._filtered_entries()} == {
+                "x/autoround-int4", "x/nvfp4",
+            }
+
+    @pytest.mark.asyncio
+    async def test_download_card_warns_on_hw_incompatible(self):
+        """The Download confirm card leads with the no-compatible-hardware
+        warning (still proceedable) when the slug's fit verdict is
+        incompatible-hw — instead of pitching the download unqualified."""
+        from club3090_cockpit.data import FitVerdict
+
+        nv = self._label_entry("nvfp4")
+        nv.fit = FitVerdict(
+            verdict="incompatible-hw", required_sm=9.0, card_sm=8.6,
+            card="rtx-3090", error="requires sm >= 9 (this card is sm_8.6)",
+        )
+        app, _, _ = make_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            screen = ConfirmActionScreen.__new__(ConfirmActionScreen)
+            # _serve_mode is a property over _serve_ctx; None → "" → the
+            # mode-"download" (offer) branch, which is the one under test.
+            screen._serve_ctx = None
+            text = ConfirmActionScreen._download_card_text(screen, nv)
+            assert "no compatible hardware detected" in text
+            assert "sm ≥ 9" in text
+            assert "sm_8.6" in text
+            assert "NOT boot on this machine" in text
+            # still proceedable: the manual/no-recipe path retains its message
+            # (this fixture has no hf_repo wired → manual note branch).
+            assert "no direct download recipe" in text
+            # compatible slug → no warning
+            nv.fit = FitVerdict(verdict="fits-clean", card="rtx-5090")
+            text2 = ConfirmActionScreen._download_card_text(screen, nv)
+            assert "no compatible hardware" not in text2
+
+    @pytest.mark.asyncio
     async def test_catalog_hides_deprecated_by_default_and_h_reveals(self):
         """🗑️ Deprecated slugs are HIDDEN from the catalog by default (mirrors
         `switch.sh --list`); [h] / toggle_deprecated() reveals them, and the banner


### PR DESCRIPTION
Implements the catalog UX for slugs the local rig can't run (e.g. NVFP4 on Ampere):

1. **kv-calc fit verdict knows the arch floor**: `incompatible-hw` (+ `required_sm`/`card_sm`) when the local card's SM < the slug's `required_sm` — SM derived from the hardware profiles, same source as compat C3. Bare-number `--card` skips the gate (permissive).
2. **Catalog default view**: incompatible-hw rows share the deprecated `[h]` bucket — hidden by default, `[h]` reveals; status line: `+N incompatible-hw hidden — h`.
3. **Download/serve confirm**: leads with *"⊘ no compatible hardware detected — requires sm ≥ 9 (Hopper/Blackwell); this rig's card is sm_8.6. It will NOT boot on this machine."* — **download still proceedable** (staging for another rig is legitimate).

On a 5090/GB10 the same slugs show normally with real fit numbers (verified: `fits-clean ~28.5 GB`).

Also folds in the `test-registry-json` VARIANT_KEYS update for #600's emit fields (surfaced post-merge).

**Tests**: kv-calc-fit section (f) ×7 · 2 new headless · full `scripts/tests` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)