### PR TITLE
test(offload-matrix): 3-tier suite + fix the CACHE_DISABLED per-device hole (#824)

### DIFF
--- a/scripts/offload-matrix-render.py
+++ b/scripts/offload-matrix-render.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Render offload-matrix-results.tsv.
 
-The full row is 29 columns, so this offers VIEWS rather than one unreadable table:
+The full row is 34 columns, so this offers VIEWS rather than one unreadable table:
 
   --perf   (default) throughput / latency / acceptance, with paired no-spec deltas
   --bw     bandwidth + utilisation: PCIe rx/tx, SM%, mem-controller%, CPU%, RAM read

--- a/scripts/offload-matrix.sh
+++ b/scripts/offload-matrix.sh
@@ -565,8 +565,18 @@ PY
   # Found live 2026-07-30: the engine's DEFAULT reserve (3072 MiB) left no budget at
   # 262K ctx, logging "CUDA0 has no cache budget after 3072 MiB reserve" -- a string the
   # bypass grep does not match. Both arms reported OK and ran ~12-22% slow.
-  local cache_enabled=0 reserve_seen=""
+  local cache_enabled=0 reserve_seen="" pool_lines=0 cache_partial=0
   command grep -q '\[moe-cache\] enabled:' "$log" && cache_enabled=1
+  # PER-DEVICE budget failure. '[moe-cache] enabled:' still prints when only SOME devices
+  # got a pool, so a presence check scores the arm healthy while it measures a half-cached
+  # path -- measured live 2026-07-30 (CUDA0 no budget, CUDA1 a 69-slot pool, status OK).
+  # The pool-init lines are ground truth: one 'slots=' line per device when fully
+  # allocated. Fewer than NGPU of them means the cache is NOT what was requested.
+  pool_lines=$(command grep -c 'slots=' "$log")
+  if (( cache_enabled == 1 && pool_lines < ${NGPU:-2} )); then
+    cache_enabled=0
+    cache_partial=1
+  fi
   reserve_seen=$(command grep -oE 'reserve=[0-9]+ MiB|after [0-9]+ MiB reserve' "$log" \
                  | command grep -oE '[0-9]+' | tail -1)
   local nobudget; nobudget=$(command grep -c 'no cache budget' "$log")
@@ -580,7 +590,12 @@ PY
   if (( HAS_MOE_CACHE )) && [[ "$cache" != 0 ]] && (( cache_enabled == 0 )); then
     status="CACHE_DISABLED"
     echo "  !! expert cache was REQUESTED (--moe-cache $cache) but NEVER ALLOCATED."
-    if (( nobudget > 0 )); then
+    if (( cache_partial )); then
+      echo "     reason: PARTIAL allocation -- only $pool_lines of ${NGPU:-2} devices got a"
+      echo "     pool (the 'enabled:' line still prints in this state). One GPU ran with no"
+      echo "     cache at all, so this arm measured a half-cached path. Lower the reserve"
+      echo "     (RESERVE_MB=1536) so every device fits a pool."
+    elif (( nobudget > 0 )); then
       echo "     reason: no budget after ${reserve_seen:-?} MiB reserve. Lower the reserve"
       echo "     (RESERVE_MB=1536) or reduce ctx/pool so the pool fits."
     else

--- a/scripts/tests/fixtures/offload-matrix/fake-llama-server
+++ b/scripts/tests/fixtures/offload-matrix/fake-llama-server
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Fake llama-server for the offload-matrix tier-1 suite.
+
+Reproduces the two things the sweep actually consumes:
+  1. the LOG LINES it greps for status/metrics (written to stdout; the sweep
+     redirects that into the arm log)
+  2. the HTTP surface the inline driver drives: GET /health and a streaming
+     POST /v1/chat/completions emitting `data: {...}` SSE with
+     choices[0].delta.content, terminated by `data: [DONE]`.
+
+Every log string below is one the sweep greps for. Changing a string here without
+changing the sweep (or vice versa) is exactly the drift the suite exists to catch,
+so keep this file and the sweep's grep patterns in lockstep.
+
+  [moe-cache] enabled:            -> cache_enabled
+  ... slots=N                     -> pool_slots (SUMMED over all pool lines, no tail)
+  hits=H/T                        -> hits_pct + misses
+  evictions=N                     -> evicts (tailed by NGPU)
+  expert=N KiB                    -> avg expert size, feeds derived ram_rd_mbps
+  bypassing cache                 -> INVALID_BYPASS
+  no cache budget                 -> reason text for CACHE_DISABLED
+  reserve=N MiB                   -> reserve figure in that message
+  n_ctx_seq = N                   -> ctx_slot
+  draft acceptance = F            -> accept
+  eval time ... N tokens per second -> strm
+
+FAKE_SCENARIO:
+  healthy         normal 2-GPU run, cache allocated, tokens served
+  bypass          healthy + 'bypassing cache' lines           -> INVALID_BYPASS
+  no_budget_all   no 'enabled:' line at all                   -> CACHE_DISABLED
+  partial_budget  'enabled:' PRINTS but one GPU got no pool   -> the known HOLE:
+                  reads OK today; must read CACHE_DISABLED once the detector
+                  compares pool-line count against device count (issue #824)
+  no_tokens       healthy log, zero content deltas            -> NO_TOKENS
+  req_errors      completions return HTTP 500                 -> REQ_ERRORS
+  boot_fail       exit non-zero before listening              -> BOOT_FAIL
+  hang            never answers /health                       -> TIMEOUT
+"""
+import json, os, sys, time, threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+SC    = os.environ.get("FAKE_SCENARIO", "healthy")
+NGPU  = int(os.environ.get("FAKE_NGPU", "2"))
+TOKS  = int(os.environ.get("FAKE_TOKENS", "24"))
+SLOTS = [int(s) for s in os.environ.get("FAKE_SLOTS", "742,337").split(",")]
+
+def log(s):
+    sys.stdout.write(s + "\n"); sys.stdout.flush()
+
+# --- parse only the args we care about -------------------------------------
+argv = sys.argv[1:]
+
+# --help is a CAPABILITY PROBE, not decoration. The sweep refuses to run against
+# anything that does not look like llama.cpp (no --n-gpu-layers/--override-tensor)
+# and turns the whole cache dimension off unless --moe-cache appears. FAKE_NO_CACHE
+# lets a test assert that no-moe-cache builds degrade instead of dying.
+if "--help" in argv or "-h" in argv:
+    print("usage: llama-server [options]")
+    print("  -ngl, --n-gpu-layers N")
+    print("  -ot,  --override-tensor PATTERN")
+    print("  -ctk, --cache-type-k TYPE   (f16, q8_0, q4_0, turbo4)")
+    if os.environ.get("FAKE_NO_CACHE", "0") != "1":
+        print("  --moe-cache N               expert cache pool size in MiB")
+    sys.exit(0)
+
+def opt(name, default=None):
+    return argv[argv.index(name) + 1] if name in argv else default
+host = opt("--host", "127.0.0.1")
+port = int(opt("--port", "8080"))
+ctx  = int(opt("-c", "4096"))
+
+# --- boot log ---------------------------------------------------------------
+log("build: fake (tier-1 fixture)")
+log(f"llama_context: n_ctx = {ctx}")
+log(f"llama_context: n_ctx_seq = {ctx}")
+
+if SC == "boot_fail":
+    log("ggml_backend_cuda_buffer_type_alloc_buffer: failed to allocate")
+    log("terminate called after throwing an instance of 'std::runtime_error'")
+    sys.exit(1)
+
+if SC == "no_budget_all":
+    for g in range(NGPU):
+        log(f"[moe-cache] CUDA{g} has no cache budget after 3072 MiB reserve")
+elif SC == "partial_budget":
+    # THE HOLE. 'enabled:' still prints, so a presence-check scores this healthy,
+    # while CUDA0 actually runs with no pool at all. Measured live 2026-07-30.
+    log("[moe-cache] enabled: reserve=3072 MiB admit=1/64")
+    log("[moe-cache] CUDA0 has no cache budget after 3072 MiB reserve")
+    log(f"[moe-cache] CUDA1 pool[0]: slots={SLOTS[0]} expert=1536 KiB")
+else:
+    log("[moe-cache] enabled: reserve=1536 MiB admit=1/64")
+    for g in range(NGPU):
+        log(f"[moe-cache] CUDA{g} pool[0]: slots={SLOTS[g % len(SLOTS)]} expert=1536 KiB")
+
+log(f"main: server is listening on http://{host}:{port} - starting the main loop")
+log("llama_server: listening on " + f"{host}:{port}")
+
+# --- periodic stats, so hits/misses/evictions have something to scrape ------
+def stats_loop():
+    h = 0
+    while True:
+        time.sleep(1.0)
+        h += 1000
+        for g in range(NGPU):
+            log(f"[moe-cache] CUDA{g} hits={h}/{int(h*1.35)} evictions={h//8} "
+                f"expert=1536 KiB skips=0 fill-fail=0")
+        if SC == "bypass":
+            log("[moe-cache] MAX_BATCH=8 exceeded, bypassing cache for this batch")
+
+if SC != "hang":
+    threading.Thread(target=stats_loop, daemon=True).start()
+
+# --- HTTP -------------------------------------------------------------------
+class H(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    def log_message(self, *a): pass          # keep the arm log clean
+
+    def do_GET(self):
+        if self.path.startswith("/health"):
+            self.send_response(200); self.send_header("Content-Length", "2")
+            self.end_headers(); self.wfile.write(b"ok")
+        else:
+            self.send_response(404); self.send_header("Content-Length", "0"); self.end_headers()
+
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length", 0) or 0)
+        body = self.rfile.read(n)
+        if SC == "req_errors":
+            self.send_response(500); self.send_header("Content-Length", "0"); self.end_headers()
+            return
+        try:
+            gen = int(json.loads(body).get("max_tokens", TOKS))
+        except Exception:
+            gen = TOKS
+        emit = 0 if SC == "no_tokens" else min(gen, TOKS)
+
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Transfer-Encoding", "chunked")
+        self.end_headers()
+        def chunk(s: str):
+            b = s.encode()
+            self.wfile.write(f"{len(b):X}\r\n".encode() + b + b"\r\n"); self.wfile.flush()
+        try:
+            for i in range(emit):
+                d = {"choices": [{"delta": {"content": f"tok{i} "}}]}
+                chunk("data: " + json.dumps(d) + "\n\n")
+                time.sleep(0.002)
+            chunk("data: [DONE]\n\n")
+            chunk("")                              # terminating 0-length chunk
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+        # per-request timings the sweep scrapes for server-side decode TPS
+        log(f"print_timing: eval time = 1000.00 ms / {max(emit,1)} tokens "
+            f"( 1.00 ms per token, {max(emit,1)*2.5:.2f} tokens per second)")
+        log("draft acceptance = 0.951")
+
+if SC == "hang":
+    while True:
+        time.sleep(3600)
+
+srv = ThreadingHTTPServer((host, port), H)
+srv.serve_forever()

--- a/scripts/tests/fixtures/offload-matrix/fake-nvidia-smi
+++ b/scripts/tests/fixtures/offload-matrix/fake-nvidia-smi
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Fake nvidia-smi for the offload-matrix tier-1 suite.
+
+Implements exactly the two invocations the sweep makes, and nothing else:
+
+  nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits
+      -> one integer MiB per GPU, one per line
+
+  nvidia-smi dmon -s ut -d 1 [-c N]
+      -> the 9-column utilisation/PCIe stream. The sweep averages it with
+         awk '!/^#/ && NF>=9 {s+=$2;m+=$3;r+=$8;t+=$9}', i.e.
+         $2=sm%  $3=memctl%  $8=rxpci MB/s  $9=txpci MB/s
+         Fewer than 9 fields on a data line and every bandwidth column
+         silently becomes '-', so the width matters.
+
+Knobs (env):
+  FAKE_NGPU        number of GPUs (default 2)
+  FAKE_VRAM_MIB    comma list of per-GPU memory.used, or one value for all
+  FAKE_SM / FAKE_MEMCTL / FAKE_RXPCI / FAKE_TXPCI   dmon values
+"""
+import os, sys, time
+
+NGPU = int(os.environ.get("FAKE_NGPU", "2"))
+
+def vram_list():
+    raw = os.environ.get("FAKE_VRAM_MIB", "12000")
+    vals = [v.strip() for v in raw.split(",") if v.strip()]
+    return (vals * NGPU)[:NGPU] if len(vals) < NGPU else vals[:NGPU]
+
+argv = sys.argv[1:]
+
+# --- query-gpu form ---
+if any(a.startswith("--query-gpu") for a in argv):
+    field = next(a for a in argv if a.startswith("--query-gpu")).split("=", 1)[1]
+    for v in vram_list():
+        if "memory.used" in field:
+            print(v)
+        elif "utilization.gpu" in field:
+            print(os.environ.get("FAKE_SM", "40"))
+        else:
+            print("0")
+    sys.exit(0)
+
+# --- dmon form ---
+if "dmon" in argv:
+    count = None
+    if "-c" in argv:
+        try: count = int(argv[argv.index("-c") + 1])
+        except Exception: count = None
+    delay = 1
+    if "-d" in argv:
+        try: delay = int(argv[argv.index("-d") + 1])
+        except Exception: delay = 1
+
+    sm  = os.environ.get("FAKE_SM", "40")
+    mem = os.environ.get("FAKE_MEMCTL", "25")
+    rx  = os.environ.get("FAKE_RXPCI", "1200")
+    tx  = os.environ.get("FAKE_TXPCI", "800")
+
+    print("# gpu    sm   mem   enc   dec   jpg   ofa  rxpci  txpci", flush=True)
+    print("# Idx     %     %     %     %     %     %   MB/s   MB/s", flush=True)
+    n = 0
+    try:
+        while count is None or n < count:
+            for g in range(NGPU):
+                # 9 fields exactly — the sweep requires NF>=9
+                print(f"{g:5d} {sm:>5} {mem:>5} {0:5d} {0:5d} {0:5d} {0:5d} {rx:>6} {tx:>6}", flush=True)
+            n += 1
+            if count is None or n < count:
+                time.sleep(delay)
+    except (KeyboardInterrupt, BrokenPipeError):
+        pass
+    sys.exit(0)
+
+# anything else: behave like a tool that exists but was asked something unknown
+sys.exit(0)

--- a/scripts/tests/test-offload-matrix-mocked.sh
+++ b/scripts/tests/test-offload-matrix-mocked.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# test-offload-matrix-mocked — TIER 1 guards for scripts/offload-matrix.sh.
+#
+# Drives the REAL sweep end-to-end against a fake llama-server and a fake nvidia-smi,
+# so every status-classification and row-integrity path is exercised deterministically
+# with no GPU and no model. This is where the sweep's actual logic gets asserted: the
+# defects it has already shipped were all "plausible wrong row", never a crash.
+#
+# HERMETIC BY CONSTRUCTION — both of these are load-bearing, not conveniences:
+#   INHERIT=0                  the sweep unconditionally runs `pgrep -x llama-server`
+#                              and, if one is up, inherits -m/-ot/-t/-ub/-ct from its
+#                              argv. Without this a stray production server silently
+#                              rewrites the config under test.
+#   ALLOW_CONCURRENT_SERVER=1  the same detection makes the sweep refuse to start
+#                              (exit 2) while a server runs. Mocked arms allocate no
+#                              VRAM, so there is genuinely nothing to contend for.
+#
+# Asserts STRUCTURE and STATUS only — never a throughput value. Numbers from a fake
+# server mean nothing, and real numbers are not portable across rigs.
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SWEEP="$ROOT_DIR/scripts/offload-matrix.sh"
+REND="$ROOT_DIR/scripts/offload-matrix-render.py"
+FIX="$ROOT_DIR/scripts/tests/fixtures/offload-matrix"
+PORT="${TEST_PORT:-8137}"
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+for f in "$SWEEP" "$FIX/fake-llama-server" "$FIX/fake-nvidia-smi"; do
+  [[ -f "$f" ]] || fail "missing fixture or script: $f"
+done
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin"
+install -m 0755 "$FIX/fake-nvidia-smi"  "$TMP/bin/nvidia-smi"
+install -m 0755 "$FIX/fake-llama-server" "$TMP/bin/fake-llama-server"
+export PATH="$TMP/bin:$PATH"
+: > "$TMP/model.gguf"          # existence is all the sweep checks
+
+NCOL=$(python3 - "$SWEEP" <<'PY'
+import re,sys
+src=open(sys.argv[1],encoding="utf-8").read()
+print(len(re.search(r"HDR=\$'(.*?)'",src,re.S).group(1).split("\\t")))
+PY
+)
+
+# Run one arm of the real sweep under a given fake-server scenario.
+run_scenario() {
+  # two statements deliberately: `local a="$1" b="$TMP/$a"` expands BOTH words before
+  # local assigns anything, so $a is unbound under set -u
+  local scen="$1"
+  local out="$TMP/$scen"
+  mkdir -p "$out"
+  FAKE_SCENARIO="$scen" FAKE_NGPU=2 FAKE_SLOTS="742,337" FAKE_TOKENS=12 \
+  MODEL="$TMP/model.gguf" LLAMA_SERVER="$TMP/bin/fake-llama-server" \
+  LAYERS_TOTAL=48 FIRST_MOE_LAYER=1 \
+  OUT_DIR="$out" TSV="$out/r.tsv" PORT="$PORT" HOST=127.0.0.1 \
+  PRESET=smoke SWEEP_OFFLOAD=4 SWEEP_N=1 SWEEP_NMAX=0 SWEEP_CTX=4096 \
+  SWEEP_CACHE=1024 SWEEP_ADMIT=1/64 SWEEP_SHAPE=copy \
+  REPS=1 ROUNDS=2 GEN=8 BOOT_TIMEOUT=30 \
+  INHERIT=0 ALLOW_CONCURRENT_SERVER=1 \
+    bash "$SWEEP" > "$out/sweep.log" 2>&1 || true
+  [[ -f "$out/r.tsv" ]] || { sed -n '1,25p' "$out/sweep.log" >&2; fail "$scen: no TSV produced"; }
+  echo "$out/r.tsv"
+}
+
+status_of() { awk -F'\t' 'NR>1{print $NF}' "$1" | head -1; }
+
+# Column count is the invariant that caught the original 32-for-33 printf defect and
+# the short early-exit rows. Checked on EVERY scenario, including the failure paths --
+# those are exactly the rows that used to come out ragged.
+assert_shape() {
+  local tsv="$1" scen="$2"
+  local widths; widths=$(awk -F'\t' '{print NF}' "$tsv" | sort -u | paste -sd,)
+  [[ "$widths" == "$NCOL" ]] || fail "$scen: ragged TSV — widths [$widths], header is $NCOL"
+  [[ "$(wc -l < "$tsv")" -ge 2 ]] || fail "$scen: header only, no data row"
+}
+
+echo "  running mocked arms (no GPU, no model) ..."
+
+# 1. healthy -> OK, with a real pool sum and non-zero throughput
+tsv=$(run_scenario healthy); assert_shape "$tsv" healthy
+[[ "$(status_of "$tsv")" == "OK" ]] || fail "healthy should be OK, got '$(status_of "$tsv")'"
+pool=$(python3 - "$tsv" <<'PY'
+import csv,sys
+r=list(csv.DictReader(open(sys.argv[1],encoding="utf-8"),delimiter="\t"))
+print(r[0].get("pool_slots","-"))
+PY
+)
+# 742 + 337 = 1079: pool_slots must SUM both pool-init lines, not tail to the last one
+[[ "$pool" == "1079" ]] || fail "pool_slots should sum all pool lines (742+337=1079), got '$pool'"
+echo "  ✓ healthy -> OK, pool_slots sums every pool line (1079)"
+
+# 2. a decode that declined the cache invalidates the arm
+tsv=$(run_scenario bypass); assert_shape "$tsv" bypass
+[[ "$(status_of "$tsv")" == "INVALID_BYPASS" ]] || fail "bypass should be INVALID_BYPASS, got '$(status_of "$tsv")'"
+echo "  ✓ bypass -> INVALID_BYPASS"
+
+# 3. cache requested, never allocated on ANY device
+tsv=$(run_scenario no_budget_all); assert_shape "$tsv" no_budget_all
+[[ "$(status_of "$tsv")" == "CACHE_DISABLED" ]] || fail "no_budget_all should be CACHE_DISABLED, got '$(status_of "$tsv")'"
+echo "  ✓ no_budget_all -> CACHE_DISABLED"
+
+# 4. ⚠️ THE HOLE (issue #824). '[moe-cache] enabled:' still prints while ONE device got
+#    no pool, so a presence-check scores the arm healthy and it silently measures a
+#    half-cached path. Observed live 2026-07-30: CUDA0 no budget, CUDA1 a 69-slot pool.
+#    Correct detection compares pool-line count against device count.
+tsv=$(run_scenario partial_budget); assert_shape "$tsv" partial_budget
+st=$(status_of "$tsv")
+[[ "$st" == "CACHE_DISABLED" ]] || fail \
+  "partial_budget must be CACHE_DISABLED, got '$st' — the detector is keying on the presence of '[moe-cache] enabled:' instead of comparing pool-line count to device count (issue #824)"
+echo "  ✓ partial_budget -> CACHE_DISABLED (per-device budget failure is caught)"
+
+# 5. zero tokens must never read OK — this shipped as agg=0.00/OK once
+tsv=$(run_scenario no_tokens); assert_shape "$tsv" no_tokens
+[[ "$(status_of "$tsv")" == "NO_TOKENS" ]] || fail "no_tokens should be NO_TOKENS, got '$(status_of "$tsv")'"
+echo "  ✓ no_tokens -> NO_TOKENS"
+
+# 6. HTTP failures surface as REQ_ERRORS (and outrank the cache states)
+tsv=$(run_scenario req_errors); assert_shape "$tsv" req_errors
+[[ "$(status_of "$tsv")" =~ ^(REQ_ERRORS|NO_TOKENS)$ ]] || fail "req_errors should be REQ_ERRORS/NO_TOKENS, got '$(status_of "$tsv")'"
+echo "  ✓ req_errors -> $(status_of "$tsv")"
+
+# 7. a server that dies before listening still writes a FULL-WIDTH row. Early-exit rows
+#    used to omit `shape` and land 4 columns short, and a ctx ladder that OOMs produces
+#    these routinely — so every one of them was silently shifted.
+tsv=$(run_scenario boot_fail); assert_shape "$tsv" boot_fail
+[[ "$(status_of "$tsv")" == "BOOT_FAIL" ]] || fail "boot_fail should be BOOT_FAIL, got '$(status_of "$tsv")'"
+echo "  ✓ boot_fail -> BOOT_FAIL, row still full width"
+
+# 8. status=OK implies real throughput. Checked across every row produced above.
+python3 - "$TMP" <<'PY' || exit 1
+import csv,glob,sys,os
+bad=[]
+for p in glob.glob(os.path.join(sys.argv[1],"*","r.tsv")):
+    for r in csv.DictReader(open(p,encoding="utf-8"),delimiter="\t"):
+        if r["status"]=="OK":
+            try: agg=float(r["agg"])
+            except Exception: agg=0.0
+            if agg<=0: bad.append((os.path.basename(os.path.dirname(p)),r["agg"]))
+        if r["status"]!="OK" and r.get("bypass","0") not in ("-","0"):
+            pass  # bypass>0 with a non-OK status is correct
+        if r.get("bypass","0") not in ("-","0") and r["status"]=="OK":
+            bad.append((os.path.basename(os.path.dirname(p)),"bypass>0 but OK"))
+if bad: sys.exit(f"FAIL: status=OK with no throughput / bypass: {bad}")
+print("  ✓ invariant: status=OK implies agg>0 and bypass==0")
+PY
+
+# 9. the renderer must survive every view on real produced rows — one view once died
+#    with KeyError and another rendered '-' forever.
+cat "$TMP"/healthy/r.tsv > "$TMP/all.tsv"
+for s in bypass no_budget_all partial_budget no_tokens boot_fail; do
+  tail -n +2 "$TMP/$s/r.tsv" >> "$TMP/all.tsv"
+done
+for view in --perf --bw --cache --all; do
+  python3 "$REND" "$TMP/all.tsv" "$view" > "$TMP/render$view.txt" 2>"$TMP/render$view.err" \
+    || { sed -n '1,15p' "$TMP/render$view.err" >&2; fail "renderer crashed on $view"; }
+  [[ -s "$TMP/render$view.txt" ]] || fail "renderer produced nothing for $view"
+done
+python3 "$REND" "$TMP/all.tsv" --perf --md > "$TMP/render.md" || fail "renderer crashed on --md"
+grep -q '^|' "$TMP/render.md" || fail "--md produced no markdown table"
+echo "  ✓ renderer handles every view (+ --md) over mixed-status rows"
+
+# 10. non-OK arms must be called out, so a reader cannot fold a broken arm into a conclusion
+grep -qE "NOT OK|⚠" "$TMP/render--perf.txt" || fail "renderer must flag non-OK arms in its summary"
+echo "  ✓ renderer flags non-OK arms"
+
+echo "test-offload-matrix-mocked: ok"

--- a/scripts/tests/test-offload-matrix-static.sh
+++ b/scripts/tests/test-offload-matrix-static.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# test-offload-matrix-static — TIER 0 guards for scripts/offload-matrix.sh and its
+# renderer. Nothing here boots a server or touches a GPU; these are the checks that
+# can be made from the source text alone, and they cover the whole class of defect
+# this harness has already shipped: rows whose column count silently disagrees with
+# the header, and a renderer that reads columns the driver never writes.
+#
+# The harness exists to produce numbers that DECIDE serving configs. Its failure mode
+# is not a crash — it is a plausible wrong number. So these assert structure, never
+# throughput values. See issue #824.
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SWEEP="$ROOT_DIR/scripts/offload-matrix.sh"
+REND="$ROOT_DIR/scripts/offload-matrix-render.py"
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+[[ -f "$SWEEP" ]] || fail "missing $SWEEP"
+[[ -f "$REND"  ]] || fail "missing $REND"
+
+# 1. both halves parse
+bash -n "$SWEEP" || fail "bash -n: syntax error in offload-matrix.sh"
+python3 -m py_compile "$REND" || fail "py_compile: syntax error in the renderer"
+echo "  ✓ syntax (bash -n + py_compile)"
+
+# 2. the header is the ONLY definition of column count, and status is last.
+#    emit_row derives width from it; anything that hand-counts columns is the bug
+#    this suite exists to prevent.
+NCOL=$(python3 - "$SWEEP" <<'PY'
+import re,sys
+src=open(sys.argv[1],encoding="utf-8").read()
+m=re.search(r"HDR=\$'(.*?)'",src,re.S) or sys.exit("no HDR")
+f=m.group(1).split("\\t")
+assert f[-1]=="status", f"header must end with status, ends with {f[-1]}"
+assert len(f)==len(set(f)), "duplicate column name in header"
+print(len(f))
+PY
+) || fail "header malformed"
+[[ "$NCOL" -ge 30 ]] || fail "header collapsed to $NCOL columns — expected the full row"
+echo "  ✓ header well-formed: $NCOL unique columns, ends with 'status'"
+
+# 3. exactly ONE writer appends rows, and it is emit_row. A second hand-rolled
+#    printf is how the 32-specifiers-for-33-arguments defect shipped: bash re-runs
+#    a short format string for the surplus args, so every arm wrote a truncated row
+#    PLUS a junk row containing only the status.
+appends=$(grep -cE '>> *"\$TSV"' "$SWEEP")
+[[ "$appends" == "1" ]] || fail "expected exactly 1 append to \$TSV (inside emit_row), found $appends"
+grep -qE '^emit_row\(\)' "$SWEEP" || fail "emit_row not defined"
+echo "  ✓ single row emitter (1 append site)"
+
+# 4. emit_row itself: pads short rows to header width, and REFUSES to write an
+#    over-long row rather than corrupting the TSV. Extracted and exercised in
+#    isolation so this is a real unit test, not a grep.
+emit_src=$(awk '/^emit_row\(\)/,/^}/' "$SWEEP")
+[[ -n "$emit_src" ]] || fail "could not extract emit_row"
+tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+(
+  set -euo pipefail
+  TSV="$tmp/t.tsv"; NCOL=5
+  eval "$emit_src"
+  emit_row OK a b                       # short: must pad
+  emit_row OK a b c d                   # exact: must not pad
+  emit_row OK a b c d e f 2>/dev/null && exit 3   # over-long: must refuse (non-zero)
+  exit 0
+) || fail "emit_row accepted an over-long row (would corrupt the TSV)"
+widths=$(awk -F'\t' '{print NF}' "$tmp/t.tsv" | sort -u)
+[[ "$widths" == "5" ]] || fail "emit_row produced ragged rows: widths [$widths], expected all 5"
+[[ "$(awk -F'\t' '{print $NF}' "$tmp/t.tsv" | sort -u)" == "OK" ]] || fail "status must be the last field"
+[[ "$(awk -F'\t' 'NR==1{print $3}' "$tmp/t.tsv")" == "-" ]] || fail "short rows must pad with '-'"
+echo "  ✓ emit_row pads short rows, refuses over-long rows, keeps status last"
+
+# 5. every status the renderer explains must be one the driver can actually emit,
+#    and vice versa. Drift in either direction means an arm renders with no
+#    explanation, or the renderer documents a state that cannot happen.
+python3 - "$SWEEP" "$REND" <<'PY' || exit 1
+import re,sys
+sweep=open(sys.argv[1],encoding="utf-8").read()
+rend =open(sys.argv[2],encoding="utf-8").read()
+emitted=set(re.findall(r'status="([A-Z_]{3,})"',sweep)) | set(re.findall(r'emit_row ([A-Z_]{3,})',sweep))
+emitted.discard("OK")                      # OK is the default, never explained
+known=set(re.findall(r'"([A-Z_]{3,})":',rend))
+if emitted-known: sys.exit(f"FAIL: driver emits statuses the renderer cannot explain: {sorted(emitted-known)}")
+if known-emitted: sys.exit(f"FAIL: renderer explains statuses the driver never emits: {sorted(known-emitted)}")
+print(f"  ✓ status vocabulary agrees both ways ({len(emitted)} non-OK states)")
+PY
+
+# 6. every column the renderer reads must exist in the header. One view once
+#    crashed with KeyError and another silently rendered '-' forever because they
+#    referenced columns the driver never wrote. Derived cells are '_'-prefixed and
+#    'reps' is synthesised at merge time; everything else must be a real column.
+python3 - "$SWEEP" "$REND" <<'PY' || exit 1
+import re,sys
+sweep=open(sys.argv[1],encoding="utf-8").read()
+rend =open(sys.argv[2],encoding="utf-8").read()
+hdr=set(re.search(r"HDR=\$'(.*?)'",sweep,re.S).group(1).split("\\t"))
+def tup(name):
+    m=re.search(rf"^{name}\s*=\s*\((.*?)\)",rend,re.S|re.M)
+    return set(re.findall(r'"([a-z_]+)"',m.group(1))) if m else set()
+refs=set()
+refs|=tup("NUM"); refs|=tup("KEY"); refs|=tup("INTCOL")
+# Scan ONLY inside the VIEWS dict. A whole-file scan also matches plain view-name
+# tuples like `if view in ("bw","all")`, which are not column references at all.
+views=re.search(r"^VIEWS\s*=\s*\{(.*?)^\}",rend,re.S|re.M)
+if not views: sys.exit("FAIL: no VIEWS dict in renderer")
+refs|=set(re.findall(r'\("[^"]*",\s*"([a-z_][a-z_0-9]*)"\)',views.group(1)))
+synthetic={"reps"}
+missing={c for c in refs if not c.startswith("_")} - hdr - synthetic
+if missing: sys.exit(f"FAIL: renderer reads columns absent from the header: {sorted(missing)}")
+print(f"  ✓ every renderer column resolves ({len(refs)} referenced)")
+PY
+
+# 7. the pairing key MUST include shape. Workload shape flips the SIGN of a
+#    speculation result on this stack (+81% copy vs +3.9% prose), so pairing a
+#    copy-heavy spec arm against a prose baseline manufactures a gain that does
+#    not exist. This is the one renderer bug that produces a confident wrong number.
+python3 - "$REND" <<'PY' || exit 1
+import re,sys
+rend=open(sys.argv[1],encoding="utf-8").read()
+key=re.search(r"^KEY\s*=\s*\((.*?)\)",rend,re.S|re.M)
+if not key: sys.exit("FAIL: no KEY tuple in renderer")
+cols=set(re.findall(r'"([a-z_]+)"',key.group(1)))
+for must in ("shape","offload","ctx_slot","cache_mb"):
+    if must not in cols: sys.exit(f"FAIL: pairing KEY missing '{must}' — spec arms would mispair")
+print(f"  ✓ pairing key is shape-aware ({len(cols)} dimensions)")
+PY
+
+# 8. pool_slots must sum EVERY 'slots=' line with no tail/head. This looks like a
+#    bug and has been reported as one; it is NOT. 'slots=' appears only in the
+#    pool-init lines, never in the periodic stats emissions, so summing them all is
+#    correct — on a 4-pool run, 742+337+558+279 = 1916, the reported figure. Adding
+#    a `tail -N` would silently DROP two pools and roughly halve the number.
+#    Asserted so nobody "fixes" it back into a defect.
+pool_line=$(grep -nE 'pool=\$\(' "$SWEEP" | head -1 | cut -d: -f1)
+[[ -n "$pool_line" ]] || fail "could not find the pool_slots extraction"
+pool_expr=$(sed -n "${pool_line}p" "$SWEEP")
+grep -q 'slots=' <<<"$pool_expr"            || fail "pool extraction no longer reads slots="
+grep -qE '\| *(tail|head) ' <<<"$pool_expr" && fail "pool_slots must NOT tail/head — it would drop pools (see #824)"
+echo "  ✓ pool_slots sums all pool-init lines (no tail — the reported 'bug' is a false positive)"
+
+# 9. the renderer's own docstring states the row width; keep it honest, since it is
+#    what a reader trusts before running anything.
+doc_n=$(grep -oE 'full row is [0-9]+ columns' "$REND" | grep -oE '[0-9]+' || true)
+if [[ -n "$doc_n" ]]; then
+  [[ "$doc_n" == "$NCOL" ]] || fail "renderer docstring says $doc_n columns, header has $NCOL"
+  echo "  ✓ renderer docstring column count matches the header ($NCOL)"
+fi
+
+echo "test-offload-matrix-static: ok"

--- a/scripts/tests/tier2/test-offload-matrix-real.sh
+++ b/scripts/tests/tier2/test-offload-matrix-real.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# test-offload-matrix-real — TIER 2. Needs a real GPU + a real model. NOT part of the
+# default `scripts/tests/*.sh` sweep (it lives one directory down so the glob misses it),
+# and additionally refuses to run without OFFLOAD_MATRIX_TIER2=1.
+#
+# ── Why this tier exists ──────────────────────────────────────────────────────
+# Tiers 0 and 1 assert the sweep's logic against a FAKE server whose log strings are
+# hard-coded from what the engine emitted when the fixture was written. That is exactly
+# the thing that rots: an engine bump renames a log line, the fake keeps emitting the old
+# one, tier 1 stays green, and the real sweep silently reports '-' for a whole column.
+#
+# So tier 2's job is NOT to re-test the logic. It is to prove the REAL engine still emits
+# every string the scrapers depend on. If this fails and tier 1 passes, the fixture is
+# stale -- fix `fixtures/offload-matrix/fake-llama-server`, not the sweep.
+#
+# Asserts structure, status and log-contract only. NEVER a throughput value: those are
+# not portable across rigs, and asserting them would make this test a rig detector.
+#
+# Usage:
+#   OFFLOAD_MATRIX_TIER2=1 MODEL=/path/to/model.gguf LLAMA_SERVER=/path/to/llama-server \
+#     bash scripts/tests/tier2/test-offload-matrix-real.sh
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SWEEP="$ROOT_DIR/scripts/offload-matrix.sh"
+REND="$ROOT_DIR/scripts/offload-matrix-render.py"
+fail() { echo "FAIL: $1" >&2; exit 1; }
+skip() { echo "SKIP: $1"; exit 0; }
+
+[[ "${OFFLOAD_MATRIX_TIER2:-0}" == 1 ]] || skip "set OFFLOAD_MATRIX_TIER2=1 to run the real-GPU tier"
+command -v nvidia-smi >/dev/null 2>&1 || skip "no nvidia-smi"
+nvidia-smi --query-gpu=name --format=csv,noheader >/dev/null 2>&1 || skip "no usable GPU"
+[[ -n "${MODEL:-}"  && -f "${MODEL:-}" ]] || skip "set MODEL=/path/to/model.gguf"
+[[ -n "${LLAMA_SERVER:-}" && -x "${LLAMA_SERVER:-}" ]] || skip "set LLAMA_SERVER=/path/to/llama-server"
+
+# A real server must not be up: the sweep boots its own per arm and would refuse (exit 2),
+# and overriding that here would measure under contention.
+if pgrep -x llama-server >/dev/null; then
+  fail "a llama-server is already running — stop it first (this tier boots its own)"
+fi
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+PORT="${TEST_PORT:-8138}"
+NGPU=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
+
+echo "  booting ONE short real arm (ctx 4096, 2 rounds) on $NGPU GPU(s) ..."
+MODEL="$MODEL" LLAMA_SERVER="$LLAMA_SERVER" \
+OUT_DIR="$TMP" TSV="$TMP/r.tsv" PORT="$PORT" HOST=127.0.0.1 \
+PRESET=smoke SWEEP_N=1 SWEEP_NMAX=0 SWEEP_CTX=4096 SWEEP_SHAPE=code \
+SWEEP_CACHE="${TIER2_CACHE:-0}" REPS=1 ROUNDS=2 GEN=32 BOOT_TIMEOUT=600 \
+INHERIT=0 \
+  bash "$SWEEP" > "$TMP/sweep.log" 2>&1 || true
+
+[[ -f "$TMP/r.tsv" ]] || { sed -n '1,40p' "$TMP/sweep.log" >&2; fail "no TSV produced"; }
+
+# ── structural invariants (same ones tier 1 asserts, now on real output) ──
+NCOL=$(head -1 "$TMP/r.tsv" | awk -F'\t' '{print NF}')
+widths=$(awk -F'\t' '{print NF}' "$TMP/r.tsv" | sort -u | paste -sd,)
+[[ "$widths" == "$NCOL" ]] || fail "ragged TSV on real output — widths [$widths], header $NCOL"
+[[ "$(wc -l < "$TMP/r.tsv")" -ge 2 ]] || fail "header only, no data row"
+status=$(awk -F'\t' 'NR==2{print $NF}' "$TMP/r.tsv")
+echo "  ✓ real arm produced a full-width row (status=$status)"
+
+if [[ "$status" != "OK" ]]; then
+  sed -n '1,40p' "$TMP/sweep.log" >&2
+  fail "real arm did not reach OK (status=$status) — read the log above before trusting any sweep"
+fi
+
+# ── THE POINT OF THIS TIER: the real engine still emits what the scrapers need ──
+# Every pattern below is one the sweep greps out of the arm log. A miss here with tier 1
+# green means the FIXTURE is stale, not the sweep.
+arm_log=$(ls -t "$TMP"/*.log 2>/dev/null | grep -v sweep.log | head -1)
+[[ -n "$arm_log" ]] || arm_log="$TMP/sweep.log"
+miss=0
+check() {  # $1=label  $2=ERE
+  if grep -qE "$2" "$arm_log" 2>/dev/null; then
+    echo "    ✓ $1"
+  else
+    echo "    ✗ $1   (pattern: $2)"; miss=1
+  fi
+}
+echo "  log contract — real engine vs what the scrapers expect:"
+check "context size (ctx_slot)"      'n_ctx_seq *= *[0-9]+|n_ctx_per_seq *= *[0-9]+'
+check "decode timing (strm)"         'eval time'
+check "tokens-per-second figure"     '[0-9.]+ tokens per second'
+(( miss == 0 )) || fail "the real engine no longer emits a scraped pattern — update the fake-llama-server fixture to match, then re-check tier 1"
+
+# cache-specific contract only when the cache was actually requested
+if [[ "${TIER2_CACHE:-0}" != 0 ]]; then
+  echo "  expert-cache contract:"
+  check "cache enabled line"  '\[moe-cache\] enabled:'
+  check "pool-init slots="    'slots=[0-9]+'
+  check "hits=H/T"            'hits=[0-9]+/[0-9]+'
+  (( miss == 0 )) || fail "expert-cache log strings drifted — update the fixture"
+  # one pool-init line per device, the invariant behind the CACHE_DISABLED fix
+  pool_lines=$(grep -c 'slots=' "$arm_log")
+  [[ "$pool_lines" -ge "$NGPU" ]] || fail \
+    "only $pool_lines pool line(s) for $NGPU device(s) — a per-device budget failure should have been caught as CACHE_DISABLED, not OK"
+  echo "    ✓ $pool_lines pool line(s) for $NGPU device(s)"
+fi
+
+# ── renderer over genuinely-produced rows ──
+for view in --perf --bw --cache; do
+  python3 "$REND" "$TMP/r.tsv" "$view" >/dev/null 2>"$TMP/err" || { cat "$TMP/err" >&2; fail "renderer crashed on $view over real rows"; }
+done
+echo "  ✓ renderer handles real rows"
+
+echo "test-offload-matrix-real: ok"


### PR DESCRIPTION
Implements the tiered suite from #824, and fixes the two defects the suite caught while being built.

## Tiers

| tier | file | needs | budget | job |
|---|---|---|---|---|
| 0 — static | `scripts/tests/test-offload-matrix-static.sh` | nothing | <1 s | source-level invariants: header/emitter integrity, sweep↔renderer agreement |
| 1 — mocked | `scripts/tests/test-offload-matrix-mocked.sh` | nothing | ~55 s | drives the **real sweep** end-to-end against a fake `llama-server` + fake `nvidia-smi`; asserts status classification and row integrity on every path |
| 2 — real | `scripts/tests/tier2/test-offload-matrix-real.sh` | GPU + model, `OFFLOAD_MATRIX_TIER2=1` | ~2–5 min | **fixture-rot detection**: proves the real engine still emits every log string the scrapers grep |

Tier 2 lives in `tier2/` so the default `scripts/tests/*.sh` glob never runs it, and it SKIPs (exit 0) without its env gate. Tiers 0+1 run in the default sweep.

Per the issue's scope rule, **no test asserts a throughput value** — structure, status, and log-contract only. Real numbers aren't portable across rigs; fake numbers mean nothing.

## Tier-0 highlights

- `emit_row` is extracted and unit-tested in isolation: pads short rows, **refuses** over-long rows, keeps `status` last. This makes the shipped ragged-row defects (32-specifiers-for-33-args; early-exit rows 4 columns short) unrepresentable.
- Status vocabulary is asserted **both directions** between sweep and renderer (8 non-OK states).
- Every column the renderer reads must resolve against the header; the pairing key must include `shape` (shape flips the sign of spec results, so a mispair manufactures a gain).
- The `pool_slots` no-`tail` guard from the issue is asserted as **correct-as-written**, so nobody "fixes" the false positive and halves the number.

## Tier-1 fixtures

`fixtures/offload-matrix/fake-llama-server` reproduces the two surfaces the sweep consumes: the greppable log lines (`[moe-cache] enabled:`, `slots=`, `hits=H/T`, `bypassing cache`, `eval time`, `n_ctx_seq`, …) and the HTTP surface the inline driver uses (`/health`, streaming SSE `chat/completions`), plus a `--help` that satisfies the capability probe. 8 scenarios: `healthy`, `bypass`, `no_budget_all`, `partial_budget`, `no_tokens`, `req_errors`, `boot_fail`, `hang`.

`fake-nvidia-smi` answers `--query-gpu` and emits the 9-column `dmon` stream (the sweep's awk needs `NF>=9`, so the width is part of the contract).

The test is hermetic against a live server by construction: `INHERIT=0` (the sweep otherwise adopts config from any running llama-server's argv) and `ALLOW_CONCURRENT_SERVER=1` (mocked arms hold no VRAM).

## Fixes (both red→green proven by the suite)

**1. The `CACHE_DISABLED` per-device hole from the issue.** The detector keyed on the presence of `[moe-cache] enabled:`, which still prints when only *some* devices get a pool — a per-device budget failure ran a half-cached path while reporting `OK` (observed live 2026-07-30: one device no budget, the other a 69-slot pool). Now: count pool-init `slots=` lines and compare against the device count; distinct operator message for the partial case. Tier 1's `partial_budget` scenario failed against the unfixed script with exactly this diagnosis, and passes after.

**2. Renderer docstring** claimed 29 columns; the header has 34. Caught by tier 0 on its first run; now asserted so it can't drift.

## Verification

- Tier 0: 9/9 green
- Tier 1: 10/10 green (and the `partial_budget` case demonstrably red before fix 1)
- Tier 2: SKIPs cleanly without its gate; no existing test references these files

Closes #824.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4LeYTBtjVXgpDgXSNUSgr
