### PR TITLE
fix(preflight): gate qwen-35b-a3b-dual-nvfp4 on homogeneous arch, and make the class drift-proof (#783)

### DIFF
--- a/models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4/fp8.yml
+++ b/models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4/fp8.yml
@@ -48,6 +48,20 @@
 # Engine-profile: vllm-stable
 # Requires-min-gpu-count: 2
 # Tensor-parallel: 2
+# Requires-homogeneous-arch: true
+#   ^ arch-gated activation path -- this is the nvidia modelopt NVFP4 export,
+#     whose FP8 attention layers hardcode FlashInferFP8ScaledMMLinearKernel in
+#     modelopt.py and BYPASS the shared kernel selector, so no per-rank fallback
+#     exists to reach. On a mixed pair the lower-capability rank dies with
+#     `BackendSupportedError: No suitable auto backends found for bmm_fp8`
+#     (modelopt.py:536 -> flashinfer_scaled_fp8_mm -> bmm_fp8), in the GDN
+#     in_proj_qkvz during profile_run. Measured on 5090 sm_120 + 3090 Ti sm_86,
+#     club-3090 #783 / disc #768 Test 3.
+#     NOTE: fallback_sm reasons PER CARD, but a weight-only fallback is a
+#     property of the whole TP GROUP -- valid per card, invalid across ranks.
+#     Sibling `dual/nvfp4-fast/fp8.yml` is compressed-tensors, NOT modelopt:
+#     it routes through init_fp8_linear_kernel() where Marlin is reachable, so
+#     it is deliberately NOT gated here.
 services:
   vllm-qwen36-35b-a3b-dual-nvfp4:
     # Pinned to a vLLM STABLE release (immutable, #407); the launchers inject

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -77,6 +77,28 @@ def _entry(
     default_port,
     kvcalc_key=None,
     requires_nvlink=False,
+    # True when the slug has an ARCH-GATED kernel path that torch.compile (or a
+    # hardcoded quant-method kernel) emits PER RANK, so a mixed-compute-capability
+    # TP group must be REFUSED rather than warned. The canonical case is a
+    # quantization method that bypasses the shared kernel selector and therefore
+    # has no per-rank fallback to reach — nvidia modelopt NVFP4 hardcodes
+    # FlashInferFP8ScaledMMLinearKernel for its FP8 attention layers, so a
+    # sub-sm_90 rank in the group dies even though `fallback_sm` says that card
+    # is individually fine (fallback_sm reasons per card; the weight-only
+    # fallback is a property of the whole TP GROUP).
+    #
+    # ⚠️ NOT every NVFP4 slug: compressed-tensors exports (unsloth `nvfp4-fast`,
+    # migtissera tess) route through init_fp8_linear_kernel() -> shared selector,
+    # where Marlin IS reachable — mixed-arch is solvable there and gating them
+    # would foreclose it (validated on DiffusionGemma, disc #768 Test 6).
+    # The axis is the QUANT RUNTIME, not the weights_variant string.
+    #
+    # Mirrored by `# Requires-homogeneous-arch: true` in the compose header,
+    # which is what preflight.sh actually reads. `test-homogeneous-arch-drift`
+    # asserts the two agree in BOTH directions — #762 shipped the guard on only
+    # the reported slug and the 35B-A3B sibling silently kept crash-looping
+    # (#783). TP=1 slugs never need this: there is no TP group to disagree.
+    requires_homogeneous_arch=False,
     required_engine_features=None,
     recommended_engine_features=None,
     required_sm=None,
@@ -109,6 +131,7 @@ def _entry(
         "mem_util": mem_util,
         "compose_path": compose_path,
         "requires_nvlink": requires_nvlink,
+        "requires_homogeneous_arch": requires_homogeneous_arch,
         "required_engine_features": list(required_engine_features or []),
         "default_port": default_port,
         "gpu_assignment_mode": "contiguous",
@@ -302,6 +325,7 @@ COMPOSE_REGISTRY = {
         tp=2, max_ctx=262144, max_num_seqs=2, mem_util=0.92,
         compose_path="models/qwen3.6-27b/vllm/compose/dual/nvfp4/mtp.yml",
         default_port=8077, required_sm=9.0, fallback_sm=7.5,
+        requires_homogeneous_arch=True,
         kvcalc_key="qwen3.6-27b:nvfp4-dual",
         status="experimental",
         status_note="Qwen3.6-27B NVFP4 (nvidia modelopt MIXED_PRECISION — see single-nvfp4) at TP=2 @262K full ctx, 2x Hopper/Blackwell native (the 2x 5090 configuration is the primary community target; fallback_sm=7.5). HOMOGENEOUS RIGS ONLY (#762 @paulp83): mixed-arch TP crashes in torch.compile AOT -- a 5090 sm_120 + 3090 Ti sm_86 pair loads weights fine via the Marlin fallback, then the Inductor emits `tl.float8e4nv` MXFP8 ACTIVATION kernels the Ampere rank cannot compile (`type fp8e4nv not supported in this architecture`); TP1 dies, TP0 hangs on the broadcast. fallback_sm reasons PER CARD but the weight-only fallback is a property of the whole TP GROUP -- guarded from 2026-07-26 by Requires-homogeneous-arch in preflight. LIVE-VALIDATED ON 2x3090 sm_86 (HOMOGENEOUS) 2026-07-11 via the Marlin W4A16 fallback: boots @262K + fp8 KV + MTP n=3 (accept 97%+), 69.7 narr / 85.5 code decode TPS, 23.77 GB/card, 8-pack think-off 110/150 — statistically TIES the fp8 production tier's 109 (weight-identical path; native-FP4 activations unmeasured). On Ampere it works but has NO edge (~20% slower than the AutoRound tier for the same model) — prefer AutoRound/fp8 there; this slug's value on sub-sm_90 cards is models/cases where NVFP4 is the only quant. First native-FP4 community boot + rebench-full still wanted (funnel). Mirrors vllm/qwen-27b-dual-max's shape (TP=2 + MTP n=3 + fp8/e4m3 KV + vision @262K) with NVFP4 weights instead of FP8: ~11 GB/card weights vs dual-max's 14.5 — bigger KV pool headroom on 32 GB cards. On native-FP4 GEMM parts (Blackwell) NVIDIA claims near-fp8 throughput at 2.5x less weight memory. No DEFAULTS row (opt-in only).",
@@ -872,6 +896,7 @@ COMPOSE_REGISTRY = {
         tp=2, max_ctx=262144, max_num_seqs=1, mem_util=0.92,
         compose_path="models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4/fp8.yml",
         default_port=8079, required_sm=9.0, fallback_sm=7.5,
+        requires_homogeneous_arch=True,
         kvcalc_key="qwen3.6-35b-a3b:nvfp4-dual",
         status="experimental",
         status_note="Qwen3.6-35B-A3B NVFP4 (see single-nvfp4) at TP=2 @262K full ctx, 2x Hopper/Blackwell native (2x 5090 primary community target; ~11.7 GB/card weights; fallback_sm=7.5 — sub-9.0 cards run it via the Marlin W4A16 fallback, validated on the 27B sibling 2026-07-11, though on Ampere the AutoRound tier serves this model faster). 🧪 first community boot + rebench-full validates. Mirrors vllm/qwen-35b-a3b-dual's shape (no drafter — MTP net-negative on this MoE, vision on, thinking off) with NVFP4 weights + fp8/e4m3 KV instead of AutoRound + e5m2. No DEFAULTS row (opt-in only).",
@@ -996,6 +1021,7 @@ COMPOSE_REGISTRY = {
         tp=4, max_ctx=200000, max_num_seqs=1, mem_util=0.85,
         compose_path="models/nemotron-3-puzzle-75b/vllm/compose/multi4/nvfp4/mtp.yml",
         default_port=8095, required_sm=9.0, fallback_sm=7.5,
+        requires_homogeneous_arch=True,
         kvcalc_key="SKIP",
         status="caveats",
         status_note="Nemotron-3 Puzzle 75B-A9B NVFP4 (nvidia modelopt MIXED: NVFP4 routed-expert FFNs + FP8 Mamba/shared projections), 4-card TP=4 @200K single-stream, built-in MTP via --speculative-config. Mamba2-Transformer hybrid LatentMoE, 9.3B active / 75.3B total. 🧪 Experimental — CANNOT be booted/validated on the maintainer's 2x3090 rig (needs 4x3090); shown in switch.sh --list, launch requires --force. fp8_e4m3 attention KV (checkpoint-declared) + fp16 Mamba SSM state (stochastic-rounded; never fp8). kv-calc bypassed (hybrid arch, no spec → kvcalc SKIP + model kv_calc_supported=false). NVIDIA supported-HW = Blackwell+Hopper ONLY; arch NemotronHPuzzleForCausalLM aliases to the NemotronH loader (registered v0.24.0 + v0.25.0; card tested v0.20.0) and CONFIRMED to run on 4x3090 (#706, @TheFuzy: weights 13.31 GiB/card, arch/quant/mamba/MTP all work on Ampere). This config is FIT-TUNED for 24 GB after our first cut OOM'd at 262K single-stream (profile-run prefill blew up with chunked-prefill off): chunked prefill ON + max-num-batched-tokens 8192 + max-model-len 200000 + fp8 KV. Concurrency (max_num_seqs>1 + --long-prefill-token-threshold) is a follow-up gated on a community VRAM report. FP8 sibling (83 GB) too big for 4x24GB → NVFP4 is the only quad-3090 fit. No DEFAULTS row (opt-in only). Community-float to 4x3090 owners.",

--- a/scripts/tests/test-homogeneous-arch-drift.sh
+++ b/scripts/tests/test-homogeneous-arch-drift.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Drift-guard for the mixed-architecture TP refusal (#762, #783).
+#
+# `scripts/preflight.sh` reads `# Requires-homogeneous-arch: true` from the
+# COMPOSE HEADER. The registry carries the same fact as `requires_homogeneous_arch`.
+# Two sources, one truth — so they can drift, and drift here is expensive: the
+# failure mode is a user's 12-iteration crash-loop instead of a one-line refusal.
+#
+# That is exactly what happened. #762 shipped the guard on the single slug the
+# bug report named; the 35B-A3B modelopt sibling has the same hardcoded-kernel
+# property and stayed unguarded, crash-looping on mixed rigs until it surfaced
+# in disc #768 Test 3 (#783). A per-slug guard with no class-level check will
+# keep missing siblings.
+#
+# Three checks:
+#   (a) registry True  -> compose header MUST carry the marker (the #783 gap);
+#   (b) compose header -> registry MUST be True (no orphan headers preflight
+#       honours but the catalog/c3 can't see);
+#   (c) TP=1 slugs must NOT set it — there is no TP group to disagree, so a
+#       flag there is a copy-paste error that would refuse a valid single-card
+#       boot on a mixed rig.
+#
+# NOT asserted: that every nvfp4 slug is gated. The axis is the QUANT RUNTIME,
+# not the weights_variant string — compressed-tensors exports (unsloth
+# `nvfp4-fast`, migtissera tess) reach Marlin through the shared kernel
+# selector and mixed-arch is solvable for them (disc #768 Test 6, DiffusionGemma).
+# Gating by `weights_variant == "nvfp4"` would foreclose that. See #783.
+set -euo pipefail
+
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+export PYTHONPATH="$ROOT_DIR${PYTHONPATH:+:$PYTHONPATH}"
+
+python3 - <<'PY'
+import re
+import sys
+from pathlib import Path
+
+from scripts.lib.profiles.compose_registry import COMPOSE_REGISTRY
+
+# Matches what preflight.sh's compose_meta_get accepts: a header comment line
+# `# Requires-homogeneous-arch: <value>`, case-insensitive key, anywhere in the
+# leading comment block. Kept deliberately loose on whitespace so a reformat
+# doesn't silently disarm the guard.
+MARKER = re.compile(
+    r"^\s*#\s*Requires-homogeneous-arch\s*:\s*(\S+)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+TRUTHY = {"true", "yes", "1"}
+
+failures = []
+checked = 0
+gated = []
+
+for slug, entry in sorted(COMPOSE_REGISTRY.items()):
+    rel = entry.get("compose_path")
+    if not rel:
+        continue
+    path = Path(rel)
+    if not path.is_file():
+        # Missing compose files are the job of test-registry-json / the
+        # existence gates; don't duplicate (or double-report) them here.
+        continue
+
+    checked += 1
+    text = path.read_text(encoding="utf-8")
+    m = MARKER.search(text)
+    header_on = bool(m) and m.group(1).strip().lower() in TRUTHY
+    registry_on = bool(entry.get("requires_homogeneous_arch", False))
+    tp = entry.get("tp")
+
+    # (a) registry says gated, compose header doesn't -> preflight WON'T refuse.
+    #     This is the #783 bug: the fact was known, the enforcement point missed.
+    if registry_on and not header_on:
+        failures.append(
+            f"{slug}: registry requires_homogeneous_arch=True but "
+            f"{rel} has no `# Requires-homogeneous-arch: true` header — "
+            f"preflight reads the HEADER, so mixed-arch boots are NOT refused. "
+            f"This is the #783 failure mode."
+        )
+
+    # (b) header says gated, registry doesn't -> preflight refuses but the
+    #     catalog/c3/compat layer has no idea, so the slug looks launchable.
+    if header_on and not registry_on:
+        failures.append(
+            f"{slug}: {rel} carries `# Requires-homogeneous-arch: true` but the "
+            f"registry entry does not set requires_homogeneous_arch=True — "
+            f"preflight refuses while the catalog still advertises it."
+        )
+
+    # (c) TP=1 can't have a heterogeneous TP group. A flag here refuses a boot
+    #     that would have worked.
+    if (registry_on or header_on) and tp == 1:
+        failures.append(
+            f"{slug}: requires_homogeneous_arch set on a TP=1 slug (tp={tp}). "
+            f"A single-card slug has no TP group to disagree across; this would "
+            f"refuse a valid boot on a mixed rig."
+        )
+
+    if registry_on or header_on:
+        gated.append(f"{slug} (tp={tp})")
+
+if not checked:
+    print("FAIL test-homogeneous-arch-drift: no registered composes found on disk")
+    sys.exit(1)
+
+if failures:
+    print("FAIL test-homogeneous-arch-drift:")
+    for f in failures:
+        print(f"  - {f}")
+    sys.exit(1)
+
+print(
+    f"PASS test-homogeneous-arch-drift: {checked} composes checked, "
+    f"{len(gated)} arch-gated"
+)
+for g in gated:
+    print(f"  gated: {g}")
+PY


### PR DESCRIPTION
Closes #783.

## The bug

`vllm/qwen-35b-a3b-dual-nvfp4` crash-loops on a mixed-arch TP=2 pair instead of being refused by preflight. Evidence from [@paulp83's Test 3 in disc #768](https://github.com/noonghunna/club-3090/discussions/768), 5090 sm_120 + 3090 Ti sm_86:

```
BackendSupportedError: No suitable auto backends found for bmm_fp8
  modelopt.py:536 -> FlashInferFP8ScaledMMLinearKernel -> flashinfer_scaled_fp8_mm() -> bmm_fp8()
  Worker_TP1 (3090 Ti, sm_8.6), during profile_run(), GDN in_proj_qkvz
```

## Why the #762 guard missed it

**It was scoped to a crash signature, not to the property causing it.** #762 was `ValueError: type fp8e4nv not supported in this architecture` (Triton, torch.compile AOT). This is `BackendSupportedError ... bmm_fp8` (FlashInfer, no arch backend). Same root cause, different symptom, different layer — so a signature-matched guard let the sibling through, and the only thing that surfaced it was a contributor spending an evening on a crash-loop.

The property, from the analysis in #768:

- **modelopt** hardcodes `FlashInferFP8ScaledMMLinearKernel` for FP8 attention, **bypassing the shared kernel selector** → no per-rank fallback exists to reach.
- **compressed-tensors** goes through `init_fp8_linear_kernel()` → shared selector → **Marlin is reachable** → mixed-arch is solvable.

`fallback_sm` doesn't save us: it reasons **per card**, but the weight-only fallback is a property of the whole **TP group**.

## Changes

1. **`Requires-homogeneous-arch: true`** on `models/qwen3.6-35b-a3b/vllm/compose/dual/nvfp4/fp8.yml` — this is what `preflight.sh` actually reads. Verified end-to-end: `compose_meta_get <compose> requires-homogeneous-arch` now returns `true` (and still `UNSET` on the `-fast` sibling).

2. **New registry field `requires_homogeneous_arch`**, set on the three modelopt TP≥2 slugs:

   | slug | tp |
   |---|--:|
   | `vllm/qwen-27b-dual-nvfp4` | 2 |
   | `vllm/qwen-35b-a3b-dual-nvfp4` | 2 |
   | `vllm/nemotron-75b-multi-mtp` | 4 |

3. **New `test-homogeneous-arch-drift`** — the actual class fix. Two sources of one truth (compose header for preflight, registry for catalog/c3/compat) can drift, and drift costs a user a crash-loop. Asserts:
   - (a) registry `True` → compose header **must** carry the marker ← *the #783 gap*
   - (b) compose header → registry **must** be `True` (no orphan headers preflight honours but the catalog can't see)
   - (c) TP=1 slugs **must not** set it — no TP group to disagree across, so a flag there would refuse a valid boot

## Deliberately NOT gated

`vllm/qwen-35b-a3b-dual-nvfp4-fast` (unsloth) and `vllm/tess-dual-nvfp4` (migtissera) are **compressed-tensors**, not modelopt. Mixed-arch is potentially *solvable* for them via the DiffusionGemma route (guard-removal + `VLLM_TEST_FORCE_FP8_MARLIN`), which passed a full gate in #768 Test 6. Gating them would foreclose an experiment that's been asked for.

This is why the test does **not** assert "every nvfp4 slug is gated" — the axis is the quant runtime, not the `weights_variant` string. A `weights_variant == "nvfp4"` rule would have been simpler and wrong.

## Verification

The new test fails on each case it guards, not just passes on the fixed tree:

| injected fault | result |
|---|---|
| header removed from the gated compose | ✅ red, names #783 as the failure mode |
| orphan header on an ungated compose | ✅ red |
| flag set on a TP=1 slug | ✅ red (both checks fire) |
| restored | ✅ green, 68 composes checked, 3 arch-gated |

**Full suite: 86/86 PASS.**

## Not in scope

@paulp83's DiffusionGemma mixed-arch fix (vendored `marlin.py` guard removal + the six-compose env pass-throughs) is his work and still isn't upstreamed — tracked in disc #768, awaiting a PR from him. Worth noting the env pass-through half is a standalone bug (shell env vars silently dropped) that doesn't depend on any mixed-arch conclusion holding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfF565T9eSLaqGzidyJ1Pm
