### PR TITLE
fix(launch): runtime-agnostic GPU pinning via UUIDs — CDI/NixOS support

### DIFF
--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -88,6 +88,38 @@ Mechanics and boundaries:
 
 ---
 
+## Pinning specific GPUs on multi-GPU rigs (and CDI / NixOS runtimes)
+
+`bash scripts/launch.sh --gpus 1,2` pins the model to host GPUs 1+2 (leaving GPU 0 free for e.g. a desktop session or an image-gen stack). As of [#610] the launcher resolves your indices to **GPU UUIDs** (`nvidia-smi -L`) and exports them as *both* `NVIDIA_VISIBLE_DEVICES` and `CUDA_VISIBLE_DEVICES` — one mechanism that works on **both** container GPU runtimes:
+
+| Runtime | How devices reach the container | What pins the cards |
+|---|---|---|
+| classic `nvidia` runtime (default Docker + nvidia-container-toolkit) | `NVIDIA_VISIBLE_DEVICES` (the runtime hook) | the UUID exposure itself; the CUDA mask is a no-op that agrees with it |
+| **CDI** (NixOS `hardware.nvidia-container-toolkit`, `nvidia-ctk cdi`, Podman) | the compose `deploy` block's CDI `device_ids` (typically `nvidia.com/gpu=all`) — **`NVIDIA_VISIBLE_DEVICES` is IGNORED** | the in-container `CUDA_VISIBLE_DEVICES` UUID mask |
+
+Why UUIDs and not indices: the classic runtime **renumbers** the exposed set inside the container (host GPUs 1,2 become 0,1), so an index-based inner mask would point at the wrong or a nonexistent card. UUIDs are stable under any exposure order.
+
+**CDI rigs (NixOS etc.)** — swap the compose's `deploy` device block for the CDI form and let the CUDA mask do the selection:
+
+```yaml
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: cdi
+              device_ids:
+                - nvidia.com/gpu=all
+```
+
+then `bash scripts/launch.sh --gpus 1,2` as normal (the composes pass `CUDA_VISIBLE_DEVICES` through). Manual/no-launcher equivalent: `CUDA_VISIBLE_DEVICES=GPU-xxxx,GPU-yyyy docker compose -f … up -d` with the UUIDs from `nvidia-smi -L` (indices also work under CDI-with-all-exposed, but UUIDs are unambiguous).
+
+**Gotchas:**
+- *In-container renumbering is expected, not a bug*: with 2 of 3 cards pinned, `nvidia-smi` **inside** the container shows them as GPU 0/1 (classic runtime) or shows *all* cards while CUDA uses only the masked pair (CDI). Verify placement with **host** `nvidia-smi` — the utilization lands on the cards you picked.
+- The single-card GGUF composes (beellama / llama.cpp / ik-llama) select via `device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}"]` interpolated on the **host** side — they honor the same launcher export on the classic runtime; on CDI, apply the device-block swap above.
+- Estate (multi-instance) GPU pinning on CDI rigs is a tracked follow-up on [#610].
+
+[#610]: https://github.com/noonghunna/club-3090/issues/610
+
 ## NVLink
 
 **Not required.** Dual-card composes auto-detect NVLink and configure themselves accordingly.

--- a/models/agents-a1/vllm/compose/dual/fp8-dynamic/fp8.yml
+++ b/models/agents-a1/vllm/compose/dual/fp8-dynamic/fp8.yml
@@ -144,6 +144,12 @@ services:
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/diffusiongemma-26b-a4b/vllm/compose/dual/fp8/base.yml
+++ b/models/diffusiongemma-26b-a4b/vllm/compose/dual/fp8/base.yml
@@ -75,6 +75,12 @@ services:
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/gemma-4-12b/vllm/compose/dual/bf16/mtp.yml
+++ b/models/gemma-4-12b/vllm/compose/dual/bf16/mtp.yml
@@ -53,6 +53,12 @@ services:
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/gemma-4-12b/vllm/compose/single/autoround-int8/mtp.yml
+++ b/models/gemma-4-12b/vllm/compose/single/autoround-int8/mtp.yml
@@ -45,6 +45,12 @@ services:
       - ../../../cache/triton:/root/.triton/cache
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/gemma-4-12b/vllm/compose/single/qat-w4a16/mtp.yml
+++ b/models/gemma-4-12b/vllm/compose/single/qat-w4a16/mtp.yml
@@ -53,6 +53,12 @@ services:
       - ../../../patches/gemma4-unified-vision-unquant:/etc/club3090/g4patch:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/gemma-4-26b-a4b/vllm/compose/dual/awq/mtp.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/dual/awq/mtp.yml
@@ -55,6 +55,12 @@ services:
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/gemma-4-26b-a4b/vllm/compose/single/awq/int8.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/single/awq/int8.yml
@@ -80,6 +80,12 @@ services:
       - ../../../patches/vllm-pr40391-v0.22.0:/etc/club3090/pr40391:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/gemma-4-31b/vllm/compose/dual/autoround-int4/bf16-mtp.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/autoround-int4/bf16-mtp.yml
@@ -87,6 +87,12 @@ services:
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/gemma-4-31b/vllm/compose/dual/autoround-int4/int8.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/autoround-int4/int8.yml
@@ -149,6 +149,12 @@ services:
       #     streaming multi-tool-call regression).
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/gemma-4-31b/vllm/compose/dual/qat-awq-int4/base.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/qat-awq-int4/base.yml
@@ -82,6 +82,12 @@ services:
       # NO overlay mounts — overlay-free on stock v0.24.0 (bf16 KV needs no patch).
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/gemma-4-31b/vllm/compose/dual/qat-w4a16/int8.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/qat-w4a16/int8.yml
@@ -152,6 +152,12 @@ services:
       #     streaming multi-tool-call regression).
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/gemma-4-31b/vllm/compose/single/autoround-int4/fp8-mtp.yml
+++ b/models/gemma-4-31b/vllm/compose/single/autoround-int4/fp8-mtp.yml
@@ -78,6 +78,12 @@ services:
       # PR #41745 overlay dropped 2026-05-08: merged upstream + nightly contains it.
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/qwen3.6-27b/vllm-lmcache/compose/dual/fp8/lmcache.yml
+++ b/models/qwen3.6-27b/vllm-lmcache/compose/dual/fp8/lmcache.yml
@@ -102,6 +102,12 @@ services:
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml
@@ -92,6 +92,12 @@ services:
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/qwen3.6-27b/vllm/compose/dual/awq-bf16-int4/int8.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/awq-bf16-int4/int8.yml
@@ -87,6 +87,12 @@ services:
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/qwen3.6-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/fp8/mtp.yml
@@ -110,6 +110,12 @@ services:
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/qwen3.6-27b/vllm/compose/dual/nvfp4/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/nvfp4/mtp.yml
@@ -87,6 +87,12 @@ services:
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/qwen3.6-27b/vllm/compose/multi4/autoround-int4/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/multi4/autoround-int4/mtp.yml
@@ -81,6 +81,12 @@ services:
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/qwen3.6-27b/vllm/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/multi4/fp8/mtp.yml
@@ -95,6 +95,12 @@ services:
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/qwen3.6-27b/vllm/compose/single/autoround-int4/minimal.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/autoround-int4/minimal.yml
@@ -62,8 +62,12 @@ services:
       - ../../../patches/froggeric-chat-template/chat_template.jinja:/etc/qwen-froggeric-chat-template.jinja:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
-      # Uncomment the next line to pin to a specific GPU (e.g. GPU 0):
-      # - CUDA_VISIBLE_DEVICES=0
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/qwen3.6-27b/vllm/compose/single/nvfp4/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/nvfp4/mtp.yml
@@ -71,7 +71,12 @@ services:
       - ../../../patches/froggeric-chat-template/chat_template.jinja:/etc/qwen-froggeric-chat-template.jinja:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
-      # Pin to a specific GPU on multi-card rigs, e.g.: CUDA_VISIBLE_DEVICES=0
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/qwen3.6-35b-a3b/vllm/compose/dual/autoround-int4/fp8.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/dual/autoround-int4/fp8.yml
@@ -72,6 +72,12 @@ services:
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4/fp8.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4/fp8.yml
@@ -63,6 +63,12 @@ services:
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/qwen3.6-35b-a3b/vllm/compose/single/autoround-int4/preview.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/single/autoround-int4/preview.yml
@@ -51,6 +51,12 @@ services:
       - ../../../cache/triton:/root/.triton/cache
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/qwen3.6-35b-a3b/vllm/compose/single/nvfp4/fp8.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/single/nvfp4/fp8.yml
@@ -68,6 +68,12 @@ services:
       - ../../../cache/triton:/root/.triton/cache
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/models/vibethinker-3b/vllm/compose/single/bf16/fp8.yml
+++ b/models/vibethinker-3b/vllm/compose/single/bf16/fp8.yml
@@ -86,8 +86,12 @@ services:
       - ../../../cache/triton:/root/.triton/cache
     environment:
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
-      # Uncomment the next line to pin to a specific GPU (e.g. GPU 0):
-      # - CUDA_VISIBLE_DEVICES=0
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
       - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -1309,8 +1309,39 @@ case "$_launch_status" in
 esac
 echo ""
 if [[ -n "$SELECTED_GPU_CSV" ]]; then
-  export CUDA_VISIBLE_DEVICES="$SELECTED_GPU_CSV"
-  export NVIDIA_VISIBLE_DEVICES="$SELECTED_GPU_CSV"
+  # Resolve the selected indices to GPU UUIDs so ONE selection mechanism works
+  # on BOTH container GPU runtimes (#610):
+  #   - classic nvidia runtime: honors NVIDIA_VISIBLE_DEVICES (indices OR
+  #     UUIDs) but RENUMBERS the exposed set inside the container — so an
+  #     index-based CUDA_VISIBLE_DEVICES would point at the wrong (or a
+  #     nonexistent) card;
+  #   - CDI runtimes (NixOS, nvidia-ctk cdi): IGNORE NVIDIA_VISIBLE_DEVICES
+  #     entirely (devices come from the compose's CDI device_ids, typically
+  #     nvidia.com/gpu=all) — only a CUDA-level mask can pin cards there.
+  # UUIDs sidestep both problems: the classic runtime exposes-by-UUID, and
+  # CUDA_VISIBLE_DEVICES masks-by-UUID regardless of exposure order. The
+  # composes pass CUDA_VISIBLE_DEVICES through (bare env passthrough).
+  # Fallback to raw indices if the UUID query fails (pre-UUID behavior).
+  _gpu_uuid_csv=""
+  if command -v nvidia-smi >/dev/null 2>&1; then
+    IFS=',' read -ra _sel_idx <<< "$SELECTED_GPU_CSV"
+    for _idx in "${_sel_idx[@]}"; do
+      _uuid="$(nvidia-smi --query-gpu=uuid --format=csv,noheader -i "$_idx" 2>/dev/null | head -1 | tr -d ' ')"
+      if [[ "$_uuid" != GPU-* ]]; then
+        _gpu_uuid_csv=""
+        break
+      fi
+      _gpu_uuid_csv="${_gpu_uuid_csv:+${_gpu_uuid_csv},}${_uuid}"
+    done
+  fi
+  if [[ -n "$_gpu_uuid_csv" ]]; then
+    export CUDA_VISIBLE_DEVICES="$_gpu_uuid_csv"
+    export NVIDIA_VISIBLE_DEVICES="$_gpu_uuid_csv"
+    echo "[launch] GPU selection ${SELECTED_GPU_CSV} → UUID-pinned (runtime-agnostic: classic nvidia + CDI, #610)" >&2
+  else
+    export CUDA_VISIBLE_DEVICES="$SELECTED_GPU_CSV"
+    export NVIDIA_VISIBLE_DEVICES="$SELECTED_GPU_CSV"
+  fi
 fi
 if [[ -n "$TP_VALUE" ]]; then
   export TP="$TP_VALUE"

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -139,14 +139,39 @@ _preflight_csv_token() {
   printf '%s' "$value"
 }
 
+# UUID→index normalization (#610): launch.sh --gpus exports GPU UUIDs (the
+# runtime-agnostic form — CDI ignores NVIDIA_VISIBLE_DEVICES, and indices
+# renumber inside classic-runtime containers). Preflight's checks are all
+# host-index-based, so translate any GPU-xxxx token back to its host index
+# here — ONE choke point for every selector consumer. Unknown tokens pass
+# through untouched (they fail the match downstream with the existing error).
+_preflight_selector_normalize() {
+  local selector="$1" token out="" idx
+  [[ "$selector" != *GPU-* ]] && { printf '%s' "$selector"; return 0; }
+  local uuid_map
+  uuid_map="$(nvidia-smi --query-gpu=index,uuid --format=csv,noheader,nounits 2>/dev/null || true)"
+  IFS=',' read -ra _pf_norm_tokens <<< "$selector"
+  for token in "${_pf_norm_tokens[@]}"; do
+    token="$(_preflight_trim "$token")"
+    if [[ "$token" == GPU-* && -n "$uuid_map" ]]; then
+      idx="$(awk -F', *' -v u="$token" '$2 == u {print $1; exit}' <<< "$uuid_map")"
+      [[ -n "$idx" ]] && token="$idx"
+    fi
+    out="${out:+${out},}${token}"
+  done
+  printf '%s' "$out"
+}
+
 _preflight_selector() {
+  local raw=""
   if [[ -n "${CLUB3090_GPU:-}" ]]; then
-    printf '%s' "${CLUB3090_GPU}"
+    raw="${CLUB3090_GPU}"
   elif [[ -n "${NVIDIA_VISIBLE_DEVICES:-}" && "${NVIDIA_VISIBLE_DEVICES}" != "all" && "${NVIDIA_VISIBLE_DEVICES}" != "void" ]]; then
-    printf '%s' "${NVIDIA_VISIBLE_DEVICES}"
+    raw="${NVIDIA_VISIBLE_DEVICES}"
   elif [[ -n "${CUDA_VISIBLE_DEVICES:-}" && "${CUDA_VISIBLE_DEVICES}" != "all" && "${CUDA_VISIBLE_DEVICES}" != "void" ]]; then
-    printf '%s' "${CUDA_VISIBLE_DEVICES}"
+    raw="${CUDA_VISIBLE_DEVICES}"
   fi
+  [[ -n "$raw" ]] && _preflight_selector_normalize "$raw"
 }
 
 _preflight_selector_is_specific() {

--- a/scripts/tests/test-compose-gpu-mask-passthrough.sh
+++ b/scripts/tests/test-compose-gpu-mask-passthrough.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# test-compose-gpu-mask-passthrough.sh — every compose that selects GPUs via
+# the NVIDIA_VISIBLE_DEVICES env line MUST also pass CUDA_VISIBLE_DEVICES
+# through (#610): CDI runtimes (NixOS, nvidia-ctk cdi) ignore
+# NVIDIA_VISIBLE_DEVICES entirely, so the CUDA-level mask is the only thing
+# that pins cards there. launch.sh --gpus exports both as GPU UUIDs
+# (renumbering-proof on the classic runtime too). A new compose that copies
+# the NVIDIA line but forgets the CUDA passthrough silently regresses CDI
+# rigs — this guard reds instead.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+fails=0
+while IFS= read -r f; do
+  # bare passthrough form: "- CUDA_VISIBLE_DEVICES" (no =value; unset → absent)
+  if ! grep -Eq '^\s*- CUDA_VISIBLE_DEVICES\s*$' "$f"; then
+    echo "FAIL: $f sets NVIDIA_VISIBLE_DEVICES but does not pass CUDA_VISIBLE_DEVICES through (#610 CDI regression)" >&2
+    fails=$((fails+1))
+  fi
+done < <(grep -rlE '^\s*- NVIDIA_VISIBLE_DEVICES=' models/*/*/compose --include='*.yml' 2>/dev/null | grep -v '/_archive/' || true)
+
+# launch.sh must still carry the UUID resolution (the other half of #610).
+grep -q 'query-gpu=uuid' scripts/launch.sh \
+  || { echo "FAIL: launch.sh lost the --gpus index→UUID resolution (#610)" >&2; fails=$((fails+1)); }
+
+if [[ $fails -gt 0 ]]; then
+  echo "$fails GPU-mask passthrough check(s) failed" >&2
+  exit 1
+fi
+echo "PASS: all NVIDIA_VISIBLE_DEVICES composes pass CUDA_VISIBLE_DEVICES through; launch.sh UUID resolution present"


### PR DESCRIPTION
Fixes #610 (Discord report: NixOS/CDI rig, `--gpus 1,2` silently ignored).

**Mechanism**: `--gpus N,M` now resolves to **GPU UUIDs** and exports both `NVIDIA_VISIBLE_DEVICES` + `CUDA_VISIBLE_DEVICES` — one selection that works on the classic runtime (exposes-by-UUID, renumbering-proof) AND CDI (where only the in-container CUDA UUID mask can pin cards). 26 composes gain a bare `CUDA_VISIBLE_DEVICES` passthrough (unset → absent → zero change); preflight learned to normalize UUID selectors back to host indices (caught live by the first boot attempt); new drift guard + HARDWARE.md section with the CDI deploy-block recipe.

**Live-verified** (classic runtime, 2×3090): `--gpus 1` → host GPU0 empty (1 MiB), GPU1 = 20.7 GB, UUID vars set in-container. The CDI leg goes to the reporter for validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)