### PR TITLE
docs(nemotron): add util→KV-pool headroom note to the compose

### DIFF
--- a/models/nemotron-3-puzzle-75b/vllm/compose/multi4/nvfp4/mtp.yml
+++ b/models/nemotron-3-puzzle-75b/vllm/compose/multi4/nvfp4/mtp.yml
@@ -161,6 +161,14 @@ services:
       - "${MAX_MODEL_LEN:-200000}"
       # NVIDIA's stated default is 0.85 (0.9 only for H200-class / more VRAM). 0.85 is
       # also the safer first-boot value with the 512-expert MoE + CUDA-graph capture.
+      # HEADROOM — util goes ENTIRELY to the KV pool (weights/activation/CUDA-graph are fixed),
+      # so raising it buys context + concurrency. Measured @ util 0.85 (@TheFuzy, #706): KV pool
+      # 314,979 tokens → N=2 both-streams-at-full ceiling ≈ 157K (pool÷2); a single 262K stream
+      # fits. Each +0.01 util ≈ +240 MB/card KV ≈ +25K pool tokens (~+12K per stream at N=2).
+      # Estimates (extrapolated — confirm live): 0.88 → ~185K N=2 · 0.90 → ~200K · 0.92 → ~222K,
+      # but 0.92 leaves only ~1.5 GB/card margin — this hybrid's Mamba/GDN forward spikes activation
+      # (it's what OOM'd the profile_run under --no-enable-chunked-prefill), so >0.90 risks OOM under
+      # a concurrent prefill. 0.88–0.90 is the safe "more room" bump; boot + soak before trusting >0.90.
       - --gpu-memory-utilization
       - "${GPU_MEMORY_UTILIZATION:-0.85}"
       # No --quantization flag: vLLM auto-detects the mixed NVFP4/FP8 scheme from the


### PR DESCRIPTION
Follow-up to #716 (which merged before this note could ride along). Adds a comment at the `--gpu-memory-utilization` flag documenting the context/concurrency headroom the knob buys, so quad-3090 owners tuning for more context don't re-derive it.

From @TheFuzy's util-0.85 measurement ([#706](https://github.com/noonghunna/club-3090/discussions/706)): util goes **entirely to the KV pool** (weights/activation/CUDA-graph are fixed), so raising it lifts the N=2 context ceiling.

| util | KV pool | N=2 both-full ceiling |
|---|---|---|
| 0.85 (measured) | 314,979 tok | ~157K |
| 0.88 (est.) | ~370K | ~185K |
| 0.90 (est.) | ~405K | ~200K |
| 0.92 (est.) | ~444K | ~222K — but ~1.5 GB/card margin ⚠️ |

Note flags that **>0.90 is tight** (the Mamba/GDN forward spikes activation — it's what OOM'd the profile_run under `--no-enable-chunked-prefill`), so 0.88–0.90 is the safe "more room" bump; boot + soak before trusting higher.

Comment-only — YAML parses, status-drift green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm