### PR TITLE
c3+pull: detect in-progress downloads + per-repo lock (#617)

### DIFF
--- a/scripts/lib/profiles/downloader.py
+++ b/scripts/lib/profiles/downloader.py
@@ -79,6 +79,7 @@ import os
 import re
 import shutil
 import subprocess
+import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
@@ -146,6 +147,14 @@ def pull_dir(hf_home: Path, slug: str) -> Path:
 def incomplete_dir(hf_home: Path, slug: str) -> Path:
     """The atomic-staging `.incomplete` tree (deleted on ANY failure)."""
     return pull_dir(hf_home, slug) / ".incomplete"
+
+
+# A lock dir that exists but has NO `pid` file yet is a holder mid-acquire
+# (mkdir done, pid write imminent) — refuse rather than reclaim it, so two racing
+# callers can't both proceed. Only reclaim a pidless lock OLDER than this (a
+# genuinely broken/abandoned one). The real mkdir→pid-write gap is microseconds;
+# 10s is a safe margin against a slow filesystem.
+_LOCK_ACQUIRE_GRACE_S = 10.0
 
 
 def download_lock_dir(hf_home: Path, slug: str) -> Path:
@@ -462,7 +471,22 @@ def download_model(einput, *, fetcher: Optional[Any] = None) -> DownloadResult:
                     files=[],
                     detail=f"pid={active['pid']} since {active['since']}",
                 )
-            _rmtree(lock)                              # stale holder → reclaim
+            # Not a LIVE holder. Reclaiming the WRONG case re-opens the dup race
+            # this lock closes, so split it: a pidless lock that's still FRESH is
+            # a holder mid-acquire (pid write imminent) → refuse, don't steal it.
+            # A pid-present-but-dead lock, or an old pidless one, is genuinely
+            # abandoned → reclaim.
+            if not (lock / "pid").exists():
+                try:
+                    fresh = (time.time() - lock.stat().st_mtime) < _LOCK_ACQUIRE_GRACE_S
+                except OSError:
+                    fresh = False
+                if fresh:                              # mid-acquire → refuse
+                    return DownloadResult(
+                        ok=False, failure="in-progress",
+                        local_dir=str(final_dir), files=[], detail="acquiring",
+                    )
+            _rmtree(lock)                              # dead/abandoned → reclaim
         except OSError:
             break
     if not acquired:

--- a/scripts/lib/profiles/downloader.py
+++ b/scripts/lib/profiles/downloader.py
@@ -82,6 +82,7 @@ import subprocess
 import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
@@ -145,6 +146,52 @@ def pull_dir(hf_home: Path, slug: str) -> Path:
 def incomplete_dir(hf_home: Path, slug: str) -> Path:
     """The atomic-staging `.incomplete` tree (deleted on ANY failure)."""
     return pull_dir(hf_home, slug) / ".incomplete"
+
+
+def download_lock_dir(hf_home: Path, slug: str) -> Path:
+    """The atomic per-repo download lock (`mkdir` = acquire). Its `pid` file
+    holds the live holder's PID + UTC start time so a 2nd concurrent
+    `download_model` for the SAME slug can REFUSE (holder alive) vs RECLAIM
+    (holder dead). Without it, repeated ① Bring [D] presses each spawned a
+    fresh download that rmtree'd + re-fetched the shared `.incomplete`,
+    racing 5-deep (club-3090 #617)."""
+    return pull_dir(hf_home, slug) / ".download.lock"
+
+
+def _pid_alive(pid: int) -> bool:
+    """True if `pid` is a live process. Signal 0 probes without delivering."""
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True   # exists, just not ours to signal
+    except OSError:
+        return False
+    return True
+
+
+def read_active_download(hf_home: Path, slug: str) -> Optional[dict]:
+    """`{'pid': int, 'since': str}` if a LIVE download lock is held for `slug`;
+    `None` when there is no lock OR the lock is STALE (dead holder — a
+    crashed/killed download; the caller may reclaim it). A cheap stat, safe to
+    poll from the UI — this is the disk-truth an in-progress probe reads."""
+    pidf = download_lock_dir(hf_home, slug) / "pid"
+    try:
+        raw = pidf.read_text(encoding="utf-8").splitlines()
+    except (OSError, ValueError):
+        return None
+    if not raw:
+        return None
+    try:
+        pid = int(raw[0].strip())
+    except ValueError:
+        return None
+    if not _pid_alive(pid):
+        return None
+    return {"pid": pid, "since": raw[1].strip() if len(raw) > 1 else ""}
 
 
 # ---------------------------------------------------------------------------
@@ -385,6 +432,58 @@ class DiskError(RuntimeError):
 # THE download stage.
 # ---------------------------------------------------------------------------
 def download_model(einput, *, fetcher: Optional[Any] = None) -> DownloadResult:
+    """Public entry — serialize per-repo via an atomic pull-dir lock, then run
+    the verified fetch (`_download_model_impl`).
+
+    A 2nd concurrent `download_model` for the SAME slug is REFUSED with
+    `failure="in-progress"` (`.detail="pid=<N> since <T>"`) instead of racing
+    into — and rmtree-ing — the first's `.incomplete` staging (the club-3090
+    #617 five-duplicate-downloads bug). A STALE lock (dead holder: a crashed
+    or SIGKILL'd download that couldn't run `finally`) is reclaimed on the next
+    call, so a leaked lock self-heals — more robust than a signal trap (which a
+    SIGKILL skips anyway). The lock releases in `finally` on every normal /
+    exception return path."""
+    hf_home = Path(einput.hf_home)
+    slug = einput.slug
+    final_dir = pull_dir(hf_home, slug)
+    lock = download_lock_dir(hf_home, slug)
+
+    acquired = False
+    for _attempt in range(2):
+        try:
+            lock.mkdir(parents=True, exist_ok=False)   # atomic acquire
+            acquired = True
+            break
+        except FileExistsError:
+            active = read_active_download(hf_home, slug)
+            if active is not None:                     # live holder → refuse
+                return DownloadResult(
+                    ok=False, failure="in-progress", local_dir=str(final_dir),
+                    files=[],
+                    detail=f"pid={active['pid']} since {active['since']}",
+                )
+            _rmtree(lock)                              # stale holder → reclaim
+        except OSError:
+            break
+    if not acquired:
+        return DownloadResult(
+            ok=False, failure="disk", local_dir=str(final_dir), files=[]
+        )
+    try:
+        (lock / "pid").write_text(
+            f"{os.getpid()}\n"
+            f"{datetime.now(timezone.utc).isoformat(timespec='seconds')}\n",
+            encoding="utf-8",
+        )
+    except OSError:
+        pass
+    try:
+        return _download_model_impl(einput, fetcher=fetcher)
+    finally:
+        _rmtree(lock)
+
+
+def _download_model_impl(einput, *, fetcher: Optional[Any] = None) -> DownloadResult:
     """Fetch EXACTLY `deriver.download_set(api)`, etag-SHA-verify every
     `*.safetensors`, atomically stage into the CONTRACT-2 host `--model`
     dir. Returns the structured `DownloadResult` (== §6 capture-point-2

--- a/scripts/lib/profiles/swap_apply.py
+++ b/scripts/lib/profiles/swap_apply.py
@@ -272,6 +272,15 @@ def apply_swap(
         except TypeError:
             dl = download_fn(ei)  # an injected mock may omit the fetcher kwarg
         if not getattr(dl, "ok", False):
+            # A concurrent download of this slug already holds the pull-dir
+            # lock — surface it distinctly (in_progress) so pull.sh exits with
+            # the rc=3 "already running" contract, NOT the rc=1 failure path
+            # (club-3090 #617: retries must reflect the live download, not
+            # stack a duplicate).
+            if getattr(dl, "failure", "") == "in-progress":
+                return {"ok": False, "in_progress": True,
+                        "error": "download already in progress",
+                        "detail": getattr(dl, "detail", "")}
             return {"ok": False,
                     "error": f"download failed: {getattr(dl, 'failure', '?')}",
                     "detail": getattr(dl, "detail", "")}

--- a/scripts/pull.sh
+++ b/scripts/pull.sh
@@ -135,6 +135,13 @@ print(f"[apply-swap] resolving Route-C swap for {args.slug} "
 res = SA.apply_swap(root, args.slug, args.profile_like, hf_home=args.hf_home,
                     do_download=not _emit_only)
 if not res.get("ok"):
+    # rc=3 = "already downloading" (distinct from rc=1 failure): a concurrent
+    # download of this slug holds the pull-dir lock; do NOT start a duplicate
+    # (club-3090 #617). Callers (c3) treat rc=3 as "reflect the live download".
+    if res.get("in_progress"):
+        print(f"[apply-swap] already in progress ({res.get('detail','')}) "
+              "— not starting a duplicate", flush=True)
+        sys.exit(3)
     print(f"[apply-swap] ERROR: {res.get('error')}", file=sys.stderr, flush=True)
     if res.get("detail"):
         print(f"[apply-swap]   detail: {res['detail']}", file=sys.stderr, flush=True)

--- a/scripts/tests/test-download-lock.sh
+++ b/scripts/tests/test-download-lock.sh
@@ -13,7 +13,7 @@ ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
 python3 - <<'PY'
-import sys, os, tempfile, subprocess
+import sys, os, tempfile, subprocess, time
 sys.path.insert(0, "scripts")
 from pathlib import Path
 from lib.profiles import downloader as DL
@@ -62,6 +62,34 @@ r = DL.download_model(EI())
 assert r is sentinel, "stale lock must be reclaimed and the fetch proceed"
 assert not lock.exists(), "lock must be RELEASED (rmdir) after the fetch"
 print("PASS 3: stale lock reclaimed → fetch proceeded → lock released")
+
+# 4) MID-ACQUIRE window → refuse (pidless + FRESH lock = a holder just mkdir'd
+#    and hasn't written its pid yet; reclaiming it would let BOTH callers
+#    proceed — the very dup race the lock closes) -----------------------------
+def _must_not_fetch(einput, *, fetcher=None):
+    raise AssertionError("must NOT reach the fetch for a fresh pidless lock")
+DL._download_model_impl = _must_not_fetch  # type: ignore
+lock = DL.download_lock_dir(tmp, slug)
+lock.mkdir(parents=True, exist_ok=True)
+(lock / "pid").unlink(missing_ok=True)         # no pid yet, mtime = now (fresh)
+r = DL.download_model(EI())
+assert r.ok is False and r.failure == "in-progress", \
+    f"fresh pidless lock (mid-acquire) must be refused, got ok={r.ok} failure={r.failure}"
+assert lock.exists(), "must NOT reclaim a fresh pidless lock (holder mid-acquire)"
+print("PASS 4: fresh pidless lock (mid-acquire) refused — not stolen")
+
+# 5) OLD pidless lock → reclaim (a genuinely broken/abandoned lock, past grace)
+sentinel2 = DL.DownloadResult(ok=True, local_dir=str(tmp / "y"), files=["g"])
+DL._download_model_impl = lambda einput, *, fetcher=None: sentinel2  # type: ignore
+lock = DL.download_lock_dir(tmp, slug)
+lock.mkdir(parents=True, exist_ok=True)
+(lock / "pid").unlink(missing_ok=True)
+old = time.time() - (DL._LOCK_ACQUIRE_GRACE_S + 5)
+os.utime(lock, (old, old))                     # age past the grace window
+r = DL.download_model(EI())
+assert r is sentinel2, "old pidless lock must be reclaimed and the fetch proceed"
+assert not lock.exists(), "lock released after reclaim + fetch"
+print("PASS 5: old pidless lock reclaimed → fetch proceeded → lock released")
 
 print("OK test-download-lock")
 PY

--- a/scripts/tests/test-download-lock.sh
+++ b/scripts/tests/test-download-lock.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Guard: the per-repo download lock in downloader.download_model (club-3090
+# #617 — repeated ① Bring [D] presses spawned 5 concurrent hf downloads racing
+# into the same .incomplete). Asserts:
+#   1. a 2nd download while a LIVE holder exists is REFUSED (failure=in-progress,
+#      detail carries the holder pid) — never races/rmtrees the first's staging;
+#   2. a STALE lock (dead holder — a crashed/SIGKILL'd download) is RECLAIMED
+#      and the fetch proceeds, and the lock is RELEASED afterwards;
+#   3. read_active_download reflects live-vs-stale.
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+python3 - <<'PY'
+import sys, os, tempfile, subprocess
+sys.path.insert(0, "scripts")
+from pathlib import Path
+from lib.profiles import downloader as DL
+
+tmp = Path(tempfile.mkdtemp())
+slug = "org/Test-FP8"
+
+class EI:
+    slug = "org/Test-FP8"
+    hf_home = str(tmp)
+
+# 1) LIVE holder → refuse ---------------------------------------------------
+holder = subprocess.Popen(["sleep", "60"])
+try:
+    lock = DL.download_lock_dir(tmp, slug)
+    lock.mkdir(parents=True)
+    (lock / "pid").write_text(
+        f"{holder.pid}\n2026-01-01T00:00:00+00:00\n", encoding="utf-8"
+    )
+    r = DL.download_model(EI())
+    assert r.ok is False and r.failure == "in-progress", \
+        f"expected in-progress refusal, got ok={r.ok} failure={r.failure}"
+    assert f"pid={holder.pid}" in (r.detail or ""), \
+        f"detail must carry holder pid: {r.detail!r}"
+    act = DL.read_active_download(tmp, slug)
+    assert act and act["pid"] == holder.pid, f"read_active live: {act}"
+    print("PASS 1: live holder refused (failure=in-progress, pid in detail)")
+finally:
+    holder.terminate()
+    holder.wait()
+
+# holder dead now → the lock is stale
+assert DL.read_active_download(tmp, slug) is None, \
+    "dead-holder lock must read stale (None)"
+print("PASS 2: dead-holder lock reads stale (None) → reclaimable")
+
+# 2) STALE lock → reclaim + proceed + release -------------------------------
+# stub the fetch so no network/deriver is needed; prove we got PAST the lock.
+sentinel = DL.DownloadResult(ok=True, local_dir=str(tmp / "x"), files=["f"])
+DL._download_model_impl = lambda einput, *, fetcher=None: sentinel  # type: ignore
+lock = DL.download_lock_dir(tmp, slug)
+if not lock.exists():
+    lock.mkdir(parents=True)
+(lock / "pid").write_text("2147483646\nSTALE\n", encoding="utf-8")  # dead pid
+r = DL.download_model(EI())
+assert r is sentinel, "stale lock must be reclaimed and the fetch proceed"
+assert not lock.exists(), "lock must be RELEASED (rmdir) after the fetch"
+print("PASS 3: stale lock reclaimed → fetch proceeded → lock released")
+
+print("OK test-download-lock")
+PY

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -6400,7 +6400,13 @@ class CockpitApp(App):
         # a live download, so the shared "k" falls through to serving_stop
         # everywhere else (mode 1 is producer-only, so no surface leak).
         if action == "bring_cancel_download":
-            return self._active_mode == 1 and bool(self._active_bring_download())
+            # Cancelable when this session started a download (tracker) OR a
+            # disk-truth download lock is live for the fit-checked repo (a
+            # prior session / bare pull.sh — the tracker can't see it). #617.
+            return self._active_mode == 1 and (
+                bool(self._active_bring_download())
+                or self._bring_disk_download()[1] is not None
+            )
 
         # Arrow-key focus descent (tab bar ↔ primary list).  These are gated here —
         # BEFORE _ALWAYS_ON — so the result is fully controlled (neither is in
@@ -7769,7 +7775,11 @@ class CockpitApp(App):
         # #617: a re-run fit-check (or refresh) must SEE an in-flight [D] download
         # for this repo — render "⏳ downloading" + suppress the [D] re-offer,
         # rather than the stale disk verdict that invites a second 20+ GB fetch.
-        downloading = repo in self._active_bring_download()
+        # Two sources: the in-memory tracker (this session) OR disk truth (the
+        # pull-dir download lock) — the latter survives a c3 restart AND sees a
+        # download started outside this session (a bare pull.sh --apply-swap).
+        disk_dl = self._data.bring_download_in_progress(repo)
+        downloading = (repo in self._active_bring_download()) or bool(disk_dl)
         if lane_pane is not None:
             lane_pane.populate(res, weights_present, downloading=downloading)
         # N9 — carry the fit-check result forward: pre-arm ② Serve with the
@@ -7787,9 +7797,11 @@ class CockpitApp(App):
             if getattr(res, "error", ""):
                 lane_pane.set_weights_line("")
             elif downloading:
+                pct = (disk_dl or {}).get("pct")
+                pcts = f" (resuming {pct}%)" if isinstance(pct, int) else ""
                 lane_pane.set_weights_line(
-                    "  [cyan]⏳ downloading…[/cyan] [dim](in progress — leave it "
-                    "running; \\[k] cancels)[/dim]"
+                    f"  [cyan]⏳ downloading{pcts}…[/cyan] [dim](in progress — leave "
+                    "it running; \\[k] cancels)[/dim]"
                 )
             elif weights_present:
                 lane_pane.set_weights_line(
@@ -7816,6 +7828,39 @@ class CockpitApp(App):
             self._bring_downloads = d
         return d
 
+    def _bring_disk_download(self):
+        """``(repo, info)`` when a disk-truth download lock is live for the
+        CURRENTLY fit-checked repo, else ``(None, None)``.  Lets [k] cancel a
+        download this session's in-memory tracker can't see — one started
+        before a c3 restart or by a bare ``pull.sh --apply-swap`` (#617)."""
+        byo = self._last_byo
+        repo = getattr(byo, "repo", "") if byo is not None else ""
+        if not repo:
+            return None, None
+        info = self._data.bring_download_in_progress(repo)
+        return (repo, info) if info is not None else (None, None)
+
+    def _kill_bring_pid(self, pid) -> None:
+        """Best-effort kill of a disk-detected download holder (its PID from
+        the pull-dir lock).  Tries the process GROUP first (takes the `hf`
+        child too), then the bare PID.  A leaked lock self-heals via the
+        downloader's stale-reclaim regardless."""
+        import os as _os
+        import signal as _sig
+        try:
+            pid = int(pid)
+        except (TypeError, ValueError):
+            return
+        if pid <= 0:
+            return
+        try:
+            _os.killpg(_os.getpgid(pid), _sig.SIGTERM)
+        except (ProcessLookupError, PermissionError, OSError):
+            try:
+                _os.kill(pid, _sig.SIGTERM)
+            except (ProcessLookupError, PermissionError, OSError):
+                pass
+
     def action_bring_download(self) -> None:
         """[D] — §2b-6: download the fit-checked repo's weights (the REAL
         pull.sh run — Path B fetch into the pull dir).  Guarded on a successful
@@ -7837,6 +7882,17 @@ class CockpitApp(App):
         if repo in self._active_bring_download():
             self.notify(
                 f"Already downloading {repo} — press [k] to cancel.",
+                title="Download", timeout=4,
+            )
+            return
+        # Disk-truth guard: a download from a PRIOR c3 session or a bare
+        # pull.sh holds the pull-dir lock but isn't in this session's tracker —
+        # still must not stack a duplicate (#617).  [k] cancels it.
+        _disk = self._data.bring_download_in_progress(repo)
+        if _disk is not None:
+            self.notify(
+                f"Already downloading {repo} (pid {_disk.get('pid')}) — "
+                "press [k] to cancel.",
                 title="Download", timeout=4,
             )
             return
@@ -7864,11 +7920,19 @@ class CockpitApp(App):
         cancel).  check_action gates this to mode 1 + an active download so the
         shared [k] falls through to serving_stop everywhere else."""
         dls = self._active_bring_download()
-        if not dls:
-            return
-        repo = next(iter(dls))
-        dls.pop(repo, None)
-        self._cancel_bring_download()
+        if dls:
+            # In-session download → cancel via the runner (SIGINT→TERM→KILL).
+            repo = next(iter(dls))
+            dls.pop(repo, None)
+            self._cancel_bring_download()
+        else:
+            # Disk-detected download (prior session / bare pull.sh) → kill the
+            # lock holder PID directly; the downloader's stale-reclaim frees the
+            # lock. (#617)
+            repo, info = self._bring_disk_download()
+            if info is None:
+                return
+            self._kill_bring_pid(info.get("pid"))
         try:
             self.query_one("#lane-bring-pane", LaneBringPane).set_weights_line(
                 "  [yellow]download cancelled[/yellow] — press [bold]\\[D][/bold] to restart"

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -996,6 +996,53 @@ class CockpitData:
         except OSError:
             return False
 
+    def bring_download_in_progress(
+        self, repo: str, expected_gb: Optional[float] = None
+    ) -> Optional[dict]:
+        """Disk-truth in-progress probe for a brought download (club-3090 #617).
+
+        Returns ``{"in_progress": True, "pid": int, "pct": <0-100|None>}`` when a
+        LIVE download lock is held for this repo — downloader.py writes
+        ``<pull_dir>/.download.lock/pid`` = holder PID + UTC start on acquire and
+        removes it on release. Unlike the in-memory ``_active_bring_download``
+        tracker, this survives a c3 restart AND sees a download started outside
+        this session (e.g. a bare ``pull.sh --apply-swap``), so the fit-check can
+        REFLECT a running download instead of re-offering [D] and stacking a
+        duplicate. Returns None when no lock, a STALE lock (dead holder), or an
+        unreadable one. A cheap stat — safe to call on every fit-check render.
+        ``pct`` from ``.incomplete`` bytes / ``expected_gb`` when the size is
+        known, else None."""
+        d = self.bring_pull_dir(repo)
+        try:
+            raw = (d / ".download.lock" / "pid").read_text(
+                encoding="utf-8"
+            ).splitlines()
+            pid = int(raw[0].strip())
+        except (OSError, ValueError, IndexError):
+            return None
+        if pid <= 0:
+            return None
+        try:
+            os.kill(pid, 0)                 # signal 0 = liveness probe
+        except ProcessLookupError:
+            return None                     # stale (dead holder) — not running
+        except PermissionError:
+            pass                            # alive, just not ours
+        except OSError:
+            return None
+        pct = None
+        if expected_gb and expected_gb > 0:
+            try:
+                got = sum(
+                    f.stat().st_size
+                    for f in (d / ".incomplete").rglob("*")
+                    if f.is_file()
+                )
+                pct = max(0, min(100, int(got / (expected_gb * 1e9) * 100)))
+            except OSError:
+                pct = None
+        return {"in_progress": True, "pid": pid, "pct": pct}
+
     def last_swap_compose(self) -> str:
         """The serve-locally compose emitted by the most recent Route-C
         apply-swap download ("" if none). Captured from pull.sh's

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -1814,6 +1814,55 @@ class TestBringFunnelStagedReveal:
             assert repo not in app._active_bring_download()
 
     @pytest.mark.asyncio
+    async def test_bring_download_disk_detected_suppresses_noops_cancels(
+        self, monkeypatch, tmp_path
+    ):
+        """#617 disk-truth: a download detected ON DISK (in-memory tracker EMPTY
+        — a prior c3 session or a bare pull.sh holds the pull-dir lock) still
+        shows '⏳ downloading', no-ops a fresh [D] instead of stacking a
+        duplicate, and [k] kills the lock holder PID."""
+        monkeypatch.setenv("HF_HOME", str(tmp_path))
+        app, _, _ = make_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_bring(pilot)
+            repo, prof = "unsloth/Qwen3-27B-abliterated", "vllm/dual"
+            # disk says in-progress (pid 424242); the in-memory tracker stays EMPTY
+            monkeypatch.setattr(
+                app._data, "bring_download_in_progress",
+                lambda r, expected_gb=None: (
+                    {"in_progress": True, "pid": 424242, "pct": 42}
+                    if r == repo else None
+                ),
+            )
+            app.run_byo_check(repo, prof)
+            await _settle(pilot)
+            line = app.query_one("#lane-bring-weights-line", Static)
+            assert "downloading" in str(line.render())     # disk-detected, tracker empty
+            assert not app._active_bring_download()
+
+            # fresh [D] must NOT launch a worker (disk-guard blocks the duplicate)
+            app._active_mode = 1
+            launched = {"n": 0}
+            monkeypatch.setattr(
+                app, "run_bring_download_worker",
+                lambda *a, **k: launched.__setitem__("n", launched["n"] + 1),
+            )
+            app.action_bring_download()
+            await _settle(pilot)
+            assert launched["n"] == 0
+            assert not app._active_bring_download()
+
+            # [k] kills the disk holder PID (no in-memory handle to cancel)
+            killed = {"pid": None}
+            monkeypatch.setattr(
+                app, "_kill_bring_pid",
+                lambda pid: killed.__setitem__("pid", pid),
+            )
+            app.action_bring_cancel_download()
+            await _settle(pilot)
+            assert killed["pid"] == 424242
+
+    @pytest.mark.asyncio
     async def test_inspect_error_reveals_nothing(self):
         responses = fake_responses(
             **{"deriver.py --inventory": ok(json.dumps(

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -647,6 +647,41 @@ class TestLoadCatalog:
         assert e_unk.weights_state == WEIGHTS_UNKNOWN          # no weights entry to join
 
     @pytest.mark.asyncio
+    async def test_bring_download_in_progress_live_stale_absent(self, tmp_path, monkeypatch):
+        """#617 disk-truth probe: bring_download_in_progress reads the pull-dir
+        download lock — in-progress for a LIVE holder (with pct from .incomplete
+        bytes), None for a STALE (dead-holder) lock or no lock at all."""
+        import subprocess
+        cd = CockpitData(ROOT, runner=full_runner())
+        monkeypatch.setattr(cd, "_bring_hf_home", lambda: tmp_path)
+        repo = "org/Tess-4-27B-FP8"
+
+        assert cd.bring_download_in_progress(repo) is None        # no lock → absent
+
+        pull = cd.bring_pull_dir(repo)
+        (pull / ".download.lock").mkdir(parents=True)
+        inc = pull / ".incomplete"
+        inc.mkdir()
+        (inc / "part.bin").write_bytes(b"x" * 1000)               # 1000 bytes staged
+
+        holder = subprocess.Popen(["sleep", "30"])
+        try:
+            (pull / ".download.lock" / "pid").write_text(
+                f"{holder.pid}\n2026-01-01T00:00:00+00:00\n", encoding="utf-8"
+            )
+            info = cd.bring_download_in_progress(repo, expected_gb=2e-6)  # 2000 B expected
+            assert info is not None and info["in_progress"] is True
+            assert info["pid"] == holder.pid
+            assert info["pct"] == 50                              # 1000 / 2000 B
+            # pct is None when the total size is unknown
+            assert cd.bring_download_in_progress(repo)["pct"] is None
+        finally:
+            holder.terminate()
+            holder.wait()
+
+        assert cd.bring_download_in_progress(repo) is None        # dead holder → stale
+
+    @pytest.mark.asyncio
     async def test_weights_download_plan_and_progress(self, tmp_path):
         """Download UX (service): the download plan is `WEIGHT_KEY=… setup.sh
         <model>` (disk write, no reconcile/confirm gate); progress = bytes-on-disk


### PR DESCRIPTION
## Why

Live dogfood of the ① Bring funnel: repeated [D] presses on `huginnfork/Tess-4-27B-FP8` spawned **5 concurrent `hf download` processes** racing into the same `.incomplete` staging dir (10 min → only 450 MB moved). Two gaps, both the *disk-truth* half that #643's in-memory tracker couldn't cover:

1. **No in-progress detection** — `hf` stages into `.incomplete/` and only moves files to the final dir on completion, but presence checks look at the *final* dir → a mid-flight download reads as absent → false "download did not complete".
2. **No dedup** — nothing locked per-repo, so every retry launched a fresh download instead of reflecting/resuming the running one.

## What

**Per-repo lock (scripts):**
- `downloader.py` — `download_model` is now a thin locking wrapper around `_download_model_impl` (body moved verbatim, no behaviour change). Atomic `mkdir <pull_dir>/.download.lock` acquire + a `pid` file (holder PID + UTC start). A 2nd concurrent `download_model` for the same slug is **refused** (`failure="in-progress"`, rc=3 via `pull.sh`) instead of racing; a **stale** lock (dead holder) self-heals via reclaim (robust to SIGKILL, which skips traps). Lock is **shared with the catalog path** — kept non-breaking (extracted impl unchanged; composes with the in-memory `_active_downloads`).
- `swap_apply.py` surfaces `in_progress`; `pull.sh --apply-swap` exits **rc=3** (distinct from rc=1 failure).

**Disk-backed detection (c3):**
- `services.bring_download_in_progress(repo)` — reads the lock (live PID) + `.incomplete` bytes → `{in_progress, pid, pct}`; survives a c3 restart AND sees a download started outside the session (a bare `pull.sh`).
- `app.py` — fit-check render, `action_bring_download` no-op guard, `[k]` cancel gate, and cancel are all **disk-aware** now; the render shows "⏳ downloading (resuming NN%)".

**Acquire-window race fix (review follow-up):** the lock acquires with `mkdir` then writes its pid a beat later — a 2nd caller in that window saw a pidless lock and reclaimed it, letting both proceed. Now a *pidless* lock only reclaims past a 10 s grace (a fresh pidless lock = holder mid-acquire → refused). A pid-present-but-dead lock still reclaims immediately.

## Tests

- `scripts/tests/test-download-lock.sh` — **PASS 1–5**: live-refuse, dead-reads-stale, stale-reclaim+release, fresh-pidless-refuse (mid-acquire), old-pidless-reclaim. Adjacent `test-pull` / `test-pullgate-download` / `test-pullemit-capture` still pass.
- c3: `test_services.test_bring_download_in_progress_live_stale_absent` + `test_app_headless.test_bring_download_disk_detected_suppresses_noops_cancels` (new) + the #643 bring/download tests — all pass in the main-tree venv.

Reviewed the fork's diff + independently re-verified on-branch here; the acquire-window fix + its two guard cases are mine on top.

Note: surfaced a **separate** finding during dogfood — the download's file selection grabbed `model-00001..07` but **omitted `mtp_grafted.safetensors`** (a non-`model-*` weight file the inventory lists). Not in this PR's scope; tracked for a follow-up (the downloader should fetch *all* inventory weight files).

Ref: #617
Builds on #643.

🤖 Generated with [Claude Code](https://claude.com/claude-code)