### PR TITLE
Add Nemotron-3-Puzzle-75B-A9B (NVFP4) — experimental vllm/nemotron-75b-multi-mtp (4×3090)

### DIFF
--- a/models/nemotron-3-puzzle-75b/vllm/cache/.gitignore
+++ b/models/nemotron-3-puzzle-75b/vllm/cache/.gitignore
@@ -1,0 +1,5 @@
+# Per-variant compile/Triton artifacts. These get regenerated on first boot
+# of any variant whose config changed; not source. Don't commit.
+*
+!.gitignore
+!README.md

--- a/models/nemotron-3-puzzle-75b/vllm/cache/README.md
+++ b/models/nemotron-3-puzzle-75b/vllm/cache/README.md
@@ -1,0 +1,10 @@
+# vLLM compile/Triton caches (host-mounted)
+
+Per-variant artifacts for `torch.compile` (Inductor) + Triton kernel JIT.
+Mounted into containers at `/root/.cache/vllm/torch_compile_cache` and
+`/root/.triton/cache`. First boot of a fresh variant warms the cache
+(~60-90 sec); subsequent boots reuse cached graphs and skip recompile.
+
+Safe to delete (`rm -rf cache/triton/* cache/torch_compile/*`) — only
+costs you one slow cold start to regenerate. Variants share the cache
+directory but key off their own config hash, so no cross-contamination.

--- a/models/nemotron-3-puzzle-75b/vllm/compose/multi4/nvfp4/mtp.yml
+++ b/models/nemotron-3-puzzle-75b/vllm/compose/multi4/nvfp4/mtp.yml
@@ -117,7 +117,7 @@ services:
       - --
     command:
       - --model
-      - /root/.cache/huggingface/nemotron-3-puzzle-75b-a9b-nvfp4
+      - /root/.cache/huggingface/nemotron-3-puzzle-75b-nvfp4
       - --served-model-name
       - nemotron-3-puzzle-75b
       - --tensor-parallel-size

--- a/models/nemotron-3-puzzle-75b/vllm/compose/multi4/nvfp4/mtp.yml
+++ b/models/nemotron-3-puzzle-75b/vllm/compose/multi4/nvfp4/mtp.yml
@@ -1,0 +1,179 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Nemotron-3-Puzzle-75B-A9B (NVIDIA NVFP4 — 75.3B total / 9.3B active,
+#              Mamba2-Transformer Hybrid LatentMoE, 512 routed experts + 1 shared)
+#   Topology:  Quad 3090 PCIe (TP=4, no NVLink — auto-detected via NVLINK_MODE)
+#   Drafter:   MTP n=3 (NVIDIA's built-in MTP head — the accelerated path from the card)
+#   KV:        two separate caches (hybrid model):
+#              • Attention layers → default (bf16); tiny (few attn layers). fp8 is an
+#                OPTIONAL lever only when chasing 1M ctx — NOT set here.
+#              • Mamba2 SSM state → float16 + stochastic rounding (NVIDIA's config;
+#                precision-critical recurrent state — do NOT fp8 this).
+#   Vision:    no
+#   Max ctx:   262K default (model card: up to 1M) — ESTIMATE, unmeasured on Ampere
+#   Genesis:   N/A — Genesis is Qwen3-Next-specific
+#   Status:    🧪 EXPERIMENTAL — UNTESTED on this stack; Ampere unvalidated by NVIDIA
+#   Best for:  Quad-3090 owners wanting a fast 75B-class hybrid MoE — COMMUNITY-FLOAT draft
+# ---------------------------------------------------------------------------
+# ⚠️  READ BEFORE RUNNING — this is a SPECULATIVE Ampere port, not a validated recipe.
+#
+# NVIDIA's model card lists supported microarchitectures as **Blackwell + Hopper ONLY**
+# (tested on 1×/8× H100 and 8× B200). NVFP4 is "optimized for Blackwell-class GPUs."
+# There is NO Ampere / consumer-GPU support statement. On a 4× RTX 3090 (Ampere sm_86)
+# FOUR things are unproven and any one could stop it booting:
+#   1. NVFP4 (routed experts) + FP8 (Mamba/shared projections) → on sm_86 there is no
+#      native FP4/FP8 compute, so both must DEQUANTIZE (NVFP4 → Marlin W4A16, FP8 → bf16).
+#      Whether vLLM's ModelOpt loader provides that fallback for THIS mixed scheme on
+#      Ampere is the open question. No speed edge if it does (all 4-bit → same Marlin path).
+#   2. `--mamba-backend flashinfer` — FlashInfer's Mamba2 kernels on sm_86 are unverified here.
+#   3. The Puzzle per-layer heterogeneity (experts-per-token 4–22) under the aliased NemotronH path.
+#   4. **MTP spec-dec on the Ampere-dequantized path** — MTP is the ONE spec-dec method that
+#      works on hybrid/Mamba models (EAGLE/DFlash are blocked by state rollback), and NVIDIA
+#      validated it on Hopper/Blackwell — but MTP-over-Marlin-dequant on sm_86 is its own unknown.
+#      **If MTP errors or degrades, comment out the two `--speculative-config` lines in the command
+#      below to run without MTP — that isolates MTP from the base model load.**
+#
+# Arch support IS present: vLLM registry aliases `NemotronHPuzzleForCausalLM` →
+# `NemotronHForCausalLM`; confirmed in v0.24.0 (this pin) AND v0.25.0. NVIDIA validated on
+# vLLM v0.20.0. So the arch string will not be rejected — the risk is the Ampere quant/kernel
+# path (+ MTP on it), not the model registry. This draft exists to be floated to 4×3090 owners:
+# "does it boot, is it coherent, does MTP hold, what TPS?"
+#
+# Flags below are transcribed from NVIDIA's v0.20.0 reference command (MTP variant), plus
+# club-3090's PCIe multi-card conventions. VALIDATE each flag against the pinned image before
+# trusting it (v0.20.0 → v0.24.0 flag drift is possible).
+#
+# VRAM (ESTIMATE, unmeasured): ~44–48 GB weights (mixed NVFP4/FP8) + the MTP head across 96 GB
+# (4×3090) → ~12 GB/card, huge headroom for the tiny hybrid-KV. Comfortably fits; the constraint
+# is correctness, not memory. (Will NOT fit a usable context on 2×3090 — hence no local eval.)
+#
+# num_speculative_tokens: NVIDIA left this a variable. 3 is a reasonable start; tune to the MTP
+# head depth / your accept rate. Override with NUM_SPEC_TOKENS=.
+#
+# Run (direct docker — NOT registry-wired; there is no launch.sh slug for this yet):
+#   docker compose -f nemotron-3-puzzle-75b-multi4-nvfp4-mtp.yml up -d
+# ===========================================================================
+# Hardware metadata (parsed by scripts/preflight.sh):
+# Requires-min-vram-gb: 24
+# Engine-profile: vllm-stable
+# Requires-min-gpu-count: 4
+# Tensor-parallel: 4
+services:
+  vllm-nemotron-puzzle-75b:
+    # vLLM STABLE. v0.24.0 registers NemotronHPuzzleForCausalLM (verified 2026-07-14).
+    # NVIDIA's card used v0.20.0; any v0.20+ stable should carry the arch. Override with
+    # VLLM_IMAGE=... to pin a specific build (e.g. to match NVIDIA's exact version).
+    image: ${VLLM_IMAGE:-vllm/vllm-openai:v0.24.0}
+    container_name: "${ESTATE_CONTAINER:-vllm-nemotron-puzzle-75b-multi4-mtp}"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
+    ports:
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8095}}:8000"
+    volumes:
+      - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
+      # torch.compile + Triton kernel caches (first boot warms; reused after).
+      - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
+      - ../../../cache/triton:/root/.triton/cache
+      # NVLink auto-detection — runs inside container at boot (sets _NVLINK_ENABLED).
+      - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      - CUDA_VISIBLE_DEVICES
+      - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
+      - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
+      - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}
+      - VLLM_WORKER_MULTIPROC_METHOD=spawn
+      - NVLINK_MODE=${NVLINK_MODE:-auto}
+      - NCCL_CUMEM_ENABLE=0
+      - NCCL_P2P_DISABLE=1
+      - VLLM_NO_USAGE_STATS=1
+      - VLLM_USE_FLASHINFER_SAMPLER=1
+      - OMP_NUM_THREADS=1
+      # DeepGEMM is a no-op on Ampere; launcher auto-injects VLLM_USE_DEEP_GEMM=0 on
+      # consumer Blackwell. Left unset here = arch default.
+      - VLLM_USE_DEEP_GEMM
+      - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True,max_split_size_mb:512}
+    shm_size: "16gb"
+    ipc: host
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    entrypoint:
+      - bash
+      - -c
+      - |
+        # NVLink auto-detection (sets NCCL env + _NVLINK_ENABLED). On PCIe-only rigs
+        # (the common 4×3090 case) custom all-reduce is disabled — NVLink-assumed
+        # allreduce paths break on PCIe.
+        source /etc/club3090/detect_nvlink.sh
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@"
+        else
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@"
+        fi
+      - --
+    command:
+      - --model
+      - /root/.cache/huggingface/nemotron-3-puzzle-75b-a9b-nvfp4
+      - --served-model-name
+      - nemotron-3-puzzle-75b
+      - --tensor-parallel-size
+      - "${TP:-4}"
+      - --pipeline-parallel-size
+      - "${PP:-1}"
+      # 512-expert MoE → expert-parallel across the TP group (NVIDIA's config).
+      - --enable-expert-parallel
+      - --async-scheduling
+      # --- MTP speculative decoding (NVIDIA's accelerated path). Comment out the two lines
+      # below to run without MTP (no-drafter fallback) if MTP misbehaves on Ampere. ---
+      - --speculative-config
+      - '{"method":"mtp","num_speculative_tokens":${NUM_SPEC_TOKENS:-3}}'
+      # --- Mamba2 SSM state cache (NOT the attention KV cache) ---
+      # float16 + stochastic rounding is NVIDIA's precision-preserving recurrent-state
+      # config. Do NOT lower this to fp8 — SSM state accumulates recurrently and is
+      # precision-sensitive; that is exactly why NVIDIA rounds instead of shrinking it.
+      - --mamba-backend
+      - flashinfer
+      - --mamba_ssm_cache_dtype
+      - float16
+      - --enable-mamba-cache-stochastic-rounding
+      - --mamba-cache-philox-rounds
+      - "5"
+      # --- attention KV cache: left at DEFAULT (bf16). It's tiny on this hybrid (few
+      # attention layers), so fp8 buys little on 96 GB. To chase the 1M ceiling later,
+      # add:  --kv-cache-dtype fp8   (Ampere = storage-only, no speed) — NOT in base. ---
+      - --max-model-len
+      - "${MAX_MODEL_LEN:-262144}"
+      # NVIDIA's stated default is 0.85 (0.9 only for H200-class / more VRAM). 0.85 is
+      # also the safer first-boot value with the 512-expert MoE + CUDA-graph capture.
+      - --gpu-memory-utilization
+      - "${GPU_MEMORY_UTILIZATION:-0.85}"
+      # No --quantization flag: vLLM auto-detects the mixed NVFP4/FP8 scheme from the
+      # checkpoint's quant config (faithful to NVIDIA). If auto-detect misfires on
+      # Ampere, try:  --quantization modelopt_fp4
+      - --trust-remote-code
+      # Chunked prefill OFF — NVIDIA's explicit throughput recommendation for this model
+      # (`--no-enable-chunked-prefill`; also the safer path for hybrid-Mamba prefill).
+      # vLLM defaults chunked-prefill ON, so this flag is required to honor the rec.
+      - --no-enable-chunked-prefill
+      - --reasoning-parser
+      - nemotron_v3
+      - --enable-auto-tool-choice
+      - --tool-call-parser
+      - qwen3_coder
+      # Reasoning is ON by default (NVIDIA's default). Toggle per-request via
+      # chat_template_kwargs, or flip ENABLE_THINKING=false here. Add "low_effort": true
+      # for low-effort reasoning. force_nonempty_content=true is NVIDIA's tool-calling rec.
+      - --default-chat-template-kwargs
+      - '{"enable_thinking": ${ENABLE_THINKING:-true}, "force_nonempty_content": true}'
+      # Sampling per generation_config.json / NVIDIA API examples: temp 1.0, top_p 0.95
+      # (NOT Qwen's 0.6/0.95/20 — this model wants higher temperature). No top_k/rep-penalty.
+      - --override-generation-config
+      - '{"temperature":${TEMP:-1.0},"top_p":${TOP_P:-0.95}}'
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8000"

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -924,6 +924,25 @@ COMPOSE_REGISTRY = {
         status_note="Tess-4-27B NVFP4 (migtissera compressed-tensors, W4A4 recipe; Marlin W4A16 weight-only on Ampere) at TP=2 @131K + fp8 KV, spec-off — THE FASTEST TESS on 2x24GB: 62.4 tok/s decode (CV 0.2%) vs the llama.cpp catalog entry's 57.9 with MTP, and the first vLLM-servable Tess on consumer cards (validated 2026-07-11, BENCHMARKS). Froggeric template pinned (repo template stock-broken). Drafter-less BY FORENSIC RESULT: grafted MTP head = 0% accept in vLLM (works only token-fed in llama.cpp), EAGLE3 ~40% = net-negative on this trunk (club #662). kvcalc SKIP: Tess is a qwen35 HYBRID (KV on 16/64 layers) and no hybrid kv-calc model exists for it yet — follow-up at promotion. A0 8-pack LANDED 2026-07-12: 106/150 off / 113/150 on — UNDERSHOOTS the GGUF bar (116/117), gap cli-40-concentrated (17 vs 25 off); deterministic packs tie+ (RM-off 14/15 best-ever). Fallback arms DONE 2026-07-12: huginnfork NVFP4A16 = gated wash (recipe doesn't matter on Ampere, both 4-bit dequant same Marlin path); FP8 W8A16 = 111/117 (ON ties GGUF, gap was PRECISION not serving-path — cli-40 OFF 17->22). FP8 not productized (35GB, slower, GGUF already production 116/117). Slug stays as the FAST experimental vLLM-Tess with the honest agentic-undershoot caveat; stress/soak still unrun. Slug stays experimental; llamacpp/tess-dual-mtp (now Production) remains the tess recommendation.",
     ),
 
+    # Nemotron-3 Puzzle 75B-A9B NVFP4 — hybrid Mamba2-Transformer LatentMoE (512 routed
+    # experts, 2 KV heads, 88 heterogeneous Puzzle-NAS layers), built-in MTP. NON-FUNCTIONAL
+    # on the 2x3090 rig: needs 4x3090 (TP=4). 🧪 experimental (shown in --list, --force to
+    # launch, excluded from DEFAULTS). drafter=nemotron-mtp-builtin (the built-in MTP head;
+    # the compose carries the matching --speculative-config → c3 spec column shows MTP).
+    # kvcalc SKIP (hybrid; paired with model-YAML kv_calc_supported=
+    # false). fallback_sm=7.5 lets the 4x-3090 canonical scenario validate via Marlin W4A16.
+    # Engine support for the arch on vllm/vllm-openai:v0.24.0 is UNVERIFIED until a 4-card boot.
+    "vllm/nemotron-75b-multi-mtp": _entry(
+        model="nemotron-3-puzzle-75b", weights_variant="nvfp4", workload="fast-chat",
+        engine="vllm-stable", drafter="nemotron-mtp-builtin", kv_format="bf16",
+        tp=4, max_ctx=262144, max_num_seqs=1, mem_util=0.85,
+        compose_path="models/nemotron-3-puzzle-75b/vllm/compose/multi4/nvfp4/mtp.yml",
+        default_port=8095, required_sm=9.0, fallback_sm=7.5,
+        kvcalc_key="SKIP",
+        status="experimental",
+        status_note="Nemotron-3 Puzzle 75B-A9B NVFP4 (nvidia modelopt MIXED: NVFP4 routed-expert FFNs + FP8 Mamba/shared projections), 4-card TP=4 @262K, built-in MTP via --speculative-config. Mamba2-Transformer hybrid LatentMoE, 9.3B active / 75.3B total. 🧪 Experimental — CANNOT be booted/validated on the maintainer's 2x3090 rig (needs 4x3090); shown in switch.sh --list, launch requires --force. bf16 attention KV (fp8 NOT forced — the hybrid holds KV on only a few attn layers, so it's tiny) + fp16 Mamba SSM state (stochastic-rounded; never fp8). kv-calc bypassed (hybrid arch, no spec → kvcalc SKIP + model kv_calc_supported=false). NVIDIA supported-HW = Blackwell+Hopper ONLY; arch NemotronHPuzzleForCausalLM aliases to the NemotronH loader (registered v0.24.0 + v0.25.0; card tested v0.20.0) but the Ampere quant/kernel path (NVFP4->Marlin W4A16, FP8->bf16, flashinfer-mamba on sm_86) is UNVERIFIED — first 4-card boot is the validation. FP8 sibling (83 GB) too big for 4x24GB → NVFP4 is the only quad-3090 fit. No DEFAULTS row (opt-in only). Community-float to 4x3090 owners.",
+    ),
+
     # Ornith-1.0-9B — DeepReinforce agentic-coding RL fine-tune. Qwen3-Next DENSE-FFN
     # HYBRID (arch=qwen35: 8 full-attn + 24 GDN/DeltaNet layers, NON-MoE) — only 8/32
     # layers carry GQA KV so 262K fits at 4.25 GiB KV. No MTP head → drafter-free

--- a/scripts/lib/profiles/drafters/nemotron-mtp-builtin.yml
+++ b/scripts/lib/profiles/drafters/nemotron-mtp-builtin.yml
@@ -1,0 +1,20 @@
+schema_version: 1
+id: nemotron-mtp-builtin
+display_name: Nemotron-3 Puzzle built-in MTP head
+spec_method: mtp
+model_compat:
+  - nemotron-3-puzzle-75b
+n_default: 3
+n_max: 7
+download: false
+vram_footprint_gb: 0
+status: experimental
+# Built-in MTP head shipped inside the NVFP4 checkpoint (the MTP layers are kept
+# higher-precision, not NVFP4-quantized). Grounded from NVIDIA's reference command:
+# '{"method":"mtp","num_speculative_tokens":N}' — n_default=3 (best throughput at
+# typical batch), 5/7 for latency-sensitive low-batch (card guidance). No separate
+# drafter weights → download: false, local_model_path: null. {N} is substituted from
+# n_default (or the compose's ${NUM_SPEC_TOKENS:-N} override). UNVALIDATED on Ampere —
+# MTP-over-Marlin-dequant on sm_86 is unverified; first 4x3090 boot is the check.
+speculative_config_template: '{"method":"mtp","num_speculative_tokens":{N}}'
+local_model_path: null

--- a/scripts/lib/profiles/engines/vllm-stable.yml
+++ b/scripts/lib/profiles/engines/vllm-stable.yml
@@ -19,6 +19,11 @@ supported_model_families:
                      # 2026-07-11 (62.4 tok/s TP=2, forensics-week boots; slug
                      # vllm/tess-dual-nvfp4). Family also covers Deckard-40B if a
                      # vLLM path is ever added there.
+  - nemotron-h-puzzle-moe   # Nemotron-3 Puzzle 75B-A9B (NemotronHPuzzleForCausalLM, hybrid
+                            # Mamba2+attn MoE) — arch aliases to the NemotronH loader (registered
+                            # in v0.24.0 + v0.25.0; NVIDIA card tested v0.20.0). UNVERIFIED on-rig
+                            # (Blackwell/Hopper-only per NVIDIA; needs 4x3090) — drives the 🧪
+                            # community-float slug vllm/nemotron-75b-multi-mtp.
 features:
   int8_per_token_head: true    # NATIVE for qwen3-next (uniform head dims) since v0.22.0 — that's why the
                                # flag is true. NOT correct for Gemma-4 (hetero heads): on v0.24.0 int8-PTH

--- a/scripts/lib/profiles/models/nemotron-3-puzzle-75b.yml
+++ b/scripts/lib/profiles/models/nemotron-3-puzzle-75b.yml
@@ -1,0 +1,44 @@
+schema_version: 1
+id: nemotron-3-puzzle-75b
+display_name: Nemotron-3 Puzzle 75B-A9B (hybrid Mamba2+attn MoE)
+family: nemotron-h-puzzle-moe
+hidden_size: 4096
+num_hidden_layers: 88
+# Heterogeneous Puzzle-NAS arch: per-layer block_configs mix Mamba2, attention, and
+# MoE blocks (num_experts_per_tok varies 4-22 per layer). The exact Mamba-vs-attn split
+# is not flattened here — these geometry fields are informational only, because
+# kv_calc_supported=false (no kv-calc model exists for this hybrid; see bottom).
+num_attn_heads: 32
+num_kv_heads: 2
+max_ctx_supported: 262144
+attention_k_eq_v: false
+# MoE (from config.json)
+num_experts: 512
+num_experts_per_tok: 8          # representative — varies 4-22 per layer
+active_params_b: 9.3
+weights:
+  nvfp4:
+    path: nemotron-3-puzzle-75b-nvfp4
+    local_subdir: nemotron-3-puzzle-75b-nvfp4
+    size_gb: 53.5
+    format: modelopt
+    status: experimental
+    hf_repo: nvidia/NVIDIA-Nemotron-Labs-3-Puzzle-75B-A9B-NVFP4
+    engine: vllm
+    kind: main
+    verify_glob: "*.safetensors"
+    manual_note: "NVIDIA modelopt MIXED quant of Nemotron-3-Puzzle-75B-A9B (Mamba2-Transformer hybrid LatentMoE, 512 routed experts + 1 shared, 9.3B active / 75.3B total): NVFP4 gs16 on the routed-expert FFNs + FP8 on the Mamba/shared-expert projections; MTP head kept higher-precision. Arch NemotronHPuzzleForCausalLM aliases to the NemotronH loader (registered in vLLM v0.24.0 + v0.25.0; NVIDIA card tested on v0.20.0). NVIDIA supported-hardware = Blackwell + Hopper ONLY; NVFP4 kernels native sm_90+, Marlin W4A16 fallback sm_7.5+. CANNOT be validated on the 2x3090 reference rig (needs 4x3090, TP=4) — drives the community-float vllm/nemotron-75b-multi-mtp slug. 53.5 GB / 6 shards. FP8 sibling (83 GB) is too big for 4x24GB → NVFP4 is the only practical quad-3090 fit."
+default_weight_variant: nvfp4
+compatible_drafters:
+  - nemotron-mtp-builtin
+# TP=4 only: 53.5 GB weights need 4x24GB (won't fit 2 cards). num_attn_heads=32 % 4 == 0;
+# num_kv_heads=2 with tp=4 → vLLM replicates KV (tp % kv == 0); experts 512 % 4 == 0.
+valid_tp:
+  - 4
+requires_genesis: false
+# Hybrid Mamba2+attention: KV cache lives only on the attention layers plus a fixed-size
+# Mamba SSM state — NOT the standard transformer formula. kv-calc has no model for this
+# arch, so it is bypassed (kvcalc_key="SKIP" in the registry). false here makes compat.py
+# skip the C12 KV-projection check instead of shelling out to kv-calc (which would reject
+# an unknown --model).
+kv_calc_supported: false

--- a/scripts/tests/test-compose-registry-disk.sh
+++ b/scripts/tests/test-compose-registry-disk.sh
@@ -25,8 +25,8 @@ def check(cond, msg):
         print(f"FAIL: {msg}")
         failures.append(msg)
 
-check(len(COMPOSE_REGISTRY) == 64, f"registry has 64 entries (got {len(COMPOSE_REGISTRY)})")
-check(len(disk_paths) == 65, f"disk has 65 compose files (got {len(disk_paths)})")
+check(len(COMPOSE_REGISTRY) == 65, f"registry has 65 entries (got {len(COMPOSE_REGISTRY)})")
+check(len(disk_paths) == 66, f"disk has 66 compose files (got {len(disk_paths)})")
 check(registry_paths <= disk_paths, "all registry compose_path values exist on disk")
 parked_disk_only = disk_paths - registry_paths
 # Disk-only (non-registry) composes allowed: parked SGLang archives, plus the experimental

--- a/scripts/tests/test-profiles-compat.sh
+++ b/scripts/tests/test-profiles-compat.sh
@@ -24,10 +24,10 @@ run_test "load_profiles parses all profile groups" <<'PY'
 from scripts.lib.profiles.compat import load_profiles
 p = load_profiles()
 assert len(p.hardware) == 10  # +dgx-spark (#576 follow-up)
-assert len(p.models) == 12
+assert len(p.models) == 13
 assert len(p.workloads) == 5
 assert len(p.engines) == 13
-assert len(p.drafters) == 12
+assert len(p.drafters) == 13
 assert len(p.calibration) == 5
 PY
 


### PR DESCRIPTION
## What

Wires **NVIDIA Nemotron-3-Puzzle-75B-A9B-NVFP4** into the catalog as an experimental, MTP, 4-card slug: **`vllm/nemotron-75b-multi-mtp`**.

A dense 27B under-uses a 96 GB rig — its value on 4 cards is *fit* + concurrency, not decode speed. This is a **Mamba2-Transformer hybrid LatentMoE** (75.3B total / **9.3B active**, 512 routed experts): low decode compute, and because only a handful of its 88 layers are attention (the rest are fixed-size Mamba SSM state, not growing KV), **256K context is cheap on VRAM**. ~53.5 GB weights fit comfortably across 4×3090.

## Why experimental (not production)

**It cannot be validated on the maintainer's 2×3090 reference rig — it needs 4×3090 (TP=4).** NVIDIA's model card lists supported hardware as **Blackwell + Hopper only**; NVFP4 is "optimized for Blackwell-class GPUs." On Ampere (sm_86) three things are unproven, any one of which could stop the boot:

1. NVFP4 (routed experts) + FP8 (Mamba/shared) must **dequantize** → Marlin W4A16 / bf16 fallback,
2. `--mamba-backend flashinfer` Mamba2 kernels on sm_86,
3. the Puzzle per-layer heterogeneity loading under the aliased NemotronH path.

Arch support *is* present — vLLM registers `NemotronHPuzzleForCausalLM` (aliased to the working NemotronH loader) in **v0.24.0 and v0.25.0**; NVIDIA validated on v0.20.0. So the string isn't rejected; the risk is the Ampere quant/kernel path. This slug exists to be **floated to 4×3090 owners** — "does it boot, is it coherent, what TPS?" — as `status=experimental` (shown in `--list`, `--force` to launch, excluded from defaults). "It doesn't boot" is a useful answer.

## Wiring

| File | Change |
|---|---|
| `models/nemotron-3-puzzle-75b.yml` | New profile — `nvfp4` modelopt weights, `valid_tp:[4]`, **`kv_calc_supported: false`** |
| `drafters/nemotron-mtp-builtin.yml` | Built-in MTP head (`spec_method: mtp`) → the c3 spec column reads MTP |
| `engines/vllm-stable.yml` | +family `nemotron-h-puzzle-moe` |
| `compose_registry.py` | `vllm/nemotron-75b-multi-mtp` — `drafter=nemotron-mtp-builtin`, `kv_format=bf16`, **`kvcalc_key=SKIP`**, `fallback_sm=7.5`, port 8095 |
| `.../compose/multi4/nvfp4/mtp.yml` | TP=4 · `--enable-expert-parallel` · MTP · flashinfer mamba · fp16 SSM state · bf16 attn KV · `--no-enable-chunked-prefill` · sampling temp 1.0/top_p 0.95 |
| `.../vllm/cache/` | mount scaffolding (mirrors the qwen pattern) |
| guard counts | registry-disk 64→65 / 65→66; profiles-compat models 12→13, drafters 12→13 |

**kv-calc:** no code change — this hybrid's KV isn't the standard transformer formula, so `kvcalc_key="SKIP"` (precedent: `vllm/tess-dual-nvfp4`) paired with model `kv_calc_supported: false` (bypasses compat C12). **KV:** bf16 attention KV (not fp8 — the hybrid KV is tiny, so fp8 buys nothing at 256K) + fp16 Mamba SSM state (stochastic-rounded; never fp8).

## Testing

Full catalog test sweep green. Tester download uses the hardened lightweight path — a single download, since the MTP is a built-in head (no external drafter):

```
scripts/pull.sh nvidia/NVIDIA-Nemotron-Labs-3-Puzzle-75B-A9B-NVFP4 --profile-like vllm/minimal
```

**Next:** a 4×3090 boot report (community float) promotes it off experimental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
