### PR TITLE
deriver: include a dedicated MTP head in the weight download set (#617)

### DIFF
--- a/scripts/lib/profiles/deriver.py
+++ b/scripts/lib/profiles/deriver.py
@@ -402,6 +402,20 @@ def select_weight_files(
             # Index present but no obvious shard naming — fall back to all
             # non-adapter top-level safetensors as the set.
             shards = sorted(safet)
+        else:
+            # A dedicated MTP/nextn head (e.g. `mtp_grafted.safetensors`) is a
+            # real weight the model needs with MTP enabled, but it's neither a
+            # `model-*` nor `-of-` shard, so the filter above drops it —
+            # which silently omitted Tess-4-27B-FP8's MTP head and would break
+            # MTP serving (club-3090 #617). `detect_mtp_head` already sees such a
+            # file; union it into the download set so it's actually fetched.
+            mtp_head = [
+                n for n in safet
+                if n not in shards
+                and ("mtp" in n.lower() or "nextn" in n.lower())
+            ]
+            if mtp_head:
+                shards = sorted(set(shards) | set(mtp_head))
         return shards, None
 
     # No index: must be exactly one complete set.

--- a/scripts/tests/test-pullgate-download.sh
+++ b/scripts/tests/test-pullgate-download.sh
@@ -132,6 +132,22 @@ check("chat_template.jinja" in ds and "vocab.json" in ds
       and "merges.txt" in ds,
       "download_set reconciles BOTH v2's *.jinja AND legacy vocab/merges")
 
+# 1b. A dedicated MTP/nextn head (e.g. `mtp_grafted.safetensors`) is a real
+# weight the model needs with MTP enabled, but it's neither a `model-*` nor
+# `-of-` shard — the shard filter used to DROP it, silently omitting
+# Tess-4-27B-FP8's MTP head → broken MTP serving (club-3090 #617). It must now
+# be unioned into the weight set.
+MTP_API = {"siblings": [{"rfilename": n} for n in (
+    "model-00001-of-00007.safetensors", "model-00007-of-00007.safetensors",
+    "model.safetensors.index.json", "mtp_grafted.safetensors",
+    "config.json", "tokenizer.json",
+)]}
+mtp_ds = D.download_set(MTP_API)
+check("mtp_grafted.safetensors" in mtp_ds,
+      f"download_set unions a dedicated MTP head (mtp_grafted.safetensors); got={sorted(mtp_ds)}")
+check("model-00001-of-00007.safetensors" in mtp_ds,
+      "download_set still includes the main shards alongside the MTP head")
+
 # ---------------------------------------------------------------------------
 # 2. sized_download_gb sizes EXACTLY download_set; gates.c2a_disk consumes
 #    the SHARED set (no drift between [C2a] / E2 / E3).


### PR DESCRIPTION
## Why

Live dogfood surfaced this alongside the #644 download-lock work: `huginnfork/Tess-4-27B-FP8` downloaded its **7 `model-*` shards but silently omitted `mtp_grafted.safetensors`** — the grafted MTP head. The swap compose enables MTP (`--speculative-config mtp`), so vLLM would fail to find the MTP weights at boot.

## Root cause

`select_weight_files` builds the sharded set as `"-of-" in n or n.startswith("model-")`. A dedicated MTP/nextn head file is neither → dropped from the download set — even though `detect_mtp_head` / `_has_mtp_weight_file` already recognize it (that's how the swap decided "MTP kept").

## Fix

In the sharded branch, union any non-shard, non-adapter `*.safetensors` whose name contains `mtp`/`nextn` into the weight set (mirrors the existing `_has_mtp_weight_file` predicate). Shards + the MTP head both get fetched; unrelated/adapter files are still excluded.

## Test

`test-pullgate-download.sh` gains an MTP-head fixture asserting `download_set` unions `mtp_grafted.safetensors` alongside the `model-*` shards. Guard **PASS**; adjacent `test-download-lock` / `test-pull` unaffected.

Ref: #617 (the follow-up flagged in #644).

🤖 Generated with [Claude Code](https://claude.com/claude-code)