### PR TITLE
fix(c3): route-G GGUF serve — single /models mount + runtime-dir compose

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -1378,26 +1378,79 @@ class CockpitData:
             return {"compose_path": "", "compose_yaml": "", "error": "no services"}
         _svc_name, svc = next(iter(services.items()))
         cmd = self._normalize_compose_command(svc.get("command"))
-        mount = "/models/brought.gguf"
-        mmproj_mount = "/models/brought.mmproj" if mmproj_host_file else ""
-        mtp_mount = "/models/brought-mtp.gguf" if mtp_draft_host_file else ""
+        # Brought GGUFs live UNDER MODEL_DIR (the pull dir), and the sibling
+        # already mounts MODEL_DIR → /models (its `-m /models/<rel>`).  So address
+        # each file at /models/<realpath-relative-to-MODEL_DIR> and mount MODEL_DIR
+        # ONCE — never per-file INTO /models: that races the sibling's own /models
+        # mount and dies at boot with "read-only file system" (OCI can't create the
+        # /models/brought-* mountpoints inside an already-mounted /models — the
+        # 2026-07-09 live-boot ExitCode 128).  ``realpath`` also follows the pull-dir
+        # symlink into the curated store.
+        model_dir = os.path.realpath(self.weights_model_dir())
+        extra_vols: list[str] = []
+
+        def _container_path(host_file: str, tag: str) -> str:
+            rp = os.path.realpath(host_file)
+            rel = os.path.relpath(rp, model_dir)
+            if not rel.startswith(".."):
+                return "/models/" + rel            # covered by the MODEL_DIR mount
+            cp = f"/brought/{tag}-{_P(rp).name}"    # outside MODEL_DIR → its own mount
+            extra_vols.append(f"{rp}:{cp}:ro")
+            return cp
+
+        mount = _container_path(weights_host_file, "model")
+        mmproj_mount = (
+            _container_path(mmproj_host_file, "mmproj") if mmproj_host_file else ""
+        )
+        mtp_mount = (
+            _container_path(mtp_draft_host_file, "mtp") if mtp_draft_host_file else ""
+        )
         svc["command"] = self._rewrite_gguf_command(
             cmd,
             model_mount=mount,
             mmproj_mount=mmproj_mount,
             mtp_draft_mount=mtp_mount,
         )
-        vols = list(svc.get("volumes") or [])
-        vols.append(f"{weights_host_file}:{mount}:ro")
-        if mmproj_host_file:
-            vols.append(f"{mmproj_host_file}:{mmproj_mount}:ro")
-        if mtp_draft_host_file:
-            vols.append(f"{mtp_draft_host_file}:{mtp_mount}:ro")
+
+        def _abs_vol(v: str) -> str:
+            """Relocatable volume.  The /models mount source may be
+            ``${MODEL_DIR:-../relative}`` — whose ``:-`` defeats a naive ``split(':')``
+            — so key off the ``:/models`` TARGET and replace everything before it with
+            the absolute MODEL_DIR (drops the relative fallback so the compose works
+            from any dir).  Other simple relative bind srcs → absolute vs the sibling
+            dir; ``${..}`` / absolute / named-volume srcs pass through."""
+            i = v.find(":/models")
+            if i != -1 and v[i + 8:i + 9] in ("", ":"):   # ':/models' or ':/models:mode'
+                return f"{model_dir}{v[i:]}"
+            if "${" not in v:
+                parts = v.split(":")
+                if len(parts) >= 2 and parts[0].startswith(("./", "../")):
+                    abs_src = os.path.abspath(
+                        os.path.join(compose_file.parent, parts[0])
+                    )
+                    return f"{abs_src}:{':'.join(parts[1:])}"
+            return v
+
+        vols = [_abs_vol(v) for v in (svc.get("volumes") or [])] + extra_vols
+        # The /models/<rel> command paths depend on MODEL_DIR being mounted at
+        # /models.  Real llama.cpp/ik siblings ship that mount; guarantee it in case
+        # one doesn't (never leave the model path dangling).
+        if not any(":/models:" in v or v.endswith(":/models") for v in vols):
+            vols.insert(0, f"{model_dir}:/models:ro")
         svc["volumes"] = vols
         san = (served_name or _P(weights_host_file).stem)[:40]
         san = "".join(c if c.isalnum() or c in "-_" else "-" for c in san)
         svc["container_name"] = f"llama-brought-{san or 'gguf'}"
-        out_path = compose_file.parent / f"_brought-gguf-{san or 'x'}.yml"
+        # Write to a RUNTIME dir on the model disk — NOT the project tree (a
+        # throwaway BYO serve shouldn't drop files beside catalog composes;
+        # 2026-07-09 dogfood).  The compose is now self-contained (absolute /models
+        # mount + /models/<rel> command paths), so its location is free.
+        run_dir = _P(model_dir) / ".cache" / "huggingface" / "club3090" / "composes"
+        try:
+            run_dir.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            run_dir = compose_file.parent          # fallback: beside the sibling
+        out_path = run_dir / f"_brought-gguf-{san or 'x'}.yml"
         header = (
             "# GENERATED GGUF serve-locally compose (route-G) — clone of\n"
             f"#   {compose_rel}\n"

--- a/tools/serve-cockpit/tests/test_uiux_phase4_gguf.py
+++ b/tools/serve-cockpit/tests/test_uiux_phase4_gguf.py
@@ -159,8 +159,17 @@ class TestNormalizeCommand:
         assert not all(len(t) == 1 for t in toks)
 
 
+def _emitted_volumes(compose_path: str) -> list:
+    doc = yaml.safe_load(Path(compose_path).read_text(encoding="utf-8"))
+    return next(iter(doc["services"].values())).get("volumes") or []
+
+
 class TestEmitGgufCompose:
-    def test_emit_list_form_still_works(self, tmp_path: Path):
+    # Brought files live UNDER MODEL_DIR (the pull dir), the sibling mounts
+    # MODEL_DIR → /models, so route-G addresses them at /models/<rel> and mounts
+    # MODEL_DIR ONCE — NOT the old fixed /models/brought.* + per-file mounts (which
+    # died at boot with "read-only file system"; 2026-07-09 dogfood).
+    def test_emit_list_form_still_works(self, tmp_path: Path, monkeypatch):
         rel = "models/m/llama-cpp/compose/single/q4/serve.yml"
         _write_sibling(
             tmp_path, rel,
@@ -168,6 +177,7 @@ class TestEmitGgufCompose:
         )
         _stub_registry(tmp_path, "llama-cpp/q4km", rel)
         data = CockpitData(tmp_path)
+        monkeypatch.setattr(data, "weights_model_dir", lambda: str(tmp_path))
         weights = tmp_path / "weights" / "model-Q4_K_M.gguf"
         weights.parent.mkdir(parents=True)
         weights.write_bytes(b"gguf")
@@ -176,10 +186,60 @@ class TestEmitGgufCompose:
         )
         assert res["error"] == "", res
         cmd = _load_emitted_cmd(res["compose_path"])
-        assert "--model" in cmd or "-m" in cmd
-        assert "/models/brought.gguf" in cmd
+        mi = cmd.index("--model") if "--model" in cmd else cmd.index("-m")
+        assert cmd[mi + 1].startswith("/models/")
+        assert cmd[mi + 1].endswith("model-Q4_K_M.gguf")
+        assert "brought" not in cmd[mi + 1]
 
-    def test_emit_folded_scalar_command_rewrites_model(self, tmp_path: Path):
+    def test_emit_single_models_mount_no_per_file(self, tmp_path: Path, monkeypatch):
+        """The mount BUG: exactly ONE absolute MODEL_DIR → /models mount, and NO
+        per-file mount into /models (that races the /models mount → read-only)."""
+        rel = "models/m/llama-cpp/compose/single/q4/mtp-vision.yml"
+        _write_sibling(
+            tmp_path, rel,
+            "--host 0.0.0.0 -m /models/${GGUF_FILE:-old.gguf} "
+            "--mmproj /models/old-mmproj.gguf",
+        )
+        _stub_registry(tmp_path, "llama-cpp/q4-vision", rel)
+        data = CockpitData(tmp_path)
+        monkeypatch.setattr(data, "weights_model_dir", lambda: str(tmp_path))
+        wdir = tmp_path / "pulls" / "repo"
+        wdir.mkdir(parents=True)
+        for n in ("main-Q4_K_M.gguf", "mmproj-F16.gguf", "mtp-Q4_K_M.gguf"):
+            (wdir / n).write_bytes(b"x")
+        res = data.emit_gguf_compose(
+            "llama-cpp/q4-vision", str(wdir / "main-Q4_K_M.gguf"),
+            served_name="V", mmproj_host_file=str(wdir / "mmproj-F16.gguf"),
+            mtp_draft_host_file=str(wdir / "mtp-Q4_K_M.gguf"),
+        )
+        assert res["error"] == "", res
+        vols = _emitted_volumes(res["compose_path"])
+        models_mounts = [v for v in vols if ":/models:" in v or v.endswith(":/models")]
+        assert len(models_mounts) == 1, vols
+        assert models_mounts[0] == f"{tmp_path}:/models:ro"          # absolute, single
+        assert not any("/models/brought" in v for v in vols)         # no per-file mounts
+        # all three artifacts addressed under the single /models mount
+        cmd = " ".join(_load_emitted_cmd(res["compose_path"]))
+        assert "/models/pulls/repo/main-Q4_K_M.gguf" in cmd
+        assert "/models/pulls/repo/mmproj-F16.gguf" in cmd
+        assert "/models/pulls/repo/mtp-Q4_K_M.gguf" in cmd
+
+    def test_emit_writes_to_runtime_dir_not_project(self, tmp_path: Path, monkeypatch):
+        """The compose must NOT land beside the sibling in the project tree."""
+        rel = "models/m/llama-cpp/compose/single/q4/serve.yml"
+        _write_sibling(tmp_path, rel, ["--host", "0.0.0.0", "--model", "/old.gguf"])
+        _stub_registry(tmp_path, "llama-cpp/q4km", rel)
+        data = CockpitData(tmp_path)
+        monkeypatch.setattr(data, "weights_model_dir", lambda: str(tmp_path))
+        w = tmp_path / "w" / "m-Q4_K_M.gguf"
+        w.parent.mkdir(parents=True)
+        w.write_bytes(b"g")
+        res = data.emit_gguf_compose("llama-cpp/q4km", str(w), served_name="X")
+        assert res["error"] == "", res
+        assert "/compose/single/q4/" not in res["compose_path"]      # not beside sibling
+        assert "club3090/composes" in res["compose_path"]            # runtime dir
+
+    def test_emit_folded_scalar_command_rewrites_model(self, tmp_path: Path, monkeypatch):
         """BLOCKER fix: real siblings use ``command: >-`` → str → must shlex.split."""
         rel = "models/m/ik-llama/compose/single/iq4/mtp.yml"
         _write_sibling(
@@ -194,6 +254,7 @@ class TestEmitGgufCompose:
 
         _stub_registry(tmp_path, "ik-llama/iq4ks-mtp", rel)
         data = CockpitData(tmp_path)
+        monkeypatch.setattr(data, "weights_model_dir", lambda: str(tmp_path))
         weights = tmp_path / "w" / "Tess-Q4_K_M.gguf"
         weights.parent.mkdir(parents=True)
         weights.write_bytes(b"gguf")
@@ -203,14 +264,13 @@ class TestEmitGgufCompose:
         assert res["error"] == "", res
         cmd = _load_emitted_cmd(res["compose_path"])
         assert len(cmd) < 40
-        assert "--model" in cmd or "-m" in cmd
         mi = cmd.index("--model") if "--model" in cmd else cmd.index("-m")
-        assert cmd[mi + 1] == "/models/brought.gguf"
+        assert cmd[mi + 1].startswith("/models/") and cmd[mi + 1].endswith("Tess-Q4_K_M.gguf")
         # Sibling built-in MTP --spec-type must not survive for a foreign model.
         assert not any(t.startswith("--spec-") for t in cmd)
         assert "mtp:n_max" not in " ".join(cmd)
 
-    def test_emit_rewrites_mmproj_not_only_appends(self, tmp_path: Path):
+    def test_emit_rewrites_mmproj_not_only_appends(self, tmp_path: Path, monkeypatch):
         rel = "models/m/llama-cpp/compose/single/q4/mtp-vision.yml"
         _write_sibling(
             tmp_path, rel,
@@ -220,6 +280,7 @@ class TestEmitGgufCompose:
         )
         _stub_registry(tmp_path, "llama-cpp/q4km-vision", rel)
         data = CockpitData(tmp_path)
+        monkeypatch.setattr(data, "weights_model_dir", lambda: str(tmp_path))
         weights = tmp_path / "w" / "main.gguf"
         mmproj = tmp_path / "w" / "brought-mmproj.gguf"
         weights.parent.mkdir(parents=True)
@@ -235,14 +296,10 @@ class TestEmitGgufCompose:
         cmd = _load_emitted_cmd(res["compose_path"])
         assert cmd.count("--mmproj") == 1
         mi = cmd.index("--mmproj")
-        assert cmd[mi + 1] == "/models/brought.mmproj"
+        assert cmd[mi + 1].startswith("/models/") and cmd[mi + 1].endswith("brought-mmproj.gguf")
         assert "sibling-mmproj" not in " ".join(cmd)
-        # volumes mount brought projector
-        doc = yaml.safe_load(Path(res["compose_path"]).read_text(encoding="utf-8"))
-        vols = next(iter(doc["services"].values()))["volumes"]
-        assert any("brought.mmproj" in str(v) for v in vols)
 
-    def test_emit_strips_sibling_drafter_flags(self, tmp_path: Path):
+    def test_emit_strips_sibling_drafter_flags(self, tmp_path: Path, monkeypatch):
         rel = "models/m/beellama/compose/single/q4/dflash.yml"
         _write_sibling(
             tmp_path, rel,
@@ -252,6 +309,7 @@ class TestEmitGgufCompose:
         )
         _stub_registry(tmp_path, "beellama/q4-dflash", rel)
         data = CockpitData(tmp_path)
+        monkeypatch.setattr(data, "weights_model_dir", lambda: str(tmp_path))
         weights = tmp_path / "w" / "foreign.gguf"
         weights.parent.mkdir(parents=True)
         weights.write_bytes(b"gguf")
@@ -267,9 +325,10 @@ class TestEmitGgufCompose:
         assert "dflash" not in joined.lower()
         assert "--spec-dflash-cross-ctx" not in cmd
         assert "--spec-draft-ngl" not in cmd
-        assert "/models/brought.gguf" in cmd
+        mi = cmd.index("--model") if "--model" in cmd else cmd.index("-m")
+        assert cmd[mi + 1].startswith("/models/") and cmd[mi + 1].endswith("foreign.gguf")
 
-    def test_emit_wires_brought_mtp_draft(self, tmp_path: Path):
+    def test_emit_wires_brought_mtp_draft(self, tmp_path: Path, monkeypatch):
         rel = "models/m/llama-cpp/compose/single/q4/mtp.yml"
         _write_sibling(
             tmp_path, rel,
@@ -278,6 +337,7 @@ class TestEmitGgufCompose:
         )
         _stub_registry(tmp_path, "llama-cpp/q4-mtp", rel)
         data = CockpitData(tmp_path)
+        monkeypatch.setattr(data, "weights_model_dir", lambda: str(tmp_path))
         weights = tmp_path / "w" / "Tess-Q4_K_M.gguf"
         mtp = tmp_path / "w" / "mtp-Q4_K_M.gguf"
         weights.parent.mkdir(parents=True)
@@ -292,8 +352,29 @@ class TestEmitGgufCompose:
         assert res["error"] == "", res
         cmd = _load_emitted_cmd(res["compose_path"])
         assert "--spec-draft-model" in cmd
-        assert "/models/brought-mtp.gguf" in cmd
+        di = cmd.index("--spec-draft-model")
+        assert cmd[di + 1].startswith("/models/") and cmd[di + 1].endswith("mtp-Q4_K_M.gguf")
         assert "--spec-type" in cmd
         assert "draft-mtp" in cmd
         # Only the brought draft path — not a sibling leftover.
         assert "old.gguf" not in " ".join(cmd)
+
+    def test_emit_file_outside_model_dir_gets_own_mount(self, tmp_path: Path, monkeypatch):
+        """A brought file NOT under MODEL_DIR → its own /brought/ mount, never /models."""
+        rel = "models/m/llama-cpp/compose/single/q4/serve.yml"
+        _write_sibling(tmp_path, rel, ["--host", "0.0.0.0", "--model", "/old.gguf"])
+        _stub_registry(tmp_path, "llama-cpp/q4km", rel)
+        data = CockpitData(tmp_path)
+        # MODEL_DIR is one subtree; the weights live in a DIFFERENT subtree.
+        monkeypatch.setattr(data, "weights_model_dir", lambda: str(tmp_path / "model-root"))
+        (tmp_path / "model-root").mkdir()
+        w = tmp_path / "elsewhere" / "m-Q4_K_M.gguf"
+        w.parent.mkdir(parents=True)
+        w.write_bytes(b"g")
+        res = data.emit_gguf_compose("llama-cpp/q4km", str(w), served_name="X")
+        assert res["error"] == "", res
+        cmd = _load_emitted_cmd(res["compose_path"])
+        mi = cmd.index("--model") if "--model" in cmd else cmd.index("-m")
+        assert cmd[mi + 1].startswith("/brought/")                   # not /models/../
+        vols = _emitted_volumes(res["compose_path"])
+        assert any(str(w) in v and cmd[mi + 1] in v for v in vols)   # explicit mount


### PR DESCRIPTION
First live boot of route-G (#650, maintainer-gated) with `migtissera/Tess-4-27B-GGUF` surfaced two bugs compile-only tests missed:

| Bug | Cause | Fix |
|---|---|---|
| **Boot fails `ExitCode 128`** | `emit_gguf_compose` bind-mounted the 3 brought GGUFs as individual files into `/models/brought.*`, but the sibling already mounts `MODEL_DIR → /models` → OCI can't create mountpoints inside an already-mounted `/models` (*read-only file system*). | Brought files live **under MODEL_DIR** → address each at `/models/<realpath-relative-to-MODEL_DIR>` (realpath follows the pull-dir symlink) + mount MODEL_DIR **once**. Files outside MODEL_DIR get their own `/brought/` mount. A `/models` mount is guaranteed. |
| **Compose in project tree** | Written next to the sibling to inherit *relative* mounts. | Volume made absolute (`MODEL_DIR:/models`, dropping the `${MODEL_DIR:-../rel}` fallback) → compose is relocatable → written to a **runtime dir** (`MODEL_DIR/.cache/huggingface/club3090/composes/`), not the repo. |

**Live-validated end-to-end on the c3-emitted compose:** Tess loads (main + mmproj vision + the brought **MTP drafter** — spec-decode engages) and serves (`capital of France → Paris`).

Tests: 3 new (single-mount, runtime-dir, outside-MODEL_DIR) + 5 existing emit tests updated to `/models/<rel>`. **13 phase-4 + 229 services green.**