### PR TITLE
bench-agentic: guard truncated tool-call replay (fixes turn-2 HTTP 500, #665)

### DIFF
--- a/scripts/bench-agentic.sh
+++ b/scripts/bench-agentic.sh
@@ -171,7 +171,11 @@ def run_turn(messages, fixture_turn, session_id, turn_idx):
         "messages": messages,
         "tools": TOOLS,
         "tool_choice": "required",  # guarantee a tool call every turn
-        "max_tokens": 150,
+        # #665: max_tokens=150 truncated the tool-call JSON on reasoning models
+        # (Tess) mid-object → unterminated `arguments` that poisoned every later
+        # turn (HTTP 500 on replay). 600 lets the call complete; the _safe_args
+        # guard below backstops any residual clip.
+        "max_tokens": 600,
         "temperature": 0.3,
         "stream": True,
         "stream_options": {"include_usage": True},
@@ -226,10 +230,22 @@ def run_turn(messages, fixture_turn, session_id, turn_idx):
 
     # Reconstruct assistant message from real tool calls.
     # tool_choice=required guarantees at least one; treat empty as a server bug.
+    # #665 guard: a reasoning model can burn max_tokens mid-object → truncated,
+    # unterminated `arguments` JSON. Replaying that assistant turn poisons EVERY
+    # subsequent turn — llama-server throws HTTP 500 in func_args_not_string() when
+    # it re-parses the client-supplied history. Substitute "{}" for any args that
+    # don't parse, so a single clip can't kill the whole ramp.
+    def _safe_args(a):
+        a = a or "{}"
+        try:
+            json.loads(a)
+            return a
+        except (json.JSONDecodeError, ValueError):
+            return "{}"
     tool_calls_response = [
         {"id": s["id"] or f"call_t{turn_idx}_s{session_id}_{i}",
          "type": "function",
-         "function": {"name": s["name"], "arguments": s["args"] or "{}"}}
+         "function": {"name": s["name"], "arguments": _safe_args(s["args"])}}
         for i, s in sorted(tool_calls_acc.items()) if s["name"]
     ]
     # #255: decouple the context ramp from tool-call success. A turn that fails
@@ -262,7 +278,7 @@ def run_turn(messages, fixture_turn, session_id, turn_idx):
     # The model may have called a different tool than the original session;
     # that's intentional — fixed results make TTFT measurements reproducible
     # across runs and engines. Only the first call gets the full result; any
-    # additional calls (rare with max_tokens=150) get a placeholder so the
+    # additional calls (rare even at max_tokens=600) get a placeholder so the
     # context size matches the single-tool-call case.
     messages.append({
         "role": "tool",


### PR DESCRIPTION
## Summary

Fixes a hard **HTTP 500 at turn 2** in `bench-agentic.sh` when benching a reasoning model, diagnosed in exhaustive detail by **@seanyourhighness** (#665) while benching Tess-4-27B on a single 4090.

## Root cause (verified against master)

`bench-agentic.sh` sends `tool_choice: "required"` + **`max_tokens: 150`**. A heavy reasoner burns that budget and the tool-call JSON `arguments` truncates mid-object (`finish_reason=length`) → `{"service":"checkout","window":"24h"` (unterminated). The harness accumulates that string and **replays it in `messages`** on the next turn; llama-server then throws in `common/chat.cpp func_args_not_string()` re-parsing the client-supplied history → **500**, killing the whole ramp. Sean provided a minimal harness-free curl repro.

## Fix
- **`max_tokens` 150 → 600** — completes the call (176 tok observed in the report).
- **`_safe_args` guard** — validate each accumulated `arguments` parses as JSON before replaying; substitute `"{}"` if truncated. So a single clip can't poison later turns even if a slower model still hits the budget.

## Not in this PR
- **Upstream llama.cpp:** malformed *client-supplied* `arguments` returns 500 (server_error) when it should be 4xx — template-independent, being filed against llama.cpp separately (+ `docs/UPSTREAM.md` row).
- The `preflight_autodetect` / `CONTAINER=none` behavior Sean also flagged — triaged separately.

Validated: `bash -n` + `py_compile` on the embedded heredoc; live re-run of the agentic ramp against our Tess serve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
