### PR TITLE
Vendor Google's canonical Gemma 4 chat template (2026-07-09 fix) — repoint all 11 gemma vLLM composes

### DIFF
--- a/models/diffusiongemma-26b-a4b/vllm/compose/dual/fp8/base.yml
+++ b/models/diffusiongemma-26b-a4b/vllm/compose/dual/fp8/base.yml
@@ -65,6 +65,10 @@ services:
       - "${ESTATE_PORT:-${PORT:-8042}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
+      # Google Gemma 4 CANONICAL chat template (published 2026-07-09) — SHARED
+      # from the gemma-4-31b tree (one canonical template family-wide); the
+      # image-bundled example predates Google's fix (see the patch README).
+      - ../../../../../gemma-4-31b/vllm/patches/google-canonical-chat-template/chat_template.jinja:/etc/club3090/gemma-canonical-template.jinja:ro
       # 3 Ampere/TP fix-mounts over the official :gemma image's vllm pkg (NOT upstream —
       # see ../../../patches/gemma-image-fixes/README.md). marlin.py + marlin_utils_fp8.py
       # = sm_86 fp8 Marlin K-pad; diffusion_gemma.py = TP-vocab soft-embed + dtype fix.
@@ -177,7 +181,7 @@ services:
       - --reasoning-parser
       - gemma4
       - --chat-template
-      - /vllm-workspace/examples/tool_chat_template_gemma4.jinja
+      - /etc/club3090/gemma-canonical-template.jinja
       # Thinking: left at the model/template natural default (NOT force-disabled) — the
       # earlier "stuck in thinking / empty answer" was the 256-tok cap above, not thinking.
       # The reasoning parser routes any thinking into the `reasoning` field; clients can

--- a/models/gemma-4-12b/vllm/compose/dual/bf16/mtp.yml
+++ b/models/gemma-4-12b/vllm/compose/dual/bf16/mtp.yml
@@ -48,6 +48,10 @@ services:
       - "${ESTATE_PORT:-${PORT:-8036}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
+      # Google Gemma 4 CANONICAL chat template (published 2026-07-09) — SHARED
+      # from the gemma-4-31b tree (one canonical template family-wide); the
+      # image-bundled example predates Google's fix (see the patch README).
+      - ../../../../../gemma-4-31b/vllm/patches/google-canonical-chat-template/chat_template.jinja:/etc/club3090/gemma-canonical-template.jinja:ro
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
@@ -123,7 +127,7 @@ services:
       - --reasoning-parser
       - gemma4
       - --chat-template
-      - /vllm-workspace/examples/tool_chat_template_gemma4.jinja
+      - /etc/club3090/gemma-canonical-template.jinja
       # ⏸️ MTP DISABLED on v0.24.0 — Gemma-4 MTP × tool-calling is broken (upstream vLLM #39043;
       #    MTP fix #42006 closed-unmerged). Verified on-rig 2026-07-01: MTP-off tools PASS (KV 496K,
       #    streaming 3/3, no leak), MTP-on tools FAIL. Re-enable when a stable vLLM ships the fix:

--- a/models/gemma-4-12b/vllm/compose/single/autoround-int8/mtp.yml
+++ b/models/gemma-4-12b/vllm/compose/single/autoround-int8/mtp.yml
@@ -41,6 +41,10 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8038}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
+      # Google Gemma 4 CANONICAL chat template (published 2026-07-09) — SHARED
+      # from the gemma-4-31b tree (one canonical template family-wide); the
+      # image-bundled example predates Google's fix (see the patch README).
+      - ../../../../../gemma-4-31b/vllm/patches/google-canonical-chat-template/chat_template.jinja:/etc/club3090/gemma-canonical-template.jinja:ro
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
     environment:
@@ -104,7 +108,7 @@ services:
       - --reasoning-parser
       - gemma4
       - --chat-template
-      - /vllm-workspace/examples/tool_chat_template_gemma4.jinja
+      - /etc/club3090/gemma-canonical-template.jinja
       - --override-generation-config
       - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-64},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host

--- a/models/gemma-4-12b/vllm/compose/single/qat-w4a16/mtp.yml
+++ b/models/gemma-4-12b/vllm/compose/single/qat-w4a16/mtp.yml
@@ -45,6 +45,10 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8038}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
+      # Google Gemma 4 CANONICAL chat template (published 2026-07-09) — SHARED
+      # from the gemma-4-31b tree (one canonical template family-wide); the
+      # image-bundled example predates Google's fix (see the patch README).
+      - ../../../../../gemma-4-31b/vllm/patches/google-canonical-chat-template/chat_template.jinja:/etc/club3090/gemma-canonical-template.jinja:ro
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
       # EVAL workaround for vLLM #44494 — sitecustomize (auto-loaded via PYTHONPATH) forces
@@ -113,7 +117,7 @@ services:
       - --reasoning-parser
       - gemma4
       - --chat-template
-      - /vllm-workspace/examples/tool_chat_template_gemma4.jinja
+      - /etc/club3090/gemma-canonical-template.jinja
       - --override-generation-config
       - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-64},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host

--- a/models/gemma-4-26b-a4b/vllm/compose/dual/awq/mtp.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/dual/awq/mtp.yml
@@ -49,6 +49,10 @@ services:
       - "${ESTATE_PORT:-${PORT:-8041}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
+      # Google Gemma 4 CANONICAL chat template (published 2026-07-09) — SHARED
+      # from the gemma-4-31b tree (one canonical template family-wide); the
+      # image-bundled example predates Google's fix (see the patch README).
+      - ../../../../../gemma-4-31b/vllm/patches/google-canonical-chat-template/chat_template.jinja:/etc/club3090/gemma-canonical-template.jinja:ro
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
       # NVLink auto-detection — runs inside container at boot (same path as dual-max).
@@ -134,7 +138,7 @@ services:
       - --reasoning-parser
       - gemma4
       - --chat-template
-      - /vllm-workspace/examples/tool_chat_template_gemma4.jinja
+      - /etc/club3090/gemma-canonical-template.jinja
       - --enable-prefix-caching
       - --enable-chunked-prefill
       # Head-of-line fix: cap a long prefill's per-step tokens so a concurrent short/agentic

--- a/models/gemma-4-26b-a4b/vllm/compose/single/awq/int8.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/single/awq/int8.yml
@@ -69,6 +69,10 @@ services:
       - "${ESTATE_PORT:-${PORT:-8040}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
+      # Google Gemma 4 CANONICAL chat template (published 2026-07-09) — SHARED
+      # from the gemma-4-31b tree (one canonical template family-wide); the
+      # image-bundled example predates Google's fix (see the patch README).
+      - ../../../../../gemma-4-31b/vllm/patches/google-canonical-chat-template/chat_template.jinja:/etc/club3090/gemma-canonical-template.jinja:ro
       # Separate cache dirs from the bf16/no-overlay single (the overlay file
       # set differs → cudagraph capture re-keys on the patched kernel paths).
       - ../../../cache/torch_compile_int8:/root/.cache/vllm/torch_compile_cache
@@ -167,7 +171,7 @@ services:
       - --reasoning-parser
       - gemma4
       - --chat-template
-      - /vllm-workspace/examples/tool_chat_template_gemma4.jinja
+      - /etc/club3090/gemma-canonical-template.jinja
       - --enable-prefix-caching
       - --enable-chunked-prefill
       # Head-of-line fix: cap a long prefill's per-step tokens so a concurrent short/agentic

--- a/models/gemma-4-31b/vllm/compose/dual/autoround-int4/bf16-mtp.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/autoround-int4/bf16-mtp.yml
@@ -73,6 +73,9 @@ services:
       - "${ESTATE_PORT:-${PORT:-8030}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
+      # Google Gemma 4 CANONICAL chat template (published 2026-07-09) — vendored;
+      # the image-bundled example predates Google's fix (see the patch README).
+      - ../../../patches/google-canonical-chat-template/chat_template.jinja:/etc/club3090/gemma-canonical-template.jinja:ro
       # torch.compile + Triton kernel caches — first boot warms (~5-7 min);
       # subsequent boots reuse cached graphs (~3 min). Pattern from dual-turbo.yml.
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
@@ -191,6 +194,6 @@ services:
       - --reasoning-parser
       - gemma4
       - --chat-template
-      - /vllm-workspace/examples/tool_chat_template_gemma4.jinja
+      - /etc/club3090/gemma-canonical-template.jinja
       - --speculative-config
       - '{"model":"/root/.cache/huggingface/gemma-4-31b-it-assistant","num_speculative_tokens":4}'

--- a/models/gemma-4-31b/vllm/compose/dual/autoround-int4/int8.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/autoround-int4/int8.yml
@@ -119,6 +119,9 @@ services:
       - "${ESTATE_PORT:-${PORT:-8032}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
+      # Google Gemma 4 CANONICAL chat template (published 2026-07-09) — vendored;
+      # the image-bundled example predates Google's fix (see the patch README).
+      - ../../../patches/google-canonical-chat-template/chat_template.jinja:/etc/club3090/gemma-canonical-template.jinja:ro
       # torch.compile + Triton kernel caches — first boot warms (~5-7 min);
       # subsequent boots reuse cached graphs (~3 min). Separate cache dirs
       # from dual.yml because the overlay file set differs (cudagraph
@@ -258,7 +261,7 @@ services:
       - --reasoning-parser
       - gemma4
       - --chat-template
-      - /vllm-workspace/examples/tool_chat_template_gemma4.jinja
+      - /etc/club3090/gemma-canonical-template.jinja
       # SPEC_N_MAX overridable for matched-config head-to-head against
       # qwen3.6-27b/vllm/compose/dual/autoround-int4/int8.yml (Qwen's built-in MTP caps at
       # n=3 architecturally, so the canonical apples-to-apples bench uses

--- a/models/gemma-4-31b/vllm/compose/dual/qat-awq-int4/base.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/qat-awq-int4/base.yml
@@ -73,6 +73,9 @@ services:
       - "${ESTATE_PORT:-${PORT:-8032}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
+      # Google Gemma 4 CANONICAL chat template (published 2026-07-09) — vendored;
+      # the image-bundled example predates Google's fix (see the patch README).
+      - ../../../patches/google-canonical-chat-template/chat_template.jinja:/etc/club3090/gemma-canonical-template.jinja:ro
       # torch.compile + Triton kernel caches — first boot warms (~5-7 min);
       # subsequent boots reuse cached graphs (~3 min).
       - ../../../cache/torch_compile_qatawq:/root/.cache/vllm/torch_compile_cache
@@ -169,6 +172,6 @@ services:
       - --reasoning-parser
       - gemma4
       - --chat-template
-      - /vllm-workspace/examples/tool_chat_template_gemma4.jinja
+      - /etc/club3090/gemma-canonical-template.jinja
       # ⏸️ MTP disabled — see the caveat block in the header. Do NOT add --speculative-config
       #    on v0.24.0 (breaks tool-calling); restore it only when vLLM #39043/#42006 land.

--- a/models/gemma-4-31b/vllm/compose/dual/qat-w4a16/int8.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/qat-w4a16/int8.yml
@@ -122,6 +122,9 @@ services:
       - "${ESTATE_PORT:-${PORT:-8033}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
+      # Google Gemma 4 CANONICAL chat template (published 2026-07-09) — vendored;
+      # the image-bundled example predates Google's fix (see the patch README).
+      - ../../../patches/google-canonical-chat-template/chat_template.jinja:/etc/club3090/gemma-canonical-template.jinja:ro
       # torch.compile + Triton kernel caches — first boot warms (~5-7 min);
       # subsequent boots reuse cached graphs (~3 min). Separate cache dirs
       # from dual.yml because the overlay file set differs (cudagraph
@@ -261,7 +264,7 @@ services:
       - --reasoning-parser
       - gemma4
       - --chat-template
-      - /vllm-workspace/examples/tool_chat_template_gemma4.jinja
+      - /etc/club3090/gemma-canonical-template.jinja
       # SPEC_N_MAX defaults to 3 — the n-swept TPS optimum for THIS quant (2026-06-07,
       # dual @370W): the QAT-int4's fast acceptance decay (67/42/26/14% per-pos) makes
       # n=3 the best balance — top narrative (74.0 TPS), code tied with n=4 (87.7), and

--- a/models/gemma-4-31b/vllm/compose/single/autoround-int4/fp8-mtp.yml
+++ b/models/gemma-4-31b/vllm/compose/single/autoround-int4/fp8-mtp.yml
@@ -71,6 +71,9 @@ services:
       - "${ESTATE_PORT:-${PORT:-8031}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
+      # Google Gemma 4 CANONICAL chat template (published 2026-07-09) — vendored;
+      # the image-bundled example predates Google's fix (see the patch README).
+      - ../../../patches/google-canonical-chat-template/chat_template.jinja:/etc/club3090/gemma-canonical-template.jinja:ro
       # torch.compile + Triton kernel caches — first boot warms (~5-7 min);
       # subsequent boots reuse cached graphs (~3 min). Pattern from dual-turbo.yml.
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
@@ -153,6 +156,6 @@ services:
       - --tool-call-parser
       - gemma4
       - --chat-template
-      - /vllm-workspace/examples/tool_chat_template_gemma4.jinja
+      - /etc/club3090/gemma-canonical-template.jinja
       - --speculative-config
       - '{"model":"/root/.cache/huggingface/gemma-4-31b-it-assistant","num_speculative_tokens":4}'

--- a/models/gemma-4-31b/vllm/patches/google-canonical-chat-template/README.md
+++ b/models/gemma-4-31b/vllm/patches/google-canonical-chat-template/README.md
@@ -1,0 +1,39 @@
+# Google Gemma 4 Canonical Chat Template (vendored)
+
+**Source:** `google/gemma-4-31B-it` @ main, template published **2026-07-09**
+("fix: chat template — null handling, reasoning preservation, turn-tag balance").
+Identical file ships in `google/gemma-4-12B-it` and `google/gemma-4-26B-A4B-it` —
+one canonical template family-wide.
+**sha256:** `ae53464bf3be25802b3a5b37def7fd89667067d7577049b3b2d74c4d8de4c6d4`
+
+## Why vendored
+
+The gemma vLLM composes previously pointed at the image-bundled
+`/vllm-workspace/examples/tool_chat_template_gemma4.jinja`. That copy (as of
+`vllm/vllm-openai:v0.25.1`) **predates Google's 2026-07-09 fix** and differs in
+three functional ways, each an agent-loop failure class:
+
+1. Injects an empty `<|channel>thought` block into *history* model-turns when
+   thinking is off (phantom thought channels in replayed conversations).
+2. `preserve_thinking` applied to every turn; canonical scopes it to
+   **tool-call turns only** (reasoning-preservation fix).
+3. Turn-closure emission ignores the next turn; canonical adds the
+   `next_nt.found` guard (the turn-tag-balance fix for tool loops).
+
+Vendoring (rather than trusting the image copy) pins the fixed bytes and makes
+template provenance auditable — same rationale as the froggeric template for the
+qwen3_5 family.
+
+## Consumers
+
+All gemma-family vLLM composes (31B, 12B, 26B-A4B, diffusiongemma) mount this
+file and pass it via `--chat-template`. GGUF lanes keep their embedded
+templates (minja compatibility unvalidated — do NOT point llama.cpp at this
+file without a minja parse check first).
+
+## Drop trigger
+
+A future `vllm-stable` pin whose bundled example is byte-identical to (or
+newer than) the canonical → repoint composes at the image path and retire this
+dir. Check: `diff` this file against `/vllm-workspace/examples/tool_chat_template_gemma4.jinja`
+in the new image.

--- a/models/gemma-4-31b/vllm/patches/google-canonical-chat-template/chat_template.jinja
+++ b/models/gemma-4-31b/vllm/patches/google-canonical-chat-template/chat_template.jinja
@@ -1,0 +1,390 @@
+{#
+  Template: Google Gemma 4 Canonical Chat Template
+  Author: Google Gemma Engineering Team
+  Published: 2026-07-09
+  Context: Fixed tool-calling loops, turn closures, and thinking content-ordering.
+#}
+{%- macro format_parameters(properties, required, filter_keys=false) -%}
+    {%- set standard_keys = ['description', 'type', 'properties', 'required', 'nullable'] -%}
+    {%- set ns = namespace(found_first=false) -%}
+    {%- for key, value in properties | dictsort -%}
+        {%- set add_comma = false -%}
+        {%- if not filter_keys or key not in standard_keys -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {{ key }}:{
+            {%- if value['description'] -%}
+                description:<|"|>{{ value['description'] }}<|"|>
+                {%- set add_comma = true -%}
+            {%- endif -%}
+            {%- if value['type'] | upper == 'STRING' -%}
+                {%- if value['enum'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    enum:{{ format_argument(value['enum']) }}
+                {%- endif -%}
+            {%- elif value['type'] | upper == 'ARRAY' -%}
+                {%- if value['items'] is mapping and value['items'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    items:{
+                    {%- set ns_items = namespace(found_first=false) -%}
+                    {%- for item_key, item_value in value['items'] | dictsort -%}
+                        {%- if item_value is not none -%}
+                            {%- if ns_items.found_first %},{% endif -%}
+                            {%- set ns_items.found_first = true -%}
+                            {%- if item_key == 'properties' -%}
+                                properties:{
+                                {%- if item_value is mapping -%}
+                                    {{- format_parameters(item_value, value['items']['required'] | default([])) -}}
+                                {%- endif -%}
+                                }
+                            {%- elif item_key == 'required' -%}
+                                required:[
+                                {%- for req_item in item_value -%}
+                                    <|"|>{{- req_item -}}<|"|>
+                                    {%- if not loop.last %},{% endif -%}
+                                {%- endfor -%}
+                                ]
+                            {%- elif item_key == 'type' -%}
+                                {%- if item_value is string -%}
+                                    type:{{ format_argument(item_value | upper) }}
+                                {%- else -%}
+                                    type:{{ format_argument(item_value | map('upper') | list) }}
+                                {%- endif -%}
+                            {%- else -%}
+                                {{ item_key }}:{{ format_argument(item_value) }}
+                            {%- endif -%}
+                        {%- endif -%}
+                    {%- endfor -%}
+                    }
+                {%- endif -%}
+            {%- endif -%}
+            {%- if value['nullable'] %}
+                {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                nullable:true
+            {%- endif -%}
+            {%- if value['type'] | upper == 'OBJECT' -%}
+                {%- if value['properties'] is defined and value['properties'] is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value['properties'], value['required'] | default([])) -}}
+                    }
+                {%- elif value is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value, value['required'] | default([]), filter_keys=true) -}}
+                    }
+                {%- endif -%}
+                {%- if value['required'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    required:[
+                    {%- for item in value['required'] | default([]) -%}
+                        <|"|>{{- item -}}<|"|>
+                        {%- if not loop.last %},{% endif -%}
+                    {%- endfor -%}
+                    ]
+                {%- endif -%}
+            {%- endif -%}
+            {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+            type:<|"|>{{ value['type'] | upper }}<|"|>}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+{%- macro format_function_declaration(tool_data) -%}
+    declaration:{{- tool_data['function']['name'] -}}{description:<|"|>{{- tool_data['function']['description'] -}}<|"|>
+    {%- set params = tool_data['function']['parameters'] -%}
+    {%- if params -%}
+        ,parameters:{
+        {%- if params['properties'] -%}
+            properties:{ {{- format_parameters(params['properties'], params['required']) -}} },
+        {%- endif -%}
+        {%- if params['required'] -%}
+            required:[
+            {%- for item in params['required'] -%}
+                <|"|>{{- item -}}<|"|>
+                {{- ',' if not loop.last -}}
+            {%- endfor -%}
+            ],
+        {%- endif -%}
+        {%- if params['type'] -%}
+            type:<|"|>{{- params['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    {%- if 'response' in tool_data['function'] -%}
+        {%- set response_declaration = tool_data['function']['response'] -%}
+        ,response:{
+        {%- if response_declaration['description'] -%}
+            description:<|"|>{{- response_declaration['description'] -}}<|"|>,
+        {%- endif -%}
+        {%- if response_declaration['type'] | upper == 'OBJECT' -%}
+            type:<|"|>{{- response_declaration['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    }
+{%- endmacro -%}
+{%- macro format_argument(argument, escape_keys=True) -%}
+    {%- if argument is none -%}
+        {{- 'null' -}}
+    {%- elif argument is string -%}
+        {{- '<|"|>' + argument + '<|"|>' -}}
+    {%- elif argument is boolean -%}
+        {{- 'true' if argument else 'false' -}}
+    {%- elif argument is mapping -%}
+        {{- '{' -}}
+        {%- set ns = namespace(found_first=false) -%}
+        {%- for key, value in argument | dictsort -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {%- if escape_keys -%}
+                {{- '<|"|>' + key + '<|"|>' -}}
+            {%- else -%}
+                {{- key -}}
+            {%- endif -%}
+            :{{- format_argument(value, escape_keys=escape_keys) -}}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- elif argument is sequence -%}
+        {{- '[' -}}
+        {%- for item in argument -%}
+            {{- format_argument(item, escape_keys=escape_keys) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- ']' -}}
+    {%- else -%}
+        {{- argument -}}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro strip_thinking(text) -%}
+    {%- set ns = namespace(result='') -%}
+    {%- for part in text.split('<channel|>') -%}
+        {%- if '<|channel>' in part -%}
+            {%- set ns.result = ns.result + part.split('<|channel>')[0] -%}
+        {%- else -%}
+            {%- set ns.result = ns.result + part -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- ns.result | trim -}}
+{%- endmacro -%}
+
+{%- macro format_tool_response_block(tool_name, response) -%}
+    {{- '<|tool_response>' -}}
+    {%- if response is mapping -%}
+        {{- 'response:' + tool_name + '{' -}}
+        {%- for key, value in response | dictsort -%}
+            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- else -%}
+        {{- 'response:' + tool_name + '{value:' + format_argument(response, escape_keys=False) + '}' -}}
+    {%- endif -%}
+    {{- '<tool_response|>' -}}
+{%- endmacro -%}
+
+{#- ===== SETUP ===== -#}
+{%- set ns = namespace(prev_message_type=None, prev_non_tool_role=None) -%}
+{%- set loop_messages = messages -%}
+{%- set enable_thinking = enable_thinking | default(false) -%}
+{%- set preserve_thinking = preserve_thinking | default(false) -%}
+{{- bos_token -}}
+{#- Handle System/Tool Definitions Block -#}
+{%- if enable_thinking or tools or (messages and messages[0]['role'] in ['system', 'developer']) -%}
+    {{- '<|turn>system\n' -}}
+    {#- Inject Thinking token at the very top of the FIRST system turn -#}
+    {%- if enable_thinking -%}
+        {{- '<|think|>\n' -}}
+        {%- set ns.prev_message_type = 'think' -%}
+    {%- endif -%}
+    {%- if messages and messages[0]['role'] in ['system', 'developer'] -%}
+        {%- if messages[0]['content'] is string -%}
+            {{- messages[0]['content'] | trim -}}
+        {%- elif messages[0]['content'] is sequence -%}
+            {%- for item in messages[0]['content'] -%}
+                {{- item['text'] | trim + ' '-}}
+            {%- endfor -%}
+        {%- endif -%}
+        {%- set loop_messages = messages[1:] -%}
+    {%- endif -%}
+    {%- if tools -%}
+        {%- for tool in tools %}
+            {{- '<|tool>' -}}
+            {{- format_function_declaration(tool) | trim -}}
+            {{- '<tool|>' -}}
+        {%- endfor %}
+        {%- set ns.prev_message_type = 'tool' -%}
+    {%- endif -%}
+    {{- '<turn|>\n' -}}
+{%- endif %}
+
+{#- Pre-scan: find last user message index for reasoning guard -#}
+{%- set ns_turn = namespace(last_user_idx=-1) -%}
+{%- for i in range(loop_messages | length) -%}
+    {%- if loop_messages[i]['role'] == 'user' -%}
+        {%- set ns_turn.last_user_idx = i -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{#- Loop through messages -#}
+{%- for message in loop_messages -%}
+    {%- if message['role'] != 'tool' -%}
+    {%- set ns.prev_message_type = None -%}
+    {%- set role = 'model' if message['role'] == 'assistant' else message['role'] -%}
+    {#- Detect continuation using tracked state — O(1) instead of O(n) backward scan -#}
+    {%- set continue_same_model_turn = (role == 'model' and ns.prev_non_tool_role == 'assistant') -%}
+    {%- if not continue_same_model_turn -%}
+        {{- '<|turn>' + role + '\n' }}
+
+    {%- endif -%}
+
+    {#- Render reasoning/reasoning_content as thinking channel -#}
+    {%- set thinking_text = message.get('reasoning') or message.get('reasoning_content') -%}
+    {%- set thinking_gate = (loop.index0 > ns_turn.last_user_idx) or (preserve_thinking and message.get('tool_calls')) -%}
+    {%- if thinking_text and thinking_gate -%}
+        {{- '<|channel>thought\n' + thinking_text + '\n<channel|>' -}}
+    {%- endif -%}
+
+            {%- if message.get('tool_calls') -%}
+                {%- for tool_call in message.get('tool_calls') -%}
+                    {%- set function = tool_call['function'] -%}
+                    {{- '<|tool_call>call:' + function['name'] + '{' -}}
+                    {%- if function['arguments'] is mapping -%}
+                        {%- set ns_args = namespace(found_first=false) -%}
+                        {%- for key, value in function['arguments'] | dictsort -%}
+                            {%- if ns_args.found_first %},{% endif -%}
+                            {%- set ns_args.found_first = true -%}
+                            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+                        {%- endfor -%}
+                    {%- elif function['arguments'] is none -%}
+                    {%- else -%}
+                        {{- raise_exception(
+                            "chat_template: tool_calls[].function.arguments must be a "
+                            "JSON object (mapping), not a string. Deserialize arguments "
+                            "before passing to the template."
+                        ) -}}
+                    {%- endif -%}
+                    {{- '}<tool_call|>' -}}
+                {%- endfor -%}
+                {%- set ns.prev_message_type = 'tool_call' -%}
+            {%- endif -%}
+
+            {%- set ns_tr_out = namespace(flag=false) -%}
+            {%- if message.get('tool_responses') -%}
+                {#- Legacy: tool_responses embedded on the assistant message (Google/Gemma native) -#}
+                {%- for tool_response in message.get('tool_responses') -%}
+                    {{- format_tool_response_block(tool_response['name'] | default('unknown', true), tool_response['response']) -}}
+                    {%- set ns_tr_out.flag = true -%}
+                    {%- set ns.prev_message_type = 'tool_response' -%}
+                {%- endfor -%}
+            {%- elif message.get('tool_calls') -%}
+                {#- OpenAI Chat Completions: forward-scan consecutive role:tool messages -#}
+                {%- set ns_tool_scan = namespace(stopped=false) -%}
+                {%- for k in range(loop.index0 + 1, loop_messages | length) -%}
+                    {%- if ns_tool_scan.stopped -%}
+                    {%- elif loop_messages[k]['role'] != 'tool' -%}
+                        {%- set ns_tool_scan.stopped = true -%}
+                    {%- else -%}
+                        {%- set follow = loop_messages[k] -%}
+                        {#- Resolve tool_call_id to function name -#}
+                        {%- set ns_tname = namespace(name=follow.get('name') or 'unknown') -%}
+                        {%- for tc in message.get('tool_calls') -%}
+                            {%- if tc.get('id') == follow.get('tool_call_id') -%}
+                                {%- set ns_tname.name = tc['function']['name'] -%}
+                            {%- endif -%}
+                        {%- endfor -%}
+                        {#- Handle content as string or content-parts array -#}
+                        {%- set tool_body = follow.get('content') -%}
+                        {%- if tool_body is string -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- elif tool_body is sequence and tool_body is not string -%}
+                            {%- set ns_txt = namespace(s='') -%}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') == 'text' -%}
+                                    {%- set ns_txt.s = ns_txt.s + (part.get('text') | default('')) -%}
+                                {%- endif -%}
+                            {%- endfor -%}
+                            {{- format_tool_response_block(ns_tname.name, ns_txt.s) -}}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') in ['image', 'image_url'] -%}
+                                    {{- '<|image|>' -}}
+                                {%- elif part.get('type') in ['audio', 'input_audio'] -%}
+                                    {{- '<|audio|>' -}}
+                                {%- elif part.get('type') == 'video' -%}
+                                    {{- '<|video|>' -}}
+                                {%- endif -%}
+                            {%- endfor -%}
+                        {%- else -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- endif -%}
+                        {%- set ns_tr_out.flag = true -%}
+                        {%- set ns.prev_message_type = 'tool_response' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+
+            {%- set captured_content -%}
+            {%- if message.get('content') is string -%}
+                {%- if role == 'model' -%}
+                    {{- strip_thinking(message['content']) -}}
+                {%- else -%}
+                    {{- message['content'] | trim -}}
+                {%- endif -%}
+            {%- elif message.get('content') is sequence -%}
+                {%- for item in message['content'] -%}
+                    {%- if item.get('type') == 'text' -%}
+                        {%- if role == 'model' -%}
+                            {{- strip_thinking(item['text']) -}}
+                        {%- else -%}
+                            {{- item['text'] | trim -}}
+                        {%- endif -%}
+                    {%- elif item.get('type') in ['image', 'image_url'] -%}
+                        {{- '<|image|>' -}}
+                    {%- elif item.get('type') in ['audio', 'input_audio'] -%}
+                        {{- '<|audio|>' -}}
+                    {%- elif item.get('type') == 'video' -%}
+                        {{- '<|video|>' -}}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+            {%- endset -%}
+
+            {{- captured_content -}}
+            {%- set has_content = captured_content | trim | length > 0 -%}
+
+        {#- Forward-scan: find next non-tool message role for continuation detection -#}
+        {%- set next_nt = namespace(role=None, found=false) -%}
+        {%- for j in range(loop.index0 + 1, loop_messages | length) -%}
+            {%- if not next_nt.found -%}
+                {%- if loop_messages[j]['role'] != 'tool' -%}
+                    {%- set next_nt.role = loop_messages[j]['role'] -%}
+                    {%- set next_nt.found = true -%}
+                {%- endif -%}
+            {%- endif -%}
+        {%- endfor -%}
+
+        {%- set continues_into_next = (
+            role == 'model'
+            and next_nt.role == 'assistant'
+            and (not message.get('tool_calls') or ns_tr_out.flag)
+        ) -%}
+
+        {%- if ns.prev_message_type == 'tool_call' and not ns_tr_out.flag -%}
+            {{- '<|tool_response>' -}}
+        {%- elif continues_into_next -%}
+        {%- elif not (ns_tr_out.flag and not has_content and not next_nt.found) -%}
+            {{- '<turn|>\n' -}}
+        {%- endif -%}
+
+    {#- Track previous non-tool role for next iteration (avoids O(n) backward scan) -#}
+    {%- set ns.prev_non_tool_role = message['role'] -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- if add_generation_prompt -%}
+    {%- if ns.prev_message_type != 'tool_response' and ns.prev_message_type != 'tool_call' -%}
+        {{- '<|turn>model\n' -}}
+        {%- if not enable_thinking -%}
+            {{- '<|channel>thought\n<channel|>' -}}
+        {%- endif -%}
+    {%- elif ns.prev_message_type == 'tool_response' and enable_thinking -%}
+        {{- '<|channel>thought\n' -}}
+    {%- endif -%}
+{%- endif -%}

--- a/scripts/lib/profiles/patches.yml
+++ b/scripts/lib/profiles/patches.yml
@@ -235,6 +235,41 @@ patches:
       drop_when: "each affected engine profile pins a vLLM nightly after d5b31c95"
     status: verified
 
+  - id: gemma-google-canonical-chat-template
+    model: [gemma-4-31b, gemma-4-12b, gemma-4-26b-a4b, diffusiongemma-26b-a4b]
+    files:
+      - models/gemma-4-31b/vllm/patches/google-canonical-chat-template/chat_template.jinja
+    load_bearing_when:
+      - composes:
+          - vllm/gemma-int8-mtp
+          - vllm/gemma-bf16-mtp
+        reason: "The image-bundled /vllm-workspace/examples/tool_chat_template_gemma4.jinja in the v0.25.1-era pins PREDATES Google's 2026-07-09 canonical template fix (repo commit: null handling, reasoning preservation, turn-tag balance). Three functional deltas, each an agent-loop failure class: (1) the old copy injects an empty thought channel into HISTORY model-turns when thinking is off; (2) preserve_thinking applied to every turn vs canonical scoping to tool-call turns only; (3) turn-closure emission ignores the next turn (unbalanced turn tags in tool loops). All gemma-family vLLM composes (11) now mount this vendored canonical instead of the image path. GGUF gemma lanes keep embedded templates (minja compat with this file UNVALIDATED - do not repoint them without a minja parse check)."
+        evidence: "models/gemma-4-31b/vllm/patches/google-canonical-chat-template/README.md (provenance + sha + diff summary)"
+    delivery:               # DEPRECATED/READ-ONLY (test-only) — see header
+      dockerfile_bake: false
+      entrypoint_invoke: true
+      genesis: false
+    delivery_gaps: []
+    delivery_mechanism: chat_template
+    delivery_spec:
+      jinja: models/gemma-4-31b/vllm/patches/google-canonical-chat-template/chat_template.jinja
+      mounted_at: /etc/club3090/gemma-canonical-template.jinja
+      mount_mode: ro
+      invoke: "--chat-template /etc/club3090/gemma-canonical-template.jinja"
+      wired_at: [volumes, entrypoint]
+      note: "sha256 ae53464bf3be25802b3a5b37def7fd89667067d7577049b3b2d74c4d8de4c6d4 (google/gemma-4-31B-it @ main, template published 2026-07-09; byte-identical across the 12B/26B-A4B/31B repos). Mounted read-only; the compose --chat-template flag points here so the model-dir and image-example templates are both bypassed deterministically."
+    drift_guard:
+      kind: behavioral
+      check: "Boot log renders the canonical header (Google Gemma 4 Canonical Chat Template) via the mounted path; tool-call smoke (auto tool choice, one get_weather-class call) returns finish_reason=tool_calls with valid JSON args; a 3-turn tool loop replays without unbalanced turn tags (the fix classes). Warm-first: send 3 warm-ups before judging output (gemma cudagraph-warmup gibberish is NOT corruption). Any behavioral/TPS comparison the guard performs MUST use the SELF-CONTAINED symmetric restart+settle protocol: identical docker restart on BOTH arms -> healthy -> fixed 60s settle -> >=3 bench.sh runs/arm -> compare the GRAND MEAN of the SAME canonical segment; flag ONLY a deterministic regression reproduced across ALL 3 runs."
+      on_fail: capability-degraded   # serves with the stale image-example template semantics
+    capability: chat-template-override
+    foundational: false
+    upstream:
+      ref: "google/gemma-4-{12B,26B-A4B,31B}-it @ main - canonical template published 2026-07-09"
+      status: upstream-adopted-vendored
+      drop_when: "a future vllm-stable pin bundles an example template byte-identical-or-newer vs the canonical (diff check in the patch README) -> repoint composes at the image path and retire this dir."
+    status: verified
+
   - id: qwen-froggeric-chat-template
     model: [qwen3.6-27b, tess-4-27b]
     files:

--- a/scripts/lib/profiles/patches.yml
+++ b/scripts/lib/profiles/patches.yml
@@ -241,8 +241,9 @@ patches:
       - models/gemma-4-31b/vllm/patches/google-canonical-chat-template/chat_template.jinja
     load_bearing_when:
       - composes:
-          - vllm/gemma-int8-mtp
-          - vllm/gemma-bf16-mtp
+          - vllm/gemma-31b-dual
+          - vllm/gemma-12b-single-int8-mtp
+          - vllm/gemma-26ba4b-single
         reason: "The image-bundled /vllm-workspace/examples/tool_chat_template_gemma4.jinja in the v0.25.1-era pins PREDATES Google's 2026-07-09 canonical template fix (repo commit: null handling, reasoning preservation, turn-tag balance). Three functional deltas, each an agent-loop failure class: (1) the old copy injects an empty thought channel into HISTORY model-turns when thinking is off; (2) preserve_thinking applied to every turn vs canonical scoping to tool-call turns only; (3) turn-closure emission ignores the next turn (unbalanced turn tags in tool loops). All gemma-family vLLM composes (11) now mount this vendored canonical instead of the image path. GGUF gemma lanes keep embedded templates (minja compat with this file UNVALIDATED - do not repoint them without a minja parse check)."
         evidence: "models/gemma-4-31b/vllm/patches/google-canonical-chat-template/README.md (provenance + sha + diff summary)"
     delivery:               # DEPRECATED/READ-ONLY (test-only) — see header


### PR DESCRIPTION
## What

Google published a **canonical Gemma 4 chat template** (2026-07-09, identical across `google/gemma-4-{12B,26B-A4B,31B}-it`) fixing *"null handling, reasoning preservation, turn-tag balance"*. Our gemma vLLM slugs were pointing at the **image-bundled** `tool_chat_template_gemma4.jinja`, which predates the fix.

**The three functional deltas** (from a direct diff, image example vs canonical — each an agent-loop failure class):
1. Old copy injects an **empty `<|channel>thought` block into history model-turns** when thinking is off — phantom thought channels in replayed conversations.
2. `preserve_thinking` applied to **every** turn; canonical scopes it to **tool-call turns only**.
3. Turn-closure emission ignores the next turn; canonical adds the `next_nt.found` guard — the **unbalanced turn-tag** fix for tool loops.

## Changes

- Vendored at `models/gemma-4-31b/vllm/patches/google-canonical-chat-template/` (sha `ae53464b…`, full provenance + diff summary + drop-trigger in the README) — same pattern as the froggeric template for the qwen3_5 family.
- **All 11 gemma-family vLLM composes** (31B ×5, 12B ×3, 26B-A4B ×2, diffusiongemma) repointed to the vendored mount.
- `patches.yml` entry with behavioral drift guard (symmetric-protocol encoded).
- GGUF gemma lanes untouched — embedded templates; minja compatibility with this file is unvalidated (noted in the entry; the from_json lesson from the Pajito template applies in reverse).
- Rig-local: the 10 local gemma model dirs' `chat_template.jinja` refreshed to canonical (originals kept as `.bak`) so non-compose serving paths also benefit.

## Validation

- CPU render battery: canonical renders all shapes the image example does (plain/system/tools/tool-loop), and the fix deltas verified by direct diff.
- Guards: `test-patch-attribution` (70 entries) · `test-compose-mounts-resolve` · `test-compose-status-drift` — green.
- **Boot gate queued** (rig is running the qwen template full-gate overnight): `vllm/gemma-int8-mtp` compose boot + canonical-header check + tool-call smoke + 3-turn loop, warm-first per the gemma cudagraph rule. Merge after it reports here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm