### PR TITLE
fix(patch-attribution): decode docker compose output as utf-8, not locale

### DIFF
--- a/scripts/lib/profiles/patch_attribution.py
+++ b/scripts/lib/profiles/patch_attribution.py
@@ -224,6 +224,12 @@ def _docker_compose_config(path: Path) -> str | None:
             cwd=str(path.parent),
             capture_output=True,
             text=True,
+            # Locale-independent decode: text=True otherwise decodes the child's
+            # stdout with the LOCALE encoding, so `docker compose config` output
+            # containing an em-dash dies with UnicodeDecodeError on an LC_ALL=C
+            # rig (#779). Same class as the read_text pins, different mechanism.
+            encoding="utf-8",
+            errors="replace",
             timeout=60,
         )
     except (OSError, subprocess.SubprocessError):


### PR DESCRIPTION
First ratchet step for #779. **Does not close it** — 41 of the 42 C-locale failures remain.

## What

`subprocess.run(..., text=True)` decodes the child's stdout with the **locale** encoding. `_docker_compose_config()` shells out to `docker compose config`, whose output carries the em-dashes every compose header has, so on an `LC_ALL=C` rig:

```
File "scripts/lib/profiles/patch_attribution.py", line 331, in compose_effective_text
    body = service_body(compose_effective_text(root, name_or_path))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 16
```

Six lines: `encoding="utf-8"` + `errors="replace"` on the call.

## Why this one is worth noting beyond the one-line diff

`patch_attribution.py` **already pins `encoding="utf-8"` on every one of its own reads** (lines 131, 175, 180, 285). It is fully compliant with the AGENTS.md rule — and still dies, because the rule covers "any Python read of a repo source file" and says nothing about reading a **subprocess's** output. Compliance wasn't sufficient.

That's a fix class #779 didn't originally name, and it isn't rare: **39 `text=True` / `universal_newlines=True` sites without `encoding=`, across 23 files.** Worth extending the AGENTS.md encoding rule to cover it, so the next person pinning reads doesn't stop one layer short like I did.

`errors="replace"` rather than strict: this is a diagnostic read of third-party tool output, and degrading a stray byte to `�` is better than aborting a compose-coverage check.

## Verification

| Check | Result |
|---|---|
| `test-patch-attribution`, normal locale | PASS |
| `test-patch-attribution`, `PYTHONUTF8=0 PYTHONCOERCECLOCALE=0 LC_ALL=C` | **PASS** (was failing) |
| Full suite, normal locale | **84 / 0** |
| Full suite, C locale | 42 → **43** pass |

## Honest framing

One site, one test. I measured this specifically to find out whether #779 had a high-yield core worth a bounded pass — it doesn't. The 42 failures are diffuse, each tripping on its own sites across five classes (~220 sites, 50+ files). Details and the revised sizing are in #779.

This ships because it's correct and verified, not because it moves the needle much. The genuinely useful next step there is a **locale gate** asserting the pass count (now 43) so the number can only ratchet up — deliberately not bundled here, since a suite-under-C-locale gate needs its own design (it has to exclude itself, and it costs ~3 min of wall clock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
