### PR TITLE
NVFP4: unhide on fallback-capable hardware (fallback_sm + c3 ⚑ badge)

### DIFF
--- a/models/qwen3.6-27b/vllm/compose/dual/nvfp4/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/nvfp4/mtp.yml
@@ -4,9 +4,10 @@
 #              NVFP4 gs16 FFN + FP8-static attention/linear_attn + FP8 KV scales
 #              baked + UNQUANTIZED mtp.* head — 21.9 GB)
 #   Topology:  Dual Hopper/Blackwell (TP=2) — 2× 5090 is the primary target;
-#              H100 / RTX 6000 Pro / GB10 pairs also qualify. required_sm=9.0:
-#              the launchers REFUSE this on Ampere (sm_86) — NVFP4 has no
-#              kernel there (NVIDIA supports Hopper + Blackwell only).
+#              H100 / RTX 6000 Pro / GB10 pairs also qualify. required_sm=9.0
+#              (native); fallback_sm=7.5 — sub-9.0 cards RUN it via the Marlin
+#              W4A16 weight-only fallback (vLLM v0.24+; live-validated on
+#              2x 3090 sm_86 2026-07-11, ~20% slower than the AutoRound tier).
 #   Drafter:   MTP n=3 (built-in — the checkpoint keeps mtp.* unquantized;
 #              SPEC=off disables it — tight-RAM / spec-dec-fails mitigation, #617)
 #   KV:        fp8 → e4m3 (this checkpoint BAKES FP8 KV scales — modelopt
@@ -23,8 +24,10 @@
 #              memory than bf16 — pending first community validation
 # ---------------------------------------------------------------------------
 # ⚠️ AUTHORED BLIND — READ THIS FIRST.
-# The maintainer rig is 2× RTX 3090 (Ampere sm_86) and CANNOT BOOT NVFP4: this
-# compose has never been started anywhere. It mirrors the production-validated
+# FIRST BOOT: the maintainer rig (2× RTX 3090 sm_86) via the Marlin W4A16
+# fallback, 2026-07-11 — 262K + fp8 KV + MTP n=3 (accept 97%+), 69.7/85.5
+# decode TPS, 23.77 GB/card, 8-pack think-off 110/150 (ties the fp8 tier's
+# 109). Native-FP4 (sm_90+) validation still wanted. It mirrors the production-validated
 # vllm/qwen-27b-dual-max shape (TP=2 + MTP n=3 + fp8/e4m3 KV + vision @262K)
 # with the weights swapped to nvidia/Qwen3.6-27B-NVFP4 per NVIDIA's own model
 # card recipe (--quantization modelopt). If you have 2× Hopper/Blackwell

--- a/models/qwen3.6-27b/vllm/compose/single/nvfp4/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/nvfp4/mtp.yml
@@ -4,9 +4,11 @@
 #              NVFP4 gs16 FFN + FP8-static attention/linear_attn + FP8 KV scales
 #              baked + UNQUANTIZED mtp.* head — 21.9 GB)
 #   Topology:  Single Hopper/Blackwell card, 32 GB+ — 5090 is the primary
-#              target; H100 / RTX 6000 Pro / GB10 also qualify. required_sm=9.0:
-#              the launchers REFUSE this on Ampere (sm_86) — NVFP4 has no
-#              kernel there (NVIDIA supports Hopper + Blackwell only).
+#              target; H100 / RTX 6000 Pro / GB10 also qualify. required_sm=9.0
+#              (native); fallback_sm=7.5 — sub-9.0 cards RUN it via the Marlin
+#              W4A16 weight-only fallback (vLLM v0.24+, confirmed on sm_86
+#              2026-07-11; no native-FP4 speed edge), though this single-card
+#              config needs >24 GB VRAM regardless.
 #   Drafter:   MTP n=3 (built-in — the checkpoint keeps mtp.* unquantized;
 #              SPEC=off disables it — tight-RAM / spec-dec-fails mitigation, #617)
 #   KV:        fp8 → e4m3 at scale=1.0 (hf_quant_config DECLARES FP8 KV but
@@ -30,8 +32,9 @@
 #              5090 default 65K keeps MTP's ~2x (131/155 TPS); SPEC=off for max ctx
 # ---------------------------------------------------------------------------
 # ⚠️ AUTHORED BLIND — READ THIS FIRST.
-# The maintainer rig is Ampere sm_86 and CANNOT BOOT NVFP4: this compose is
-# community-validated only. Two 5090s (#613 @guybrush01, #617 @paulp83) swept the
+# NVFP4 runs on the sm_86 maintainer rig via the Marlin W4A16 fallback
+# (confirmed 2026-07-11 on the dual sibling), but this 21.9 GB single-card
+# config exceeds a 24 GB card — so it remains community-validated only. Two 5090s (#613 @guybrush01, #617 @paulp83) swept the
 # config space: MTP-on OOMs at 98K but PASSES at 65K + util 0.85 (verify-stress
 # all-pass, 131/155 TPS, MTP accept 3.2) — that's now the default. SPEC=off is the
 # max-ctx fallback (81K/98K @ 71 TPS) and the tight-system-RAM path (MTP's draft

--- a/models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4/fp8.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4/fp8.yml
@@ -4,7 +4,9 @@
 #              NVFP4 gs16 expert FFNs + FP8-static attention/linear_attn +
 #              UNQUANTIZED mtp.* head — 23.4 GB, 3B active params)
 #   Topology:  Dual Hopper/Blackwell (TP=2) — 2× 5090 is the primary target;
-#              required_sm=9.0: the launchers REFUSE this on Ampere (sm_86).
+#              required_sm=9.0 (native); fallback_sm=7.5 — sub-9.0 cards run
+#              it via the Marlin W4A16 fallback (validated on the 27B sibling
+#              2026-07-11; on Ampere the AutoRound tier is faster).
 #   Drafter:   none — DELIBERATE. Built-in MTP is NET-NEGATIVE on this MoE
 #              (-51% measured on the AutoRound tier; the head shares the MoE
 #              forward — learnings/qwen3.6-35b-a3b.md). Don't re-add blind.
@@ -21,8 +23,9 @@
 #              community validation
 # ---------------------------------------------------------------------------
 # ⚠️ AUTHORED BLIND — READ THIS FIRST.
-# The maintainer rig is 2× RTX 3090 (Ampere sm_86) and CANNOT BOOT NVFP4:
-# this compose has never been started anywhere. It mirrors the validated
+# NVFP4 runs on the maintainer rig (2× RTX 3090 sm_86) via the Marlin W4A16
+# fallback since v0.24 (validated on the 27B sibling 2026-07-11), but this
+# compose itself has not been booted yet. It mirrors the validated
 # vllm/qwen-35b-a3b-dual shape (TP=2, no drafter, vision on, thinking off,
 # 262K) with NVFP4 weights + fp8/e4m3 KV per NVIDIA's model-card recipe
 # (--quantization modelopt). If you have 2× Hopper/Blackwell cards, YOU are

--- a/models/qwen3.6-35b-a3b/vllm/compose/single/nvfp4/fp8.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/single/nvfp4/fp8.yml
@@ -3,8 +3,10 @@
 #   Model:     Qwen3.6-35B-A3B NVFP4 (nvidia modelopt MIXED_PRECISION MoE:
 #              NVFP4 gs16 expert FFNs + FP8-static attention/linear_attn +
 #              UNQUANTIZED mtp.* head — 23.4 GB, 3B active params)
-#   Topology:  Single Hopper/Blackwell card, 32 GB+ — required_sm=9.0: the
-#              launchers REFUSE this on Ampere (sm_86). THE GB10 / DGX-Spark
+#   Topology:  Single Hopper/Blackwell card, 32 GB+ — required_sm=9.0 (native;
+#              fallback_sm=7.5 — sub-9.0 runs via the Marlin W4A16 fallback,
+#              validated on the 27B sibling 2026-07-11, but a 24 GB Ampere card
+#              can't VRAM-fit this config anyway). THE GB10 / DGX-Spark
 #              slug: a 3B-active MoE is the right shape for big-capacity,
 #              lower-bandwidth unified-memory parts.
 #   Drafter:   none — DELIBERATE. On this MoE the built-in MTP head shares the
@@ -33,7 +35,7 @@
 #              unified-memory (GB10) first; single-5090 community-validated
 # ---------------------------------------------------------------------------
 # ✅ FIRST COMMUNITY VALIDATION — single RTX 5090, #619 (@paulp83), 2026-07-07.
-# Authored on the sm_86 dev rig (which can't boot NVFP4), first booted + gated
+# Authored on the sm_86 dev rig, first booted + gated
 # on a 5090: vLLM v0.24.0 (quant=modelopt_mixed), verify-full 9/9, verify-
 # stress needle-clean (9.8K + 29K), soak-continuous PASS (15 MiB growth /
 # 100% retention / 0 err / p50 311 TPS). Decode 255.8 narr / 257.9 code TPS

--- a/scripts/lib/profiles/compat.py
+++ b/scripts/lib/profiles/compat.py
@@ -1090,7 +1090,10 @@ def from_compose_name(
         nvlink_active=nvlink_active,
         requires_nvlink=bool(entry.get("requires_nvlink", False)),
         required_engine_features=list(entry.get("required_engine_features", [])),
-        required_sm=entry.get("required_sm"),
+        # fallback_sm (weight-only fallback floor, e.g. NVFP4→Marlin W4A16 @7.5)
+        # replaces required_sm as the HARD floor when present — the C3 gate then
+        # admits fallback-band hardware (sm_86 live-confirmed 2026-07-11).
+        required_sm=entry.get("fallback_sm") or entry.get("required_sm"),
         project_vram=project_vram,
     )
     result.compose_name = name

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -62,6 +62,7 @@ def _entry(
     required_engine_features=None,
     recommended_engine_features=None,
     required_sm=None,
+    fallback_sm=None,
     status="production",
     status_note=None,
     category=None,
@@ -101,6 +102,17 @@ def _entry(
         entry["recommended_engine_features"] = list(recommended_engine_features)
     if required_sm is not None:
         entry["required_sm"] = required_sm
+    if fallback_sm is not None:
+        # Weight-only fallback floor. required_sm = the NATIVE-kernel SM;
+        # fallback_sm = the lowest SM where the format still RUNS via a
+        # weight-only fallback kernel (e.g. NVFP4 -> Marlin W4A16, floor
+        # sm 7.5 per vLLM marlin_utils_fp4). In the band
+        # [fallback_sm, required_sm) the gates ALLOW with a fallback
+        # annotation instead of refusing (kv-calc emits `hw_fallback`;
+        # c3 shows the slug with a ⚑ badge instead of hiding it).
+        # Live-confirmed on 2x3090 sm_86 2026-07-11: NVFP4-27B boots,
+        # 69.7/85.5 TPS, 8-pack 110/150 (ties the fp8 tier's 109).
+        entry["fallback_sm"] = fallback_sm
     if category is not None:
         entry["category"] = category
     return entry
@@ -246,20 +258,20 @@ COMPOSE_REGISTRY = {
         engine="vllm-stable", drafter="qwen-mtp-builtin", kv_format="fp8_e4m3",
         tp=1, max_ctx=65536, max_num_seqs=1, mem_util=0.85,
         compose_path="models/qwen3.6-27b/vllm/compose/single/nvfp4/mtp.yml",
-        default_port=8076, required_sm=9.0,
+        default_port=8076, required_sm=9.0, fallback_sm=7.5,
         kvcalc_key="qwen3.6-27b:nvfp4-single",
         status="experimental",
-        status_note="Qwen3.6-27B NVFP4 (nvidia modelopt MIXED_PRECISION: NVFP4 FFN + FP8 attention + FP8 KV scales + unquantized MTP head), single Hopper/Blackwell card (required_sm=9.0 — H100 / 5090 / RTX 6000 Pro / GB10; NOT Ampere). 🧪 AUTHORED BLIND on the sm_86 dev rig, community-validated on two 5090s (#613 @guybrush01 + #617 @paulp83). Root cause of the original OOM was MTP, not ctx: MTP-on at 98K left no room for the draft head + cudagraphs + GDN prefill scratch. Default is now MTP-on + MAX_MODEL_LEN=65536 + mem_util=0.85 — the config that keeps MTP's ~2x AND fits (verify-stress all-pass, 131/155 TPS decode, MTP accept ~3.2, ~1.4 GB VRAM free @ 65K). SPEC=off trades MTP for more ctx (81K/98K @ 71 TPS) and is the tight-system-RAM path (MTP's draft load OOM-kills a 28 GB host, #617). 80 GB+ cards raise MAX_MODEL_LEN toward 262K with MTP on. fp8/e4m3 KV runs scale=1.0 (FP8 KV declared in hf_quant_config, NO k_scale/v_scale tensors shipped — index-verified, the #594-tied regime). ~2.5x smaller than bf16, NVIDIA MMLU-Pro/GSM8K deltas <1% vs bf16 per the model card. 8-pack quality owed (stays 🧪). No DEFAULTS row (opt-in only).",
+        status_note="Qwen3.6-27B NVFP4 (nvidia modelopt MIXED_PRECISION: NVFP4 FFN + FP8 attention + FP8 KV scales + unquantized MTP head), single Hopper/Blackwell card (native sm_90+ — H100 / 5090 / RTX 6000 Pro / GB10; fallback_sm=7.5: sub-9.0 cards RUN it via the Marlin W4A16 weight-only fallback since vLLM v0.24 — no native-FP4 speed edge, and this single-card config needs >24 GB VRAM regardless). 🧪 AUTHORED BLIND on the sm_86 dev rig, community-validated on two 5090s (#613 @guybrush01 + #617 @paulp83). Root cause of the original OOM was MTP, not ctx: MTP-on at 98K left no room for the draft head + cudagraphs + GDN prefill scratch. Default is now MTP-on + MAX_MODEL_LEN=65536 + mem_util=0.85 — the config that keeps MTP's ~2x AND fits (verify-stress all-pass, 131/155 TPS decode, MTP accept ~3.2, ~1.4 GB VRAM free @ 65K). SPEC=off trades MTP for more ctx (81K/98K @ 71 TPS) and is the tight-system-RAM path (MTP's draft load OOM-kills a 28 GB host, #617). 80 GB+ cards raise MAX_MODEL_LEN toward 262K with MTP on. fp8/e4m3 KV runs scale=1.0 (FP8 KV declared in hf_quant_config, NO k_scale/v_scale tensors shipped — index-verified, the #594-tied regime). ~2.5x smaller than bf16, NVIDIA MMLU-Pro/GSM8K deltas <1% vs bf16 per the model card. 8-pack think-off measured 2026-07-11 on the dual sibling (sm_86 Marlin fallback, weight-identical): 110/150 — ties the fp8 tier's 109; native-FP4 activation path still owed (stays 🧪). No DEFAULTS row (opt-in only).",
     ),
     "vllm/qwen-27b-dual-nvfp4": _entry(
         model="qwen3.6-27b", weights_variant="nvfp4", workload="long-ctx-single",
         engine="vllm-stable", drafter="qwen-mtp-builtin", kv_format="fp8_e4m3",
         tp=2, max_ctx=262144, max_num_seqs=2, mem_util=0.92,
         compose_path="models/qwen3.6-27b/vllm/compose/dual/nvfp4/mtp.yml",
-        default_port=8077, required_sm=9.0,
+        default_port=8077, required_sm=9.0, fallback_sm=7.5,
         kvcalc_key="qwen3.6-27b:nvfp4-dual",
         status="experimental",
-        status_note="Qwen3.6-27B NVFP4 (nvidia modelopt MIXED_PRECISION — see single-nvfp4) at TP=2 @262K full ctx, 2x Hopper/Blackwell (required_sm=9.0; the 2x 5090 configuration is the primary community target). 🧪 AUTHORED BLIND on an sm_86 rig — cannot boot here; first community boot + rebench-full validates (funnel). Mirrors vllm/qwen-27b-dual-max's shape (TP=2 + MTP n=3 + fp8/e4m3 KV + vision @262K) with NVFP4 weights instead of FP8: ~11 GB/card weights vs dual-max's 14.5 — bigger KV pool headroom on 32 GB cards. On native-FP4 GEMM parts (Blackwell) NVIDIA claims near-fp8 throughput at 2.5x less weight memory. No DEFAULTS row (opt-in only).",
+        status_note="Qwen3.6-27B NVFP4 (nvidia modelopt MIXED_PRECISION — see single-nvfp4) at TP=2 @262K full ctx, 2x Hopper/Blackwell native (the 2x 5090 configuration is the primary community target; fallback_sm=7.5). LIVE-VALIDATED ON 2x3090 sm_86 2026-07-11 via the Marlin W4A16 fallback: boots @262K + fp8 KV + MTP n=3 (accept 97%+), 69.7 narr / 85.5 code decode TPS, 23.77 GB/card, 8-pack think-off 110/150 — statistically TIES the fp8 production tier's 109 (weight-identical path; native-FP4 activations unmeasured). On Ampere it works but has NO edge (~20% slower than the AutoRound tier for the same model) — prefer AutoRound/fp8 there; this slug's value on sub-sm_90 cards is models/cases where NVFP4 is the only quant. First native-FP4 community boot + rebench-full still wanted (funnel). Mirrors vllm/qwen-27b-dual-max's shape (TP=2 + MTP n=3 + fp8/e4m3 KV + vision @262K) with NVFP4 weights instead of FP8: ~11 GB/card weights vs dual-max's 14.5 — bigger KV pool headroom on 32 GB cards. On native-FP4 GEMM parts (Blackwell) NVIDIA claims near-fp8 throughput at 2.5x less weight memory. No DEFAULTS row (opt-in only).",
     ),
 
     # Qwen 3.6 27B, llama.cpp single-card.
@@ -808,20 +820,20 @@ COMPOSE_REGISTRY = {
         engine="vllm-stable", drafter=None, kv_format="fp8_e4m3",
         tp=1, max_ctx=131072, max_num_seqs=1, mem_util=0.92,
         compose_path="models/qwen3.6-35b-a3b/vllm/compose/single/nvfp4/fp8.yml",
-        default_port=8078, required_sm=9.0,
+        default_port=8078, required_sm=9.0, fallback_sm=7.5,
         kvcalc_key="qwen3.6-35b-a3b:nvfp4-single",
         status="caveats",
-        status_note="Qwen3.6-35B-A3B NVFP4 (nvidia modelopt MIXED_PRECISION MoE: NVFP4 expert FFNs + FP8 attention; ~23.4 GB), single Hopper/Blackwell card (required_sm=9.0; NOT Ampere). 🧪 authored on the sm_86 dev rig (can't boot NVFP4 here), FIRST community validation on a single RTX 5090 in #619 (@paulp83): boots clean on vLLM v0.24.0 (quant=modelopt_mixed), verify-full 9/9 (tool-calls + streaming + reasoning), verify-stress needle-clean (9.8K + 29K), soak-continuous PASS (15 MiB growth / 100% retention / 0 err / p50 311 TPS). Decode 255.8 narr / 257.9 code TPS @ 60 ms TTFT — ~2.5-3x our 2x3090 AutoRound tier (native FP4 GEMM). VRAM 30.6/32 GB @131K — TIGHT but flat through soak on a 32 GB card. ⚠️ PROMOTED to Production w/ caveats 2026-07-09 on TWO independent 5090 validations (#619 @paulp83 + #612/#652 @guybrush01, within noise: verify-full 9/9, verify-stress to ~120K, soak PASS ~311 TPS). CAVEAT: 8-pack quality NOT yet cross-rig-measured (sandboxes weren't built on these runs; quality run pending, gated on #492) — reverts to 🧪 if a quality run regresses. THE GB10/DGX-Spark single-card ask: 3B-active MoE suits unified-memory parts — GB10 128 GB runs the full 262K via MAX_MODEL_LEN env (131K default sized for 5090 32 GB). NO MTP by design: the built-in head is net-negative on this MoE (-51% measured on the AutoRound tier; @paulp83's speculative_config=None confirms it loaded MTP-off). fp8/e4m3 KV @ scale=1.0 (FP8 KV declared in hf_quant_config, no scale tensors shipped — same as the 27B nvfp4). No DEFAULTS row (opt-in only).",
+        status_note="Qwen3.6-35B-A3B NVFP4 (nvidia modelopt MIXED_PRECISION MoE: NVFP4 expert FFNs + FP8 attention; ~23.4 GB), single Hopper/Blackwell card (native sm_90+; fallback_sm=7.5 — sub-9.0 runs via the Marlin W4A16 fallback, validated on the 27B sibling 2026-07-11, but this 23.4 GB single-card config needs a 32 GB card regardless). Authored on the sm_86 dev rig, FIRST community validation on a single RTX 5090 in #619 (@paulp83): boots clean on vLLM v0.24.0 (quant=modelopt_mixed), verify-full 9/9 (tool-calls + streaming + reasoning), verify-stress needle-clean (9.8K + 29K), soak-continuous PASS (15 MiB growth / 100% retention / 0 err / p50 311 TPS). Decode 255.8 narr / 257.9 code TPS @ 60 ms TTFT — ~2.5-3x our 2x3090 AutoRound tier (native FP4 GEMM). VRAM 30.6/32 GB @131K — TIGHT but flat through soak on a 32 GB card. ⚠️ PROMOTED to Production w/ caveats 2026-07-09 on TWO independent 5090 validations (#619 @paulp83 + #612/#652 @guybrush01, within noise: verify-full 9/9, verify-stress to ~120K, soak PASS ~311 TPS). CAVEAT: 8-pack quality NOT yet cross-rig-measured (sandboxes weren't built on these runs; quality run pending, gated on #492) — reverts to 🧪 if a quality run regresses. THE GB10/DGX-Spark single-card ask: 3B-active MoE suits unified-memory parts — GB10 128 GB runs the full 262K via MAX_MODEL_LEN env (131K default sized for 5090 32 GB). NO MTP by design: the built-in head is net-negative on this MoE (-51% measured on the AutoRound tier; @paulp83's speculative_config=None confirms it loaded MTP-off). fp8/e4m3 KV @ scale=1.0 (FP8 KV declared in hf_quant_config, no scale tensors shipped — same as the 27B nvfp4). No DEFAULTS row (opt-in only).",
     ),
     "vllm/qwen-35b-a3b-dual-nvfp4": _entry(
         model="qwen3.6-35b-a3b", weights_variant="nvfp4", workload="fast-chat",
         engine="vllm-stable", drafter=None, kv_format="fp8_e4m3",
         tp=2, max_ctx=262144, max_num_seqs=1, mem_util=0.92,
         compose_path="models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4/fp8.yml",
-        default_port=8079, required_sm=9.0,
+        default_port=8079, required_sm=9.0, fallback_sm=7.5,
         kvcalc_key="qwen3.6-35b-a3b:nvfp4-dual",
         status="experimental",
-        status_note="Qwen3.6-35B-A3B NVFP4 (see single-nvfp4) at TP=2 @262K full ctx, 2x Hopper/Blackwell (2x 5090 primary community target; ~11.7 GB/card weights). 🧪 AUTHORED BLIND on an sm_86 rig — first community boot + rebench-full validates. Mirrors vllm/qwen-35b-a3b-dual's shape (no drafter — MTP net-negative on this MoE, vision on, thinking off) with NVFP4 weights + fp8/e4m3 KV instead of AutoRound + e5m2. No DEFAULTS row (opt-in only).",
+        status_note="Qwen3.6-35B-A3B NVFP4 (see single-nvfp4) at TP=2 @262K full ctx, 2x Hopper/Blackwell native (2x 5090 primary community target; ~11.7 GB/card weights; fallback_sm=7.5 — sub-9.0 cards run it via the Marlin W4A16 fallback, validated on the 27B sibling 2026-07-11, though on Ampere the AutoRound tier serves this model faster). 🧪 first community boot + rebench-full validates. Mirrors vllm/qwen-35b-a3b-dual's shape (no drafter — MTP net-negative on this MoE, vision on, thinking off) with NVFP4 weights + fp8/e4m3 KV instead of AutoRound + e5m2. No DEFAULTS row (opt-in only).",
     ),
 
     # Agents-A1 — InternScience's 35B agentic MoE (Qwen3-Next MoE arch, OWN model

--- a/scripts/lib/profiles/gates.py
+++ b/scripts/lib/profiles/gates.py
@@ -323,15 +323,19 @@ def _resolve_arch_row(gc, root, runtime, arches, model_slug: str):
 
 
 def _required_sm(engine: dict, entry: dict, kv_format: str) -> float:
-    """hardware SM ≥ max(engine.min_sm, registry required_sm,
+    """hardware SM ≥ max(engine.min_sm, registry SM floor,
     arch-kernel SM rule for the requested runtime).
 
     - engine.min_sm        : engines/<id>.yml `min_sm`
-    - registry required_sm : compose_registry `required_sm` (9.0 rows)
+    - registry SM floor    : compose_registry `fallback_sm` when present
+                             (the weight-only-fallback floor — e.g. NVFP4 →
+                             Marlin W4A16, sm 7.5; live-confirmed on sm_86
+                             2026-07-11), else `required_sm` (the native
+                             floor, hard gate when no fallback exists)
     - arch-kernel SM rule  : _ARCH_KERNEL_SM[kv_format] (fp8_e4m3 / Gemma-TQ3)
     """
     eng_sm = float(engine.get("min_sm") or 0.0)
-    reg_sm = float(entry.get("required_sm") or 0.0)
+    reg_sm = float(entry.get("fallback_sm") or entry.get("required_sm") or 0.0)
     arch_sm = float(_ARCH_KERNEL_SM.get(kv_format, 0.0))
     return max(eng_sm, reg_sm, arch_sm)
 

--- a/scripts/tests/test-kv-calc-fit.sh
+++ b/scripts/tests/test-kv-calc-fit.sh
@@ -171,11 +171,16 @@ if parsed_a:
               for v in variants.values()),
           "(e) every variant value carries a verdict string")
 
-# (f) required_sm gate — the arch floor surfaced in the fit verdict (the
-# cockpit's hide/warn signal for hardware-incompatible slugs, e.g. NVFP4 on
-# Ampere). Three contract points: below-floor card → incompatible-hw with
-# required_sm/card_sm populated; at/above-floor card → a REAL priced verdict;
-# bare-number --card carries no arch info → gate skipped (permissive).
+# (f) required_sm / fallback_sm gate — the arch floor surfaced in the fit
+# verdict. The NVFP4 slugs carry fallback_sm=7.5 (Marlin W4A16 weight-only
+# fallback; live-confirmed on 2x3090 sm_86 2026-07-11): a card in the band
+# [fallback_sm, required_sm) gets a REAL priced verdict PLUS an `hw_fallback`
+# annotation (the cockpit ⚑ badge) instead of incompatible-hw. Contract:
+# band card → priced + annotated; native card → priced, NO annotation;
+# bare-number --card carries no arch info → gate skipped; --fit-all mirrors.
+# (incompatible-hw remains the verdict for required_sm rows with NO
+# fallback_sm / cards below the fallback floor — no such combo exists in the
+# current registry+card tables, so that branch has no live fixture.)
 rc_f, out_f, err_f = run_fit("--fit", "vllm/qwen-27b-dual-nvfp4", "--card", "rtx-3090", "--json")
 check(rc_f == 0, f"(f) nvfp4 --card rtx-3090 exits 0 (got {rc_f})")
 try:
@@ -183,28 +188,34 @@ try:
 except Exception as exc:  # noqa: BLE001
     df = {}
     check(False, f"(f) nvfp4/3090 output is valid JSON (got {exc})")
-check(df.get("verdict") == "incompatible-hw",
-      f"(f) nvfp4 on rtx-3090 → incompatible-hw (got {df.get('verdict')!r})")
-check(df.get("required_sm") == 9.0 and df.get("card_sm") == 8.6,
-      f"(f) incompatible-hw carries required_sm=9.0/card_sm=8.6 (got {df!r})")
-check("sm" in str(df.get("error", "")),
-      f"(f) incompatible-hw error names the sm floor (got {df.get('error')!r})")
+check(df.get("verdict") in VERDICTS_OK and df.get("verdict") != "incompatible-hw",
+      f"(f) nvfp4 on rtx-3090 (fallback band) → real priced verdict (got {df.get('verdict')!r})")
+fb = df.get("hw_fallback") or {}
+check(fb.get("required_sm") == 9.0 and fb.get("card_sm") == 8.6,
+      f"(f) hw_fallback carries required_sm=9.0/card_sm=8.6 (got {fb!r})")
+check("fallback" in str(fb.get("note", "")),
+      f"(f) hw_fallback note names the fallback (got {fb.get('note')!r})")
 
 rc_g, out_g, _err_g = run_fit("--fit", "vllm/qwen-27b-dual-nvfp4", "--card", "rtx-5090", "--json")
 dg = json.loads(out_g) if rc_g == 0 else {}
 check(dg.get("verdict") in VERDICTS_OK and dg.get("verdict") != "incompatible-hw",
       f"(f) nvfp4 on rtx-5090 (sm 12.0) → real priced verdict (got {dg.get('verdict')!r})")
+check("hw_fallback" not in dg,
+      f"(f) native-sm card carries NO hw_fallback annotation (got {dg.get('hw_fallback')!r})")
 
 rc_h, out_h, _err_h = run_fit("--fit", "vllm/qwen-27b-dual-nvfp4", "--card", "64", "--json")
 dh = json.loads(out_h) if rc_h == 0 else {}
-check(dh.get("verdict") != "incompatible-hw",
-      f"(f) bare-number --card 64 skips the sm gate — permissive (got {dh.get('verdict')!r})")
+check(dh.get("verdict") != "incompatible-hw" and "hw_fallback" not in dh,
+      f"(f) bare-number --card 64 skips the sm gate — permissive, unannotated (got {dh.get('verdict')!r})")
 
-# batch parity: --fit-all --card rtx-3090 marks nvfp4 incompatible-hw too
+# batch parity: --fit-all --card rtx-3090 prices + annotates nvfp4 too
 rc_i, out_i, _err_i = run_fit("--fit-all", "--card", "rtx-3090", "--json")
 di = json.loads(out_i) if rc_i == 0 else {"variants": {}}
-check(di.get("variants", {}).get("vllm/qwen-27b-single-nvfp4", {}).get("verdict") == "incompatible-hw",
-      "(f) --fit-all on rtx-3090 marks single-nvfp4 incompatible-hw")
+d_single = di.get("variants", {}).get("vllm/qwen-27b-single-nvfp4", {})
+check(d_single.get("verdict") != "incompatible-hw",
+      f"(f) --fit-all on rtx-3090: single-nvfp4 NOT incompatible-hw (got {d_single.get('verdict')!r})")
+check((d_single.get("hw_fallback") or {}).get("card_sm") == 8.6,
+      f"(f) --fit-all on rtx-3090: single-nvfp4 carries hw_fallback (got {d_single.get('hw_fallback')!r})")
 
 if failures:
     print(f"\n{len(failures)} assertion(s) failed.", file=sys.stderr)

--- a/tools/kv-calc.py
+++ b/tools/kv-calc.py
@@ -1462,16 +1462,35 @@ def fit_verdict(target: str, card: Optional[str], vram_default: float) -> dict:
 
     # required_sm gate (compat C3's arch floor, surfaced in the FIT verdict so
     # the cockpit can hide/warn hardware-incompatible slugs — e.g. NVFP4 on
-    # Ampere: the VRAM would "fit" but the kernels don't exist below sm 9.0).
-    _req_sm = COMPOSE_REGISTRY[slug].get("required_sm")
+    # Ampere: the VRAM would "fit" but the NATIVE kernels don't exist below
+    # sm 9.0). Since v0.24 some formats have a weight-only FALLBACK kernel
+    # below required_sm (registry `fallback_sm` — NVFP4 -> Marlin W4A16,
+    # floor sm 7.5; live-confirmed on 2x3090 2026-07-11). In the band
+    # [fallback_sm, required_sm) we PRICE the fit normally and attach an
+    # `hw_fallback` annotation instead of hiding — the cockpit badges it.
+    _entry_reg = COMPOSE_REGISTRY[slug]
+    _req_sm = _entry_reg.get("required_sm")
+    _fb_sm = _entry_reg.get("fallback_sm")
     _card_sm = _resolve_card_sm(card)
+    _hw_fallback = None
     if _req_sm is not None and _card_sm is not None and _card_sm < float(_req_sm):
-        return {
-            "verdict": "incompatible-hw",
-            "required_sm": float(_req_sm),
-            "card_sm": _card_sm,
-            "error": f"requires sm >= {float(_req_sm):g} (this card is sm_{_card_sm:g})",
-        }
+        if _fb_sm is not None and _card_sm >= float(_fb_sm):
+            _hw_fallback = {
+                "required_sm": float(_req_sm),
+                "card_sm": _card_sm,
+                "note": (
+                    f"no native kernels below sm {float(_req_sm):g} — runs via "
+                    f"weight-only fallback (Marlin); works, no speed edge vs "
+                    f"native 4-bit quants on this card"
+                ),
+            }
+        else:
+            return {
+                "verdict": "incompatible-hw",
+                "required_sm": float(_req_sm),
+                "card_sm": _card_sm,
+                "error": f"requires sm >= {float(_req_sm):g} (this card is sm_{_card_sm:g})",
+            }
 
     try:
         spec = MODEL_SPECS[model_id]
@@ -1495,12 +1514,15 @@ def fit_verdict(target: str, card: Optional[str], vram_default: float) -> dict:
     except Exception as exc:  # any pricing-path failure → honest unknown
         return {"verdict": "unknown", "error": f"pricing {slug!r} failed: {exc}"}
 
-    return {
+    res = {
         "verdict": _RAW_VERDICT_MAP[pred.verdict],
         "vram_est_gb": round(pred.total_gb, 4),
         "band_gb": FIT_BAND_GB,
         "max_ctx": int(max_ctx_fit),
     }
+    if _hw_fallback is not None:
+        res["hw_fallback"] = _hw_fallback
+    return res
 
 
 def fit_all_verdicts(card: Optional[str], vram_default: float) -> dict:
@@ -1530,8 +1552,16 @@ def fit_all_verdicts(card: Optional[str], vram_default: float) -> dict:
     for slug, entry in COMPOSE_REGISTRY.items():
         # required_sm gate first — applies to SKIP (non-vLLM) slugs too, and
         # short-circuits the pricing for slugs whose kernels can't exist here.
+        # Slugs with a `fallback_sm` at/below this card fall THROUGH to normal
+        # pricing (fit_verdict re-checks and attaches the hw_fallback note).
         _req_sm = entry.get("required_sm")
-        if _req_sm is not None and _card_sm is not None and _card_sm < float(_req_sm):
+        _fb_sm = entry.get("fallback_sm")
+        if (
+            _req_sm is not None
+            and _card_sm is not None
+            and _card_sm < float(_req_sm)
+            and not (_fb_sm is not None and _card_sm >= float(_fb_sm))
+        ):
             variants[slug] = {
                 "verdict": "incompatible-hw",
                 "required_sm": float(_req_sm),

--- a/tools/serve-cockpit/club3090_cockpit/data.py
+++ b/tools/serve-cockpit/club3090_cockpit/data.py
@@ -178,10 +178,23 @@ class FitVerdict:
     # Populated only for verdict == "incompatible-hw".
     required_sm: Optional[float] = None
     card_sm: Optional[float] = None
+    # Populated when the card sits in a registry fallback band
+    # (fallback_sm <= card_sm < required_sm): the slug RUNS here via a
+    # weight-only fallback kernel (e.g. NVFP4 -> Marlin W4A16 on Ampere,
+    # live-confirmed 2026-07-11) and kv-calc prices it normally — the fit
+    # verdict is a real fits-*/wont-fit, this dict just carries the badge
+    # data: {"required_sm": float, "card_sm": float, "note": str}.
+    # Fallback-band slugs are VISIBLE by default (not [h]-hidden).
+    hw_fallback: Optional[dict[str, Any]] = None
 
     # Compact glyph for the Catalog "fit" column.
     @property
     def glyph(self) -> str:
+        # Fallback-band + fits → flag glyph: "runs here, via fallback kernels
+        # (no native speed edge)". wont-fit/unknown keep their own glyphs —
+        # the VRAM story outranks the kernel story.
+        if self.hw_fallback and self.verdict in ("fits-clean", "fits-constrained"):
+            return "⚑"
         return {
             "fits-clean": "●",
             "fits-constrained": "◐",
@@ -204,6 +217,7 @@ class FitVerdict:
             error=str(d.get("error", "")),
             required_sm=_as_float(d.get("required_sm")),
             card_sm=_as_float(d.get("card_sm")),
+            hw_fallback=d.get("hw_fallback") if isinstance(d.get("hw_fallback"), dict) else None,
         )
 
 


### PR DESCRIPTION
## Summary

**NVFP4 runs on 3090s** — confirmed live tonight (v0.24.0 Marlin W4A16 fallback, floor sm 7.5): the shipped `dual/nvfp4/mtp.yml` boots on 2× RTX 3090 at 262K + fp8 KV + MTP n=3 (97%+ accept), 69.7/85.5 decode TPS, **8-pack think-off 110/150 — ties the fp8 production tier's 109**. c3 hiding these slugs as `incompatible-hw` was factually wrong.

## Design: visible with an honest badge, not silent parity
- New registry field **`fallback_sm`** (weight-only-fallback floor) alongside `required_sm` (native floor). Set to 7.5 on the 4 NVFP4 slugs.
- **kv-calc**: in the band `[fallback_sm, required_sm)` the fit is priced normally + annotated `hw_fallback` (both `--fit` and `--fit-all`). Live on this rig: `fits-clean · 22.08 GB · 262K + hw_fallback note`.
- **c3**: `FitVerdict.hw_fallback` → **⚑ glyph, visible by default**; `incompatible-hw`/`[h]` hiding retained for true incompatibles (headless tests pass unchanged).
- **gates/compat**: hard SM floor = `fallback_sm` when present.
- **Honesty pass**: 4 status_notes + 4 compose headers drop the false "REFUSES on Ampere / cannot boot here" claims, cite the measured numbers, and keep the honest downside (no speed edge vs AutoRound on Ampere; sub-sm_90 value = models where NVFP4 is the only quant).
- `test-kv-calc-fit` §(f) rewritten to the new contract.

## Validation
14 guard tests + kv-calc `--calibration` + 248 c3 fast tests + c3 headless hide tests — all green. Backed by tonight's live boot + 8-pack on the actual checkpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)