### PR TITLE
Switch Qwen vLLM KV fp8_e5m2→fp8_e4m3 + HOL threshold on by default

### DIFF
--- a/models/agents-a1/vllm/compose/dual/fp8-dynamic/fp8.yml
+++ b/models/agents-a1/vllm/compose/dual/fp8-dynamic/fp8.yml
@@ -5,7 +5,8 @@
 #   Drafter:   none — NO MTP head in the checkpoint (safetensors-verified: 0 mtp
 #              tensors of 62,547; config's mtp_num_hidden_layers=1 is an inherited
 #              arch default). EAGLE/DFlash blocked on Qwen3-Next (DeltaNet rollback).
-#   KV:        fp8_e5m2 (storage-only on Ampere)
+#   KV:        fp8_e4m3 (FlashInfer on Ampere, verified 2026-07-14; +1 mantissa bit vs e5m2 —
+#              and e4m3 is the correct pairing for an fp8-dynamic checkpoint)
 #   Vision:    yes (limit-mm-per-prompt image=2)
 #   Max ctx:   262K — staggered-NIAH exact-recall validated to 240K (91%), VRAM Δ0
 #   Genesis:   N/A on this path (drafter-free stock vLLM; Genesis is Qwen3-Next-
@@ -228,7 +229,7 @@ services:
       - --limit-mm-per-prompt
       - '{"image":2,"audio":0}'
       - --kv-cache-dtype
-      - "${KV_CACHE_DTYPE:-fp8_e5m2}"
+      - "${KV_CACHE_DTYPE:-fp8_e4m3}"
       - --reasoning-parser
       - qwen3
       - --default-chat-template-kwargs

--- a/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml
@@ -3,7 +3,7 @@
 #   Model:     Qwen3.6-27B (Lorbus AutoRound INT4 + BF16 mtp.fc preserved)
 #   Topology:  Dual 3090 (TP=2, NVLink auto-detected via NVLINK_MODE)
 #   Drafter:   MTP n=3 (built-in)
-#   KV:        fp8_e5m2 (1 byte/token)
+#   KV:        fp8_e4m3 (1 byte/token — more mantissa precision than e5m2; matches dual-max)
 #   Vision:    yes
 #   Max ctx:   262K (237K single-prompt verified)
 #   Genesis:   none — intentionally Genesis-free (isolation control + fallback)
@@ -26,7 +26,7 @@
 #     69.05 narr (CV 2.3%) / 88.58 code (CV 3.4%) TPS single-stream, AL 3.4, VRAM 23.6 GB/card
 #
 # What's intentionally NOT enabled:
-#   - TurboQuant KV — sidesteps vllm#40831 entirely. fp8_e5m2 is plenty for
+#   - TurboQuant KV — sidesteps vllm#40831 entirely. fp8_e4m3 is plenty for
 #     262K across two cards. For 4-stream concurrency at 262K, switch to
 #     dual/turbo.yml (which uses TurboQuant KV + Genesis P65).
 #
@@ -160,7 +160,7 @@ services:
       - --max-num-batched-tokens
       - "8192"
       - --kv-cache-dtype
-      - "${KV_CACHE_DTYPE:-fp8_e5m2}"
+      - "${KV_CACHE_DTYPE:-fp8_e4m3}"
       - --trust-remote-code
       # froggeric chat-template override (see volumes block + docs/UPSTREAM.md)
       - --chat-template
@@ -174,6 +174,17 @@ services:
       - qwen3_coder
       - --enable-prefix-caching
       - --enable-chunked-prefill
+      # Head-of-line fix (Zylone's vLLM tip; validated on-rig 2026-07-14). Caps a long
+      # prefill's per-step tokens so a concurrent short/agentic request isn't starved.
+      # DEFAULT 2048 = ON — this is an N=2 concurrency lane. On-rig A/B (262K, N=2):
+      # short-request TTFT under a 60K concurrent prefill 14.8s -> 2.6s @ 2048 (5.8x);
+      # 5.5s @ 4096 (2.7x). Works at NATIVE 262K — the DeltaNet block_size is 1600 here
+      # (well under the 8192 batch), so no context-lowering needed. Must stay
+      # < max-num-batched-tokens (8192) and >= block_size (1600 @ 262K).
+      # Scheduling-only (no quality change); ~6% slower on an UNCONTENDED long prefill.
+      # Set LONG_PREFILL_TOKEN_THRESHOLD=0 to disable.
+      - --long-prefill-token-threshold
+      - "${LONG_PREFILL_TOKEN_THRESHOLD:-2048}"
       - --speculative-config
       - '{"method":"mtp","num_speculative_tokens":3}'
       - --override-generation-config

--- a/models/qwen3.6-27b/vllm/compose/multi4/autoround-int4/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/multi4/autoround-int4/mtp.yml
@@ -3,7 +3,7 @@
 #   Model:     Qwen3.6-27B (Lorbus AutoRound INT4 + BF16 mtp.fc preserved)
 #   Topology:  Quad 3090 (TP=4, NVLink auto-detected via NVLINK_MODE)
 #   Drafter:   MTP n=3 (built-in)
-#   KV:        fp8_e5m2 (1 byte/token)
+#   KV:        fp8_e4m3 (1 byte/token)
 #   Vision:    yes
 #   Max ctx:   262K (237K single-prompt verified)
 #   Genesis:   none — intentionally Genesis-free (isolation control + fallback)
@@ -17,7 +17,7 @@
 #   Best for:  4-card Qwen "fast" tier (vllm/qwen-27b-multi-fast) — AutoRound int4 + fp8 KV + MTP, TP=4 ⭐
 # ---------------------------------------------------------------------------
 # Quad RTX 3090 — Qwen3.6-27B "fast" tier at TP=4 (vllm/qwen-27b-multi-fast).
-# AutoRound INT4 weights + MTP n=3 + fp8_e5m2 KV + vision. The serving config is
+# AutoRound INT4 weights + MTP n=3 + fp8_e4m3 KV + vision. The serving config is
 # identical to the 2-card vllm/dual (≡ vllm/qwen-27b-dual-fast) — only the
 # tensor-parallel size and the required gpu-count bump to 4. vllm/dual at TP=2 is
 # the on-rig proxy (this dev rig has 2 cards). Promoted to ✅ Production 2026-07-05
@@ -28,7 +28,7 @@
 # What the extra cards buy you (vs the 2-card vllm/dual):
 #   - TP=4 → ~2× the aggregate KV headroom at 262K (more concurrent streams /
 #     more decode-batch room) and the weights sharded thinner per card
-#   - everything else identical: full 262K, vision + tools + MTP n=3, fp8_e5m2 KV
+#   - everything else identical: full 262K, vision + tools + MTP n=3, fp8_e4m3 KV
 #
 # Pair with the "max accuracy" 4-card tier (vllm/qwen-27b-multi-max,
 # multi4/fp8/mtp.yml): FP8 weights + int8-PTH KV for higher fidelity at 262K.
@@ -149,7 +149,7 @@ services:
       - --max-num-batched-tokens
       - "8192"
       - --kv-cache-dtype
-      - "${KV_CACHE_DTYPE:-fp8_e5m2}"
+      - "${KV_CACHE_DTYPE:-fp8_e4m3}"
       - --trust-remote-code
       # froggeric chat-template override (see volumes block + docs/UPSTREAM.md)
       - --chat-template
@@ -163,6 +163,14 @@ services:
       - qwen3_coder
       - --enable-prefix-caching
       - --enable-chunked-prefill
+      # Head-of-line fix (Zylone; validated on the dual-fast sibling — same 27B, block_size
+      # 1600, batch 8192). DEFAULT 2048 = ON (N=2 concurrency lane): caps a long prefill's
+      # per-step tokens so a concurrent short/agentic request isn't starved. The 4-card
+      # analogue of the dual-fast A/B (14.8s -> 2.6s @ 2048); not independently 4-card boot-
+      # tested here. Must stay < max-num-batched-tokens (8192) and >= block_size (1600).
+      # Set LONG_PREFILL_TOKEN_THRESHOLD=0 to disable.
+      - --long-prefill-token-threshold
+      - "${LONG_PREFILL_TOKEN_THRESHOLD:-2048}"
       - --speculative-config
       - '{"method":"mtp","num_speculative_tokens":3}'
       - --override-generation-config

--- a/models/qwen3.6-27b/vllm/compose/single/autoround-int4/minimal.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/autoround-int4/minimal.yml
@@ -3,7 +3,7 @@
 #   Model:     Qwen3.6-27B (Lorbus AutoRound INT4 + BF16 mtp.fc preserved)
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   none (no spec-decode — simplest path)
-#   KV:        fp8_e5m2 (no TQ3 to avoid cudagraph cascade bugs)
+#   KV:        fp8_e4m3 (no TQ3 to avoid cudagraph cascade bugs)
 #   Vision:    no
 #   Max ctx:   65K (mem-util 0.95)
 #   Genesis:   none — bare vLLM, isolation control
@@ -118,7 +118,7 @@ services:
       - --max-num-seqs
       - "${MAX_NUM_SEQS:-1}"
       - --kv-cache-dtype
-      - "${KV_CACHE_DTYPE:-fp8_e5m2}"
+      - "${KV_CACHE_DTYPE:-fp8_e4m3}"
       - --trust-remote-code
       # froggeric chat-template override (see volumes block + docs/UPSTREAM.md)
       - --chat-template

--- a/models/qwen3.6-35b-a3b/vllm/compose/dual/autoround-int4/fp8.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/dual/autoround-int4/fp8.yml
@@ -6,8 +6,8 @@
 #              this MoE under vLLM TP=2: the draft forward incurs inter-GPU sync
 #              the acceptance gain can't amortize). MTP head is present in the
 #              weights but intentionally unused. See dual-mtp variant / BENCHMARKS.
-#   KV:        fp8_e5m2 (1 B/tok; vLLM's only viable KV quant on sm_86 —
-#              q5_0/q4_1/asymmetric K-V are llama.cpp-only and unnecessary here)
+#   KV:        fp8_e4m3 (1 B/tok; +1 mantissa bit vs e5m2 for finer KV precision —
+#              routes to FlashInfer on sm_86, verified live 2026-07-14; matches dual-max)
 #   Vision:    yes (limit-mm-per-prompt image=2) — vision tower retained + validated
 #   Max ctx:   262K (model's full max — NIAH-clean to 240K, 7.81× concurrency,
 #              2.05M-token KV pool: DeltaNet-hybrid KV is cheap so 262K fits easily)
@@ -44,7 +44,12 @@
 #   draft : none
 #
 # KV format:
-#   - fp8_e5m2 chosen over fp8_e4m3 (Triton fp8e4nv unsupported on sm_86).
+#   - fp8_e4m3 (not e5m2): +1 mantissa bit → finer KV precision at 1 B/tok, and matches
+#     dual-max. The prior "fp8e4nv unsupported on sm_86" note was the Triton path only —
+#     the fp8-checkpoint→FlashInfer path handles e4m3 on Ampere (verified live 2026-07-14:
+#     FlashInfer, block_size 2096, KV pool 2.0M, coherent). e5m2 was the incidental prior
+#     default (AutoRound loader sidesteps vLLM's e5m2/fp8 guard). Quality numbers above
+#     predate the switch (e5m2); e4m3 expected neutral-or-better (KV-dtype 8-pack-neutral here).
 # ===========================================================================
 # Hardware metadata (parsed by scripts/preflight.sh):
 # Requires-min-vram-gb: 24
@@ -144,7 +149,7 @@ services:
       - --limit-mm-per-prompt
       - '{"image":2,"audio":0}'
       - --kv-cache-dtype
-      - "${KV_CACHE_DTYPE:-fp8_e5m2}"
+      - "${KV_CACHE_DTYPE:-fp8_e4m3}"
       - --trust-remote-code
       - --reasoning-parser
       - qwen3
@@ -155,3 +160,13 @@ services:
       - qwen3_coder
       - --enable-prefix-caching
       - --enable-chunked-prefill
+      # Head-of-line fix (Zylone's vLLM tip). Caps a long prefill's per-step tokens so a
+      # concurrent short/agentic request isn't starved. DEFAULT 0 = OFF here, on purpose:
+      # this compose ships max_num_seqs=1 (single-stream), so there is no concurrent request
+      # to protect — the flag is inert until you raise concurrency. To enable agentic serving:
+      #   MAX_NUM_SEQS=8 LONG_PREFILL_TOKEN_THRESHOLD=2560 switch.sh <slug>
+      # Value must stay < max-num-batched-tokens (8192) and >= block_size — which is 2096 at
+      # 262K on this MoE (live-measured 2026-07-14), so use >=2560, NOT 2048. Works at native
+      # 262K (no context-lowering needed). Scheduling-only; no quality change.
+      - --long-prefill-token-threshold
+      - "${LONG_PREFILL_TOKEN_THRESHOLD:-0}"

--- a/models/qwen3.6-35b-a3b/vllm/compose/single/autoround-int4/preview.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/single/autoround-int4/preview.yml
@@ -4,7 +4,7 @@
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   none (smoke compose — built-in MTP head added in a follow-up
 #              once base boot is validated)
-#   KV:        fp8_e5m2 (no TQ3 — Genesis-only, not available here)
+#   KV:        fp8_e4m3 (FlashInfer on sm_86; no TQ3 — Genesis-only, not available here)
 #   Vision:    off (limit-mm-per-prompt image=0 audio=0) for first boot
 #   Max ctx:   8K (conservative — KV pool tight after 20 GB weights on 24 GB card)
 #   Genesis:   N/A — stock vLLM v0.22.0 (vllm-stable); Genesis path retired (#254)
@@ -29,7 +29,9 @@
 #   draft : none on this compose
 #
 # KV format:
-#   - fp8_e5m2 chosen over fp8_e4m3 (Triton fp8e4nv unsupported on sm_86).
+#   - fp8_e4m3 (not e5m2): finer KV precision; routes to FlashInfer on sm_86 (the
+#     "fp8e4nv unsupported" note was the Triton path only — verified on the dual MoE
+#     2026-07-14, same model + loader). e5m2 was the incidental prior default.
 #   - TQ3 not available without Genesis.
 # ===========================================================================
 # Hardware metadata (parsed by scripts/preflight.sh):
@@ -109,7 +111,7 @@ services:
       - --limit-mm-per-prompt
       - '{"image":0,"audio":0}'
       - --kv-cache-dtype
-      - "${KV_CACHE_DTYPE:-fp8_e5m2}"
+      - "${KV_CACHE_DTYPE:-fp8_e4m3}"
       - --trust-remote-code
       - --reasoning-parser
       - qwen3

--- a/models/vibethinker-3b/vllm/compose/single/bf16/fp8.yml
+++ b/models/vibethinker-3b/vllm/compose/single/bf16/fp8.yml
@@ -4,7 +4,7 @@
 #              SFT+RL fine-tune of Qwen2.5-Coder-3B. Qwen2 dense, GQA 16h/2kv.)
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   none (no spec-decode — no MTP head, no matched draft model)
-#   KV:        fp8_e5m2 (storage-only — bf16 weights untouched, so NO quality hit; halves the
+#   KV:        fp8_e4m3 (storage-only — bf16 weights untouched, so NO quality hit; halves the
 #              cache. At the default single-concurrency mem_util 0.40 → 174K-token / 1.33x pool,
 #              ~9.8 GB total, frees ~14 GB to co-reside w/ a 27B — full 131K retained)
 #   Vision:    no (text-only)
@@ -20,9 +20,9 @@
 #              (AIME, LiveCodeBench, LeetCode). NOT an open-domain-knowledge or
 #              prose model (the authors say so) — pick a larger general model for that.
 # ---------------------------------------------------------------------------
-# VibeThinker-3B on vLLM — single 3090, bf16 weights + fp8_e5m2 KV.
+# VibeThinker-3B on vLLM — single 3090, bf16 weights + fp8_e4m3 KV.
 # A 3B reasoning model: ~5.8 GB of bf16 weights leave the bulk of a 24 GB card free.
-# KV is quantized to fp8_e5m2 (storage-only — weights stay bf16, so quality is intact;
+# KV is quantized to fp8_e4m3 (storage-only — weights stay bf16, so quality is intact;
 # A/B'd 2026-06-16: math/code answers identical to bf16 KV). Combined with single concurrency
 # (max_num_seqs=1) the default GPU_MEMORY_UTILIZATION is 0.40 — sized for ONE full-131K stream,
 # not a fat multi-seq pool: ~9.8 GB total (5.8 GB weights + a 174K-token / 1.33x fp8-KV pool),
@@ -61,7 +61,7 @@
 #                                               ~0.37 is the 1.0x floor for full 131K; raise for
 #                                               more concurrency; lower needs a smaller MAX_MODEL_LEN.)
 #   MAX_NUM_SEQS     concurrent sequences      (default: 1 — single concurrency)
-#   KV_CACHE_DTYPE   K/V cache dtype           (default: fp8_e5m2; set 'auto' for bf16 KV)
+#   KV_CACHE_DTYPE   K/V cache dtype           (default: fp8_e4m3; set 'auto' for bf16 KV)
 #   TEMP / TOP_P / TOP_K / MIN_P               (defaults: 1.0 / 0.95 / -1 / 0.0)
 #   PORT             host port                 (default: 8074)
 #   VLLM_IMAGE       engine image              (default: vllm/vllm-openai:v0.22.0)
@@ -141,7 +141,7 @@ services:
       - --max-num-seqs
       - "${MAX_NUM_SEQS:-1}"
       - --kv-cache-dtype
-      - "${KV_CACHE_DTYPE:-fp8_e5m2}"
+      - "${KV_CACHE_DTYPE:-fp8_e4m3}"
       - --trust-remote-code
       # NO tool-calling: VibeThinker is a math/code/STEM reasoning model — the authors
       # don't support function-calling, and it emits bare JSON (not <tool_call>) so no

--- a/scripts/lib/profiles/compat.py
+++ b/scripts/lib/profiles/compat.py
@@ -899,7 +899,19 @@ def fits(
     # would route to Triton and still fail — this proxy would wrongly allow it; revisit then.
     # nvfp4 weights added 2026-07-13 (#686): tess/qwen NVFP4 run e4m3 KV via FlashInfer
     # on sm_86 — live-validated (A0 8-pack on 2x3090, BENCHMARKS) — while gemma stays rejected.
-    _fp8w_ampere_kv = effective_kv == "fp8_e4m3" and str(effective_weights or "").startswith(("fp8", "nvfp4"))
+    # Qwen3-Next family added 2026-07-14: autoround-int4 weights + e4m3 KV ALSO route to
+    # FlashInfer on sm_86 (live-verified — dual-fast + 35b-a3b-dual boot: block_size 1600/2096,
+    # FlashInfer selected, coherent). The backend split is model-driven (DeltaNet hybrid attn),
+    # NOT weight-variant-driven, so key on family here — gemma (gemma4-swa-dense) stays on
+    # Triton → correctly rejected regardless of weight variant. See docs/DTYPE_MATRIX.md.
+    # bf16/fp16 (full-precision) weights added 2026-07-14: no W4A16 quant kernel to force
+    # Triton, so fp8_e4m3 KV routes to FlashInfer on sm_86 — live-verified on vibethinker-3b
+    # (bf16 Qwen2-dense: FlashInfer selected, coherent). Only gemma-style W4A16 on a non-
+    # qwen3-next family still routes to Triton → stays correctly rejected.
+    _fp8w_ampere_kv = effective_kv == "fp8_e4m3" and (
+        str(effective_weights or "").startswith(("fp8", "nvfp4", "bf16", "fp16"))
+        or model.family.startswith("qwen3-next")
+    )
     unsupported_hw = [
         hw.id for hw in hardware
         if effective_kv not in hw.supported_kv_formats

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -163,7 +163,7 @@ COMPOSE_REGISTRY = {
     # Qwen 3.6 27B, vLLM single-card.
     "vllm/minimal": _entry(
         model="qwen3.6-27b", weights_variant="autoround-int4", workload="fast-chat",
-        engine="vllm-stable", drafter=None, kv_format="fp8_e5m2",
+        engine="vllm-stable", drafter=None, kv_format="fp8_e4m3",
         tp=1, max_ctx=32768, max_num_seqs=1, mem_util=0.92,
         compose_path="models/qwen3.6-27b/vllm/compose/single/autoround-int4/minimal.yml",
         default_port=8020,
@@ -173,7 +173,7 @@ COMPOSE_REGISTRY = {
     # Qwen 3.6 27B, vLLM dual/multi-card.
     "vllm/dual": _entry(
         model="qwen3.6-27b", weights_variant="autoround-int4", workload="long-ctx-single",
-        engine="vllm-stable", drafter="qwen-mtp-builtin", kv_format="fp8_e5m2",
+        engine="vllm-stable", drafter="qwen-mtp-builtin", kv_format="fp8_e4m3",
         tp=2, max_ctx=262144, max_num_seqs=2, mem_util=0.92,
         compose_path="models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml",
         default_port=8010,
@@ -194,7 +194,7 @@ COMPOSE_REGISTRY = {
     # (qwen,vllm,dual) DEFAULT stays "vllm/dual" (the long-established slug).
     "vllm/qwen-27b-dual-fast": _entry(
         model="qwen3.6-27b", weights_variant="autoround-int4", workload="long-ctx-single",
-        engine="vllm-stable", drafter="qwen-mtp-builtin", kv_format="fp8_e5m2",
+        engine="vllm-stable", drafter="qwen-mtp-builtin", kv_format="fp8_e4m3",
         tp=2, max_ctx=262144, max_num_seqs=2, mem_util=0.92,
         compose_path="models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml",
         default_port=8010,
@@ -233,7 +233,7 @@ COMPOSE_REGISTRY = {
     ),
     "vllm/qwen-27b-multi-fast": _entry(
         model="qwen3.6-27b", weights_variant="autoround-int4", workload="long-ctx-single",
-        engine="vllm-stable", drafter="qwen-mtp-builtin", kv_format="fp8_e5m2",
+        engine="vllm-stable", drafter="qwen-mtp-builtin", kv_format="fp8_e4m3",
         tp=4, max_ctx=262144, max_num_seqs=2, mem_util=0.92,
         compose_path="models/qwen3.6-27b/vllm/compose/multi4/autoround-int4/mtp.yml",
         default_port=8014,
@@ -805,7 +805,7 @@ COMPOSE_REGISTRY = {
     # slug `vllm/diffusiongemma-dual` (launch requires --force).
     "vllm/qwen-a3b-preview-single": _entry(
         model="qwen3.6-35b-a3b", weights_variant="autoround-int4", workload="fast-chat",
-        engine="vllm-stable", drafter=None, kv_format="fp8_e5m2",
+        engine="vllm-stable", drafter=None, kv_format="fp8_e4m3",
         tp=1, max_ctx=8192, max_num_seqs=1, mem_util=0.95,
         compose_path="models/qwen3.6-35b-a3b/vllm/compose/single/autoround-int4/preview.yml",
         default_port=8050,
@@ -815,7 +815,7 @@ COMPOSE_REGISTRY = {
     ),
     "vllm/qwen-35b-a3b-dual": _entry(
         model="qwen3.6-35b-a3b", weights_variant="autoround-int4", workload="fast-chat",
-        engine="vllm-stable", drafter=None, kv_format="fp8_e5m2",
+        engine="vllm-stable", drafter=None, kv_format="fp8_e4m3",
         tp=2, max_ctx=262144, max_num_seqs=1, mem_util=0.92,
         compose_path="models/qwen3.6-35b-a3b/vllm/compose/dual/autoround-int4/fp8.yml",
         default_port=8051,
@@ -873,7 +873,7 @@ COMPOSE_REGISTRY = {
     # swap + generate-compose (first model onboarded through the lane end-to-end).
     "vllm/agents-a1-dual": _entry(
         model="agents-a1", weights_variant="fp8-dynamic", workload="long-ctx-single",
-        engine="vllm-stable", drafter=None, kv_format="fp8_e5m2",
+        engine="vllm-stable", drafter=None, kv_format="fp8_e4m3",
         tp=2, max_ctx=262144, max_num_seqs=1, mem_util=0.92,
         compose_path="models/agents-a1/vllm/compose/dual/fp8-dynamic/fp8.yml",
         default_port=8072,
@@ -977,7 +977,7 @@ COMPOSE_REGISTRY = {
     # (Qwen2 dense). First dense-family + first sub-4B model in the catalog.
     "vllm/vibethinker-3b-single": _entry(
         model="vibethinker-3b", weights_variant="bf16", workload="long-ctx-single",
-        engine="vllm-stable", drafter=None, kv_format="fp8_e5m2",
+        engine="vllm-stable", drafter=None, kv_format="fp8_e4m3",
         tp=1, max_ctx=131072, max_num_seqs=1, mem_util=0.40,
         compose_path="models/vibethinker-3b/vllm/compose/single/bf16/fp8.yml",
         default_port=8074,

--- a/scripts/lib/profiles/gates.py
+++ b/scripts/lib/profiles/gates.py
@@ -68,18 +68,24 @@ from typing import Any, Callable, Optional
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
-# Arch-kernel SM rule (locked design [C0] / brief): per-KV-format SM floors —
-# none loadable on Ampere sm_86 (RTX 3090). Floors are the vLLM kernel truth:
-#   fp8_e4m3            8.9  — vLLM "FP8 KV cache … requires SM89+" (Ada+;
-#                              was 9.0 here — corrected for #246, since the
-#                              launcher now injects e4m3 on 4090s. The gemma
-#                              fp8 slug keeps its explicit required_sm 9.0.)
+# Arch-kernel SM rule (locked design [C0] / brief): per-KV-format SM floors.
+# Floors are the vLLM kernel truth:
+#   fp8_e4m3            8.6  — CORRECTED 2026-07-14: fp8_e4m3 KV *storage* runs on
+#                              Ampere sm_86 via FlashInfer (live-verified — Qwen3-
+#                              Next dual-fast + 35b-a3b + vibethinker bf16 all boot
+#                              on 2x3090, FlashInfer selected, coherent). The old
+#                              "requires SM89+" floor was really the *Triton* fp8e4nv
+#                              path (W4A16 models like Gemma) — those keep their
+#                              explicit registry required_sm (gemma fp8 = 9.0), which
+#                              still gates them here. So e4m3's own floor is just
+#                              Ampere-minimum; per-model Triton gating lives in
+#                              required_sm. Mirrors compat.py `_fp8w_ampere_kv`.
 #   turboquant_3bit_nc  9.0  — MAINLINE TQ3 kernels (Genesis-Ampere TQ3 is a
 #                              different path; mirrors arch_patches Gemma
 #                              kernel_constraints)
 #   nvfp4               family-gated (see _ARCH_KERNEL_SM_FAMILY) — NOT a floor
 _ARCH_KERNEL_SM = {
-    "fp8_e4m3": 8.9,
+    "fp8_e4m3": 8.6,
     "turboquant_3bit_nc": 9.0,
 }
 
@@ -526,7 +532,9 @@ def c0_engine_support(
             f"registry.required_sm={entry.get('required_sm')}, "
             f"arch-kernel[{kv_format}]="
             f"{_ARCH_KERNEL_SM.get(kv_format, 0.0):g}); "
-            f"e.g. fp8_e4m3 needs SM 8.9+, Gemma-TQ3 SM 9.0+ — NOT loadable on sm_86"
+            f"e.g. Gemma-4 fp8 needs SM 9.0+ (Triton fp8e4nv path; via required_sm), "
+            f"Gemma-TQ3 SM 9.0+ — NOT loadable on sm_86 (fp8_e4m3 KV itself runs on "
+            f"Ampere via FlashInfer for FlashInfer-path models)"
         )
 
     # 3d-bis. family-specific kernels — a numeric floor can't express these.

--- a/scripts/tests/test-generate-from-profile.sh
+++ b/scripts/tests/test-generate-from-profile.sh
@@ -169,10 +169,13 @@ check("--trust-remote-code" not in text,
       "e1: --trust-remote-code must NOT be emitted when trc not resolved-permitted")
 
 # A clean derived case that NEEDS a dtype (fp8 row + torch_dtype) maps a
-# kv_arg-mapped --kv-cache-dtype (fp8_e5m2 -> fp8_e5m2).
+# kv_arg-mapped --kv-cache-dtype (fp8_e5m2 -> fp8_e5m2). kv_format is pinned explicitly
+# below so this fixture stays independent of the seed slug's registry default (which switched
+# to fp8_e4m3 on 2026-07-14; note kv_arg maps fp8_e4m3 -> the short "fp8" form).
 der_fp8 = mk_der(weight_format="fp8", torch_dtype="bfloat16")
 ei_fp8 = mk_einput("vllm/qwen-a3b-preview-single", der=der_fp8,
                    gpu_count=1, sel_gpus=(0,))
+ei_fp8.runtime["kv_format"] = "fp8_e5m2"  # pin a distinct KV; registry-default-independent
 ok2, _ = gc.derived_emittable(ei_fp8)
 check(ok2, "e1: fp8+torch_dtype clean single-GPU case must be emittable")
 t2, m2 = gc.generate_from_profile(root, ei_fp8)

--- a/scripts/tests/test-launch-compat.sh
+++ b/scripts/tests/test-launch-compat.sh
@@ -117,11 +117,13 @@ GPU_5090X2='0|NVIDIA GeForce RTX 5090|32607|12.0;1|NVIDIA GeForce RTX 5090|32607
 # ampere -> NOTHING injected (compose defaults; the no-op is data equality)
 out="$(python3 "$HELPER" resolve-variant-pin --variant vllm/dual --format shell --gpu-spec "$GPU_3090")"
 assert_not_contains "$out" "KV_CACHE_DTYPE"
-# ada / blackwell pilot slugs -> native-fp8 swap
+# vllm/dual + vllm/minimal are now fp8_e4m3-native on ALL arches (2026-07-14 KV switch): the
+# compose default already gives native fp8 on Ada/Blackwell, so there is nothing to swap -> no
+# injection. (#246's Qwen e5m2->e4m3 arch-swap is now vestigial for these slugs — see followup.)
 out="$(python3 "$HELPER" resolve-variant-pin --variant vllm/dual --format shell --gpu-spec "$GPU_4090")"
-assert_contains "$out" "KV_CACHE_DTYPE=fp8_e4m3"
+assert_not_contains "$out" "KV_CACHE_DTYPE"
 out="$(python3 "$HELPER" resolve-variant-pin --variant vllm/minimal --format shell --gpu-spec "$GPU_5090X2")"
-assert_contains "$out" "KV_CACHE_DTYPE=fp8_e4m3"
+assert_not_contains "$out" "KV_CACHE_DTYPE"
 # non-pilot slug (same kv_format) -> no injection until the #246 A/B expands the pilot
 out="$(python3 "$HELPER" resolve-variant-pin --variant vllm/qwen-27b-dual-fast --format shell --gpu-spec "$GPU_4090")"
 assert_not_contains "$out" "KV_CACHE_DTYPE"

--- a/scripts/tests/test-profiles-compat.sh
+++ b/scripts/tests/test-profiles-compat.sh
@@ -155,12 +155,25 @@ assert not r.valid
 assert any(reason.startswith("C4:") for reason in r.reasons), r.reasons
 PY
 
-run_test "C5 hardware KV support: Ampere rejects fp8_e4m3" <<'PY'
+run_test "C5 hardware KV support: Ampere rejects fp8_e4m3 on the Triton path (gemma)" <<'PY'
 from scripts.lib.profiles.compat import load_profiles, fits
 p = load_profiles()
-r = fits([p.hardware["rtx-3090"]], p.models["qwen3.6-27b"], p.workloads["long-ctx-single"], p.engines["vllm-nightly-mtp"], kv_format="fp8_e4m3", tp=1, project_vram=False)
+# gemma-4 (W4A16 → Triton, whose fp8e4nv path needs sm_89+) is the Triton-path model:
+# fp8_e4m3 KV is correctly REJECTED on Ampere. (Qwen3-Next routes to FlashInfer and is
+# now allowed on Ampere — see the positive test below; changed 2026-07-14.)
+r = fits([p.hardware["rtx-3090"]], p.models["gemma-4-31b"], p.workloads["long-ctx-single"], p.engines["vllm-gemma-stable"], kv_format="fp8_e4m3", tp=1, project_vram=False)
 assert not r.valid
 assert any(reason.startswith("C5:") for reason in r.reasons), r.reasons
+PY
+
+run_test "C5 hardware KV support: Ampere ALLOWS fp8_e4m3 for Qwen3-Next (FlashInfer path)" <<'PY'
+from scripts.lib.profiles.compat import load_profiles, fits
+p = load_profiles()
+# Qwen3-Next (DeltaNet hybrid attn) routes fp8_e4m3 KV to FlashInfer on sm_86 regardless of
+# weight variant — live-verified 2026-07-14 (dual-fast autoround-int4 + 35b-a3b-dual both boot,
+# FlashInfer selected, coherent). So C5 must PASS even with autoround-int4 weights on the 3090.
+r = fits([p.hardware["rtx-3090"], p.hardware["rtx-3090"]], p.models["qwen3.6-27b"], p.workloads["long-ctx-single"], p.engines["vllm-stable"], p.drafters["qwen-mtp-builtin"], kv_format="fp8_e4m3", tp=2, weights_variant="autoround-int4", project_vram=False)
+assert "C5" not in r.diagnostics["constraints_failed"], r.reasons
 PY
 
 run_test "C6 Genesis one-way: TQ3 KV on non-Genesis engine rejected (via C15)" <<'PY'
@@ -298,7 +311,7 @@ name = to_compose_name(
     p.models["qwen3.6-27b"],
     p.engines["vllm-stable"],
     p.drafters["qwen-mtp-builtin"],
-    "fp8_e5m2",
+    "fp8_e4m3",
     2,
     1,
     workload=p.workloads["long-ctx-single"],


### PR DESCRIPTION
## What

Two related Qwen-serving tuning changes, validated together on the 2×3090:

1. **KV `fp8_e5m2` → `fp8_e4m3`** on all 8 real e5m2 vLLM slugs — 27B `dual`(dual-fast)/`minimal`/`multi-fast`, 35b-a3b `dual`/`preview`, `agents-a1`, `vibethinker`.
2. **`--long-prefill-token-threshold` ON by default (2048)** on the two N=2 concurrency lanes (`vllm/dual` + `vllm/qwen-27b-multi-fast`).

## Why — KV switch

- e4m3 has **+1 mantissa bit** (2× significand precision) at the same 1 B/tok, and it **matches dual-max** (which has no field quality reports; dual-fast on e5m2 does).
- e5m2 on dual-fast was **incidental** — the AutoRound loader sidesteps vLLM's `fp8_e5m2`-with-fp8-checkpoint guard; it was never a quality choice.
- **Live-verified e4m3** on dual-fast / 35b-a3b / agents-a1 / vibethinker: FlashInfer backend, identical KV pool, coherent output.
- No 8-pack A/B (maintainer waived) — expected neutral-or-better: KV-dtype is 8-pack-neutral on this stack (int8-PTH vs e4m3 = 110=110 exact) and NIAH is blind to KV-quant drift.

## The infra part — unwinding "fp8_e4m3 needs SM 8.9+"

That belief is the **Triton `fp8e4nv` path only**. FlashInfer-path models run e4m3 on Ampere sm_86 — so the swap required correcting the assumption in every layer that encoded it:

| Layer | Change |
|---|---|
| `compat.py` C5 `_fp8w_ampere_kv` | allow e4m3 on sm≥8.6 for **Qwen3-Next family** (any weights) + **bf16/fp16** weights; gemma (`gemma4-swa-dense`, W4A16→Triton) stays rejected |
| `gates.py` C0 `_ARCH_KERNEL_SM["fp8_e4m3"]` | `8.9 → 8.6`; Triton-path models stay gated by their explicit registry `required_sm` (gemma=9.0) |
| `compose_registry.py` | `kv_format` updated for the 8 slugs |
| compose comments | corrected the stale "Triton fp8e4nv unsupported on sm_86" notes on the 35b-a3b composes |
| 3 test fixtures | profiles-compat ("Ampere rejects e4m3" now uses gemma + a new positive Qwen-allowed test), launch-compat (#246 matrix), generate-from-profile (kv_arg map) |

## Why — HOL threshold

On-rig A/B (dual-fast, 262K, N=2, 60K concurrent prefill): short-request TTFT **14.8s → 2.6s @ 2048 (5.8×)**. Scheduling-only (no quality change); ~6% slower on an *uncontended* long prefill. Works at native 262K — the DeltaNet block_size is **1600**, not the ~8192 an earlier note projected.

- `vllm/qwen-35b-a3b-dual` stays **inert** (`:-0`): ships N=1, and its block_size is 2096 (2048 would be invalid).
- `multi-fast` (4-card) is inferred from the dual-fast A/B (same 27B block_size 1600 / batch 8192) — **not independently 4-card boot-tested**.

## Test

Full suite **81/81 green**. Live boots on dual-fast, 35b-a3b, agents-a1, vibethinker (all FlashInfer + coherent).

## Follow-up (not in this PR)

The #246 arch-aware KV injection (Ampere-e5m2 → native-e4m3 swap on Ada/Blackwell) is now **vestigial for Qwen** — e4m3 is universal, nothing to swap. Mechanism left intact; flagged in the launch-compat test comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm