### PR TITLE
report.sh: capture motherboard + BIOS (#690)

### DIFF
--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -150,6 +150,30 @@ section "System"
   echo "- **OS:** $os_name"
   echo "- **Kernel:** $(uname -r)"
 
+  # Motherboard / BIOS — from sysfs DMI (readable WITHOUT root; serials/UUIDs
+  # are root-only in sysfs so they are never exposed here). #690.
+  _dmi() {
+    local v; v="$(cat "/sys/class/dmi/id/$1" 2>/dev/null)"
+    v="${v//$'\n'/ }"; v="${v#"${v%%[![:space:]]*}"}"; v="${v%"${v##*[![:space:]]}"}"
+    # drop common OEM placeholder junk so it degrades to "(not exposed)"
+    case "$v" in
+      "To Be Filled By O.E.M."|"To be filled by O.E.M."|"Default string"|      "System manufacturer"|"System Product Name"|"System Version"|      "Not Applicable"|"None"|"N/A"|"Unknown"|"0.0.0"|"") v="" ;;
+    esac
+    printf '%s' "$v"
+  }
+  _mb_vendor="$(_dmi board_vendor)"; _mb_name="$(_dmi board_name)"
+  _mb_product="$(_dmi product_name)"; _mb_bios="$(_dmi bios_version)"; _mb_biosdate="$(_dmi bios_date)"
+  _mb="$_mb_vendor${_mb_vendor:+${_mb_name:+ }}$_mb_name"
+  if [[ -n "$_mb" ]]; then
+    [[ -n "$_mb_product" && "$_mb_product" != "$_mb" ]] && _mb="$_mb  (system: $_mb_product)"
+    echo "- **Motherboard:** $_mb"
+  elif [[ -n "$_mb_product" ]]; then
+    echo "- **Motherboard:** (board DMI not exposed; system: $_mb_product)"
+  else
+    echo "- **Motherboard:** (not exposed)"
+  fi
+  [[ -n "$_mb_bios" ]] && echo "- **BIOS:** ${_mb_bios}${_mb_biosdate:+ ($_mb_biosdate)}"
+
   # Environment detection
   env_kind="bare metal"
   if grep -qiE 'microsoft|wsl' /proc/version 2>/dev/null; then


### PR DESCRIPTION
Closes #690.

Adds **Motherboard** + **BIOS** to `report.sh`'s System section, so cross-rig reports carry the board/chipset context that determines P2P support, PCIe generation, bifurcation, and ACS — the exact things we had to *infer* in the #688 4×3090 P2P thread.

## What

Reads from `/sys/class/dmi/id/*` (`board_vendor`, `board_name`, `product_name`, `bios_version`, `bios_date`):

```
- **Motherboard:** ASRock X99 Taichi  (system: To Be Filled…filtered)
- **BIOS:** P3.60 (05/14/2020)
```

- **No root, no new deps** — sysfs DMI is world-readable; the sensitive `*_serial` / `product_uuid` fields are root-only in sysfs, so they're **never exposed**.
- **Placeholder-junk filtered** — "To Be Filled By O.E.M.", "Default string", etc. → degrade to `(not exposed)`.
- **Graceful degradation** — VM / stripped DMI → `(not exposed)` (verified on this QEMU rig), no blank-line spam.
- Sits inside the existing `{ … } | redact` block; board/BIOS strings aren't redact-sensitive.

## Validation

- `bash -n` clean; `test-report-calib.sh` green (System section is independent of the kv-calc block it tests).
- Live `report.sh --verify` on this rig renders:
  ```
  - **Kernel:** 6.8.0-134-generic
  - **Motherboard:** (board DMI not exposed; system: Standard PC (Q35 + ICH9, 2009))
  - **BIOS:** 4.2025.05-2 (11/13/2025)
  - **Environment:** qemu (virtualized)
  ```
  (bare-metal rigs populate `board_vendor`/`board_name` with the real board.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm