### PR TITLE
Harden the AI Studio installer — fix all six #715 gaps (closes #715)

### DIFF
--- a/scripts/gpu-mode.sh
+++ b/scripts/gpu-mode.sh
@@ -82,6 +82,15 @@ compose_at() {
     fi
 }
 
+# #715 gap 4 — start-failure tracking. start_* helpers used to swallow a failed
+# `compose up` ('… || echo "failed"' returns 0), so every mode printed "failed"
+# per-service yet exited 0 and the caller declared the scene ready (#686). Each
+# start site now RECORDS its failure; the dispatch tail prints a summary and
+# exits 1 when any service failed. Failures don't abort mid-scene (a partial
+# scene beats an aborted one) — they just can't masquerade as success anymore.
+FAILED_SERVICES=()
+c3_mark_start_failure() { FAILED_SERVICES+=("$1"); }
+
 # Like compose_at, but injects per-invocation env assignments that survive `sudo`.
 # `sudo docker compose` sanitizes the caller's environment, so vars set in the shell
 # don't reach compose interpolation — pass them as leading `VAR=val` args to the
@@ -106,7 +115,7 @@ compose_cmd() {
 
 start_service() {
     printf "  ${GREEN}▲${NC} Starting %-12s" "$1..."
-    compose_cmd "$1" "up -d" && echo "done" || echo "failed"
+    compose_cmd "$1" "up -d" && echo "done" || { echo "failed"; c3_mark_start_failure "$1"; }
 }
 
 stop_service() {
@@ -117,7 +126,7 @@ stop_service() {
 # Project-specific helpers
 start_27b_dual_mtp() {
     printf "  ${GREEN}▲${NC} Starting 27b-dual-mtp..."
-    compose_at "$DUAL_27B_DIR" "up -d" fp8-mtp.yml && echo "done" || echo "failed"
+    compose_at "$DUAL_27B_DIR" "up -d" fp8-mtp.yml && echo "done" || { echo "failed"; c3_mark_start_failure "27b-dual-mtp"; }
 }
 stop_27b_dual_mtp() {
     printf "  ${RED}▼${NC} Stopping 27b-dual-mtp..."
@@ -126,7 +135,7 @@ stop_27b_dual_mtp() {
 
 start_27b_dual_dflash() {
     printf "  ${GREEN}▲${NC} Starting 27b-dual-dflash..."
-    compose_at "$DUAL_27B_DIR" "up -d" dflash.yml && echo "done" || echo "failed"
+    compose_at "$DUAL_27B_DIR" "up -d" dflash.yml && echo "done" || { echo "failed"; c3_mark_start_failure "27b-dual-dflash"; }
 }
 stop_27b_dual_dflash() {
     printf "  ${RED}▼${NC} Stopping 27b-dual-dflash..."
@@ -135,7 +144,7 @@ stop_27b_dual_dflash() {
 
 start_27b_dual_dflash_noviz() {
     printf "  ${GREEN}▲${NC} Starting 27b-dflash-noviz..."
-    compose_at "$DUAL_27B_DIR" "up -d" dflash-noviz.yml && echo "done" || echo "failed"
+    compose_at "$DUAL_27B_DIR" "up -d" dflash-noviz.yml && echo "done" || { echo "failed"; c3_mark_start_failure "27b-dual-dflash-noviz"; }
 }
 stop_27b_dual_dflash_noviz() {
     printf "  ${RED}▼${NC} Stopping 27b-dflash-noviz..."
@@ -144,7 +153,7 @@ stop_27b_dual_dflash_noviz() {
 
 start_27b_dual_turbo() {
     printf "  ${GREEN}▲${NC} Starting 27b-dual-turbo..."
-    compose_at "$DUAL_27B_DIR" "up -d" turbo.yml && echo "done" || echo "failed"
+    compose_at "$DUAL_27B_DIR" "up -d" turbo.yml && echo "done" || { echo "failed"; c3_mark_start_failure "27b-dual-turbo"; }
 }
 stop_27b_dual_turbo() {
     printf "  ${RED}▼${NC} Stopping 27b-dual-turbo..."
@@ -163,7 +172,7 @@ stop_all_27b() {
 # vllm/qwen-35b-a3b-dual (AutoRound INT4 + fp8 KV + 262K + vision, :8051).
 start_35b_a3b_dual() {
     printf "  ${GREEN}▲${NC} Starting 35b-a3b-dual..."
-    compose_at "$A3B_DUAL_DIR" "up -d" fp8.yml && echo "done" || echo "failed"
+    compose_at "$A3B_DUAL_DIR" "up -d" fp8.yml && echo "done" || { echo "failed"; c3_mark_start_failure "35b-a3b-dual"; }
 }
 stop_35b_a3b_dual() {
     printf "  ${RED}▼${NC} Stopping 35b-a3b-dual..."
@@ -173,7 +182,7 @@ stop_35b_a3b_dual() {
 # Gemma 4 12B single-card vLLM (gemma4_unified arch-preview image, AutoRound INT8 + MTP n=2).
 start_gemma_12b() {
     printf "  ${GREEN}▲${NC} Starting gemma-12b..."
-    compose_at "$GEMMA_12B_DIR" "up -d" mtp.yml && echo "done" || echo "failed"
+    compose_at "$GEMMA_12B_DIR" "up -d" mtp.yml && echo "done" || { echo "failed"; c3_mark_start_failure "gemma-12b"; }
 }
 stop_gemma_12b() {
     printf "  ${RED}▼${NC} Stopping gemma-12b..."
@@ -187,7 +196,12 @@ start_comfyui() {
     # Pin COMFYUI_ROOT into repo-root .env so the compose's `--env-file` mounts the SAME tree the
     # downloads went into (not the /mnt default) on any rig whose MODEL_DIR isn't /mnt — #510/#530.
     type c3_persist_comfy_root >/dev/null 2>&1 && c3_persist_comfy_root || true
-    compose_at "$COMPOSE_BASE/comfyui" "up -d" && echo "done" || echo "failed"
+    # Pre-create the bind-mount sources USER-OWNED before sudo docker can root-own
+    # them (#715 gap 1); a damaged (root-owned) tree fails loud with the chown fix.
+    if type c3_precreate_comfy_mounts >/dev/null 2>&1 && ! c3_precreate_comfy_mounts; then
+        echo "failed"; c3_mark_start_failure "comfyui"; return 0
+    fi
+    compose_at "$COMPOSE_BASE/comfyui" "up -d" && echo "done" || { echo "failed"; c3_mark_start_failure "comfyui"; }
 }
 stop_comfyui() {
     printf "  ${RED}▼${NC} Stopping comfyui..."
@@ -198,7 +212,7 @@ stop_comfyui() {
 # "director" LLM (:8090, GPU0). See services/studio/ + docs/ai-studio/video.md.
 start_studio_gallery() {
     printf "  ${GREEN}▲${NC} Starting studio-gallery (:8189)..."
-    compose_at "$COMPOSE_BASE/studio/gallery" "up -d" && echo "done" || echo "failed"
+    compose_at "$COMPOSE_BASE/studio/gallery" "up -d" && echo "done" || { echo "failed"; c3_mark_start_failure "studio-gallery"; }
 }
 # Director placement lever — STUDIO_DIRECTOR_DEVICE (gpu0|gpu1|cpu) from the rig .env, set by
 # c3's Settings "Director placement" field (default gpu0). gpu0 = ~4.6 GB on GPU0 (fast craft,
@@ -230,7 +244,7 @@ start_studio_director() {
     printf "  ${GREEN}▲${NC} Starting studio-director ($label)..."
     compose_at_env "$COMPOSE_BASE/studio/enhancer" "up -d" docker-compose.yml \
         "DIRECTOR_NGL=$ngl" "STUDIO_DIRECTOR_CUDA=$cvd" "STUDIO_DIRECTOR_GPU=$gpu" "DIRECTOR_THINK_ARGS=$think_args" \
-        && echo "done" || echo "failed"
+        && echo "done" || { echo "failed"; c3_mark_start_failure "studio-director"; }
 }
 stop_studio_director() {
     printf "  ${RED}▼${NC} Stopping studio-director..."
@@ -264,20 +278,20 @@ wait_gpu_vram_settle() {
 }
 start_studio_orchestrator() {
     printf "  ${GREEN}▲${NC} Starting studio-orchestrator (:8190, long-clip chaining)..."
-    compose_at "$COMPOSE_BASE/studio/orchestrator" "up -d --build" && echo "done" || echo "failed"
+    compose_at "$COMPOSE_BASE/studio/orchestrator" "up -d --build" && echo "done" || { echo "failed"; c3_mark_start_failure "studio-orchestrator"; }
 }
 # Native-button image shim (:8191): ComfyUI reverse-proxy that crafts Ideogram-4 JSON
 # captions (via the director) so OWUI's native 🖼️ image button renders instead of hitting
 # the "blocked by safety filter" placeholder. Needs the director (:8090) up.
 start_studio_image_shim() {
     printf "  ${GREEN}▲${NC} Starting studio-image-shim (:8191, native-button Ideogram captions)..."
-    compose_at "$COMPOSE_BASE/studio/image-shim" "up -d --build" && echo "done" || echo "failed"
+    compose_at "$COMPOSE_BASE/studio/image-shim" "up -d --build" && echo "done" || { echo "failed"; c3_mark_start_failure "studio-image-shim"; }
 }
 # Integrated-voices TTS + audio mixdown (:8192, Kokoro on CPU). The pipe POSTs /narrate after a
 # video render to mix a voiceover over the clip's native audio (ducked + normalized). No GPU.
 start_studio_tts() {
     printf "  ${GREEN}▲${NC} Starting studio-tts (:8192, Kokoro voices + mixdown, CPU)..."
-    compose_at "$COMPOSE_BASE/studio/tts" "up -d --build" && echo "done" || echo "failed"
+    compose_at "$COMPOSE_BASE/studio/tts" "up -d --build" && echo "done" || { echo "failed"; c3_mark_start_failure "studio-tts"; }
 }
 # Premium voice (:8193, Step-Audio-EditX, GPU1, isolated transformers 4.53.3). LAZY: the container
 # comes up cheap (~0 GB) so the OWUI voice lane appears as soon as ai-studio starts it; the ~14 GB
@@ -286,7 +300,7 @@ start_studio_tts() {
 # `--build` picks up server.py edits (layer-cached → fast when unchanged).
 start_step_voice() {
     printf "  ${GREEN}▲${NC} Starting step-voice (:8193, lazy — model loads on first use, GPU1)..."
-    compose_at "$COMPOSE_BASE/studio/step-voice" "up -d --build" && echo "done" || echo "failed"
+    compose_at "$COMPOSE_BASE/studio/step-voice" "up -d --build" && echo "done" || { echo "failed"; c3_mark_start_failure "step-voice"; }
 }
 stop_step_voice() {
     printf "  ${RED}▼${NC} Stopping step-voice..."
@@ -307,7 +321,7 @@ stop_gemma_mtp() {
 
 start_gemma_int8() {
     printf "  ${GREEN}▲${NC} Starting gemma-int8..."
-    compose_at "$GEMMA_DUAL_DIR" "up -d" int8.yml && echo "done" || echo "failed"
+    compose_at "$GEMMA_DUAL_DIR" "up -d" int8.yml && echo "done" || { echo "failed"; c3_mark_start_failure "gemma-int8"; }
 }
 stop_gemma_int8() {
     printf "  ${RED}▼${NC} Stopping gemma-int8..."
@@ -323,7 +337,7 @@ stop_all_gemma() {
 
 start_deckard() {
     printf "  ${GREEN}▲${NC} Starting deckard-40b..."
-    compose_at "$DECKARD_DIR" "up -d" mtp.yml && echo "done" || echo "failed"
+    compose_at "$DECKARD_DIR" "up -d" mtp.yml && echo "done" || { echo "failed"; c3_mark_start_failure "deckard"; }
 }
 stop_deckard() {
     printf "  ${RED}▼${NC} Stopping deckard-40b..."
@@ -731,7 +745,7 @@ mode_ai_studio() {
     start_service searxng
     echo ""
     echo -e "${GREEN}AI-studio mode active.${NC} — one scene; pick the lane in Open WebUI."
-    echo -e "  Open WebUI:  http://$LANIP:8080   (image · video · music · SFX · voice lanes)"
+    echo -e "  Open WebUI:  http://$LANIP:${OWUI_PORT:-8080}   (image · video · music · SFX · voice lanes)"
     echo -e "  Gallery:     http://$LANIP:8189   (all generated media; survives ComfyUI down)"
     echo -e "  ComfyUI:     http://$LANIP:8188   (full node graph / control)"
     echo -e "${YELLOW}First ComfyUI boot can take a few min (clones + node deps). Video DiT splits across both 3090s (DisTorch); image/audio lanes run on GPU0 beside the director.${NC}"
@@ -1076,3 +1090,12 @@ case "${1:-}" in
     --list-modes)       list_modes "${2:-}" ;;
     *)                  usage ;;
 esac
+
+# #715 gap 4 — propagate start failures to the exit code (see FAILED_SERVICES).
+if [ "${#FAILED_SERVICES[@]}" -gt 0 ]; then
+    echo "" >&2
+    echo -e "${RED}✗ ${#FAILED_SERVICES[@]} service(s) FAILED to start: ${FAILED_SERVICES[*]}${NC}" >&2
+    echo "  Inspect: sudo docker compose logs <service>   (in its compose dir)" >&2
+    echo "  Then re-run this mode — starts are idempotent." >&2
+    exit 1
+fi

--- a/scripts/setup-ai-studio.sh
+++ b/scripts/setup-ai-studio.sh
@@ -30,6 +30,13 @@ STUDIO_DIR="$REPO_DIR/services/studio"
 # alongside it instead of the rig's /mnt fallback). See services/comfyui/comfyui-paths.sh.
 # shellcheck disable=SC1091
 . "$COMFYUI_DIR/comfyui-paths.sh"
+# Open WebUI host port — #715 gap 3: no longer hardcoded. Set OWUI_PORT in the env or
+# repo .env (compose reads .env via --env-file; export it for the register/pipe helpers).
+OWUI_PORT="${OWUI_PORT:-8080}"
+export OWUI_PORT
+# Testability hook (#715 gap 5 regression test): the bring-up step must run even under
+# SKIP_BUILD/SKIP_DOWNLOAD — the test stubs this to assert it was reached.
+GPU_MODE_BIN="${GPU_MODE_BIN:-$REPO_DIR/scripts/gpu-mode.sh}"
 # LAN IP for the final URLs. Resolve via the shared helper: env / .env win, else auto-detect and
 # PERSIST to .env (the source of truth) — or, if nothing detects, fall back to localhost and tell
 # the user to set LANIP in .env. Keeps setup + gpu-mode from drifting. (#504, #512)
@@ -92,6 +99,13 @@ if [ -z "$ASSUME_YES" ]; then
     case "$reply" in [yY]|[yY][eE][sS]) ;; *) echo "  aborted."; exit 0 ;; esac
 fi
 
+# --- 0b. Pre-create every studio bind-mount dir USER-OWNED (#715 gap 1) --------
+# Must happen before ANY `sudo docker` below — Docker root-owns missing bind-mount
+# sources, and the later non-sudo download step then can't write to them (a mess
+# the installer used to create itself). Fails loud with the exact chown fix when a
+# previously-damaged (root-owned) tree is detected.
+c3_precreate_comfy_mounts || exit 1
+
 # --- 1. Build the ComfyUI image (clones a pinned ComfyUI + custom nodes on first boot) ---
 if [ -z "${SKIP_BUILD:-}" ]; then
     say "── [1/4] Building ComfyUI image (comfyui-local:latest) ──"
@@ -115,24 +129,23 @@ fi
 # gpu-mode's start_service swallows that failure ('… || echo "failed"' returns
 # 0). So gate the bring-up on 8080 being free, and verify OWUI afterwards,
 # instead of reporting a false "ready" (#686).
-if ! docker ps --format '{{.Names}} {{.Ports}}' 2>/dev/null | grep -qE '^open-webui .*:8080->'; then
-    _p8080=""
+if ! docker ps --format '{{.Names}} {{.Ports}}' 2>/dev/null | grep -qE "^open-webui .*:${OWUI_PORT}->"; then
+    _powui=""
     if command -v ss >/dev/null 2>&1; then
-        _p8080=$(ss -Hltn 2>/dev/null | awk '{print $4}' | grep -E ':8080$' | head -1)
+        _powui=$(ss -Hltn 2>/dev/null | awk '{print $4}' | grep -E ":${OWUI_PORT}\$" | head -1)
     elif command -v lsof >/dev/null 2>&1; then
-        _p8080=$(lsof -iTCP:8080 -sTCP:LISTEN -Pn 2>/dev/null | tail -n +2 | head -1)
+        _powui=$(lsof -iTCP:"$OWUI_PORT" -sTCP:LISTEN -Pn 2>/dev/null | tail -n +2 | head -1)
     fi
-    if [ -n "$_p8080" ]; then
-        warn "  ✗ Port 8080 is already in use — Open WebUI can't bind it (listener: $_p8080)."
-        echo "     OWUI's host port 8080 is fixed (baked into the compose + the pipe/register helpers)."
-        echo "     Free 8080 first — e.g. move the other service (a llama-server router: add"
-        echo "     '--port 8081' and point your client at the new port) — then re-run this script." >&2
+    if [ -n "$_powui" ]; then
+        warn "  ✗ Port $OWUI_PORT is already in use — Open WebUI can't bind it (listener: $_powui)."
+        echo "     Either free the port, or move OWUI: set OWUI_PORT=<free port> in the repo .env" >&2
+        echo "     (and export it when running the register/pipe helpers), then re-run this script." >&2
         exit 1
     fi
 fi
 
 say "── [3/4] Starting the studio (gpu-mode ai-studio) ──"
-bash "$REPO_DIR/scripts/gpu-mode.sh" ai-studio
+bash "$GPU_MODE_BIN" ai-studio
 
 # gpu-mode's start_service swallows a failed 'compose up' (#686), so trust the
 # container STATE, not the exit code: a bind failure leaves open-webui missing
@@ -142,7 +155,7 @@ case "$_owui_status" in
     Up*) ;;   # running (optionally "(healthy)") — good
     *)
         warn "  ✗ Open WebUI did not come up (status: ${_owui_status:-missing})."
-        echo "     Most common cause: something else is bound to its host port 8080." >&2
+        echo "     Most common cause: something else is bound to its host port $OWUI_PORT." >&2
         echo "     Inspect:  docker ps -a | grep open-webui" >&2
         echo "               docker logs open-webui 2>&1 | tail -20" >&2
         echo "     Fix the conflict, then re-run:  bash scripts/setup-ai-studio.sh" >&2
@@ -188,7 +201,7 @@ fi
 # --- Done — onboarding -------------------------------------------------------
 echo ""
 ok "═══ AI Studio ready ═══"
-echo "  Open WebUI:  http://$LANIP:8080   ← start here"
+echo "  Open WebUI:  http://$LANIP:$OWUI_PORT   ← start here"
 echo "  ComfyUI:     http://$LANIP:8188   ← optional: full node-graph control"
 echo "  Gallery:     http://$LANIP:8189   ← your renders (survive ComfyUI restarts)"
 echo ""
@@ -207,8 +220,8 @@ if [ "$PIPE_OK" != "1" ] && [ -z "${SKIP_PIPE:-}" ]; then
     echo ""
     _n=$((_n + 1))
 fi
-echo "    $_n. On the 'Studio' function (Admin → Functions → Studio), set the 'browser_base'"
-echo "       valve to http://$LANIP:8189 so returned media links open from your browser."; _n=$((_n + 1))
+echo "    $_n. Media links are pre-pointed at http://$LANIP:8189 (stamped at pipe install — #715)."
+echo "       If they 404 from another machine, check Admin → Functions → Studio → 'browser_base' valve."; _n=$((_n + 1))
 echo "    $_n. Pick a lane in the model selector (🎬 Video · 🖼️ Image · 🎵 Audio), type an idea,"
 echo "       and refine by just replying. Full guide: docs/ai-studio/README.md"
 echo ""

--- a/scripts/tests/test-setup-ai-studio-skip-path.sh
+++ b/scripts/tests/test-setup-ai-studio-skip-path.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# setup-ai-studio.sh skip-path regression (#715 gap 5).
+#
+# The invariant: SKIP_BUILD / SKIP_DOWNLOAD skip ONLY the build / download —
+# the bring-up (gpu-mode ai-studio) and the rest of the flow MUST still run.
+# @MoppelMat's #686 install "printed the two skip lines and produced nothing";
+# whatever the mechanism on his checkout (gaps 1+4 compounding is the leading
+# read), this pins the invariant so a future refactor can't reintroduce it.
+#
+# Also exercises #715 gap 1 for free: the run pre-creates the studio bind-mount
+# dirs USER-OWNED under a tmp MODEL_DIR before any (stubbed) docker call.
+#
+# Everything external is stubbed: docker / nvidia-smi via PATH shims, the
+# bring-up via the GPU_MODE_BIN hook. No container, no GPU, no .env writes
+# (LANIP + MODEL_DIR pinned via env; C3 paths derive under the tmp dir).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "ASSERTION FAILED: $1" >&2; exit 1; }
+
+# --- PATH shims --------------------------------------------------------------
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/docker" <<'SH'
+#!/usr/bin/env bash
+# minimal docker stub for the setup-ai-studio skip-path test
+case "$1" in
+  compose) exit 0 ;;                      # `docker compose version`
+  info)    exit 0 ;;
+  ps)
+    # both invocations: the port-gate names+ports format and the -a names+status check
+    if [[ "$*" == *'{{.Names}} {{.Ports}}'* ]]; then
+      echo "open-webui 0.0.0.0:8080->8080/tcp"
+    else
+      printf 'open-webui\tUp 2 minutes\n'
+    fi
+    exit 0 ;;
+  *) exit 0 ;;
+esac
+SH
+cat > "$TMP/bin/nvidia-smi" <<'SH'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-L" ]]; then
+  echo "GPU 0: STUB RTX 3090 (UUID: GPU-stub-0)"
+  echo "GPU 1: STUB RTX 3090 (UUID: GPU-stub-1)"
+  exit 0
+fi
+exit 0
+SH
+chmod +x "$TMP/bin/docker" "$TMP/bin/nvidia-smi"
+
+# --- gpu-mode stub (the GPU_MODE_BIN testability hook) -----------------------
+cat > "$TMP/fake-gpu-mode.sh" <<SH
+#!/usr/bin/env bash
+echo "FAKE-GPU-MODE \$*" >> "$TMP/gpu-mode-calls"
+exit 0
+SH
+chmod +x "$TMP/fake-gpu-mode.sh"
+
+# --- run: both skips set → the bring-up must still happen --------------------
+out="$(PATH="$TMP/bin:$PATH" \
+  SKIP_BUILD=1 SKIP_DOWNLOAD=1 SKIP_PIPE=1 SKIP_OWUI_WIRING=1 SKIP_DISK_CHECK=1 \
+  ASSUME_YES=1 LANIP=127.0.0.1 MODEL_DIR="$TMP/models" C3_PATHS_NO_ENV=1 \
+  GPU_MODE_BIN="$TMP/fake-gpu-mode.sh" \
+  bash "$ROOT_DIR/scripts/setup-ai-studio.sh" 2>&1)" || fail "setup exited non-zero under skip flags:
+$out"
+
+# the two skip lines printed (the flags took effect) …
+grep -q "SKIP_BUILD set"    <<<"$out" || fail "missing the SKIP_BUILD skip line"
+grep -q "SKIP_DOWNLOAD set" <<<"$out" || fail "missing the SKIP_DOWNLOAD skip line"
+# … AND the bring-up still ran (#715 gap 5 — the invariant)
+grep -q "\[3/4\] Starting the studio" <<<"$out" || fail "bring-up step banner missing — skip flags removed functionality:
+$out"
+[ -f "$TMP/gpu-mode-calls" ] || fail "gpu-mode was never invoked under skip flags"
+grep -q "FAKE-GPU-MODE ai-studio" "$TMP/gpu-mode-calls" || fail "gpu-mode not called with ai-studio: $(cat "$TMP/gpu-mode-calls")"
+
+# gap 1 side-assert: the studio bind-mount dirs were pre-created USER-OWNED
+for d in ComfyUI models input output user pip-cache; do
+  [ -d "$TMP/comfyui/$d" ] || fail "bind-mount dir not pre-created: \$COMFYUI_ROOT/$d"
+  [ -w "$TMP/comfyui/$d" ] || fail "pre-created dir not writable: \$COMFYUI_ROOT/$d"
+done
+[ -d "$TMP/models" ] || fail "MODEL_DIR not pre-created"
+
+echo "test-setup-ai-studio-skip-path: ok"

--- a/services/comfyui/comfyui-paths.sh
+++ b/services/comfyui/comfyui-paths.sh
@@ -147,3 +147,86 @@ c3_ensure_comfy_models_dir() {
   echo "       (or set COMFYUI_MODELS_DIR directly; c3 Settings writes MODEL_DIR to repo .env)." >&2
   exit 1
 }
+
+
+# Pre-create EVERY studio bind-mount source dir USER-OWNED before any `sudo docker`
+# runs (#715 gap 1). The studio containers run as root under `sudo docker compose`,
+# and Docker auto-creates a missing bind-mount source dir ROOT-OWNED — so the later
+# non-sudo download step can't write to it, a mess the installer used to create
+# itself and then blame the user for. mkdir -p as the CALLING user prevents the
+# whole class. If a dir already exists root-owned (a previously-damaged install),
+# prevention can't help — detect it and say exactly how to fix it instead.
+# Call from setup-ai-studio.sh (before the build) AND gpu-mode's start_comfyui
+# (before compose up). Idempotent; fails only on the damaged-install case.
+c3_precreate_comfy_mounts() {
+  local d bad=""
+  # the comfyui compose's host-side mount sources (services/comfyui/docker-compose.yml)
+  # + the shared HF cache root.
+  for d in \
+      "$COMFYUI_ROOT/ComfyUI" \
+      "$COMFYUI_ROOT/models" \
+      "$COMFYUI_ROOT/input" \
+      "$COMFYUI_ROOT/output" \
+      "$COMFYUI_ROOT/user" \
+      "$COMFYUI_ROOT/pip-cache" \
+      "$MODEL_DIR"; do
+    mkdir -p "$d" 2>/dev/null || true
+    [ -w "$d" ] || bad="$bad $d"
+  done
+  if [ -n "$bad" ]; then
+    echo "ERROR: studio bind-mount dir(s) not writable by $(id -un):$bad" >&2
+    echo "       (Usually root-owned leftovers from an earlier run where Docker" >&2
+    echo "       auto-created them under sudo. Fix once:)" >&2
+    echo "         sudo chown -R $(id -un):$(id -gn)$bad" >&2
+    return 1
+  fi
+  return 0
+}
+
+# Hardened `hf` for every studio download script (#715 gap 2) — the same guards the
+# main stack mandates, made repo-portable. Every download_*.sh sources this file (or
+# inherits via `export -f` from download_studio_models.sh), so their bare `hf download`
+# calls transparently gain:
+#   • XET OFF by default   — the classic LFS path RESUMES from .incomplete; Xet restarts
+#     from 0 on failure, so retries on it are lossy (caller may re-enable via env).
+#   • a read timeout       — a dead socket errors instead of hanging forever.
+#   • retry-until-success  — transient network errors resume mid-file (6 attempts).
+#   • a false-DONE guard   — on a mid-run network loss, huggingface_hub can degrade to
+#     "returning existing local_dir" and exit 0 with the payload still *.incomplete
+#     (observed live 2026-07-16); rc=0 with leftover .incomplete files is treated as a
+#     FAILURE and retried, not reported as success.
+# Non-download subcommands pass straight through.
+hf() {
+  if [ "${1:-}" != "download" ]; then command hf "$@"; return; fi
+  # recover --local-dir for the false-DONE .incomplete scan (absent -> cache-mode, skip scan)
+  local _dest="" _prev="" _a
+  for _a in "$@"; do
+    [ "$_prev" = "--local-dir" ] && _dest="$_a"
+    _prev="$_a"
+  done
+  local _attempt=1 _max=6 _rc
+  while :; do
+    HF_HUB_DISABLE_XET="${HF_HUB_DISABLE_XET:-1}" \
+    HF_HUB_DOWNLOAD_TIMEOUT="${HF_HUB_DOWNLOAD_TIMEOUT:-30}" \
+      command hf "$@" && _rc=0 || _rc=$?
+    if [ "$_rc" -eq 0 ]; then
+      if [ -n "$_dest" ] && [ -d "$_dest" ] && \
+         find "$_dest" -name '*.incomplete' -print -quit 2>/dev/null | grep -q .; then
+        echo "[hf-fetch] rc=0 but *.incomplete remains under $_dest (offline-degrade false DONE) — retrying" >&2
+        _rc=75  # EX_TEMPFAIL
+      else
+        return 0
+      fi
+    fi
+    if [ "$_attempt" -ge "$_max" ]; then
+      echo "[hf-fetch] giving up after $_max attempts (rc=$_rc)" >&2
+      return "$_rc"
+    fi
+    echo "[hf-fetch] retry $_attempt/$_max in 8s (rc=$_rc) — the classic path resumes from .incomplete" >&2
+    _attempt=$((_attempt + 1))
+    sleep 8
+  done
+}
+# Inherit into child bash processes (download_studio_models.sh runs each lane script
+# as `bash download_X.sh`) so even the two children that don't source this file get it.
+export -f hf 2>/dev/null || true

--- a/services/openwebui/docker-compose.yml
+++ b/services/openwebui/docker-compose.yml
@@ -6,7 +6,10 @@ services:
     container_name: open-webui
     restart: unless-stopped
     ports:
-      - "8080:8080"
+      # Host port is a knob (#715 gap 3): set OWUI_PORT in the repo .env (compose reads
+      # it via --env-file) AND export it for setup-ai-studio.sh + the pipe helper.
+      # The container-internal port stays 8080 (docker-exec helpers rely on it).
+      - "${OWUI_PORT:-8080}:8080"
     volumes:
       - open-webui-data:/app/backend/data
     env_file:

--- a/services/studio/push-pipe-to-owui.sh
+++ b/services/studio/push-pipe-to-owui.sh
@@ -33,7 +33,7 @@ FN_ID="${POS[0]:-studio}"
 OWUI="${POS[1]:-open-webui}"
 DB="${OWUI_DB:-/app/backend/data/webui.db}"
 DOCKER="${DOCKER:-sudo docker}"
-HEALTH_URL="${OWUI_HEALTH_URL:-http://localhost:8080/health}"
+HEALTH_URL="${OWUI_HEALTH_URL:-http://localhost:${OWUI_PORT:-8080}/health}"
 
 echo "[push] building studio_pipe.py …"
 python3 "$HERE/build_studio_pipe.py"
@@ -41,10 +41,27 @@ PIPE="$HERE/studio_pipe.py"
 [ -f "$PIPE" ] || { echo "[push] ERROR: $PIPE not found"; exit 1; }
 echo "[push] pipe = $(wc -c < "$PIPE") bytes"
 
+# #715 gap 6 — stamp the configured LAN IP into the pipe's browser_base default so
+# gallery/media links open from OTHER machines without the manual valve step (the
+# runtime cousin of the #703 LANIP class). LANIP: env wins, else repo .env; unset /
+# localhost keeps the localhost default (single-machine rigs). Stamps a TEMP copy —
+# the tracked studio_pipe.py is never mutated.
+_lanip="${LANIP:-}"
+if [ -z "$_lanip" ] && [ -f "$HERE/../../.env" ]; then
+    _lanip="$(grep -E '^LANIP=' "$HERE/../../.env" 2>/dev/null | tail -1 | cut -d= -f2- || true)"
+fi
+_lanip="${_lanip%\"}"; _lanip="${_lanip#\"}"
+PIPE_PUSH="$PIPE"
+if [ -n "$_lanip" ] && [ "$_lanip" != "localhost" ] && [ "$_lanip" != "127.0.0.1" ]; then
+    PIPE_PUSH="$(mktemp /tmp/studio_pipe_push.XXXXXX.py)"
+    sed "s|http://localhost:8189|http://${_lanip}:8189|g" "$PIPE" > "$PIPE_PUSH"
+    echo "[push] browser_base default stamped → http://${_lanip}:8189 (#715)"
+fi
+
 $DOCKER ps --format '{{.Names}}' | grep -qx "$OWUI" || { echo "[push] ERROR: container '$OWUI' is not running"; exit 1; }
 
 echo "[push] copy → $OWUI : install/update function '$FN_ID' in $DB …"
-$DOCKER cp "$PIPE" "$OWUI:/tmp/_studio_pipe_push.py"
+$DOCKER cp "$PIPE_PUSH" "$OWUI:/tmp/_studio_pipe_push.py"
 $DOCKER exec -e FN_ID="$FN_ID" -e DB="$DB" -e FN_NAME="${OWUI_FN_NAME:-🎬 Studio}" "$OWUI" python -c '
 import os, sqlite3, time, json, sys
 fn_id, db, fn_name = os.environ["FN_ID"], os.environ["DB"], os.environ["FN_NAME"]


### PR DESCRIPTION
## Summary

Fixes every gap from #715 (the #686 failure-class cluster), prevention-first:

| gap | fix | validation |
|---|---|---|
| **1** 🔴 root-owned bind mounts (self-inflicted) | `c3_precreate_comfy_mounts` pre-creates all studio mount sources **user-owned** before any `sudo docker` (setup step 0b + `start_comfyui`); a damaged root-owned tree fails loud **with the exact `chown` fix** | regression test asserts dirs pre-created + writable |
| **2** 🟠 fragile ~120 GB pull (bare `hf`) | hardened `hf()` wrapper in `comfyui-paths.sh`, inherited by **all** download children (`export -f`): Xet off (resumable), read timeout, 6-attempt resume-retry, **false-DONE guard** (rc=0 with leftover `*.incomplete` from huggingface_hub's offline-degrade → treated as failure; observed live 2026-07-16) | unit-tested: false-DONE detected → retried → clean exit |
| **3** 🟠 OWUI port 8080 hardcoded | `OWUI_PORT` knob: compose publishes `${OWUI_PORT:-8080}`, setup's gate/messages/URLs + push-pipe health URL honor it. **Finding:** the register/unregister helpers are `docker exec`'d *inside* the container where 8080 is container-internal — correctly left unchanged | `docker compose config` with `OWUI_PORT=9090` → `published: 9090` |
| **4** 🟠 `gpu-mode` swallows compose failures | all **16** start sites record failures; dispatch tail prints a summary + **exits 1** when any service failed. Deliberately no mid-scene abort (a partial scene beats an aborted one) — it just can't masquerade as success | `gpu-mode status` smoke clean; `bash -n`; sweep green |
| **5** 🟠 skip flags "reduce to no functionality" | invariant **pinned by a new regression test** (`test-setup-ai-studio-skip-path.sh`, stubbed docker/nvidia-smi/`GPU_MODE_BIN`): `SKIP_BUILD+SKIP_DOWNLOAD` must still reach the bring-up. Archaeology: the #686 symptom was most plausibly gaps 1+4 compounding — bring-up *ran*, every service silently failed | the new test |
| **6** 🟠 links hardcode `localhost` | `push-pipe-to-owui.sh` stamps the configured **LANIP** into the pipe's `browser_base` default at push time (temp copy — the tracked `studio_pipe.py` never mutated); the manual-valve onboarding step becomes a verify | script-level; covered by the stamp log line |

## Tests
Full suite **82/82** (81 + the new regression test).

## Deferred
Live `gpu-mode ai-studio` bring-up validation — the rig is mid-quality-eval; will run post-eval and note here before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm