### PR TITLE
feat(c3): persistent download logs + hf-CLI/token preflight for downloads

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -44,7 +44,7 @@ from club3090_tui_core.detect import (
     match_target_to_registry,
 )
 from club3090_tui_core.registry import VariantRow, parse_variant_rows
-from club3090_tui_core.runner import SubprocessRunner
+from club3090_tui_core.runner import CoreRunState, SubprocessRunner
 
 from .data import (
     ActionPlan,
@@ -260,6 +260,71 @@ ProbeServedFn = Callable[[Any], Awaitable["ServedProbe"]]
 
 
 # ── The service class ───────────────────────────────────────────────────────────
+
+
+class DownloadLog:
+    """Persistent per-download log — ``<config>/logs/c3-download-<ts>-<kind>.log``.
+
+    The "no logs for c3" fix (2026-07-27 community triage): a download's
+    streamed lines, spawn errors and exit state survive the pane.  Best-effort
+    everywhere — a failed write must never break a download.  The child ENV is
+    never logged (it carries HF_TOKEN); the argv is (it never does).
+    """
+
+    KEEP = 30  # newest logs retained; older pruned at construction
+
+    def __init__(self, kind: str, cmd: list[str]):
+        self.path: Optional[Path] = None
+        self._fh = None
+        try:
+            base = os.environ.get("C3_CONFIG_DIR")
+            d = (Path(base) if base else Path.home() / ".config" / "club-3090") / "logs"
+            d.mkdir(parents=True, exist_ok=True)
+            ts = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+            slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", kind).strip("-") or "download"
+            self.path = d / f"c3-download-{ts}-{slug}.log"
+            self._fh = self.path.open("a", encoding="utf-8")
+            self._fh.write(f"# c3 download log · kind={kind} · started {ts}\n")
+            self._fh.write(f"# cmd: {' '.join(map(str, cmd))}\n")
+            self._fh.flush()
+            self._prune(d)
+        except OSError:
+            self.path = None
+            self._fh = None
+
+    def _prune(self, d: Path) -> None:
+        try:
+            logs = sorted(d.glob("c3-download-*.log"), key=lambda p: p.stat().st_mtime)
+            for old in logs[: max(0, len(logs) - self.KEEP)]:
+                old.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+    def line(self, s: str) -> None:
+        if self._fh is None:
+            return
+        try:
+            self._fh.write(s.rstrip("\n") + "\n")
+            self._fh.flush()
+        except (OSError, ValueError):
+            self._fh = None
+
+    def complete(self, state) -> None:
+        """Footer from the run state (also fired by the runner's on_complete)."""
+        if self._fh is None:
+            return
+        try:
+            err = getattr(state, "error", "") or ""
+            self._fh.write(
+                f"# done · exit={getattr(state, 'exit_code', None)} · "
+                f"verdict={getattr(state, 'verdict', '')}"
+                + (f" · error={err}" if err else "")
+                + "\n"
+            )
+            self._fh.close()
+        except (OSError, ValueError):
+            pass
+        self._fh = None
 
 
 class CockpitData:
@@ -506,6 +571,71 @@ class CockpitData:
             except Exception:
                 pass
 
+    # ── Download plumbing: persistent logs + preflight ────────────────────────
+    # 2026-07-27 community triage: a failed download left NOTHING on disk (pane
+    # scrollback only), and a missing `hf` CLI surfaced as an opaque spawn error.
+    # Every download now (a) tees its stream to <config>/logs/ and (b) preflights
+    # its prerequisites with actionable pane lines BEFORE spawning.
+
+    @staticmethod
+    def _c3_config_dir() -> Path:
+        """Mirror __main__.settings_path(): C3_CONFIG_DIR or ~/.config/club-3090."""
+        base = os.environ.get("C3_CONFIG_DIR")
+        return Path(base) if base else Path.home() / ".config" / "club-3090"
+
+    def _hf_cli_present(self) -> bool:
+        """The `hf` CLI every download path shells out to (route-G directly;
+        setup.sh + pull.sh's HubFetcher underneath)."""
+        return bool(shutil.which("hf")) or (
+            Path.home() / ".local" / "bin" / "hf"
+        ).exists()
+
+    def _hf_token_file(self) -> Path:
+        return Path.home() / ".cache" / "huggingface" / "token"
+
+    def download_preflight(self, *, needs_hf_cli: bool = True) -> tuple[list[str], list[str]]:
+        """(blockers, notes) checked BEFORE spawning a download.
+
+        Blockers stop the spawn (the pane gets the fix, not a stack trace);
+        notes are informational and never block.  ``C3_SKIP_DOWNLOAD_PREFLIGHT=1``
+        bypasses both (tests; power users who know their rig)."""
+        if os.environ.get("C3_SKIP_DOWNLOAD_PREFLIGHT") == "1":
+            return [], []
+        blockers: list[str] = []
+        notes: list[str] = []
+        if needs_hf_cli and not self._hf_cli_present():
+            blockers += [
+                "✗ preflight: the Hugging Face CLI ('hf') is not installed — the download can't start.",
+                "  fix: run `bash scripts/setup.sh` once in a terminal (it offers an isolated install),",
+                "  or:  pipx install 'huggingface-hub[hf_transfer]' && pipx ensurepath",
+            ]
+        if not os.environ.get("HF_TOKEN") and not self._hf_token_file().exists():
+            notes.append(
+                "ℹ preflight: no HF token found (env HF_TOKEN / ~/.cache/huggingface/token) — "
+                "gated repos will fail with 401; set one in [S] Settings."
+            )
+        return blockers, notes
+
+    def _preflight_failed_state(self, run_type: str, blockers: list[str]) -> CoreRunState:
+        """A failed CoreRunState WITHOUT spawning — the same shape start_raw
+        returns on a spawn failure, so panes handle it identically."""
+        st = CoreRunState(run_type=run_type, started=time.time())
+        st.finished = time.time()
+        st.exit_code = -1
+        st.verdict = "failed"
+        st.error = blockers[0] if blockers else "preflight failed"
+        st.done.set()
+        return st
+
+    @staticmethod
+    def _tee(on_line: Optional[Callable[[str], None]], log: "DownloadLog") -> Callable[[str], None]:
+        """One emitter: every line goes to the log AND (when set) the pane."""
+        def emit(line: str) -> None:
+            log.line(line)
+            if on_line is not None:
+                on_line(line)
+        return emit
+
     # ── Download (Download UX): fetch a slug's weights via setup.sh ───────────────
 
     def weights_download_plan(self, model: str, variant: str) -> ActionPlan:
@@ -553,8 +683,20 @@ class CockpitData:
         if comp_keys:
             env["WEIGHT_EXTRA_KEYS"] = " ".join(comp_keys)
         env.setdefault("HF_HOME", str(Path(root) / ".cache" / "huggingface"))
-        if on_line is not None:
-            self._download_runner.set_callbacks(on_line=on_line)
+        log = DownloadLog(f"weights-{model}", plan.cmd)
+        emit = self._tee(on_line, log)
+        if log.path:
+            emit(f"[log] {log.path}")
+        blockers, notes = self.download_preflight()
+        for n in notes:
+            emit(n)
+        if blockers:
+            for b in blockers:
+                emit(b)
+            st = self._preflight_failed_state(plan.kind, blockers)
+            log.complete(st)
+            return st
+        self._download_runner.set_callbacks(on_line=emit, on_complete=log.complete)
         return await self._download_runner.start_raw(
             plan.cmd, env=env, run_type=plan.kind, parser=None
         )
@@ -571,8 +713,11 @@ class CockpitData:
         env["MODEL_DIR"] = self.weights_model_dir()
         env["COMFYUI_MODELS_DIR"] = self.comfyui_models_dir()
         env.setdefault("HF_HOME", str(Path(self.weights_model_dir()) / ".cache" / "huggingface"))
-        if on_line is not None:
-            self._download_runner.set_callbacks(on_line=on_line)
+        log = DownloadLog("studio", plan.cmd)
+        emit = self._tee(on_line, log)
+        if log.path:
+            emit(f"[log] {log.path}")
+        self._download_runner.set_callbacks(on_line=emit, on_complete=log.complete)
         return await self._download_runner.start_raw(
             plan.cmd, env=env, run_type=plan.kind, parser=None
         )
@@ -1078,6 +1223,7 @@ class CockpitData:
         env = dict(os.environ)
         env.setdefault("HF_HOME", str(self._bring_hf_home()))
         self._last_swap_compose = ""
+        log = DownloadLog(f"bring-{repo.rsplit('/', 1)[-1]}", ["(bring)", repo])
 
         def _capture(line: str) -> None:
             # Route-C apply-swap prints "[apply-swap] compose: <path>" — capture
@@ -1088,8 +1234,19 @@ class CockpitData:
             if on_line is not None:
                 on_line(line)
 
-        if apply_swap or on_line is not None:
-            self._download_runner.set_callbacks(on_line=_capture)
+        emit = self._tee(_capture, log)
+        if log.path:
+            emit(f"[log] {log.path}")
+        blockers, notes = self.download_preflight()
+        for n in notes:
+            emit(n)
+        if blockers:
+            for b in blockers:
+                emit(b)
+            st = self._preflight_failed_state("download", blockers)
+            log.complete(st)
+            return st
+        self._download_runner.set_callbacks(on_line=emit, on_complete=log.complete)
         if gguf_includes:
             # GGUF bring (route-G): pull.sh is the SAFETENSORS evaluate/download
             # path — it ABORTS `unsupported-format (no config.json)` on a GGUF repo.
@@ -1122,6 +1279,7 @@ class CockpitData:
                 # compose (do_download=False).  ② Serve uses this so a present-weights
                 # serve needs no [D] step.  Only meaningful alongside --apply-swap.
                 cmd.append("--emit-only")
+        log.line(f"# cmd: {' '.join(map(str, cmd))}")
         return await self._download_runner.start_raw(
             cmd,
             env=env,

--- a/tools/serve-cockpit/tests/conftest.py
+++ b/tools/serve-cockpit/tests/conftest.py
@@ -20,8 +20,18 @@ real runner.  This fixture guarantees the real one never runs.
 from __future__ import annotations
 
 import asyncio
+import os
+import tempfile
 
 import pytest
+
+# Download plumbing must stay hermetic under test: DownloadLog must never touch
+# the user's real ~/.config/club-3090, and download_preflight must never depend
+# on the HOST's `hf` CLI / token state (a dev box with hf installed would pass
+# where CI fails, and vice versa).  Explicit preflight/log tests override these
+# per-test via monkeypatch.
+os.environ.setdefault("C3_SKIP_DOWNLOAD_PREFLIGHT", "1")
+os.environ.setdefault("C3_CONFIG_DIR", tempfile.mkdtemp(prefix="c3-tests-config-"))
 
 from club3090_tui_core.runner import SubprocessRunner
 from club3090_cockpit.services import RealRunner

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -14,6 +14,7 @@ script calls.  Covers:
 from __future__ import annotations
 
 import json
+import os
 import time
 from pathlib import Path
 from typing import Any, Optional
@@ -1108,6 +1109,102 @@ class TestByoCheck:
         cd = CockpitData(ROOT, runner=runner)
         res = await cd.byo_check("org/Model-GGUF", "llamacpp/deckard40B-dual-mtp")
         assert res.fit_verdict == "unsupported-format"
+
+    # ── Download logs + preflight (2026-07-27 triage fixes) ──────────────────
+
+    @staticmethod
+    def _dl_capture():
+        import asyncio as _a
+
+        class _CaptureDL:
+            def __init__(self):
+                self.calls = []
+                self.cbs = {}
+
+            def set_callbacks(self, **kw):
+                self.cbs = kw
+
+            async def start_raw(self, cmd, env=None, run_type=None, parser=None):
+                self.calls.append(list(cmd))
+                h = type("H", (), {})()
+                h.done = _a.Event()
+                h.done.set()
+                h.exit_code = 0
+                return h
+
+        return _CaptureDL()
+
+    @pytest.mark.asyncio
+    async def test_download_log_written_and_announced(self, tmp_path, monkeypatch):
+        """Every weights download tees to <config>/logs/ and announces the path
+        as the pane's first line (the "no logs for c3" fix)."""
+        monkeypatch.setenv("C3_CONFIG_DIR", str(tmp_path))
+        cap = self._dl_capture()
+        lines: list[str] = []
+        cd = CockpitData(ROOT, runner=full_runner(), download_runner=cap)
+        await cd.run_weights_download("qwen3.6-27b", "autoround-int4", on_line=lines.append)
+        logs = list((tmp_path / "logs").glob("c3-download-*weights-qwen3.6-27b*.log"))
+        assert len(logs) == 1
+        text = logs[0].read_text(encoding="utf-8")
+        assert "# cmd: bash scripts/setup.sh qwen3.6-27b" in text
+        assert lines and lines[0].startswith("[log] ")
+        assert cap.calls  # preflight skipped suite-wide -> spawn reached
+
+    @pytest.mark.asyncio
+    async def test_preflight_blocks_weights_download_without_hf_cli(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("C3_CONFIG_DIR", str(tmp_path))
+        monkeypatch.delenv("C3_SKIP_DOWNLOAD_PREFLIGHT", raising=False)
+        monkeypatch.setattr(CockpitData, "_hf_cli_present", lambda self: False)
+        cap = self._dl_capture()
+        lines: list[str] = []
+        cd = CockpitData(ROOT, runner=full_runner(), download_runner=cap)
+        st = await cd.run_weights_download("qwen3.6-27b", "autoround-int4", on_line=lines.append)
+        assert not cap.calls, "must not spawn on a preflight blocker"
+        assert st.verdict == "failed"
+        assert "hf" in st.error
+        joined = "\n".join(lines)
+        assert "setup.sh" in joined and "pipx install" in joined
+        text = next((tmp_path / "logs").glob("c3-download-*.log")).read_text(encoding="utf-8")
+        assert "preflight" in text and "# done" in text
+
+    @pytest.mark.asyncio
+    async def test_preflight_blocks_bring_download_too(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("C3_CONFIG_DIR", str(tmp_path))
+        monkeypatch.delenv("C3_SKIP_DOWNLOAD_PREFLIGHT", raising=False)
+        monkeypatch.setattr(CockpitData, "_hf_cli_present", lambda self: False)
+        cap = self._dl_capture()
+        cd = CockpitData(ROOT, runner=full_runner(), download_runner=cap)
+        st = await cd.run_bring_download("org/Model-GGUF", "llamacpp/deckard40B-dual-mtp")
+        assert not cap.calls
+        assert st.verdict == "failed"
+
+    @pytest.mark.asyncio
+    async def test_preflight_token_note_never_blocks(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("C3_SKIP_DOWNLOAD_PREFLIGHT", raising=False)
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.setattr(CockpitData, "_hf_cli_present", lambda self: True)
+        monkeypatch.setattr(
+            CockpitData, "_hf_token_file", lambda self: tmp_path / "absent-token"
+        )
+        cd = CockpitData(ROOT, runner=full_runner(), download_runner=self._dl_capture())
+        blockers, notes = cd.download_preflight()
+        assert not blockers
+        assert any("401" in n for n in notes)
+
+    def test_download_log_prune_keeps_newest(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("C3_CONFIG_DIR", str(tmp_path))
+        from club3090_cockpit.services import DownloadLog
+
+        d = tmp_path / "logs"
+        d.mkdir()
+        for i in range(35):
+            f = d / f"c3-download-old{i:03d}-x.log"
+            f.write_text("x", encoding="utf-8")
+            os.utime(f, (1000 + i, 1000 + i))
+        DownloadLog("prune-test", ["true"])
+        remaining = list(d.glob("c3-download-*.log"))
+        assert len(remaining) == DownloadLog.KEEP
+        assert any("prune-test" in p.name for p in remaining)  # newest survives
 
     def test_profile_like_is_gguf_engine(self):
         cd = CockpitData(ROOT, runner=full_runner())


### PR DESCRIPTION
The remaining two fixes from the 2026-07-27 community download triage (follow-ups to #792). Both target the same incident shape: a failed download left no artifact to paste ("i did not found any logs for c3" — accurate), and a missing `hf` CLI would surface as an opaque spawn error rather than its fix.

## 1. Persistent download logs

Every download — catalog weights (setup.sh), Bring & Validate (route-G / pull.sh), and studio — now tees its stream to `<C3_CONFIG_DIR|~/.config/club-3090>/logs/c3-download-<ts>-<kind>.log`:

- header: timestamp + the argv (**env is never logged** — it carries `HF_TOKEN`; argv never does)
- body: every streamed line the pane sees
- footer: exit code / verdict / error, written from the runner's `on_complete` (so spawn failures land too)
- the pane's **first line announces the path** (`[log] …`) so the artifact is discoverable, not just existent
- best-effort throughout (a failed write can never break a download); newest 30 logs retained

## 2. Download preflight

Before spawning weights/bring downloads, `download_preflight()` checks:

- **`hf` CLI present** (every download path shells out to it) → on missing: blocks the spawn and prints the fix in-pane — "run `bash scripts/setup.sh` once in a terminal (it offers an isolated install), or `pipx install 'huggingface-hub[hf_transfer]'`…" — returning the same failed `CoreRunState` shape as a spawn failure, so panes need no new handling
- **HF token** (env + `~/.cache/huggingface/token`) → missing is a *note*, never a block: "gated repos will fail with 401; set one in [S] Settings"

`C3_SKIP_DOWNLOAD_PREFLIGHT=1` bypasses (power users / tests). Studio downloads get logging only (their orchestrator manages its own fetch tooling).

## Hermeticity

conftest now sets a suite-wide tmp `C3_CONFIG_DIR` and the preflight skip, so tests neither depend on the host's `hf`/token state nor write to the real config dir; the six new preflight/log tests override per-test.

## Validation

- 6 new tests: log written + announced, blocker paths for weights **and** bring, token note non-blocking, prune-keeps-newest
- services + registry: **258 passed** · targeted headless (`-k "download or byo or gguf"`): **26 passed**
- live smoke on the reference rig: preflight returns clean (hf present, token present), `DownloadLog` round-trips header/line/footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
