### PR TITLE
fix(studio): setup-ai-studio silently no-ops when .env lacks LANIP (#686)

### DIFF
--- a/scripts/tests/test-comfyui-paths.sh
+++ b/scripts/tests/test-comfyui-paths.sh
@@ -109,4 +109,16 @@ chk "persist respects an existing COMFYUI_OUTPUT_DIR" "/data/custom-out|1" \
   "$(grep '^COMFYUI_OUTPUT_DIR=' "$_tmpenv" | cut -d= -f2-)|$(grep -c '^COMFYUI_OUTPUT_DIR=' "$_tmpenv")"
 rm -f "$_tmpenv"
 
+# P (#686) — sourcing under a `set -e`+pipefail caller (setup-ai-studio.sh) MUST NOT
+#     silently exit when .env lacks a LANIP line. The grep-no-match returned 1, pipefail
+#     propagated it, the assignment failed, and set -e killed the caller BEFORE the
+#     LAN-IP auto-detect could run → "no output at all". Copy the helper into a throwaway
+#     repo root so C3_REPO_ROOT/.env (a MODEL_DIR-only .env) is controlled.
+_reroot="$(mktemp -d)"; mkdir -p "$_reroot/services/comfyui"
+cp "$HELPER" "$_reroot/services/comfyui/comfyui-paths.sh"
+printf 'MODEL_DIR=%s/models\n' "$_reroot" > "$_reroot/.env"   # NO LANIP line
+( cd "$_reroot" && bash -c 'set -euo pipefail; . services/comfyui/comfyui-paths.sh' ) >/dev/null 2>&1
+chk "no silent set-e exit when .env lacks LANIP (#686)" "0" "$?"
+rm -rf "$_reroot"
+
 if [ "$fails" -eq 0 ]; then echo "PASS: comfyui-paths derivation"; exit 0; else echo "FAIL: $fails assertion(s)"; exit 1; fi

--- a/services/comfyui/comfyui-paths.sh
+++ b/services/comfyui/comfyui-paths.sh
@@ -27,14 +27,18 @@ if [ -z "${C3_PATHS_NO_ENV:-}" ] && [ -n "$C3_REPO_ROOT" ]; then
   if [ -f "$_c3_env" ]; then
     # MODEL_DIR (the studio's one knob) — env wins over .env.
     if [ -z "${MODEL_DIR:-}" ]; then
-      MODEL_DIR="$(grep -E '^MODEL_DIR=' "$_c3_env" 2>/dev/null | tail -1 | cut -d= -f2-)"
+      # `|| true`: a no-match grep returns 1, which pipefail propagates → the
+      # assignment fails → a `set -e` caller (setup-ai-studio.sh) exits SILENTLY
+      # before it can auto-detect. MODEL_DIR is usually present so it rarely bit;
+      # LANIP (below) is usually absent, which is the #686 silent-no-op.
+      MODEL_DIR="$(grep -E '^MODEL_DIR=' "$_c3_env" 2>/dev/null | tail -1 | cut -d= -f2- || true)"
       MODEL_DIR="${MODEL_DIR%\"}"; MODEL_DIR="${MODEL_DIR#\"}"   # strip optional surrounding quotes
     fi
     # LANIP for the printed URLs — pin it here when auto-detect can't pick the right NIC, or on
     # hosts without `hostname -I` / `ip` (club-3090 #512). Env wins; auto-detect (c3_lan_ip) is the
     # fallback when neither sets it.
     if [ -z "${LANIP:-}" ]; then
-      LANIP="$(grep -E '^LANIP=' "$_c3_env" 2>/dev/null | tail -1 | cut -d= -f2-)"
+      LANIP="$(grep -E '^LANIP=' "$_c3_env" 2>/dev/null | tail -1 | cut -d= -f2- || true)"   # || true: see MODEL_DIR note above (#686)
       LANIP="${LANIP%\"}"; LANIP="${LANIP#\"}"
       [ -n "$LANIP" ] && export LANIP
     fi


### PR DESCRIPTION
## Problem (#686, MoppelMat)

`bash scripts/setup-ai-studio.sh` produces **no output at all** on a fresh rig — until you manually add `LANIP=` to `.env`. He nailed it with `bash -x`: the trace dies right after the empty `LANIP=` read.

## Root cause

`services/comfyui/comfyui-paths.sh` reads LANIP from `.env`:

```bash
LANIP="$(grep -E '^LANIP=' "$_c3_env" | tail -1 | cut -d= -f2-)"
```

When `.env` has **no `LANIP` line** (the default fresh state), `grep` returns 1, `pipefail` propagates it, so the **assignment itself returns 1** — and a `set -e` caller (`setup-ai-studio.sh`) **exits silently**, *before* `c3_resolve_lanip` could auto-detect and persist the IP. The auto-detect was designed to handle exactly this; it just never got to run.

(The `MODEL_DIR` line right above has the identical latent bug but never bit, because `MODEL_DIR` is always present in `.env`.)

## Fix

`|| true` on both grep command-subs. Sourcing now completes, the auto-detect runs as intended (detects + writes `LANIP` to `.env` on first run and prints `✔ LAN IP … detected`), and no fresh studio user hits the silent no-op.

## Tests

`test-comfyui-paths.sh` — added **case P**: source under `set -euo pipefail` with a LANIP-less `.env` must exit `0`. Verified it **fails on the pre-fix helper** (rc 1) and passes on the fix. Full test green.

Reproduced before + after:
```
pre-fix : source under set-e caller, .env w/o LANIP → rc 1 (silent exit)  ← the bug
post-fix: → rc 0, then c3_resolve_lanip detects + persists the IP          ← intended flow
```

Refs #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)