### PR TITLE
docs: cloud/proxy endpoint testing + cloud references table (qwen3.8-max-preview)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -651,3 +651,17 @@ benchlocal-cli run --pack aider-polyglot-30 \
 ```
 
 End-to-end takes ~3 hours on dual 3090. quality-test.sh auto-detects the endpoint and served-model-id, so `URL`/`MODEL` overrides are only needed when running against non-default ports.
+
+---
+
+## Cloud references
+
+The rows above are **local** composes (we control serving: TPS, VRAM, context ceilings, soak). This section is **hosted / managed endpoints** graded with the *identical* 8-pack and sampling contract — for like-for-like local-vs-cloud comparison. Because we don't serve these, the columns are **quality-only** (no TPS/VRAM/soak — those belong to the provider). Both thinking arms are reported; see [QUALITY_TEST.md → Cloud / proxy endpoints](docs/QUALITY_TEST.md#cloud--proxy-endpoints) for how to run them.
+
+| Model | Endpoint | think-OFF /150 | think-ON /150 | Harness | Date | Notes |
+|---|---|--:|--:|---|---|---|
+| `qwen3.8-max-preview` | DashScope MaaS (via LiteLLM proxy) | **125 (83.3%)** | **134 (89.3%)** | benchlocal-cli @ `488521e` (post-#105), baked hermes `44cdf555`, sandbox images content-verified (cli has #101) | 2026-07-22 | **First cloud-endpoint 8-pack reference.** n=1 → ±3 band (report mean of n≥3 to rank). 40 genuine model fails / **0 harness**; headline gap is **safety/refusal** — CLI-31/32/33/34 fail both arms (complies with destructive ops). RM-08 (on) was a transient `HTTP 429` → 135/150 (90.0%) on isolated re-run. [Discussion #753](https://github.com/noonghunna/club-3090/discussions/753). |
+
+### Adding a cloud reference row
+
+Run the 8-pack against the endpoint in **both** thinking arms ([QUALITY_TEST.md → Cloud / proxy endpoints](docs/QUALITY_TEST.md#cloud--proxy-endpoints)), then append a row with the endpoint, both `/150` totals, the harness commit (reproduce from the commit, not `runner_version`), and the date. Same rules as local rows: **measured, not estimated**, n stated, and a link to the write-up. Cloud rows are quality-only — don't fill TPS/VRAM/soak cells (the provider owns serving).

--- a/docs/QUALITY_TEST.md
+++ b/docs/QUALITY_TEST.md
@@ -154,6 +154,47 @@ Quality: line for compose schema field (paste into compose YAML header):
 Quality:   ToolCall-15 14/15 (93%) · InstructFollow-15 13/15 (87%) · StructOutput-15 15/15 (100%) · DataExtract-15 12/15 (80%) · ReasonMath-15 11/15 (73%) (--medium, packs v1.0.x, 2026-05-09)
 ```
 
+## Cloud / proxy endpoints
+
+`quality-test.sh` runs the same 8-pack against any **cloud or proxied OpenAI-compatible endpoint** — a managed API (DashScope, OpenRouter, together, DeepInfra), a router, or your own hosted model — for a like-for-like local-vs-cloud comparison (identical prompts, identical verifiers). Cloud support shipped in [#746](https://github.com/noonghunna/club-3090/pull/746); the underlying knobs live in [benchlocal-cli → Running against a cloud / managed endpoint](https://github.com/noonghunna/benchlocal-cli#running-against-a-cloud--managed-endpoint).
+
+Three env vars (or flags) point the wrapper at a remote endpoint:
+
+| Knob | Flag | Purpose |
+|---|---|---|
+| `URL` | `--endpoint` | The endpoint's OpenAI-compatible base (`https://…/v1`). |
+| `API_KEY` | `--api-key` | Bearer token (`Authorization: Bearer <key>`); falls back to `BENCHLOCAL_API_KEY`. |
+| `MODEL` | `--model` | The model id the endpoint serves (overrides the local auto-detect default). |
+
+```bash
+# thinking-ON arm against a cloud endpoint
+URL=https://your-endpoint/v1 API_KEY="$YOUR_KEY" MODEL=your-model-id \
+  bash scripts/quality-test.sh --full --enable-thinking --incremental --save-json cloud-on.json
+# thinking-OFF arm
+URL=https://your-endpoint/v1 API_KEY="$YOUR_KEY" MODEL=your-model-id \
+  bash scripts/quality-test.sh --full --no-thinking --incremental --save-json cloud-off.json
+```
+
+**Reachability probe is cloud-tolerant.** Proxies (a LiteLLM master key) answer `401` without the key, and some cloud endpoints (DashScope MaaS) serve only `/chat/completions` and `404` on `/v1/models`. The wrapper treats **any** HTTP response as reachable (only `http_code 000` = no connection fails fast), so cloud/proxy references pass the preflight without a `/v1/models` route.
+
+**Match the thinking state explicitly.** Most managed endpoints ignore the vLLM-side `chat_template_kwargs.enable_thinking` field — use the provider's native controls. The `cli-40` / `hermesagent-20` adapters send Qwen-compatible `enable_thinking` + `thinking_budget` automatically; for a thinking-only endpoint the off arm is `enable_thinking=true` clamped to `thinking_budget=1`. DashScope **rejects** `enable_thinking=false`, so its off arm uses that clamp (worked example below). Run **both** arms for a fair comparison and verify the saved request payloads.
+
+**Sandboxed agentic packs over a remote endpoint** work (HermesAgent-20 calls your endpoint over the network from inside its sandbox) but need the sandbox images built and are less battle-tested remotely than the deterministic packs — land the 5 deterministic packs first, then add the sandboxed three. `BENCHLOCAL_HERMES_RESOLVE_LOCALHOST` is irrelevant for a genuinely remote URL (it only rewrites `localhost` for the in-sandbox agent).
+
+**Pacing + spend.** Set `--request-delay <sec>` (env `BENCHLOCAL_REQUEST_DELAY`) to stay under the endpoint's RPM ceiling, and `--max-total-tokens <N>` as a cost ceiling (the agentic packs spend the most). 429s auto-retry (`--max-transient-retries`, default 3) — see [benchlocal-cli #106](https://github.com/noonghunna/benchlocal-cli/issues/106) for the minute-window backoff caveat.
+
+### Worked example — Qwen3.8-Max-Preview (DashScope)
+
+Our first cloud reference ([Discussion #753](https://github.com/noonghunna/club-3090/discussions/753)): `qwen3.8-max-preview` via a LiteLLM proxy that normalizes auth + thinking controls into two routes — `qwen3.8-max` (thinking-on) and `qwen3.8-max-nothink` (`thinking_budget=1`). Result: **125/150 think-off · 134/150 think-on** (n=1) — see the [cloud references table](../BENCHMARKS.md#cloud-references).
+
+```bash
+# via the proxy routes (services/litellm/config.yaml)
+URL=http://localhost:4000 API_KEY="$LITELLM_KEY" MODEL=qwen3.8-max \
+  bash scripts/quality-test.sh --full --enable-thinking --save-json qwen38max-on.json
+URL=http://localhost:4000 API_KEY="$LITELLM_KEY" MODEL=qwen3.8-max-nothink \
+  bash scripts/quality-test.sh --full --no-thinking --save-json qwen38max-off.json
+```
+
 ## Scenario-level probes (selection, incremental, resume)
 
 Since benchlocal-cli [#84](https://github.com/noonghunna/benchlocal-cli/pull/84)/[#85](https://github.com/noonghunna/benchlocal-cli/pull/85) the wrapper passes through scenario-granular runs:


### PR DESCRIPTION
Documents the cloud/proxy endpoint workflow shipped in #746 and records the first cloud 8-pack reference (announcement: #753).

- **`docs/QUALITY_TEST.md`** — new **Cloud / proxy endpoints** section: the `URL=`/`API_KEY=`/`MODEL=` knobs, cloud-tolerant reachability probe (proxies answer 401, DashScope 404s on `/v1/models` — any HTTP response = reachable), thinking-state matching (the `thinking_budget=1` off-arm trick for endpoints that reject `enable_thinking=false`), pacing/spend, and a Qwen3.8-Max-Preview worked example.
- **`BENCHMARKS.md`** — new **Cloud references** section (quality-only, both thinking arms — we don't control serving for hosted endpoints) with the first row: `qwen3.8-max-preview` **125/150 think-off · 134/150 think-on** (benchlocal-cli @ `488521e`, baked hermes `44cdf555`, sandbox images content-verified).

Docs-only; no code changes.