### PR TITLE
fix(tests): make test-submit-bench self-contained instead of rig-dependent

### DIFF
--- a/scripts/lib/bench-row-formatter.sh
+++ b/scripts/lib/bench-row-formatter.sh
@@ -10,19 +10,30 @@
 _BENCH_ROW_LIB_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 _BENCH_ROW_ROOT="$(cd -- "${_BENCH_ROW_LIB_DIR}/../.." && pwd)"
 
+# Enumerate results/rebench/<tag>/ dirs that carry every artifact the formatter
+# requires. DISCOVERY, deliberately not a hardcoded tag list: this used to name
+# six specific 2026-05 tags, which only ever existed as UNTRACKED local output
+# on the maintainer rig (results/* is gitignored), so every fresh clone found
+# zero of them and test-submit-bench.sh was red for every contributor (#776).
+# The four -f guards mirror the require_file() calls in _bench_row_python and
+# submit-bench.sh's own preflight, so a half-written dir from an interrupted
+# rebench is skipped rather than handed downstream to fail mid-format.
 bench_row_fixtures() {
-  local tag
-  for tag in \
-    qwen-int8-pth-n4-2026-05-10 \
-    qwen-bf16-n4-2026-05-11 \
-    qwen-int8-tq3-n3-2026-05-11 \
-    qwen-tq3-mtp-genesis-2026-05-11 \
-    gemma-int8-pth-n4-2026-05-11 \
-    gemma-bf16-n4-2026-05-11; do
-    if [[ -d "${_BENCH_ROW_ROOT}/results/rebench/${tag}" ]]; then
-      printf '%s\n' "${_BENCH_ROW_ROOT}/results/rebench/${tag}"
-    fi
-  done
+  local results_dir="${_BENCH_ROW_ROOT}/results/rebench"
+  [[ -d "$results_dir" ]] || return 0
+  local dir
+  # -L follows symlinks: a bulky results/ tree parked on another volume and
+  # symlinked back in is normal practice on big rigs, and a plain `-type d`
+  # silently skips those, which would reproduce #776's "found 0" from a
+  # different direction. 2>/dev/null swallows the warning from a dangling link
+  # (its artifacts then fail the -f guards below and it is skipped anyway).
+  while IFS= read -r dir; do
+    [[ -f "${dir}/_internal.json" ]] || continue
+    [[ -f "${dir}/REPORT.md" ]] || continue
+    [[ -f "${dir}/container-config.json" ]] || continue
+    [[ -f "${dir}/rig.txt" ]] || continue
+    printf '%s\n' "$dir"
+  done < <(find -L "$results_dir" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
 }
 
 bench_row_section() {
@@ -55,6 +66,17 @@ MODE = sys.argv[1]
 TAG_DIR = Path(sys.argv[2]).resolve()
 ROOT = Path(os.environ.get("BENCH_ROW_REPO_ROOT", ".")).resolve()
 
+# Community rigs run non-UTF-8 locales (minimal VMs / containers with LC_ALL=C),
+# where a PIPED stdout defaults to ASCII — and every section name carries "×"
+# ("2× RTX 3090"), so emitting a row raised UnicodeEncodeError for those users.
+# Same #599 class the launcher paths already pin, and the same reason nobody
+# caught it: this path had never run outside the maintainer rig (#776).
+# Repro: PYTHONUTF8=0 PYTHONCOERCECLOCALE=0 LC_ALL=C (plain LC_ALL=C is coerced).
+#
+# This fixes the FORMATTER only. submit-bench.sh remains broken on those rigs for
+# an unrelated reason (argv decoded with surrogateescape) — tracked in #777.
+sys.stdout.reconfigure(encoding="utf-8")
+
 
 def die(msg: str) -> None:
     print(f"[bench-row] ERROR: {msg}", file=sys.stderr)
@@ -63,14 +85,14 @@ def die(msg: str) -> None:
 
 def read_text(path: Path) -> str:
     try:
-        return path.read_text(errors="replace")
+        return path.read_text(encoding="utf-8", errors="replace")
     except Exception:
         return ""
 
 
 def read_json(path: Path) -> Any:
     try:
-        return json.loads(path.read_text(errors="replace"))
+        return json.loads(path.read_text(encoding="utf-8", errors="replace"))
     except Exception:
         return None
 

--- a/scripts/tests/test-submit-bench.sh
+++ b/scripts/tests/test-submit-bench.sh
@@ -1,6 +1,40 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# test-submit-bench.sh — BENCHMARKS.md row formatter + submit-bench.sh plumbing.
+#
+# SELF-CONTAINED BY CONSTRUCTION (#776). This test used to require six specific
+# results/rebench/<tag>/ dirs of real 2026-05 benchmark output. Those were never
+# committed — results/* is gitignored — so they existed only as untracked files
+# on the maintainer rig. The test therefore PASSED here and could not pass on
+# any fresh clone, which made the suite permanently red for every external
+# contributor and meant this path had never actually been exercised in CI.
+#
+# It now synthesizes its own fixtures under results/rebench/_selftest-*/ (the
+# gitignored subtree, same convention as test-measurement-record.sh) and asserts
+# against those, so the verdict is identical on a fresh clone and on this rig.
+# Any real local rebench dirs are additionally validated read-only as a bonus —
+# never depended on, and never written to.
+#
+# Asserts:
+#   (a) bench_row_fixtures() discovers every synthetic fixture, and SKIPS a dir
+#       missing a required artifact rather than handing it downstream to fail;
+#   (b) section_name() routes all FIVE branches — dual, quad, single vLLM,
+#       single llama.cpp, Gemma — where the old real fixtures covered only
+#       dual + Gemma, so three branches were never tested at all;
+#   (c) the Gemma section emits 11 columns and every other section 9;
+#   (d) every row is a markdown table row citing results/rebench/<tag>/REPORT.md;
+#   (e) formatter fallbacks work: docker-inspect list AND bare-dict shapes,
+#       compose path from label AND inferred from container name, date from the
+#       tag AND from REPORT.md, peak VRAM present AND absent ("TBD"), all three
+#       soak verdicts, and pp from narrative+code AND from prompt_processing;
+#   (f) bench.sh's BENCH_MOCK output shape, incl. thinking + PP modes;
+#   (g) submit-bench.sh writes BENCHMARKS-row.md and prints all three routes;
+#   (h) a missing tag fails loud;
+#   (i) --auto-submit and --auto-submit --as-pr generate ISSUE/PR bodies and
+#       invoke gh with the right title (via GH_MOCK);
+#   (j) an unauthenticated gh aborts --auto-submit instead of half-submitting.
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
@@ -30,17 +64,304 @@ assert_columns() {
   fi
 }
 
+REBENCH_DIR="${ROOT_DIR}/results/rebench"
+
+# Clear leftovers from a hard-killed previous run BEFORE generating, so the test
+# is idempotent even if a SIGKILL skipped the EXIT trap. Only ever _selftest-*:
+# real benchmark history is never touched, read or written.
+rm -rf "${REBENCH_DIR}"/_selftest-*
+
+TMP_BIN="$(mktemp -d)"
+cleanup() {
+  rm -rf "${REBENCH_DIR}"/_selftest-* "$TMP_BIN"
+}
+trap cleanup EXIT
+
+# --- synthesize fixtures ----------------------------------------------------
+# Each fixture carries the four artifacts the formatter requires (_internal.json,
+# REPORT.md, container-config.json, rig.txt), shaped to drive one section branch
+# plus a distinct set of formatter fallbacks.
+python3 - "$REBENCH_DIR" "$ROOT_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+REBENCH = Path(sys.argv[1])
+ROOT = Path(sys.argv[2])
+
+QWEN_DUAL = str(ROOT / "models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml")
+QWEN_SINGLE = str(ROOT / "models/qwen3.6-27b/vllm/compose/single/autoround-int4/minimal.yml")
+GEMMA_DUAL = str(ROOT / "models/gemma-4-31b/vllm/compose/dual/qat-w4a16/int8.yml")
+
+
+def cmd(served, tp, kv, ctx, spec=None):
+    out = [
+        "--served-model-name", served,
+        "--tensor-parallel-size", str(tp),
+        "--kv-cache-dtype", kv,
+        "--max-model-len", str(ctx),
+        "--max-num-seqs", "4",
+        "--gpu-memory-utilization", "0.92",
+    ]
+    if spec is not None:
+        out += ["--speculative-config", json.dumps(spec)]
+    return out
+
+
+def rig(n_gpus, power="300"):
+    lines = ["hostname: selftest-rig"]
+    for i in range(n_gpus):
+        lines.append(f"GPU {i}: NVIDIA GeForce RTX 3090 (UUID: GPU-{i:04d})")
+    if power:
+        lines.append(f"power_cap_w: {power}")
+    return "\n".join(lines) + "\n"
+
+
+def internal(tps=(70.0, 85.0), pp=(1400.0, 1500.0), vram=("22345 MiB", "22990 MiB"),
+             mtp=None, quality=(110, 150), aider=(38, 225), soak=None):
+    bench = {}
+    if tps:
+        bench["narrative"] = {"wall_tps_mean": tps[0]}
+        bench["code"] = {"wall_tps_mean": tps[1]}
+        if pp:
+            bench["narrative"]["pp_tps_mean"] = pp[0]
+            bench["code"]["pp_tps_mean"] = pp[1]
+    if vram:
+        bench["gpu_state"] = [{"mem_used": v} for v in vram]
+    if mtp:
+        bench["mtp"] = mtp
+    out = {"bench": bench}
+    if quality:
+        out["quality"] = {"total_passed": quality[0], "total_total": quality[1]}
+    if aider:
+        out["aider"] = {"passed_count": aider[0], "total_count": aider[1]}
+    if soak:
+        out["soak"] = soak
+    return out
+
+
+# tag -> (container-config blob, _internal.json, REPORT.md body, rig.txt)
+FIXTURES = {
+    # Dual-card TP=2. Compose path from the docker-compose LABEL, MTP notes,
+    # clean soak, date parsed from the TAG, docker-inspect LIST shape.
+    "_selftest-qwen-dual-mtp-2026-01-02": (
+        [{
+            "Name": "/vllm-qwen-dual",
+            "Config": {
+                "Image": "vllm/vllm-openai:v0.25.1",
+                "Labels": {"com.docker.compose.project.config_files": QWEN_DUAL},
+                "Cmd": cmd("qwen3.6-27b-autoround", 2, "fp8_e5m2", 262144,
+                           {"method": "mtp", "num_speculative_tokens": 3}),
+                "Env": ["VLLM_USE_V1=1"],
+            },
+        }],
+        internal(mtp={"mean_accept_length": 2.41, "avg_accept_rate": 62.8},
+                 soak={"verdict": "PASS", "silent_empty": "0 / 40"}),
+        "**Date:** 2026-01-02\n\nVerify-stress: **12/12**\n",
+        rig(2),
+    ),
+    # Dual-card with GENESIS_* env -> "Genesis on" note. Compose path INFERRED
+    # from the container name (no label), TQ3 kv display, borderline soak.
+    "_selftest-qwen-dual-genesis-2026-01-02": (
+        [{
+            "Name": "/vllm-qwen-dual-tq3-mtp-genesis",
+            "Config": {
+                "Image": "vllm/vllm-openai:v0.25.1",
+                "Labels": {},
+                "Cmd": cmd("qwen3.6-27b-autoround", 2, "turboquant_3bit_nc", 262144,
+                           {"method": "mtp", "num_speculative_tokens": 2}),
+                "Env": ["GENESIS_ENABLE=1"],
+            },
+        }],
+        internal(mtp={"mean_accept_length": 1.98, "avg_accept_rate": 51.0},
+                 soak={"verdict": "PASS", "silent_empty": "2 / 40", "max_growth_mib": "148"}),
+        "**Date:** 2026-01-02\n\nVerify-stress: **11/12**\n",
+        rig(2, power="275"),
+    ),
+    # Single-card vLLM TP=1. BARE DICT container-config (not a list), NO date in
+    # the tag so it must come from REPORT.md, no MTP, no aider.
+    "_selftest-qwen-single-vllm": (
+        {
+            "Name": "/vllm-qwen-minimal",
+            "Config": {
+                "Image": "vllm/vllm-openai:v0.25.1",
+                "Labels": {"com.docker.compose.project.config_files": QWEN_SINGLE},
+                "Cmd": cmd("qwen3.6-27b-autoround", 1, "auto", 48000),
+                "Env": [],
+            },
+        },
+        internal(vram=("21008 MiB",), aider=None,
+                 soak={"verdict": "PASS", "silent_empty": "0"}),
+        "**Date:** 2026-01-03\n\n**Overall:** PASS\n",
+        rig(1),
+    ),
+    # Single-card llama.cpp, routed by container NAME rather than compose path.
+    # No gpu_state -> peak VRAM must degrade to "TBD" instead of crashing.
+    "_selftest-qwen-llamacpp-2026-01-04": (
+        [{
+            "Name": "/llama-cpp-qwen-single",
+            "Config": {
+                "Image": "ghcr.io/ggml-org/llama.cpp:server-cuda-b9967",
+                "Labels": {},
+                "Cmd": cmd("qwen3.6-27b", 1, "q8_0", 131072),
+                "Env": [],
+            },
+        }],
+        internal(vram=None, quality=None, aider=None,
+                 soak={"verdict": "FAIL", "silent_empty": "5 / 40"}),
+        "Verify-stress: **9/12**\n",
+        rig(1, power=""),
+    ),
+    # Quad-card: TP=4 -> multi4 section, compose path inferred from tp alone.
+    "_selftest-qwen-multi4-2026-01-05": (
+        [{
+            "Name": "/vllm-qwen-multi4",
+            "Config": {
+                "Image": "vllm/vllm-openai:v0.25.1",
+                "Labels": {},
+                "Cmd": cmd("qwen3.6-27b-autoround", 4, "fp8_e4m3", 262144,
+                           {"method": "mtp", "num_speculative_tokens": 3}),
+                "Env": [],
+            },
+        }],
+        internal(tps=(96.0, 118.0), vram=("21500 MiB",) * 4,
+                 mtp={"mean_accept_length": 2.55, "avg_accept_rate": 66.1},
+                 soak={"verdict": "PASS", "silent_empty": "0 / 40"}),
+        "**Date:** 2026-01-05\n\nVerify-stress: **12/12**\n",
+        rig(4),
+    ),
+    # Gemma -> the ONLY 11-column section. Exercises mtp.per_position and
+    # pp_display's single-key "prompt_processing" fallback.
+    "_selftest-gemma-dual-2026-01-06": (
+        [{
+            "Name": "/vllm-gemma-dual",
+            "Config": {
+                "Image": "vllm/vllm-openai:v0.25.1",
+                "Labels": {"com.docker.compose.project.config_files": GEMMA_DUAL},
+                "Cmd": cmd("gemma-4-31b", 2, "int8_per_token_head", 224000,
+                           {"method": "mtp", "num_speculative_tokens": 4}),
+                "Env": [],
+            },
+        }],
+        {
+            "bench": {
+                "narrative": {"wall_tps_mean": 53.2},
+                "code": {"wall_tps_mean": 57.9},
+                "prompt_processing": {"pp_tps_mean": 980.0},
+                "gpu_state": [{"mem_used": "23100 MiB"}, {"mem_used": "23050 MiB"}],
+                "mtp": {"mean_accept_length": 1.74, "avg_accept_rate": 44.2,
+                        "per_position": "0.62/0.31/0.14/0.05"},
+            },
+            "quality": {"total_passed": 104, "total_total": 150},
+            "soak": {"verdict": "PASS", "silent_empty": "0 / 40"},
+        },
+        "**Date:** 2026-01-06\n\nVerify-stress: **12/12**\n",
+        rig(2),
+    ),
+}
+
+for tag, (config_blob, internal_blob, report, rig_txt) in FIXTURES.items():
+    d = REBENCH / tag
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "container-config.json").write_text(json.dumps(config_blob, indent=2), encoding="utf-8")
+    (d / "_internal.json").write_text(json.dumps(internal_blob, indent=2), encoding="utf-8")
+    (d / "REPORT.md").write_text(f"# {tag}\n\n{report}", encoding="utf-8")
+    (d / "rig.txt").write_text(rig_txt, encoding="utf-8")
+
+# Negative fixture: a dir left by an INTERRUPTED rebench, missing _internal.json.
+# bench_row_fixtures() must skip it, not emit a path that then fails to format.
+partial = REBENCH / "_selftest-partial-interrupted"
+partial.mkdir(parents=True, exist_ok=True)
+(partial / "REPORT.md").write_text("# interrupted\n", encoding="utf-8")
+(partial / "rig.txt").write_text(rig(2), encoding="utf-8")
+PY
+
+# --- expected section per synthetic fixture ---------------------------------
+declare -A EXPECT_SECTION=(
+  [_selftest-qwen-dual-mtp-2026-01-02]="Dual-card (2× RTX 3090, TP=2)"
+  [_selftest-qwen-dual-genesis-2026-01-02]="Dual-card (2× RTX 3090, TP=2)"
+  [_selftest-qwen-single-vllm]="Single-card (1× RTX 3090) — vLLM"
+  [_selftest-qwen-llamacpp-2026-01-04]="Single-card (1× RTX 3090) — llama.cpp"
+  [_selftest-qwen-multi4-2026-01-05]="Quad-card (4× RTX 3090, TP=4)"
+  [_selftest-gemma-dual-2026-01-06]="Gemma 4 31B (community-experimental)"
+)
+
+# (a) discovery finds every synthetic fixture and skips the partial one.
 fixtures=()
 while IFS= read -r fixture; do
   fixtures+=("$fixture")
 done < <(bench_row_fixtures)
 
-if [[ "${#fixtures[@]}" -lt 6 ]]; then
-  echo "ASSERTION FAILED: expected at least 6 submit-bench fixtures, found ${#fixtures[@]}" >&2
-  exit 1
-fi
+for tag in "${!EXPECT_SECTION[@]}"; do
+  found=0
+  for dir in "${fixtures[@]}"; do
+    if [[ "${dir##*/}" == "$tag" ]]; then
+      found=1
+      break
+    fi
+  done
+  if [[ "$found" != 1 ]]; then
+    echo "ASSERTION FAILED: bench_row_fixtures() did not discover synthetic fixture: $tag" >&2
+    printf '  discovered: %s\n' "${fixtures[@]##*/}" >&2
+    exit 1
+  fi
+done
 
 for dir in "${fixtures[@]}"; do
+  if [[ "${dir##*/}" == "_selftest-partial-interrupted" ]]; then
+    echo "ASSERTION FAILED: bench_row_fixtures() emitted a dir missing _internal.json" >&2
+    exit 1
+  fi
+done
+
+# (b)(c)(d) each synthetic fixture routes to the right section with the right
+# column count and cites its own REPORT.md.
+for tag in "${!EXPECT_SECTION[@]}"; do
+  dir="${REBENCH_DIR}/${tag}"
+  section="$(bench_row_section "$dir")"
+  row="$(bench_row_format "$dir")"
+  if [[ "$section" != "${EXPECT_SECTION[$tag]}" ]]; then
+    echo "ASSERTION FAILED: $tag -> section '$section', expected '${EXPECT_SECTION[$tag]}'" >&2
+    exit 1
+  fi
+  [[ "$row" == \|*\| ]] || {
+    echo "ASSERTION FAILED: row is not a markdown table row for $dir" >&2
+    echo "$row" >&2
+    exit 1
+  }
+  assert_contains "$row" "Report: \`results/rebench/${tag}/REPORT.md\`"
+  if [[ "$section" == "Gemma 4 31B (community-experimental)" ]]; then
+    assert_columns "$row" 11
+  else
+    assert_columns "$row" 9
+  fi
+done
+
+# (e) the fallbacks the previous real fixtures never exercised.
+row="$(bench_row_format "${REBENCH_DIR}/_selftest-qwen-llamacpp-2026-01-04")"
+assert_contains "$row" "TBD"                      # no gpu_state -> peak VRAM degrades
+assert_contains "$row" "Soak: ✗ FAIL"
+row="$(bench_row_format "${REBENCH_DIR}/_selftest-qwen-single-vllm")"
+assert_contains "$row" "2026-01-03"               # date from REPORT.md, not the tag
+assert_contains "$row" "verify-stress PASS"       # **Overall:** PASS form
+assert_contains "$row" "Soak: ✓ PASS"
+row="$(bench_row_format "${REBENCH_DIR}/_selftest-qwen-dual-genesis-2026-01-02")"
+assert_contains "$row" "Genesis on"
+assert_contains "$row" "TQ3"
+assert_contains "$row" "Soak: ⚠ borderline"
+row="$(bench_row_format "${REBENCH_DIR}/_selftest-gemma-dual-2026-01-06")"
+assert_contains "$row" "0.62/0.31/0.14/0.05"      # mtp.per_position (Gemma-only column)
+assert_contains "$row" "980"                      # prompt_processing pp fallback
+row="$(bench_row_format "${REBENCH_DIR}/_selftest-qwen-multi4-2026-01-05")"
+assert_contains "$row" "/card"                    # multi-GPU peak VRAM suffix
+
+# Bonus: validate any REAL local rebench output read-only. Never depended on —
+# on a fresh clone there is none, and the assertions above already stand alone.
+real_count=0
+for dir in "${fixtures[@]}"; do
+  case "${dir##*/}" in
+    _selftest-*) continue ;;
+  esac
   section="$(bench_row_section "$dir")"
   row="$(bench_row_format "$dir")"
   [[ "$row" == \|*\| ]] || {
@@ -54,22 +375,36 @@ for dir in "${fixtures[@]}"; do
   else
     assert_columns "$row" 9
   fi
+  real_count=$((real_count + 1))
 done
 
-out="$(BENCH_MOCK=1 RUNS=1 WARMUPS=0 bash scripts/bench.sh)"
+# (f) bench.sh mock output shape.
+#
+# PREFLIGHT_NO_AUTODETECT=1 + CONTAINER=none + ENGINE_KIND pinned, per the #478
+# precedent in test-measurement-record.sh: unpinned, bench.sh adopts whatever
+# container happens to be running on the rig, and ENGINE_KIND=llamacpp flips
+# BENCH_MOCK from the PP_MODE=log branch to PP_MODE=fallback (bench.sh:126-128).
+# Both branches emit "PP tok/s", so this was not failing — but WHICH branch got
+# tested depended on rig state, so on a rig with a llama.cpp container up the
+# log branch was never exercised at all. Pinning makes the coverage of both
+# branches deliberate, and stops the autodetect naming an unrelated container.
+MOCK_ENV=(PREFLIGHT_NO_AUTODETECT=1 CONTAINER=none BENCH_MOCK=1 RUNS=1 WARMUPS=0)
+
+out="$(env "${MOCK_ENV[@]}" ENGINE_KIND=vllm bash scripts/bench.sh)"
 assert_contains "$out" "PP tok/s"
-out="$(ENABLE_THINKING=1 BENCH_MOCK=1 RUNS=1 WARMUPS=0 bash scripts/bench.sh 2>&1)"
+out="$(env "${MOCK_ENV[@]}" ENGINE_KIND=vllm ENABLE_THINKING=1 bash scripts/bench.sh 2>&1)"
 assert_contains "$out" "[bench] thinking: enabled"
 assert_contains "$out" "PP tok/s"
-out="$(BENCH_MOCK=1 PP=1 RUNS=1 WARMUPS=0 bash scripts/bench.sh)"
+out="$(env "${MOCK_ENV[@]}" ENGINE_KIND=vllm PP=1 bash scripts/bench.sh)"
 assert_contains "$out" "summary [prompt-processing]"
 assert_contains "$out" "PP tok/s"
+# The llamacpp engine forces PP_MODE=fallback independently of PP=1 — cover it
+# explicitly rather than inheriting it by accident from a running container.
+out="$(env "${MOCK_ENV[@]}" ENGINE_KIND=llamacpp bash scripts/bench.sh)"
+assert_contains "$out" "PP tok/s"
 
-tag="qwen-int8-pth-n4-2026-05-10"
-rm -f "results/rebench/${tag}/BENCHMARKS-row.md" \
-      "results/rebench/${tag}/PR-body.md" \
-      "results/rebench/${tag}/ISSUE-body.md" \
-      "results/rebench/${tag}/auto-submit-mock.log"
+# (g) submit-bench.sh end-to-end against a synthetic tag.
+tag="_selftest-qwen-dual-mtp-2026-01-02"
 
 out="$(bash scripts/submit-bench.sh --tag "$tag")"
 assert_contains "$out" "Generated BENCHMARKS row for section: Dual-card (2× RTX 3090, TP=2)"
@@ -79,12 +414,14 @@ assert_contains "$out" "2. Direct PR"
 assert_contains "$out" "3. Manual edit"
 test -s "results/rebench/${tag}/BENCHMARKS-row.md"
 
+# (h) missing tag fails loud.
 if out="$(bash scripts/submit-bench.sh --tag does-not-exist 2>&1)"; then
   echo "ASSERTION FAILED: missing tag unexpectedly succeeded" >&2
   exit 1
 fi
 assert_contains "$out" "tag dir not found: results/rebench/does-not-exist"
 
+# (i) --auto-submit (issue) and --as-pr (PR) via GH_MOCK.
 out="$(GH_MOCK=1 GH_MOCK_USER=octocat bash scripts/submit-bench.sh --tag "$tag" --auto-submit)"
 assert_contains "$out" "Issue title: [bench] @octocat ${tag}"
 test -s "results/rebench/${tag}/auto-submit-mock.log"
@@ -99,9 +436,8 @@ test -s "results/rebench/${tag}/PR-body.md"
 assert_contains "$(cat "results/rebench/${tag}/auto-submit-mock.log")" "gh pr create --title bench(matrix): @octocat ${tag}"
 assert_contains "$(cat "results/rebench/${tag}/PR-body.md")" "results/rebench/${tag}/REPORT.md"
 
-tmp_bin="$(mktemp -d)"
-trap 'rm -rf "$tmp_bin"; rm -f "results/rebench/${tag}/BENCHMARKS-row.md" "results/rebench/${tag}/PR-body.md" "results/rebench/${tag}/ISSUE-body.md" "results/rebench/${tag}/auto-submit-mock.log"' EXIT
-cat > "${tmp_bin}/gh" <<'MOCK_GH'
+# (j) unauthenticated gh must abort, not half-submit.
+cat > "${TMP_BIN}/gh" <<'MOCK_GH'
 #!/usr/bin/env bash
 if [[ "$1" == "auth" && "$2" == "status" ]]; then
   exit 1
@@ -109,12 +445,39 @@ fi
 echo "unexpected gh call: $*" >&2
 exit 2
 MOCK_GH
-chmod +x "${tmp_bin}/gh"
+chmod +x "${TMP_BIN}/gh"
 
-if out="$(PATH="${tmp_bin}:${PATH}" bash scripts/submit-bench.sh --tag "$tag" --auto-submit 2>&1)"; then
+if out="$(PATH="${TMP_BIN}:${PATH}" bash scripts/submit-bench.sh --tag "$tag" --auto-submit 2>&1)"; then
   echo "ASSERTION FAILED: unauthenticated gh path unexpectedly succeeded" >&2
   exit 1
 fi
 assert_contains "$out" "not authed with gh. Run: gh auth login"
 
-echo "test-submit-bench: ok"
+# (k) the FORMATTER under a non-UTF-8 locale. Every section name carries "×", so
+# a piped stdout defaulting to ASCII made bench_row_format die with
+# UnicodeEncodeError on community rigs running LC_ALL=C (#599 class) — never
+# caught because this path had never run off the maintainer rig (#776).
+# PYTHONUTF8=0 + PYTHONCOERCECLOCALE=0 are load-bearing: modern Python coerces a
+# bare LC_ALL=C to C.UTF-8, so without them this assertion is vacuous.
+#
+# Scope: the formatter only. submit-bench.sh itself is still broken under a
+# non-UTF-8 locale for a DIFFERENT reason — Python decodes sys.argv with
+# ASCII+surrogateescape there, so the row it passes to its python heredocs
+# arrives as lone surrogates and no encoding= pin can save the write. That needs
+# os.fsencode()-based argv recovery and is tracked separately (#777).
+locale_env=(PYTHONUTF8=0 PYTHONCOERCECLOCALE=0 LC_ALL=C LANG=C)
+row="$(env "${locale_env[@]}" bash -c "source scripts/lib/bench-row-formatter.sh; bench_row_format '${REBENCH_DIR}/${tag}'")"
+[[ "$row" == \|*\| ]] || {
+  echo "ASSERTION FAILED: formatter did not emit a row under a non-UTF-8 locale" >&2
+  echo "$row" >&2
+  exit 1
+}
+assert_contains "$row" "Report: \`results/rebench/${tag}/REPORT.md\`"
+assert_contains "$row" "2× 3090"   # simplify_gpu() drops the "NVIDIA GeForce RTX " prefix
+section="$(env "${locale_env[@]}" bash -c "source scripts/lib/bench-row-formatter.sh; bench_row_section '${REBENCH_DIR}/${tag}'")"
+if [[ "$section" != "Dual-card (2× RTX 3090, TP=2)" ]]; then
+  echo "ASSERTION FAILED: section under non-UTF-8 locale was '$section'" >&2
+  exit 1
+fi
+
+echo "test-submit-bench: ok (${#EXPECT_SECTION[@]} synthetic fixtures, ${real_count} local rebench dir(s) also validated)"


### PR DESCRIPTION
Fixes #776.

`test-submit-bench.sh` required six specific `results/rebench/<tag>/` directories of real 2026-05 benchmark output. `results/*` is gitignored, so those were **never committed** — they exist only as untracked leftovers on the maintainer rig. The test passed here and could not pass on any fresh clone, which made the suite permanently red for every external contributor and meant this path had never actually executed in CI.

@datanerdie hit it in #764 and reported it correctly as pre-existing and unrelated. It was — and it was ours.

## The dependency was wider than the issue said

I scoped #776 to the fixture-count assertion. Reading the whole file, the second half is just as rig-bound: it hard-codes `tag="qwen-int8-pth-n4-2026-05-10"`, runs `submit-bench.sh --tag` against that real directory, and **writes generated files into real benchmark history** (`BENCHMARKS-row.md`, `PR-body.md`, `ISSUE-body.md`, `auto-submit-mock.log`), removing them in a trap. The fixture assertion only failed first because `set -e` stopped there.

## Approach

Option (a) from the issue — synthesize fixtures — with one correction: the issue's option (b) ("commit trimmed fixtures") isn't viable as written, because `.gitignore:65` is `results/*`, so committing anything under it needs a negation rule. And no `submit-bench.sh` changes turned out to be needed: it does `cd "$ROOT_DIR"` and resolves `results/rebench/<tag>` relatively, so synthetic dirs in the repo's own gitignored `results/` work against it unmodified.

- **`bench_row_fixtures()`** — discover tag dirs carrying all four required artifacts, instead of naming six stale tags. The `-f` guards mirror the `require_file()` calls downstream, so a half-written dir from an interrupted rebench is skipped rather than handed on to fail mid-format (there's a negative fixture for that). `find -L`, because a bulky `results/` parked on another volume and symlinked back in is normal on big rigs, and a plain `-type d` skips symlinks — which would reproduce #776's "found 0" from a different direction.
- **`test-submit-bench.sh`** — synthesizes its own fixtures under `results/rebench/_selftest-*/`, the gitignored subtree, same convention `test-measurement-record.sh` already uses. Cleaned up in an EXIT trap *and* at startup, so a SIGKILL'd run self-heals. Real benchmark dirs are never read or written — only `_selftest-*` is ever removed.

## Coverage goes up, not down

The six real dirs only ever exercised **two** of `section_name()`'s five branches. The synthetic set covers all five, plus fallbacks that were unreachable before:

| Fixture | Section branch | Also exercises |
|---|---|---|
| `_selftest-qwen-dual-mtp-*` | Dual-card TP=2 | compose path from label, MTP notes, date from tag, inspect-list shape |
| `_selftest-qwen-dual-genesis-*` | Dual-card TP=2 | `GENESIS_*` → "Genesis on", TQ3 kv, borderline soak |
| `_selftest-qwen-single-vllm` | Single-card vLLM | **bare-dict** container-config, **date from REPORT.md**, `**Overall:** PASS` form |
| `_selftest-qwen-llamacpp-*` | Single-card llama.cpp | routing by container name, **absent `gpu_state` → "TBD"**, `Soak: ✗ FAIL` |
| `_selftest-qwen-multi4-*` | Quad-card TP=4 | compose path inferred from `tp` alone, `/card` VRAM suffix |
| `_selftest-gemma-dual-*` | Gemma (11 cols) | `mtp.per_position`, `prompt_processing` pp fallback |

Three section branches, both container-config shapes, both date sources, all three soak verdicts and both pp paths were previously untested.

## Second rig-only failure, found while verifying

Since the whole point is "does this work off the maintainer rig", I ran it under the repo's documented non-UTF-8 repro. It crashed:

```
UnicodeEncodeError: 'ascii' codec can't encode character '\xd7' in position 12
```

`\xd7` is the `×` in every section name. Under `LC_ALL=C` a piped stdout defaults to ASCII, so `bench_row_format` died for anyone on a minimal VM or container — the #599 class that `AGENTS.md` already has a standing rule for, unnoticed for the same reason as #776. Fixed by pinning stdout plus the two artifact reads, and the new `(k)` case reproduces it: remove the pin and the test goes red with that exact error.

**Scoped deliberately.** `submit-bench.sh` is *still* broken on those rigs, for an unrelated and deeper reason — Python decodes `sys.argv` with ASCII+`surrogateescape` there, so the row arrives as lone surrogates and no `encoding=` pin helps. Worse, `write_text` truncates on open, so pinning only the read wipes `BENCHMARKS.md` to zero bytes (measured: 46 → 0). I started on that fix, backed it out, and filed **#777** with the root cause and the trap, rather than ship a half-fix here.

## Verification

| Environment | Before | After |
|---|--:|--:|
| Fresh worktree, full suite | 83 / **1** | **84 / 0** |
| Fresh worktree, this test | fail: `found 0` | ok (6 synthetic, 0 local) |
| 6 real dirs symlinked in (maintainer-rig equivalent) | ok | ok (6 synthetic, **6 local** also validated) |
| Non-UTF-8 locale (`PYTHONUTF8=0 PYTHONCOERCECLOCALE=0 LC_ALL=C`) | `UnicodeEncodeError` | ok |
| Run twice back-to-back | — | ok (idempotent) |
| Dangling symlink in `results/rebench/` | — | ok (skipped) |

All checks ran in a `git worktree` off `master`, i.e. a genuine fresh-clone environment with no untracked `results/`, rather than in the working tree where the bug hides. The real-data column used symlinks to the six actual 2026-05 dirs, so the read-only bonus path is verified against genuine output, and `git status` stayed clean throughout.

One gap I did not close: `insert_row()` is still untested — `GH_MOCK=1` exits at `submit-bench.sh:285` and `insert_row` is called at 307, on the real-`gh` path. It's the only function that mutates a tracked file and it also runs `git switch -c`, so it's simultaneously the riskiest and least-covered code in the script. Noted in #777.

Reported-by: @datanerdie

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
