### PR TITLE
fix(c3): hide [D] when brought weights on disk; ② Serve emits swap

### DIFF
--- a/scripts/pull.sh
+++ b/scripts/pull.sh
@@ -72,12 +72,15 @@ ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 # structured-emit helper (which forces the evaluate-only gate).
 _pull_json=0
 _pull_apply_swap=0
+_pull_emit_only=0
 _pull_args=()
 for _a in "$@"; do
     if [ "$_a" = "--json" ]; then
         _pull_json=1
     elif [ "$_a" = "--apply-swap" ]; then
         _pull_apply_swap=1
+    elif [ "$_a" = "--emit-only" ]; then
+        _pull_emit_only=1
     else
         _pull_args+=("$_a")
     fi
@@ -90,11 +93,18 @@ done
 # serve-locally compose that CLONES the --profile-like sibling with --model
 # re-pointed at those weights. The c3 [D] press on a Route-C fit-check is the
 # explicit opt-in; without --apply-swap this script's behaviour is unchanged.
+#
+# --emit-only (with --apply-swap): skip the SHA-verified download and JUST emit
+# the serve-locally compose (do_download=False). For when the weights are
+# already on disk — c3's ② Serve uses this so a present-weights serve needs no
+# [D] download step (the mount points at the existing pull dir).
 if [ "$_pull_apply_swap" -eq 1 ]; then
+    export _PULL_EMIT_ONLY="$_pull_emit_only"
     exec python3 - "${ROOT_DIR}" "${_pull_args[@]+"${_pull_args[@]}"}" <<'PY'
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -117,9 +127,13 @@ ap.add_argument("--hardware-gpus", default=None)
 ap.add_argument("--out", default=None)
 args, _unknown = ap.parse_known_args(sys.argv[2:])
 
+_emit_only = os.environ.get("_PULL_EMIT_ONLY") == "1"
 print(f"[apply-swap] resolving Route-C swap for {args.slug} "
-      f"(profile-like={args.profile_like})", flush=True)
-res = SA.apply_swap(root, args.slug, args.profile_like, hf_home=args.hf_home)
+      f"(profile-like={args.profile_like})"
+      + (" [emit-only — weights on disk, no download]" if _emit_only else ""),
+      flush=True)
+res = SA.apply_swap(root, args.slug, args.profile_like, hf_home=args.hf_home,
+                    do_download=not _emit_only)
 if not res.get("ok"):
     print(f"[apply-swap] ERROR: {res.get('error')}", file=sys.stderr, flush=True)
     if res.get("detail"):

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -5044,14 +5044,18 @@ class LaneBringPane(Container):
             line.update("")
             line.add_class("funnel-hidden")
 
-    def populate(self, res: ByoResult) -> None:
+    def populate(self, res: ByoResult, weights_present: Optional[bool] = None) -> None:
         card = self.query_one("#lane-bring-result-card", Static)
-        card.update(_byo_result_text(res))
+        card.update(_byo_result_text(res, weights_present))
 
 
-def _byo_result_text(res: ByoResult) -> str:
+def _byo_result_text(res: ByoResult, weights_present: Optional[bool] = None) -> str:
     """Render a ByoResult into the verdict card text (shared by Run · BYO + the
-    producer lane's ① Bring stage)."""
+    producer lane's ① Bring stage).
+
+    ``weights_present`` (probed once by the caller) makes the Route-C next-step
+    honest: on disk → point at ② Serve (no download); absent → the [D] download
+    affordance.  ``None`` = unknown → keep the download prompt (safe default)."""
     if res.error:
         return f"[red]Fit-check failed:[/red] {res.error}"
     # Route-C swap (a curated-arch fine-tune → serve via the sibling's recipe with
@@ -5066,6 +5070,20 @@ def _byo_result_text(res: ByoResult) -> str:
         mtp = ("[dim]MTP dropped — no head in this checkpoint[/dim]"
                if res.drop_spec_config
                else "[dim]MTP kept — head present[/dim]")
+        # Presence-aware next-step: [D] emits the serve compose, so when the
+        # weights are already on disk it must NOT read as "download" — point
+        # straight at ② Serve (which emits the compose itself, no download).
+        if weights_present:
+            next_step = (
+                f"  [green]✓ weights on disk[/green] — [green]→ press[/green] "
+                f"[bold]\\[⏎][/bold] [green]② Serve to serve[/green] "
+                f"[bold]{brought}[/bold] [dim](no download needed)[/dim]"
+            )
+        else:
+            next_step = (
+                f"  [green]→ Press[/green] [bold]\\[D][/bold] "
+                f"[green]to download + serve[/green] [bold]{brought}[/bold]"
+            )
         return "\n".join([
             f"  [bold]{res.repo}[/bold]",
             f"  [green]✓ Servable[/green] — a fine-tune of [green]{res.sibling_slug}[/green]",
@@ -5075,8 +5093,7 @@ def _byo_result_text(res: ByoResult) -> str:
             "recipe (chat template, tools, spec-dec) with your weights.",
             f"  {mtp}",
             "",
-            f"  [green]→ Press[/green] [bold]\\[D][/bold] [green]to download + serve[/green] "
-            f"[bold]{brought}[/bold]",
+            next_step,
             f"  [dim]engine verdict: {res.fit_verdict or 'no-fit-model'} → Route-C swap "
             "(generic fit-math can't price a curated-hybrid arch)[/dim]",
         ])
@@ -7517,8 +7534,15 @@ class CockpitApp(App):
         res = await self._data.byo_check(repo, profile_like)
         # Cache the arch facts for the lane ② Serve + the Promote scaffold (Phase 5).
         self._last_byo = res
+        # Probe on-disk ONCE (skip on a fit-check error) — feeds BOTH the verdict
+        # card's presence-aware next-step and the weights-line below, so they can't
+        # disagree (the [D]-when-already-present contradiction).
+        weights_present = bool(
+            not getattr(res, "error", "")
+            and self._data.bring_weights_present(repo)
+        )
         if lane_pane is not None:
-            lane_pane.populate(res)
+            lane_pane.populate(res, weights_present)
         # N9 — carry the fit-check result forward: pre-arm ② Serve with the
         # resolved target so the producer pipeline flows ① → ② without re-entry.
         try:
@@ -7532,7 +7556,7 @@ class CockpitApp(App):
         if lane_pane is not None:
             if getattr(res, "error", ""):
                 lane_pane.set_weights_line("")
-            elif self._data.bring_weights_present(repo):
+            elif weights_present:
                 lane_pane.set_weights_line(
                     "  [green]✓ weights on disk[/green] — "
                     "[green]→ ② Serve[/green] [dim](\\[2/]] next stage)[/dim]"
@@ -9613,6 +9637,21 @@ class CockpitApp(App):
         if swap_compose and getattr(self._last_byo, "route", "") == "C":
             self._serve_generated_compose(swap_compose)
             return
+        # Route-C with the weights ALREADY on disk but no swap compose emitted yet
+        # (the user went straight to ② Serve because [D] was hidden — weights
+        # present): emit the serve-locally clone NOW with do_download=False (no
+        # download), then serve it.  This is the present-weights path that needs no
+        # [D] step — the "② Serve owns the compose emission" half of the UX fix.
+        if (
+            getattr(self._last_byo, "route", "") == "C"
+            and getattr(self._last_byo, "sibling_slug", "")
+            and self._data.bring_weights_present(getattr(self._last_byo, "repo", ""))
+        ):
+            self.run_bring_emit_and_serve(
+                getattr(self._last_byo, "repo", ""),
+                getattr(self._last_byo, "profile_like", ""),
+            )
+            return
         # Otherwise (non-swap route, or the swap download hasn't run) the CATALOG
         # slug whose compose we reproduce: the Route-C sibling, else the
         # profile-like the fit-check was run against.  We do NOT fall back to a
@@ -9633,6 +9672,49 @@ class CockpitApp(App):
             )
             return
         self.generate_and_preview_compose(slug)
+
+    @work(exclusive=True, group="bring-emit-serve")
+    async def run_bring_emit_and_serve(self, repo: str, profile_like: str) -> None:
+        """② Serve for a Route-C brought model whose weights are ALREADY on disk:
+        emit the serve-locally swap compose WITHOUT downloading (pull.sh
+        --apply-swap --emit-only), then hand it to the reconcile-gated serve.
+        This is the present-weights path — no [D] download step needed."""
+        lane_pane = None
+        try:
+            lane_pane = self.query_one("#lane-serve-pane", LaneServePane)
+            lane_pane.set_status(
+                "[dim]Emitting serve compose[/dim] "
+                "[dim](apply-swap --emit-only — weights on disk, no download)…[/dim]"
+            )
+        except Exception:
+            pass
+        from rich.markup import escape
+
+        def _on_line(line: str) -> None:
+            if lane_pane is not None:
+                try:
+                    lane_pane.set_status(f"[dim]{escape(line.strip()[-100:])}[/dim]")
+                except Exception:
+                    pass
+
+        self._bring_swap_compose = ""
+        handle = await self._data.run_bring_download(
+            repo, profile_like, apply_swap=True, emit_only=True, on_line=_on_line
+        )
+        try:
+            await handle.done.wait()
+        except Exception:
+            pass
+        swap_compose = self._data.last_swap_compose()
+        if not swap_compose:
+            self.notify(
+                "② Serve: apply-swap --emit-only produced no compose — see the log. "
+                "You can still press [D] to download + emit.",
+                title="② Serve", severity="warning", timeout=6,
+            )
+            return
+        self._bring_swap_compose = swap_compose
+        self._serve_generated_compose(swap_compose)
 
     @work(exclusive=True, group="generate-compose")
     async def generate_and_preview_compose(self, slug: str) -> None:

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -1008,6 +1008,7 @@ class CockpitData:
         profile_like: str,
         *,
         apply_swap: bool = False,
+        emit_only: bool = False,
         on_line: Optional[Callable[[str], None]] = None,
     ) -> Any:
         """§2b-6 — the lane's weights download: the REAL ``pull.sh`` run
@@ -1037,6 +1038,11 @@ class CockpitData:
             # The BYO weight-swap ACTION: download the brought weights AND emit a
             # serve-locally clone of the sibling compose (--model at the weights).
             cmd.append("--apply-swap")
+        if emit_only:
+            # Weights already on disk — skip the download, JUST emit the serve
+            # compose (do_download=False).  ② Serve uses this so a present-weights
+            # serve needs no [D] step.  Only meaningful alongside --apply-swap.
+            cmd.append("--emit-only")
         return await self._download_runner.start_raw(
             cmd,
             env=env,

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -10329,7 +10329,11 @@ class TestProducerLaneHandoff:
             assert "unsloth/Qwen3-27B-abliterated" in body   # the brought repo
 
     @pytest.mark.asyncio
-    async def test_bring_result_points_forward_to_serve(self):
+    async def test_bring_result_points_forward_to_serve(self, monkeypatch, tmp_path):
+        # Route-C fit-check, weights ABSENT → the card's next-step points at the
+        # [D] download (which emits the serve compose + serves).  The presence-
+        # aware card MUST show the download prompt here, not the ② Serve pointer.
+        monkeypatch.setenv("HF_HOME", str(tmp_path))
         app, _, _ = make_app(surface="producer")
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.press("2")
@@ -10339,7 +10343,30 @@ class TestProducerLaneHandoff:
             card = str(app.query_one("#lane-bring-pane", LaneBringPane).query_one(
                 "#lane-bring-result-card", Static
             ).render())
-            assert "→ ② Serve" in card
+            assert "[D]" in card and "download" in card
+            assert "vllm/dual" in card
+
+    @pytest.mark.asyncio
+    async def test_bring_result_present_points_to_serve(self, monkeypatch, tmp_path):
+        # Route-C fit-check, weights already ON DISK → the card drops the [D]
+        # download prompt and points straight at ② Serve (no download needed).
+        # This is the [D]-when-already-present contradiction fix.
+        monkeypatch.setenv("HF_HOME", str(tmp_path))
+        app, _, _ = make_app(surface="producer")
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.press("2")
+            await _settle(pilot)
+            # land the brought weights at the pull dir the presence probe reads
+            d = app._data.bring_pull_dir("unsloth/Qwen3-27B-abliterated")
+            d.mkdir(parents=True)
+            (d / "model.safetensors").write_bytes(b"x")
+            app.run_byo_check("unsloth/Qwen3-27B-abliterated", "vllm/dual")
+            await _settle(pilot)
+            card = str(app.query_one("#lane-bring-pane", LaneBringPane).query_one(
+                "#lane-bring-result-card", Static
+            ).render())
+            assert "② Serve" in card and "no download" in card
+            assert "[D]" not in card               # the download prompt is gone
             assert "vllm/dual" in card
 
     @pytest.mark.asyncio

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -740,11 +740,23 @@ class TestLoadCatalog:
         assert "--apply-swap" in dl.cmd, dl.cmd
         assert cd.last_swap_compose() == "/tmp/_brought-x.yml"
 
+        assert "--emit-only" not in dl.cmd, dl.cmd    # default: full download
+
         dl2 = _SwapDL(emit=False)
         cd2 = CockpitData(ROOT, runner=full_runner(), download_runner=dl2)
         await cd2.run_bring_download("some/Fine-Tune", "vllm/dual", apply_swap=False)
         assert "--apply-swap" not in dl2.cmd, dl2.cmd
         assert cd2.last_swap_compose() == ""
+
+        # emit_only=True (present weights) → --apply-swap AND --emit-only, so
+        # pull.sh emits the serve compose WITHOUT downloading (② Serve's no-[D] path)
+        dl3 = _SwapDL(emit=True)
+        cd3 = CockpitData(ROOT, runner=full_runner(), download_runner=dl3)
+        await cd3.run_bring_download(
+            "some/Fine-Tune", "vllm/dual", apply_swap=True, emit_only=True
+        )
+        assert "--apply-swap" in dl3.cmd and "--emit-only" in dl3.cmd, dl3.cmd
+        assert cd3.last_swap_compose() == "/tmp/_brought-x.yml"
 
     @pytest.mark.asyncio
     async def test_weights_state_partial_until_companion_present(self, tmp_path):


### PR DESCRIPTION
## Problem (found in live BYO-funnel dogfood)

A Route-C fit-check whose weights were **already on disk** rendered a self-contradiction in ① Bring:

- the verdict card hardcoded **"→ Press [D] to download + serve"**, while
- the weights-line right below it correctly said **"✓ weights on disk → ② Serve"**.

So the user was told to download something already present. The obvious "just hide [D]" is wrong, though: for a Route-C brought model **[D] isn't only download** — `run_bring_download(apply_swap=True)` emits the serve-locally swap compose (`_bring_swap_compose`) that ② Serve then serves (`app.py` `action_serve_untested`). Hide [D] naively and there's nothing to serve.

## Fix — presence-aware, "② Serve owns the emission"

| State | Card next-step | ② Serve |
|---|---|---|
| weights **absent** | → Press **[D]** to download + serve | serves the compose [D] emitted |
| weights **on disk** | ✓ weights on disk → press **[⏎] ② Serve** *(no download needed)* | emits the swap compose itself (`--emit-only`, no download) then serves |

- **`_byo_result_text(res, weights_present)`** — presence probed **once** in the fit-check handler and fed to BOTH the card and the weights-line, so they can never disagree again.
- **`pull.sh --emit-only`** (with `--apply-swap`) → passes `do_download=False` so `apply_swap` emits the serve compose **without** downloading.
- **`action_serve_untested`** — Route-C + weights present + no compose yet → `run_bring_emit_and_serve` emits via `pull.sh --apply-swap --emit-only`, then serves. A present-weights brought model now serves straight from ② Serve with no [D] step.

## Tests

- **Fixed** `test_bring_result_points_forward_to_serve` — it was **red since #628** (asserted "→ ② Serve" on an absent-weights card that, post-#628, honestly shows the [D] prompt). Now checks the absent → [D] behavior.
- **Added** `test_bring_result_present_points_to_serve` — present → ② Serve pointer, `[D]` gone.
- **Extended** the `run_bring_download` test for `--emit-only`.
- 139 touched-surface tests pass; `pull.sh --emit-only` validated end-to-end against ThinkingCap (weights present → emits compose, zero download).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
