### PR TITLE
concurrency-probe: report aggregate tok/s (verdict + RESULT + sweep)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -195,6 +195,24 @@ Not TPS, but load-bearing. Every shipped variant is validated against:
 
 The single-card vLLM Cliff 2b status is canonicalized in [#41](https://github.com/noonghunna/club-3090/issues/41) — fix is gated on upstream [Sandermage genesis-vllm-patches#19](https://github.com/Sandermage/genesis-vllm-patches/issues/19). See [docs/CLIFFS.md](docs/CLIFFS.md) for the byte-level explanation.
 
+### Concurrency sweep — dense 27B vs 35B-A3B MoE aggregate throughput (`concurrency-probe.sh`)
+
+First first-party aggregate matrix (2026-07-10, @noonghunna 2× 3090 PCIe, vLLM v0.24.0, `SWEEP` mode — fresh boot per N, 5 rounds, steady-state last round). **Aggregate = summed completion tokens / wall**; per-stream = median decode tok/s. All arms clean (0 errors, 0 silent-empty, 0 VRAM growth, retention ≥99%).
+
+**Agent shape (16K-token prompt / 256 gen):**
+
+| N | 27B `dual-fast` (MTP n=3) per-stream | ×N decode-agg | 35B-A3B `dual` (MTP off) per-stream | ×N decode-agg |
+|--:|--:|--:|--:|--:|
+| 1 | 87.3 | 87 | — | — |
+| 2 | 51.8 | **104** ⭐ | 133.0 | 266 |
+| 4 | 22.1 | 88 | 68.0 | **272** ⭐ |
+| 8 | 6.8 | 54 ⚠ | 32.6 | 261 |
+| 16 | — | — | 15.4 | 246 |
+
+**Generation shape (512-token prompt / 800 gen):** 27B @ N=8 → **211 tok/s aggregate** (58.4/stream) · 35B-A3B @ N=16 → **1,037 tok/s aggregate** (92.8/stream, retention 99.4%).
+
+Takeaways: (1) the **dense 27B's batching knee is N=2** at agent contexts — decode-aggregate *halves* by N=8 (MTP-under-batching + chunked-prefill interleave; per-stream falls faster than N grows); (2) the **A3B MoE holds ~250–270 decode-agg flat to N=16** (3B active params + tiny hybrid-attention KV) — the multi-agent serving pick; (3) at 16K contexts *end-to-end generated* tok/s is prefill-bound (~20 for 27B, ~93–121 for MoE, nearly flat in N) — batching at deep context buys utilization, not generated tokens; the >1K aggregate lives at generation-heavy shapes. See FAQ "How do I serve multiple coding agents concurrently".
+
 ### Cross-engine — Luce DFlash (lucebox-hub) on Qwen3.5-27B
 
 Not directly comparable to vLLM rows above (different engine, different bench script, different model — Qwen3.5-27B not 3.6 because the 3.6 DFlash draft is still under training as of 2026-05-04). Bench harness: `lucebox-hub/dflash/scripts/bench_he.py`, HumanEval 10 prompts, n_gen=128.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -226,6 +226,26 @@ bash scripts/rebench-full.sh \
 
 The chained scripts run in host-only mode (no `docker logs` / `docker inspect` scrapes) when `--url` is set, so the entire suite works against any OpenAI-API endpoint.
 
+### How do I serve multiple coding agents concurrently — and what total throughput can I expect?
+
+Use **vLLM** (llama.cpp is single-user-oriented: `-np` splits the KV pool statically; vLLM continuous-batches). Two knobs:
+
+1. **`MAX_NUM_SEQS`** — the concurrent-stream cap. Every vLLM compose accepts it as an env override: `MAX_NUM_SEQS=8 bash scripts/switch.sh <slug>`. It's a *cap, not a reservation* — raising it is ~free when streams are idle.
+2. **Context vs concurrency** — the KV pool is shared: N streams × per-stream context must fit it. Drop `MAX_MODEL_LEN` if you want more streams instead of depth.
+
+**Pick the model by architecture, not size.** Measured on the reference rig (2× 3090, `concurrency-probe.sh`, 2026-07-10):
+
+| shape | dense 27B (`vllm/qwen-27b-dual-fast`, MTP n=3) | MoE 35B-A3B (`vllm/qwen-35b-a3b-dual`, MTP off) |
+|---|---|---|
+| agent ctx (16K in / 256 out), decode-aggregate | peaks **~104 tok/s @ N=2**, collapses to ~54 by N=8 | **~250–270 tok/s flat N=2→16** (still clean at 16) |
+| generation (0.5K in / 800 out), aggregate | **211 tok/s** @ N=8 | **~1,037 tok/s** @ N=16 (92.8 tok/s *per stream*, 99.4% retention, 0 leak) |
+
+Why: the A3B MoE has **3B active params** (cheap decode → the batching knee sits far higher) and hybrid-attention **tiny KV** (~a fraction of the dense 27B's per token → many more streams fit). The dense 27B stays the single/dual-agent *quality* pick; for **3+ concurrent agents, serve `vllm/qwen-35b-a3b-dual` with `MAX_NUM_SEQS` raised**.
+
+Three caveats: aggregate numbers are **summed across streams** — a single request never sees them (per-stream *falls* as N rises); at long agent contexts throughput becomes **prefill-bound** (end-to-end generated tok/s is nearly flat in N — batching buys utilization/latency-hiding, not more generated tokens); and for agents run **thinking-OFF** (tool-call accuracy) and mind Cliff 2 on single-card vLLM (`docs/CLIFFS.md`).
+
+Measure your own rig: `SWEEP="2 4 8 16" SLUG=<slug> URL=http://localhost:<port> bash scripts/concurrency-probe.sh` — reboots per N, reports per-stream + aggregate + the knee.
+
 ### Which KV-cache quant should I use? (`q4_0` / `q5_0` / `turbo3` / `fp8`)
 
 KV-cache quant trades **quality ↔ context ceiling ↔ a little speed**, and the metric that matters is **tail precision** (99.9th-percentile KL divergence), not perplexity — the worst 0.1% of positions are exactly where quantization breaks JSON keys, closing braces, and tool-call grammar. [Anbeeld's KV-quant long-context benchmarks](https://anbeeld.com/articles/kv-cache-quantization-benchmarks-for-long-context) measured this on **Qwen3.6-27B / single RTX 3090 — the same model + GPU as this stack**:

--- a/scripts/concurrency-probe.sh
+++ b/scripts/concurrency-probe.sh
@@ -51,6 +51,9 @@ SLUG="${SLUG:-}"                      # required for SWEEP (reboot target)
 SWEEP_DRY="${SWEEP_DRY:-0}"
 BOOT_TIMEOUT="${BOOT_TIMEOUT:-360}"
 
+# Remember whether the caller pinned MODEL — SWEEP re-resolves after each boot
+# and must not clobber an explicit pin.
+MODEL_PINNED="${MODEL:+1}"
 MODEL="${MODEL:-$(curl -s -m 5 "${URL}/v1/models" 2>/dev/null \
   | python3 -c 'import json,sys;print(json.load(sys.stdin)["data"][0]["id"])' 2>/dev/null || echo qwen3.6-27b)}"
 # best-effort container for VRAM + cmd introspection (name heuristic)
@@ -238,6 +241,18 @@ if [[ -n "$SWEEP" ]]; then
       sleep 2
     done
     if [[ "$ready" != "1" ]]; then echo "[sweep] N=$N: not ready in ${BOOT_TIMEOUT}s — skipping"; continue; fi
+    # Re-resolve the served model AFTER the boot. The top-of-script autodetect
+    # ran BEFORE the sweep booted anything on $URL, so it silently fell back to
+    # the default — which 404s every request against any other model (the whole
+    # arm reads as errors=N). Skip when the caller pinned MODEL explicitly.
+    if [[ -z "$MODEL_PINNED" ]]; then
+      det="$(curl -s -m 5 "${URL}/v1/models" 2>/dev/null \
+        | python3 -c 'import json,sys;print(json.load(sys.stdin)["data"][0]["id"])' 2>/dev/null || true)"
+      if [[ -n "$det" && "$det" != "$MODEL" ]]; then
+        echo "[sweep] served model: $det (re-resolved post-boot; was: $MODEL)"
+        MODEL="$det"
+      fi
+    fi
     out="$(run_probe "$N" || true)"; echo "$out"
     line="$(printf '%s\n' "$out" | grep -m1 '^RESULT ' || true)"
     clean="$(sed -n 's/.* clean=\([0-9]*\).*/\1/p' <<<"$line")"

--- a/scripts/concurrency-probe.sh
+++ b/scripts/concurrency-probe.sh
@@ -152,7 +152,7 @@ def one(stream, rnd):
 
 print(f"\n{'round':>5} {'done':>7} {'silent':>7} {'errors':>7} {'vram_MB':>8} {'agg_t/s':>8} {'per-strm':>9}")
 vram0=vram_used_mb()
-vram_by_round=[]; mtps_by_round=[]; bad=0
+vram_by_round=[]; mtps_by_round=[]; agg_by_round=[]; bad=0
 for rnd in range(1,ROUNDS+1):
     t0=time.time()
     with cf.ThreadPoolExecutor(max_workers=N) as ex:
@@ -164,7 +164,7 @@ for rnd in range(1,ROUNDS+1):
     agg=sum(r["toks"] for r in res)/wall if wall else 0
     tps_ok=[r["tps"] for r in res if r["ok"] and r["tps"]>0]
     mtps=statistics.median(tps_ok) if tps_ok else 0.0
-    mtps_by_round.append(mtps)
+    mtps_by_round.append(mtps); agg_by_round.append(agg)
     print(f"{rnd:>5} {done:>4}/{N:<2} {silent:>7} {errs:>7} {v:>8} {agg:>8.1f} {mtps:>9.1f}")
     if done<N or silent or errs: bad+=1
 
@@ -178,6 +178,9 @@ vram_peak=max(vram_by_round) if vram_by_round else -1
 # Round 1 is cudagraph/cold warmup (systematically slow) — anchoring retention
 # on it would flatter the ratio, so drop it once there are >=4 rounds.
 report_tps=mtps_by_round[-1] if mtps_by_round else 0.0
+# aggregate = summed completion tokens / wall per round (what "total rig
+# throughput at N agents" means); steady-state = last round, like per-stream.
+report_agg=agg_by_round[-1] if agg_by_round else 0.0
 warm_tps=mtps_by_round[1:] if ROUNDS>=4 else mtps_by_round
 if len(warm_tps)>=3 and warm_tps[0]>0:
     early=statistics.median(warm_tps[:2]); late=statistics.median(warm_tps[-2:])
@@ -193,7 +196,8 @@ PASS=clean_fit and floor_ok and (retention_ok if VALIDATE else True)
 print(f"\n=== verdict (N={N}) ===")
 print(f"  VRAM: cold {vram0} -> warm {warm} MB (pool fill {pool_fill} MB, expected) "
       f"-> final {vram_by_round[-1]} MB (post-warm growth {leak} MB / {GROWTH})  peak {vram_peak} MB")
-print(f"  per-stream decode: {report_tps:.1f} tok/s (steady) · retention {retention*100:.1f}% "
+print(f"  per-stream decode: {report_tps:.1f} tok/s (steady) · aggregate {report_agg:.1f} tok/s "
+      f"({N} streams) · retention {retention*100:.1f}% "
       f"(min {RETENTION_MIN*100:.0f}%)" + (f" · floor {TPS_FLOOR:.0f}" if TPS_FLOOR>0 else " · floor off"))
 flags=[]
 if not clean_fit: flags.append("fit")
@@ -206,7 +210,7 @@ if PASS:
           f"vram_peak_gb: {vram_peak/1024:.1f} }}")
 # machine-readable line for SWEEP parsing
 print(f"RESULT N={N} clean={int(clean_fit)} pass={int(PASS)} mps_tps={report_tps:.2f} "
-      f"retention={retention:.3f} leak={leak} vram_peak={vram_peak} floor_ok={int(floor_ok)}")
+      f"agg_tps={report_agg:.2f} retention={retention:.3f} leak={leak} vram_peak={vram_peak} floor_ok={int(floor_ok)}")
 raise SystemExit(0 if PASS else 1)
 PY
 }
@@ -218,7 +222,7 @@ if [[ -n "$SWEEP" ]]; then
     exit 2
   fi
   echo "[sweep] slug=$SLUG N in { $SWEEP } · floor=${TPS_FLOOR} tok/s/stream · reboots the server per N"
-  knee=""; knee_tps=""
+  knee=""; knee_tps=""; knee_agg=""; sweep_rows=""
   for N in $SWEEP; do
     if [[ "$SWEEP_DRY" == "1" ]]; then
       echo "[sweep:dry] would: MAX_NUM_SEQS=$N switch.sh $SLUG  ->  wait ready  ->  probe N=$N"
@@ -238,14 +242,20 @@ if [[ -n "$SWEEP" ]]; then
     line="$(printf '%s\n' "$out" | grep -m1 '^RESULT ' || true)"
     clean="$(sed -n 's/.* clean=\([0-9]*\).*/\1/p' <<<"$line")"
     mps="$(sed -n 's/.* mps_tps=\([0-9.]*\).*/\1/p' <<<"$line")"
+    agg="$(sed -n 's/.* agg_tps=\([0-9.]*\).*/\1/p' <<<"$line")"
+    sweep_rows="${sweep_rows:-}
+  N=$N  per-stream=${mps:-?} tok/s  aggregate=${agg:-?} tok/s  clean=${clean:-?}"
     # knee = largest N that is fit-clean AND (floor off OR per-stream TPS >= floor)
     above="$(awk -v t="$mps" -v f="$TPS_FLOOR" 'BEGIN{print (f<=0 || t>=f)?1:0}')"
-    if [[ "$clean" == "1" && "$above" == "1" ]]; then knee="$N"; knee_tps="$mps"; fi
+    if [[ "$clean" == "1" && "$above" == "1" ]]; then knee="$N"; knee_tps="$mps"; knee_agg="$agg"; fi
   done
+  echo ""
+  echo "=== sweep summary (per-stream vs aggregate) ==="
+  echo "${sweep_rows:-  (no completed rows)}"
   echo ""
   echo "=== sweep knee ==="
   if [[ -n "$knee" ]]; then
-    echo "  largest clean N at/above floor: N=$knee (${knee_tps} tok/s/stream)"
+    echo "  largest clean N at/above floor: N=$knee (${knee_tps} tok/s/stream · ${knee_agg:-?} tok/s aggregate)"
     echo "  -> validate the envelope row at max_num_seqs: $knee"
   else
     echo "  no N met the bar — lower the sweep range or the target_ctx, or check the floor."


### PR DESCRIPTION
The probe computed aggregate throughput per round but never surfaced it in the verdict/RESULT/knee — so "what total tok/s at N concurrent agents?" had no first-party answer. Adds `aggregate` to the verdict line, `agg_tps=` to the machine-readable RESULT, and a per-N summary table + aggregate-in-knee to SWEEP mode. Knee logic unchanged. Offline guard green; being live-validated with a full sweep on `vllm/qwen-27b-dual-fast` (N=1/2/4/8) — results will land in BENCHMARKS + a new FAQ entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)