### PR TITLE
feat(c3): route-G [D] downloads GGUF files directly, not via pull.sh

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -8341,6 +8341,27 @@ class CockpitApp(App):
         except Exception:
             return "", None
 
+    def _gguf_download_includes(self) -> list[str]:
+        """hf-download ``--include`` patterns for the picked GGUF quant: the main
+        quant file(s) + the vision mmproj + a quant-matched external MTP drafter (if
+        the repo ships one).  Empty when this isn't a GGUF bring (→ pull.sh path).
+        A GGUF repo has no config.json, so pull.sh aborts unsupported-format."""
+        quant, _ = self._funnel_gguf_selection()
+        inv = getattr(self, "_last_inventory", None)
+        if not quant or inv is None or not getattr(inv, "has_gguf", False):
+            return []
+        pats: list[str] = []
+        for v in getattr(inv, "gguf_variants", []):
+            if v.quant == quant:
+                pats += list(getattr(v, "files", []) or [f"*{quant}*.gguf"])
+                break
+        else:
+            pats.append(f"*{quant}*.gguf")
+        pats += list(getattr(inv, "gguf_mmproj", []))     # vision projector(s)
+        pats.append(f"*mtp*{quant}*.gguf")                # external MTP drafter if present
+        seen: set = set()
+        return [p for p in pats if p and not (p in seen or seen.add(p))]
+
     def _bring_expected_size_gb(self) -> Optional[float]:
         """Best-effort size from last Inspect inventory (safetensors total or GGUF pick)."""
         q, gb = self._funnel_gguf_selection()
@@ -8486,8 +8507,10 @@ class CockpitApp(App):
             and getattr(self._last_byo, "route", "") == "C"
         )
         self._bring_swap_compose = ""
+        gguf_includes = self._gguf_download_includes()
         handle = await self._data.run_bring_download(
-            repo, profile_like, apply_swap=apply_swap, on_line=_on_line
+            repo, profile_like, apply_swap=apply_swap,
+            gguf_includes=gguf_includes or None, on_line=_on_line,
         )
         # Attach the real handle to the tracker entry (registered synchronously in
         # action_bring_download).  If it's already gone, we were cancelled before

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -1065,6 +1065,7 @@ class CockpitData:
         *,
         apply_swap: bool = False,
         emit_only: bool = False,
+        gguf_includes: Optional[list[str]] = None,
         on_line: Optional[Callable[[str], None]] = None,
     ) -> Any:
         """§2b-6 — the lane's weights download: the REAL ``pull.sh`` run
@@ -1089,16 +1090,38 @@ class CockpitData:
 
         if apply_swap or on_line is not None:
             self._download_runner.set_callbacks(on_line=_capture)
-        cmd = ["bash", "scripts/pull.sh", repo, "--profile-like", profile_like]
-        if apply_swap:
-            # The BYO weight-swap ACTION: download the brought weights AND emit a
-            # serve-locally clone of the sibling compose (--model at the weights).
-            cmd.append("--apply-swap")
-        if emit_only:
-            # Weights already on disk — skip the download, JUST emit the serve
-            # compose (do_download=False).  ② Serve uses this so a present-weights
-            # serve needs no [D] step.  Only meaningful alongside --apply-swap.
-            cmd.append("--emit-only")
+        if gguf_includes:
+            # GGUF bring (route-G): pull.sh is the SAFETENSORS evaluate/download
+            # path — it ABORTS `unsupported-format (no config.json)` on a GGUF repo.
+            # So fetch the picked quant's files DIRECTLY into the pull dir with the
+            # same guards as hf-download.sh (classic LFS = resumable; token survives
+            # a non-login shell).  One `--include` per pattern.  (2026-07-09 dogfood.)
+            pull = self.bring_pull_dir(repo)
+            env.setdefault("HF_HUB_DISABLE_XET", "1")
+            env.setdefault("HF_HUB_DOWNLOAD_TIMEOUT", "30")
+            if not env.get("HF_TOKEN"):
+                try:
+                    tok = (Path.home() / ".cache" / "huggingface" / "token").read_text(
+                        encoding="utf-8").strip()
+                    if tok:
+                        env["HF_TOKEN"] = tok
+                except OSError:
+                    pass
+            hf_bin = shutil.which("hf") or str(Path.home() / ".local" / "bin" / "hf")
+            cmd = [hf_bin, "download", repo, "--local-dir", str(pull)]
+            for pat in gguf_includes:
+                cmd += ["--include", pat]
+        else:
+            cmd = ["bash", "scripts/pull.sh", repo, "--profile-like", profile_like]
+            if apply_swap:
+                # The BYO weight-swap ACTION: download the brought weights AND emit a
+                # serve-locally clone of the sibling compose (--model at the weights).
+                cmd.append("--apply-swap")
+            if emit_only:
+                # Weights already on disk — skip the download, JUST emit the serve
+                # compose (do_download=False).  ② Serve uses this so a present-weights
+                # serve needs no [D] step.  Only meaningful alongside --apply-swap.
+                cmd.append("--emit-only")
         return await self._download_runner.start_raw(
             cmd,
             env=env,

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -3794,3 +3794,43 @@ class TestServeOverrides:
         d = cd.serve_override_defaults("vllm/dual", "org/Foo")
         assert d["DRAFTER_OPTIONS"] == ["mtp", "mtp_assistant"]   # engine-driven
         assert d["SPEC_METHOD"] == "mtp" and d["SPEC_N"] == "3"
+
+
+class TestBringGgufDownload:
+    """route-G [D]: a GGUF bring must fetch the picked quant's files directly (hf
+    download --include), NOT pull.sh — pull.sh aborts unsupported-format on a GGUF
+    repo (no config.json).  (2026-07-09 dogfood.)"""
+
+    def test_gguf_includes_build_hf_download_cmd(self, tmp_path):
+        import asyncio
+        d = CockpitData(tmp_path)
+        cap = {}
+
+        class R:
+            def set_callbacks(self, **k): pass
+            async def start_raw(self, cmd, **kw):
+                cap["cmd"] = cmd; cap["env"] = kw["env"]; return "h"
+
+        d._download_runner = R()
+        asyncio.run(d.run_bring_download(
+            "org/Repo-GGUF", "llamacpp/default",
+            gguf_includes=["org_Repo-Q8_0.gguf", "mmproj-f16.gguf"]))
+        c = cap["cmd"]
+        assert c[1] == "download" and "pull.sh" not in " ".join(c)     # hf download, not pull.sh
+        assert "--local-dir" in c and str(d.bring_pull_dir("org/Repo-GGUF")) in c
+        assert c.count("--include") == 2
+        assert cap["env"].get("HF_HUB_DISABLE_XET") == "1"             # resumable classic LFS
+
+    def test_no_gguf_includes_uses_pull_sh(self, tmp_path):
+        import asyncio
+        d = CockpitData(tmp_path)
+        cap = {}
+
+        class R:
+            def set_callbacks(self, **k): pass
+            async def start_raw(self, cmd, **kw):
+                cap["cmd"] = cmd; return "h"
+
+        d._download_runner = R()
+        asyncio.run(d.run_bring_download("org/Repo", "vllm/dual"))
+        assert cap["cmd"][:2] == ["bash", "scripts/pull.sh"]           # safetensors path unchanged


### PR DESCRIPTION
Pressing **[D]** on a brought **GGUF** repo ran `pull.sh` (the *safetensors* path), which aborts `unsupported-format (no config.json)` on a GGUF repo → nothing downloaded (*"download did not complete — weights not on disk"*). Route-G handled **fit** + **serve**; **download** was the last gap.

- **`run_bring_download(gguf_includes=[…])`** → fetch the files directly: `hf download <repo> --local-dir <pull> --include <pat>…` with the `hf-download.sh` guards (Xet off = resumable classic LFS, token from file). Else `pull.sh` unchanged.
- **`app._gguf_download_includes()`** → picked quant file(s) + vision **mmproj** + a quant-matched external **MTP drafter** glob (matches migtissera's; harmlessly empty for bartowski's embedded build).

**Validated:** mock-runner confirms the emitted command (`hf download`, Xet off, `--local-dir`→pull dir, one `--include`/file) vs `pull.sh` unchanged; a **real** `hf download --include` of the bartowski mmproj completed **exit 0**. +2 services tests, **232 green**.

⚠️ Maintainer rig: `/mnt/models` at 98 % (41 G free) — a full Q8 (~29 GB) fits but tight; prune first.