### PR TITLE
fix(c3): ② Serve honest for Route-C + [s] advance key

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -5076,7 +5076,7 @@ def _byo_result_text(res: ByoResult, weights_present: Optional[bool] = None) -> 
         if weights_present:
             next_step = (
                 f"  [green]✓ weights on disk[/green] — [green]press[/green] "
-                f"[bold]\\[⏎][/bold] [green]to continue to ② Serve[/green] "
+                f"[bold]\\[s][/bold] [green]to continue to ② Serve[/green] "
                 f"[dim](serves {brought} — no download)[/dim]"
             )
         else:
@@ -5216,28 +5216,49 @@ class LaneServePane(Container):
                 "untested).[/dim]"
             )
             return
-        slug = (
-            getattr(byo, "sibling_slug", "")
-            or getattr(byo, "profile_like", "")
-        )
+        route = str(getattr(byo, "route", "") or "").upper()
+        sibling = getattr(byo, "sibling_slug", "")
         repo = getattr(byo, "repo", "") or "—"
-        lines = [
-            "[green]● armed from ① Bring[/green] — ⏎ serves the resolved catalog compose (untested):",
-            "",
-            f"  [bold]brought[/bold]   [cyan]{repo}[/cyan]",
-        ]
-        if slug:
-            lines.append(f"  [bold]serves[/bold]    [green]{slug}[/green]  [dim](resolved catalog profile)[/dim]")
+        brought = repo.rsplit("/", 1)[-1]
+        if route == "C" and sibling:
+            # #628/#630 — a Route-C fine-tune serves YOUR brought weights via the
+            # sibling's proven recipe (chat-template · tools · spec-dec), NOT a
+            # catalog reproduction.  Honest text + a clear serve action (no dead
+            # end — bring-funnel-design §2b item 7).
+            lines = [
+                f"[green]● armed from ① Bring[/green] — serves [bold]{brought}[/bold] "
+                "[dim](your brought weights)[/dim]:",
+                "",
+                f"  [bold]brought[/bold]  [cyan]{repo}[/cyan]",
+                f"  [bold]recipe[/bold]   [green]{sibling}[/green] "
+                "[dim](chat-template · tools · spec-dec — applied to your weights)[/dim]",
+                "",
+                "  [green]→ press [bold]\\[⏎][/bold] to serve[/green] "
+                "[dim](reconcile-gated · 👤 untested)[/dim]",
+            ]
         else:
-            lines.append(
-                "  [yellow]no servable catalog target resolved[/yellow] — the fit-check found "
-                "no sibling/profile slug (the bring-your-own weight-swap is a deferred follow-up)."
-            )
-        lines.append("")
-        lines.append(
-            "[yellow]Note: serves an UNTESTED reproduction of the catalog profile's "
-            "compose — NOT your brought model's weights.[/yellow]"
-        )
+            slug = sibling or getattr(byo, "profile_like", "")
+            lines = [
+                "[green]● armed from ① Bring[/green] — ⏎ serves the resolved catalog "
+                "compose (untested):",
+                "",
+                f"  [bold]brought[/bold]  [cyan]{repo}[/cyan]",
+            ]
+            if slug:
+                lines.append(
+                    f"  [bold]serves[/bold]   [green]{slug}[/green]  "
+                    "[dim](resolved catalog profile)[/dim]"
+                )
+                lines.append("")
+                lines.append(
+                    "[yellow]Note: serves an UNTESTED reproduction of the catalog "
+                    "profile's compose — NOT your brought model's weights.[/yellow]"
+                )
+            else:
+                lines.append(
+                    "  [yellow]no servable catalog target resolved[/yellow] — the "
+                    "fit-check found no sibling/profile slug."
+                )
         body.update("\n".join(lines))
 
 
@@ -6257,7 +6278,8 @@ class CockpitApp(App):
             if self._active_mode == 0:
                 return self._current_subtab() == "tab-containers"
             if self._active_mode == 1:
-                return self._active_validate_tab() == "tab-evidence"
+                # ① Bring (advance → ② Serve) + ④ Measure (submit-to-localmaxxing)
+                return self._active_validate_tab() in ("tab-bring", "tab-evidence")
             return False
 
         # Sub-tab cycle keys: both modes have sub-tabs (merged 0 = 4 tabs; lane 1
@@ -7559,7 +7581,7 @@ class CockpitApp(App):
             elif weights_present:
                 lane_pane.set_weights_line(
                     "  [green]✓ weights on disk[/green] — "
-                    "[green]→ ② Serve[/green] [dim](press \\[⏎] to continue)[/dim]"
+                    "[green]→ ② Serve[/green] [dim](press \\[s] to continue)[/dim]"
                 )
             else:
                 lane_pane.set_weights_line(
@@ -7646,7 +7668,7 @@ class CockpitApp(App):
         if self._data.bring_weights_present(repo):
             lane_pane.set_weights_line(
                 "  [green]✓ weights downloaded[/green] — "
-                "[green]→ ② Serve[/green] [dim](press \\[⏎] to continue)[/dim]"
+                "[green]→ ② Serve[/green] [dim](press \\[s] to continue)[/dim]"
             )
         else:
             lane_pane.set_weights_line(
@@ -8653,7 +8675,7 @@ class CockpitApp(App):
           primary action.)"""
         tab = self._active_validate_tab()
         if tab == "tab-bring":
-            self._bring_primary()
+            self._trigger_lane_bring()          # ⏎ ALWAYS fit-checks (advance = [s])
         elif tab == "tab-serve":
             self.action_serve_untested()
         elif tab == "tab-run":
@@ -8663,30 +8685,32 @@ class CockpitApp(App):
         elif tab == "tab-promote":
             self.action_promote_catalog()
 
-    def _bring_primary(self) -> None:
-        """⏎ on ① Bring — DWIM:
-          - a fresh/changed target (or no cached result) → run the fit-check;
-          - an ALREADY fit-checked, servable target whose weights are ON DISK →
-            ADVANCE to the pre-armed ② Serve (the card's "press [⏎] ② Serve").
-            Re-running the fit-check on ⏎ was the reported confusion; the [Fit]
-            button still forces a re-check.
-        Weights ABSENT stays on fit-check — the card there points at [D]
-        (download is the real next step), not ② Serve."""
+    def _bring_advance_to_serve(self) -> None:
+        """[s] on ① Bring — advance to the pre-armed ② Serve, but ONLY when the
+        fit-checked target is servable AND its weights are on disk.  ⏎ stays
+        fit-check; [s] is the explicit "proceed" (the reported "⏎ re-ran the
+        fit-check" fix — a dedicated key, not an overload).  Guards:
+          - no servable fit-check yet → ask the user to fit-check (⏎) first;
+          - weights absent → [D] download is the next step, not ② Serve."""
         byo = self._last_byo
-        try:
-            cur_repo = self.query_one("#lane-bring-url-input", Input).value.strip()
-        except Exception:
-            cur_repo = ""
         servable = bool(
             byo is not None
             and not getattr(byo, "error", "")
             and (getattr(byo, "sibling_slug", "") or getattr(byo, "profile_like", ""))
-            and cur_repo == getattr(byo, "repo", "")
         )
-        if servable and self._data.bring_weights_present(getattr(byo, "repo", "")):
-            self._advance_to_serve()
-        else:
-            self._trigger_lane_bring()
+        if not servable:
+            self.notify(
+                "Fit-check a model first (⏎ on ① Bring).",
+                title="② Serve", severity="warning", timeout=3,
+            )
+            return
+        if not self._data.bring_weights_present(getattr(byo, "repo", "")):
+            self.notify(
+                "Weights not on disk yet — press [D] to download first.",
+                title="② Serve", severity="warning", timeout=4,
+            )
+            return
+        self._advance_to_serve()
 
     def _advance_to_serve(self) -> None:
         """Advance the Bring & Validate lane from ① Bring to the pre-armed
@@ -8945,11 +8969,17 @@ class CockpitApp(App):
     def action_s_key(self) -> None:
         """[s] is context-sensitive:
           - merged mode 0 · Containers : gated `docker restart <name>`.
+          - Bring & Validate · ① Bring  : advance to the armed ② Serve (weights on disk).
           - Bring & Validate · ④ Measure : gated submit-to-localmaxxing for the tag.
         Other contexts ignore it."""
-        if self._active_mode == 1 and self._active_validate_tab() == "tab-evidence":
-            self.action_evidence_submit()
-            return
+        if self._active_mode == 1:
+            tab = self._active_validate_tab()
+            if tab == "tab-bring":
+                self._bring_advance_to_serve()
+                return
+            if tab == "tab-evidence":
+                self.action_evidence_submit()
+                return
         self.action_container_restart()
 
     def action_container_restart(self) -> None:

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -9390,19 +9390,20 @@ class TestTier1PrimaryActionAndSKeyHonesty:
                 assert app.check_action("s_key", ()) is False, tab
 
     @pytest.mark.asyncio
-    async def test_s_key_gated_to_evidence_only_in_lane(self):
-        """In the Bring & Validate lane [s] is valid ONLY on ④ Measure (submit),
-        not on ① Bring / ② Serve / ③ Gate / ⑤ Promote."""
+    async def test_s_key_gated_to_bring_and_evidence_in_lane(self):
+        """In the Bring & Validate lane [s] is valid on ① Bring (advance → ②
+        Serve) and ④ Measure (submit), NOT on ② Serve / ③ Gate / ⑤ Promote."""
         app, _, _ = make_app(surface="producer")
         async with app.run_test(size=(120, 40)) as pilot:
             await _settle(pilot)
             await pilot.press("2")
             await _settle(pilot)
             tc = app.query_one("#validate-tabs", TabbedContent)
-            tc.active = "tab-evidence"
-            await pilot.pause()
-            assert app.check_action("s_key", ()) is True
-            for tab in ("tab-bring", "tab-serve", "tab-run", "tab-promote"):
+            for tab in ("tab-bring", "tab-evidence"):
+                tc.active = tab
+                await pilot.pause()
+                assert app.check_action("s_key", ()) is True, tab
+            for tab in ("tab-serve", "tab-run", "tab-promote"):
                 tc.active = tab
                 await pilot.pause()
                 assert app.check_action("s_key", ()) is False, tab
@@ -10370,9 +10371,29 @@ class TestProducerLaneHandoff:
             assert "vllm/dual" in card
 
     @pytest.mark.asyncio
-    async def test_bring_enter_advances_to_serve_when_present(self, monkeypatch, tmp_path):
-        # After a servable fit-check with weights ON DISK, ⏎ on ① Bring ADVANCES
-        # to the pre-armed ② Serve — not re-run the fit-check (the reported bug).
+    async def test_bring_s_key_advances_to_serve_when_present(self, monkeypatch, tmp_path):
+        # After a servable fit-check with weights ON DISK, [s] on ① Bring ADVANCES
+        # to the pre-armed ② Serve (the dedicated "proceed" key).
+        monkeypatch.setenv("HF_HOME", str(tmp_path))
+        app, _, _ = make_app(surface="producer")
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.press("2")
+            await _settle(pilot)
+            d = app._data.bring_pull_dir("unsloth/Qwen3-27B-abliterated")
+            d.mkdir(parents=True)
+            (d / "model.safetensors").write_bytes(b"x")
+            app.query_one("#lane-bring-url-input", Input).value = "unsloth/Qwen3-27B-abliterated"
+            app.run_byo_check("unsloth/Qwen3-27B-abliterated", "vllm/dual")
+            await _settle(pilot)
+            app.query_one("#validate-tabs", TabbedContent).active = "tab-bring"
+            app.action_s_key()                                   # [s] on ① Bring
+            await _settle(pilot)
+            assert app.query_one("#validate-tabs", TabbedContent).active == "tab-serve"
+
+    @pytest.mark.asyncio
+    async def test_bring_enter_always_fitchecks_never_advances(self, monkeypatch, tmp_path):
+        # ⏎ on ① Bring ALWAYS fit-checks — even with weights on disk it must NOT
+        # skip to ② Serve (advance is [s]'s job; ⏎ stays fit-check).
         monkeypatch.setenv("HF_HOME", str(tmp_path))
         app, _, _ = make_app(surface="producer")
         async with app.run_test(size=(120, 40)) as pilot:
@@ -10387,12 +10408,12 @@ class TestProducerLaneHandoff:
             app.query_one("#validate-tabs", TabbedContent).active = "tab-bring"
             app._validate_primary()                              # ⏎ on ① Bring
             await _settle(pilot)
-            assert app.query_one("#validate-tabs", TabbedContent).active == "tab-serve"
+            assert app.query_one("#validate-tabs", TabbedContent).active == "tab-bring"
 
     @pytest.mark.asyncio
-    async def test_bring_enter_refits_when_weights_absent(self, monkeypatch, tmp_path):
-        # weights ABSENT → ⏎ stays on ① Bring (re-fit); the card there points at
-        # [D] (download is the real next step), so ⏎ must NOT skip to ② Serve.
+    async def test_bring_s_key_no_advance_when_weights_absent(self, monkeypatch, tmp_path):
+        # [s] with weights ABSENT → stays on ① Bring ([D] download is the next
+        # step, not ② Serve).
         monkeypatch.setenv("HF_HOME", str(tmp_path))
         app, _, _ = make_app(surface="producer")
         async with app.run_test(size=(120, 40)) as pilot:
@@ -10402,9 +10423,28 @@ class TestProducerLaneHandoff:
             app.run_byo_check("unsloth/Qwen3-27B-abliterated", "vllm/dual")
             await _settle(pilot)
             app.query_one("#validate-tabs", TabbedContent).active = "tab-bring"
-            app._validate_primary()
+            app.action_s_key()
             await _settle(pilot)
             assert app.query_one("#validate-tabs", TabbedContent).active == "tab-bring"
+
+    @pytest.mark.asyncio
+    async def test_serve_armed_route_c_serves_your_weights(self, monkeypatch, tmp_path):
+        # ② Serve armed for a Route-C brought model reflects the TRUTH: serves
+        # YOUR weights via the sibling recipe — NOT a catalog reproduction, and no
+        # dead end (bring-funnel-design §2b item 7).
+        monkeypatch.setenv("HF_HOME", str(tmp_path))
+        app, _, _ = make_app(surface="producer")
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.press("2")
+            await _settle(pilot)
+            app.run_byo_check("unsloth/Qwen3-27B-abliterated", "vllm/dual")
+            await _settle(pilot)
+            body = str(app.query_one("#lane-serve-pane", LaneServePane).query_one(
+                "#lane-serve-body", Static
+            ).render())
+            assert "your brought weights" in body
+            assert "to serve" in body                          # a clear action, no dead end
+            assert "NOT your brought model" not in body        # stale contradiction is gone
 
     @pytest.mark.asyncio
     async def test_serve_tab_rearms_from_cached_byo(self):


### PR DESCRIPTION
## Problem (live dogfood, ② Serve)

1. **Dead end + false text.** The ② Serve armed card claimed it serves *"the resolved catalog compose … NOT your brought model's weights"* — the **opposite** of what #628/#630 do for a Route-C fine-tune (they serve **your** weights via the sibling's recipe). Unarmed, it showed a dim placeholder that reads as empty. `bring-funnel-design.md §2b item 7` explicitly forbids this: *"the UI must clearly present the path to ② Serve — no dead end."*
2. **⏎ overload (from #631).** ⏎ on ① Bring runs the fit-check, so the #631 "advance-on-⏎" re-fit instead of proceeding.

## Fix

- **`set_armed` is route-aware.** Route-C → *"serves `<brought>` (your brought weights) via `<sibling>`'s recipe (chat-template · tools · spec-dec) → \[⏎] to serve"*. Non-swap routes keep the honest *"catalog reproduction, untested"* wording. No more dead end, no more contradiction.
- **⏎ always fit-checks; `[s]` advances.** A dedicated `[s]` (Serve) on ① Bring jumps to the pre-armed ② Serve — guarded on servable + weights-on-disk (absent → notify to press `[D]`). `[s]` joins the existing context-routed `s_key` (Containers restart · ④ Measure submit). Card + weights-line now read *"press \[s] to continue to ② Serve"*.

## Tests

`test_bring_s_key_advances_to_serve_when_present` · `_no_advance_when_weights_absent` · `test_bring_enter_always_fitchecks_never_advances` · `test_serve_armed_route_c_serves_your_weights` · updated `s_key`-gating for tab-bring. **195 touched-surface tests pass.**

> Next: **Phase 2 — the ② Serve override editor** (served-name · ctx · KV · spec · util, applied as compose env at serve). This PR is the dead-end fix it builds on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
