### PR TITLE
Env-ify --max-num-batched-tokens across vLLM composes (behavior-identical)

### DIFF
--- a/models/agents-a1/vllm/compose/dual/fp8-dynamic/fp8.yml
+++ b/models/agents-a1/vllm/compose/dual/fp8-dynamic/fp8.yml
@@ -222,7 +222,7 @@ services:
       - --max-num-seqs
       - "${MAX_NUM_SEQS:-1}"
       - --max-num-batched-tokens
-      - "8192"
+      - "${MAX_NUM_BATCHED_TOKENS:-8192}"
       
       
       - --limit-mm-per-prompt

--- a/models/gemma-4-12b/vllm/compose/dual/bf16/mtp.yml
+++ b/models/gemma-4-12b/vllm/compose/dual/bf16/mtp.yml
@@ -115,7 +115,7 @@ services:
       - --max-num-seqs
       - "${MAX_NUM_SEQS:-4}"
       - --max-num-batched-tokens
-      - "4096"
+      - "${MAX_NUM_BATCHED_TOKENS:-4096}"
       - --trust-remote-code
       - --enable-auto-tool-choice
       - --tool-call-parser

--- a/models/gemma-4-26b-a4b/vllm/compose/dual/awq/mtp.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/dual/awq/mtp.yml
@@ -119,7 +119,7 @@ services:
       - --max-num-seqs
       - "256"
       - --max-num-batched-tokens
-      - "4096"
+      - "${MAX_NUM_BATCHED_TOKENS:-4096}"
       - --limit-mm-per-prompt
       - '{"image":0,"audio":0}'
       - --kv-cache-dtype

--- a/models/gemma-4-26b-a4b/vllm/compose/single/awq/int8.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/single/awq/int8.yml
@@ -154,7 +154,7 @@ services:
       - --max-num-seqs
       - "${MAX_NUM_SEQS:-256}"
       - --max-num-batched-tokens
-      - "4096"
+      - "${MAX_NUM_BATCHED_TOKENS:-4096}"
       - --limit-mm-per-prompt
       - '{"image":0,"audio":0}'
       - --trust-remote-code

--- a/models/gemma-4-31b/vllm/compose/dual/autoround-int4/bf16-mtp.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/autoround-int4/bf16-mtp.yml
@@ -174,7 +174,7 @@ services:
       - "${MAX_NUM_SEQS:-4}"
       # Vision tower: max_tokens_per_mm_item=2496 must fit in batched tokens.
       - --max-num-batched-tokens
-      - "4096"
+      - "${MAX_NUM_BATCHED_TOKENS:-4096}"
       - --trust-remote-code
       # Tool-call support per vLLM Gemma 4 recipe — required for any soak /
       # agent traffic that includes a `tools: [...]` array. Without these,

--- a/models/gemma-4-31b/vllm/compose/dual/autoround-int4/int8.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/autoround-int4/int8.yml
@@ -242,7 +242,7 @@ services:
       - "${MAX_NUM_SEQS:-4}"
       # Vision tower: max_tokens_per_mm_item=2496 must fit in batched tokens.
       - --max-num-batched-tokens
-      - "4096"
+      - "${MAX_NUM_BATCHED_TOKENS:-4096}"
       - --trust-remote-code
       # Tool-call support — required for soak / agent traffic that includes
       # `tools: [...]` array. The vendored tool-parser overlay above also

--- a/models/gemma-4-31b/vllm/compose/dual/qat-awq-int4/base.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/qat-awq-int4/base.yml
@@ -158,7 +158,7 @@ services:
       - "${MAX_NUM_SEQS:-2}"
       # Vision tower: max_tokens_per_mm_item=2496 must fit in batched tokens.
       - --max-num-batched-tokens
-      - "4096"
+      - "${MAX_NUM_BATCHED_TOKENS:-4096}"
       - --trust-remote-code
       # Tool-call support — native gemma4 ParserEngine (#45588) on v0.24.0. Streaming
       # multi-tool validated clean (all args, no <|tool_call> leak) 2026-07-01.

--- a/models/gemma-4-31b/vllm/compose/dual/qat-w4a16/int8.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/qat-w4a16/int8.yml
@@ -245,7 +245,7 @@ services:
       - "${MAX_NUM_SEQS:-4}"
       # Vision tower: max_tokens_per_mm_item=2496 must fit in batched tokens.
       - --max-num-batched-tokens
-      - "4096"
+      - "${MAX_NUM_BATCHED_TOKENS:-4096}"
       - --trust-remote-code
       # Tool-call support — required for soak / agent traffic that includes
       # `tools: [...]` array. The vendored tool-parser overlay above also

--- a/models/gemma-4-31b/vllm/compose/single/autoround-int4/fp8-mtp.yml
+++ b/models/gemma-4-31b/vllm/compose/single/autoround-int4/fp8-mtp.yml
@@ -137,7 +137,7 @@ services:
       # --limit-mm-per-prompt image=0, the encoder-budget computation still
       # asserts. 4096 (above 2496 floor) leaves more profiling room than 8192.
       - --max-num-batched-tokens
-      - "4096"
+      - "${MAX_NUM_BATCHED_TOKENS:-4096}"
       - --limit-mm-per-prompt
       - '{"image":0,"audio":0}'
       # fp8 KV per vLLM recipe — halves KV pool footprint vs bf16 default.

--- a/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml
@@ -158,7 +158,7 @@ services:
       - --max-num-seqs
       - "${MAX_NUM_SEQS:-2}"
       - --max-num-batched-tokens
-      - "8192"
+      - "${MAX_NUM_BATCHED_TOKENS:-8192}"
       - --kv-cache-dtype
       - "${KV_CACHE_DTYPE:-fp8_e5m2}"
       - --trust-remote-code

--- a/models/qwen3.6-27b/vllm/compose/dual/awq-bf16-int4/int8.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/awq-bf16-int4/int8.yml
@@ -153,7 +153,7 @@ services:
       - --max-num-seqs
       - "2"
       - --max-num-batched-tokens
-      - "8192"
+      - "${MAX_NUM_BATCHED_TOKENS:-8192}"
       - --kv-cache-dtype
       - "${KV_CACHE_DTYPE:-int8_per_token_head}"
       - --trust-remote-code

--- a/models/qwen3.6-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/fp8/mtp.yml
@@ -184,7 +184,7 @@ services:
       - --max-num-seqs
       - "2"
       - --max-num-batched-tokens
-      - "8192"
+      - "${MAX_NUM_BATCHED_TOKENS:-8192}"
       - --kv-cache-dtype
       - "${KV_CACHE_DTYPE:-fp8}"
       - --trust-remote-code

--- a/models/qwen3.6-27b/vllm/compose/dual/nvfp4/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/nvfp4/mtp.yml
@@ -183,7 +183,7 @@ services:
       - --max-num-seqs
       - "2"
       - --max-num-batched-tokens
-      - "8192"
+      - "${MAX_NUM_BATCHED_TOKENS:-8192}"
       # fp8 (= e4m3) at scale=1.0. hf_quant_config DECLARES FP8 KV
       # (kv_cache_quant_algo=FP8) but the checkpoint ships NO k_scale/v_scale
       # tensors (safetensors-index-verified 2026-07-06), and Qwen3-Next hybrid

--- a/models/qwen3.6-27b/vllm/compose/multi4/autoround-int4/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/multi4/autoround-int4/mtp.yml
@@ -147,7 +147,7 @@ services:
       - --max-num-seqs
       - "2"
       - --max-num-batched-tokens
-      - "8192"
+      - "${MAX_NUM_BATCHED_TOKENS:-8192}"
       - --kv-cache-dtype
       - "${KV_CACHE_DTYPE:-fp8_e5m2}"
       - --trust-remote-code

--- a/models/qwen3.6-27b/vllm/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/multi4/fp8/mtp.yml
@@ -162,7 +162,7 @@ services:
       - --max-num-seqs
       - "2"
       - --max-num-batched-tokens
-      - "8192"
+      - "${MAX_NUM_BATCHED_TOKENS:-8192}"
       - --kv-cache-dtype
       - "${KV_CACHE_DTYPE:-fp8}"
       - --trust-remote-code

--- a/models/qwen3.6-27b/vllm/compose/single/nvfp4/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/nvfp4/mtp.yml
@@ -157,7 +157,7 @@ services:
       - --max-num-seqs
       - "1"
       - --max-num-batched-tokens
-      - "8192"
+      - "${MAX_NUM_BATCHED_TOKENS:-8192}"
       # fp8 (= e4m3) at scale=1.0 — FP8 KV is DECLARED in hf_quant_config but
       # no k_scale/v_scale tensors ship (the #594-tied regime). NOT fp8_e5m2
       # (rejected with fp8 checkpoints), NOT nvfp4 KV (no FP4 FMHA on consumer

--- a/models/qwen3.6-35b-a3b/vllm/compose/dual/autoround-int4/fp8.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/dual/autoround-int4/fp8.yml
@@ -138,7 +138,7 @@ services:
       - --max-num-seqs
       - "${MAX_NUM_SEQS:-1}"
       - --max-num-batched-tokens
-      - "8192"
+      - "${MAX_NUM_BATCHED_TOKENS:-8192}"
       # Vision ON: image tower retained + validated (read a test image correctly
       # at 262K). max-num-batched-tokens ≥ per-image token budget.
       - --limit-mm-per-prompt

--- a/models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4-fast/fp8.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4-fast/fp8.yml
@@ -175,7 +175,7 @@ services:
       - --max-num-seqs
       - "${MAX_NUM_SEQS:-1}"
       - --max-num-batched-tokens
-      - "8192"
+      - "${MAX_NUM_BATCHED_TOKENS:-8192}"
       - --limit-mm-per-prompt
       - '{"image":2,"audio":0}'
       # fp8 (= e4m3). The checkpoint's calibrated k/v scales LOAD and apply

--- a/models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4/fp8.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4/fp8.yml
@@ -132,7 +132,7 @@ services:
       - --max-num-seqs
       - "${MAX_NUM_SEQS:-1}"
       - --max-num-batched-tokens
-      - "8192"
+      - "${MAX_NUM_BATCHED_TOKENS:-8192}"
       - --limit-mm-per-prompt
       - '{"image":2,"audio":0}'
       # fp8 (= e4m3) at scale=1.0 (FP8 KV declared, no scale tensors shipped —

--- a/models/qwen3.6-35b-a3b/vllm/compose/single/autoround-int4/preview.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/single/autoround-int4/preview.yml
@@ -105,7 +105,7 @@ services:
       - --max-num-seqs
       - "1"
       - --max-num-batched-tokens
-      - "4096"
+      - "${MAX_NUM_BATCHED_TOKENS:-4096}"
       - --limit-mm-per-prompt
       - '{"image":0,"audio":0}'
       - --kv-cache-dtype

--- a/models/qwen3.6-35b-a3b/vllm/compose/single/nvfp4/fp8.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/single/nvfp4/fp8.yml
@@ -125,7 +125,7 @@ services:
       - --max-num-seqs
       - "${MAX_NUM_SEQS:-1}"
       - --max-num-batched-tokens
-      - "8192"
+      - "${MAX_NUM_BATCHED_TOKENS:-8192}"
       - --limit-mm-per-prompt
       - '{"image":2,"audio":0}'
       # fp8 (= e4m3) at scale=1.0 — FP8 KV declared in hf_quant_config, no

--- a/models/tess-4-27b/vllm/compose/dual/nvfp4/fp8.yml
+++ b/models/tess-4-27b/vllm/compose/dual/nvfp4/fp8.yml
@@ -146,7 +146,7 @@ services:
       - --max-num-seqs
       - "${MAX_NUM_SEQS:-2}"
       - --max-num-batched-tokens
-      - "8192"
+      - "${MAX_NUM_BATCHED_TOKENS:-8192}"
       # fp8 (= e4m3) at scale=1.0 — no scale tensors in this checkpoint;
       # measured quality-equivalent regime on this family.
       - --kv-cache-dtype


### PR DESCRIPTION
## What
Env-ifies `--max-num-batched-tokens` in **22 vLLM composes** — it was hardcoded, while the flags right next to it (`--max-model-len`, `--max-num-seqs`) were already `${VAR:-…}`.

Each compose keeps its **exact prior default** (behavior-identical):
- `8192` → `${MAX_NUM_BATCHED_TOKENS:-8192}` — Qwen 27B (×7), Qwen 35B-A3B (×4), tess-4-27b, agents-a1
- `4096` → `${MAX_NUM_BATCHED_TOKENS:-4096}` — Gemma 26B-A4B / 31B / 12B (×8), Qwen 35B-A3B preview

## Why
`--max-num-batched-tokens` is the prefill chunk size — bigger = faster prefill (fewer, larger forward passes), at the cost of activation memory. Making it env-overridable lets operators tune prefill-speed vs memory (and free headroom for concurrency) without editing files. It also sets up the concurrency follow-ups — the `--long-prefill-token-threshold` pilots on the high-concurrency Gemma lanes + the N=2 Qwen lanes.

## Safety
**No behavior change at defaults** — each compose keeps its prior value. All catalog guards green (compose-mounts-resolve, status-drift, registry-disk, launch/switch parity, image-drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
