### PR TITLE
hotfix: prefix caching OFF on nvfp4 MTP slugs — unpatched #43559 pair (#810)

### DIFF
--- a/models/qwen3.6-27b/vllm/compose/dual/nvfp4/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/nvfp4/mtp.yml
@@ -214,8 +214,11 @@ services:
       # Prefix-caching ON by default (flipped 2026-07-17, #710/#736): this
       # compose ships NO MTP arg, so the vllm#43559 corruption pair cannot
       # form here — the #720 off-default was pure TTFT cost (measured 7.4x on
-      # long prefixes). Opt out: PREFIX_CACHE_ARG=--no-enable-prefix-caching
-      - "${PREFIX_CACHE_ARG:---enable-prefix-caching}"
+      # ⚠️ #810: SPEC_ARGS injects MTP by default, so prefix-cache-ON forms the
+      # vllm#43559 corruption pair (the old exemption note claiming 'no MTP arg' was
+      # stale). Defaults OFF until pr48375 is wired here (#810).
+      # Re-enable at your own risk: PREFIX_CACHE_ARG=--enable-prefix-caching
+      - "${PREFIX_CACHE_ARG:---no-enable-prefix-caching}"
       - --enable-chunked-prefill
       # MTP n=3 — the checkpoint keeps mtp.* unquantized. Applied by the
       # entrypoint unless SPEC=off (tight-RAM / spec-dec-fails mitigation, #617).

--- a/models/qwen3.6-27b/vllm/compose/single/nvfp4/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/nvfp4/mtp.yml
@@ -180,7 +180,11 @@ services:
       - --enable-auto-tool-choice
       - --tool-call-parser
       - qwen3_coder
-      - --enable-prefix-caching
+      # ⚠️ #810: this slug injects MTP via SPEC_ARGS by default — MTP + prefix caching
+      # is the vllm#43559 DeltaNet corruption pair, and pr48375 is NOT wired here yet.
+      # Prefix caching therefore defaults OFF until the wiring lands (#810).
+      # Re-enable at your own risk: PREFIX_CACHE_ARG=--enable-prefix-caching
+      - "${PREFIX_CACHE_ARG:---no-enable-prefix-caching}"
       - --enable-chunked-prefill
       # MTP n=3 — mtp.* is unquantized in the checkpoint. Applied by the
       # entrypoint unless SPEC=off (see the environment block + entrypoint):


### PR DESCRIPTION
Per #810: both nvfp4 MTP slugs form the DeltaNet corruption pair (default-on SPEC_ARGS MTP + prefix caching) without pr48375. Single slug had a literal flag (no seam); dual's seam defaulted ON under a stale exemption note. Both now seam-OFF with in-compose caveats; full patch wiring + the property-based guard follow in #810.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4LeYTBtjVXgpDgXSNUSgr