### PR TITLE
c3: add catalog "offload" column (weight-offload backend facet)

### DIFF
--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -60,6 +60,14 @@ def _entry(
     # its weights are positive-symmetric int4 (the c3 serve-confirm checkbox reads
     # this to offer VLLM_MARLIN_INPUT_DTYPE=int8 per-launch). #609.
     act8_capable=False,
+    # Weight-offload backend when the slug serves a model too large to fit VRAM
+    # by paging expert/layer weights to host RAM. None = fully resident (the
+    # default — every existing slug). "uva" = vLLM zero-copy demand-paged expert
+    # offload (GPU computes, weights stream over PCIe); "n-cpu-moe" = llama.cpp
+    # CPU-computed expert offload (weights stay in RAM, only activations cross
+    # PCIe); "prefetch" = vLLM bulk layer prefetch. Surfaced as the c3 catalog
+    # "offload" column. First used by the Laguna 118B-MoE offload slugs.
+    offload=None,
     chat_template="native",
     tp,
     max_ctx,
@@ -92,6 +100,7 @@ def _entry(
         "kv_format": kv_format,
         "act_format": act_format,
         "act8_capable": act8_capable,
+        "offload": offload,
         "chat_template": chat_template,
         "tp": tp,
         "pp": 1,

--- a/scripts/lib/registry-emit.sh
+++ b/scripts/lib/registry-emit.sh
@@ -670,6 +670,9 @@ for vr in _tui_registry.parse_variant_rows(tab):
             # W4A8-int8-activation capability (c3 serve-confirm checkbox, #609) —
             # True when the compose is wired + weights are positive-sym int4.
             "act8_capable": bool((COMPOSE_REGISTRY.get(d["slug"], {}) or {}).get("act8_capable")),
+            # Weight-offload backend (catalog "offload" column) — None = resident
+            # (default) / "uva" / "n-cpu-moe" / "prefetch". Laguna 118B-MoE slugs.
+            "offload": (COMPOSE_REGISTRY.get(d["slug"], {}) or {}).get("offload"),
             # Weights quant_label + FORMAT from the model profile (catalog
             # Weights column fallbacks) — see _weights_meta() above.
             "weights_quant_label": _weights_meta(

--- a/scripts/tests/test-registry-json.sh
+++ b/scripts/tests/test-registry-json.sh
@@ -74,6 +74,9 @@ VARIANT_KEYS = {
     "chat_template",
     # c3 serve-confirm W4A8 checkbox capability (#609).
     "act8_capable",
+    # c3 catalog offload column: weight-offload backend — None (resident, the
+    # default) / "uva" / "n-cpu-moe" / "prefetch".
+    "offload",
 }
 v0 = d["variants"][0]
 need(set(v0.keys()) == VARIANT_KEYS,

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -238,6 +238,14 @@ def _act_label(e: "CatalogEntry") -> str:
     return (getattr(e.row, "act_format", "") or "") or "—"
 
 
+def _offload_label(e: "CatalogEntry") -> str:
+    """Weight-offload backend for the catalog offload column — the registry
+    ``offload`` facet (emitted like ``act_format``): "uva" (vLLM demand-paged
+    expert offload) / "n-cpu-moe" (llama.cpp CPU-computed) / "prefetch"; "—" for
+    a fully-resident slug (the default) or when the contract didn't carry it."""
+    return (getattr(e.row, "offload", "") or "") or "—"
+
+
 # ── Catalog column picker (#724) ─────────────────────────────────────────────
 # The CANONICAL catalog column set — the ONE source for the header build, the
 # row-cell build and the [|] columns picker.  (key, header) pairs in DEFAULT
@@ -253,6 +261,7 @@ _CATALOG_COLUMNS: "list[tuple[str, str]]" = [
     ("gb", "GB"),
     ("kv", "kv"),
     ("act", "act"),
+    ("offload", "offload"),
     ("spec", "spec"),
     ("ctx", "ctx"),
     ("tps", "TPS (rig)"),
@@ -1187,6 +1196,7 @@ class CatalogPane(Container):
                 "gb": _size_label(e),
                 "kv": _kv_label(e),
                 "act": _act_label(e),
+                "offload": _offload_label(e),
                 "spec": _spec_label(e),
                 "ctx": e.ctx_label or "—",
                 "tps": tps,

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -4543,6 +4543,9 @@ def _variant_row_from_dict(d: dict[str, Any]) -> VariantRow:
         # Activation compute format (catalog act column, #723) — same pattern;
         # "" when the contract didn't carry it (older emit) → the column shows "—".
         object.__setattr__(row, "act_format", str(d.get("act_format") or ""))
+        # Weight-offload backend (catalog offload column) — same pattern;
+        # "" when the contract didn't carry it (resident/older emit) → shows "—".
+        object.__setattr__(row, "offload", str(d.get("offload") or ""))
         object.__setattr__(row, "chat_template", str(d.get("chat_template") or "native"))
         # W4A8-int8-activation capability (c3 serve-confirm checkbox, #609).
         object.__setattr__(row, "act8_capable", bool(d.get("act8_capable")))


### PR DESCRIPTION
## What

Adds a catalog **`offload`** column to c3 — the weight-offload backend a slug uses to serve a model that doesn't fit VRAM. Mirrors the `act_format` / #723-#724 facet pattern exactly.

Vocabulary:
- **`None`** — fully resident (the default; **every existing slug** → column shows `—`)
- **`uva`** — vLLM zero-copy demand-paged expert offload (GPU computes, routed experts stream over PCIe)
- **`n-cpu-moe`** — llama.cpp CPU-computed expert offload (weights stay in RAM, only activations cross PCIe)
- **`prefetch`** — vLLM bulk layer prefetch

## Why

The catalog had **no dimension to represent weight offload**. It's needed by the first offloaded model on the stack — Poolside Laguna S 2.1 (118B MoE), served via vLLM UVA expert offload on 2×3090 — where the offload backend is a load-bearing serving fact (UVA vs prefetch is a ~25× decode difference). The existing LMCache KV-offload slug can adopt the facet retroactively.

## Change (5 additive touch-points)

| File | Change |
|---|---|
| `compose_registry.py` `_entry` | new `offload=None` field (+ facet comment) |
| `registry-emit.sh --json` | emit `offload` (mirrors `act_format`) |
| c3 `services.py` | thread `offload` onto the row |
| c3 `app.py` | `_offload_label()` + `("offload","offload")` in `_CATALOG_COLUMNS` + row cell |

Every existing registry entry defaults to `offload=None`, so all 68 current slugs render `—` and nothing else moves. Backward-compatible with older emit (`""` → `—`).

## Tests

- Registry imports clean; all 68 entries carry the key.
- Emit-parity: `test-switch-registry-parity`, `test-launch-registry-parity`, `test-registry-emit-no-yaml`, `test-compose-status-drift` — green.
- c3 pytest: **248** `test_services` + `test_registry_parser`, **81** catalog/app-headless (incl. full app boot) — green.

## Not in this PR

The Laguna catalog entry itself is **held** (drafted, staged out-of-repo) pending the `67dbeda4` re-quant re-measure and the llama.cpp `--n-cpu-moe` head-to-head that decides the engine default. This PR is just the enabling column.
