### PR TITLE
feat(c3): Spec Dec column in Catalog (drafter) + funnel fold

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -203,6 +203,36 @@ def _kv_label(e: "CatalogEntry") -> str:
     return _KV_LABELS.get(kv, kv or "—")
 
 
+# Spec Dec column — DERIVED from the registry `drafter` id (already in-app as
+# row.drafter; emitted at registry-emit.sh, threaded in services.py) → a compact
+# method[·mechanism] token, by PATTERN on the id (zero emit/guard change; the id
+# reliably encodes the mechanism).  DFlash is ALWAYS an external drafter, so it
+# needs no suffix; the built-in-vs-external split exists only WITHIN MTP, so the
+# suffix names the actual mechanism (`gguf` external GGUF drafter · `asst`
+# external assistant draft-model) — the "drafter type matters" distinction — not
+# a vague "ext".  The bare `MTP` = built-in head (the common qwen case).  The
+# slug detail card carries the full form (n= count + source).
+def _spec_token(drafter: str) -> str:
+    """Pure ``drafter``-id → compact spec-dec label.  '' when no drafter."""
+    dr = (drafter or "").strip().lower()
+    if not dr:
+        return ""
+    if "dflash" in dr:
+        return "DFlash"
+    if "ngram" in dr:
+        return "ngram"
+    if "assistant" in dr:      # gemma *-it-assistant → spec_method mtp_assistant
+        return "MTP·asst"
+    if "mtp" in dr:            # builtin head vs external gguf drafter
+        return "MTP·gguf" if "gguf" in dr else "MTP"
+    return "spec"              # unknown non-empty drafter — safety fallback
+
+
+def _spec_label(e: "CatalogEntry") -> str:
+    """Compact spec-dec method token for the catalog Spec Dec column ('—' = none)."""
+    return _spec_token(getattr(e.row, "drafter", "")) or "—"
+
+
 def _weights_glyph(e: CatalogEntry) -> str:
     """Download-state prefix for the catalog slug cell (Download UX).  ⏳NN%
     downloading · ⬇ absent (not on disk) · ⚠ partial (interrupted/wrong).
@@ -367,12 +397,22 @@ def funnel_slug_options(
         )
         tail = f"{model}-{quant}" if quant else model
         label = f"{topo or '—'}/{eng}/{tail}"
+        # Spec-dec facet (the Catalog Spec Dec column, mirrored into the funnel —
+        # a producer picks partly by which drafter a candidate enables).  Folded
+        # into the LABEL, not just appended, so two slugs identical on
+        # topology/engine/quant but differing only by drafter (e.g. fp8-mtp vs a
+        # no-drafter fp8) get disambiguated by `· MTP` instead of falling to the
+        # serving-stem tail.  Skipped for no-drafter slugs (keeps them clean).
+        spec = _spec_token(getattr(row, "drafter", ""))
+        if spec:
+            label = f"{label}  ·  {spec}"
         status = (getattr(row, "status", "") or "").strip().lower()
         raw.append((label, stem, ProfileOption(label=label, slug=slug, topology=topo or "—", status=status)))
     # §2b dogfood r2 (maintainer): the label is topology/engine/model-quant
-    # ONLY — a serving-stem tail duplicated the path axes and read as a
-    # second slug.  The stem is appended SOLELY to disambiguate genuine
-    # collisions (two slugs sharing all three axes, e.g. fp8-mtp vs turbo).
+    # (+ the spec-dec facet above) — a serving-stem tail duplicated the path axes
+    # and read as a second slug.  The stem is appended SOLELY to disambiguate
+    # genuine collisions that survive even the spec facet (two slugs sharing all
+    # axes AND drafter, e.g. fp8-mtp vs turbo).
     counts: dict[str, int] = {}
     for label, _stem, _o in raw:
         counts[label] = counts.get(label, 0) + 1
@@ -723,6 +763,11 @@ class HelpScreen(ModalScreen):
             "  ✅ production   ❗ caveats   🧪 experimental",
             "  🐣 incubating  👀 preview   🚧 upstream-gated   🚫 deprecated",
             "",
+            "[bold]Spec Dec column[/bold] (default drafter)",
+            "",
+            "  MTP built-in head · MTP·gguf ext GGUF drafter · MTP·asst ext assistant",
+            "  DFlash ext drafter · ngram · — none",
+            "",
             "[bold]Fit glyphs (local card)[/bold]",
             "",
             "  ● fits-clean   ◐ fits-constrained   ○ won't-fit   · skip / unknown",
@@ -844,13 +889,15 @@ class CatalogPane(Container):
         # Fit is STILL computed (it feeds the pop-up + the serving-row exemption);
         # it just no longer occupies a Catalog column.
         # Column budget, left→right: identity (model · slug) → config the user
-        # picks by (weights · kv) → money (ctx · TPS · 8pk) → topology/engine
+        # picks by (weights · kv · spec) → money (ctx · TPS · 8pk) → topology/engine
         # (largely slug-redundant, fold first on a narrow terminal) → status.
+        # `spec` groups with weights/kv (the serving-config facets): which drafter
+        # (MTP / MTP·gguf / MTP·asst / DFlash / — none) the slug enables by default.
         # Status is deliberately LAST: its glyph is the one emoji-width column, so
         # putting it at the tail means nothing follows it to misalign (belt +
         # braces with the VS16-free glyphs in _STATUS_GLYPH).
         # "(rig)" keeps the our-rig provenance at 4 chars ("our rig" cost 8 more).
-        table.add_columns("model", "slug", "weights", "kv", "ctx", "TPS (rig)", "8pk (rig)", "topo", "engine", "status")
+        table.add_columns("model", "slug", "weights", "kv", "spec", "ctx", "TPS (rig)", "8pk (rig)", "topo", "engine", "status")
         # Full enriched catalog, and the current filter substring.
         self._entries: list[CatalogEntry] = []
         self._filter: str = ""
@@ -974,6 +1021,7 @@ class CatalogPane(Container):
                 slug_cell,
                 _weights_label(e),
                 _kv_label(e),
+                _spec_label(e),
                 e.ctx_label or "—",
                 tps,
                 e.measurement.quality_label,

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -941,13 +941,13 @@ class TestNavNodesExist:
             # (F6 shortened "our rig" → "rig" for column budget).
             # Serve-confirm rework: the "fit" column moved into the serve pop-up.
             # Model-filter: a "model" column leads the table (group-by-model view).
-            # Layout, left→right: identity (model · slug) → config (weights · kv)
-            # → money (ctx · TPS · 8pk) → topology/engine (slug-redundant, fold
-            # first) → status LAST (its emoji glyph is the one variable-width cell,
-            # so nothing follows it to misalign — see _STATUS_GLYPH note).
+            # Layout, left→right: identity (model · slug) → config (weights · kv
+            # · spec) → money (ctx · TPS · 8pk) → topology/engine (slug-redundant,
+            # fold first) → status LAST (its emoji glyph is the one variable-width
+            # cell, so nothing follows it to misalign — see _STATUS_GLYPH note).
             for expected in (
-                "model", "slug", "weights", "kv", "ctx", "TPS (rig)", "8pk (rig)",
-                "topo", "engine", "status",
+                "model", "slug", "weights", "kv", "spec", "ctx", "TPS (rig)",
+                "8pk (rig)", "topo", "engine", "status",
             ):
                 assert expected in col_labels, f"missing {expected!r}: {col_labels}"
             # "source" is gone.
@@ -958,9 +958,12 @@ class TestNavNodesExist:
             assert col_labels[0] == "model", col_labels
             # status is the LAST column (emoji-width slop has nothing after it).
             assert col_labels[-1] == "status", col_labels
-            # config (weights · kv) sits between the identity and the money columns.
+            # config (weights · kv · spec) sits between the identity and the money
+            # columns, in that order (the three serving-config facets grouped).
             assert col_labels.index("weights") < col_labels.index("ctx"), col_labels
             assert col_labels.index("kv") < col_labels.index("ctx"), col_labels
+            assert col_labels.index("spec") < col_labels.index("ctx"), col_labels
+            assert col_labels.index("kv") < col_labels.index("spec"), col_labels
             # every money column sits LEFT of topo/engine.
             fold = col_labels.index("topo")
             for money in ("ctx", "TPS (rig)", "8pk (rig)"):
@@ -1127,10 +1130,12 @@ class TestCatalogWired:
             pane.set_filter("")
             assert len(pane._filtered_entries()) == 2
 
-    def _label_entry(self, quant: str, weights_format: str = "", quant_label: str = ""):
+    def _label_entry(self, quant: str, weights_format: str = "", quant_label: str = "",
+                     drafter: str = ""):
         """Minimal CatalogEntry whose compose path carries the given <quant>/ dir
         (weights_variant derives from the path) + optional threaded format /
-        quant_label (the emit weights_quant_label / weights_format joins)."""
+        quant_label (the emit weights_quant_label / weights_format joins) +
+        optional drafter id (the emit drafter join → Spec Dec column)."""
         from club3090_cockpit.data import CatalogEntry as _CE
         from club3090_tui_core import VariantRow as _VR
 
@@ -1146,6 +1151,7 @@ class TestCatalogWired:
             object.__setattr__(row, "weights_format", weights_format)
         if quant_label:
             object.__setattr__(row, "weights_quant_label", quant_label)
+        object.__setattr__(row, "drafter", drafter)
         return _CE(row=row)
 
     def test_weights_label_quant_segment_beats_provider_prefix(self):
@@ -1193,6 +1199,31 @@ class TestCatalogWired:
             _weights_label(self._label_entry("mudler-apex-compact"))
             == "mudler-apex-compact"
         )
+
+    def test_spec_label_from_drafter_id(self):
+        """The Spec Dec column derives METHOD·mechanism from the registry drafter
+        id (already in-app as row.drafter).  DFlash is always external → no suffix;
+        the built-in-vs-external split lives WITHIN MTP → `gguf` / `asst` name the
+        mechanism.  None → '—'."""
+        from club3090_cockpit.app import _spec_label, _spec_token
+
+        for drafter, want in {
+            "qwen-mtp-builtin": "MTP",
+            "carnice-mtp-gguf": "MTP·gguf",
+            "unsloth-mtp-gguf": "MTP·gguf",
+            "qwopus-mtp-gguf": "MTP·gguf",
+            "gemma-it-assistant": "MTP·asst",
+            "gemma-26b-it-assistant": "MTP·asst",
+            "anbeeld-qwen-dflash": "DFlash",
+            "gemma-dflash": "DFlash",
+            "zlab-qwen-dflash": "DFlash",
+        }.items():
+            assert _spec_label(self._label_entry("fp8", drafter=drafter)) == want, drafter
+        # No drafter → the column shows an em-dash; the pure token is empty so the
+        # funnel can skip the suffix entirely.
+        assert _spec_label(self._label_entry("fp8", drafter="")) == "—"
+        assert _spec_token("") == ""
+        assert _spec_token("some-future-ngram-drafter") == "ngram"
 
     @pytest.mark.asyncio
     async def test_catalog_submission_legend_in_status_line(self):
@@ -1773,6 +1804,32 @@ class TestFunnelSlugOptionsPure:
         assert by_slug["vllm/minimal"] == "single/vllm/qwen3.6-27b-autoround-int4"
         assert by_slug["vllm/dual"] == "dual/vllm/qwen3.6-27b-autoround-int4  ·  fp8-mtp"
         assert by_slug["vllm/qwen-27b-dual-turbo"] == "dual/vllm/qwen3.6-27b-autoround-int4  ·  turbo"
+
+    def test_funnel_spec_facet_folds_into_label_and_disambiguates(self):
+        """The Spec Dec facet is mirrored into the funnel label (a producer picks
+        partly by which drafter a candidate enables).  It's FOLDED into the label
+        so two slugs identical on topology/engine/quant but differing ONLY by
+        drafter split on `· MTP` instead of falling to the serving-stem tail;
+        no-drafter slugs stay clean."""
+        from types import SimpleNamespace as NS
+
+        from club3090_cockpit.app import funnel_slug_options
+
+        rows = [
+            NS(slug="vllm/dual-mtp", engine="vllm-stable", model="qwen3.6-27b",
+               file="fp8-mtp.yml", status="production", compose_dir="",
+               drafter="qwen-mtp-builtin",
+               compose_path="models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml"),
+            NS(slug="vllm/dual-plain", engine="vllm-stable", model="qwen3.6-27b",
+               file="base.yml", status="production", compose_dir="", drafter="",
+               compose_path="models/qwen3.6-27b/vllm/compose/dual/autoround-int4/base.yml"),
+        ]
+        by_slug = {o.slug: o.label for o in funnel_slug_options(rows, "safetensors")}
+        # Same topology/engine/quant, differ only by drafter → the spec facet
+        # disambiguates; NO stem tail is appended (the spec split already made the
+        # labels distinct).  The no-drafter sibling stays bare.
+        assert by_slug["vllm/dual-mtp"] == "dual/vllm/qwen3.6-27b-autoround-int4  ·  MTP"
+        assert by_slug["vllm/dual-plain"] == "dual/vllm/qwen3.6-27b-autoround-int4"
 
     def test_size_floor_hides_too_small_topologies_only(self):
         from club3090_cockpit.app import funnel_slug_options


### PR DESCRIPTION
## What

Adds a **Spec Dec** column to the c3 Catalog (Run · Catalog) that shows which speculative-decoding drafter each slug enables *by default* — a serving-config facet alongside `weights` and `kv`.

```
model         slug              weights   kv       spec      ctx    …  status
qwen3.6-27b   vllm/dual         int4·AR   fp8/e5m2 MTP       262K      ✅
              vllm/dual-max     fp8       fp8/e4m3 MTP       262K      ✅
              beellama/dflash   q8kxl     —        DFlash    200K      ✅
              …carnice          q5km      —        MTP·gguf  262K      🧪
              …single/nvfp4     nvfp4     fp8/e4m3 MTP        98K      🧪
gemma-4-31b   …gemma-dflash     int4·AR   —        DFlash     32K      ✅
              …gemma-mtp        int4·AR   int8-PTH MTP·asst   32K      ✅
```

**Label vocabulary** (Help legend added): `MTP` built-in head · `MTP·gguf` external GGUF drafter · `MTP·asst` external assistant model · `DFlash` external drafter · `ngram` (reserved) · `—` none.

## How

Derived entirely from the registry **`drafter`** id that `registry-emit.sh` already emits and `services.py` already threads into `row.drafter` — **no emit / registry / guard changes**. `_spec_token()` pattern-maps the id to a compact `method·mechanism` token.

Design rationale: **DFlash is always an external drafter**, so the built-in-vs-external split only exists *within* MTP — the suffix therefore names the actual mechanism (`gguf` / `asst`), i.e. the "drafter type matters" distinction, rather than a vague `ext`. The bare `MTP` = built-in head (the common qwen case). Full form (`n=` count + source) stays in the slug detail card.

## Bring & Validate

The funnel mirrors the facet: the spec token is **folded into the option label** (not just appended), so two candidates identical on topology/engine/quant but differing only by drafter disambiguate on `· MTP` instead of falling to the serving-stem tail. No-drafter slugs stay bare.

## Tests

- `test_spec_label_from_drafter_id` — every real drafter id → correct `method·mechanism`; none → `—`; `ngram` future-proofed.
- `test_funnel_spec_facet_folds_into_label_and_disambiguates` — the fold + spec-based disambiguation.
- Column-set + ordering assertions updated (`weights · kv · spec` before `ctx`).
- Green: 239 (services + registry_parser) · 92 (catalog/funnel headless) · 11 (help/glyph). No `scripts/tests/*.sh` touched — in-app derive, emit contract unchanged.

Footprint: `app.py` + `test_app_headless.py` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
