### PR TITLE
Wire benchlocal scenario selection + incremental/resume through the quality stack

### DIFF
--- a/docs/QUALITY_TEST.md
+++ b/docs/QUALITY_TEST.md
@@ -154,6 +154,41 @@ Quality: line for compose schema field (paste into compose YAML header):
 Quality:   ToolCall-15 14/15 (93%) · InstructFollow-15 13/15 (87%) · StructOutput-15 15/15 (100%) · DataExtract-15 12/15 (80%) · ReasonMath-15 11/15 (73%) (--medium, packs v1.0.x, 2026-05-09)
 ```
 
+## Scenario-level probes (selection, incremental, resume)
+
+Since benchlocal-cli [#84](https://github.com/noonghunna/benchlocal-cli/pull/84)/[#85](https://github.com/noonghunna/benchlocal-cli/pull/85) the wrapper passes through scenario-granular runs:
+
+```bash
+# one or more specific scenarios (pack-qualified, repeatable)
+bash scripts/quality-test.sh --scenario cli-40/CLI-31 --scenario reasonmath-15/RM-04 --no-thinking
+
+# a curated probe set from a file (newline PACK_ID/SCENARIO_ID, # comments)
+bash scripts/quality-test.sh --scenarios-file scripts/scenario-sets/tess4-engine-window.txt \
+    --enable-thinking --repeat 3
+
+# journal each scored scenario (fsynced sidecar) so an interrupt is resumable
+bash scripts/quality-test.sh --full --no-thinking --incremental
+
+# resume an interrupted (or inspect-then-continue) run — restores the original
+# pack-set/selection/thinking/sampling/timeout config; only missing arms run
+bash scripts/quality-test.sh --resume results/quality/quality-<ts>.json.partial.jsonl
+```
+
+**Probe discipline (the tool enforces most of this):**
+
+- A selection result is **PARTIAL** — the JSON carries top-level `selection` + per-pack `catalog_scenario_count`, human output says `PARTIAL SELECTION`, and history ingestion / `rescore` refuse it without `--allow-partial`. **It is never a `/150` claim** — full 8-pack both modes remains the bar for BENCHMARKS rows, `Quality:` lines, and promotions.
+- Thinking-ON probes sample at temp 1.0 by pack contract → single ON probes are draws; pass `--repeat 3` (cheap at scenario granularity) when a number gates a decision.
+- `--resume` is mutually exclusive with mode/pack/selection/thinking/sampling/timeout flags — it restores those from the saved run; the wrapper refuses the combination rather than fork the config.
+
+**Curated probe sets** live in `scripts/scenario-sets/` with provenance headers:
+
+| file | what | when to run |
+|---|---|---|
+| `tess4-model-floor.txt` | 14 fails-everywhere (+2 thinking-only) across 2 rigs / 2 drafters / 2 engine builds — the Tess retrain-target list (#665 intersection) | before/after a Tess fine-tune or retrained drafter head; quantifying a "did the model move" claim |
+| `tess4-engine-window.txt` | CLI-25/31/32 — the b9932→b9967 engine-window flips | first probe on any new engine build/pin arm, before paying for a full 8-pack |
+
+**`scripts/rerun-failed-packs.sh`** now re-runs a prior run's failures as ONE selection run (was: whole-pack loops) — 6 failures over 5 packs = 6 scenarios, with `--incremental` durability and a REPRODUCED/FIXED verdict per original failure. `RERUN_DRY=1` previews the plan.
+
 ## Diagnosing failures
 
 Failure reasons are surfaced in three places, cheapest first:

--- a/scripts/quality-test.sh
+++ b/scripts/quality-test.sh
@@ -48,6 +48,22 @@ MODES
                      toolcall-15  instructfollow-15  structoutput-15
                      dataextract-15  reasonmath-15
                      bugfind-15  cli-40  hermesagent-20  (require Docker)
+  --scenario P/S   Run one pack-qualified scenario, e.g. cli-40/CLI-31 (repeatable;
+                   intersects with --pack / mode when one is given, else the pack
+                   set is derived from the selection).
+  --scenarios-file F
+                   Newline-delimited PACK_ID/SCENARIO_ID selections (# comments OK).
+                   Curated probe sets live in scripts/scenario-sets/.
+                   ⚠ Selection results are PARTIAL — labeled in the JSON
+                   (selection + catalog_scenario_count) and never a /150 claim;
+                   history ingestion and rescore refuse them without --allow-partial.
+  --incremental    Journal each scored scenario to <save-json>.partial.jsonl
+                   (fsynced) so an interrupted run is inspectable and resumable.
+  --resume PATH    Resume a result.json or .partial.jsonl: restores the original
+                   pack-set/selection/thinking/sampling/timeout config and runs
+                   only the missing scenario/repeat arms. Mutually exclusive with
+                   mode/--pack/--scenario/thinking/sampling/timeout flags.
+  --allow-partial  Permit a partial (selection) result into --history-file / rescore.
                      humaneval-plus-30  lcb-v6-30  gsm-symbolic-30
                      gpqa-diamond  (gated metadata-only until access approved)
 
@@ -217,11 +233,19 @@ MAX_TOKENS="${MAX_TOKENS:-}"
 REPEAT=""
 PREVIOUS_RESULT=""
 SAVE_JSON_OVERRIDE=""
+# benchlocal #84/#85: scenario-level selection + incremental/resume passthroughs.
+SCENARIOS=()
+SCENARIOS_FILE=""
+INCREMENTAL=0
+RESUME=""
+ALLOW_PARTIAL=0
+MODE_EXPLICIT=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --quick|--medium|--full|--reasoning)
       MODE="$1"
+      MODE_EXPLICIT=1
       shift
       ;;
     --pack)
@@ -231,6 +255,38 @@ while [[ $# -gt 0 ]]; do
         exit 2
       fi
       shift 2
+      ;;
+    --scenario)
+      if [[ -z "${2:-}" ]]; then
+        echo "✗ --scenario requires PACK_ID/SCENARIO_ID (e.g. cli-40/CLI-31)" >&2
+        exit 2
+      fi
+      SCENARIOS+=("$2")
+      shift 2
+      ;;
+    --scenarios-file)
+      if [[ -z "${2:-}" || ! -f "${2:-}" ]]; then
+        echo "✗ --scenarios-file requires an existing file (see scripts/scenario-sets/)" >&2
+        exit 2
+      fi
+      SCENARIOS_FILE="$2"
+      shift 2
+      ;;
+    --incremental)
+      INCREMENTAL=1
+      shift
+      ;;
+    --resume)
+      if [[ -z "${2:-}" || ! -e "${2:-}" ]]; then
+        echo "✗ --resume requires an existing results.json or .partial.jsonl" >&2
+        exit 2
+      fi
+      RESUME="$2"
+      shift 2
+      ;;
+    --allow-partial)
+      ALLOW_PARTIAL=1
+      shift
       ;;
     --model)
       MODEL="${2:-}"
@@ -349,6 +405,29 @@ if [[ "$ENABLE_THINKING" == "1" && "$NO_THINKING" == "1" ]]; then
   exit 2
 fi
 
+# --resume restores pack-set/selection/thinking/sampling/timeout from the saved
+# run — passing any of those alongside it would silently fork the config, so refuse.
+if [[ -n "$RESUME" ]]; then
+  _resume_conflicts=()
+  # (if-form, not `[[ ]] &&` — a false condition would trip set -e)
+  if [[ "$MODE_EXPLICIT" == "1" ]]; then _resume_conflicts+=("$MODE"); fi
+  if [[ -n "$PACK" ]]; then _resume_conflicts+=(--pack); fi
+  if [[ ${#SCENARIOS[@]} -gt 0 ]]; then _resume_conflicts+=(--scenario); fi
+  if [[ -n "$SCENARIOS_FILE" ]]; then _resume_conflicts+=(--scenarios-file); fi
+  if [[ "$SANDBOXED_ONLY" == "1" ]]; then _resume_conflicts+=(--sandboxed-only); fi
+  if [[ -n "$REPEAT" ]]; then _resume_conflicts+=(--repeat); fi
+  if [[ -n "$PREVIOUS_RESULT" ]]; then _resume_conflicts+=(--previous-result); fi
+  if [[ "$ENABLE_THINKING" == "1" ]]; then _resume_conflicts+=(--enable-thinking); fi
+  if [[ "$NO_THINKING" == "1" ]]; then _resume_conflicts+=(--no-thinking); fi
+  if [[ -n "$THINKING_MAX_TOKENS" ]]; then _resume_conflicts+=(--thinking-max-tokens); fi
+  if [[ -n "$MAX_TOKENS" ]]; then _resume_conflicts+=(--max-tokens); fi
+  if [[ "$SAMPLING_FROM_SERVER" == "1" ]]; then _resume_conflicts+=(--sampling-from-server); fi
+  if [[ ${#_resume_conflicts[@]} -gt 0 ]]; then
+    echo "✗ --resume restores the original run configuration; drop: ${_resume_conflicts[*]}" >&2
+    exit 2
+  fi
+fi
+
 if ! command -v benchlocal-cli >/dev/null 2>&1; then
   cat >&2 <<EOF
 ✗ benchlocal-cli not found on \$PATH
@@ -453,7 +532,20 @@ fi
 # `tools/build-sandboxes.sh` that only exists inside a benchlocal-cli *checkout*
 # (not a pip install, and not here) — so surface the correct steps UP FRONT
 # instead of letting users discover a dead path mid-run (club-3090 #492).
-if [[ -z "$PACK" ]] && { [[ "$MODE" == "--full" && "$NO_SANDBOX" != "1" ]] || [[ "$SANDBOXED_ONLY" == "1" ]]; }; then
+# Does a scenario selection touch the Docker-sandboxed packs? (drives the
+# same image preflight that --full gets — cli-40 probes are the primary use)
+SELECTION_HAS_SANDBOX=0
+if [[ ${#SCENARIOS[@]} -gt 0 || -n "$SCENARIOS_FILE" ]]; then
+  _sel_lines="$(printf '%s\n' ${SCENARIOS[@]+"${SCENARIOS[@]}"})"
+  if [[ -n "$SCENARIOS_FILE" ]]; then
+    _sel_lines+=$'\n'"$(command grep -vE '^[[:space:]]*(#|$)' "$SCENARIOS_FILE" 2>/dev/null || true)"
+  fi
+  if command grep -qE '^(bugfind-15|cli-40|hermesagent-20)/' <<<"$_sel_lines"; then
+    SELECTION_HAS_SANDBOX=1
+  fi
+fi
+
+if { [[ -z "$PACK" ]] && { [[ "$MODE" == "--full" && "$NO_SANDBOX" != "1" ]] || [[ "$SANDBOXED_ONLY" == "1" ]]; }; } || [[ "$SELECTION_HAS_SANDBOX" == "1" && "$NO_SANDBOX" != "1" ]]; then
   _sb_missing=()
   _sb_stale=()
   if ! command -v docker >/dev/null 2>&1; then
@@ -551,7 +643,16 @@ if [[ "$TIMEOUT_PER_CASE_SET" == "1" ]]; then
 else
   TIMEOUT_DISPLAY="pack-default (60s deterministic / 300s cli-40+hermes / 1800s aider)"
 fi
-if [[ -n "$PACK" ]]; then
+if [[ -n "$RESUME" ]]; then
+  echo "[quality-test] RESUME ${RESUME}  endpoint=${URL}  model=${MODEL} (config restored from the saved run)"
+elif [[ ${#SCENARIOS[@]} -gt 0 || -n "$SCENARIOS_FILE" ]]; then
+  _sel_n=${#SCENARIOS[@]}
+  if [[ -n "$SCENARIOS_FILE" ]]; then
+    _sel_n=$(( _sel_n + $(command grep -cvE '^[[:space:]]*(#|$)' "$SCENARIOS_FILE" 2>/dev/null || echo 0) ))
+  fi
+  echo "[quality-test] SELECTION (${_sel_n} scenarios${SCENARIOS_FILE:+, file=$SCENARIOS_FILE})${PACK:+ ∩ pack=$PACK}  endpoint=${URL}  model=${MODEL}  timeout=${TIMEOUT_DISPLAY}"
+  echo "[quality-test] ⚠ partial-selection result — never a canonical pack total (needs --allow-partial for history/rescore)"
+elif [[ -n "$PACK" ]]; then
   echo "[quality-test] pack=${PACK}  endpoint=${URL}  model=${MODEL}  timeout=${TIMEOUT_DISPLAY}"
 else
   echo "[quality-test] mode=${MODE}  endpoint=${URL}  model=${MODEL}  timeout=${TIMEOUT_DISPLAY}"
@@ -579,12 +680,31 @@ fi
 if [[ "$PROGRESS" == "1" ]]; then
   CLI_ARGS+=(--progress)
 fi
-if [[ "$SANDBOXED_ONLY" == "1" ]]; then
+if [[ -n "$RESUME" ]]; then
+  # resume restores pack-set/selection/thinking/sampling/timeout from the journal
+  CLI_ARGS+=(--resume "$RESUME")
+elif [[ "$SANDBOXED_ONLY" == "1" ]]; then
   CLI_ARGS+=(--sandboxed-only)
 elif [[ -n "$PACK" ]]; then
   CLI_ARGS+=(--pack "$PACK")
+elif [[ ${#SCENARIOS[@]} -gt 0 || -n "$SCENARIOS_FILE" ]]; then
+  : # bare selection: benchlocal derives the pack set from it (mode "custom")
 else
   CLI_ARGS+=("$MODE")
+fi
+if [[ -z "$RESUME" ]]; then
+  for _sc in ${SCENARIOS[@]+"${SCENARIOS[@]}"}; do
+    CLI_ARGS+=(--scenario "$_sc")
+  done
+  if [[ -n "$SCENARIOS_FILE" ]]; then
+    CLI_ARGS+=(--scenarios-file "$SCENARIOS_FILE")
+  fi
+fi
+if [[ "$INCREMENTAL" == "1" ]]; then
+  CLI_ARGS+=(--incremental)
+fi
+if [[ "$ALLOW_PARTIAL" == "1" ]]; then
+  CLI_ARGS+=(--allow-partial)
 fi
 if [[ "$NO_SANDBOX" == "1" && "$SANDBOXED_ONLY" != "1" ]]; then
   CLI_ARGS+=(--no-sandboxed-packs)

--- a/scripts/rerun-failed-packs.sh
+++ b/scripts/rerun-failed-packs.sh
@@ -1,22 +1,25 @@
 #!/usr/bin/env bash
 #
-# rerun-failed-packs.sh — re-test ONLY the packs that had failures in a prior
+# rerun-failed-packs.sh — re-test ONLY the scenarios that failed in a prior
 # quality run, and report which failures reproduced vs flipped (flakes).
 #
-# Why: benchlocal-cli's finest run granularity is --pack (no per-scenario run
-# filter — see noonghunna/benchlocal-cli#82), and a --full re-run costs 1-2 h.
-# After any full run, the variance question is almost always "are these
-# failures real?" — answering it only needs the packs that failed.
+# Since benchlocal-cli #84 (scenario-level selection) this runs the failed
+# scenarios as ONE selection run instead of re-running each affected pack —
+# e.g. 6 failures spread over 5 packs = 6 scenarios, not ~100. (The original
+# pack-level version of this script predated #84; the name is kept for
+# muscle-memory/back-compat.)
 #
 # What it does:
-#   1. Parses a saved RunResult JSON: failed scenarios -> the affected packs.
-#   2. Re-runs ONLY those packs via quality-test.sh (keeping its hermes-env +
-#      timeout guards), passing --previous-result so benchlocal emits its own
-#      per-scenario delta, matching the ORIGINAL run's thinking mode from the
-#      JSON (thinking_enabled) — no mode flag to get wrong.
+#   1. Parses a saved RunResult JSON: failed scenarios -> PACK_ID/SCENARIO_ID
+#      selections (written to a temp scenarios-file).
+#   2. Re-runs them in a single quality-test.sh invocation (keeping its
+#      hermes-env + timeout guards), with --previous-result so benchlocal
+#      emits its per-scenario delta gated on exactly the selected keys, and
+#      --incremental so an interrupted re-run is resumable. Thinking mode is
+#      taken from the ORIGINAL run's JSON (thinking_enabled) — nothing to get
+#      wrong.
 #   3. Prints a consolidated verdict per original failure:
-#      REPRODUCED (real) / FIXED (flake or environment) + any NEW regressions
-#      in the re-run packs.
+#      REPRODUCED (real) / FIXED (flake or environment).
 #
 # Usage:
 #   bash scripts/rerun-failed-packs.sh <result.json> [--repeat N] [extra quality-test.sh args...]
@@ -24,11 +27,12 @@
 #   URL= / MODEL= env override the endpoint (default: autodetect via
 #   quality-test.sh, same as any other run). --repeat N re-runs each scenario
 #   N times (benchlocal aggregates at >=50% pass) — use N>=3 for flakiness
-#   stats on the failing packs.
+#   stats; at scenario granularity that's cheap.
 #
-#   RERUN_DRY=1  print the plan (packs + mode + commands) without running.
+#   RERUN_DRY=1  print the plan (selection + mode + command) without running.
 #
-# Output JSONs land next to the original as <original>.rerun.<pack>.json.
+# Output JSON lands next to the original as <original>.rerun.json (a PARTIAL
+# selection result — never a canonical pack total).
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
@@ -36,7 +40,7 @@ ROOT_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 
 RESULT_JSON="${1:-}"
 if [[ -z "$RESULT_JSON" || "$RESULT_JSON" == "-h" || "$RESULT_JSON" == "--help" ]]; then
-  sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  sed -n '2,35p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
   exit 2
 fi
 if [[ ! -f "$RESULT_JSON" ]]; then
@@ -46,96 +50,93 @@ if [[ ! -f "$RESULT_JSON" ]]; then
 fi
 shift
 
-# --- 1. plan: failed packs + thinking mode from the original run -------------
+# --- 1. plan: failed scenario selections + thinking mode from the original ----
 PLAN="$(python3 - "$RESULT_JSON" <<'PY'
 import json, sys
 d = json.load(open(sys.argv[1], encoding="utf-8"))
-failed_packs = []
+selections = []
 failures = []
 for p in d.get("packs", []):
     pid = p.get("pack_id", "?")
-    bad = [s for s in p.get("scenarios", []) if s.get("passed") is not True]
-    if bad:
-        failed_packs.append(pid)
-        for s in bad:
+    for s in p.get("scenarios", []):
+        if s.get("passed") is not True:
+            selections.append(f"{pid}/{s.get('id','?')}")
             failures.append(f"{pid}/{s.get('id','?')}:{s.get('failure_mode','fail')}")
 mode = "--enable-thinking" if d.get("thinking_enabled") else "--no-thinking"
 print(mode)
-print(" ".join(failed_packs))
+print(" ".join(selections))
 print(" ".join(failures))
 PY
 )"
 MODE_FLAG="$(sed -n '1p' <<<"$PLAN")"
-FAILED_PACKS="$(sed -n '2p' <<<"$PLAN")"
+SELECTIONS="$(sed -n '2p' <<<"$PLAN")"
 ORIG_FAILURES="$(sed -n '3p' <<<"$PLAN")"
 
-if [[ -z "$FAILED_PACKS" ]]; then
+if [[ -z "$SELECTIONS" ]]; then
   echo "✓ no failed scenarios in $RESULT_JSON — nothing to re-run."
   exit 0
 fi
+N_SEL="$(wc -w <<<"$SELECTIONS" | tr -d ' ')"
 
 echo "[rerun] original run: $RESULT_JSON  (mode: ${MODE_FLAG#--})"
-echo "[rerun] failed packs: $FAILED_PACKS"
-echo "[rerun] original failures: $(wc -w <<<"$ORIG_FAILURES" | tr -d ' ')"
+echo "[rerun] failed scenarios (${N_SEL}): $SELECTIONS"
+
+SEL_FILE="$(mktemp --suffix=.rerun-scenarios.txt)"
+trap 'rm -f "$SEL_FILE"' EXIT
+{
+  echo "# auto-generated by rerun-failed-packs.sh from $RESULT_JSON"
+  tr ' ' '\n' <<<"$SELECTIONS"
+} > "$SEL_FILE"
+
+RERUN_JSON="${RESULT_JSON}.rerun.json"
 
 if [[ "${RERUN_DRY:-0}" == "1" ]]; then
-  for pack in $FAILED_PACKS; do
-    echo "[dry] quality-test.sh --pack $pack $MODE_FLAG --previous-result $RESULT_JSON --save-json ${RESULT_JSON}.rerun.${pack}.json $*"
-  done
+  echo "[dry] selection file (${SEL_FILE}):"
+  sed 's/^/[dry]   /' "$SEL_FILE"
+  echo "[dry] quality-test.sh --scenarios-file $SEL_FILE $MODE_FLAG --previous-result $RESULT_JSON --incremental --save-json $RERUN_JSON $*"
   exit 0
 fi
 
-# --- 2. re-run each failed pack via the wrapper -------------------------------
-for pack in $FAILED_PACKS; do
-  echo
-  echo "════ re-running pack: $pack ════"
-  bash "${SCRIPT_DIR}/quality-test.sh" --pack "$pack" "$MODE_FLAG" \
-    --previous-result "$RESULT_JSON" \
-    --save-json "${RESULT_JSON}.rerun.${pack}.json" \
-    "$@"
-done
+# --- 2. one selection re-run via the wrapper -----------------------------------
+bash "${SCRIPT_DIR}/quality-test.sh" --scenarios-file "$SEL_FILE" "$MODE_FLAG" \
+  --previous-result "$RESULT_JSON" \
+  --incremental \
+  --save-json "$RERUN_JSON" \
+  "$@"
 
-# --- 3. consolidated verdict ---------------------------------------------------
-python3 - "$RESULT_JSON" $FAILED_PACKS <<'PY'
+# --- 3. consolidated verdict ----------------------------------------------------
+python3 - "$RESULT_JSON" "$RERUN_JSON" <<'PY'
 import json, sys
-orig_path, packs = sys.argv[1], sys.argv[2:]
+orig_path, rerun_path = sys.argv[1], sys.argv[2]
 orig = json.load(open(orig_path, encoding="utf-8"))
 orig_state = {}
 for p in orig.get("packs", []):
     for s in p.get("scenarios", []):
         orig_state[(p["pack_id"], s["id"])] = s.get("passed") is True
 
-repro, fixed, new_reg, missing = [], [], [], []
-for pack in packs:
-    try:
-        rr = json.load(open(f"{orig_path}.rerun.{pack}.json", encoding="utf-8"))
-    except FileNotFoundError:
-        missing.append(pack)
-        continue
-    for p in rr.get("packs", []):
-        for s in p.get("scenarios", []):
-            key = (p["pack_id"], s["id"])
-            now_pass = s.get("passed") is True
-            was_pass = orig_state.get(key)
-            tag = f"{key[0]}/{key[1]}"
-            if was_pass is False and not now_pass:
-                repro.append(f"{tag} ({s.get('failure_mode','fail')})")
-            elif was_pass is False and now_pass:
-                fixed.append(tag)
-            elif was_pass is True and not now_pass:
-                new_reg.append(f"{tag} ({s.get('failure_mode','fail')})")
+try:
+    rr = json.load(open(rerun_path, encoding="utf-8"))
+except FileNotFoundError:
+    print(f"✗ no rerun JSON at {rerun_path} — the selection run did not complete", file=sys.stderr)
+    sys.exit(1)
+
+repro, fixed = [], []
+for p in rr.get("packs", []):
+    for s in p.get("scenarios", []):
+        key = (p["pack_id"], s["id"])
+        tag = f"{key[0]}/{key[1]}"
+        if s.get("passed") is True:
+            fixed.append(tag)
+        else:
+            repro.append(f"{tag} ({s.get('failure_mode','fail')})")
 
 print("\n════ rerun verdict ════")
 print(f"REPRODUCED ({len(repro)}) — likely real:")
 for t in repro: print(f"  ✗ {t}")
 print(f"FIXED on re-run ({len(fixed)}) — flake / environment:")
 for t in fixed: print(f"  ↺ {t}")
-if new_reg:
-    print(f"NEW regressions ({len(new_reg)}) — variance cuts both ways:")
-    for t in new_reg: print(f"  ⚠ {t}")
-if missing:
-    print(f"(no rerun JSON for: {', '.join(missing)})")
 print("\nNote: single re-run separates 'stable' from 'flaky', not 'model' from")
-print("'harness'. For flakiness RATES, add --repeat 3 and read benchlocal's")
-print(">=50% aggregation in the per-pack delta output.")
+print("'harness'. For flakiness RATES, add --repeat 3 (cheap at scenario")
+print("granularity) and read benchlocal's >=50% aggregation in the delta output.")
+print("The rerun JSON is a PARTIAL selection result — not a pack total.")
 PY

--- a/scripts/scenario-sets/tess4-engine-window.txt
+++ b/scripts/scenario-sets/tess4-engine-window.txt
@@ -1,0 +1,15 @@
+# Tess-4-27B engine-window discriminators ("Set B") — cheap engine-arm check.
+#
+# Provenance: the three scenarios seanyourhighness's 2× stable think-ON runs on
+# llama.cpp b9932 never passed while the reference rig's b9967 run passes all
+# three; none sit in either rig's churn set (club-3090 #665, 2026-07-11). They
+# localize an engine-build behavior change to the b9932→b9967 window — probe
+# them first on any new engine build/pin arm (e.g. a vLLM or llama.cpp bump)
+# before paying for a full 8-pack.
+#
+# Use: bash scripts/quality-test.sh --scenarios-file scripts/scenario-sets/tess4-engine-window.txt \
+#        --enable-thinking --repeat 3
+# (These flipped on the THINKING leg — probe reasoning-ON, and repeat: temp 1.0.)
+cli-40/CLI-25
+cli-40/CLI-31
+cli-40/CLI-32

--- a/scripts/scenario-sets/tess4-model-floor.txt
+++ b/scripts/scenario-sets/tess4-model-floor.txt
@@ -1,0 +1,31 @@
+# Tess-4-27B model-floor probe set ("Set A") — the retrain-target list.
+#
+# Provenance: scenario-level intersection of 6 full 8-pack runs across 2 rigs
+# (reference 2×3090 + seanyourhighness's 1×4090), 2 external drafters (MTP,
+# DFlash/EAGLE3), 2 engine builds (llama.cpp b9246→b9967; his b9932), both
+# reasoning modes — club-3090 #665 (2026-07-11). The 14 below failed EVERY run;
+# the 2 marked thinking-only failed stably only in the reasoning-ON legs.
+#
+# Use: bash scripts/quality-test.sh --scenarios-file scripts/scenario-sets/tess4-model-floor.txt \
+#        [--no-thinking | --enable-thinking] [--repeat 3]
+# Probe discipline: results are PARTIAL (never a /150 claim); thinking-ON legs
+# sample at temp 1.0 by pack contract → use --repeat 3 when a number gates anything.
+#
+# fails-everywhere (14):
+bugfind-15/BF-03
+cli-40/CLI-08
+cli-40/CLI-11
+cli-40/CLI-17
+cli-40/CLI-24
+cli-40/CLI-33
+cli-40/CLI-34
+cli-40/CLI-37
+cli-40/CLI-38
+dataextract-15/DE-07
+hermesagent-20/HA-08
+hermesagent-20/HA-16
+reasonmath-15/RM-13
+structoutput-15/SO-07
+# thinking-only-stable tail (2):
+cli-40/CLI-13
+hermesagent-20/HA-02

--- a/scripts/tests/test-rerun-failed-packs.sh
+++ b/scripts/tests/test-rerun-failed-packs.sh
@@ -31,11 +31,13 @@ cat > "$TMP/r.json" <<'JSON'
 }
 JSON
 out="$(RERUN_DRY=1 bash "$S" "$TMP/r.json" 2>&1)"
-echo "$out" | command grep -q "failed packs: reasonmath-15$" || fail "plan should list only reasonmath-15 (got: $out)"
+echo "$out" | command grep -q "failed scenarios (1): reasonmath-15/RM-04$" || fail "plan should select only reasonmath-15/RM-04 (got: $out)"
 echo "$out" | command grep -q -- "--enable-thinking" || fail "plan should derive --enable-thinking from thinking_enabled=true"
 echo "$out" | command grep -q -- "--previous-result $TMP/r.json" || fail "plan should pass --previous-result"
-echo "$out" | command grep -qv "toolcall-15" || true
-echo "$out" | command grep -q "\[dry\] quality-test.sh --pack toolcall-15" && fail "clean pack must not be re-run"
+echo "$out" | command grep -q -- "--scenarios-file" || fail "plan should run ONE selection via --scenarios-file (post benchlocal #84)"
+echo "$out" | command grep -q -- "--incremental" || fail "plan should pass --incremental for resume durability"
+echo "$out" | command grep -q "\[dry\]   reasonmath-15/RM-04" || fail "selection file should contain the failed scenario"
+echo "$out" | command grep -q "toolcall-15/TC-01" && fail "passing scenario must not be selected"
 
 # 4. all-clean result → exit 0, nothing to re-run
 cat > "$TMP/clean.json" <<'JSON'

--- a/scripts/tests/test-scenario-sets.sh
+++ b/scripts/tests/test-scenario-sets.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Guard for scripts/scenario-sets/*.txt: every non-comment line must be a
+# pack-qualified scenario ID (KNOWN_PACK/ID), IDs unique per file, and each
+# file must carry a provenance header (a probe set without provenance decays
+# into a magic list). Also: quality-test.sh must actually expose the
+# passthrough flags these files are consumed through.
+set -euo pipefail
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+SETS_DIR="${ROOT_DIR}/scripts/scenario-sets"
+QT="${ROOT_DIR}/scripts/quality-test.sh"
+
+fail() { echo "ASSERTION FAILED: $1" >&2; exit 1; }
+
+KNOWN_PACKS="toolcall-15 instructfollow-15 structoutput-15 dataextract-15 reasonmath-15 bugfind-15 cli-40 hermesagent-20 aider-polyglot-30 humaneval-plus-30 lcb-v6-30"
+
+ls "$SETS_DIR"/*.txt >/dev/null 2>&1 || fail "no scenario-set files in $SETS_DIR"
+
+for f in "$SETS_DIR"/*.txt; do
+  base="$(basename "$f")"
+  # provenance header: first line must be a comment mentioning where the set came from
+  head -1 "$f" | command grep -q '^#' || fail "$base: first line must be a provenance comment"
+  command grep -qiE '^#.*(provenance|#66[0-9]|#6[0-9][0-9])' "$f" || fail "$base: header must state provenance"
+
+  seen=""
+  while IFS= read -r line; do
+    # strip comments/blank
+    case "$line" in ''|\#*|' '*'#'*) [[ "$line" =~ ^[[:space:]]*(#|$) ]] && continue ;; esac
+    [[ "$line" =~ ^[a-z0-9-]+/[A-Z]+-[0-9]+$ ]] || fail "$base: malformed selection line: '$line'"
+    pack="${line%%/*}"
+    command grep -qw "$pack" <<<"$KNOWN_PACKS" || fail "$base: unknown pack '$pack' in '$line'"
+    case " $seen " in *" $line "*) fail "$base: duplicate selection '$line'";; esac
+    seen="$seen $line"
+  done < "$f"
+done
+
+# the wrapper must expose the flags the sets are consumed through
+for flag in --scenario --scenarios-file --incremental --resume --allow-partial; do
+  command grep -q -- "$flag)" "$QT" || fail "quality-test.sh missing passthrough case for $flag"
+done
+
+echo "test-scenario-sets: PASS"


### PR DESCRIPTION
## What

The club-3090 half of benchlocal-cli [#84](https://github.com/noonghunna/benchlocal-cli/pull/84) (scenario selection) + [#85](https://github.com/noonghunna/benchlocal-cli/pull/85) (incremental/resume):

- **`quality-test.sh` passthroughs**: `--scenario PACK/ID` (repeatable), `--scenarios-file`, `--incremental`, `--resume`, `--allow-partial`. Bare selections derive the pack set upstream (`custom` mode — no mode flag sent); the sandbox-image preflight now also fires when a selection touches bugfind/cli-40/hermes; `--resume` refuses mode/pack/selection/thinking/sampling/timeout flags (it restores those from the saved run — refusing beats silently forking the config). Selection runs print the partial-result warning up front.
- **`scripts/scenario-sets/`** — curated probe sets with provenance headers:
  - `tess4-model-floor.txt` — the 14 fails-everywhere scenarios (+2 thinking-only) from the #665 cross-rig intersection: the Tess retrain-target list, runnable as a before/after eval.
  - `tess4-engine-window.txt` — CLI-25/31/32, the b9932→b9967 flips: first probe on any new engine build/pin arm before paying for a full 8-pack.
- **`rerun-failed-packs.sh`** — failures now re-run as ONE selection run (6 failures over 5 packs = 6 scenarios, not ~100) with `--incremental` resume durability; verdict logic unchanged (REPRODUCED/FIXED).
- **`docs/QUALITY_TEST.md`** — "Scenario-level probes" section: flags, the probe discipline (partial ≠ `/150` claim; ON probes `--repeat 3`), the curated-set table.

## Validation

- `test-scenario-sets.sh` (new): selection-line format, known packs, per-file uniqueness, provenance header required, wrapper flag presence.
- `test-rerun-failed-packs.sh` updated for the single-selection plan; green.
- `test-quality-baseline` / `test-quality-thinking` green (no regression in existing passthroughs).
- **Live end-to-end** against the running Tess serve (b9967): `--scenarios-file tess4-engine-window.txt --no-thinking` → custom-mode selection, sandbox auto-enabled, `[PARTIAL SELECTION: 3 scenarios]` labeling, "3 of 40 selected" partial rendering, exit 0 — and 3/3 pass, incidentally confirming the engine-window trio holds on b9967 in the greedy leg too.

Scoped change (scripts + docs, not catalog-shape) → targeted guards per the scoping rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm