### PR TITLE
Route every compose port through ${BIND_HOST:-0.0.0.0} + guard test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -175,9 +175,14 @@
 # PORT=9876
 
 # Host interface to bind the API port on. Default is 0.0.0.0 (all interfaces).
-# Set to 127.0.0.1 to restrict to localhost — prevents IDE agents (Cline,
-# Cursor) from competing for the max-num-seqs=1 slot and causing verify-stress
-# HTTP 000 failures during benchmark runs.
+# Honored by every compose under models/ (enforced by test-compose-bind-host).
+#
+# Set to 127.0.0.1 to restrict to localhost. Two reasons you might:
+#   - Security: none of the served engines have auth, so on 0.0.0.0 anyone who
+#     can reach the host on that port gets an unauthenticated API. If the box
+#     isn't on a trusted network, bind loopback and reach it over an SSH tunnel.
+#   - Benchmarking: keeps IDE agents (Cline, Cursor) from competing for the
+#     max-num-seqs=1 slot and causing verify-stress HTTP 000 failures.
 # BIND_HOST=127.0.0.1
 
 # Docker restart policy for launched model containers. Default: unless-stopped

--- a/models/diffusiongemma-26b-a4b/vllm/compose/dual/fp8/base.yml
+++ b/models/diffusiongemma-26b-a4b/vllm/compose/dual/fp8/base.yml
@@ -62,7 +62,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-vllm-diffusiongemma-26b-a4b-fp8-tp2}"
     restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
-      - "${ESTATE_PORT:-${PORT:-8042}}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8042}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
       # Google Gemma 4 CANONICAL chat template (published 2026-07-09) — SHARED

--- a/models/gemma-4-12b/beellama/compose/single/beellama-q8kxl/base.yml
+++ b/models/gemma-4-12b/beellama/compose/single/beellama-q8kxl/base.yml
@@ -65,7 +65,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-beellama-gemma4-12b}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8067}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8067}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # server target ENTRYPOINT is /app/llama-server — args only below.

--- a/models/gemma-4-12b/llama-cpp/compose/single/unsloth-q8kxl/base.yml
+++ b/models/gemma-4-12b/llama-cpp/compose/single/unsloth-q8kxl/base.yml
@@ -45,7 +45,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-llama-cpp-gemma4-12b}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8069}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8069}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     command: >-

--- a/models/gemma-4-12b/vllm/compose/dual/bf16/mtp.yml
+++ b/models/gemma-4-12b/vllm/compose/dual/bf16/mtp.yml
@@ -45,7 +45,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-vllm-gemma-4-12b-dual-mtp}"
     restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
-      - "${ESTATE_PORT:-${PORT:-8036}}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8036}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
       # Google Gemma 4 CANONICAL chat template (published 2026-07-09) — SHARED

--- a/models/gemma-4-26b-a4b/vllm/compose/dual/awq/mtp.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/dual/awq/mtp.yml
@@ -46,7 +46,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-vllm-gemma-4-26b-a4b-awq-mtp-tp2}"
     restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
-      - "${ESTATE_PORT:-${PORT:-8041}}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8041}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
       # Google Gemma 4 CANONICAL chat template (published 2026-07-09) — SHARED

--- a/models/gemma-4-26b-a4b/vllm/compose/single/awq/int8.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/single/awq/int8.yml
@@ -66,7 +66,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-vllm-gemma-26b-a4b-awq-int8-tp1}"
     restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
-      - "${ESTATE_PORT:-${PORT:-8040}}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8040}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
       # Google Gemma 4 CANONICAL chat template (published 2026-07-09) — SHARED

--- a/models/gemma-4-31b/beellama/compose/dual/beellama-q4ks-dflash/dflash.yml
+++ b/models/gemma-4-31b/beellama/compose/dual/beellama-q4ks-dflash/dflash.yml
@@ -72,7 +72,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-beellama-gemma4-31b-dual}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8062}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8062}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     command: >-

--- a/models/gemma-4-31b/beellama/compose/dual/beellama-q8kxl-dflash/dflash.yml
+++ b/models/gemma-4-31b/beellama/compose/dual/beellama-q8kxl-dflash/dflash.yml
@@ -65,7 +65,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-beellama-gemma4-31b-dual-dflash}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8066}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8066}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     command: >-

--- a/models/gemma-4-31b/beellama/compose/single/beellama-q4ks-dflash/dflash.yml
+++ b/models/gemma-4-31b/beellama/compose/single/beellama-q4ks-dflash/dflash.yml
@@ -108,7 +108,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-beellama-gemma4-31b}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8061}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8061}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # server target ENTRYPOINT is /app/llama-server — args only below.

--- a/models/gemma-4-31b/vllm/compose/dual/autoround-int4/bf16-mtp.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/autoround-int4/bf16-mtp.yml
@@ -70,7 +70,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-vllm-gemma-4-31b-mtp}"
     restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
-      - "${ESTATE_PORT:-${PORT:-8030}}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8030}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
       # Google Gemma 4 CANONICAL chat template (published 2026-07-09) — vendored;

--- a/models/gemma-4-31b/vllm/compose/dual/autoround-int4/int8.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/autoround-int4/int8.yml
@@ -116,7 +116,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-vllm-gemma-4-31b-mtp-int8}"
     restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
-      - "${ESTATE_PORT:-${PORT:-8032}}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8032}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
       # Google Gemma 4 CANONICAL chat template (published 2026-07-09) — vendored;

--- a/models/gemma-4-31b/vllm/compose/dual/qat-awq-int4/base.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/qat-awq-int4/base.yml
@@ -70,7 +70,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-vllm-gemma-4-31b-qat-awq-int4}"
     restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
-      - "${ESTATE_PORT:-${PORT:-8032}}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8032}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
       # Google Gemma 4 CANONICAL chat template (published 2026-07-09) — vendored;

--- a/models/gemma-4-31b/vllm/compose/dual/qat-w4a16/int8.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/qat-w4a16/int8.yml
@@ -119,7 +119,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-vllm-gemma-4-31b-qat-w4a16}"
     restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
-      - "${ESTATE_PORT:-${PORT:-8033}}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8033}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
       # Google Gemma 4 CANONICAL chat template (published 2026-07-09) — vendored;

--- a/models/gemma-4-31b/vllm/compose/single/autoround-int4/fp8-mtp.yml
+++ b/models/gemma-4-31b/vllm/compose/single/autoround-int4/fp8-mtp.yml
@@ -68,7 +68,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-vllm-gemma-4-31b-mtp-tp1}"
     restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
-      - "${ESTATE_PORT:-${PORT:-8031}}:8000"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8031}}:8000"
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
       # Google Gemma 4 CANONICAL chat template (published 2026-07-09) — vendored;

--- a/models/ornith-1.0-35b/ik-llama/compose/dual/deepreinforce-q8/ngram.yml
+++ b/models/ornith-1.0-35b/ik-llama/compose/dual/deepreinforce-q8/ngram.yml
@@ -32,7 +32,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-ik-llama-ornith-35b}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8071}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8071}}:8080"
     volumes:
       - "${MODEL_DIR:-/mnt/models/huggingface}:/models:ro"
     command: >-

--- a/models/ornith-1.0-9b/ik-llama/compose/single/deepreinforce-q4km/ngram.yml
+++ b/models/ornith-1.0-9b/ik-llama/compose/single/deepreinforce-q4km/ngram.yml
@@ -41,7 +41,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-ik-llama-ornith-9b}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8070}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8070}}:8080"
     volumes:
       - "${MODEL_DIR:-/mnt/models/huggingface}:/models:ro"
     # ENTRYPOINT is /app/llama-server — args only. The ngram self-spec stage is

--- a/models/qwen3-omni-30b-a3b/vllm-omni/compose/dual/autoround-int4/omni.yml
+++ b/models/qwen3-omni-30b-a3b/vllm-omni/compose/dual/autoround-int4/omni.yml
@@ -52,7 +52,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-vllm-omni-qwen3-omni-30b}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8042}}:8091"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8042}}:8091"
     ipc: host
     shm_size: "16gb"
     environment:

--- a/models/qwen3.6-27b/beellama/compose/dual/beellama-q8kxl-dflash/dflash.yml
+++ b/models/qwen3.6-27b/beellama/compose/dual/beellama-q8kxl-dflash/dflash.yml
@@ -71,7 +71,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-beellama-qwen36-27b-dual-dflash}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8065}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8065}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     command: >-

--- a/models/qwen3.6-27b/beellama/compose/dual/beellama-q8kxl-mtp/mtp.yml
+++ b/models/qwen3.6-27b/beellama/compose/dual/beellama-q8kxl-mtp/mtp.yml
@@ -53,7 +53,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-beellama-qwen36-27b-dual}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8064}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8064}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     command: >-

--- a/models/qwen3.6-27b/beellama/compose/dual/carnice-v2-q8/mtp-q8kv.yml
+++ b/models/qwen3.6-27b/beellama/compose/dual/carnice-v2-q8/mtp-q8kv.yml
@@ -74,7 +74,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-beellama-carnice-v2-dual}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8070}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8070}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # server target ENTRYPOINT is /app/llama-server — args only below.

--- a/models/qwen3.6-27b/beellama/compose/single/beellama-q5ks-dflash/dflash.yml
+++ b/models/qwen3.6-27b/beellama/compose/single/beellama-q5ks-dflash/dflash.yml
@@ -95,7 +95,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-beellama-qwen36-27b}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8060}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8060}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # server target ENTRYPOINT is /app/llama-server — args only below.

--- a/models/qwen3.6-27b/beellama/compose/single/carnice-v2-q5km/mtp-kvarn4.yml
+++ b/models/qwen3.6-27b/beellama/compose/single/carnice-v2-q5km/mtp-kvarn4.yml
@@ -122,7 +122,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-beellama-carnice-v2}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8068}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8068}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # server target ENTRYPOINT is /app/llama-server — args only below.

--- a/models/qwen3.6-27b/beellama/compose/single/qwopus-coder-mtp-q5km/mtp.yml
+++ b/models/qwen3.6-27b/beellama/compose/single/qwopus-coder-mtp-q5km/mtp.yml
@@ -93,7 +93,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-beellama-qwopus-coder}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8067}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8067}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # server target ENTRYPOINT is /app/llama-server — args only below.

--- a/models/qwen3.6-27b/ik-llama/compose/dual/ex0bit-prism-pro-dq/mtp-vision.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/dual/ex0bit-prism-pro-dq/mtp-vision.yml
@@ -50,7 +50,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b-prism-pro-dq-dual}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8010}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8010}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     command: >-

--- a/models/qwen3.6-27b/ik-llama/compose/dual/ex0bit-prism-pro-dq/mtp.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/dual/ex0bit-prism-pro-dq/mtp.yml
@@ -37,7 +37,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b-prism-pro-dq-dual}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8053}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8053}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     command: >-

--- a/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/long.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/long.yml
@@ -37,7 +37,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b-prism-pro-dq-long}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8052}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8052}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     command: >-

--- a/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/mtp.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/mtp.yml
@@ -43,7 +43,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b-prism-pro-dq}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8020}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8020}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     command: >-

--- a/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/two-stage.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/two-stage.yml
@@ -46,7 +46,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b-prism-pro-dq-two-stage}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8020}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8020}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     command: >-

--- a/models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/mtp-vision.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/mtp-vision.yml
@@ -116,7 +116,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b-vision}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8020}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8020}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # server target ENTRYPOINT is /app/llama-server — args only below.

--- a/models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/mtp.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/mtp.yml
@@ -111,7 +111,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8020}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8020}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # server target ENTRYPOINT is /app/llama-server — args only below.

--- a/models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/two-stage.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/two-stage.yml
@@ -99,7 +99,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-27b-two-stage}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8020}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8020}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # ⚠ -np 1 is intentional on a single 24 GB card — do NOT raise it to

--- a/models/qwen3.6-27b/llama-cpp/compose/single/pi-reasoning-q4km/mtp.yml
+++ b/models/qwen3.6-27b/llama-cpp/compose/single/pi-reasoning-q4km/mtp.yml
@@ -91,7 +91,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-llama-cpp-pi-reasoning}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8063}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8063}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # -np 1 is intentional on a single 24 GB card — extra slots divide a compute-bound GPU

--- a/models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/bounded-thinking.yml
+++ b/models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/bounded-thinking.yml
@@ -57,7 +57,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-llama-cpp-qwen36-27b-bounded-thinking}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8020}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8020}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # ⚠ -np 1 is intentional on a single 24 GB card — do NOT raise it to

--- a/models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/mtp-vision.yml
+++ b/models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/mtp-vision.yml
@@ -96,7 +96,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-llama-cpp-qwen36-27b-vision}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8020}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8020}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # ⚠ -np 1 is intentional on a single 24 GB card — do NOT raise it to

--- a/models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/mtp.yml
+++ b/models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/mtp.yml
@@ -87,7 +87,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-llama-cpp-qwen36-27b}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8020}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8020}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # ⚠ -np 1 is intentional on a single 24 GB card — do NOT raise it to

--- a/models/qwen3.6-27b/sglang/compose/dual/autoround-int4/eagle3-experimental.yml
+++ b/models/qwen3.6-27b/sglang/compose/dual/autoround-int4/eagle3-experimental.yml
@@ -98,7 +98,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-sglang-qwen36-27b-eagle3-dual}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-8041}:30000"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-8041}:30000"
     ipc: host
     shm_size: "32g"
     deploy:

--- a/models/qwen3.6-27b/sglang/compose/single/autoround-int4/eagle3-experimental.yml
+++ b/models/qwen3.6-27b/sglang/compose/single/autoround-int4/eagle3-experimental.yml
@@ -88,7 +88,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-sglang-qwen36-27b-eagle3}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-8040}:30000"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-8040}:30000"
     ipc: host
     shm_size: "16g"
     deploy:

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/dual/mudler-apex-quality/mtp.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/dual/mudler-apex-quality/mtp.yml
@@ -38,7 +38,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-35b-a3b-apex-quality-dual}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8055}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8055}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
       - ../../../patches/apex-qwen-chat-template.jinja:/etc/apex-qwen-chat-template.jinja:ro

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/single/byteshape-iq4xs/mtp.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/single/byteshape-iq4xs/mtp.yml
@@ -55,7 +55,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-35b-a3b-byteshape}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8058}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8058}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     command: >-

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/fit-mtp.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/fit-mtp.yml
@@ -80,7 +80,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-35b-a3b-apex-fit}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8057}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8057}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
       - ../../../patches/apex-qwen-chat-template.jinja:/etc/apex-qwen-chat-template.jinja:ro

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/long.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/long.yml
@@ -36,7 +36,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-35b-a3b-apex-compact-long}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8056}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8056}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
       - ../../../patches/apex-qwen-chat-template.jinja:/etc/apex-qwen-chat-template.jinja:ro

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/mtp.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/mtp.yml
@@ -42,7 +42,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-ik-llama-qwen36-35b-a3b-apex-compact}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8054}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8054}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
       - ../../../patches/apex-qwen-chat-template.jinja:/etc/apex-qwen-chat-template.jinja:ro

--- a/models/qwen3.6-35b-a3b/llama-cpp/compose/dual/morikomorizz-q6kp/mtp.yml
+++ b/models/qwen3.6-35b-a3b/llama-cpp/compose/dual/morikomorizz-q6kp/mtp.yml
@@ -92,7 +92,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-llama-cpp-hauhaucs-35ba3b}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8073}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8073}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # ⚠ -np 1 is intentional — one decode stream per dual-card config; extra

--- a/models/qwen3.6-40b-deckard/llama-cpp/compose/dual/piehsoft-q6k/mtp.yml
+++ b/models/qwen3.6-40b-deckard/llama-cpp/compose/dual/piehsoft-q6k/mtp.yml
@@ -84,7 +84,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-llama-cpp-deckard-40b}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8199}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8199}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # ⚠ -np 1 is intentional — do NOT raise it. One decode stream per dual-card

--- a/models/tess-4-27b/llama-cpp/compose/dual/migtissera-q4km/mtp.yml
+++ b/models/tess-4-27b/llama-cpp/compose/dual/migtissera-q4km/mtp.yml
@@ -107,7 +107,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-llama-cpp-tess-4-27b}"
     restart: unless-stopped
     ports:
-      - "${ESTATE_PORT:-${PORT:-8020}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8020}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # ⚠ -np 1 is intentional — do NOT raise it. One decode stream per dual-card

--- a/models/vibethinker-3b/llama-cpp/compose/single/prithivmlmods-q8/q8kv.yml
+++ b/models/vibethinker-3b/llama-cpp/compose/single/prithivmlmods-q8/q8kv.yml
@@ -69,7 +69,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-llama-cpp-vibethinker-3b}"
     restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
-      - "${ESTATE_PORT:-${PORT:-8075}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8075}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     environment:

--- a/scripts/tests/test-compose-bind-host.sh
+++ b/scripts/tests/test-compose-bind-host.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# test-compose-bind-host.sh — every compose that publishes a port MUST route the
+# host side through ${BIND_HOST:-0.0.0.0}. This is the contract already emitted by
+# scripts/lib/generate_compose.py and documented in docs/ADDING_MODELS.md; the
+# hand-written composes had drifted off it.
+#
+# Why it matters: none of the engines we ship (vLLM, llama.cpp, ik_llama,
+# beellama, SGLang) have auth. A compose with a bare "ports: - ${PORT}:8000"
+# publishes on 0.0.0.0 with no way to narrow it, so an operator on a shared or
+# untrusted LAN has to patch the file locally and re-patch after every update.
+# With the knob present, BIND_HOST=127.0.0.1 in .env is enough.
+#
+# The default stays 0.0.0.0, so this guard does NOT assert a loopback default —
+# only that the operator has the choice.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+fails=0
+checked=0
+
+while IFS= read -r f; do
+  # Walk the list items directly under the compose's `ports:` key.
+  while IFS= read -r m; do
+    [ -n "$m" ] || continue
+    checked=$((checked+1))
+    case "$m" in
+      *BIND_HOST*) ;;
+      *)
+        echo "FAIL: $f publishes a port without a BIND_HOST knob:" >&2
+        echo "        $(printf '%s' "$m" | sed 's/^[[:space:]]*//')" >&2
+        echo "      expected the host side to route through \${BIND_HOST:-0.0.0.0}" >&2
+        fails=$((fails+1))
+        ;;
+    esac
+  done <<EOF
+$(awk '
+  /^[[:space:]]*ports:[[:space:]]*$/ { inports=1; next }
+  inports {
+    if ($0 ~ /^[[:space:]]*-[[:space:]]/) { print; next }
+    inports=0
+  }
+' "$f")
+EOF
+done < <(grep -rlE '^[[:space:]]*ports:[[:space:]]*$' models --include='*.yml' 2>/dev/null | grep -v '/_archive/' | sort || true)
+
+# The generator is the source of this contract — if it stops emitting the knob,
+# every newly generated compose regresses silently.
+grep -q 'BIND_HOST:-0.0.0.0' scripts/lib/generate_compose.py \
+  || { echo "FAIL: generate_compose.py no longer emits the \${BIND_HOST:-0.0.0.0} prefix" >&2; fails=$((fails+1)); }
+
+if [[ $fails -gt 0 ]]; then
+  echo "$fails BIND_HOST check(s) failed" >&2
+  exit 1
+fi
+echo "PASS: $checked published port mapping(s) across all live composes route through BIND_HOST"


### PR DESCRIPTION
## Summary

Closes #763. `generate_compose.py` emits `${BIND_HOST:-0.0.0.0}` on the host side of every port mapping and `docs/ADDING_MODELS.md` documents that as the compose contract — but **46 of the 86 composes under `models/` don't follow it**, publishing a bare `"${ESTATE_PORT:-${PORT:-N}}:8080"` instead. The split falls along authorship lines: everything with the knob is a generator-shaped vLLM compose (`:8000`); everything without it is hand-written llama.cpp / ik-llama / beellama / SGLang (`:8080`, `:30000`) plus a few vLLM Gemma composes. This brings all of them onto the documented contract and adds a guard so they can't drift off it again.

Since no engine we ship has auth, a compose without the knob gives the operator no way to narrow the bind except editing a tracked file — which `git checkout <tag>` then silently reverts on the next update. That happened on my own fleet: a box serving `beellama/dflash` was re-exposed on `0.0.0.0` on a LAN by a routine tag update, because its loopback bind only existed as a local commit the checkout detached away from.

**The default does not change.** It stays `0.0.0.0`, so this is behaviour-preserving for everyone who doesn't set `BIND_HOST` — it only gives `BIND_HOST=127.0.0.1` in `.env` something to bind on the other 46.

## Type of change

- [x] Other — cross-cutting compose consistency + a guard test. No serving flags, images, weights, ports, or defaults are touched.

## What's in it

1. **46 composes** get the `${BIND_HOST:-0.0.0.0}:` prefix on the host side. One line each, no other edits. `_archive/` is left alone, matching `test-compose-gpu-mask-passthrough`'s convention.
2. **`scripts/tests/test-compose-bind-host.sh`** — asserts every live compose publishing a port routes it through `BIND_HOST`, and that `generate_compose.py` still emits the prefix. Verified it bites: reverting the compose commit makes it fail with all 46 named.
3. **`.env.example`** — the knob currently reads as a benchmarking aid (avoiding IDE-agent contention for the `max-num-seqs=1` slot). Added the security rationale and noted it now applies to every compose.

## Verification

No rig report or bench: this change cannot move TPS or alter serving behaviour — the container-side port, all flags, and the `0.0.0.0` default are untouched, and with `BIND_HOST` unset the rendered compose is byte-identical to before. So the meaningful verification is the test suite, run on Linux (2× 3090, Ubuntu, bash 5.2):

```
with this PR:            PASS=83  FAIL=1
pristine upstream master: PASS=82 FAIL=1
```

Same single failure on both — `test-submit-bench.sh` (`expected at least 6 submit-bench fixtures, found 0`), pre-existing and unrelated. The `+1` is the new guard.

All YAML re-parsed cleanly (90 files). Spot-checked the rendered mapping across all three shapes:

```
vLLM     - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8032}}:8000"
llama.cpp- "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8060}}:8080"
SGLang   - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-8041}:30000"
```

## Notes for review

- Happy to reshape: live-composes-only, drop the guard, or split by engine family if a 46-file diff is unwelcome as one unit. It's mechanical and regenerable either way.
- I left `_archive/` untouched for consistency with the existing GPU-mask guard, but can include it if you'd rather the invariant be exceptionless.
