### PR TITLE
concurrency-probe: report NaN aggregate when a round had errors

### DIFF
--- a/docs/PCIE_P2P.md
+++ b/docs/PCIE_P2P.md
@@ -18,6 +18,37 @@ This is the home for **getting the most out of a PCIe-only multi-GPU rig** — u
 | **2. NCCL** | Is the granted path *used* for transfers? | `NCCL_P2P_LEVEL` set + layer 1 granted — this is where most of the P2P benefit flows, at any GPU count |
 | **3. vLLM's custom all-reduce** | Is vLLM's *extra* kernel on top of NCCL active? | vLLM's own log: the `Custom allreduce is disabled…` line means no. At >2 GPUs it requires a **full NVLink mesh** and never consults P2P ([#786](https://github.com/noonghunna/club-3090/issues/786)) — so on 3+-card PCIe rigs layer 3 is always off, *by design, not misconfiguration*, and P2P still pays through layer 2 |
 
+### Why layer 3's gate asks about NVLink and not peer access (2026-07-30)
+
+Read from `vllm/distributed/device_communicators/custom_all_reduce.py` (verified identical in v0.24.0 and v0.25.1). **The NVLink test was never intended as the requirement — it is a cheap pre-filter in front of an expensive one**, and its own comments say so:
+
+```python
+# test nvlink first, this will filter out most of the cases
+# where custom allreduce is not supported
+fully_connected = current_platform.is_fully_connected(physical_device_ids)
+if world_size > 2 and not fully_connected:
+    logger.warning("Custom allreduce is disabled because it's not supported on"
+                   " more than two PCIe-only GPUs. ...")
+    return                      # <-- disqualifies, instead of falling through
+# test P2P capability, this checks software/cudaruntime support
+# this is expensive to compute at the first time
+# then we cache the result
+if not current_platform.is_rocm() and not _can_p2p(rank, world_size):
+```
+
+`gpu_p2p_access_check()` spawns subprocesses to test real transfers — slow on first call, hence cached. `is_fully_connected` exists to avoid paying that when it would fail anyway. The narrow defect: at `world_size > 2` the pre-filter `return`s rather than deferring to the P2P check a patched PCIe rig would pass. An early-out optimisation became a hard gate.
+
+Two details confirming it is a heuristic and not a kernel limit:
+
+- The condition is literally `world_size > 2`. **At TP=2 the NVLink test is skipped entirely**, which is exactly why dual-card PCIe rigs get layer 3 and 4-card rigs do not — the peer-access result is never consulted at world>2.
+- `_SUPPORTED_WORLD_SIZES = [2, 4, 6, 8]` — the kernel itself supports 4 cards. Patching `is_fully_connected` works rather than crashing.
+
+**Why `>2` plausibly exists** (inference from the algorithm shape, *not* stated upstream): custom AR has every rank write into every peer's buffer. At 2 GPUs that is one peer over one link; at 4 on a shared PCIe fabric the N−1 peer writes per rank contend for the same host-bridge bandwidth, while NVLink is point-to-point per pair and NCCL's ring/tree is topology-aware. It reads as an NVSwitch-era assumption never retested against P2P-patched consumer hardware.
+
+**The 8 MiB cap is why forcing the gate is a tradeoff, not a free win.** `CustomAllreduce(max_size=8192 * 1024)` — tensors above 8 MiB fall back to NCCL regardless. So decode-sized tensors take the custom path and win, while prefill-sized ones exceed the cap, go through NCCL anyway, and still pay the registration overhead.
+
+**We measured the bypass and deliberately do not ship it.** Forcing `is_fully_connected → True` at TP=4 on a patched 4×3090 gives **≈ +15% decode**, independently reproduced by [@superalesha](https://github.com/noonghunna/club-3090/discussions/773#discussioncomment-17834828) at **+14.8%** (80.9 → 92.9 tok/s single-stream, 144 → 165 at 16 users) — **with prefill paying for it** (TTFT +9% at c16, consistent with the cap above). Note the flag is read twice, once to build the communicator and once in `should_custom_ar`, so a half-patch does nothing. club-3090 keeps the gate: the tradeoff is workload-dependent, and monkeypatching an engine's topology gate is not something we want in a default path on other people's rigs. The clean upstream fix is to let `world_size > 2` fall through to `_can_p2p` and gate on measured benefit instead of link type.
+
 **Where NVLink fits:** a bridge is the native version of layer 1 (no patched driver needed) and a faster layer 2 for the bridged pair. Layer 3 follows the same mesh rule: **2× 3090 + bridge → all three layers on**; **4× 3090 with two pairwise bridges → layer 3 still off** (consumer cards bridge exactly two GPUs; full meshes are NVSwitch/SXM territory). `report.sh`'s *Interconnect verdict* (§7) resolves all three layers for you.
 
 ---
@@ -128,7 +159,7 @@ From cross-rig data on this stack (2× 3090, TP=2):
 
 **Translation:** code / spec-decode workloads see a real lift (the K+1 cross-card verify is bandwidth-bound, so it benefits most); narrative decode barely moves. For most users the stock no-P2P PCIe path is already perfectly fine — **P2P is an enthusiast tuning lever, not a requirement.**
 
-⚠️ **These are DUAL-card measurements — do not extrapolate them to 3+ GPUs.** At world_size > 2 without NVLink, **vLLM force-disables its custom all-reduce kernel** (its gate queries NVML for NVLink and never consults peer access — [#786](https://github.com/noonghunna/club-3090/issues/786)), so whatever P2P is worth at TP=4 arrives **through NCCL peer transfers only** — a lower ceiling than the dual-card custom-kernel path above. An earlier revision of this section claimed the gain "grows with GPU count"; that was a projection, not a measurement, and is withdrawn — **no measured multi-GPU P2P A/B exists yet** ([disc #773](https://github.com/noonghunna/club-3090/discussions/773) has the first candidate rig).
+⚠️ **These are DUAL-card measurements — do not extrapolate them to 3+ GPUs.** At world_size > 2 without NVLink, **vLLM force-disables its custom all-reduce kernel** (its gate queries NVML for NVLink and never consults peer access — [#786](https://github.com/noonghunna/club-3090/issues/786)), so whatever P2P is worth at TP=4 arrives **through NCCL peer transfers only** — a lower ceiling than the dual-card custom-kernel path above. An earlier revision claimed the gain "grows with GPU count"; that was a projection, not a measurement, and stays withdrawn. **UPDATE 2026-07-30 — a measured multi-GPU A/B now exists, on ONE rig:** [disc #773](https://github.com/noonghunna/club-3090/discussions/773) (4× 3090, patched P2P, vLLM 0.25.1, MTP n=3, 220 W, one sitting) reports TP=2 → TP=4 as **prefill +55% @10K / +62% @90K, TTFT −38% @90K, decode +4.0% prose / −2.6% code**. Read it as *four cards read faster; they do not write faster* — the win is prefill and TTFT, and the decode column is inside run-to-run noise. It is one rig, one sitting, and it is a **TP-scaling** A/B (2 vs 4 cards, P2P on throughout), **not** a P2P-on-vs-off A/B at fixed TP — that one still does not exist. So: do not extrapolate "P2P scales with GPU count" from it, and do not cite the decode figures as a P2P result.
 
 ---
 

--- a/scripts/concurrency-probe.sh
+++ b/scripts/concurrency-probe.sh
@@ -181,7 +181,7 @@ def one(stream, rnd):
 
 print(f"\n{'round':>5} {'done':>7} {'silent':>7} {'errors':>7} {'vram_MB':>8} {'agg_t/s':>8} {'per-strm':>9} {'ttft_ms':>8} {'pf_t/s':>7}")
 vram0=vram_used_mb()
-vram_by_round=[]; mtps_by_round=[]; agg_by_round=[]; ttft_by_round=[]; pf_by_round=[]; bad=0
+vram_by_round=[]; mtps_by_round=[]; agg_by_round=[]; ttft_by_round=[]; pf_by_round=[]; bad=0; err_rounds=0
 for rnd in range(1,ROUNDS+1):
     t0=time.time()
     with cf.ThreadPoolExecutor(max_workers=N) as ex:
@@ -202,6 +202,7 @@ for rnd in range(1,ROUNDS+1):
     ttft_by_round.append(ttft_med); pf_by_round.append(pf)
     print(f"{rnd:>5} {done:>4}/{N:<2} {silent:>7} {errs:>7} {v:>8} {agg:>8.1f} {mtps:>9.1f} {ttft_med*1000:>8.0f} {pf:>7.0f}")
     if done<N or silent or errs: bad+=1
+    if errs: err_rounds+=1
 
 # VRAM: leak = post-warm growth (round 2 baseline), NOT the expected cold->warm fill.
 warm_i=1 if ROUNDS>=3 else 0
@@ -216,6 +217,15 @@ report_tps=mtps_by_round[-1] if mtps_by_round else 0.0
 # aggregate = summed completion tokens / wall per round (what "total rig
 # throughput at N agents" means); steady-state = last round, like per-stream.
 report_agg=agg_by_round[-1] if agg_by_round else 0.0
+# An aggregate computed over a round that had errors is not a throughput number:
+# failed streams contribute toks=0 while their prefill still counts in the wall,
+# so the figure is (survivors' tokens)/(full round wall) and reads 5-10x low. It
+# has been quoted out of context as a measured regression before. Report NaN so a
+# broken arm cannot be mistaken for a slow one — clean= and the FAIL verdict below
+# already carry the diagnosis.
+if err_rounds:
+    report_agg=float("nan")
+    report_tps=float("nan")
 warm_tps=mtps_by_round[1:] if ROUNDS>=4 else mtps_by_round
 if len(warm_tps)>=3 and warm_tps[0]>0:
     early=statistics.median(warm_tps[:2]); late=statistics.median(warm_tps[-2:])


### PR DESCRIPTION
An aggregate computed over an errored round is not a throughput number. Failed streams contribute `toks=0` while their prefill still counts toward the round wall, so the printed figure is (survivors' tokens) / (full round wall) — it reads 5–10× low.

That is not hypothetical. In a recent spec-dec × concurrency arm, 35/35 requests returned HTTP 500 from a drafter-state bug, and the arm was recorded and quoted as a **5–13× throughput collapse**. The `RESULT` line already carried `clean=0` and the verdict already printed `FAIL — fit`, but `agg_tps=3.9` travelled without them and a physical explanation was sought for a number that had no physical meaning. Root cause of the underlying crash is fixed separately in the engine fork; this change stops the measurement harness from manufacturing quotable numbers out of failed runs.

**Change:** track `err_rounds`; if any round had errors, emit `nan` for both `agg_tps` and `mps_tps`. `clean=`/`pass=` and the FAIL verdict are unchanged — this only removes the misleading magnitude.

**Testing:** `bash -n` + embedded-Python `compile()` both clean. `scripts/tests/test-concurrency-probe.sh` behaves identically before and after (verified against `HEAD~1` in a scratch worktree) — note it has one **pre-existing** unrelated failure, `SWEEP-without-SLUG error message missing`, which this branch neither causes nor fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4LeYTBtjVXgpDgXSNUSgr