### PR TITLE
Detect MTP head in BYO Route-C swap instead of blanket spec-drop

### DIFF
--- a/scripts/lib/profiles/deriver.py
+++ b/scripts/lib/profiles/deriver.py
@@ -315,6 +315,43 @@ def _siblings(api: dict) -> list[dict]:
     return out
 
 
+def _declares_mtp(config: dict) -> bool:
+    """True when config.json declares a multi-token-prediction head — Qwen3-Next
+    uses `mtp_num_hidden_layers`; other families use `num_nextn_predict_layers`.
+    Checks the top level AND a nested `text_config` (VLMs nest the LM config)."""
+    for cfg in (config or {}, (config or {}).get("text_config") or {}):
+        if not isinstance(cfg, dict):
+            continue
+        for key in ("mtp_num_hidden_layers", "num_nextn_predict_layers"):
+            v = cfg.get(key)
+            if isinstance(v, int) and v > 0:
+                return True
+    return False
+
+
+def _has_mtp_weight_file(api: dict) -> bool:
+    """True when the repo ships a dedicated MTP-head weights file — the layout
+    fine-tune re-quants use (e.g. `model_mtp_bf16.safetensors`)."""
+    for s in _siblings(api):
+        name = (s.get("rfilename") or "").lower()
+        if name.endswith(".safetensors") and ("mtp" in name or "nextn" in name):
+            return True
+    return False
+
+
+def detect_mtp_head(config: dict, api: dict) -> bool:
+    """Whether a brought checkpoint actually carries an MTP draft head, so the
+    Route-C weight-swap keeps `--speculative-config` instead of blanket-dropping
+    it. The blanket drop was a bug: fine-tunes that PRESERVE the head (e.g.
+    ThinkingCap) were served MTP-off. Signal (no extra fetch — config + siblings
+    are already in hand): config DECLARES the MTP layers AND a dedicated mtp
+    weights file is present. Ground-truth for the separate-file layout every
+    fine-tune uses. An embedded-head repo (head baked into the shards with no
+    named file) still falls back to drop — the named-file layout is the norm and
+    the alternative is reading each shard's index weight_map."""
+    return _declares_mtp(config) and _has_mtp_weight_file(api)
+
+
 def select_weight_files(
     api: dict,
 ) -> tuple[Optional[list[str]], Optional[DeriverError]]:
@@ -997,6 +1034,11 @@ def derive(
         "config_num_hidden_layers": _int(config or {}, "num_hidden_layers"),
         "config_num_attention_heads": _int(config or {}, "num_attention_heads"),
         "config_num_key_value_heads": _int(config or {}, "num_key_value_heads"),
+        # Additive: does the brought checkpoint carry an MTP draft head? The
+        # Route-C weight-swap (pull.sh _swap_path) reads this to keep vs drop
+        # --speculative-config, instead of the old blanket "fine-tune → no MTP"
+        # drop that silently served head-preserving fine-tunes MTP-off.
+        "has_mtp_head": detect_mtp_head(config or {}, api or {}),
     }
     res.diagnostics["resolution"] = "derived"
 

--- a/scripts/pull.sh
+++ b/scripts/pull.sh
@@ -197,12 +197,15 @@ def _swap_path(slug, der, eligible):
                 quant_match = meta.get("format") or first_slug
         except Exception:
             quant_match = None
+        # Keep --speculative-config IFF the brought checkpoint actually carries
+        # an MTP head (deriver.detect_mtp_head: config declares MTP layers + a
+        # dedicated mtp weights file). The old blanket drop served head-
+        # preserving fine-tunes (e.g. ThinkingCap AutoRound) MTP-off; a plain
+        # re-quant without the head still drops.
+        has_mtp = bool((der.profile or {}).get("has_mtp_head"))
         return {"route": "C", "sibling_slug": sibling,
                 "quant_match": quant_match,
-                # The curated configs use a built-in MTP head; a generic repo
-                # carries no MTP head, so drop --speculative-config unless an
-                # -MTP variant is brought (mirrors the human NOTE + docs).
-                "drop_spec_config": True}
+                "drop_spec_config": not has_mtp}
     # No curated sibling -> the self-contained GGUF fallback (route B).
     return {"route": "B", "sibling_slug": None,
             "quant_match": "gguf", "drop_spec_config": False}

--- a/scripts/tests/test-pull-swap.sh
+++ b/scripts/tests/test-pull-swap.sh
@@ -150,10 +150,26 @@ quant_match = (m.weights[first] or {}).get("format") or first
 check(isinstance(quant_match, str) and quant_match,
       f"route-C: quant_match resolved from the curated model's weights "
       f"(got {quant_match!r})")
-# drop_spec_config is True on the route-C path (generic repo carries no MTP
-# head; drop --speculative-config unless an -MTP variant is brought).
-check(True, "route-C: drop_spec_config=True (curated MTP head absent in a "
-            "generic repo) — mirrors the human NOTE + BRING_YOUR_OWN docs")
+# drop_spec_config is now DETECTED, not blanket-True: _swap_path keeps
+# --speculative-config when the brought checkpoint actually carries an MTP head
+# (deriver.detect_mtp_head: config DECLARES the MTP layers + a dedicated mtp
+# weights file). Regression guard for the bug where head-preserving fine-tunes
+# (e.g. ThinkingCap AutoRound) were silently served MTP-off.
+from scripts.lib.profiles.deriver import detect_mtp_head
+_mtp_api = {"siblings": [{"rfilename": "model-00001-of-00007.safetensors"},
+                         {"rfilename": "model_mtp_bf16.safetensors"}]}
+_plain_api = {"siblings": [{"rfilename": "model.safetensors"}]}
+check(detect_mtp_head({"mtp_num_hidden_layers": 1}, _mtp_api) is True,
+      "route-C: MTP head PRESENT (config declares + mtp weights file) -> keep "
+      "--speculative-config (drop_spec_config=False)")
+check(detect_mtp_head({"num_hidden_layers": 48}, _plain_api) is False,
+      "route-C: plain re-quant (no MTP declared, no mtp file) -> drop "
+      "--speculative-config (drop_spec_config=True)")
+check(detect_mtp_head({"text_config": {"num_nextn_predict_layers": 1}}, _mtp_api) is True,
+      "route-C: MTP declared in nested text_config (VLM) + file present -> keep")
+check(detect_mtp_head({"mtp_num_hidden_layers": 1}, _plain_api) is False,
+      "route-C: declares MTP but no dedicated mtp weights file -> drop "
+      "(embedded head not detectable without the index; conservative)")
 
 # Route B: an arch with NO curated sibling -> the self-contained GGUF
 # fallback (route B, no sibling/quant_match).


### PR DESCRIPTION
## What

The BYO fit-check's **Route-C weight-swap** (`pull.sh` `_swap_path`) hardcoded `"drop_spec_config": True` on the premise *"a generic repo carries no MTP head."* That's false for a fine-tune that **preserves** the head — so it silently served such models **MTP-off**, dropping spec-dec despite the head being present.

Surfaced live via the c3 Bring & Validate dogfood on **`josefprusa/ThinkingCap-Qwen3.6-27B-int4-AutoRound-v1`** — whose AutoRound INT4 ships the full 15-tensor BF16 MTP head (`model_mtp_bf16.safetensors`, mapped in the index). The funnel armed ② Serve with `drop --speculative-config (no MTP head in fine-tune)` — wrong.

## Fix

Detect it instead of assuming. `deriver.detect_mtp_head(config, api)` → `True` when:
1. config **declares** the MTP layers (`mtp_num_hidden_layers`, or nested `text_config.num_nextn_predict_layers`), **and**
2. a **dedicated mtp weights file** is present (`*mtp*` / `*nextn*` `.safetensors`).

Ground-truth for the separate-file layout fine-tune re-quants use, from signals the deriver **already has** (config + siblings) — **no extra fetch**. Exposed as an additive `has_mtp_head` on `der.profile`; `_swap_path` sets `drop_spec_config = not has_mtp_head`. An embedded-head repo (head in the shards, no named file) still falls back to drop — conservative, and the named-file layout is the norm.

## Validation

Real HF metadata:
- `josefprusa/ThinkingCap …AutoRound` → `has_mtp_head=True` → **keep** `--speculative-config` ✓
- `sahilchachra/ThinkingCap …AWQ` (plain re-quant, single file) → `False` → **drop** ✓

`test-pull-swap` replaces its tautology `check(True, …)` with a real `detect_mtp_head` unit test (declares+file → keep · plain → drop · nested `text_config` VLM → keep · declares-but-no-file → drop). Pull-gate suite green: `test-pull-swap` · `test-pull` · `test-pullgate-{deriver,gates,download}` · `test-pullemit-capture`.

c3 consumers (`data.py`/`app.py`) read the bool unchanged — no c3 logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
