### PR TITLE
Add Tess-4-27B to the catalog (llama.cpp dual, external MTP, 262K)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -277,6 +277,18 @@ Dense 40B uncensored community merge of Qwen3.6 (DavidAU Opus-Deckard). Q6_K GGU
 
 ---
 
+## Tess-4-27B
+
+Migtissera's Qwen3.5-based dense 27B instruct/agentic fine-tune (`migtissera/Tess-4-27B-GGUF`). Q4_K_M GGUF with a **separate (external) MTP draft head** — the catalog's first external-MTP compose (engaged via `--spec-draft-model … --spec-type draft-mtp`, vs Deckard's *embedded* head). Arch is `qwen35-dense` (standard GQA, 64 layers) per the GGUF header. Vision-capable base (F16 mmproj on disk) but shipped **text-only**. llama.cpp mainline, pin `server-cuda-b9246`.
+
+### Dual-card (2× RTX 3090) — llama.cpp
+
+| Compose | Rig | KV | Max ctx | Narr / Code TPS | PP tok/s | Peak VRAM | Date | Notes |
+| --- | --- | --- | ---: | ---: | ---: | ---: | --- | --- |
+| `mtp.yml` (ext MTP n=2) | @noonghunna (2× 3090, PCIe) | q4_0/q4_0 | 262144 | 52 / 68 | ~1325 (short) / ~1017 (90K) | 12.6+17.2 GB | 2026-07-09 | ⚠️ Production w/ caveats. External MTP (separate `mtp-*.gguf` draft). decode CV 2.4%, TTFT 233 ms. **verify-stress 8/8** (NIAH ladder clean to 240,634 tok = 91% of 262K, ~5.9 GB free at deepest fill). **soak-continuous PASS** (0 err, 0/100 silent-empty, p50 66.4, 96.3% retention). 8-pack (benchlocal `--full`): **115/150 think-off · 118/150 think-on** — ties/edges qwen3.6-27b **dual-max (109)** and LEADS agentic (hermesagent **15/20 vs 9** · cli-40 **25/40 vs 20**); per-pack OFF: toolcall 14·instructfollow 13·structoutput 14·dataextract 12·reasonmath 11·bugfind 11. **vs dual-max:** ~½ the throughput (52 vs ~114 TPS) for a quality tie/edge + vision base + smaller footprint (12.6+17.2 vs ~22 GB/card). ⚠️ Caveat: streaming tool-calls + thinking-ON → `finish=length` (use thinking-off for tool/agent). Arch confirmed `qwen35-dense` from GGUF header. |
+
+---
+
 ## See also
 
 - [docs/SINGLE_CARD.md](docs/SINGLE_CARD.md) — single-card variant picker

--- a/models/tess-4-27b/llama-cpp/compose/dual/migtissera-q4km/mtp.yml
+++ b/models/tess-4-27b/llama-cpp/compose/dual/migtissera-q4km/mtp.yml
@@ -1,0 +1,128 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Tess-4-27B (Qwen3.5-based dense 27B, migtissera Q4_K_M GGUF)
+#   Engine:    llama.cpp (mainline server-cuda-b9246, external draft-mtp)
+#   Topology:  Dual 3090 (layer-split -ts 1,1)
+#   Drafter:   MTP n=2 external — --spec-draft-model mtp-Tess-*.gguf + --spec-type draft-mtp
+#   KV:        q4_0 K + q4_0 V
+#   Vision:    no (base is VL-capable; mmproj on disk, not mounted — text-only ship)
+#   Template:  native (GGUF-embedded, Qwen-style)
+#   Max ctx:   262144 (q4_0 KV; validated to 240K NIAH on the dual split)
+#   Genesis:   N/A — llama.cpp engine
+#   Status:    ⚠️ Production w/ caveats
+#   Caveats:   Streaming tool-calls + thinking-ON → finish=length (heavy reasoner
+#              exhausts the token budget before emitting the call); use thinking-OFF
+#              (the shipped default) for tool/agent workloads. cli-40 62% think-off
+#              (mid-tier autonomous-CLI). See BENCHMARKS.md / learnings/tess-4-27b.md.
+#   Engine-profile: llama-cpp-local
+#   Quality:   core 8-pack 115/150 (77%) think-off, 118/150 (79%) think-on
+#              (benchlocal --full, 2026-07-09); leads the agentic packs (hermes
+#              15/20, cli 25/40) vs the qwen3.6-27b dual-max reference (9, 20).
+#   Best for:  Vision-capable-base agentic/chat alternative to the fast qwen dual —
+#              trades ~½ the throughput for a quality-tie-to-edge + smaller footprint. ⭐
+# NOTE: Arch CONFIRMED qwen35-dense (standard GQA, 64 layers) from the GGUF header
+# — same family as Deckard-40B. Migtissera ships the MTP head as a SEPARATE GGUF
+# (external draft), so this compose passes --spec-draft-model (contrast Deckard's
+# embedded head, which needs only --spec-type draft-mtp).
+# ---------------------------------------------------------------------------
+# Tess-4-27B on llama.cpp — dual 3090, external MTP n=2, 262K ctx, text-only.
+#
+# Tess-4-27B is migtissera's Qwen3.5-based dense 27B instruct/agentic fine-tune
+# (thinking model; emits <think>). We serve the migtissera Q4_K_M GGUF with the
+# repo's separate MTP draft head (hf: migtissera/Tess-4-27B-GGUF).
+#
+# Layer-split across both 3090s via `-ts 1,1` (tensor-split), pipelining layers
+# across the PCIe bus (no NVLink needed — layer-split avoids cross-GPU all-reduce).
+# The 16 GB Q4_K_M fits one 24 GB card, but 262K q4_0 KV wants the dual pool;
+# a single-card long-ctx variant is architecturally valid but not yet benched.
+#
+# External MTP: the draft head is a standalone GGUF (mtp-Tess-4-27B-Q4_K_M.gguf).
+# On mainline llama.cpp b9246 it is engaged via `--spec-draft-model <file>
+# --spec-type draft-mtp` (drafter: tess-mtp-gguf, spec_method mtp_gguf).
+# Validated 2026-07-09: decode ~52 narrative / 68 code tok/s, prefill ~1.3K tok/s.
+#
+# Context ceiling (q4_0 KV): verify-stress NIAH ladder recalls cleanly to 240,634
+# tok (91% of 262144) with ~5.9 GB VRAM free at the deepest fill; soak-continuous
+# PASS (0 err, 0/100 silent-empty, p50 66.4 tok/s, 96.3% retention).
+#
+# Engine pin: validated on `ghcr.io/ggml-org/llama.cpp:server-cuda-b9246` (the
+# shared `llama-cpp-local` pin). draft-mtp spec type (PR #22673, mainline) works
+# on it. Bump via env once a newer build is validated:
+#   LLAMACPP_IMAGE=ghcr.io/ggml-org/llama.cpp:server-cuda-bXXXX
+#
+# Override defaults via .env or shell:
+#   MODEL_DIR              host dir to mount as /models  (default: ../../../../../../models-cache)
+#   GGUF_FILE             main weights path under /models
+#   MTP_DRAFT_FILE        external MTP draft path under /models
+#   CTX_SIZE              KV pool size        (default: 262144)
+#   BATCH_SIZE            llama.cpp -b        (default: 4096)
+#   UBATCH_SIZE           llama.cpp -ub       (default: 512)
+#   KV_TYPE               K and V quant type  (default: q4_0)
+#   NP                    parallel slots      (default: 1)
+#   MTP_DRAFT_N_MAX       MTP draft tokens    (default: 2)
+#   TENSOR_SPLIT          manual tensor split (default: 1,1)
+#   SERVED_NAME           --alias value       (default: tess-4-27b)
+#   REASONING             thinking gate       (default: off — stack-wide policy)
+#   REASONING_FORMAT      reasoning routing   (default: deepseek — hygiene)
+#   REPEAT_PENALTY        repetition penalty  (default: 1.0 — validated neutral)
+#   DRY_MULTIPLIER        DRY sampler strength (default: 0.0 = OFF). For severe long-ctx
+#                         loops set 0.8 (strongest loop-breaker; opt-in, #517).
+#   DRY_BASE / DRY_ALLOWED_LENGTH  DRY tuning (defaults: 1.75 / 2; active when DRY_MULTIPLIER>0)
+#   PORT                  host port           (default: 8020)
+#   CUDA_VISIBLE_DEVICES  which GPUs to use   (default: 0,1)
+#
+# Quick start:
+#   1. Get the GGUF + MTP draft (setup.sh/launch.sh auto-fetch, or manually):
+#        hf download migtissera/Tess-4-27B-GGUF \
+#          Tess-4-27B-Q4_K_M.gguf mtp-Tess-4-27B-Q4_K_M.gguf \
+#          --local-dir <MODEL_DIR>/tess-4-27b-gguf/migtissera-q4km
+#   2. From this directory:
+#        MODEL_DIR=/your/models/dir docker compose -f mtp.yml up -d
+#   3. curl http://localhost:8020/v1/models  → should list tess-4-27b.
+
+services:
+  llama-cpp-tess-4-27b:
+    image: ${LLAMACPP_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda-b9246}
+    container_name: "${ESTATE_CONTAINER:-llama-cpp-tess-4-27b}"
+    restart: unless-stopped
+    ports:
+      - "${ESTATE_PORT:-${PORT:-8020}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+    # ⚠ -np 1 is intentional — do NOT raise it. One decode stream per dual-card
+    #   config; extra slots divide throughput and can OOM the spec-context buffer.
+    command: >-
+      --host 0.0.0.0
+      --port 8080
+      -m /models/${GGUF_FILE:-tess-4-27b-gguf/migtissera-q4km/Tess-4-27B-Q4_K_M.gguf}
+      --alias ${SERVED_NAME:-tess-4-27b}
+      -c ${CTX_SIZE:-262144}
+      -b ${BATCH_SIZE:-4096}
+      -ub ${UBATCH_SIZE:-512}
+      -ngl 99
+      -ts ${TENSOR_SPLIT:-1,1}
+      -fa on
+      --cache-type-k ${KV_TYPE:-q4_0}
+      --cache-type-v ${KV_TYPE:-q4_0}
+      -np ${NP:-1}
+      --spec-draft-model /models/${MTP_DRAFT_FILE:-tess-4-27b-gguf/migtissera-q4km/mtp-Tess-4-27B-Q4_K_M.gguf}
+      --spec-type draft-mtp
+      --spec-draft-n-max ${MTP_DRAFT_N_MAX:-2}
+      --jinja
+      --reasoning ${REASONING:-off}
+      --reasoning-format ${REASONING_FORMAT:-deepseek}
+      --temp ${TEMP:-${TEMPERATURE:-0.6}}
+      --top-p ${TOP_P:-0.95}
+      --top-k ${TOP_K:-20}
+      --min-p ${MIN_P:-0.0}
+      --repeat-penalty ${REPEAT_PENALTY:-1.0}
+      --dry-multiplier ${DRY_MULTIPLIER:-0.0}
+      --dry-base ${DRY_BASE:-1.75}
+      --dry-allowed-length ${DRY_ALLOWED_LENGTH:-2}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -858,6 +858,21 @@ COMPOSE_REGISTRY = {
         category="uncensored",
     ),
 
+    # Tess-4-27B — Qwen3.5-based dense 27B (migtissera Q4_K_M GGUF), llama.cpp dual.
+    # First EXTERNAL-MTP compose in the catalog: the nextn head ships as a SEPARATE
+    # GGUF (mtp-Tess-*.gguf), engaged via --spec-draft-model + --spec-type draft-mtp
+    # (contrast Deckard's embedded head). kv_format q4_0 (K+V). kvcalc SKIP.
+    "llamacpp/tess-dual-mtp": _entry(
+        model="tess-4-27b", weights_variant="migtissera-q4km", workload="fast-chat",
+        engine="llama-cpp-local", drafter="tess-mtp-gguf", kv_format="q4_0",
+        tp=2, max_ctx=262144, max_num_seqs=1, mem_util=None,
+        compose_path="models/tess-4-27b/llama-cpp/compose/dual/migtissera-q4km/mtp.yml",
+        default_port=8020,
+        kvcalc_key="SKIP",
+        status="caveats",
+        status_note="Tess-4-27B (migtissera Q4_K_M GGUF, 16 GB) — Qwen3.5-based dense 27B instruct/agentic fine-tune on dual 3090 llama.cpp. Arch CONFIRMED qwen35-dense (standard GQA, 64 layers) from the GGUF header — same family as Deckard-40B. EXTERNAL MTP n=2 (separate mtp-*.gguf draft via --spec-draft-model, spec_method mtp_gguf) — first external-draft compose in the catalog. q4_0 KV, 262K ctx. Live-validated 2026-07-09 on server-cuda-b9246: decode ~52 narrative / 68 code tok/s (TTFT 233 ms), prefill ~1.3K tok/s; verify-stress 8/8 (NIAH ladder clean to 240,634 tok = 91% of 262K, ~5.9 GB free at deepest fill); soak-continuous PASS (0 err, 0/100 silent-empty, p50 66.4 tok/s, 96.3% retention). Quality (benchlocal --full): core 8-pack 115/150 (77%) think-off, 118/150 (79%) think-on — ties-to-edges the qwen3.6-27b dual-max reference (109) and LEADS the agentic packs (hermesagent 15/20 vs 9, cli-40 25/40 vs 20). CAVEAT: streaming tool-calls + thinking-ON -> finish=length (heavy reasoner blows the token budget before emitting the call); use thinking-OFF (shipped default) for tool/agent streaming. Trades ~1/2 the qwen-dual throughput for a quality tie/edge + vision-capable base + smaller footprint (~12.7+17.2 GB layer-split vs ~22 GB/card TP=2).",
+    ),
+
     # Ornith-1.0-9B — DeepReinforce agentic-coding RL fine-tune. Qwen3-Next DENSE-FFN
     # HYBRID (arch=qwen35: 8 full-attn + 24 GDN/DeltaNet layers, NON-MoE) — only 8/32
     # layers carry GQA KV so 262K fits at 4.25 GiB KV. No MTP head → drafter-free
@@ -936,6 +951,8 @@ DEFAULTS = {
     ("qwen3.6-35b-a3b", "vllm", "dual"): "vllm/qwen-35b-a3b-dual",
     # Deckard: only one compose (dual llama.cpp MTP), so the dual default is trivial.
     ("qwen3.6-40b-deckard", "llamacpp", "dual"): "llamacpp/deckard40B-dual-mtp",
+    # Tess-4-27B: single dual llama.cpp compose (external MTP); ⚠️ caveats = functional.
+    ("tess-4-27b", "llamacpp", "dual"): "llamacpp/tess-dual-mtp",
 }
 
 

--- a/scripts/lib/profiles/drafters/tess-mtp-gguf.yml
+++ b/scripts/lib/profiles/drafters/tess-mtp-gguf.yml
@@ -1,0 +1,25 @@
+schema_version: 1
+id: tess-mtp-gguf
+display_name: Tess-4-27B external MTP GGUF draft
+spec_method: mtp_gguf
+model_compat:
+  - tess-4-27b
+engine_compat:
+  engine_type: llama.cpp
+n_default: 2
+n_max: 3
+download:
+  hf_repo: migtissera/Tess-4-27B-GGUF
+  size_gb: 1.9
+vram_footprint_gb: variable
+status: production
+# Migtissera ships the Tess-4-27B nextn (MTP) head as a SEPARATE GGUF
+# (mtp-Tess-4-27B-Q4_K_M.gguf), unlike Deckard's embedded head. Engaged on
+# mainline llama.cpp via `--spec-draft-model <file> --spec-type draft-mtp`
+# (spec_method: mtp_gguf). Live-validated on server-cuda-b9246 (dual 3090, 262K):
+# rebench decode ~52 narr / 68 code, verify-stress 8/8 (NIAH→240K), soak PASS
+# (2026-07-09). No vLLM `--speculative-config` form exists (llama.cpp-only draft
+# flag set) → OUT of the #141 vLLM-only generator scope; captured null so the
+# schema stays uniform and the generator never selects it.
+speculative_config_template: null   # N/A — llama.cpp engine, not vLLM
+local_model_path: null

--- a/scripts/lib/profiles/engines/llama-cpp-mainline.yml
+++ b/scripts/lib/profiles/engines/llama-cpp-mainline.yml
@@ -20,7 +20,8 @@ supported_kv_formats:
   - q8_0
   - k8v4
 supported_drafters:
-  - mtp
+  - mtp                   # embedded nextn head (self-spec) — 27B built-in, Deckard-40B
+  - mtp_gguf              # external draft GGUF via --spec-draft-model — Tess-4-27B; live-validated on server-cuda-b9246 (dual 3090, 262K, 2026-07-09)
 supported_weight_formats:
   - gguf
 required_overlays: []

--- a/scripts/lib/profiles/models/tess-4-27b.yml
+++ b/scripts/lib/profiles/models/tess-4-27b.yml
@@ -1,0 +1,50 @@
+schema_version: 1
+id: tess-4-27b
+display_name: Tess 4 27B
+family: qwen35-dense
+# Migtissera's Tess-4-27B — a Qwen3.5-based dense 27B instruct/agentic fine-tune.
+# Arch CONFIRMED from the GGUF header (general.architecture=qwen35): STANDARD GQA
+# attention, uniform across all 64 layers — NOT a Qwen3-Next/DeltaNet hybrid (no
+# GDN / linear-attention layers). Same qwen35-dense family as Qwen3.6-40B-Deckard,
+# 64 layers instead of 97. The base is VL-capable (an F16 mmproj ships alongside
+# the weights), but this catalog entry serves TEXT-ONLY — no mmproj is mounted.
+# A vision variant (mtp-vision.yml) can be added once validated.
+hidden_size: 5120
+num_hidden_layers: 64
+num_attn_heads: 24
+num_kv_heads: 4
+head_dim_attn: 256          # key_length == value_length == 256
+intermediate_size: 17408    # feed_forward_length
+attention_k_eq_v: false     # standard GQA — K and V are separate caches (same as Deckard/27B)
+max_ctx_supported: 262144
+# rope_theta = 1e7. MTP: migtissera ships the nextn (MTP) predict-layer as a
+# SEPARATE GGUF (mtp-Tess-4-27B-Q4_K_M.gguf) — an EXTERNAL draft, engaged via
+# `--spec-draft-model <file> --spec-type draft-mtp` (drafter: tess-mtp-gguf).
+# The main quant carries NO embedded nextn head (contrast Deckard, embedded).
+vision_capable: false
+weights:
+  migtissera-q4km:
+    path: tess-4-27b-gguf/migtissera-q4km
+    local_subdir: tess-4-27b-gguf/migtissera-q4km
+    size_gb: 18                 # 16 GB main Q4_K_M + 1.9 GB external MTP draft
+    format: gguf
+    status: production
+    # Migtissera's GGUF build carries BOTH the main Q4_K_M weights and the
+    # separate mtp-*.gguf draft head; setup.sh/launch.sh fetch both (the MTP
+    # draft is required for --spec-type draft-mtp spec-decode).
+    hf_repo: migtissera/Tess-4-27B-GGUF
+    files:
+      - Tess-4-27B-Q4_K_M.gguf
+      - mtp-Tess-4-27B-Q4_K_M.gguf
+    engine: llama-cpp
+    kind: gguf
+    verify_glob: "*.gguf"
+default_weight_variant: migtissera-q4km
+compatible_drafters:
+  - tess-mtp-gguf
+# num_kv_heads=4 supports TP up to 4; we ship + validated dual (TP=2). Single-card
+# (16 GB Q4_K_M fits one 24 GB card) is architecturally valid but not yet benched.
+valid_tp:
+  - 1
+  - 2
+requires_genesis: false

--- a/scripts/tests/test-compose-registry-disk.sh
+++ b/scripts/tests/test-compose-registry-disk.sh
@@ -25,8 +25,8 @@ def check(cond, msg):
         print(f"FAIL: {msg}")
         failures.append(msg)
 
-check(len(COMPOSE_REGISTRY) == 61, f"registry has 61 entries (got {len(COMPOSE_REGISTRY)})")
-check(len(disk_paths) == 62, f"disk has 62 compose files (got {len(disk_paths)})")
+check(len(COMPOSE_REGISTRY) == 62, f"registry has 62 entries (got {len(COMPOSE_REGISTRY)})")
+check(len(disk_paths) == 63, f"disk has 63 compose files (got {len(disk_paths)})")
 check(registry_paths <= disk_paths, "all registry compose_path values exist on disk")
 parked_disk_only = disk_paths - registry_paths
 # Disk-only (non-registry) composes allowed: parked SGLang archives, plus the experimental

--- a/scripts/tests/test-profiles-compat.sh
+++ b/scripts/tests/test-profiles-compat.sh
@@ -24,10 +24,10 @@ run_test "load_profiles parses all profile groups" <<'PY'
 from scripts.lib.profiles.compat import load_profiles
 p = load_profiles()
 assert len(p.hardware) == 10  # +dgx-spark (#576 follow-up)
-assert len(p.models) == 11
+assert len(p.models) == 12
 assert len(p.workloads) == 5
 assert len(p.engines) == 13
-assert len(p.drafters) == 11
+assert len(p.drafters) == 12
 assert len(p.calibration) == 5
 PY
 


### PR DESCRIPTION
## Summary

Adds **Tess-4-27B** to the curated catalog — migtissera's Qwen3.5-based dense 27B (Q4_K_M GGUF) on **llama.cpp, dual 3090, external MTP, 262K**. The catalog's first **external-MTP** compose (the nextn draft ships as a separate `mtp-*.gguf`, engaged via `--spec-draft-model … --spec-type draft-mtp`, vs Deckard's *embedded* head).

Slug `llamacpp/tess-dual-mtp`; `launch.sh tess-4-27b` resolves it on a dual rig.

## What's in it
- `scripts/lib/profiles/models/tess-4-27b.yml` — profile (`family: qwen35-dense`, weights map incl. external MTP draft, `vision_capable: false` text-only ship)
- `scripts/lib/profiles/drafters/tess-mtp-gguf.yml` — `spec_method: mtp_gguf`
- `scripts/lib/profiles/engines/llama-cpp-mainline.yml` — add `mtp_gguf` to `supported_drafters` (**additive**; live-validated that mainline `b9246` serves external `draft-mtp`)
- compose `models/tess-4-27b/llama-cpp/compose/dual/migtissera-q4km/mtp.yml` (⚠️ caveats) + registry `_entry` + `DEFAULTS` row
- catalog count bumps (registry 62 · disk 63 · models 12 · drafters 12) + `BENCHMARKS.md` Tess section (with dual-max comparison)

## Validation (reference rig, 2× RTX 3090, PCIe)
- **Guard gates:** 27 relevant tests green — every catalog-shape gate (`test-compose-registry-disk`, `-mounts-resolve`, `-model-weights-registry`, `-switch/-launch-registry-parity`, `-profiles-compat`, `-patch-attribution`, `-compose-status-drift`, default resolvers) + pull-surface gates.
- **Boot-verify of the *shipped* compose:** serves at `n_ctx=262144`, external `draft-mtp` engaged (acceptance 1.0), "Paris"/`finish=stop`, VRAM 12.6+17.2 GB.
- **rebench-full:** decode 52 narr / 68 code TPS, **verify-stress 8/8** (NIAH clean to 240,634 tok = 91% of 262K), **soak-continuous PASS** (0 err, 0/100 silent-empty, 96.3% retention).
- **8-pack (`benchlocal --full`):** **115/150** think-off · **118/150** think-on — ties/edges the qwen3.6-27b **dual-max (109)** and **leads the agentic packs** (hermes 15/20 vs 9, cli-40 25/40 vs 20).

## Caveat (ships ⚠️ Production w/ caveats)
Streaming tool-calls **+ thinking-ON** → `finish=length` (heavy reasoner exhausts the token budget before emitting the call). Non-streaming tool-calls are fine; use thinking-OFF (the shipped default) for tool/agent workloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
