### PR TITLE
fix(launcher): GGUF verify-glob (#634) + .env engine-image passthrough (#632)

### DIFF
--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -81,7 +81,15 @@ if [[ -f "${ROOT_DIR}/.env" ]]; then
     _env_line="${_env_line#"${_env_line%%[![:space:]]*}"}"   # strip leading whitespace
     _env_line="${_env_line%$'\r'}"                           # strip trailing CR
     [[ "$_env_line" == "export "* ]] && _env_line="${_env_line#export }"
-    [[ "$_env_line" == CLUB3090_DEFAULT_* ]] || continue
+    # #632 — pass model-default pins AND user engine-image overrides through to
+    # docker compose.  IK_LLAMA_IMAGE/LLAMACPP_IMAGE were silently dropped here
+    # (only CLUB3090_DEFAULT_* passed), so a .env cu12 pin never reached the
+    # ik-llama/llama.cpp composes.  Shell env still wins (checked below); the
+    # vllm/beellama images get profile-injected later regardless.
+    case "$_env_line" in
+      CLUB3090_DEFAULT_*|VLLM_IMAGE=*|BEELLAMA_IMAGE=*|IK_LLAMA_IMAGE=*|LLAMACPP_IMAGE=*|VLLM_NIGHTLY_SHA=*) ;;
+      *) continue ;;
+    esac
     _env_key="${_env_line%%=*}"
     [[ "$_env_key" == "$_env_line" || -z "$_env_key" ]] && continue
     [[ -n "${!_env_key+x}" ]] && continue                    # already set in env → shell wins
@@ -92,6 +100,11 @@ if [[ -f "${ROOT_DIR}/.env" ]]; then
   done < "${ROOT_DIR}/.env"
   unset _env_line _env_key _env_val
 fi
+# #632 — surface a user engine-image pin (ik-llama / llama.cpp images are NOT
+# profile-injected, so a .env/shell pin is the only override path; echo it so a
+# wrong-image boot is never silent).  Fires only when actually set.
+[[ -n "${IK_LLAMA_IMAGE:-}" ]] && echo "[launch] ik-llama image pinned: ${IK_LLAMA_IMAGE}"
+[[ -n "${LLAMACPP_IMAGE:-}" ]] && echo "[launch] llama.cpp image pinned: ${LLAMACPP_IMAGE}"
 MODEL_DIR="${MODEL_DIR:-${ROOT_DIR}/models-cache}"
 # shellcheck source=preflight.sh
 source "${ROOT_DIR}/scripts/preflight.sh"

--- a/scripts/lib/profiles/swap_apply.py
+++ b/scripts/lib/profiles/swap_apply.py
@@ -133,10 +133,13 @@ def apply_command_overrides(
 
 
 def _gate_spec_via_entrypoint(svc: dict) -> None:
-    """Move ``--speculative-config <json>`` out of ``command`` and re-add it from
-    an entrypoint gated on ``${SPEC:-on}`` (mirrors the shipped nvfp4 compose), so
-    SPEC=off drops the MTP drafter at up-time.  No-op if the command carries no
-    ``--speculative-config``.  Mutates ``svc`` in place."""
+    """Move ``--speculative-config <json>`` out of ``command`` and REBUILD it from
+    an entrypoint gated on ``${SPEC:-on}`` (mirrors the shipped nvfp4 compose), with
+    the drafter method + n parameterized by ``${DRAFTER_METHOD}`` / ``${DRAFTER_N}``
+    (defaults = the sibling's).  So the c3 ② Serve editor can toggle spec-dec off
+    AND switch the drafter type (mtp / mtp_assistant / …).  No-op if the command
+    carries no ``--speculative-config``.  Mutates ``svc`` in place."""
+    import re
     cmd = list(svc.get("command") or [])
     spec_val = None
     out: list = []
@@ -150,27 +153,34 @@ def _gate_spec_via_entrypoint(svc: dict) -> None:
         i += 1
     if spec_val is None:
         return
+    mm = re.search(r'"method"\s*:\s*"([a-z0-9_]+)"', spec_val or "")
+    nn = re.search(r'"num_speculative_tokens"\s*:\s*(\d+)', spec_val or "")
+    d_method = mm.group(1) if mm else "mtp"
+    d_n = nn.group(1) if nn else "3"
     svc["command"] = out
     env_list = list(svc.get("environment") or [])
-    if "SPEC" not in env_list:
-        env_list.append("SPEC")
+    for e in ("SPEC", "DRAFTER_METHOD", "DRAFTER_N"):
+        if e not in env_list:
+            env_list.append(e)
     svc["environment"] = env_list
-    # `$$` = docker-compose-escaped `$` (evaluated by the container's bash at
-    # runtime, NOT interpolated by compose).  The JSON spec value has no single
-    # quotes, so single-quoting it for the bash array is safe.
+    # `$$` = docker-compose-escaped `$` (bash evaluates it at runtime, NOT compose).
+    # printf builds the JSON so the method/n substitute cleanly — no quote-in-YAML
+    # escaping hell.  ${DRAFTER_METHOD}/${DRAFTER_N} default to the sibling's.
+    script = (
+        "# SPEC=off drops the drafter; DRAFTER_METHOD/DRAFTER_N select the type\n"
+        "# (defaults = the sibling's).  Toggled/selected by the c3 ② Serve editor.\n"
+        "SPEC_ARGS=()\n"
+        'if [ "$${SPEC:-on}" != "off" ]; then\n'
+        "  _cfg=$$(printf '{\"method\":\"%s\",\"num_speculative_tokens\":%s}' "
+        '"$${DRAFTER_METHOD:-' + d_method + '}" "$${DRAFTER_N:-' + d_n + '}")\n'
+        '  SPEC_ARGS=(--speculative-config "$$_cfg")\n'
+        "else\n"
+        '  echo "[brought] SPEC=off — drafter disabled (no spec-dec)" >&2\n'
+        "fi\n"
+        'exec vllm serve "$$@" "$${SPEC_ARGS[@]}"'
+    )
     svc["entrypoint"] = [
-        "bash", "-c",
-        (
-            "# SPEC=off drops the built-in MTP drafter (tight-RAM / no-spec path);\n"
-            "# default on. Toggled by the c3 ② Serve override editor.\n"
-            "SPEC_ARGS=()\n"
-            'if [ "$${SPEC:-on}" != "off" ]; then\n'
-            f"  SPEC_ARGS=(--speculative-config '{spec_val}')\n"
-            "else\n"
-            '  echo "[brought] SPEC=off — MTP drafter disabled (no spec-dec)" >&2\n'
-            "fi\n"
-            'exec vllm serve "$$@" "$${SPEC_ARGS[@]}"'
-        ),
+        "bash", "-c", script,
         "--",
     ]
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -622,7 +622,11 @@ download_weight_key() {
   _verify_downloaded_files "$WEIGHT_REPO" "$WEIGHT_SUBDIR" "$WEIGHT_VERIFY_GLOB" "${WEIGHT_REVISION:-main}"
 }
 
-VERIFY_GLOB="${VERIFY_GLOB_OVERRIDE:-*.safetensors}"
+# #634 — honour the PRIMARY recipe's verify_glob (set by load_weight_recipe →
+# line 100, e.g. "*.gguf" for GGUF keys), NOT a re-hardcoded *.safetensors, or
+# every GGUF primary fetch (WEIGHTS=gguf/iq4ks) fails verify despite a good
+# download.  An explicit VERIFY_GLOB_OVERRIDE still wins.
+VERIFY_GLOB="${VERIFY_GLOB_OVERRIDE:-${VERIFY_GLOB}}"
 _hf_download_repo "${MODEL_REPO}" "${MODEL_SUBDIR}" "${GGUF_FILES}" "${MODEL_REVISION:-}"
 _verify_downloaded_files "${MODEL_REPO}" "${MODEL_SUBDIR}" "${VERIFY_GLOB}" "${MODEL_REVISION:-main}"
 

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -100,6 +100,11 @@ if [[ -f "${ROOT_DIR}/.env" ]]; then
   done < "${ROOT_DIR}/.env"
   unset _env_line _env_key _env_val
 fi
+# #632 — surface a user engine-image pin (ik-llama / llama.cpp images are NOT
+# profile-injected, so a .env/shell pin is the only override path; echo it so a
+# wrong-image boot is never silent).  Fires only when actually set.
+[[ -n "${IK_LLAMA_IMAGE:-}" ]] && echo "[switch] ik-llama image pinned: ${IK_LLAMA_IMAGE}"
+[[ -n "${LLAMACPP_IMAGE:-}" ]] && echo "[switch] llama.cpp image pinned: ${LLAMACPP_IMAGE}"
 
 # Surface the resolved MODEL_DIR + its source so the precedence is unambiguous
 # (the exact confusion behind #425 / #187). Unset → the compose's built-in

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -5361,12 +5361,9 @@ class LaneServePane(Container):
         except Exception:
             pass
         kv_opts = list(d.get("KV_OPTIONS") or _OV_KV)               # engine-declared
-        drafter = d.get("SPEC_DRAFTER") or "spec-dec"
-        spec_opts = [(f"{drafter} (on)", "on"), ("off — no spec-dec", "off")]
         for wid, key, presets, custom in (
             ("#ov-ctx", "MAX_MODEL_LEN", [(v, v) for v in _OV_CTX], True),
             ("#ov-kv", "KV_CACHE_DTYPE", [(v, v) for v in kv_opts], True),
-            ("#ov-spec", "SPEC", spec_opts, False),
             ("#ov-util", "GPU_MEMORY_UTILIZATION", [(v, v) for v in _OV_UTIL], True),
         ):
             try:
@@ -5381,6 +5378,26 @@ class LaneServePane(Container):
                 sel.value = val if val in [o[1] for o in opts] else opts[0][1]
             except Exception:
                 pass
+        # spec-dec: the dropdown lists the ENGINE's supported drafters + off; the
+        # VALUE is the drafter METHOD (or "off").  collect maps method→SPEC=on +
+        # DRAFTER_METHOD, off→SPEC=off (the swap entrypoint parameterizes the method).
+        try:
+            drafters = list(d.get("DRAFTER_OPTIONS") or [])
+            # fallback (engine not resolvable) → a plain on/off "on" option
+            cur = d.get("SPEC_METHOD") or (drafters[0] if drafters else "on")
+            spec_n = d.get("SPEC_N") or ""
+            spec_opts = [
+                ((f"{m} n={spec_n}" if (m == cur and spec_n) else m), m)
+                for m in drafters
+            ] or [("on", "on")]
+            spec_opts.append(("off — no spec-dec", "off"))
+            sel = self.query_one("#ov-spec", Select)
+            sel.set_options(spec_opts)
+            method_vals = [o[1] for o in spec_opts]
+            sel.value = (cur if (str(d.get("SPEC")) == "on" and cur in method_vals)
+                         else "off")
+        except Exception:
+            pass
 
     def collect_overrides(self) -> dict:
         """Read the editor fields → env overrides for the serve.  Only non-empty
@@ -5402,7 +5419,6 @@ class LaneServePane(Container):
         for wid, key, custom_id in (
             ("#ov-ctx", "MAX_MODEL_LEN", "#ov-ctx-custom"),
             ("#ov-kv", "KV_CACHE_DTYPE", "#ov-kv-custom"),
-            ("#ov-spec", "SPEC", None),
             ("#ov-util", "GPU_MEMORY_UTILIZATION", "#ov-util-custom"),
         ):
             try:
@@ -5415,6 +5431,18 @@ class LaneServePane(Container):
                     out[key] = str(v)
             except Exception:
                 pass
+        # spec-dec: the dropdown value is the drafter METHOD (or "off").  off →
+        # SPEC=off; a method → SPEC=on + DRAFTER_METHOD (the swap entrypoint's
+        # ${DRAFTER_METHOD} rebuilds --speculative-config for that drafter).
+        try:
+            sv = self.query_one("#ov-spec", Select).value
+            if sv == "off":
+                out["SPEC"] = "off"
+            elif sv not in (None, Select.BLANK):
+                out["SPEC"] = "on"
+                out["DRAFTER_METHOD"] = str(sv)
+        except Exception:
+            pass
         return out
 
 

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -2198,23 +2198,25 @@ class CockpitData:
                 # sibling's --speculative-config method + num_speculative_tokens.
                 sm = _re.search(r'"method"\s*:\s*"([a-z0-9_]+)"', txt)
                 if sm:
-                    drafter = sm.group(1).upper()
+                    method = sm.group(1)
                     nm = _re.search(r'"num_speculative_tokens"\s*:\s*(\d+)', txt)
-                    out["SPEC_DRAFTER"] = f"{drafter} n={nm.group(1)}" if nm else drafter
+                    out["SPEC_METHOD"] = method                    # raw, e.g. "mtp"
+                    out["SPEC_N"] = nm.group(1) if nm else ""
+                    out["SPEC_DRAFTER"] = (
+                        f"{method.upper()} n={nm.group(1)}" if nm else method.upper())
         except Exception:
             pass
-        # KV dropdown options come from the ENGINE's supported set (not a generic
-        # vLLM list) — a vLLM pin, llama.cpp and ik-llama each support a different
-        # KV family.  The "✎ custom…" escape hatch reaches anything not listed
-        # (e.g. turboquant_4bit_nc, which v0.24.0 supports but the profile hasn't
-        # been widened to yet).
+        # KV + drafter dropdown options come from the ENGINE's supported set (not a
+        # generic vLLM list) — vLLM, llama.cpp, beellama each support a different
+        # family.  The "✎ custom…" hatch (KV) reaches anything not listed.
         out["KV_OPTIONS"] = self.engine_kv_formats(out["ENGINE"])
+        out["DRAFTER_OPTIONS"] = self.engine_drafters(out["ENGINE"])
         return out
 
-    def engine_kv_formats(self, engine: str) -> list:
-        """KV dtypes the ENGINE declares support for (its profile's
-        ``supported_kv_formats``).  Stdlib line-parse — the c3 path has no PyYAML.
-        Empty list → the caller uses a generic fallback."""
+    def _engine_yaml_list(self, engine: str, key: str) -> list:
+        """A top-level YAML list block (``key:`` then ``  - item``) from the
+        engine profile.  Stdlib line-parse — the c3 path has no PyYAML.  Empty
+        list → the caller uses a generic fallback."""
         out: list = []
         if not engine:
             return out
@@ -2223,7 +2225,7 @@ class CockpitData:
                  / "engines" / f"{engine}.yml")
             grab = False
             for ln in p.read_text(encoding="utf-8").splitlines():
-                if ln.strip().startswith("supported_kv_formats:"):
+                if ln.strip().startswith(f"{key}:"):
                     grab = True
                     continue
                 if grab:
@@ -2237,6 +2239,15 @@ class CockpitData:
         except Exception:
             pass
         return out
+
+    def engine_kv_formats(self, engine: str) -> list:
+        """KV dtypes the ENGINE declares support for (``supported_kv_formats``)."""
+        return self._engine_yaml_list(engine, "supported_kv_formats")
+
+    def engine_drafters(self, engine: str) -> list:
+        """Spec-dec drafters the ENGINE declares support for
+        (``supported_drafters`` — vLLM: mtp/mtp_assistant; beellama: dflash/…)."""
+        return self._engine_yaml_list(engine, "supported_drafters")
 
     def serve_generated(
         self, compose_path: str, overrides: Optional[dict[str, str]] = None

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -10494,6 +10494,31 @@ class TestProducerLaneHandoff:
             assert pane.collect_overrides()["KV_CACHE_DTYPE"] == "turboquant_4bit_nc"
 
     @pytest.mark.asyncio
+    async def test_serve_override_spec_selects_drafter_method(self, monkeypatch, tmp_path):
+        # The spec dropdown VALUE is the drafter method; collect maps method →
+        # SPEC=on + DRAFTER_METHOD, and "off" → SPEC=off (no DRAFTER_METHOD).
+        from textual.widgets import Select as _S
+        monkeypatch.setenv("HF_HOME", str(tmp_path))
+        app, _, _ = make_app(surface="producer")
+        async with app.run_test(size=(120, 48)) as pilot:
+            await pilot.press("2")
+            await _settle(pilot)
+            app.run_byo_check("unsloth/Qwen3-27B-abliterated", "vllm/dual")
+            await _settle(pilot)
+            pane = app.query_one("#lane-serve-pane", LaneServePane)
+            sel = pane.query_one("#ov-spec", _S)
+            # simulate the engine-driven drafter options, then switch the type
+            sel.set_options([("MTP n=3", "mtp"),
+                             ("mtp_assistant", "mtp_assistant"),
+                             ("off — no spec-dec", "off")])
+            sel.value = "mtp_assistant"
+            ovr = pane.collect_overrides()
+            assert ovr["SPEC"] == "on" and ovr["DRAFTER_METHOD"] == "mtp_assistant"
+            sel.value = "off"
+            ovr2 = pane.collect_overrides()
+            assert ovr2["SPEC"] == "off" and "DRAFTER_METHOD" not in ovr2
+
+    @pytest.mark.asyncio
     async def test_serve_armed_route_c_serves_your_weights(self, monkeypatch, tmp_path):
         # ② Serve armed for a Route-C brought model reflects the TRUTH: serves
         # YOUR weights via the sibling recipe — NOT a catalog reproduction, and no

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -3739,3 +3739,12 @@ class TestServeOverrides:
         assert cd.engine_kv_formats("llama-cpp-mainline") == ["q4_0", "q5_0", "q8_0", "k8v4"]
         # the editor's KV options come from the engine, not a generic list
         assert cd.serve_override_defaults("vllm/dual", "org/Foo")["KV_OPTIONS"] == vk
+
+    def test_engine_drafters_and_options(self):
+        repo_root = Path(__file__).resolve().parents[3]
+        cd = CockpitData(repo_root, runner=full_runner())
+        assert cd.engine_drafters("vllm-stable") == ["mtp", "mtp_assistant"]
+        assert "dflash" in cd.engine_drafters("beellama-local")
+        d = cd.serve_override_defaults("vllm/dual", "org/Foo")
+        assert d["DRAFTER_OPTIONS"] == ["mtp", "mtp_assistant"]   # engine-driven
+        assert d["SPEC_METHOD"] == "mtp" and d["SPEC_N"] == "3"


### PR DESCRIPTION
Two verified onboarding bugs from @DelspoN (1× 3090, driver 580.159).

## #634 — GGUF primary fetches fail verify despite a good download

`setup.sh:625` re-hardcoded `VERIFY_GLOB=*.safetensors` right before the primary download/verify, clobbering the recipe glob that `load_weight_recipe "${PRIMARY_WEIGHT_KEY}"` (line 321 → 100) had already set. So every GGUF primary key (`WEIGHTS=gguf`/`iq4ks`) downloaded fine, then failed verify with *"No *.safetensors found"* → `exit 1`.

**Fix:** default to the recipe's glob — `VERIFY_GLOB="${VERIFY_GLOB_OVERRIDE:-${VERIFY_GLOB}}"`. `VERIFY_GLOB_OVERRIDE` still wins.

## #632 — `.env` engine-image pins silently dropped (launch.sh)

launch.sh's `.env` load loop gated to `CLUB3090_DEFAULT_*` only, so `IK_LLAMA_IMAGE`/`LLAMACPP_IMAGE` never reached compose — and those two GGUF engines are *not* profile-injected, so `.env` is their only override path (the natural persistence for #633's cu12 workaround). switch.sh already loaded them (no filter).

*(DelspoN cited the engine-pin whitelist — that's the vllm/beellama-only profile-injection path; the real drop was the `.env` loop filter. Traced + confirmed.)*

**Fix:** broaden launch.sh's allowlist to the engine-image keys (`VLLM_IMAGE`/`BEELLAMA_IMAGE`/`IK_LLAMA_IMAGE`/`LLAMACPP_IMAGE`/`VLLM_NIGHTLY_SHA`); both launchers now echo an ik-llama/llama.cpp image pin so a wrong-image boot is never silent.

## Verified

- `.env` loop now loads `IK_LLAMA_IMAGE`/`LLAMACPP_IMAGE` and still drops un-allowlisted keys.
- Guards green: `test-model-switch` · `test-launch-compat` · `test-launch-registry-parity` · `test-switch-registry-parity` · `test-setup-picker` · `test-model-weights-registry`.

Closes #634. Closes #632. Companion to #633 (the cu12 workaround this makes persistable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
