### PR TITLE
Add vllm/qwen-35b-a3b-dual-nvfp4-fast: Ampere-validated unsloth NVFP4 MoE slug

### DIFF
--- a/models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4-fast/fp8.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4-fast/fp8.yml
@@ -83,7 +83,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-vllm-qwen36-35b-a3b-dual-nvfp4-fast}"
     restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
-      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8080}}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8081}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
       # torch.compile + Triton kernel caches — warm-start across boots.

--- a/models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4-fast/fp8.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4-fast/fp8.yml
@@ -1,0 +1,187 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Qwen3.6-35B-A3B NVFP4-Fast (unsloth compressed-tensors MIXED
+#              recipe: W4A4 NVFP4 gs16 expert FFNs + FP8-dynamic W8A8
+#              attention/linear_attn/lm_head + UNQUANTIZED mtp.* head +
+#              unquantized vision tower — 23.6 GB, 3B active params)
+#   Topology:  Dual-card TP=2 — VALIDATED ON 2× RTX 3090 (sm_86, Marlin
+#              weight-only fallback); native FP4 (sm_90+) unvalidated — the
+#              INVERSE of the dual/nvfp4 sibling. required_sm=9.0 (native),
+#              fallback_sm=7.5.
+#   Drafter:   none — DELIBERATE. Built-in MTP is NET-NEGATIVE on this MoE at
+#              vLLM TP=2 (-51% measured on the AutoRound tier; the head shares
+#              the MoE forward — learnings/qwen3.6-35b-a3b.md). The checkpoint
+#              DOES ship the head unquantized (unlike llm-compressor's usual
+#              drop) — kept OFF here; don't re-add blind.
+#   KV:        fp8 → e4m3. The checkpoint ships a `kv_cache_scheme` AND 32
+#              real k_scale/v_scale tensors (unlike the nvidia exports, which
+#              declare FP8 KV but ship no scales) — whether they LOAD on the
+#              Qwen hybrid is UNVERIFIED (vLLM force-disables runtime KV-scale
+#              calc on this family); assume scale=1.0 (the #594-tied regime)
+#              until verified.
+#   Vision:    yes (image only; tower unquantized)
+#   Max ctx:   262K (validated on 2× 24 GB: 22.46 GB/card peak @ util 0.92)
+#   Genesis:   none — intentionally Genesis-free
+#   Status:    🧪 Experimental
+#   Quality:   toolcall-15 14/15 (93%) · instructfollow-15 13/15 (87%) ·
+#              structoutput-15 14/15 (93%) · dataextract-15 12/15 (80%) ·
+#              reasonmath-15 11/15 (73%) · bugfind-15 12/15 (80%) ·
+#              hermesagent-20 7/20 (35%; 4 of 13 fails were 300 s runner
+#              timeouts) · cli-40 20/40 (50%) (--full --no-thinking,
+#              2026-07-11) — statistical TIE with the AutoRound tier's
+#              104-equivalent; cli-40 +6 is the best measured on this MoE.
+#   Best for:  full-ctx fast MoE when you want/have the NVFP4 artifact — on
+#              Ampere it TIES the AutoRound tier (decode −1.5%); on native-FP4
+#              cards it's the checkpoint built for the silicon (unvalidated)
+# ---------------------------------------------------------------------------
+# FIRST-PARTY VALIDATED ON AMPERE (2026-07-11, reference 2× 3090):
+#   - First confirmed boot of the MARLIN NvFp4 MoE backend on Ampere.
+#   - bench.sh: wall 175.5 narr / 172.2 code · decode 179.5 / 179.4 (n=5,
+#     CV ≤0.8%) vs the AutoRound tier's 182.3/182.3 → −1.5%, statistical tie.
+#     Prefill 8,289 tok/s @10K · 5,155 @90K (TTFT 1.2 s / 17.9 s).
+#   - 8-pack --full think-off: 103/150 (see Quality line) vs the tier's
+#     104-equivalent (79/90 + HA 11 + CLI 14, 2026-05-30) → quality tie.
+#   - Still 🧪 because verify-full / verify-stress / soak-continuous have NOT
+#     yet run on this compose — the ✅ gate needs them. Note: the 8-pack was
+#     run with the froggeric family template; the repo's own chat_template
+#     .jinja is BYTE-IDENTICAL to the validated AutoRound checkpoint's
+#     (sha e84f32a2…), so this compose ships unpinned like the sibling.
+#   - Full row: BENCHMARKS.md → Qwen3.6-35B-A3B section (2026-07-11).
+#
+# vs siblings in dual/:
+#   - dual/autoround-int4/fp8.yml ⭐ — the production tier; same shape, ~equal
+#     speed + quality on Ampere. Pick it unless you specifically want NVFP4.
+#   - dual/nvfp4/fp8.yml 🧪 — nvidia modelopt export: no KV scales, MTP head
+#     unquantized too, needs `--quantization modelopt`. Authored blind for
+#     Blackwell; THIS compose is the Ampere-validated NVFP4 path.
+#
+# ⚠️ Native-FP4 rigs (2× 5090 / Hopper / Blackwell): Ampere executes
+# weight-only W4A16 — your silicon also quantizes ACTIVATIONS (true W4A4),
+# which is reported to cost real quality on this family (~2× KLD, huginnfork).
+# Our 103/150 is the W4A16 bound, NOT your number. If you run this natively:
+#   1. bash scripts/switch.sh vllm/qwen-35b-a3b-dual-nvfp4-fast
+#   2. bash scripts/rebench-full.sh --with-8pack-thinking=both
+#   3. Report via the numbers-from-your-rig template — the native-W4A4
+#      quality number is the missing datapoint for the whole NVFP4 arc.
+# SM120 note: if engine startup aborts in FlashInfer JIT, see the workaround
+# posted in discussion #608 (TORCH_CUDA_ARCH_LIST=12.0+PTX + FlashInfer off).
+#
+# Run:
+#   cd <repo>/models/qwen3.6-35b-a3b/vllm/compose
+#   docker compose -f dual/nvfp4-fast/fp8.yml up -d
+# ===========================================================================
+# Hardware metadata (parsed by scripts/preflight.sh):
+# Requires-min-vram-gb: 24
+# Engine-profile: vllm-stable
+# Requires-min-gpu-count: 2
+# Tensor-parallel: 2
+services:
+  vllm-qwen36-35b-a3b-dual-nvfp4-fast:
+    # Pinned to a vLLM STABLE release (immutable, #407); the launchers inject
+    # the engine-profile image over this default (#254).
+    image: ${VLLM_IMAGE:-vllm/vllm-openai:v0.24.0}
+    container_name: "${ESTATE_CONTAINER:-vllm-qwen36-35b-a3b-dual-nvfp4-fast}"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
+    ports:
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8080}}:8000"
+    volumes:
+      - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
+      # torch.compile + Triton kernel caches — warm-start across boots.
+      - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
+      - ../../../cache/triton:/root/.triton/cache
+      # NVLink auto-detection — runs inside container at boot.
+      - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
+      # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
+      # nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so this mask is what
+      # actually pins cards there; on the classic runtime the UUID form is
+      # renumbering-proof. Unset → absent (no masking).
+      - CUDA_VISIBLE_DEVICES
+      - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
+      - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
+      - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}
+      - VLLM_WORKER_MULTIPROC_METHOD=spawn
+      - NVLINK_MODE=${NVLINK_MODE:-auto}
+      - NCCL_CUMEM_ENABLE=0
+      # Safe PCIe default (mirrors the validated dual composes); rigs with
+      # working P2P set NCCL_P2P_DISABLE=0.
+      - NCCL_P2P_DISABLE=${NCCL_P2P_DISABLE:-1}
+      - VLLM_NO_USAGE_STATS=1
+      - OMP_NUM_THREADS=1
+      # DeepGEMM (fp8-GEMM — this checkpoint's attention layers are FP8): no
+      # recipe on consumer Blackwell (5090/GB10) — launchers auto-inject
+      # VLLM_USE_DEEP_GEMM=0 there (disc #571); raw compose users set it.
+      - VLLM_USE_DEEP_GEMM
+      - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
+    shm_size: "16gb"
+    ipc: host
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    entrypoint:
+      - bash
+      - -c
+      - |
+        # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
+        source /etc/club3090/detect_nvlink.sh
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve "$$@"
+        else
+          exec vllm serve --disable-custom-all-reduce "$$@"
+        fi
+      - --
+    command:
+      - --model
+      - /root/.cache/huggingface/qwen3.6-35b-a3b-nvfp4-fast
+      - --served-model-name
+      - qwen3.6-35b-a3b
+      - qwen3.6-35b-a3b-autoround
+      - qwen3.6-35b-a3b-nvfp4-fast
+      # NO --quantization flag — this is a compressed-tensors checkpoint and
+      # vLLM auto-detects it. Do NOT pass `--quantization modelopt` (that's
+      # the nvidia export's recipe; it fails config validation here).
+      - --dtype
+      - bfloat16
+      - --tensor-parallel-size
+      - "${TP:-2}"
+      - --pipeline-parallel-size
+      - "${PP:-1}"
+      - --max-model-len
+      - "${MAX_MODEL_LEN:-262144}"
+      - --gpu-memory-utilization
+      - "${GPU_MEMORY_UTILIZATION:-0.92}"
+      - --max-num-seqs
+      - "${MAX_NUM_SEQS:-1}"
+      - --max-num-batched-tokens
+      - "8192"
+      - --limit-mm-per-prompt
+      - '{"image":2,"audio":0}'
+      # fp8 (= e4m3). This checkpoint ships kv_cache_scheme + 32 k/v scale
+      # tensors (unlike the nvidia export) — load-on-hybrid UNVERIFIED, so
+      # treat as scale=1.0 (the #594-tied regime) until proven otherwise.
+      - --kv-cache-dtype
+      - "${KV_CACHE_DTYPE:-fp8}"
+      - --trust-remote-code
+      - --reasoning-parser
+      - qwen3
+      - --default-chat-template-kwargs
+      - '{"enable_thinking": false}'
+      - --enable-auto-tool-choice
+      - --tool-call-parser
+      - qwen3_coder
+      - --enable-prefix-caching
+      - --enable-chunked-prefill
+      # NO --speculative-config: built-in MTP is net-negative on this MoE
+      # (the checkpoint's unquantized mtp.* head is present but unused).
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8000"

--- a/models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4-fast/fp8.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4-fast/fp8.yml
@@ -41,8 +41,14 @@
 #     Prefill 8,289 tok/s @10K · 5,155 @90K (TTFT 1.2 s / 17.9 s).
 #   - 8-pack --full think-off: 103/150 (see Quality line) vs the tier's
 #     104-equivalent (79/90 + HA 11 + CLI 14, 2026-05-30) → quality tie.
-#   - Still 🧪 because verify-full / verify-stress / soak-continuous have NOT
-#     yet run on this compose — the ✅ gate needs them. Note: the 8-pack was
+#   - switch.sh --force boot of THIS compose: ready 272s, all 3 served names
+#     on :8081. verify-full 7✓/1✗/2 skips (skips = Genesis marker + MTP
+#     metrics, both N/A here). The ✗ is streaming-tool-calls-with-thinking-ON
+#     → finish=length — the KNOWN family caveat class (same signature Tess
+#     ships ⚠️ for: the reasoner burns the token budget before emitting the
+#     call; non-streaming tool-calls, plain streaming, and thinking each pass).
+#   - Still 🧪 because verify-stress / soak-continuous remain unrun — the ✅/⚠️
+#     promotion gate needs them. Note: the 8-pack was
 #     run with the froggeric family template; the repo's own chat_template
 #     .jinja is BYTE-IDENTICAL to the validated AutoRound checkpoint's
 #     (sha e84f32a2…), so this compose ships unpinned like the sibling.

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -836,6 +836,17 @@ COMPOSE_REGISTRY = {
         status_note="Qwen3.6-35B-A3B NVFP4 (see single-nvfp4) at TP=2 @262K full ctx, 2x Hopper/Blackwell native (2x 5090 primary community target; ~11.7 GB/card weights; fallback_sm=7.5 — sub-9.0 cards run it via the Marlin W4A16 fallback, validated on the 27B sibling 2026-07-11, though on Ampere the AutoRound tier serves this model faster). 🧪 first community boot + rebench-full validates. Mirrors vllm/qwen-35b-a3b-dual's shape (no drafter — MTP net-negative on this MoE, vision on, thinking off) with NVFP4 weights + fp8/e4m3 KV instead of AutoRound + e5m2. No DEFAULTS row (opt-in only).",
     ),
 
+    "vllm/qwen-35b-a3b-dual-nvfp4-fast": _entry(
+        model="qwen3.6-35b-a3b", weights_variant="nvfp4-fast", workload="fast-chat",
+        engine="vllm-stable", drafter=None, kv_format="fp8_e4m3",
+        tp=2, max_ctx=262144, max_num_seqs=1, mem_util=0.92,
+        compose_path="models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4-fast/fp8.yml",
+        default_port=8080, required_sm=9.0, fallback_sm=7.5,
+        kvcalc_key="qwen3.6-35b-a3b:nvfp4-dual",
+        status="experimental",
+        status_note="Qwen3.6-35B-A3B NVFP4-Fast (unsloth compressed-tensors MIXED: true W4A4 NVFP4 expert FFNs + FP8-dynamic attention; quant auto-detects — NOT modelopt), TP=2 @262K. THE AMPERE-VALIDATED NVFP4 PATH — inverse of dual-nvfp4: FIRST-PARTY VALIDATED on the reference 2x3090 2026-07-11 (first MoE-FP4 fallback boot anywhere, MARLIN NvFp4 MoE backend): decode 179.5/179.4 (n=5, CV<=0.8%) + 8-pack think-off 103/150 = DOUBLE STATISTICAL TIE with the AutoRound tier (182.3/182.3, 104-equiv) at full 262K, 22.46 GB/card; cli-40 20/40 = best measured on this MoE. See BENCHMARKS 2026-07-11. 🧪 until verify-full/stress/soak run (bench + 8-pack done). NATIVE FP4 (sm_90+) UNVALIDATED — there the silicon quantizes activations too (true W4A4; family is activation-quant-sensitive), so the native quality number is the arc's missing datapoint. Ships 32 real k/v scale tensors (nvidia's export ships none) — load-on-hybrid unverified, assume scale=1.0. mtp.* head shipped unquantized but OFF (net-negative on this MoE at TP=2). On Ampere, pick the AutoRound tier unless you specifically want the NVFP4 artifact. No DEFAULTS row (opt-in only).",
+    ),
+
     # Agents-A1 — InternScience's 35B agentic MoE (Qwen3-Next MoE arch, OWN model
     # per its card's base_model; NOT a qwen fine-tune slug). Official FP8-dynamic
     # compressed-tensors checkpoint; on Ampere sm_86 vLLM serves it Marlin FP8-MoE

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -841,7 +841,7 @@ COMPOSE_REGISTRY = {
         engine="vllm-stable", drafter=None, kv_format="fp8_e4m3",
         tp=2, max_ctx=262144, max_num_seqs=1, mem_util=0.92,
         compose_path="models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4-fast/fp8.yml",
-        default_port=8080, required_sm=9.0, fallback_sm=7.5,
+        default_port=8081, required_sm=9.0, fallback_sm=7.5,
         kvcalc_key="qwen3.6-35b-a3b:nvfp4-dual",
         status="experimental",
         status_note="Qwen3.6-35B-A3B NVFP4-Fast (unsloth compressed-tensors MIXED: true W4A4 NVFP4 expert FFNs + FP8-dynamic attention; quant auto-detects — NOT modelopt), TP=2 @262K. THE AMPERE-VALIDATED NVFP4 PATH — inverse of dual-nvfp4: FIRST-PARTY VALIDATED on the reference 2x3090 2026-07-11 (first MoE-FP4 fallback boot anywhere, MARLIN NvFp4 MoE backend): decode 179.5/179.4 (n=5, CV<=0.8%) + 8-pack think-off 103/150 = DOUBLE STATISTICAL TIE with the AutoRound tier (182.3/182.3, 104-equiv) at full 262K, 22.46 GB/card; cli-40 20/40 = best measured on this MoE. See BENCHMARKS 2026-07-11. 🧪 until verify-full/stress/soak run (bench + 8-pack done). NATIVE FP4 (sm_90+) UNVALIDATED — there the silicon quantizes activations too (true W4A4; family is activation-quant-sensitive), so the native quality number is the arc's missing datapoint. Ships 32 real k/v scale tensors (nvidia's export ships none) — load-on-hybrid unverified, assume scale=1.0. mtp.* head shipped unquantized but OFF (net-negative on this MoE at TP=2). On Ampere, pick the AutoRound tier unless you specifically want the NVFP4 artifact. No DEFAULTS row (opt-in only).",

--- a/scripts/lib/profiles/models/qwen3.6-35b-a3b.yml
+++ b/scripts/lib/profiles/models/qwen3.6-35b-a3b.yml
@@ -58,6 +58,17 @@ weights:
     kind: main
     verify_glob: "*.safetensors"
     manual_note: "Official NVIDIA modelopt MIXED_PRECISION quant of Qwen/Qwen3.6-35B-A3B (MoE): NVFP4 gs16 on the expert FFNs (161 targets) + FP8 static on self_attn/linear_attn projections (130 targets) + mtp.* kept UNQUANTIZED. KV: SAME as the 27B NVFP4 — hf_quant_config declares kv_cache_quant_algo=FP8 but NO k_scale/v_scale tensors ship (index-verified 2026-07-06; config.json kv_cache_scheme is null); fp8 KV runs at scale=1.0 on Qwen3-Next hybrid (calculate_kv_scales disabled), the same regime our production 27B fp8 tier quality-tied at (#594). Hopper/Blackwell only (sm >= 9.0) — NOT runnable on this rig's Ampere; drives the community-validated vllm/qwen-35b-a3b-{single,dual}-nvfp4 slugs. 23.4 GB / 3 shards."
+  nvfp4-fast:
+    path: qwen3.6-35b-a3b-nvfp4-fast
+    local_subdir: qwen3.6-35b-a3b-nvfp4-fast
+    size_gb: 24
+    format: compressed-tensors
+    status: experimental
+    hf_repo: unsloth/Qwen3.6-35B-A3B-NVFP4-Fast
+    engine: vllm
+    kind: main
+    verify_glob: "*.safetensors"
+    manual_note: "unsloth compressed-tensors MIXED quant of Qwen/Qwen3.6-35B-A3B (MoE): true W4A4 NVFP4 gs16 on the expert FFNs + FP8-dynamic W8A8 on attention/linear_attn/lm_head + mtp.* kept UNQUANTIZED bf16 (19 tensors — unlike llm-compressor's usual drop) + vision tower unquantized. KV: UNLIKE the nvidia export, ships kv_cache_scheme AND 32 real k_scale/v_scale tensors — load-on-Qwen-hybrid UNVERIFIED (runtime calc force-disabled on this family); treat as scale=1.0 until proven. Quant AUTO-DETECTS (do NOT pass --quantization modelopt). VALIDATED ON AMPERE 2026-07-11 (first MoE-FP4 fallback boot: MARLIN NvFp4 MoE backend): decode 179.5/179.4 + 8-pack 103/150 = double statistical tie with the AutoRound tier at full 262K, 22.46 GB/card — see BENCHMARKS. Native FP4 (sm_90+) UNVALIDATED; W4A4 activations there are the quality unknown (family is activation-quant-sensitive). chat_template.jinja byte-identical to the AutoRound checkpoint's. 23.6 GB / 5 shards."
   gptq_int4:
     path: qwen3.6-35b-a3b-gptq-int4
     local_subdir: qwen3.6-35b-a3b-gptq-int4

--- a/scripts/lib/registry-emit.sh
+++ b/scripts/lib/registry-emit.sh
@@ -417,9 +417,14 @@ registry_variant_rows_json() {
     echo "[registry-emit] ERROR: registry_variant_rows failed" >&2
     return 2
   fi
-  # Pass the tab rows via the environment (not stdin) so the heredoc below can
-  # still serve as the python script's stdin.
-  REGISTRY_TAB="$rows" python3 - "$root" <<'PY_JSON'
+  # Pass the tab rows via a TEMP FILE (not stdin — the heredoc below owns the
+  # python script's stdin; not env — a single env value is capped at
+  # MAX_ARG_STRLEN ~128 KB on Linux and the emit sits just under it at 63
+  # entries, 2026-07-11).
+  local _tab_file _py_rc
+  _tab_file="$(mktemp)"
+  printf '%s' "$rows" > "$_tab_file"
+  REGISTRY_TAB_FILE="$_tab_file" python3 - "$root" <<'PY_JSON'
 from __future__ import annotations
 
 import dataclasses
@@ -468,7 +473,8 @@ from scripts.lib.profiles.compat import load_profiles  # noqa: E402
 from scripts.lib.profiles.compose_registry import COMPOSE_REGISTRY, DEFAULTS  # noqa: E402
 from scripts.lib.profiles.launch_compat import ProfileError, resolve_variant_pin  # noqa: E402
 
-tab = os.environ.get("REGISTRY_TAB", "")
+_tab_path = os.environ.get("REGISTRY_TAB_FILE", "")
+tab = Path(_tab_path).read_text(encoding="utf-8") if _tab_path and Path(_tab_path).exists() else ""
 
 # --- profiles: sourced via the EXISTING loaders (never re-derived).  Loaded
 #     HERE (not after the variants block) because the baselines join below
@@ -709,6 +715,9 @@ payload = {
 json.dump(payload, sys.stdout, sort_keys=True, default=str)
 sys.stdout.write("\n")
 PY_JSON
+  _py_rc=$?
+  rm -f "$_tab_file"
+  return "$_py_rc"
 }
 
 # x_default_dispatch ROOT TOKEN TOPOLOGY MODEL  →  resolved slug on stdout.

--- a/scripts/tests/test-baselines.sh
+++ b/scripts/tests/test-baselines.sh
@@ -146,9 +146,14 @@ PY
 # shellcheck source=/dev/null
 source scripts/lib/registry-emit.sh
 json="$(registry_variant_rows_json "$ROOT_DIR")"
-# Env (not a pipe): the heredoc below owns the python interpreter's stdin —
-# the same trick registry-emit itself uses for REGISTRY_TAB.
-EMIT_JSON="$json" python3 - <<'PY'
+# Temp file (not env, not a pipe): the heredoc below owns the python
+# interpreter's stdin, and a single env value is capped at MAX_ARG_STRLEN
+# (~128 KB on Linux) — the emit crossed that at 63 registry entries
+# ("Argument list too long", 2026-07-11).
+emit_file="$(mktemp)"
+trap 'rm -f "$emit_file"' EXIT
+printf '%s' "$json" > "$emit_file"
+EMIT_JSON_FILE="$emit_file" python3 - <<'PY'
 import json
 import os
 import sys
@@ -156,7 +161,7 @@ from pathlib import Path
 
 import yaml
 
-d = json.loads(os.environ["EMIT_JSON"])
+d = json.loads(Path(os.environ["EMIT_JSON_FILE"]).read_text(encoding="utf-8"))
 by_slug = {v["slug"]: v for v in d["variants"]}
 rows = yaml.safe_load(Path("scripts/lib/profiles/baselines.yml").read_text())["baselines"]
 

--- a/scripts/tests/test-compose-registry-disk.sh
+++ b/scripts/tests/test-compose-registry-disk.sh
@@ -25,8 +25,8 @@ def check(cond, msg):
         print(f"FAIL: {msg}")
         failures.append(msg)
 
-check(len(COMPOSE_REGISTRY) == 62, f"registry has 62 entries (got {len(COMPOSE_REGISTRY)})")
-check(len(disk_paths) == 63, f"disk has 63 compose files (got {len(disk_paths)})")
+check(len(COMPOSE_REGISTRY) == 63, f"registry has 63 entries (got {len(COMPOSE_REGISTRY)})")
+check(len(disk_paths) == 64, f"disk has 64 compose files (got {len(disk_paths)})")
 check(registry_paths <= disk_paths, "all registry compose_path values exist on disk")
 parked_disk_only = disk_paths - registry_paths
 # Disk-only (non-registry) composes allowed: parked SGLang archives, plus the experimental

--- a/scripts/tests/test-registry-json.sh
+++ b/scripts/tests/test-registry-json.sh
@@ -25,12 +25,19 @@ json="$(bash scripts/lib/registry-emit.sh --json "$ROOT_DIR" 2>/dev/null)"
 # python pass. The JSON is passed via the environment (not stdin) so the heredoc
 # can serve as the python script. Exits non-zero with a clear message on the
 # first mismatch.
-REGISTRY_JSON="$json" python3 - <<'PY'
+# Temp file, not env: a single env value is capped at MAX_ARG_STRLEN
+# (~128 KB on Linux) — the emit crossed that at 63 registry entries
+# ("Argument list too long", 2026-07-11).
+json_file="$(mktemp)"
+trap 'rm -f "$json_file"' EXIT
+printf '%s' "$json" > "$json_file"
+REGISTRY_JSON_FILE="$json_file" python3 - <<'PY'
 import json
 import os
 import sys
+from pathlib import Path
 
-d = json.loads(os.environ["REGISTRY_JSON"])
+d = json.loads(Path(os.environ["REGISTRY_JSON_FILE"]).read_text(encoding="utf-8"))
 
 def need(cond, msg):
     if not cond:


### PR DESCRIPTION
## What

Catalog entry for `unsloth/Qwen3.6-35B-A3B-NVFP4-Fast` — the first NVFP4 slug that is **Ampere-validated first** (inverse of the authored-blind `dual-nvfp4`):

- `nvfp4-fast` weights variant (compressed-tensors mixed: true W4A4 NVFP4 expert FFNs + FP8-dynamic attention/linear_attn; MTP head shipped unquantized; 32 real k/v scale tensors; quant **auto-detects** — not modelopt)
- `models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4-fast/fp8.yml` (port 8080, mirrors the production `dual/autoround-int4/fp8.yml` shape: TP=2, 262K, fp8 KV, no drafter, vision on, thinking off)
- Registry entry `vllm/qwen-35b-a3b-dual-nvfp4-fast` (`required_sm=9.0`, `fallback_sm=7.5`, 🧪, no DEFAULTS row)

## Validation (reference 2×3090, 2026-07-11 — BENCHMARKS row on master)

- First confirmed boot of the **MARLIN NvFp4 MoE backend** on Ampere
- Decode **179.5 / 179.4** (n=5, CV ≤0.8%) vs AutoRound tier 182.3/182.3 → **−1.5%, statistical tie**
- 8-pack `--full` think-off **103/150** vs the tier's 104-equivalent → **quality tie** (cli-40 20/40 = best measured on this MoE)
- Full 262K @ 22.46 GB/card; prefill 8,289 @10K / 5,155 @90K
- Ships 🧪: verify-full / verify-stress / soak-continuous not yet run (bench + 8-pack done)

## Honesty notes

- Ampere executes weight-only W4A16 — **native-FP4 rigs (2×5090/Hopper) quantize activations too; their quality number is the arc's missing datapoint** (compose header carries the ask + the SM120 FlashInfer workaround pointer)
- Checkpoint KV scales: shipped but **load-on-hybrid unverified** — documented as scale=1.0 until proven
- Repo chat template byte-identical to the validated AutoRound checkpoint's → compose ships unpinned like the sibling

## Gates

`test-compose-registry-disk` · `test-compose-status-drift` · `test-switch-registry-parity` · `test-launch-registry-parity` · `test-profiles-compat` · `test-model-weights-registry` · `test-compose-mounts-resolve` — all PASS (counts bumped 62→63 / 63→64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm

## ADDING_MODELS.md audit (post-open)

Full-checklist audit after opening found gaps in my initial pass; now addressed:

- **Full `scripts/tests/*.sh` suite run (77 tests)** — surfaced a real latent bug the targeted set missed: the registry emit crossed **MAX_ARG_STRLEN (~128 KB)** at 63 entries, breaking `test-baselines` + `test-registry-json` ("Argument list too long") with the runtime `REGISTRY_TAB` env-pass a few KB from the same cliff. **Fixed in this PR** (second commit): all three now pass via temp file. Suite is 76/77; `test-submit-bench` needs gitignored `results/rebench` fixtures absent in a fresh worktree (env artifact, passes in the main checkout).
- **`diagnose-profile.sh vllm/qwen-35b-a3b-dual-nvfp4-fast` → GREEN** (benign calibration-freshness note: extrapolates from the `dual` sibling row — the documented lightweight-path behavior; no new calibration anchors needed, KV math unchanged).
- **Remaining pre-merge gate: the compose file itself has not been booted** — validation was an equivalent hand `docker run`; `switch.sh vllm/qwen-35b-a3b-dual-nvfp4-fast` + `verify-full` queue behind the 27B provider A/B currently occupying the rig. Will report here before merge.
