### PR TITLE
fix(c3): ⏎ on ① Bring advances to ② Serve when weights present

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -5075,9 +5075,9 @@ def _byo_result_text(res: ByoResult, weights_present: Optional[bool] = None) -> 
         # straight at ② Serve (which emits the compose itself, no download).
         if weights_present:
             next_step = (
-                f"  [green]✓ weights on disk[/green] — [green]→ press[/green] "
-                f"[bold]\\[⏎][/bold] [green]② Serve to serve[/green] "
-                f"[bold]{brought}[/bold] [dim](no download needed)[/dim]"
+                f"  [green]✓ weights on disk[/green] — [green]press[/green] "
+                f"[bold]\\[⏎][/bold] [green]to continue to ② Serve[/green] "
+                f"[dim](serves {brought} — no download)[/dim]"
             )
         else:
             next_step = (
@@ -7559,7 +7559,7 @@ class CockpitApp(App):
             elif weights_present:
                 lane_pane.set_weights_line(
                     "  [green]✓ weights on disk[/green] — "
-                    "[green]→ ② Serve[/green] [dim](\\[2/]] next stage)[/dim]"
+                    "[green]→ ② Serve[/green] [dim](press \\[⏎] to continue)[/dim]"
                 )
             else:
                 lane_pane.set_weights_line(
@@ -7646,7 +7646,7 @@ class CockpitApp(App):
         if self._data.bring_weights_present(repo):
             lane_pane.set_weights_line(
                 "  [green]✓ weights downloaded[/green] — "
-                "[green]→ ② Serve[/green] [dim](\\[2/]] next stage)[/dim]"
+                "[green]→ ② Serve[/green] [dim](press \\[⏎] to continue)[/dim]"
             )
         else:
             lane_pane.set_weights_line(
@@ -8653,7 +8653,7 @@ class CockpitApp(App):
           primary action.)"""
         tab = self._active_validate_tab()
         if tab == "tab-bring":
-            self._trigger_lane_bring()
+            self._bring_primary()
         elif tab == "tab-serve":
             self.action_serve_untested()
         elif tab == "tab-run":
@@ -8662,6 +8662,40 @@ class CockpitApp(App):
             self._open_evidence_report()
         elif tab == "tab-promote":
             self.action_promote_catalog()
+
+    def _bring_primary(self) -> None:
+        """⏎ on ① Bring — DWIM:
+          - a fresh/changed target (or no cached result) → run the fit-check;
+          - an ALREADY fit-checked, servable target whose weights are ON DISK →
+            ADVANCE to the pre-armed ② Serve (the card's "press [⏎] ② Serve").
+            Re-running the fit-check on ⏎ was the reported confusion; the [Fit]
+            button still forces a re-check.
+        Weights ABSENT stays on fit-check — the card there points at [D]
+        (download is the real next step), not ② Serve."""
+        byo = self._last_byo
+        try:
+            cur_repo = self.query_one("#lane-bring-url-input", Input).value.strip()
+        except Exception:
+            cur_repo = ""
+        servable = bool(
+            byo is not None
+            and not getattr(byo, "error", "")
+            and (getattr(byo, "sibling_slug", "") or getattr(byo, "profile_like", ""))
+            and cur_repo == getattr(byo, "repo", "")
+        )
+        if servable and self._data.bring_weights_present(getattr(byo, "repo", "")):
+            self._advance_to_serve()
+        else:
+            self._trigger_lane_bring()
+
+    def _advance_to_serve(self) -> None:
+        """Advance the Bring & Validate lane from ① Bring to the pre-armed
+        ② Serve stage (⏎'s "proceed" after a successful fit-check).  ② Serve was
+        armed by the fit-check's set_armed, so ⏎ there serves straightaway."""
+        try:
+            self.query_one("#validate-tabs", TabbedContent).active = "tab-serve"
+        except Exception:
+            pass
 
     def _run_validation_selected(self) -> None:
         """Stage the selected Run step as a confirm-gated validation launch."""

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -10370,6 +10370,43 @@ class TestProducerLaneHandoff:
             assert "vllm/dual" in card
 
     @pytest.mark.asyncio
+    async def test_bring_enter_advances_to_serve_when_present(self, monkeypatch, tmp_path):
+        # After a servable fit-check with weights ON DISK, ⏎ on ① Bring ADVANCES
+        # to the pre-armed ② Serve — not re-run the fit-check (the reported bug).
+        monkeypatch.setenv("HF_HOME", str(tmp_path))
+        app, _, _ = make_app(surface="producer")
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.press("2")
+            await _settle(pilot)
+            d = app._data.bring_pull_dir("unsloth/Qwen3-27B-abliterated")
+            d.mkdir(parents=True)
+            (d / "model.safetensors").write_bytes(b"x")
+            app.query_one("#lane-bring-url-input", Input).value = "unsloth/Qwen3-27B-abliterated"
+            app.run_byo_check("unsloth/Qwen3-27B-abliterated", "vllm/dual")
+            await _settle(pilot)
+            app.query_one("#validate-tabs", TabbedContent).active = "tab-bring"
+            app._validate_primary()                              # ⏎ on ① Bring
+            await _settle(pilot)
+            assert app.query_one("#validate-tabs", TabbedContent).active == "tab-serve"
+
+    @pytest.mark.asyncio
+    async def test_bring_enter_refits_when_weights_absent(self, monkeypatch, tmp_path):
+        # weights ABSENT → ⏎ stays on ① Bring (re-fit); the card there points at
+        # [D] (download is the real next step), so ⏎ must NOT skip to ② Serve.
+        monkeypatch.setenv("HF_HOME", str(tmp_path))
+        app, _, _ = make_app(surface="producer")
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.press("2")
+            await _settle(pilot)
+            app.query_one("#lane-bring-url-input", Input).value = "unsloth/Qwen3-27B-abliterated"
+            app.run_byo_check("unsloth/Qwen3-27B-abliterated", "vllm/dual")
+            await _settle(pilot)
+            app.query_one("#validate-tabs", TabbedContent).active = "tab-bring"
+            app._validate_primary()
+            await _settle(pilot)
+            assert app.query_one("#validate-tabs", TabbedContent).active == "tab-bring"
+
+    @pytest.mark.asyncio
     async def test_serve_tab_rearms_from_cached_byo(self):
         app, _, _ = make_app(surface="producer")
         async with app.run_test(size=(120, 40)) as pilot:


### PR DESCRIPTION
## Problem (live dogfood, follow-on to #630)

After #630 the ① Bring card correctly says **"press [⏎] ② Serve"** when the brought weights are on disk — but pressing ⏎ on the ① Bring tab **re-ran the fit-check** instead of proceeding. `_validate_primary` routed ⏎ on `tab-bring` → `_trigger_lane_bring()` (fit-check); ② Serve is a *separate* tab, so the card's instruction was unreachable by ⏎.

## Fix

`⏎` on ① Bring is now **DWIM** (`_bring_primary`):

| State | ⏎ does |
|---|---|
| already fit-checked, **servable**, weights **on disk**, repo input unchanged | **advance to the pre-armed ② Serve tab** (⏎ there serves via #630's emit-and-serve) |
| fresh / changed target, or weights **absent** | run the fit-check (unchanged); absent stays here because the card points at **[D]** — download is the real next step |

The `[Fit]` button still forces a re-check. Also fixed the stale `"([2/]] next stage)"` weights-line hint → `"(press [⏎] to continue)"`, and the present-card next-step wording.

## Tests

- `test_bring_enter_advances_to_serve_when_present` — present → active tab flips to `tab-serve`.
- `test_bring_enter_refits_when_weights_absent` — absent → stays on `tab-bring`.
- 156 touched-surface tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
