### PR TITLE
feat(byo): apply-swap — download + serve a Route-C fine-tune

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,11 @@ models/*/vllm/patches/genesis
 # gitignored so a crash-leftover never lands in `git add -A`.
 c3-genc-*.yml
 
+# BYO Route-C apply-swap serve-locally composes (pull.sh --apply-swap): a clone
+# of the sibling compose with --model → the brought weights, written IN the
+# sibling's compose dir so its relative ../ mounts resolve. Generated artifact.
+_brought-*.yml
+
 # Python
 __pycache__/
 *.pyc

--- a/scripts/lib/profiles/pull.py
+++ b/scripts/lib/profiles/pull.py
@@ -812,8 +812,8 @@ def run_pull(
                             f" NOTE: this arch is the curated '{_slugs[0]}' "
                             f"({_row.get('family')}) — generic derive can't fit it, "
                             f"but the curated path can: clone that model's compose and "
-                            f"point --model at your weights (use a quantized + MTP "
-                            f"variant; the bf16 base won't fit and lacks the MTP head). "
+                            f"point --model at your weights (use a quantized "
+                            f"variant; the bf16 base is too large to fit). "
                             f"See docs/BRING_YOUR_OWN.md → 'Swap a curated model for a "
                             f"fine-tune / abliterated variant'."
                         )

--- a/scripts/lib/profiles/swap_apply.py
+++ b/scripts/lib/profiles/swap_apply.py
@@ -1,0 +1,227 @@
+"""BYO Route-C apply-swap: download a curated-arch fine-tune's weights and emit
+a serve-locally compose that CLONES the ``--profile-like`` sibling's real compose
+(keeping its curated chat-template / parsers / MTP wiring) with ``--model``
+re-pointed at the brought weights.
+
+This is a DISTINCT action from the locked 6-stratum pull gate (``pull.run_pull``):
+it never runs the stratum-5 eligibility hard-stop that (correctly) refuses to
+*price* an un-fittable curated-hybrid arch. The fit is inherited from the sibling
+compose, so there is nothing to price — the user's ``pull.sh --apply-swap`` (the
+c3 [D] press on a Route-C fit-check) is the explicit opt-in.
+
+Why clone the sibling's real compose and NOT ``generate_from_profile``: the
+derived-vllm template drops the curated model's chat template, reasoning/tool
+parsers, and MTP config — serving a Qwen3.6 fine-tune through it is broken. We
+read the sibling's actual compose file and surgically override only ``--model``,
+``--served-model-name``, the volume mount, and (per the brought checkpoint's MTP
+head) ``--speculative-config``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml  # available on the pull.sh path (generate_compose already parses YAML)
+
+from scripts.lib.profiles import deriver as D
+from scripts.lib.profiles import downloader as DL
+from scripts.lib.profiles.einput import EInput
+
+# The generated serve-locally compose is written ALONGSIDE the sibling compose
+# (so the sibling's relative ../ mounts — caches, chat template — resolve) and
+# gitignored via the `_brought-*.yml` pattern.
+_BROUGHT_MODEL_MOUNT = "/brought-model"
+
+
+def resolve_swap(slug: str, der: Any, root: Path) -> dict:
+    """Route-C swap resolution — mirror of pull.sh ``_swap_path``'s Route-C
+    branch: the uncurated arch maps to a curated hybrid/MoE sibling we serve.
+    Returns ``{route, sibling_slug, quant_match, has_mtp_head}``. ``route`` is
+    "C" only for a non-curated, non-generic-dense arch that resolves to a
+    curated sibling; else "B" (GGUF fallback) or None."""
+    from scripts.lib.profiles import pull as P  # _FAMILY_WEIGHT_FIELDS (RO)
+    from scripts.lib import generate_compose as gc
+
+    blank = {"route": None, "sibling_slug": None, "quant_match": None,
+             "has_mtp_head": False}
+    if der is None or getattr(der, "error", None) is not None:
+        return blank
+    if getattr(der, "tier1", None) is not None:
+        return blank
+    if bool(getattr(der, "generic_dense_eligible", False)):
+        return blank
+
+    arch = (der.profile or {}).get("arch")
+    try:
+        rt = gc._load_yaml(root, "scripts/lib/profiles/profile_runtime.yml")
+        canon, row = gc.resolve_arch_from_config(rt, gc.load_arches(root), arch)
+    except Exception:
+        canon, row = None, None
+
+    sibling, family = None, None
+    if row is not None:
+        family = row.get("family")
+        slugs = (((rt.get("arch_model_xref") or {}).get(canon) or {})
+                 .get("model_slugs") or [])
+        if slugs:
+            sibling = slugs[0]
+
+    if sibling is not None and family in P._FAMILY_WEIGHT_FIELDS:
+        quant_match = None
+        try:
+            from scripts.lib.profiles.compat import load_profiles
+            model = load_profiles().models.get(sibling)
+            if model is not None and getattr(model, "weights", None):
+                first_slug = next(iter(model.weights))
+                meta = model.weights[first_slug] or {}
+                quant_match = meta.get("format") or first_slug
+        except Exception:
+            quant_match = None
+        return {"route": "C", "sibling_slug": sibling, "quant_match": quant_match,
+                "has_mtp_head": bool((der.profile or {}).get("has_mtp_head"))}
+
+    return {"route": "B", "sibling_slug": None, "quant_match": "gguf",
+            "has_mtp_head": False}
+
+
+def _min_einput(slug: str, der: Any, hf_home: Path) -> EInput:
+    """The minimal EInput ``downloader.download_model`` reads (slug / hf_home /
+    der.profile._hf_api). Every other field is dummy — download_model never
+    touches runtime / c2a / gpu topology."""
+    return EInput(
+        slug=slug, terminal="proceed", is_override_accepted=False, der=der,
+        runtime={}, selected_files=[], hf_home=Path(hf_home), c2a=None,
+        hardware_sm=0.0, visible_gpu_count=0, per_gpu_vram_mib=[],
+        selected_gpu_indices=[], selected_gpu_vram_mib=[], topology_summary="",
+        club3090_commit="", diagnostics={},
+    )
+
+
+def apply_command_overrides(
+    cmd: list, *, model_path: str, served_name: str, drop_spec: bool,
+) -> list:
+    """Surgery on the vllm ``command`` list: re-point ``--model``, replace
+    ``--served-model-name`` value(s) with the brought name, and drop
+    ``--speculative-config`` + its value iff the brought checkpoint has no MTP
+    head. ``--quantization`` is left UNTOUCHED — the Route-C precondition is that
+    the brought weights match the sibling compose's quant."""
+    out: list = []
+    i, n = 0, len(cmd)
+    while i < n:
+        tok = cmd[i]
+        if tok == "--model":
+            out += ["--model", model_path]
+            i += 2
+            continue
+        if tok == "--served-model-name":
+            out += ["--served-model-name", served_name]
+            i += 1
+            while i < n and not str(cmd[i]).startswith("--"):
+                i += 1  # drop the sibling's served-name value(s)
+            continue
+        if tok == "--speculative-config" and drop_spec:
+            i += 2  # drop the flag AND its config value
+            continue
+        out.append(tok)
+        i += 1
+    return out
+
+
+def emit_swap_compose(
+    root: Path, profile_like: str, weights_host_dir: Path, *,
+    served_name: str, has_mtp_head: bool, brought_san: str,
+) -> Path:
+    """Clone the ``--profile-like`` sibling's compose, override --model → the
+    mounted brought weights (+ served-name / spec-config), and write it
+    ALONGSIDE the sibling compose (relative mounts resolve there). Returns the
+    written path (``_brought-<san>.yml``, gitignored)."""
+    from scripts.lib.profiles.compose_registry import COMPOSE_REGISTRY
+
+    entry = COMPOSE_REGISTRY.get(profile_like)
+    if entry is None:
+        raise ValueError(
+            f"--profile-like '{profile_like}' is not a COMPOSE_REGISTRY slug"
+        )
+    compose_rel = entry["compose_path"]
+    compose_file = root / compose_rel
+    doc = yaml.safe_load(compose_file.read_text(encoding="utf-8"))
+
+    services = (doc or {}).get("services") or {}
+    if not services:
+        raise ValueError(f"sibling compose {compose_rel} has no services")
+    svc_name, svc = next(iter(services.items()))
+
+    svc["command"] = apply_command_overrides(
+        list(svc.get("command") or []),
+        model_path=_BROUGHT_MODEL_MOUNT, served_name=served_name,
+        drop_spec=not has_mtp_head,
+    )
+    vols = list(svc.get("volumes") or [])
+    vols.append(f"{weights_host_dir}:{_BROUGHT_MODEL_MOUNT}:ro")
+    svc["volumes"] = vols
+    svc["container_name"] = f"vllm-brought-{brought_san}"
+
+    out_path = compose_file.parent / f"_brought-{brought_san}.yml"
+    header = (
+        "# GENERATED serve-locally compose (BYO Route-C apply-swap) — a clone of\n"
+        f"#   {compose_rel}\n"
+        f"# with --model re-pointed at the brought weights ({_BROUGHT_MODEL_MOUNT}).\n"
+        "# Do NOT hand-edit or commit; regenerate via: pull.sh <repo> "
+        "--profile-like <slug> --apply-swap\n"
+    )
+    out_path.write_text(
+        header + yaml.safe_dump(doc, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+    return out_path
+
+
+def apply_swap(
+    root: Path, slug: str, profile_like: str, *, hf_home: Optional[str] = None,
+    fetcher: Any = None, download_fn: Any = None, do_download: bool = True,
+) -> dict:
+    """Orchestrate: derive → resolve Route-C swap → download weights
+    (SHA-verified, via ``download_model``) → emit the sibling-clone serve
+    compose. Returns a result dict with ``ok`` + ``compose_path`` (the artifact
+    c3 serves) or ``error``.
+
+    ``do_download=False`` skips the fetch (tests / a pre-downloaded model) and
+    points the mount at the (possibly not-yet-present) pull dir."""
+    download_fn = download_fn or DL.download_model
+    der = D.derive(slug, hf_home=hf_home)
+    if der.error is not None:
+        return {"ok": False, "error": f"derive: {der.error}"}
+
+    plan = resolve_swap(slug, der, root)
+    if plan["route"] != "C":
+        return {"ok": False,
+                "error": f"not a Route-C swap (route={plan['route']}); "
+                         "--apply-swap only applies to a curated-arch fine-tune"}
+
+    hf_home_p = D.resolve_hf_home(hf_home)
+    weights_dir = DL.pull_dir(hf_home_p, slug)
+
+    if do_download:
+        ei = _min_einput(slug, der, hf_home_p)
+        try:
+            dl = download_fn(ei, fetcher=fetcher)
+        except TypeError:
+            dl = download_fn(ei)  # an injected mock may omit the fetcher kwarg
+        if not getattr(dl, "ok", False):
+            return {"ok": False,
+                    "error": f"download failed: {getattr(dl, 'failure', '?')}",
+                    "detail": getattr(dl, "detail", "")}
+        if getattr(dl, "local_dir", ""):
+            weights_dir = Path(dl.local_dir)
+
+    served = slug.rsplit("/", 1)[-1]
+    compose_path = emit_swap_compose(
+        root, profile_like, weights_dir, served_name=served,
+        has_mtp_head=plan["has_mtp_head"], brought_san=DL.sanitize_slug(slug),
+    )
+    return {
+        "ok": True, "route": "C", "sibling_slug": plan["sibling_slug"],
+        "served_model_name": served, "has_mtp_head": plan["has_mtp_head"],
+        "weights_dir": str(weights_dir), "compose_path": str(compose_path),
+    }

--- a/scripts/pull.sh
+++ b/scripts/pull.sh
@@ -71,14 +71,70 @@ ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 # byte-identical. Present -> strip it and hand the remaining argv to the
 # structured-emit helper (which forces the evaluate-only gate).
 _pull_json=0
+_pull_apply_swap=0
 _pull_args=()
 for _a in "$@"; do
     if [ "$_a" = "--json" ]; then
         _pull_json=1
+    elif [ "$_a" = "--apply-swap" ]; then
+        _pull_apply_swap=1
     else
         _pull_args+=("$_a")
     fi
 done
+
+# --apply-swap: the BYO Route-C weight-swap ACTION (strictly additive, like
+# --json). It NEVER runs the locked 6-stratum gate — a curated-arch fine-tune
+# hard-stops there at stratum-5 `no-fit-model`, which is correct (nothing to
+# price). Instead it downloads the brought weights SHA-verified and emits a
+# serve-locally compose that CLONES the --profile-like sibling with --model
+# re-pointed at those weights. The c3 [D] press on a Route-C fit-check is the
+# explicit opt-in; without --apply-swap this script's behaviour is unchanged.
+if [ "$_pull_apply_swap" -eq 1 ]; then
+    exec python3 - "${ROOT_DIR}" "${_pull_args[@]+"${_pull_args[@]}"}" <<'PY'
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+
+from scripts.lib.profiles import swap_apply as SA   # the apply-swap action
+
+ap = argparse.ArgumentParser(prog="pull.sh --apply-swap", add_help=False)
+ap.add_argument("slug")
+ap.add_argument("--profile-like", required=True, dest="profile_like")
+ap.add_argument("--hf-home", default=None)
+# tolerate (ignore) the flags a caller may carry over from the fit-check line
+for _f in ("--dry-run", "--yes", "--force-download", "--experimental-arch",
+           "--trust-remote-code", "--recommend"):
+    ap.add_argument(_f, action="store_true")
+ap.add_argument("--hardware", default=None)
+ap.add_argument("--hardware-gpus", default=None)
+ap.add_argument("--out", default=None)
+args, _unknown = ap.parse_known_args(sys.argv[2:])
+
+print(f"[apply-swap] resolving Route-C swap for {args.slug} "
+      f"(profile-like={args.profile_like})", flush=True)
+res = SA.apply_swap(root, args.slug, args.profile_like, hf_home=args.hf_home)
+if not res.get("ok"):
+    print(f"[apply-swap] ERROR: {res.get('error')}", file=sys.stderr, flush=True)
+    if res.get("detail"):
+        print(f"[apply-swap]   detail: {res['detail']}", file=sys.stderr, flush=True)
+    sys.exit(1)
+
+mtp = "MTP kept" if res.get("has_mtp_head") else "MTP dropped (no head)"
+print(f"[apply-swap] sibling={res['sibling_slug']}  served-as={res['served_model_name']}"
+      f"  ({mtp})", flush=True)
+print(f"[apply-swap] weights: {res['weights_dir']}", flush=True)
+# The final, machine-parseable line the c3 lane greps for → serve this compose.
+print(f"[apply-swap] compose: {res['compose_path']}", flush=True)
+print("[apply-swap] ok", flush=True)
+PY
+fi
 
 if [ "$_pull_json" -eq 0 ]; then
     exec python3 "${ROOT_DIR}/scripts/lib/profiles/pull.py" "$@"

--- a/scripts/tests/test-pull-swap.sh
+++ b/scripts/tests/test-pull-swap.sh
@@ -219,6 +219,87 @@ rm -f "$_sh_out" "$_sh_err" "$_py_out" "$_py_err"
 # (same discipline as test-pull.sh).
 rm -rf "$ROOT_DIR/.pull-captures"
 
+# ---------------------------------------------------------------------------
+# 4: apply-swap EMIT — swap_apply.emit_swap_compose clones the sibling's REAL
+#    compose (curated chat-template / parsers preserved) with --model re-pointed
+#    at the brought weights, keeping --speculative-config iff the checkpoint has
+#    an MTP head. No network (reads the on-disk vllm/dual compose). The download
+#    + Route-C derive is exercised live by the c3 dogfood, not here.
+# ---------------------------------------------------------------------------
+python3 - "$ROOT_DIR" <<'PY' || failures=$((failures+1))
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+sys.path.insert(0, str(root))
+
+import yaml
+from scripts.lib.profiles import swap_apply as SA
+
+ok = True
+
+
+def check(cond, msg):
+    global ok
+    print(("PASS: " if cond else "FAIL: ") + msg, file=sys.stdout if cond else sys.stderr)
+    if not cond:
+        ok = False
+
+
+def _cmd(compose_path):
+    doc = yaml.safe_load(Path(compose_path).read_text(encoding="utf-8"))
+    svc = next(iter(doc["services"].values()))
+    return svc, svc["command"], Path(compose_path).read_text(encoding="utf-8")
+
+
+def _val(cmd, flag):
+    return cmd[cmd.index(flag) + 1] if flag in cmd else None
+
+
+# pure command-list surgery (no I/O)
+_in = ["--model", "/old", "--served-model-name", "a", "b",
+       "--quantization", "auto_round", "--speculative-config", '{"method":"mtp"}']
+_keep = SA.apply_command_overrides(_in, model_path="/brought-model",
+                                   served_name="mine", drop_spec=False)
+check(_val(_keep, "--model") == "/brought-model", "override: --model repointed")
+check(_val(_keep, "--served-model-name") == "mine" and "a" not in _keep and "b" not in _keep,
+      "override: --served-model-name replaces ALL sibling served values")
+check(_val(_keep, "--quantization") == "auto_round", "override: --quantization untouched")
+check("--speculative-config" in _keep, "override: spec-config KEPT when drop_spec=False")
+_drop = SA.apply_command_overrides(_in, model_path="/b", served_name="m", drop_spec=True)
+check("--speculative-config" not in _drop, "override: spec-config + value DROPPED when drop_spec=True")
+
+# full emit against the real vllm/dual sibling compose — MTP-head present
+p_mtp = SA.emit_swap_compose(root, "vllm/dual", Path("/tmp/brought-weights"),
+                             served_name="ThinkingCap", has_mtp_head=True,
+                             brought_san="test-mtp")
+svc, cmd, txt = _cmd(p_mtp)
+check(_val(cmd, "--model") == "/brought-model", "emit(MTP): --model at the mounted brought weights")
+check("--speculative-config" in cmd, "emit(MTP): --speculative-config KEPT (head present)")
+check('"method":"mtp"' in _val(cmd, "--speculative-config"),
+      "emit(MTP): spec-config JSON survives the YAML round-trip")
+check("qwen-froggeric-chat-template" in txt, "emit(MTP): curated chat template PRESERVED")
+check(_val(cmd, "--reasoning-parser") == "qwen3" and _val(cmd, "--tool-call-parser") == "qwen3_coder",
+      "emit(MTP): curated parsers PRESERVED")
+check(any("/brought-model:ro" in str(v) for v in svc["volumes"]),
+      "emit(MTP): brought-weights volume mount added")
+check(str(svc.get("container_name", "")).startswith("vllm-brought-"),
+      "emit(MTP): container_name distinct (no collision with the sibling)")
+p_mtp.unlink()
+
+# no MTP head → spec-config dropped, curated flags still intact
+p_plain = SA.emit_swap_compose(root, "vllm/dual", Path("/tmp/brought-weights"),
+                               served_name="plain", has_mtp_head=False,
+                               brought_san="test-plain")
+_, cmd2, txt2 = _cmd(p_plain)
+check("--speculative-config" not in cmd2, "emit(no-head): --speculative-config DROPPED")
+check("--reasoning-parser" in cmd2 and "qwen-froggeric" in txt2,
+      "emit(no-head): curated flags still preserved")
+p_plain.unlink()
+
+sys.exit(0 if ok else 1)
+PY
+
 if [ "$failures" != 0 ]; then
     echo "$failures assertion group(s) failed." >&2
     exit 1

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -5054,6 +5054,32 @@ def _byo_result_text(res: ByoResult) -> str:
     producer lane's ① Bring stage)."""
     if res.error:
         return f"[red]Fit-check failed:[/red] {res.error}"
+    # Route-C swap (a curated-arch fine-tune → serve via the sibling's recipe with
+    # the brought weights): the engine verdict is "no-fit-model" because the generic
+    # fit-math can't PRICE a curated-hybrid arch — but the OUTCOME is servable. A red
+    # "not eligible / no-fit-model" headline + "② Serve armed with <sibling>" read as
+    # a self-contradicting dead-end (and named the wrong model). Reframe: green
+    # "✓ Servable", the [D] next-step names the BROUGHT model, raw verdict dimmed for
+    # debugging. Non-swap cases (eligible / Route A / B / plain no-fit) fall through.
+    if str(res.route).upper() == "C" and res.sibling_slug:
+        brought = res.repo.rsplit("/", 1)[-1]
+        mtp = ("[dim]MTP dropped — no head in this checkpoint[/dim]"
+               if res.drop_spec_config
+               else "[dim]MTP kept — head present[/dim]")
+        return "\n".join([
+            f"  [bold]{res.repo}[/bold]",
+            f"  [green]✓ Servable[/green] — a fine-tune of [green]{res.sibling_slug}[/green]",
+            f"  [bold]arch[/bold]  [cyan]{res.arch or '—'}[/cyan]",
+            "",
+            f"  [dim]How it serves:[/dim] reuses [green]{res.sibling_slug}[/green]'s proven "
+            "recipe (chat template, tools, spec-dec) with your weights.",
+            f"  {mtp}",
+            "",
+            f"  [green]→ Press[/green] [bold]\\[D][/bold] [green]to download + serve[/green] "
+            f"[bold]{brought}[/bold]",
+            f"  [dim]engine verdict: {res.fit_verdict or 'no-fit-model'} → Route-C swap "
+            "(generic fit-math can't price a curated-hybrid arch)[/dim]",
+        ])
     lines: list[str] = []
     elig = "[green]eligible[/green]" if res.eligible else "[red]not eligible[/red]"
     lines.append(f"  [bold]{res.repo}[/bold]   {elig}")

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -7560,12 +7560,38 @@ class CockpitApp(App):
                 except Exception:
                     pass
 
-        handle = await self._data.run_bring_download(repo, profile_like, on_line=_on_line)
+        # Route-C fine-tune → apply-swap: pull.sh downloads the brought weights
+        # AND emits a serve-locally clone of the sibling compose (--model at the
+        # weights). Any other route is the plain Path-B fetch.
+        apply_swap = bool(
+            self._last_byo is not None
+            and getattr(self._last_byo, "route", "") == "C"
+        )
+        self._bring_swap_compose = ""
+        handle = await self._data.run_bring_download(
+            repo, profile_like, apply_swap=apply_swap, on_line=_on_line
+        )
         try:
             await handle.done.wait()
         except Exception:
             pass
         if lane_pane is None:
+            return
+        if apply_swap:
+            # The swap compose is the servable artifact — its presence (not the
+            # HF pull-dir probe) is the success signal for a Route-C swap.
+            swap_compose = self._data.last_swap_compose()
+            if swap_compose:
+                self._bring_swap_compose = swap_compose
+                lane_pane.set_weights_line(
+                    "  [green]✓ weights + swap compose ready[/green] — "
+                    "[green]→ ② Serve[/green] [dim](serves the brought model)[/dim]"
+                )
+            else:
+                lane_pane.set_weights_line(
+                    "  [red]apply-swap did not complete[/red] — check the pull.sh "
+                    "output [dim](re-press \\[D] to retry)[/dim]"
+                )
             return
         if self._data.bring_weights_present(repo):
             lane_pane.set_weights_line(
@@ -9553,12 +9579,19 @@ class CockpitApp(App):
                 timeout=4,
             )
             return
-        # The CATALOG slug whose compose we reproduce: the Route-C sibling, else
-        # the profile-like the fit-check was run against.  We do NOT swap in the
-        # brought model's weights (no --repo on generate-compose.sh yet) and we do
-        # NOT fall back to a generic profile — if neither resolves, this route has
-        # no servable target yet (the bring-your-own weight-swap is a pending
-        # follow-up).
+        # Route-C apply-swap: if the [D] download emitted a serve-locally clone of
+        # the sibling compose (--model at the BROUGHT weights + MTP per the head),
+        # serve THAT directly — not a reproduction of the sibling's own catalog
+        # compose. This is the bring-your-own weight-swap, now wired.
+        swap_compose = getattr(self, "_bring_swap_compose", "")
+        if swap_compose and getattr(self._last_byo, "route", "") == "C":
+            self._serve_generated_compose(swap_compose)
+            return
+        # Otherwise (non-swap route, or the swap download hasn't run) the CATALOG
+        # slug whose compose we reproduce: the Route-C sibling, else the
+        # profile-like the fit-check was run against.  We do NOT fall back to a
+        # generic profile — if neither resolves, this route has no servable
+        # target yet.
         slug = (
             getattr(self._last_byo, "sibling_slug", "")
             or getattr(self._last_byo, "profile_like", "")

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -996,11 +996,18 @@ class CockpitData:
         except OSError:
             return False
 
+    def last_swap_compose(self) -> str:
+        """The serve-locally compose emitted by the most recent Route-C
+        apply-swap download ("" if none). Captured from pull.sh's
+        ``[apply-swap] compose: <path>`` line; ② Serve serves it directly."""
+        return getattr(self, "_last_swap_compose", "")
+
     async def run_bring_download(
         self,
         repo: str,
         profile_like: str,
         *,
+        apply_swap: bool = False,
         on_line: Optional[Callable[[str], None]] = None,
     ) -> Any:
         """§2b-6 — the lane's weights download: the REAL ``pull.sh`` run
@@ -1012,10 +1019,26 @@ class CockpitData:
         (conftest blocks the real spawn)."""
         env = dict(os.environ)
         env.setdefault("HF_HOME", str(self._bring_hf_home()))
-        if on_line is not None:
-            self._download_runner.set_callbacks(on_line=on_line)
+        self._last_swap_compose = ""
+
+        def _capture(line: str) -> None:
+            # Route-C apply-swap prints "[apply-swap] compose: <path>" — capture
+            # it so ② Serve can serve the emitted sibling-clone compose.
+            marker = "[apply-swap] compose:"
+            if marker in line:
+                self._last_swap_compose = line.split(marker, 1)[1].strip()
+            if on_line is not None:
+                on_line(line)
+
+        if apply_swap or on_line is not None:
+            self._download_runner.set_callbacks(on_line=_capture)
+        cmd = ["bash", "scripts/pull.sh", repo, "--profile-like", profile_like]
+        if apply_swap:
+            # The BYO weight-swap ACTION: download the brought weights AND emit a
+            # serve-locally clone of the sibling compose (--model at the weights).
+            cmd.append("--apply-swap")
         return await self._download_runner.start_raw(
-            ["bash", "scripts/pull.sh", repo, "--profile-like", profile_like],
+            cmd,
             env=env,
             run_type="download",
             parser=None,

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -1225,6 +1225,40 @@ class TestCatalogWired:
         assert _spec_token("") == ""
         assert _spec_token("some-future-ngram-drafter") == "ngram"
 
+    def test_byo_result_route_c_reframes_as_servable(self):
+        """A Route-C swap (curated-arch fine-tune) reframes the engine's
+        'no-fit-model' verdict into a positive, actionable card — regression guard
+        for the self-contradicting fit-check ('not eligible' red + '② Serve armed
+        with <sibling>' green, which named the wrong model)."""
+        from dataclasses import replace
+        from club3090_cockpit.app import _byo_result_text
+        from club3090_cockpit.data import ByoResult
+        res = ByoResult(
+            repo="josefprusa/ThinkingCap-Qwen3.6-27B-int4-AutoRound-v1",
+            profile_like="vllm/dual", arch="Qwen3_5ForConditionalGeneration",
+            eligible=False, fit_verdict="no-fit-model", note="engine jargon",
+            route="C", sibling_slug="qwen3.6-27b", quant_match="auto_round",
+            drop_spec_config=False, error=None,
+        )
+        txt = _byo_result_text(res)
+        assert "✓ Servable" in txt                       # positive headline
+        assert "not eligible" not in txt                 # no scary red for a servable swap
+        assert "\\[D]" in txt                            # explicit [D] next-step
+        # the [D] action names the BROUGHT model, not the sibling
+        action = txt.split("→ Press")[1]
+        assert "ThinkingCap-Qwen3.6-27B-int4-AutoRound-v1" in action
+        assert "qwen3.6-27b" in txt                      # sibling recipe named
+        assert "MTP kept" in txt                         # has_mtp_head True
+        # raw verdict only in the dim debug line, not as the headline
+        assert txt.index("no-fit-model") > txt.index("✓ Servable")
+        # no-head fine-tune → MTP dropped
+        assert "MTP dropped" in _byo_result_text(replace(res, drop_spec_config=True))
+        # a normal eligible model is UNCHANGED (old card: eligible + ② Serve armed)
+        plain = _byo_result_text(replace(
+            res, eligible=True, fit_verdict="fits-clean", route=None, sibling_slug=None,
+        ))
+        assert "eligible" in plain and "② Serve" in plain and "✓ Servable" not in plain
+
     @pytest.mark.asyncio
     async def test_catalog_submission_legend_in_status_line(self):
         """When any loaded row's numbers came from a community submission

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -717,6 +717,36 @@ class TestLoadCatalog:
         assert "WEIGHT_EXTRA_KEYS" not in cap2.env
 
     @pytest.mark.asyncio
+    async def test_run_bring_download_apply_swap_flag_and_capture(self):
+        """Route-C apply-swap: run_bring_download(apply_swap=True) appends
+        --apply-swap to pull.sh AND captures the emitted serve-locally compose
+        from the `[apply-swap] compose: <path>` line (② Serve serves it). With
+        apply_swap=False it does neither — the plain Path-B fetch is unchanged."""
+        import asyncio
+
+        class _SwapDL:
+            def __init__(self, emit): self.cmd = None; self._on = None; self._emit = emit
+            def set_callbacks(self, on_line=None, **kw): self._on = on_line
+            async def start_raw(self, cmd, env=None, run_type=None, parser=None):
+                self.cmd = cmd
+                if self._on and self._emit:
+                    self._on("[apply-swap] compose: /tmp/_brought-x.yml")
+                h = type("H", (), {})(); h.done = asyncio.Event(); h.done.set(); h.exit_code = 0
+                return h
+
+        dl = _SwapDL(emit=True)
+        cd = CockpitData(ROOT, runner=full_runner(), download_runner=dl)
+        await cd.run_bring_download("some/Fine-Tune", "vllm/dual", apply_swap=True)
+        assert "--apply-swap" in dl.cmd, dl.cmd
+        assert cd.last_swap_compose() == "/tmp/_brought-x.yml"
+
+        dl2 = _SwapDL(emit=False)
+        cd2 = CockpitData(ROOT, runner=full_runner(), download_runner=dl2)
+        await cd2.run_bring_download("some/Fine-Tune", "vllm/dual", apply_swap=False)
+        assert "--apply-swap" not in dl2.cmd, dl2.cmd
+        assert cd2.last_swap_compose() == ""
+
+    @pytest.mark.asyncio
     async def test_weights_state_partial_until_companion_present(self, tmp_path):
         """A slug with a companion (DFlash draft) is PARTIAL while the core is on
         disk but the companion subdir is missing, and PRESENT once both exist —


### PR DESCRIPTION
## What

Builds the BYO **Route-C apply-swap** — the "swap_path apply" the funnel task deferred. A curated-arch fine-tune (e.g. `josefprusa/ThinkingCap-Qwen3.6-27B-int4-AutoRound-v1` → `qwen3.6-27b`) hard-stops at the pull gate's stratum-5 `no-fit-model` (correct — nothing to *price*), so the c3 Bring **[D]** download failed with *"download did not complete."* Route-C was pure guidance with no code behind it. Now **[D]** downloads the weights and emits a serve-ready compose.

## How (locked gate untouched)

A **distinct action**, opted into by `pull.sh --apply-swap` (wrapper-intercepted, strictly additive like `--json`) — it never runs `run_pull`'s eligibility gate:

1. **Resolve** the Route-C swap (arch → curated sibling via `arch_model_xref`, `has_mtp_head` from `deriver.detect_mtp_head` — the #627 signal).
2. **Download** the brought weights SHA-verified via `downloader.download_model` (a minimal `EInput`).
3. **Emit** a serve-locally compose that **clones the `--profile-like` sibling's *real* compose** — keeping its curated **chat template / reasoning+tool parsers / MTP wiring** (the derived-vllm template drops all that → a broken Qwen3.6 serve) — with `--model` → a `<weights>:/brought-model:ro` mount, `--served-model-name` → the brought basename, and `--speculative-config` **kept iff the checkpoint has an MTP head** (else dropped). Written alongside the sibling as `_brought-<san>.yml` (gitignored) so relative `../` mounts resolve.

**c3:** `run_bring_download(apply_swap=)` appends `--apply-swap` + captures the emitted compose (`last_swap_compose()`); the [D] worker passes it on `route == "C"` and stashes it; **② Serve serves the swap compose directly** — not a reproduction of the sibling's own weights.

Also fixes the stale `pull.py` NOTE (*"the bf16 base … lacks the MTP head"* — the base has it → now just the size reason).

## Design decisions / edge cases

- **`--quantization` left untouched** — the Route-C precondition is that the brought weights match the sibling compose's quant (`auto_round`); overriding with the weights-*format* slug would mismatch vLLM's quant name.
- **Embedded-head repos** (MTP baked into shards, no named `*mtp*.safetensors`) conservatively fall back to drop — the named-file layout is what fine-tunes use; ThinkingCap has it.
- **`--served-model-name`** becomes the brought basename → verify/bench need `MODEL=<basename>`.
- **Port** left at the sibling's default (collides only if the sibling is running; a serve-locally eval doesn't).

## Validation

- `test-pull-swap.sh` **section 4** (19 assertions): emit repoints `--model`, keeps/drops `--speculative-config` by head presence, preserves the curated chat-template + parsers, JSON args survive the YAML round-trip, distinct `container_name`; plus the pure `apply_command_overrides` surgery.
- `test_services` apply_swap flag + compose-capture wiring (**224 c3 tests pass**).
- **Locked-gate hard-stop tests stay green**; `pull.sh --json` fit-check byte-identical (still `no-fit-model` + route-C).
- **Live e2e**: `apply_swap` on real ThinkingCap metadata emits a correct swap compose (MTP kept, curated flags preserved). Guards green: `test-pull` · `test-pullgate-{download,gates}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
