### PR TITLE
fix(p2p): nccl_only verdict state — never claim custom-AR-ON that vLLM vetoes at world>2 (#786)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -68,9 +68,23 @@ contributor happened to mention. **Every `Rig` cell should state, in order:**
    [PCIE_P2P.md §7](docs/PCIE_P2P.md). **So this field is automatic on any run
    from 2026-07-05 onward** — the only rows missing it are older ones, and those
    can't be used in a P2P comparison.
-4. anything else non-default — virtualization, riser/PCIe gen, cooling.
+4. **resolved custom-all-reduce state** — `custom AR on` / `custom AR off` /
+   `custom AR off (vLLM >2-PCIe gate)`. This is a **silent recipe axis**: vLLM
+   force-disables its custom all-reduce at world_size > 2 without a FULLY-
+   connected NVLink mesh — pairwise 3090 bridges (2 bridges on 4 cards) do NOT
+   qualify (its gate checks 1-hop NVLink via NVML, never peer access — [#786](https://github.com/noonghunna/club-3090/issues/786),
+   found via [disc #773](https://github.com/noonghunna/club-3090/discussions/773)),
+   so **every dual row and every multi3+/multi4 PCIe row differ on this axis by
+   construction** — and dual rows split again between first-party (AR off via
+   `--disable-custom-all-reduce`, the no-P2P reference rig) and community
+   P2P/NVLink duals (AR on). A TP=2-vs-TP=4 comparison that doesn't state it is
+   comparing recipes, not topologies. `report.sh` resolves it in the
+   *Interconnect verdict* (the `via NCCL` wording = vLLM vetoed its kernel);
+   ground truth in any vLLM log is the presence/absence of the
+   `Custom allreduce is disabled…` line.
+5. anything else non-default — virtualization, riser/PCIe gen, cooling.
 
-`report.sh --full` captures all four automatically. It is only when a row is
+`report.sh --full` captures all five automatically. It is only when a row is
 hand-written that they go missing — which is exactly how the confound in the
 `multi-fast` @ryanmpelletier row (softened below) got published.
 

--- a/docs/PCIE_P2P.md
+++ b/docs/PCIE_P2P.md
@@ -112,7 +112,9 @@ From cross-rig data on this stack (2× 3090, TP=2):
 | DFlash / spec-decode path — patched P2P | **+19–22%** | [#95](https://github.com/noonghunna/club-3090/issues/95) |
 | NVLink hardware (reference, power-matched A/B) | **~+15%** | [#77](https://github.com/noonghunna/club-3090/issues/77) |
 
-**Translation:** code / spec-decode workloads see a real lift (the K+1 cross-card verify is bandwidth-bound, so it benefits most); narrative decode barely moves. The gain also grows with GPU count (more all-reduce traffic at TP=4). For most users the stock no-P2P PCIe path is already perfectly fine — **P2P is an enthusiast tuning lever, not a requirement.**
+**Translation:** code / spec-decode workloads see a real lift (the K+1 cross-card verify is bandwidth-bound, so it benefits most); narrative decode barely moves. For most users the stock no-P2P PCIe path is already perfectly fine — **P2P is an enthusiast tuning lever, not a requirement.**
+
+⚠️ **These are DUAL-card measurements — do not extrapolate them to 3+ GPUs.** At world_size > 2 without NVLink, **vLLM force-disables its custom all-reduce kernel** (its gate queries NVML for NVLink and never consults peer access — [#786](https://github.com/noonghunna/club-3090/issues/786)), so whatever P2P is worth at TP=4 arrives **through NCCL peer transfers only** — a lower ceiling than the dual-card custom-kernel path above. An earlier revision of this section claimed the gain "grows with GPU count"; that was a projection, not a measurement, and is withdrawn — **no measured multi-GPU P2P A/B exists yet** ([disc #773](https://github.com/noonghunna/club-3090/discussions/773) has the first candidate rig).
 
 ---
 
@@ -125,6 +127,10 @@ bash scripts/report.sh
 ```
 
 Read the **"Interconnect verdict"** line under *Boot log highlights* — the report cross-references host capability against the running container's engagement automatically: `✓ engaged`, `⚠ WARN` (NVLink bridge present but idle), or `ℹ` (P2P-capable driver, container not using it), each naming the fix. The raw evidence sits directly above it: the `[nvlink]` boot line plus the resolved `NCCL_P2P_LEVEL` + custom-all-reduce env. On rigs with no P2P capability the verdict line is deliberately absent — silence means "nothing to gain here", not "check failed". (This is exactly the round-trip the field was added to avoid — [#446](https://github.com/noonghunna/club-3090/issues/446), [#488](https://github.com/noonghunna/club-3090/issues/488).)
+
+**On 3+ PCIe cards, expect "engaged via NCCL", not "custom all-reduce ON".** vLLM vetoes its custom kernel at world_size > 2 without NVLink and logs `Custom allreduce is disabled because it's not supported on more than two PCIe-only GPUs` — that line is **expected on every 3+-card PCIe rig, patched or not**, and is not a misconfiguration. The same veto fires on **pairwise NVLink bridges** at 3+ cards (2 bridges on 4x 3090 is never a full 1-hop mesh — consumer cards bridge exactly two GPUs), so a quad-3090-with-bridges rig is also NCCL-only in vLLM; only NVSwitch/SXM-class full meshes keep the custom kernel at world>2. The report folds it into the verdict automatically ([#786](https://github.com/noonghunna/club-3090/issues/786)); P2P remains active on the NCCL path.
+
+**Transfer-verified P2P — the strongest evidence tier.** Everything above is ultimately a driver *assertion* (the topo matrix, the module license, a clean boot — all the same query asked three ways). vLLM ships a functional check that actually moves bytes: boot once with `VLLM_SKIP_P2P_CHECK=0` and it performs an IPC write/read-back across every directed GPU pair, caching the result to `~/.cache/vllm/gpu_p2p_access_cache_for_<devices>.json`. `report.sh` reads that cache automatically when present (host first, then the serving container) and adds a **"Transfer check"** line — `✓ N/N directed pairs OK` upgrades the verdict from driver-asserted to *measured*, and a partial result flags advertised-but-broken peer access that no driver query can see. The check costs seconds and the cache is a durable, paste-able artifact (idea from [disc #773](https://github.com/noonghunna/club-3090/discussions/773)).
 
 ---
 

--- a/scripts/detect_nvlink.sh
+++ b/scripts/detect_nvlink.sh
@@ -25,6 +25,40 @@
 
 NVLINK_MODE="${NVLINK_MODE:-auto}"
 _P2P_LEVEL=NVL   # NCCL_P2P_LEVEL used when _NVLINK_ENABLED=1 (overridden by pcie_p2p)
+_GPU_COUNT=$(nvidia-smi -L 2>/dev/null | grep -c 'GPU' || echo 0)
+
+# What may we honestly claim about vLLM's custom all-reduce? Only "ON" for <=2
+# GPUs, or for a FULLY-CONNECTED NVLink mesh: vLLM hard-disables its custom
+# kernel at world_size>2 unless every GPU pair is 1-hop NVLink (its gate
+# queries NVML for NVLink, never peer access). Two consequences (club-3090
+# #786): a >2-GPU PCIe-P2P boot must not assert it, and neither may a >2-GPU
+# rig with PAIRWISE bridges — consumer 3090-class cards bridge exactly two
+# cards, so 4x 3090 = 2 separate bridges = never a full mesh. P2P/NVLink still
+# runs via NCCL in both cases. The auditor (p2p-state.sh) keys on both wordings.
+_ar_claim() {
+  if [ "${_GPU_COUNT:-0}" -gt 2 ] && [ "${_P2P_LEVEL:-NVL}" != "NVL" ]; then
+    printf 'custom all-reduce engine-gated (vLLM disables its custom kernel at >2 PCIe-only GPUs — P2P runs via NCCL; #786)'
+  elif [ "${_GPU_COUNT:-0}" -gt 2 ] && [ "${_NVLINK_PARTIAL:-0}" -eq 1 ]; then
+    printf 'custom all-reduce engine-gated (NVLink mesh not fully connected — pairwise bridges; vLLM requires full 1-hop connectivity at world>2, so its kernel is off and NVLink/P2P runs via NCCL; #786)'
+  else
+    printf 'custom all-reduce ON'
+  fi
+}
+
+# Full-mesh NVLink probe (>2 GPUs): every off-diagonal GPU-GPU cell in
+# `topo -m` must be NV<n>. Pairwise 3090 bridges (2 bridges on 4 cards) fail
+# this; NVSwitch/SXM meshes pass. Exit 0 = full mesh.
+_nvlink_full_mesh() {
+  nvidia-smi topo -m 2>/dev/null | awk '
+    NR == 1 { for (i = 1; i <= NF; i++) if ($i ~ /^GPU[0-9]+$/) ngpu++ ; next }
+    $1 ~ /^GPU[0-9]+$/ {
+      rows++
+      for (i = 2; i <= ngpu + 1; i++)
+        if ($i != "X" && $i !~ /^NV[0-9]+$/) partial = 1
+    }
+    END { exit (rows > 0 && !partial) ? 0 : 1 }
+  '
+}
 
 # True (0) when nvidia-smi reports working P2P between ALL GPU pairs — e.g. a patched
 # consumer-GPU driver (NVIDIA's stock driver software-disables P2P → reports "CNS") on a
@@ -62,22 +96,27 @@ case "$NVLINK_MODE" in
     _NVLINK_ENABLED=1
     _P2P_LEVEL="${NCCL_P2P_LEVEL:-PHB}"
     if _pcie_p2p_available; then
-      echo "[nvlink] NVLINK_MODE=pcie_p2p — forcing PCIe P2P; driver confirms peer access (nvidia-smi topo -p2p: OK) — NCCL_P2P_LEVEL=$_P2P_LEVEL, custom all-reduce ON"
+      echo "[nvlink] NVLINK_MODE=pcie_p2p — forcing PCIe P2P; driver confirms peer access (nvidia-smi topo -p2p: OK) — NCCL_P2P_LEVEL=$_P2P_LEVEL, $(_ar_claim)"
     else
       _P2P_UNVERIFIED=1
       echo "[nvlink] WARNING: NVLINK_MODE=pcie_p2p set, but nvidia-smi topo -p2p does NOT report peer access as OK — the driver likely refused P2P (a closed GeForce driver disables it; the open kernel modules or a patched module + a P2P-capable board are what enable it). Forcing the NCCL/all-reduce config on as requested, but NCCL will silently fall back → throughput ≈ P2P-off. Verify with: nvidia-smi topo -p2p rw. Guide: docs/PCIE_P2P.md" >&2
     fi
     ;;
   auto)
-    GPU_COUNT=$(nvidia-smi -L 2>/dev/null | grep -c 'GPU' || echo 0)
+    GPU_COUNT="$_GPU_COUNT"
     if [ "$GPU_COUNT" -gt 2 ]; then
       # Check topology matrix for any NVLink connections (e.g. 2 bridges on 4 cards).
       if nvidia-smi topo -m 2>/dev/null | grep -qP '\bNV[0-9]+\b'; then
         _NVLINK_ENABLED=1
-        echo "[nvlink] $GPU_COUNT GPUs detected — NVLink found, enabling NVLink mode"
+        if _nvlink_full_mesh; then
+          echo "[nvlink] $GPU_COUNT GPUs detected — NVLink full mesh, enabling NVLink mode"
+        else
+          _NVLINK_PARTIAL=1
+          echo "[nvlink] $GPU_COUNT GPUs detected — NVLink found on GPU pairs but the mesh is NOT fully connected (pairwise bridges, e.g. 2 bridges on 4 cards) — enabling NVLink mode; NCCL uses NVLink per bridged pair"
+        fi
       elif _pcie_p2p_available; then
         _NVLINK_ENABLED=1; _P2P_LEVEL="${NCCL_P2P_LEVEL:-PHB}"
-        echo "[nvlink] $GPU_COUNT GPUs — no NVLink, but nvidia-smi reports P2P=OK (patched driver / P2P-capable layout) — auto-enabling PCIe P2P (NCCL_P2P_LEVEL=$_P2P_LEVEL, custom all-reduce ON)"
+        echo "[nvlink] $GPU_COUNT GPUs — no NVLink, but nvidia-smi reports P2P=OK (patched driver / P2P-capable layout) — auto-enabling PCIe P2P (NCCL_P2P_LEVEL=$_P2P_LEVEL, $(_ar_claim))"
       else
         _NVLINK_ENABLED=0
         echo "[nvlink] $GPU_COUNT GPUs detected — no NVLink, no P2P — using PCIe mode"
@@ -129,7 +168,7 @@ if [ "$_NVLINK_ENABLED" -eq 1 ]; then
     # engagement is NOT proven. Say so — never print "ENABLED" without evidence (#688).
     echo "[nvlink] P2P REQUESTED (UNVERIFIED) — NCCL_P2P_LEVEL=$NCCL_P2P_LEVEL + custom all-reduce configured as forced, but peer access is UNCONFIRMED (topo -p2p ≠ OK; see the warning above). If the driver refused P2P, NCCL falls back and throughput ≈ P2P-off — verify with nvidia-smi topo -p2p rw. expandable_segments stripped (PYTORCH_CUDA_ALLOC_CONF=$PYTORCH_CUDA_ALLOC_CONF)"
   else
-    echo "[nvlink] P2P ENABLED — NCCL_P2P_LEVEL=$NCCL_P2P_LEVEL, custom all-reduce ON, expandable_segments stripped (PYTORCH_CUDA_ALLOC_CONF=$PYTORCH_CUDA_ALLOC_CONF)"
+    echo "[nvlink] P2P ENABLED — NCCL_P2P_LEVEL=$NCCL_P2P_LEVEL, $(_ar_claim), expandable_segments stripped (PYTORCH_CUDA_ALLOC_CONF=$PYTORCH_CUDA_ALLOC_CONF)"
   fi
 else
   export NCCL_P2P_DISABLE=1
@@ -138,4 +177,4 @@ else
   echo "[nvlink] P2P DISABLED — NCCL_P2P_DISABLE=1, custom all-reduce OFF, expandable_segments ON"
 fi
 
-unset -f _pcie_p2p_available 2>/dev/null || true   # don't leak the probe into the sourcing shell
+unset -f _pcie_p2p_available _ar_claim _nvlink_full_mesh 2>/dev/null || true   # don't leak the probes into the sourcing shell

--- a/scripts/lib/p2p-state.sh
+++ b/scripts/lib/p2p-state.sh
@@ -8,6 +8,9 @@
 # Verdict matrix (report.sh renders it; preflight prints the capability line):
 #   <2 GPUs, or no capability          -> silent (nothing useful to say)
 #   capability + engagement ON         -> one OK line
+#   capability + engagement NCCL-ONLY  -> OK line stating vLLM vetoed its custom
+#                                        all-reduce (NVLink-only gate at
+#                                        world>2 — #786); P2P still live via NCCL
 #   NVLink bridge + engagement OFF     -> WARN (hardware idle; ~15% decode
 #                                        left on the table per the #77 A/B)
 #   PCIe-P2P-capable + engagement OFF  -> INFO (launcher boots auto-enable;
@@ -81,8 +84,9 @@ p2p_driver_flavor() {
 # Engagement classifier — PURE (takes the boot-trail/env text on stdin so the
 # caller decides where it comes from and tests can feed fixtures).
 # report.sh already gathers exactly this text: the container's `[nvlink]`
-# boot lines + resolved NCCL_P2P*/NVLINK_MODE env.
-# Prints: "on" | "off" | "unknown".
+# boot lines + resolved NCCL_P2P*/NVLINK_MODE env + vLLM's own custom-AR
+# gate line when present.
+# Prints: "on" | "nccl_only" | "off" | "unknown" | "requested".
 p2p_classify_engagement() {
   local text
   text="$(cat)"
@@ -92,6 +96,20 @@ p2p_classify_engagement() {
   # wins over the "custom all-reduce" signal the forced path also carries.
   case "$text" in
     *"P2P REQUESTED (UNVERIFIED)"*) echo requested; return 0 ;;
+  esac
+  # vLLM runtime veto (#786): at world_size>2 without NVLink, vLLM disables its
+  # custom all-reduce regardless of peer access — its gate queries NVML for
+  # NVLink only. A pre-#786 boot trail still asserts "custom all-reduce ON" in
+  # that case, so this check must run BEFORE the "on" match. P2P itself stays
+  # live via NCCL peer transfers → a distinct state, not "on" and not "off".
+  # Matches vLLM's log line AND the post-#786 decider trail wording.
+  case "$text" in
+    *"Custom allreduce is disabled"*|*"custom all-reduce engine-gated"*)
+      case "$text" in
+        *"P2P off"*|*"using PCIe mode"*|*"forcing PCIe mode"*|*NCCL_P2P_DISABLE=1*)
+          echo off; return 0 ;;
+      esac
+      echo nccl_only; return 0 ;;
   esac
   # The [nvlink] decision trail is authoritative (it states what the boot
   # resolved, post-override); env is the fallback for pre-trail entrypoints.
@@ -122,7 +140,7 @@ p2p_verdict() {
   fi
   [[ "$cap" != "none" ]] || return 0
   case "$eng" in
-    on)      state="" ;;
+    on|nccl_only) state="" ;;
     off)     state="is running with P2P OFF" ;;
     unknown) state="shows no P2P engagement signal (no [nvlink] boot line / NCCL env)" ;;
     *)       return 0 ;;
@@ -132,9 +150,49 @@ p2p_verdict() {
       echo "✓ interconnect: NVLink engaged (custom all-reduce ON)" ;;
     pcie_p2p:on)
       echo "✓ interconnect: PCIe P2P engaged (patched driver, custom all-reduce ON)" ;;
+    pcie_p2p:nccl_only)
+      echo "✓ interconnect: PCIe P2P engaged via NCCL peer transfers. vLLM auto-disabled its custom all-reduce kernel — expected at >2 PCIe-only GPUs (its gate checks NVLink, not peer access; #786), NOT a misconfiguration. P2P is still active on the NCCL path." ;;
+    nvlink:nccl_only)
+      echo "✓ interconnect: P2P engaged via NCCL peer transfers, but vLLM disabled its custom all-reduce — the NVLink mesh is not fully connected across all GPUs (vLLM requires full 1-hop connectivity at world>2). Peer transfers remain active." ;;
     nvlink:*)
       echo "⚠ interconnect WARN: an NVLink bridge is present on this host but the serving container ${state} — the bridge is idle. On modern vLLM the NVLink win is workload-shaped: small on decode (~3-5%) but large on prefill / long-context (+35-49%) (BENCHMARKS #698; the ~15% #77 figure was the older v7.72.2 image). Boot via launch.sh/switch.sh (auto-detects) or set NVLINK_MODE=force_on; if auto-detect misses on your rig, please file it. Full guide: docs/PCIE_P2P.md" ;;
     pcie_p2p:*)
-      echo "ℹ interconnect: this driver reports PCIe P2P available (patched driver / P2P-capable layout) but the serving container ${state}. Launcher boots auto-enable it; for direct docker compose set NVLINK_MODE=pcie_p2p (+10–22% code TPS measured, #91/#295). Full guide: docs/PCIE_P2P.md" ;;
+      echo "ℹ interconnect: this driver reports PCIe P2P available (patched driver / P2P-capable layout) but the serving container ${state}. Launcher boots auto-enable it; for direct docker compose set NVLINK_MODE=pcie_p2p (+10–22% code TPS measured on DUAL-card rigs, #91/#295; at >2 GPUs the gain path is NCCL-only — see docs/PCIE_P2P.md). Full guide: docs/PCIE_P2P.md" ;;
   esac
+}
+
+# ── Transfer-verified P2P (folded from #787) ─────────────────────────────────
+# Every other signal in this file bottoms out in a driver ASSERTION (topo -p2p,
+# modinfo, a clean boot). vLLM ships a functional check that actually moves
+# bytes — `gpu_p2p_access_check()` (enabled by VLLM_SKIP_P2P_CHECK=0): IPC
+# write/read-back across every directed pair, cached as JSON. We READ that
+# cache when it exists; we never run the check ourselves (it's off by default
+# upstream). Advertised-but-broken peer access fails it — the class no driver
+# query can see (#688's cousin, closed by construction).
+
+# Parse a gpu_p2p_access_cache JSON on stdin ({"0->1": true, ...}).
+# Prints "ok total" (directed pairs); silent when no pair entries parse.
+p2p_transfer_cache_parse() {
+  # grep exits 1 on a cache with no pair entries — that's "nothing to report",
+  # not an error, and must not trip a pipefail caller.
+  { grep -oE '"[0-9]+->[0-9]+"[[:space:]]*:[[:space:]]*(true|false)' || true; } | awk '
+    { total++; if ($0 ~ /true/) ok++ }
+    END { if (total > 0) printf "%d %d\n", ok, total }'
+}
+
+# Newest host-side cache file, if any (container-side lookup is the caller's
+# job — report.sh checks the serving container too).
+p2p_transfer_cache_file() {
+  ls -t "$HOME"/.cache/vllm/gpu_p2p_access_cache_for_*.json 2>/dev/null | head -1 || true
+}
+
+# Pure formatter: p2p_transfer_verdict <ok> <total> <src> — one line or nothing.
+p2p_transfer_verdict() {
+  local ok="${1:-0}" total="${2:-0}" src="${3:-}"
+  [[ "${total:-0}" -gt 0 ]] || return 0
+  if [[ "$ok" -eq "$total" ]]; then
+    echo "✓ interconnect: P2P verified by TRANSFER — ${ok}/${total} directed pairs OK (vLLM gpu_p2p_access_check cache: ${src}). Measured data-path result, not a driver assertion."
+  else
+    echo "⚠ interconnect WARN: P2P transfer check has only ${ok}/${total} directed pairs OK — peer access is advertised but BROKEN on some pairs (vLLM cache: ${src}). NCCL silently falls back on failing pairs → throughput ≈ P2P-off there. Guide: docs/PCIE_P2P.md"
+  fi
 }

--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -819,10 +819,15 @@ else
     # guess whether P2P was engaged (the gap that forced asks on #446 / #488).
     nvlink_boot=$(docker logs "$CONTAINER" 2>&1 | grep -E '\[nvlink\]' | head -8)
     p2p_env=$(docker exec "$CONTAINER" env 2>/dev/null | grep -E '^(NCCL_P2P|NVLINK_MODE|NCCL_CUMEM)=' | sort)
+    # vLLM's runtime custom-AR veto (world>2 without NVLink — its gate never
+    # consults peer access). Fed to the classifier so the verdict can't claim
+    # "custom all-reduce ON" that vLLM already vetoed (#786).
+    vllm_ar_gate=$(docker logs "$CONTAINER" 2>&1 | grep -m1 'Custom allreduce is disabled' || true)
     echo "**Interconnect / P2P engagement:**"
-    if [[ -n "$nvlink_boot" || -n "$p2p_env" ]]; then
+    if [[ -n "$nvlink_boot" || -n "$p2p_env" || -n "$vllm_ar_gate" ]]; then
       echo '```'
       [[ -n "$nvlink_boot" ]] && echo "$nvlink_boot"
+      [[ -n "$vllm_ar_gate" ]] && { echo "# vLLM runtime:"; echo "$vllm_ar_gate"; }
       [[ -n "$p2p_env" ]] && { echo "# resolved container env:"; echo "$p2p_env"; }
       echo '```'
     else
@@ -832,7 +837,7 @@ else
     # Silent on single-GPU / no-capability rigs so the OK/WARN/INFO line is
     # always signal, never boilerplate.
     _p2p_verdict_line="$(p2p_verdict "$(p2p_gpu_count)" "$(p2p_host_capability)" \
-      "$(printf '%s\n%s' "$nvlink_boot" "$p2p_env" | p2p_classify_engagement)")"
+      "$(printf '%s\n%s\n%s' "$nvlink_boot" "$vllm_ar_gate" "$p2p_env" | p2p_classify_engagement)")"
     [[ -n "$_p2p_verdict_line" ]] && { echo; echo "**Interconnect verdict:** ${_p2p_verdict_line}"; }
     # Kernel-module flavor — the WHY behind a P2P result on GeForce cards. A
     # proprietary (closed) module refuses P2P; the open modules can grant it, with
@@ -844,6 +849,25 @@ else
         proprietary) echo; echo "**NVIDIA kernel module:** proprietary (closed) — refuses P2P on GeForce; the open kernel modules (\`nvidia-open\`, or a patched fork) are what enable it. A \`CNS\` in \`topo -p2p rw\` above is this. See docs/PCIE_P2P.md." ;;
         open)        echo; echo "**NVIDIA kernel module:** open (\`Dual MIT/GPL\`) — P2P-capable on GeForce; whether it's granted is the \`topo -p2p rw\` result above (\`OK\` = engaged, \`CNS\` = board/layout still refusing). Metadata can't tell stock \`nvidia-open\` from a patched fork — the topo result is the proof." ;;
       esac
+      # Transfer-verified P2P (#786, read-only tier folded from #787): report
+      # vLLM's functional-check cache when a boot ever ran with
+      # VLLM_SKIP_P2P_CHECK=0 — host first, then the serving container.
+      # Absence is normal (the check is off by default upstream); when present
+      # it upgrades the verdict above from driver-asserted to measured.
+      _tc_json=""; _tc_src=""
+      _tc_f="$(p2p_transfer_cache_file)"
+      if [[ -n "$_tc_f" ]]; then
+        _tc_json="$(cat "$_tc_f" 2>/dev/null)"; _tc_src="${_tc_f/#$HOME/\~}"
+      fi
+      if [[ -z "$_tc_json" ]]; then
+        _tc_f="$(docker exec "$CONTAINER" sh -c 'ls -t /root/.cache/vllm/gpu_p2p_access_cache_for_*.json 2>/dev/null | head -1' 2>/dev/null || true)"
+        [[ -n "$_tc_f" ]] && { _tc_json="$(docker exec "$CONTAINER" cat "$_tc_f" 2>/dev/null)"; _tc_src="container:${_tc_f}"; }
+      fi
+      if [[ -n "$_tc_json" ]]; then
+        read -r _tc_ok _tc_total <<<"$(printf '%s' "$_tc_json" | p2p_transfer_cache_parse)" || true
+        _tc_line="$(p2p_transfer_verdict "${_tc_ok:-0}" "${_tc_total:-0}" "$_tc_src")"
+        [[ -n "$_tc_line" ]] && { echo; echo "**Transfer check:** ${_tc_line}"; }
+      fi
     fi
     echo
 

--- a/scripts/tests/test-p2p-state.sh
+++ b/scripts/tests/test-p2p-state.sh
@@ -14,6 +14,7 @@ trap 'rm -rf "$TMP"' EXIT
 fail() { echo "FAIL: $1" >&2; exit 1; }
 assert_contains() { [[ "$1" == *"$2"* ]] || { echo "FAIL: missing '$2' in: $1" >&2; exit 1; }; }
 assert_empty() { [[ -z "$1" ]] || { echo "FAIL: expected silence, got: $1" >&2; exit 1; }; }
+assert_not_contains() { [[ "$1" != *"$2"* ]] || { echo "FAIL: must NOT contain '$2': $1" >&2; exit 1; }; }
 
 source scripts/lib/p2p-state.sh
 
@@ -118,5 +119,90 @@ mk_modinfo ""
 r="$(PATH="$TMP:$PATH" bash -c 'source scripts/lib/p2p-state.sh; p2p_driver_flavor')"
 [[ "$r" == "unknown" ]] || fail "empty license -> unknown (got $r)"
 echo "  ✓ driver-flavor probe: NVIDIA->proprietary, Dual MIT/GPL->open, empty->unknown"
+
+# ── 6. #786: vLLM custom-AR veto at world>2 → nccl_only, never a false "ON" ──
+VLLM_WARN='Custom allreduce is disabled because it'"'"'s not supported on more than two PCIe-only GPUs. To silence this warning, specify disable_custom_all_reduce=True'
+# pre-#786 trail (asserts AR ON) + vLLM veto line -> nccl_only, NOT on
+r="$(printf '%s\n%s' '[nvlink] 4 GPUs — no NVLink, but nvidia-smi reports P2P=OK — auto-enabling PCIe P2P (NCCL_P2P_LEVEL=PHB, custom all-reduce ON)' "$VLLM_WARN" | p2p_classify_engagement)"
+[[ "$r" == "nccl_only" ]] || fail "old trail + vLLM veto -> nccl_only (got $r)"
+# bare stack (no trail) + vLLM veto + NCCL level env -> nccl_only (was: unknown, alesha's false negative)
+r="$(printf '%s\n%s' "$VLLM_WARN" 'NCCL_P2P_LEVEL=PHB' | p2p_classify_engagement)"
+[[ "$r" == "nccl_only" ]] || fail "bare stack + veto + level -> nccl_only (got $r)"
+# vLLM veto but P2P explicitly disabled -> off (AR off AND P2P off)
+r="$(printf '%s\n%s' "$VLLM_WARN" 'NCCL_P2P_DISABLE=1' | p2p_classify_engagement)"
+[[ "$r" == "off" ]] || fail "veto + P2P disabled -> off (got $r)"
+# post-#786 decider trail wording alone -> nccl_only
+r="$(echo '[nvlink] 4 GPUs — no NVLink, but nvidia-smi reports P2P=OK (patched driver / P2P-capable layout) — auto-enabling PCIe P2P (NCCL_P2P_LEVEL=PHB, custom all-reduce engine-gated (vLLM disables its custom kernel at >2 PCIe-only GPUs — P2P runs via NCCL; #786))' | p2p_classify_engagement)"
+[[ "$r" == "nccl_only" ]] || fail "engine-gated trail -> nccl_only (got $r)"
+# requested still wins over the veto line (#688 precedence preserved)
+r="$(printf '%s\n%s' '[nvlink] P2P REQUESTED (UNVERIFIED) — custom all-reduce configured as forced' "$VLLM_WARN" | p2p_classify_engagement)"
+[[ "$r" == "requested" ]] || fail "requested beats veto (got $r)"
+# 2-GPU trail with true AR ON and no veto line -> still on (unchanged)
+r="$(echo '[nvlink] PCIe topology (PHB) but nvidia-smi reports P2P=OK (patched driver / shared root complex) — auto-enabling PCIe P2P (NCCL_P2P_LEVEL=PHB, custom all-reduce ON)' | p2p_classify_engagement)"
+[[ "$r" == "on" ]] || fail "2-GPU AR-on trail -> on (got $r)"
+# verdict lines for the new state
+out="$(p2p_verdict 4 pcie_p2p nccl_only)"
+assert_contains "$out" "via NCCL"
+assert_contains "$out" "NOT a misconfiguration"
+assert_not_contains "$out" "custom all-reduce ON"
+out="$(p2p_verdict 4 nvlink nccl_only)";  assert_contains "$out" "NCCL"
+assert_empty "$(p2p_verdict 1 pcie_p2p nccl_only)"                   # single GPU -> silent
+assert_empty "$(p2p_verdict 2 none nccl_only)"                       # no capability -> silent
+echo "  ✓ #786: vLLM AR veto -> nccl_only state; verdict never claims custom-AR-ON"
+
+# ── 7. #786 decider wording: >2-GPU PCIe-P2P boot must not assert AR ON ──────
+L4='GPU 0: RTX 3090\nGPU 1: RTX 3090\nGPU 2: RTX 3090\nGPU 3: RTX 3090\n'
+TOPO_PHB4='\tGPU0\tGPU1\tGPU2\tGPU3\nGPU0\t X \tPHB\tPHB\tPHB\nGPU1\tPHB\t X \tPHB\tPHB\nGPU2\tPHB\tPHB\t X \tPHB\nGPU3\tPHB\tPHB\tPHB\t X \n'
+P2P_OK4=' \tGPU0\tGPU1\tGPU2\tGPU3\nGPU0\tX\tOK\tOK\tOK\nGPU1\tOK\tX\tOK\tOK\nGPU2\tOK\tOK\tX\tOK\nGPU3\tOK\tOK\tOK\tX\n'
+mk_smi "$L4" "$TOPO_PHB4" "$P2P_OK4"
+d="$(run_decider)"
+assert_contains "$d" "engine-gated"
+assert_not_contains "$d" "custom all-reduce ON"
+r="$(PATH="$TMP:$PATH" bash -c 'source scripts/lib/p2p-state.sh; p2p_host_capability')"
+[[ "$r" == "pcie_p2p" ]] || fail "4-GPU PHB + p2p OK -> pcie_p2p (got $r)"
+# decider trail round-trips through the auditor to nccl_only
+r="$(printf '%s' "$d" | p2p_classify_engagement)"
+[[ "$r" == "nccl_only" ]] || fail "4-GPU decider trail -> nccl_only (got $r)"
+# 2-GPU P2P boot keeps the true claim
+mk_smi "$L2" "$TOPO_PHB" "$P2P_OK"
+d="$(run_decider)"
+assert_contains "$d" "custom all-reduce ON"
+# 4x 3090 with PAIRWISE bridges (2 bridges on 4 cards) — NVLink present but the
+# mesh is not fully connected, so vLLM's custom AR is off just like PCIe >2.
+TOPO_NV4_PAIR='\tGPU0\tGPU1\tGPU2\tGPU3\nGPU0\t X \tNV4\tPHB\tPHB\nGPU1\tNV4\t X \tPHB\tPHB\nGPU2\tPHB\tPHB\t X \tNV4\nGPU3\tPHB\tPHB\tNV4\t X \n'
+mk_smi "$L4" "$TOPO_NV4_PAIR" "$P2P_OK4"
+d="$(run_decider)"
+assert_contains "$d" "NOT fully connected"
+assert_contains "$d" "engine-gated"
+assert_not_contains "$d" "custom all-reduce ON"
+r="$(printf '%s' "$d" | p2p_classify_engagement)"
+[[ "$r" == "nccl_only" ]] || fail "pairwise-NVLink 4-GPU trail -> nccl_only (got $r)"
+# full 1-hop mesh (NVSwitch/SXM class) — the only >2-GPU case where AR ON is true
+TOPO_NV4_FULL='\tGPU0\tGPU1\tGPU2\tGPU3\nGPU0\t X \tNV12\tNV12\tNV12\nGPU1\tNV12\t X \tNV12\tNV12\nGPU2\tNV12\tNV12\t X \tNV12\nGPU3\tNV12\tNV12\tNV12\t X \n'
+mk_smi "$L4" "$TOPO_NV4_FULL" "$P2P_OK4"
+d="$(run_decider)"
+assert_contains "$d" "NVLink full mesh"
+assert_contains "$d" "custom all-reduce ON"
+r="$(printf '%s' "$d" | p2p_classify_engagement)"
+[[ "$r" == "on" ]] || fail "full-mesh 4-GPU trail -> on (got $r)"
+echo "  ✓ #786 decider: >2-GPU PCIe-P2P AND pairwise-NVLink print engine-gated (round-trip nccl_only); 2-GPU + full-mesh keep AR ON"
+
+# ── 8. transfer-verified P2P cache (read-only tier folded from #787) ─────────
+j='{"0->1": true, "1->0": true, "0->2": true, "2->0": true, "1->2": true, "2->1": true}'
+r="$(printf '%s' "$j" | p2p_transfer_cache_parse)"
+[[ "$r" == "6 6" ]] || fail "full-OK cache -> 6 6 (got $r)"
+j='{"0->1": true, "1->0": false, "0->2": true, "2->0": true}'
+r="$(printf '%s' "$j" | p2p_transfer_cache_parse)"
+[[ "$r" == "3 4" ]] || fail "partial cache -> 3 4 (got $r)"
+r="$(printf '%s' '{"not": "a cache"}' | p2p_transfer_cache_parse)"
+[[ -z "$r" ]] || fail "garbage JSON -> silent (got $r)"
+out="$(p2p_transfer_verdict 6 6 '~/.cache/vllm/gpu_p2p_access_cache_for_0,1,2.json')"
+assert_contains "$out" "verified by TRANSFER"
+assert_contains "$out" "6/6"
+out="$(p2p_transfer_verdict 3 4 'container:/root/.cache/vllm/x.json')"
+assert_contains "$out" "WARN"
+assert_contains "$out" "3/4"
+assert_empty "$(p2p_transfer_verdict 0 0 x)"                          # no data -> silent
+echo "  ✓ transfer-cache parse + verdict: full OK / partial WARN / garbage silent"
 
 echo "test-p2p-state: ok"


### PR DESCRIPTION
Fixes #786. Found by @alesha-pro in discussion #773 (§4 of their follow-up); verified against our code before this fix.

## The bug

vLLM disables its custom all-reduce at `world_size > 2` unless **every GPU pair is 1-hop NVLink** — `is_fully_connected()` queries NVML for NVLink and never consults peer access. Our boot trail asserted `custom all-reduce ON` on every P2P-enabled boot regardless of GPU count, the composes obediently omitted `--disable-custom-all-reduce`, vLLM silently overrode us, and `p2p_verdict()` (which classifies from our own trail) printed `✓ engaged (patched driver, custom all-reduce ON)` — a claim vLLM had already vetoed. Affected: every multi3+/multi4 PCIe-P2P boot, **and** every >2-GPU rig with *pairwise* NVLink bridges (2 bridges on 4× 3090 is never a full mesh — consumer cards bridge exactly two GPUs).

On bare `vllm serve` stacks (no trail) the same gap surfaced as the mirror failure alesha-pro predicted: fall-through to "capable but unused" — a false negative on rigs where NCCL P2P is verifiably active.

## The fix — three layers

1. **Decider (`detect_nvlink.sh`)** stops asserting what vLLM will veto: `_ar_claim()` prints `custom all-reduce engine-gated (…)` at >2 GPUs on PCIe-P2P **or** a partial NVLink mesh (new `_nvlink_full_mesh` probe over `topo -m`); 2-GPU boots and full 1-hop meshes (NVSwitch/SXM class) keep the true `custom all-reduce ON`.
2. **Classifier (`p2p-state.sh`)** gains a `nccl_only` state, keyed on **vLLM's own** `Custom allreduce is disabled…` log line (so pre-fix trails and bare stacks classify correctly too — the discriminator alesha-pro proposed) plus the new trail wording. Precedence: still below `requested` (#688 guard intact), above the `on` match.
3. **Verdict** for `nccl_only`: `✓ interconnect: PCIe P2P engaged via NCCL peer transfers. vLLM auto-disabled its custom all-reduce kernel — expected at >2 PCIe-only GPUs …, NOT a misconfiguration.` (NVLink-partial-mesh variant included.) `report.sh` now feeds the vLLM gate line to the classifier and shows it in the boot-log block.

## Folded from #787 (closed): read-only transfer-verified tier

`p2p_transfer_cache_parse` / `p2p_transfer_cache_file` / `p2p_transfer_verdict` read vLLM's `gpu_p2p_access_cache_for_*.json` (written when a boot runs with `VLLM_SKIP_P2P_CHECK=0` — a real IPC write/read-back per directed pair). `report.sh` checks host then serving container and prints a **Transfer check** line: full-OK upgrades the verdict from driver-asserted to measured; partial flags advertised-but-broken pairs. We never run the check ourselves.

## Tests

`test-p2p-state.sh` extended (+3 sections): veto→`nccl_only` fixtures incl. pre-fix trails and bare stacks, precedence vs #688, off-signal handling; decider round-trips for 4-GPU PCIe-P2P, **pairwise-NVLink** (engine-gated) and **full-mesh** (AR ON retained) topologies via faked `nvidia-smi`; transfer-cache parse (full/partial/garbage) + verdict formatting. Sibling suites green: `test-detect-nvlink-alloc-conf`, `test-detect-nvlink-autop2p`, `test-compose-nvlink-escape`.

## Docs (second commit)

- `BENCHMARKS.md` Rig-cell convention: **resolved custom-AR state** becomes required field #4 — dual rows and multi3+/multi4 PCIe rows differ on this axis *by construction*, and first-party duals (AR off via `--disable-custom-all-reduce`) split from community P2P/NVLink duals (AR on).
- `docs/PCIE_P2P.md`: §6 gains scoped to dual-card (the "grows with GPU count" projection withdrawn — no measured multi-GPU P2P A/B exists yet); §7 documents the expected "engaged via NCCL" verdict at >2 cards and the transfer-verified tier.

## Not in scope

No compose changes — omitting `--disable-custom-all-reduce` when `_NVLINK_ENABLED=1` stays as-is (vLLM resolves it correctly at runtime; on 2-GPU P2P rigs the kernel genuinely engages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
