### PR TITLE
c3: add opt-in master logging

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/__main__.py
+++ b/tools/serve-cockpit/club3090_cockpit/__main__.py
@@ -55,7 +55,7 @@ def save_settings(settings: dict) -> None:
 
 
 def apply_persisted_settings(app, environ) -> None:
-    """Apply MODEL_DIR / HF_TOKEN to the app + process env before run().
+    """Apply MODEL_DIR / HF_TOKEN / C3_LOG to the app before run().
 
     Precedence (highest first): an explicit shell env var > the persisted
     setting (``c3-settings.json``) > the bundled default.  An env var is a
@@ -79,6 +79,15 @@ def apply_persisted_settings(app, environ) -> None:
     cols = s.get("catalog_columns")
     if isinstance(cols, dict):
         app.catalog_columns_pref = cols
+    # Master logging: strict C3_LOG=1|0 shell override wins for this launch.
+    # Invalid/absent values fall back to the persisted boolean, default OFF.
+    from .session_logging import env_log_override
+
+    env_override = env_log_override(environ)
+    persisted_log = s.get("logging_enabled")
+    enabled = env_override if env_override is not None else persisted_log is True
+    app._c3_log_env_override = env_override is not None
+    app.configure_session_logging(enabled)
 
 
 def load_surface_setting() -> "str | None":

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -42,6 +42,7 @@ NEVER executed live — tests inject fakes and conftest blocks the real spawn.
 from __future__ import annotations
 
 import dataclasses
+import logging
 import re
 from collections import OrderedDict
 from pathlib import Path
@@ -61,6 +62,7 @@ from textual.widgets import (
     Label,
     Select,
     Static,
+    Switch,
     TabbedContent,
     TabPane,
     Tabs,
@@ -4348,11 +4350,24 @@ class SettingsScreen(ModalScreen):
         Binding("escape", "cancel", "Cancel", show=True),
     ]
 
-    def __init__(self, model_dir: str, hf_token_set: bool, director_device: str = "gpu0", **kwargs):
+    def __init__(
+        self,
+        model_dir: str,
+        hf_token_set: bool,
+        director_device: str = "gpu0",
+        *,
+        log_enabled: bool = False,
+        log_path: str = "",
+        log_env_override: bool = False,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
         self._model_dir = model_dir or ""
         self._hf_token_set = hf_token_set
         self._director_device = director_device if director_device in ("gpu0", "gpu1", "cpu") else "gpu0"
+        self._log_enabled = log_enabled
+        self._log_path = log_path
+        self._log_env_override = log_env_override
 
     def compose(self) -> ComposeResult:
         with Vertical():
@@ -4373,6 +4388,20 @@ class SettingsScreen(ModalScreen):
                 value=self._director_device, allow_blank=False, id="set-director-device",
             )
             yield Label(
+                "Master logging  [dim](app + non-download commands · downloads always log)[/dim]",
+                classes="settings-field",
+            )
+            log_switch = Switch(value=self._log_enabled, id="set-c3-log")
+            log_switch.disabled = self._log_env_override
+            yield log_switch
+            if self._log_path:
+                yield Label(f"[dim]Active log: {self._log_path}[/dim]", classes="settings-field")
+            elif self._log_env_override:
+                yield Label(
+                    "[dim]C3_LOG controls this launch; change the shell override to alter it.[/dim]",
+                    classes="settings-field",
+                )
+            yield Label(
                 "[dim]Ctrl+S save · Esc cancel · HF_HOME auto-derived under the model dir · "
                 "director change applies on next ai-studio start[/dim]",
                 classes="settings-field",
@@ -4383,8 +4412,14 @@ class SettingsScreen(ModalScreen):
         mdir = self.query_one("#set-model-dir", Input).value.strip()
         tok = self.query_one("#set-hf-token", Input).value.strip()
         dev = str(self.query_one("#set-director-device", Select).value)
+        log_enabled = self.query_one("#set-c3-log", Switch).value
         self.app.pop_screen()
-        self.app.apply_settings(model_dir=mdir, hf_token=tok, director_device=dev)  # type: ignore[attr-defined]
+        self.app.apply_settings(  # type: ignore[attr-defined]
+            model_dir=mdir,
+            hf_token=tok,
+            director_device=dev,
+            log_enabled=log_enabled,
+        )
 
     def action_cancel(self) -> None:
         self.app.pop_screen()
@@ -7309,6 +7344,9 @@ class CockpitApp(App):
             self.sub_title = f"{self.SUB_TITLE} · ▸ LEAN"
         # Injectable service layer — defaults to the real (live-read) impl.
         self._data: CockpitData = data or CockpitData(repo_root)
+        self._session_log = None
+        self._c3_log_enabled = False
+        self._c3_log_env_override = False
         self._active_mode = 0  # 0=Run & Operate (merged) · 1=Bring & Validate
         # Cache the last-loaded variants so detect/match + containers can match
         # running engines back to registry slugs.
@@ -7572,11 +7610,16 @@ class CockpitApp(App):
         footer.set_class(modal_topmost, "base-footer-hidden")
 
     def push_screen(self, *args, **kwargs):
+        screen = args[0] if args else kwargs.get("screen")
+        logging.getLogger("club3090_cockpit").info(
+            "push screen %s", type(screen).__name__ if screen is not None else "unknown"
+        )
         result = super().push_screen(*args, **kwargs)
         self._sync_base_footer_visibility()
         return result
 
     def pop_screen(self, *args, **kwargs):
+        logging.getLogger("club3090_cockpit").info("pop screen")
         result = super().pop_screen(*args, **kwargs)
         self._sync_base_footer_visibility()
         return result
@@ -9647,11 +9690,24 @@ class CockpitApp(App):
         """[S] — open Settings (MODEL_DIR + HF_TOKEN + director placement)."""
         import os as _os
         self.push_screen(
-            SettingsScreen(self._data.weights_model_dir(), bool(_os.environ.get("HF_TOKEN")),
-                           self._data.director_device())
+            SettingsScreen(
+                self._data.weights_model_dir(),
+                bool(_os.environ.get("HF_TOKEN")),
+                self._data.director_device(),
+                log_enabled=self._c3_log_enabled,
+                log_path=str(getattr(self._session_log, "path", "") or ""),
+                log_env_override=self._c3_log_env_override,
+            )
         )
 
-    def apply_settings(self, *, model_dir: str, hf_token: str, director_device: str = "gpu0") -> None:
+    def apply_settings(
+        self,
+        *,
+        model_dir: str,
+        hf_token: str,
+        director_device: str = "gpu0",
+        log_enabled: Optional[bool] = None,
+    ) -> None:
         """Persist + apply Settings.  MODEL_DIR / HF_TOKEN persist to c3-settings.json;
         the director placement persists to the repo .env (STUDIO_DIRECTOR_DEVICE — what
         gpu-mode reads, applied on the next ai-studio start).  Empty text fields are
@@ -9668,6 +9724,13 @@ class CockpitApp(App):
             _os.environ["HF_TOKEN"] = hf_token
             s["hf_token"] = hf_token
             json_changed = True
+        if (
+            log_enabled is not None
+            and not self._c3_log_env_override
+            and log_enabled != s.get("logging_enabled")
+        ):
+            s["logging_enabled"] = bool(log_enabled)
+            json_changed = True
         if json_changed:
             save_settings(s)
         env_changed = False
@@ -9679,8 +9742,49 @@ class CockpitApp(App):
             self.notify(msg, title="Settings", timeout=4)
         else:
             self.notify("No changes.", title="Settings", timeout=2)
+        if log_enabled is not None and not self._c3_log_env_override:
+            self.configure_session_logging(log_enabled)
         if model_dir:
             self.load_catalog()   # re-stat weights against the (possibly new) dir
+
+    def configure_session_logging(self, enabled: bool) -> None:
+        """Apply the master switch without logging settings or environment data."""
+        from .session_logging import SessionLog
+
+        enabled = bool(enabled)
+        if enabled and self._session_log is None:
+            self._session_log = SessionLog()
+        elif not enabled and self._session_log is not None:
+            self._session_log.close()
+            self._session_log = None
+        self._c3_log_enabled = enabled
+        self._data.set_logging_enabled(enabled)
+
+    async def _dispatch_action(self, namespace, action_name: str, params) -> bool:
+        """Log action names only; parameters may contain user-entered values."""
+        logger = logging.getLogger("club3090_cockpit")
+        logger.info("action %s target=%s", action_name, type(namespace).__name__)
+        try:
+            return await super()._dispatch_action(namespace, action_name, params)
+        except Exception:
+            logger.exception("action %s failed", action_name)
+            raise
+
+    def _log_unhandled_exception(self, error: Exception) -> None:
+        logging.getLogger("club3090_cockpit").error(
+            "unhandled exception",
+            exc_info=(type(error), error, error.__traceback__),
+        )
+
+    def _handle_exception(self, error: Exception) -> None:
+        """Capture Textual/asyncio failures before Textual tears down the app."""
+        self._log_unhandled_exception(error)
+        super()._handle_exception(error)
+
+    def on_unmount(self) -> None:
+        if self._session_log is not None:
+            self._session_log.close()
+            self._session_log = None
 
     def on_mouse_down(self, event) -> None:
         """RIGHT-CLICK → copy.  A TUI captures the mouse, so the terminal's native

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -33,6 +33,7 @@ import shutil
 import subprocess
 import time
 import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Optional, Protocol
 
@@ -227,9 +228,13 @@ class Runner(Protocol):
 class RealRunner:
     """Production runner — actually shells out (READ contracts only)."""
 
+    def __init__(self, *, logging_enabled: bool = False):
+        self.logging_enabled = logging_enabled
+
     async def run(
         self, cmd: list[str], *, cwd: str, timeout: float = 30.0
     ) -> RunResult:
+        log = RunLog("read", cmd) if self.logging_enabled else None
         try:
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
@@ -238,17 +243,20 @@ class RealRunner:
                 stderr=asyncio.subprocess.PIPE,
             )
             out, err = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-            return RunResult(
+            result = RunResult(
                 returncode=proc.returncode if proc.returncode is not None else -1,
                 stdout=out.decode("utf-8", errors="replace"),
                 stderr=err.decode("utf-8", errors="replace"),
             )
         except asyncio.TimeoutError:
-            return RunResult(returncode=-1, stdout="", stderr="timeout", timed_out=True)
+            result = RunResult(returncode=-1, stdout="", stderr="timeout", timed_out=True)
         except FileNotFoundError as exc:
-            return RunResult(returncode=127, stdout="", stderr=str(exc))
+            result = RunResult(returncode=127, stdout="", stderr=str(exc))
         except Exception as exc:  # pragma: no cover - defensive
-            return RunResult(returncode=-1, stdout="", stderr=str(exc))
+            result = RunResult(returncode=-1, stdout="", stderr=str(exc))
+        if log is not None:
+            log.complete_result(result)
+        return result
 
 
 # Detect seam: async callables matching the core signatures.
@@ -262,29 +270,30 @@ ProbeServedFn = Callable[[Any], Awaitable["ServedProbe"]]
 # ── The service class ───────────────────────────────────────────────────────────
 
 
-class DownloadLog:
-    """Persistent per-download log — ``<config>/logs/c3-download-<ts>-<kind>.log``.
+class RunLog:
+    """Persistent subprocess log — ``<config>/logs/c3-<category>-<ts>-<kind>.log``.
 
-    The "no logs for c3" fix (2026-07-27 community triage): a download's
-    streamed lines, spawn errors and exit state survive the pane.  Best-effort
-    everywhere — a failed write must never break a download.  The child ENV is
-    never logged (it carries HF_TOKEN); the argv is (it never does).
+    Best-effort everywhere — a failed write must never break the underlying
+    action.  The child ENV is never logged (it carries HF_TOKEN); the argv is
+    safe to log.  ``DownloadLog`` below keeps the #793 always-on behavior while
+    general runs are constructed only when the master logging switch is on.
     """
 
     KEEP = 30  # newest logs retained; older pruned at construction
 
-    def __init__(self, kind: str, cmd: list[str]):
+    def __init__(self, kind: str, cmd: list[str], *, category: str = "run"):
         self.path: Optional[Path] = None
         self._fh = None
+        self.category = category
         try:
             base = os.environ.get("C3_CONFIG_DIR")
             d = (Path(base) if base else Path.home() / ".config" / "club-3090") / "logs"
             d.mkdir(parents=True, exist_ok=True)
-            ts = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
-            slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", kind).strip("-") or "download"
-            self.path = d / f"c3-download-{ts}-{slug}.log"
+            ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+            slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", kind).strip("-") or category
+            self.path = d / f"c3-{category}-{ts}-{slug}.log"
             self._fh = self.path.open("a", encoding="utf-8")
-            self._fh.write(f"# c3 download log · kind={kind} · started {ts}\n")
+            self._fh.write(f"# c3 {category} log · kind={kind} · started {ts}\n")
             self._fh.write(f"# cmd: {' '.join(map(str, cmd))}\n")
             self._fh.flush()
             self._prune(d)
@@ -294,7 +303,10 @@ class DownloadLog:
 
     def _prune(self, d: Path) -> None:
         try:
-            logs = sorted(d.glob("c3-download-*.log"), key=lambda p: p.stat().st_mtime)
+            logs = sorted(
+                d.glob(f"c3-{self.category}-*.log"),
+                key=lambda p: p.stat().st_mtime,
+            )
             for old in logs[: max(0, len(logs) - self.KEEP)]:
                 old.unlink(missing_ok=True)
         except OSError:
@@ -325,6 +337,50 @@ class DownloadLog:
         except (OSError, ValueError):
             pass
         self._fh = None
+
+    def complete_result(self, result: RunResult) -> None:
+        """Footer for a read runner, with noisy output only when it is useful."""
+        if self._fh is None:
+            return
+        stdout = result.stdout or ""
+        stderr = result.stderr or ""
+        parseable_json = False
+        if result.ok and stdout.strip():
+            try:
+                json.loads(stdout)
+                parseable_json = True
+            except (TypeError, ValueError):
+                pass
+        try:
+            nonparseable_output = bool(stderr.strip()) or bool(
+                stdout.strip() and not parseable_json
+            )
+            if not result.ok or nonparseable_output:
+                if stdout:
+                    self._fh.write("# stdout\n")
+                    self._fh.write(stdout.rstrip("\n") + "\n")
+                if stderr:
+                    self._fh.write("# stderr\n")
+                    self._fh.write(stderr.rstrip("\n") + "\n")
+            self._fh.write(
+                f"# done · exit={result.returncode} · "
+                f"verdict={'passed' if result.ok else 'failed'}"
+                + (" · error=timeout" if result.timed_out else "")
+                + "\n"
+            )
+            self._fh.close()
+        except (OSError, ValueError):
+            pass
+        self._fh = None
+
+
+class DownloadLog(RunLog):
+    """Always-on #793 download log; intentionally outside the master switch."""
+
+    KEEP = 30
+
+    def __init__(self, kind: str, cmd: list[str]):
+        super().__init__(kind, cmd, category="download")
 
 
 class CockpitData:
@@ -369,6 +425,7 @@ class CockpitData:
         # on each ``load_catalog_rows``; empty on the raw-tab fallback path.
         self.catalog_defaults: list[dict] = []
         self._runner: Runner = runner or RealRunner()
+        self._logging_enabled = False
         self._detect_endpoint: DetectEndpointFn = detect_endpoint_fn or core_detect_endpoint
         self._get_gpu_info: GetGpuInfoFn = get_gpu_info_fn or core_get_gpu_info
         # A7: the live-config probe seam.  Defaults to the real httpx + docker
@@ -399,6 +456,73 @@ class CockpitData:
         # own READY_TIMEOUT is already 600s, so a TTL near that would prune a
         # still-booting claim; keep it well above a worst-case boot.
         self._claim_ttl = 1800.0  # seconds
+
+    def set_logging_enabled(self, enabled: bool) -> None:
+        """Apply the master switch to read and non-download write runners."""
+        self._logging_enabled = bool(enabled)
+        if isinstance(self._runner, RealRunner):
+            self._runner.logging_enabled = self._logging_enabled
+
+    async def _start_raw_logged(
+        self,
+        runner: SubprocessRunner,
+        cmd: list[str],
+        *,
+        env: dict,
+        run_type: str,
+        parser: Any,
+        on_event: Optional[Callable[[Any], None]] = None,
+        on_line: Optional[Callable[[str], None]] = None,
+    ) -> Any:
+        """Start a non-download stream, teeing it when master logging is on.
+
+        Callback values are never serialized.  In particular, ``env`` is passed
+        to the child only and is intentionally absent from the log.
+        """
+        existing_event = getattr(runner, "_on_event", None)
+        existing_line = getattr(runner, "_on_line", None)
+        existing_complete = getattr(runner, "_on_complete", None)
+        event_cb = on_event if on_event is not None else existing_event
+        line_cb = on_line if on_line is not None else existing_line
+        log = RunLog(run_type, cmd) if self._logging_enabled else None
+
+        def emit(line: str) -> None:
+            if log is not None:
+                log.line(line)
+            if line_cb is not None:
+                line_cb(line)
+
+        def complete(state: Any) -> None:
+            try:
+                if log is not None:
+                    log.complete(state)
+                if existing_complete is not None:
+                    existing_complete(state)
+            finally:
+                # ``SubprocessRunner`` stores callbacks on the runner instance.
+                # Restore the prior set after this asynchronous run finishes so
+                # repeated launches do not build callback/log wrapper chains.
+                runner.set_callbacks(
+                    on_event=existing_event,
+                    on_line=existing_line,
+                    on_complete=existing_complete,
+                )
+
+        if log is not None or on_event is not None or on_line is not None:
+            runner.set_callbacks(
+                on_event=event_cb,
+                on_line=emit if log is not None or line_cb is not None else None,
+                on_complete=complete,
+            )
+        try:
+            return await runner.start_raw(cmd, env=env, run_type=run_type, parser=parser)
+        except Exception:
+            runner.set_callbacks(
+                on_event=existing_event,
+                on_line=existing_line,
+                on_complete=existing_complete,
+            )
+            raise
 
     # ── small JSON helper ──────────────────────────────────────────────────────
 
@@ -3252,7 +3376,8 @@ class CockpitData:
                 _run_env = dict(_os.environ)
                 if plan.env:
                     _run_env.update(plan.env)
-                state = await self._write_runner.start_raw(
+                state = await self._start_raw_logged(
+                    self._write_runner,
                     plan.cmd,
                     env=_run_env,
                     run_type=run_type or plan.kind,
@@ -3430,14 +3555,16 @@ class CockpitData:
         if url:
             env["URL"] = url
         parser = self._validation_parser(kind)
-        if on_event is not None or on_line is not None:
-            # Per-launch callbacks for the live pane.  set_callbacks is on the
-            # shared runner; the caller owns wiring/teardown.
-            self._write_runner.set_callbacks(on_event=on_event, on_line=on_line)
         # No reconcile gate (validation does not claim a GPU); straight to the
         # streamer.  In tests this is the FakeWriteRunner; live it is blocked.
-        return await self._write_runner.start_raw(
-            plan.cmd, env=env, run_type=plan.kind, parser=parser
+        return await self._start_raw_logged(
+            self._write_runner,
+            plan.cmd,
+            env=env,
+            run_type=plan.kind,
+            parser=parser,
+            on_event=on_event,
+            on_line=on_line,
         )
 
     # ── Producer / ③ Gate: the FULL validation battery (report.sh --full) ─────────
@@ -3494,12 +3621,16 @@ class CockpitData:
             env["MODEL"] = model
         if url:
             env["URL"] = url
-        if on_event is not None or on_line is not None:
-            self._write_runner.set_callbacks(on_event=on_event, on_line=on_line)
         # No reconcile gate (uses the serving model; claims no GPU); straight to
         # the streamer.  In tests this is the FakeWriteRunner; live it is blocked.
-        return await self._write_runner.start_raw(
-            plan.cmd, env=env, run_type=plan.kind, parser=_NullParser()
+        return await self._start_raw_logged(
+            self._write_runner,
+            plan.cmd,
+            env=env,
+            run_type=plan.kind,
+            parser=_NullParser(),
+            on_event=on_event,
+            on_line=on_line,
         )
 
     # ── Validate / Doctor: health + estate-diagnose + profile-triage (READS) ──────
@@ -4484,10 +4615,14 @@ class CockpitData:
                 env["C3T_TARGET_CONTAINER"] = target.container
             if getattr(target, "slug", ""):
                 env["C3T_TARGET_SLUG"] = target.slug
-        if on_event is not None or on_line is not None:
-            self._write_runner.set_callbacks(on_event=on_event, on_line=on_line)
-        return await self._write_runner.start_raw(
-            handoff.plan.cmd, env=env, run_type=handoff.plan.kind, parser=_NullParser()
+        return await self._start_raw_logged(
+            self._write_runner,
+            handoff.plan.cmd,
+            env=env,
+            run_type=handoff.plan.kind,
+            parser=_NullParser(),
+            on_event=on_event,
+            on_line=on_line,
         )
 
     # ── Hook 2: Promote to catalog — SCAFFOLD + GATE (design §3.5b) ────────────────

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -234,7 +234,7 @@ class RealRunner:
     async def run(
         self, cmd: list[str], *, cwd: str, timeout: float = 30.0
     ) -> RunResult:
-        log = RunLog("read", cmd) if self.logging_enabled else None
+        log = ReadLog(cmd) if self.logging_enabled else None
         try:
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
@@ -280,6 +280,7 @@ class RunLog:
     """
 
     KEEP = 30  # newest logs retained; older pruned at construction
+    LOG_SUCCESS_OUTPUT = True
 
     def __init__(self, kind: str, cmd: list[str], *, category: str = "run"):
         self.path: Optional[Path] = None
@@ -345,7 +346,7 @@ class RunLog:
         stdout = result.stdout or ""
         stderr = result.stderr or ""
         parseable_json = False
-        if result.ok and stdout.strip():
+        if self.LOG_SUCCESS_OUTPUT and result.ok and stdout.strip():
             try:
                 json.loads(stdout)
                 parseable_json = True
@@ -355,7 +356,7 @@ class RunLog:
             nonparseable_output = bool(stderr.strip()) or bool(
                 stdout.strip() and not parseable_json
             )
-            if not result.ok or nonparseable_output:
+            if not result.ok or (self.LOG_SUCCESS_OUTPUT and nonparseable_output):
                 if stdout:
                     self._fh.write("# stdout\n")
                     self._fh.write(stdout.rstrip("\n") + "\n")
@@ -372,6 +373,21 @@ class RunLog:
         except (OSError, ValueError):
             pass
         self._fh = None
+
+
+class ReadLog(RunLog):
+    """High-churn read record pool, isolated from actionable write logs.
+
+    Healthy poll bodies are intentionally omitted: argv + exit status retain
+    the audit record without repeatedly dumping df/meminfo/nvidia-smi output.
+    Failures still include stdout/stderr through ``RunLog.complete_result``.
+    """
+
+    KEEP = 100
+    LOG_SUCCESS_OUTPUT = False
+
+    def __init__(self, cmd: list[str]):
+        super().__init__("read", cmd, category="read")
 
 
 class DownloadLog(RunLog):

--- a/tools/serve-cockpit/club3090_cockpit/session_logging.py
+++ b/tools/serve-cockpit/club3090_cockpit/session_logging.py
@@ -1,0 +1,85 @@
+"""c3 application-session logging.
+
+The app log is opt-in and deliberately separate from the always-on download
+logs.  It never serializes settings or process environments: callers log event
+names and exception objects only.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping, Optional
+
+
+def config_dir() -> Path:
+    """Return ``C3_CONFIG_DIR`` or the normal per-user c3 config directory."""
+    base = os.environ.get("C3_CONFIG_DIR")
+    return Path(base) if base else Path.home() / ".config" / "club-3090"
+
+
+def env_log_override(environ: Mapping[str, str]) -> Optional[bool]:
+    """Parse the strict per-launch ``C3_LOG=1|0`` override."""
+    value = str(environ.get("C3_LOG") or "").strip()
+    if value == "1":
+        return True
+    if value == "0":
+        return False
+    return None
+
+
+class SessionLog:
+    """One opt-in Python log file for the lifetime of a c3 app instance."""
+
+    KEEP = 10
+
+    def __init__(self) -> None:
+        self.path: Optional[Path] = None
+        self._handler: Optional[logging.FileHandler] = None
+        try:
+            log_dir = config_dir() / "logs"
+            log_dir.mkdir(parents=True, exist_ok=True)
+            ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+            self.path = log_dir / f"c3-session-{ts}.log"
+            handler = logging.FileHandler(self.path, encoding="utf-8")
+            formatter = logging.Formatter(
+                "%(asctime)sZ %(levelname)s %(name)s: %(message)s",
+                datefmt="%Y-%m-%dT%H:%M:%S",
+            )
+            formatter.converter = time.gmtime
+            handler.setFormatter(formatter)
+            handler.setLevel(logging.INFO)
+            logging.getLogger().addHandler(handler)
+            logging.getLogger("club3090_cockpit").setLevel(logging.INFO)
+            self._handler = handler
+            self._prune(log_dir)
+            logging.getLogger("club3090_cockpit").info("c3 session log started")
+        except OSError:
+            self.path = None
+            self._handler = None
+
+    def _prune(self, log_dir: Path) -> None:
+        try:
+            logs = sorted(
+                log_dir.glob("c3-session-*.log"),
+                key=lambda path: path.stat().st_mtime,
+            )
+            for old in logs[: max(0, len(logs) - self.KEEP)]:
+                old.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+    def close(self) -> None:
+        handler = self._handler
+        if handler is None:
+            return
+        try:
+            logging.getLogger("club3090_cockpit").info("c3 session log stopped")
+            handler.flush()
+        finally:
+            logging.getLogger().removeHandler(handler)
+            handler.close()
+            self._handler = None

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -30,7 +30,7 @@ from typing import Any, Optional
 
 import pytest
 
-from textual.widgets import Button, DataTable, Input, Select, Static, TabbedContent, TabPane, Label, Tabs
+from textual.widgets import Button, DataTable, Input, Select, Static, Switch, TabbedContent, TabPane, Label, Tabs
 from textual.widgets._footer import FooterKey
 from textual.widgets._tabbed_content import ContentTabs
 
@@ -11479,6 +11479,7 @@ class TestSettings:
         # would make the persisted-settings tests non-deterministic — clear it;
         # the env-precedence tests below set it explicitly.
         monkeypatch.delenv("MODEL_DIR", raising=False)
+        monkeypatch.delenv("C3_LOG", raising=False)
 
     @pytest.mark.asyncio
     async def test_s_opens_settings_modal(self):
@@ -11492,19 +11493,81 @@ class TestSettings:
             assert isinstance(app.screen, SettingsScreen)
 
     @pytest.mark.asyncio
+    async def test_settings_shows_active_log_path(self):
+        app, _, _ = make_app()
+        app.configure_session_logging(True)
+        active_path = str(app._session_log.path)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            await pilot.press("S")
+            await _settle(pilot)
+            switch = app.screen.query_one("#set-c3-log", Switch)
+            assert switch.value is True
+            labels = "\n".join(str(label.render()) for label in app.screen.query(Label))
+            assert active_path in labels
+        app.configure_session_logging(False)
+
+    def test_session_log_captures_traceback_without_settings_values(self):
+        from club3090_cockpit import __main__ as M
+
+        M.save_settings({
+            "model_dir": "/private/models",
+            "hf_token": "hf_super_secret",
+            "logging_enabled": False,
+        })
+        app, _, _ = make_app()
+        M.apply_persisted_settings(app, {"C3_LOG": "1"})
+        path = app._session_log.path
+        try:
+            raise RuntimeError("traceback sentinel")
+        except RuntimeError as exc:
+            app._log_unhandled_exception(exc)
+        app.configure_session_logging(False)
+        text = path.read_text(encoding="utf-8")
+        assert "Traceback" in text
+        assert "RuntimeError: traceback sentinel" in text
+        assert "hf_super_secret" not in text
+        assert "/private/models" not in text
+
+    def test_c3_log_env_override_wins_over_persisted(self):
+        from club3090_cockpit import __main__ as M
+
+        M.save_settings({"logging_enabled": True})
+        app, _, _ = make_app()
+        M.apply_persisted_settings(app, {"C3_LOG": "0"})
+        assert app._c3_log_enabled is False
+        assert app._c3_log_env_override is True
+        assert app._session_log is None
+        app.apply_settings(model_dir="", hf_token="", log_enabled=False)
+        assert M.load_settings()["logging_enabled"] is True
+
+        M.save_settings({"logging_enabled": False})
+        app2, _, _ = make_app()
+        M.apply_persisted_settings(app2, {"C3_LOG": "1"})
+        assert app2._c3_log_enabled is True
+        assert app2._c3_log_env_override is True
+        assert app2._session_log.path.exists()
+        app2.configure_session_logging(False)
+
+    @pytest.mark.asyncio
     async def test_apply_settings_persists_and_applies(self):
         import os
         from club3090_cockpit import __main__ as M
         app, _, _ = make_app()
         async with app.run_test(size=(120, 40)) as pilot:
             await _settle(pilot)
-            app.apply_settings(model_dir="/tmp/my-models", hf_token="hf_secret123")
+            app.apply_settings(
+                model_dir="/tmp/my-models",
+                hf_token="hf_secret123",
+                log_enabled=True,
+            )
             await _settle(pilot)
             assert app._data.weights_model_dir() == "/tmp/my-models"
             assert os.environ.get("HF_TOKEN") == "hf_secret123"
             s = M.load_settings()
             assert s.get("model_dir") == "/tmp/my-models"
             assert s.get("hf_token") == "hf_secret123"
+            assert s.get("logging_enabled") is True
 
     @pytest.mark.asyncio
     async def test_blank_fields_keep_current(self):

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -13,6 +13,7 @@ script calls.  Covers:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import time
@@ -74,6 +75,7 @@ from club3090_cockpit.data import (
 from club3090_cockpit.services import CockpitData, RealRunner, RunResult, _variant_row_from_dict
 
 
+_REAL_RUN = RealRunner.run
 ROOT = Path("/tmp/fake-club-3090-root")
 
 
@@ -1205,6 +1207,120 @@ class TestByoCheck:
         remaining = list(d.glob("c3-download-*.log"))
         assert len(remaining) == DownloadLog.KEEP
         assert any("prune-test" in p.name for p in remaining)  # newest survives
+
+    @pytest.mark.asyncio
+    async def test_master_logging_defaults_off_for_write_runner(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("C3_CONFIG_DIR", str(tmp_path))
+
+        class WriteRunner:
+            async def start_raw(self, cmd, env, run_type, parser):
+                return CoreRunState(run_type=run_type, started=time.time())
+
+        cd = CockpitData(ROOT, runner=full_runner(), write_runner=WriteRunner())
+        await cd._start_raw_logged(
+            cd._write_runner,
+            ["bash", "scripts/verify.sh"],
+            env={"HF_TOKEN": "hf_must_not_leak"},
+            run_type="verify",
+            parser=object(),
+        )
+        assert not list((tmp_path / "logs").glob("c3-run-*.log"))
+
+    @pytest.mark.asyncio
+    async def test_write_runner_log_stream_footer_and_env_redaction(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("C3_CONFIG_DIR", str(tmp_path))
+
+        class WriteRunner:
+            def __init__(self):
+                self.callbacks = {}
+
+            def set_callbacks(self, **callbacks):
+                self.callbacks = callbacks
+
+            async def start_raw(self, cmd, env, run_type, parser):
+                self.callbacks["on_line"]("streamed line")
+                state = CoreRunState(
+                    run_type=run_type,
+                    started=time.time(),
+                    finished=time.time(),
+                    exit_code=0,
+                    verdict="passed",
+                )
+                state.done.set()
+                self.callbacks["on_complete"](state)
+                return state
+
+        writer = WriteRunner()
+        cd = CockpitData(ROOT, runner=full_runner(), write_runner=writer)
+        cd.set_logging_enabled(True)
+        await cd._start_raw_logged(
+            writer,
+            ["bash", "scripts/verify.sh"],
+            env={"HF_TOKEN": "hf_must_not_leak"},
+            run_type="verify",
+            parser=object(),
+        )
+        assert all(callback is None for callback in writer.callbacks.values())
+        log = next((tmp_path / "logs").glob("c3-run-*-verify.log"))
+        text = log.read_text(encoding="utf-8")
+        assert "# cmd: bash scripts/verify.sh" in text
+        assert "streamed line" in text
+        assert "# done · exit=0 · verdict=passed" in text
+        assert "hf_must_not_leak" not in text
+        assert "HF_TOKEN" not in text
+
+    @pytest.mark.asyncio
+    async def test_read_runner_logs_failure_but_omits_healthy_json(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("C3_CONFIG_DIR", str(tmp_path))
+
+        class Proc:
+            def __init__(self, rc, out, err):
+                self.returncode = rc
+                self._out = out
+                self._err = err
+
+            async def communicate(self):
+                return self._out.encode(), self._err.encode()
+
+        responses = iter([
+            Proc(0, '{"large": [1, 2, 3]}', ""),
+            Proc(2, "partial output", "parse failed"),
+        ])
+
+        async def fake_exec(*args, **kwargs):
+            return next(responses)
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        runner = RealRunner(logging_enabled=True)
+        healthy = await _REAL_RUN(runner, ["bash", "registry-emit"], cwd="/tmp")
+        failed = await _REAL_RUN(runner, ["bash", "kv-calc"], cwd="/tmp")
+        assert healthy.ok and not failed.ok
+        logs = list((tmp_path / "logs").glob("c3-run-*-read.log"))
+        assert len(logs) == 2
+        texts = [path.read_text(encoding="utf-8") for path in logs]
+        healthy_text = next(text for text in texts if "registry-emit" in text)
+        failed_text = next(text for text in texts if "kv-calc" in text)
+        assert '"large"' not in healthy_text
+        assert "# done · exit=0 · verdict=passed" in healthy_text
+        assert "partial output" in failed_text
+        assert "parse failed" in failed_text
+        assert "# done · exit=2 · verdict=failed" in failed_text
+
+    def test_session_log_prune_keeps_ten(self, tmp_path, monkeypatch):
+        from club3090_cockpit.session_logging import SessionLog
+
+        monkeypatch.setenv("C3_CONFIG_DIR", str(tmp_path))
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        for i in range(12):
+            path = log_dir / f"c3-session-old{i:03d}.log"
+            path.write_text("old", encoding="utf-8")
+            os.utime(path, (1000 + i, 1000 + i))
+        session = SessionLog()
+        session.close()
+        remaining = list(log_dir.glob("c3-session-*.log"))
+        assert len(remaining) == SessionLog.KEEP
+        assert session.path in remaining
 
     def test_profile_like_is_gguf_engine(self):
         cd = CockpitData(ROOT, runner=full_runner())

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -1270,7 +1270,9 @@ class TestByoCheck:
         assert "HF_TOKEN" not in text
 
     @pytest.mark.asyncio
-    async def test_read_runner_logs_failure_but_omits_healthy_json(self, tmp_path, monkeypatch):
+    async def test_read_runner_logs_failure_but_omits_healthy_poll_output(
+        self, tmp_path, monkeypatch
+    ):
         monkeypatch.setenv("C3_CONFIG_DIR", str(tmp_path))
 
         class Proc:
@@ -1284,6 +1286,12 @@ class TestByoCheck:
 
         responses = iter([
             Proc(0, '{"large": [1, 2, 3]}', ""),
+            Proc(
+                0,
+                "Filesystem 1K-blocks Used Available Use% Mounted on\n"
+                "/dev/root 1 1 0 100% /\n",
+                "",
+            ),
             Proc(2, "partial output", "parse failed"),
         ])
 
@@ -1292,19 +1300,48 @@ class TestByoCheck:
 
         monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
         runner = RealRunner(logging_enabled=True)
-        healthy = await _REAL_RUN(runner, ["bash", "registry-emit"], cwd="/tmp")
+        healthy_json = await _REAL_RUN(runner, ["bash", "registry-emit"], cwd="/tmp")
+        healthy_text = await _REAL_RUN(runner, ["df", "-P"], cwd="/tmp")
         failed = await _REAL_RUN(runner, ["bash", "kv-calc"], cwd="/tmp")
-        assert healthy.ok and not failed.ok
-        logs = list((tmp_path / "logs").glob("c3-run-*-read.log"))
-        assert len(logs) == 2
+        assert healthy_json.ok and healthy_text.ok and not failed.ok
+        logs = list((tmp_path / "logs").glob("c3-read-*-read.log"))
+        assert len(logs) == 3
+        assert not list((tmp_path / "logs").glob("c3-run-*-read.log"))
         texts = [path.read_text(encoding="utf-8") for path in logs]
-        healthy_text = next(text for text in texts if "registry-emit" in text)
+        healthy_json_log = next(text for text in texts if "registry-emit" in text)
+        healthy_text_log = next(text for text in texts if "# cmd: df -P" in text)
         failed_text = next(text for text in texts if "kv-calc" in text)
-        assert '"large"' not in healthy_text
-        assert "# done · exit=0 · verdict=passed" in healthy_text
+        assert '"large"' not in healthy_json_log
+        assert "# done · exit=0 · verdict=passed" in healthy_json_log
+        assert "Filesystem" not in healthy_text_log
+        assert "/dev/root" not in healthy_text_log
+        assert "# done · exit=0 · verdict=passed" in healthy_text_log
         assert "partial output" in failed_text
         assert "parse failed" in failed_text
         assert "# done · exit=2 · verdict=failed" in failed_text
+
+    def test_read_churn_cannot_prune_write_logs(self, tmp_path, monkeypatch):
+        from club3090_cockpit.services import ReadLog, RunLog
+
+        monkeypatch.setenv("C3_CONFIG_DIR", str(tmp_path))
+        write_log = RunLog(
+            "serve", ["bash", "scripts/switch.sh", "vllm/default"]
+        )
+        write_path = write_log.path
+        write_log.complete_result(RunResult(1, "boot output", "serve crashed"))
+
+        for i in range(ReadLog.KEEP + 5):
+            read_log = ReadLog(["poll", str(i)])
+            read_log.complete_result(RunResult(0, f"healthy poll dump {i}", ""))
+
+        assert write_path is not None and write_path.exists()
+        assert "serve crashed" in write_path.read_text(encoding="utf-8")
+        read_logs = list((tmp_path / "logs").glob("c3-read-*.log"))
+        assert len(read_logs) == ReadLog.KEEP
+        assert not any(
+            "healthy poll dump" in path.read_text(encoding="utf-8")
+            for path in read_logs
+        )
 
     def test_session_log_prune_keeps_ten(self, tmp_path, monkeypatch):
         from club3090_cockpit.session_logging import SessionLog


### PR DESCRIPTION
## Decided behavior

The new master switch defaults OFF and governs the app session log plus non-download subprocess logs. Download logs remain always-on exactly as shipped in #793.

## Acceptance

- [x] Add a persisted Settings toggle with per-launch C3_LOG=1|0 precedence.
- [x] Create one discoverable UTC-stamped session log and capture screen/action transitions plus full unhandled-exception tracebacks.
- [x] Generalize RunLog for streamed writes and read-runner command/exit records while omitting healthy JSON output.
- [x] Never serialize child environments or Settings values; add token/env redaction regressions.
- [x] Retain the newest 10 session logs while downloads keep their existing newest-30 policy.
- [x] Keep logging default-off and cover explicit enable, footers, failures, pruning, and callback restoration hermetically.

## Tests

- 262 passed: test_services.py + test_registry_parser.py
- 88 passed, 483 deselected: test_app_headless.py filtered to settings or log
- Python syntax compile and git diff --check passed

No GPU or live-service validation was run or required.

Fixes #795