### PR TITLE
preflight: warn on single-card GPU_MEMORY_UTILIZATION override above default

### DIFF
--- a/scripts/lib/profiles/baselines.yml
+++ b/scripts/lib/profiles/baselines.yml
@@ -337,6 +337,11 @@ baselines:
     ttft_ms: 158
     prefill_tps: { 10k: 1364, 90k: 875 }
     quality_8pk: "107/150"
+    # thinking-ON here is pack-defaults (mixed regime), NOT force-on: the 2026-06-07
+    # #515 quant-A/B ran the fp8 dual-max config full 8-pack = 110/150 (autoround
+    # sibling 109/150); measured then but never promoted to this row until 2026-07-08.
+    # Source: results/quality/quality-2026-06-07T15-18-18.json (endpoint :8013).
+    quality_8pk_think_on: "110/150"
     ctx_validated: { tokens: 245760, niah: "clean@240K" }
     date: 2026-06-30
     engine_pin: "vllm/vllm-openai:v0.24.0"

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1371,6 +1371,42 @@ _driver_cuda_version() {
   printf '%s' "$v"
 }
 
+# preflight_single_card_util <compose_file> [variant]
+# Advisory WARN (never blocks; runs even under --force) when the user raises
+# GPU_MEMORY_UTILIZATION above the compose's validated default on a SINGLE-CARD
+# (TP<=1) config. On one GPU a higher util shrinks the free VRAM a large
+# tool-response prefill needs for its activation peak, so vLLM OOMs mid-prefill
+# even though boot succeeds (verify-stress step 2/8). Two 5090 testers hit this
+# by setting util=0.92 on the nvfp4 slug whose validated default is 0.85 (#617).
+# No-op unless the user overrode the env AND the compose ships a
+# `GPU_MEMORY_UTILIZATION:-<default>` (so it never fires for non-vLLM engines,
+# dual/multi-card, or a plain default run).
+preflight_single_card_util() {
+  local compose_file="$1" variant="${2:-}"
+  [[ -f "$compose_file" ]] || return 0
+  local user_util="${GPU_MEMORY_UTILIZATION:-}"
+  [[ -n "$user_util" ]] || return 0                 # only when explicitly overridden
+
+  local tp=""
+  if declare -F compose_meta_get >/dev/null 2>&1; then
+    tp="$(compose_meta_get "$compose_file" tensor-parallel 2>/dev/null || true)"
+  fi
+  [[ "$tp" =~ ^[0-9]+$ ]] || return 0               # unknown topology → stay quiet
+  (( tp <= 1 )) || return 0                          # single-card only
+
+  local default_util
+  default_util="$(command grep -oE 'GPU_MEMORY_UTILIZATION:-[0-9.]+' "$compose_file" | head -1 | sed -E 's/.*:-//')"
+  [[ -n "$default_util" ]] || return 0               # compose ships no util default
+
+  if awk -v u="$user_util" -v d="$default_util" 'BEGIN{exit !((u+0) > (d+0))}'; then
+    echo "[preflight] WARN:  GPU_MEMORY_UTILIZATION=${user_util} exceeds ${variant:-this config}'s validated single-card default of ${default_util}." >&2
+    echo "[preflight]        On one GPU a higher util steals the headroom a large tool-response prefill needs for its" >&2
+    echo "[preflight]        activation peak — vLLM can OOM mid-prefill (verify-stress step 2/8) even though boot succeeds." >&2
+    echo "[preflight]        Fix: grow context via MAX_MODEL_LEN and keep GPU_MEMORY_UTILIZATION <= ${default_util}. (#617)" >&2
+  fi
+  return 0
+}
+
 preflight_ik_llama_image() {
   local variant="${1:-}"
   [[ "$variant" == ik-llama/* ]] || return 0

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -1024,6 +1024,9 @@ up_variant() {
     # No-op for composes without an LMCache-l1-gb metadata header.
     preflight_lmcache_ram "${full_dir}/${file}" || exit 1
     preflight_kv_format_hint "${full_dir}/${file}" || true
+    # Single-card util-override guard — runs even under --force (the nvfp4 slug
+    # launches with --force, and util=0.92 on one card OOMs the tool-prefill; #617).
+    preflight_single_card_util "${full_dir}/${file}" "$v" || true
   fi
   gpu_preflight
 


### PR DESCRIPTION
## Why

On #617, two 5090 testers hit the same trap: setting `GPU_MEMORY_UTILIZATION=0.92` on the single-card **nvfp4** slug (validated default **0.85**) boots fine, then **OOMs at verify-stress step 2/8** (the ~25K-token tool-response prefill). On one GPU, a higher util reserves more of the card for weights+KV and leaves *less* headroom for the transient activation peak of a large prefill — so it OOMs mid-prefill even though load succeeded. vLLM's own error already says "lower `--gpu-memory-utilization`", but nothing warned the user up front, so it read as a mysterious boot-ok-then-500.

This is user config (not a slug bug), but it's now bitten two testers, so a cheap up-front nudge is worth it.

## What

`preflight_single_card_util()` — an **advisory WARN** (never blocks) that fires **only** when:
- the user **overrode** `GPU_MEMORY_UTILIZATION` (env set), **and**
- the target is **single-card** (`TP<=1`), **and**
- the compose ships a `GPU_MEMORY_UTILIZATION:-<default>` (⇒ vLLM only), **and**
- the override is **strictly above** that default.

Runs **even under `--force`** (the nvfp4 slug launches with `--force`), alongside the other force-independent hints in `switch.sh`. No-ops for dual/multi-card, non-vLLM engines, a plain default run, or util at/below the default. Message points at the real fix: grow ctx via `MAX_MODEL_LEN`, keep util ≤ default.

## Verified (sm_86 dev rig — logic is engine-agnostic, no nvfp4 boot needed)

Behavior matrix:
| case | result |
|---|---|
| single, util 0.92 (>0.85) | **WARN** |
| single, util 0.85 (=default) | silent |
| single, util 0.80 (<default) | silent |
| single, no override | silent |
| dual, util 0.99 | silent |

Guards green: `test-preflight-compose-deps`, `test-model-switch`, `test-switch-registry-parity`, `test-launch-compat` + `bash -n` on both files.

Ref: #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)