### PR TITLE
fix(submit-bench): work on non-UTF-8 locales; make the BENCHMARKS.md write atomic

### DIFF
--- a/scripts/submit-bench.sh
+++ b/scripts/submit-bench.sh
@@ -114,17 +114,34 @@ write_pr_body() {
   if [[ -f "$template" ]]; then
     python3 - "$template" "$body_file" "$tag" "$row" <<'PY'
 from pathlib import Path
+import os
 import sys
 
-template, body_file, tag, row = sys.argv[1:5]
-text = Path(template).read_text()
+
+def argv_utf8(i: int) -> str:
+    """Recover a UTF-8 argv value regardless of locale.
+
+    Under a non-UTF-8 locale Python decodes argv with ASCII + surrogateescape,
+    so the row's "×" / "—" arrive as LONE SURROGATES. No encoding= pin can save
+    a later write — strict utf-8 refuses surrogates outright. os.fsencode()
+    reverses surrogateescape losslessly, giving back the original bytes to
+    decode properly, and is a no-op under a UTF-8 locale. (#777)
+    """
+    return os.fsencode(sys.argv[i]).decode("utf-8", "replace")
+
+
+# Paths stay as-received: surrogateescape round-trips correctly through the
+# filesystem calls, and re-decoding them would corrupt a non-UTF-8 filename.
+template, body_file = sys.argv[1], sys.argv[2]
+tag, row = argv_utf8(3), argv_utf8(4)
+text = Path(template).read_text(encoding="utf-8")
 text = text.replace("<TAG>", tag)
 text = text.replace("<!-- The generated BENCHMARKS.md row goes here -->", row)
 text = text.replace(
     "<!-- Output of `bash scripts/report.sh` (redacted) -->",
     f"See `results/rebench/{tag}/rig.txt`.",
 )
-Path(body_file).write_text(text)
+Path(body_file).write_text(text, encoding="utf-8")
 PY
   else
     {
@@ -176,13 +193,26 @@ insert_row() {
   python3 - "$section" "$row" <<'PY'
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
-section = sys.argv[1]
-row = sys.argv[2]
-path = Path("BENCHMARKS.md")
-lines = path.read_text().splitlines()
+
+def argv_utf8(i: int) -> str:
+    """Recover a UTF-8 argv value regardless of locale — see write_pr_body's
+    copy for the full rationale. Short version: a non-UTF-8 locale decodes argv
+    with ASCII + surrogateescape, so the row arrives as lone surrogates that no
+    strict encode will write; os.fsencode() reverses that losslessly. (#777)"""
+    return os.fsencode(sys.argv[i]).decode("utf-8", "replace")
+
+
+section = argv_utf8(1)
+row = argv_utf8(2)
+# BENCHMARKS_FILE is a test seam (see test-submit-bench.sh) — it lets the suite
+# exercise this function, the only one here that mutates a tracked file, against
+# a throwaway copy. Unset in normal use.
+path = Path(os.environ.get("BENCHMARKS_FILE") or "BENCHMARKS.md")
+lines = path.read_text(encoding="utf-8").splitlines()
 
 heading_idx = None
 for i, line in enumerate(lines):
@@ -216,7 +246,19 @@ for i in range(table_start, len(lines)):
         break
 
 lines.insert(insert_at, row)
-path.write_text("\n".join(lines) + "\n")
+
+# ATOMIC write. Path.write_text() opens with mode "w", which TRUNCATES on open —
+# so any failure between open and flush leaves the target EMPTY. That turned the
+# #777 encode error into silent destruction of a tracked file: measured 46 bytes
+# -> 0. Write a sibling temp file and os.replace() it in, so BENCHMARKS.md is
+# either fully updated or completely untouched, whatever goes wrong. (#777)
+tmp = path.with_name(path.name + ".submit-bench.tmp")
+try:
+    tmp.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+except BaseException:
+    tmp.unlink(missing_ok=True)
+    raise
 PY
 }
 
@@ -266,6 +308,19 @@ fi
 if [[ "${GH_MOCK:-0}" == "1" ]]; then
   MOCK_LOG="$TAG_DIR/auto-submit-mock.log"
   if [[ "$AS_PR" -eq 1 ]]; then
+    # Mock fidelity: with BENCHMARKS_FILE pointed at a throwaway copy, actually
+    # perform the insert so the suite covers insert_row(). Otherwise it is
+    # unreachable under GH_MOCK (this branch exits before the real-gh path at the
+    # bottom of the script), and the one function here that mutates a tracked
+    # file — and runs `git switch -c` — ships with no coverage at all. Refuses
+    # the repo's own BENCHMARKS.md, so a bare GH_MOCK run still cannot touch it.
+    if [[ -n "${BENCHMARKS_FILE:-}" ]]; then
+      if [[ "$(cd -- "$(dirname -- "$BENCHMARKS_FILE")" && pwd)/$(basename -- "$BENCHMARKS_FILE")" == "${ROOT_DIR}/BENCHMARKS.md" ]]; then
+        die "refusing to insert into the repo's own BENCHMARKS.md under GH_MOCK; point BENCHMARKS_FILE at a copy"
+      fi
+      insert_row "$SECTION" "$ROW"
+      log "GH_MOCK=1 — inserted row under '${SECTION}' into ${BENCHMARKS_FILE}"
+    fi
     {
       echo "git switch -c ${BRANCH}"
       echo "insert BENCHMARKS.md row under: ${SECTION}"

--- a/scripts/tests/test-submit-bench.sh
+++ b/scripts/tests/test-submit-bench.sh
@@ -453,18 +453,17 @@ if out="$(PATH="${TMP_BIN}:${PATH}" bash scripts/submit-bench.sh --tag "$tag" --
 fi
 assert_contains "$out" "not authed with gh. Run: gh auth login"
 
-# (k) the FORMATTER under a non-UTF-8 locale. Every section name carries "×", so
-# a piped stdout defaulting to ASCII made bench_row_format die with
-# UnicodeEncodeError on community rigs running LC_ALL=C (#599 class) — never
-# caught because this path had never run off the maintainer rig (#776).
+# (k) a non-UTF-8 locale, end to end. Two independent failure mechanisms lived
+# here, both invisible on the maintainer rig (#776) because the path never ran
+# off it:
+#   1. every section name carries "×", and a piped stdout defaults to ASCII, so
+#      the formatter died with UnicodeEncodeError (#599 class, fixed in #778);
+#   2. Python decodes sys.argv with ASCII+surrogateescape under such a locale, so
+#      the row reached submit-bench.sh's python heredocs as LONE SURROGATES —
+#      which strict utf-8 refuses, so no encoding= pin helps. Fixed with
+#      os.fsencode()-based recovery (#777).
 # PYTHONUTF8=0 + PYTHONCOERCECLOCALE=0 are load-bearing: modern Python coerces a
-# bare LC_ALL=C to C.UTF-8, so without them this assertion is vacuous.
-#
-# Scope: the formatter only. submit-bench.sh itself is still broken under a
-# non-UTF-8 locale for a DIFFERENT reason — Python decodes sys.argv with
-# ASCII+surrogateescape there, so the row it passes to its python heredocs
-# arrives as lone surrogates and no encoding= pin can save the write. That needs
-# os.fsencode()-based argv recovery and is tracked separately (#777).
+# bare LC_ALL=C to C.UTF-8, so without them these assertions are vacuous.
 locale_env=(PYTHONUTF8=0 PYTHONCOERCECLOCALE=0 LC_ALL=C LANG=C)
 row="$(env "${locale_env[@]}" bash -c "source scripts/lib/bench-row-formatter.sh; bench_row_format '${REBENCH_DIR}/${tag}'")"
 [[ "$row" == \|*\| ]] || {
@@ -477,6 +476,114 @@ assert_contains "$row" "2× 3090"   # simplify_gpu() drops the "NVIDIA GeForce R
 section="$(env "${locale_env[@]}" bash -c "source scripts/lib/bench-row-formatter.sh; bench_row_section '${REBENCH_DIR}/${tag}'")"
 if [[ "$section" != "Dual-card (2× RTX 3090, TP=2)" ]]; then
   echo "ASSERTION FAILED: section under non-UTF-8 locale was '$section'" >&2
+  exit 1
+fi
+
+# ...and submit-bench.sh itself, on the --as-pr path, which is where the argv
+# surrogates bit: it reads the unicode-bearing PR template and writes the body.
+#
+# Checked with an explicit `if !` rather than a bare assignment: under `set -e` a
+# failing command substitution aborts the test with NO message, so a regression
+# here would surface as a silent rc=1 and cost someone an afternoon.
+run_submit_locale() {
+  local what="$1"; shift
+  if ! out="$(env "${locale_env[@]}" GH_MOCK=1 GH_MOCK_USER=octocat bash scripts/submit-bench.sh "$@" 2>&1)"; then
+    echo "ASSERTION FAILED: submit-bench.sh ${what} failed under a non-UTF-8 locale" >&2
+    echo "--- output ---" >&2
+    echo "$out" >&2
+    exit 1
+  fi
+}
+
+run_submit_locale "--auto-submit --as-pr" --tag "$tag" --auto-submit --as-pr
+assert_contains "$out" "PR title: bench(matrix): @octocat ${tag}"
+assert_contains "$(cat "results/rebench/${tag}/PR-body.md")" "2× 3090"
+run_submit_locale "--auto-submit" --tag "$tag" --auto-submit
+assert_contains "$out" "Issue title: [bench] @octocat ${tag}"
+
+# (l) insert_row() — the only function here that mutates a tracked file, and
+# until now the only one with NO coverage: GH_MOCK exits before the real-gh path
+# that calls it. Exercised against a throwaway copy via BENCHMARKS_FILE, under
+# both locales, because its write is where a half-done encoding fix destroys
+# data: Path.write_text truncates on open, so the failed encode left the target
+# at 0 bytes (measured 46 -> 0). It now writes a temp sibling + os.replace.
+bench_copy="${TMP_BIN}/BENCHMARKS-copy.md"
+for loc in utf8 c; do
+  cp BENCHMARKS.md "$bench_copy"
+  before_bytes="$(wc -c < "$bench_copy")"
+  if [[ "$loc" == "c" ]]; then
+    insert_out="$(env "${locale_env[@]}" GH_MOCK=1 GH_MOCK_USER=octocat BENCHMARKS_FILE="$bench_copy" \
+      bash scripts/submit-bench.sh --tag "$tag" --auto-submit --as-pr 2>&1)" || insert_rc=$?
+  else
+    insert_out="$(GH_MOCK=1 GH_MOCK_USER=octocat BENCHMARKS_FILE="$bench_copy" \
+      bash scripts/submit-bench.sh --tag "$tag" --auto-submit --as-pr 2>&1)" || insert_rc=$?
+  fi
+  if [[ "${insert_rc:-0}" != 0 ]]; then
+    echo "ASSERTION FAILED: insert_row run failed ($loc locale, rc=${insert_rc})" >&2
+    echo "$insert_out" >&2
+    exit 1
+  fi
+  assert_contains "$insert_out" "inserted row under 'Dual-card (2× RTX 3090, TP=2)'"
+  after_bytes="$(wc -c < "$bench_copy")"
+  if (( after_bytes <= before_bytes )); then
+    echo "ASSERTION FAILED: insert_row ($loc locale) did not grow the file: ${before_bytes} -> ${after_bytes} bytes" >&2
+    exit 1
+  fi
+  # The row must land inside the Dual-card table, and the rest of the file must
+  # survive intact — a truncating write would take the unicode headings with it.
+  assert_contains "$(cat "$bench_copy")" "results/rebench/${tag}/REPORT.md"
+  assert_contains "$(cat "$bench_copy")" "Dual-card (2× RTX 3090, TP=2)"
+  inserted_under="$(awk '/^#+ Dual-card \(2× RTX 3090, TP=2\)/{f=1;next} f&&/^#/{exit} f&&/^\|/{print;exit}' "$bench_copy")"
+  [[ -n "$inserted_under" ]] || {
+    echo "ASSERTION FAILED: no table row under the Dual-card heading after insert ($loc)" >&2
+    exit 1
+  }
+  # No temp file left behind by the atomic write.
+  if compgen -G "${bench_copy}.submit-bench.tmp" >/dev/null; then
+    echo "ASSERTION FAILED: atomic-write temp file leaked ($loc)" >&2
+    exit 1
+  fi
+done
+
+# A FAILED insert must leave the target byte-identical. The reachable failure is
+# an unknown section (SystemExit before any write); the unreachable-by-default one
+# is an encode error mid-write, which is why the write goes through a temp sibling
+# + os.replace rather than write_text — the latter truncates on open, and with an
+# ASCII-named section (the Gemma row is the only one) that turned a #777 encode
+# error into 180693 -> 0 bytes. That A/B is in the PR; asserted here is the
+# invariant it protects: a failing insert never damages the file.
+# A target file WITHOUT the derived section reaches insert_row's own not-found
+# branch. (`--section` can't be used for this: it is validated against the file
+# up front, so it exits before insert_row ever runs.)
+bench_stub="${TMP_BIN}/BENCHMARKS-stub.md"
+printf '# Bench\n\n## Some Other Section\n\n| a | b |\n|---|---|\n| 1 | 2 |\n' > "$bench_stub"
+before_sum="$(sha256sum < "$bench_stub")"
+if out="$(GH_MOCK=1 GH_MOCK_USER=octocat BENCHMARKS_FILE="$bench_stub" \
+          bash scripts/submit-bench.sh --tag "$tag" --auto-submit --as-pr 2>&1)"; then
+  echo "ASSERTION FAILED: insert into a file lacking the section unexpectedly succeeded" >&2
+  exit 1
+fi
+assert_contains "$out" "section not found in BENCHMARKS.md"
+bench_copy="$bench_stub"
+if [[ "$(sha256sum < "$bench_copy")" != "$before_sum" ]]; then
+  echo "ASSERTION FAILED: a failed insert modified the target file" >&2
+  exit 1
+fi
+if compgen -G "${bench_copy}.submit-bench.tmp" >/dev/null; then
+  echo "ASSERTION FAILED: atomic-write temp file leaked after a failed insert" >&2
+  exit 1
+fi
+
+# The repo's own BENCHMARKS.md must be refused outright, so a bare GH_MOCK run
+# can never mutate tracked history.
+if out="$(GH_MOCK=1 GH_MOCK_USER=octocat BENCHMARKS_FILE="${ROOT_DIR}/BENCHMARKS.md" \
+          bash scripts/submit-bench.sh --tag "$tag" --auto-submit --as-pr 2>&1)"; then
+  echo "ASSERTION FAILED: insert into the repo's own BENCHMARKS.md was allowed" >&2
+  exit 1
+fi
+assert_contains "$out" "refusing to insert into the repo's own BENCHMARKS.md"
+if ! git diff --quiet -- BENCHMARKS.md; then
+  echo "ASSERTION FAILED: BENCHMARKS.md was modified by the test" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Fixes #777.

`submit-bench.sh` could not run on a non-UTF-8-locale rig. `--auto-submit --as-pr` died reading the unicode-bearing PR template, so a contributor on a minimal VM or container with `LC_ALL=C` could not submit a bench at all.

## Pinning `encoding=` is not the fix

The row reaches these python heredocs through **`sys.argv`**, and under such a locale Python decodes argv with ASCII + `surrogateescape` — so every `×`/`—` arrives as a *lone surrogate*, which strict utf-8 refuses. Pin the reads and the crash simply relocates to the write:

```
UnicodeEncodeError: 'utf-8' codec can't encode characters in position 534-535: surrogates not allowed
```

- **argv recovery** — `os.fsencode(sys.argv[i]).decode("utf-8", "replace")` in both heredocs. Reverses `surrogateescape` losslessly, no-op under a UTF-8 locale, so no branching. Paths stay as-received: `surrogateescape` round-trips correctly through filesystem calls, and re-decoding one would corrupt a genuinely non-UTF-8 filename.
- **`encoding="utf-8"`** on all four reads/writes.
- **Atomic `BENCHMARKS.md` write** — temp sibling + `os.replace`.

## Correction to what I wrote in the issue

I claimed in #777 that pinning the read alone would wipe `BENCHMARKS.md` on any `--as-pr` run. **That was too broad.** The `section` string is *also* surrogate-laden, so the heading lookup normally fails first and exits before any write.

The write is only reached when the section name is **pure ASCII** — and exactly one catalog section is:

```
non-ASCII: ### Dual-card (2× RTX 3090, TP=2)
non-ASCII: ### Quad-card (4× RTX 3090, TP=4)
non-ASCII: ### Single-card (1× RTX 3090) — vLLM
ASCII    : ## Gemma 4 31B (community-experimental)   <-- lookup survives surrogateescape
```

So a **Gemma** submission would have destroyed the file; the others would have errored out first. Measured, with `insert_row`'s argv recovery removed so the write is reached:

| write strategy | encode errors | file |
|---|--:|---|
| `write_text` (before) | 2 | **180693 → 0 bytes — destroyed** |
| temp + `os.replace` (after) | 2 | 180693 → 180693 — intact |

Mechanism right, reach overstated. The atomic write stands on its own merits regardless: `write_text` truncates on open, so *any* future mid-write failure would have the same effect.

## `insert_row()` had no coverage at all

`GH_MOCK=1` exits at `submit-bench.sh:285`; `insert_row` is called at 307 on the real-`gh` path. So the only function here that mutates a tracked file — and which also runs `git switch -c` — shipped completely untested, which is how both bugs in it survived.

`GH_MOCK --as-pr` now performs a **real** insert when `BENCHMARKS_FILE` points at a throwaway copy (the mock previously *claimed* an insert it didn't do), and **refuses the repo's own `BENCHMARKS.md`** outright, so a bare `GH_MOCK` run still cannot touch tracked history.

## Verification

| Check | Result |
|---|---|
| `test-submit-bench`, normal locale | ok |
| `test-submit-bench`, `PYTHONUTF8=0 PYTHONCOERCECLOCALE=0 LC_ALL=C` | ok |
| Full suite, fresh worktree | **84 / 0** |
| `insert_row` against a copy, both locales | row lands under the right heading, file grows, no temp leak |
| Failed insert (target lacks the section) | target byte-identical, no temp leak |
| Guard bites: remove argv recovery | fails with a named assertion + the surrogate error |
| `BENCHMARKS.md` after the run | untouched (`git diff --quiet`) |

Each guard was verified by mutating the fix back out and confirming the test goes red — not assumed. The `--section` route turned out to be validated up front, before `insert_row` runs, so the failed-insert case uses a target file lacking the derived section to actually reach `insert_row`'s own error path.

The locale runs are checked with an explicit `if !` rather than a bare assignment, because under `set -e` a failing command substitution aborts with **no message** — which is exactly how the first version of this test hid its own failure from me and cost a diagnostic round.

## Scope

Deliberately submit-bench only. Running the **whole** suite under `LC_ALL=C` reveals **42 of 84 tests failing** — 34 `UnicodeEncodeError` + 29 `UnicodeDecodeError`, only 1 assertion — i.e. the script layer broadly ignores the `encoding="utf-8"` rule AGENTS.md already mandates, and a C-locale user plausibly cannot pull, generate a compose, or diagnose a profile. Confirmed pre-existing on pristine `origin/master`. Filed as **#779** with the triage order (reads, writes+atomic, argv, stdout, then a ratcheting suite gate) rather than swept blindly here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
