### PR TITLE
Promote nemotron-75b-multi-mtp: experimental → ⚠️ production w/ caveats (#706)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -463,6 +463,16 @@ InternScience's own 35B agentic MoE (Qwen3-Next MoE architecture; card declares 
 
 ---
 
+## Nemotron-3-Puzzle-75B-A9B (NVIDIA NVFP4 hybrid MoE — ⚠️ production w/ caveats)
+
+NVIDIA's Nemotron-3-Puzzle-75B-A9B — a **Mamba2-Transformer Hybrid LatentMoE** (75.3B total / 9.3B active, 512 routed + 1 shared expert), NVFP4 modelopt-mixed weights (NVFP4 routed-expert FFNs + FP8 Mamba/shared projections). The **quad-3090 flagship**: a fast 75B-class hybrid MoE for 4-card owners (dense Qwen 27B underuses 96 GB). NVIDIA's card lists Blackwell/Hopper only — but it runs clean on **Ampere** via the NVFP4→Marlin-W4A16 + FP8→bf16 dequant + `flashinfer`-Mamba fallbacks. First validated end-to-end by @TheFuzy on 4×3090 ([#706](https://github.com/noonghunna/club-3090/discussions/706)).
+
+| Compose | Rig | KV | Max ctx | Narr / Code TPS | PP tok/s | Peak VRAM | Date | Notes |
+| --- | --- | --- | ---: | ---: | ---: | ---: | --- | --- |
+| `vllm/nemotron-75b-multi-mtp` | @TheFuzy (4× 3090 PCIe, EPYC 7302P, 250 W caps, PCIe-P2P engaged; [#706](https://github.com/noonghunna/club-3090/discussions/706)) | fp8_e4m3 attn + fp16 Mamba SSM | 200K (**N=2**) | **104 / 128** (decode 105.4 / 130.3, n=5, CV 4.6%, TTFT 148 / 130 ms) | 2.9K→4.9K t/s (10K→30K NIAH) | ~21.4 GB/card | 2026-07-14 | **First real Ampere datapoint — full validation at N=2 concurrency.** TP=4 + expert-parallel, MTP n=3, `--mamba-backend flashinfer`, util 0.85. **verify-full 9/9** (incl. streaming tool-calls thinking-ON, no leak) · **verify-stress** NIAH clean @10K+30K + ~25K tool-prefill OK · **soak-continuous PASS** (0 MiB growth, 0/25 silent-empty, 100% retention, p50 **185 TPS** batched) · agentic decode 128–146 TPS to 44K ctx (sub-linear TTFT). KV pool 4.18 GiB = 314,979 tokens. ⚠️ 8-pack quality pending; 262K + N≥4 untested (pool > 262K → 262K should fit). |
+
+---
+
 ## Quality benches — Aider Polyglot 30
 
 Pass rate on a curated 30-exercise subset of [aider-polyglot-benchmark](https://github.com/Aider-AI/polyglot-benchmark) (5 per language across cpp/go/java/javascript/python/rust, mix of easy/medium/hard). Tests **edit-format reliability** AND **algorithmic correctness** — does the model emit diffs aider can apply, AND do the resulting tests pass.

--- a/models/nemotron-3-puzzle-75b/vllm/compose/multi4/nvfp4/mtp.yml
+++ b/models/nemotron-3-puzzle-75b/vllm/compose/multi4/nvfp4/mtp.yml
@@ -12,11 +12,16 @@
 #   Vision:    no
 #   Max ctx:   200K default (TheFuzy's proven 4×3090 value, #706; card: up to 1M) — env-overridable
 #   Genesis:   N/A — Genesis is Qwen3-Next-specific
-#   Status:    🧪 EXPERIMENTAL — quant/kernel path CONFIRMED on 4×3090 (#706); config fit-tuned
-#              for 24 GB, pending end-to-end re-test
-#   Best for:  Quad-3090 owners wanting a fast 75B-class hybrid MoE — single-stream (concurrency TBD)
+#   Status:    ⚠️ Production w/ caveats — FULL 4×3090 validation 2026-07-14 (@TheFuzy, #706):
+#              verify-full 9/9 + verify-stress (NIAH clean) + soak-continuous PASS + bench + agentic,
+#              at N=2 concurrency. First real Ampere datapoint; see BENCHMARKS.md.
+#   Caveats:   • 8-pack behavioral quality NOT yet run (operational metrics only) • single-rig
+#              validation (one 4×3090) • ships max_num_seqs=1 default (N=2 validated — env-overridable)
+#              • 200K default (262K untested — KV pool 314,979 tok > 262K, should fit; confirm live).
+#   Best for:  Quad-3090 owners wanting a fast 75B-class hybrid MoE — validated at N=2 concurrency ⭐
 # ---------------------------------------------------------------------------
-# ⚠️  STATUS — CONFIRMED to load + serve on 4× RTX 3090 (@TheFuzy ran an equivalent config, #706).
+# ⚠️  STATUS — FULLY VALIDATED on 4× RTX 3090 (@TheFuzy, #706): verify 9/9 + stress + soak PASS
+#     + bench + agentic, at N=2. Promoted 🧪 → ⚠️ Production w/ caveats 2026-07-14 (8-pack pending).
 #
 # NVIDIA's model card lists supported microarchitectures as **Blackwell + Hopper ONLY**
 # (tested on 1×/8× H100 and 8× B200). NVFP4 is "optimized for Blackwell-class GPUs."

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -939,7 +939,7 @@ COMPOSE_REGISTRY = {
         compose_path="models/nemotron-3-puzzle-75b/vllm/compose/multi4/nvfp4/mtp.yml",
         default_port=8095, required_sm=9.0, fallback_sm=7.5,
         kvcalc_key="SKIP",
-        status="experimental",
+        status="caveats",
         status_note="Nemotron-3 Puzzle 75B-A9B NVFP4 (nvidia modelopt MIXED: NVFP4 routed-expert FFNs + FP8 Mamba/shared projections), 4-card TP=4 @200K single-stream, built-in MTP via --speculative-config. Mamba2-Transformer hybrid LatentMoE, 9.3B active / 75.3B total. 🧪 Experimental — CANNOT be booted/validated on the maintainer's 2x3090 rig (needs 4x3090); shown in switch.sh --list, launch requires --force. fp8_e4m3 attention KV (checkpoint-declared) + fp16 Mamba SSM state (stochastic-rounded; never fp8). kv-calc bypassed (hybrid arch, no spec → kvcalc SKIP + model kv_calc_supported=false). NVIDIA supported-HW = Blackwell+Hopper ONLY; arch NemotronHPuzzleForCausalLM aliases to the NemotronH loader (registered v0.24.0 + v0.25.0; card tested v0.20.0) and CONFIRMED to run on 4x3090 (#706, @TheFuzy: weights 13.31 GiB/card, arch/quant/mamba/MTP all work on Ampere). This config is FIT-TUNED for 24 GB after our first cut OOM'd at 262K single-stream (profile-run prefill blew up with chunked-prefill off): chunked prefill ON + max-num-batched-tokens 8192 + max-model-len 200000 + fp8 KV. Concurrency (max_num_seqs>1 + --long-prefill-token-threshold) is a follow-up gated on a community VRAM report. FP8 sibling (83 GB) too big for 4x24GB → NVFP4 is the only quad-3090 fit. No DEFAULTS row (opt-in only). Community-float to 4x3090 owners.",
     ),
 


### PR DESCRIPTION
## What
Promotes `vllm/nemotron-75b-multi-mtp` from `🧪 experimental` → `⚠️ Production w/ caveats` on the strength of @TheFuzy's full 4×3090 validation ([#706](https://github.com/noonghunna/club-3090/discussions/706)).

## Why — first real Ampere validation, clean sweep at N=2
`report.sh --full` on 4×3090, N=2 concurrency, 200K:

| | |
|---|---|
| verify-full | **9/9** (incl. streaming tool-calls thinking-ON, no leak) |
| verify-stress | NIAH recall clean @10K+30K · ~25K tool-prefill OK · agent/coding/reasoning ✓ |
| soak-continuous | **PASS** — 0 MiB growth · 0 err · 0/25 silent-empty · 100% retention · p50 **185 TPS** |
| bench | decode 105 narr / 130 code single-stream; agentic 128–146 TPS to 44K ctx |
| VRAM | ~21.4 GB/card @ util 0.85 · KV pool 4.18 GiB (314,979 tok) · PCIe P2P engaged |

Confirms it's **not Blackwell-only**, runs **concurrent (N=2)**, and is **stable under load**.

## Changes
- **Registry:** `status="experimental"` → `"caveats"` (makes it functional — launchable without `--force`, shown in `switch.sh --list`).
- **Compose header:** `🧪 EXPERIMENTAL` → `⚠️ Production w/ caveats` + the required `Caveats:` line.
- **BENCHMARKS.md:** new Nemotron section with TheFuzy's row.

## Caveats (why not full ✅)
- 8-pack behavioral quality **not yet run** (operational metrics only — TheFuzy may run it off-time)
- single-rig validation (one 4×3090)
- ships `max_num_seqs=1` default (N=2 validated, env-overridable)
- 200K default (262K untested; KV pool > 262K so a single stream should fit)

## Test
Full guard sweep **81/81** green (incl. `test-compose-status-drift`: header ⚠️ ↔ registry `caveats`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm