### PR TITLE
feat(c3): ② Serve override editor — retune served-name/ctx/KV/spec/util

### DIFF
--- a/scripts/lib/profiles/swap_apply.py
+++ b/scripts/lib/profiles/swap_apply.py
@@ -105,7 +105,11 @@ def apply_command_overrides(
     ``--served-model-name`` value(s) with the brought name, and drop
     ``--speculative-config`` + its value iff the brought checkpoint has no MTP
     head. ``--quantization`` is left UNTOUCHED — the Route-C precondition is that
-    the brought weights match the sibling compose's quant."""
+    the brought weights match the sibling compose's quant.
+
+    The served-name is emitted as ``${SERVED_NAME:-<brought>}`` so the ② Serve
+    override editor can rename the endpoint at up-time (env interpolation) without
+    a re-emit — same shape as the compose's ${MAX_MODEL_LEN}/${KV_CACHE_DTYPE}."""
     out: list = []
     i, n = 0, len(cmd)
     while i < n:
@@ -115,7 +119,7 @@ def apply_command_overrides(
             i += 2
             continue
         if tok == "--served-model-name":
-            out += ["--served-model-name", served_name]
+            out += ["--served-model-name", f"${{SERVED_NAME:-{served_name}}}"]
             i += 1
             while i < n and not str(cmd[i]).startswith("--"):
                 i += 1  # drop the sibling's served-name value(s)
@@ -126,6 +130,49 @@ def apply_command_overrides(
         out.append(tok)
         i += 1
     return out
+
+
+def _gate_spec_via_entrypoint(svc: dict) -> None:
+    """Move ``--speculative-config <json>`` out of ``command`` and re-add it from
+    an entrypoint gated on ``${SPEC:-on}`` (mirrors the shipped nvfp4 compose), so
+    SPEC=off drops the MTP drafter at up-time.  No-op if the command carries no
+    ``--speculative-config``.  Mutates ``svc`` in place."""
+    cmd = list(svc.get("command") or [])
+    spec_val = None
+    out: list = []
+    i, n = 0, len(cmd)
+    while i < n:
+        if cmd[i] == "--speculative-config":
+            spec_val = cmd[i + 1] if i + 1 < n else None
+            i += 2
+            continue
+        out.append(cmd[i])
+        i += 1
+    if spec_val is None:
+        return
+    svc["command"] = out
+    env_list = list(svc.get("environment") or [])
+    if "SPEC" not in env_list:
+        env_list.append("SPEC")
+    svc["environment"] = env_list
+    # `$$` = docker-compose-escaped `$` (evaluated by the container's bash at
+    # runtime, NOT interpolated by compose).  The JSON spec value has no single
+    # quotes, so single-quoting it for the bash array is safe.
+    svc["entrypoint"] = [
+        "bash", "-c",
+        (
+            "# SPEC=off drops the built-in MTP drafter (tight-RAM / no-spec path);\n"
+            "# default on. Toggled by the c3 ② Serve override editor.\n"
+            "SPEC_ARGS=()\n"
+            'if [ "$${SPEC:-on}" != "off" ]; then\n'
+            f"  SPEC_ARGS=(--speculative-config '{spec_val}')\n"
+            "else\n"
+            '  echo "[brought] SPEC=off — MTP drafter disabled (no spec-dec)" >&2\n'
+            "fi\n"
+            'exec vllm serve "$$@" "$${SPEC_ARGS[@]}"'
+        ),
+        "--",
+    ]
 
 
 def emit_swap_compose(
@@ -157,6 +204,12 @@ def emit_swap_compose(
         model_path=_BROUGHT_MODEL_MOUNT, served_name=served_name,
         drop_spec=not has_mtp_head,
     )
+    # SPEC on/off gating (only when the checkpoint HAS an MTP head — else there's
+    # nothing to toggle): pull --speculative-config out of the command and gate it
+    # behind ${SPEC:-on} via the SAME entrypoint pattern the nvfp4 compose ships,
+    # so the ② Serve override editor can flip spec-decode at up-time (no re-emit).
+    if has_mtp_head:
+        _gate_spec_via_entrypoint(svc)
     vols = list(svc.get("volumes") or [])
     vols.append(f"{weights_host_dir}:{_BROUGHT_MODEL_MOUNT}:ro")
     svc["volumes"] = vols

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -5136,6 +5136,15 @@ def _byo_result_text(res: ByoResult, weights_present: Optional[bool] = None) -> 
     return "\n".join(lines)
 
 
+# ② Serve override-editor dropdown presets (loose validation; dropdowns to prevent
+# typos — the resolved slug's own default is folded in at arm-time if it's not here).
+_OV_CTX = ["16384", "32768", "65536", "98304", "131072", "196608", "262144"]
+_OV_KV = ["fp8_e5m2", "fp8_e4m3", "turboquant_4bit_nc", "turboquant_3bit_nc",
+          "int8_per_token_head", "bf16"]
+_OV_UTIL = ["0.80", "0.85", "0.90", "0.92", "0.95"]
+_OV_SPEC = ["on", "off"]
+
+
 class LaneServePane(Container):
     """② Serve — generate a minimal compose for the resolved CATALOG profile, then
     serve it (untested) through the reconcile-gated path (R3b-1, the critical new
@@ -5173,6 +5182,16 @@ class LaneServePane(Container):
         color: $text-muted;
         margin-top: 1;
     }
+    LaneServePane #lane-serve-overrides {
+        height: auto;
+        margin-top: 1;
+        border: round $primary-darken-2;
+        padding: 0 1;
+    }
+    LaneServePane #lane-serve-ov-title { margin-bottom: 1; }
+    LaneServePane .ov-row { height: 3; margin-bottom: 0; }
+    LaneServePane .ov-lbl { width: 12; content-align: left middle; height: 3; }
+    LaneServePane .ov-row Input, LaneServePane .ov-row Select { width: 1fr; }
     """
 
     def compose(self) -> ComposeResult:
@@ -5193,21 +5212,52 @@ class LaneServePane(Container):
             "[/yellow][/dim]",
             id="lane-serve-body",
         )
+        # Override editor — revealed (populated) only for a Route-C brought model
+        # with weights on disk (set_armed).  Values ride on the serve's plan.env →
+        # the compose's ${VAR} at up-time (no re-emit).
+        yield Vertical(
+            Label("[bold]Override before serve[/bold] [dim](optional · defaults from the "
+                  "resolved slug)[/dim]", id="lane-serve-ov-title"),
+            Horizontal(Label("served as", classes="ov-lbl"),
+                       Input(id="ov-served-name"), classes="ov-row"),
+            Horizontal(Label("ctx", classes="ov-lbl"),
+                       Select([(v, v) for v in _OV_CTX], id="ov-ctx", allow_blank=False),
+                       classes="ov-row"),
+            Horizontal(Label("KV cache", classes="ov-lbl"),
+                       Select([(v, v) for v in _OV_KV], id="ov-kv", allow_blank=False),
+                       classes="ov-row"),
+            Horizontal(Label("spec-dec", classes="ov-lbl"),
+                       Select([(v, v) for v in _OV_SPEC], id="ov-spec", allow_blank=False),
+                       classes="ov-row"),
+            Horizontal(Label("VRAM util", classes="ov-lbl"),
+                       Select([(v, v) for v in _OV_UTIL], id="ov-util", allow_blank=False),
+                       classes="ov-row"),
+            id="lane-serve-overrides", classes="funnel-hidden",
+        )
         yield Label(
-            "[dim]\\[⏎] generate + preview + serve (reconcile-gated · untested)[/dim]",
+            "[dim]\\[⏎] serve with the values above (reconcile-gated · 👤 untested)[/dim]",
             id="lane-serve-hint",
         )
 
     def set_status(self, text: str) -> None:
         self.query_one("#lane-serve-body", Static).update(text)
 
-    def set_armed(self, byo: "Optional[ByoResult]") -> None:
+    def set_armed(
+        self, byo: "Optional[ByoResult]",
+        overrides_defaults: Optional[dict] = None,
+    ) -> None:
         """N9 — pre-arm ② Serve from the cached ① Bring fit-check: show the
         resolved servable catalog target so ⏎ here serves it WITHOUT re-entering
         ① Bring.  Pure render off the cached ByoResult (no I/O).  When there's no
-        usable fit-check yet, restore the calm "run ① Bring first" placeholder."""
+        usable fit-check yet, restore the calm "run ① Bring first" placeholder.
+
+        For a Route-C brought model, ``overrides_defaults`` (from
+        ``serve_override_defaults``) pre-fills + reveals the override editor;
+        other routes hide it (the editor rides the swap compose's ${VAR} env)."""
         body = self.query_one("#lane-serve-body", Static)
+        ov = self.query_one("#lane-serve-overrides", Vertical)
         if byo is None or getattr(byo, "error", ""):
+            ov.add_class("funnel-hidden")
             body.update(
                 "[dim]Stage ② of the Bring & Validate pipeline.\n"
                 "\n"
@@ -5220,6 +5270,11 @@ class LaneServePane(Container):
         sibling = getattr(byo, "sibling_slug", "")
         repo = getattr(byo, "repo", "") or "—"
         brought = repo.rsplit("/", 1)[-1]
+        if route == "C" and sibling and overrides_defaults:
+            self._populate_overrides(overrides_defaults)
+            ov.remove_class("funnel-hidden")
+        else:
+            ov.add_class("funnel-hidden")
         if route == "C" and sibling:
             # #628/#630 — a Route-C fine-tune serves YOUR brought weights via the
             # sibling's proven recipe (chat-template · tools · spec-dec), NOT a
@@ -5260,6 +5315,59 @@ class LaneServePane(Container):
                     "fit-check found no sibling/profile slug."
                 )
         body.update("\n".join(lines))
+
+    def _populate_overrides(self, d: dict) -> None:
+        """Pre-fill the editor from the resolved slug's defaults.  The slug's own
+        value is folded into each dropdown if it isn't already a preset (so the
+        default is always selectable — loose validation, no typo surface)."""
+        try:
+            self.query_one("#ov-served-name", Input).value = str(d.get("SERVED_NAME", ""))
+        except Exception:
+            pass
+        for wid, key, presets in (
+            ("#ov-ctx", "MAX_MODEL_LEN", _OV_CTX),
+            ("#ov-kv", "KV_CACHE_DTYPE", _OV_KV),
+            ("#ov-spec", "SPEC", _OV_SPEC),
+            ("#ov-util", "GPU_MEMORY_UTILIZATION", _OV_UTIL),
+        ):
+            try:
+                sel = self.query_one(wid, Select)
+                val = str(d.get(key, "")).strip()
+                opts = list(presets)
+                if val and val not in opts:
+                    opts = [val] + opts
+                sel.set_options([(o, o) for o in opts])
+                sel.value = val if val in opts else opts[0]
+            except Exception:
+                pass
+
+    def collect_overrides(self) -> dict:
+        """Read the editor fields → env overrides for the serve.  Only non-empty
+        values are returned (empty = keep the compose's own default).  Returns
+        ``{}`` when the editor is hidden (non-Route-C serve — no override surface)."""
+        out: dict = {}
+        try:
+            if self.query_one("#lane-serve-overrides", Vertical).has_class("funnel-hidden"):
+                return {}
+        except Exception:
+            return {}
+        try:
+            name = self.query_one("#ov-served-name", Input).value.strip()
+            if name:
+                out["SERVED_NAME"] = name
+        except Exception:
+            pass
+        for wid, key in (
+            ("#ov-ctx", "MAX_MODEL_LEN"), ("#ov-kv", "KV_CACHE_DTYPE"),
+            ("#ov-spec", "SPEC"), ("#ov-util", "GPU_MEMORY_UTILIZATION"),
+        ):
+            try:
+                v = self.query_one(wid, Select).value
+                if v not in (None, Select.BLANK):
+                    out[key] = str(v)
+            except Exception:
+                pass
+        return out
 
 
 class LanePromotePane(Container):
@@ -7568,8 +7676,9 @@ class CockpitApp(App):
         # N9 — carry the fit-check result forward: pre-arm ② Serve with the
         # resolved target so the producer pipeline flows ① → ② without re-entry.
         try:
+            armed_byo = res if not getattr(res, "error", "") else None
             self.query_one("#lane-serve-pane", LaneServePane).set_armed(
-                res if not getattr(res, "error", "") else None
+                armed_byo, self._armed_overrides_defaults(armed_byo)
             )
         except Exception:
             pass
@@ -9819,6 +9928,23 @@ class CockpitApp(App):
             )
         )
 
+    def _armed_overrides_defaults(self, byo) -> Optional[dict]:
+        """② Serve override-editor pre-fill for a Route-C armed model (else None,
+        which keeps the editor hidden — the editor rides the swap compose's env)."""
+        if (
+            byo is None
+            or getattr(byo, "error", "")
+            or str(getattr(byo, "route", "") or "").upper() != "C"
+            or not getattr(byo, "sibling_slug", "")
+        ):
+            return None
+        try:
+            return self._data.serve_override_defaults(
+                getattr(byo, "profile_like", ""), getattr(byo, "repo", "")
+            )
+        except Exception:
+            return None
+
     def _serve_generated_compose(self, compose_path: str) -> None:
         """Stage the serve of a GENERATED compose through the reconcile gate.
 
@@ -9829,7 +9955,14 @@ class CockpitApp(App):
         # entry staged by a PRIOR catalog serve so that stale slug can NEVER drive
         # a false "✓ serving <that model>" via _serve_slug_for / failure capture.
         self._staged_entry = None
-        plan = self._data.serve_generated(compose_path)
+        # ② Serve override editor — collect the field values (empty when the editor
+        # is hidden / non-Route-C).  They ride on plan.env → the compose's ${VAR}.
+        overrides = {}
+        try:
+            overrides = self.query_one("#lane-serve-pane", LaneServePane).collect_overrides()
+        except Exception:
+            overrides = {}
+        plan = self._data.serve_generated(compose_path, overrides or None)
         self.push_screen(ConfirmActionScreen(plan))
 
     # ── Phase 5 · Hook 2: Promote the BYO model to the catalog (design §3.5b) ──────────
@@ -9986,7 +10119,9 @@ class CockpitApp(App):
         # resolved target is shown WITHOUT re-entering ① Bring (the pipeline flows).
         if tab_id == "tab-serve":
             try:
-                self.query_one("#lane-serve-pane", LaneServePane).set_armed(self._last_byo)
+                self.query_one("#lane-serve-pane", LaneServePane).set_armed(
+                    self._last_byo, self._armed_overrides_defaults(self._last_byo)
+                )
             except Exception:
                 pass
         # Only respond to tabs that belong to the current mode's active panel.

--- a/tools/serve-cockpit/club3090_cockpit/data.py
+++ b/tools/serve-cockpit/club3090_cockpit/data.py
@@ -745,6 +745,11 @@ class ActionPlan:
     # (submit-bench POST/PR) so the confirm copy can warn it leaves the rig.
     requires_confirm: bool = True
     network: bool = False
+    # Extra env merged over os.environ when the cmd runs (dispatch_action).  Used
+    # by the ② Serve override editor to pass MAX_MODEL_LEN / KV_CACHE_DTYPE / SPEC
+    # / GPU_MEMORY_UTILIZATION / SERVED_NAME to `docker compose up` — the compose
+    # interpolates ${VAR}, so no compose rewrite per serve.
+    env: Optional[dict[str, str]] = None
 
 
 # ── Phase 4: Doctor (estate + profile triage reads) ──────────────────────────────

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -2165,7 +2165,36 @@ class CockpitData:
             return _fail(res.stdout.strip()[:300] or "generator emitted no compose")
         return {"compose_path": tmp_path, "compose_yaml": yaml_text, "error": ""}
 
-    def serve_generated(self, compose_path: str) -> ActionPlan:
+    def serve_override_defaults(self, profile_like: str, repo: str) -> dict[str, str]:
+        """Pre-fill values for the ② Serve override editor, read from the resolved
+        ``profile_like`` sibling compose's ``${VAR:-default}`` env knobs (+ the
+        brought repo name for SERVED_NAME).  Best-effort: any field we can't parse
+        falls back to a sane default.  Pure READ (regex over the compose text) —
+        no PyYAML (keeps this importable on the launcher's stdlib-only path)."""
+        import re as _re
+        out = {
+            "SERVED_NAME": repo.rsplit("/", 1)[-1] if repo else "",
+            "MAX_MODEL_LEN": "262144",
+            "KV_CACHE_DTYPE": "fp8_e5m2",
+            "GPU_MEMORY_UTILIZATION": "0.92",
+            "SPEC": "on",
+        }
+        try:
+            from scripts.lib.profiles.compose_registry import COMPOSE_REGISTRY
+            entry = COMPOSE_REGISTRY.get(profile_like)
+            if entry:
+                txt = (self.repo_root / entry["compose_path"]).read_text(encoding="utf-8")
+                for var in ("MAX_MODEL_LEN", "KV_CACHE_DTYPE", "GPU_MEMORY_UTILIZATION"):
+                    m = _re.search(r"\$\{" + var + r":-([^}]+)\}", txt)
+                    if m:
+                        out[var] = m.group(1).strip().strip('"')
+        except Exception:
+            pass
+        return out
+
+    def serve_generated(
+        self, compose_path: str, overrides: Optional[dict[str, str]] = None
+    ) -> ActionPlan:
         """Serve a GENERATED (producer-lane ②) compose, badged untested.
 
         Serving a generated compose CLAIMS the GPU exactly like any serve, so the
@@ -2173,13 +2202,24 @@ class CockpitData:
         through the SAME ConfirmActionScreen → run_reconcile_for_modal →
         dispatch_action gate (the dual-writer lease MUST hold).  We launch it via
         ``docker compose -f <path> up`` — the generated compose is a verbatim
-        minimal reproduction, NOT a registry slug switch.sh knows about."""
+        minimal reproduction, NOT a registry slug switch.sh knows about.
+
+        ``overrides`` (the ② Serve editor's field values — MAX_MODEL_LEN /
+        KV_CACHE_DTYPE / SPEC / GPU_MEMORY_UTILIZATION / SERVED_NAME) ride on
+        ``plan.env`` and interpolate into the compose's ``${VAR}`` at up-time —
+        so a re-tuned serve needs no compose rewrite.  MODEL_DIR is pinned here
+        too so the sibling's HF-cache mount resolves off the models disk."""
+        env: dict[str, str] = {"MODEL_DIR": self.weights_model_dir()}
+        for k, v in (overrides or {}).items():
+            if v is not None and str(v) != "":
+                env[k] = str(v)
         return ActionPlan(
             kind="serve",
             cmd=["docker", "compose", "-f", compose_path, "up", "-d"],
             description=f"serve generated compose {Path(compose_path).name} (untested)",
             requires_reconcile=True,
             requires_confirm=True,
+            env=env,
         )
 
     def set_default(self, slug: str) -> ActionPlan:
@@ -2473,9 +2513,15 @@ class CockpitData:
             import os as _os
 
             try:
+                # plan.env (e.g. the ② Serve override editor's field values) is
+                # merged OVER os.environ so `docker compose up` interpolates the
+                # re-tuned ${MAX_MODEL_LEN}/${KV_CACHE_DTYPE}/${SPEC}/… .
+                _run_env = dict(_os.environ)
+                if plan.env:
+                    _run_env.update(plan.env)
                 state = await self._write_runner.start_raw(
                     plan.cmd,
-                    env=dict(_os.environ),
+                    env=_run_env,
                     run_type=run_type or plan.kind,
                     parser=run_parser,
                 )

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -10428,6 +10428,45 @@ class TestProducerLaneHandoff:
             assert app.query_one("#validate-tabs", TabbedContent).active == "tab-bring"
 
     @pytest.mark.asyncio
+    async def test_serve_override_editor_reveals_prefills_and_collects(self, monkeypatch, tmp_path):
+        # Route-C fit-check → the ② Serve override editor is revealed + pre-filled
+        # from the resolved slug's defaults; an edit round-trips via collect_overrides.
+        from textual.widgets import Input as _I, Select as _S
+        monkeypatch.setenv("HF_HOME", str(tmp_path))
+        app, _, _ = make_app(surface="producer")
+        async with app.run_test(size=(120, 46)) as pilot:
+            await pilot.press("2")
+            await _settle(pilot)
+            app.run_byo_check("unsloth/Qwen3-27B-abliterated", "vllm/dual")
+            await _settle(pilot)
+            pane = app.query_one("#lane-serve-pane", LaneServePane)
+            ov = pane.query_one("#lane-serve-overrides")
+            assert not ov.has_class("funnel-hidden")            # revealed for Route-C
+            assert pane.query_one("#ov-served-name", _I).value  # pre-filled served-name
+            assert pane.query_one("#ov-kv", _S).value == "fp8_e5m2"
+            assert pane.query_one("#ov-spec", _S).value == "on"
+            # edits round-trip
+            pane.query_one("#ov-served-name", _I).value = "MyCustomName"
+            pane.query_one("#ov-ctx", _S).value = "65536"
+            pane.query_one("#ov-spec", _S).value = "off"
+            ovr = pane.collect_overrides()
+            assert ovr["SERVED_NAME"] == "MyCustomName"
+            assert ovr["MAX_MODEL_LEN"] == "65536"
+            assert ovr["SPEC"] == "off"
+
+    @pytest.mark.asyncio
+    async def test_serve_override_editor_hidden_and_empty_without_route_c(self):
+        # No fit-check → editor hidden and collect_overrides returns {} (so a
+        # non-Route-C serve applies no overrides).
+        app, _, _ = make_app(surface="producer")
+        async with app.run_test(size=(120, 46)) as pilot:
+            await pilot.press("2")
+            await _settle(pilot)
+            pane = app.query_one("#lane-serve-pane", LaneServePane)
+            assert pane.query_one("#lane-serve-overrides").has_class("funnel-hidden")
+            assert pane.collect_overrides() == {}
+
+    @pytest.mark.asyncio
     async def test_serve_armed_route_c_serves_your_weights(self, monkeypatch, tmp_path):
         # ② Serve armed for a Route-C brought model reflects the TRUTH: serves
         # YOUR weights via the sibling recipe — NOT a catalog reproduction, and no

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -3700,3 +3700,30 @@ class TestStudioSidecarEnumeration:
         # No services/studio/* present → no sidecar rows (only any top-level dirs).
         names = CockpitData(tmp_path, runner=full_runner())._known_service_dirs()
         assert not any(n.startswith("studio-") for n in names)
+
+
+class TestServeOverrides:
+    """② Serve override editor — plan.env threading + compose-default pre-fill."""
+
+    def test_serve_generated_overrides_ride_plan_env(self):
+        cd = CockpitData(ROOT, runner=full_runner())
+        plan = cd.serve_generated("/tmp/x.yml", {
+            "MAX_MODEL_LEN": "65536", "SPEC": "off",
+            "KV_CACHE_DTYPE": "", "SERVED_NAME": "Foo",   # empty is dropped
+        })
+        assert plan.env["MAX_MODEL_LEN"] == "65536"
+        assert plan.env["SPEC"] == "off"
+        assert plan.env["SERVED_NAME"] == "Foo"
+        assert "KV_CACHE_DTYPE" not in plan.env          # empty override dropped
+        assert plan.env["MODEL_DIR"]                     # pinned (HF mount resolves)
+        # no overrides → only the pinned MODEL_DIR rides
+        assert cd.serve_generated("/tmp/x.yml").env == {"MODEL_DIR": cd.weights_model_dir()}
+
+    def test_serve_override_defaults_parses_sibling_compose(self):
+        repo_root = Path(__file__).resolve().parents[3]
+        cd = CockpitData(repo_root, runner=full_runner())
+        d = cd.serve_override_defaults("vllm/dual", "org/MyFineTune")
+        assert d["SERVED_NAME"] == "MyFineTune"          # from the brought repo name
+        assert d["MAX_MODEL_LEN"] == "262144"            # parsed ${MAX_MODEL_LEN:-262144}
+        assert d["KV_CACHE_DTYPE"] == "fp8_e5m2"
+        assert d["SPEC"] == "on"


### PR DESCRIPTION
## What

Phase 2 of the ② Serve rework (Phase 1 = #635, the dead-end + `[s]` fix). A **Route-C brought model** can now be **re-tuned before serve** — no hand-editing a compose. The editor is revealed + pre-filled (from the resolved slug's defaults) only when ② Serve is armed for a Route-C swap; hidden otherwise.

| Field | Compose env | Control |
|---|---|---|
| served name | `SERVED_NAME` | Input |
| ctx | `MAX_MODEL_LEN` | Select (presets + the slug's own default folded in) |
| KV cache | `KV_CACHE_DTYPE` | Select (`fp8_e5m2` · `fp8_e4m3` · `turboquant_4bit_nc` · …) |
| spec-decode | `SPEC` on/off | Select |
| VRAM util | `GPU_MEMORY_UTILIZATION` | Select |

Dropdowns constrain the typo-prone fields; validation stays **loose** (the reconcile gate + the boot are the real check — this is a 👤 untested surface).

## How — all five ride **env**, no per-serve compose rewrite

- **`data.py`** — `ActionPlan` gains `env`; dispatch merges `{**os.environ, **plan.env}` (`services.py:~2483`).
- **`services.py`** — `serve_generated(compose_path, overrides)` → `plan.env` (+ pins `MODEL_DIR` so the sibling's HF-cache mount resolves); `serve_override_defaults()` parses the sibling compose's `${VAR:-default}` for pre-fill (stdlib regex, no PyYAML).
- **`swap_apply.py`** — the emit parameterizes `--served-model-name ${SERVED_NAME:-…}` and gates `--speculative-config` behind `${SPEC:-on}` via **the same entrypoint the shipped nvfp4 compose uses**, so `SPEC=off` drops the MTP drafter at up-time.
- **`app.py`** — `LaneServePane` fields + `collect_overrides()` → `serve_generated`.

## Validated

- Emitted compose `docker compose config` resolves `SERVED_NAME=X` and `SPEC=off` (entrypoint gate) cleanly.
- **169** byo/serve/override tests pass (plan.env threading · `serve_override_defaults` parse · UI reveal/pre-fill/collect round-trip · hidden-when-non-Route-C).

> Follow-up (noted, not in this PR): `verify-stress.sh`'s Cliff-1/DS-conv hint strings are hardcoded for the Genesis Qwen compose and misfire on the stock nvfp4 path (surfaced on #617) — scope them to the Genesis composes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
