### PR TITLE
fix(c3): GGUF-only repos redirect the validate leg to the quant picker (route-G) instead of dead-ending

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -5552,6 +5552,21 @@ def _byo_result_text(res: ByoResult, weights_present: Optional[bool] = None,
     affordance.  ``None`` = unknown → keep the download prompt (safe default)."""
     if res.error:
         return f"[red]Fit-check failed:[/red] {res.error}"
+    # GGUF redirect (services.byo_check intercept): the safetensors evaluate leg
+    # can't score a GGUF-only repo — route the user to the quant picker instead
+    # of a dead-end verdict.  NOT an error (red) and NOT servable-yet (green).
+    if res.fit_verdict == "gguf-pick-quant":
+        return "\n".join([
+            f"  [bold]{res.repo}[/bold]",
+            "  [yellow]◆ GGUF-only repo[/yellow] — the profile fit-check is "
+            "safetensors-only.",
+            f"  {res.note}",
+            "",
+            "  [green]→ Pick a quant in the GGUF table above, then re-run the "
+            "fit-check[/green]",
+            "  [dim]route-G serves it via a GGUF-engine sibling clone "
+            "(size-fit only)[/dim]",
+        ])
     # Route-C swap (a curated-arch fine-tune → serve via the sibling's recipe with
     # the brought weights): the engine verdict is "no-fit-model" because the generic
     # fit-math can't PRICE a curated-hybrid arch — but the OUTCOME is servable. A red
@@ -8541,7 +8556,12 @@ class CockpitApp(App):
         # N9 — carry the fit-check result forward: pre-arm ② Serve with the
         # resolved target so the producer pipeline flows ① → ② without re-entry.
         try:
-            armed_byo = res if not getattr(res, "error", "") else None
+            armed_byo = (
+                res
+                if not getattr(res, "error", "")
+                and getattr(res, "fit_verdict", "") != "gguf-pick-quant"
+                else None
+            )
             self._arm_serve_pane(armed_byo)
         except Exception:
             pass

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -1171,7 +1171,46 @@ class CockpitData:
         )
         if data is None:
             return ByoResult(repo=repo, profile_like=profile_like, error=err or "no output")
-        return ByoResult.from_dict(repo, profile_like, data)
+        res = ByoResult.from_dict(repo, profile_like, data)
+        # The evaluate leg is safetensors-only BY DESIGN (the deriver's fit math
+        # reads config.json), so a GGUF-only repo aborts `unsupported-format`
+        # here even though route-G handles it first-class.  Intercept exactly
+        # that verdict, confirm the format from the inventory (error path only —
+        # the success path pays no extra API call), and redirect to the quant
+        # picker instead of surfacing a dead-end the user reads as "downloads
+        # are broken" (2026-07-27 community triage: a DavidAU *-GGUF repo +
+        # `--profile-like llamacpp/…` looked like a c3 download failure).
+        if res.fit_verdict == "unsupported-format":
+            inv = await self.bring_inspect(repo)
+            n = len(getattr(inv, "gguf_variants", None) or [])
+            if not getattr(inv, "error", "") and n and not inv.has_safetensors:
+                if self.profile_like_is_gguf_engine(profile_like):
+                    note = (
+                        f"GGUF-only repo — {n} quant(s) discovered. Pick one to "
+                        f"fit-check against {profile_like} (size-fit; the full "
+                        "gate math is safetensors-only)."
+                    )
+                else:
+                    note = (
+                        f"GGUF-only repo — {n} quant(s) discovered, but "
+                        f"{profile_like} is a safetensors engine. Pick a quant "
+                        "and a GGUF-engine sibling (llamacpp / ik-llama / "
+                        "beellama)."
+                    )
+                return ByoResult(
+                    repo=repo, profile_like=profile_like, arch="gguf",
+                    eligible=False, fit_verdict="gguf-pick-quant", note=note,
+                )
+        return res
+
+    # GGUF-engine slug prefixes (the registry's engine path segment) — the
+    # engines whose sibling composes route-G can clone.  vllm (safetensors)
+    # is deliberately absent.
+    _GGUF_ENGINE_PREFIXES = frozenset({"llamacpp", "ik-llama", "beellama"})
+
+    def profile_like_is_gguf_engine(self, profile_like: str) -> bool:
+        """True iff the slug's engine segment is a GGUF engine (route-G clonable)."""
+        return (profile_like or "").split("/", 1)[0] in self._GGUF_ENGINE_PREFIXES
 
     # Topology → card count (same tokens as funnel_slug_options / compose paths).
     _GGUF_TOPO_CARDS = {

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -1043,6 +1043,80 @@ class TestByoCheck:
         res = await cd.byo_check("org/Model", "vllm/dual")
         assert res.error
 
+    # ── GGUF redirect: the safetensors evaluate leg on a GGUF-only repo ──────
+    UNSUPPORTED_JSON = (
+        '{"arch": null, "eligible": false, "fit_verdict": "unsupported-format",'
+        ' "note": "unsupported-format: org/Model-GGUF (no config.json)",'
+        ' "swap_path": {"drop_spec_config": false, "quant_match": null,'
+        ' "route": null, "sibling_slug": null}}'
+    )
+    GGUF_INV_JSON = (
+        '{"formats": ["gguf"], "safetensors": null, "gguf_variants":'
+        ' [{"quant": "Q4_K_M", "size_gb": 16.8, "parts": 1, "files": ["a.gguf"]},'
+        '  {"quant": "MTP-IQ4_XS", "size_gb": 15.9, "parts": 1, "files": ["b.gguf"]}]}'
+    )
+
+    @pytest.mark.asyncio
+    async def test_byo_gguf_only_redirects_to_quant_picker(self):
+        """unsupported-format + GGUF-only inventory -> gguf-pick-quant, not a
+        dead-end (the 2026-07-27 community-triage class)."""
+        runner = full_runner(**{
+            "pull.sh": ok(self.UNSUPPORTED_JSON),
+            "--inventory": ok(self.GGUF_INV_JSON),
+        })
+        cd = CockpitData(ROOT, runner=runner)
+        res = await cd.byo_check("org/Model-GGUF", "llamacpp/deckard40B-dual-mtp")
+        assert res.fit_verdict == "gguf-pick-quant"
+        assert res.arch == "gguf"
+        assert res.eligible is False
+        assert not res.error
+        assert "2 quant(s)" in res.note
+        assert "llamacpp/deckard40B-dual-mtp" in res.note
+
+    @pytest.mark.asyncio
+    async def test_byo_gguf_only_safetensors_profile_suggests_gguf_engines(self):
+        runner = full_runner(**{
+            "pull.sh": ok(self.UNSUPPORTED_JSON),
+            "--inventory": ok(self.GGUF_INV_JSON),
+        })
+        cd = CockpitData(ROOT, runner=runner)
+        res = await cd.byo_check("org/Model-GGUF", "vllm/dual")
+        assert res.fit_verdict == "gguf-pick-quant"
+        assert "safetensors engine" in res.note
+        assert "llamacpp" in res.note
+
+    @pytest.mark.asyncio
+    async def test_byo_unsupported_format_non_gguf_passes_through(self):
+        """A genuinely unsupported repo (no GGUF either) keeps the original
+        verdict — the intercept must not swallow it."""
+        runner = full_runner(**{
+            "pull.sh": ok(self.UNSUPPORTED_JSON),
+            "--inventory": ok('{"formats": [], "safetensors": null, "gguf_variants": []}'),
+        })
+        cd = CockpitData(ROOT, runner=runner)
+        res = await cd.byo_check("org/NotAModel", "vllm/dual")
+        assert res.fit_verdict == "unsupported-format"
+
+    @pytest.mark.asyncio
+    async def test_byo_unsupported_format_inventory_error_passes_through(self):
+        """Inventory fetch failure -> keep the original verdict (never crash
+        the fit-check on the redirect's own probe)."""
+        runner = full_runner(**{
+            "pull.sh": ok(self.UNSUPPORTED_JSON),
+            "--inventory": ok(""),
+        })
+        cd = CockpitData(ROOT, runner=runner)
+        res = await cd.byo_check("org/Model-GGUF", "llamacpp/deckard40B-dual-mtp")
+        assert res.fit_verdict == "unsupported-format"
+
+    def test_profile_like_is_gguf_engine(self):
+        cd = CockpitData(ROOT, runner=full_runner())
+        assert cd.profile_like_is_gguf_engine("llamacpp/deckard40B-dual-mtp")
+        assert cd.profile_like_is_gguf_engine("ik-llama/iq4ks-mtp")
+        assert cd.profile_like_is_gguf_engine("beellama/dflash")
+        assert not cd.profile_like_is_gguf_engine("vllm/dual")
+        assert not cd.profile_like_is_gguf_engine("")
+
 
 class TestScenesDoctor:
     @pytest.mark.asyncio


### PR DESCRIPTION
## What broke (community triage, 2026-07-27)

A user brought `DavidAU/…-MTP-GGUF` through Bring & Validate with `--profile-like llamacpp/deckard40B-dual-mtp` and hit pull.sh's raw `unsupported-format (no config.json)` abort — which read as "c3 can't download at all." Meanwhile Inspect had already discovered all 16 GGUF quants, and route-G would have served the repo one keypress away. Root cause: the funnel's fit-check dispatch (`if gguf_quant: … else: byo_check(...)`) sends any no-quant-picked repo — and everything from the older Run·BYO pane, which has no picker — into the safetensors evaluate leg, which is `config.json`-gated by design.

## The fix

`services.byo_check` intercepts exactly the `unsupported-format` verdict, confirms GGUF-only from the deriver inventory (error path only — the success path pays no extra HF API call), and returns a new `fit_verdict="gguf-pick-quant"` with an engine-aware note:

- GGUF-engine `profile_like` (`llamacpp` / `ik-llama` / `beellama`): "pick a quant to fit-check against `<slug>` (size-fit; full gate math is safetensors-only)" — the user's slug carries through as route-G's emit template, so compose generation still happens against their chosen sibling.
- Safetensors `profile_like` (`vllm/…`): points at the GGUF-engine siblings instead.

The verdict card renders it as a routed next step (yellow ◆, not a red error), and the redirect never arms ② Serve. Genuinely-unsupported repos (no GGUF either) and inventory-fetch failures pass through with the original verdict untouched.

## Tests

6 new in `test_services.py`: redirect for both engine classes, non-GGUF pass-through, inventory-error pass-through, and the engine-prefix helper. Suites: services **237 passed**, registry parser **33 passed**, phase-4 GGUF + `-k "byo or gguf"` headless **16 passed**.

## Not in this PR (queued from the same triage)

Persistent download logs, download preflight (`hf` CLI / token), and a hint line on bare pull.sh's unsupported-format abort for terminal users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
