### PR TITLE
deriver: resolve HF_HOME from MODEL_DIR (bare pull.sh → model disk, not ~/.cache)

### DIFF
--- a/scripts/lib/profiles/deriver.py
+++ b/scripts/lib/profiles/deriver.py
@@ -195,14 +195,51 @@ def _load_kv_calc():
 
 
 # ---------------------------------------------------------------------------
-# HF_HOME resolution (--hf-home > $HF_HOME > $XDG_CACHE_HOME/huggingface > ~)
+# HF_HOME resolution
+#   --hf-home > $HF_HOME > $MODEL_DIR/.cache/huggingface > $XDG_CACHE_HOME/hf > ~
 # ---------------------------------------------------------------------------
+def _model_dir_from_env_or_dotenv() -> Optional[str]:
+    """MODEL_DIR from the environment, else parsed from the repo `.env` (the
+    SAME value switch.sh / launch.sh / c3 resolve). `None` if set in neither.
+    Read with `encoding="utf-8"` (non-UTF-8-locale rigs, #599)."""
+    env = os.environ.get("MODEL_DIR")
+    if env:
+        return env
+    try:
+        for raw in (REPO_ROOT / ".env").read_text(
+            encoding="utf-8", errors="replace"
+        ).splitlines():
+            s = raw.strip().rstrip("\r")
+            if not s or s.startswith("#") or "=" not in s:
+                continue
+            if s.startswith("export "):
+                s = s[len("export "):]
+            key, _, val = s.partition("=")
+            if key.strip() == "MODEL_DIR":
+                val = val.strip().strip('"').strip("'")
+                return val or None
+    except OSError:
+        pass
+    return None
+
+
 def resolve_hf_home(hf_home: Optional[str] = None) -> Path:
+    """HF_HOME precedence: `--hf-home > $HF_HOME > $MODEL_DIR/.cache/huggingface
+    > $XDG_CACHE_HOME/huggingface > ~/.cache/huggingface`.
+
+    The MODEL_DIR step keeps a bare `pull.sh <repo>` — run with only `.env`'s
+    MODEL_DIR set and no explicit HF_HOME — on the MODEL DISK, instead of
+    silently falling to `~/.cache` on root (the footgun that misplaced a brought
+    model's weights, #617-followup). c3 is unaffected: it sets HF_HOME
+    explicitly, which still wins here."""
     if hf_home:
         return Path(hf_home).expanduser()
     env = os.environ.get("HF_HOME")
     if env:
         return Path(env).expanduser()
+    model_dir = _model_dir_from_env_or_dotenv()
+    if model_dir:
+        return Path(model_dir).expanduser() / ".cache" / "huggingface"
     xdg = os.environ.get("XDG_CACHE_HOME")
     if xdg:
         return Path(xdg).expanduser() / "huggingface"

--- a/scripts/tests/test-hf-home-resolve.sh
+++ b/scripts/tests/test-hf-home-resolve.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Guard: deriver.resolve_hf_home precedence (club-3090 #617-followup). A bare
+# `pull.sh <repo>` — only `.env`'s MODEL_DIR set, no explicit HF_HOME — must land
+# on the MODEL DISK (MODEL_DIR/.cache/huggingface), NOT silently on ~/.cache (the
+# footgun that misplaced a brought model's weights). Precedence asserted:
+#   --hf-home > $HF_HOME > $MODEL_DIR/.cache/hf (env OR .env) > $XDG > ~/.cache
+set -euo pipefail
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+python3 - <<'PY'
+import os, sys, tempfile
+sys.path.insert(0, "scripts")
+from pathlib import Path
+from lib.profiles import deriver as D
+
+def clear():
+    for k in ("HF_HOME", "MODEL_DIR", "XDG_CACHE_HOME"):
+        os.environ.pop(k, None)
+
+# 1) --hf-home wins over everything
+clear()
+os.environ["HF_HOME"] = "/tmp/should-lose"
+assert D.resolve_hf_home("/tmp/explicit") == Path("/tmp/explicit"), "--hf-home must win"
+print("PASS 1: --hf-home wins")
+
+# 2) $HF_HOME wins over MODEL_DIR
+clear()
+os.environ["MODEL_DIR"] = "/mnt/models/huggingface"
+os.environ["HF_HOME"] = "/tmp/hfhome"
+assert D.resolve_hf_home() == Path("/tmp/hfhome"), "$HF_HOME must win over MODEL_DIR"
+print("PASS 2: $HF_HOME > MODEL_DIR")
+
+# 3) MODEL_DIR (env) → MODEL_DIR/.cache/huggingface  (THE fix)
+clear()
+os.environ["MODEL_DIR"] = "/mnt/models/huggingface"
+assert D.resolve_hf_home() == Path("/mnt/models/huggingface/.cache/huggingface"), \
+    "MODEL_DIR must resolve to the model disk, not ~/.cache"
+print("PASS 3: MODEL_DIR (env) → model disk")
+
+# 4) MODEL_DIR read from .env when env unset (the bare-pull.sh case), via a
+#    temp REPO_ROOT so the assertion is deterministic regardless of the live .env
+tmp = Path(tempfile.mkdtemp())
+(tmp / ".env").write_text('export MODEL_DIR="/data/models"\n', encoding="utf-8")
+orig = D.REPO_ROOT
+D.REPO_ROOT = tmp
+try:
+    clear()
+    assert D.resolve_hf_home() == Path("/data/models/.cache/huggingface"), \
+        "bare call must read MODEL_DIR from .env → model disk"
+    print("PASS 4: MODEL_DIR from .env → model disk")
+
+    # 5) no MODEL_DIR anywhere → the ~/.cache fallback is preserved
+    (tmp / ".env").write_text("PORT=8010\n", encoding="utf-8")
+    clear()
+    assert D.resolve_hf_home() == Path.home() / ".cache" / "huggingface", \
+        "no MODEL_DIR anywhere → ~/.cache fallback"
+    print("PASS 5: no MODEL_DIR → ~/.cache fallback preserved")
+finally:
+    D.REPO_ROOT = orig
+
+print("OK test-hf-home-resolve")
+PY


### PR DESCRIPTION
## Why

Live dogfood footgun: a bare `pull.sh <repo>` — or a `nohup … --apply-swap` — run with only `.env`'s `MODEL_DIR` set and **no explicit `HF_HOME`** silently downloads to `~/.cache/huggingface` on the **root disk**, not the models volume. That's how a brought model's 35 GB landed in the wrong place this week, and it hits users identically (a bare `hf`/`pull.sh` outside c3 falls to `~/.cache`).

Root cause: `resolve_hf_home` precedence was `--hf-home > $HF_HOME > $XDG > ~/.cache` — **`MODEL_DIR` was not consulted**, even though `switch.sh`/`launch.sh`/c3 all resolve it. Both the plain-pull and apply-swap paths route `hf_home` through this function (`swap_apply.apply_swap:265`), so one fix covers both.

## Fix

Insert a `MODEL_DIR` step: `--hf-home > $HF_HOME > $MODEL_DIR/.cache/huggingface > $XDG > ~/.cache`. `MODEL_DIR` is read from the environment, else parsed from the repo `.env` (`encoding="utf-8"`, #599) — the same value the launchers use. **c3 is unaffected** (it sets `HF_HOME` explicitly, which still wins).

## Test

New guard `test-hf-home-resolve.sh` — PASS 1-5: `--hf-home` wins · `$HF_HOME > MODEL_DIR` · `MODEL_DIR` (env) → model disk · `MODEL_DIR` from `.env` → model disk · no `MODEL_DIR` anywhere → `~/.cache` fallback preserved. `test-pull` / `test-pullgate-download` / `test-download-lock` still green. Live check: `resolve_hf_home()` bare on-rig now returns `/mnt/models/huggingface/.cache/huggingface`.

Ref: #617 (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)