### PR TITLE
hf(): stall watchdog + stale-lock clearing — fix the setup lock-wait hang (closes #726)

### DIFF
--- a/scripts/tests/test-hf-fetch-hardening.sh
+++ b/scripts/tests/test-hf-fetch-hardening.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# The hardened hf() wrapper (services/comfyui/comfyui-paths.sh) — #715 gap 2 + #726.
+#
+# Three failure classes, each reproduced with a PATH-shimmed `hf`:
+#   1. STALE LOCK (#726): an orphaned *.lock under the dest download cache (no live
+#      holder, old mtime) is cleared before the attempt, so it can't wedge the run.
+#   2. STALL (#726): an attempt that produces no byte growth (hf_hub's unbounded
+#      "Still waiting to acquire lock" wait, or a dead peer) is killed by the
+#      watchdog after HF_FETCH_STALL_TIMEOUT and the retry succeeds.
+#   3. FALSE DONE (#715): rc=0 with leftover *.incomplete (huggingface_hub
+#      offline-degrade) is treated as failure and retried.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "ASSERTION FAILED: $1" >&2; exit 1; }
+
+mkdir -p "$TMP/bin" "$TMP/dest/.cache/huggingface/download"
+
+# shim harness: behavior file selects the fake hf's mode per case
+cat > "$TMP/bin/hf" <<SH
+#!/usr/bin/env bash
+mode="\$(cat "$TMP/mode")"
+case "\$mode" in
+  ok) exit 0 ;;
+  hang) sleep 3600 ;;
+  hang-then-ok)
+    if [ -f "$TMP/second" ]; then exit 0; fi
+    touch "$TMP/second"; sleep 3600 ;;
+  falsedone-then-ok)
+    if [ -f "$TMP/second" ]; then rm -f "$TMP/dest/.cache/huggingface/download/x.incomplete"; exit 0; fi
+    touch "$TMP/second"; touch "$TMP/dest/.cache/huggingface/download/x.incomplete"; exit 0 ;;
+esac
+SH
+chmod +x "$TMP/bin/hf"
+
+run_wrapped() {  # <mode> [env...] — source the lib fresh + run one wrapped download
+  local mode="$1"; shift
+  echo "$mode" > "$TMP/mode"
+  rm -f "$TMP/second"
+  env -i PATH="$TMP/bin:/usr/bin:/bin" HOME="$TMP" "$@" bash -c '
+    set -uo pipefail
+    C3_PATHS_NO_ENV=1 MODEL_DIR="'"$TMP"'/models" . "'"$ROOT_DIR"'/services/comfyui/comfyui-paths.sh"
+    hf download some/repo --local-dir "'"$TMP"'/dest"
+  ' 2>&1
+}
+
+# --- 1. stale lock cleared (no live holder, old mtime) -----------------------
+lock="$TMP/dest/.cache/huggingface/download/model.safetensors.lock"
+touch "$lock"
+touch -d '30 minutes ago' "$lock"
+out="$(run_wrapped ok)" || fail "case 1: wrapper failed on a clean download: $out"
+grep -q "clearing stale download lock" <<<"$out" || fail "case 1: stale lock not cleared: $out"
+[ ! -f "$lock" ] || fail "case 1: stale lock file still present"
+
+# --- 1b. a FRESH lock is spared (could be a live SoftFileLock holder) --------
+touch "$lock"
+out="$(run_wrapped ok)" || fail "case 1b: wrapper failed: $out"
+grep -q "clearing stale download lock" <<<"$out" && fail "case 1b: FRESH lock was wrongly cleared"
+[ -f "$lock" ] || fail "case 1b: fresh lock removed"
+rm -f "$lock"
+
+# --- 2. stall watchdog kills the hung attempt; retry succeeds ---------------
+start=$(date +%s)
+out="$(run_wrapped hang-then-ok HF_FETCH_STALL_TIMEOUT=15)" || fail "case 2: wrapper failed after stall: $out"
+took=$(( $(date +%s) - start ))
+grep -q "no byte growth" <<<"$out" || fail "case 2: watchdog never fired: $out"
+grep -q "retry 1/" <<<"$out" || fail "case 2: no retry after the kill: $out"
+[ "$took" -lt 120 ] || fail "case 2: took ${took}s — watchdog didn't bound the hang"
+
+# --- 3. false DONE (rc=0 + leftover .incomplete) is retried ------------------
+out="$(run_wrapped falsedone-then-ok)" || fail "case 3: wrapper failed: $out"
+grep -q "false DONE" <<<"$out" || fail "case 3: false-DONE not detected: $out"
+find "$TMP/dest" -name '*.incomplete' | grep -q . && fail "case 3: .incomplete still present after retry"
+
+echo "test-hf-fetch-hardening: ok"

--- a/services/comfyui/comfyui-paths.sh
+++ b/services/comfyui/comfyui-paths.sh
@@ -195,7 +195,33 @@ c3_precreate_comfy_mounts() {
 #     "returning existing local_dir" and exit 0 with the payload still *.incomplete
 #     (observed live 2026-07-16); rc=0 with leftover .incomplete files is treated as a
 #     FAILURE and retried, not reported as success.
+#   • a stall watchdog     — HF_HUB_DOWNLOAD_TIMEOUT only bounds SOCKET reads; hf_hub's
+#     "Still waiting to acquire lock" wait is unbounded and hangs the whole install
+#     (#726 — kodcuserkan, 3 attempts stuck on the same HiDream .lock). If dest bytes
+#     stop growing for HF_FETCH_STALL_TIMEOUT (default 300s) the attempt is killed and
+#     the retry loop takes over. Tune/disable: HF_FETCH_STALL_TIMEOUT=<secs|0>.
+#   • stale-lock clearing  — before each attempt, *.lock files under the dest download
+#     cache with NO live holder (fuser; age-only fallback) and ≥5 min age are removed,
+#     so a lock orphaned by a killed run (SoftFileLock filesystems / dead holders)
+#     can't wedge every future attempt (#726). A lock a LIVE process holds is spared.
 # Non-download subcommands pass straight through.
+
+# stale-lock sweep for c3_hf's retry loop (#726) — see the bullet above.
+_c3_hf_clear_stale_locks() {
+  local _cache="$1/.cache/huggingface/download" _lk _age_min
+  [ -d "$_cache" ] || return 0
+  # without fuser we can't see a live fcntl holder — demand a longer age instead
+  if command -v fuser >/dev/null 2>&1; then _age_min=5; else _age_min=10; fi
+  find "$_cache" -name '*.lock' -mmin "+$_age_min" 2>/dev/null | while IFS= read -r _lk; do
+    if command -v fuser >/dev/null 2>&1 && fuser -s "$_lk" 2>/dev/null; then
+      continue  # a live process holds it — a real concurrent download, leave it
+    fi
+    echo "[hf-fetch] clearing stale download lock (no live holder, >${_age_min}min): $_lk" >&2
+    rm -f "$_lk" 2>/dev/null || true
+  done
+  return 0
+}
+
 hf() {
   if [ "${1:-}" != "download" ]; then command hf "$@"; return; fi
   # recover --local-dir for the false-DONE .incomplete scan (absent -> cache-mode, skip scan)
@@ -204,11 +230,42 @@ hf() {
     [ "$_prev" = "--local-dir" ] && _dest="$_a"
     _prev="$_a"
   done
-  local _attempt=1 _max=6 _rc
+  local _attempt=1 _max=6 _rc _hfpid _wpid _stall="${HF_FETCH_STALL_TIMEOUT:-300}"
   while :; do
-    HF_HUB_DISABLE_XET="${HF_HUB_DISABLE_XET:-1}" \
-    HF_HUB_DOWNLOAD_TIMEOUT="${HF_HUB_DOWNLOAD_TIMEOUT:-30}" \
-      command hf "$@" && _rc=0 || _rc=$?
+    [ -n "$_dest" ] && _c3_hf_clear_stale_locks "$_dest"
+    # setsid → own process GROUP, so the watchdog kill takes any subprocess the
+    # downloader spawned with it (an orphaned child would keep holding the lock
+    # AND the callers' stdout pipe). Fallback: plain background + single-pid kill.
+    if command -v setsid >/dev/null 2>&1; then
+      HF_HUB_DISABLE_XET="${HF_HUB_DISABLE_XET:-1}" \
+      HF_HUB_DOWNLOAD_TIMEOUT="${HF_HUB_DOWNLOAD_TIMEOUT:-30}" \
+        setsid hf "$@" &   # exec via PATH — the real binary, not this function
+    else
+      HF_HUB_DISABLE_XET="${HF_HUB_DISABLE_XET:-1}" \
+      HF_HUB_DOWNLOAD_TIMEOUT="${HF_HUB_DOWNLOAD_TIMEOUT:-30}" \
+        command hf "$@" &
+    fi
+    _hfpid=$!
+    _wpid=""
+    if [ -n "$_dest" ] && [ "$_stall" -gt 0 ] 2>/dev/null; then
+      (
+        _last=-1; _same=0
+        while kill -0 "$_hfpid" 2>/dev/null; do
+          sleep 15
+          _cur=$(du -sb "$_dest" 2>/dev/null | cut -f1) || _cur=0
+          if [ "${_cur:-0}" = "$_last" ]; then _same=$((_same + 15)); else _same=0; _last="${_cur:-0}"; fi
+          if [ "$_same" -ge "$_stall" ]; then
+            echo "[hf-fetch] no byte growth for ${_stall}s — killing the stalled attempt (lock-wait or dead peer); retrying" >&2
+            echo "[hf-fetch] if another download is genuinely running, check: pgrep -af 'hf download'" >&2
+            kill -- "-$_hfpid" 2>/dev/null || kill "$_hfpid" 2>/dev/null
+            exit 0
+          fi
+        done
+      ) &
+      _wpid=$!
+    fi
+    wait "$_hfpid" && _rc=0 || _rc=$?
+    [ -n "$_wpid" ] && { kill "$_wpid" 2>/dev/null; wait "$_wpid" 2>/dev/null; } || true
     if [ "$_rc" -eq 0 ]; then
       if [ -n "$_dest" ] && [ -d "$_dest" ] && \
          find "$_dest" -name '*.incomplete' -print -quit 2>/dev/null | grep -q .; then


### PR DESCRIPTION
## Summary

Fixes #726 — `setup-ai-studio.sh` hanging forever on huggingface_hub's `Still waiting to acquire lock` (3 attempts wedged on the same HiDream `.lock`).

**Root cause:** hf_hub's lock wait is **unbounded** — `HF_HUB_DOWNLOAD_TIMEOUT` only bounds socket reads — and a `.lock` orphaned by an interrupted run (SoftFileLock filesystems / dead holders) blocks every subsequent attempt at the same file, forever.

**Fix** (in the hardened `hf()` wrapper — the single chokepoint since #727):
- **stale-lock sweep** before each attempt: `*.lock` under the dest download cache with no live holder (`fuser`; age-only fallback) and ≥5 min age is cleared. A lock a live process genuinely holds is spared → concurrent runs stay safe.
- **stall watchdog**: zero byte growth for `HF_FETCH_STALL_TIMEOUT` (default 300 s; `0` disables) kills the attempt with an actionable message; the retry loop takes over, and the next attempt's sweep clears the now-orphaned lock — a self-healing cycle.
- **process-group kill** (`setsid`): the watchdog kill takes any spawned subprocess with it — an orphan would keep holding the lock *and* the caller's stdout pipe. The regression test's first run caught exactly this failure mode live.

## Tests
- New `scripts/tests/test-hf-fetch-hardening.sh`: 4 deterministic PATH-shimmed cases — stale lock cleared / fresh lock spared / hang → watchdog kill → retry succeeds / false-DONE retried.
- Full suite **83/83**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm