### PR TITLE
Add --long-prefill-token-threshold to gemma-4-26b-a4b concurrent lanes (validated: 18s->1.1s HOL)

### DIFF
--- a/models/gemma-4-26b-a4b/vllm/compose/dual/awq/mtp.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/dual/awq/mtp.yml
@@ -137,6 +137,12 @@ services:
       - /vllm-workspace/examples/tool_chat_template_gemma4.jinja
       - --enable-prefix-caching
       - --enable-chunked-prefill
+      # Head-of-line fix: cap a long prefill's per-step tokens so a concurrent short/agentic
+      # request gets budget in the same step. Must be < max-num-batched-tokens (4096) and
+      # >= block_size (Gemma non-hybrid -> small, no floor). On-rig A/B 2026-07-14: short-request
+      # TTFT under a 60K concurrent prefill 18.0s -> 1.09s (16.5x); solo long-prefill +~6%.
+      - --long-prefill-token-threshold
+      - "${LONG_PREFILL_TOKEN_THRESHOLD:-2048}"
       # ⏸️ MTP DISABLED on v0.24.0 — Gemma-4 MTP × tool-calling is broken (upstream vLLM #39043;
       #    MTP fix #42006 closed-unmerged). A/B-verified on-rig 2026-07-01: MTP-off tools PASS,
       #    MTP-on tools FAIL (<pad>/<|tool_call> leak). Re-enable when a stable vLLM ships the fix:

--- a/models/gemma-4-26b-a4b/vllm/compose/single/awq/int8.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/single/awq/int8.yml
@@ -170,6 +170,12 @@ services:
       - /vllm-workspace/examples/tool_chat_template_gemma4.jinja
       - --enable-prefix-caching
       - --enable-chunked-prefill
+      # Head-of-line fix: cap a long prefill's per-step tokens so a concurrent short/agentic
+      # request gets budget in the same step. Must be < max-num-batched-tokens (4096) and
+      # >= block_size (Gemma non-hybrid -> small, no floor). On-rig A/B 2026-07-14: short-request
+      # TTFT under a 60K concurrent prefill 18.0s -> 1.09s (16.5x); solo long-prefill +~6%.
+      - --long-prefill-token-threshold
+      - "${LONG_PREFILL_TOKEN_THRESHOLD:-2048}"
       # External MTP assistant drafter — n=4 per gemma-26b-it-assistant DrafterProfile.
       # Same external-drafter path as the dual; bypasses MoE expert routing.
       - --speculative-config


### PR DESCRIPTION
## What
Adds `--long-prefill-token-threshold ${LONG_PREFILL_TOKEN_THRESHOLD:-2048}` to the two **`gemma-4-26b-a4b`** high-concurrency lanes (`dual/awq/mtp` + `single/awq/int8` — both `max_num_seqs=256`, chunked-prefill on, batch 4096).

## Why — validated on-rig (Zylone's vLLM scheduling tip)
Head-of-line blocking: a concurrent short/agentic request stuck behind a long prefill. On-rig A/B (`gemma-4-26b-a4b`, 2×3090, TP=2):

| metric | baseline | threshold 2048 | Δ |
|---|--:|--:|---|
| **short TTFT under a 60K concurrent prefill** | **18.00s** | **1.09s** | **16.5× (−94%)** |
| solo short (reference) | 0.05s | 0.05s | — |
| solo long-prefill | ~18s | 19.16s | +~6% |

Scheduling-only (no quality change); the ~6% is finer prefill chunking on an *uncontended* long request. Flag accepted with no block-size floor (Gemma non-hybrid). Env-overridable via `LONG_PREFILL_TOKEN_THRESHOLD`; must stay `< max-num-batched-tokens` (4096) — `2048` satisfies it.

## Scope (deliberately narrow)
- **Included:** the 2 `gemma-4-26b-a4b` lanes — chunked-prefill *explicitly* on, and the exact config the A/B validated.
- **NOT the Qwen dense lanes:** at their 262K max-model-len, Qwen's (DeltaNet-hybrid) `block_size` scales toward the 8192 batch (4128 at 125K per `learnings/qwen3.6-27b.md`), so a threshold below it leaves no room to help. It's a Gemma-family win (small block_size vs 4096 batch), not a Qwen-262K one.
- **Follow-up:** the 31B/12B Gemma lanes (chunked-prefill not explicit) + a concurrency variant for the single-stream Qwen 35B-A3B MoE.

Guards green (mounts-resolve, status-drift, registry-disk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
