### PR TITLE
feat(estate): UUID-pin estate GPUs + placement assertion (#610 Phase A)

### DIFF
--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -116,7 +116,7 @@ then `bash scripts/launch.sh --gpus 1,2` as normal (the composes pass `CUDA_VISI
 **Gotchas:**
 - *In-container renumbering is expected, not a bug*: with 2 of 3 cards pinned, `nvidia-smi` **inside** the container shows them as GPU 0/1 (classic runtime) or shows *all* cards while CUDA uses only the masked pair (CDI). Verify placement with **host** `nvidia-smi` — the utilization lands on the cards you picked.
 - The single-card GGUF composes (beellama / llama.cpp / ik-llama) select via `device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}"]` interpolated on the **host** side — they honor the same launcher export on the classic runtime; on CDI, apply the device-block swap above.
-- Estate (multi-instance) GPU pinning on CDI rigs is a tracked follow-up on [#610].
+- Estate (multi-instance) GPU pinning is UUID-pinned the same way (#610 Phase A): each instance's `gpus: [..]` stays index-based in the estate file, and the boot path resolves them to UUIDs — so estates land on the cards they claimed on CDI rigs too. After boot, a **placement assertion** (`docker exec … nvidia-smi --query-compute-apps=gpu_uuid`) confirms the model actually ran on the requested GPUs and prints a loud ⚠ on mismatch — no more silent wrong-card serving.
 
 [#610]: https://github.com/noonghunna/club-3090/issues/610
 

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -95,6 +95,9 @@ fi
 MODEL_DIR="${MODEL_DIR:-${ROOT_DIR}/models-cache}"
 # shellcheck source=preflight.sh
 source "${ROOT_DIR}/scripts/preflight.sh"
+# Runtime-agnostic GPU selection helpers (#610 Phase A) — gpu_select_export
+# (UUID-pin the --gpus set) + gpu_select_assert_placement (post-boot check).
+source "${ROOT_DIR}/scripts/lib/gpu-select.sh"
 
 # --- arg parsing ---
 ENGINE=""
@@ -1309,39 +1312,10 @@ case "$_launch_status" in
 esac
 echo ""
 if [[ -n "$SELECTED_GPU_CSV" ]]; then
-  # Resolve the selected indices to GPU UUIDs so ONE selection mechanism works
-  # on BOTH container GPU runtimes (#610):
-  #   - classic nvidia runtime: honors NVIDIA_VISIBLE_DEVICES (indices OR
-  #     UUIDs) but RENUMBERS the exposed set inside the container — so an
-  #     index-based CUDA_VISIBLE_DEVICES would point at the wrong (or a
-  #     nonexistent) card;
-  #   - CDI runtimes (NixOS, nvidia-ctk cdi): IGNORE NVIDIA_VISIBLE_DEVICES
-  #     entirely (devices come from the compose's CDI device_ids, typically
-  #     nvidia.com/gpu=all) — only a CUDA-level mask can pin cards there.
-  # UUIDs sidestep both problems: the classic runtime exposes-by-UUID, and
-  # CUDA_VISIBLE_DEVICES masks-by-UUID regardless of exposure order. The
-  # composes pass CUDA_VISIBLE_DEVICES through (bare env passthrough).
-  # Fallback to raw indices if the UUID query fails (pre-UUID behavior).
-  _gpu_uuid_csv=""
-  if command -v nvidia-smi >/dev/null 2>&1; then
-    IFS=',' read -ra _sel_idx <<< "$SELECTED_GPU_CSV"
-    for _idx in "${_sel_idx[@]}"; do
-      _uuid="$(nvidia-smi --query-gpu=uuid --format=csv,noheader -i "$_idx" 2>/dev/null | head -1 | tr -d ' ')"
-      if [[ "$_uuid" != GPU-* ]]; then
-        _gpu_uuid_csv=""
-        break
-      fi
-      _gpu_uuid_csv="${_gpu_uuid_csv:+${_gpu_uuid_csv},}${_uuid}"
-    done
-  fi
-  if [[ -n "$_gpu_uuid_csv" ]]; then
-    export CUDA_VISIBLE_DEVICES="$_gpu_uuid_csv"
-    export NVIDIA_VISIBLE_DEVICES="$_gpu_uuid_csv"
-    echo "[launch] GPU selection ${SELECTED_GPU_CSV} → UUID-pinned (runtime-agnostic: classic nvidia + CDI, #610)" >&2
-  else
-    export CUDA_VISIBLE_DEVICES="$SELECTED_GPU_CSV"
-    export NVIDIA_VISIBLE_DEVICES="$SELECTED_GPU_CSV"
-  fi
+  # Resolve the selected indices to GPU UUIDs and export both CUDA_/NVIDIA_
+  # VISIBLE_DEVICES so ONE selection mechanism works on both container GPU
+  # runtimes (#610). Logic lives in the shared gpu-select.sh lib (Phase A).
+  gpu_select_export "$SELECTED_GPU_CSV" "launch"
 fi
 if [[ -n "$TP_VALUE" ]]; then
   export TP="$TP_VALUE"
@@ -1369,6 +1343,12 @@ else
     echo "  - 'Genesis patches' / 'MTP acceptance' skipped on llama.cpp = expected (vLLM-only checks)"
     exit 1
   }
+  # Post-boot placement assertion (#610 Phase A): when the user pinned a GPU
+  # set, confirm the model actually landed there (loud warn on mismatch, never
+  # fatal). Runs after verify so the compute processes exist to inspect.
+  if [[ -n "$SELECTED_GPU_CSV" ]]; then
+    gpu_select_assert_placement "$ENDPOINT_CONTAINER" "${CUDA_VISIBLE_DEVICES:-}" "launch"
+  fi
 fi
 
 echo ""

--- a/scripts/lib/gpu-select.sh
+++ b/scripts/lib/gpu-select.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# gpu-select.sh — runtime-agnostic GPU selection helpers (#610 Phase A).
+#
+# ONE mechanism for pinning specific GPUs on BOTH container runtimes:
+#   - classic nvidia runtime: honors NVIDIA_VISIBLE_DEVICES but RENUMBERS the
+#     exposed set inside the container (host GPUs 1,2 -> 0,1) — so an
+#     index-based CUDA mask points at the wrong / a nonexistent card;
+#   - CDI runtimes (NixOS, nvidia-ctk cdi): IGNORE NVIDIA_VISIBLE_DEVICES
+#     entirely (devices come from the compose's CDI device_ids) — only a
+#     CUDA-level mask pins cards there.
+# GPU UUIDs sidestep both: the classic runtime exposes-by-UUID, and
+# CUDA_VISIBLE_DEVICES masks-by-UUID regardless of exposure order.
+#
+# Source this file; it defines functions only (no side effects on source).
+# Shared by scripts/launch.sh (--gpus) and — via the parallel python resolver
+# in estate_cli.py — the estate boot path. test-gpu-select asserts the two
+# resolvers agree.
+
+# gpu_select_indices_to_uuids "<idx_csv>"
+#   Resolve a comma-separated list of host GPU indices to their UUIDs.
+#   Echoes the UUID csv on success; echoes NOTHING (empty) on any failure
+#   (no nvidia-smi, an index that doesn't resolve) so callers fall back to
+#   raw indices — the pre-UUID behavior.
+gpu_select_indices_to_uuids() {
+  local idx_csv="$1" out="" idx uuid
+  [[ -z "$idx_csv" ]] && return 0
+  command -v nvidia-smi >/dev/null 2>&1 || return 0
+  local IFS=','
+  read -ra _gpu_sel_idx <<< "$idx_csv"
+  for idx in "${_gpu_sel_idx[@]}"; do
+    idx="${idx//[[:space:]]/}"
+    [[ -z "$idx" ]] && continue
+    uuid="$(nvidia-smi --query-gpu=uuid --format=csv,noheader -i "$idx" 2>/dev/null | head -1 | tr -d '[:space:]')"
+    if [[ "$uuid" != GPU-* ]]; then
+      # Any index that fails to resolve -> abandon the whole set (partial
+      # UUID pinning is worse than the index fallback).
+      printf '' && return 0
+    fi
+    out="${out:+${out},}${uuid}"
+  done
+  printf '%s' "$out"
+}
+
+# gpu_select_export "<idx_csv>" ["<log_prefix>"]
+#   Resolve the indices to UUIDs and EXPORT both CUDA_VISIBLE_DEVICES and
+#   NVIDIA_VISIBLE_DEVICES (UUIDs when resolvable, raw indices otherwise).
+#   Emits a one-line note to stderr when UUID-pinned. The launcher's #611
+#   inline block, factored out.
+gpu_select_export() {
+  local idx_csv="$1" log_prefix="${2:-gpu}" uuids
+  [[ -z "$idx_csv" ]] && return 0
+  uuids="$(gpu_select_indices_to_uuids "$idx_csv")"
+  if [[ -n "$uuids" ]]; then
+    export CUDA_VISIBLE_DEVICES="$uuids"
+    export NVIDIA_VISIBLE_DEVICES="$uuids"
+    echo "[${log_prefix}] GPU selection ${idx_csv} → UUID-pinned (runtime-agnostic: classic nvidia + CDI, #610)" >&2
+  else
+    export CUDA_VISIBLE_DEVICES="$idx_csv"
+    export NVIDIA_VISIBLE_DEVICES="$idx_csv"
+  fi
+}
+
+# gpu_select_container_uuids "<container>"
+#   The GPU UUIDs the container's COMPUTE PROCESSES are actually running on —
+#   the runtime-agnostic ground truth of placement. Uses --query-compute-apps
+#   (NOT --query-gpu): under CDI the container sees ALL cards via nvidia-smi,
+#   but only RUNS on the CUDA-masked set, so the compute-apps view is what
+#   reflects the real pinning. Echoes a sorted, unique UUID csv (empty if no
+#   compute apps yet / nvidia-smi unavailable in the container).
+gpu_select_container_uuids() {
+  local container="$1"
+  [[ -z "$container" ]] && return 0
+  docker exec "$container" nvidia-smi \
+      --query-compute-apps=gpu_uuid --format=csv,noheader 2>/dev/null \
+    | tr -d '[:space:]' | grep '^GPU-' | sort -u | paste -sd, -
+}
+
+# gpu_select_assert_placement "<container>" "<requested_uuid_csv>" ["<log_prefix>"]
+#   Post-boot placement assertion (#610 Phase A): compare where the model
+#   ACTUALLY landed against what was requested. A loud warning on mismatch
+#   instead of silent wrong-card serving — the failure mode that opened #610.
+#   Non-fatal (returns 0): a warning, never a boot abort. Skips silently when
+#   the request wasn't UUID-based or placement can't be read.
+gpu_select_assert_placement() {
+  local container="$1" requested="$2" log_prefix="${3:-gpu}" actual
+  [[ -z "$container" || -z "$requested" ]] && return 0
+  # Only meaningful when the request is UUIDs (a specific selection).
+  [[ "$requested" == GPU-* ]] || return 0
+  actual="$(gpu_select_container_uuids "$container")"
+  [[ -z "$actual" ]] && return 0  # no compute apps yet / can't read — don't cry wolf
+  # Requested must be a subset of actual (actual may list more if the app
+  # spans them; a mismatch is a requested UUID that isn't running).
+  local IFS=',' u miss=""
+  read -ra _gpu_req <<< "$requested"
+  for u in "${_gpu_req[@]}"; do
+    [[ -z "$u" ]] && continue
+    case ",${actual}," in
+      *",${u},"*) : ;;
+      *) miss="${miss:+${miss} }${u}" ;;
+    esac
+  done
+  if [[ -n "$miss" ]]; then
+    echo "[${log_prefix}] ⚠ PLACEMENT MISMATCH: requested GPU(s) not running the model — ${miss}" >&2
+    echo "[${log_prefix}]   requested: ${requested}" >&2
+    echo "[${log_prefix}]   actual:    ${actual}" >&2
+    echo "[${log_prefix}]   On a CDI runtime this usually means CUDA_VISIBLE_DEVICES didn't reach the container (see docs/HARDWARE.md → Pinning specific GPUs)." >&2
+  else
+    echo "[${log_prefix}] ✓ placement verified — model running on the requested GPU(s)" >&2
+  fi
+  return 0
+}

--- a/scripts/lib/profiles/estate_cli.py
+++ b/scripts/lib/profiles/estate_cli.py
@@ -136,6 +136,88 @@ def parse_fake_gpus(value: str) -> list[GpuInfo]:
     return sorted(out, key=lambda gpu: gpu.index)
 
 
+# --- GPU UUID resolution (#610 Phase A) -------------------------------------
+# The estate boot path pins GPUs by index (ESTATE_GPUS / CUDA_VISIBLE_DEVICES),
+# which CDI runtimes IGNORE and the classic runtime renumbers — the exact bug
+# gpu-select.sh fixed for `launch.sh --gpus`. Resolve to UUIDs here so estate
+# instances land on the cards they claimed on both runtimes. This is the
+# python twin of scripts/lib/gpu-select.sh; test-gpu-select asserts parity.
+
+
+def resolve_gpu_uuids(indices) -> str | None:
+    """Comma-separated host GPU indices -> their UUID csv. Returns None on any
+    failure (no nvidia-smi, an index that doesn't resolve, fake-GPU test mode)
+    so callers fall back to raw indices — the pre-UUID behavior."""
+    idxs = [str(i).strip() for i in indices if str(i).strip() != ""]
+    if not idxs:
+        return None
+    # Honor the CLUB3090_FAKE_GPUS test seam: no real nvidia-smi to query.
+    if os.environ.get("CLUB3090_FAKE_GPUS"):
+        return None
+    uuids = []
+    for idx in idxs:
+        proc = subprocess.run(
+            ["nvidia-smi", "--query-gpu=uuid", "--format=csv,noheader", "-i", idx],
+            text=True, capture_output=True, check=False,
+        )
+        uuid = (proc.stdout or "").strip().splitlines()[0].strip() if proc.stdout.strip() else ""
+        if proc.returncode != 0 or not uuid.startswith("GPU-"):
+            return None  # partial UUID pinning is worse than the index fallback
+        uuids.append(uuid)
+    return ",".join(uuids)
+
+
+def container_placement_uuids(container: str) -> str:
+    """The GPU UUIDs the container's COMPUTE PROCESSES actually run on — the
+    runtime-agnostic ground truth (--query-compute-apps, NOT --query-gpu: under
+    CDI the container sees all cards but runs on the CUDA-masked set). Sorted,
+    unique csv; empty when no compute apps yet / nvidia-smi unavailable."""
+    proc = subprocess.run(
+        ["docker", "exec", container, "nvidia-smi",
+         "--query-compute-apps=gpu_uuid", "--format=csv,noheader"],
+        text=True, capture_output=True, check=False,
+    )
+    if proc.returncode != 0:
+        return ""
+    seen = sorted({ln.strip() for ln in proc.stdout.splitlines() if ln.strip().startswith("GPU-")})
+    return ",".join(seen)
+
+
+def assert_placement(inst: "InstanceSpec", requested_uuids: str | None) -> dict:
+    """Post-boot placement assertion for one instance (#610 Phase A): confirm
+    the model landed on the GPU(s) it claimed. Loud warning on mismatch; never
+    raises. Returns the {requested, actual, placement: ok|mismatch|unknown}
+    verdict — the single shape the state report + (Phase C) c3 badge read."""
+    verdict = assert_placement_quiet(inst, requested_uuids)
+    if verdict["placement"] == "mismatch":
+        actual_set = set(verdict["actual"].split(","))
+        missing = [u for u in requested_uuids.split(",") if u and u not in actual_set]
+        print(f"[estate] ⚠ PLACEMENT MISMATCH for {inst.name}: requested GPU(s) not running the model — {' '.join(missing)}", file=sys.stderr)
+        print(f"[estate]   requested: {requested_uuids}", file=sys.stderr)
+        print(f"[estate]   actual:    {verdict['actual']}", file=sys.stderr)
+        print("[estate]   On a CDI runtime this usually means CUDA_VISIBLE_DEVICES didn't reach the container (docs/HARDWARE.md → Pinning specific GPUs).", file=sys.stderr)
+    elif verdict["placement"] == "ok":
+        print(f"[estate] ✓ placement verified for {inst.name} — model on the requested GPU(s)", file=sys.stderr)
+    return verdict
+
+
+def assert_placement_quiet(inst: "InstanceSpec", requested_uuids: str | None) -> dict:
+    """assert_placement's verdict WITHOUT the stderr prints — for the parallel
+    boot path (captured stdout) and the state report. Same {requested, actual,
+    placement} shape."""
+    verdict = {"requested": requested_uuids or "", "actual": "", "placement": "unknown"}
+    if not requested_uuids or not requested_uuids.startswith("GPU-"):
+        return verdict
+    actual = container_placement_uuids(container_name(inst.name))
+    verdict["actual"] = actual
+    if not actual:
+        return verdict
+    actual_set = set(actual.split(","))
+    missing = [u for u in requested_uuids.split(",") if u and u not in actual_set]
+    verdict["placement"] = "mismatch" if missing else "ok"
+    return verdict
+
+
 def detect_gpus_from_host() -> list[GpuInfo]:
     fake = os.environ.get("CLUB3090_FAKE_GPUS")
     if fake:
@@ -345,13 +427,19 @@ def compose_abs_path(compose_name: str) -> Path:
 def compose_env(inst: InstanceSpec) -> dict[str, str]:
     env = load_dotenv()
     joined = ",".join(str(gpu) for gpu in inst.gpu_indices)
+    # Pin CUDA_/NVIDIA_VISIBLE_DEVICES by UUID so the instance lands on the
+    # cards it claimed on BOTH runtimes (#610 Phase A) — CDI ignores the
+    # NVIDIA index form, the classic runtime renumbers it. ESTATE_GPUS stays
+    # index-based (the compose's device_ids interpolation reads the host view).
+    # Falls back to indices when UUIDs can't be resolved (pre-#610 behavior).
+    visible = resolve_gpu_uuids(inst.gpu_indices) or joined
     env.update(
         {
             "ESTATE_GPUS": joined,
             "ESTATE_PORT": str(inst.port),
             "ESTATE_CONTAINER": container_name(inst.name),
-            "CUDA_VISIBLE_DEVICES": joined,
-            "NVIDIA_VISIBLE_DEVICES": joined,
+            "CUDA_VISIBLE_DEVICES": visible,
+            "NVIDIA_VISIBLE_DEVICES": visible,
             "PORT": str(inst.port),
         }
     )
@@ -388,12 +476,16 @@ def compose_override_doc(inst: InstanceSpec) -> dict[str, Any]:
     GPUs it claimed.
     """
     joined = ",".join(str(gpu) for gpu in inst.gpu_indices)
+    # UUID-pin (#610 Phase A): CDI ignores the NVIDIA index form and the
+    # classic runtime renumbers it; UUIDs mask correctly on both. Fall back to
+    # indices when UUIDs can't be resolved.
+    visible = resolve_gpu_uuids(inst.gpu_indices) or joined
     return {
         "services": {
             service: {
                 "environment": {
-                    "CUDA_VISIBLE_DEVICES": joined,
-                    "NVIDIA_VISIBLE_DEVICES": joined,
+                    "CUDA_VISIBLE_DEVICES": visible,
+                    "NVIDIA_VISIBLE_DEVICES": visible,
                 }
             }
             for service in compose_service_names(inst.compose_name)
@@ -561,6 +653,11 @@ def boot_instance_parallel(index: int, total: int, inst: InstanceSpec, timeout: 
         run_compose(inst, "up", log_path=log_path)
         elapsed_s = wait_ready_quiet(inst, timeout)
         append_log(log_path, f"[estate] healthy after {elapsed_s}s")
+        # Placement assertion (#610 Phase A) — into the per-instance log (the
+        # parallel path has no clean stdout; the verdict lands where the boot
+        # log is). Non-fatal.
+        _pv = assert_placement_quiet(inst, resolve_gpu_uuids(inst.gpu_indices))
+        append_log(log_path, f"[estate] placement: {_pv['placement']} (requested={_pv['requested'] or '-'} actual={_pv['actual'] or '-'})")
         return BootOutcome(index=index, total=total, inst=inst, ok=True, elapsed_s=elapsed_s, log_path=log_path)
     except Exception as exc:
         elapsed_s = int(time.monotonic() - start)
@@ -628,6 +725,7 @@ def command_boot(args: argparse.Namespace) -> int:
             print(f"[estate] [{i}/{total}] booting {inst.name}: {inst.compose_name} GPUs={list(inst.gpu_indices)} port={inst.port}")
             run_compose(inst, "up")
             wait_ready(inst, args.timeout)
+            assert_placement(inst, resolve_gpu_uuids(inst.gpu_indices))
         print("[estate] all selected instances are healthy")
         return 0
     except EstateCliError as exc:

--- a/scripts/tests/test-compose-gpu-mask-passthrough.sh
+++ b/scripts/tests/test-compose-gpu-mask-passthrough.sh
@@ -20,9 +20,13 @@ while IFS= read -r f; do
   fi
 done < <(grep -rlE '^\s*- NVIDIA_VISIBLE_DEVICES=' models/*/*/compose --include='*.yml' 2>/dev/null | grep -v '/_archive/' || true)
 
-# launch.sh must still carry the UUID resolution (the other half of #610).
-grep -q 'query-gpu=uuid' scripts/launch.sh \
-  || { echo "FAIL: launch.sh lost the --gpus index→UUID resolution (#610)" >&2; fails=$((fails+1)); }
+# The UUID resolution (other half of #610) moved into the shared
+# scripts/lib/gpu-select.sh lib (Phase A); launch.sh must source + use it.
+# (test-gpu-select asserts the lib itself + bash/python resolver parity.)
+grep -q 'query-gpu=uuid' scripts/lib/gpu-select.sh \
+  || { echo "FAIL: gpu-select.sh lost the index→UUID resolution (#610)" >&2; fails=$((fails+1)); }
+grep -q 'scripts/lib/gpu-select.sh' scripts/launch.sh \
+  || { echo "FAIL: launch.sh no longer sources gpu-select.sh (#610)" >&2; fails=$((fails+1)); }
 
 if [[ $fails -gt 0 ]]; then
   echo "$fails GPU-mask passthrough check(s) failed" >&2

--- a/scripts/tests/test-gpu-select.sh
+++ b/scripts/tests/test-gpu-select.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# test-gpu-select.sh — the shared GPU-UUID resolver (#610 Phase A) has TWO
+# implementations that MUST agree: scripts/lib/gpu-select.sh (bash, for
+# launch.sh) and resolve_gpu_uuids() in estate_cli.py (python, for the estate
+# boot path). This guard asserts:
+#   1. both resolve the SAME indices to the SAME UUID csv (real nvidia-smi);
+#   2. both fall back to empty/None identically when a resolver can't run
+#      (fake-GPU test mode / no nvidia-smi);
+#   3. gpu_select_export sets both CUDA_ and NVIDIA_VISIBLE_DEVICES;
+#   4. the launcher sources the lib (no re-inlined resolver drift).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+# shellcheck source=../lib/gpu-select.sh
+source "$ROOT/scripts/lib/gpu-select.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# (4) launch.sh sources the lib rather than re-inlining the resolver.
+grep -q 'scripts/lib/gpu-select.sh' scripts/launch.sh \
+  || fail "launch.sh no longer sources gpu-select.sh (resolver drift risk)"
+grep -q 'gpu_select_export' scripts/launch.sh \
+  || fail "launch.sh no longer calls gpu_select_export"
+
+# (2) fallback parity: with no real GPUs to resolve, both yield empty/None.
+if ! command -v nvidia-smi >/dev/null 2>&1; then
+  bash_out="$(gpu_select_indices_to_uuids "0,1")"
+  [[ -z "$bash_out" ]] || fail "bash resolver should be empty without nvidia-smi (got '$bash_out')"
+fi
+# python resolver under the fake-GPU seam must return None (empty print).
+py_fake="$(CLUB3090_FAKE_GPUS='0:RTX 3090:24576:8.6' python3 - <<'PY'
+import sys
+sys.path.insert(0, ".")
+from scripts.lib.profiles.estate_cli import resolve_gpu_uuids
+v = resolve_gpu_uuids([0, 1])
+print("" if v is None else v)
+PY
+)"
+[[ -z "$py_fake" ]] || fail "python resolver should be None under CLUB3090_FAKE_GPUS (got '$py_fake')"
+
+# (3) gpu_select_export exports both masks (UUID when resolvable, else index).
+( gpu_select_export "0" "test" >/dev/null 2>&1
+  [[ -n "${CUDA_VISIBLE_DEVICES:-}" && -n "${NVIDIA_VISIBLE_DEVICES:-}" ]] \
+    || { echo "gpu_select_export did not set both masks" >&2; exit 1; }
+  [[ "${CUDA_VISIBLE_DEVICES}" == "${NVIDIA_VISIBLE_DEVICES}" ]] \
+    || { echo "masks disagree: cuda=${CUDA_VISIBLE_DEVICES} nvidia=${NVIDIA_VISIBLE_DEVICES}" >&2; exit 1; }
+) || fail "gpu_select_export contract"
+
+# (1) real-hardware parity: only when nvidia-smi is present with >=1 GPU.
+if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1; then
+  n="$(nvidia-smi -L | grep -c '^GPU ' || echo 0)"
+  if [[ "$n" -ge 1 ]]; then
+    bash_uuids="$(gpu_select_indices_to_uuids "0")"
+    py_uuids="$(python3 - <<'PY'
+import sys
+sys.path.insert(0, ".")
+from scripts.lib.profiles.estate_cli import resolve_gpu_uuids
+v = resolve_gpu_uuids([0])
+print("" if v is None else v)
+PY
+)"
+    [[ "$bash_uuids" == "$py_uuids" ]] \
+      || fail "bash/python resolver disagree for GPU 0: bash='$bash_uuids' python='$py_uuids'"
+    [[ "$bash_uuids" == GPU-* ]] \
+      || fail "resolver returned a non-UUID for GPU 0: '$bash_uuids'"
+  fi
+fi
+
+echo "PASS: gpu-select.sh + estate_cli resolver agree; launcher sources the lib; export sets both masks"


### PR DESCRIPTION
First implementation phase of the multi-cluster plan (#610). Extends the #611 GPU-UUID primitive to the estate path and adds a post-boot placement assertion — the foundation A′ (`cluster.sh`) and C (c3 cluster UX) build on.

**What lands:**
- **`scripts/lib/gpu-select.sh`** (new shared lib) — factors the #611 inline resolver out of launch.sh (`gpu_select_export`) + adds `gpu_select_assert_placement`. launch.sh sources it and asserts placement after verify-full.
- **estate_cli.py** — `resolve_gpu_uuids()` (python twin); `compose_env`/`compose_override_doc` now UUID-pin `CUDA_/NVIDIA_VISIBLE_DEVICES` (`ESTATE_GPUS` stays index-based). `assert_placement()` after each instance is ready → `{requested, actual, placement}` verdict (the shape `cluster.sh status` + the c3 badge will read).
- Placement uses **`--query-compute-apps=gpu_uuid`** (not `--query-gpu`): under CDI the container *sees* all cards but *runs* on the CUDA-masked set — compute-apps is the runtime-agnostic ground truth.
- **`test-gpu-select`** (new) — asserts the bash + python resolvers agree on real hardware.

**Live-verified** (2×3090, classic runtime): `launch.sh --gpus 1` → UUID-pinned, verify-full 8/8, `✓ placement verified`, host GPU0 = 1 MiB / GPU1 = 20.8 GB. estate `compose_env` confirmed UUID-izing. **CDI leg still awaits @mog.** 11-guard relevant sweep green.

Part of #610 (Phase A). Next: A′ `cluster.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)