### PR TITLE
tools: add repack_prefix.py — safetensors key-rename for AutoRound INT4 checkpoints

### DIFF
--- a/scripts/lib/repackage_autoround_int4.py
+++ b/scripts/lib/repackage_autoround_int4.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Repackage an AutoRound INT4 checkpoint that the transformers `_weight_conversions`
+revert bug left malformed.
+
+Two output modes (tensor DATA is never decoded/re-encoded in either):
+
+  --mode text-only  (default)
+    1. Strips the stray ``model.language_model.`` weight-key prefix down to
+       ``model.`` so a text-only ``Qwen3_5ForCausalLM`` loader finds its tensors.
+    2. Drops orphan duplicate shards (index-referenced files only).
+    3. Emits a clean, contiguously-numbered shard set + flat index.
+
+  --mode multimodal-wrapper  (--ref-config REQUIRED)
+    Produces the reference-shaped ``Qwen3_5ForConditionalGeneration`` layout so
+    vLLM's MTP speculative path fires (speculative.py fires on top-level
+    ``model_type == "qwen3_5"``; the draft sizes itself from
+    ``text_config.mtp_num_hidden_layers``). Input is the deduped ``model.*``
+    artifact:
+      * weight keys: ``model.<X>`` -> ``model.language_model.<X>`` (single
+        infix; the loader mapper inserts the internal ``.model.``). ``lm_head.*``
+        and ``mtp.*`` are untouched.
+      * config.json: rebuilt from --ref-config (canonical nested wrapper with
+        text_config + vision_config), overlaying THIS checkpoint's
+        ``quantization_config`` with its keys re-prefixed to
+        ``model.language_model.layers.*`` so Marlin/AutoRound matches every
+        quantized tensor.
+    No vision weights are needed -- serve with ``--language-model-only`` (the
+    vision tower becomes a meta-device StageMissingLayer).
+
+Each safetensors file is rewritten by renaming keys in its JSON header and
+stream-copying the data section verbatim.
+
+STDLIB ONLY. Reads default to utf-8 per repo convention.
+"""
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import shutil
+import sys
+
+from safetensors_repack import (
+    make_renamer,
+    reprefix_config,
+    rewrite_file,
+)
+
+# mode->direction mapping
+_MODE_DIR = {"text-only": "strip", "multimodal-wrapper": "inject"}
+
+
+def _direction(mode: str) -> str:
+    d = _MODE_DIR.get(mode)
+    if d is None:
+        raise ValueError(f"unknown mode: {mode!r}")
+    return d
+
+
+def build_mm_config(src_cfg: dict, ref_cfg: dict) -> dict:
+    """Reference nested wrapper as template; overlay THIS checkpoint's quant config
+    with keys re-prefixed to the language_model layout."""
+    cfg = copy.deepcopy(ref_cfg)
+    cfg["architectures"] = ["Qwen3_5ForConditionalGeneration"]
+    cfg["model_type"] = "qwen3_5"
+
+    src_qc = src_cfg.get("quantization_config")
+    if src_qc is None:
+        raise ValueError("source config.json has no quantization_config")
+    qc = copy.deepcopy(src_qc)
+    qc = reprefix_config({"quantization_config": qc}, "inject")["quantization_config"]
+
+    cfg["quantization_config"] = qc
+
+    # ensure the MTP draft can size itself
+    tc = cfg.get("text_config")
+    if not isinstance(tc, dict):
+        raise ValueError("--ref-config has no text_config block")
+    if tc.get("mtp_num_hidden_layers") is None:
+        src_tc = src_cfg.get("text_config", src_cfg)
+        tc["mtp_num_hidden_layers"] = src_tc.get("mtp_num_hidden_layers", 1)
+    return cfg
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--src", required=True)
+    ap.add_argument("--dst", required=True)
+    ap.add_argument("--mode", choices=["text-only", "multimodal-wrapper"],
+                    default="text-only")
+    ap.add_argument("--ref-config",
+                    help="reference Qwen3_5ForConditionalGeneration config.json "
+                         "(required for --mode multimodal-wrapper)")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    if args.mode == "multimodal-wrapper" and not args.ref_config:
+        ap.error("--ref-config is required for --mode multimodal-wrapper")
+
+    direction = _direction(args.mode)
+    src, dst = args.src, args.dst
+    rename_key = make_renamer(direction)
+
+    idx_path = os.path.join(src, "model.safetensors.index.json")
+    idx = json.load(open(idx_path, encoding="utf-8"))
+    wm = idx["weight_map"]
+
+    ref_files = sorted(set(wm.values()))
+    model_shards = [f for f in ref_files if f != "model_extra_tensors.safetensors"]
+    has_extra = "model_extra_tensors.safetensors" in ref_files
+    n_out = len(model_shards) + (1 if has_extra else 0)
+
+    fmap = {}
+    for i, f in enumerate(sorted(model_shards), start=1):
+        fmap[f] = f"model-{i:05d}-of-{n_out:05d}.safetensors"
+    if has_extra:
+        fmap["model_extra_tensors.safetensors"] = f"model-{n_out:05d}-of-{n_out:05d}.safetensors"
+
+    renamed_keys = sum(1 for k in wm if rename_key(k) != k)
+    print(f"mode: {args.mode}")
+    print(f"referenced files: {len(ref_files)} (orphans dropped)")
+    print(f"weight_map keys: {len(wm)}  keys renamed: {renamed_keys}")
+    print("file remap:")
+    for a, b in fmap.items():
+        print(f"  {a}  ->  {b}")
+    if args.dry_run:
+        print("dry-run: no files written")
+        return 0
+
+    os.makedirs(dst, exist_ok=True)
+
+    total_size = 0
+    for old_f in ref_files:
+        s = os.path.join(src, old_f)
+        d = os.path.join(dst, fmap[old_f])
+        print(f"rewriting {old_f} -> {fmap[old_f]}")
+        sizes = rewrite_file(s, d, rename_key)
+        total_size += sum(sizes.values())
+
+    new_wm = {rename_key(k): fmap[v] for k, v in wm.items()}
+    new_idx = {"metadata": {"total_size": total_size}, "weight_map": new_wm}
+    json.dump(new_idx, open(os.path.join(dst, "model.safetensors.index.json"), "w", encoding="utf-8"),
+              indent=2)
+
+    src_cfg = json.load(open(os.path.join(src, "config.json"), encoding="utf-8"))
+
+    if args.mode == "multimodal-wrapper":
+        ref_cfg = json.load(open(args.ref_config, encoding="utf-8"))
+        cfg = build_mm_config(src_cfg, ref_cfg)
+        json.dump(cfg, open(os.path.join(dst, "config.json"), "w", encoding="utf-8"), indent=2)
+    else:
+        cfg = reprefix_config(copy.deepcopy(src_cfg), "strip")
+        json.dump(cfg, open(os.path.join(dst, "config.json"), "w", encoding="utf-8"), indent=2)
+
+        sqc_path = os.path.join(src, "quantization_config.json")
+        if os.path.exists(sqc_path):
+            sqc = json.load(open(sqc_path, encoding="utf-8"))
+            # quantization_config.json has the same block_name_to_quantize shape
+            sqc = reprefix_config({"quantization_config": sqc}, "strip")["quantization_config"]
+            json.dump(sqc, open(os.path.join(dst, "quantization_config.json"), "w", encoding="utf-8"), indent=2)
+
+    # copy aux files verbatim (tokenizer + fable-specific chat template)
+    for aux in ("chat_template.jinja", "generation_config.json", "tokenizer.json",
+                "tokenizer_config.json", "special_tokens_map.json", "vocab.json", "merges.txt",
+                "added_tokens.json", "preprocessor_config.json"):
+        p = os.path.join(src, aux)
+        if os.path.exists(p):
+            shutil.copy2(p, os.path.join(dst, aux))
+            print(f"copied {aux}")
+
+    print(f"\nDONE ({args.mode}). total_size={total_size/1e9:.2f} GB -> {dst}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lib/safetensors_repack.py
+++ b/scripts/lib/safetensors_repack.py
@@ -1,0 +1,140 @@
+"""Low-level safetensors header-rename + verbatim-data-copy primitives.
+
+Used by:
+  - tools/repack_prefix.py  (standalone CLI)
+  - scripts/lib/repackage_autoround_int4.py  (AutoRound INT4 repackager)
+
+STDLIB ONLY.  Reads default to utf-8 per repo convention.
+"""
+from __future__ import annotations
+
+import json
+import struct
+
+COPY_CHUNK = 32 * 1024 * 1024  # 32 MiB
+
+
+# ---------------------------------------------------------------------------
+# Renamer factories
+# ---------------------------------------------------------------------------
+
+def make_renamer(direction: str):
+    """Return a key-renaming callable.
+
+    direction "strip":  model.language_model.* -> model.*
+    direction "inject": model.* -> model.language_model.*
+    """
+    if direction == "strip":
+        old, new = "model.language_model.", "model."
+    elif direction == "inject":
+        old, new = "model.", "model.language_model."
+    else:
+        raise ValueError(f"unknown direction: {direction!r}")
+
+    def rn(k: str) -> str:
+        if k == "__metadata__":
+            return k
+        if direction == "inject" and k.startswith(new):
+            return k  # already prefixed — don't double-inject
+        if k.startswith(old):
+            return new + k[len(old):]
+        return k  # lm_head.*, mtp.* untouched
+    return rn
+
+
+# ---------------------------------------------------------------------------
+# Header I/O
+# ---------------------------------------------------------------------------
+
+def read_header(path: str):
+    """Read a safetensors file's JSON header.  Returns (header_length, dict)."""
+    with open(path, "rb") as f:
+        hlen = struct.unpack("<Q", f.read(8))[0]
+        hdr = json.loads(f.read(hlen).decode("utf-8"))
+    return hlen, hdr
+
+
+# ---------------------------------------------------------------------------
+# Core rewrite
+# ---------------------------------------------------------------------------
+
+def rewrite_file(src: str, dst: str, rename_key) -> dict:
+    """Copy *src* -> *dst* renaming header keys; stream-copy data verbatim.
+
+    Returns {new_key: nbytes} for building the index.
+    """
+    hlen, hdr = read_header(src)
+    meta = hdr.get("__metadata__")
+    new_hdr: dict = {}
+    if meta is not None:
+        new_hdr["__metadata__"] = meta
+    sizes: dict[str, int] = {}
+    for k, v in hdr.items():
+        if k == "__metadata__":
+            continue
+        nk = rename_key(k)
+        if nk in new_hdr:
+            raise ValueError(f"key collision after rename: {nk}")
+        new_hdr[nk] = v
+        off = v["data_offsets"]
+        sizes[nk] = off[1] - off[0]
+
+    blob = json.dumps(new_hdr, separators=(",", ":")).encode("utf-8")
+    pad = (8 - (len(blob) % 8)) % 8
+    blob = blob + b" " * pad
+
+    with open(src, "rb") as fin, open(dst, "wb") as fout:
+        fin.seek(8 + hlen)  # skip original header -> data section
+        fout.write(struct.pack("<Q", len(blob)))
+        fout.write(blob)
+        while True:
+            chunk = fin.read(COPY_CHUNK)
+            if not chunk:
+                break
+            fout.write(chunk)
+    return sizes
+
+
+# ---------------------------------------------------------------------------
+# Config.json re-prefixing  (Qwen3.5/3.6 block_name_to_quantize + extra_config)
+# ---------------------------------------------------------------------------
+
+def reprefix_config(cfg: dict, direction: str) -> dict:
+    """Re-prefix ``quantization_config`` keys in a config.json dict.
+
+    ``block_name_to_quantize`` entries are exact string matches
+    (e.g. ``"model.layers"`` <-> ``"model.language_model.layers"``).
+    ``extra_config`` keys are prefix-matched with a trailing dot so that
+    ``model.layers.*`` never matches inside ``model.language_model.layers.*``.
+
+    Mutates and returns *cfg*.
+    """
+    qc = cfg.get("quantization_config")
+    if qc is None:
+        return cfg
+
+    if direction == "strip":
+        old_bn, new_bn = "model.language_model.layers", "model.layers"
+        old_ec, new_ec = "model.language_model.layers.", "model.layers."
+    else:
+        old_bn, new_bn = "model.layers", "model.language_model.layers"
+        old_ec, new_ec = "model.layers.", "model.language_model.layers."
+
+    bnq = qc.get("block_name_to_quantize")
+    if isinstance(bnq, list):
+        qc["block_name_to_quantize"] = [
+            new_bn if b == old_bn else b for b in bnq
+        ]
+    elif isinstance(bnq, str) and bnq == old_bn:
+        qc["block_name_to_quantize"] = new_bn
+
+    ec = qc.get("extra_config")
+    if isinstance(ec, dict):
+        qc["extra_config"] = {}
+        for k, v in ec.items():
+            if k.startswith(old_ec):
+                qc["extra_config"][new_ec + k[len(old_ec):]] = v
+            else:
+                qc["extra_config"][k] = v
+
+    return cfg

--- a/scripts/tests/test-repack-prefix.sh
+++ b/scripts/tests/test-repack-prefix.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# ──────────────────────────────────────────────────────────────────────────────
+# test-repack-prefix.sh — smoke test for tools/repack_prefix.py
+# ──────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+TOOL="$REPO/tools/repack_prefix.py"
+SRC="$TMP/src"
+DST="$TMP/dst"
+
+echo "=== test-repack-prefix: generate dummy checkpoint ==="
+mkdir -p "$SRC" "$DST"
+
+export SRCD="$SRC"
+python3 <<'PYEOF'
+import json, struct, os
+
+srcd = os.environ['SRCD']
+
+data = b'\x00\x00\x00\x00' * 8
+hdr = {
+    'model.language_model.layers.0.self_attn.q_proj.qweight': {
+        'dtype': 'F32', 'shape': [8], 'data_offsets': [0, 32],
+    },
+    'model.language_model.layers.0.self_attn.k_proj.qweight': {
+        'dtype': 'F32', 'shape': [8], 'data_offsets': [32, 64],
+    },
+}
+blob = json.dumps(hdr, separators=(',', ':')).encode()
+pad = (8 - (len(blob) % 8)) % 8
+blob = blob + b' ' * pad
+
+with open(os.path.join(srcd, 'model-00001-of-00001.safetensors'), 'wb') as f:
+    f.write(struct.pack('<Q', len(blob)))
+    f.write(blob)
+    f.write(data * 2)
+
+idx = {
+    'metadata': {'total_size': 64},
+    'weight_map': {
+        'model.language_model.layers.0.self_attn.q_proj.qweight': 'model-00001-of-00001.safetensors',
+        'model.language_model.layers.0.self_attn.k_proj.qweight': 'model-00001-of-00001.safetensors',
+    },
+}
+json.dump(idx, open(os.path.join(srcd, 'model.safetensors.index.json'), 'w'))
+
+cfg = {
+    'architectures': ['Qwen3_5ForCausalLM'],
+    'model_type': 'qwen3_5',
+    'quantization_config': {
+        'quant_method': 'auto-round',
+        'bits': 4,
+        'block_name_to_quantize': ['model.language_model.layers'],
+        'extra_config': {
+            'model.language_model.layers.0.self_attn.q_proj': {'bits': 16},
+        },
+    },
+}
+json.dump(cfg, open(os.path.join(srcd, 'config.json'), 'w'))
+print('generated dummy checkpoint in ' + srcd)
+PYEOF
+
+# ── Run repack_prefix.py strip ──────────────────────────────────────────────
+echo "=== test-repack-prefix: strip direction ==="
+python3 "$TOOL" --src "$SRC" --dst "$DST/stripped" --direction strip || {
+    echo "FAIL: strip run"; exit 1
+}
+
+# ── Verify strip ────────────────────────────────────────────────────────────
+echo "=== test-repack-prefix: verify strip ==="
+export DSTD="$DST"
+python3 <<'PYEOF'
+import json, os, struct
+
+dstd = os.environ['DSTD']
+out = os.path.join(dstd, 'stripped')
+
+idx = json.load(open(os.path.join(out, 'model.safetensors.index.json')))
+for k in idx['weight_map']:
+    assert k.startswith('model.'), 'key ' + k + ' should start with model.'
+    assert not k.startswith('model.language_model.'), 'key ' + k + ' should be stripped'
+print('  index: ' + str(len(idx['weight_map'])) + ' keys OK')
+
+cfg = json.load(open(os.path.join(out, 'config.json')))
+bnq = cfg['quantization_config']['block_name_to_quantize']
+assert isinstance(bnq, list) and bnq == ['model.layers'], 'bnq=' + str(bnq)
+ec = cfg['quantization_config']['extra_config']
+for k in ec:
+    assert k.startswith('model.layers.'), 'extra_config key ' + k + ' should start with model.layers.'
+print('  config.json quant keys OK')
+
+with open(os.path.join(out, 'model-00001-of-00001.safetensors'), 'rb') as f:
+    hlen = struct.unpack('<Q', f.read(8))[0]
+    hdr = json.loads(f.read(hlen))
+    for k in hdr:
+        if k == '__metadata__':
+            continue
+        assert k.startswith('model.'), 'safetensors key ' + k + ' should start with model.'
+        assert not k.startswith('model.language_model.'), 'safetensors key ' + k + ' should be stripped'
+    remaining = f.read()
+    assert len(remaining) == 64, 'expected 64 data bytes, got ' + str(len(remaining))
+    assert all(b == 0 for b in remaining), 'data bytes should be all zeros'
+print('  safetensors header + data integrity OK')
+
+print('strip: PASS')
+PYEOF
+
+# ── Roundtrip: strip -> inject ──────────────────────────────────────────────
+echo "=== test-repack-prefix: roundtrip (strip then inject) ==="
+# Use the stripped output as source for inject
+python3 "$TOOL" --src "$DST/stripped" --dst "$DST/roundtripped" --direction inject || {
+    echo "FAIL: roundtrip inject run"; exit 1
+}
+
+python3 <<'PYEOF'
+import json, os, struct
+
+dstd = os.environ['DSTD']
+out = os.path.join(dstd, 'roundtripped')
+
+idx = json.load(open(os.path.join(out, 'model.safetensors.index.json')))
+for k in idx['weight_map']:
+    assert k.startswith('model.language_model.'), 'key ' + k + ' should have language_model prefix'
+print('  index: ' + str(len(idx['weight_map'])) + ' keys OK')
+
+cfg = json.load(open(os.path.join(out, 'config.json')))
+bnq = cfg['quantization_config']['block_name_to_quantize']
+assert bnq == ['model.language_model.layers'], 'bnq=' + str(bnq)
+ec = cfg['quantization_config']['extra_config']
+for k in ec:
+    assert k.startswith('model.language_model.layers.'), 'extra_config key ' + k + ' should be prefixed'
+print('  config.json quant keys OK')
+
+print('roundtrip: PASS')
+PYEOF
+
+# ── Dry-run ─────────────────────────────────────────────────────────────────
+echo "=== test-repack-prefix: dry-run ==="
+python3 "$TOOL" --src "$SRC" --dst "$DST/dry" --direction strip --dry-run || {
+    echo "FAIL: dry-run"; exit 1
+}
+echo "dry-run: PASS"
+
+echo ""
+echo "=== ALL PASS ==="

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,14 @@
+# Tools
+
+| Tool | Purpose |
+|---|---|
+| [`repack_prefix.py`](repack_prefix.py) | Rename the `model.language_model.` ↔ `model.` prefix in safetensors checkpoint headers, stream-copying data bytes verbatim. Also re-prefixes `config.json` quantization keys. |
+| [`kv-calc.py`](kv-calc.py) | KV-cache calculator — estimate VRAM usage for a given model / ctx / batch. |
+| [`bump-engine-nightlies.sh`](bump-engine-nightlies.sh) | Bump engine image tags to the latest nightly across all composes. |
+| [`serve-cockpit/`](serve-cockpit/) | Textual TUI for inspecting and switching serving stacks. |
+| [`charts/`](charts/) | Performance / VRAM chart generation scripts. |
+| [`model-switch/`](model-switch/) | Helper scripts for model switching logic. |
+| [`residency-instrument/`](residency-instrument/) | VRAM residency instrumentation. |
+| [`test-console/`](test-console/) | Interactive test harnesses. |
+| [`tui-core/`](tui-core/) | Shared TUI widgets. |
+| [`grammar-eval/`](grammar-eval/) | Grammar evaluation tooling. |

--- a/tools/repack_prefix.py
+++ b/tools/repack_prefix.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Repack the ``model.language_model.`` <-> ``model.`` prefix in a safetensors checkpoint.
+
+Renames weight keys in safetensors JSON headers and stream-copies the binary
+data verbatim (never decode/re-encode).  Re-prefixes ``quantization_config``
+keys in ``config.json`` so the checkpoint loads correctly.
+
+Two directions:
+
+  strip  (default)   ``model.language_model.*`` -> ``model.*``
+                     Use when a VLM-wrapper artifact should become a plain
+                     ``Qwen3_5ForCausalLM`` text-only checkpoint.
+
+  inject              ``model.*`` -> ``model.language_model.*``
+                     Use when a text-only checkpoint must be embedded into a
+                     ``Qwen3_5ForConditionalGeneration`` multimodal layout so
+                     vLLM's MTP speculative path fires.
+
+STDLIB ONLY.  Reads default to utf-8 per repo convention.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+
+# Allow standalone invocation even when scripts/lib/ isn't on the path.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_LIB = os.path.join(_HERE, "..", "scripts", "lib")
+if os.path.isdir(_LIB) and _LIB not in sys.path:
+    sys.path.insert(0, _LIB)
+
+# fmt: off
+from safetensors_repack import (  # noqa: E402 — import after sys.path fixup
+    make_renamer,
+    read_header,
+    reprefix_config,
+    rewrite_file,
+)
+# fmt: on
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Repack safetensors checkpoint prefix.",
+    )
+    ap.add_argument("--src", required=True, help="source checkpoint directory")
+    ap.add_argument("--dst", required=True, help="output directory")
+    ap.add_argument(
+        "--direction",
+        choices=["strip", "inject"],
+        default="strip",
+        help="strip: model.language_model.* -> model.*  |  "
+        "inject: model.* -> model.language_model.*",
+    )
+    ap.add_argument("--dry-run", action="store_true",
+                    help="print what would be done without writing files")
+    args = ap.parse_args()
+
+    src, dst = args.src, args.dst
+    rename_key = make_renamer(args.direction)
+
+    # --- Load index ---------------------------------------------------------
+    idx_path = os.path.join(src, "model.safetensors.index.json")
+    if not os.path.exists(idx_path):
+        print(f"FATAL: no index found at {idx_path}", file=sys.stderr)
+        return 1
+
+    idx = json.load(open(idx_path, encoding="utf-8"))
+    wm = idx["weight_map"]
+
+    ref_files = sorted(set(wm.values()))
+    model_shards = [f for f in ref_files if f != "model_extra_tensors.safetensors"]
+    has_extra = "model_extra_tensors.safetensors" in ref_files
+    n_out = len(model_shards) + (1 if has_extra else 0)
+
+    fmap = {}  # old filename -> new contiguously-numbered filename
+    for i, f in enumerate(sorted(model_shards), start=1):
+        fmap[f] = f"model-{i:05d}-of-{n_out:05d}.safetensors"
+    if has_extra:
+        fmap["model_extra_tensors.safetensors"] = (
+            f"model-{n_out:05d}-of-{n_out:05d}.safetensors"
+        )
+
+    renamed_keys = sum(1 for k in wm if rename_key(k) != k)
+    print(f"direction: {args.direction}")
+    print(f"referenced files: {len(ref_files)}")
+    print(f"weight_map keys: {len(wm)}  keys renamed: {renamed_keys}")
+    print("file remap:")
+    for a, b in fmap.items():
+        print(f"  {a}  ->  {b}")
+
+    if args.dry_run:
+        print("dry-run: no files written")
+        return 0
+
+    os.makedirs(dst, exist_ok=True)
+
+    # --- Rewrite safetensors files ------------------------------------------
+    total_size = 0
+    for old_f in ref_files:
+        s = os.path.join(src, old_f)
+        if not os.path.exists(s):
+            print(f"WARNING: referenced file not found, skipping: {s}", file=sys.stderr)
+            continue
+        d = os.path.join(dst, fmap[old_f])
+        print(f"rewriting {old_f} -> {fmap[old_f]}")
+        sizes = rewrite_file(s, d, rename_key)
+        total_size += sum(sizes.values())
+
+    # --- Write new index ----------------------------------------------------
+    new_wm = {rename_key(k): fmap[v] for k, v in wm.items()}
+    new_idx = {"metadata": {"total_size": total_size}, "weight_map": new_wm}
+    json.dump(
+        new_idx,
+        open(os.path.join(dst, "model.safetensors.index.json"), "w", encoding="utf-8"),
+        indent=2,
+    )
+
+    # --- Re-prefix config.json ----------------------------------------------
+    src_cfg_path = os.path.join(src, "config.json")
+    if os.path.exists(src_cfg_path):
+        cfg = json.load(open(src_cfg_path, encoding="utf-8"))
+        cfg = reprefix_config(cfg, args.direction)
+        json.dump(cfg, open(os.path.join(dst, "config.json"), "w", encoding="utf-8"), indent=2)
+        print("re-prefixed config.json")
+
+    # --- Copy auxiliary files (best-effort) ---------------------------------
+    for aux in (
+        "chat_template.jinja",
+        "generation_config.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "special_tokens_map.json",
+        "vocab.json",
+        "merges.txt",
+        "added_tokens.json",
+        "preprocessor_config.json",
+        "quantization_config.json",
+    ):
+        p = os.path.join(src, aux)
+        if os.path.exists(p):
+            shutil.copy2(p, os.path.join(dst, aux))
+            print(f"copied {aux}")
+
+    print(f"\nDONE ({args.direction}). total_size={total_size/1e9:.2f} GB -> {dst}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
As discussed in #677: a stdlib-only tool that renames tensor keys in safetensors headers and verbatim-copies the data.

Two modes:
- **strip** — removes the `model.language_model.` prefix for normal text-only loading
- **inject** — wraps keys with the prefix so vLLM MTP spec-dec never loads the vision encoder

Includes `scripts/lib/safetensors_repack.py` (importable core shared with `repackage_autoround_int4.py`), a `tools/README.md` entry, and `scripts/tests/test-repack-prefix.sh` (smoke test).