### PR TITLE
fix(qwen3.6-27b): FlashInfer sampler OFF on the 2×3090 MTP composes

### DIFF
--- a/models/qwen3.6-27b/vllm-lmcache/compose/dual/fp8/lmcache.yml
+++ b/models/qwen3.6-27b/vllm-lmcache/compose/dual/fp8/lmcache.yml
@@ -116,7 +116,13 @@ services:
       - NCCL_CUMEM_ENABLE=0
       - NCCL_P2P_DISABLE=1
       - VLLM_NO_USAGE_STATS=1
-      - VLLM_USE_FLASHINFER_SAMPLER=1
+      # FlashInfer sampler OFF: measured -3.0% narrative / -1.7% code decode on the
+      # 2x3090 flagship (bench.sh, 5 measured runs/arm, symmetric boots, single
+      # variable). With MTP spec-decode active, sampling routes through the
+      # rejection-sampler path where the FlashInfer kernel adds overhead without a
+      # win. Also trims sampler workspace, which is load-bearing on 24 GB (same
+      # reasoning as nemotron dual/w4a16/turbo.yml). Reported by @Aduer in #671.
+      - VLLM_USE_FLASHINFER_SAMPLER=0
       # DeepGEMM (vLLM's fp8-GEMM path) is built for Hopper (sm_90) + datacenter
       # Blackwell (sm_100/103). Consumer Blackwell (5090 / PRO 6000 / GB10,
       # sm_120/121) has no recipe and hard-fails "recipe not found" at boot

--- a/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml
@@ -116,7 +116,13 @@ services:
       - NCCL_CUMEM_ENABLE=0
       - NCCL_P2P_DISABLE=1
       - VLLM_NO_USAGE_STATS=1
-      - VLLM_USE_FLASHINFER_SAMPLER=1
+      # FlashInfer sampler OFF: measured -3.0% narrative / -1.7% code decode on the
+      # 2x3090 flagship (bench.sh, 5 measured runs/arm, symmetric boots, single
+      # variable). With MTP spec-decode active, sampling routes through the
+      # rejection-sampler path where the FlashInfer kernel adds overhead without a
+      # win. Also trims sampler workspace, which is load-bearing on 24 GB (same
+      # reasoning as nemotron dual/w4a16/turbo.yml). Reported by @Aduer in #671.
+      - VLLM_USE_FLASHINFER_SAMPLER=0
       - OMP_NUM_THREADS=1
       # expandable_segments:True crashes boot on some setups (likely cuMemMap path).
       # Known: JusefPol on NVLink (PR #31), WSL2 single-card 3090 Ti.

--- a/models/qwen3.6-27b/vllm/compose/dual/awq-bf16-int4/int8.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/awq-bf16-int4/int8.yml
@@ -103,7 +103,13 @@ services:
       - NCCL_CUMEM_ENABLE=0
       - NCCL_P2P_DISABLE=1
       - VLLM_NO_USAGE_STATS=1
-      - VLLM_USE_FLASHINFER_SAMPLER=1
+      # FlashInfer sampler OFF: measured -3.0% narrative / -1.7% code decode on the
+      # 2x3090 flagship (bench.sh, 5 measured runs/arm, symmetric boots, single
+      # variable). With MTP spec-decode active, sampling routes through the
+      # rejection-sampler path where the FlashInfer kernel adds overhead without a
+      # win. Also trims sampler workspace, which is load-bearing on 24 GB (same
+      # reasoning as nemotron dual/w4a16/turbo.yml). Reported by @Aduer in #671.
+      - VLLM_USE_FLASHINFER_SAMPLER=0
       - OMP_NUM_THREADS=1
       # expandable_segments:True crashes boot on some setups (likely cuMemMap path).
       # Known: JusefPol on NVLink (PR #31), WSL2 single-card 3090 Ti.

--- a/models/qwen3.6-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/fp8/mtp.yml
@@ -128,7 +128,13 @@ services:
       - NCCL_CUMEM_ENABLE=0
       - NCCL_P2P_DISABLE=1
       - VLLM_NO_USAGE_STATS=1
-      - VLLM_USE_FLASHINFER_SAMPLER=1
+      # FlashInfer sampler OFF: measured -3.0% narrative / -1.7% code decode on the
+      # 2x3090 flagship (bench.sh, 5 measured runs/arm, symmetric boots, single
+      # variable). With MTP spec-decode active, sampling routes through the
+      # rejection-sampler path where the FlashInfer kernel adds overhead without a
+      # win. Also trims sampler workspace, which is load-bearing on 24 GB (same
+      # reasoning as nemotron dual/w4a16/turbo.yml). Reported by @Aduer in #671.
+      - VLLM_USE_FLASHINFER_SAMPLER=0
       - OMP_NUM_THREADS=1
       # DeepGEMM (vLLM's fp8-GEMM path) is built for Hopper (sm_90) + datacenter
       # Blackwell (sm_100/103). Consumer Blackwell (5090 / PRO 6000 / GB10,


### PR DESCRIPTION
## What

Sets `VLLM_USE_FLASHINFER_SAMPLER=0` on the four **2×3090** Qwen3.6-27B MTP composes.

## Why

Our own A/B, posted in #671, measured the flag as a **mild regression** on the flagship dual recipe:

| decode TPS | sampler off | sampler on | Δ |
|---|---:|---:|---:|
| narrative | 73.23 | 71.00 | **−3.0%** |
| code | 94.95 | 93.31 | **−1.7%** |

`bench.sh`, 5 measured runs/arm, symmetric boots, single variable, v0.25.1 + v21.3 template + prefix-ON + MTP n=3.

The flag shipped **with no comment and no recorded rationale**, so nothing is known to depend on it.

**Mechanism:** with MTP spec-decode active, sampling routes through the rejection-sampler path, where the FlashInfer kernel adds overhead without a win. Disabling it also trims sampler workspace — load-bearing on 24 GB, and exactly the reasoning already documented in `nemotron-3-puzzle-75b/vllm/compose/dual/w4a16/turbo.yml`, which has shipped `=0` all along:

> `# Ampere attention path: TRITON_ATTN … + FlashInfer sampler OFF (trims workspace). Both are load-bearing on 24 GB.`

Set explicitly to `0` rather than deleting the line, matching that precedent, so the decision stays self-documenting and doesn't drift with vLLM defaults.

## Scope — deliberately narrower than the measurement's implication

**Changed** (2×3090, measured code path):
- `dual/autoround-int4/fp8-mtp.yml` ← measured directly
- `dual/fp8/mtp.yml`
- `dual/awq-bf16-int4/int8.yml`
- `vllm-lmcache dual/fp8/lmcache.yml`

**Deliberately NOT changed** — the Ampere measurement doesn't transfer:
- `dual/nvfp4/mtp.yml`, `single/nvfp4/mtp.yml`, `nemotron multi4/nvfp4/mtp.yml` — blind Blackwell/5090 slugs. **FlashInfer is strongest on Blackwell**, so an Ampere number is the wrong basis for touching them.
- `multi4/autoround-int4/mtp.yml`, `multi4/fp8/mtp.yml` — 4×3090, unmeasured for this knob.

Those five want their own measurement on their own hardware before anyone changes them.

## Credit

Reported by @Aduer in #671 — he spotted that the flag ships in the recipe *after* we'd posted the A/B arguing against it, i.e. we'd been shipping a knob our own benchmark said to remove.

## Gates

11 scoped compose/registry/parity tests green: `compose-image-drift`, `compose-mounts-resolve`, `compose-status-drift`, `compose-restart-policy`, `compose-gpu-mask-passthrough`, `compose-nvlink-escape`, `launch-registry-parity`, `switch-registry-parity`, `registry-json`, `generate-compose`, `deepgemm-fp8-parity`.

Not a new slug/model/engine, so scoped rather than the full sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm