### PR TITLE
fix(c3): honest 'won't fit' verdict + reachable custom-slug hatch

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -5064,6 +5064,18 @@ class LaneBringPane(Container):
         sel.remove_class("funnel-hidden")
         self.query_one("#lane-bring-profile-title", Label).remove_class("funnel-hidden")
         self.query_one("#lane-bring-fit-btn", Button).remove_class("funnel-hidden")
+        # Bug B (2026-07-09): when the §2b size floor leaves ONLY the ✎ custom-slug
+        # sentinel, _set_select_options pre-selects it under prevent(Select.Changed)
+        # — so the Changed-gated custom-Input reveal never fires and the escape
+        # hatch is unreachable (re-picking the already-selected sentinel is a no-op).
+        # Reveal the Input eagerly iff the sentinel is the sole option; keep it
+        # hidden (until a genuine pick) whenever real slugs exist.
+        real = [v for (_l, v) in options if v != PROFILE_CUSTOM_SENTINEL]
+        custom = self.query_one("#lane-bring-profile-custom", Input)
+        if real:
+            custom.add_class("profile-custom-hidden")
+        else:
+            custom.remove_class("profile-custom-hidden")
 
     def hide_slug_stage(self) -> None:
         self.query_one("#lane-bring-profile-input", Select).add_class("funnel-hidden")
@@ -7938,12 +7950,14 @@ class CockpitApp(App):
     def _reveal_funnel_slugs(
         self, artifact_format: str, artifact_gb: Optional[float]
     ) -> None:
+        vram = self._known_gpu_vram_gb()
+        gpus = self._known_gpu_count()
         opts = funnel_slug_options(
             self._variants or [],
             artifact_format,
             artifact_gb=artifact_gb,
-            vram_gb=self._known_gpu_vram_gb(),
-            gpu_count=self._known_gpu_count(),
+            vram_gb=vram,
+            gpu_count=gpus,
         )
         # ONE visible recommendation (§2b follow-up): smallest fitting
         # topology + curated engine preference — starred AND pre-selected;
@@ -7961,6 +7975,30 @@ class CockpitApp(App):
             # Dogfood r2 — the pre-selected recommendation's details show
             # immediately (updates ride on_select_changed thereafter).
             pane.show_slug_details(self._funnel_slug_details(rec) if rec else "")
+            # Bug A (2026-07-09): the §2b size floor can hide EVERY slug — a 54G
+            # bf16 repo on a 48G rig — leaving only the ✎ sentinel with NO
+            # explanation.  Surface an honest verdict, distinguishing "too big for
+            # the rig" (compat slugs exist but all exceed VRAM) from "no compatible
+            # recipe" (artifact→engine compat matched nothing at all).
+            if not opts:
+                unfloored = funnel_slug_options(self._variants or [], artifact_format)
+                if unfloored and artifact_gb:
+                    total = (vram or 0) * (gpus or 0)
+                    rig = (
+                        f"{gpus}×{vram:.0f}={total:.0f} GB total"
+                        if (vram and gpus) else "your rig's VRAM"
+                    )
+                    pane.set_next_hint(
+                        f"[yellow]⚠ won't fit[/yellow] — these weights "
+                        f"(~{artifact_gb:.0f} GB) exceed every topology on {rig}. "
+                        f"Bring a smaller quant (an FP8 build, or a GGUF) — "
+                        f"or ✎ custom slug to point at one by hand."
+                    )
+                else:
+                    pane.set_next_hint(
+                        "[yellow]no catalog recipe matches this artifact[/yellow] "
+                        "— use ✎ custom slug to point at one by hand."
+                    )
         except Exception:
             pass
 

--- a/tools/serve-cockpit/tests/test_uiux_funnel_oversized.py
+++ b/tools/serve-cockpit/tests/test_uiux_funnel_oversized.py
@@ -1,0 +1,89 @@
+"""Bring funnel — oversized-artifact verdict + reachable custom-slug hatch.
+
+Regression coverage for the 2026-07-09 dogfood (migtissera/Tess-4-27B, 54 GB bf16
+on a 48 GB rig): the §2b size floor hid every slug, leaving only the ✎ sentinel
+with (A) no "won't fit" explanation and (B) an unreachable custom-slug Input (the
+sole sentinel is pre-selected under prevent(Select.Changed), so the Changed-gated
+reveal never fires)."""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import Input, Label
+
+from club3090_cockpit.app import LaneBringPane, PROFILE_CUSTOM_SENTINEL
+from tests.test_app_headless import _settle, make_app
+
+
+class TestCustomHatchReachable:
+    @pytest.mark.asyncio
+    async def test_sentinel_only_reveals_custom_input(self):
+        """Bug B — when the only option is the sentinel, the custom Input must be
+        revealed eagerly (the Changed-gated reveal can't fire on a sole option)."""
+        app, _, _ = make_app(surface="producer")
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.press("2")
+            await _settle(pilot)
+            pane = app.query_one("#lane-bring-pane", LaneBringPane)
+            pane.reveal_slug_stage([("✎ custom slug…", PROFILE_CUSTOM_SENTINEL)], None)
+            await pilot.pause()
+            custom = pane.query_one("#lane-bring-profile-custom", Input)
+            assert not custom.has_class("profile-custom-hidden"), (
+                "sentinel-only dropdown must reveal the custom-slug Input"
+            )
+
+    @pytest.mark.asyncio
+    async def test_real_slugs_keep_custom_hidden(self):
+        """The hatch stays hidden (until a genuine pick) whenever real slugs exist."""
+        app, _, _ = make_app(surface="producer")
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.press("2")
+            await _settle(pilot)
+            pane = app.query_one("#lane-bring-pane", LaneBringPane)
+            pane.reveal_slug_stage(
+                [("dual/vllm/foo", "vllm/foo"),
+                 ("✎ custom slug…", PROFILE_CUSTOM_SENTINEL)],
+                "vllm/foo",
+            )
+            await pilot.pause()
+            custom = pane.query_one("#lane-bring-profile-custom", Input)
+            assert custom.has_class("profile-custom-hidden")
+
+
+class TestOversizedVerdict:
+    @pytest.mark.asyncio
+    async def test_oversized_safetensors_shows_wont_fit(self, monkeypatch):
+        """Bug A — a safetensors artifact bigger than every hostable topology gets
+        an honest "won't fit" hint, not a silent empty dropdown."""
+        app, _, _ = make_app(surface="producer")
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.press("2")
+            await _settle(pilot)
+            entries, _err = await app._data.load_catalog_rows()
+            app._variants = [e.row for e in entries]
+            # pin a 2×24 GB rig so the floor is deterministic
+            monkeypatch.setattr(app, "_known_gpu_vram_gb", lambda: 24.0)
+            monkeypatch.setattr(app, "_known_gpu_count", lambda: 2)
+            app._reveal_funnel_slugs("safetensors", 54.0)  # bigger than 48 GB total
+            await pilot.pause()
+            hint = str(app.query_one("#lane-bring-hint", Label).render()).lower()
+            assert "won't fit" in hint or "wont fit" in hint, hint
+            # and the escape hatch is reachable in this state
+            custom = app.query_one("#lane-bring-profile-custom", Input)
+            assert not custom.has_class("profile-custom-hidden")
+
+    @pytest.mark.asyncio
+    async def test_normal_size_shows_slugs_no_wont_fit(self, monkeypatch):
+        """A normal-size artifact keeps the recommended list (no false 'won't fit')."""
+        app, _, _ = make_app(surface="producer")
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.press("2")
+            await _settle(pilot)
+            entries, _err = await app._data.load_catalog_rows()
+            app._variants = [e.row for e in entries]
+            monkeypatch.setattr(app, "_known_gpu_vram_gb", lambda: 24.0)
+            monkeypatch.setattr(app, "_known_gpu_count", lambda: 2)
+            app._reveal_funnel_slugs("safetensors", 15.0)
+            await pilot.pause()
+            hint = str(app.query_one("#lane-bring-hint", Label).render()).lower()
+            assert "won't fit" not in hint and "wont fit" not in hint


### PR DESCRIPTION
Live-dogfood fix (2026-07-09, `migtissera/Tess-4-27B` — 54 GB bf16 on a 48 GB rig).

The §2b topology floor correctly hid every slug (single ≤21.6 GB, dual ≤43.2 GB, no multi-card slug), but the funnel showed **only the `✎ custom slug…` sentinel with no explanation**, and the custom-slug Input never appeared. Two cascading bugs (neither a regression — the floor #582 + reveal are byte-identical to pre-Grok; a 55 GB repo is just the first to hit the all-hidden edge):

| Bug | Fix |
|---|---|
| **A** — floor empties list → silent empty dropdown | `_reveal_funnel_slugs`: honest verdict — *"⚠ won't fit — weights exceed every topology on Nx24 GB; bring a smaller quant"* vs *"no catalog recipe matches this artifact"* (distinguished via an unfloored recompute) |
| **B** — custom Input never appears | `reveal_slug_stage`: the sole sentinel is pre-selected under `prevent(Select.Changed)`, so the Changed-gated reveal never fires. Now reveals the Input eagerly iff the sentinel is the sole option (hidden when real slugs exist) |

Tests: `test_uiux_funnel_oversized.py` — custom-hatch reachable, won't-fit verdict fires, no false verdict at normal size. **254 c3 tests green.**