### PR TITLE
fix(c3): put repo root on sys.path so ② Serve emit can import scripts

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -286,6 +286,15 @@ class CockpitData:
         download_runner: Optional[SubprocessRunner] = None,
     ):
         self.repo_root = Path(repo_root)
+        # Make the repo's `scripts` package importable process-wide: c3 runs from
+        # tools/serve-cockpit/, so the repo root ISN'T on sys.path, yet the emit
+        # paths do `from scripts.lib.profiles.compose_registry import …`.  Without
+        # this the ② Serve route-G/route-C emit dies with "No module named
+        # 'scripts'" (and fit-check's topology detection silently degrades).
+        # 2026-07-09 dogfood — previously only one call site guarded this.
+        import sys as _sys
+        if str(self.repo_root) not in _sys.path:
+            _sys.path.insert(0, str(self.repo_root))
         self.card = card
         # FIX 2 — the registry's top-level ``defaults`` array (curated
         # per-(model,engine,topology) recommendations) from registry-emit --json.

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -314,6 +314,17 @@ def full_runner(**overrides) -> FakeRunner:
 # ===========================================================================
 
 
+class TestScriptsImportable:
+    def test_init_puts_repo_root_on_sys_path(self, tmp_path):
+        """route-G/C ② Serve emit does `from scripts.lib.profiles...`; c3 runs from
+        tools/serve-cockpit/ so the repo root ISN'T on sys.path by default. __init__
+        must add it, else serve dies "No module named 'scripts'" (2026-07-09)."""
+        import sys
+        assert str(tmp_path) not in sys.path
+        CockpitData(tmp_path, runner=full_runner())
+        assert str(tmp_path) in sys.path
+
+
 class TestParseHelpers:
     def test_strip_ansi(self):
         assert strip_ansi("\x1b[0;32m✓\x1b[0m serving") == "✓ serving"


### PR DESCRIPTION
Clicking **Serve** for a brought GGUF (route-G) died with `No module named 'scripts'`.

**Cause:** c3 runs from `tools/serve-cockpit/`, so the repo root isn't on `sys.path` — yet `emit_gguf_compose` (and `swap_apply` for route-C) do `from scripts.lib.profiles.compose_registry import …`. Only **one** of the three call sites guarded this with a `sys.path.insert`; the emit site surfaced the `ImportError` to the user, and fit-check's topology detection *silently degraded* (its import is swallowed).

**Fix:** add `repo_root` to `sys.path` **once** in `CockpitData.__init__`, so all three sites work.

**Validated the right way this time:** simulating c3's runtime (repo root NOT pre-added), `scripts` is unimportable before `CockpitData` init and importable after → `emit_gguf_compose` returns no error. That's the exact condition #654's validation harness masked by inserting the path itself. +1 regression test (243 c3 tests green).