### PR TITLE
Harden setup-ai-studio.sh: fail loud on OWUI port-8080 conflict (#686)

### DIFF
--- a/scripts/setup-ai-studio.sh
+++ b/scripts/setup-ai-studio.sh
@@ -109,8 +109,45 @@ else
 fi
 
 # --- 3. Bring the studio up via gpu-mode ------------------------------------
+# Open WebUI's host port 8080 is fixed (hardcoded in services/openwebui, and the
+# pipe/register helpers all talk to :8080). If another service already holds it,
+# OWUI silently fails to bind and the studio comes up half-working — and
+# gpu-mode's start_service swallows that failure ('… || echo "failed"' returns
+# 0). So gate the bring-up on 8080 being free, and verify OWUI afterwards,
+# instead of reporting a false "ready" (#686).
+if ! docker ps --format '{{.Names}} {{.Ports}}' 2>/dev/null | grep -qE '^open-webui .*:8080->'; then
+    _p8080=""
+    if command -v ss >/dev/null 2>&1; then
+        _p8080=$(ss -Hltn 2>/dev/null | awk '{print $4}' | grep -E ':8080$' | head -1)
+    elif command -v lsof >/dev/null 2>&1; then
+        _p8080=$(lsof -iTCP:8080 -sTCP:LISTEN -Pn 2>/dev/null | tail -n +2 | head -1)
+    fi
+    if [ -n "$_p8080" ]; then
+        warn "  ✗ Port 8080 is already in use — Open WebUI can't bind it (listener: $_p8080)."
+        echo "     OWUI's host port 8080 is fixed (baked into the compose + the pipe/register helpers)."
+        echo "     Free 8080 first — e.g. move the other service (a llama-server router: add"
+        echo "     '--port 8081' and point your client at the new port) — then re-run this script." >&2
+        exit 1
+    fi
+fi
+
 say "── [3/4] Starting the studio (gpu-mode ai-studio) ──"
 bash "$REPO_DIR/scripts/gpu-mode.sh" ai-studio
+
+# gpu-mode's start_service swallows a failed 'compose up' (#686), so trust the
+# container STATE, not the exit code: a bind failure leaves open-webui missing
+# or Exited/Restarting rather than Up.
+_owui_status="$(docker ps -a --format '{{.Names}}\t{{.Status}}' 2>/dev/null | awk -F'\t' '$1=="open-webui"{print $2; exit}')"
+case "$_owui_status" in
+    Up*) ;;   # running (optionally "(healthy)") — good
+    *)
+        warn "  ✗ Open WebUI did not come up (status: ${_owui_status:-missing})."
+        echo "     Most common cause: something else is bound to its host port 8080." >&2
+        echo "     Inspect:  docker ps -a | grep open-webui" >&2
+        echo "               docker logs open-webui 2>&1 | tail -20" >&2
+        echo "     Fix the conflict, then re-run:  bash scripts/setup-ai-studio.sh" >&2
+        exit 1 ;;
+esac
 
 # --- 4. Install the OWUI Studio pipe (install-if-absent; needs an OWUI admin) ---
 # PIPE_OK drives the onboarding below: a fresh install has no OWUI admin yet (you create it by


### PR DESCRIPTION
## What
Two guards in `setup-ai-studio.sh` so an Open WebUI port conflict fails **loud** instead of reporting a false "AI Studio ready" over a half-started stack.

## Why (#686)
OWUI's host port **8080 is hardcoded** (the `services/openwebui` compose *and* the pipe/register helpers all talk to `:8080`). When another service already holds 8080, OWUI can't bind — but `gpu-mode`'s `start_service` swallows the failed `docker compose up`:

```sh
compose_cmd "$1" "up -d" && echo "done" || echo "failed"   # prints "failed", returns 0
```

So `setup-ai-studio.sh`'s `set -e` never fires, and it walks on to "ready." A user (@MoppelMat, 4×3090) hit this — their `llama-server` router had 8080, OWUI silently failed, ComfyUI/etc. came up half-working, and the script claimed success.

## The fix
Decoupled from `gpu-mode`'s exit code — trust host/container **state**:
- **Before `gpu-mode ai-studio`:** if a *non-OWUI* listener holds 8080 (`ss`, `lsof` fallback), abort with an actionable message (free the port / move the other service). Our own already-running OWUI is recognized via `docker ps` and skipped → no false positive.
- **After:** verify the `open-webui` container is actually `Up`; a bind failure leaves it missing / `Exited` / `Restarting`.

Left `gpu-mode`'s broader `… || echo "failed"` swallow pattern untouched (it's shared across every mode — changing it is a wider blast radius; noted as a deeper follow-up).

## Test
- `bash -n` clean.
- Live: the guard matches our running `open-webui` (correctly skips), post-up check passes `Up (healthy)`, a simulated 8080 listener is detected, status-parse handles `Up`/`Exited`/missing.

Fixes the silent-failure half of https://github.com/noonghunna/club-3090/discussions/686 (the port-8080 conflict MoppelMat reported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm