### PR TITLE
c3 catalog: provider/GB/act columns + [|] column picker (closes #723, closes #724)

### DIFF
--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -51,6 +51,11 @@ def _entry(
     engine,
     drafter,
     kv_format,
+    # Activation compute format (the A in W4A16/W4A8/W8A8). Default "16bit" —
+    # engine-native half precision (fp16/bf16 per the compose --dtype); a slug
+    # that dynamic-quantizes activations sets "int8" (W4A8/W8A8 class) or "fp8".
+    # Surfaced as the c3 catalog "act" column (#723).
+    act_format="16bit",
     tp,
     max_ctx,
     max_num_seqs,
@@ -80,6 +85,7 @@ def _entry(
         "engine": engine,
         "drafter": drafter,
         "kv_format": kv_format,
+        "act_format": act_format,
         "tp": tp,
         "pp": 1,
         "max_ctx": max_ctx,

--- a/scripts/lib/registry-emit.sh
+++ b/scripts/lib/registry-emit.sh
@@ -663,6 +663,9 @@ for vr in _tui_registry.parse_variant_rows(tab):
             # KV-cache format from the registry (for the catalog KV column) —
             # int8_per_token_head / fp8_e4m3 / fp8_e5m2 / turboquant_3bit_nc / bf16 / q*.
             "kv_format": (COMPOSE_REGISTRY.get(d["slug"], {}) or {}).get("kv_format"),
+            # Activation compute format (for the catalog act column, #723) —
+            # "16bit" default (fp16/bf16 per compose --dtype) / "int8" / "fp8".
+            "act_format": (COMPOSE_REGISTRY.get(d["slug"], {}) or {}).get("act_format"),
             # Weights quant_label + FORMAT from the model profile (catalog
             # Weights column fallbacks) — see _weights_meta() above.
             "weights_quant_label": _weights_meta(

--- a/scripts/tests/test-registry-json.sh
+++ b/scripts/tests/test-registry-json.sh
@@ -67,6 +67,9 @@ VARIANT_KEYS = {
     # c3 catalog Weights/KV columns (#600): registry kv_format + the model
     # profile's weights format / explicit quant_label joins.
     "kv_format", "weights_format", "weights_quant_label",
+    # c3 catalog act column (#723): registry act_format facet — "16bit"
+    # default / "int8" / "fp8" (the A in W4A16/W4A8/W8A8).
+    "act_format",
 }
 v0 = d["variants"][0]
 need(set(v0.keys()) == VARIANT_KEYS,

--- a/tools/serve-cockpit/club3090_cockpit/__main__.py
+++ b/tools/serve-cockpit/club3090_cockpit/__main__.py
@@ -73,6 +73,12 @@ def apply_persisted_settings(app, environ) -> None:
     tok = str(s.get("hf_token") or "").strip()
     if tok and not environ.get("HF_TOKEN"):
         environ["HF_TOKEN"] = tok
+    # Catalog columns (#724): the [|] picker's persisted order/visibility —
+    # applied via an app attribute (CatalogPane reads it on mount) so a
+    # directly-constructed app (tests) always starts canonical.
+    cols = s.get("catalog_columns")
+    if isinstance(cols, dict):
+        app.catalog_columns_pref = cols
 
 
 def load_surface_setting() -> "str | None":

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -238,6 +238,65 @@ def _act_label(e: "CatalogEntry") -> str:
     return (getattr(e.row, "act_format", "") or "") or "—"
 
 
+# ── Catalog column picker (#724) ─────────────────────────────────────────────
+# The CANONICAL catalog column set — the ONE source for the header build, the
+# row-cell build and the [|] columns picker.  (key, header) pairs in DEFAULT
+# order; the picker persists a {"order": [...], "hidden": [...]} dict under
+# the "catalog_columns" settings key (c3-settings.json), applied at launch by
+# __main__.apply_persisted_settings (same hermetic hook as [S] settings — an
+# app constructed directly, e.g. in tests, always starts canonical).
+_CATALOG_COLUMNS: "list[tuple[str, str]]" = [
+    ("model", "model"),
+    ("slug", "slug"),
+    ("provider", "provider"),
+    ("weights", "weights"),
+    ("gb", "GB"),
+    ("kv", "kv"),
+    ("act", "act"),
+    ("spec", "spec"),
+    ("ctx", "ctx"),
+    ("tps", "TPS (rig)"),
+    ("8pk", "8pk (rig)"),
+    ("topo", "topo"),
+    ("engine", "engine"),
+    ("status", "status"),
+]
+_CATALOG_HEADERS = dict(_CATALOG_COLUMNS)
+_CATALOG_PINNED = {"slug"}  # identity — never hideable
+
+
+def _sanitize_catalog_columns(saved: Any) -> tuple[list[str], set[str]]:
+    """Normalise a persisted ``{"order": [...], "hidden": [...]}`` into a safe
+    ``(order, hidden)`` pair: unknown keys dropped, canonical keys missing from
+    a saved order inserted next to their canonical neighbour (a NEWLY-shipped
+    column appears, visible, without wiping the user's layout), pinned keys
+    forced visible.  Tolerant of any malformed shape → canonical defaults."""
+    default_order = [k for k, _ in _CATALOG_COLUMNS]
+    try:
+        raw_order = [str(k) for k in (saved or {}).get("order", [])]
+        raw_hidden = [str(k) for k in (saved or {}).get("hidden", [])]
+    except (AttributeError, TypeError):
+        return list(default_order), set()
+    order = [k for k in raw_order if k in _CATALOG_HEADERS]
+    # de-dup, first occurrence wins
+    seen: set[str] = set()
+    order = [k for k in order if not (k in seen or seen.add(k))]
+    hidden = {k for k in raw_hidden if k in _CATALOG_HEADERS}
+    if not order:
+        return list(default_order), hidden - _CATALOG_PINNED
+    for i, k in enumerate(default_order):
+        if k in seen:
+            continue
+        pos = 0
+        for prev in reversed(default_order[:i]):
+            if prev in order:
+                pos = order.index(prev) + 1
+                break
+        order.insert(pos, k)
+        seen.add(k)
+    return order, hidden - _CATALOG_PINNED
+
+
 # Spec Dec column — DERIVED from the registry `drafter` id (already in-app as
 # row.drafter; emitted at registry-emit.sh, threaded in services.py) → a compact
 # method[·mechanism] token, by PATTERN on the id (zero emit/guard change; the id
@@ -913,7 +972,7 @@ class CatalogPane(Container):
         )
         yield Label(
             "[dim]\\[\\\\] model   \\[/] filter   \\[⏎] serve   \\[e] explain   "
-            "\\[d] set-default   \\[D] clear-default[/dim]",
+            "\\[d] set-default   \\[D] clear-default   \\[|] columns[/dim]",
             id="catalog-hint",
         )
 
@@ -940,7 +999,14 @@ class CatalogPane(Container):
         # putting it at the tail means nothing follows it to misalign (belt +
         # braces with the VS16-free glyphs in _STATUS_GLYPH).
         # "(rig)" keeps the our-rig provenance at 4 chars ("our rig" cost 8 more).
-        table.add_columns("model", "slug", "provider", "weights", "GB", "kv", "act", "spec", "ctx", "TPS (rig)", "8pk (rig)", "topo", "engine", "status")
+        # #724: the header set is DYNAMIC — _CATALOG_COLUMNS order filtered by
+        # the user's picker state ([|]), applied at launch from the persisted
+        # "catalog_columns" settings key via apply_persisted_settings (an app
+        # constructed directly — tests — starts canonical).
+        self._col_order, self._col_hidden = _sanitize_catalog_columns(
+            getattr(self.app, "catalog_columns_pref", None)
+        )
+        self._apply_columns_to_table(table)
         # Full enriched catalog, and the current filter substring.
         self._entries: list[CatalogEntry] = []
         self._filter: str = ""
@@ -965,6 +1031,58 @@ class CatalogPane(Container):
         # prompted to set it ([S]).
         self._model_dir_note: str = ""
 
+    # ── Column picker (#724) ─────────────────────────────────────────────────
+
+    def _visible_columns(self) -> list[str]:
+        return [k for k in self._col_order if k not in self._col_hidden]
+
+    def _apply_columns_to_table(self, table: DataTable) -> None:
+        table.clear(columns=True)
+        table.add_columns(*[_CATALOG_HEADERS[k] for k in self._visible_columns()])
+
+    def set_columns(self, order: list[str], hidden: list[str]) -> None:
+        """Apply a new column order/visibility (the [|] picker result), persist
+        it to c3-settings.json ("catalog_columns"), and re-render."""
+        self._col_order, self._col_hidden = _sanitize_catalog_columns(
+            {"order": list(order or []), "hidden": list(hidden or [])}
+        )
+        pref = {"order": list(self._col_order), "hidden": sorted(self._col_hidden)}
+        try:
+            setattr(self.app, "catalog_columns_pref", pref)  # in-session remounts
+        except Exception:
+            pass
+        try:
+            from .__main__ import load_settings, save_settings
+
+            s = load_settings()
+            s["catalog_columns"] = pref
+            save_settings(s)
+        except Exception:
+            pass
+        try:
+            self._apply_columns_to_table(self.query_one("#catalog-table", DataTable))
+            self._render_rows()
+        except Exception:
+            pass
+
+    def open_columns_picker(self) -> None:
+        """Open the [|] columns picker; applies via set_columns on ⏎."""
+        def _done(res: Optional[dict]) -> None:
+            if res:
+                self.set_columns(res.get("order", []), res.get("hidden", []))
+
+        try:
+            self.app.push_screen(
+                CatalogColumnsScreen(self._col_order, self._col_hidden), _done
+            )
+        except Exception:
+            pass
+
+    def on_data_table_header_selected(self, event) -> None:
+        """Clicking the catalog table header opens the columns picker (#724)."""
+        if getattr(getattr(event, "data_table", None), "id", "") == "catalog-table":
+            self.open_columns_picker()
+
     def set_model_dir_note(self, note: str) -> None:
         """Set/clear the model-dir banner (e.g. '⚠ model dir not found — [S]')."""
         new = (note or "").strip()
@@ -986,7 +1104,7 @@ class CatalogPane(Container):
             self._entries = []
             table.clear()
             status_label.update(f"[red]Catalog error:[/red] {error}")
-            table.add_row(*(["—"] * 14))
+            table.add_row(*(["—"] * len(self._visible_columns())))
             return
 
         self._entries = list(entries)
@@ -1059,22 +1177,25 @@ class CatalogPane(Container):
             # confirm pop-up — see ConfirmActionScreen._render_serve_card).  Fit is
             # STILL computed here for the serving-row exemption + the pop-up; we
             # just don't emit a fit cell.
-            table.add_row(
-                model_cell,
-                slug_cell,
-                _provider_label(e),
-                _weights_label(e),
-                _size_label(e),
-                _kv_label(e),
-                _act_label(e),
-                _spec_label(e),
-                e.ctx_label or "—",
-                tps,
-                e.measurement.quality_label,
-                e.topology,
-                e.engine,
-                Text.from_markup(_status_glyph(e.status)),
-            )
+            # #724: build the FULL cell set once, emit in the user's column
+            # order/visibility (keys = _CATALOG_COLUMNS keys).
+            cells = {
+                "model": model_cell,
+                "slug": slug_cell,
+                "provider": _provider_label(e),
+                "weights": _weights_label(e),
+                "gb": _size_label(e),
+                "kv": _kv_label(e),
+                "act": _act_label(e),
+                "spec": _spec_label(e),
+                "ctx": e.ctx_label or "—",
+                "tps": tps,
+                "8pk": e.measurement.quality_label,
+                "topo": e.topology,
+                "engine": e.engine,
+                "status": Text.from_markup(_status_glyph(e.status)),
+            }
+            table.add_row(*(cells[k] for k in self._visible_columns()))
 
         banner = f"[yellow]{self._model_dir_note}[/yellow]  ·  " if self._model_dir_note else ""
         # Surface an active model scope (dropdown) the same way the text filter is shown.
@@ -4171,6 +4292,126 @@ class SettingsScreen(ModalScreen):
         self.app.pop_screen()
 
 
+class CatalogColumnsScreen(ModalScreen):
+    """[|] Catalog columns picker (#724) — show/hide + reorder the catalog
+    table's columns.  Per the modal rule, this screen never touches the pane:
+    it ``dismiss``es ``{"order": [...], "hidden": [...]}`` (or ``None`` on
+    cancel) and the caller applies + persists via ``CatalogPane.set_columns``."""
+
+    DEFAULT_CSS = """
+    CatalogColumnsScreen {
+        align: center middle;
+    }
+    CatalogColumnsScreen > Vertical {
+        width: 56;
+        height: auto;
+        max-height: 80%;
+        border: thick $accent;
+        background: $surface;
+        padding: 1 2;
+    }
+    CatalogColumnsScreen .settings-title {
+        text-style: bold;
+        color: $accent;
+        margin-bottom: 1;
+    }
+    CatalogColumnsScreen #columns-table {
+        height: auto;
+        max-height: 18;
+    }
+    """
+
+    BINDINGS = [
+        Binding("space", "toggle", "Show/Hide", show=True),
+        Binding("shift+up", "move_up", "Move ↑", show=True),
+        Binding("shift+down", "move_down", "Move ↓", show=True),
+        Binding("r", "reset", "Reset", show=True),
+        Binding("enter", "apply", "Apply", show=True, priority=True),
+        Binding("escape", "cancel", "Cancel", show=True),
+    ]
+
+    def __init__(self, order: list[str], hidden: set[str], **kwargs):
+        super().__init__(**kwargs)
+        # sanitize on the way IN so the picker always shows a coherent set
+        self._order, self._hidden = _sanitize_catalog_columns(
+            {"order": list(order or []), "hidden": list(hidden or [])}
+        )
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Label("Catalog columns", classes="settings-title")
+            table: DataTable = DataTable(id="columns-table")
+            table.cursor_type = "row"
+            yield table
+            yield Label(
+                "[dim]space show/hide · shift+↑/↓ move · r reset · ⏎ apply · "
+                "esc cancel · slug is pinned[/dim]"
+            )
+            yield Footer()
+
+    def on_mount(self) -> None:
+        table = self.query_one("#columns-table", DataTable)
+        table.add_columns("shown", "column")
+        self._refill(cursor=0)
+
+    def _refill(self, cursor: int) -> None:
+        table = self.query_one("#columns-table", DataTable)
+        table.clear()
+        for k in self._order:
+            shown = "✓" if k not in self._hidden else "·"
+            pin = "  (pinned)" if k in _CATALOG_PINNED else ""
+            table.add_row(shown, f"{_CATALOG_HEADERS[k]}{pin}", key=k)
+        try:
+            table.move_cursor(row=max(0, min(cursor, len(self._order) - 1)))
+        except Exception:
+            pass
+
+    def _cursor(self) -> int:
+        try:
+            return int(self.query_one("#columns-table", DataTable).cursor_row or 0)
+        except Exception:
+            return 0
+
+    def action_toggle(self) -> None:
+        i = self._cursor()
+        if not (0 <= i < len(self._order)):
+            return
+        k = self._order[i]
+        if k in _CATALOG_PINNED:
+            self.app.bell()
+            return
+        if k in self._hidden:
+            self._hidden.discard(k)
+        else:
+            self._hidden.add(k)
+        self._refill(cursor=i)
+
+    def _move(self, delta: int) -> None:
+        i = self._cursor()
+        j = i + delta
+        if not (0 <= i < len(self._order) and 0 <= j < len(self._order)):
+            return
+        self._order[i], self._order[j] = self._order[j], self._order[i]
+        self._refill(cursor=j)
+
+    def action_move_up(self) -> None:
+        self._move(-1)
+
+    def action_move_down(self) -> None:
+        self._move(1)
+
+    def action_reset(self) -> None:
+        self._order = [k for k, _ in _CATALOG_COLUMNS]
+        self._hidden = set()
+        self._refill(cursor=0)
+
+    def action_apply(self) -> None:
+        self.dismiss({"order": list(self._order), "hidden": sorted(self._hidden)})
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
 class PodCreateScreen(ModalScreen):
     """C2 (#610 Phase C): compose a new pod (a model on a GPU set + port).
     Collects name · slug · GPU set, then ``dismiss``es the params — the app
@@ -6375,6 +6616,8 @@ class CockpitApp(App):
         Binding("slash", "filter_catalog", "Filter", show=False),
         Binding("backslash", "toggle_catalog_model", "Model", show=False),
         Binding("h", "toggle_catalog_deprecated", "Deprecated", show=False),
+        # #724 — [|] catalog column picker (show/hide + reorder, persisted).
+        Binding("vertical_bar", "catalog_columns", "Columns", show=False),
         Binding("u", "copy_endpoint", "API URL", show=False),
         Binding("e", "explain", "Explain", show=False),
         # 2-mode merge: [1] = merged Run & Operate, [2] = Bring & Validate lane.
@@ -9482,6 +9725,14 @@ class CockpitApp(App):
         if self._active_mode == 0 and self._current_subtab() == "tab-catalog":
             try:
                 self.query_one("#catalog-pane", CatalogPane).toggle_deprecated()
+            except Exception:
+                pass
+
+    def action_catalog_columns(self) -> None:
+        """[|] catalog column picker (#724) — merged mode 0 · Catalog tab."""
+        if self._active_mode == 0 and self._current_subtab() == "tab-catalog":
+            try:
+                self.query_one("#catalog-pane", CatalogPane).open_columns_picker()
             except Exception:
                 pass
 

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -208,6 +208,36 @@ def _kv_label(e: "CatalogEntry") -> str:
     return _KV_LABELS.get(kv, kv or "—")
 
 
+def _provider_label(e: "CatalogEntry") -> str:
+    """Weights author/org for the catalog provider column (#723) — the org
+    segment of the joined ``WeightsMeta.hf_repo`` (``weights.py list --json``,
+    set by ``enrich_weights``).  "—" when the slug has no joined meta (e.g. a
+    self-grabbed GGUF compose) or the entry hasn't been enriched yet."""
+    meta = getattr(e, "weights", None)
+    repo = (getattr(meta, "hf_repo", "") or "").strip()
+    if "/" in repo:
+        return repo.split("/", 1)[0]
+    return repo or "—"
+
+
+def _size_label(e: "CatalogEntry") -> str:
+    """Weights artifact size for the catalog GB column (#723) — the joined
+    ``WeightsMeta.size_gb``; "—" when unknown/unjoined."""
+    meta = getattr(e, "weights", None)
+    gb = getattr(meta, "size_gb", None)
+    if gb is None:
+        return "—"
+    return f"{gb:g}G"
+
+
+def _act_label(e: "CatalogEntry") -> str:
+    """Activation compute format for the catalog act column (#723) — the
+    registry ``act_format`` facet (emitted like ``kv_format``): "16bit"
+    (fp16/bf16 engine-native) / "int8" (W4A8/W8A8 class) / "fp8"; "—" when the
+    contract didn't carry it (older emit)."""
+    return (getattr(e.row, "act_format", "") or "") or "—"
+
+
 # Spec Dec column — DERIVED from the registry `drafter` id (already in-app as
 # row.drafter; emitted at registry-emit.sh, threaded in services.py) → a compact
 # method[·mechanism] token, by PATTERN on the id (zero emit/guard change; the id
@@ -897,15 +927,20 @@ class CatalogPane(Container):
         # Fit is STILL computed (it feeds the pop-up + the serving-row exemption);
         # it just no longer occupies a Catalog column.
         # Column budget, left→right: identity (model · slug) → config the user
-        # picks by (weights · kv · spec) → money (ctx · TPS · 8pk) → topology/engine
-        # (largely slug-redundant, fold first on a narrow terminal) → status.
+        # picks by (provider · weights · GB · kv · act · spec) → money (ctx ·
+        # TPS · 8pk) → topology/engine (largely slug-redundant, fold first on a
+        # narrow terminal) → status.
+        # #723 additions: `provider` (weights author/org, before weights), `GB`
+        # (artifact size, before kv), `act` (activation compute format, before
+        # spec) — provider/GB join from the enriched WeightsMeta, act from the
+        # registry act_format facet (same plumbing as kv_format).
         # `spec` groups with weights/kv (the serving-config facets): which drafter
         # (MTP / MTP·gguf / MTP·asst / DFlash / — none) the slug enables by default.
         # Status is deliberately LAST: its glyph is the one emoji-width column, so
         # putting it at the tail means nothing follows it to misalign (belt +
         # braces with the VS16-free glyphs in _STATUS_GLYPH).
         # "(rig)" keeps the our-rig provenance at 4 chars ("our rig" cost 8 more).
-        table.add_columns("model", "slug", "weights", "kv", "spec", "ctx", "TPS (rig)", "8pk (rig)", "topo", "engine", "status")
+        table.add_columns("model", "slug", "provider", "weights", "GB", "kv", "act", "spec", "ctx", "TPS (rig)", "8pk (rig)", "topo", "engine", "status")
         # Full enriched catalog, and the current filter substring.
         self._entries: list[CatalogEntry] = []
         self._filter: str = ""
@@ -951,7 +986,7 @@ class CatalogPane(Container):
             self._entries = []
             table.clear()
             status_label.update(f"[red]Catalog error:[/red] {error}")
-            table.add_row("—", "—", "—", "—", "—", "—", "—", "—", "—", "—")
+            table.add_row(*(["—"] * 14))
             return
 
         self._entries = list(entries)
@@ -1027,8 +1062,11 @@ class CatalogPane(Container):
             table.add_row(
                 model_cell,
                 slug_cell,
+                _provider_label(e),
                 _weights_label(e),
+                _size_label(e),
                 _kv_label(e),
+                _act_label(e),
                 _spec_label(e),
                 e.ctx_label or "—",
                 tps,

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -4540,6 +4540,9 @@ def _variant_row_from_dict(d: dict[str, Any]) -> VariantRow:
         # KV-cache format from the registry (catalog KV column) — attached same
         # as the facets above; "" when the contract didn't carry it.
         object.__setattr__(row, "kv_format", str(d.get("kv_format") or ""))
+        # Activation compute format (catalog act column, #723) — same pattern;
+        # "" when the contract didn't carry it (older emit) → the column shows "—".
+        object.__setattr__(row, "act_format", str(d.get("act_format") or ""))
         # Weights quant_label + FORMAT from the model profile (emit join) —
         # the catalog Weights column's fallbacks for weights_variant tokens that
         # carry no recognisable quant segment: quant_label is the explicit

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -945,11 +945,17 @@ class TestNavNodesExist:
             # · spec) → money (ctx · TPS · 8pk) → topology/engine (slug-redundant,
             # fold first) → status LAST (its emoji glyph is the one variable-width
             # cell, so nothing follows it to misalign — see _STATUS_GLYPH note).
+            # #723: provider (before weights) · GB (before kv) · act (before spec).
             for expected in (
-                "model", "slug", "weights", "kv", "spec", "ctx", "TPS (rig)",
-                "8pk (rig)", "topo", "engine", "status",
+                "model", "slug", "provider", "weights", "GB", "kv", "act",
+                "spec", "ctx", "TPS (rig)", "8pk (rig)", "topo", "engine",
+                "status",
             ):
                 assert expected in col_labels, f"missing {expected!r}: {col_labels}"
+            # #723 ordering: provider < weights < GB < kv < act < spec.
+            for a, b in (("provider", "weights"), ("weights", "GB"),
+                         ("GB", "kv"), ("kv", "act"), ("act", "spec")):
+                assert col_labels.index(a) < col_labels.index(b), col_labels
             # "source" is gone.
             assert "source" not in col_labels, col_labels
             # "fit" is gone — it lives in the serve confirm pop-up now.

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -922,6 +922,79 @@ class TestNavNodesExist:
             await _enter_operate(pilot, tab="tab-doctor")
             assert operate.active == "tab-doctor"
 
+    def test_sanitize_catalog_columns(self):
+        """#724: the picker-state sanitizer — canonical defaults, unknown keys
+        dropped, newly-shipped canonical keys inserted at their canonical
+        neighbour, pinned keys forced visible, dedup."""
+        from club3090_cockpit.app import _sanitize_catalog_columns, _CATALOG_COLUMNS
+
+        default = [k for k, _ in _CATALOG_COLUMNS]
+        # None / malformed → canonical, nothing hidden
+        assert _sanitize_catalog_columns(None) == (default, set())
+        assert _sanitize_catalog_columns("nonsense") == (default, set())
+        # unknown keys dropped from both order + hidden
+        order, hidden = _sanitize_catalog_columns(
+            {"order": ["slug", "bogus", "model"], "hidden": ["bogus", "topo"]}
+        )
+        assert "bogus" not in order and "bogus" not in hidden
+        assert hidden == {"topo"}
+        # saved partial order respected; missing canonical keys re-inserted
+        # after their canonical predecessor (all 14 keys present exactly once)
+        assert sorted(order) == sorted(default)
+        # user-relative order preserved (slug stays before model) and every
+        # canonical key is present exactly once, even from a degenerate
+        # hand-edited 2-key saved order
+        assert order[0] == "slug"
+        assert order.index("slug") < order.index("model")
+        # the REALISTIC missing-key case — a saved full layout from before a
+        # new column shipped: the new key slots at its canonical position
+        # (act's canonical left neighbour is kv) without disturbing the rest
+        order13 = [k for k in default if k != "act"]
+        merged, _ = _sanitize_catalog_columns({"order": order13, "hidden": []})
+        assert merged.index("act") == merged.index("kv") + 1
+        assert [k for k in merged if k != "act"] == order13
+        # pinned slug can never be hidden
+        _, hidden2 = _sanitize_catalog_columns({"order": default, "hidden": ["slug"]})
+        assert "slug" not in hidden2
+        # dedup — first occurrence wins
+        order3, _ = _sanitize_catalog_columns({"order": ["kv", "kv", "slug"], "hidden": []})
+        assert order3.count("kv") == 1
+
+    @pytest.mark.asyncio
+    async def test_catalog_columns_pref_applies_and_persists(self, monkeypatch, tmp_path):
+        """#724 end-to-end: a persisted catalog_columns pref (applied the way
+        __main__.apply_persisted_settings does) drives the header set — hidden
+        columns gone, custom order kept — and set_columns() writes the pref to
+        c3-settings.json for the next launch."""
+        monkeypatch.setenv("C3_CONFIG_DIR", str(tmp_path))
+        from club3090_cockpit.app import _CATALOG_COLUMNS, CatalogPane
+        from club3090_cockpit import __main__ as M
+
+        default = [k for k, _ in _CATALOG_COLUMNS]
+        # act moved right after slug; topo/engine hidden
+        order = ["model", "slug", "act"] + [
+            k for k in default if k not in ("model", "slug", "act")
+        ]
+        app, _, _ = make_app()
+        app.catalog_columns_pref = {"order": order, "hidden": ["topo", "engine"]}
+        async with app.run_test(size=(120, 40)) as pilot:
+            table = app.query_one("#catalog-table", DataTable)
+            col_labels = [str(c.label) for c in table.columns.values()]
+            assert "topo" not in col_labels and "engine" not in col_labels
+            assert col_labels[:3] == ["model", "slug", "act"]
+            # the picker apply path: unhide everything, restore canonical —
+            # persisted for the next launch
+            pane = app.query_one("#catalog-pane", CatalogPane)
+            pane.set_columns(default, [])
+            col_labels = [
+                str(c.label)
+                for c in app.query_one("#catalog-table", DataTable).columns.values()
+            ]
+            assert col_labels[0] == "model" and col_labels[-1] == "status"
+            assert "topo" in col_labels and "engine" in col_labels
+        saved = M.load_settings().get("catalog_columns")
+        assert saved == {"order": default, "hidden": []}
+
     @pytest.mark.asyncio
     async def test_benchmarks_tab_is_gone(self):
         """Fold 3 removed the standalone Validate · Benchmarks tab + its pane."""

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -724,14 +724,18 @@ class TestLoadCatalog:
             "slug": "beellama/qwen-dflash-dual", "port": 8065, "status": "experimental",
             "weights_companions": ["anbeeld-dflash-iq4xs"],
             "drafter": "anbeeld-qwen-dflash", "vision": False,
+            "act_format": "16bit",
         })
         assert getattr(row, "weights_companions") == ["anbeeld-dflash-iq4xs"]
         assert getattr(row, "drafter") == "anbeeld-qwen-dflash"
         assert getattr(row, "vision") is False
+        # #723: activation-format facet attaches like kv_format.
+        assert getattr(row, "act_format") == "16bit"
         # absent → safe defaults
         bare = _variant_row_from_dict({"slug": "x/y", "port": 1})
         assert getattr(bare, "weights_companions") == []
         assert getattr(bare, "vision") is False
+        assert getattr(bare, "act_format") == ""  # older emit → column shows "—"
 
     @pytest.mark.asyncio
     async def test_run_weights_download_injects_companion_keys(self):
@@ -3771,7 +3775,7 @@ class TestServeOverrides:
         d = cd.serve_override_defaults("vllm/dual", "org/MyFineTune")
         assert d["SERVED_NAME"] == "MyFineTune"          # from the brought repo name
         assert d["MAX_MODEL_LEN"] == "262144"            # parsed ${MAX_MODEL_LEN:-262144}
-        assert d["KV_CACHE_DTYPE"] == "fp8_e5m2"
+        assert d["KV_CACHE_DTYPE"] == "fp8_e4m3"  # the fast tier's KV since the #594-era flip
         assert d["SPEC"] == "on"
         assert d["ENGINE"] == "vllm-stable"              # only parsing gives this
         assert d["SPEC_DRAFTER"] == "MTP n=3"            # real drafter, not "on"


### PR DESCRIPTION
## Summary

Two catalog-table features, one branch (the picker builds directly on the new column set):

**#723 — three new columns**, order: `model · slug · provider · weights · GB · kv · act · spec · ctx · TPS (rig) · 8pk (rig) · topo · engine · status`
- `provider` / `GB` render from the already-joined `WeightsMeta` (`hf_repo` org / `size_gb`, `enrich_weights`) — zero contract change
- `act` is a new registry facet on the `kv_format` plumbing: `_entry(act_format="16bit")` default → `registry-emit --json` → services attach → `_act_label`. All 65 entries carry the default; future W4A8-class slugs set `"int8"` (the A in W4A16/W4A8 — see #609)

**#724 — `[|]` column picker** (hotkey + header click): show/hide + reorder, `slug` pinned, persisted to `c3-settings.json` and applied at launch via `apply_persisted_settings` (hermetic — directly-constructed apps/tests start canonical). Forward-compat: saved layouts get newly-shipped columns inserted at their canonical position, visible.

Also: one pre-existing stale fixture fixed in its own commit (`test_serve_override_defaults_parses_sibling_compose` asserted `vllm/dual`'s KV as `fp8_e5m2`; the fast tier flipped to `fp8_e4m3` in the #594 era — failed on master before this branch).

## Tests

- c3 fast suites (test_services + test_registry_parser): **248 passed**
- targeted headless (columns + picker + sanitize): **passed** (incl. hidden/reordered boot, persistence roundtrip, new-column insertion)
- full c3 suite: **855 passed** on the #723 state; re-run on the final branch state in progress (will note result before merge)
- repo gates: test-registry-json (VARIANT_KEYS extended for `act_format`), test-switch-registry-parity, test-launch-registry-parity, test-registry-emit-no-yaml, test-compose-registry-disk — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm