### PR TITLE
feat(c3): route-G supports embedded MTP, not just external drafters

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -10815,12 +10815,18 @@ class CockpitApp(App):
         except Exception:
             pass
         served = repo.rsplit("/", 1)[-1]
+        # No external drafter? The main gguf may still carry an EMBEDDED MTP head
+        # (nextn) — activate it with --spec-type and no draft model.  (bartowski /
+        # unsloth builds embed it; migtissera ships an external mtp-*.gguf instead.)
+        embedded_mtp = bool(weights_file) and not mtp_draft and \
+            self._data.gguf_has_embedded_mtp(weights_file)
         res = self._data.emit_gguf_compose(
             profile,
             weights_file,
             served_name=served,
             mmproj_host_file=mmproj,
             mtp_draft_host_file=mtp_draft,
+            embedded_mtp=embedded_mtp,
         )
         if res.get("error") or not res.get("compose_path"):
             self.notify(

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -1265,6 +1265,64 @@ class CockpitData:
             return [str(x) for x in raw]
         return shlex.split(str(raw))
 
+    @staticmethod
+    def _gguf_nextn_predict_layers(path: str) -> int:
+        """The GGUF ``<arch>.nextn_predict_layers`` value = the model's EMBEDDED MTP
+        (self-speculation) layer count; 0 when absent.  Minimal stdlib GGUF-metadata
+        parser — the ``gguf`` package isn't in the c3 venv.  Early-returns on the key
+        (it sits with the arch hyper-params, before the big tokenizer arrays)."""
+        import struct
+        _S = {0: 1, 1: 1, 2: 2, 3: 2, 4: 4, 5: 4, 6: 4, 7: 1, 10: 8, 11: 8, 12: 8}
+        try:
+            with open(path, "rb") as f:
+                if f.read(4) != b"GGUF":
+                    return 0
+                (ver,) = struct.unpack("<I", f.read(4))
+                if ver < 2:
+                    return 0
+                f.read(8)                                    # tensor_count
+                (kvc,) = struct.unpack("<Q", f.read(8))      # metadata_kv_count
+
+                def _skip(vt: int) -> None:
+                    if vt in _S:
+                        f.seek(_S[vt], 1)
+                    elif vt == 8:                            # string
+                        (n,) = struct.unpack("<Q", f.read(8)); f.seek(n, 1)
+                    elif vt == 9:                            # array
+                        (et,) = struct.unpack("<I", f.read(4))
+                        (cnt,) = struct.unpack("<Q", f.read(8))
+                        if et in _S:
+                            f.seek(_S[et] * cnt, 1)
+                        elif et == 8:
+                            for _ in range(cnt):
+                                (m,) = struct.unpack("<Q", f.read(8)); f.seek(m, 1)
+                        else:
+                            raise ValueError(f"nested array type {et}")
+                    else:
+                        raise ValueError(f"value type {vt}")
+
+                for _ in range(kvc):
+                    (kl,) = struct.unpack("<Q", f.read(8))
+                    key = f.read(kl)
+                    (vt,) = struct.unpack("<I", f.read(4))
+                    if key.endswith(b".nextn_predict_layers"):
+                        if vt in (0, 2, 4, 10):              # uint 8/16/32/64
+                            return int.from_bytes(f.read(_S[vt]), "little")
+                        if vt in (1, 3, 5, 11):              # int 8/16/32/64
+                            return int.from_bytes(f.read(_S[vt]), "little", signed=True)
+                        return 1                             # present, odd type
+                    _skip(vt)
+        except Exception:
+            return 0
+        return 0
+
+    def gguf_has_embedded_mtp(self, path: str) -> bool:
+        """True iff the GGUF carries an EMBEDDED MTP head (``nextn_predict_layers``
+        ≥ 1) — activated by ``--spec-type draft-mtp`` with NO separate draft model,
+        distinct from an EXTERNAL ``mtp-*.gguf`` drafter (which uses
+        ``--spec-draft-model`` too)."""
+        return self._gguf_nextn_predict_layers(path) >= 1
+
     def _rewrite_gguf_command(
         self,
         cmd: list,
@@ -1272,6 +1330,7 @@ class CockpitData:
         model_mount: str,
         mmproj_mount: str = "",
         mtp_draft_mount: str = "",
+        embedded_mtp: bool = False,
     ) -> list:
         """Rewrite sibling argv for a brought GGUF:
 
@@ -1335,12 +1394,19 @@ class CockpitData:
             str(x) == "--mmproj" or str(x).startswith("--mmproj=") for x in out
         ):
             out += ["--mmproj", mmproj_mount]
-        # Brought MTP draft (bonus) — only after stripping sibling drafter flags.
+        # Spec-decode, after stripping the sibling's own drafter flags:
+        #   • EXTERNAL drafter (a brought mtp-*.gguf, e.g. migtissera Tess) →
+        #     --spec-draft-model + --spec-type draft-mtp
+        #   • else EMBEDDED MTP head (nextn baked into the main gguf, e.g. bartowski
+        #     / unsloth builds) → --spec-type draft-mtp WITH NO draft model
+        # External wins if somehow both are present (the preferred path on this rig).
         if mtp_draft_mount:
             out += [
                 "--spec-draft-model", mtp_draft_mount,
                 "--spec-type", "draft-mtp",
             ]
+        elif embedded_mtp:
+            out += ["--spec-type", "draft-mtp"]   # activate the embedded nextn head
         return out
 
     def emit_gguf_compose(
@@ -1351,6 +1417,7 @@ class CockpitData:
         served_name: str = "",
         mmproj_host_file: str = "",
         mtp_draft_host_file: str = "",
+        embedded_mtp: bool = False,
     ) -> dict:
         """Clone a GGUF-engine sibling compose with --model → the downloaded .gguf.
 
@@ -1419,6 +1486,7 @@ class CockpitData:
             model_mount=mount,
             mmproj_mount=mmproj_mount,
             mtp_draft_mount=mtp_mount,
+            embedded_mtp=embedded_mtp,
         )
 
         def _abs_vol(v: str) -> str:

--- a/tools/serve-cockpit/tests/test_uiux_phase4_gguf.py
+++ b/tools/serve-cockpit/tests/test_uiux_phase4_gguf.py
@@ -378,3 +378,52 @@ class TestEmitGgufCompose:
         assert cmd[mi + 1].startswith("/brought/")                   # not /models/../
         vols = _emitted_volumes(res["compose_path"])
         assert any(str(w) in v and cmd[mi + 1] in v for v in vols)   # explicit mount
+
+
+def _mini_gguf(tmp_path: Path, nextn: int) -> Path:
+    """A minimal valid GGUF header (v3) carrying one metadata KV:
+    ``qwen35.nextn_predict_layers`` = ``nextn`` (uint32).  Enough to exercise the
+    stdlib parser without a real multi-GB weights file."""
+    import struct
+    p = tmp_path / f"mini-nextn{nextn}.gguf"
+    key = b"qwen35.nextn_predict_layers"
+    kv = struct.pack("<Q", len(key)) + key + struct.pack("<I", 4) + struct.pack("<I", nextn)
+    buf = (b"GGUF" + struct.pack("<I", 3) + struct.pack("<Q", 0)   # magic, v3, 0 tensors
+           + struct.pack("<Q", 1) + kv)                             # 1 KV
+    p.write_bytes(buf)
+    return p
+
+
+class TestEmbeddedMtp:
+    def test_parser_reads_nextn_predict_layers(self, tmp_path: Path):
+        data = CockpitData(tmp_path)
+        assert data._gguf_nextn_predict_layers(str(_mini_gguf(tmp_path, 2))) == 2
+        assert data.gguf_has_embedded_mtp(str(_mini_gguf(tmp_path, 1))) is True
+        assert data.gguf_has_embedded_mtp(str(_mini_gguf(tmp_path, 0))) is False
+        bad = tmp_path / "not.gguf"; bad.write_bytes(b"NOPE" + b"\x00" * 32)
+        assert data.gguf_has_embedded_mtp(str(bad)) is False        # never raises
+
+    def test_embedded_mtp_activates_spec_type_no_draft_model(self, tmp_path: Path):
+        """Embedded MTP (nextn in the main gguf, no separate drafter) → --spec-type
+        draft-mtp with NO --spec-draft-model (the bartowski/unsloth case)."""
+        data = CockpitData(tmp_path)
+        cmd = ["--host", "0.0.0.0", "-m", "/models/x.gguf", "--spec-type", "mtp:n=2"]
+        out = data._rewrite_gguf_command(
+            cmd, model_mount="/models/brought.gguf", embedded_mtp=True)
+        assert "--spec-type" in out and out[out.index("--spec-type") + 1] == "draft-mtp"
+        assert "--spec-draft-model" not in out
+        assert "mtp:n=2" not in out                                 # sibling flag stripped
+
+    def test_external_drafter_wins_over_embedded(self, tmp_path: Path):
+        data = CockpitData(tmp_path)
+        out = data._rewrite_gguf_command(
+            ["-m", "/old.gguf"], model_mount="/models/b.gguf",
+            mtp_draft_mount="/models/mtp.gguf", embedded_mtp=True)
+        assert "--spec-draft-model" in out
+        assert out[out.index("--spec-draft-model") + 1] == "/models/mtp.gguf"
+
+    def test_no_mtp_no_spec_flags(self, tmp_path: Path):
+        data = CockpitData(tmp_path)
+        out = data._rewrite_gguf_command(
+            ["-m", "/old.gguf"], model_mount="/models/b.gguf", embedded_mtp=False)
+        assert "--spec-type" not in out and "--spec-draft-model" not in out


### PR DESCRIPTION
Route-G only wired spec-decode when a **separate** `mtp-*.gguf` drafter was present (migtissera-style). A GGUF with an **embedded** MTP head (nextn baked into the main quant — **bartowski**/unsloth-style) got the sibling's `--spec-type` stripped and nothing re-added → served as a base model, **no spec-decode**.

| | External drafter (migtissera) | Embedded MTP (bartowski) |
|---|---|---|
| Packaging | main + separate `mtp-*.gguf` | nextn baked into each main quant |
| Detect | glob for `mtp-*.gguf` | `<arch>.nextn_predict_layers ≥ 1` (new stdlib GGUF parser) |
| Wire | `--spec-draft-model X --spec-type draft-mtp` | `--spec-type draft-mtp` (no draft model) |
| Before | ✅ #654 | ⚠️ dormant → **now ✅** |

**Changes:** `gguf_has_embedded_mtp()` (minimal stdlib metadata parser — `gguf` isn't in the c3 venv); `_rewrite_gguf_command(embedded_mtp=…)` (external wins if both, else embedded activates `--spec-type` alone); `run_gguf_emit_and_serve` computes it on the main gguf when no external drafter.

**Live-validated** on the embedded-MTP unsloth GGUF: llama.cpp logs *"creating MTP draft context **against the target model**"* (self-speculation, no separate file) + *"adding speculative implementation 'draft-mtp'"*, serves (`2+2 → Four`) — distinct from #654's external `"loading draft model …mtp-Tess…"`. +5 tests (parser via synthetic mini-GGUF + both branches). **230 services + 17 phase-4 green.**