### PR TITLE
fix(scripts): guarantee Python UTF-8 mode + gate it (#779)

### DIFF
--- a/scripts/arch-ab.sh
+++ b/scripts/arch-ab.sh
@@ -38,6 +38,15 @@
 # results/rebench/246-ab-bundle-<host>-<date>.tgz to attach to issue #246.
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 # shellcheck source=lib/compose-meta.sh

--- a/scripts/bench-agentic.sh
+++ b/scripts/bench-agentic.sh
@@ -65,6 +65,15 @@
 
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 if [[ -f "${ROOT_DIR}/scripts/preflight.sh" ]]; then
   # shellcheck source=preflight.sh

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -72,6 +72,15 @@
 
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 # Auto-detect running container + port (URL/CONTAINER env vars still win).
 # See scripts/preflight.sh::preflight_autodetect_endpoint.
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/catalog-baseline.sh
+++ b/scripts/catalog-baseline.sh
@@ -53,6 +53,15 @@
 #                        tests point this at a copy)
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/concurrency-probe.sh
+++ b/scripts/concurrency-probe.sh
@@ -34,6 +34,15 @@
 #   SWEEP ("" = single-N) · SLUG (required for SWEEP) · SWEEP_DRY (0) ·
 #   BOOT_TIMEOUT (360).
 set -euo pipefail
+
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 
 URL="${URL:-http://localhost:8010}"

--- a/scripts/diagnose-estate.sh
+++ b/scripts/diagnose-estate.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 exec python3 "${ROOT_DIR}/scripts/lib/profiles/estate_cli.py" diagnose "$@"

--- a/scripts/diagnose-profile.sh
+++ b/scripts/diagnose-profile.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 exec python3 "${ROOT_DIR}/scripts/lib/profiles/diagnose_profile_cli.py" "$@"

--- a/scripts/engine-pin-bump.sh
+++ b/scripts/engine-pin-bump.sh
@@ -40,6 +40,15 @@
 # Exit: 0 on success/clean check; 2 on refusal (unknown engine, no-op, malformed ref).
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT="${PIN_BUMP_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 
 ENGINE_ID="" NEW_REF_ARG="" CHECK=0

--- a/scripts/generate-compose.sh
+++ b/scripts/generate-compose.sh
@@ -18,5 +18,14 @@
 # thin argv pass-through, matching the diagnose-profile.sh pattern).
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 exec python3 "${ROOT_DIR}/scripts/lib/generate_compose.py" "$@"

--- a/scripts/gpu-mode.sh
+++ b/scripts/gpu-mode.sh
@@ -5,6 +5,15 @@
 
 set -e
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 # Repo root: auto-detected from this script's real location (resolving the
 # /usr/local/bin/gpu-mode symlink on the reference rig), so the script is portable to
 # any clone. Override with CLUB3090_DIR=... if needed.

--- a/scripts/health.sh
+++ b/scripts/health.sh
@@ -25,6 +25,15 @@
 
 set -uo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 URL="${URL:-http://localhost:8020}"
 CONTAINER="${CONTAINER:-}"
 LOG_LINES="${LOG_LINES:-200}"

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -52,6 +52,15 @@
 
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 # The VRAM-budget block formats dot-decimal numbers emitted by kv-calc.py JSON
 # (e.g. "9.0") with `printf "%.2f"`. Under a comma-decimal LC_NUMERIC locale
 # (de_DE, fr_FR, …) bash printf rejects the dot — `printf: 9.0: invalid number`

--- a/scripts/lib/bench-row-formatter.sh
+++ b/scripts/lib/bench-row-formatter.sh
@@ -7,6 +7,15 @@
 #   bench_row_section <rebench-tag-dir>
 #   bench_row_fixtures
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 _BENCH_ROW_LIB_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 _BENCH_ROW_ROOT="$(cd -- "${_BENCH_ROW_LIB_DIR}/../.." && pwd)"
 

--- a/scripts/lib/owui-register.sh
+++ b/scripts/lib/owui-register.sh
@@ -15,6 +15,15 @@
 # container→host path (works on the bundle's OWUI; on a setup without it, add the
 # host IP instead via Admin → Settings → Connections).
 set -uo pipefail
+
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
 PORT="${1:?usage: owui-register.sh <port> [owui_container]}"
 OWUI="${2:-${OWUI_CONTAINER:-open-webui}}"
 log(){ echo "[owui-register] $*"; }

--- a/scripts/lib/owui-unregister.sh
+++ b/scripts/lib/owui-unregister.sh
@@ -15,6 +15,15 @@
 # HS256 token forged from the container's secret (/app/backend/.webui_secret_key) +
 # the admin user id. Removes http://host.docker.internal:<port>/v1 and its paired key.
 set -uo pipefail
+
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
 PORT="${1:?usage: owui-unregister.sh <port> [owui_container]}"
 OWUI="${2:-${OWUI_CONTAINER:-open-webui}}"
 DOCKER="${DOCKER:-docker}"

--- a/scripts/lib/registry-emit.sh
+++ b/scripts/lib/registry-emit.sh
@@ -4,6 +4,15 @@
 # Source this file, declare the destination arrays in the caller, then call
 # derive_switch_variant_tables or derive_launch_variant_tables with ROOT_DIR.
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 registry_variant_rows() {
   local root="$1"
   python3 - "$root" <<'PY_EMIT'

--- a/scripts/pod.sh
+++ b/scripts/pod.sh
@@ -19,6 +19,15 @@
 # resolved to UUIDs at boot (#610 Phase A) so pods land on the cards they
 # claimed on both container runtimes (classic nvidia + CDI/NixOS).
 set -euo pipefail
+
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 ESTATE_CLI="${ROOT_DIR}/scripts/lib/profiles/estate_cli.py"
 

--- a/scripts/power-cap-sweep.sh
+++ b/scripts/power-cap-sweep.sh
@@ -136,6 +136,15 @@
 #   real curves — recording the cooling class is essential for cross-rig
 #   comparison. The script does NOT auto-detect this; you must specify.
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 set -euo pipefail
 
 # Defaults — override via flags

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -18,6 +18,15 @@
 # Hard failures get a one-line ERROR + a "Fix:" hint.
 
 # Avoid double-sourcing.
+
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
 [[ -n "${_PREFLIGHT_LOADED:-}" ]] && return 0
 _PREFLIGHT_LOADED=1
 _PREFLIGHT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/pull.sh
+++ b/scripts/pull.sh
@@ -65,6 +65,15 @@
 # `--dry-run` contract surface.
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Intercept --json (strictly additive). Absent -> the original exec path,

--- a/scripts/quality-test.sh
+++ b/scripts/quality-test.sh
@@ -22,6 +22,15 @@
 
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 # ---- usage / help ------------------------------------------------------------
 
 usage() {

--- a/scripts/rebench-full.sh
+++ b/scripts/rebench-full.sh
@@ -93,6 +93,15 @@
 #                       (finish_reason=length before the final answer).
 #
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 set -euo pipefail
 
 # --- canonical cwd ----------------------------------------------------------

--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -31,6 +31,15 @@
 
 set -uo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 DO_VERIFY=0
 DO_STRESS=0
 DO_SOAK=0

--- a/scripts/rerun-failed-packs.sh
+++ b/scripts/rerun-failed-packs.sh
@@ -35,6 +35,15 @@
 # selection result — never a canonical pack total).
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -41,6 +41,15 @@
 
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 WEIGHTS_READER="${ROOT_DIR}/scripts/lib/profiles/weights.py"
 

--- a/scripts/soak-test.sh
+++ b/scripts/soak-test.sh
@@ -82,6 +82,15 @@
 #   1 fail
 #   2 inconclusive / timeout / preflight could not run
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 set -euo pipefail
 
 usage() {

--- a/scripts/spec-sweep.sh
+++ b/scripts/spec-sweep.sh
@@ -42,6 +42,15 @@
 #   TEMP        sampling temp for measured gens (default 0.6)
 #   SWEEP_DRY   1 = print the plan, boot/measure nothing
 set -euo pipefail
+
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/submit-bench.sh
+++ b/scripts/submit-bench.sh
@@ -9,6 +9,15 @@
 
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -70,6 +70,15 @@
 
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 COMPOSE_BIN="${COMPOSE_BIN:-docker compose}"
 READY_TIMEOUT="${READY_TIMEOUT:-600}"

--- a/scripts/tests/test-artifact-inventory.sh
+++ b/scripts/tests/test-artifact-inventory.sh
@@ -8,6 +8,15 @@
 # masquerade as a servable variant, and lineage must ride along.
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/tests/test-baselines.sh
+++ b/scripts/tests/test-baselines.sh
@@ -9,6 +9,15 @@
 # must not block on immediate re-bench; the debt just stays visible.
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/tests/test-bench-agentic-ramp.sh
+++ b/scripts/tests/test-bench-agentic-ramp.sh
@@ -6,6 +6,15 @@
 # success path (normal tool-call flow still works), fully offline (no GPU).
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/tests/test-catalog-baseline.sh
+++ b/scripts/tests/test-catalog-baseline.sh
@@ -8,6 +8,15 @@
 # the write-path upsert (both add and replace).
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/tests/test-classifier.sh
+++ b/scripts/tests/test-classifier.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 # test-classifier.sh — v0.8.0 [F] STEP F2 (club-3090 #147).
 #
 # Contract test for CONTRACT-2 Tier-2 + Appendix A: the §6.1 semantic-

--- a/scripts/tests/test-compose-image-drift.sh
+++ b/scripts/tests/test-compose-image-drift.sh
@@ -11,6 +11,15 @@
 #     launcher-injected var, so the literal is always in step with the engine.
 #   - pip-method engines (vllm-pip-baseline) — no docker image to match.
 set -euo pipefail
+
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 python3 - "$ROOT_DIR" <<'PY'

--- a/scripts/tests/test-compose-mounts-resolve.sh
+++ b/scripts/tests/test-compose-mounts-resolve.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 export PYTHONPATH="$ROOT_DIR${PYTHONPATH:+:$PYTHONPATH}"

--- a/scripts/tests/test-compose-nvlink-escape.sh
+++ b/scripts/tests/test-compose-nvlink-escape.sh
@@ -23,6 +23,15 @@
 #   docker compose -f <file> config   # a baked `[ "0" = "1" ]` == interpolated too early
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/tests/test-compose-registry-disk.sh
+++ b/scripts/tests/test-compose-registry-disk.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 export PYTHONPATH="$ROOT_DIR${PYTHONPATH:+:$PYTHONPATH}"

--- a/scripts/tests/test-compose-restart-policy.sh
+++ b/scripts/tests/test-compose-restart-policy.sh
@@ -16,6 +16,15 @@
 # composes already use a literal unless-stopped and are out of scope here.
 set -uo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/tests/test-compose-status-drift.sh
+++ b/scripts/tests/test-compose-status-drift.sh
@@ -10,6 +10,15 @@
 #   (c) the registry `status` is consistent with its compose header.
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 export PYTHONPATH="$ROOT_DIR${PYTHONPATH:+:$PYTHONPATH}"

--- a/scripts/tests/test-dedup.sh
+++ b/scripts/tests/test-dedup.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 # test-dedup.sh — v0.8.0 [F] STEP F5 (club-3090 #147).
 #
 # Contract test for CONTRACT-4: the §6.3 canonical-tuple-hash dedup +

--- a/scripts/tests/test-deepgemm-fp8-parity.sh
+++ b/scripts/tests/test-deepgemm-fp8-parity.sh
@@ -14,6 +14,15 @@
 # keeps them in sync.
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/tests/test-diagnose-estate.sh
+++ b/scripts/tests/test-diagnose-estate.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT

--- a/scripts/tests/test-diagnose-profile.sh
+++ b/scripts/tests/test-diagnose-profile.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 assert_contains() {

--- a/scripts/tests/test-download-lock.sh
+++ b/scripts/tests/test-download-lock.sh
@@ -9,6 +9,15 @@
 #   3. read_active_download reflects live-vs-stale.
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/tests/test-envelopes.sh
+++ b/scripts/tests/test-envelopes.sh
@@ -8,6 +8,15 @@
 # broken injection contract. An EMPTY envelopes file is valid.
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 HELPER="scripts/lib/profiles/launch_compat.py"

--- a/scripts/tests/test-estate-json.sh
+++ b/scripts/tests/test-estate-json.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT

--- a/scripts/tests/test-generate-compose.sh
+++ b/scripts/tests/test-generate-compose.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 # test-generate-compose.sh — v0.8.0 STEP 4 (club-3090 #141 / PR #147).
 #
 # Golden-parity + refusal/degraded contract for scripts/generate-compose.sh.

--- a/scripts/tests/test-generate-from-profile.sh
+++ b/scripts/tests/test-generate-from-profile.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 # test-generate-from-profile.sh — v0.8.0 [E] STEP E1 (club-3090 #141 / #147).
 #
 # Contract test for the ADDITIVE derived-emission path: EInput (CONTRACT-1),

--- a/scripts/tests/test-gpu-mode-list.sh
+++ b/scripts/tests/test-gpu-mode-list.sh
@@ -11,6 +11,15 @@
 # additive contract: an unknown mode still falls through to usage().
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/tests/test-gpu-select.sh
+++ b/scripts/tests/test-gpu-select.sh
@@ -9,6 +9,15 @@
 #   3. gpu_select_export sets both CUDA_ and NVIDIA_VISIBLE_DEVICES;
 #   4. the launcher sources the lib (no re-inlined resolver drift).
 set -euo pipefail
+
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 # shellcheck source=../lib/gpu-select.sh

--- a/scripts/tests/test-hf-home-resolve.sh
+++ b/scripts/tests/test-hf-home-resolve.sh
@@ -5,6 +5,15 @@
 # footgun that misplaced a brought model's weights). Precedence asserted:
 #   --hf-home > $HF_HOME > $MODEL_DIR/.cache/hf (env OR .env) > $XDG > ~/.cache
 set -euo pipefail
+
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/tests/test-hf-repos-resolve.sh
+++ b/scripts/tests/test-hf-repos-resolve.sh
@@ -9,6 +9,15 @@
 # Run it manually or periodically (HF rate-limits, so not every commit).
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 if [[ "${CLUB3090_CHECK_HF_REPOS:-0}" != "1" ]]; then

--- a/scripts/tests/test-hwdetect.sh
+++ b/scripts/tests/test-hwdetect.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 # test-hwdetect.sh — v0.8.2 STEP V4 (CONTRACT-3 §8: optional whichllm
 # hardware-detect-ONLY subprocess).
 #

--- a/scripts/tests/test-kv-calc-fit.sh
+++ b/scripts/tests/test-kv-calc-fit.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 # test-kv-calc-fit.sh — fixture test for `tools/kv-calc.py --fit … --json`.
 #
 # Contract: `--fit <slug|model> --card <gpu> --json` emits

--- a/scripts/tests/test-kv-generic-dense.sh
+++ b/scripts/tests/test-kv-generic-dense.sh
@@ -14,6 +14,15 @@
 #      / SWA-only fixtures (no number emitted on ineligible).
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/tests/test-kvcalc-version.sh
+++ b/scripts/tests/test-kvcalc-version.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 # test-kvcalc-version.sh — v0.8.0 [F] STEP F6 (club-3090 #147).
 #
 # CONTRACT-5 (iii) — the MANDATORY G2 regression. Asserts the

--- a/scripts/tests/test-launch-compat.sh
+++ b/scripts/tests/test-launch-compat.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 HELPER="${ROOT_DIR}/scripts/lib/profiles/launch_compat.py"
 GPU_3090='0|RTX_3090|24576|8.6'

--- a/scripts/tests/test-launch-registry-parity.sh
+++ b/scripts/tests/test-launch-registry-parity.sh
@@ -2,6 +2,15 @@
 # PR-B — launch.sh tables are derived from compose_registry.py.
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/tests/test-list-topology-filter.sh
+++ b/scripts/tests/test-list-topology-filter.sh
@@ -10,6 +10,15 @@
 # PR-B's Defaults view.
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/tests/test-lmcache-env-passthrough.sh
+++ b/scripts/tests/test-lmcache-env-passthrough.sh
@@ -9,6 +9,15 @@
 # (e.g. L1=30, L2 off) even when the user launches with LMCACHE_L1_GB/LMCACHE_L2.
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/tests/test-locale-utf8.sh
+++ b/scripts/tests/test-locale-utf8.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-locale-utf8.sh — the non-UTF-8-locale guarantee (#779).
+#
+# Repo sources are full of unicode (— × → ⚠). On a rig whose locale is neither
+# UTF-8 nor C, Python decodes file reads, stdout AND sys.argv with the locale
+# codec, which crashed large parts of the script layer: on a real
+# en_US.ISO-8859-1 locale the suite was 46 pass / 38 fail.
+#
+# Python already auto-enables UTF-8 mode (PEP 540) for the C/POSIX locale, so
+# `LC_ALL=C` alone is NOT the at-risk case and cannot demonstrate any of this.
+# The at-risk case is a genuine single-byte locale (de_DE.iso88591 and friends),
+# where UTF-8 mode stays off. Every script that runs python3 therefore exports
+# PYTHONUTF8, which covers reads, writes, stdout and argv in one move — the argv
+# class especially, where no `encoding=` pin can help (surrogateescape, #777).
+#
+# `${PYTHONUTF8:-1}` and not `=1`: a user who deliberately sets PYTHONUTF8=0
+# keeps control. We supply the default, we don't override an explicit choice.
+#
+# Asserts:
+#   (a) every python3-invoking script under scripts/ exports PYTHONUTF8 — this
+#       is the invariant that DECAYS, since a new script silently reintroduces
+#       the bug and nothing else would notice;
+#   (b) the export precedes the first python3 use in each file (an export below
+#       the call site is inert);
+#   (c) it defaults rather than forces, so an explicit PYTHONUTF8=0 still wins;
+#   (d) functionally, with a REAL single-byte locale when one can be built:
+#       representative scripts run clean and emit unicode intact. Skipped with a
+#       printed note when `localedef` is unavailable — never silently passed.
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+fail() {
+  echo "ASSERTION FAILED: $*" >&2
+  exit 1
+}
+
+# --- (a)+(b)+(c) the static invariant -------------------------------------
+missing=()
+late=()
+forced=()
+checked=0
+
+# A python3 mention inside a COMMENT is not an invocation — including the very
+# comment this convention ships with, which names python3 in its own text. Match
+# only executable lines, or every file self-reports as broken.
+first_python3_line() {
+  # `|| true` throughout: `set -o pipefail` is on, and a grep that legitimately
+  # matches nothing exits 1, which would abort this test with NO message at all.
+  grep -nE '(^|[^a-z-])python3' "$1" 2>/dev/null | grep -vE '^[0-9]+:[[:space:]]*#' | head -1 | cut -d: -f1 || true
+}
+
+while IFS= read -r f; do
+  # This gate is exempt from its own rule: its probes deliberately set and unset
+  # PYTHONUTF8 to prove both directions, so a blanket export would make them
+  # vacuous. (It also self-matches on its own function name and grep pattern.)
+  [[ "${f##*/}" == "test-locale-utf8.sh" ]] && continue
+
+  # Skip files that never actually invoke python3 — nothing to protect.
+  first_py="$(first_python3_line "$f")"
+  [[ -n "$first_py" ]] || continue
+  checked=$((checked + 1))
+
+  if ! grep -q 'export PYTHONUTF8' "$f"; then
+    missing+=("$f")
+    continue
+  fi
+
+  export_line="$(grep -n 'export PYTHONUTF8' "$f" | head -1 | cut -d: -f1 || true)"
+  if (( export_line > first_py )); then
+    late+=("$f (export at ${export_line}, first python3 at ${first_py})")
+  fi
+
+  # Must DEFAULT, not force: `${PYTHONUTF8:-1}` keeps an explicit 0 working.
+  if grep -qE '^export PYTHONUTF8=1\s*$' "$f"; then
+    forced+=("$f")
+  fi
+done < <(find scripts -maxdepth 2 -name '*.sh' -type f | sort)
+
+if (( ${#missing[@]} > 0 )); then
+  echo "ASSERTION FAILED: script(s) run python3 without exporting PYTHONUTF8 (#779)." >&2
+  printf '  %s\n' "${missing[@]}" >&2
+  echo "  Fix: add near the top, above the first python3 call:" >&2
+  echo '    export PYTHONUTF8="${PYTHONUTF8:-1}"' >&2
+  exit 1
+fi
+
+if (( ${#late[@]} > 0 )); then
+  echo "ASSERTION FAILED: PYTHONUTF8 exported BELOW the first python3 call (inert)." >&2
+  printf '  %s\n' "${late[@]}" >&2
+  exit 1
+fi
+
+if (( ${#forced[@]} > 0 )); then
+  echo "ASSERTION FAILED: PYTHONUTF8 forced to 1 instead of defaulted." >&2
+  printf '  %s\n' "${forced[@]}" >&2
+  echo '  Use `export PYTHONUTF8="${PYTHONUTF8:-1}"` so an explicit 0 still wins.' >&2
+  exit 1
+fi
+
+(( checked >= 80 )) || fail "expected to check 80+ python3-invoking scripts, checked ${checked} (discovery broke?)"
+
+# --- (d) functional leg on a REAL single-byte locale -----------------------
+# Synthesized rather than assumed: modern minimal images ship C.UTF-8 and often
+# no single-byte locale at all, so there is usually nothing installed to test
+# against — which is precisely why this class went unnoticed for so long.
+if ! command -v localedef >/dev/null 2>&1; then
+  echo "test-locale-utf8: ok (static invariant over ${checked} scripts; functional leg SKIPPED — localedef unavailable)"
+  exit 0
+fi
+
+TMP_LOC="$(mktemp -d)"
+trap 'rm -rf "$TMP_LOC"' EXIT
+
+if ! localedef -f ISO-8859-1 -i en_US "${TMP_LOC}/en_US.ISO-8859-1" >/dev/null 2>&1; then
+  echo "test-locale-utf8: ok (static invariant over ${checked} scripts; functional leg SKIPPED — localedef could not build ISO-8859-1)"
+  exit 0
+fi
+
+hostile=(env "LOCPATH=${TMP_LOC}" LC_ALL=en_US.ISO-8859-1 LANG=en_US.ISO-8859-1)
+
+# Sanity-check the hostile env is actually hostile — otherwise this leg proves
+# nothing. PYTHONUTF8 is explicitly cleared here so we observe the raw locale.
+# `-u` must precede the assignments: `env FOO=1 -u BAR cmd` treats `-u` as the
+# command name, not an option.
+raw_mode="$(env -u PYTHONUTF8 "LOCPATH=${TMP_LOC}" LC_ALL=en_US.ISO-8859-1 LANG=en_US.ISO-8859-1 \
+  python3 -c 'import sys; print(sys.flags.utf8_mode)')"
+[[ "$raw_mode" == "0" ]] || fail "synthesized locale did not disable UTF-8 mode (utf8_mode=${raw_mode}); the functional leg would be vacuous"
+
+# A script's exported default must reach the python3 it spawns.
+probe="$("${hostile[@]}" bash -c '
+  export PYTHONUTF8="${PYTHONUTF8:-1}"
+  python3 -c "import sys; print(sys.flags.utf8_mode, sys.stdout.encoding)"
+')"
+[[ "$probe" == "1 utf-8" ]] || fail "the exported default did not reach the child python (got: ${probe})"
+
+# An explicit 0 must still win — we default, we do not override.
+probe0="$("${hostile[@]}" PYTHONUTF8=0 bash -c '
+  export PYTHONUTF8="${PYTHONUTF8:-1}"
+  python3 -c "import sys; print(sys.flags.utf8_mode)"
+')"
+[[ "$probe0" == "0" ]] || fail "an explicit PYTHONUTF8=0 was overridden (got: ${probe0}); the default must not force"
+
+# End to end: a real script that reads unicode-bearing repo sources and prints
+# unicode must produce BYTE-IDENTICAL output under both locales. Stronger than
+# probing for one character — it catches silent mojibake as well as crashes,
+# which matters because a single-byte locale DECODES any byte happily and
+# corrupts quietly rather than raising (only the encode side blows up).
+if ! ref="$(bash scripts/switch.sh --list 2>&1)"; then
+  fail "switch.sh --list failed under the NORMAL locale; the comparison would be meaningless"
+fi
+if ! out="$("${hostile[@]}" bash scripts/switch.sh --list 2>&1)"; then
+  echo "ASSERTION FAILED: switch.sh --list failed under a real ISO-8859-1 locale" >&2
+  echo "$out" | tail -20 >&2
+  exit 1
+fi
+# Guard against a vacuous comparison: if the output were pure ASCII, matching
+# bytes would prove nothing about encoding at all.
+if ! printf '%s' "$ref" | grep -qP '[^\x00-\x7F]' 2>/dev/null; then
+  fail "switch.sh --list emitted no non-ASCII characters; this leg cannot detect an encoding fault"
+fi
+if [[ "$ref" != "$out" ]]; then
+  echo "ASSERTION FAILED: switch.sh --list output differs between locales (mojibake)." >&2
+  diff <(printf '%s' "$ref") <(printf '%s' "$out") | head -10 >&2
+  exit 1
+fi
+
+echo "test-locale-utf8: ok (static invariant over ${checked} scripts; functional leg on a real ISO-8859-1 locale)"

--- a/scripts/tests/test-loop-input.sh
+++ b/scripts/tests/test-loop-input.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 # test-loop-input.sh — v0.8.0 [F] STEP F1 (club-3090 #147).
 #
 # Contract test for CONTRACT-1: the `FInput` capture-bundle reader. The

--- a/scripts/tests/test-measurement-record.sh
+++ b/scripts/tests/test-measurement-record.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 # test-measurement-record.sh — producer-only measurement-record emitter.
 #
 # Validates scripts/lib/profiles/measurement_record.py WITHOUT a GPU or a

--- a/scripts/tests/test-model-default-resolver.sh
+++ b/scripts/tests/test-model-default-resolver.sh
@@ -14,6 +14,15 @@
 #   - community seam returns None today → skipped
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/tests/test-model-switch.sh
+++ b/scripts/tests/test-model-switch.sh
@@ -7,6 +7,15 @@
 # Real end-to-end switching is hardware-bound and validated manually.
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/tests/test-model-weights-registry.sh
+++ b/scripts/tests/test-model-weights-registry.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 READER="${ROOT_DIR}/scripts/lib/profiles/weights.py"
 

--- a/scripts/tests/test-parallel-boot.sh
+++ b/scripts/tests/test-parallel-boot.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT

--- a/scripts/tests/test-patch-attribution.sh
+++ b/scripts/tests/test-patch-attribution.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 python3 - "$ROOT_DIR" <<'PY'

--- a/scripts/tests/test-pod-cli.sh
+++ b/scripts/tests/test-pod-cli.sh
@@ -5,6 +5,15 @@
 #   create (with D1 fit) · count!=TP hard-reject · GPU-collision reject ·
 #   list --json · status · rm · the index-based estate file.
 set -euo pipefail
+
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 

--- a/scripts/tests/test-profiles-compat.sh
+++ b/scripts/tests/test-profiles-compat.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 export PYTHONPATH="$ROOT_DIR${PYTHONPATH:+:$PYTHONPATH}"

--- a/scripts/tests/test-pull-swap.sh
+++ b/scripts/tests/test-pull-swap.sh
@@ -25,6 +25,15 @@
 # swap derivation reuses the shipped read-only registry helpers directly.
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 export PYTHONPATH="$ROOT_DIR${PYTHONPATH:+:$PYTHONPATH}"

--- a/scripts/tests/test-pull.sh
+++ b/scripts/tests/test-pull.sh
@@ -23,6 +23,15 @@
 # goldens and an injected d_runner for the dry-run-refusal golden.
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 export PYTHONPATH="$ROOT_DIR${PYTHONPATH:+:$PYTHONPATH}"

--- a/scripts/tests/test-pullemit-capture.sh
+++ b/scripts/tests/test-pullemit-capture.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 # test-pullemit-capture.sh — v0.8.0 [E] STEP E3 (club-3090 #141 / #147).
 #
 # Contract test for CONTRACT-4 (E3 half): the derived BOOT stage

--- a/scripts/tests/test-pullgate-deriver.sh
+++ b/scripts/tests/test-pullgate-deriver.sh
@@ -22,6 +22,15 @@
 #      the old drop-unknown-keys behaviour).
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 export PYTHONPATH="$ROOT_DIR${PYTHONPATH:+:$PYTHONPATH}"

--- a/scripts/tests/test-pullgate-download.sh
+++ b/scripts/tests/test-pullgate-download.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 # test-pullgate-download.sh — v0.8.0 [E] STEP E2 (club-3090 #141 / #147).
 #
 # Contract test for CONTRACT-3: the HF download stage. The test IS the spec;

--- a/scripts/tests/test-pullgate-gates.sh
+++ b/scripts/tests/test-pullgate-gates.sh
@@ -25,6 +25,15 @@
 #   design-lock: [C0] state set is EXACTLY the locked 3.
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 export PYTHONPATH="$ROOT_DIR${PYTHONPATH:+:$PYTHONPATH}"

--- a/scripts/tests/test-registry-json.sh
+++ b/scripts/tests/test-registry-json.sh
@@ -9,6 +9,15 @@
 # additive).
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/tests/test-repack-prefix.sh
+++ b/scripts/tests/test-repack-prefix.sh
@@ -4,6 +4,15 @@
 # ──────────────────────────────────────────────────────────────────────────────
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
 TMP=$(mktemp -d)

--- a/scripts/tests/test-stream-toolcall-probe.sh
+++ b/scripts/tests/test-stream-toolcall-probe.sh
@@ -4,6 +4,15 @@
 # the probe classifies + exit-codes each correctly. No GPU / real model needed.
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/tests/test-submit-bench.sh
+++ b/scripts/tests/test-submit-bench.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 # test-submit-bench.sh — BENCHMARKS.md row formatter + submit-bench.sh plumbing.
 #
 # SELF-CONTAINED BY CONSTRUCTION (#776). This test used to require six specific

--- a/scripts/tests/test-submit-pull.sh
+++ b/scripts/tests/test-submit-pull.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 # test-submit-pull.sh — v0.8.2 STEP V2 (CONTRACT-1.2 / 1.3).
 #
 # Contract test for the user-invoked, consented failure on-ramp:

--- a/scripts/tests/test-switch-explain.sh
+++ b/scripts/tests/test-switch-explain.sh
@@ -19,6 +19,15 @@
 # --explain with no slug errors).
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/tests/test-switch-registry-parity.sh
+++ b/scripts/tests/test-switch-registry-parity.sh
@@ -2,6 +2,15 @@
 # CONTRACT-2b-ii — switch.sh ↔ compose_registry.py parity.
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/tests/test-trust-pipeline.sh
+++ b/scripts/tests/test-trust-pipeline.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 # test-trust-pipeline.sh — v0.8.0 [F] STEP F4 (club-3090 #147).
 #
 # Contract test for CONTRACT-3 + CONTRACT-3a: the §6.2 inbound-trust

--- a/scripts/tests/test-verify-stress-ceiling.sh
+++ b/scripts/tests/test-verify-stress-ceiling.sh
@@ -11,6 +11,15 @@
 #   9. Small compose skips the ladder (ceiling ≤ start)
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/tests/test-weights-revision.sh
+++ b/scripts/tests/test-weights-revision.sh
@@ -8,6 +8,15 @@
 # written to.
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 

--- a/scripts/verify-full.sh
+++ b/scripts/verify-full.sh
@@ -43,6 +43,15 @@
 
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 RUN_BENCH=0
 for arg in "$@"; do
   case "$arg" in

--- a/scripts/verify-stress.sh
+++ b/scripts/verify-stress.sh
@@ -84,6 +84,15 @@
 #                          (default: 240, auto-bumped to 480 if container has
 #                          VLLM_ENFORCE_EAGER=1).
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 set -euo pipefail
 
 # Auto-detect running container + port (URL/CONTAINER env vars still win).

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -19,6 +19,15 @@
 
 set -euo pipefail
 
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
 # Auto-detect running container + port + served model (env vars still win).
 # See scripts/preflight.sh::preflight_autodetect_endpoint / _model.
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"


### PR DESCRIPTION
Closes #779.

On a rig whose locale is neither UTF-8 nor C, Python decodes file reads, stdout **and** `sys.argv` with the locale codec. Repo sources are full of unicode, so large parts of the script layer died there — on a real `en_US.ISO-8859-1` locale the suite was **46 pass / 38 fail**.

## Two corrections to how I originally framed this issue

**1. `LC_ALL=C` was never the at-risk case.** I wrote in #779 that a user on `LC_ALL=C` "plausibly cannot pull, generate a compose, or diagnose a profile." Wrong — Python auto-enables UTF-8 mode (PEP 540) for the C/POSIX locale:

```
LC_ALL=C                                       utf8_mode=1  stdout=utf-8   <-- protected
LC_ALL=C PYTHONCOERCECLOCALE=0 PYTHONUTF8=0    utf8_mode=0  stdout=ascii   <-- only failing config
```

Every failure in the issue required `PYTHONUTF8=0` **explicitly set**. The genuinely at-risk case is a single-byte locale (`en_US.ISO-8859-1`, `de_DE.iso88591`) where UTF-8 mode stays off. This PR is verified against exactly that — synthesized with `localedef`, since no such locale is installed on any rig here, which is itself why the class went unnoticed.

**2. It is not a 220-site sweep.** I'd measured one site fixed flipping one test and concluded "long tail, no shortcut". True per-site, but I was counting sites instead of looking for a systemic lever. UTF-8 mode covers reads, writes, stdout **and** argv in one move — including the argv `surrogateescape` class that no `encoding=` pin can fix (#777).

## The change

`export PYTHONUTF8="${PYTHONUTF8:-1}"` in the 89 scripts that invoke python3, above their first call. Exported, so nested scripts and child processes inherit it.

**Defaulted, not forced** — a user who deliberately sets `PYTHONUTF8=0` keeps control. We supply the default; we don't override an explicit choice.

## The gate is the point

`test-locale-utf8.sh`, because the invariant is what **decays**: a new script silently reintroduces the bug and nothing else would notice. That's exactly how the codebase reached this state despite AGENTS.md already carrying the encoding rule.

Static: the export exists, sits **above** the first python3 call (below it is inert), and defaults rather than forces. A python3 mention inside a comment doesn't count — including the convention's own comment, which names python3 in its text and made every file self-report as broken on the first run.

Functional, on a real ISO-8859-1 locale built with `localedef`: the hostile env genuinely disables UTF-8 mode (else the leg is vacuous), the export reaches the child python, an explicit `0` still wins, and `switch.sh --list` emits **byte-identical** output under both locales. Byte-identical rather than probing for one character, because a single-byte locale decodes any byte happily and corrupts **quietly** — only the encode side raises, so a character probe would miss silent mojibake. Skips with a printed note where `localedef` is unavailable, never silently.

## Verification

| Check | Result |
|---|---|
| Full suite, normal locale | **85 / 0** |
| Full suite, real `en_US.ISO-8859-1` | **85 / 0** (master: 46 / 38) |
| Gate bites: export removed | names the file + prints the fix |
| Gate bites: export moved below first call | `export at 326, first python3 at 111` |
| Explicit `PYTHONUTF8=0` | still honoured |

Both gate failure modes were confirmed by breaking the fix and re-running, not assumed.

## Follow-ups, not in this PR

- **AGENTS.md's encoding rule should be amended** to lead with this guarantee, keep explicit `encoding=` as defence-in-depth for the **write** class specifically (where a half-applied fix destroys data — #777/#780: 180693 bytes → 0), and add the subprocess class from #781. Docs change, deliberately separate.
- A `.py` tool invoked directly (`python3 tools/kv-calc.py`) on a single-byte locale is still exposed — no shell script is involved to export the var. In-repo callers all go through the scripts, so nothing here regresses.
- The per-site pins already landed (#778/#780/#781) stay: still correct, and they hold if the env var is ever overridden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
