### PR TITLE
fix(ik-llama): driver-aware cu13/cu12 select + preflight hint + docs (#633)

### DIFF
--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -9,6 +9,7 @@ What this stack assumes about your hardware. True regardless of which model or e
 - **NVIDIA RTX 3090 (24 GB, Ampere SM 8.6)** — 1 or 2 cards.
 - **PCIe Gen 4 slot** — Gen 3 works but allreduce on dual-card is slower (mild impact on multi-tenant; minimal impact on single-stream).
 - **NVIDIA driver 580.x or newer** — for CUDA 13 runtime in vLLM nightly. `nvidia-smi` to check. Older drivers won't load CUDA 13 kernels.
+  - ⚠️ **The ik-llama `cu13` pin needs CUDA ≥ 13.2 specifically** (not just 580.x). Its digest is a CUDA 13.2 runtime, so a driver whose *supported* CUDA < 13.2 — e.g. 580.159 = CUDA 13.0 — forward-compat-fails on GeForce (error 804) → CPU fallback → crash loop ([#633](../../../noonghunna/club-3090/issues/633)). The launcher **auto-selects the cu12 sibling build** (same build, backward-compatible) on such drivers; override with `IK_LLAMA_IMAGE=…:cu12-server-4574` in `.env`. Check your ceiling top-right in `nvidia-smi`.
 - **Linux** (Ubuntu 22.04+ tested). vLLM is Linux + CUDA only. llama.cpp works on macOS / Windows but our recipes assume Linux paths.
 - **Docker + NVIDIA Container Toolkit** for vLLM. llama.cpp doesn't need Docker.
 

--- a/models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/mtp.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/mtp.yml
@@ -66,7 +66,13 @@
 # Engine pinned by digest (engine policy):
 #   ghcr.io/ikawrakow/ik-llama-cpp@sha256:5f914f1ccade922417af58c94bd1cbb558052c8852d86678ead3fe693eec0143
 #     @sha256:c13e0798e4117649962833adc932362b64cb7080cfc9dbb1235161f43f8d5c49
-#   cu13 = matches our CUDA 13.2 host driver.
+#   cu13 = a CUDA 13.2 RUNTIME. Requires a driver whose supported CUDA >= 13.2
+#   (nvidia-smi top-right). ⚠️ On a driver < 13.2 — e.g. 580.159 = CUDA 13.0,
+#   which satisfies the README's "580.x+" but NOT this pin — cu13 forward-compat-
+#   fails on GeForce (CUDA error 804) -> silent CPU fallback -> crash loop (#633).
+#   The launcher auto-selects the cu12 sibling build there (same build 4574,
+#   CUDA 12.6, backward-compatible, community-validated ~68 TPS). Pin
+#   IK_LLAMA_IMAGE=ghcr.io/ikawrakow/ik-llama-cpp:cu12-server-4574 in .env to force it.
 #
 # Quick start:
 #   1. Get the MTP-IQ4_KS GGUF:

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1342,3 +1342,49 @@ except Exception:
   fi
   return 0
 }
+
+# ── #633 — ik-llama cu13/cu12 driver-aware image selection ────────────────────
+# The pinned cu13 ik-llama image has a CUDA 13.2 runtime; on a driver whose
+# supported CUDA < 13.2 the forward-compat path fails on GeForce (CUDA error
+# 804) → silent CPU fallback → segfault crash-loop, with no actionable hint
+# (launch just times out after 600 s). Auto-pick the cu12 sibling build (same
+# build 4574, CUDA 12.6, backward-compatible with the 13.0 driver — validated on
+# a 580.159 rig, #633) unless the user pinned IK_LLAMA_IMAGE. ik-llama only.
+IK_LLAMA_CU13_MIN_CUDA="13.2"
+IK_LLAMA_CU12_FALLBACK="${IK_LLAMA_CU12_FALLBACK:-ghcr.io/ikawrakow/ik-llama-cpp:cu12-server-4574}"
+
+# _cuda_ge A B → 0 (true) iff major.minor A >= B
+_cuda_ge() {
+  local a1="${1%%.*}" b1="${2%%.*}" a2 b2
+  a2="${1#*.}"; [[ "$a2" == "$1" ]] && a2=0
+  b2="${2#*.}"; [[ "$b2" == "$2" ]] && b2=0
+  (( 10#${a1:-0} > 10#${b1:-0} )) && return 0
+  (( 10#${a1:-0} < 10#${b1:-0} )) && return 1
+  (( 10#${a2:-0} >= 10#${b2:-0} ))
+}
+
+# Driver's max supported CUDA (major.minor), or "" if undetectable.
+_driver_cuda_version() {
+  local v
+  v="$(nvidia-smi --query 2>/dev/null | grep -m1 -oE 'CUDA Version[[:space:]]*:[[:space:]]*[0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+' || true)"
+  [[ -z "$v" ]] && v="$(nvidia-smi 2>/dev/null | grep -m1 -oE 'CUDA Version:?[[:space:]]*[0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+' || true)"
+  printf '%s' "$v"
+}
+
+preflight_ik_llama_image() {
+  local variant="${1:-}"
+  [[ "$variant" == ik-llama/* ]] || return 0
+  if [[ -n "${IK_LLAMA_IMAGE:-}" ]]; then
+    echo "[preflight] ik-llama image pinned (.env/shell): ${IK_LLAMA_IMAGE}"
+    return 0
+  fi
+  local drv; drv="$(_driver_cuda_version)"
+  [[ -z "$drv" ]] && return 0                    # undetectable → leave compose default (cu13)
+  _cuda_ge "$drv" "$IK_LLAMA_CU13_MIN_CUDA" && return 0   # >=13.2 → cu13 runtime OK
+  export IK_LLAMA_IMAGE="$IK_LLAMA_CU12_FALLBACK"
+  echo "[preflight] ⚠ driver CUDA ${drv} < ${IK_LLAMA_CU13_MIN_CUDA} (the cu13 ik-llama pin's runtime)." >&2
+  echo "[preflight]   cu13 would forward-compat-fail on GeForce (error 804) → CPU fallback → crash loop (#633)." >&2
+  echo "[preflight]   Auto-selected the cu12 sibling build (same build, CUDA 12.6, backward-compatible):" >&2
+  echo "[preflight]     IK_LLAMA_IMAGE=${IK_LLAMA_CU12_FALLBACK}" >&2
+  echo "[preflight]   Pin IK_LLAMA_IMAGE in .env to override." >&2
+}

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -1024,6 +1024,7 @@ up_variant() {
 
   echo "[switch] bringing up: ${v}  (${dir}/${file})"
   export_variant_engine_pin "$v"
+  preflight_ik_llama_image "$v"   # #633 — cu12 fallback on <13.2 drivers (unless pinned)
   (cd "${full_dir}" && ${COMPOSE_BIN} -f "${file}" up -d --remove-orphans)
 }
 


### PR DESCRIPTION
Verified from @DelspoN's report (1× 3090, driver 580.159 = CUDA 13.0) + our own `ik_cu13_forward_compat` notes.

## Problem

The pinned `cu13` ik-llama digest is a **CUDA 13.2 runtime**. On a driver whose *supported* CUDA < 13.2 — e.g. **580.159 = CUDA 13.0**, which satisfies the README's "580.x+" but **not** this pin — the forward-compat path fails on GeForce (CUDA error 804) → silent CPU fallback → segfault crash-loop. `launch.sh` just times out after 600 s with no hint, and `nvidia-smi` works inside the container (NVML ≠ libcuda), making it hard to triage.

## Fix (all three, per the thread)

1. **Driver-aware select** — `preflight_ik_llama_image()` detects the driver's supported CUDA and, for ik-llama variants on a driver **< 13.2** with `IK_LLAMA_IMAGE` unset, auto-selects the **cu12 sibling build** (`cu12-server-4574` — same build as the cu13 digest, CUDA 12.6, backward-compatible, DelspoN-validated ~68 TPS). ≥13.2 keeps cu13; a user `IK_LLAMA_IMAGE` pin always wins.
2. **Preflight hint** — a `⚠` block naming the mismatch + the exact `IK_LLAMA_IMAGE=…` to override.
3. **Docs** — qualified the driver requirement in the ik-llama compose header + `HARDWARE.md` ("580.x+" is insufficient; needs CUDA ≥ 13.2).

Wired in `switch.sh` right after `export_variant_engine_pin`, before compose-up (the single up path — `launch.sh` delegates here).

## Verification

- `_cuda_ge` logic verified: 13.3/13.2 → GE (keep cu13), 13.0 & 12.6 → LT (use cu12), 14.0 → GE. Detection reads `13.3` on this rig.
- Guards green: `test-model-switch` · `test-switch-registry-parity` · `test-launch-compat` · `test-compose-status-drift`.
- ⚠️ **This rig is CUDA 13.3**, so the `<13.2` *boot* path is verified by logic + DelspoN's `cu12-server-4574` validation, not a local boot. Pinned to the **build-number tag** (rolling `cu12` tags are unsafe — `cu12-server-100` rejects the compose's `--spec-type` flag, per the report).

Closes #633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
