### PR TITLE
fix(compat): C5 false-rejects nvfp4 + fp8_e4m3 KV on Ampere (#686)

### DIFF
--- a/scripts/lib/profiles/compat.py
+++ b/scripts/lib/profiles/compat.py
@@ -893,11 +893,13 @@ def fits(
     # validated proxy for that backend split — Qwen fp8 dual/multi-max WORK on the 3090
     # (#594: boot/decode/NIAH/quality/soak all green), while gemma-4-31b + fp8_e4m3 FAILS
     # at KV-init on the same sm_86/v0.24.0 stack (learnings/gemma-4-31b.md 2026-07-01).
-    # So bypass the hardware supported_kv_formats gate for fp8_e4m3 + fp8-weights on
+    # So bypass the hardware supported_kv_formats gate for fp8_e4m3 + fp8/nvfp4-weights on
     # sm>=8.6 without listing fp8_e4m3 in the Ampere profile (keeps Gemma correctly
     # rejected). See docs/DTYPE_MATRIX.md. Caveat: a future Gemma-*fp8-weights* checkpoint
     # would route to Triton and still fail — this proxy would wrongly allow it; revisit then.
-    _fp8w_ampere_kv = effective_kv == "fp8_e4m3" and str(effective_weights or "").startswith("fp8")
+    # nvfp4 weights added 2026-07-13 (#686): tess/qwen NVFP4 run e4m3 KV via FlashInfer
+    # on sm_86 — live-validated (A0 8-pack on 2x3090, BENCHMARKS) — while gemma stays rejected.
+    _fp8w_ampere_kv = effective_kv == "fp8_e4m3" and str(effective_weights or "").startswith(("fp8", "nvfp4"))
     unsupported_hw = [
         hw.id for hw in hardware
         if effective_kv not in hw.supported_kv_formats


### PR DESCRIPTION
## Bug (reported in #686)

`pod.sh create hermes --gpus 2,3 --slug vllm/tess-dual-nvfp4` on a 4×3090 fails:

```
[pod] ✗ C5: kv_format=fp8_e4m3 not supported by hardware: rtx-3090, rtx-3090
```

…but that slug **runs fine on Ampere** — we booted + benched it on our own 2×3090 last night (the A0 8-pack, 106/113). It's a false rejection.

## Cause

The C5 check has a deliberate Ampere-`fp8_e4m3` bypass (e4m3 KV works on sm_86 for checkpoints that route to **FlashInfer**, but not for those routing to **Triton**, which needs SM89+). The proxy for "routes to FlashInfer" was `weights_variant.startswith("fp8")` — which correctly allows the fp8 tiers but **misses nvfp4**, whose weights ALSO route e4m3 KV through FlashInfer on Ampere.

## Fix

One predicate: `startswith("fp8")` → `startswith(("fp8", "nvfp4"))`.

- **Allows:** `fp8*` and `nvfp4*` weights + `fp8_e4m3` on sm≥8.6 — both live-validated (Tess-nvfp4 A0 8-pack + the qwen-nvfp4 dual BENCHMARKS row).
- **Still rejects:** Gemma (`autoround-int4` / `qat-w4a16` / `awq` weights → Triton path → genuinely fails KV-init on sm_86) — `test-profiles-compat` asserts this and stays green.

## Validation

- `test-profiles-compat`, `test-pullgate-gates`, `test-diagnose-profile` — all green.
- `diagnose-profile.sh vllm/tess-dual-nvfp4` now validates (C5 passes) on the sm_86 dev profile.

Note for @MoppelMat: this is the surgical fix vs commenting out the whole C5 `fail()` (which also disables the *correct* Gemma rejection). `git pull` after merge and revert the local `compat.py` edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm