### PR TITLE
feat(resolver): arch-gate beellama DFlash single-card default off non-sm_86 (#693)

### DIFF
--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -931,7 +931,7 @@ resolve_launch_default_variant() {
     topology="$(launch_topology_from_selected)"
     MODEL_NAME="${MODEL_NAME:-$PRIMARY_MODEL}"
     MODEL_NAME="$(normalize_model_name "$MODEL_NAME")"
-    if ! target="$(x_default_dispatch "$ROOT_DIR" "$variant" "$topology" "$MODEL_NAME")"; then
+    if ! target="$(x_default_dispatch "$ROOT_DIR" "$variant" "$topology" "$MODEL_NAME" "$(primary_sm_from_gpu_spec "$(selected_gpu_profile_spec 2>/dev/null || true)")")"; then
       echo "[launch] ERROR: cannot resolve default variant '${variant}'." >&2
       exit 1
     fi
@@ -983,7 +983,7 @@ try_bare_launch_default() {
   local pin_key pin_value
   pin_key="$(model_pin_key "$model")"
   pin_value="${!pin_key:-}"
-  if ! target="$(model_default_target "$ROOT_DIR" "$model" "$topology")"; then
+  if ! target="$(model_default_target "$ROOT_DIR" "$model" "$topology" "$(primary_sm_from_gpu_spec "$(selected_gpu_profile_spec 2>/dev/null || true)")")"; then
     return 1
   fi
   MODEL_NAME="$model"
@@ -1016,7 +1016,7 @@ try_pinned_fast_path() {
   fi
   local topology target
   topology="$(launch_topology_from_selected)"
-  if ! target="$(model_default_target "$ROOT_DIR" "$model" "$topology")"; then
+  if ! target="$(model_default_target "$ROOT_DIR" "$model" "$topology" "$(primary_sm_from_gpu_spec "$(selected_gpu_profile_spec 2>/dev/null || true)")")"; then
     return 1
   fi
   if [[ ! -t 0 ]]; then

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -63,6 +63,7 @@ def _entry(
     recommended_engine_features=None,
     required_sm=None,
     fallback_sm=None,
+    default_arch_allow=None,
     status="production",
     status_note=None,
     category=None,
@@ -113,6 +114,14 @@ def _entry(
         # Live-confirmed on 2x3090 sm_86 2026-07-11: NVFP4-27B boots,
         # 69.7/85.5 TPS, 8-pack 110/150 (ties the fp8 tier's 109).
         entry["fallback_sm"] = fallback_sm
+    if default_arch_allow is not None:
+        # GPU arches (compute-cap strings, e.g. "8.6") on which this slug is
+        # validated enough to be an AUTO-DEFAULT. When set, the curated-default
+        # walk skips it on any OTHER detected arch (see default_arch_gated).
+        # This gates only the *default* — an explicit selection / user pin still
+        # launches it (with a warning). #693: beellama DFlash returns gibberish
+        # on Ada/sm_8.9; we only ever validated it on sm_8.6.
+        entry["default_arch_allow"] = list(default_arch_allow)
     if category is not None:
         entry["category"] = category
     return entry
@@ -357,6 +366,9 @@ COMPOSE_REGISTRY = {
     # in the compose. kv_format reflects K-side precision (V is q4_1).
     "beellama/dflash": _entry(
         model="qwen3.6-27b", weights_variant="beellama-q5ks-dflash", workload="fast-chat",
+        # sm_86-only auto-default: DFlash returns gibberish on Ada/sm_8.9 (#693);
+        # off-86 the curated walk steers to ik-llama/iq4ks-mtp instead.
+        default_arch_allow=["8.6"],
         engine="beellama-local", drafter="anbeeld-qwen-dflash", kv_format="q5_0",
         tp=1, max_ctx=102400, max_num_seqs=1, mem_util=None,
         compose_path="models/qwen3.6-27b/beellama/compose/single/beellama-q5ks-dflash/dflash.yml",
@@ -364,7 +376,7 @@ COMPOSE_REGISTRY = {
         default_port=8060,
         kvcalc_key="SKIP",
         status="caveats",
-        status_note="Single-GPU default. Launchers inject the beellama engine pin (Anbeeld's official v0.3.2-preview digest — engines/beellama-local.yml install.spec); sm_86 verified on this rig 2026-07-04 (verify-full all-pass), sm_89 runs the sm_80 cubins. 5090/sm_120: official images build on CUDA 12.4 and carry NO sm_120 (upstream ask Anbeeld#85) — self-build with CUDA_DOCKER_ARCH=120 + CUDA_VERSION=12.8.1 (engine notes have the verified recipe) or the unmaintained v0.3.0-feature-level snapshot ghcr.io/noonghunna/beellama-cpp:multiarch-v0.3.0-efe856397. Usable ctx ceiling 160K (200K OOMs on prefill); ships 102K. DFlash prose is net-positive on tok/s (+27% vs no-spec, re-tested 2026-06-03); the earlier 'prose-DFlash regression' is RETRACTED — it was an AR over-read + wrong baseline (docs/UPSTREAM.md).",
+        status_note="Single-GPU default. Launchers inject the beellama engine pin (Anbeeld's official v0.3.2-preview digest — engines/beellama-local.yml install.spec); sm_86 verified on this rig 2026-07-04 (verify-full all-pass); sm_89 IS natively compiled (890 in the image's CUDA ARCHS per the #693 boot log — NOT an sm_80 fallback) but DFlash returns gibberish on Ada, so default_arch_allow=[\"8.6\"] steers 4090/5090 off this default (#693). 5090/sm_120: official images build on CUDA 12.4 and carry NO sm_120 (upstream ask Anbeeld#85) — self-build with CUDA_DOCKER_ARCH=120 + CUDA_VERSION=12.8.1 (engine notes have the verified recipe) or the unmaintained v0.3.0-feature-level snapshot ghcr.io/noonghunna/beellama-cpp:multiarch-v0.3.0-efe856397. Usable ctx ceiling 160K (200K OOMs on prefill); ships 102K. DFlash prose is net-positive on tok/s (+27% vs no-spec, re-tested 2026-06-03); the earlier 'prose-DFlash regression' is RETRACTED — it was an AR over-read + wrong baseline (docs/UPSTREAM.md).",
     ),
 
     # Qwopus3.6-27B-Coder (Jackrong coder fine-tune of Qwen3.6-27B) — single 3090, Q5_K_M
@@ -681,6 +693,11 @@ COMPOSE_REGISTRY = {
     # (Gemma-4 MTP) merges — see docs/UPSTREAM.md.
     "beellama/gemma-dflash": _entry(
         model="gemma-4-31b", weights_variant="beellama-q4ks-dflash", workload="fast-chat",
+        # sm_86-only auto-default: same beellama DFlash path as #693 (validated
+        # only on sm_8.6). Gemma has no other single-card default, so off-86 the
+        # curated walk returns None → "pick explicitly" (honest: no validated
+        # fast single-card Gemma path exists on Ada).
+        default_arch_allow=["8.6"],
         engine="beellama-local", drafter="anbeeld-gemma-dflash", kv_format="q5_0",
         tp=1, max_ctx=128000, max_num_seqs=1, mem_util=None,
         compose_path="models/gemma-4-31b/beellama/compose/single/beellama-q4ks-dflash/dflash.yml",
@@ -688,7 +705,7 @@ COMPOSE_REGISTRY = {
         default_port=8061,
         kvcalc_key="SKIP",
         status="caveats",
-        status_note="Single-GPU default — the only viable fast single-card Gemma-4 path on Ampere. Launchers inject the beellama engine pin (Anbeeld's official v0.3.2-preview digest — engines/beellama-local.yml install.spec); sm_89 runs the sm_80 cubins. 5090/sm_120: official images build on CUDA 12.4 and carry NO sm_120 (upstream ask Anbeeld#85) — self-build with CUDA_DOCKER_ARCH=120 + CUDA_VERSION=12.8.1 (engine notes) or the unmaintained v0.3.0-feature-level snapshot ghcr.io/noonghunna/beellama-cpp:multiarch-v0.3.0-efe856397. DFlash prose is net-positive on tok/s (+28–31% vs no-spec, re-tested 2026-06-03; earlier 'prose regression' RETRACTED — AR over-read + wrong baseline); re-point to mainline llama.cpp#23398 Gemma-4 MTP when it merges — docs/UPSTREAM.md.",
+        status_note="Single-GPU default — the only viable fast single-card Gemma-4 path on Ampere. Launchers inject the beellama engine pin (Anbeeld's official v0.3.2-preview digest — engines/beellama-local.yml install.spec); sm_89 IS natively compiled (890 in the image's CUDA ARCHS — NOT an sm_80 fallback) but the same beellama DFlash path (validated only on sm_86) is unvalidated/likely-broken on Ada, so default_arch_allow=[\"8.6\"] steers off-86 users off this default (#693). 5090/sm_120: official images build on CUDA 12.4 and carry NO sm_120 (upstream ask Anbeeld#85) — self-build with CUDA_DOCKER_ARCH=120 + CUDA_VERSION=12.8.1 (engine notes) or the unmaintained v0.3.0-feature-level snapshot ghcr.io/noonghunna/beellama-cpp:multiarch-v0.3.0-efe856397. DFlash prose is net-positive on tok/s (+28–31% vs no-spec, re-tested 2026-06-03; earlier 'prose regression' RETRACTED — AR over-read + wrong baseline); re-point to mainline llama.cpp#23398 Gemma-4 MTP when it merges — docs/UPSTREAM.md.",
     ),
     # Dual-card beellama Gemma-4 (layer-split, 262K) — PARKED upstream-gated 2026-05-31.
     # Boots + recalls 262K fine, but DFlash spec-dec is broken on multi-GPU in our pinned
@@ -1074,13 +1091,35 @@ def model_set():
     return {model for (model, _engine, _topology) in DEFAULTS}
 
 
-def _functional_default(model, engine, topology):
-    """A DEFAULTS slug for (model, engine, topology) whose status is functional.
+def default_arch_gated(slug, detected_sm):
+    """True when `slug` may NOT auto-default on the detected GPU arch.
 
-    Returns the slug only when an entry exists AND its registry status is NOT
-    in the (NA) set (experimental/preview/upstream-gated/deprecated) — a
-    broken/preview config must never become someone's auto-default (§12.5).
-    Returns None otherwise.
+    A slug with a `default_arch_allow` list (compute-cap strings) is validated
+    as a default only on those arches. FAIL-OPEN: no allow-list, or an
+    unknown/empty `detected_sm`, never gates — so CI / headless / an
+    undetectable GPU keep today's behavior. #693: beellama DFlash is validated
+    only on sm_8.6 and returns gibberish on sm_8.9 (Ada), so its default slug
+    carries default_arch_allow=["8.6"].
+    """
+    if not detected_sm:
+        return False
+    entry = COMPOSE_REGISTRY.get(slug)
+    if not entry:
+        return False
+    allow = entry.get("default_arch_allow")
+    if not allow:
+        return False
+    return detected_sm not in allow
+
+
+def _functional_default(model, engine, topology, detected_sm=None):
+    """A DEFAULTS slug for (model, engine, topology) whose status is functional
+    AND (when detected_sm is known) not arch-gated off the detected arch.
+
+    Returns the slug only when an entry exists, its registry status is NOT in
+    the (NA) set (experimental/preview/upstream-gated/deprecated), and it is not
+    default_arch_gated for detected_sm — a broken/preview/off-arch config must
+    never become someone's auto-default (§12.5, #693). Returns None otherwise.
     """
     slug = DEFAULTS.get((model, engine, topology))
     if not slug:
@@ -1090,17 +1129,19 @@ def _functional_default(model, engine, topology):
         return None
     if entry.get("status", "production") not in FUNCTIONAL_STATUSES:
         return None
+    if default_arch_gated(slug, detected_sm):
+        return None
     return slug
 
 
-def curated_default_target(model, topology):
+def curated_default_target(model, topology, detected_sm=None):
     """Curated fallback (§4): walk ENGINE_PREFERENCE[family], first functional
-    DEFAULTS slug wins. Returns the slug, or None if no functional curated
-    default exists for (model, topology).
+    (and, for detected_sm, not-arch-gated) DEFAULTS slug wins. Returns the slug,
+    or None if no functional curated default exists for (model, topology[, sm]).
     """
     family = _topology_family(topology)
     for engine in ENGINE_PREFERENCE.get(family, []):
-        slug = _functional_default(model, engine, topology)
+        slug = _functional_default(model, engine, topology, detected_sm)
         if slug:
             return slug
     return None

--- a/scripts/lib/registry-emit.sh
+++ b/scripts/lib/registry-emit.sh
@@ -274,7 +274,60 @@ PY_DEFAULT
 
 # --- PR-B: model-default resolver (the single injection point) ---------------
 #
-# model_default_target ROOT MODEL TOPOLOGY  →  resolved slug on stdout.
+# primary_sm_from_gpu_spec GPU_SPEC  →  first GPU's compute-cap ("8.6") on stdout.
+# GPU_SPEC is the switch/launch "idx|name|mem|sm;idx|name|mem|sm" form. Empty
+# output when the spec is empty/malformed → callers fail-open (no arch gating).
+primary_sm_from_gpu_spec() {
+  local spec="${1:-}" first
+  first="${spec%%;*}"            # first GPU entry
+  [[ "$first" == *"|"* ]] || { printf ''; return 0; }
+  printf '%s' "${first##*|}"     # last |-field = sm
+}
+
+# warn_if_default_arch_gated ROOT SLUG DETECTED_SM  →  loud stderr warning when
+# SLUG is validated as a default only on other arches than DETECTED_SM (its
+# default_arch_allow). No-op otherwise. Covers explicit selection + user pins of
+# an off-arch slug (the curated default already steers away). #693.
+warn_if_default_arch_gated() {
+  local root="$1" slug="$2" sm="$3"
+  [[ -n "$slug" && -n "$sm" ]] || return 0
+  python3 - "$root" "$slug" "$sm" <<'PY_ARCH_WARN'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+sys.path.insert(0, str(root))
+from scripts.lib.profiles.compose_registry import (  # noqa: E402
+    COMPOSE_REGISTRY,
+    curated_default_target,
+    default_arch_gated,
+    model_of_slug,
+    slug_topology,
+)
+
+slug, sm = sys.argv[2], sys.argv[3]
+if not default_arch_gated(slug, sm):
+    raise SystemExit(0)
+entry = COMPOSE_REGISTRY.get(slug, {})
+allow = ", ".join("sm_" + a for a in entry.get("default_arch_allow", []))
+model = model_of_slug(slug)
+alt = curated_default_target(model, slug_topology(slug) or "single", sm) if model else None
+rec = (
+    f"Recommended on your card: {alt} (pin it: scripts/switch.sh --set-default {alt})."
+    if alt
+    else "No validated single-card default exists for your arch — run a dual "
+    "config or pick a slug explicitly."
+)
+print(
+    f"[arch-gate] WARNING: {slug} is validated as a default only on {allow} "
+    f"(RTX 3090); your GPU is sm_{sm}. beellama's DFlash path returns gibberish "
+    f"on Ada/sm_8.9 and is unvalidated on other arches (club-3090 #693). {rec}",
+    file=sys.stderr,
+)
+PY_ARCH_WARN
+}
+
+# model_default_target ROOT MODEL TOPOLOGY [DETECTED_SM]  →  resolved slug on stdout.
 #
 # Resolution precedence ladder (design §3); `--variant X` (caller-explicit) is
 # handled by the callers BEFORE they reach here, so this implements:
@@ -288,7 +341,7 @@ PY_DEFAULT
 # only the resolved slug goes to stdout. Returns non-zero with a clear message
 # when no functional default exists at any topology (never crashes).
 model_default_target() {
-  local root="$1" model="$2" topology="$3"
+  local root="$1" model="$2" topology="$3" detected_sm="${4:-}"
   # Compute the .env pin key for this model, then read its value from the
   # environment (the caller has already loaded .env into the env).
   local pin_key pin_value
@@ -302,7 +355,7 @@ PY_PINKEY
 )"
   pin_value="${!pin_key:-}"
 
-  python3 - "$root" "$model" "$topology" "$pin_value" "$pin_key" <<'PY_MODEL_DEFAULT'
+  python3 - "$root" "$model" "$topology" "$pin_value" "$pin_key" "$detected_sm" <<'PY_MODEL_DEFAULT'
 from __future__ import annotations
 
 import sys
@@ -321,7 +374,8 @@ from scripts.lib.profiles.compose_registry import (  # noqa: E402
     _topology_family,
 )
 
-model, topology, pin_value, pin_key = sys.argv[2:6]
+model, topology, pin_value, pin_key, detected_sm = sys.argv[2:7]
+_sm = detected_sm or None
 
 
 def warn(msg: str) -> None:
@@ -368,8 +422,8 @@ if community:
     print(community)
     raise SystemExit(0)
 
-# 3) Curated fallback (§4) at the detected topology.
-slug = curated_default_target(model, topology)
+# 3) Curated fallback (§4) at the detected topology (arch-gated for the GPU).
+slug = curated_default_target(model, topology, _sm)
 if slug:
     print(slug)
     raise SystemExit(0)
@@ -377,7 +431,7 @@ if slug:
 # 4) Degradation (§6): notice + nearest-lower topology, then a clear message.
 fallback_topology = _nearest_lower_topology(topology)
 while fallback_topology:
-    slug = curated_default_target(model, fallback_topology)
+    slug = curated_default_target(model, fallback_topology, _sm)
     if slug:
         warn(
             f"no functional default for {model!r} on the detected "
@@ -720,7 +774,7 @@ PY_JSON
   return "$_py_rc"
 }
 
-# x_default_dispatch ROOT TOKEN TOPOLOGY MODEL  →  resolved slug on stdout.
+# x_default_dispatch ROOT TOKEN TOPOLOGY MODEL [DETECTED_SM]  →  slug on stdout.
 #
 # Parses an `X/default` token (design §13.1): if X is an engine name →
 # engine-recommendation (registry_default_target on the given MODEL); else if X
@@ -728,7 +782,7 @@ PY_JSON
 # sets come from the registry and are disjoint. The caller passes the model to
 # use for the engine-recommendation branch (its PRIMARY_MODEL / chosen model).
 x_default_dispatch() {
-  local root="$1" token="$2" topology="$3" model="$4" x
+  local root="$1" token="$2" topology="$3" model="$4" detected_sm="${5:-}" x
   x="${token%/default}"
   local kind
   kind="$(python3 - "$root" "$x" <<'PY_DISPATCH'
@@ -750,7 +804,7 @@ PY_DISPATCH
       registry_default_target "$root" "$model" "$x" "$topology"
       ;;
     model)
-      model_default_target "$root" "$x" "$topology"
+      model_default_target "$root" "$x" "$topology" "$detected_sm"
       ;;
     *)
       echo "[default] ERROR: '${token}': '${x}' is neither a known engine nor a known model." >&2

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -205,7 +205,7 @@ resolve_default_variant() {
     return 0
   elif [[ "$variant" =~ ^([^/]+)/default$ ]]; then
     topology="$(switch_topology_from_gpus)"
-    if ! target="$(x_default_dispatch "$ROOT_DIR" "$variant" "$topology" "$PRIMARY_MODEL")"; then
+    if ! target="$(x_default_dispatch "$ROOT_DIR" "$variant" "$topology" "$PRIMARY_MODEL" "$(primary_sm_from_gpu_spec "$(switch_gpu_profile_spec 2>/dev/null || true)")")"; then
       echo "ERROR: cannot resolve default variant '${variant}'." >&2
       exit 1
     fi
@@ -1211,6 +1211,10 @@ fi
 
 [[ -n "$VARIANT" ]] || usage
 VARIANT="$(resolve_default_variant "$VARIANT")"
+# Explicit selection / pin of an off-arch default (e.g. beellama/dflash on a
+# 4090) still launches — but warn loudly (#693). The curated default already
+# steered away; this catches the deliberate-or-pinned case.
+warn_if_default_arch_gated "$ROOT_DIR" "$VARIANT" "$(primary_sm_from_gpu_spec "$(switch_gpu_profile_spec 2>/dev/null || true)")"
 
 resolve_ready_url "${VARIANT}"
 down_running

--- a/scripts/tests/test-model-default-resolver.sh
+++ b/scripts/tests/test-model-default-resolver.sh
@@ -66,6 +66,47 @@ assert_contains "$out" "falling back to the dual default" "gemma multi4 degradat
 assert_eq "$(model_default_target "$ROOT_DIR" gemma-4-31b multi4 2>/dev/null)" \
   "vllm/gemma-31b-dual" "gemmamulti4 degrades to dual slug"
 
+# --- arch-gate: beellama DFlash default steers off non-sm_86 (#693) ----------
+# On sm_8.6 (RTX 3090) the beellama DFlash default is unchanged; on any other
+# DETECTED arch the curated walk skips it (DFlash returns gibberish on Ada) and
+# falls through to the next functional engine. sm empty/unknown → fail-open (so
+# CI / headless keep today's behavior — the 3-arg calls above prove that).
+assert_eq "$(model_default_target "$ROOT_DIR" qwen3.6-27b single 8.6 2>/dev/null)" \
+  "beellama/dflash" "qwen single sm_8.6 → beellama (on-arch, unchanged)"
+assert_eq "$(model_default_target "$ROOT_DIR" qwen3.6-27b single 8.9 2>/dev/null)" \
+  "ik-llama/iq4ks-mtp" "qwen single sm_8.9 (Ada) → steers to ik-llama (#693)"
+assert_eq "$(model_default_target "$ROOT_DIR" qwen3.6-27b single 12.0 2>/dev/null)" \
+  "ik-llama/iq4ks-mtp" "qwen single sm_12.0 (Blackwell) → steers to ik-llama"
+assert_eq "$(model_default_target "$ROOT_DIR" qwen3.6-27b single '' 2>/dev/null)" \
+  "beellama/dflash" "qwen single sm unknown → fail-open (beellama)"
+# gemma single has no other single default → off-arch degrades to pick-explicitly.
+assert_eq "$(model_default_target "$ROOT_DIR" gemma-4-31b single 8.6 2>/dev/null)" \
+  "beellama/gemma-dflash" "gemma single sm_8.6 → beellama (unchanged)"
+if model_default_target "$ROOT_DIR" gemma-4-31b single 8.9 >/dev/null 2>&1; then
+  note "gemma single sm_8.9 should have NO default (beellama gated, no fallback)"
+fi
+assert_contains "$(model_default_target "$ROOT_DIR" gemma-4-31b single 8.9 2>&1)" \
+  "pick a config explicitly" "gemma single sm_8.9 → pick-explicitly"
+# X/default dispatch threads the sm too.
+assert_eq "$(x_default_dispatch "$ROOT_DIR" qwen3.6-27b/default single qwen3.6-27b 8.9 2>/dev/null)" \
+  "ik-llama/iq4ks-mtp" "qwen/default X-dispatch on sm_8.9 → ik-llama"
+assert_eq "$(x_default_dispatch "$ROOT_DIR" qwen3.6-27b/default single qwen3.6-27b 8.6 2>/dev/null)" \
+  "beellama/dflash" "qwen/default X-dispatch on sm_8.6 → beellama"
+
+# --- helpers: primary_sm_from_gpu_spec + warn_if_default_arch_gated -----------
+assert_eq "$(primary_sm_from_gpu_spec '0|NVIDIA GeForce RTX 4090|24564|8.9;1|x|24564|8.9')" \
+  "8.9" "primary_sm_from_gpu_spec extracts the first GPU sm"
+assert_eq "$(primary_sm_from_gpu_spec '')" "" "primary_sm_from_gpu_spec empty → empty"
+warn_out="$(warn_if_default_arch_gated "$ROOT_DIR" beellama/dflash 8.9 2>&1 >/dev/null)"
+assert_contains "$warn_out" "arch-gate" "warn fires for beellama/dflash on sm_8.9"
+assert_contains "$warn_out" "ik-llama/iq4ks-mtp" "warn recommends ik-llama for qwen"
+assert_contains "$(warn_if_default_arch_gated "$ROOT_DIR" beellama/gemma-dflash 8.9 2>&1 >/dev/null)" \
+  "No validated single-card default" "gemma warn → no-fallback message"
+assert_eq "$(warn_if_default_arch_gated "$ROOT_DIR" beellama/dflash 8.6 2>&1)" \
+  "" "warn silent for beellama/dflash on sm_8.6 (on-arch)"
+assert_eq "$(warn_if_default_arch_gated "$ROOT_DIR" ik-llama/iq4ks-mtp 8.9 2>&1)" \
+  "" "warn silent for a non-gated slug"
+
 # --- X/default dispatch ------------------------------------------------------
 # engine name → engine recommendation (back-compat).
 assert_eq "$(x_default_dispatch "$ROOT_DIR" vllm/default single qwen3.6-27b 2>/dev/null)" \


### PR DESCRIPTION
## Why

beellama's DFlash path returns gibberish (`//////`) on Ada — **[#693](https://github.com/noonghunna/club-3090/issues/693)** reproduced it on a 4090 (native sm_89 kernels present; it's a DFlash *code* bug, not a cubin gap). But `beellama/dflash` (Qwen) and `beellama/gemma-dflash` (Gemma) are the shipped **single-card defaults**, so a bare `launch.sh` on a 4090/5090 silently landed on a broken config.

## What

A per-slug **`default_arch_allow`** field (compute-cap allow-list). When set, the curated-default walk skips the slug on any *other* detected arch:

| rig | qwen single default | gemma single default |
|---|---|---|
| sm_8.6 (3090) | `beellama/dflash` (unchanged) | `beellama/gemma-dflash` (unchanged) |
| sm_8.9 (4090) | **→ `ik-llama/iq4ks-mtp`** | **→ "pick explicitly"** (no other default) |
| sm_12.0 (5090) | **→ `ik-llama/iq4ks-mtp`** | **→ "pick explicitly"** |
| unknown / CI | `beellama/dflash` (fail-open) | `beellama/gemma-dflash` (fail-open) |

- **Steers, doesn't block:** on Ada, spec-dec still works via MTP (`ik-llama/iq4ks-mtp`) — only DFlash is broken. Gemma has no other single default, so it honestly degrades to "pick explicitly".
- **FAIL-OPEN:** unknown/empty `detected_sm` never gates → CI / headless / sm_8.6 keep today's behavior, so **parity + existing tests are unaffected**.
- **Explicit selection / user pin still launches** (never block) but **warns loudly** (`warn_if_default_arch_gated`) with the validated path.
- **Threading:** `model_default_target` / `x_default_dispatch` take an optional `DETECTED_SM`; `switch.sh` + `launch.sh` derive it from their gpu-spec on the actual-boot paths. The `--list` display loop and `registry-emit --json` stay **arch-blind** (canonical) → `switch`↔`emit` parity holds and c3 is unchanged.

## Also

Corrects a wrong registry `status_note`: sm_89 is **natively compiled** (`890` in the image's CUDA `ARCHS` per the #693 boot log), **not** an sm_80 fallback — so the Ada gibberish is a DFlash code bug (contrast the 5090/sm_120, which has *no* kernels at all and needs a CUDA-12.8 rebuild).

## Tests
- Arch-gate steering (8.6 / 8.9 / 12.0 / unknown), gemma degradation, X-dispatch sm threading, `primary_sm_from_gpu_spec`, `warn_if_default_arch_gated` (fires off-arch, silent on-arch / non-gated) — added to `test-model-default-resolver`.
- **Live-validated on 2×3090** (sm_8.6 → unchanged; faked 8.9 → steers + warns).
- Full sweep green except 3 environment-only artifacts (`test-classifier`/`test-dedup` = 45s sweep timeout, `test-submit-bench` = gitignored fixtures absent in a fresh worktree — all pass on master).

Refs #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)