### PR TITLE
c3: W4A8 int8-activation opt-in on the serve-confirm modal (#609)

### DIFF
--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -56,6 +56,10 @@ def _entry(
     # that dynamic-quantizes activations sets "int8" (W4A8/W8A8 class) or "fp8".
     # Surfaced as the c3 catalog "act" column (#723).
     act_format="16bit",
+    # True when the slug's compose is wired for the W4A8 int8-activation knob AND
+    # its weights are positive-symmetric int4 (the c3 serve-confirm checkbox reads
+    # this to offer VLLM_MARLIN_INPUT_DTYPE=int8 per-launch). #609.
+    act8_capable=False,
     tp,
     max_ctx,
     max_num_seqs,
@@ -86,6 +90,7 @@ def _entry(
         "drafter": drafter,
         "kv_format": kv_format,
         "act_format": act_format,
+        "act8_capable": act8_capable,
         "tp": tp,
         "pp": 1,
         "max_ctx": max_ctx,
@@ -168,7 +173,7 @@ def compose_header_status(text):
 COMPOSE_REGISTRY = {
     # Qwen 3.6 27B, vLLM single-card.
     "vllm/minimal": _entry(
-        model="qwen3.6-27b", weights_variant="autoround-int4", workload="fast-chat",
+        model="qwen3.6-27b", weights_variant="autoround-int4", act8_capable=True, workload="fast-chat",
         engine="vllm-stable", drafter=None, kv_format="fp8_e4m3",
         tp=1, max_ctx=32768, max_num_seqs=1, mem_util=0.92,
         compose_path="models/qwen3.6-27b/vllm/compose/single/autoround-int4/minimal.yml",
@@ -178,7 +183,7 @@ COMPOSE_REGISTRY = {
 
     # Qwen 3.6 27B, vLLM dual/multi-card.
     "vllm/dual": _entry(
-        model="qwen3.6-27b", weights_variant="autoround-int4", workload="long-ctx-single",
+        model="qwen3.6-27b", weights_variant="autoround-int4", act8_capable=True, workload="long-ctx-single",
         engine="vllm-stable", drafter="qwen-mtp-builtin", kv_format="fp8_e4m3",
         tp=2, max_ctx=262144, max_num_seqs=2, mem_util=0.92,
         compose_path="models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml",
@@ -199,7 +204,7 @@ COMPOSE_REGISTRY = {
     # same port) — it just names the fast tier in the symmetric family. The
     # (qwen,vllm,dual) DEFAULT stays "vllm/dual" (the long-established slug).
     "vllm/qwen-27b-dual-fast": _entry(
-        model="qwen3.6-27b", weights_variant="autoround-int4", workload="long-ctx-single",
+        model="qwen3.6-27b", weights_variant="autoround-int4", act8_capable=True, workload="long-ctx-single",
         engine="vllm-stable", drafter="qwen-mtp-builtin", kv_format="fp8_e4m3",
         tp=2, max_ctx=262144, max_num_seqs=2, mem_util=0.92,
         compose_path="models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml",
@@ -238,7 +243,7 @@ COMPOSE_REGISTRY = {
         status_note="🗑️ DEPRECATED 2026-07-16 (maintainer decision, tier-space review). Qwen3.6-27B 'balanced' tier, 2-card: cyankiwi AWQ-BF16-INT4 + int8-PTH KV + MTP n=3, TP=2 @262K. Dominated by the fast tier (vllm/dual) on every measured axis — decode ~67 vs ~89 code TPS, KV pool 370K/1.41x vs 622K/2.37x, 8-pack tie (105 vs 109, within ±5-7 noise) — and its ONLY reason-to-exist, the int8-PTH KV fidelity bet (#470), was invalidated by #594/#595: int8-PTH routes to TRITON_ATTN and craters decode at depth vs fp8/e4m3→FlashInfer (the same finding that flipped dual-max off int8-PTH). The pending long-ctx NIAH A/B is moot. Not a DEFAULTS target (nothing to repoint). Replacements: vllm/dual (fast) for speed+pool; vllm/qwen-27b-dual-max (fp8 + fp8/e4m3 KV) for weight fidelity. History: live-validated 2026-06-07 (Marlin WNA16, ~67 TPS); the cyankiwi awq-bf16-int4 weights stay registered (BYO-servable).",
     ),
     "vllm/qwen-27b-multi-fast": _entry(
-        model="qwen3.6-27b", weights_variant="autoround-int4", workload="long-ctx-single",
+        model="qwen3.6-27b", weights_variant="autoround-int4", act8_capable=True, workload="long-ctx-single",
         engine="vllm-stable", drafter="qwen-mtp-builtin", kv_format="fp8_e4m3",
         tp=4, max_ctx=262144, max_num_seqs=2, mem_util=0.92,
         compose_path="models/qwen3.6-27b/vllm/compose/multi4/autoround-int4/mtp.yml",

--- a/scripts/lib/registry-emit.sh
+++ b/scripts/lib/registry-emit.sh
@@ -666,6 +666,9 @@ for vr in _tui_registry.parse_variant_rows(tab):
             # Activation compute format (for the catalog act column, #723) —
             # "16bit" default (fp16/bf16 per compose --dtype) / "int8" / "fp8".
             "act_format": (COMPOSE_REGISTRY.get(d["slug"], {}) or {}).get("act_format"),
+            # W4A8-int8-activation capability (c3 serve-confirm checkbox, #609) —
+            # True when the compose is wired + weights are positive-sym int4.
+            "act8_capable": bool((COMPOSE_REGISTRY.get(d["slug"], {}) or {}).get("act8_capable")),
             # Weights quant_label + FORMAT from the model profile (catalog
             # Weights column fallbacks) — see _weights_meta() above.
             "weights_quant_label": _weights_meta(

--- a/scripts/tests/test-registry-json.sh
+++ b/scripts/tests/test-registry-json.sh
@@ -70,6 +70,8 @@ VARIANT_KEYS = {
     # c3 catalog act column (#723): registry act_format facet — "16bit"
     # default / "int8" / "fp8" (the A in W4A16/W4A8/W8A8).
     "act_format",
+    # c3 serve-confirm W4A8 checkbox capability (#609).
+    "act8_capable",
 }
 v0 = d["variants"][0]
 need(set(v0.keys()) == VARIANT_KEYS,

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -1862,6 +1862,8 @@ class ConfirmActionScreen(ModalScreen):
         Binding("k", "stop", "Stop", show=True, priority=True),
         Binding("k", "cancel_download", "Cancel download", show=True, priority=True),
         Binding("f", "force", "Force", show=True, priority=True),
+        # W4A8 int8-activation opt-in (#609) — shown only for act8-capable serve slugs.
+        Binding("a", "toggle_act8", "int8 acts", show=True),
         Binding("escape", "cancel", "Cancel", show=True),
     ]
 
@@ -1877,8 +1879,30 @@ class ConfirmActionScreen(ModalScreen):
         self._on_confirm = on_confirm
         # The state-aware SERVE context (None → the legacy Confirm/Force modal).
         self._serve_ctx: Optional[ServeContext] = serve_ctx
+        # W4A8 int8-activation opt-in (#609) — a per-launch toggle ([a]) shown only
+        # for act8-capable slugs. Default from the "prefer_int8_activations" Settings
+        # pref (else OFF). When ON, the serve cmd gets VLLM_MARLIN_INPUT_DTYPE=int8.
+        self._act8_on: bool = self._act8_capable() and self._act8_pref_default()
 
     # ── presentation predicates ───────────────────────────────────────────────────
+
+    def _act8_capable(self) -> bool:
+        """True iff this serve targets a slug wired for the W4A8 int8-activation
+        knob (registry act8_capable). START mode only — the knob is a launch flag."""
+        ctx = self._serve_ctx
+        if ctx is None or ctx.mode != "start" or ctx.entry is None:
+            return False
+        return bool(getattr(getattr(ctx.entry, "row", None), "act8_capable", False))
+
+    @staticmethod
+    def _act8_pref_default() -> bool:
+        """The 'prefer int8 activations where capable' Settings default (else OFF)."""
+        try:
+            from .__main__ import load_settings
+
+            return bool(load_settings().get("prefer_int8_activations"))
+        except Exception:
+            return False
 
     @property
     def _is_serve(self) -> bool:
@@ -2082,6 +2106,19 @@ class ConfirmActionScreen(ModalScreen):
                     f"{req_s} (Hopper/Blackwell class){got_s}. "
                     "[yellow]Serving here will NOT boot.[/yellow]"
                 )
+            # W4A8 int8-activation opt-in (#609) — only for act8-capable slugs.
+            if self._act8_capable():
+                if self._act8_on:
+                    lines.append(
+                        "  [bold]int8 acts[/bold] [green]ON[/green] "
+                        "([green]VLLM_MARLIN_INPUT_DTYPE=int8[/green] — ~+50% prefill, "
+                        "quality-tied ⚑) · [a] toggle"
+                    )
+                else:
+                    lines.append(
+                        "  [bold]int8 acts[/bold] [dim]off[/dim] "
+                        "(W4A8 int8 activations — ~+50% prefill ⚑ experimental) · [a] enable"
+                    )
             note = (entry.status_note or "").strip()
             if note:
                 lines.append(f"  [bold]caveat[/bold] [yellow]{note}[/yellow]")
@@ -2323,10 +2360,15 @@ class ConfirmActionScreen(ModalScreen):
                 return bool(resolved and mode == "stop")
             if action == "start":
                 return bool(resolved and mode == "start")
+            # W4A8 int8-activation toggle — only for act8-capable START slugs.
+            if action == "toggle_act8":
+                return self._act8_capable()
             # confirm/force never apply in serve mode.
             if action in ("confirm", "force"):
                 return False
             return True
+        if action == "toggle_act8":
+            return False
         if action == "confirm":
             return bool(resolved and rec.safe)
         if action == "force":
@@ -2390,8 +2432,36 @@ class ConfirmActionScreen(ModalScreen):
         self.app.pop_screen()
         self.app.cancel_download(ctx.entry.slug)  # type: ignore[attr-defined]
 
+    def action_toggle_act8(self) -> None:
+        """[a] → flip the W4A8 int8-activation opt-in (#609). No-op for slugs that
+        aren't act8-capable (check_action hides the key there)."""
+        if not self._act8_capable():
+            return
+        self._act8_on = not self._act8_on
+        self._render_serve_card()   # reflect ON/OFF in the card
+
+    @staticmethod
+    def _with_act8_env(cmd: list[str]) -> list[str]:
+        """Prepend `env VLLM_MARLIN_INPUT_DTYPE=int8` to a serve cmd (#609). switch.sh
+        runs `docker compose`, which reads the env for the compose's bare
+        `- VLLM_MARLIN_INPUT_DTYPE` passthrough → int8 activations in the container.
+        Idempotent."""
+        if "VLLM_MARLIN_INPUT_DTYPE=int8" in cmd:
+            return cmd
+        return ["env", "VLLM_MARLIN_INPUT_DTYPE=int8", *cmd]
+
     def _commit(self, *, force: bool) -> None:
         plan = self._plan
+        # W4A8 (#609): when the int8-activation opt-in is ON for an act8-capable
+        # slug, inject the env into the serve cmd BEFORE the force re-issue (so
+        # _with_force still finds the switch.sh positional last).
+        if self._act8_on and self._act8_capable() and plan.kind == "serve":
+            plan = ActionPlan(
+                kind=plan.kind, cmd=self._with_act8_env(plan.cmd),
+                description=plan.description + " +int8-acts",
+                is_write=plan.is_write, requires_reconcile=plan.requires_reconcile,
+                force=plan.force, force_reason=plan.force_reason,
+            )
         if force and not plan.force:
             # Re-issue the plan as a forced one (with a surfaced reason) so the
             # executor's force path is taken explicitly — never silently.  In serve

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -4543,6 +4543,8 @@ def _variant_row_from_dict(d: dict[str, Any]) -> VariantRow:
         # Activation compute format (catalog act column, #723) — same pattern;
         # "" when the contract didn't carry it (older emit) → the column shows "—".
         object.__setattr__(row, "act_format", str(d.get("act_format") or ""))
+        # W4A8-int8-activation capability (c3 serve-confirm checkbox, #609).
+        object.__setattr__(row, "act8_capable", bool(d.get("act8_capable")))
         # Weights quant_label + FORMAT from the model profile (emit join) —
         # the catalog Weights column's fallbacks for weights_variant tokens that
         # carry no recognisable quant segment: quant_label is the explicit

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -995,6 +995,47 @@ class TestNavNodesExist:
         saved = M.load_settings().get("catalog_columns")
         assert saved == {"order": default, "hidden": []}
 
+    def test_act8_serve_toggle(self):
+        """#609: the W4A8 int8-activation opt-in on the serve-confirm modal —
+        shown + wired only for act8-capable START slugs, injects the env, hidden
+        elsewhere. Tests the modal's logic directly (no app mount needed)."""
+        from club3090_cockpit.app import ConfirmActionScreen, ServeContext
+        from club3090_cockpit.data import ActionPlan, CatalogEntry
+        from club3090_cockpit.services import _variant_row_from_dict
+
+        def modal(act8, mode="start"):
+            row = _variant_row_from_dict({"slug": "vllm/dual", "port": 8010, "act8_capable": act8})
+            ctx = ServeContext(mode=mode, entry=CatalogEntry(row=row))
+            m = ConfirmActionScreen.__new__(ConfirmActionScreen)
+            m._plan = ActionPlan(kind="serve", cmd=["bash", "scripts/switch.sh", "vllm/dual"])
+            m._serve_ctx = ctx
+            m._act8_on = False
+            m._reconcile = None
+            return m
+
+        # capable START slug → toggle available + gated ON
+        cap = modal(True)
+        assert cap._act8_capable() is True
+        assert cap.check_action("toggle_act8", ()) is True
+        # env attaches (idempotent, prepended before switch.sh)
+        cap._act8_on = True
+        inj = cap._with_act8_env(cap._plan.cmd)
+        assert inj[:2] == ["env", "VLLM_MARLIN_INPUT_DTYPE=int8"]
+        assert cap._with_act8_env(inj) == inj  # idempotent
+
+        # NON-capable slug → toggle hidden, capability False
+        nocap = modal(False)
+        assert nocap._act8_capable() is False
+        assert nocap.check_action("toggle_act8", ()) is False
+
+        # capable but STOP mode (not a launch) → not offered
+        stop = modal(True, mode="stop")
+        assert stop._act8_capable() is False
+
+        # row facet plumbs through from the emit contract
+        assert getattr(_variant_row_from_dict({"slug": "x", "port": 1, "act8_capable": True}), "act8_capable") is True
+        assert getattr(_variant_row_from_dict({"slug": "x", "port": 1}), "act8_capable") is False
+
     @pytest.mark.asyncio
     async def test_benchmarks_tab_is_gone(self):
         """Fold 3 removed the standalone Validate · Benchmarks tab + its pane."""


### PR DESCRIPTION
Adds a per-launch **`[a]` toggle** to the ⏎ serve-confirm card, shown only for `act8_capable` START slugs (`vllm/dual`, `vllm/minimal`, `vllm/qwen-27b-multi-fast` + the `dual-fast` alias). When ON, the serve cmd gets `env VLLM_MARLIN_INPUT_DTYPE=int8` prepended — switch.sh runs `docker compose`, which reads it for the compose's bare `- VLLM_MARLIN_INPUT_DTYPE` passthrough (from #730/#731) → int8 activations in the container (~+50% prefill, 8-pack-tied).

- registry `_entry` gains `act8_capable` (default False); True on the 4 wired autoround slugs. Emitted in `registry-emit --json`, attached in `services.py`, `VARIANT_KEYS` extended.
- Modal: `[a]` gated by `check_action` to act8-capable START only; card shows ON/off; `_commit` injects the env before the `--force` re-issue (verified `--force` still lands before the switch.sh slug). Default from a `prefer_int8_activations` setting (else OFF); Settings-UI for that pref deferred (works via c3-settings.json today).
- Registry-grounded capability (no app-side guessing); the catalog `act` column keeps showing the slug DEFAULT (16bit).

Tests: act8 toggle behavior (capable→shown+env, non-capable→hidden, stop-mode→off, facet plumbing) + repo gates green (registry-json/switch-parity/launch-parity/emit-no-yaml/registry-disk). Locally validated in the running app by the maintainer. Full c3 suite running as a backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm