### PR TITLE
fix(c3): route-C swap compose — absolute mounts + runtime-dir location

### DIFF
--- a/scripts/lib/profiles/swap_apply.py
+++ b/scripts/lib/profiles/swap_apply.py
@@ -19,6 +19,7 @@ head) ``--speculative-config``.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any, Optional
 
@@ -28,10 +29,35 @@ from scripts.lib.profiles import deriver as D
 from scripts.lib.profiles import downloader as DL
 from scripts.lib.profiles.einput import EInput
 
-# The generated serve-locally compose is written ALONGSIDE the sibling compose
-# (so the sibling's relative ../ mounts — caches, chat template — resolve) and
-# gitignored via the `_brought-*.yml` pattern.
+# The generated serve-locally compose is written to a RUNTIME dir on the model
+# disk (NOT the project tree — a throwaway BYO serve shouldn't drop files beside
+# catalog composes; 2026-07-09 dogfood).  Every relative sibling mount (caches,
+# chat template, scripts, the MODEL_DIR fallback) is absolutized first so the
+# compose is relocatable.  Gitignored via the `_brought-*.yml` pattern.
 _BROUGHT_MODEL_MOUNT = "/brought-model"
+
+
+def _absolutize_volume(v: str, base_dir: Path) -> str:
+    """Resolve a compose volume's RELATIVE bind source to absolute (vs ``base_dir``,
+    the sibling compose dir) so the emitted compose can live OUTSIDE that dir.
+    Handles ``${VAR:-relpath}`` (absolutize the fallback in place) and plain
+    ``./``/``../`` sources; leaves absolute / named-volume / ``${VAR}``-without-a-
+    relative-fallback sources untouched.  The container TARGET starts at the first
+    ``:/`` (a ``${VAR:-...}`` source contains ``:-``, never ``:/``).  Pure."""
+    i = v.find(":/")
+    if i == -1:
+        return v                       # named volume / no bind target
+    src, rest = v[:i], v[i:]           # rest = ':/target[:mode]'
+    if src.startswith("${") and ":-" in src and src.endswith("}"):
+        var, _, fb = src[2:-1].partition(":-")
+        if fb and not fb.startswith(("/", "~", "$")):
+            fb = os.path.abspath(os.path.join(base_dir, fb))
+        return f"${{{var}:-{fb}}}{rest}"
+    if src.startswith(("./", "../")) or (
+        "/" in src and not src.startswith(("/", "~", "$"))
+    ):
+        return f"{os.path.abspath(os.path.join(base_dir, src))}{rest}"
+    return v
 
 
 def resolve_swap(slug: str, der: Any, root: Path) -> dict:
@@ -222,10 +248,21 @@ def emit_swap_compose(
         _gate_spec_via_entrypoint(svc)
     vols = list(svc.get("volumes") or [])
     vols.append(f"{weights_host_dir}:{_BROUGHT_MODEL_MOUNT}:ro")
-    svc["volumes"] = vols
+    # Absolutize every relative bind source (vs the sibling dir) so the compose can
+    # be written OUTSIDE that dir without its ../ mounts dangling.
+    svc["volumes"] = [_absolutize_volume(v, compose_file.parent) for v in vols]
     svc["container_name"] = f"vllm-brought-{brought_san}"
 
+    # Write to a RUNTIME dir beside the pull dir (<MODEL_DIR>/.cache/huggingface/
+    # club3090/composes/), NOT the project tree; fall back beside the sibling.
     out_path = compose_file.parent / f"_brought-{brought_san}.yml"
+    if weights_host_dir.parent.name == "pulls":
+        cand_dir = weights_host_dir.parent.parent / "composes"
+        try:
+            cand_dir.mkdir(parents=True, exist_ok=True)
+            out_path = cand_dir / f"_brought-{brought_san}.yml"
+        except OSError:
+            pass
     header = (
         "# GENERATED serve-locally compose (BYO Route-C apply-swap) — a clone of\n"
         f"#   {compose_rel}\n"

--- a/scripts/tests/test-pull-swap.sh
+++ b/scripts/tests/test-pull-swap.sh
@@ -283,9 +283,22 @@ check(_val(cmd, "--reasoning-parser") == "qwen3" and _val(cmd, "--tool-call-pars
       "emit(MTP): curated parsers PRESERVED")
 check(any("/brought-model:ro" in str(v) for v in svc["volumes"]),
       "emit(MTP): brought-weights volume mount added")
+check(not any(str(v).split(":/", 1)[0].startswith(("./", "../"))
+              or "/../" in str(v).split(":/", 1)[0] for v in svc["volumes"]),
+      "emit(MTP): sibling relative ../ mounts absolutized (compose is relocatable)")
 check(str(svc.get("container_name", "")).startswith("vllm-brought-"),
       "emit(MTP): container_name distinct (no collision with the sibling)")
 p_mtp.unlink()
+
+# weights under a pulls/ dir → compose lands in the RUNTIME composes dir, not repo
+import tempfile
+_pd = Path(tempfile.mkdtemp()) / "club3090" / "pulls" / "repo-z"
+_pd.mkdir(parents=True)
+p_loc = SA.emit_swap_compose(root, "vllm/dual", _pd, served_name="loc",
+                             has_mtp_head=False, brought_san="loc-z")
+check("club3090/composes" in str(p_loc) and str(root) not in str(p_loc),
+      "emit: compose written to RUNTIME composes dir, NOT the project tree")
+p_loc.unlink()
 
 # no MTP head → spec-config dropped, curated flags still intact
 p_plain = SA.emit_swap_compose(root, "vllm/dual", Path("/tmp/brought-weights"),


### PR DESCRIPTION
Companion to #654 (route-G): the **safetensors weight-swap** path had the same *compose-in-the-project-tree* issue — `swap_apply.emit_swap_compose` wrote `_brought-<san>.yml` **next to the sibling** compose (so its relative `../` mounts resolved), dropping throwaway files beside catalog composes.

Route-C's *mount* was already fine (it dir-mounts the brought weights to a distinct `/brought-model`), so this is **location-only**:
- New `_absolutize_volume` resolves every sibling volume to absolute (`${VAR:-../rel}` → `${VAR:-/abs}`, plain `../rel` → `/abs`) — the vLLM sibling has **5** relative mounts (HF cache, torch_compile, triton, froggeric chat template, detect_nvlink).
- With absolute mounts the compose is relocatable → written to the **runtime dir** beside the pull dir (`<MODEL_DIR>/.cache/huggingface/club3090/composes/`), falling back beside the sibling.

Validated at emit level: all relative sources absolutized, `${MODEL_DIR}` env kept, brought mount intact, compose lands in the runtime dir not the repo. +2 assertions in `test-pull-swap.sh`'s emit group.

⚠️ `test-pull-swap.sh` has a **pre-existing** env failure on the maintainer rig (identical on master, unrelated to this change).