### PR TITLE
Wire froggeric template onto the 4 native 35B-A3B vLLM composes — closes the template-consistency audit's exposed combination

### DIFF
--- a/models/qwen3.6-35b-a3b/vllm/compose/dual/autoround-int4/fp8.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/dual/autoround-int4/fp8.yml
@@ -71,6 +71,12 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8051}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
+      # froggeric family chat template (pinned; version + gate history in the
+      # patch PROVENANCE) — SHARED from the qwen3.6-27b tree. Wired 2026-07-18
+      # after the 35B template A/B (froggeric ≥ stock: toolcall 15/15 vs 14/15,
+      # hermes tie, verify-full pass) + the #671 arc's lesson that the stock
+      # template's client-shape breaks (VSCode ≥1.126) don't show on bench packs.
+      - ../../../../../qwen3.6-27b/vllm/patches/froggeric-chat-template/chat_template.jinja:/etc/qwen-froggeric-chat-template.jinja:ro
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
       # NVLink auto-detection — runs inside container at boot (same path as dual-max).
@@ -151,6 +157,8 @@ services:
       - --kv-cache-dtype
       - "${KV_CACHE_DTYPE:-fp8_e4m3}"
       - --trust-remote-code
+      - --chat-template
+      - /etc/qwen-froggeric-chat-template.jinja
       - --reasoning-parser
       - qwen3
       - --default-chat-template-kwargs

--- a/models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4/fp8.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4/fp8.yml
@@ -59,6 +59,12 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8079}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
+      # froggeric family chat template (pinned; version + gate history in the
+      # patch PROVENANCE) — SHARED from the qwen3.6-27b tree. Wired 2026-07-18
+      # after the 35B template A/B (froggeric ≥ stock: toolcall 15/15 vs 14/15,
+      # hermes tie, verify-full pass) + the #671 arc's lesson that the stock
+      # template's client-shape breaks (VSCode ≥1.126) don't show on bench packs.
+      - ../../../../../qwen3.6-27b/vllm/patches/froggeric-chat-template/chat_template.jinja:/etc/qwen-froggeric-chat-template.jinja:ro
       # torch.compile + Triton kernel caches — warm-start across boots.
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
@@ -142,6 +148,8 @@ services:
       - --kv-cache-dtype
       - "${KV_CACHE_DTYPE:-fp8}"
       - --trust-remote-code
+      - --chat-template
+      - /etc/qwen-froggeric-chat-template.jinja
       - --reasoning-parser
       - qwen3
       - --default-chat-template-kwargs

--- a/models/qwen3.6-35b-a3b/vllm/compose/single/autoround-int4/preview.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/single/autoround-int4/preview.yml
@@ -49,6 +49,12 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8050}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
+      # froggeric family chat template (pinned; version + gate history in the
+      # patch PROVENANCE) — SHARED from the qwen3.6-27b tree. Wired 2026-07-18
+      # after the 35B template A/B (froggeric ≥ stock: toolcall 15/15 vs 14/15,
+      # hermes tie, verify-full pass) + the #671 arc's lesson that the stock
+      # template's client-shape breaks (VSCode ≥1.126) don't show on bench packs.
+      - ../../../../../qwen3.6-27b/vllm/patches/froggeric-chat-template/chat_template.jinja:/etc/qwen-froggeric-chat-template.jinja:ro
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
     environment:
@@ -113,6 +119,8 @@ services:
       - --kv-cache-dtype
       - "${KV_CACHE_DTYPE:-fp8_e4m3}"
       - --trust-remote-code
+      - --chat-template
+      - /etc/qwen-froggeric-chat-template.jinja
       - --reasoning-parser
       - qwen3
       - --default-chat-template-kwargs

--- a/models/qwen3.6-35b-a3b/vllm/compose/single/nvfp4/fp8.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/single/nvfp4/fp8.yml
@@ -71,6 +71,12 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8078}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
+      # froggeric family chat template (pinned; version + gate history in the
+      # patch PROVENANCE) — SHARED from the qwen3.6-27b tree. Wired 2026-07-18
+      # after the 35B template A/B (froggeric ≥ stock: toolcall 15/15 vs 14/15,
+      # hermes tie, verify-full pass) + the #671 arc's lesson that the stock
+      # template's client-shape breaks (VSCode ≥1.126) don't show on bench packs.
+      - ../../../../../qwen3.6-27b/vllm/patches/froggeric-chat-template/chat_template.jinja:/etc/qwen-froggeric-chat-template.jinja:ro
       # torch.compile + Triton kernel caches — warm-start across boots.
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
@@ -137,6 +143,8 @@ services:
       - --kv-cache-dtype
       - "${KV_CACHE_DTYPE:-fp8}"
       - --trust-remote-code
+      - --chat-template
+      - /etc/qwen-froggeric-chat-template.jinja
       - --reasoning-parser
       - qwen3
       - --default-chat-template-kwargs

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -817,7 +817,7 @@ COMPOSE_REGISTRY = {
     # degrades out of the curated <model>/default walk; reachable only by explicit
     # slug `vllm/diffusiongemma-dual` (launch requires --force).
     "vllm/qwen-a3b-preview-single": _entry(
-        model="qwen3.6-35b-a3b", weights_variant="autoround-int4", workload="fast-chat",
+        model="qwen3.6-35b-a3b", weights_variant="autoround-int4", workload="fast-chat", chat_template="froggeric",
         engine="vllm-stable", drafter=None, kv_format="fp8_e4m3",
         tp=1, max_ctx=8192, max_num_seqs=1, mem_util=0.95,
         compose_path="models/qwen3.6-35b-a3b/vllm/compose/single/autoround-int4/preview.yml",
@@ -827,7 +827,7 @@ COMPOSE_REGISTRY = {
         status_note="MoE onboarding smoke — Cliff 2 mitigations unavailable without Genesis. Do NOT use for long-ctx.",
     ),
     "vllm/qwen-35b-a3b-dual": _entry(
-        model="qwen3.6-35b-a3b", weights_variant="autoround-int4", workload="fast-chat",
+        model="qwen3.6-35b-a3b", weights_variant="autoround-int4", workload="fast-chat", chat_template="froggeric",
         engine="vllm-stable", drafter=None, kv_format="fp8_e4m3",
         tp=2, max_ctx=262144, max_num_seqs=1, mem_util=0.92,
         compose_path="models/qwen3.6-35b-a3b/vllm/compose/dual/autoround-int4/fp8.yml",
@@ -846,7 +846,7 @@ COMPOSE_REGISTRY = {
     # (FP8 KV declared in hf_quant_config, no scale tensors shipped,
     # index-verified 2026-07-06; the #594-quality-tied regime).
     "vllm/qwen-35b-a3b-single-nvfp4": _entry(
-        model="qwen3.6-35b-a3b", weights_variant="nvfp4", workload="fast-chat",
+        model="qwen3.6-35b-a3b", weights_variant="nvfp4", workload="fast-chat", chat_template="froggeric",
         engine="vllm-stable", drafter=None, kv_format="fp8_e4m3",
         tp=1, max_ctx=131072, max_num_seqs=1, mem_util=0.92,
         compose_path="models/qwen3.6-35b-a3b/vllm/compose/single/nvfp4/fp8.yml",
@@ -856,7 +856,7 @@ COMPOSE_REGISTRY = {
         status_note="Qwen3.6-35B-A3B NVFP4 (nvidia modelopt MIXED_PRECISION MoE: NVFP4 expert FFNs + FP8 attention; ~23.4 GB), single Hopper/Blackwell card (native sm_90+; fallback_sm=7.5 — sub-9.0 runs via the Marlin W4A16 fallback, validated on the 27B sibling 2026-07-11, but this 23.4 GB single-card config needs a 32 GB card regardless). Authored on the sm_86 dev rig, FIRST community validation on a single RTX 5090 in #619 (@paulp83): boots clean on vLLM v0.24.0 (quant=modelopt_mixed), verify-full 9/9 (tool-calls + streaming + reasoning), verify-stress needle-clean (9.8K + 29K), soak-continuous PASS (15 MiB growth / 100% retention / 0 err / p50 311 TPS). Decode 255.8 narr / 257.9 code TPS @ 60 ms TTFT — ~2.5-3x our 2x3090 AutoRound tier (native FP4 GEMM). VRAM 30.6/32 GB @131K — TIGHT but flat through soak on a 32 GB card. ⚠️ PROMOTED to Production w/ caveats 2026-07-09 on TWO independent 5090 validations (#619 @paulp83 + #612/#652 @guybrush01, within noise: verify-full 9/9, verify-stress to ~120K, soak PASS ~311 TPS). CAVEAT: 8-pack quality NOT yet cross-rig-measured (sandboxes weren't built on these runs; quality run pending, gated on #492) — reverts to 🧪 if a quality run regresses. THE GB10/DGX-Spark single-card ask: 3B-active MoE suits unified-memory parts — GB10 128 GB runs the full 262K via MAX_MODEL_LEN env (131K default sized for 5090 32 GB). NO MTP by design: the built-in head is net-negative on this MoE (-51% measured on the AutoRound tier; @paulp83's speculative_config=None confirms it loaded MTP-off). fp8/e4m3 KV @ scale=1.0 (FP8 KV declared in hf_quant_config, no scale tensors shipped — same as the 27B nvfp4). No DEFAULTS row (opt-in only).",
     ),
     "vllm/qwen-35b-a3b-dual-nvfp4": _entry(
-        model="qwen3.6-35b-a3b", weights_variant="nvfp4", workload="fast-chat",
+        model="qwen3.6-35b-a3b", weights_variant="nvfp4", workload="fast-chat", chat_template="froggeric",
         engine="vllm-stable", drafter=None, kv_format="fp8_e4m3",
         tp=2, max_ctx=262144, max_num_seqs=1, mem_util=0.92,
         compose_path="models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4/fp8.yml",

--- a/scripts/lib/profiles/patches.yml
+++ b/scripts/lib/profiles/patches.yml
@@ -272,7 +272,7 @@ patches:
     status: verified
 
   - id: qwen-froggeric-chat-template
-    model: [qwen3.6-27b, tess-4-27b]
+    model: [qwen3.6-27b, tess-4-27b, qwen3.6-35b-a3b]
     files:
       - models/qwen3.6-27b/vllm/patches/froggeric-chat-template/chat_template.jinja
     load_bearing_when:
@@ -280,6 +280,7 @@ patches:
           - vllm/minimal
           - vllm/dual
           - vllm/tess-dual-nvfp4
+          - vllm/qwen-35b-a3b-dual
         reason: "Default Qwen3.6 chat template mis-handles tool-call XML / reasoning delimiters / streaming (the #145 silent-break class); the froggeric override fixes 7 default-template defects and is behavior-critical for every tool/agent compose. Tess-4-27B (same qwen3_5 template family) additionally NEEDS it because its repo template is stock-broken (developer-role crash). Carnice/Qwopus are intentional excludes (they ship their own carnice template)."
         evidence: "models/qwen3.6-27b/vllm/patches/froggeric-chat-template/PROVENANCE.md; docs/UPSTREAM.md (froggeric template re-eval #150 / v19 adopted PR #157)"
     delivery:               # DEPRECATED/READ-ONLY (test-only) — see header


### PR DESCRIPTION
## What

The template-consistency audit found exactly one unjustified exposure: the 35B-A3B vLLM slugs — **including the production MoE flagship `vllm/qwen-35b-a3b-dual`** — serve the pure stock qwen3_5 template with tool-calling enabled, the combination froggeric exists to fix. The #671 arc proved the stock template's client-shape breaks (VSCode ≥1.126 → immediate-stop renders) are invisible to bench packs.

## Evidence (same-config A/B on the production MoE, 2026-07-18)

| | stock (shipped) | froggeric v21.3 |
|---|---|---|
| toolcall-15 | 14/15 | **15/15** |
| hermesagent-20 | 10/20 | 10/20 (tie) |
| verify-full | ALL PASS | ALL PASS |

Free-or-better on everything measured, plus the client-shape protection the packs can't measure.

## Changes

- 4 composes gain the shared froggeric mount + `--chat-template` (v21.3 as of #738): `dual/autoround-int4` (production), `dual/nvfp4`, `single/nvfp4`, `single/autoround-int4/preview`
- Registry `chat_template` facet: the 4 slugs `native` → `froggeric` (catalog now 23 froggeric / 11 gemma-canonical / 32 native)
- patches.yml froggeric entry: `qwen3.6-35b-a3b` added to models + the dual slug to `load_bearing_when`
- Guards green: patch-attribution · mounts-resolve · status-drift · registry-json · both parity suites

## Merge gate

⏳ Live compose-boot of `vllm/qwen-35b-a3b-dual` via `switch.sh` on this branch (chained behind the running FlashInfer A/B; result lands here). Note the A/B's arm B was this exact serving config hand-mirrored — the compose boot is the formality gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm