### PR TITLE
concurrency-probe: TTFT + prefill columns (already-measured, never reported)

### DIFF
--- a/scripts/concurrency-probe.sh
+++ b/scripts/concurrency-probe.sh
@@ -162,9 +162,9 @@ def one(stream, rnd):
     except Exception as e:
         return {"ok":False,"toks":0,"silent":False,"err":str(e)[:80],"dt":time.time()-t0,"ttft":None,"tps":0.0}
 
-print(f"\n{'round':>5} {'done':>7} {'silent':>7} {'errors':>7} {'vram_MB':>8} {'agg_t/s':>8} {'per-strm':>9}")
+print(f"\n{'round':>5} {'done':>7} {'silent':>7} {'errors':>7} {'vram_MB':>8} {'agg_t/s':>8} {'per-strm':>9} {'ttft_ms':>8} {'pf_t/s':>7}")
 vram0=vram_used_mb()
-vram_by_round=[]; mtps_by_round=[]; agg_by_round=[]; bad=0
+vram_by_round=[]; mtps_by_round=[]; agg_by_round=[]; ttft_by_round=[]; pf_by_round=[]; bad=0
 for rnd in range(1,ROUNDS+1):
     t0=time.time()
     with cf.ThreadPoolExecutor(max_workers=N) as ex:
@@ -177,7 +177,13 @@ for rnd in range(1,ROUNDS+1):
     tps_ok=[r["tps"] for r in res if r["ok"] and r["tps"]>0]
     mtps=statistics.median(tps_ok) if tps_ok else 0.0
     mtps_by_round.append(mtps); agg_by_round.append(agg)
-    print(f"{rnd:>5} {done:>4}/{N:<2} {silent:>7} {errs:>7} {v:>8} {agg:>8.1f} {mtps:>9.1f}")
+    # concurrent prefill: median TTFT across streams; prefill rate derived as
+    # PTOK/ttft (same convention as bench.sh's prefill probe: prompt_tokens/TTFT).
+    ttfts=[r["ttft"] for r in res if r["ok"] and r["ttft"]]
+    ttft_med=statistics.median(ttfts) if ttfts else 0.0
+    pf=(PTOK/ttft_med) if ttft_med>0 else 0.0
+    ttft_by_round.append(ttft_med); pf_by_round.append(pf)
+    print(f"{rnd:>5} {done:>4}/{N:<2} {silent:>7} {errs:>7} {v:>8} {agg:>8.1f} {mtps:>9.1f} {ttft_med*1000:>8.0f} {pf:>7.0f}")
     if done<N or silent or errs: bad+=1
 
 # VRAM: leak = post-warm growth (round 2 baseline), NOT the expected cold->warm fill.
@@ -211,6 +217,10 @@ print(f"  VRAM: cold {vram0} -> warm {warm} MB (pool fill {pool_fill} MB, expect
 print(f"  per-stream decode: {report_tps:.1f} tok/s (steady) · aggregate {report_agg:.1f} tok/s "
       f"({N} streams) · retention {retention*100:.1f}% "
       f"(min {RETENTION_MIN*100:.0f}%)" + (f" · floor {TPS_FLOOR:.0f}" if TPS_FLOOR>0 else " · floor off"))
+steady_ttft=ttft_by_round[-1] if ttft_by_round else 0.0
+steady_pf=pf_by_round[-1] if pf_by_round else 0.0
+print(f"  concurrent prefill: steady TTFT {steady_ttft*1000:.0f} ms (median of {N} streams) "
+      f"· ~{steady_pf:.0f} tok/s/stream derived @ {PTOK}-tok prompts")
 flags=[]
 if not clean_fit: flags.append("fit")
 if TPS_FLOOR>0 and not floor_ok: flags.append("tps-floor")
@@ -222,7 +232,8 @@ if PASS:
           f"vram_peak_gb: {vram_peak/1024:.1f} }}")
 # machine-readable line for SWEEP parsing
 print(f"RESULT N={N} clean={int(clean_fit)} pass={int(PASS)} mps_tps={report_tps:.2f} "
-      f"agg_tps={report_agg:.2f} retention={retention:.3f} leak={leak} vram_peak={vram_peak} floor_ok={int(floor_ok)}")
+      f"agg_tps={report_agg:.2f} retention={retention:.3f} leak={leak} vram_peak={vram_peak} floor_ok={int(floor_ok)} "
+      f"ttft_ms={steady_ttft*1000:.0f} pf_tps={steady_pf:.1f}")
 raise SystemExit(0 if PASS else 1)
 PY
 }


### PR DESCRIPTION
The probe measures per-request TTFT internally (streaming first-token time) but never surfaced it. Adds: `ttft_ms` + `pf_t/s` per-round columns (prefill derived as `PROMPT_TOKENS/ttft`, bench.sh convention), a `concurrent prefill:` verdict line, and additive `ttft_ms=`/`pf_tps=` fields on the RESULT line (SWEEP-parse compatible).

Field-validated on the Laguna concurrency campaign: the deep-prompt rung exposed the mixed-regime split (60.2 tok/s aggregate steady decode vs 16.3 with 33.6 s TTFT during simultaneous 4×10K context loads) that pure-decode reporting hides. Groundwork for the #805 rebench-full concurrency step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4LeYTBtjVXgpDgXSNUSgr