### PR TITLE
fix(nvlink): pcie_p2p no longer falsely claims "engaged" without verifying peer access

### DIFF
--- a/scripts/detect_nvlink.sh
+++ b/scripts/detect_nvlink.sh
@@ -13,10 +13,15 @@
 #                and cards on separate root complexes can't P2P — both correctly stay off.
 #   force_on   — assert NVLink present (NCCL_P2P_LEVEL=NVL).
 #   force_off  — no P2P at all (NCCL_P2P_DISABLE=1).
-#   pcie_p2p   — FORCE PCIe P2P on (assert the patched driver is loaded + working),
-#                bypassing auto-detect. Sets NCCL_P2P_LEVEL=PHB (or your own NCCL_P2P_LEVEL),
-#                P2P ENABLED, custom all-reduce ON. Use when you trust the patch but auto's
-#                `topo -p2p r` probe doesn't report OK. See club-3090 #290.
+#   pcie_p2p   — FORCE the PCIe P2P config on (NCCL_P2P_LEVEL=PHB or your own,
+#                custom all-reduce ON), bypassing auto-detect. It ALSO probes
+#                `topo -p2p` and reports honestly: "P2P ENABLED" when the driver
+#                confirms peer access, "P2P REQUESTED (UNVERIFIED)" + a warning
+#                when it doesn't (a closed GeForce driver refuses P2P; the open
+#                kernel modules / a patched module + a P2P-capable board enable
+#                it). The config is forced either way — this is the escape hatch
+#                for a rig whose probe is stricter than reality — but we never
+#                claim "engaged" without evidence. See club-3090 #290, #688.
 
 NVLINK_MODE="${NVLINK_MODE:-auto}"
 _P2P_LEVEL=NVL   # NCCL_P2P_LEVEL used when _NVLINK_ENABLED=1 (overridden by pcie_p2p)
@@ -48,10 +53,20 @@ case "$NVLINK_MODE" in
     echo "[nvlink] NVLINK_MODE=force_off — forcing PCIe mode (P2P off)"
     ;;
   pcie_p2p)
-    # Explicit opt-in for PCIe P2P (no NVLink) — e.g. a patched consumer-GPU driver.
+    # Explicit opt-in for PCIe P2P (no NVLink) — a patched module OR a driver/board
+    # that grants peer access (some server boards + the open kernel modules do).
+    # Force the config on either way (the escape hatch for a rig whose topo -p2p
+    # probe is stricter than reality), but VERIFY peer access and flag it honestly
+    # when the driver didn't grant it — else we'd falsely report "P2P engaged" on a
+    # closed/stock driver that silently refuses it (club-3090 #688).
     _NVLINK_ENABLED=1
     _P2P_LEVEL="${NCCL_P2P_LEVEL:-PHB}"
-    echo "[nvlink] NVLINK_MODE=pcie_p2p — forcing PCIe P2P (NCCL_P2P_LEVEL=$_P2P_LEVEL, custom all-reduce ON)"
+    if _pcie_p2p_available; then
+      echo "[nvlink] NVLINK_MODE=pcie_p2p — forcing PCIe P2P; driver confirms peer access (nvidia-smi topo -p2p: OK) — NCCL_P2P_LEVEL=$_P2P_LEVEL, custom all-reduce ON"
+    else
+      _P2P_UNVERIFIED=1
+      echo "[nvlink] WARNING: NVLINK_MODE=pcie_p2p set, but nvidia-smi topo -p2p does NOT report peer access as OK — the driver likely refused P2P (a closed GeForce driver disables it; the open kernel modules or a patched module + a P2P-capable board are what enable it). Forcing the NCCL/all-reduce config on as requested, but NCCL will silently fall back → throughput ≈ P2P-off. Verify with: nvidia-smi topo -p2p rw. Guide: docs/PCIE_P2P.md" >&2
+    fi
     ;;
   auto)
     GPU_COUNT=$(nvidia-smi -L 2>/dev/null | grep -c 'GPU' || echo 0)
@@ -109,7 +124,13 @@ if [ "$_NVLINK_ENABLED" -eq 1 ]; then
   _alloc="$(printf '%s' "$_alloc" | sed -E 's/(^|,)expandable_segments:[^,]*//g; s/^,+//; s/,+$//; s/,+/,/g')"
   [ -n "$_alloc" ] || _alloc="max_split_size_mb:512"
   export PYTORCH_CUDA_ALLOC_CONF="$_alloc"
-  echo "[nvlink] P2P ENABLED — NCCL_P2P_LEVEL=$NCCL_P2P_LEVEL, custom all-reduce ON, expandable_segments stripped (PYTORCH_CUDA_ALLOC_CONF=$PYTORCH_CUDA_ALLOC_CONF)"
+  if [ "${_P2P_UNVERIFIED:-0}" -eq 1 ]; then
+    # pcie_p2p forced, but topo -p2p didn't confirm peer access. Config is applied;
+    # engagement is NOT proven. Say so — never print "ENABLED" without evidence (#688).
+    echo "[nvlink] P2P REQUESTED (UNVERIFIED) — NCCL_P2P_LEVEL=$NCCL_P2P_LEVEL + custom all-reduce configured as forced, but peer access is UNCONFIRMED (topo -p2p ≠ OK; see the warning above). If the driver refused P2P, NCCL falls back and throughput ≈ P2P-off — verify with nvidia-smi topo -p2p rw. expandable_segments stripped (PYTORCH_CUDA_ALLOC_CONF=$PYTORCH_CUDA_ALLOC_CONF)"
+  else
+    echo "[nvlink] P2P ENABLED — NCCL_P2P_LEVEL=$NCCL_P2P_LEVEL, custom all-reduce ON, expandable_segments stripped (PYTORCH_CUDA_ALLOC_CONF=$PYTORCH_CUDA_ALLOC_CONF)"
+  fi
 else
   export NCCL_P2P_DISABLE=1
   unset NCCL_P2P_LEVEL 2>/dev/null || true

--- a/scripts/lib/p2p-state.sh
+++ b/scripts/lib/p2p-state.sh
@@ -12,6 +12,8 @@
 #                                        left on the table per the #77 A/B)
 #   PCIe-P2P-capable + engagement OFF  -> INFO (launcher boots auto-enable;
 #                                        direct compose users can opt in)
+#   pcie_p2p forced, grant UNVERIFIED  -> WARN (looked engaged, wasn't — #688;
+#                                        driver didn't confirm peer access)
 
 # GPU count (host).
 p2p_gpu_count() {
@@ -53,6 +55,29 @@ _p2p_pairs_ok() {
   '
 }
 
+# NVIDIA kernel-module flavor: "open" | "proprietary" | "unknown". The open
+# kernel modules (`nvidia-open`, OR a fork like aikitoria/open-gpu-kernel-modules)
+# report license "Dual MIT/GPL"; the closed/proprietary module reports "NVIDIA".
+# This is the reliable, actionable signal for GeForce P2P triage — a proprietary
+# module REFUSES peer access; the open modules can GRANT it. It is host-side
+# (needs /lib/modules → modinfo), so it belongs here / in report.sh, not in the
+# in-container detect_nvlink.sh boot path.
+#   IMPORTANT: this canNOT fingerprint the aikitoria patch specifically. That
+#   fork is the open modules with the P2P block removed — identical license,
+#   version, and filename to stock nvidia-open. The functional proof a
+#   P2P-enabling module is actually working is `topo -p2p rw = OK`
+#   (_p2p_pairs_ok), NOT this flavor probe. So we report open-vs-proprietary and
+#   pair it with the topo result; we never claim "aikitoria detected".
+p2p_driver_flavor() {
+  local lic
+  lic="$(modinfo -F license nvidia 2>/dev/null)"
+  case "$lic" in
+    *NVIDIA*)    echo proprietary ;;
+    *GPL*|*MIT*) echo open ;;
+    *)           echo unknown ;;
+  esac
+}
+
 # Engagement classifier — PURE (takes the boot-trail/env text on stdin so the
 # caller decides where it comes from and tests can feed fixtures).
 # report.sh already gathers exactly this text: the container's `[nvlink]`
@@ -61,6 +86,13 @@ _p2p_pairs_ok() {
 p2p_classify_engagement() {
   local text
   text="$(cat)"
+  # A forced PCIe-P2P request whose driver grant we could NOT confirm: the
+  # NCCL/all-reduce config is applied but peer access is unverified. Must NOT
+  # read as "on" — that's the false-engaged bug from #688. Checked FIRST so it
+  # wins over the "custom all-reduce" signal the forced path also carries.
+  case "$text" in
+    *"P2P REQUESTED (UNVERIFIED)"*) echo requested; return 0 ;;
+  esac
   # The [nvlink] decision trail is authoritative (it states what the boot
   # resolved, post-override); env is the fallback for pre-trail entrypoints.
   case "$text" in
@@ -81,6 +113,13 @@ p2p_classify_engagement() {
 p2p_verdict() {
   local count="$1" cap="$2" eng="$3" state
   [[ "${count:-0}" -ge 2 ]] || return 0
+  # A forced-but-unverified P2P request is worth flagging EVEN when the
+  # capability probe says "none": the request asked for P2P, the driver didn't
+  # confirm it. This is the #688 case (looked engaged, wasn't) — never silent.
+  if [[ "$eng" == "requested" ]]; then
+    echo "⚠ interconnect WARN: NVLINK_MODE=pcie_p2p forced PCIe P2P on, but nvidia-smi does not report peer access as OK — the driver likely refused it (a closed GeForce driver disables P2P; the open kernel modules or a patched module + a P2P-capable board enable it). NCCL falls back, so throughput ≈ P2P-off. Verify: nvidia-smi topo -p2p rw. Guide: docs/PCIE_P2P.md"
+    return 0
+  fi
   [[ "$cap" != "none" ]] || return 0
   case "$eng" in
     on)      state="" ;;

--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -825,6 +825,17 @@ else
     _p2p_verdict_line="$(p2p_verdict "$(p2p_gpu_count)" "$(p2p_host_capability)" \
       "$(printf '%s\n%s' "$nvlink_boot" "$p2p_env" | p2p_classify_engagement)")"
     [[ -n "$_p2p_verdict_line" ]] && { echo; echo "**Interconnect verdict:** ${_p2p_verdict_line}"; }
+    # Kernel-module flavor — the WHY behind a P2P result on GeForce cards. A
+    # proprietary (closed) module refuses P2P; the open modules can grant it, with
+    # `topo -p2p rw` above the functional proof. Only meaningful multi-GPU.
+    # We report open-vs-proprietary (detectable); we do NOT claim to fingerprint
+    # the aikitoria patch — it's metadata-identical to stock nvidia-open.
+    if [[ "$(p2p_gpu_count)" -ge 2 ]]; then
+      case "$(p2p_driver_flavor)" in
+        proprietary) echo; echo "**NVIDIA kernel module:** proprietary (closed) — refuses P2P on GeForce; the open kernel modules (\`nvidia-open\`, or a patched fork) are what enable it. A \`CNS\` in \`topo -p2p rw\` above is this. See docs/PCIE_P2P.md." ;;
+        open)        echo; echo "**NVIDIA kernel module:** open (\`Dual MIT/GPL\`) — P2P-capable on GeForce; whether it's granted is the \`topo -p2p rw\` result above (\`OK\` = engaged, \`CNS\` = board/layout still refusing). Metadata can't tell stock \`nvidia-open\` from a patched fork — the topo result is the proof." ;;
+      esac
+    fi
     echo
 
     genesis_results=$(docker logs "$CONTAINER" 2>&1 | grep -E '\[INFO:genesis\.apply_all\] (Genesis|✅) Results' | tail -1)

--- a/scripts/tests/test-detect-nvlink-alloc-conf.sh
+++ b/scripts/tests/test-detect-nvlink-alloc-conf.sh
@@ -15,10 +15,12 @@ fail=0
 # $1 = NVLINK_MODE, $2 = pre-set PYTORCH_CUDA_ALLOC_CONF ("__UNSET__" to leave unset).
 resolve() {
   local mode="$1" pre="$2"
+  # 2>/dev/null: pcie_p2p's honest "unverified" warning (no mocked nvidia-smi here)
+  # goes to stderr — irrelevant to the alloc-conf assertion, so keep output clean.
   if [[ "$pre" == "__UNSET__" ]]; then
-    NVLINK_MODE="$mode" bash -c "unset PYTORCH_CUDA_ALLOC_CONF; source '$DETECT' >/dev/null; printf '%s' \"\${PYTORCH_CUDA_ALLOC_CONF:-}\""
+    NVLINK_MODE="$mode" bash -c "unset PYTORCH_CUDA_ALLOC_CONF; source '$DETECT' >/dev/null 2>&1; printf '%s' \"\${PYTORCH_CUDA_ALLOC_CONF:-}\""
   else
-    PYTORCH_CUDA_ALLOC_CONF="$pre" NVLINK_MODE="$mode" bash -c "source '$DETECT' >/dev/null; printf '%s' \"\${PYTORCH_CUDA_ALLOC_CONF:-}\""
+    PYTORCH_CUDA_ALLOC_CONF="$pre" NVLINK_MODE="$mode" bash -c "source '$DETECT' >/dev/null 2>&1; printf '%s' \"\${PYTORCH_CUDA_ALLOC_CONF:-}\""
   fi
 }
 

--- a/scripts/tests/test-detect-nvlink-autop2p.sh
+++ b/scripts/tests/test-detect-nvlink-autop2p.sh
@@ -62,5 +62,38 @@ check "4gpu PHB + mixed P2P -> off"      4 PHB MIXED "DISABLE=1|LEVEL="
 # >2 GPUs, no P2P at all -> off
 check "4gpu PHB + no P2P -> off"         4 PHB CNS "DISABLE=1|LEVEL="
 
+# ── pcie_p2p FORCE mode: config forced on either way, message must be HONEST ──
+# The #688 false-"engaged" fix: forcing NVLINK_MODE=pcie_p2p applies the NCCL /
+# all-reduce config regardless (escape hatch), but the boot line only says
+# "ENABLED" when topo -p2p confirms; "REQUESTED (UNVERIFIED)" when it doesn't.
+pcie_text() {  # $1=gpus $2=p2p(OK/CNS) -> combined [nvlink] stdout+stderr
+  PATH="$MOCK_DIR:$PATH" FAKE_GPUS="$1" FAKE_LINK=PHB FAKE_P2P="$2" NVLINK_MODE=pcie_p2p \
+    bash -c "source '$DETECT' 2>&1"
+}
+pcie_env() {   # $1=gpus $2=p2p -> resolved NCCL env (config must be forced ON both ways)
+  PATH="$MOCK_DIR:$PATH" FAKE_GPUS="$1" FAKE_LINK=PHB FAKE_P2P="$2" NVLINK_MODE=pcie_p2p \
+    bash -c "source '$DETECT' >/dev/null 2>&1; printf 'DISABLE=%s|LEVEL=%s' \"\${NCCL_P2P_DISABLE:-}\" \"\${NCCL_P2P_LEVEL:-}\""
+}
+ptext_ok="$(pcie_text 2 OK)"
+case "$ptext_ok" in
+  *"P2P ENABLED"*) [[ "$ptext_ok" == *UNVERIFIED* ]] \
+      && { echo "[autop2p] FAIL: pcie_p2p + topo OK must not also say UNVERIFIED" >&2; fail=1; } \
+      || echo "[autop2p] ok: pcie_p2p + topo OK -> ENABLED (verified)" ;;
+  *) echo "[autop2p] FAIL: pcie_p2p + topo OK should say ENABLED — got: $ptext_ok" >&2; fail=1 ;;
+esac
+ptext_cns="$(pcie_text 2 CNS)"
+case "$ptext_cns" in
+  *"P2P ENABLED"*) echo "[autop2p] FAIL: pcie_p2p + topo CNS must NOT falsely say ENABLED (#688 bug)" >&2; fail=1 ;;
+  *"P2P REQUESTED (UNVERIFIED)"*) echo "[autop2p] ok: pcie_p2p + topo CNS -> UNVERIFIED (honest)" ;;
+  *) echo "[autop2p] FAIL: pcie_p2p + topo CNS should say UNVERIFIED — got: $ptext_cns" >&2; fail=1 ;;
+esac
+# config forced ON in BOTH cases — the escape hatch is preserved
+for p2p in OK CNS; do
+  penv="$(pcie_env 2 "$p2p")"
+  [ "$penv" = "DISABLE=|LEVEL=PHB" ] \
+    && echo "[autop2p] ok: pcie_p2p ($p2p) forces config on (DISABLE unset, LEVEL=PHB)" \
+    || { echo "[autop2p] FAIL: pcie_p2p ($p2p) must force config on — got '$penv'" >&2; fail=1; }
+done
+
 if [ "$fail" -ne 0 ]; then echo "[autop2p] FAILED" >&2; exit 1; fi
-echo "[autop2p] PASS: auto promotes to PCIe P2P only when topo -p2p reports OK on all pairs"
+echo "[autop2p] PASS: auto promotes to PCIe P2P only when topo -p2p reports OK; pcie_p2p force reports honestly (ENABLED vs UNVERIFIED) while always applying the config"

--- a/scripts/tests/test-p2p-state.sh
+++ b/scripts/tests/test-p2p-state.sh
@@ -29,12 +29,24 @@ out="$(p2p_verdict 2 nvlink unknown)"; assert_contains "$out" "⚠ interconnect 
 out="$(p2p_verdict 2 pcie_p2p off)";  assert_contains "$out" "ℹ interconnect"
 assert_contains "$out" "NVLINK_MODE=pcie_p2p"
 out="$(p2p_verdict 4 nvlink off)";    assert_contains "$out" "WARN"   # multi-GPU too
+# forced-but-unverified pcie_p2p — WARN even when capability probe says none (#688).
+out="$(p2p_verdict 2 none requested)"; assert_contains "$out" "⚠ interconnect WARN"
+assert_contains "$out" "topo -p2p rw"
+assert_contains "$out" "forced PCIe P2P on"
+out="$(p2p_verdict 4 none requested)"; assert_contains "$out" "⚠ interconnect WARN"  # multi-GPU too
+assert_empty "$(p2p_verdict 1 none requested)"                       # single GPU still silent
 
 # ── 2. engagement classifier (pure, stdin fixtures) ───────────────────────────
 r="$(echo '[nvlink] detected NVLink (NV4) between GPU0-GPU1 — enabling NVLink mode' | p2p_classify_engagement)"
 [[ "$r" == "on" ]] || fail "nvlink boot line -> on (got $r)"
-r="$(echo '[nvlink] NVLINK_MODE=pcie_p2p — forcing PCIe P2P (NCCL_P2P_LEVEL=PHB, custom all-reduce ON)' | p2p_classify_engagement)"
-[[ "$r" == "on" ]] || fail "pcie_p2p boot line -> on (got $r)"
+r="$(echo '[nvlink] NVLINK_MODE=pcie_p2p — forcing PCIe P2P; driver confirms peer access (nvidia-smi topo -p2p: OK) — NCCL_P2P_LEVEL=PHB, custom all-reduce ON' | p2p_classify_engagement)"
+[[ "$r" == "on" ]] || fail "verified pcie_p2p boot line -> on (got $r)"
+# forced-but-UNVERIFIED pcie_p2p -> requested, NOT on (the #688 false-engaged guard).
+r="$(echo '[nvlink] P2P REQUESTED (UNVERIFIED) — NCCL_P2P_LEVEL=PHB + custom all-reduce configured as forced, but peer access is UNCONFIRMED (topo -p2p ≠ OK; see the warning above)' | p2p_classify_engagement)"
+[[ "$r" == "requested" ]] || fail "unverified pcie_p2p -> requested (got $r)"
+# combined warn(stderr)+trail as report.sh greps them together -> still requested
+r="$(printf '%s\n%s' '[nvlink] WARNING: NVLINK_MODE=pcie_p2p set, but nvidia-smi topo -p2p does NOT report peer access as OK' '[nvlink] P2P REQUESTED (UNVERIFIED) — custom all-reduce configured as forced' | p2p_classify_engagement)"
+[[ "$r" == "requested" ]] || fail "combined warn+trail -> requested (got $r)"
 r="$(echo '[nvlink] PCIe topology (PHB), P2P not available (topo -p2p: no OK) — using PCIe mode' | p2p_classify_engagement)"
 [[ "$r" == "off" ]] || fail "pcie-mode boot line -> off (got $r)"
 r="$(echo '[nvlink] NVLINK_MODE=force_off — forcing PCIe mode (P2P off)' | p2p_classify_engagement)"
@@ -91,5 +103,20 @@ d="$(run_decider)"; assert_contains "$d" "P2P=OK"                     # decider:
 mk_smi "$L2" "$TOPO_PHB" "$P2P_CNS"
 d="$(run_decider)"; assert_contains "$d" "using PCIe mode"            # decider: none
 echo "  ✓ decider (detect_nvlink.sh) and auditor (p2p-state.sh) agree on all 3 fixtures"
+
+# ── 5. driver-flavor probe via faked modinfo ─────────────────────────────────
+# open modules (nvidia-open / aikitoria fork) report "Dual MIT/GPL"; closed
+# reports "NVIDIA". We report open-vs-proprietary; the fork is NOT fingerprintable.
+mk_modinfo() { printf '#!/usr/bin/env bash\nprintf %%s %q\n' "$1" > "$TMP/modinfo"; chmod +x "$TMP/modinfo"; }
+mk_modinfo "NVIDIA"
+r="$(PATH="$TMP:$PATH" bash -c 'source scripts/lib/p2p-state.sh; p2p_driver_flavor')"
+[[ "$r" == "proprietary" ]] || fail "license NVIDIA -> proprietary (got $r)"
+mk_modinfo "Dual MIT/GPL"
+r="$(PATH="$TMP:$PATH" bash -c 'source scripts/lib/p2p-state.sh; p2p_driver_flavor')"
+[[ "$r" == "open" ]] || fail "license Dual MIT/GPL -> open (got $r)"
+mk_modinfo ""
+r="$(PATH="$TMP:$PATH" bash -c 'source scripts/lib/p2p-state.sh; p2p_driver_flavor')"
+[[ "$r" == "unknown" ]] || fail "empty license -> unknown (got $r)"
+echo "  ✓ driver-flavor probe: NVIDIA->proprietary, Dual MIT/GPL->open, empty->unknown"
 
 echo "test-p2p-state: ok"


### PR DESCRIPTION
## Problem (#688)

`NVLINK_MODE=pcie_p2p` set `_NVLINK_ENABLED=1` and printed **`P2P ENABLED — custom all-reduce ON`** on the env var alone — it never checked the driver actually granted peer access. `p2p_classify_engagement` then read that line as `on`, so `report.sh` reported P2P engaged even on a stock/closed GeForce driver that silently refuses it (NCCL falls back → throughput ≈ P2P-off).

This false `✓` misled a 4×3090 A/B on #688: the "P2P on" arm looked engaged but wasn't — the user (correctly) suspected the numbers, then ran `nvidia-smi topo -p2p rw` and found the truth. The launcher should have run that check for them.

## Fix

The `pcie_p2p` force path now runs the **existing** `_pcie_p2p_available` probe (`topo -p2p r`) and reports honestly:

| driver grants P2P? | boot line | classify | verdict |
|---|---|---|---|
| **yes** (`topo -p2p: OK`) | `P2P ENABLED` | `on` | `✓ PCIe P2P engaged` |
| **no** (`≠ OK`) | `P2P REQUESTED (UNVERIFIED)` + warning w/ `topo -p2p rw` verify cmd | `requested` | `⚠ WARN: forced but driver refused` |

**The config is still forced on either way** — the escape hatch for a patched driver whose probe is stricter than reality is preserved. We just never *claim* engagement without evidence.

- `p2p_classify_engagement` gains a `requested` state (checked first).
- `p2p_verdict` emits a WARN for `requested` **even when capability=none** — previously that case was silently dropped (cap=none → return 0), so a refused-P2P rig got *no* warning at all.

## Also: driver-flavor reporting (answers "detect aikitoria?" from the thread)

`p2p_driver_flavor()` reports **open vs proprietary** kernel module (via `modinfo license`) — the actionable P2P-triage signal for GeForce (proprietary refuses P2P; open modules can grant it). `report.sh` renders it in the interconnect section, paired with the `topo -p2p` result.

⚠️ It deliberately does **not** claim to fingerprint the aikitoria fork specifically: that fork is NVIDIA's open modules with the P2P block removed, so its `license`/`version`/filename are identical to stock `nvidia-open`. The functional proof a P2P-enabling module is *working* is `topo -p2p rw = OK`, not module metadata — so we report the detectable part and let the topo result be the proof.

## Tests
- `test-detect-nvlink-autop2p`: pcie_p2p verified→`ENABLED` / unverified→`UNVERIFIED` message, and config-forced-on in **both** cases.
- `test-p2p-state`: `requested` classify + verdict (WARN at cap=none, silent at 1 GPU); `p2p_driver_flavor` (NVIDIA→proprietary, Dual MIT/GPL→open, empty→unknown).
- **Live-validated on the reference rig** (proprietary driver + CNS → correctly says `UNVERIFIED`, flavor `proprietary`; `auto` path unchanged).

Scoped support-script change (no catalog-shape impact) — ran the 6 nvlink/p2p/estate/report tests, all green.

Refs #688, #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)