### PR TITLE
feat(pull): GGUF hint on the unsupported-format abort (last item from the 07-27 download triage)

### DIFF
--- a/scripts/lib/profiles/pull.py
+++ b/scripts/lib/profiles/pull.py
@@ -1711,6 +1711,26 @@ def _maybe_submit_verb(argv: list[str]) -> Optional[int]:
     )
 
 
+def _unsupported_format_hint(slug: str) -> list[str]:
+    """Actionable hint lines for the `unsupported-format` abort.
+
+    The evaluate path is safetensors-only BY DESIGN (the fit math reads
+    config.json), and this abort is USUALLY a GGUF-only repo hitting it
+    (2026-07-27 community triage: the bare abort read as "downloads are
+    broken").  No detection here — the deriver 404s on config.json before any
+    file listing exists, and a print site must not add network calls — so the
+    wording stays conditional.
+    """
+    return [
+        "hint: 'unsupported-format' means no transformers config.json — "
+        "usually a GGUF-only repo. GGUF is served WITHOUT this evaluate path:",
+        "hint:   c3 → Bring & Validate → pick a quant in the GGUF table (route-G), or fetch directly:",
+        f"hint:   hf download {slug} --include '<Quant>*.gguf'",
+        "hint:   then serve it via a llama.cpp/ik compose — docs/ADDING_MODELS.md "
+        "→ 'Run a local GGUF without the catalog'",
+    ]
+
+
 def main(argv: list[str]) -> int:
     import argparse
 
@@ -1823,6 +1843,9 @@ def main(argv: list[str]) -> int:
         print(f"[pull] reason={res.abort_reason}")
     if res.detail:
         print(f"[pull] {res.detail}")
+    if res.abort_reason == "unsupported-format":
+        for h in _unsupported_format_hint(res.slug):
+            print(f"[pull] {h}")
     for n in res.notices:
         print(f"[pull] note: {n}")
     if res.emitted and not args.out:

--- a/scripts/tests/test-pull.sh
+++ b/scripts/tests/test-pull.sh
@@ -360,6 +360,13 @@ check(r.stratum is P.Stratum.DERIVER
       f"g12: no safetensors -> stratum-1 unsupported-format "
       f"(got {r.stratum.name}/{r.abort_reason})")
 
+# g12a-hint: the CLI prints an actionable GGUF hint on this abort (the
+# 2026-07-27 triage class — bare pull.sh on a *-GGUF repo read as broken).
+h = "\n".join(P._unsupported_format_hint(s))
+check("route-G" in h and f"hf download {s}" in h
+      and "Run a local GGUF without the catalog" in h,
+      "g12a-hint: unsupported-format hint carries route-G + hf download + doc pointer")
+
 # g12b: multiple top-level safetensors, no index -> ambiguous-weight-set.
 s = "fixtures/ambiguous"
 ff = FixtureFetcher({


### PR DESCRIPTION
Closes out the third and final follow-up from the 2026-07-27 community download triage (siblings: #792 route-G redirect, #793 logs+preflight) — this one for terminal users running bare `pull.sh`.

On `reason=unsupported-format` (and only there), the CLI now prints what the verdict means and the three ways forward: c3's Bring quant picker (route-G), a copy-paste `hf download <slug> --include '<Quant>*.gguf'` with the actual slug substituted, and the ADDING_MODELS.md → 'Run a local GGUF without the catalog' pointer.

Deliberately **no GGUF detection**: the deriver 404s on `config.json` before any file listing exists, and a print site must not add network calls — so the wording is conditional ('usually a GGUF-only repo'). `--json` output is unchanged (machine consumers were fixed in #792).

**Tests:** new g12a-hint content assertion beside the existing GGUF-only fixture; the full pull family is green (test-pull + pullgate-deriver/gates/download + pullemit-capture + submit-pull + pull-swap). **Live-verified** against the exact triage repo/command: the hint renders directly under the abort, above the diagnostics pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)