### PR TITLE
fix(setup): consent-gated hf-CLI install — fixes PEP 668 externally-managed wall on WSL

### DIFF
--- a/docs/WSL_SETUP.md
+++ b/docs/WSL_SETUP.md
@@ -105,6 +105,16 @@ In VS Code, set the file's EOL to **LF** (bottom-right status bar) and enable `"
 
 ## 7. Download weights — `WEIGHTS` + `MODEL_DIR`
 
+**Prerequisite — the `hf` CLI.** `setup.sh` fetches weights with Hugging Face's `hf` CLI. On a fresh Ubuntu 24.04 / WSL, the usual `pip install huggingface-hub` is blocked (`error: externally-managed-environment` — that's [PEP 668](https://peps.python.org/pep-0668/), not a bug on your end). If the CLI is missing, `setup.sh` will **offer to install it for you** — isolated, via `pipx`/`uv`, no changes to system Python — just answer **Y**. To install it yourself first:
+
+```bash
+sudo apt install -y pipx
+pipx install 'huggingface-hub[hf_transfer]'
+pipx ensurepath      # then restart the terminal so `hf` lands on PATH
+```
+
+> ⚠️ **Don't use a raw `python -m venv` for this.** Activating a venv rewrites your `PATH` and can hide `docker` and your model paths (a common WSL trip-up). `pipx` installs the `hf` CLI *isolated* but on your PATH — no `activate`, nothing shadowed.
+
 For the **robust single-card path on a 24 GB card** (recommended on WSL2 — see step 10), fetch the **GGUF** weights for llama.cpp / ik_llama:
 
 ```bash

--- a/scripts/lib/profiles/downloader.py
+++ b/scripts/lib/profiles/downloader.py
@@ -109,17 +109,23 @@ class DownloadResult:
     failure: Optional[str] = None
     local_dir: str = ""
     # Actionable detail (populated for "hf-cli-missing"; the canonical
-    # install hint mirrored from setup.sh:418-421). Optional / additive —
-    # existing failure paths leave it "".
+    # PEP-668-aware install hint, in sync with setup.sh `ensure_hf_cli`).
+    # Optional / additive — existing failure paths leave it "".
     detail: str = ""
 
 
 # The canonical actionable message when NEITHER `hf` nor `huggingface-cli`
-# resolves — mirrors setup.sh:418-421 verbatim in intent.
+# resolves — PEP-668-aware (the bare `pip install` fails on externally-managed
+# Ubuntu 24.04 / WSL); mirrors the manual-options set in setup.sh `ensure_hf_cli`.
+# This library RETURNS the message (pull.sh surfaces it via
+# DownloadResult.detail); the interactive consent-gated install lives in setup.sh.
 _HF_CLI_MISSING_MSG = (
-    "neither 'hf' nor 'huggingface-cli' found. Install with: "
-    "pip install 'huggingface-hub[hf_transfer]'  or:  "
-    "uv tool install --with hf_transfer huggingface-hub"
+    "the 'hf' CLI is required but not installed. Recommended (isolated, on PATH, "
+    "works on Ubuntu 24.04 / WSL): 'sudo apt install -y pipx && "
+    "pipx install huggingface-hub[hf_transfer] && pipx ensurepath' then restart "
+    "your shell. Or with uv: 'uv tool install --with hf_transfer huggingface-hub'. "
+    "Quick override (modifies system Python): "
+    "'pip install --break-system-packages huggingface-hub[hf_transfer]'."
 )
 
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -547,6 +547,72 @@ if [[ "${SKIP_MODEL:-0}" == "1" ]]; then
   exit 0
 fi
 
+# Ensure an HF download CLI ('hf', or legacy 'huggingface-cli') is available.
+# If neither is present, offer a CONSENT-GATED, ISOLATED install (uv tool / pipx
+# — lands on PATH, no changes to system Python). We deliberately NEVER run
+# `pip --break-system-packages` or `sudo apt` on the user's behalf; those stay
+# copy-paste the user owns. Returns 0 when a CLI is available (already or after
+# an accepted install); prints the working manual options + returns 1 otherwise.
+# Honors CLUB3090_ASSUME_YES=1 for non-interactive opt-in. Fixes the PEP 668
+# `externally-managed-environment` wall on Ubuntu 24.04 / WSL, where the old
+# bare `pip install` hint could not run.
+ensure_hf_cli() {
+  command -v hf >/dev/null 2>&1 && return 0
+  command -v huggingface-cli >/dev/null 2>&1 && return 0
+
+  # First ISOLATED installer available (never touches system Python).
+  local installer="" cmd=""
+  if command -v uv >/dev/null 2>&1; then
+    installer="uv";   cmd="uv tool install --with hf_transfer huggingface-hub"
+  elif command -v pipx >/dev/null 2>&1; then
+    installer="pipx"; cmd="pipx install 'huggingface-hub[hf_transfer]'"
+  fi
+
+  if [[ -n "$installer" ]]; then
+    local go=""
+    if [[ "${CLUB3090_ASSUME_YES:-0}" == "1" ]]; then
+      go=1
+      echo "[model] hf CLI missing — CLUB3090_ASSUME_YES=1, installing via ${installer} (isolated)." >&2
+    elif [[ -t 0 ]]; then
+      echo "[model] The Hugging Face CLI ('hf') is required to download weights, but it's not installed." >&2
+      echo "[model] I can install it for you, isolated (on your PATH, no changes to system Python):" >&2
+      echo "[model]     ${cmd}" >&2
+      local reply=""
+      read -rp "[model] Install it now? [Y/n] " reply
+      case "${reply}" in ""|[Yy]|[Yy][Ee][Ss]) go=1 ;; esac
+    fi
+    if [[ -n "$go" ]]; then
+      echo "[model] Installing: ${cmd}" >&2
+      if eval "$cmd" >&2; then
+        # Freshly-installed console scripts land in ~/.local/bin (pipx + uv's
+        # default tool bin) — make them visible to THIS run, no shell restart.
+        export PATH="${HOME}/.local/bin:${PATH}"
+        hash -r 2>/dev/null || true
+        if command -v hf >/dev/null 2>&1 || command -v huggingface-cli >/dev/null 2>&1; then
+          echo "[model] hf CLI installed and on PATH." >&2
+          return 0
+        fi
+        echo "[model] Installed, but 'hf' isn't on PATH in this shell yet — restart your terminal (or run 'pipx ensurepath' / add ~/.local/bin to PATH) and re-run setup.sh." >&2
+        return 1
+      fi
+      echo "[model] Automatic install did not complete — use a manual option below." >&2
+    fi
+  fi
+
+  # No isolated installer, declined, or install failed → the working manual set.
+  {
+    echo "ERROR: the Hugging Face CLI ('hf') is required but not installed."
+    echo "  Recommended — isolated, puts 'hf' on your PATH (works on Ubuntu 24.04 / WSL):"
+    echo "    sudo apt install -y pipx && pipx install 'huggingface-hub[hf_transfer]' && pipx ensurepath"
+    echo "    (then restart your shell and re-run this command)"
+    echo "  Or, with uv:"
+    echo "    uv tool install --with hf_transfer huggingface-hub"
+    echo "  Quick override — modifies SYSTEM Python (only on a dedicated box / WSL):"
+    echo "    pip install --break-system-packages 'huggingface-hub[hf_transfer]'"
+  } >&2
+  return 1
+}
+
 _hf_download_repo() {
   local repo="$1"
   local subdir="$2"
@@ -556,6 +622,8 @@ _hf_download_repo() {
   local rev_args=()
   [[ -n "$revision" ]] && rev_args=(--revision "$revision")
   mkdir -p "${MODEL_DIR}/${subdir}"
+  # Guarantee a download CLI (consent-gated isolated install if missing).
+  ensure_hf_cli || exit 1
   if command -v hf >/dev/null 2>&1; then
     echo "[model]   Using 'hf download' (hf_transfer if available) ..."
     # files is intentionally word-split: empty -> whole repo; non-empty -> selected files.
@@ -566,10 +634,8 @@ _hf_download_repo() {
     HF_HUB_ENABLE_HF_TRANSFER=1 HF_HUB_DISABLE_XET=1 \
       huggingface-cli download "$repo" ${files} "${rev_args[@]}" --local-dir "${MODEL_DIR}/${subdir}"
   else
-    echo "ERROR: neither 'hf' nor 'huggingface-cli' found. Install with:" >&2
-    echo "  pip install 'huggingface-hub[hf_transfer]'" >&2
-    echo "or:" >&2
-    echo "  uv tool install --with hf_transfer huggingface-hub" >&2
+    # Unreachable: ensure_hf_cli returned 0 so one of the above resolves.
+    echo "ERROR: hf CLI unexpectedly unavailable after ensure_hf_cli." >&2
     exit 1
   fi
 }

--- a/scripts/tests/test-pullgate-download.sh
+++ b/scripts/tests/test-pullgate-download.sh
@@ -657,10 +657,12 @@ with tempfile.TemporaryDirectory() as td:
           f"'hf-cli-missing') (got ok={getattr(r,'ok',None)} "
           f"fail={getattr(r,'failure',None)})")
     check(r is not None and "hf download" not in (r.detail or "")
-          and "huggingface-cli" in (r.detail or "")
-          and "uv tool install" in (r.detail or ""),
-          f"missing-CLI carries the canonical actionable detail "
-          f"(setup.sh:418-421 install hint); detail={getattr(r,'detail',None)!r}")
+          and "pipx" in (r.detail or "")
+          and "uv tool install" in (r.detail or "")
+          and "break-system-packages" in (r.detail or ""),
+          f"missing-CLI carries the canonical PEP-668-aware install hint "
+          f"(pipx / uv / --break-system-packages; in sync with setup.sh "
+          f"ensure_hf_cli); detail={getattr(r,'detail',None)!r}")
     final = DL.pull_dir(Path(td), "Org/NoCli")
     check(not (final / ".incomplete").exists(),
           "missing-CLI: .incomplete tree deleted (no residue)")


### PR DESCRIPTION
## Problem (from a Discord WSL user)

Following [`WSL_SETUP.md`](docs/WSL_SETUP.md), a fresh Ubuntu 24.04 / WSL2 user hits step 7 with:

```
ERROR: neither 'hf' nor 'huggingface-cli' found. Install with:
  pip install 'huggingface-hub[hf_transfer]'
llama@…:~/club-3090$ pip install 'huggingface-hub[hf_transfer]'
error: externally-managed-environment
```

The `pip install` command **we suggested** is exactly the one PEP 668 blocks on modern Ubuntu — so setup handed them a dead end. (Their next move, a raw `venv`, then broke `docker`/paths — a classic WSL trip-up.)

## Fix

`setup.sh` gains **`ensure_hf_cli`** — when the CLI is missing it **offers to install it**, with two hard rules:

- **Consent-gated** — `[Y/n]` prompt, TTY-only. Non-interactive never prompts and never installs (honors `CLUB3090_ASSUME_YES=1` for scripted opt-in).
- **Isolated-only** — auto-install runs *only* via `uv tool` / `pipx` (on PATH, **no changes to system Python**). It **never** runs `pip --break-system-packages` or `sudo apt` on the user's behalf — those stay copy-paste the user owns.

Declined / no isolated installer / non-TTY → prints the **working** manual options (pipx · uv · `--break-system-packages`) and exits. After an accepted install it prepends `~/.local/bin` so the download continues in the **same run** (no shell restart).

| File | Change |
|---|---|
| `scripts/setup.sh` | `ensure_hf_cli` (consent-gated isolated install + PEP-668-aware manual fallback); called before the download dispatch. |
| `scripts/lib/profiles/downloader.py` | `_HF_CLI_MISSING_MSG` → same PEP-668-aware message (pull.sh surfaces it via `DownloadResult.detail`). |
| `docs/WSL_SETUP.md` | Step-7 prerequisite + the venv footgun warning (the exact thing the reporter hit). |
| `scripts/tests/test-pullgate-download.sh` | Fixture asserts the new options (pipx / uv / `--break-system-packages`). |

## Tests
Unit-tested `ensure_hf_cli` (extracted + mocked PATH):
- no CLI + non-TTY → manual options + `rc=1` ✓
- `hf` present → `rc=0`, **no behavior change** ✓
- **pipx present + non-TTY + no consent → does NOT install** ✓ (the critical safety property)
- `CLUB3090_ASSUME_YES=1` + pipx → installs via isolated pipx ✓

Download/pull test suite green (`test-pull`, `test-pullemit-capture`, `test-download-lock`, `test-pullgate-download`, `test-studio-derig`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)