### PR TITLE
feat(c3): cluster view in the Operate pane — C1 (#610 Phase C)

### DIFF
--- a/scripts/lib/profiles/estate_cli.py
+++ b/scripts/lib/profiles/estate_cli.py
@@ -1063,6 +1063,16 @@ def report_state_payload(args: argparse.Namespace) -> tuple[dict[str, Any], int]
 
     inst_rows = []
     for inst in instances:
+        running = _probe_running(inst.name)
+        # D3 (#610 addendum 3): carry the per-instance placement verdict so the
+        # c3 cluster view (C1) reads ONE source for its health badge. Only probe
+        # a RUNNING instance (the docker-exec check is meaningless otherwise).
+        placement = {"requested": "", "actual": "", "placement": "unknown"}
+        if running is True:
+            try:
+                placement = assert_placement_quiet(inst, resolve_gpu_uuids(inst.gpu_indices))
+            except Exception:
+                pass
         inst_rows.append(
             {
                 "name": inst.name,
@@ -1070,7 +1080,8 @@ def report_state_payload(args: argparse.Namespace) -> tuple[dict[str, Any], int]
                 "gpus": list(inst.gpu_indices),
                 "port": inst.port,
                 "container": container_name(inst.name),
-                "running": _probe_running(inst.name),
+                "running": running,
+                "placement": placement,
             }
         )
     payload["active_estate"] = {

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -2308,6 +2308,10 @@ class OperateOrchPane(Container):
                 yield Label("GPU1", classes="gpu-card-title")
                 yield Static("[dim]querying nvidia-smi…[/dim]", id="gpu1-bar")
             yield Static("[dim]reading estate…[/dim]", id="serving-line")
+            # C1 (#610 Phase C): clusters (estate instances) grouped with their
+            # GPUs stacked + a placement health badge. Shown only when the
+            # estate file declares ≥1 cluster; empty otherwise.
+            yield Static("", id="cluster-view")
             yield Static("[dim]reading health.sh…[/dim]", id="doctor-line")
             yield Label("Scenes  [dim](⏎ to switch — gated)[/dim]", id="scene-heading")
             scene_table: DataTable = DataTable(
@@ -2379,6 +2383,7 @@ class OperateOrchPane(Container):
         self._populate_error(state)
         self._populate_gpus(state)
         self._populate_serving(state)
+        self._populate_clusters(state)
         self._populate_doctor(state)
         self._populate_scenes(state.scenes)
         # #11-ext — re-render the scene preview every poll (NOT only when the scene
@@ -2497,6 +2502,50 @@ class OperateOrchPane(Container):
         if not bits:
             return ""
         return "\n   " + "  ·  ".join(bits)
+
+    def _populate_clusters(self, state: EstateState) -> None:
+        """C1 (#610 Phase C): render the estate's CLUSTERS (instances) grouped —
+        each cluster header (name · slug · :port · state · placement badge) with
+        its member GPUs stacked beneath, and a trailing 'free GPUs' line. Reads
+        the `active_estate.instances` block of the report-state poll (which now
+        carries the per-instance placement verdict, D3). Hidden when the estate
+        declares no clusters — the common single-model case is unaffected."""
+        view = self.query_one("#cluster-view", Static)
+        est = (getattr(state, "estate_report", None) or {}).get("active_estate") or {}
+        instances = est.get("instances") if isinstance(est, dict) else None
+        if not instances:
+            view.update("")
+            return
+        total_gpus = len(getattr(state, "gpus", []) or [])
+        claimed = {g for inst in instances for g in (inst.get("gpus") or [])}
+        free = sorted(i for i in range(total_gpus) if i not in claimed) if total_gpus else []
+        lines: list[str] = [f"[bold]Clusters[/bold]  [dim]({len(instances)} · {len(claimed)}/{total_gpus or '?'} GPUs claimed)[/dim]"]
+        for inst in instances:
+            name = str(inst.get("name") or "?")
+            slug = str(inst.get("compose") or inst.get("slug") or "?")
+            port = inst.get("port")
+            running = inst.get("running")
+            gpus = inst.get("gpus") or []
+            placement = (inst.get("placement") or {}).get("placement", "unknown")
+            # State glyph + placement badge (the C1 health signal, fed by the
+            # Phase-A assertion via D3 — never renders requested-but-not-actual).
+            if running is True:
+                state_glyph = "[green]●[/green]"
+                badge = {
+                    "ok": "  [green]✓ placed[/green]",
+                    "mismatch": "  [red]⚠ PLACEMENT MISMATCH[/red]",
+                }.get(placement, "  [dim]placement …[/dim]")
+            elif running is False:
+                state_glyph, badge = "[dim]○[/dim]", "  [dim]down (plan)[/dim]"
+            else:
+                state_glyph, badge = "[yellow]◐[/yellow]", "  [yellow]liveness unknown[/yellow]"
+            port_s = f":{port}" if port else ""
+            lines.append(f"  {state_glyph} [bold]{name}[/bold]  [dim]{slug}{port_s}[/dim]{badge}")
+            # GPUs stacked under the cluster header.
+            gpu_s = " ".join(f"GPU{g}" for g in gpus) if gpus else "[dim](none)[/dim]"
+            lines.append(f"      [dim]└─[/dim] {gpu_s}")
+        lines.append(f"  [dim]free: {('GPU' + ' GPU'.join(map(str, free))) if free else '(none)'}[/dim]")
+        view.update("\n".join(lines))
 
     def populate_power_cap(self, st: PowerCapState) -> None:
         # #10(a): cache the active cap per GPU so the GPU cards can annotate it.

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -2286,6 +2286,41 @@ class TestBatch1OperateServingPanel:
             line = str(app.query_one("#serving-line", Static).render())
             assert "no model serving" in line.lower()
 
+    @pytest.mark.asyncio
+    async def test_cluster_view_groups_gpus_with_placement_badge(self):
+        """C1 (#610 Phase C): the cluster-view groups estate instances with
+        their GPUs stacked and a placement health badge fed by the D3 verdict —
+        ✓ placed / ⚠ MISMATCH — and lists free GPUs. Empty when no clusters."""
+        app, _, _ = make_app(target=ServingTarget())
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot)
+            orch = app.query_one("#operate-orch-pane", OperateOrchPane)
+
+            # No estate → the cluster view is empty (single-model case unaffected).
+            orch._populate_clusters(EstateState(gpus=[GpuInfo(index=0, mem_used_mib=1)]))
+            assert str(app.query_one("#cluster-view", Static).render()).strip() == ""
+
+            # Two clusters on a 3-GPU rig: one placed-ok, one placement-mismatch;
+            # GPU 2 free.
+            state = EstateState(
+                gpus=[GpuInfo(index=i, mem_used_mib=1) for i in range(3)],
+                estate_report={"active_estate": {"instances": [
+                    {"name": "chat", "compose": "vllm/minimal", "gpus": [0], "port": 8020,
+                     "running": True, "placement": {"placement": "ok"}},
+                    {"name": "coder", "compose": "vllm/dual", "gpus": [1], "port": 8010,
+                     "running": True, "placement": {"placement": "mismatch"}},
+                ]}},
+            )
+            orch._populate_clusters(state)
+            view = str(app.query_one("#cluster-view", Static).render())
+            assert "Clusters" in view
+            assert "chat" in view and "coder" in view          # both cluster headers
+            assert "vllm/minimal" in view and ":8020" in view   # slug + port
+            assert "GPU0" in view and "GPU1" in view            # GPUs stacked under clusters
+            assert "✓ placed" in view                           # ok badge (chat)
+            assert "MISMATCH" in view                           # ⚠ badge (coder)
+            assert "free: GPU2" in view                         # GPU 2 unassigned
+
 
 class TestF9SlugMasquerade:
     """F9 — a port/substring registry match is a SHAPE guess, not an identity:


### PR DESCRIPTION
The cockpit surface for multi-model clusters. The Operate/Orch pane now groups estate instances with their GPUs **stacked** and a **placement health badge** fed by the Phase-A assertion.

**Data path (single source):** the estate poll already runs `report-state --json`; D3 extended its `active_estate.instances[]` with a per-instance `placement: {requested, actual, placement}` verdict — one poll feeds both `cluster.sh status` and the cockpit badge.

**C1 render** (`_populate_clusters` → `#cluster-view`):
- one cluster header per instance: `● name · slug · :port · <badge>`;
- GPUs **stacked** beneath (`└─ GPU0 GPU1`) + a trailing free-GPU line;
- badge = the Phase-A verdict — `✓ placed` / `⚠ PLACEMENT MISMATCH` — so the view shows where clusters *actually* landed (the failure mode that opened #610);
- hidden when no clusters (single-model case unaffected).

**Live-verified** (2×3090): `cluster.sh up chat` → `report-state` carries `placement=ok` → C1 renders `✓ placed`. New headless test (grouping + GPU stacking + ✓/⚠ badges + free line); 239 fast c3 + estate guards green.

**Design:** serve-cockpit-design.md §10. **C2** (the in-TUI setup wizard) is the remaining Phase-C piece — the CLI wizard + `cluster.sh create` cover the capability today.

Part of #610 (Phase C, C1). Next: C2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)