### PR TITLE
fix(quality): precise benchlocal-cli source detection (version alone is blind to unbumped pushes)

### DIFF
--- a/scripts/quality-test.sh
+++ b/scripts/quality-test.sh
@@ -465,6 +465,23 @@ if [[ -z "$PACK" ]] && { [[ "$MODE" == "--full" && "$NO_SANDBOX" != "1" ]] || [[
     _bl_bin="$(command -v benchlocal-cli || true)"
     _bl_mtime=0
     [[ -n "$_bl_bin" ]] && _bl_mtime="$(stat -c %Y "$_bl_bin" 2>/dev/null || echo 0)"
+    # Editable-checkout installs (maintainer rigs): `git pull` updates the code
+    # WITHOUT rewriting the console script, so the script mtime under-reports
+    # "CLI last updated". Take max(script mtime, checkout last-commit time).
+    if [[ -n "$_bl_bin" ]]; then
+      _bl_py="$(head -1 "$_bl_bin" 2>/dev/null | sed 's/^#!//')"
+      _bl_src_dir="$([[ -x "$_bl_py" ]] && "$_bl_py" -c 'import importlib.metadata as m, json
+try:
+    d = json.loads(m.distribution("benchlocal-cli").read_text("direct_url.json") or "{}")
+    u = d.get("url", "")
+    print(u[7:] if (d.get("dir_info") or {}).get("editable") and u.startswith("file://") else "")
+except Exception:
+    pass' 2>/dev/null)"
+      if [[ -n "$_bl_src_dir" && -d "$_bl_src_dir" ]]; then
+        _bl_commit_ts="$(git -C "$_bl_src_dir" log -1 --format=%ct 2>/dev/null || echo 0)"
+        [[ "$_bl_commit_ts" -gt "$_bl_mtime" ]] && _bl_mtime="$_bl_commit_ts"
+      fi
+    fi
     for _img in benchlocal-sandbox-bugfind benchlocal-sandbox-cli benchlocal-sandbox-hermes; do
       if ! docker image inspect "${_img}:latest" >/dev/null 2>&1; then
         _sb_missing+=("${_img}:latest")
@@ -480,7 +497,7 @@ if [[ -z "$PACK" ]] && { [[ "$MODE" == "--full" && "$NO_SANDBOX" != "1" ]] || [[
       if [[ -n "$_img_created" && "$_bl_mtime" -gt 0 ]]; then
         _img_epoch="$(date -d "$_img_created" +%s 2>/dev/null || echo 0)"
         if [[ "$_img_epoch" -gt 0 && "$_img_epoch" -lt "$_bl_mtime" ]]; then
-          _sb_stale+=("${_img}:latest ($(date -d "@${_img_epoch}" +%F) < CLI $(date -d "@${_bl_mtime}" +%F))")
+          _sb_stale+=("${_img}:latest (built $(date -d "@${_img_epoch}" '+%F %H:%M') < CLI updated $(date -d "@${_bl_mtime}" '+%F %H:%M'))")
         fi
       fi
     done

--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -575,7 +575,32 @@ section "Quality tooling (benchlocal-cli + sandboxes)"
     # editable-checkout installs; console-script shebang points at the env).
     bl_py=$(head -1 "$bl_bin" 2>/dev/null | sed 's/^#!//')
     bl_ver=$([[ -x "$bl_py" ]] && "$bl_py" -c 'import importlib.metadata as m; print(m.version("benchlocal-cli"))' 2>/dev/null || true)
-    echo "- **benchlocal-cli:** \`${bl_bin}\` (version: \`${bl_ver:-unknown}\`, installed/updated: ${bl_when})"
+    # PRECISE source — the metadata version is frozen at install time and
+    # fixes are pushed without bumping it, so it alone can't identify the
+    # code. pip records the truth in direct_url.json: a git install carries
+    # the exact commit; an editable install carries the checkout dir → git
+    # describe (path itself withheld from the public report).
+    bl_src=$([[ -x "$bl_py" ]] && "$bl_py" - <<'PYEOF' 2>/dev/null
+import importlib.metadata as m, json, subprocess
+try:
+    raw = m.distribution("benchlocal-cli").read_text("direct_url.json") or ""
+    d = json.loads(raw)
+except Exception:
+    d = {}
+vcs = (d.get("vcs_info") or {}).get("commit_id")
+if vcs:
+    print(f"git@{vcs[:9]}")
+elif (d.get("dir_info") or {}).get("editable") and str(d.get("url", "")).startswith("file://"):
+    path = d["url"][7:]
+    try:
+        desc = subprocess.run(["git", "-C", path, "describe", "--tags", "--always", "--dirty"],
+                              capture_output=True, text=True, timeout=5).stdout.strip()
+        print(f"{desc} (editable checkout)" if desc else "editable checkout")
+    except Exception:
+        print("editable checkout")
+PYEOF
+    )
+    echo "- **benchlocal-cli:** \`${bl_bin}\` (version: \`${bl_ver:-unknown}\`${bl_src:+, source: \`${bl_src}\`}, installed/updated: ${bl_when})"
     if have docker && docker info >/dev/null 2>&1; then
       stale_any=0
       echo "- **Sandbox images** (needed by the --full sandboxed packs):"


### PR DESCRIPTION
Follow-up to #605 answering "will it pick up branch/sha following the version?" — **now it does**. The metadata version is frozen at install and fixes get pushed without bumps (live proof: this rig reports `0.9.4` while the checkout is at `v0.9.7-6-gc541550`). pip's `direct_url.json` carries the truth:

- **report.sh**: `source: git@<sha9>` (pip-from-git) or `source: v0.9.7-6-gc541550 (editable checkout)` (path withheld from the public report).
- **quality-test.sh**: staleness reference becomes `max(console-script mtime, editable-checkout last-commit time)` — `git pull` in a checkout doesn't rewrite the console script, so mtime alone under-reports. Caught a real boundary on this rig (sandboxes built ~1 h before the same day's last commit); timestamps now carry `%H:%M`.

Guards green, report section verified live + leak-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)