### PR TITLE
offload-matrix: Tier 0 + Tier 1 test suite, and fix a partial-cache blind spot

### DIFF
--- a/scripts/offload-matrix-render.py
+++ b/scripts/offload-matrix-render.py
@@ -129,6 +129,7 @@ if bad:
                 "BOOT_FAIL":      "  server never started (OOM at this ctx/pool is the usual cause)",
                 "TIMEOUT":        "  server did not reach /health before BOOT_TIMEOUT",
                 "CACHE_DISABLED": "  expert cache requested but NEVER allocated -- try RESERVE_MB=1536",
+                "CACHE_PARTIAL":  "  cache allocated on only SOME devices -- throughput blends cached and uncached",
                 "PORT_BUSY":      "  port was already served by another process; arm did not boot",
                 "MB_CLAMP_CONFLICT": "  n-max too high for the [1,8] MAX_BATCH clamp; cache would bypass"}.get(r["status"], "")
         print(f"   {r['arm']}: {r['status']}{note}")

--- a/scripts/offload-matrix.sh
+++ b/scripts/offload-matrix.sh
@@ -565,8 +565,15 @@ PY
   # Found live 2026-07-30: the engine's DEFAULT reserve (3072 MiB) left no budget at
   # 262K ctx, logging "CUDA0 has no cache budget after 3072 MiB reserve" -- a string the
   # bypass grep does not match. Both arms reported OK and ran ~12-22% slow.
-  local cache_enabled=0 reserve_seen=""
-  command grep -q '\[moe-cache\] enabled:' "$log" && cache_enabled=1
+  # Count DEVICES THAT ACTUALLY GOT A POOL, not the presence of the "enabled:" line.
+  # A per-device budget failure still prints "enabled:" while one GPU runs with no
+  # pool at all — measured 2026-07-30: CUDA0 got no budget, CUDA1 allocated 69 slots,
+  # and "enabled:" printed regardless. Keying on that line reports OK for a run that
+  # is half-uncached.
+  local cache_enabled=0 reserve_seen="" pooled_devs=0
+  pooled_devs=$(command grep -oE 'CUDA[0-9]+ pool\[' "$log" 2>/dev/null \
+                | awk '{print $1}' | sort -u | command grep -c '' )
+  (( pooled_devs > 0 )) && cache_enabled=1
   reserve_seen=$(command grep -oE 'reserve=[0-9]+ MiB|after [0-9]+ MiB reserve' "$log" \
                  | command grep -oE '[0-9]+' | tail -1)
   local nobudget; nobudget=$(command grep -c 'no cache budget' "$log")
@@ -579,13 +586,21 @@ PY
   # conclusion, so it must never read OK.
   if (( HAS_MOE_CACHE )) && [[ "$cache" != 0 ]] && (( cache_enabled == 0 )); then
     status="CACHE_DISABLED"
-    echo "  !! expert cache was REQUESTED (--moe-cache $cache) but NEVER ALLOCATED."
+    echo "  !! expert cache was REQUESTED (--moe-cache $cache) but NO DEVICE ALLOCATED A POOL."
     if (( nobudget > 0 )); then
       echo "     reason: no budget after ${reserve_seen:-?} MiB reserve. Lower the reserve"
       echo "     (RESERVE_MB=1536) or reduce ctx/pool so the pool fits."
     else
-      echo "     no '[moe-cache] enabled:' line in $log -- check the build and flags."
+      echo "     no '[moe-cache] CUDAn pool[' lines in $log -- check the build and flags."
     fi
+  elif (( HAS_MOE_CACHE )) && [[ "$cache" != 0 ]] && (( NGPU > 0 )) && (( pooled_devs < NGPU )); then
+    # PARTIAL: some devices cached, others not. Worse than either extreme, because
+    # the arm looks healthy and the uncached device silently drags the whole number.
+    status="CACHE_PARTIAL"
+    echo "  !! expert cache allocated on only $pooled_devs of $NGPU devices."
+    echo "     The uncached device(s) run at no-cache speed and this arm's throughput"
+    echo "     is a blend of two regimes — not comparable with a fully-cached arm."
+    (( nobudget > 0 )) && echo "     reason: no budget after ${reserve_seen:-?} MiB reserve on at least one device."
   fi
   # zero throughput means every request failed — never let that land as OK (the
   # first live run reported agg=0.00 with status OK because the prompt builder

--- a/scripts/tests/fixtures/fake-llama-server.py
+++ b/scripts/tests/fixtures/fake-llama-server.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Fake llama-server for offload-matrix Tier 1 tests.
+
+Emits the exact log lines offload-matrix.sh scrapes and serves the two endpoints
+it calls, so the whole sweep-matrix logic can be exercised deterministically with
+no GPU, no model and no engine. Scenario is chosen with FAKE_SCENARIO:
+
+  healthy    both devices allocate pools, tokens stream normally
+  partial    only CUDA0 allocates a pool (the per-device budget failure that
+             still prints "enabled:" -- must be caught as CACHE_PARTIAL)
+  nobudget   no device allocates a pool, "no cache budget" logged
+  bypass     pools allocated but every decode logs "bypassing cache"
+  notokens   endpoints answer but the stream yields zero content deltas
+
+Anything the real server prints that the script does NOT scrape is omitted on
+purpose: the fixture documents the contract, so an accidental dependency on some
+other line shows up as a test failure rather than working by luck.
+"""
+import json, os, sys, threading, time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+SC   = os.environ.get("FAKE_SCENARIO", "healthy")
+NDEV = int(os.environ.get("FAKE_NDEV", "2"))
+TOKS = int(os.environ.get("FAKE_TOKENS", "40"))
+
+if "--help" in sys.argv:                      # engine-scope probe
+    print("  -ngl,  --n-gpu-layers N\n  -ot,   --override-tensor PATTERN\n         --moe-cache N")
+    raise SystemExit(0)
+
+def arg(flag, default=None):
+    return sys.argv[sys.argv.index(flag) + 1] if flag in sys.argv else default
+
+def log(s): print(s, flush=True)
+
+port  = int(arg("--port", "8099"))
+n_ctx = int(arg("-c", "32768"))
+n_par = int(arg("-np", "1"))
+log(f"print_info: n_layer          = 48")
+log(f"print_info: n_expert         = 256")
+log(f"llama_context: n_ctx_seq     = {n_ctx // max(n_par,1)}")
+
+pooled = {"healthy": NDEV, "partial": 1, "nobudget": 0}.get(SC, NDEV)
+if "--moe-cache" in sys.argv:
+    if SC == "nobudget":
+        for d in range(NDEV):
+            log(f"[moe-cache] CUDA{d} has no cache budget after 3072 MiB reserve")
+    else:
+        if SC == "partial":
+            log("[moe-cache] CUDA1 has no cache budget after 3072 MiB reserve")
+        log("[moe-cache] enabled: mode=on budget=fixed reserve=1536 MiB min-expert=1024 KiB admit=1/64")
+        for d in range(pooled):
+            log(f"[moe-cache] CUDA{d} pool[0]: type=iq3_s expert=1320 KiB slots={700+d} total=900 MiB")
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a): pass
+    def do_GET(self):
+        self.send_response(200); self.end_headers(); self.wfile.write(b"ok")
+    def do_POST(self):
+        self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        if SC == "bypass":
+            log("[moe-cache] bypassing cache: decode batch of 4 tokens exceeds "
+                "GGML_CUDA_MOE_CACHE_MAX_BATCH=1 — raise it to at least draft_max+1.")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream"); self.end_headers()
+        n = 0 if SC == "notokens" else TOKS
+        for _ in range(n):
+            self.wfile.write(b'data: {"choices":[{"delta":{"content":"x"}}]}\n\n'); self.wfile.flush()
+        self.wfile.write(b"data: [DONE]\n\n"); self.wfile.flush()
+        log(f"slot print_timing: id  0 | task 1 | n_decoded = {n}, tg = 40.00 t/s")
+        if pooled:
+            for d in range(pooled):
+                log(f"[moe-cache] CUDA{d} hits=500/1000 (50.0%) used=64/64 enqueued=64 filled=64 "
+                    f"fill-fail=0 evictions=10 skips=0 admission=0 queue=0 jobs/0 MiB "
+                    f"dispatch-fail=0 collect-fail=0")
+
+srv = HTTPServer(("127.0.0.1", port), H)
+threading.Thread(target=srv.serve_forever, daemon=True).start()
+log("main: server is listening")
+try:
+    while True: time.sleep(0.2)
+except KeyboardInterrupt:
+    pass

--- a/scripts/tests/test-offload-matrix-mocked.sh
+++ b/scripts/tests/test-offload-matrix-mocked.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# test-offload-matrix-mocked — Tier 1 guards for scripts/offload-matrix.sh.
+#
+# Runs the REAL sweep against a fake llama-server (scripts/tests/fixtures/) that
+# emits the exact log lines the script scrapes and serves the two endpoints it
+# calls. No GPU, no model, no engine — but the whole boot -> drive -> scrape ->
+# emit -> render path executes, which is where the silent-wrongness defects live.
+#
+# Each case asserts a STATUS and then the row invariants. A harness that reports
+# a healthy status for an unhealthy run is the failure mode that matters here;
+# throughput values are deliberately never asserted.
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SWEEP="$ROOT_DIR/scripts/offload-matrix.sh"
+FAKE="$ROOT_DIR/scripts/tests/fixtures/fake-llama-server.py"
+fail() { echo "FAIL: $1" >&2; [[ -n "${LOG:-}" && -f "${LOG:-}" ]] && tail -20 "$LOG" >&2; exit 1; }
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"; pkill -f fake-llama-server >/dev/null 2>&1 || true' EXIT
+touch "$TMP/model.gguf"
+
+# pick a port nothing is using, so a stray local server can't poison the run
+PORT=8891; while ss -ltn 2>/dev/null | grep -q ":$PORT "; do PORT=$((PORT+1)); done
+
+CTX_SEQ=32768
+run_case() {  # $1=scenario; each case gets its own ctx so arms stay distinguishable
+  local sc="$1"; shift
+  CTX_SEQ=$((CTX_SEQ + 1024))
+  local out="$TMP/$sc"; rm -rf "$out"
+  LOG="$TMP/$sc.log"
+  env FAKE_SCENARIO="$sc" FAKE_NDEV=2 NGPU=2 \
+      MODEL="$TMP/model.gguf" LLAMA_SERVER="$FAKE" INHERIT=0 OUT_DIR="$out" PORT="$PORT" \
+      LAYERS_TOTAL=48 N_EXPERT=256 REPS=1 ROUNDS=2 GEN=8 BOOT_TIMEOUT=40 \
+      SWEEP_OFFLOAD=19 SWEEP_N=1 SWEEP_NMAX=0 SWEEP_CTX="$CTX_SEQ" SWEEP_CACHE=8192 \
+      SWEEP_ADMIT="1/64" SWEEP_SHAPE=copy "$@" \
+      bash "$SWEEP" > "$LOG" 2>&1 || true
+  STATUS="$(awk -F'\t' 'NR>1{print $NF}' "$out/offload-matrix-results.tsv" 2>/dev/null | head -1)"
+  TSV="$out/offload-matrix-results.tsv"
+}
+
+# ---- row invariants, asserted after every case -------------------------------
+invariants() {
+  local tsv="$1" ncol row n
+  ncol=$(head -1 "$tsv" | awk -F'\t' '{print NF}')
+  while IFS= read -r row; do
+    n=$(awk -F'\t' '{print NF}' <<<"$row")
+    (( n == ncol )) || fail "V1 field count: row has $n fields, header has $ncol"
+  done < <(tail -n +2 "$tsv")
+  # V2: status=OK implies non-zero throughput
+  awk -F'\t' -v OK=1 'NR>1 && $NF=="OK" && ($14=="-" || $14+0==0){exit 1}' "$tsv" \
+    || fail "V2: a row with status=OK has zero/absent throughput"
+  # V3: bypass>0 implies status != OK
+  awk -F'\t' 'NR>1 && $(NF-2)+0>0 && $NF=="OK"{exit 1}' "$tsv" \
+    || fail "V3: bypass>0 but status=OK"
+}
+
+# 1. healthy — both devices pool, arm is usable
+run_case healthy
+[[ "$STATUS" == "OK" ]] || fail "healthy scenario should be OK, got '$STATUS'"
+invariants "$TSV"
+echo "  ✓ healthy: OK + invariants hold"
+
+# 2. PARTIAL — only CUDA0 pools. The engine STILL prints "[moe-cache] enabled:",
+#    so a detector keying on that line reports OK for a half-uncached run. This
+#    is the defect found live on 2026-07-30; it must not regress.
+run_case partial
+[[ "$STATUS" == "CACHE_PARTIAL" ]] || fail "per-device pool failure should be CACHE_PARTIAL, got '$STATUS'"
+grep -q "only 1 of 2 devices" "$LOG" || fail "CACHE_PARTIAL should say how many devices got a pool"
+invariants "$TSV"
+echo "  ✓ partial-pool caught as CACHE_PARTIAL (not OK)"
+
+# 3. no budget anywhere — nothing pools at all
+run_case nobudget
+[[ "$STATUS" == "CACHE_DISABLED" ]] || fail "no pools should be CACHE_DISABLED, got '$STATUS'"
+grep -qi "reserve" "$LOG" || fail "CACHE_DISABLED should name the reserve as the remedy"
+invariants "$TSV"
+echo "  ✓ no-pool caught as CACHE_DISABLED with remedy"
+
+# 4. bypass warning present — pools exist but decodes decline them
+run_case bypass
+[[ "$STATUS" == "INVALID_BYPASS" ]] || fail "bypass warning should be INVALID_BYPASS, got '$STATUS'"
+invariants "$TSV"
+echo "  ✓ cache bypass caught as INVALID_BYPASS"
+
+# 5. zero tokens — endpoints answer but nothing streams. Must never read OK.
+run_case notokens
+[[ "$STATUS" == "NO_TOKENS" ]] || fail "zero tokens should be NO_TOKENS, got '$STATUS'"
+invariants "$TSV"
+echo "  ✓ zero-token run caught as NO_TOKENS"
+
+# 6. the renderer must exclude every non-OK arm from its conclusions
+{ head -1 "$TMP/healthy/offload-matrix-results.tsv"; \
+  for f in "$TMP"/*/offload-matrix-results.tsv; do tail -n +2 "$f"; done; } > "$TMP/all.tsv"
+out="$(python3 "$ROOT_DIR/scripts/offload-matrix-render.py" "$TMP/all.tsv" 2>&1)" \
+  || fail "renderer crashed on the combined mocked TSV"
+for s in CACHE_PARTIAL CACHE_DISABLED INVALID_BYPASS NO_TOKENS; do
+  grep -q "$s" <<<"$out" || fail "renderer did not surface $s"
+done
+grep -q "NOT OK" <<<"$out" || fail "renderer must list non-OK arms separately"
+echo "  ✓ renderer surfaces every failure status and separates them"
+
+echo "test-offload-matrix-mocked: ok (Tier 1 — mocked server, no GPU)"

--- a/scripts/tests/test-offload-matrix-mocked.sh
+++ b/scripts/tests/test-offload-matrix-mocked.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SWEEP="$ROOT_DIR/scripts/offload-matrix.sh"
 FAKE="$ROOT_DIR/scripts/tests/fixtures/fake-llama-server.py"
+export PYTHONUTF8="${PYTHONUTF8:-1}"   # repo rule: locale must not decide python decoding
 fail() { echo "FAIL: $1" >&2; [[ -n "${LOG:-}" && -f "${LOG:-}" ]] && tail -20 "$LOG" >&2; exit 1; }
 TMP="$(mktemp -d)"
 # NOTE the bracket in the pattern below. An unbracketed pkill -f matches the

--- a/scripts/tests/test-offload-matrix-mocked.sh
+++ b/scripts/tests/test-offload-matrix-mocked.sh
@@ -14,7 +14,12 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SWEEP="$ROOT_DIR/scripts/offload-matrix.sh"
 FAKE="$ROOT_DIR/scripts/tests/fixtures/fake-llama-server.py"
 fail() { echo "FAIL: $1" >&2; [[ -n "${LOG:-}" && -f "${LOG:-}" ]] && tail -20 "$LOG" >&2; exit 1; }
-TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"; pkill -f fake-llama-server >/dev/null 2>&1 || true' EXIT
+TMP="$(mktemp -d)"
+# NOTE the bracket in the pattern below. An unbracketed pkill -f matches the
+# killing command's OWN command line and kills this shell (exit 144), so the
+# trap never finishes and the fixture it should reap survives. Bracketing the
+# first character makes the pattern unable to match itself.
+trap 'rm -rf "$TMP"; pkill -f "[f]ake-llama-server" >/dev/null 2>&1 || true' EXIT
 touch "$TMP/model.gguf"
 
 # pick a port nothing is using, so a stray local server can't poison the run

--- a/scripts/tests/test-offload-matrix.sh
+++ b/scripts/tests/test-offload-matrix.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# test-offload-matrix — Tier 0 (static) guards for scripts/offload-matrix.sh and
+# its renderer. No server boot, no GPU, no model: everything here is verifiable
+# from the sources plus a synthetic TSV.
+#
+# The harness produces numbers that decide serving configs, so its failure mode
+# is a plausible WRONG number rather than a crash. Six defects of that shape
+# shipped during development (see #824). Each check below guards one of them.
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SWEEP="$ROOT_DIR/scripts/offload-matrix.sh"
+RENDER="$ROOT_DIR/scripts/offload-matrix-render.py"
+fail() { echo "FAIL: $1" >&2; exit 1; }
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+# 1. syntax, both halves
+bash -n "$SWEEP" || fail "bash -n: syntax error in offload-matrix.sh"
+python3 -c "import ast,sys; ast.parse(open(sys.argv[1],encoding='utf-8').read())" "$RENDER" \
+  || fail "renderer: syntax error"
+echo "  ✓ syntax (sweep + renderer)"
+
+# 2. MODEL is mandatory and the refusal is actionable (not a traceback)
+set +e; out="$(MODEL= INHERIT=0 bash "$SWEEP" 2>&1)"; rc=$?; set -e
+[[ "$rc" == "2" ]] || fail "missing MODEL should exit 2, got $rc"
+grep -q "MODEL=" <<<"$out" || fail "missing-MODEL error should name the MODEL variable"
+echo "  ✓ refuses without MODEL (exit 2, actionable)"
+
+# 3. COLUMN PARITY — guards the defect where the TSV printf carried 32 format
+#    specifiers for 33 arguments: bash re-ran the format for the surplus arg, so
+#    every arm wrote a short row PLUS a junk status-only row. Header is the only
+#    place the width may be defined.
+hdr_n="$(python3 - "$SWEEP" <<'PY'
+import re,sys
+s=open(sys.argv[1],encoding="utf-8").read()
+print(len(re.search(r"HDR=\$'([^']+)'",s).group(1).split(r"\t")))
+PY
+)"
+row_n="$(python3 - "$SWEEP" <<'PY'
+import re,sys
+s=open(sys.argv[1],encoding="utf-8").read()
+blk=re.search(r'emit_row "\$status" \\\n((?:.*\\\n)*.*)\n',s).group(1)
+print(len(re.findall(r'"[^"]*"', blk)))
+PY
+)"
+[[ -n "$hdr_n" && -n "$row_n" ]] || fail "could not extract header/emit_row widths"
+(( row_n == hdr_n - 1 )) || fail "emit_row passes $row_n values; header holds $hdr_n (expected $((hdr_n-1)) + status)"
+grep -q 'NCOL=\$(awk' "$SWEEP" || fail "row width must be derived from \$HDR, not hand-counted"
+echo "  ✓ column parity: header $hdr_n = $row_n values + status, width derived from \$HDR"
+
+# 4. STATUS-ENUM PARITY — every status the sweep can emit must be explained by
+#    the renderer. This has already caught real drift (CACHE_DISABLED shipped
+#    with no renderer annotation within an hour of being added).
+missing="$(python3 - "$SWEEP" "$RENDER" <<'PY'
+import re,sys
+sw=open(sys.argv[1],encoding="utf-8").read(); rd=open(sys.argv[2],encoding="utf-8").read()
+emitted={m for m in re.findall(r'status="([A-Z_]{4,})"',sw)} | {m for m in re.findall(r'emit_row ([A-Z_]{4,})',sw)}
+known={m for m in re.findall(r'"([A-Z_]{4,})":',rd)}
+print(" ".join(sorted(emitted-known)))
+PY
+)"
+[[ -z "$missing" ]] || fail "renderer does not annotate status(es): $missing"
+echo "  ✓ status-enum parity (sweep ↔ renderer)"
+
+# 5. PAIRING KEY INCLUDES shape — workload shape FLIPS THE SIGN of speculative
+#    results, so pairing a spec arm against a baseline of another shape
+#    manufactures a gain that does not exist.
+grep -qE '^KEY *= *\(' "$RENDER" || fail "renderer should define an explicit pairing KEY"
+python3 - "$RENDER" <<'PY' || exit 1
+import re,sys
+k=re.search(r'^KEY *= *\(([^)]*)\)',open(sys.argv[1],encoding="utf-8").read(),re.M).group(1)
+need={"offload","N","ctx_slot","cache_mb","admit","throttle","shape"}
+have={x.strip().strip('"\'') for x in k.split(",") if x.strip()}
+missing=need-have
+if missing: print(f"FAIL: pairing KEY missing {sorted(missing)}",file=sys.stderr); sys.exit(1)
+PY
+echo "  ✓ pairing key includes shape (guards the sign-flip mispair)"
+
+# 6. ENGINE-SCOPE GUARD — the tool emits llama.cpp flags and scrapes llama.cpp
+#    log lines, so it must refuse a binary that is not one. vLLM's CPU offload
+#    measures a different mechanism entirely and would produce numbers that look
+#    valid and mean nothing.
+touch "$TMP/fake.gguf"
+set +e
+out="$(MODEL="$TMP/fake.gguf" INHERIT=0 PLAN=1 LAYERS_TOTAL=48 LLAMA_SERVER=/bin/true \
+       bash "$SWEEP" 2>&1)"; rc=$?
+set -e
+[[ "$rc" == "2" ]] || fail "non-llama.cpp server should exit 2, got $rc"
+grep -qi "llama.cpp" <<<"$out" || fail "engine-scope refusal should say what it accepts"
+echo "  ✓ refuses a non-llama.cpp server (exit 2)"
+
+# 7. PLAN=1 enumerates arms and boots nothing. Needs a binary that passes the
+#    scope probe above, so this doubles as the minimal fake-server stub the
+#    Tier 1 suite will grow from: --help must advertise the flags the tool emits.
+cat > "$TMP/fake-llama-server" <<'STUB'
+#!/usr/bin/env bash
+if [[ " $* " == *" --help "* ]]; then
+  echo "  -ngl,  --n-gpu-layers N"
+  echo "  -ot,   --override-tensor PATTERN"
+  echo "         --moe-cache N"
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$TMP/fake-llama-server"
+out="$(MODEL="$TMP/fake.gguf" INHERIT=0 PLAN=1 LAYERS_TOTAL=48 LLAMA_SERVER="$TMP/fake-llama-server" \
+       SWEEP_OFFLOAD="19 28" SWEEP_N="1 4" bash "$SWEEP" 2>&1)" || fail "PLAN=1 should exit 0"
+grep -qiE 'arm|stage|plan' <<<"$out" || fail "PLAN=1 should enumerate the planned sequence"
+grep -q '\[OK\]' <<<"$out" && fail "PLAN=1 must not produce measured arms"
+echo "  ✓ PLAN=1 enumerates without booting"
+
+# 8. Renderer survives a mixed TSV (OK + every failure status) and never
+#    silently drops a non-OK arm into the conclusions.
+python3 - "$SWEEP" "$TMP/t.tsv" <<'PY'
+import re,sys
+hdr=re.search(r"HDR=\$'([^']+)'",open(sys.argv[1],encoding="utf-8").read()).group(1).split(r"\t")
+i={k:n for n,k in enumerate(hdr)}
+def row(**kw):
+    r=["-"]*len(hdr)
+    for k,v in kw.items(): r[i[k]]=str(v)
+    return "\t".join(r)
+rows=[row(arm="A",rep=1,shape="copy",offload=19,N=1,ctx_slot=262144,drafter="none",nmax=0,
+          cache_mb=8192,admit=1,throttle=64,agg=34.0,strm=34.4,status="OK"),
+      row(arm="B",rep=1,shape="copy",offload=19,N=1,ctx_slot=262144,drafter="ngram-mod",nmax=3,
+          cache_mb=8192,admit=1,throttle=64,agg=60.0,strm=60.5,status="OK"),
+      row(arm="C",rep=1,shape="copy",offload=28,N=8,drafter="none",nmax=0,status="BOOT_FAIL"),
+      row(arm="D",rep=1,shape="copy",offload=19,N=1,drafter="ngram-mod",nmax=3,status="CACHE_DISABLED")]
+open(sys.argv[2],"w",encoding="utf-8").write("\t".join(hdr)+"\n"+"\n".join(rows)+"\n")
+PY
+out="$(python3 "$RENDER" "$TMP/t.tsv" 2>&1)" || fail "renderer crashed on a mixed TSV"
+grep -q "NOT OK" <<<"$out" || fail "renderer must list non-OK arms separately"
+grep -q "CACHE_DISABLED" <<<"$out" || fail "renderer must surface CACHE_DISABLED"
+grep -qE '\+7[0-9]\.[0-9]%' <<<"$out" || fail "renderer should pair B against A and show the delta"
+echo "  ✓ renderer handles mixed TSV; non-OK arms excluded from conclusions"
+
+echo "test-offload-matrix: ok (Tier 0 — static, no server)"

--- a/scripts/tests/test-offload-matrix.sh
+++ b/scripts/tests/test-offload-matrix.sh
@@ -20,7 +20,7 @@ python3 -c "import ast,sys; ast.parse(open(sys.argv[1],encoding='utf-8').read())
 echo "  ✓ syntax (sweep + renderer)"
 
 # 2. MODEL is mandatory and the refusal is actionable (not a traceback)
-set +e; out="$(MODEL= INHERIT=0 bash "$SWEEP" 2>&1)"; rc=$?; set -e
+set +e; out="$(MODEL= INHERIT=0 OUT_DIR="$TMP/out" bash "$SWEEP" 2>&1)"; rc=$?; set -e
 [[ "$rc" == "2" ]] || fail "missing MODEL should exit 2, got $rc"
 grep -q "MODEL=" <<<"$out" || fail "missing-MODEL error should name the MODEL variable"
 echo "  ✓ refuses without MODEL (exit 2, actionable)"
@@ -82,7 +82,7 @@ echo "  ✓ pairing key includes shape (guards the sign-flip mispair)"
 touch "$TMP/fake.gguf"
 set +e
 out="$(MODEL="$TMP/fake.gguf" INHERIT=0 PLAN=1 LAYERS_TOTAL=48 LLAMA_SERVER=/bin/true \
-       bash "$SWEEP" 2>&1)"; rc=$?
+       OUT_DIR="$TMP/out" bash "$SWEEP" 2>&1)"; rc=$?
 set -e
 [[ "$rc" == "2" ]] || fail "non-llama.cpp server should exit 2, got $rc"
 grep -qi "llama.cpp" <<<"$out" || fail "engine-scope refusal should say what it accepts"
@@ -103,7 +103,7 @@ exit 0
 STUB
 chmod +x "$TMP/fake-llama-server"
 out="$(MODEL="$TMP/fake.gguf" INHERIT=0 PLAN=1 LAYERS_TOTAL=48 LLAMA_SERVER="$TMP/fake-llama-server" \
-       SWEEP_OFFLOAD="19 28" SWEEP_N="1 4" bash "$SWEEP" 2>&1)" || fail "PLAN=1 should exit 0"
+       OUT_DIR="$TMP/out" SWEEP_OFFLOAD="19 28" SWEEP_N="1 4" bash "$SWEEP" 2>&1)" || fail "PLAN=1 should exit 0"
 grep -qiE 'arm|stage|plan' <<<"$out" || fail "PLAN=1 should enumerate the planned sequence"
 grep -q '\[OK\]' <<<"$out" && fail "PLAN=1 must not produce measured arms"
 echo "  ✓ PLAN=1 enumerates without booting"
@@ -131,5 +131,10 @@ grep -q "NOT OK" <<<"$out" || fail "renderer must list non-OK arms separately"
 grep -q "CACHE_DISABLED" <<<"$out" || fail "renderer must surface CACHE_DISABLED"
 grep -qE '\+7[0-9]\.[0-9]%' <<<"$out" || fail "renderer should pair B against A and show the delta"
 echo "  ✓ renderer handles mixed TSV; non-OK arms excluded from conclusions"
+
+# 9. The suite must not pollute the repo: the sweep mkdir's $PWD/offload-matrix-out
+#    unless OUT_DIR is set, and a test that leaves artifacts behind is a bad test.
+[[ -e "$ROOT_DIR/offload-matrix-out" ]] && fail "test leaked offload-matrix-out into the repo"
+echo "  ✓ no artifacts left in the repo"
 
 echo "test-offload-matrix: ok (Tier 0 — static, no server)"

--- a/scripts/tests/test-offload-matrix.sh
+++ b/scripts/tests/test-offload-matrix.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SWEEP="$ROOT_DIR/scripts/offload-matrix.sh"
 RENDER="$ROOT_DIR/scripts/offload-matrix-render.py"
+export PYTHONUTF8="${PYTHONUTF8:-1}"   # repo rule: locale must not decide python decoding
 fail() { echo "FAIL: $1" >&2; exit 1; }
 TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
 


### PR DESCRIPTION
Closes the first two tiers of #824, and fixes a detector defect found while validating the engine work that motivated it.

## The fix: `CACHE_PARTIAL`

`CACHE_DISABLED` keyed on the presence of a `[moe-cache] enabled:` line. A **per-device** budget failure still prints that line while one GPU runs with no pool at all — measured live on the reference rig: CUDA0 got no budget, CUDA1 allocated a 69-slot pool, `enabled:` printed, and the arm reported **`OK`**. Throughput on such a run blends a cached and an uncached device and is comparable to neither.

Detection now counts **devices that actually got a pool** against the device count:

| pooled devices | status |
|---|---|
| 0 | `CACHE_DISABLED` (unchanged) |
| 0 < n < NGPU | **`CACHE_PARTIAL`** (new) |

## Tier 0 — static, 9 checks, ~1.2 s

No server, no GPU, no model. Each check guards a defect that actually shipped in this harness during development (all six are listed in #824):

- **column parity** — header width == `emit_row` values + status, and the width must derive from `$HDR`. Guards the `printf` that carried 32 specifiers for 33 arguments: bash re-ran the format for the surplus arg, so every arm wrote a short row *plus* a junk status-only row.
- **status-enum parity**, sweep ↔ renderer. This one has already earned itself — `CACHE_DISABLED` shipped with no renderer annotation within an hour of being added, and it caught `CACHE_PARTIAL` in this very PR.
- **pairing key includes `shape`** — workload shape flips the *sign* of speculative results, so a mispair manufactures a gain that does not exist.
- plus: syntax both halves, `MODEL` mandatory, engine-scope refusal, `PLAN=1` boots nothing, renderer survives a mixed TSV, and the suite leaves no artifacts in the repo.

**Mutation-tested**: deleting the `CACHE_DISABLED` annotation reds the suite with the right message. A green run is not evidence that a check can fail.

## Tier 1 — mocked server, 5 scenarios, ~15 s

Runs the **real sweep end-to-end** against a fake `llama-server` that emits the exact log lines the script scrapes and serves the two endpoints it calls. No GPU, no model, no engine — but boot → drive → scrape → emit → render all execute, which is where the silent defects live.

| scenario | asserted status |
|---|---|
| healthy | `OK` |
| **partial** | **`CACHE_PARTIAL`** — the regression guard for the fix above |
| nobudget | `CACHE_DISABLED`, remedy named |
| bypass | `INVALID_BYPASS` |
| notokens | `NO_TOKENS` |

Each case also asserts row invariants (field count == header count; `OK` implies non-zero throughput; `bypass>0` implies not `OK`), and a final pass proves the renderer surfaces every failure status and separates them from the conclusions.

**Throughput values are deliberately never asserted.** They are not portable across rigs, and the failure mode that matters is a healthy status on an unhealthy run.

The fixture documents the scrape contract by construction — it emits only what the script actually reads, so an accidental dependency on some other log line fails the suite rather than working by luck.

## Notes

- `test-locale-utf8` caught the missing `PYTHONUTF8` export in both suites before this PR opened — exactly its job.
- The mocked suite's EXIT trap needed a bracketed process pattern: the unbracketed form matches the killing command's own command line, self-kills with exit 144, and leaves the fixture it was meant to reap still running. Observed, then fixed.
- Tier 2 (short real-GPU run) is still to come and will stay **out** of the default `scripts/tests/*.sh` sweep so the suite remains fast.

## Tests

`test-offload-matrix` ✅ · `test-offload-matrix-mocked` ✅ · `test-locale-utf8` ✅ (93 scripts) · `test-artifact-inventory` ✅. Scoped change — no registry, compose or profile touched.