### PR TITLE
feat(cluster): scripts/cluster.sh — GPU-cluster management CLI (#610 Phase A′)

### DIFF
--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -118,6 +118,19 @@ then `bash scripts/launch.sh --gpus 1,2` as normal (the composes pass `CUDA_VISI
 - The single-card GGUF composes (beellama / llama.cpp / ik-llama) select via `device_ids: ["${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}"]` interpolated on the **host** side — they honor the same launcher export on the classic runtime; on CDI, apply the device-block swap above.
 - Estate (multi-instance) GPU pinning is UUID-pinned the same way (#610 Phase A): each instance's `gpus: [..]` stays index-based in the estate file, and the boot path resolves them to UUIDs — so estates land on the cards they claimed on CDI rigs too. After boot, a **placement assertion** (`docker exec … nvidia-smi --query-compute-apps=gpu_uuid`) confirms the model actually ran on the requested GPUs and prints a loud ⚠ on mismatch — no more silent wrong-card serving.
 
+**Multiple models on one host (clusters).** `scripts/cluster.sh` manages named model-on-GPU-set instances (a "cluster" = one model pinned to a chosen GPU set + port) over the estate file — one validation path shared with hand-written estates:
+
+```bash
+bash scripts/cluster.sh create chat  --gpus 0   --slug beellama/dflash    # TP=1 on GPU 0
+bash scripts/cluster.sh create coder --gpus 1,2 --slug vllm/dual          # TP=2 on GPUs 1+2
+bash scripts/cluster.sh up chat        # boot just this cluster (UUID-pinned + placement-asserted)
+bash scripts/cluster.sh list           # clusters + free GPUs   (--json for tooling)
+bash scripts/cluster.sh status         # live serving + placement per cluster
+bash scripts/cluster.sh down chat ; bash scripts/cluster.sh rm chat
+```
+
+`create` fit-checks the slug against the **selected GPU set** (`kv-calc --card`) and hard-rejects a GPU count that doesn't match the compose's tensor-parallel size. Heterogeneous sets are estimated against the smallest card in the set.
+
 [#610]: https://github.com/noonghunna/club-3090/issues/610
 
 ## NVLink

--- a/scripts/cluster.sh
+++ b/scripts/cluster.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# cluster.sh — GPU-cluster management (#610 Phase A′).
+#
+# A "cluster" = a named model on a chosen GPU set + port (an estate instance).
+# This is the ergonomic front over the estate CLI (estate_cli.py owns the
+# schema, validate_estate, kv-calc fit, and boot/down — ONE validation path
+# shared with hand-written estate files and, later, the c3 wizard).
+#
+# Usage:
+#   bash scripts/cluster.sh create <name> --gpus 1,2 --slug vllm/dual [--port N]
+#   bash scripts/cluster.sh list [--json]
+#   bash scripts/cluster.sh status [--json]
+#   bash scripts/cluster.sh up <name>        # boot just this cluster
+#   bash scripts/cluster.sh down <name>      # stop just this cluster
+#   bash scripts/cluster.sh rm <name>        # remove from the estate file
+#
+# The artifact is the estate file (default scripts/lib/profiles/estate.yml;
+# override with --file). GPU indices stay index-based in the file and are
+# resolved to UUIDs at boot (#610 Phase A) so clusters land on the cards they
+# claimed on both container runtimes (classic nvidia + CDI/NixOS).
+set -euo pipefail
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+ESTATE_CLI="${ROOT_DIR}/scripts/lib/profiles/estate_cli.py"
+
+usage() {
+  sed -n '2,26p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+cmd="${1:-}"
+[[ -n "$cmd" ]] || { usage; exit 2; }
+shift || true
+
+case "$cmd" in
+  create|list|status|rm)
+    exec python3 "$ESTATE_CLI" "$cmd" "$@"
+    ;;
+  up)
+    name="${1:-}"; shift || true
+    [[ -n "$name" ]] || { echo "cluster.sh up <name>" >&2; exit 2; }
+    exec python3 "$ESTATE_CLI" boot --only "$name" "$@"
+    ;;
+  down)
+    name="${1:-}"; shift || true
+    [[ -n "$name" ]] || { echo "cluster.sh down <name>" >&2; exit 2; }
+    exec python3 "$ESTATE_CLI" down --only "$name" "$@"
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    echo "cluster.sh: unknown command '$cmd'" >&2
+    usage
+    exit 2
+    ;;
+esac

--- a/scripts/lib/profiles/estate_cli.py
+++ b/scripts/lib/profiles/estate_cli.py
@@ -1135,9 +1135,266 @@ def command_report_state(args: argparse.Namespace) -> int:
     return 0
 
 
+# ===========================================================================
+# Cluster verbs (#610 Phase A′) — create / list / status / rm.
+# A "cluster" is an estate instance (a named model on a GPU set + port). These
+# add the CLI surface scripts/cluster.sh (and, later, the c3 wizard/view) wrap;
+# up/down reuse `boot`/`down --only <name>`. ONE validation path: everything
+# routes through validate_estate + kv-calc, so a hand-written estate file, the
+# CLI, and the wizard pass identical gates (#610 addendum 3, D2).
+# ===========================================================================
+
+KVCALC = REPO_ROOT / "tools" / "kv-calc.py"
+
+
+def _selected_gpu_infos(indices: list[int]) -> list[GpuInfo]:
+    """Map requested host GPU indices to their detected GpuInfo, erroring on an
+    index the rig doesn't have."""
+    by_idx = {g.index: g for g in detect_gpus_from_host()}
+    out = []
+    for i in indices:
+        if i not in by_idx:
+            raise EstateCliError(f"GPU index {i} not present (detected: {sorted(by_idx)})")
+        out.append(by_idx[i])
+    return out
+
+
+def fit_slug_on_gpuset(slug: str, gpu_infos: list[GpuInfo]) -> dict:
+    """D1 (#610 addendum 3): fit-check a slug against the SELECTED GPU set.
+    kv-calc --card is single-card + registry TP, so:
+      - count != compose TP  -> HARD REJECT (raise);
+      - heterogeneous set     -> fit with the min-VRAM card (conservative floor)
+                                 + a note; true per-card het modeling is a
+                                 deferred kv-calc enhancement;
+      - homogeneous, count==TP -> the common path.
+    Returns {verdict, card, note, ...kv-calc fields}. kvcalc_key=SKIP slugs
+    (ik/llama) skip pricing with verdict 'skip'."""
+    entry = COMPOSE_REGISTRY.get(slug)
+    if not entry:
+        raise EstateCliError(f"unknown slug `{slug}`")
+    tp = int(entry.get("tp") or 1)
+    n = len(gpu_infos)
+    if n != tp:
+        raise EstateCliError(
+            f"slug `{slug}` is TP={tp} but you selected {n} GPU(s) — "
+            f"a cluster's GPU count must equal the compose's tensor-parallel size"
+        )
+    if entry.get("kvcalc_key") in (None, "SKIP"):
+        return {"verdict": "skip", "card": None, "note": "non-vLLM slug — kv-calc prices vLLM only"}
+    cards = {g.hardware_id for g in gpu_infos}
+    note = ""
+    if len(cards) == 1:
+        card = next(iter(cards))
+    else:
+        # Heterogeneous: fit against the smallest card in the set (floor).
+        floor = min(gpu_infos, key=lambda g: g.mem_mib)
+        card = floor.hardware_id
+        note = f"heterogeneous set {sorted(cards)} — estimate uses the smallest card ({card})"
+    proc = subprocess.run(
+        ["python3", str(KVCALC), "--fit", slug, "--card", card, "--json"],
+        text=True, capture_output=True, check=False, cwd=REPO_ROOT,
+    )
+    try:
+        verdict = json.loads(proc.stdout) if proc.stdout.strip() else {}
+    except json.JSONDecodeError:
+        verdict = {}
+    verdict.setdefault("verdict", "unknown")
+    verdict["card"] = card
+    verdict["note"] = note
+    return verdict
+
+
+def _cluster_free_gpus(instances: list[InstanceSpec]) -> tuple[list[int], list[int]]:
+    """(claimed, free) host GPU indices given the estate's instances."""
+    claimed = sorted({g for inst in instances for g in inst.gpu_indices})
+    try:
+        all_idx = [g.index for g in detect_gpus_from_host()]
+    except EstateCliError:
+        all_idx = claimed  # can't detect — report what we know
+    free = [i for i in all_idx if i not in claimed]
+    return claimed, free
+
+
+def command_create(args: argparse.Namespace) -> int:
+    path = estate_path(args.file)
+    try:
+        gpu_indices = [int(x) for x in str(args.gpus).split(",") if str(x).strip() != ""]
+        if not gpu_indices:
+            raise EstateCliError("--gpus must list at least one index, e.g. --gpus 1,2")
+        if COMPOSE_REGISTRY.get(args.slug) is None:
+            raise EstateCliError(f"unknown slug `{args.slug}` — see `switch.sh --list`")
+        # Existing estate (or a fresh doc).
+        if path.exists():
+            data, instances = parse_estate_yaml(path)
+        else:
+            data, instances = {"schema_version": 1, "estate": []}, []
+        if any(inst.name == args.name for inst in instances):
+            raise EstateCliError(f"cluster `{args.name}` already exists in {path}")
+        gpu_infos = _selected_gpu_infos(gpu_indices)
+        # D1 fit-vs-set (raises on count!=TP).
+        fit = fit_slug_on_gpuset(args.slug, gpu_infos)
+        if fit["verdict"] in ("wont-fit", "incompatible-hw"):
+            reason = fit.get("error") or fit["verdict"]
+            raise EstateCliError(f"slug `{args.slug}` does not fit the selected GPU(s): {reason}")
+        # Port: explicit, else the registry default nudged off collisions.
+        used_ports = {inst.port for inst in instances}
+        entry = COMPOSE_REGISTRY[args.slug]
+        port = int(args.port) if args.port else default_port(int(entry["default_port"]), len(instances), used_ports)
+        new_inst = InstanceSpec(name=args.name, compose_name=args.slug, gpu_indices=tuple(gpu_indices), port=port)
+        # ONE validation path: the whole set (GPU collision, port collision, per-instance fits).
+        candidate = instances + [new_inst]
+        profiles = load_profiles()
+        hardware, _ = hardware_for_estate(data, profiles)
+        nvlink_active, nvlink_pairs = detect_nvlink_pairs()
+        result = validate_estate(candidate, hardware, profiles, nvlink_active, nvlink_pairs)
+        if not result.valid:
+            print(f"[cluster] ✗ cannot create `{args.name}` — validation failed:", file=sys.stderr)
+            inst_res = result.per_instance.get(args.name)
+            for reason in (inst_res.reasons if inst_res else []):
+                print(f"    - {reason}", file=sys.stderr)
+            for failure in result.cross_instance_failures:
+                print(f"    - {failure}", file=sys.stderr)
+            return 1
+        # Append + persist (indices stay in the file; UUIDs resolved at boot).
+        data.setdefault("schema_version", 1)
+        data.setdefault("estate", [])
+        data["estate"].append({"name": args.name, "compose": args.slug, "gpus": gpu_indices, "port": port})
+        write_estate(path, data)
+        fit_line = fit["verdict"] + (f" (~{fit['vram_est_gb']:.1f} GiB/card)" if fit.get("vram_est_gb") else "")
+        if fit.get("note"):
+            fit_line += f" · {fit['note']}"
+        print(f"[cluster] ✓ created `{args.name}`: {args.slug} on GPU {gpu_indices} port {port} — fit {fit_line}")
+        print(f"[cluster]   boot it:  bash scripts/cluster.sh up {args.name}")
+        return 0
+    except EstateCliError as exc:
+        print(f"[cluster] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+def command_list(args: argparse.Namespace) -> int:
+    path = estate_path(args.file)
+    if not path.exists():
+        if getattr(args, "json", False):
+            print(json.dumps({"file": str(path), "clusters": [], "free_gpus": []}))
+        else:
+            print(f"[cluster] no estate file at {path} — create one with `cluster.sh create`")
+        return 0
+    try:
+        _data, instances = parse_estate_yaml(path)
+    except EstateCliError as exc:
+        print(f"[cluster] ERROR: {exc}", file=sys.stderr)
+        return 1
+    claimed, free = _cluster_free_gpus(instances)
+    clusters = [
+        {"name": i.name, "slug": i.compose_name, "gpus": list(i.gpu_indices), "port": i.port}
+        for i in instances
+    ]
+    if getattr(args, "json", False):
+        print(json.dumps({"file": str(path), "clusters": clusters, "claimed_gpus": claimed, "free_gpus": free}, indent=2))
+        return 0
+    if not clusters:
+        print(f"[cluster] no clusters defined in {path}")
+    else:
+        print(f"[cluster] {len(clusters)} cluster(s) in {path}:")
+        for c in clusters:
+            print(f"  {c['name']:20s} {c['slug']:32s} GPU {c['gpus']}  port {c['port']}")
+    print(f"[cluster] free GPU(s): {free if free else '(none)'}")
+    return 0
+
+
+def command_status(args: argparse.Namespace) -> int:
+    path = estate_path(args.file)
+    if not path.exists():
+        if getattr(args, "json", False):
+            print(json.dumps({"file": str(path), "clusters": []}))
+        else:
+            print(f"[cluster] no estate file at {path}")
+        return 0
+    try:
+        _data, instances = parse_estate_yaml(path)
+    except EstateCliError as exc:
+        print(f"[cluster] ERROR: {exc}", file=sys.stderr)
+        return 1
+    rows = []
+    for inst in instances:
+        try:
+            running = container_running(inst.name)
+        except Exception:
+            running = False
+        serving = endpoint_ready(inst.port) if running else False
+        placement = {"requested": "", "actual": "", "placement": "unknown"}
+        if running:
+            placement = assert_placement_quiet(inst, resolve_gpu_uuids(inst.gpu_indices))
+        rows.append({
+            "name": inst.name, "slug": inst.compose_name, "gpus": list(inst.gpu_indices),
+            "port": inst.port, "running": running, "serving": serving, "placement": placement,
+        })
+    if getattr(args, "json", False):
+        print(json.dumps({"file": str(path), "clusters": rows}, indent=2))
+        return 0
+    if not rows:
+        print(f"[cluster] no clusters defined in {path}")
+        return 0
+    print(f"[cluster] status ({path}):")
+    for r in rows:
+        state = "serving" if r["serving"] else ("running" if r["running"] else "down")
+        pl = r["placement"]["placement"]
+        pl_mark = {"ok": "✓", "mismatch": "⚠ MISMATCH", "unknown": ""}.get(pl, "")
+        print(f"  {r['name']:20s} {state:8s} GPU {r['gpus']}  port {r['port']}  {pl_mark}")
+    return 0
+
+
+def command_rm(args: argparse.Namespace) -> int:
+    path = estate_path(args.file)
+    try:
+        if not path.exists():
+            raise EstateCliError(f"no estate file at {path}")
+        data, instances = parse_estate_yaml(path)
+        target = next((i for i in instances if i.name == args.name), None)
+        if target is None:
+            raise EstateCliError(f"cluster `{args.name}` not found in {path}")
+        try:
+            if container_running(target.name):
+                raise EstateCliError(f"cluster `{args.name}` is running — `cluster.sh down {args.name}` first")
+        except EstateCliError:
+            raise
+        except Exception:
+            pass  # docker unavailable — allow removal from the plan
+        data["estate"] = [e for e in data.get("estate", []) if str(e.get("name")) != args.name]
+        write_estate(path, data)
+        print(f"[cluster] ✓ removed `{args.name}` from {path}")
+        return 0
+    except EstateCliError as exc:
+        print(f"[cluster] ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="club-3090 estate planner")
     sub = parser.add_subparsers(dest="command", required=True)
+
+    create = sub.add_parser("create")
+    create.add_argument("name")
+    create.add_argument("--gpus", required=True, help="comma-separated host GPU indices, e.g. 1,2")
+    create.add_argument("--slug", required=True, help="registry compose slug, e.g. vllm/dual")
+    create.add_argument("--port", type=int, default=0)
+    create.add_argument("--file", default=str(DEFAULT_ESTATE_PATH))
+    create.set_defaults(func=command_create)
+
+    clist = sub.add_parser("list")
+    clist.add_argument("--file", default=str(DEFAULT_ESTATE_PATH))
+    clist.add_argument("--json", action="store_true")
+    clist.set_defaults(func=command_list)
+
+    cstatus = sub.add_parser("status")
+    cstatus.add_argument("--file", default=str(DEFAULT_ESTATE_PATH))
+    cstatus.add_argument("--json", action="store_true")
+    cstatus.set_defaults(func=command_status)
+
+    crm = sub.add_parser("rm")
+    crm.add_argument("name")
+    crm.add_argument("--file", default=str(DEFAULT_ESTATE_PATH))
+    crm.set_defaults(func=command_rm)
 
     validate = sub.add_parser("validate")
     validate.add_argument("--file", default=str(DEFAULT_ESTATE_PATH))

--- a/scripts/tests/test-cluster-cli.sh
+++ b/scripts/tests/test-cluster-cli.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# test-cluster-cli.sh — scripts/cluster.sh + the estate_cli cluster verbs
+# (#610 Phase A′). Runs hardware-free via CLUB3090_FAKE_GPUS (kv-calc prices
+# by card NAME, no real GPU needed) so CI exercises the full lifecycle:
+#   create (with D1 fit) · count!=TP hard-reject · GPU-collision reject ·
+#   list --json · status · rm · the index-based estate file.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+# Two fake RTX 3090s so a TP=2 slug fits and a TP=1 slug leaves GPU 0 free.
+export CLUB3090_FAKE_GPUS='0:NVIDIA GeForce RTX 3090:24576:8.6,1:NVIDIA GeForce RTX 3090:24576:8.6'
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+EST="$TMP/estate.yml"
+CL=(bash scripts/cluster.sh)
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# 1. create a TP=1 cluster on GPU 1 — must fit + write the file.
+"${CL[@]}" create chat --gpus 1 --slug vllm/minimal --file "$EST" >/dev/null 2>&1 \
+  || fail "create chat (TP=1 on GPU 1) should succeed"
+[[ -f "$EST" ]] || fail "estate file not written"
+grep -q 'name: chat' "$EST" || fail "chat not in estate file"
+# Indices stay index-based in the file (UUIDs resolved at boot, #610 Phase A).
+grep -qE '^\s*-\s*1\s*$' "$EST" || fail "estate file should store index-based gpus"
+
+# 2. D1: count != compose TP -> hard reject (vllm/dual is TP=2).
+if "${CL[@]}" create bad --gpus 1 --slug vllm/dual --file "$EST" >/dev/null 2>&1; then
+  fail "create with 1 GPU for a TP=2 slug must be rejected (D1)"
+fi
+err="$("${CL[@]}" create bad --gpus 1 --slug vllm/dual --file "$EST" 2>&1 || true)"
+grep -q 'TP=2' <<<"$err" || fail "D1 rejection should name the TP mismatch (got: $err)"
+
+# 3. GPU collision -> validate_estate reject (GPU 1 already claimed by chat).
+if "${CL[@]}" create chat2 --gpus 1 --slug vllm/minimal --file "$EST" >/dev/null 2>&1; then
+  fail "second cluster on the same GPU must be rejected"
+fi
+
+# 4. list --json: one cluster, GPU 0 free.
+json="$("${CL[@]}" list --json --file "$EST" 2>/dev/null)"
+python3 - "$json" <<'PY' || exit 1
+import json, sys
+d = json.loads(sys.argv[1])
+assert len(d["clusters"]) == 1, d
+assert d["clusters"][0]["name"] == "chat", d
+assert d["free_gpus"] == [0], d
+assert d["claimed_gpus"] == [1], d
+print("  list --json ok")
+PY
+
+# 5. status (nothing running) -> down, placement unknown, valid --json shape.
+sjson="$("${CL[@]}" status --json --file "$EST" 2>/dev/null)"
+python3 - "$sjson" <<'PY' || exit 1
+import json, sys
+d = json.loads(sys.argv[1])
+c = d["clusters"][0]
+assert c["running"] is False, c
+assert c["placement"]["placement"] == "unknown", c
+assert set(c["placement"]) == {"requested", "actual", "placement"}, c
+print("  status --json ok")
+PY
+
+# 6. a second, non-colliding cluster on GPU 0 succeeds.
+"${CL[@]}" create chat0 --gpus 0 --slug vllm/minimal --file "$EST" >/dev/null 2>&1 \
+  || fail "create chat0 on the free GPU 0 should succeed"
+
+# 7. rm removes it from the plan.
+"${CL[@]}" rm chat0 --file "$EST" >/dev/null 2>&1 || fail "rm chat0 should succeed"
+grep -q 'name: chat0' "$EST" && fail "chat0 still in estate file after rm"
+
+echo "PASS: cluster.sh create/list/status/rm + D1 count!=TP + GPU-collision rejects (fake-GPU)"


### PR DESCRIPTION
The CLI seam Phase C (c3 cluster UX) consumes — and a full headless/SSH cluster capability standalone. A **cluster** = a named model on a chosen GPU set + port (an estate instance).

```bash
bash scripts/cluster.sh create coder --gpus 1,2 --slug vllm/dual   # fit-checked vs the selected set
bash scripts/cluster.sh up coder      # boot (UUID-pinned + placement-asserted, Phase A)
bash scripts/cluster.sh list --json   # clusters + free GPUs
bash scripts/cluster.sh status        # live serving + placement per cluster
bash scripts/cluster.sh down/rm coder
```

**Design (per #610 addendum 3):**
- **D2** — create/list/status/rm are NEW verbs **in estate_cli.py** (owns schema + `validate_estate` + boot/down → one validation path); up/down reuse `boot`/`down --only`; `cluster.sh` is the bash front.
- **D1 fit-vs-set** — `kv-calc --card` is single-card + registry TP, so `create` **hard-rejects count ≠ compose TP**, estimates heterogeneous sets against the **min-VRAM card**, and re-runs `validate_estate` (GPU/port collisions, per-instance fits) before append.
- **D3** — `status` carries the `{requested, actual, placement}` verdict per cluster.
- GPU indices stay **index-based** in the estate file; UUIDs resolve at boot (Phase A). No schema bump.

**Live-verified** (2×3090): create (fit-clean ~20.2 GiB) → up → `✓ placement verified` → status `serving ✓ placement=ok`, GPU0 idle / GPU1 loaded → down → rm. New `test-cluster-cli` runs the full lifecycle hardware-free.

Part of #610 (Phase A′). Next: Phase C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)