### PR TITLE
feat(bench): shared capture lib + bench.sh capture backlog (#841)

### DIFF
--- a/docs/BENCH_CARD.md
+++ b/docs/BENCH_CARD.md
@@ -104,3 +104,56 @@ Three rows in this template exist because their absence has repeatedly cost real
 **See also:** [CONTRIBUTING.md](../CONTRIBUTING.md) (bench + verify protocol) ·
 [OFFLOAD_MATRIX.md](OFFLOAD_MATRIX.md) (multi-dimension sweeps — use its TSV output rather than
 hand-running many A/Bs) · [RESULTS_CARD.md](RESULTS_CARD.md) (the model-level card these bench cards feed into).
+
+---
+
+## What `bench.sh` now fills in for you
+
+`bench.sh` carries a capture layer (`scripts/lib/capture.sh`) that auto-fills most of the
+**Fingerprint** and **Integrity** sections above. Copy these straight off the run instead of
+reassembling them from memory afterwards — the reason the panel exists is that reconstructing it
+later is exactly when the awkward facts get dropped.
+
+| Card field | Where it comes from now |
+|---|---|
+| **Config** — KV, ctx, drafter, key flags | `CONFIG FINGERPRINT` block: KV cache type, served ctx + slots, weights ftype, drafter, and a `-m/-ot/-t/-ub/-ct/-ngl/-ts` argv fingerprint read from the serving process. No operator input needed. |
+| **Env** — non-default vars | `moe-cache cfg` line: the `--moe-cache` cap plus `GGML_CUDA_MOE_CACHE_{RESERVE_MB,ADMIT_AFTER,THROTTLE,MAX_BATCH,STATS}`. The **resulting pool size does not identify the arm** — the census self-limits below the cap — so record the config, not just the census. |
+| **GPU** — VRAM / util | `CAPTURE: VRAM` (idle / peak / post, per device) and `CAPTURE: PCIe` (sm%, memctl%, host cpu%). |
+| **Cache** — hits start → end | `CAPTURE: EXPERT CACHE`, per device, with **marginal** and cumulative rates. |
+| **resource-cost row** (A/B) | pool slots + total MiB per device, straight from the census. |
+
+### Additions to the Integrity panel
+
+Add these four lines to the checklist in both templates. Each is printed by the run.
+
+- [ ] **`status: OK`** — the capture layer's own verdict (`NO_TOKENS` / `REQ_ERRORS` /
+      `CACHE_DISABLED` / `INVALID_BYPASS` / `OK`). **`NO_TOKENS` means the run measured nothing** —
+      a `0.00` TPS printed next to a healthy-looking TTFT is a scrape failure, not a slow model.
+      Do not quote a throughput number from a non-`OK` run.
+- [ ] **cache health counters all zero** — `fill-fail` / `dispatch-fail` / `collect-fail` / `skips`.
+      All-zero is the pass condition; anything else invalidates the cache reading for that run.
+- [ ] **swap check PASS** — pages of the *serving process* in swap make every number in the run
+      suspect, and nothing else in the pipeline notices. Needs `SERVER_PID` (auto-detected on bare
+      metal).
+- [ ] **n-usable == n per shape** — chat-tuned models EOS early, and a 5-run shape silently
+      degenerates to n=1 while still printing `n=5`. When these differ the CV is not trustworthy;
+      re-run with `FORCE_TOKENS=<n>`.
+
+Two numbers on the card need their provenance stated, because both are easy to quote wrongly:
+
+- **Cache hit rate — quote the MARGINAL one.** Cumulative rates embed the cold-fill phase, so a
+  *bigger* pool reports a *lower* cumulative rate on the same traffic. Only the marginal rate across
+  the measured window is comparable across boots. Keep the per-device split (a CUDA0/CUDA1
+  asymmetry is routing-entropy signal; averaging it away hides it).
+- **Draft acceptance — never without its fire rate.** A drafter measured at 0.992 acceptance that
+  fired on 5 of ~20 requests contributes almost nothing end-to-end. The run prints both.
+
+### Knobs worth setting
+
+| Env | Why |
+|---|---|
+| `SERVER_LOG=<path>` | Bare-metal (`CONTAINER=none`) runs. Unlocks engine-side `print_timing` TPS, the client-vs-engine cross-check, expert-cache telemetry and drafter acceptance — all of which otherwise read "log scrape unavailable". |
+| `ENDPOINT=chat` \| `completion` | `chat` (default) applies the model's template — the historical behaviour, so numbers stay comparable. `completion` drives raw `/v1/completions` with no template, for base models. Numbers are **not** comparable across modes. |
+| `STREAM_CALIB=1` | ~3 s STREAM-triad ceiling on the host, so the derived miss-path RAM demand can be stated as a fraction ("~29 of ~99 GB/s"). Off by default. The *contention* probe (co-running STREAM during decode) is deliberately not included — it perturbs the run by construction. |
+| `FORCE_TOKENS=<n>` | The fix when `n-usable < n`. |
+| `CAPTURE=0` | Suppress the capture layer entirely (for a harness parsing the older output shape). |

--- a/docs/BENCH_CARD.md
+++ b/docs/BENCH_CARD.md
@@ -42,11 +42,44 @@ Both templates share the same four-part contract:
 **GPU:** <VRAM/card> · <power> · <util>
 **Cache (if the engine has one):** hits <start>% → <end>% (<cold | warming | plateaued>)
 
+<!-- The block below is CONDITIONAL: include it only when the run offloaded to CPU
+     (same gate the capture layer uses). It REPLACES the generic Cache line above.
+     On a GPU-resident run every row here would be a dash pretending to be data.
+     `bash scripts/bench.sh CARD=snapshot` fills all of it automatically. -->
+
+### CPU offload + expert cache
+
+**Offload:** detected via <argv -ot | --n-cpu-moe | boot log> · **RSS** <X> GiB / <Y> GiB total · swap <PASS/FAIL>
+**Cache config:** cap=<MiB> · RESERVE_MB/ADMIT_AFTER/THROTTLE/MAX_BATCH=<…>
+
+> The cache config **is** the arm identity — the pool self-limits below the requested cap, so
+> pool size alone does not identify which arm a run was.
+
+| device | pool (slots · MiB · type) | marginal hits | cumulative | evictions | skips† |
+|---|---|--:|--:|--:|--:|
+| CUDA0 | 3038 slots · 12911 MiB · mxfp4 | **60.3%** | 59.3% | 42171 | 13955 |
+| CUDA1 | 3126 slots · 13285 MiB · mxfp4 | **80.4%** | 79.4% | 9158 | 2330 |
+
+†`skips` = admission throttling (the insert queue exhausted under the configured `THROTTLE`) — a
+**load signal, not a defect**. The hard-failure counters are fill / dispatch / collect-fail, and
+those are on the integrity panel.
+
+**PCIe** (gen<cur>/<max> ×<width> — ⚠️ if cur < max under load): decode rx <mean> / <peak> MB/s
+(<%> of practical link) · prefill rx <mean> / <peak> MB/s · <note if one card dominates>
+
+**RAM path:** derived miss demand ~<X> of ~<Y> GB/s ceiling (<Z>%) — **derived, not measured**
+(misses × expert size ÷ elapsed). State the window: **decode-window** or **whole-run** (a whole-run
+figure is diluted by prefill, during which the cache is not on the hot path).
+
 ### Integrity
 - [ ] wall-TPS scrape agrees with engine-side timings (±5%) — if not, say which number is used and why
 - [ ] CVs within rig norm (decode <5%, prefill <2%)
 - [ ] quiet box: no builds / downloads / other GPU work during measured runs
 - [ ] cache state steady across measured runs (a warming cache understates the mean)
+- [ ] cache **hard-failure** counters zero (fill / dispatch / collect) — `skips` is load, not failure
+- [ ] n-usable == n for every shape (a chat-tuned model EOSing early makes n=5 mean n=1)
+- [ ] VRAM growth / leak delta — with an expert cache active this is **growth** (lazy pool + graph
+      allocation on first inference); only a monotonic rise across REPEATED runs is a leak
 
 **One-line verdict:** <what this run establishes — and what it must NOT be quoted for>
 ```
@@ -76,10 +109,31 @@ card**, not in whoever-ran-it's memory.
 | decode code | 39.96 | 38.59 | −3.4% | outside band — real |
 | TTFT short  | 1085 ms | 1604 ms | +47.8% | ⛔ decisive |
 | prefill 10K | 902   | 1035  | +14.7% | real |
+| **marginal hits** CUDA0 | 41.0% | 48.0% | +17.1% | outside band — real |
+| **marginal hits** CUDA1 | 50.0% | 58.0% | +16.0% | outside band — real |
 | **resource cost** (pool slots / KV headroom / VRAM) | 8887 | 7554 | **−15.0%** | the hidden cost |
 
+<!-- The marginal-hits rows are CONDITIONAL on both arms having offloaded, and they are the rows
+     that catch an under-warmed pool. Quote MARGINAL, never cumulative: a cumulative rate shows the
+     BIGGER pool as worse (it spent longer cold-filling), so an A/B read off cumulative numbers
+     rejects the better config. Marginal is measured over the same window in both arms. -->
+
 **Invariants (must match across arms or the A/B is confounded):**
-cache hit% __ / __ · VRAM __ / __ · ctx __ / __ · <anything the knob shouldn't touch>
+
+| field | A | B | |
+|---|---|---|---|
+| model / weights ftype | | | |
+| served ctx | | | |
+| KV cache type | | | |
+| drafter | | | |
+| moe-cache config (cap + RESERVE_MB / ADMIT_AFTER / THROTTLE / MAX_BATCH) | | | |
+| CPU-offload method (`-ot` regex / `--n-cpu-moe`) | | | |
+| serving argv (threads / ubatch / ngl / split) | | | |
+| pool census per device (slots, ±5%) — only meaningful when the config above MATCHED | | | |
+
+A **moe-cache config mismatch is a confound, exactly like a model mismatch** — it changes what is
+being measured. If one of these differences *is* the knob under test, name it (`KNOB=<text>`) so it
+is attributed rather than treated as an accident.
 
 ### Integrity
 (the Template-1 checklist, once per arm)
@@ -107,6 +161,28 @@ hand-running many A/Bs) · [RESULTS_CARD.md](RESULTS_CARD.md) (the model-level c
 
 ---
 
+## Rendering a card straight from the run
+
+```bash
+bash scripts/bench.sh                                   # no card (default, unchanged output)
+CARD=snapshot bash scripts/bench.sh | tee run-A.log     # Template 1, ready to paste
+CARD=ab BASELINE=run-A.log bash scripts/bench.sh        # Template 2 against that saved run
+```
+
+The card prints as a fenced markdown block at the end of the run. Everything the run can know is
+filled in; everything that is human judgement — the one-line verdict, the A/B decision, the knob
+name, "quiet box" — stays an explicit `<fill: …>` placeholder. **A card that guesses its own verdict
+is worse than no card**, so the renderer will not do it.
+
+A/B knobs: `KNOB=<text>` names the thing under test (differences matching it are attributed instead
+of confounding the card) · `NOISE_BAND=<pct>` overrides the band (default: 2× the worst decode CV
+across both arms, and the card says which) · `EXPECTATION="<text>"` fills the pre-registered
+expectation · `BOOT_POLICY="<text>"` fills the boot-policy line.
+
+The baseline is any previously saved `bench.sh` log. Parsing is strict: a log that is missing its
+fingerprint or summary blocks fails with `baseline unparseable: <why>` rather than rendering half a
+delta — and the run's own measurements are still printed.
+
 ## What `bench.sh` now fills in for you
 
 `bench.sh` carries a capture layer (`scripts/lib/capture.sh`) that auto-fills most of the
@@ -130,14 +206,21 @@ Add these four lines to the checklist in both templates. Each is printed by the 
       `CACHE_DISABLED` / `INVALID_BYPASS` / `OK`). **`NO_TOKENS` means the run measured nothing** —
       a `0.00` TPS printed next to a healthy-looking TTFT is a scrape failure, not a slow model.
       Do not quote a throughput number from a non-`OK` run.
-- [ ] **cache health counters all zero** — `fill-fail` / `dispatch-fail` / `collect-fail` / `skips`.
-      All-zero is the pass condition; anything else invalidates the cache reading for that run.
+- [ ] **cache hard-failure counters zero** — `fill-fail` / `dispatch-fail` / `collect-fail`. Those
+      are the real defect paths; any non-zero invalidates the cache reading for that run.
+      **`skips` is NOT one of them**: it counts admission throttling (the insert queue exhausted
+      under the configured `THROTTLE`), so under a low `ADMIT_AFTER` a non-zero value is normal
+      steady-state pressure and a `THROTTLE` tuning signal. A live run on a healthy server showed
+      skips at 0.5% of misses, tracking the per-device miss asymmetry exactly.
 - [ ] **swap check PASS** — pages of the *serving process* in swap make every number in the run
       suspect, and nothing else in the pipeline notices. Needs `SERVER_PID` (auto-detected on bare
       metal).
 - [ ] **n-usable == n per shape** — chat-tuned models EOS early, and a 5-run shape silently
       degenerates to n=1 while still printing `n=5`. When these differ the CV is not trustworthy;
       re-run with `FORCE_TOKENS=<n>`.
+- [ ] **VRAM growth / leak delta** — labelled *growth* when an expert cache is active (its pool and
+      graphs allocate lazily on first inference, so one run grows VRAM by design) and *leak*
+      otherwise. Only a monotonic rise across REPEATED runs is evidence of a leak.
 
 Two numbers on the card need their provenance stated, because both are easy to quote wrongly:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,7 +85,7 @@ These are cross-cutting references both tracks reach for.
 | [`KERNEL_MATRIX.md`](KERNEL_MATRIX.md) | Quant-kernel availability and alignment constraints. |
 | [`QUALITY_TEST.md`](QUALITY_TEST.md) | The quality-test harness and what it measures. |
 | [`OFFLOAD_MATRIX.md`](OFFLOAD_MATRIX.md) | Sweeping **CPU-offloaded MoE** serving configs (llama.cpp forks only) — the 8 dimensions, the order to tune them in, and the traps that produce plausible wrong numbers. |
-| [`BENCH_CARD.md`](BENCH_CARD.md) | The per-run `bench.sh` card — Snapshot (first numbers) and A/B (config change) templates, with the integrity checklist that catches plausible-but-wrong measurements. |
+| [`BENCH_CARD.md`](BENCH_CARD.md) | The per-run `bench.sh` card — Snapshot (first numbers) and A/B (config change) templates, with the integrity checklist that catches plausible-but-wrong measurements. Also: which card fields `bench.sh` now auto-fills, and its capture knobs (`SERVER_LOG`, `ENDPOINT`, `STREAM_CALIB`). |
 | [`RESULTS_CARD.md`](RESULTS_CARD.md) | The standard 3-panel format (Serving · Quality · Takeaways) for sharing a config's measured results. |
 | [`ANNOUNCEMENT_TEMPLATE.md`](ANNOUNCEMENT_TEMPLATE.md) | The "we shipped X" Announcements-post skeleton that wraps a Results Card (intro+credits · Results Card · getting it · run it · credits). |
 | [`STRUCTURED_COT.md`](STRUCTURED_COT.md) | The bounded-thinking / structured-CoT compose path. |

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -63,12 +63,43 @@
 #                      throughput. vLLM-oriented (ignore_eos/min_tokens). 0 = off
 #                      (model decides length). Default: 0.
 #
+# Capture knobs (the always-on capture layer — scripts/lib/capture.sh):
+#   SERVER_LOG         Path to a BARE-METAL server log. CONTAINER=none runs used to
+#                      report "log scrape unavailable" and every engine-side number
+#                      had to be hand-extracted; point this at the file the server
+#                      writes and the engine-side TPS, expert-cache and drafter
+#                      captures all light up. Default: unset (docker log scrape,
+#                      or nothing).
+#   SERVER_PID         Pin the serving process for /proc inspection (argv fingerprint,
+#                      moe-cache env, RSS, swap). Default: auto (`pgrep -x`).
+#                      SERVER_PID=none disables /proc inspection entirely.
+#   ENDPOINT           chat (default) drives /v1/chat/completions with the model's
+#                      chat template applied — the historical bench behaviour, kept
+#                      as the default so numbers stay comparable. ENDPOINT=completion
+#                      drives raw /v1/completions with NO template, for base models
+#                      and for isolating template overhead.
+#   STREAM_CALIB       1 = run a ~3 s STREAM-triad RAM-bandwidth ceiling calibration
+#                      on the idle box before the bench, so the derived miss-path
+#                      demand can be stated as a fraction of what this host delivers.
+#                      Default: 0 (opt-in — it costs 3 s and needs numpy).
+#                      NOTE: the CONTENTION probe (co-running STREAM during decode)
+#                      is deliberately NOT here — it perturbs the run by construction
+#                      and belongs in a separate opt-in arm.
+#   CAPTURE            0 = skip the whole capture layer (the pre-capture output
+#                      shape, for a harness that parses it). Default: 1.
+#   SHORT_EOS_FRAC     A run whose completion is below this fraction of max_tokens
+#                      counts as a short-EOS run and is excluded from "n-usable".
+#                      Chat-tuned models EOS early and silently degenerate a 5-run
+#                      shape to n=1. Default: 0.25.
+#
 # Usage:
 #   bash scripts/bench.sh
 #   ONLY=code bash scripts/bench.sh
 #   PP=1 bash scripts/bench.sh
 #   RUNS=10 bash scripts/bench.sh
 #   FORCE_TOKENS=4000 bash scripts/bench.sh   # fixed 4000-tok output (diffusion / sustained-TPS)
+#   SERVER_LOG=/var/log/llama-server.log bash scripts/bench.sh   # bare metal
+#   STREAM_CALIB=1 bash scripts/bench.sh      # + RAM-bandwidth ceiling
 
 set -euo pipefail
 
@@ -114,6 +145,15 @@ PREFILL_RUNS="${PREFILL_RUNS:-3}"
 export PREFILL_PROBE PREFILL_DEPTHS PREFILL_RUNS
 ENABLE_THINKING="${ENABLE_THINKING:-0}"
 FORCE_TOKENS="${FORCE_TOKENS:-0}"
+# --- capture layer knobs (see the header block) -----------------------------
+CAPTURE="${CAPTURE:-1}"
+ENDPOINT="${ENDPOINT:-chat}"
+STREAM_CALIB="${STREAM_CALIB:-0}"
+SHORT_EOS_FRAC="${SHORT_EOS_FRAC:-0.25}"
+case "$ENDPOINT" in
+  chat|completion) : ;;
+  *) echo "ERROR: ENDPOINT must be 'chat' or 'completion' (got '$ENDPOINT')" >&2; exit 1 ;;
+esac
 
 need() {
   command -v "$1" >/dev/null 2>&1 || { echo "ERROR: '$1' not in PATH." >&2; exit 1; }
@@ -213,6 +253,130 @@ if [[ "$ENABLE_THINKING" != "1" ]] && server_reasoning_on; then
   echo "[bench] WARN: server appears to have reasoning enabled, but bench requests send enable_thinking=false. Use ENABLE_THINKING=1 for reasoning-on TPS." >&2
 fi
 
+# ===========================================================================
+# CAPTURE LAYER — everything from here to the end of the run is ADDITIVE.
+#
+# A bench harness's failure mode is a PLAUSIBLE WRONG NUMBER, not a crash. The
+# captures below exist because each has already produced one: a decode scrape
+# that printed 0.00 next to a healthy TTFT; a cumulative cache hit rate that
+# said a bigger pool was worse; a drafter reporting 0.992 acceptance that fired
+# on 5 of ~20 requests. Shared with the sweep via scripts/lib/capture.sh.
+#
+# CONDITIONALITY CONTRACT:
+#   ALWAYS        KV cache type · config fingerprint (argv + /props + moe-cache
+#                 env + --moe-cache cap) · system RAM + swap · PCIe
+#   IF OFFLOAD    expert-cache pool census / hits / evictions / health counters
+#   IF OFFLOAD
+#     AND CACHE   marginal (not cumulative) hit rate · derived RAM-read demand
+# Every capture degrades to ONE `capture: <thing> unavailable (<why>)` line.
+# ===========================================================================
+CAP_ENABLED=0
+CAP_T0=""; CAP_T1=""
+CAP_DMON_PID=""; CAP_VRAM_PID=""; CAP_LINK_PID=""
+CAP_VRAM_IDLE=""; CAP_CPU0=""
+CAP_ARGV=""; CAP_OFFLOAD=""; CAP_CACHE_WANTED=0
+CAP_WORK=""
+if [[ "$CAPTURE" == "1" && -f "${ROOT_DIR}/scripts/lib/capture.sh" ]]; then
+  # shellcheck source=lib/capture.sh
+  source "${ROOT_DIR}/scripts/lib/capture.sh"
+  CAP_ENABLED=1
+  CAP_WORK="$(mktemp -d)"
+  trap '[[ -n "${CAP_WORK:-}" ]] && rm -rf "$CAP_WORK"' EXIT
+  cap_init "$CAP_WORK" || true
+
+  CAP_ARGV="$(cap_proc_argv || true)"
+
+  echo ""
+  echo "========== CONFIG FINGERPRINT =========="
+  echo "  endpoint       : ${URL}  (mode=${ENDPOINT})"
+  echo "  model          : ${MODEL}"
+  if [[ -n "${CAP_PID:-}" ]]; then
+    echo "  serving pid    : ${CAP_PID}$([[ -n "$CAP_ARGV" ]] || echo '  (argv unreadable — different uid?)')"
+  else
+    echo "  serving pid    : unknown (set SERVER_PID=<pid> for argv/RSS/swap capture)"
+  fi
+  echo "  log source     : ${CAP_LOG_SOURCE:-none}${SERVER_LOG:+ (${SERVER_LOG})}"
+  _v="$(cap_props_get "default_generation_settings.n_ctx" || true)"
+  _s="$(cap_props_get "total_slots" || true)"
+  [[ -n "$_v" ]] && echo "  served ctx     : ${_v}${_s:+  (slots=${_s})}"
+  _v="$(cap_props_get "model_ftype" || true)"
+  [[ -n "$_v" ]] && echo "  weights ftype  : ${_v}"
+  _v="$(cap_props_get "default_generation_settings.params.speculative.types" || true)"
+  [[ -n "$_v" ]] && echo "  drafter        : ${_v}"
+  # ALWAYS-ON: KV cache type. Offload or not, a bench without its KV type is a rumor.
+  _v="$(cap_kv_type "$CAP_ARGV" || true)"
+  [[ -n "$_v" ]] && echo "  KV cache type  : ${_v}"
+  # ALWAYS-ON: argv fingerprint — solves the fingerprint problem without operator input.
+  if [[ -n "$CAP_ARGV" ]]; then
+    _v="$(cap_argv_fingerprint "$CAP_ARGV" || true)"
+    [[ -n "$_v" ]] && echo "  serving argv   : ${_v}"
+  fi
+  # ALWAYS-ON: the cache CONFIG, not just the resulting pool. The census
+  # self-limits below the requested cap, so pool size alone can't identify an arm.
+  _v="$(cap_moe_cache_config "$CAP_ARGV" || true)"
+  [[ -n "$_v" ]] && echo "  moe-cache cfg  : ${_v}"
+  case "$_v" in *"moe_cache_cap=<unset>"*) : ;; *) CAP_CACHE_WANTED=1 ;; esac
+  # The GATE for every moe-cache capture below.
+  CAP_OFFLOAD="$(cap_offload_detected "$CAP_ARGV" || true)"
+  if [[ -n "$CAP_OFFLOAD" ]]; then
+    echo "  CPU offload    : DETECTED via ${CAP_OFFLOAD}"
+  else
+    echo "  CPU offload    : not detected (moe-cache captures skipped)"
+  fi
+
+  # ALWAYS-ON (item 8): host RAM is the requirement launchers cannot detect, and
+  # it is two lines from /proc. The swap leg is the free integrity item — pages of
+  # the SERVING PROCESS in swap make every number in the run suspect.
+  echo ""
+  echo "========== SYSTEM RAM =========="
+  _v="$(cap_ram_status || true)"
+  [[ -n "$_v" ]] && echo "  ${_v}"
+  _v="$(cap_swap_verdict || true)"
+  [[ -n "$_v" ]] && echo "  swap check     : ${_v}"
+
+  if [[ "$STREAM_CALIB" == "1" ]]; then
+    echo ""
+    echo "========== RAM BANDWIDTH CEILING (STREAM triad, idle box) =========="
+    _sc="$(cap_stream_triad_gbps 3 || true)"
+    CAP_STREAM="${_sc%% *}"
+    _scw="${_sc##* }"
+    if [[ -n "$CAP_STREAM" ]]; then
+      echo "  triad ceiling  : ${CAP_STREAM} GB/s  (${_scw} concurrent workers, ~3 s, measured on THIS host)"
+      echo "                   Sustained STREAM-triad, not a spec sheet figure. A box that is"
+      echo "                   already serving reports a LOWER ceiling than an idle one — which"
+      echo "                   is the honest denominator for a run measured under that load."
+    fi
+  fi
+
+  # --- start the windowed samplers ----------------------------------------
+  CAP_DMON_PID="$(cap_dmon_start "$CAP_WORK/dmon" || true)"
+  CAP_LINK_PID="$(cap_pcie_link_sampler_start "$CAP_WORK/link" || true)"
+  CAP_VRAM_PID="$(cap_vram_peak_start "$CAP_WORK/vpeak" || true)"
+  CAP_VRAM_IDLE="$(cap_vram_used || true)"
+  CAP_CPU0="$(cap_cpu_snap || true)"
+  # Cache counters BEFORE the measured window, so the MARGINAL rate can be derived.
+  if [[ -n "$CAP_OFFLOAD" ]]; then
+    cap_refresh_log
+    cap_moe_parse counters > "$CAP_WORK/counters0" 2>/dev/null || true
+  fi
+  # Line offset at the start of the measured window. Per-request scrapes
+  # (acceptance, timings, bypass) count only what happened AFTER this point —
+  # otherwise a log that already held a previous run's lines inflates every
+  # count, and the drafter fire rate can exceed 100%.
+  CAP_LOG_OFFSET=0
+  [[ -n "$CAP_LOG" && -r "$CAP_LOG" ]] && CAP_LOG_OFFSET="$(command grep -c '' "$CAP_LOG" 2>/dev/null || echo 0)"
+  export CAP_LINE_OFFSET="$CAP_LOG_OFFSET"
+  # The prefill probe and PP fallback ask for ~16-token completions; a decode rate
+  # measured over 16 tokens is start-up dominated. Exclude them from the decode
+  # cross-check so it compares like with like.
+  export CAP_MIN_DECODE_TOKENS="${CAP_MIN_DECODE_TOKENS:-32}"
+  CAP_T0="$(date +%s)"
+  export BENCH_PHASE_FILE="$CAP_WORK/phases" BENCH_SUMMARY_JSON="$CAP_WORK/summary.json"
+  export BENCH_ENDPOINT="$ENDPOINT" BENCH_SHORT_EOS_FRAC="$SHORT_EOS_FRAC"
+fi
+export BENCH_ENDPOINT="${BENCH_ENDPOINT:-$ENDPOINT}"
+export BENCH_SHORT_EOS_FRAC="${BENCH_SHORT_EOS_FRAC:-$SHORT_EOS_FRAC}"
+
 python3 - "$URL" "$MODEL" "$WARMUPS" "$RUNS" "$QUIET" "$ONLY" \
             "$CONTAINER" "$PP_MODE" "$PP_FALLBACK_TOKENS" "$PP_MAX_TOKENS" \
             "$ENABLE_THINKING" "$FORCE_TOKENS" \
@@ -229,6 +393,91 @@ PP_FALLBACK_TOKENS = int(PP_FALLBACK_TOKENS); PP_MAX_TOKENS = int(PP_MAX_TOKENS)
 ENABLE_THINKING = ENABLE_THINKING == "1"
 FORCE = int(FORCE)   # >0: force EXACTLY this many output tokens (max+min+ignore_eos)
 
+# --- capture-layer plumbing (all optional; absent => historical behaviour) ---
+# ENDPOINT=chat (default) keeps the historical /v1/chat/completions path with the
+# model's template applied. ENDPOINT=completion drives raw /v1/completions with NO
+# template — for base models, and for isolating template overhead on a chat model.
+ENDPOINT_MODE = os.environ.get("BENCH_ENDPOINT", "chat")
+PHASE_FILE = os.environ.get("BENCH_PHASE_FILE", "")
+SUMMARY_JSON = os.environ.get("BENCH_SUMMARY_JSON", "")
+try:
+    SHORT_EOS_FRAC = float(os.environ.get("BENCH_SHORT_EOS_FRAC", "0.25"))
+except ValueError:
+    SHORT_EOS_FRAC = 0.25
+SUMMARY = {"shapes": {}, "endpoint": ENDPOINT_MODE}
+
+
+def progress(msg):
+    """Item 6: one line per run, FLUSHED, on stderr.
+
+    Section summaries buffer to section end (correct — a partial table is worse
+    than none), but a prefill probe at depth can then sit silent for 10+ minutes
+    with no way to tell it apart from a hang. stderr keeps stdout's shape intact
+    for anything parsing it."""
+    sys.stderr.write(msg + "\n")
+    sys.stderr.flush()
+
+
+def mark_phase(label, t0, t1):
+    """Record a measured window so PCIe/dmon samples can be sliced by PHASE.
+
+    Decode and prefill PCIe traffic differ by ~100x on an offloaded MoE, so a
+    whole-run mean describes neither phase."""
+    if not PHASE_FILE:
+        return
+    try:
+        with open(PHASE_FILE, "a", encoding="utf-8") as fh:
+            fh.write(f"{label} {t0:.0f} {t1:.0f}\n")
+    except OSError:
+        pass
+
+
+_TOKEN_RATIO = [None]
+
+
+def token_ratio():
+    """Item 7: measured tokens-per-word for THIS tokenizer.
+
+    The haystack builders sized filler by WORD count, which is a per-tokenizer
+    guess: a "40K" warm-up tokenized to 55K under DeepSeek's tokenizer (+37%).
+    Prefer the server's own /tokenize; fall back to one tiny max_tokens=1 request
+    and read usage.prompt_tokens; fall back to the word heuristic (ratio 1.0),
+    which is exactly the historical behaviour."""
+    if _TOKEN_RATIO[0] is not None:
+        return _TOKEN_RATIO[0]
+    sample = ("club3090 prompt processing calibration filler with stable token shape. "
+              "This sentence is intentionally plain so tokenizer variance stays modest. ") * 20
+    words = max(len(sample.split()), 1)
+    ratio = None
+    try:
+        body = json.dumps({"content": sample}).encode()
+        req = urllib.request.Request(f"{URL}/tokenize", data=body,
+                                     headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(req, timeout=20) as r:
+            obj = json.loads(r.read().decode("utf-8", errors="ignore"))
+        toks = obj.get("tokens", obj if isinstance(obj, list) else [])
+        if isinstance(toks, list) and toks:
+            ratio = len(toks) / words
+    except Exception:
+        ratio = None
+    if ratio is None:
+        try:
+            _w, _t, _k, ptoks = run_once(sample, 1)
+            if ptoks > words:            # a real count, not the word-split fallback
+                ratio = ptoks / words
+        except Exception:
+            ratio = None
+    if ratio is None or ratio <= 0:
+        progress("[bench] capture: token-ratio probe unavailable (no /tokenize, probe failed) "
+                 "— haystacks fall back to the word-count heuristic")
+        ratio = 1.0
+    else:
+        progress(f"[bench] capture: tokenizer ratio {ratio:.2f} tok/word "
+                 f"(haystacks sized by measured tokens, not words)")
+    _TOKEN_RATIO[0] = ratio
+    return ratio
+
+
 def run_once(prompt, max_tokens):
     # FORCE>0: force EXACTLY FORCE output tokens (overrides the per-prompt cap) so the
     # model can't self-terminate early — required to measure sustained throughput at a
@@ -236,19 +485,28 @@ def run_once(prompt, max_tokens):
     mt = FORCE if FORCE > 0 else max_tokens
     req_body = {
         "model": MODEL,
-        "messages": [{"role": "user", "content": prompt}],
         "max_tokens": mt,
         "temperature": 0.6,
         "top_p": 0.95,
         "stream": True,
         "stream_options": {"include_usage": True},
-        "chat_template_kwargs": {"enable_thinking": ENABLE_THINKING},
     }
+    if ENDPOINT_MODE == "completion":
+        # RAW completion: no chat template, no thinking kwargs (they are a chat
+        # concept). Deliberately not the default — switching endpoints changes
+        # the prompt the model actually sees, so numbers are NOT comparable
+        # across modes.
+        req_body["prompt"] = prompt
+        path = "/v1/completions"
+    else:
+        req_body["messages"] = [{"role": "user", "content": prompt}]
+        req_body["chat_template_kwargs"] = {"enable_thinking": ENABLE_THINKING}
+        path = "/v1/chat/completions"
     if FORCE > 0:
         req_body["min_tokens"] = FORCE
         req_body["ignore_eos"] = True
     body = json.dumps(req_body).encode()
-    req = urllib.request.Request(f"{URL}/v1/chat/completions", data=body,
+    req = urllib.request.Request(f"{URL}{path}", data=body,
                                  headers={"Content-Type": "application/json"})
     t_send = time.time()
     ttft = None
@@ -269,7 +527,9 @@ def run_once(prompt, max_tokens):
             choices = chunk.get("choices") or []
             if choices:
                 delta = choices[0].get("delta", {})
-                content = delta.get("content") or delta.get("reasoning_content")
+                # /v1/completions puts the text at choices[0].text, not in a delta
+                content = (delta.get("content") or delta.get("reasoning_content")
+                           or choices[0].get("text"))
                 if content and ttft is None:
                     ttft = time.time() - t_send
             usage = chunk.get("usage")
@@ -302,7 +562,30 @@ def stats(name, xs, unit=""):
     cv = (sd / m * 100) if m > 0 else 0
     return f"  {name:<14s} mean={m:7.2f}{unit}   std={sd:6.2f}   CV={cv:4.1f}%   min={min(xs):.2f}   max={max(xs):.2f}"
 
+def scrape_server_log_prefill(n):
+    """Item 4: the BARE-METAL half of the engine-side scrape.
+
+    `CONTAINER=none` runs report "log scrape unavailable" and every engine-side
+    number then has to be hand-extracted from a file that was sitting there the
+    whole time. With SERVER_LOG set, read llama.cpp's own `prompt eval time`
+    lines instead."""
+    path = os.environ.get("SERVER_LOG", "")
+    if not path or not os.path.exists(path):
+        return []
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            text = fh.read()
+    except OSError:
+        return []
+    vals = [float(m.group(1)) for m in
+            re.finditer(r"prompt eval time.*?([0-9]+(?:\.[0-9]+)?)\s+tokens per second", text)]
+    return vals[-max(n, 1):]
+
+
 def scrape_prompt_throughput(container, n):
+    vals = scrape_server_log_prefill(n)
+    if vals:
+        return vals
     if not container or container == "none" or shutil.which("docker") is None:
         return []
     try:
@@ -335,27 +618,62 @@ def run_set(label, prompt, max_tokens):
         except Exception as e:
             print(f"  warm-{i+1}  FAIL: {e}")
     print(f"\n=== measured ({RUNS}) ===")
-    walls, decodes, ttfts = [], [], []
+    walls, decodes, ttfts, toks_seen = [], [], [], []
+    errors = 0
+    mt = FORCE if FORCE > 0 else max_tokens
+    phase_t0 = time.time()
     for i in range(RUNS):
         try:
             w, t, k, _ = run_once(prompt, max_tokens)
             wtps, dtps, ttft, line = fmt(f"run-{i+1}", w, t, k)
             if not QUIET:
                 print(line)
+            progress(f"[bench] {label} run {i+1}/{RUNS}: {k} tok in {w:.1f}s "
+                     f"({dtps:.2f} decode TPS, ttft {ttft*1000:.0f}ms)")
             walls.append(wtps); decodes.append(dtps); ttfts.append(ttft)
+            toks_seen.append(k)
         except Exception as e:
+            errors += 1
             print(f"  run-{i+1}  FAIL: {e}")
+            progress(f"[bench] {label} run {i+1}/{RUNS}: FAIL: {e}")
+    mark_phase("decode", phase_t0, time.time())
+    # Item 2: a chat-tuned model answers briefly and EOSes. The per-shape stats
+    # then silently describe whichever one or two runs happened to run long — a
+    # 5-run shape degenerates to n=1 while still printing "n=5". Count the runs
+    # that are long enough to be worth a decode rate and say so.
+    floor = max(1, int(mt * SHORT_EOS_FRAC))
+    usable = [k for k in toks_seen if k >= floor]
+    SUMMARY["shapes"][label] = {
+        "n": len(walls), "n_usable": len(usable), "errors": errors,
+        "max_tokens": mt, "short_eos_floor": floor,
+        "tokens": toks_seen,
+        "wall_tps_mean": (s.mean(walls) if walls else 0.0),
+        "decode_tps_mean": (s.mean(decodes) if decodes else 0.0),
+        "ttft_mean_ms": (s.mean(ttfts) * 1000 if ttfts else 0.0),
+    }
     if walls:
         print(f"\n=== summary [{label}] (n={len(walls)}) ===")
         print(stats("wall_TPS",   walls))
         print(stats("decode_TPS", decodes))
         print(f"  TTFT          mean={s.mean(ttfts)*1000:6.0f}ms  std={s.stdev(ttfts)*1000 if len(ttfts) > 1 else 0:5.0f}ms  min={min(ttfts)*1000:.0f}ms  max={max(ttfts)*1000:.0f}ms")
+        print(f"  n-usable      {len(usable)}/{len(walls)}  (runs with >= {floor} tokens, "
+              f"{SHORT_EOS_FRAC:.0%} of max_tokens={mt})")
+        if len(usable) < len(walls):
+            short = len(walls) - len(usable)
+            print(f"  ⚠ WARN: {short}/{len(walls)} run(s) EOSed well below max_tokens "
+                  f"(tokens={toks_seen}). Decode stats for this shape rest on "
+                  f"{len(usable)} run(s), not {len(walls)} — treat the CV as unreliable.")
+            print("           Fix: FORCE_TOKENS=<n> to force a fixed output length, or use a "
+                  "prompt this model answers at length.")
+            progress(f"[bench] WARN {label}: only {len(usable)}/{len(walls)} runs usable "
+                     f"(short EOS) — see the summary block")
         if PP_MODE == "log":
             pp_vals = scrape_prompt_throughput(CONTAINER, len(walls))
             if pp_vals:
                 print(stats("PP tok/s", pp_vals))
             else:
-                print("  PP tok/s       n/a (vLLM log scrape unavailable; use PP=1 for long-prompt fallback)")
+                print("  PP tok/s       n/a (engine log scrape unavailable; use PP=1 for the "
+                      "long-prompt fallback, or SERVER_LOG=<path> on bare metal)")
         else:
             print("  PP tok/s       n/a (long-prompt fallback below)")
 
@@ -364,8 +682,10 @@ def long_prompt(target_tokens):
         "club3090 prompt processing calibration filler with stable token shape. "
         "This sentence is intentionally plain so tokenizer variance stays modest. "
     )
+    # Item 7: size by MEASURED tokens, not words. The word heuristic is a
+    # per-tokenizer guess and a "40K" haystack tokenized to 55K on DeepSeek.
     words_per_chunk = max(len(filler.split()), 1)
-    chunks = max(1, target_tokens // words_per_chunk)
+    chunks = max(1, int(target_tokens / (words_per_chunk * token_ratio())))
     return (
         "Read the following calibration text. Reply with one concise sentence summarizing its purpose.\n\n"
         + filler * chunks
@@ -379,13 +699,18 @@ def run_pp_fallback():
     )
     print("=== measured (1) ===")
     pp_vals, ttfts = [], []
+    phase_t0 = time.time()
     try:
         w, t, _k, prompt_tokens = run_once(prompt, PP_MAX_TOKENS)
         pp, ttft, line = fmt_pp("run-1", w, t, prompt_tokens)
         print(line)
+        progress(f"[bench] prompt-processing run 1/1: {prompt_tokens} prompt tok, "
+                 f"{pp:.1f} PP tok/s, ttft {ttft*1000:.0f}ms")
         pp_vals.append(pp); ttfts.append(ttft)
     except Exception as e:
         print(f"  run-1      FAIL: {e}")
+        progress(f"[bench] prompt-processing run 1/1: FAIL: {e}")
+    mark_phase("prefill", phase_t0, time.time())
     if pp_vals:
         print("\n=== summary [prompt-processing] (n=1) ===")
         print(stats("PP tok/s", pp_vals))
@@ -403,8 +728,12 @@ def prefill_prompt(target_tokens, salt):
         f"calibration {salt} segment with stable token shape for the prefill probe. "
         "This sentence is intentionally plain so tokenizer variance stays modest. "
     )
+    # Item 7: divide by the MEASURED tok/word ratio so the warm-up lands on the
+    # requested depth. The measured runs recalibrate from the warm-up's actual
+    # count regardless — this stops the WARM-UP from overshooting (the "40K" that
+    # tokenized to 55K), which is the run nothing corrects.
     words_per_chunk = max(len(filler.split()), 1)
-    chunks = max(1, target_tokens // words_per_chunk)
+    chunks = max(1, int(target_tokens / (words_per_chunk * token_ratio())))
     return (
         f"[probe {salt}] Read the following calibration text. Reply with the single word DONE.\n\n"
         + filler * chunks
@@ -450,16 +779,21 @@ def run_prefill_probe():
             print(f"  warm-1     FAIL: {e}")
         print(f"\n=== measured ({n}) ===")
         pps, ttfts = [], []
+        phase_t0 = time.time()
         for i in range(n):
             try:
                 w, t, _k, ptoks = run_once(prefill_prompt(request_tokens, salt()), PP_MAX_TOKENS)
                 pp, ttft, line = fmt_pp(f"run-{i+1}", w, t, ptoks)
                 if not QUIET:
                     print(line)
+                progress(f"[bench] {label} run {i+1}/{n}: {ptoks} prompt tok, "
+                         f"{pp:.1f} prefill tok/s, ttft {ttft*1000:.0f}ms")
                 pps.append(pp)
                 ttfts.append(ttft)
             except Exception as e:
                 print(f"  run-{i+1}    FAIL: {e}")
+                progress(f"[bench] {label} run {i+1}/{n}: FAIL: {e}")
+        mark_phase("prefill", phase_t0, time.time())
         if pps:
             print(f"\n=== summary [{label}] (n={len(pps)}) ===")
             # prompt_tokens/TTFT = the CLIENT-OBSERVED rate (includes
@@ -479,6 +813,10 @@ def run_prefill_probe():
                 vals = [v for v in vals if v > 0][-len(pps):]
                 if vals:
                     print(stats("PP tok/s (engine log, windowed)", vals))
+            SUMMARY["shapes"][label] = {
+                "n": len(pps), "n_usable": len(pps), "errors": 0,
+                "prefill_tps_mean": s.mean(pps), "ttft_mean_ms": s.mean(ttfts) * 1000,
+            }
 
 if ONLY in ("both", "narr"):
     run_set("narrative", PROMPT_NARR, MAX_NARR)
@@ -488,7 +826,314 @@ if PP_MODE == "fallback":
     run_pp_fallback()
 if os.environ.get("PREFILL_PROBE", "1") == "1":
     run_prefill_probe()
+
+# Hand the measured totals to the shell's capture layer. stdout keeps its exact
+# historical shape; the cross-checks (item 1) read this instead of re-parsing it.
+if SUMMARY_JSON:
+    try:
+        tot = sum(sum(v.get("tokens", [])) for v in SUMMARY["shapes"].values())
+        SUMMARY["total_tokens"] = tot
+        SUMMARY["total_errors"] = sum(v.get("errors", 0) for v in SUMMARY["shapes"].values())
+        SUMMARY["token_ratio"] = _TOKEN_RATIO[0]
+        tmp = SUMMARY_JSON + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(SUMMARY, fh)
+        os.replace(tmp, SUMMARY_JSON)     # atomic; a failed encode leaves no half-file
+    except Exception as e:
+        sys.stderr.write(f"[bench] capture: summary hand-off failed ({e})\n")
 PYEOF
+
+# ===========================================================================
+# CAPTURE REPORT — everything below is additive to the historical output.
+# ===========================================================================
+if (( CAP_ENABLED )); then
+  CAP_T1="$(date +%s)"
+  CAP_ELAPSED=$(( CAP_T1 - CAP_T0 )); (( CAP_ELAPSED < 1 )) && CAP_ELAPSED=1
+  cap_stop_pid "$CAP_DMON_PID"; cap_stop_pid "$CAP_LINK_PID"; cap_stop_pid "$CAP_VRAM_PID"
+  cap_refresh_log
+  # A run that produced no phase markers (every request failed) still needs a
+  # window, or the PCIe slice would silently be empty rather than reported empty.
+  [[ -s "$CAP_WORK/phases" ]] || printf 'decode %s %s\n' "$CAP_T0" "$CAP_T1" > "$CAP_WORK/phases"
+
+  # ---- PCIe: measured used + queried available (item 10) -------------------
+  echo ""
+  echo "========== CAPTURE: PCIe =========="
+  if [[ ! -s "$CAP_WORK/dmon" ]]; then
+    cap_note_unavailable "PCIe rx/tx sampling" \
+      "nvidia-smi dmon produced no output (no GPU, or dmon not supported here)"
+  else
+    for _ph in decode prefill; do
+      command grep -q "^${_ph} " "$CAP_WORK/phases" 2>/dev/null || continue
+      if _out="$(cap_dmon_phase "$CAP_WORK/dmon" "$CAP_WORK/phases" "$_ph" 2>/dev/null)"; then
+        while IFS= read -r _l; do [[ -n "$_l" ]] && echo "  ${_l}"; done <<< "$_out"
+      else
+        # Reported, never silently omitted: a phase shorter than the 1 Hz sample
+        # period genuinely has no samples, and that is a fact about the run.
+        echo "  ${_ph}: no dmon samples inside the measured windows (phase shorter than the 1 Hz sample period)"
+      fi
+    done
+    echo "  note: decode and prefill PCIe traffic differ by ~100x on an offloaded MoE —"
+    echo "        a whole-run mean describes neither. 1 Hz under-reads bursts, so the"
+    echo "        PEAK is reported next to the mean, not instead of it."
+  fi
+  # Link capability, sampled UNDER LOAD: an idle link downshifts to Gen1 by
+  # design, so an idle reading manufactures false alarms.
+  if _out="$(cap_pcie_link_under_load "$CAP_WORK/link" 2>/dev/null)"; then
+    echo "  link (sampled under load, best observed):"
+    while IFS= read -r _l; do [[ -n "$_l" ]] && echo "    ${_l}"; done <<< "$_out"
+    # Utilisation% against a STATED denominator — a bandwidth percentage with an
+    # unstated denominator is not a number anyone can check.
+    _g="$(printf '%s\n' "$_out" | command grep -oE 'gen=[0-9]+' | head -1 | cut -d= -f2 || true)"
+    _w="$(printf '%s\n' "$_out" | command grep -oE 'width=[0-9]+' | head -1 | cut -d= -f2 || true)"
+    _prac="$(cap_pcie_practical_mbps "${_g:-0}" "${_w:-0}" 2>/dev/null || true)"
+    if [[ -n "$_prac" ]]; then
+      _rx="$(cap_dmon_phase "$CAP_WORK/dmon" "$CAP_WORK/phases" decode 2>/dev/null \
+             | command grep -m1 ' all ' | command grep -oE 'rx_peak=[0-9]+' | cut -d= -f2 || true)"
+      echo "    denominator: ~${_prac} MB/s practical for a negotiated gen${_g} x${_w} link"
+      echo "                 (per-lane raw x width x 0.85; NOT a theoretical peak)"
+      [[ -n "$_rx" ]] && awk -v a="$_rx" -v b="$_prac" 'BEGIN{
+        if (b > 0) printf "    decode rx peak = %s MB/s = %.1f%% of that denominator\n", a, a*100/b }'
+    fi
+  else
+    cap_note_unavailable "PCIe link state" "nvidia-smi could not report pcie.link.* under load"
+  fi
+
+  # ---- VRAM triplet + leak delta (item 11b) --------------------------------
+  echo ""
+  echo "========== CAPTURE: VRAM =========="
+  CAP_VRAM_POST="$(cap_vram_used || true)"
+  CAP_VRAM_PEAK="$(cat "$CAP_WORK/vpeak" 2>/dev/null || true)"
+  if [[ -n "$CAP_VRAM_IDLE" ]]; then
+    echo "  idle=${CAP_VRAM_IDLE} MiB  peak=${CAP_VRAM_PEAK:-n/a} MiB  post=${CAP_VRAM_POST:-n/a} MiB"
+    if [[ -n "$CAP_VRAM_POST" ]]; then
+      # A free soak-lite leak check: VRAM that did not come back is the cheapest
+      # early warning there is for a memory-policy regression.
+      echo "  leak delta (post - idle) = $(( CAP_VRAM_POST - CAP_VRAM_IDLE )) MiB"
+    fi
+    while IFS= read -r _l; do [[ -n "$_l" ]] && echo "  ${_l} MiB (post-run)"; done \
+      < <(cap_vram_per_device 2>/dev/null || true)
+  else
+    cap_note_unavailable "VRAM triplet" "nvidia-smi not available"
+  fi
+
+  # ---- CPU (item 11d) ------------------------------------------------------
+  CAP_CPU1="$(cap_cpu_snap || true)"
+  if [[ -n "$CAP_CPU0" && -n "$CAP_CPU1" ]]; then
+    CAP_CPU_PCT="$(cap_cpu_pct "$CAP_CPU0" "$CAP_CPU1" || true)"
+    # cpu% is the missing half of offload bottleneck forensics: a low sm% next to
+    # a high cpu% says the GPU is waiting on the host, not the other way round.
+    [[ -n "$CAP_CPU_PCT" ]] && echo "  host CPU busy across the run: ${CAP_CPU_PCT}%"
+  fi
+
+  # ---- draft acceptance WITH fire rate (item 11a) --------------------------
+  echo ""
+  echo "========== CAPTURE: DRAFT ACCEPTANCE =========="
+  # Requests in the SAME windowed log the acceptance lines came from. Deriving
+  # the denominator from the summary JSON instead counts only measured runs while
+  # the numerator counted warm-ups too — which produced a 142% fire rate.
+  # Field-exact extraction. `grep -oE 'n=[0-9]+'` ALSO matches the tail of
+  # "mean=100.00", which produced a multi-line value and silently skipped the
+  # whole fire-rate block.
+  CAP_REQS="$(cap_moe_parse timings 2>/dev/null \
+              | awk '$1=="decode"{for(i=2;i<=NF;i++) if($i ~ /^n=/){split($i,a,"="); print a[2]; exit}}' || true)"
+  if cap_log_available "draft acceptance"; then
+    if _acc="$(cap_moe_parse acceptance 2>/dev/null)"; then
+      _fired="$(printf '%s' "$_acc" | command grep -oE 'fired=[0-9]+' | cut -d= -f2)"
+      _reqs="${CAP_REQS:-}"
+      echo "  ${_acc}"
+      if [[ -n "$_reqs" && "${_reqs:-0}" -gt 0 ]]; then
+        awk -v f="${_fired:-0}" -v r="$_reqs" 'BEGIN{
+          if (f > r) f = r
+          printf "  fire rate: fired on %d of %d requests in the measured window (%.1f%%)\n", f, r, f*100/r
+          if (r > 0 && f * 100 / r < 50)
+            print "  ⚠ WARN: acceptance WITHOUT a fire rate is a deception. This drafter was\n" \
+                  "          idle on most requests, so its acceptance describes a minority of\n" \
+                  "          the run and does NOT predict the end-to-end speed-up."
+        }'
+      fi
+    else
+      echo "  no drafter output in the log (spec-dec off, or the engine does not log acceptance)"
+    fi
+  fi
+
+  # ---- engine-side timings + cross-check (item 1b, item 4) -----------------
+  echo ""
+  echo "========== CAPTURE: ENGINE-SIDE TIMINGS =========="
+  if cap_log_available "engine-side timings"; then
+    if _tim="$(cap_moe_parse timings 2>/dev/null)"; then
+      while IFS= read -r _l; do
+        case "$_l" in
+          "") ;;
+          dropped_short_decode*)
+            echo "  ${_l}  (short probe completions excluded from the decode cross-check)" ;;
+          *)  echo "  ${_l}  (tok/s, from the server's own print_timing)" ;;
+        esac
+      done <<< "$_tim"
+      _eng="$(printf '%s\n' "$_tim" | command grep -m1 '^decode ' | command grep -oE 'median=[0-9.]+' | cut -d= -f2 || true)"
+      _cli="$(python3 -c '
+import json, sys
+try:
+    d = json.load(open(sys.argv[1], encoding="utf-8"))
+except Exception:
+    sys.exit(1)
+xs = [v.get("decode_tps_mean", 0) for v in d.get("shapes", {}).values() if v.get("decode_tps_mean")]
+print(f"{sum(xs)/len(xs):.2f}" if xs else "")
+' "$CAP_WORK/summary.json" 2>/dev/null || true)"
+      if [[ -n "$_eng" && -n "$_cli" ]]; then
+        _div="$(cap_divergence_pct "$_eng" "$_cli" || true)"
+        if [[ -n "$_div" ]]; then
+          echo "  cross-check: client-observed ${_cli} vs engine-side ${_eng} tok/s -> ${_div}% divergence"
+          awk -v d="$_div" 'BEGIN{ if (d+0 > 5) print "  ⚠ WARN: >5% divergence. One of these two is not measuring what its label\n          says. State WHICH number a card quotes, and why." }'
+        fi
+      fi
+    else
+      echo "  no print_timing lines in the log (engine may not emit them at this verbosity)"
+    fi
+  fi
+
+  # ---- moe-cache: GATED on CPU-offload detection (item 3) ------------------
+  echo ""
+  echo "========== CAPTURE: EXPERT CACHE (moe-cache) =========="
+  if [[ -z "$CAP_OFFLOAD" ]]; then
+    echo "  skipped: no CPU offload detected — nothing for an expert cache to cache."
+  elif ! cap_log_available "moe-cache telemetry"; then
+    : # the notice is already printed by cap_log_available
+  else
+    CAP_CACHE_OK=1
+    if _cen="$(cap_moe_parse census 2>/dev/null)"; then
+      echo "  pool census (per device — a device can hold MULTIPLE pools; slots/bytes are summed):"
+      while IFS= read -r _l; do [[ -n "$_l" ]] && echo "    ${_l}"; done <<< "$_cen"
+    else
+      _cen=""
+    fi
+    # #824: the '[moe-cache] enabled:' banner still prints when only SOME devices
+    # got a pool. Ground truth is the count of devices WITH a pool vs the device
+    # count — not the banner, and not the raw pool-line count (multi-pool devices
+    # make that count pass while a device has nothing).
+    if _pd="$(cap_moe_parse pooldev 2>/dev/null)"; then
+      _devs="$(printf '%s' "$_pd" | command grep -oE 'devices=[0-9]+' | cut -d= -f2)"
+      _enb="$(printf '%s' "$_pd" | command grep -oE 'enabled=[0-9]+' | cut -d= -f2)"
+      _nob="$(printf '%s' "$_pd" | command grep -oE 'nobudget=[0-9]+' | cut -d= -f2)"
+      echo "  allocation: ${_pd}  (GPUs on this host: ${CAP_NGPU})"
+      if (( CAP_CACHE_WANTED )) && [[ "${_devs:-0}" -lt "${CAP_NGPU:-0}" ]]; then
+        CAP_CACHE_OK=0
+        echo "  ⚠ WARN: a cache was REQUESTED but only ${_devs:-0} of ${CAP_NGPU} devices hold a pool."
+        if [[ "${_nob:-0}" != "0" ]]; then
+          echo "          reason: a device had no budget after its reserve. Lower RESERVE_MB."
+        elif [[ "${_enb:-0}" == "1" ]]; then
+          echo "          the 'enabled:' banner still printed — this is the #824 half-cached state."
+        fi
+        echo "          This run measured a HALF-CACHED path; do not quote it for a cache conclusion."
+      fi
+    fi
+    cap_moe_parse counters > "$CAP_WORK/counters1" 2>/dev/null || true
+    if [[ -s "$CAP_WORK/counters1" ]]; then
+      [[ -s "$CAP_WORK/counters0" ]] || : > "$CAP_WORK/counters0"
+      if _mar="$(cap_marginal_rates "$CAP_WORK/counters0" "$CAP_WORK/counters1" 2>/dev/null)"; then
+        echo "  hit rate, per device (MARGINAL = across the measured window only):"
+        while IFS= read -r _l; do [[ -n "$_l" ]] && echo "    ${_l}"; done <<< "$_mar"
+        echo "    note: the CUMULATIVE column embeds the cold-fill phase and is NOT"
+        echo "          boot-comparable — a BIGGER pool shows a LOWER cumulative rate on"
+        echo "          the same traffic. Compare boots on the MARGINAL column only."
+        echo "    note: the per-device split is signal, not noise — a CUDA0/CUDA1 hit"
+        echo "          asymmetry is routing entropy, and averaging it away hides it."
+      fi
+      echo "  health counters: $(cap_health_verdict "$CAP_WORK/counters1" || echo 'unreadable')"
+
+      # ---- derived RAM-read demand (item 9a) — offload AND cache ----------
+      if [[ -n "$_cen" ]]; then
+        _exp="$(printf '%s\n' "$_cen" | command grep -oE 'expert_kib=[0-9]+' | cut -d= -f2 | head -1 || true)"
+        _miss="$(printf '%s\n' "${_mar:-}" | awk '{
+          for (i = 1; i <= NF; i++) {
+            if ($i ~ /^dhits=/)    { split($i, a, "="); h += a[2] }
+            if ($i ~ /^dlookups=/) { split($i, b, "="); t += b[2] }
+          }
+        } END { m = t - h; print (m > 0 ? m : 0) }' || true)"
+        if [[ -n "$_exp" && -n "$_miss" && "${_miss:-0}" -gt 0 ]]; then
+          _ram="$(cap_ram_rd_mbps "$_miss" "$_exp" "$CAP_ELAPSED" || true)"
+          if [[ -n "$_ram" ]]; then
+            echo "  derived host-RAM read demand on the miss path: ~${_ram} MB/s"
+            echo "    = ${_miss} misses x ${_exp} KiB / ${CAP_ELAPSED}s"
+            echo "    ⚠ DERIVED, NOT A PERF COUNTER. A lower bound on the miss path only"
+            echo "      (ignores KV traffic, activations and prefetch). IMC/uncore counters"
+            echo "      are root-gated on bare metal and absent in VM guests, so this is the"
+            echo "      portable substitute — never quote it as measured bandwidth."
+            if [[ -n "${CAP_STREAM:-}" ]]; then
+              awk -v d="$_ram" -v c="${CAP_STREAM}" 'BEGIN{
+                if (c > 0) printf "    ~%.0f of ~%.0f GB/s STREAM-triad ceiling (%.0f%%)\n", d/1000, c, d/10/c }'
+            else
+              echo "    (STREAM_CALIB=1 adds a ~3 s triad ceiling so this can be stated as a fraction)"
+            fi
+          fi
+        fi
+      fi
+    fi
+    _byp="$(cap_moe_parse bypass 2>/dev/null || echo 0)"
+    echo "  bypass counter: ${_byp:-0}$( [[ "${_byp:-0}" != "0" ]] && echo '  ⚠ a decode DECLINED the cache — this run does not measure the cached path' )"
+  fi
+
+  # ---- integrity panel (items 1, 3c, 8, 11c) -------------------------------
+  echo ""
+  echo "========== CAPTURE: INTEGRITY =========="
+  CAP_TOKENS="$(python3 -c '
+import json, sys
+try:
+    d = json.load(open(sys.argv[1], encoding="utf-8"))
+except Exception:
+    sys.exit(1)
+print(d.get("total_tokens", 0))
+' "$CAP_WORK/summary.json" 2>/dev/null || echo 0)"
+  CAP_ERRS="$(python3 -c '
+import json, sys
+try:
+    d = json.load(open(sys.argv[1], encoding="utf-8"))
+except Exception:
+    sys.exit(1)
+print(d.get("total_errors", 0))
+' "$CAP_WORK/summary.json" 2>/dev/null || echo 0)"
+  CAP_TPS="${_cli:-0}"
+  CAP_STATUS="$(cap_status_classify "${CAP_TOKENS:-0}" "${CAP_TPS:-0}" "${CAP_ERRS:-0}" \
+                  "$CAP_CACHE_WANTED" "${CAP_CACHE_OK:-1}" "${_byp:-0}")"
+  echo "  status: ${CAP_STATUS}"
+  case "$CAP_STATUS" in
+    NO_TOKENS)
+      # The exact "plausible wrong number" class #824 catalogued: wall_TPS and
+      # decode_TPS printed 0.00 while TTFT printed fine, and nothing warned.
+      echo "  ⚠⚠ NO_TOKENS: the run measured ${CAP_TOKENS:-0} completion tokens at ${CAP_TPS:-0} TPS."
+      echo "     A TPS of 0.00 next to a healthy-looking TTFT is a SCRAPE failure, not a"
+      echo "     slow model. Do NOT quote any throughput number from this run."
+      echo "     Check: did the model EOS immediately? did usage arrive in the stream?"
+      echo "     (stream_options.include_usage), and does the endpoint support it?" ;;
+    REQ_ERRORS)
+      echo "  ⚠⚠ REQ_ERRORS: ${CAP_ERRS} request(s) failed. Every aggregate above is over the"
+      echo "     survivors only." ;;
+    CACHE_DISABLED)
+      echo "  ⚠⚠ CACHE_DISABLED: a cache was requested but is not (fully) allocated — see the"
+      echo "     expert-cache section. This run measured the no-cache or half-cached path." ;;
+    INVALID_BYPASS)
+      echo "  ⚠⚠ INVALID_BYPASS: ${_byp} decode(s) declined the cache." ;;
+    OK)
+      echo "  (no capture-level defect detected — this is NOT a statement about the numbers'"
+      echo "   quality, only that the measurement machinery did its job)" ;;
+  esac
+  echo "  swap check   : $(cap_swap_verdict 2>/dev/null || echo 'unavailable')"
+  if [[ -s "$CAP_WORK/counters1" ]]; then
+    echo "  cache health : $(cap_health_verdict "$CAP_WORK/counters1" 2>/dev/null || echo 'unavailable')"
+  fi
+  python3 -c '
+import json, sys
+try:
+    d = json.load(open(sys.argv[1], encoding="utf-8"))
+except Exception:
+    sys.exit(0)
+for name, v in d.get("shapes", {}).items():
+    n, u = v.get("n", 0), v.get("n_usable", 0)
+    floor = v.get("short_eos_floor", 0)
+    if n and u < n:
+        print(f"  ⚠ n-usable   : {name} {u}/{n} runs above the short-EOS floor "
+              f"({floor} tok) - the CV for this shape is not trustworthy")
+' "$CAP_WORK/summary.json" || true
+fi
 
 # GPU state
 if command -v nvidia-smi >/dev/null 2>&1; then

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -92,6 +92,32 @@
 #                      Chat-tuned models EOS early and silently degenerate a 5-run
 #                      shape to n=1. Default: 0.25.
 #
+# Card rendering (docs/BENCH_CARD.md — default OFF; unset CARD leaves output
+# byte-identical to a run without it):
+#   CARD=snapshot      Render Template 1 (SNAPSHOT) as a fenced markdown block at
+#                      the end of the run, filled from this run's own captures.
+#                      Human judgement (verdict, "quiet box", config slug) stays an
+#                      explicit <fill: …> placeholder — the renderer never guesses.
+#   CARD=ab            Render Template 2 (A/B) against a previously saved run.
+#     BASELINE=<path>    REQUIRED for CARD=ab: a saved bench.sh log (arm A). Parsing
+#                        is strict — a log missing its fingerprint or summary blocks
+#                        fails with "baseline unparseable: <why>" instead of half a
+#                        delta. The run's own numbers are printed either way.
+#     KNOB="<text>"      Names the thing under test. Fingerprint differences matching
+#                        it are ATTRIBUTED to the knob; anything else marks the card
+#                        CONFOUNDED at the top.
+#     NOISE_BAND=<pct>   Override the band. Default: 2x the worst decode CV across
+#                        both arms — and the card states which was used.
+#     EXPECTATION="<t>"  Fills the pre-registered-expectation line (default "none").
+#     BOOT_POLICY="<t>"  Fills the boot-policy line.
+#   CARD_RECORD_OUT=<path>
+#                      Debug seam: also write the in-process card record, so it can
+#                      be diffed against the one parsed back out of the run's log.
+#
+#   Usage:
+#     CARD=snapshot bash scripts/bench.sh | tee run-A.log
+#     CARD=ab BASELINE=run-A.log KNOB=moe-cache bash scripts/bench.sh
+#
 # Usage:
 #   bash scripts/bench.sh
 #   ONLY=code bash scripts/bench.sh
@@ -275,6 +301,7 @@ CAP_T0=""; CAP_T1=""
 CAP_DMON_PID=""; CAP_VRAM_PID=""; CAP_LINK_PID=""
 CAP_VRAM_IDLE=""; CAP_CPU0=""
 CAP_ARGV=""; CAP_OFFLOAD=""; CAP_CACHE_WANTED=0
+CAP_PCIE_PCT=""; CAP_RAM_DEMAND=""; CAP_RAM_WINDOW=""; CAP_RAM_SUMMARY=""
 CAP_WORK=""
 if [[ "$CAPTURE" == "1" && -f "${ROOT_DIR}/scripts/lib/capture.sh" ]]; then
   # shellcheck source=lib/capture.sh
@@ -304,8 +331,15 @@ if [[ "$CAPTURE" == "1" && -f "${ROOT_DIR}/scripts/lib/capture.sh" ]]; then
   _v="$(cap_props_get "default_generation_settings.params.speculative.types" || true)"
   [[ -n "$_v" ]] && echo "  drafter        : ${_v}"
   # ALWAYS-ON: KV cache type. Offload or not, a bench without its KV type is a rumor.
-  _v="$(cap_kv_type "$CAP_ARGV" || true)"
-  [[ -n "$_v" ]] && echo "  KV cache type  : ${_v}"
+  # The notice is emitted HERE, not inside cap_kv_type: that function returns its
+  # value on stdout, so a notice printed there gets captured by this $(...) and
+  # rendered inside the label — seen live as
+  #   "KV cache type  : capture: KV cache type unavailable (…)".
+  if _v="$(cap_kv_type "$CAP_ARGV")"; then
+    echo "  KV cache type  : ${_v}"
+  else
+    cap_note_unavailable "KV cache type" "not in argv, /props or the boot log"
+  fi
   # ALWAYS-ON: argv fingerprint — solves the fingerprint problem without operator input.
   if [[ -n "$CAP_ARGV" ]]; then
     _v="$(cap_argv_fingerprint "$CAP_ARGV" || true)"
@@ -318,26 +352,43 @@ if [[ "$CAPTURE" == "1" && -f "${ROOT_DIR}/scripts/lib/capture.sh" ]]; then
   case "$_v" in *"moe_cache_cap=<unset>"*) : ;; *) CAP_CACHE_WANTED=1 ;; esac
   # The GATE for every moe-cache capture below.
   CAP_OFFLOAD="$(cap_offload_detected "$CAP_ARGV" || true)"
+  # One rendering, used for BOTH the printed line and the card record — the card
+  # parser reads the printed line back, so a second phrasing here would make the
+  # in-process record and the parsed one disagree (caught by the round-trip test).
   if [[ -n "$CAP_OFFLOAD" ]]; then
-    echo "  CPU offload    : DETECTED via ${CAP_OFFLOAD}"
+    CAP_OFFLOAD_DESC="DETECTED via ${CAP_OFFLOAD}"
   else
-    echo "  CPU offload    : not detected (moe-cache captures skipped)"
+    CAP_OFFLOAD_DESC="not detected (moe-cache captures skipped)"
   fi
+  echo "  CPU offload    : ${CAP_OFFLOAD_DESC}"
 
   # ALWAYS-ON (item 8): host RAM is the requirement launchers cannot detect, and
   # it is two lines from /proc. The swap leg is the free integrity item — pages of
   # the SERVING PROCESS in swap make every number in the run suspect.
   echo ""
   echo "========== SYSTEM RAM =========="
-  _v="$(cap_ram_status || true)"
-  [[ -n "$_v" ]] && echo "  ${_v}"
+  if _v="$(cap_ram_status)"; then
+    CAP_RAM_SUMMARY="$_v"
+    echo "  ${_v}"
+  else
+    cap_note_unavailable "system RAM" "/proc/meminfo not readable"
+  fi
   _v="$(cap_swap_verdict || true)"
   [[ -n "$_v" ]] && echo "  swap check     : ${_v}"
 
   if [[ "$STREAM_CALIB" == "1" ]]; then
     echo ""
     echo "========== RAM BANDWIDTH CEILING (STREAM triad, idle box) =========="
-    _sc="$(cap_stream_triad_gbps 3 || true)"
+    _screc=0
+    _sc="$(cap_stream_triad_gbps 3)" || _screc=$?
+    if (( _screc == 3 )); then
+      cap_note_unavailable "STREAM triad ceiling" \
+        "numpy not installed — a pure-python loop would measure the interpreter, not RAM"
+      _sc=""
+    elif (( _screc != 0 )); then
+      cap_note_unavailable "STREAM triad ceiling" "calibration failed (rc=${_screc})"
+      _sc=""
+    fi
     CAP_STREAM="${_sc%% *}"
     _scw="${_sc##* }"
     if [[ -n "$CAP_STREAM" ]]; then
@@ -349,7 +400,8 @@ if [[ "$CAPTURE" == "1" && -f "${ROOT_DIR}/scripts/lib/capture.sh" ]]; then
   fi
 
   # --- start the windowed samplers ----------------------------------------
-  CAP_DMON_PID="$(cap_dmon_start "$CAP_WORK/dmon" || true)"
+  CAP_DMON_PID="$(cap_dmon_start "$CAP_WORK/dmon")" \
+    || { cap_note_unavailable "PCIe dmon" "nvidia-smi not in PATH"; CAP_DMON_PID=""; }
   CAP_LINK_PID="$(cap_pcie_link_sampler_start "$CAP_WORK/link" || true)"
   CAP_VRAM_PID="$(cap_vram_peak_start "$CAP_WORK/vpeak" || true)"
   CAP_VRAM_IDLE="$(cap_vram_used || true)"
@@ -418,16 +470,39 @@ def progress(msg):
     sys.stderr.flush()
 
 
-def mark_phase(label, t0, t1):
-    """Record a measured window so PCIe/dmon samples can be sliced by PHASE.
+def _log_lines():
+    """Current line count of the server log, or 0 when there isn't one.
 
-    Decode and prefill PCIe traffic differ by ~100x on an offloaded MoE, so a
-    whole-run mean describes neither phase."""
+    This is the seam that makes PHASE-ATTRIBUTED counters possible: the engine's
+    cumulative moe-cache counters carry no timestamps, but reading them truncated
+    at two different line positions gives the delta across exactly that span."""
+    path = os.environ.get("SERVER_LOG", "")
+    if not path:
+        return 0
+    try:
+        with open(path, "rb") as fh:
+            return sum(1 for _ in fh)
+    except OSError:
+        return 0
+
+
+def phase_start():
+    return time.time(), _log_lines()
+
+
+def mark_phase(label, start):
+    """Record a measured window so PCIe samples and cache counters can be sliced
+    by PHASE.
+
+    Decode and prefill differ by ~13x in mean PCIe traffic on an offloaded MoE
+    (measured), so a whole-run mean describes neither — and a miss count averaged
+    over a run that was ~40% prefill understates decode-window RAM demand."""
     if not PHASE_FILE:
         return
+    t0, l0 = start
     try:
         with open(PHASE_FILE, "a", encoding="utf-8") as fh:
-            fh.write(f"{label} {t0:.0f} {t1:.0f}\n")
+            fh.write(f"{label} {t0:.0f} {time.time():.0f} {l0} {_log_lines()}\n")
     except OSError:
         pass
 
@@ -621,7 +696,7 @@ def run_set(label, prompt, max_tokens):
     walls, decodes, ttfts, toks_seen = [], [], [], []
     errors = 0
     mt = FORCE if FORCE > 0 else max_tokens
-    phase_t0 = time.time()
+    phase_t0 = phase_start()
     for i in range(RUNS):
         try:
             w, t, k, _ = run_once(prompt, max_tokens)
@@ -636,20 +711,29 @@ def run_set(label, prompt, max_tokens):
             errors += 1
             print(f"  run-{i+1}  FAIL: {e}")
             progress(f"[bench] {label} run {i+1}/{RUNS}: FAIL: {e}")
-    mark_phase("decode", phase_t0, time.time())
+    mark_phase("decode", phase_t0)
     # Item 2: a chat-tuned model answers briefly and EOSes. The per-shape stats
     # then silently describe whichever one or two runs happened to run long — a
     # 5-run shape degenerates to n=1 while still printing "n=5". Count the runs
     # that are long enough to be worth a decode rate and say so.
     floor = max(1, int(mt * SHORT_EOS_FRAC))
     usable = [k for k in toks_seen if k >= floor]
+    def _cv(xs):
+        if len(xs) < 2:
+            return 0.0
+        m = s.mean(xs)
+        return (s.stdev(xs) / m * 100) if m > 0 else 0.0
+
     SUMMARY["shapes"][label] = {
         "n": len(walls), "n_usable": len(usable), "errors": errors,
         "max_tokens": mt, "short_eos_floor": floor,
         "tokens": toks_seen,
         "wall_tps_mean": (s.mean(walls) if walls else 0.0),
+        "wall_tps_cv": _cv(walls),
         "decode_tps_mean": (s.mean(decodes) if decodes else 0.0),
+        "decode_tps_cv": _cv(decodes),
         "ttft_mean_ms": (s.mean(ttfts) * 1000 if ttfts else 0.0),
+        "ttft_std_ms": (s.stdev(ttfts) * 1000 if len(ttfts) > 1 else 0.0),
     }
     if walls:
         print(f"\n=== summary [{label}] (n={len(walls)}) ===")
@@ -699,7 +783,7 @@ def run_pp_fallback():
     )
     print("=== measured (1) ===")
     pp_vals, ttfts = [], []
-    phase_t0 = time.time()
+    phase_t0 = phase_start()
     try:
         w, t, _k, prompt_tokens = run_once(prompt, PP_MAX_TOKENS)
         pp, ttft, line = fmt_pp("run-1", w, t, prompt_tokens)
@@ -710,7 +794,7 @@ def run_pp_fallback():
     except Exception as e:
         print(f"  run-1      FAIL: {e}")
         progress(f"[bench] prompt-processing run 1/1: FAIL: {e}")
-    mark_phase("prefill", phase_t0, time.time())
+    mark_phase("prefill", phase_t0)
     if pp_vals:
         print("\n=== summary [prompt-processing] (n=1) ===")
         print(stats("PP tok/s", pp_vals))
@@ -779,7 +863,7 @@ def run_prefill_probe():
             print(f"  warm-1     FAIL: {e}")
         print(f"\n=== measured ({n}) ===")
         pps, ttfts = [], []
-        phase_t0 = time.time()
+        phase_t0 = phase_start()
         for i in range(n):
             try:
                 w, t, _k, ptoks = run_once(prefill_prompt(request_tokens, salt()), PP_MAX_TOKENS)
@@ -793,7 +877,7 @@ def run_prefill_probe():
             except Exception as e:
                 print(f"  run-{i+1}    FAIL: {e}")
                 progress(f"[bench] {label} run {i+1}/{n}: FAIL: {e}")
-        mark_phase("prefill", phase_t0, time.time())
+        mark_phase("prefill", phase_t0)
         if pps:
             print(f"\n=== summary [{label}] (n={len(pps)}) ===")
             # prompt_tokens/TTFT = the CLIENT-OBSERVED rate (includes
@@ -813,9 +897,12 @@ def run_prefill_probe():
                 vals = [v for v in vals if v > 0][-len(pps):]
                 if vals:
                     print(stats("PP tok/s (engine log, windowed)", vals))
+            _pm = s.mean(pps)
             SUMMARY["shapes"][label] = {
                 "n": len(pps), "n_usable": len(pps), "errors": 0,
-                "prefill_tps_mean": s.mean(pps), "ttft_mean_ms": s.mean(ttfts) * 1000,
+                "prefill_tps_mean": _pm,
+                "prefill_tps_cv": ((s.stdev(pps) / _pm * 100) if len(pps) > 1 and _pm > 0 else 0.0),
+                "ttft_mean_ms": s.mean(ttfts) * 1000,
             }
 
 if ONLY in ("both", "narr"):
@@ -865,6 +952,7 @@ if (( CAP_ENABLED )); then
     for _ph in decode prefill; do
       command grep -q "^${_ph} " "$CAP_WORK/phases" 2>/dev/null || continue
       if _out="$(cap_dmon_phase "$CAP_WORK/dmon" "$CAP_WORK/phases" "$_ph" 2>/dev/null)"; then
+        printf '%s\n' "$_out" >> "$CAP_WORK/pcie.txt"
         while IFS= read -r _l; do [[ -n "$_l" ]] && echo "  ${_l}"; done <<< "$_out"
       else
         # Reported, never silently omitted: a phase shorter than the 1 Hz sample
@@ -879,6 +967,7 @@ if (( CAP_ENABLED )); then
   # Link capability, sampled UNDER LOAD: an idle link downshifts to Gen1 by
   # design, so an idle reading manufactures false alarms.
   if _out="$(cap_pcie_link_under_load "$CAP_WORK/link" 2>/dev/null)"; then
+    printf '%s\n' "$_out" > "$CAP_WORK/link.txt"
     echo "  link (sampled under load, best observed):"
     while IFS= read -r _l; do [[ -n "$_l" ]] && echo "    ${_l}"; done <<< "$_out"
     # Utilisation% against a STATED denominator — a bandwidth percentage with an
@@ -891,8 +980,11 @@ if (( CAP_ENABLED )); then
              | command grep -m1 ' all ' | command grep -oE 'rx_peak=[0-9]+' | cut -d= -f2 || true)"
       echo "    denominator: ~${_prac} MB/s practical for a negotiated gen${_g} x${_w} link"
       echo "                 (per-lane raw x width x 0.85; NOT a theoretical peak)"
-      [[ -n "$_rx" ]] && awk -v a="$_rx" -v b="$_prac" 'BEGIN{
-        if (b > 0) printf "    decode rx peak = %s MB/s = %.1f%% of that denominator\n", a, a*100/b }'
+      if [[ -n "$_rx" ]]; then
+        CAP_PCIE_PCT="$(awk -v a="$_rx" -v b="$_prac" 'BEGIN{ if (b > 0) printf "%.1f", a*100/b }')"
+        awk -v a="$_rx" -v b="$_prac" 'BEGIN{
+          if (b > 0) printf "    decode rx peak = %s MB/s = %.1f%% of that denominator\n", a, a*100/b }'
+      fi
     fi
   else
     cap_note_unavailable "PCIe link state" "nvidia-smi could not report pcie.link.* under load"
@@ -906,9 +998,21 @@ if (( CAP_ENABLED )); then
   if [[ -n "$CAP_VRAM_IDLE" ]]; then
     echo "  idle=${CAP_VRAM_IDLE} MiB  peak=${CAP_VRAM_PEAK:-n/a} MiB  post=${CAP_VRAM_POST:-n/a} MiB"
     if [[ -n "$CAP_VRAM_POST" ]]; then
-      # A free soak-lite leak check: VRAM that did not come back is the cheapest
-      # early warning there is for a memory-policy regression.
-      echo "  leak delta (post - idle) = $(( CAP_VRAM_POST - CAP_VRAM_IDLE )) MiB"
+      # A free soak-lite check on VRAM that did not come back. But the LABEL has to
+      # match what the config can legitimately do: an expert cache allocates its
+      # pool and graphs lazily, on first inference, so a single run with a cache
+      # active grows VRAM BY DESIGN. Calling that a leak cries wolf on a healthy
+      # run (measured: +1036 MiB with moe-cache active). Only a monotonic rise
+      # across REPEATED runs is evidence of a leak there.
+      _vd=$(( CAP_VRAM_POST - CAP_VRAM_IDLE ))
+      if [[ -n "$CAP_OFFLOAD" ]] && (( CAP_CACHE_WANTED )); then
+        echo "  growth delta (post - idle) = ${_vd} MiB"
+        echo "    includes lazy expert-cache pool/graph allocation on first inference —"
+        echo "    expected with a cache active. Only a MONOTONIC rise across REPEATED"
+        echo "    runs indicates a leak."
+      else
+        echo "  leak delta (post - idle) = ${_vd} MiB"
+      fi
     fi
     while IFS= read -r _l; do [[ -n "$_l" ]] && echo "  ${_l} MiB (post-run)"; done \
       < <(cap_vram_per_device 2>/dev/null || true)
@@ -1049,21 +1153,63 @@ print(f"{sum(xs)/len(xs):.2f}" if xs else "")
             if ($i ~ /^dlookups=/) { split($i, b, "="); t += b[2] }
           }
         } END { m = t - h; print (m > 0 ? m : 0) }' || true)"
-        if [[ -n "$_exp" && -n "$_miss" && "${_miss:-0}" -gt 0 ]]; then
+
+        # DECODE-WINDOW attribution. Dividing the whole-run miss count by the whole
+        # run wall dilutes the figure with the prefill phases, during which the
+        # cache is not on the hot path — a live run spent ~40% of its wall in
+        # prefill and reported ~14 GB/s where the decode-window figure is roughly
+        # double. The engine's counters carry no timestamps, so the decode windows
+        # are recovered by reading the cumulative counters truncated at the log
+        # line positions python recorded at each phase boundary.
+        _win_secs=0; _win_miss=0; _win_ok=0
+        if [[ -s "$CAP_WORK/phases" ]]; then
+          while read -r _lab _pt0 _pt1 _pl0 _pl1 _junk; do
+            [[ "$_lab" == "decode" ]] || continue
+            _win_secs=$(( _win_secs + _pt1 - _pt0 ))
+            [[ -n "${_pl1:-}" && -n "${_pl0:-}" && "${_pl1:-0}" -gt "${_pl0:-0}" ]] || continue
+            CAP_LINE_LIMIT="$_pl0" cap_moe_parse counters > "$CAP_WORK/pc0" 2>/dev/null || continue
+            CAP_LINE_LIMIT="$_pl1" cap_moe_parse counters > "$CAP_WORK/pc1" 2>/dev/null || continue
+            _wm="$(cap_marginal_rates "$CAP_WORK/pc0" "$CAP_WORK/pc1" 2>/dev/null | awk '{
+              for (i = 1; i <= NF; i++) {
+                if ($i ~ /^dhits=/)    { split($i, a, "="); h += a[2] }
+                if ($i ~ /^dlookups=/) { split($i, b, "="); t += b[2] }
+              }
+            } END { m = t - h; print (m > 0 ? m : 0) }' || true)"
+            [[ -n "$_wm" && "$_wm" -gt 0 ]] && { _win_miss=$(( _win_miss + _wm )); _win_ok=1; }
+          done < "$CAP_WORK/phases"
+        fi
+        unset CAP_LINE_LIMIT
+
+        _ram=""; _ram_scope=""; _ram_arith=""; _ram_caveat=""
+        if [[ -n "$_exp" ]] && (( _win_ok )) && (( _win_secs > 0 )) && (( _win_miss > 0 )); then
+          _ram="$(cap_ram_rd_mbps "$_win_miss" "$_exp" "$_win_secs" || true)"
+          _ram_scope="(DECODE WINDOW)"
+          _ram_arith="= ${_win_miss} misses x ${_exp} KiB / ${_win_secs}s of decode"
+        elif [[ -n "$_exp" && -n "$_miss" && "${_miss:-0}" -gt 0 ]]; then
           _ram="$(cap_ram_rd_mbps "$_miss" "$_exp" "$CAP_ELAPSED" || true)"
-          if [[ -n "$_ram" ]]; then
-            echo "  derived host-RAM read demand on the miss path: ~${_ram} MB/s"
-            echo "    = ${_miss} misses x ${_exp} KiB / ${CAP_ELAPSED}s"
-            echo "    ⚠ DERIVED, NOT A PERF COUNTER. A lower bound on the miss path only"
-            echo "      (ignores KV traffic, activations and prefetch). IMC/uncore counters"
-            echo "      are root-gated on bare metal and absent in VM guests, so this is the"
-            echo "      portable substitute — never quote it as measured bandwidth."
-            if [[ -n "${CAP_STREAM:-}" ]]; then
-              awk -v d="$_ram" -v c="${CAP_STREAM}" 'BEGIN{
-                if (c > 0) printf "    ~%.0f of ~%.0f GB/s STREAM-triad ceiling (%.0f%%)\n", d/1000, c, d/10/c }'
-            else
-              echo "    (STREAM_CALIB=1 adds a ~3 s triad ceiling so this can be stated as a fraction)"
-            fi
+          _ram_scope="(WHOLE RUN — diluted)"
+          _ram_arith="= ${_miss} misses x ${_exp} KiB / ${CAP_ELAPSED}s"
+          _ram_caveat="dilution"
+        fi
+        if [[ -n "$_ram" ]]; then
+          CAP_RAM_DEMAND="$_ram"
+          CAP_RAM_WINDOW="$([[ "$_ram_caveat" == "dilution" ]] && echo "whole-run (diluted)" || echo "decode window")"
+          echo "  derived host-RAM read demand on the miss path: ~${_ram} MB/s  ${_ram_scope}"
+          echo "    ${_ram_arith}"
+          echo "    ⚠ DERIVED, NOT A PERF COUNTER. A lower bound on the miss path only"
+          echo "      (ignores KV traffic, activations and prefetch). IMC/uncore counters"
+          echo "      are root-gated on bare metal and absent in VM guests, so this is the"
+          echo "      portable substitute — never quote it as measured bandwidth."
+          if [[ "$_ram_caveat" == "dilution" ]]; then
+            echo "    ⚠ Averaged over the FULL RUN INCLUDING non-decode phases (prefill, warm-up),"
+            echo "      during which the cache is not on the hot path — the decode-window demand"
+            echo "      is HIGHER than this. Set SERVER_LOG=<path> to get the decode-window figure."
+          fi
+          if [[ -n "${CAP_STREAM:-}" ]]; then
+            awk -v d="$_ram" -v c="${CAP_STREAM}" 'BEGIN{
+              if (c > 0) printf "    ~%.0f of ~%.0f GB/s STREAM-triad ceiling (%.0f%%)\n", d/1000, c, d/10/c }'
+          else
+            echo "    (STREAM_CALIB=1 adds a ~3 s triad ceiling so this can be stated as a fraction)"
           fi
         fi
       fi
@@ -1133,6 +1279,135 @@ for name, v in d.get("shapes", {}).items():
         print(f"  ⚠ n-usable   : {name} {u}/{n} runs above the short-EOS floor "
               f"({floor} tok) - the CV for this shape is not trustworthy")
 ' "$CAP_WORK/summary.json" || true
+
+  # ---- BENCH CARD (opt-in: CARD=snapshot | ab) ----------------------------
+  # docs/BENCH_CARD.md's templates are correct and nobody fills them in by hand
+  # under time pressure — which is when the awkward facts get left off. Everything
+  # above is already captured; this pours it into the template.
+  if [[ -n "${CARD:-}" && -f "${ROOT_DIR}/scripts/lib/card.sh" ]]; then
+    # shellcheck source=lib/card.sh
+    source "${ROOT_DIR}/scripts/lib/card.sh"
+    CARD_REC="$CAP_WORK/card.kv"
+    : > "$CARD_REC"
+    card_kv "$CARD_REC" meta.date        "$(date +%F)"
+    card_kv "$CARD_REC" meta.endpoint    "$URL"
+    card_kv "$CARD_REC" meta.mode        "$ENDPOINT"
+    card_kv "$CARD_REC" fp.model         "$MODEL"
+    card_kv "$CARD_REC" fp.ctx           "$(cap_props_get 'default_generation_settings.n_ctx' || true)"
+    card_kv "$CARD_REC" fp.slots         "$(cap_props_get 'total_slots' || true)"
+    card_kv "$CARD_REC" fp.ftype         "$(cap_props_get 'model_ftype' || true)"
+    card_kv "$CARD_REC" fp.drafter       "$(cap_props_get 'default_generation_settings.params.speculative.types' || true)"
+    card_kv "$CARD_REC" fp.kv            "$(cap_kv_type "$CAP_ARGV" || true)"
+    card_kv "$CARD_REC" fp.argv          "$(cap_argv_fingerprint "$CAP_ARGV" 2>/dev/null || true)"
+    card_kv "$CARD_REC" fp.moe           "$(cap_moe_cache_config "$CAP_ARGV" || true)"
+    card_kv "$CARD_REC" fp.offload       "${CAP_OFFLOAD_DESC:-}"
+    card_kv "$CARD_REC" proto.warmups    "$WARMUPS"
+    card_kv "$CARD_REC" proto.runs       "$RUNS"
+    card_kv "$CARD_REC" proto.force_tokens "$FORCE_TOKENS"
+    card_kv "$CARD_REC" proto.thinking   "$ENABLE_THINKING"
+    # The Env line should name what was NOT default — that is what makes a run
+    # reproducible, and it is the line most often reconstructed wrongly by hand.
+    _envnote=""
+    [[ "$RUNS" != "5" ]]            && _envnote+="RUNS=${RUNS} "
+    [[ "$WARMUPS" != "3" ]]         && _envnote+="WARMUPS=${WARMUPS} "
+    [[ "$FORCE_TOKENS" != "0" ]]    && _envnote+="FORCE_TOKENS=${FORCE_TOKENS} "
+    [[ "$ENABLE_THINKING" == "1" ]] && _envnote+="ENABLE_THINKING=1 "
+    [[ "$ENDPOINT" != "chat" ]]     && _envnote+="ENDPOINT=${ENDPOINT} "
+    [[ "$ONLY" != "both" ]]         && _envnote+="ONLY=${ONLY} "
+    [[ "$PREFILL_DEPTHS" != "10000,90000" ]] && _envnote+="PREFILL_DEPTHS=${PREFILL_DEPTHS} "
+    [[ -n "${SERVER_LOG:-}" ]]      && _envnote+="SERVER_LOG=<set> "
+    card_kv "$CARD_REC" proto.env "${_envnote:-}"
+    card_kv "$CARD_REC" gpu.vram_idle    "${CAP_VRAM_IDLE:-}"
+    card_kv "$CARD_REC" gpu.vram_peak    "${CAP_VRAM_PEAK:-}"
+    card_kv "$CARD_REC" gpu.vram_post    "${CAP_VRAM_POST:-}"
+    [[ -n "${CAP_VRAM_IDLE:-}" && -n "${CAP_VRAM_POST:-}" ]] \
+      && card_kv "$CARD_REC" gpu.leak "$(( CAP_VRAM_POST - CAP_VRAM_IDLE ))"
+    card_kv "$CARD_REC" integrity.status "${CAP_STATUS:-}"
+    card_kv "$CARD_REC" integrity.divergence "${_div:-}"
+    card_kv "$CARD_REC" integrity.stream_ceiling "${CAP_STREAM:-}"
+    [[ -s "$CAP_WORK/counters1" ]] \
+      && card_kv "$CARD_REC" integrity.health "$(cap_health_verdict "$CAP_WORK/counters1" || true)"
+    card_kv "$CARD_REC" integrity.swap "$(cap_swap_verdict 2>/dev/null || true)"
+    # --- offload / PCIe / RAM telemetry for the card's offload block ---------
+    card_kv "$CARD_REC" sys.ram "${CAP_RAM_SUMMARY:-}"
+    card_kv "$CARD_REC" ram.demand_mbps "${CAP_RAM_DEMAND:-}"
+    card_kv "$CARD_REC" ram.window      "${CAP_RAM_WINDOW:-}"
+    card_kv "$CARD_REC" ram.ceiling_gbps "${CAP_STREAM:-}"
+    card_kv "$CARD_REC" pcie.link_pct   "${CAP_PCIE_PCT:-}"
+    card_kv "$CARD_REC" pcie.practical_mbps "${_prac:-}"
+    if [[ -s "$CAP_WORK/link.txt" ]]; then
+      card_kv "$CARD_REC" pcie.link "$(command grep -m1 -oE 'GPU[0-9]+ gen=[0-9]+/[0-9]+ width=[0-9]+/[0-9]+' "$CAP_WORK/link.txt" || true)"
+      command grep -q 'WARN: never reached' "$CAP_WORK/link.txt" \
+        && card_kv "$CARD_REC" pcie.link_warn "link trained below its own maximum under load"
+    fi
+    if [[ -s "$CAP_WORK/pcie.txt" ]]; then
+      while read -r _ph _dev _rest; do
+        [[ "$_dev" == "all" || "$_dev" == GPU* ]] || continue
+        _k="pcie.${_ph}.${_dev}"
+        card_kv "$CARD_REC" "${_k}.rx_mean" "$(printf '%s' "$_rest" | command grep -oE 'rx_mean=[0-9]+' | cut -d= -f2 || true)"
+        card_kv "$CARD_REC" "${_k}.rx_peak" "$(printf '%s' "$_rest" | command grep -oE 'rx_peak=[0-9]+' | cut -d= -f2 || true)"
+      done < "$CAP_WORK/pcie.txt"
+    fi
+    # Per-device cache detail the offload table needs beyond hit rates.
+    if [[ -s "$CAP_WORK/counters1" ]]; then
+      while read -r _d _rest; do
+        [[ -n "$_d" ]] || continue
+        card_kv "$CARD_REC" "cache.${_d}.evictions" \
+          "$(printf '%s' "$_rest" | command grep -oE 'devictions=[0-9]+' | cut -d= -f2 || true)"
+      done < <(cap_marginal_rates "$CAP_WORK/counters0" "$CAP_WORK/counters1" 2>/dev/null || true)
+      while read -r _d _rest; do
+        [[ -n "$_d" ]] || continue
+        card_kv "$CARD_REC" "cache.${_d}.skips" \
+          "$(printf '%s' "$_rest" | command grep -oE 'skips=[0-9]+' | cut -d= -f2 || true)"
+      done < "$CAP_WORK/counters1"
+    fi
+    while read -r _d _rest; do
+      [[ -n "$_d" ]] || continue
+      card_kv "$CARD_REC" "cache.${_d}.type" \
+        "$(printf '%s' "$_rest" | command grep -oE 'type=[^ ]+' | cut -d= -f2 || true)"
+    done < <(cap_moe_parse census 2>/dev/null || true)
+    # Per-device cache rows stay PER DEVICE on the card (item 3d).
+    if [[ -s "$CAP_WORK/counters1" ]]; then
+      while read -r _d _rest; do
+        [[ -n "$_d" ]] || continue
+        card_kv "$CARD_REC" "cache.${_d}.marginal" \
+          "$(printf '%s' "$_rest" | command grep -oE 'marginal=[0-9.]+' | cut -d= -f2 || true)"
+        card_kv "$CARD_REC" "cache.${_d}.cumulative" \
+          "$(printf '%s' "$_rest" | command grep -oE 'cumulative=[0-9.]+' | cut -d= -f2 || true)"
+      done < <(cap_marginal_rates "$CAP_WORK/counters0" "$CAP_WORK/counters1" 2>/dev/null || true)
+      while read -r _d _rest; do
+        [[ -n "$_d" ]] || continue
+        card_kv "$CARD_REC" "cache.${_d}.cum_start" \
+          "$(printf '%s' "$_rest" | command grep -oE 'cumulative=[0-9.]+' | cut -d= -f2 || true)"
+      done < <(cap_cumulative_rates "$CAP_WORK/counters0" 2>/dev/null || true)
+    fi
+    while read -r _d _rest; do
+      [[ -n "$_d" ]] || continue
+      card_kv "$CARD_REC" "cache.${_d}.slots" \
+        "$(printf '%s' "$_rest" | command grep -oE 'slots=[0-9]+' | cut -d= -f2 || true)"
+      card_kv "$CARD_REC" "cache.${_d}.total_mib" \
+        "$(printf '%s' "$_rest" | command grep -oE 'total_mib=[0-9]+' | cut -d= -f2 || true)"
+    done < <(cap_moe_parse census 2>/dev/null || true)
+    card_kv_from_summary "$CARD_REC" "$CAP_WORK/summary.json" || true
+    # Debug seam: lets the suite diff this in-process record against the one
+    # card.sh parses back out of this run's own log. If those disagree, every
+    # A/B silently compares two different measurements.
+    [[ -n "${CARD_RECORD_OUT:-}" ]] && cp "$CARD_REC" "$CARD_RECORD_OUT"
+
+    echo ""
+    echo "========== BENCH CARD (CARD=${CARD}) =========="
+    echo "Paste the block below into the issue / discussion. Placeholders marked"
+    echo "<fill: …> are human judgement — the run cannot know them, so it will not guess."
+    echo ""
+    echo '```markdown'
+    case "$CARD" in
+      snapshot) card_render snapshot "$CARD_REC" || echo "(card render failed)" ;;
+      ab)       card_render ab "$CARD_REC" "${BASELINE:-}" \
+                  || echo "(A/B card not rendered — see the error above; the run's own numbers are intact)" ;;
+      *)        echo "(unknown CARD=${CARD}; expected 'snapshot' or 'ab')" ;;
+    esac
+    echo '```'
+  fi
 fi
 
 # GPU state

--- a/scripts/lib/capture.sh
+++ b/scripts/lib/capture.sh
@@ -259,7 +259,7 @@ sys.stdout.write(str(cur))
 cap_kv_type() {
   local argv="${1:-}" v
   if [[ -n "$argv" ]]; then
-    v="$(cap_argv_flag "$argv" -ct -ctk --cache-type-k --kv-cache-dtype || true)"
+    v="$(cap_argv_flag "$argv" -ct -ctk -ctv --cache-type-k --cache-type-v --kv-cache-dtype || true)"
     [[ -n "$v" ]] && { echo "$v (source: argv)"; return 0; }
   fi
   v="$(cap_props_get "default_generation_settings.params.cache_type_k" || true)"
@@ -269,7 +269,22 @@ cap_kv_type() {
          | tail -1 | sed -E 's/.*= *//' || true)"
     [[ -n "$v" ]] && { echo "$v (source: boot log)"; return 0; }
   fi
-  cap_note_unavailable "KV cache type" "not in argv, /props or the boot log"
+  # No flag, no /props field, nothing in the log: for llama.cpp-family servers the
+  # ENGINE DEFAULT is f16, and "f16 (engine default)" is a fact the reader can act
+  # on where "unavailable" is not. Only inferred when the family is identified —
+  # /props answering, or llama.cpp markers in the log. Anything else stays honestly
+  # unavailable rather than guessing another engine's default.
+  if [[ -n "$argv" ]] || [[ -n "$CAP_LOG" ]]; then
+    if cap_props_json >/dev/null 2>&1 \
+       || { [[ -r "${CAP_LOG:-/dev/null}" ]] \
+            && command grep -qE 'llama_context:|llama_model_loader:|llama_kv_cache' "$CAP_LOG" 2>/dev/null; }; then
+      echo "f16 (engine default; no -ctk/-ctv in argv)"
+      return 0
+    fi
+  fi
+  # NOTE: no cap_note_unavailable here. This function returns a VALUE on stdout,
+  # so a notice printed here would be captured by the caller's $(...) and rendered
+  # inside its label. The caller emits the notice on a non-zero return.
   return 1
 }
 
@@ -349,6 +364,15 @@ except OSError:
     sys.exit(1)
 if off > 0 and mode in ("acceptance", "timings", "bypass"):
     lines = lines[off:]
+# CAP_LINE_LIMIT truncates to the first N lines. Reading the cumulative counters at
+# two different limits gives the delta ACROSS that span — which is how a
+# decode-window miss count is recovered from a log that carries no timestamps.
+try:
+    _lim = int(os.environ.get("CAP_LINE_LIMIT", "0"))
+except ValueError:
+    _lim = 0
+if _lim > 0:
+    lines = lines[:_lim]
 
 DEV = re.compile(r"\b(CUDA\d+|GPU\d+|ROCm\d+)\b")
 
@@ -405,6 +429,7 @@ elif mode == "counters":
         e = per.setdefault(d.group(1), {})
         e["hits"], e["total"] = int(m.group(1)), int(m.group(2))
         for name, pat in (("evictions", r"evictions=(\d+)"), ("skips", r"skips=(\d+)"),
+                          ("admission", r"admission=(\d+)"),
                           ("fill_fail", r"fill-fail=(\d+)"),
                           ("dispatch_fail", r"dispatch-fail=(\d+)"),
                           ("collect_fail", r"collect-fail=(\d+)")):
@@ -417,6 +442,7 @@ elif mode == "counters":
         e = per[k]
         print(f"{k} hits={e.get('hits',0)} total={e.get('total',0)} "
               f"evictions={e.get('evictions',0)} skips={e.get('skips',0)} "
+              f"admission={e.get('admission',0)} "
               f"fill_fail={e.get('fill_fail',0)} dispatch_fail={e.get('dispatch_fail',0)} "
               f"collect_fail={e.get('collect_fail',0)}")
 
@@ -451,7 +477,15 @@ elif mode == "timings":
         min_dec = int(os.environ.get("CAP_MIN_DECODE_TOKENS", "0"))
     except ValueError:
         min_dec = 0
-    dec, pre, dropped = [], [], 0
+    # A bench drives two very different prefill populations: the short canonical
+    # prompts (tens of tokens) and the deep haystack probes (thousands). Their
+    # rates differ by ~4x, so one mean/median over both describes neither. Split
+    # at CAP_PREFILL_SPLIT_TOKENS and report each.
+    try:
+        split_at = int(os.environ.get("CAP_PREFILL_SPLIT_TOKENS", "2000"))
+    except ValueError:
+        split_at = 2000
+    dec, pre, pre_long, dropped = [], [], [], 0
     for ln in lines:
         m = re.search(r"([0-9.]+)\s+tokens per second", ln)
         if not m:
@@ -460,13 +494,16 @@ elif mode == "timings":
         ntok = re.search(r"/\s*(\d+)\s+tokens", ln)
         ntok = int(ntok.group(1)) if ntok else None
         if "prompt eval time" in ln:
-            pre.append(v)
+            if ntok is not None and ntok >= split_at:
+                pre_long.append(v)
+            else:
+                pre.append(v)
         elif "eval time" in ln:
             if min_dec and ntok is not None and ntok < min_dec:
                 dropped += 1
                 continue
             dec.append(v)
-    if not dec and not pre:
+    if not dec and not pre and not pre_long:
         sys.exit(1)
 
     def emit(name, xs):
@@ -479,7 +516,9 @@ elif mode == "timings":
               f"min={xs[0]:.2f} max={xs[-1]:.2f}")
 
     emit("decode", dec)
-    emit("prefill", pre)
+    emit(f"prefill_short(<{split_at}tok)", pre)
+    if pre_long:
+        emit(f"prefill_deep(>={split_at}tok)", pre_long)
     if dropped:
         print(f"dropped_short_decode n={dropped} floor={min_dec}")
 
@@ -541,26 +580,64 @@ for dev in sorted(b):
 PY
 }
 
-# cap_health_verdict <counters-file> — item 3c. All-zero is the PASS condition;
-# anything else invalidates the cache reading for this run.
+# cap_cumulative_rates <counters-file> — lifetime hit rate per device at the
+# moment the snapshot was taken. Only useful as the START of a "hits X% -> Y%"
+# pair on a card; for comparing BOOTS use the marginal rate (cap_marginal_rates).
+cap_cumulative_rates() {
+  local snap="$1"
+  [[ -r "$snap" ]] || return 1
+  awk '{
+    dev = $1; hits = 0; total = 0
+    for (i = 2; i <= NF; i++) {
+      if ($i ~ /^hits=/)  { split($i, a, "="); hits  = a[2] }
+      if ($i ~ /^total=/) { split($i, b, "="); total = b[2] }
+    }
+    if (total > 0) printf "%s cumulative=%.1f\n", dev, hits * 100 / total
+  }' "$snap"
+}
+
+# cap_health_verdict <counters-file> — the PASS condition is the HARD-FAILURE
+# counters ONLY:
+#   fill-fail / dispatch-fail / collect-fail  -> real defects; any non-zero FAILS
+#   skips / admission                         -> INFORMATIONAL load metrics
+# `skips` is the engine's `insert_skips`, whose dominant increment is admission
+# THROTTLE / queue exhaustion (inserts_left <= 0 || queue full). Under a low
+# ADMIT_AFTER every miss is an insertion candidate and THROTTLE caps insertions per
+# step, so non-zero skips is NORMAL steady-state admission pressure. A live run on
+# a healthy server showed skips at 0.5% of misses, tracking the per-device miss
+# asymmetry exactly. The original spec said "all-zero is the pass condition" — the
+# live run disproved it, so this reports skips as a THROTTLE tuning signal rather
+# than failing an otherwise healthy run.
 cap_health_verdict() {
   local snap="$1"
   [[ -r "$snap" ]] || return 1
   python3 - "$snap" <<'PY'
 import sys
 
-bad = []
+HARD = ("fill_fail", "dispatch_fail", "collect_fail")
+INFO = ("skips", "admission")
+bad, info = [], []
 with open(sys.argv[1], encoding="utf-8") as fh:
     for ln in fh:
         parts = ln.split()
         if not parts:
             continue
         kv = dict(x.split("=", 1) for x in parts[1:] if "=" in x)
-        nz = {k: v for k, v in kv.items()
-              if k in ("skips", "fill_fail", "dispatch_fail", "collect_fail") and v not in ("0", "-")}
+        nz = {k: v for k, v in kv.items() if k in HARD and v not in ("0", "-")}
         if nz:
             bad.append(f"{parts[0]}: " + " ".join(f"{k}={v}" for k, v in sorted(nz.items())))
-print("PASS (all health counters zero)" if not bad else "FAIL — " + "; ".join(bad))
+        ni = {k: v for k, v in kv.items() if k in INFO and v not in ("0", "-")}
+        if ni:
+            info.append(f"{parts[0]} " + " ".join(f"{k}={v}" for k, v in sorted(ni.items())))
+if bad:
+    print("FAIL — " + "; ".join(bad))
+else:
+    tail = ""
+    if info:
+        tail = ("  [informational: " + "; ".join(info) + " — admission throttling, expected under "
+                "low ADMIT_AFTER + steady-state eviction pressure; a THROTTLE tuning signal, "
+                "not a defect]")
+    print("PASS (no fill/dispatch/collect failures)" + tail)
 PY
 }
 
@@ -615,7 +692,8 @@ cap_stop_pid() {   # kill by pid ONLY — never pkill -f (self-match footgun)
 # nvidia-smi on its next write, so one kill tears down both.
 cap_dmon_start() {
   local out="$1"
-  cap_have nvidia-smi || { cap_note_unavailable "PCIe dmon" "nvidia-smi not in PATH"; return 1; }
+  # Echoes a PID on stdout — the caller emits the notice (see cap_kv_type).
+  cap_have nvidia-smi || return 1
   : > "$out"
   local sb=""
   cap_have stdbuf && sb="stdbuf -oL"
@@ -762,7 +840,8 @@ cap_cpu_pct() {
 # every number in the run is suspect and nothing else notices.
 cap_ram_status() {
   local pid="${1:-$CAP_PID}"
-  [[ -r /proc/meminfo ]] || { cap_note_unavailable "system RAM" "/proc/meminfo not readable"; return 1; }
+  # Returns a VALUE on stdout — the caller emits the notice (see cap_kv_type).
+  [[ -r /proc/meminfo ]] || return 1
   local rss="" vmswap=""
   if [[ -n "$pid" && -r "/proc/$pid/status" ]]; then
     rss="$(command grep -m1 '^VmRSS:' "/proc/$pid/status" 2>/dev/null | awk '{print $2}')"
@@ -909,12 +988,9 @@ PY
     printf '%s\n' "$out"
     return 0
   fi
-  if (( rc == 3 )); then
-    cap_note_unavailable "STREAM triad ceiling" \
-      "numpy not installed — a pure-python loop would measure the interpreter, not RAM"
-  else
-    cap_note_unavailable "STREAM triad ceiling" "calibration failed (rc=${rc})"
-  fi
+  # Returns a VALUE on stdout — the caller emits the notice (see cap_kv_type),
+  # distinguishing the numpy case by this return code.
+  (( rc == 3 )) && return 3
   return 1
 }
 

--- a/scripts/lib/capture.sh
+++ b/scripts/lib/capture.sh
@@ -1,0 +1,954 @@
+#!/usr/bin/env bash
+# capture.sh — shared measurement-capture primitives for the bench tooling.
+#
+# WHY THIS EXISTS
+#   A bench harness's failure mode is not a crash — it is a PLAUSIBLE WRONG
+#   NUMBER. `wall_TPS 0.00` printed next to a healthy-looking TTFT; a cumulative
+#   cache hit rate that embeds the cold-fill storm and therefore says a bigger
+#   pool is worse; a drafter reporting 0.992 acceptance that fired on 5 of ~20
+#   requests. Each of those shipped at least once. The primitives here are the
+#   ones that catch that class, factored out so `bench.sh` inherits capture that
+#   is already guarded by a test suite instead of growing a drifting copy.
+#
+# DIVISION OF LABOUR
+#   offload-matrix.sh = sweep driver (boots a server per arm)
+#   bench.sh          = canonical protocol (measures a server someone else booted)
+#   capture.sh        = the common measurement layer
+#
+#   ⚠ offload-matrix.sh adoption is DEFERRED until feat/offload-matrix-prefix-cache
+#   lands — a multi-commit feature branch is in flight on that file and rewiring it
+#   underneath would conflict for no measurement benefit. Until then the sweep keeps
+#   its own inline copies of these scrapes and the duplication is ACCEPTED. When it
+#   is adopted, the sweep's inline versions must be deleted, not left as a second
+#   implementation: two copies of a scrape is how a fixed defect comes back.
+#
+# CONTRACT FOR EVERY FUNCTION HERE
+#   1. GRACEFUL DEGRADATION IS MANDATORY. A missing source (no GPU, no server log,
+#      no dmon, a VM with no counters, a build with no expert cache) prints exactly
+#      one `capture: <thing> unavailable (<why>)` line and returns non-zero. It
+#      never aborts the caller and never prints a fabricated value. A capture that
+#      cannot run must be visibly absent, not silently zero.
+#   2. NEVER AVERAGE AWAY A PER-DEVICE SPLIT. The CUDA0/CUDA1 hit asymmetry on a
+#      layer-split MoE (~48% vs ~58% measured 2026-08-01) is routing-entropy
+#      signal. Per-device values stay per-device in the OUTPUT, not just in
+#      detection.
+#   3. DERIVED IS LABELLED DERIVED. `ram_rd_mbps` is misses x expert size / elapsed.
+#      It is NOT a hardware counter and must never be presented as one.
+#   4. `command grep`, never bare `grep` — grep is shimmed to ugrep in interactive
+#      shells on some rigs and the shim breaks exact-output matching.
+#   5. `pgrep -x` / kill-by-pid ONLY. `pgrep -f` / `pkill -f` self-match through an
+#      agent harness and have killed the calling shell (exit 144).
+#
+# USAGE
+#   source "${ROOT_DIR}/scripts/lib/capture.sh"
+#   cap_init                       # resolve pid / log source / GPU count
+#   cap_fingerprint                # always-on config fingerprint
+#   ...
+#
+# Env knobs read here (all optional):
+#   SERVER_LOG   path to a bare-metal server log (the CONTAINER=none case)
+#   CONTAINER    docker container to scrape with `docker logs` (or "none")
+#   SERVER_PID   pin the serving process; "none" disables /proc inspection
+#   URL          endpoint base, for /props
+
+[[ -n "${_CAPTURE_SH_LOADED:-}" ]] && return 0
+_CAPTURE_SH_LOADED=1
+
+# Python decodes reads/stdout/argv with the LOCALE codec; UTF-8 mode (PEP 540)
+# overrides that in one move. Defaulted, not forced (see AGENTS.md).
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
+# ---------------------------------------------------------------------------
+# degradation notices — one line per missing thing, deduped
+# ---------------------------------------------------------------------------
+_CAP_NOTED=" "
+
+# cap_note_unavailable <thing> <why>
+# The ONLY sanctioned way to report a missing source. Deduped so a source polled
+# in a loop cannot bury the report under its own warning.
+cap_note_unavailable() {
+  local thing="$1" why="${2:-no reason given}"
+  case "$_CAP_NOTED" in
+    *" ${thing}|"*) return 0 ;;
+  esac
+  _CAP_NOTED="${_CAP_NOTED}${thing}| "
+  echo "capture: ${thing} unavailable (${why})"
+  return 0
+}
+
+cap_have() { command -v "$1" >/dev/null 2>&1; }
+
+# ---------------------------------------------------------------------------
+# resolution: serving process, log source, GPU count
+# ---------------------------------------------------------------------------
+CAP_PID=""          # serving process pid, or "" when unknown
+CAP_LOG=""          # path to a readable log snapshot, or "" when unavailable
+CAP_LOG_SOURCE=""   # "server-log" | "docker" | ""
+CAP_NGPU=0
+CAP_TMPDIR=""
+
+cap_gpu_count() {
+  if cap_have nvidia-smi; then
+    nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | command grep -c . || echo 0
+  else
+    echo 0
+  fi
+}
+
+# cap_server_pid — pid of the local serving process.
+#   SERVER_PID=<n>     use it verbatim
+#   SERVER_PID=none    disable /proc inspection entirely (hermetic tests, docker)
+#   unset              pgrep -x for the known bare-metal server names
+# `pgrep -x` matches the executable NAME exactly. `pgrep -f` would match this
+# script's own command line and has killed the calling shell before — never use it.
+cap_server_pid() {
+  local pinned="${SERVER_PID:-}"
+  if [[ "$pinned" == "none" ]]; then echo ""; return 1; fi
+  if [[ -n "$pinned" ]]; then echo "$pinned"; return 0; fi
+  local p name
+  for name in llama-server ik_llama-server sglang vllm; do
+    p="$(pgrep -x "$name" 2>/dev/null | head -1 || true)"
+    [[ -n "$p" ]] && { echo "$p"; return 0; }
+  done
+  echo ""
+  return 1
+}
+
+# cap_init [tmpdir] — resolve everything the later captures depend on.
+# Safe to call more than once. Never fails the caller.
+cap_init() {
+  CAP_TMPDIR="${1:-${CAP_TMPDIR:-$(mktemp -d 2>/dev/null || echo /tmp)}}"
+  CAP_NGPU="$(cap_gpu_count)"
+  CAP_PID="$(cap_server_pid || true)"
+
+  CAP_LOG=""; CAP_LOG_SOURCE=""
+  if [[ -n "${SERVER_LOG:-}" ]]; then
+    if [[ -r "${SERVER_LOG}" ]]; then
+      CAP_LOG="${SERVER_LOG}"; CAP_LOG_SOURCE="server-log"
+    else
+      cap_note_unavailable "server log" "SERVER_LOG=${SERVER_LOG} is not readable"
+    fi
+  elif [[ -n "${CONTAINER:-}" && "${CONTAINER:-}" != "none" ]] && cap_have docker \
+       && docker inspect "${CONTAINER}" >/dev/null 2>&1; then
+    CAP_LOG="${CAP_TMPDIR}/container.log"; CAP_LOG_SOURCE="docker"
+    cap_refresh_log
+  fi
+  return 0
+}
+
+# cap_refresh_log — re-snapshot the docker log (a file log needs no refresh).
+cap_refresh_log() {
+  [[ "$CAP_LOG_SOURCE" == "docker" ]] || return 0
+  docker logs "${CONTAINER}" > "$CAP_LOG" 2>&1 || true
+}
+
+# cap_log_available <thing> — guard + one degradation notice.
+cap_log_available() {
+  if [[ -n "$CAP_LOG" && -r "$CAP_LOG" ]]; then return 0; fi
+  cap_note_unavailable "${1:-log scrape}" \
+    "no server log — pass SERVER_LOG=<path> on bare metal, or CONTAINER=<name> under docker"
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# argv / env fingerprint (item 11e — solves the config fingerprint without
+# asking the operator for anything)
+# ---------------------------------------------------------------------------
+
+# cap_proc_argv [pid] — the serving process's own command line, space-joined.
+cap_proc_argv() {
+  local pid="${1:-$CAP_PID}"
+  [[ -n "$pid" && -r "/proc/$pid/cmdline" ]] || return 1
+  tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null
+}
+
+# cap_proc_env <var> [pid] — one variable out of the process's environment.
+# /proc/<pid>/environ is only readable for our own uid; that is the common case
+# for a bare-metal server started by the same operator.
+cap_proc_env() {
+  local var="$1" pid="${2:-$CAP_PID}"
+  [[ -n "$pid" && -r "/proc/$pid/environ" ]] || return 1
+  tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null \
+    | command grep -m1 -E "^${var}=" | cut -d= -f2-
+}
+
+# cap_argv_flag "<argv>" <flag> [<flag2> ...] — value of the LAST occurrence of
+# any of the given flags. `-ct q8_0` and `--cache-type-k q8_0` are the same fact.
+cap_argv_flag() {
+  local argv="$1"; shift
+  local f v=""
+  for f in "$@"; do
+    # match "<flag> <value>" and "<flag>=<value>"
+    v="$(printf '%s ' "$argv" | command grep -oE -- "(^| )${f}[ =][^ ]+" | tail -1 \
+         | sed -E "s/^ *${f}[ =]//" || true)"
+    [[ -n "$v" ]] && { printf '%s' "$v"; return 0; }
+  done
+  return 1
+}
+
+# cap_argv_has "<argv>" <flag> — presence test (for valueless / prefix flags).
+cap_argv_has() {
+  local argv="$1" flag="$2"
+  printf '%s ' "$argv" | command grep -qE -- "(^| )${flag}([ =]|$)"
+}
+
+# cap_argv_fingerprint "<argv>" — the serving flags that change what is measured.
+# Deliberately a SUBSET: -m/-ot/-t/-ub/-ct/-ngl/-ts. A full argv echo is noise and
+# on some rigs leaks paths into pasted output.
+cap_argv_fingerprint() {
+  local argv="$1" out="" v
+  for pair in "model:-m|--model" "offload:-ot|--override-tensor" "threads:-t|--threads" \
+              "ubatch:-ub|--ubatch-size" "kv:-ct|-ctk|--cache-type-k" \
+              "ngl:-ngl|--n-gpu-layers" "split:-ts|--tensor-split"; do
+    local key="${pair%%:*}" flags="${pair#*:}"
+    # shellcheck disable=SC2086
+    v="$(cap_argv_flag "$argv" ${flags//|/ } || true)"
+    [[ -n "$v" ]] && out="${out}${key}=${v} "
+  done
+  [[ -n "$out" ]] || return 1
+  printf '%s\n' "${out% }"
+}
+
+# ---------------------------------------------------------------------------
+# /props (llama.cpp-family) — served ctx, slots, model id, drafter
+# ---------------------------------------------------------------------------
+
+# cap_props_json [url] — cached /props body, empty when the endpoint has none.
+CAP_PROPS=""
+CAP_PROPS_TRIED=0
+cap_props_json() {
+  local url="${1:-${URL:-}}"
+  if (( CAP_PROPS_TRIED )); then printf '%s' "$CAP_PROPS"; [[ -n "$CAP_PROPS" ]]; return; fi
+  CAP_PROPS_TRIED=1
+  [[ -n "$url" ]] || return 1
+  CAP_PROPS="$(curl -sf -m 5 "${url}/props" 2>/dev/null || true)"
+  [[ -n "$CAP_PROPS" ]] || return 1
+  printf '%s' "$CAP_PROPS"
+}
+
+# cap_props_get <dotted.path> — one scalar out of /props. vLLM has no /props;
+# the caller degrades on a non-zero return.
+cap_props_get() {
+  local path="$1" body
+  body="$(cap_props_json || true)"
+  [[ -n "$body" ]] || return 1
+  printf '%s' "$body" | CAP_PATH="$path" python3 -c '
+import json, os, sys
+try:
+    obj = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+cur = obj
+for part in os.environ["CAP_PATH"].split("."):
+    if isinstance(cur, dict) and part in cur:
+        cur = cur[part]
+    else:
+        sys.exit(1)
+if isinstance(cur, (dict, list)):
+    sys.exit(1)
+sys.stdout.write(str(cur))
+' 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# KV cache type (item 3 — ALWAYS captured, offload or not)
+# ---------------------------------------------------------------------------
+# Order of authority: argv (what was actually asked for) > /props > boot log.
+# Prints "<type> (source: <where>)"; returns 1 and notes unavailability if none
+# of the three can answer.
+cap_kv_type() {
+  local argv="${1:-}" v
+  if [[ -n "$argv" ]]; then
+    v="$(cap_argv_flag "$argv" -ct -ctk --cache-type-k --kv-cache-dtype || true)"
+    [[ -n "$v" ]] && { echo "$v (source: argv)"; return 0; }
+  fi
+  v="$(cap_props_get "default_generation_settings.params.cache_type_k" || true)"
+  [[ -n "$v" ]] && { echo "$v (source: /props)"; return 0; }
+  if [[ -n "$CAP_LOG" && -r "$CAP_LOG" ]]; then
+    v="$(command grep -oE 'type_k *= *[A-Za-z0-9_]+|cache_type_k *= *[A-Za-z0-9_]+' "$CAP_LOG" 2>/dev/null \
+         | tail -1 | sed -E 's/.*= *//' || true)"
+    [[ -n "$v" ]] && { echo "$v (source: boot log)"; return 0; }
+  fi
+  cap_note_unavailable "KV cache type" "not in argv, /props or the boot log"
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# CPU-offload detection (item 3 — the gate for every moe-cache capture)
+# ---------------------------------------------------------------------------
+# Two independent signals, either is sufficient:
+#   argv     -ot / --override-tensor / --n-cpu-moe / --cpu-moe
+#   boot log a "CUDA_Host model buffer" allocation (weights parked in host RAM)
+# Echoes the reason; returns 0 when offload is active.
+cap_offload_detected() {
+  local argv="${1:-}"
+  if [[ -n "$argv" ]]; then
+    local f
+    for f in -ot --override-tensor --n-cpu-moe --cpu-moe -ncmoe; do
+      if cap_argv_has "$argv" "$f"; then echo "argv ${f}"; return 0; fi
+    done
+  fi
+  if [[ -n "$CAP_LOG" && -r "$CAP_LOG" ]] \
+     && command grep -qE 'CUDA_Host +model buffer|CPU +model buffer size' "$CAP_LOG" 2>/dev/null; then
+    echo "boot log (CUDA_Host model buffer)"
+    return 0
+  fi
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# moe-cache CONFIG fingerprint (item 3a)
+# ---------------------------------------------------------------------------
+# The resulting pool size does NOT identify the arm: the census self-limits below
+# the requested cap, so two different `--moe-cache` values can produce the same
+# census. Capture what was ASKED FOR alongside what was GOT.
+cap_moe_cache_config() {
+  local argv="${1:-}" cap="" out="" v k
+  [[ -n "$argv" ]] && cap="$(cap_argv_flag "$argv" --moe-cache || true)"
+  out="moe_cache_cap=${cap:-<unset>}"
+  for k in RESERVE_MB ADMIT_AFTER THROTTLE MAX_BATCH STATS; do
+    v="$(cap_proc_env "GGML_CUDA_MOE_CACHE_${k}" || true)"
+    [[ -z "$v" ]] && v="$(printenv "GGML_CUDA_MOE_CACHE_${k}" 2>/dev/null || true)"
+    out="${out} ${k}=${v:-<unset>}"
+  done
+  printf '%s\n' "$out"
+}
+
+# ---------------------------------------------------------------------------
+# moe-cache log parsing — one python entry point, several modes
+# ---------------------------------------------------------------------------
+# Line shapes handled (both the fork's current census format and the older one):
+#   [moe-cache] enabled: reserve=1536 MiB admit=1/64
+#   [moe-cache] CUDA0 pool[0]: type=mxfp4 expert=4352 KiB slots=3038 total=12911 MiB
+#   [moe-cache] CUDA1 pool[0]: slots=742 expert=1536 KiB
+#   [moe-cache] CUDA0 hits=659183/980562 evictions=81 expert=4352 KiB skips=0 fill-fail=0
+#   [moe-cache] MAX_BATCH=8 exceeded, bypassing cache for this batch
+#   [moe-cache] CUDA0 has no cache budget after 3072 MiB reserve
+# A device can have MULTIPLE pools — slots and bytes are AGGREGATED per device,
+# never tailed to the last pool line.
+# CAP_LINE_OFFSET windows the scrape to lines written AFTER the offset — set it
+# to the log's line count at the start of the measured window and per-request
+# scrapes (acceptance, timings, bypass) stop counting the warm-ups and whatever
+# the log already held from previous runs. Cumulative COUNTERS deliberately do
+# not use it: they are read whole and differenced (see cap_marginal_rates).
+cap_moe_parse() {   # $1=mode (census|counters|acceptance|timings|bypass|pooldev) $2=log
+  local mode="$1" log="${2:-$CAP_LOG}"
+  [[ -n "$log" && -r "$log" ]] || return 1
+  CAP_MODE="$mode" python3 - "$log" <<'PY'
+import os, re, sys
+
+mode = os.environ.get("CAP_MODE", "")
+try:
+    off = int(os.environ.get("CAP_LINE_OFFSET", "0"))
+except ValueError:
+    off = 0
+try:
+    with open(sys.argv[1], encoding="utf-8", errors="replace") as fh:
+        lines = fh.read().splitlines()
+except OSError:
+    sys.exit(1)
+if off > 0 and mode in ("acceptance", "timings", "bypass"):
+    lines = lines[off:]
+
+DEV = re.compile(r"\b(CUDA\d+|GPU\d+|ROCm\d+)\b")
+
+
+def num(pat, s, cast=int):
+    m = re.search(pat, s)
+    return cast(m.group(1)) if m else None
+
+
+if mode == "census":
+    # per device: pool count, TOTAL slots, TOTAL MiB, mean expert KiB
+    per = {}
+    for ln in lines:
+        if "pool[" not in ln:
+            continue
+        d = DEV.search(ln)
+        if not d:
+            continue
+        key = d.group(1)
+        e = per.setdefault(key, {"pools": 0, "slots": 0, "mib": 0, "expert": [], "type": ""})
+        e["pools"] += 1
+        s = num(r"slots=(\d+)", ln)
+        if s:
+            e["slots"] += s
+        t = num(r"total=(\d+)\s*MiB", ln)
+        if t:
+            e["mib"] += t
+        x = num(r"expert=(\d+)\s*KiB", ln)
+        if x:
+            e["expert"].append(x)
+        ty = re.search(r"type=(\S+)", ln)
+        if ty and not e["type"]:
+            e["type"] = ty.group(1)
+    if not per:
+        sys.exit(1)
+    for k in sorted(per):
+        e = per[k]
+        exp = round(sum(e["expert"]) / len(e["expert"])) if e["expert"] else 0
+        print(f"{k} pools={e['pools']} slots={e['slots']} total_mib={e['mib']} "
+              f"expert_kib={exp} type={e['type'] or '-'}")
+
+elif mode == "counters":
+    # LAST cumulative counter emission per device (hits/total/evictions + health)
+    per = {}
+    for ln in lines:
+        if "hits=" not in ln:
+            continue
+        d = DEV.search(ln)
+        if not d:
+            continue
+        m = re.search(r"hits=(\d+)/(\d+)", ln)
+        if not m:
+            continue
+        e = per.setdefault(d.group(1), {})
+        e["hits"], e["total"] = int(m.group(1)), int(m.group(2))
+        for name, pat in (("evictions", r"evictions=(\d+)"), ("skips", r"skips=(\d+)"),
+                          ("fill_fail", r"fill-fail=(\d+)"),
+                          ("dispatch_fail", r"dispatch-fail=(\d+)"),
+                          ("collect_fail", r"collect-fail=(\d+)")):
+            v = num(pat, ln)
+            if v is not None:
+                e[name] = v
+    if not per:
+        sys.exit(1)
+    for k in sorted(per):
+        e = per[k]
+        print(f"{k} hits={e.get('hits',0)} total={e.get('total',0)} "
+              f"evictions={e.get('evictions',0)} skips={e.get('skips',0)} "
+              f"fill_fail={e.get('fill_fail',0)} dispatch_fail={e.get('dispatch_fail',0)} "
+              f"collect_fail={e.get('collect_fail',0)}")
+
+elif mode == "acceptance":
+    # Acceptance WITHOUT a fire rate is a deception: measured 2026-08-01, a drafter
+    # reported 0.992 acceptance while firing on 5 of ~20 requests (zero on novel
+    # content). Report how OFTEN it fired alongside how WELL it did when it fired.
+    acc, drafted, accepted = [], 0, 0
+    for ln in lines:
+        m = re.search(r"draft acceptance(?: rate)?\s*=\s*([0-9.]+)", ln)
+        if m:
+            acc.append(float(m.group(1)))
+        m2 = re.search(r"\(\s*(\d+)\s*accepted\s*/\s*(\d+)\s*(?:generated|drafted)", ln)
+        if m2:
+            accepted += int(m2.group(1))
+            drafted += int(m2.group(2))
+    if not acc:
+        sys.exit(1)
+    print(f"fired={len(acc)} mean={sum(acc)/len(acc):.3f} min={min(acc):.3f} "
+          f"max={max(acc):.3f} accepted={accepted} drafted={drafted}")
+
+elif mode == "timings":
+    # llama.cpp per-request print_timing. `prompt eval time` is PREFILL; the bare
+    # `eval time` is DECODE. Matching the wrong one reports prefill as decode.
+    #
+    # CAP_MIN_DECODE_TOKENS drops decode entries from very short completions. The
+    # prefill probe and the PP fallback ask for ~16 tokens, and a decode rate over
+    # 16 tokens is dominated by start-up effects — leaving them in drags the median
+    # and makes the client-vs-engine cross-check flag a divergence that is really
+    # just two different populations of request.
+    try:
+        min_dec = int(os.environ.get("CAP_MIN_DECODE_TOKENS", "0"))
+    except ValueError:
+        min_dec = 0
+    dec, pre, dropped = [], [], 0
+    for ln in lines:
+        m = re.search(r"([0-9.]+)\s+tokens per second", ln)
+        if not m:
+            continue
+        v = float(m.group(1))
+        ntok = re.search(r"/\s*(\d+)\s+tokens", ln)
+        ntok = int(ntok.group(1)) if ntok else None
+        if "prompt eval time" in ln:
+            pre.append(v)
+        elif "eval time" in ln:
+            if min_dec and ntok is not None and ntok < min_dec:
+                dropped += 1
+                continue
+            dec.append(v)
+    if not dec and not pre:
+        sys.exit(1)
+
+    def emit(name, xs):
+        if not xs:
+            print(f"{name} n=0")
+            return
+        xs = sorted(xs)
+        mid = xs[len(xs) // 2] if len(xs) % 2 else (xs[len(xs) // 2 - 1] + xs[len(xs) // 2]) / 2
+        print(f"{name} n={len(xs)} mean={sum(xs)/len(xs):.2f} median={mid:.2f} "
+              f"min={xs[0]:.2f} max={xs[-1]:.2f}")
+
+    emit("decode", dec)
+    emit("prefill", pre)
+    if dropped:
+        print(f"dropped_short_decode n={dropped} floor={min_dec}")
+
+elif mode == "bypass":
+    print(sum(1 for ln in lines if "bypassing cache" in ln))
+
+elif mode == "pooldev":
+    # #824: '[moe-cache] enabled:' still prints when only SOME devices got a pool.
+    # Ground truth is the pool-line COUNT vs the device count, never the banner.
+    devs = {DEV.search(ln).group(1) for ln in lines
+            if "pool[" in ln and DEV.search(ln)}
+    nobudget = sum(1 for ln in lines if "no cache budget" in ln)
+    enabled = 1 if any("[moe-cache] enabled:" in ln for ln in lines) else 0
+    print(f"devices={len(devs)} pool_lines={sum(1 for ln in lines if 'pool[' in ln)} "
+          f"enabled={enabled} nobudget={nobudget} devlist={','.join(sorted(devs)) or '-'}")
+
+else:
+    sys.exit(2)
+PY
+}
+
+# cap_marginal_rates <snap-start> <snap-end>
+# Item 3b. CUMULATIVE hit rates embed the cold-fill phase, so they are NOT
+# boot-comparable — a BIGGER pool shows a LOWER cumulative rate on the same
+# traffic because it spent longer filling. The MARGINAL rate across the measured
+# window is the only number two boots can be compared on. Per device, never
+# averaged (item 3d).
+cap_marginal_rates() {
+  local s0="$1" s1="$2"
+  [[ -r "$s0" && -r "$s1" ]] || return 1
+  python3 - "$s0" "$s1" <<'PY'
+import sys
+
+
+def load(p):
+    out = {}
+    with open(p, encoding="utf-8") as fh:
+        for ln in fh:
+            parts = ln.split()
+            if not parts:
+                continue
+            out[parts[0]] = dict(kv.split("=", 1) for kv in parts[1:] if "=" in kv)
+    return out
+
+
+a, b = load(sys.argv[1]), load(sys.argv[2])
+if not b:
+    sys.exit(1)
+for dev in sorted(b):
+    e1 = b[dev]
+    e0 = a.get(dev, {})
+    h1, t1 = int(e1.get("hits", 0)), int(e1.get("total", 0))
+    h0, t0 = int(e0.get("hits", 0)), int(e0.get("total", 0))
+    dh, dt = max(h1 - h0, 0), max(t1 - t0, 0)
+    de = max(int(e1.get("evictions", 0)) - int(e0.get("evictions", 0)), 0)
+    cum = f"{h1*100.0/t1:.1f}%" if t1 else "-"
+    marg = f"{dh*100.0/dt:.1f}%" if dt else "-"
+    print(f"{dev} marginal={marg} cumulative={cum} dhits={dh} dlookups={dt} devictions={de}")
+PY
+}
+
+# cap_health_verdict <counters-file> — item 3c. All-zero is the PASS condition;
+# anything else invalidates the cache reading for this run.
+cap_health_verdict() {
+  local snap="$1"
+  [[ -r "$snap" ]] || return 1
+  python3 - "$snap" <<'PY'
+import sys
+
+bad = []
+with open(sys.argv[1], encoding="utf-8") as fh:
+    for ln in fh:
+        parts = ln.split()
+        if not parts:
+            continue
+        kv = dict(x.split("=", 1) for x in parts[1:] if "=" in x)
+        nz = {k: v for k, v in kv.items()
+              if k in ("skips", "fill_fail", "dispatch_fail", "collect_fail") and v not in ("0", "-")}
+        if nz:
+            bad.append(f"{parts[0]}: " + " ".join(f"{k}={v}" for k, v in sorted(nz.items())))
+print("PASS (all health counters zero)" if not bad else "FAIL — " + "; ".join(bad))
+PY
+}
+
+# ---------------------------------------------------------------------------
+# VRAM triplet + leak delta (item 11b) — a free soak-lite leak check per run
+# ---------------------------------------------------------------------------
+
+# cap_vram_used — total MiB across all GPUs (one integer).
+cap_vram_used() {
+  cap_have nvidia-smi || return 1
+  nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null \
+    | awk 'NF{s+=$1} END{if(NR) print s+0; else exit 1}'
+}
+
+# cap_vram_per_device — "GPU<i> <MiB>" per line.
+cap_vram_per_device() {
+  cap_have nvidia-smi || return 1
+  nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null \
+    | awk 'NF{printf "GPU%d %d\n", NR-1, $1}'
+}
+
+# cap_vram_peak_start <outfile> — background sampler; echoes its pid.
+cap_vram_peak_start() {
+  local out="$1"
+  cap_have nvidia-smi || return 1
+  : > "$out"
+  ( local peak=0 v
+    while :; do
+      v="$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null \
+           | awk 'NF{s+=$1} END{print s+0}')"
+      if [[ -n "$v" ]] && (( v > peak )); then peak="$v"; echo "$peak" > "$out"; fi
+      sleep 2
+    done ) >/dev/null 2>&1 &
+  echo $!
+}
+
+cap_stop_pid() {   # kill by pid ONLY — never pkill -f (self-match footgun)
+  local pid="${1:-}"
+  [[ -n "$pid" ]] || return 0
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# PCIe: measured used (dmon) + queried available (link state) — item 10
+# ---------------------------------------------------------------------------
+
+# cap_dmon_start <outfile> — 1 Hz per-GPU utilisation/PCIe stream, EPOCH-STAMPED
+# so the samples can be sliced by phase afterwards. Echoes the pid to stop.
+# `$!` on a pipeline is the LAST element (the stamping loop); killing it SIGPIPEs
+# nvidia-smi on its next write, so one kill tears down both.
+cap_dmon_start() {
+  local out="$1"
+  cap_have nvidia-smi || { cap_note_unavailable "PCIe dmon" "nvidia-smi not in PATH"; return 1; }
+  : > "$out"
+  local sb=""
+  cap_have stdbuf && sb="stdbuf -oL"
+  # shellcheck disable=SC2086
+  $sb nvidia-smi dmon -s ut -d 1 2>/dev/null \
+    | while IFS= read -r line; do printf '%s %s\n' "$(date +%s)" "$line"; done > "$out" &
+  echo $!
+}
+
+# cap_dmon_phase <dmon-file> <phase-file> <label>
+# Per-phase means AND PEAKS. Decode and prefill PCIe traffic differ by ~100x on
+# an offloaded MoE, so a whole-run mean describes neither; and 1 Hz sampling
+# under-reads bursts, which is why the peak is reported next to the mean rather
+# than instead of it. Per-device rows are kept (item 3d).
+#
+# The phase file holds MULTIPLE windows per label (narrative + code are both
+# decode; each prefill depth is its own window). Only sample times inside one of
+# that label's windows are counted, so the warm-ups and the gaps between shapes
+# — which are not the phase — cannot dilute it.
+cap_dmon_phase() {
+  local file="$1" phases="$2" label="${3:-decode}"
+  [[ -r "$file" && -r "$phases" ]] || return 1
+  awk -v label="$label" '
+    # pass 1: this label’s measured windows
+    NR == FNR { if ($1 == label) { lo[++k] = $2 + 0; hi[k] = $3 + 0 } ; next }
+    # pass 2: stamped dmon rows
+    # <epoch> <gpu> <sm> <mem> <enc> <dec> <jpg> <ofa> <rxpci> <txpci>
+    $2 ~ /^#/ { next }
+    NF < 10   { next }
+    {
+      ts = $1 + 0; inwin = 0
+      for (i = 1; i <= k; i++) if (ts >= lo[i] && ts <= hi[i]) { inwin = 1; break }
+      if (!inwin) next
+      g = $2 + 0
+      sm = ($3 ~ /^[0-9.]+$/) ? $3 + 0 : 0
+      mc = ($4 ~ /^[0-9.]+$/) ? $4 + 0 : 0
+      rx = ($9 ~ /^[0-9.]+$/) ? $9 + 0 : 0
+      tx = ($10 ~ /^[0-9.]+$/) ? $10 + 0 : 0
+      n[g]++; srx[g]+=rx; stx[g]+=tx; ssm[g]+=sm; smc[g]+=mc
+      if (rx > prx[g]) prx[g] = rx
+      if (tx > ptx[g]) ptx[g] = tx
+      N++; SRX+=rx; STX+=tx; SSM+=sm; SMC+=mc
+      if (rx > PRX) PRX = rx
+      if (tx > PTX) PTX = tx
+    }
+    END {
+      if (!N) exit 1
+      printf "%s all rx_mean=%.0f rx_peak=%.0f tx_mean=%.0f tx_peak=%.0f sm_mean=%.1f memctl_mean=%.1f samples=%d\n",
+             label, SRX/N, PRX, STX/N, PTX, SSM/N, SMC/N, N
+      for (g in n)
+        printf "%s GPU%d rx_mean=%.0f rx_peak=%.0f tx_mean=%.0f tx_peak=%.0f sm_mean=%.1f memctl_mean=%.1f samples=%d\n",
+               label, g, srx[g]/n[g], prx[g], stx[g]/n[g], ptx[g], ssm[g]/n[g], smc[g]/n[g], n[g]
+    }' "$phases" "$file"
+}
+
+# cap_pcie_link — queried AVAILABLE link state, per device.
+# Prints: "GPU<i> gen=<cur>/<max> width=<cur>/<max>".
+cap_pcie_link() {
+  cap_have nvidia-smi || return 1
+  nvidia-smi --query-gpu=pcie.link.gen.current,pcie.link.gen.max,pcie.link.width.current,pcie.link.width.max \
+             --format=csv,noheader,nounits 2>/dev/null \
+    | awk -F', *' 'NF>=4 && $1 ~ /[0-9]/ {printf "GPU%d gen=%s/%s width=%s/%s\n", NR-1, $1, $2, $3, $4}'
+}
+
+# cap_pcie_link_sampler_start <outfile> — link state sampled UNDER LOAD.
+# An IDLE link downshifts to Gen1 x16 by design (ASPM), so an idle reading is a
+# false alarm generator. The warn condition (current < max) is only meaningful
+# while traffic is flowing, so we sample throughout the measured window and take
+# the BEST observed state as "what this link actually negotiates under load".
+cap_pcie_link_sampler_start() {
+  local out="$1"
+  cap_have nvidia-smi || return 1
+  : > "$out"
+  ( while :; do cap_pcie_link >> "$out" 2>/dev/null; sleep 3; done ) >/dev/null 2>&1 &
+  echo $!
+}
+
+# cap_pcie_link_under_load <samplefile> — best observed gen/width per device,
+# plus a WARN when it never reached the link's own maximum while under load
+# (the silently-trained-at-x8 trap, PCIE_P2P.md §8 row 2).
+cap_pcie_link_under_load() {
+  local f="$1"
+  [[ -s "$f" ]] || return 1
+  python3 - "$f" <<'PY'
+import re, sys
+
+best = {}
+with open(sys.argv[1], encoding="utf-8") as fh:
+    for ln in fh:
+        m = re.match(r"(GPU\d+) gen=(\d+)/(\d+) width=(\d+)/(\d+)", ln.strip())
+        if not m:
+            continue
+        dev, g, gm, w, wm = m.group(1), *map(int, m.groups()[1:])
+        cur = best.get(dev)
+        if cur is None or (g, w) > (cur[0], cur[2]):
+            best[dev] = (g, gm, w, wm)
+if not best:
+    sys.exit(1)
+for dev in sorted(best):
+    g, gm, w, wm = best[dev]
+    warn = ""
+    if g < gm or w < wm:
+        warn = (f"  ⚠ WARN: never reached gen{gm} x{wm} under load — link is training "
+                f"below its own maximum (check slot/riser/BIOS bifurcation)")
+    print(f"{dev} gen={g}/{gm} width={w}/{wm}{warn}")
+PY
+}
+
+# cap_pcie_practical_mbps <gen> <width>
+# Denominator for a utilisation percentage, ALWAYS stated next to the number.
+# Per-lane raw throughput after line coding: gen1 250, gen2 500, gen3 984.6,
+# gen4 1969, gen5 3938 MB/s. x0.85 for realistic large-transfer efficiency.
+cap_pcie_practical_mbps() {
+  local gen="${1:-0}" width="${2:-0}"
+  awk -v g="$gen" -v w="$width" 'BEGIN{
+    split("250 500 984.6 1969 3938 7877", L, " ")
+    if (g < 1 || g > 6 || w < 1) exit 1
+    printf "%.0f\n", L[g] * w * 0.85
+  }'
+}
+
+# ---------------------------------------------------------------------------
+# CPU + system RAM (items 8, 11d)
+# ---------------------------------------------------------------------------
+cap_cpu_snap() { awk '/^cpu /{i=$5;t=0;for(j=2;j<=NF;j++)t+=$j;print t,i}' /proc/stat 2>/dev/null; }
+
+# cap_cpu_pct "<tot0 idle0>" "<tot1 idle1>" — busy% across the window.
+# cpu_pct is the missing half of offload bottleneck forensics: on a CPU-offloaded
+# MoE a low sm% with a high cpu% says the GPU is waiting on the host, not the
+# other way round.
+cap_cpu_pct() {
+  local a="$1" b="$2"
+  awk -v a="$a" -v b="$b" 'BEGIN{
+    split(a, A, " "); split(b, B, " ")
+    dt = B[1] - A[1]; di = B[2] - A[2]
+    if (dt <= 0) exit 1
+    printf "%.1f\n", (1 - di/dt) * 100
+  }'
+}
+
+# cap_ram_status [pid] — item 8. Host RAM is the requirement launchers cannot
+# detect (the reason CPU-offload slugs land 🐣), and it is two lines from /proc.
+# The swap leg is the free integrity item: serving-process pages in swap means
+# every number in the run is suspect and nothing else notices.
+cap_ram_status() {
+  local pid="${1:-$CAP_PID}"
+  [[ -r /proc/meminfo ]] || { cap_note_unavailable "system RAM" "/proc/meminfo not readable"; return 1; }
+  local rss="" vmswap=""
+  if [[ -n "$pid" && -r "/proc/$pid/status" ]]; then
+    rss="$(command grep -m1 '^VmRSS:' "/proc/$pid/status" 2>/dev/null | awk '{print $2}')"
+    vmswap="$(command grep -m1 '^VmSwap:' "/proc/$pid/status" 2>/dev/null | awk '{print $2}')"
+  fi
+  CAP_RSS_KB="$rss" CAP_SWAP_KB="$vmswap" awk '
+    /^MemTotal:/     {tot=$2}
+    /^MemAvailable:/ {avail=$2}
+    /^SwapTotal:/    {stot=$2}
+    /^SwapFree:/     {sfree=$2}
+    END {
+      rss   = ENVIRON["CAP_RSS_KB"]
+      vmsw  = ENVIRON["CAP_SWAP_KB"]
+      printf "mem_total_gib=%.1f mem_available_gib=%.1f", tot/1048576, avail/1048576
+      if (rss != "") printf " server_rss_gib=%.1f", rss/1048576
+      printf " swap_total_gib=%.1f swap_used_gib=%.1f", stot/1048576, (stot-sfree)/1048576
+      if (vmsw != "") printf " server_swap_mib=%.0f", vmsw/1024
+      printf "\n"
+    }' /proc/meminfo
+}
+
+# cap_swap_verdict [pid] — PASS/FAIL for the integrity panel.
+cap_swap_verdict() {
+  local pid="${1:-$CAP_PID}"
+  if [[ -n "$pid" && -r "/proc/$pid/status" ]]; then
+    local vmswap
+    vmswap="$(command grep -m1 '^VmSwap:' "/proc/$pid/status" 2>/dev/null | awk '{print $2+0}')"
+    if [[ -n "$vmswap" ]] && (( vmswap > 0 )); then
+      echo "FAIL — ${vmswap} kB of the SERVING PROCESS is paged out to swap; every number in this run is suspect"
+      return 0
+    fi
+    echo "PASS (no serving-process pages in swap)"
+    return 0
+  fi
+  local used
+  used="$(awk '/^SwapTotal:/{t=$2} /^SwapFree:/{f=$2} END{print t-f}' /proc/meminfo 2>/dev/null)"
+  [[ -n "$used" ]] || return 1
+  if (( used > 0 )); then
+    echo "UNKNOWN — ${used} kB host-wide swap in use, but the serving pid is unknown (set SERVER_PID=<pid>) so it cannot be attributed"
+  else
+    echo "PASS (host swap unused)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Derived RAM-read demand (item 9a) — DERIVED, NOT A PERF COUNTER
+# ---------------------------------------------------------------------------
+# Direct IMC/uncore counters are unreadable in VM guests and vendor/root-gated on
+# bare metal, so they are not portable. This mechanises the hand-analysis instead:
+# every expert MISS reads one expert's worth of weights out of host RAM, so
+#   demand = miss_count x avg_expert_bytes / elapsed
+# It is a LOWER BOUND on the miss path only (it ignores KV traffic, activations
+# and prefetch). Never present it as a measured bandwidth.
+cap_ram_rd_mbps() {
+  local misses="${1:-0}" expert_kib="${2:-0}" elapsed="${3:-0}"
+  awk -v m="$misses" -v k="$expert_kib" -v e="$elapsed" 'BEGIN{
+    if (m <= 0 || k <= 0 || e <= 0) exit 1
+    printf "%.0f\n", m * k / 1024 / e
+  }'
+}
+
+# cap_stream_triad_gbps [seconds] — item 9b. A ~3 s STREAM-triad ceiling on the
+# IDLE box, so the derived demand above can be stated as a FRACTION of what this
+# host can actually deliver ("~29 of ~99 GB/s"). OPT-IN: it perturbs nothing by
+# itself but it is not free, and the contention probe (co-running STREAM during
+# decode) is deliberately NOT here — that one perturbs the run by construction
+# and belongs in a separate opt-in arm.
+cap_stream_triad_gbps() {
+  local secs="${1:-3}" out rc
+  out="$(python3 - "$secs" 2>/dev/null <<'PY'
+import os, sys, time
+try:
+    import numpy as np
+except ImportError:
+    sys.exit(3)
+
+secs = float(sys.argv[1])
+
+# MULTI-THREADED on purpose. numpy element-wise ops are single-threaded, and one
+# core cannot saturate a modern memory controller — a single-threaded triad reads
+# ~4 GB/s on a host whose real ceiling is ~100 GB/s. Reporting that as "the
+# ceiling" would make the derived demand look like ~90% utilisation instead of
+# ~30%, which is worse than reporting nothing.
+try:
+    ncpu = len(os.sched_getaffinity(0))
+except AttributeError:
+    ncpu = os.cpu_count() or 4
+workers = max(1, min(ncpu, 16))
+
+# Size the arrays past the LLC but inside a fraction of AVAILABLE RAM: this runs
+# next to a loaded serving process, and a calibration that triggers swap would
+# poison the very run it is meant to characterise.
+avail = 0
+try:
+    with open("/proc/meminfo", encoding="utf-8") as fh:
+        for ln in fh:
+            if ln.startswith("MemAvailable:"):
+                avail = int(ln.split()[1]) * 1024
+                break
+except OSError:
+    pass
+budget = min(2 * 1024 ** 3, avail // 8) if avail else 512 * 1024 ** 2
+per_worker = max(48 * 1024 ** 2, budget // workers)
+n = max(1 << 20, int(per_worker // (3 * 8)))     # 3 float64 arrays per worker
+
+
+def _triad(q, n, secs):
+    a = np.zeros(n); b = np.ones(n); c = np.full(n, 2.0)
+    a[:] = b + 3.0 * c                            # fault the pages in before timing
+    iters, t0 = 0, time.perf_counter()
+    end = t0 + secs
+    while time.perf_counter() < end:
+        a[:] = b + 3.0 * c
+        iters += 1
+    dt = time.perf_counter() - t0
+    # SUSTAINED, not best-iteration: triad moves 24 B per element (read b, read c,
+    # write a). Best-of understates the cost of the run it is calibrating.
+    q.put(24.0 * n * iters / dt / 1e9 if dt > 0 else 0.0)
+
+
+try:
+    import multiprocessing as mp
+    ctx = mp.get_context("fork")
+    q = ctx.Queue()
+    procs = [ctx.Process(target=_triad, args=(q, n, secs)) for _ in range(workers)]
+    for p in procs:
+        p.start()
+    total = sum(q.get(timeout=secs + 60) for _ in procs)
+    for p in procs:
+        p.join(timeout=10)
+except Exception:
+    # No fork (some containers), or the pool failed: one worker still gives a
+    # number, it is just a floor on the ceiling. Labelled as such by the caller.
+    import queue
+    q = queue.Queue()
+    _triad(q, n, secs)
+    total, workers = q.get(), 1
+
+print(f"{total:.1f} {workers}")
+PY
+  )"
+  rc=$?
+  if (( rc == 0 )) && [[ -n "$out" ]]; then
+    printf '%s\n' "$out"
+    return 0
+  fi
+  if (( rc == 3 )); then
+    cap_note_unavailable "STREAM triad ceiling" \
+      "numpy not installed — a pure-python loop would measure the interpreter, not RAM"
+  else
+    cap_note_unavailable "STREAM triad ceiling" "calibration failed (rc=${rc})"
+  fi
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Status enum (item 11c) — imported wholesale from offload-matrix
+# ---------------------------------------------------------------------------
+# Richer than "warn when TPS == 0": each state names the specific way the run is
+# not measuring what it claims to.
+#   OK              nothing below fired
+#   NO_TOKENS       zero tokens / zero TPS — the scrape or the run failed silently
+#   REQ_ERRORS      one or more requests errored
+#   CACHE_DISABLED  a cache was REQUESTED but never allocated (incl. per-device)
+#   INVALID_BYPASS  the cache exists but a decode declined it (bypass counter > 0)
+# Precedence is deliberate: NO_TOKENS and REQ_ERRORS outrank the cache states —
+# a run with no tokens has nothing to say about a cache.
+cap_status_classify() {   # $1=tokens $2=tps $3=req_errors $4=cache_requested $5=cache_ok $6=bypass
+  local toks="${1:-0}" tps="${2:-0}" errs="${3:-0}" want="${4:-0}" got="${5:-1}" byp="${6:-0}"
+  local status=OK
+  if (( byp > 0 )); then status=INVALID_BYPASS; fi
+  if [[ "$want" == "1" && "$got" != "1" ]]; then status=CACHE_DISABLED; fi
+  if [[ "${errs:-0}" != "0" && -n "${errs:-}" ]]; then status=REQ_ERRORS; fi
+  case "${toks:-0}" in ''|'-'|0|0.0|0.00) status=NO_TOKENS ;; esac
+  case "${tps:-0}" in ''|'-'|0|0.0|0.00) status=NO_TOKENS ;; esac
+  echo "$status"
+}
+
+# cap_divergence_pct <a> <b> — |a-b| / max(a,b) as a percentage; the engine-side
+# vs client-observed cross-check (item 1b). Anything over 5% means one of the two
+# numbers is not measuring what its label says.
+cap_divergence_pct() {
+  awk -v a="${1:-0}" -v b="${2:-0}" 'BEGIN{
+    if (a <= 0 || b <= 0) exit 1
+    d = a > b ? a - b : b - a
+    m = a > b ? a : b
+    printf "%.1f\n", d * 100 / m
+  }'
+}

--- a/scripts/lib/card.sh
+++ b/scripts/lib/card.sh
@@ -1,0 +1,829 @@
+#!/usr/bin/env bash
+# card.sh — render a ready-to-paste BENCH_CARD from a bench.sh run.
+#
+# WHY THIS EXISTS
+#   docs/BENCH_CARD.md's templates are correct and nobody fills them in by hand
+#   under time pressure — which is exactly when the awkward facts (a scrape that
+#   read 0.00, a cache still warming, 3 of 5 runs EOSing early) get quietly left
+#   off. bench.sh already CAPTURES all of it; this renders it into the template
+#   so the card is a by-product of the run instead of a chore after it.
+#
+# WHAT IT WILL NOT DO
+#   It never invents a human judgement. The one-line verdict, the A/B decision,
+#   the knob under test, "quiet box" — all render as explicit `<fill: …>`
+#   placeholders. A card that guesses its own verdict is worse than no card.
+#
+# OUT OF SCOPE: machine-parseable JSON. That is #249's job (the measurement-record
+#   producer). This emits MARKDOWN for a human to paste into an issue or a
+#   BENCHMARKS discussion. When #249 lands, both should read the same record —
+#   this file's RECORD SCHEMA below is the natural seam.
+#
+# RECORD SCHEMA (flat key=value, one per line; values may contain spaces)
+#   meta.date meta.endpoint meta.mode
+#   fp.model fp.ctx fp.slots fp.ftype fp.drafter fp.kv fp.argv fp.moe fp.offload
+#   proto.warmups proto.runs proto.force_tokens proto.thinking proto.env
+#   shape.<name>.{n,n_usable,decode_mean,decode_cv,wall_mean,wall_cv,ttft_mean_ms,ttft_std_ms}
+#   prefill.<label>.{n,tps_mean,tps_cv,ttft_ms}
+#   gpu.{vram_idle,vram_peak,vram_post,leak,per_device}
+#   cache.<dev>.{marginal,cumulative,cum_start,slots,total_mib,type,evictions,skips}
+#   pcie.{link,link_pct,link_warn,practical_mbps}
+#   pcie.<phase>.<all|GPUn>.{rx_mean,rx_peak}      phase = decode | prefill
+#   ram.{demand_mbps,window,ceiling_gbps}  sys.ram
+#   integrity.{status,health,swap,divergence,stream_ceiling}
+#
+#   TWO producers, one schema:
+#     * the CURRENT run  -> bench.sh fills the record in-process (exact values)
+#     * a BASELINE run   -> parsed back out of a saved bench.sh log
+#   They must agree. test-bench-card.sh renders a run, saves its log, re-parses
+#   it, and asserts the parsed record matches the in-process one field for field
+#   — otherwise an A/B would silently compare two different measurements.
+#
+# `command grep` only (ugrep shim), and no pgrep/pkill -f anywhere. See AGENTS.md.
+
+[[ -n "${_CARD_SH_LOADED:-}" ]] && return 0
+_CARD_SH_LOADED=1
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
+# card_kv <file> <key> <value> — append one record field. Values are written
+# verbatim; empty values are SKIPPED rather than written as empty, so a renderer
+# can tell "not captured" from "captured as blank".
+card_kv() {
+  local f="$1" k="$2" v="${3:-}"
+  [[ -n "$v" ]] || return 0
+  printf '%s=%s\n' "$k" "$v" >> "$f"
+}
+
+# card_kv_from_summary <record-file> <summary.json> — fold the python side's
+# per-shape statistics into the record. Schema knowledge lives HERE, next to the
+# parser that has to reproduce it from a log, so the two cannot drift apart.
+card_kv_from_summary() {
+  local rec="$1" js="$2"
+  [[ -r "$js" ]] || return 1
+  python3 - "$js" >> "$rec" <<'PY'
+import json, sys
+try:
+    with open(sys.argv[1], encoding="utf-8") as fh:
+        d = json.load(fh)
+except Exception:
+    sys.exit(1)
+
+
+def emit(k, v):
+    if v not in (None, ""):
+        print(f"{k}={v}")
+
+
+for name, v in d.get("shapes", {}).items():
+    # A prefill entry carries prefill_tps_mean; a decode shape carries decode.
+    if "prefill_tps_mean" in v:
+        p = f"prefill.{name}"
+        emit(f"{p}.n", v.get("n"))
+        emit(f"{p}.tps_mean", f"{v['prefill_tps_mean']:.2f}")
+        emit(f"{p}.tps_cv", f"{v.get('prefill_tps_cv', 0):.1f}")
+        emit(f"{p}.ttft_ms", f"{v.get('ttft_mean_ms', 0):.0f}")
+    else:
+        p = f"shape.{name}"
+        emit(f"{p}.n", v.get("n"))
+        emit(f"{p}.n_usable", v.get("n_usable"))
+        emit(f"{p}.decode_mean", f"{v.get('decode_tps_mean', 0):.2f}")
+        emit(f"{p}.decode_cv", f"{v.get('decode_tps_cv', 0):.1f}")
+        emit(f"{p}.wall_mean", f"{v.get('wall_tps_mean', 0):.2f}")
+        emit(f"{p}.wall_cv", f"{v.get('wall_tps_cv', 0):.1f}")
+        emit(f"{p}.ttft_mean_ms", f"{v.get('ttft_mean_ms', 0):.0f}")
+        emit(f"{p}.ttft_std_ms", f"{v.get('ttft_std_ms', 0):.0f}")
+PY
+}
+
+# card_parse_log <bench-log> — extract a record from a SAVED bench.sh log.
+# Strict on purpose: the baseline of an A/B is load-bearing, and half-parsing one
+# produces a confident wrong delta. Exits non-zero with a reason on stderr.
+card_parse_log() {
+  local log="${1:-}"
+  if [[ -z "$log" ]]; then
+    echo "baseline unparseable: no path given (set BASELINE=<path to a saved bench.sh log>)" >&2
+    return 1
+  fi
+  if [[ ! -r "$log" ]]; then
+    echo "baseline unparseable: cannot read '$log'" >&2
+    return 1
+  fi
+  CARD_MODE=parse _card_py "$log"
+}
+
+# card_render <mode> <current-record> [baseline-log]
+#   mode = snapshot | ab
+card_render() {
+  local mode="$1" rec="$2" base="${3:-}"
+  CARD_MODE="render_$mode" _card_py "$rec" "$base"
+}
+
+# The single embedded implementation: parser and renderer share the schema, so
+# they cannot drift into disagreeing about what a field means.
+_card_py() {
+  CARD_MODE="${CARD_MODE:-}" \
+  CARD_NOISE_BAND="${NOISE_BAND:-}" \
+  CARD_EXPECTATION="${EXPECTATION:-}" \
+  CARD_BOOT_POLICY="${BOOT_POLICY:-}" \
+  CARD_KNOB="${KNOB:-}" \
+  python3 - "$@" <<'PY'
+import os, re, sys
+
+MODE = os.environ.get("CARD_MODE", "")
+FILL = "<fill: {}>"
+
+# --- fields whose disagreement across arms CONFOUNDS an A/B ------------------
+# Everything the measurement rests on. If one of these differs and it is not the
+# declared knob, the two arms are not an A/B — they are two unrelated benches.
+INVARIANTS = [
+    ("fp.model",   "model"),
+    ("fp.ftype",   "weights ftype"),
+    ("fp.ctx",     "served ctx"),
+    ("fp.kv",      "KV cache type"),
+    ("fp.drafter", "drafter"),
+    # The moe-cache config is the ARM IDENTITY: the resulting pool self-limits
+    # below the requested cap, so two different configs can produce the same
+    # census. A mismatch here confounds an A/B exactly as hard as a model mismatch.
+    ("fp.moe",     "moe-cache config (cap + RESERVE_MB/ADMIT_AFTER/THROTTLE/MAX_BATCH)"),
+    ("fp.offload", "CPU-offload method (-ot regex / --n-cpu-moe / boot log)"),
+    ("fp.argv",    "serving argv (threads / ubatch / offload / ngl / split)"),
+]
+
+# Pool census SHAPE is compared with a tolerance rather than exactly: the census
+# self-limits against free VRAM, so an identical config can land a few slots apart
+# between boots. Beyond this it is a different cache, not noise.
+POOL_TOLERANCE_PCT = 5.0
+
+
+def load_record(path):
+    rec = {}
+    with open(path, encoding="utf-8") as fh:
+        for ln in fh:
+            ln = ln.rstrip("\n")
+            if "=" in ln:
+                k, v = ln.split("=", 1)
+                rec[k.strip()] = v.strip()
+    return rec
+
+
+def num(s, default=None):
+    try:
+        return float(re.sub(r"[^0-9.eE+-]", "", str(s)))
+    except (TypeError, ValueError):
+        return default
+
+
+# ===========================================================================
+# PARSER — a saved bench.sh log back into a record
+# ===========================================================================
+def parse_log(path):
+    # The baseline of an A/B is load-bearing. Every failure to read it exits with
+    # a reason on stderr — a traceback is not an error message an operator can act
+    # on, and half a parse produces a confident wrong delta.
+    if not path:
+        sys.stderr.write("baseline unparseable: no path given "
+                         "(set BASELINE=<path to a saved bench.sh log>)\n")
+        sys.exit(1)
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            lines = fh.read().splitlines()
+    except OSError as e:
+        sys.stderr.write(f"baseline unparseable: cannot read {path!r} ({e.strerror})\n")
+        sys.exit(1)
+    rec = {}
+    missing = []
+
+    def grab(pat, key, group=1, where=lines):
+        for ln in where:
+            m = re.search(pat, ln)
+            if m:
+                rec[key] = m.group(group).strip()
+                return True
+        return False
+
+    # --- fingerprint block ---
+    grab(r"endpoint\s+:\s*(\S+)", "meta.endpoint")
+    grab(r"endpoint\s+:.*\(mode=(\w+)\)", "meta.mode")
+    grab(r"^\s+model\s+:\s*(.+)$", "fp.model")
+    grab(r"served ctx\s+:\s*(\d+)", "fp.ctx")
+    grab(r"served ctx\s+:.*slots=(\d+)", "fp.slots")
+    grab(r"weights ftype\s+:\s*(.+)$", "fp.ftype")
+    grab(r"^\s+drafter\s+:\s*(.+)$", "fp.drafter")
+    grab(r"KV cache type\s+:\s*(.+)$", "fp.kv")
+    if rec.get("fp.kv", "").startswith("capture:"):
+        del rec["fp.kv"]
+    grab(r"serving argv\s+:\s*(.+)$", "fp.argv")
+    grab(r"moe-cache cfg\s+:\s*(.+)$", "fp.moe")
+    grab(r"CPU offload\s+:\s*(.+)$", "fp.offload")
+
+    for ln in lines:
+        m = re.match(r"=== warmups \((\d+)\) ===", ln.strip())
+        if m and "proto.warmups" not in rec:
+            rec["proto.warmups"] = m.group(1)
+        m = re.match(r"=== measured \((\d+)\) ===", ln.strip())
+        if m and "proto.runs" not in rec:
+            rec["proto.runs"] = m.group(1)
+
+    if "fp.model" not in rec:
+        missing.append("CONFIG FINGERPRINT block (no 'model :' line) — was this run "
+                       "produced by a bench.sh with the capture layer, and with CAPTURE=1?")
+
+    # --- shape summaries: '=== summary [narrative] (n=5) ===' ---
+    shapes = 0
+    i = 0
+    while i < len(lines):
+        m = re.match(r"=== summary \[([^\]]+)\] \(n=(\d+)\) ===", lines[i].strip())
+        if not m:
+            i += 1
+            continue
+        name, n = m.group(1), m.group(2)
+        # Stop at the next section header. A fixed-size slice bleeds into the
+        # FOLLOWING summary block, and since the prefill block contains
+        # "prefill tok/s", that misclassified every shape that happened to be
+        # followed by a prefill summary — the shape then vanished from the A/B.
+        block = []
+        for ln in lines[i + 1:]:
+            if ln.strip().startswith("==="):
+                break
+            block.append(ln)
+        is_prefill = any("prefill tok/s" in b for b in block)
+        key = ("prefill." if is_prefill else "shape.") + name
+        rec[f"{key}.n"] = n
+        for ln in block:
+            mm = re.match(r"\s*(wall_TPS|decode_TPS|prefill tok/s)\s+mean=\s*([0-9.]+)"
+                          r"\s+std=\s*([0-9.]+)\s+CV=\s*([0-9.]+)%", ln)
+            if mm:
+                label = {"wall_TPS": "wall", "decode_TPS": "decode",
+                         "prefill tok/s": "tps"}[mm.group(1)]
+                rec[f"{key}.{label}_mean"] = mm.group(2)
+                rec[f"{key}.{label}_cv"] = mm.group(4)
+            mt = re.match(r"\s*TTFT\s+mean=\s*([0-9.]+)ms\s+std=\s*([0-9.]+)ms", ln)
+            if mt:
+                rec[f"{key}.ttft_mean_ms"] = mt.group(1)
+                rec[f"{key}.ttft_std_ms"] = mt.group(2)
+                if is_prefill:
+                    rec[f"{key}.ttft_ms"] = mt.group(1)
+            mu = re.match(r"\s*n-usable\s+(\d+)/(\d+)", ln)
+            if mu:
+                rec[f"{key}.n_usable"] = mu.group(1)
+        shapes += 1
+        i += 1
+
+    if not shapes:
+        missing.append("no '=== summary [<shape>] (n=N) ===' block — the run produced "
+                       "no measured shape")
+
+    # --- capture sections ---
+    grab(r"^\s*status:\s*([A-Z_]+)", "integrity.status")
+    grab(r"health counters:\s*(.+)$", "integrity.health")
+    grab(r"swap check\s+:\s*(.+)$", "integrity.swap")
+    grab(r"->\s*([0-9.]+)% divergence", "integrity.divergence")
+    grab(r"triad ceiling\s+:\s*([0-9.]+) GB/s", "integrity.stream_ceiling")
+    m = re.search(r"idle=(\d+) MiB\s+peak=(\S+) MiB\s+post=(\S+) MiB",
+                  "\n".join(lines))
+    if m:
+        rec["gpu.vram_idle"], rec["gpu.vram_peak"], rec["gpu.vram_post"] = m.groups()
+    # "growth delta" is the same measurement under a label that does not cry wolf
+    # when a lazily-allocating expert cache is active (see bench.sh).
+    grab(r"(?:leak|growth) delta \(post - idle\) = (-?\d+) MiB", "gpu.leak")
+    for ln in lines:
+        if "growth delta (post - idle)" in ln:
+            rec["gpu.delta_kind"] = "growth"
+            break
+        if "leak delta (post - idle)" in ln:
+            rec["gpu.delta_kind"] = "leak"
+            break
+
+    # --- offload / PCIe / RAM telemetry ---
+    grab(r"^\s*(mem_total_gib=.*)$", "sys.ram")
+    grab(r"derived host-RAM read demand on the miss path: ~(\d+) MB/s", "ram.demand_mbps")
+    for ln in lines:
+        if "derived host-RAM read demand" in ln:
+            rec["ram.window"] = ("whole-run (diluted)" if "WHOLE RUN" in ln else "decode window")
+            break
+    grab(r"of ~(\d+) GB/s STREAM-triad ceiling", "ram.ceiling_gbps")
+    grab(r"triad ceiling\s+:\s*([0-9.]+) GB/s", "ram.ceiling_gbps")
+    grab(r"^\s*(GPU\d+ gen=\d+/\d+ width=\d+/\d+)", "pcie.link")
+    grab(r"decode rx peak = \d+ MB/s = ([0-9.]+)% of that denominator", "pcie.link_pct")
+    for ln in lines:
+        if "WARN: never reached" in ln:
+            rec["pcie.link_warn"] = "link trained below its own maximum under load"
+            break
+    for ln in lines:
+        m = re.match(r"\s*(decode|prefill) (all|GPU\d+) rx_mean=(\d+) rx_peak=(\d+)", ln)
+        if m:
+            ph, dev = m.group(1), m.group(2)
+            rec[f"pcie.{ph}.{dev}.rx_mean"] = m.group(3)
+            rec[f"pcie.{ph}.{dev}.rx_peak"] = m.group(4)
+    # skips are reported inside the health verdict's informational tail
+    for ln in lines:
+        if "health counters:" in ln or "cache health" in ln:
+            for dm in re.finditer(r"(CUDA\d+)[:\s]+skips=(\d+)", ln):
+                rec[f"cache.{dm.group(1)}.skips"] = dm.group(2)
+
+    # per-device cache rows stay PER DEVICE (never averaged)
+    for ln in lines:
+        m = re.match(r"\s*(CUDA\d+) marginal=([0-9.]+|-)% cumulative=([0-9.]+|-)%", ln)
+        if m:
+            rec[f"cache.{m.group(1)}.marginal"] = m.group(2)
+            rec[f"cache.{m.group(1)}.cumulative"] = m.group(3)
+            dv = re.search(r"devictions=(\d+)", ln)
+            if dv:
+                rec[f"cache.{m.group(1)}.evictions"] = dv.group(1)
+        m = re.match(r"\s*(CUDA\d+) pools=\d+ slots=(\d+) total_mib=(\d+)", ln)
+        if m:
+            rec[f"cache.{m.group(1)}.slots"] = m.group(2)
+            rec[f"cache.{m.group(1)}.total_mib"] = m.group(3)
+            ty = re.search(r"type=(\S+)", ln)
+            if ty and ty.group(1) != "-":
+                rec[f"cache.{m.group(1)}.type"] = ty.group(1)
+
+    if missing:
+        sys.stderr.write("baseline unparseable: " + "; ".join(missing) + "\n")
+        sys.exit(1)
+    return rec
+
+
+# ===========================================================================
+# shared render helpers
+# ===========================================================================
+def shape_names(rec, prefix):
+    out = []
+    for k in rec:
+        m = re.match(rf"{prefix}\.(.+)\.n$", k)
+        if m:
+            out.append(m.group(1))
+    return sorted(set(out))
+
+
+def is_offload(rec):
+    """Same gate as the capture layer: the offload block renders only when the run
+    actually offloaded. A generic cache line is rendered otherwise."""
+    v = rec.get("fp.offload", "")
+    return bool(v) and "not detected" not in v
+
+
+def cache_devices(rec):
+    return sorted({m.group(1) for k in rec
+                   for m in [re.match(r"cache\.([^.]+)\.", k)] if m})
+
+
+def cache_judgement(marg, cum):
+    """cold | warming | plateaued | thrashing, from marginal vs cumulative.
+
+    Stated as a rule on the card so a reader can disagree with it:
+      marginal < 5%              -> cold (the pool is not paying for itself yet)
+      |marginal - cumulative|<=2 -> plateaued (steady state reached)
+      marginal > cumulative      -> warming (cumulative still catching up)
+      marginal < cumulative      -> thrashing (the window did WORSE than lifetime)
+    """
+    m, c = num(marg), num(cum)
+    if m is None or c is None:
+        return "unknown"
+    if m < 5:
+        return "cold"
+    if abs(m - c) <= 2:
+        return "plateaued"
+    return "warming" if m > c else "thrashing"
+
+
+def offload_block(rec, devs):
+    """The CPU-offload + expert-cache section. Rendered ONLY when offload is
+    detected — on a GPU-resident run every row here would be a dash pretending to
+    be data."""
+    out = ["### CPU offload + expert cache", ""]
+    ram = rec.get("sys.ram", "")
+    rss = re.search(r"server_rss_gib=([\d.]+)", ram)
+    tot = re.search(r"mem_total_gib=([\d.]+)", ram)
+    swap = rec.get("integrity.swap", "")
+    swap_short = "PASS" if swap.startswith("PASS") else (swap.split("—")[0].strip() or FILL.format("swap"))
+    out.append(f"**Offload:** {rec.get('fp.offload', FILL.format('method'))}"
+               + (f" · **RSS** {rss.group(1)} GiB / {tot.group(1)} GiB total" if rss and tot else "")
+               + f" · swap {swap_short}")
+    out.append(f"**Cache config:** {rec.get('fp.moe', FILL.format('cap + env knobs'))}")
+    out.append("")
+    out.append("> The cache config IS the arm identity — the pool self-limits below the requested "
+               "cap, so pool size alone does not identify which arm this was.")
+    out.append("")
+    if devs:
+        out.append("| device | pool (slots · MiB · type) | marginal hits | cumulative | evictions | skips† |")
+        out.append("|---|---|--:|--:|--:|--:|")
+        for d in devs:
+            pool = " · ".join(x for x in (
+                (rec.get(f"cache.{d}.slots", "") + " slots") if rec.get(f"cache.{d}.slots") else "",
+                (rec.get(f"cache.{d}.total_mib", "") + " MiB") if rec.get(f"cache.{d}.total_mib") else "",
+                rec.get(f"cache.{d}.type", "")) if x) or "—"
+            out.append(f"| {d} | {pool} | **{rec.get(f'cache.{d}.marginal','—')}%** | "
+                       f"{rec.get(f'cache.{d}.cumulative','—')}% | "
+                       f"{rec.get(f'cache.{d}.evictions','—')} | {rec.get(f'cache.{d}.skips','0')} |")
+        out.append("")
+        out.append("†`skips` = admission throttling (insert queue exhausted under the configured "
+                   "THROTTLE) — a **load signal, not a defect**. The hard-failure counters are "
+                   "fill / dispatch / collect-fail; those are on the integrity panel.")
+        out.append("")
+        out.append("> Quote the **marginal** rate, never the cumulative: cumulative embeds the "
+                   "cold-fill phase, so a *bigger* pool reports a *lower* cumulative rate on the "
+                   "same traffic. Per-device rows stay separate — the hit asymmetry across cards "
+                   "is routing-entropy signal, and averaging it away hides it.")
+        out.append("")
+    # --- PCIe ---
+    link = rec.get("pcie.link", "")
+    warn = rec.get("pcie.link_warn", "")
+    dec_mean, dec_peak = rec.get("pcie.decode.all.rx_mean"), rec.get("pcie.decode.all.rx_peak")
+    pre_mean, pre_peak = rec.get("pcie.prefill.all.rx_mean"), rec.get("pcie.prefill.all.rx_peak")
+    if link or dec_mean:
+        bits = [f"**PCIe** ({link or FILL.format('link')}"
+                + (f" ⚠️ {warn}" if warn else "") + ")"]
+        if dec_mean:
+            pct = rec.get("pcie.link_pct")
+            bits.append(f"decode rx {dec_mean} / {dec_peak} MB/s mean/peak"
+                        + (f" ({pct}% of practical link)" if pct else ""))
+        if pre_mean:
+            bits.append(f"prefill rx {pre_mean} / {pre_peak} MB/s mean/peak")
+        out.append(": ".join([bits[0], " · ".join(bits[1:])]) if len(bits) > 1 else bits[0])
+        # Lopsided per-device traffic is worth calling out — on a layer-split MoE
+        # one card can carry nearly all of the prefill transfer.
+        per = [(d, num(rec.get(f"pcie.prefill.{d}.rx_mean")))
+               for d in sorted({m.group(1) for k in rec
+                                for m in [re.match(r"pcie\.prefill\.(GPU\d+)\.", k)] if m})]
+        per = [(d, v) for d, v in per if v is not None]
+        if len(per) > 1:
+            hi = max(per, key=lambda x: x[1])
+            lo = min(per, key=lambda x: x[1])
+            if lo[1] >= 0 and hi[1] > 0 and (lo[1] == 0 or hi[1] / max(lo[1], 1e-9) >= 3):
+                out.append("")
+                out.append(f"> Prefill PCIe traffic is lopsided: {hi[0]} {hi[1]:.0f} MB/s vs "
+                           f"{lo[0]} {lo[1]:.0f} MB/s mean. On a layer-split MoE that is expected "
+                           f"(the offloaded layers are not evenly distributed), but it bounds which "
+                           f"card the transfer path actually stresses.")
+        out.append("")
+    # --- RAM path ---
+    dem = num(rec.get("ram.demand_mbps"))
+    if dem is not None:
+        ceil_g = num(rec.get("ram.ceiling_gbps"))
+        frac = (f" of ~{ceil_g:.0f} GB/s ceiling ({dem / 10 / ceil_g:.0f}%)"
+                if ceil_g else " (run with STREAM_CALIB=1 for the ceiling)")
+        out.append(f"**RAM path:** derived miss demand ~{dem / 1000:.1f} GB/s{frac} — "
+                   f"**derived, not measured** (misses × expert size ÷ elapsed), computed over the "
+                   f"**{rec.get('ram.window', FILL.format('window'))}**.")
+        out.append("")
+    return out
+
+
+def check(ok, label, evidence=""):
+    box = "x" if ok is True else " "
+    tail = f" — {evidence}" if evidence else ""
+    return f"- [{box}] {label}{tail}"
+
+
+def integrity_block(rec):
+    """The four capture-derived additions plus the template's original four."""
+    out = []
+    div = num(rec.get("integrity.divergence"))
+    if div is None:
+        out.append(check(None, "wall-TPS scrape agrees with engine-side timings (±5%)",
+                         "engine-side timings unavailable "
+                         "(set SERVER_LOG=<path> on bare metal) — " + FILL.format("state which number the card quotes")))
+    else:
+        out.append(check(div <= 5, "wall-TPS scrape agrees with engine-side timings (±5%)",
+                         f"{div:.1f}% divergence"
+                         + ("" if div <= 5 else " — " + FILL.format("state which number this card quotes, and why"))))
+
+    worst = max([num(rec[k], 0) for k in rec if k.startswith("shape.") and k.endswith(".decode_cv")] or [0])
+    pworst = max([num(rec[k], 0) for k in rec if k.startswith("prefill.") and k.endswith(".tps_cv")] or [0])
+    out.append(check(worst < 5 and pworst < 2,
+                     "CVs within rig norm (decode <5%, prefill <2%)",
+                     f"worst decode CV {worst:.1f}%, worst prefill CV {pworst:.1f}%"))
+    out.append(check(None, "quiet box: no builds / downloads / other GPU work during measured runs",
+                     FILL.format("confirm")))
+
+    devs = cache_devices(rec)
+    if devs:
+        js = {cache_judgement(rec.get(f"cache.{d}.marginal"), rec.get(f"cache.{d}.cumulative"))
+              for d in devs}
+        out.append(check("plateaued" in js and len(js) == 1,
+                         "cache state steady across measured runs",
+                         ", ".join(sorted(js)) + " (a warming cache understates the mean)"))
+    else:
+        out.append(check(None, "cache state steady across measured runs", "no expert cache on this run"))
+
+    # --- the capture-layer additions ---
+    st = rec.get("integrity.status", "unknown")
+    out.append(check(st == "OK", f"capture status: {st}",
+                     "" if st == "OK" else "**do not quote a throughput number from this run**"))
+    h = rec.get("integrity.health", "")
+    if h:
+        # PASS is fill/dispatch/collect-fail == 0. `skips` is admission throttling,
+        # reported alongside as a tuning signal — not a defect (see capture.sh).
+        out.append(check(h.startswith("PASS"), "cache hard-failure counters zero "
+                                               "(fill / dispatch / collect)", h))
+    s = rec.get("integrity.swap", "")
+    if s:
+        out.append(check(s.startswith("PASS"), "swap check", s))
+    us = []
+    bad = False
+    for name in shape_names(rec, "shape"):
+        n, u = rec.get(f"shape.{name}.n", "?"), rec.get(f"shape.{name}.n_usable")
+        if u is None:
+            continue
+        us.append(f"{name} {u}/{n}")
+        if u != n:
+            bad = True
+    if us:
+        out.append(check(not bad, "n-usable == n for every shape", ", ".join(us)
+                         + ("" if not bad else " — the CV above is not trustworthy; re-run with FORCE_TOKENS=<n>")))
+    leak = num(rec.get("gpu.leak"))
+    if leak is not None:
+        if rec.get("gpu.delta_kind") == "growth":
+            # An expert cache allocates its pool and graphs on first inference, so a
+            # single run grows VRAM by design. Ticked because nothing is wrong —
+            # only a monotonic rise across REPEATED runs is evidence of a leak.
+            out.append(check(True, "VRAM growth accounted for",
+                             f"growth delta {leak:.0f} MiB (lazy expert-cache pool/graph "
+                             f"allocation; only a monotonic rise across REPEATED runs is a leak)"))
+        else:
+            out.append(check(abs(leak) <= 64, "VRAM returned after the run",
+                             f"leak delta {leak:.0f} MiB"))
+    return out
+
+
+def protocol_line(rec):
+    w = rec.get("proto.warmups", "?")
+    r = rec.get("proto.runs", "?")
+    extra = " · thinking=on" if rec.get("proto.thinking") == "1" else ""
+    ft = rec.get("proto.force_tokens", "0")
+    if ft not in ("0", "", None):
+        extra += f" · FORCE_TOKENS={ft}"
+    return (f"**Protocol:** {w} warm + {r} measured per shape · temperature=0.6 top_p=0.95{extra} · "
+            + FILL.format("power cap"))
+
+
+def config_line(rec):
+    bits = []
+    for key, pre in (("fp.ftype", ""), ("fp.kv", "KV "), ("fp.ctx", "ctx ")):
+        v = rec.get(key)
+        if v:
+            bits.append(f"{pre}{v}")
+    bits.append("spec-dec: " + (rec.get("fp.drafter") or FILL.format("drafter|none")))
+    off = rec.get("fp.offload", "")
+    if off and "not detected" not in off:
+        bits.append("CPU offload: yes")
+    return ("**Config:** " + FILL.format("engine+tag") + " · " + FILL.format("topology")
+            + " · " + " · ".join(bits))
+
+
+# ===========================================================================
+# TEMPLATE 1 — SNAPSHOT
+# ===========================================================================
+def render_snapshot(rec):
+    L = []
+    A = L.append
+    A(f"## 📊 bench.sh — {rec.get('fp.model', FILL.format('model'))} · "
+      f"{FILL.format('config-slug')} · {rec.get('meta.date', FILL.format('date'))}")
+    A("")
+    A(config_line(rec))
+    A(f"**Env:** {rec.get('proto.env') or '(defaults)'}")
+    A(protocol_line(rec))
+    A("")
+    A("| shape | n | decode TPS | CV | wall TPS | TTFT |")
+    A("|---|--:|--:|--:|--:|--:|")
+    for name in shape_names(rec, "shape"):
+        p = f"shape.{name}"
+        n, u = rec.get(f"{p}.n", "?"), rec.get(f"{p}.n_usable")
+        ncell = f"{n}" if (u is None or u == n) else f"{u}/{n} ⚠️"
+        A(f"| {name} | {ncell} | {rec.get(f'{p}.decode_mean','—')} | "
+          f"{rec.get(f'{p}.decode_cv','—')}% | {rec.get(f'{p}.wall_mean','—')} | "
+          f"{rec.get(f'{p}.ttft_mean_ms','—')} ± {rec.get(f'{p}.ttft_std_ms','0')} ms |")
+    pre = shape_names(rec, "prefill")
+    if pre:
+        A("")
+        A("| prefill depth | n | tok/s | CV | TTFT@depth |")
+        A("|---|--:|--:|--:|--:|")
+        for name in pre:
+            p = f"prefill.{name}"
+            A(f"| {name} | {rec.get(f'{p}.n','?')} | {rec.get(f'{p}.tps_mean','—')} | "
+              f"{rec.get(f'{p}.tps_cv','—')}% | {rec.get(f'{p}.ttft_ms','—')} ms |")
+    A("")
+    gpu = []
+    if rec.get("gpu.vram_peak"):
+        gpu.append(f"VRAM idle {rec.get('gpu.vram_idle','?')} → peak {rec['gpu.vram_peak']} "
+                   f"→ post {rec.get('gpu.vram_post','?')} MiB")
+    if rec.get("gpu.per_device"):
+        gpu.append(f"per device: {rec['gpu.per_device']}")
+    A(f"**GPU:** {' · '.join(gpu) if gpu else FILL.format('VRAM / power / util')} · "
+      + FILL.format("power cap") + " · " + FILL.format("util"))
+    devs = cache_devices(rec)
+    if is_offload(rec):
+        L.extend(offload_block(rec, devs))
+    elif devs:
+        # Non-offload engines with a cache of their own keep the generic line.
+        parts = []
+        for d in devs:
+            marg = rec.get(f"cache.{d}.marginal", "—")
+            cum0 = rec.get(f"cache.{d}.cum_start")
+            cum = rec.get(f"cache.{d}.cumulative", "—")
+            j = cache_judgement(marg, cum)
+            arrow = f"{cum0}% → {cum}%" if cum0 else f"{cum}% cumulative"
+            parts.append(f"{d} hits {arrow}, **marginal {marg}%** ({j})")
+        A(f"**Cache (if the engine has one):** {' · '.join(parts)}")
+        A("")
+        A("> Quote the **marginal** rate. Cumulative embeds the cold-fill phase, so a *bigger* "
+          "pool reports a *lower* cumulative rate on the same traffic. Per-device values are kept "
+          "separate on purpose — a CUDA0/CUDA1 asymmetry is routing-entropy signal. "
+          "Judgement rule: marginal <5% = cold; within 2pp of cumulative = plateaued; "
+          "above = warming; below = thrashing.")
+    A("")
+    A("### Integrity")
+    L.extend(integrity_block(rec))
+    A("")
+    A(f"**One-line verdict:** {FILL.format('what this run establishes — and what it must NOT be quoted for')}")
+    return "\n".join(L)
+
+
+# ===========================================================================
+# TEMPLATE 2 — A/B
+# ===========================================================================
+def render_ab(cur, base):
+    knob = os.environ.get("CARD_KNOB", "").strip()
+    band_env = os.environ.get("CARD_NOISE_BAND", "").strip()
+
+    # Noise band: given, or 2x the worst shape CV across BOTH arms. Stated either
+    # way — a band with an unstated provenance is not a band.
+    cvs = [num(r[k], 0) for r in (cur, base) for k in r
+           if k.startswith("shape.") and k.endswith(".decode_cv")]
+    if band_env:
+        band = num(band_env, 5.0)
+        how = "NOISE_BAND env, supplied by the operator"
+    elif cvs:
+        band = 2 * max(cvs)
+        how = f"derived: 2x the worst decode CV across both arms ({max(cvs):.1f}%)"
+    else:
+        band = 5.0
+        how = "default 5% — no CVs available to derive from"
+
+    # --- invariants ---
+    diffs = []
+    for key, label in INVARIANTS:
+        a, b = base.get(key), cur.get(key)
+        if a is None and b is None:
+            continue
+        if a != b:
+            diffs.append((key, label, a, b))
+    # Pool census SHAPE, per device, with a tolerance.
+    #
+    # ONLY checked when the requested cache CONFIG matched. If the config differs,
+    # a different pool is the INTENDED CONSEQUENCE of the knob, not a confound —
+    # flagging it there would make every cache-sizing A/B read as confounded. When
+    # the config is identical and the realized pool still differs materially, that
+    # IS a confound: the two boots had different VRAM available to them, so the
+    # arms are not comparable for a reason outside the config.
+    same_cfg = base.get("fp.moe") is not None and base.get("fp.moe") == cur.get("fp.moe")
+    for d in (sorted(set(cache_devices(cur)) | set(cache_devices(base))) if same_cfg else []):
+        a, b = base.get(f"cache.{d}.slots"), cur.get(f"cache.{d}.slots")
+        if a is None or b is None:
+            continue
+        av, bv = num(a), num(b)
+        if av and bv and abs(bv - av) / av * 100 > POOL_TOLERANCE_PCT:
+            diffs.append((f"cache.{d}.slots", f"pool census {d} (slots, ±{POOL_TOLERANCE_PCT:.0f}%)",
+                          a, b))
+    if knob:
+        attributed = [d for d in diffs if knob.lower() in (d[0] + " " + d[1]).lower()
+                      or knob.lower() in str(d[2]).lower() or knob.lower() in str(d[3]).lower()]
+        confounds = [d for d in diffs if d not in attributed]
+    else:
+        attributed, confounds = [], diffs
+
+    L = []
+    A = L.append
+    if confounds:
+        A("> ## ⛔ CONFOUNDED")
+        A(">")
+        A("> These arms differ in " + str(len(confounds)) + " value(s) that must be held constant. "
+          "This is not an A/B — it is two unrelated benches, and the Δ column below cannot be "
+          "attributed to any knob. Re-run with them matched, or name the intended knob with "
+          "`KNOB=<text>` if one of these IS the thing under test.")
+        A("")
+    A(f"## ⚖️ bench.sh A/B — {knob or FILL.format('knob')}: "
+      f"A: {FILL.format('arm A name')} vs B: {FILL.format('arm B name')} · "
+      f"{cur.get('fp.model', FILL.format('model'))} · {cur.get('meta.date', FILL.format('date'))}")
+    A("")
+    held = [lab for key, lab in INVARIANTS
+            if base.get(key) is not None and base.get(key) == cur.get(key)]
+    A(f"**Held constant:** {', '.join(held) if held else FILL.format('list what was held')}")
+    A(f"**Boot policy:** {os.environ.get('CARD_BOOT_POLICY') or FILL.format('same-boot | boot-per-arm ×N')}"
+      f"   **Noise band:** ±{band:.1f}% ({how})")
+    A("")
+    A(f"**Pre-registered expectation:** {os.environ.get('CARD_EXPECTATION') or 'none'}")
+    A("")
+    A("| metric | A: baseline | B: this run | Δ | verdict |")
+    A("|---|--:|--:|--:|---|")
+
+    def row(label, a, b, lower_is_better=False, kind="perf"):
+        av, bv = num(a), num(b)
+        if av is None or bv is None or av == 0:
+            A(f"| {label} | {a or '—'} | {b or '—'} | — | not comparable (missing in one arm) |")
+            return
+        d = (bv - av) / av * 100
+        if abs(d) <= band:
+            verdict = "within band — no signal"
+        elif kind == "cost":
+            # A resource row is NOT good or bad on its own — spending more pool to
+            # buy throughput may be exactly the intended trade. Report the spend
+            # and leave the judgement to the human, who has the VRAM budget.
+            verdict = ("**+{:.1f}% resource spend**" if d > 0 else "**{:.1f}% resource freed**").format(d)
+        else:
+            better = (d < 0) if lower_is_better else (d > 0)
+            verdict = "outside band — real " + ("improvement" if better else "regression")
+        A(f"| {label} | {av:.2f} | {bv:.2f} | {d:+.1f}% | {verdict} |")
+
+    for name in sorted(set(shape_names(cur, "shape")) | set(shape_names(base, "shape"))):
+        row(f"decode {name}", base.get(f"shape.{name}.decode_mean"), cur.get(f"shape.{name}.decode_mean"))
+    for name in sorted(set(shape_names(cur, "shape")) | set(shape_names(base, "shape"))):
+        row(f"TTFT {name} (ms)", base.get(f"shape.{name}.ttft_mean_ms"),
+            cur.get(f"shape.{name}.ttft_mean_ms"), lower_is_better=True)
+    for name in sorted(set(shape_names(cur, "prefill")) | set(shape_names(base, "prefill"))):
+        label = name[8:] if name.startswith("prefill-") else name
+        row(f"prefill {label}", base.get(f"prefill.{name}.tps_mean"), cur.get(f"prefill.{name}.tps_mean"))
+    # CACHE DELTAS — only when both arms actually offloaded.
+    #
+    # The MARGINAL hit rate is THE boot-comparable cache metric, and this is the row
+    # that catches an under-warmed pool: a cumulative rate would show the bigger
+    # pool as WORSE (it spent longer filling), so an A/B read off cumulative numbers
+    # rejects the better config. Marginal is measured over the same window in both
+    # arms, so it compares like with like.
+    if is_offload(cur) and is_offload(base):
+        for d in sorted(set(cache_devices(cur)) | set(cache_devices(base))):
+            row(f"marginal hits {d} (%)", base.get(f"cache.{d}.marginal"), cur.get(f"cache.{d}.marginal"))
+        if cur.get("pcie.prefill.all.rx_peak") and base.get("pcie.prefill.all.rx_peak"):
+            row("prefill PCIe rx peak (MB/s)", base.get("pcie.prefill.all.rx_peak"),
+                cur.get("pcie.prefill.all.rx_peak"), kind="cost")
+    # The hidden cost. A knob that buys throughput by spending a persistent
+    # resource (pool slots, KV headroom, VRAM) looks free until this row exists —
+    # several configs have been adopted-then-reverted for exactly that.
+    for d in sorted(set(cache_devices(cur)) | set(cache_devices(base))):
+        row(f"pool slots {d}", base.get(f"cache.{d}.slots"), cur.get(f"cache.{d}.slots"), kind="cost")
+    row("VRAM peak (MiB)", base.get("gpu.vram_peak"), cur.get("gpu.vram_peak"), kind="cost")
+
+    A("")
+    A("**Invariants (must match across arms or the A/B is confounded):**")
+    A("")
+    if not diffs:
+        A("| field | value | |")
+        A("|---|---|---|")
+        for key, label in INVARIANTS:
+            if cur.get(key) is not None:
+                A(f"| {label} | `{cur[key]}` | ✅ match |")
+    else:
+        A("| field | A: baseline | B: this run | |")
+        A("|---|---|---|---|")
+        rendered = set()
+        for key, label in INVARIANTS:
+            a, b = base.get(key), cur.get(key)
+            if a is None and b is None:
+                continue
+            rendered.add(key)
+            if a == b:
+                A(f"| {label} | `{a}` | `{b}` | ✅ match |")
+            else:
+                tag = "🔧 the declared knob" if (key, label, a, b) in attributed else "⛔ **CONFOUND**"
+                A(f"| {label} | `{a or '(absent)'}` | `{b or '(absent)'}` | {tag} |")
+        for key, label, a, b in diffs:
+            if key in rendered:
+                continue
+            tag = "🔧 the declared knob" if (key, label, a, b) in attributed else "⛔ **CONFOUND**"
+            A(f"| {label} | `{a or '(absent)'}` | `{b or '(absent)'}` | {tag} |")
+    A("")
+    A("### Integrity — arm B (this run)")
+    L.extend(integrity_block(cur))
+    A("")
+    A("### Integrity — arm A (baseline)")
+    L.extend(integrity_block(base))
+    A("")
+    A(f"**Decision:** {FILL.format('ADOPT / REJECT / PARK')} — "
+      f"{FILL.format('one sentence, naming the decisive metric')}")
+    return "\n".join(L)
+
+
+# ===========================================================================
+if MODE == "parse":
+    r = parse_log(sys.argv[1])
+    for k in sorted(r):
+        print(f"{k}={r[k]}")
+    sys.exit(0)
+
+if MODE == "render_snapshot":
+    print(render_snapshot(load_record(sys.argv[1])))
+    sys.exit(0)
+
+if MODE == "render_ab":
+    cur = load_record(sys.argv[1])
+    baseline = sys.argv[2] if len(sys.argv) > 2 else ""
+    if not baseline:
+        sys.stderr.write("baseline unparseable: CARD=ab needs BASELINE=<path to a saved bench.sh log>\n")
+        sys.exit(1)
+    print(render_ab(cur, parse_log(baseline)))
+    sys.exit(0)
+
+sys.stderr.write(f"card.sh: unknown mode {MODE!r}\n")
+sys.exit(2)
+PY
+}

--- a/scripts/tests/fixtures/bench-card/baseline-mismatched.log
+++ b/scripts/tests/fixtures/bench-card/baseline-mismatched.log
@@ -1,0 +1,40 @@
+# Fixture: a baseline that differs from the current run in FOUR values that must
+# be held constant (model, ctx, KV, threads/ubatch). Renders as CONFOUNDED.
+
+========== CONFIG FINGERPRINT ==========
+  endpoint       : http://127.0.0.1:8030  (mode=chat)
+  model          : some-other-model
+  serving pid    : 111111
+  log source     : server-log (/x/y.log)
+  served ctx     : 32768  (slots=1)
+  weights ftype  : MXFP4 MoE
+  drafter        : none
+  KV cache type  : f16 (source: argv)
+  serving argv   : model=/m/x.gguf offload=blk.*=CPU threads=48 ubatch=4096 ngl=99 split=1,1
+  moe-cache cfg  : moe_cache_cap=8192 RESERVE_MB=2048 ADMIT_AFTER=1 THROTTLE=64 MAX_BATCH=8 STATS=1000
+  CPU offload    : DETECTED via argv -ot
+
+=== summary [narrative] (n=5) ===
+  wall_TPS       mean=  17.10   std=  0.12   CV= 0.7%   min= 17.00   max= 17.30
+  decode_TPS     mean=  17.30   std=  0.10   CV= 0.6%   min= 17.20   max= 17.44
+  TTFT          mean=   612ms  std=   25ms  min=590ms  max=640ms
+  n-usable      5/5  (runs with >= 250 tokens, 25% of max_tokens=1000)
+
+=== summary [prefill-10k] (n=3) ===
+  prefill tok/s  mean= 119.40   std=  0.20   CV= 0.2%   min=119.10   max=119.60
+  TTFT          mean= 83700ms  std=  120ms  min=83500ms  max=83900ms
+
+========== CAPTURE: VRAM ==========
+  idle=23000 MiB  peak=23400 MiB  post=23000 MiB
+  leak delta (post - idle) = 0 MiB
+
+========== CAPTURE: EXPERT CACHE (moe-cache) ==========
+    CUDA0 pools=1 slots=2000 total_mib=8500 expert_kib=4352 type=mxfp4
+    CUDA1 pools=1 slots=1600 total_mib=6800 expert_kib=4352 type=mxfp4
+    CUDA0 marginal=41.0% cumulative=30.1% dhits=1 dlookups=2 devictions=0
+    CUDA1 marginal=50.0% cumulative=36.0% dhits=1 dlookups=2 devictions=0
+  health counters: PASS (all health counters zero)
+
+========== CAPTURE: INTEGRITY ==========
+  status: OK
+  swap check   : PASS (no serving-process pages in swap)

--- a/scripts/tests/fixtures/bench-card/baseline.log
+++ b/scripts/tests/fixtures/bench-card/baseline.log
@@ -1,0 +1,44 @@
+# Fixture: a SAVED bench.sh log, standing in for a previous run's arm A.
+# Hand-written on purpose: it pins the exact output shapes card.sh's parser
+# depends on (CONFIG FINGERPRINT block, '=== summary [shape] (n=N) ===' blocks,
+# the capture sections). If bench.sh's output shape changes, this fixture must
+# change with it -- which is the point: a silent change would break every A/B
+# a user runs against an older saved log.
+
+========== CONFIG FINGERPRINT ==========
+  endpoint       : http://127.0.0.1:8030  (mode=chat)
+  model          : deepseek-v4-flash
+  serving pid    : 111111
+  log source     : server-log (/x/y.log)
+  served ctx     : 65536  (slots=1)
+  weights ftype  : MXFP4 MoE
+  drafter        : none
+  KV cache type  : q8_0 (source: argv)
+  serving argv   : model=/m/x.gguf offload=blk.*=CPU threads=24 ubatch=2048 ngl=99 split=1,1
+  moe-cache cfg  : moe_cache_cap=8192 RESERVE_MB=2048 ADMIT_AFTER=1 THROTTLE=64 MAX_BATCH=8 STATS=1000
+  CPU offload    : DETECTED via argv -ot
+
+=== summary [narrative] (n=5) ===
+  wall_TPS       mean=  17.10   std=  0.12   CV= 0.7%   min= 17.00   max= 17.30
+  decode_TPS     mean=  17.30   std=  0.10   CV= 0.6%   min= 17.20   max= 17.44
+  TTFT          mean=   612ms  std=   25ms  min=590ms  max=640ms
+  n-usable      5/5  (runs with >= 250 tokens, 25% of max_tokens=1000)
+
+=== summary [prefill-10k] (n=3) ===
+  prefill tok/s  mean= 119.40   std=  0.20   CV= 0.2%   min=119.10   max=119.60
+  TTFT          mean= 83700ms  std=  120ms  min=83500ms  max=83900ms
+
+========== CAPTURE: VRAM ==========
+  idle=23000 MiB  peak=23400 MiB  post=23000 MiB
+  leak delta (post - idle) = 0 MiB
+
+========== CAPTURE: EXPERT CACHE (moe-cache) ==========
+    CUDA0 pools=1 slots=2000 total_mib=8500 expert_kib=4352 type=mxfp4
+    CUDA1 pools=1 slots=1600 total_mib=6800 expert_kib=4352 type=mxfp4
+    CUDA0 marginal=41.0% cumulative=30.1% dhits=1 dlookups=2 devictions=0
+    CUDA1 marginal=50.0% cumulative=36.0% dhits=1 dlookups=2 devictions=0
+  health counters: PASS (all health counters zero)
+
+========== CAPTURE: INTEGRITY ==========
+  status: OK
+  swap check   : PASS (no serving-process pages in swap)

--- a/scripts/tests/fixtures/bench-card/live-offload-run.log
+++ b/scripts/tests/fixtures/bench-card/live-offload-run.log
@@ -1,0 +1,172 @@
+# Fixture: a REAL bench.sh run, redacted (rig paths replaced).
+# Source: a bare-metal, CPU-offloaded, chat-tuned MoE on 2x consumer GPUs —
+# the combination the capture layer was built for. Used to prove the card
+# renderer fills its offload block from an ACTUAL run rather than only from
+# hand-written records, which is where a renderer quietly diverges from what
+# bench.sh really prints.
+#
+# NOTE: produced BEFORE the health-verdict correction, so its cache-health line
+# still uses the old over-strict wording ('FAIL' on non-zero skips). Kept as-is
+# on purpose: the parser must stay able to read logs written by older versions.
+
+========== CONFIG FINGERPRINT ==========
+  endpoint       : http://127.0.0.1:8030  (mode=chat)
+  model          : deepseek-v4-flash
+  serving pid    : 823013
+  log source     : server-log (/var/log/llama-server.log)
+  served ctx     : 65536  (slots=1)
+  weights ftype  : MXFP4 MoE
+  KV cache type  : capture: KV cache type unavailable (not in argv, /props or the boot log)
+  serving argv   : model=/models/deepseek-v4-flash/DeepSeek-V4-Flash-UD-Q8_K_XL-00001-of-00005.gguf offload=blk\.[0-9]+\.ffn_(gate|up|down)_exps\.weight=CPU threads=24 ubatch=2048 ngl=99 split=1,1
+  moe-cache cfg  : moe_cache_cap=20480 RESERVE_MB=2048 ADMIT_AFTER=1 THROTTLE=64 MAX_BATCH=8 STATS=1000
+  CPU offload    : DETECTED via argv -ot
+
+========== SYSTEM RAM ==========
+  mem_total_gib=235.9 mem_available_gib=89.9 server_rss_gib=139.2 swap_total_gib=8.0 swap_used_gib=2.4 server_swap_mib=0
+  swap check     : PASS (no serving-process pages in swap)
+
+========== RAM BANDWIDTH CEILING (STREAM triad, idle box) ==========
+  triad ceiling  : 36.0 GB/s  (16 concurrent workers, ~3 s, measured on THIS host)
+                   Sustained STREAM-triad, not a spec sheet figure. A box that is
+                   already serving reports a LOWER ceiling than an idle one — which
+                   is the honest denominator for a run measured under that load.
+[bench] narrative run 1/5: 1000 tok in 54.4s (18.54 decode TPS, ttft 479ms)
+[bench] narrative run 2/5: 1000 tok in 55.1s (18.31 decode TPS, ttft 467ms)
+[bench] narrative run 3/5: 1000 tok in 54.9s (18.41 decode TPS, ttft 529ms)
+[bench] narrative run 4/5: 1000 tok in 54.5s (18.54 decode TPS, ttft 527ms)
+[bench] narrative run 5/5: 1000 tok in 55.0s (18.36 decode TPS, ttft 534ms)
+[bench] code run 1/5: 800 tok in 43.4s (18.67 decode TPS, ttft 548ms)
+[bench] code run 2/5: 800 tok in 44.0s (18.43 decode TPS, ttft 541ms)
+[bench] code run 3/5: 800 tok in 43.7s (18.53 decode TPS, ttft 546ms)
+[bench] code run 4/5: 800 tok in 43.7s (18.53 decode TPS, ttft 541ms)
+[bench] code run 5/5: 800 tok in 44.1s (18.36 decode TPS, ttft 538ms)
+[bench] capture: tokenizer ratio 1.27 tok/word (haystacks sized by measured tokens, not words)
+[bench] prefill-10k run 1/3: 10353 prompt tok, 126.3 prefill tok/s, ttft 81947ms
+[bench] prefill-10k run 2/3: 9996 prompt tok, 129.9 prefill tok/s, ttft 76925ms
+[bench] prefill-10k run 3/3: 10353 prompt tok, 126.2 prefill tok/s, ttft 82024ms
+
+========== NARRATIVE (prompt=65 chars, max_tokens=1000) ==========
+=== warmups (3) ===
+  warm-1     wall= 55.15s  ttft=   552ms  toks=1000  wall_TPS= 18.13  decode_TPS= 18.32
+  warm-2     wall= 54.81s  ttft=   487ms  toks=1000  wall_TPS= 18.24  decode_TPS= 18.41
+  warm-3     wall= 54.47s  ttft=   467ms  toks=1000  wall_TPS= 18.36  decode_TPS= 18.52
+
+=== measured (5) ===
+  run-1      wall= 54.42s  ttft=   479ms  toks=1000  wall_TPS= 18.37  decode_TPS= 18.54
+  run-2      wall= 55.08s  ttft=   467ms  toks=1000  wall_TPS= 18.15  decode_TPS= 18.31
+  run-3      wall= 54.86s  ttft=   529ms  toks=1000  wall_TPS= 18.23  decode_TPS= 18.41
+  run-4      wall= 54.46s  ttft=   527ms  toks=1000  wall_TPS= 18.36  decode_TPS= 18.54
+  run-5      wall= 55.01s  ttft=   534ms  toks=1000  wall_TPS= 18.18  decode_TPS= 18.36
+
+=== summary [narrative] (n=5) ===
+  wall_TPS       mean=  18.26   std=  0.10   CV= 0.6%   min=18.15   max=18.37
+  decode_TPS     mean=  18.43   std=  0.11   CV= 0.6%   min=18.31   max=18.54
+  TTFT          mean=   507ms  std=   32ms  min=467ms  max=534ms
+  n-usable      5/5  (runs with >= 250 tokens, 25% of max_tokens=1000)
+  PP tok/s       mean=  31.51   std=  2.16   CV= 6.9%   min=29.75   max=34.25
+
+========== CODE (prompt=78 chars, max_tokens=800) ==========
+=== warmups (3) ===
+  warm-1     wall= 46.76s  ttft=   557ms  toks= 800  wall_TPS= 17.11  decode_TPS= 17.32
+  warm-2     wall= 44.18s  ttft=   536ms  toks= 800  wall_TPS= 18.11  decode_TPS= 18.33
+  warm-3     wall= 44.26s  ttft=   536ms  toks= 800  wall_TPS= 18.08  decode_TPS= 18.30
+
+=== measured (5) ===
+  run-1      wall= 43.39s  ttft=   548ms  toks= 800  wall_TPS= 18.44  decode_TPS= 18.67
+  run-2      wall= 43.95s  ttft=   541ms  toks= 800  wall_TPS= 18.20  decode_TPS= 18.43
+  run-3      wall= 43.71s  ttft=   546ms  toks= 800  wall_TPS= 18.30  decode_TPS= 18.53
+  run-4      wall= 43.71s  ttft=   541ms  toks= 800  wall_TPS= 18.30  decode_TPS= 18.53
+  run-5      wall= 44.11s  ttft=   538ms  toks= 800  wall_TPS= 18.14  decode_TPS= 18.36
+
+=== summary [code] (n=5) ===
+  wall_TPS       mean=  18.28   std=  0.11   CV= 0.6%   min=18.14   max=18.44
+  decode_TPS     mean=  18.51   std=  0.12   CV= 0.6%   min=18.36   max=18.67
+  TTFT          mean=   543ms  std=    4ms  min=538ms  max=548ms
+  n-usable      5/5  (runs with >= 200 tokens, 25% of max_tokens=800)
+  PP tok/s       mean=  34.96   std=  0.24   CV= 0.7%   min=34.69   max=35.26
+
+========== PREFILL-10K (target=10000 prompt tokens, max_tokens=16, cache-busted: fresh haystack per run) ==========
+=== warmups (1) ===
+  warm-1     wall= 83.05s  ttft= 82883ms  prompt_toks= 10556  PP_tok/s= 127.36
+  [calibrated: 10556 tok at request=10000 → measured runs request 9473]
+
+=== measured (3) ===
+  run-1      wall= 82.11s  ttft= 81947ms  prompt_toks= 10353  PP_tok/s= 126.34
+  run-2      wall= 77.09s  ttft= 76925ms  prompt_toks=  9996  PP_tok/s= 129.94
+  run-3      wall= 82.23s  ttft= 82024ms  prompt_toks= 10353  PP_tok/s= 126.22
+
+=== summary [prefill-10k] (n=3) ===
+  prefill tok/s  mean= 127.50   std=  2.12   CV= 1.7%   min=126.22   max=129.94
+  TTFT          mean= 80298ms  std= 2922ms  min=76925ms  max=82024ms
+  PP tok/s (engine log, windowed) mean= 127.70   std=  2.13   CV= 1.7%   min=126.41   max=130.16
+
+========== PREFILL-90K (target=90000 prompt tokens, max_tokens=16, cache-busted: fresh haystack per run) ==========
+=== warmups (1) ===
+  SKIP: 90000 tokens exceeds the served context (HTTP Error 400: Bad Request)
+
+========== CAPTURE: PCIe ==========
+  decode all rx_mean=231 rx_peak=1941 tx_mean=98 tx_peak=659 sm_mean=29.6 memctl_mean=20.6 samples=904
+  decode GPU0 rx_mean=346 rx_peak=1941 tx_mean=119 tx_peak=659 sm_mean=30.3 memctl_mean=20.2 samples=452
+  decode GPU1 rx_mean=115 rx_peak=1507 tx_mean=77 tx_peak=178 sm_mean=28.9 memctl_mean=21.0 samples=452
+  prefill all rx_mean=3031 rx_peak=28182 tx_mean=447 tx_peak=12154 sm_mean=50.9 memctl_mean=20.1 samples=444
+  prefill GPU0 rx_mean=5978 rx_peak=28182 tx_mean=831 tx_peak=12154 sm_mean=67.3 memctl_mean=21.4 samples=222
+  prefill GPU1 rx_mean=85 rx_peak=1778 tx_mean=64 tx_peak=1914 sm_mean=34.5 memctl_mean=18.8 samples=222
+  note: decode and prefill PCIe traffic differ by ~100x on an offloaded MoE —
+        a whole-run mean describes neither. 1 Hz under-reads bursts, so the
+        PEAK is reported next to the mean, not instead of it.
+  link (sampled under load, best observed):
+    GPU0 gen=4/4 width=16/16
+    GPU1 gen=4/4 width=16/16
+    denominator: ~26778 MB/s practical for a negotiated gen4 x16 link
+                 (per-lane raw x width x 0.85; NOT a theoretical peak)
+    decode rx peak = 1941 MB/s = 7.2% of that denominator
+
+========== CAPTURE: VRAM ==========
+  idle=44324 MiB  peak=45360 MiB  post=45360 MiB
+  leak delta (post - idle) = 1036 MiB
+  GPU0 22662 MiB (post-run)
+  GPU1 22698 MiB (post-run)
+  host CPU busy across the run: 37.9%
+
+========== CAPTURE: DRAFT ACCEPTANCE ==========
+  no drafter output in the log (spec-dec off, or the engine does not log acceptance)
+
+========== CAPTURE: ENGINE-SIDE TIMINGS ==========
+  decode n=16 mean=18.37 median=18.41 min=17.32 max=18.67  (tok/s, from the server's own print_timing)
+  prefill n=20 mean=52.36 median=34.72 min=29.75 max=130.16  (tok/s, from the server's own print_timing)
+  dropped_short_decode n=4 floor=32  (short probe completions excluded from the decode cross-check)
+  cross-check: client-observed 18.47 vs engine-side 18.41 tok/s -> 0.3% divergence
+
+========== CAPTURE: EXPERT CACHE (moe-cache) ==========
+  pool census (per device — a device can hold MULTIPLE pools; slots/bytes are summed):
+    CUDA0 pools=1 slots=3038 total_mib=12911 expert_kib=4352 type=mxfp4
+    CUDA1 pools=1 slots=3126 total_mib=13285 expert_kib=4352 type=mxfp4
+  allocation: devices=2 pool_lines=2 enabled=1 nobudget=0 devlist=CUDA0,CUDA1  (GPUs on this host: 2)
+  hit rate, per device (MARGINAL = across the measured window only):
+    CUDA0 marginal=60.3% cumulative=59.3% dhits=4552130 dlookups=7551498 devictions=42171
+    CUDA1 marginal=80.4% cumulative=79.4% dhits=2933098 dlookups=3647988 devictions=9158
+    note: the CUMULATIVE column embeds the cold-fill phase and is NOT
+          boot-comparable — a BIGGER pool shows a LOWER cumulative rate on
+          the same traffic. Compare boots on the MARGINAL column only.
+    note: the per-device split is signal, not noise — a CUDA0/CUDA1 hit
+          asymmetry is routing entropy, and averaging it away hides it.
+  health counters: FAIL — CUDA0: skips=13955; CUDA1: skips=2330
+  derived host-RAM read demand on the miss path: ~14119 MB/s
+    = 3714258 misses x 4352 KiB / 1118s
+    ⚠ DERIVED, NOT A PERF COUNTER. A lower bound on the miss path only
+      (ignores KV traffic, activations and prefetch). IMC/uncore counters
+      are root-gated on bare metal and absent in VM guests, so this is the
+      portable substitute — never quote it as measured bandwidth.
+    ~14 of ~36 GB/s STREAM-triad ceiling (39%)
+  bypass counter: 0
+
+========== CAPTURE: INTEGRITY ==========
+  status: OK
+  (no capture-level defect detected — this is NOT a statement about the numbers'
+   quality, only that the measurement machinery did its job)
+  swap check   : PASS (no serving-process pages in swap)
+  cache health : FAIL — CUDA0: skips=13955; CUDA1: skips=2330
+
+=== GPU state ===
+0, 0 %, 22662 MiB, 24576 MiB, 147.12 W, 64
+1, 0 %, 22698 MiB, 24576 MiB, 135.52 W, 60

--- a/scripts/tests/fixtures/offload-matrix/fake-llama-server
+++ b/scripts/tests/fixtures/offload-matrix/fake-llama-server
@@ -35,6 +35,26 @@ FAKE_SCENARIO:
   req_errors      completions return HTTP 500                 -> REQ_ERRORS
   boot_fail       exit non-zero before listening              -> BOOT_FAIL
   hang            never answers /health                       -> TIMEOUT
+  short_eos       healthy, but every completion EOSes at a handful of tokens
+                  regardless of max_tokens -> bench.sh's n-usable warning
+  low_fire        healthy + a drafter with HIGH acceptance that fires on only a
+                  MINORITY of requests -> acceptance-without-fire-rate warning
+  multipool       healthy, but each device holds TWO pools with the current
+                  census line shape (type=/expert=/slots=/total=) -> per-device
+                  aggregation, and the #824 detector must key on DEVICES-with-a
+                  -pool, not on the raw pool-line count
+
+--- bench.sh surface (additive; the sweep's driver never calls these) ---------
+  GET  /v1/models          bench.sh's reachability check
+  GET  /props              served ctx / slots / ftype / drafter fingerprint
+  POST /tokenize           the token-ratio probe (item 7)
+  POST /v1/completions     ENDPOINT=completion (choices[0].text, not a delta)
+  usage chunk              emitted ONLY when the request asks for it via
+                           stream_options.include_usage — bench.sh does, the
+                           sweep's driver does NOT, and that driver would raise
+                           IndexError on a choices-less chunk. Gating on the
+                           request is both realistic and what keeps the sweep's
+                           own suite green.
 """
 import json, os, sys, time, threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -43,6 +63,22 @@ SC    = os.environ.get("FAKE_SCENARIO", "healthy")
 NGPU  = int(os.environ.get("FAKE_NGPU", "2"))
 TOKS  = int(os.environ.get("FAKE_TOKENS", "24"))
 SLOTS = [int(s) for s in os.environ.get("FAKE_SLOTS", "742,337").split(",")]
+# tokens-per-word this fake "tokenizer" produces. >1 on purpose: the word-count
+# heuristic bench.sh used to size haystacks with is a per-tokenizer guess, and a
+# ratio of 1.0 would hide the very overshoot item 7 exists to fix.
+TOK_PER_WORD = float(os.environ.get("FAKE_TOK_PER_WORD", "1.375"))
+SHORT_EOS    = int(os.environ.get("FAKE_SHORT_EOS", "6"))
+FIRE_EVERY   = int(os.environ.get("FAKE_FIRE_EVERY", "4"))   # low_fire: 1 in N
+EXPERT_KIB   = int(os.environ.get("FAKE_EXPERT_KIB", "1536"))
+# Seconds per emitted token. The default keeps the sweep's suite fast; a test that
+# needs a measured phase LONGER than the 1 Hz dmon sample period raises it, since
+# a phase shorter than the sample period genuinely contains no samples.
+TOK_DELAY    = float(os.environ.get("FAKE_TOKEN_DELAY", "0.002"))
+_req_n       = [0]
+
+
+def fake_tokens(text):
+    return max(1, int(len(text.split()) * TOK_PER_WORD))
 
 def log(s):
     sys.stdout.write(s + "\n"); sys.stdout.flush()
@@ -69,6 +105,18 @@ host = opt("--host", "127.0.0.1")
 port = int(opt("--port", "8080"))
 ctx  = int(opt("-c", "4096"))
 
+# FAKE_PID_FILE: write our OWN pid where the caller can read it.
+# `$!` from the launching shell is NOT reliable here — the shebang plus an `env`
+# prefix re-execs, and the pid the shell recorded can end up belonging to a
+# process that is already gone while the server runs under another. A test that
+# then passes SERVER_PID=<stale> makes capture.sh fall back to `pgrep -x
+# llama-server` and adopt the RIG'S REAL SERVER. Real servers offer --pid-file
+# for the same reason.
+_pidfile = os.environ.get("FAKE_PID_FILE", "")
+if _pidfile:
+    with open(_pidfile, "w", encoding="utf-8") as _fh:
+        _fh.write(str(os.getpid()))
+
 # --- boot log ---------------------------------------------------------------
 log("build: fake (tier-1 fixture)")
 log(f"llama_context: n_ctx = {ctx}")
@@ -88,6 +136,15 @@ elif SC == "partial_budget":
     log("[moe-cache] enabled: reserve=3072 MiB admit=1/64")
     log("[moe-cache] CUDA0 has no cache budget after 3072 MiB reserve")
     log(f"[moe-cache] CUDA1 pool[0]: slots={SLOTS[0]} expert=1536 KiB")
+elif SC == "multipool":
+    # Current census line shape, TWO pools on the device that has any. The raw
+    # pool-line count is then >= NGPU while a whole device holds nothing — so a
+    # count-of-lines detector passes this and a count-of-DEVICES detector fails
+    # it. Only the second reading is correct (#824, generalised).
+    log("[moe-cache] enabled: reserve=1536 MiB admit=1/64")
+    log("[moe-cache] CUDA0 has no cache budget after 1536 MiB reserve")
+    log("[moe-cache] CUDA1 pool[0]: type=mxfp4 expert=4352 KiB slots=3038 total=12911 MiB")
+    log("[moe-cache] CUDA1 pool[1]: type=mxfp4 expert=4352 KiB slots=1000 total=4250 MiB")
 else:
     log("[moe-cache] enabled: reserve=1536 MiB admit=1/64")
     for g in range(NGPU):
@@ -98,13 +155,24 @@ log("llama_server: listening on " + f"{host}:{port}")
 
 # --- periodic stats, so hits/misses/evictions have something to scrape ------
 def stats_loop():
-    h = 0
+    tot = [0] * NGPU
+    hit = [0] * NGPU
+    n = 0
     while True:
         time.sleep(1.0)
-        h += 1000
+        n += 1
         for g in range(NGPU):
-            log(f"[moe-cache] CUDA{g} hits={h}/{int(h*1.35)} evictions={h//8} "
-                f"expert=1536 KiB skips=0 fill-fail=0")
+            # Two properties are deliberate, and both are measured behaviour:
+            #  * a COLD-FILL phase (first emissions hit almost nothing), so the
+            #    cumulative rate and the marginal rate across a later window
+            #    genuinely DISAGREE — the whole reason item 3b exists;
+            #  * a per-device ASYMMETRY (~48% vs ~58% on a layer-split MoE),
+            #    which is routing-entropy signal that averaging destroys.
+            rate = 0.05 if n <= 3 else (0.48 if g % 2 == 0 else 0.58)
+            tot[g] += 100000
+            hit[g] += int(100000 * rate)
+            log(f"[moe-cache] CUDA{g} hits={hit[g]}/{tot[g]} evictions={n * 8 + g} "
+                f"expert={EXPERT_KIB} KiB skips=0 fill-fail=0 dispatch-fail=0 collect-fail=0")
         if SC == "bypass":
             log("[moe-cache] MAX_BATCH=8 exceeded, bypassing cache for this batch")
 
@@ -116,24 +184,73 @@ class H(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
     def log_message(self, *a): pass          # keep the arm log clean
 
+    def _json(self, obj, code=200):
+        b = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(b)))
+        self.end_headers()
+        self.wfile.write(b)
+
     def do_GET(self):
         if self.path.startswith("/health"):
             self.send_response(200); self.send_header("Content-Length", "2")
             self.end_headers(); self.wfile.write(b"ok")
+        elif self.path.startswith("/v1/models"):
+            self._json({"object": "list", "data": [{"id": "fake-model", "object": "model"}]})
+        elif self.path.startswith("/props"):
+            # Shaped like llama-server's real /props: the fields bench.sh's config
+            # fingerprint reads (served ctx, slots, ftype, drafter) and nothing else.
+            self._json({
+                "default_generation_settings": {
+                    "n_ctx": ctx,
+                    "params": {"speculative": {"types": "none"}},
+                },
+                "total_slots": 1,
+                "model_alias": "fake-model",
+                "model_ftype": "MXFP4 MoE",
+            })
         else:
             self.send_response(404); self.send_header("Content-Length", "0"); self.end_headers()
 
     def do_POST(self):
         n = int(self.headers.get("Content-Length", 0) or 0)
         body = self.rfile.read(n)
+        try:
+            req = json.loads(body)
+        except Exception:
+            req = {}
+
+        if self.path.startswith("/tokenize"):
+            # The item-7 token-ratio probe. Returning MORE tokens than words is
+            # the point: a 1.0 ratio would hide the overshoot being fixed.
+            self._json({"tokens": list(range(fake_tokens(str(req.get("content", "")))))})
+            return
+
         if SC == "req_errors":
             self.send_response(500); self.send_header("Content-Length", "0"); self.end_headers()
             return
+
+        _req_n[0] += 1
+        # Which endpoint was actually driven — bench.sh's ENDPOINT knob is only
+        # meaningful if it changes the request, so a test must be able to see it.
+        log(f"[fake] request endpoint={self.path}")
+        raw_completion = self.path.startswith("/v1/completions")
+        prompt_text = req.get("prompt") if raw_completion else "".join(
+            str(m.get("content", "")) for m in (req.get("messages") or []))
+        want_usage = bool((req.get("stream_options") or {}).get("include_usage"))
         try:
-            gen = int(json.loads(body).get("max_tokens", TOKS))
+            gen = int(req.get("max_tokens", TOKS))
         except Exception:
             gen = TOKS
-        emit = 0 if SC == "no_tokens" else min(gen, TOKS)
+        if SC == "no_tokens":
+            emit = 0
+        elif SC == "short_eos":
+            # EOSes far below max_tokens no matter what was asked for — a chat-tuned
+            # model answering briefly. Degenerates a 5-run shape to n=1 in silence.
+            emit = min(gen, SHORT_EOS)
+        else:
+            emit = min(gen, TOKS)
 
         self.send_response(200)
         self.send_header("Content-Type", "text/event-stream")
@@ -144,17 +261,41 @@ class H(BaseHTTPRequestHandler):
             self.wfile.write(f"{len(b):X}\r\n".encode() + b + b"\r\n"); self.wfile.flush()
         try:
             for i in range(emit):
-                d = {"choices": [{"delta": {"content": f"tok{i} "}}]}
+                if raw_completion:
+                    d = {"choices": [{"text": f"tok{i} "}]}
+                else:
+                    d = {"choices": [{"delta": {"content": f"tok{i} "}}]}
                 chunk("data: " + json.dumps(d) + "\n\n")
-                time.sleep(0.002)
+                time.sleep(TOK_DELAY)
+            if want_usage:
+                # ONLY when asked. The sweep's driver indexes choices[0]
+                # unconditionally and would raise IndexError on a choices-less
+                # chunk — gating on the request is what a real server does and
+                # what keeps the sweep's own suite green.
+                chunk("data: " + json.dumps({
+                    "choices": [],
+                    "usage": {"completion_tokens": emit,
+                              "prompt_tokens": fake_tokens(str(prompt_text or "")),
+                              "total_tokens": emit + fake_tokens(str(prompt_text or ""))},
+                }) + "\n\n")
             chunk("data: [DONE]\n\n")
             chunk("")                              # terminating 0-length chunk
         except (BrokenPipeError, ConnectionResetError):
             pass
         # per-request timings the sweep scrapes for server-side decode TPS
+        ptoks = fake_tokens(str(prompt_text or ""))
+        log(f"print_timing: prompt eval time = 1000.00 ms / {ptoks} tokens "
+            f"( 1.00 ms per token, {ptoks * 1.0:.2f} tokens per second)")
         log(f"print_timing: eval time = 1000.00 ms / {max(emit,1)} tokens "
             f"( 1.00 ms per token, {max(emit,1)*2.5:.2f} tokens per second)")
-        log("draft acceptance = 0.951")
+        # low_fire: HIGH acceptance, but the drafter only fires on a minority of
+        # requests. Acceptance without that base rate is a deception (measured:
+        # 0.992 acceptance on 5 of ~20 requests, zero on novel content).
+        if SC == "low_fire":
+            if _req_n[0] % FIRE_EVERY == 0:
+                log("draft acceptance = 0.992")
+        else:
+            log("draft acceptance = 0.951")
 
 if SC == "hang":
     while True:

--- a/scripts/tests/test-bench-capture.sh
+++ b/scripts/tests/test-bench-capture.sh
@@ -209,7 +209,28 @@ echo "  ✓ marginal rate derived per device, and disagrees with cumulative (48/
 v=$(cap_health_verdict "$TMP/c1")
 [[ "$v" == FAIL* ]] || fail "a non-zero fill-fail must FAIL the health panel, got: $v"
 command grep -q 'CUDA1' <<<"$v" || fail "health verdict must name the offending device: $v"
-echo "  ✓ health counters: all-zero passes, non-zero fails and names the device"
+# ⚠ `skips` is NOT a hard failure. It counts admission throttling (insert queue
+#   exhausted under the configured THROTTLE), so under a low ADMIT_AFTER a non-zero
+#   value is normal steady-state pressure. A live run on a HEALTHY server showed
+#   skips at 0.5% of misses — the original "all counters zero" spec would have
+#   failed it. Report it as load, never as a defect.
+cat > "$TMP/skips.kv" <<'EOF'
+CUDA0 hits=100 total=200 evictions=5 skips=13955 admission=4000 fill_fail=0 dispatch_fail=0 collect_fail=0
+CUDA1 hits=120 total=200 evictions=6 skips=2330 admission=900 fill_fail=0 dispatch_fail=0 collect_fail=0
+EOF
+v=$(cap_health_verdict "$TMP/skips.kv")
+[[ "$v" == PASS* ]] || fail "non-zero skips with zero hard failures must PASS, got: $v"
+command grep -q 'informational' <<<"$v" || fail "skips must still be REPORTED as a load metric: $v"
+command grep -q 'skips=13955' <<<"$v" || fail "the informational tail must carry the value: $v"
+command grep -q 'THROTTLE tuning signal, not a defect' <<<"$v" \
+  || fail "the verdict must say why skips is not a defect: $v"
+# ...and each hard-failure counter on its own must still fail.
+for hard in fill_fail dispatch_fail collect_fail; do
+  printf 'CUDA0 hits=1 total=2 skips=99 %s=1\n' "$hard" > "$TMP/hard.kv"
+  [[ "$(cap_health_verdict "$TMP/hard.kv")" == FAIL* ]] \
+    || fail "a non-zero $hard must FAIL the health panel"
+done
+echo "  ✓ health: hard failures FAIL, skips/admission report as load (the corrected pass condition)"
 
 # --- acceptance WITH fire rate ----------------------------------------------
 acc=$(cap_moe_parse acceptance "$TMP/end.log") || fail "acceptance scrape returned nothing"
@@ -221,7 +242,12 @@ echo "  ✓ acceptance scrape carries fire count AND drafts-attempted"
 
 # --- timings: prefill and decode must not be confused; short runs filtered ----
 tim=$(cap_moe_parse timings "$TMP/end.log") || fail "timings scrape returned nothing"
-command grep -q '^prefill n=1 mean=2000.00' <<<"$tim" || fail "prefill timing mis-parsed: $tim"
+# The two prefill populations (short canonical prompts vs deep haystacks) differ by
+# ~4x, so they are reported separately rather than averaged into one meaningless mean.
+command grep -q '^prefill_deep(>=2000tok) n=1 mean=2000.00' <<<"$tim" \
+  || fail "deep-prefill timing mis-parsed: $tim"
+command grep -q '^prefill_short(<2000tok) n=0' <<<"$tim" \
+  || fail "the short-prefill population must be reported even when empty: $tim"
 command grep -q '^decode n=2' <<<"$tim" || fail "decode timing mis-parsed: $tim"
 tim2=$(CAP_MIN_DECODE_TOKENS=32 cap_moe_parse timings "$TMP/end.log")
 command grep -q '^decode n=1 ' <<<"$tim2" \
@@ -237,6 +263,13 @@ for want in "kv=q8_0" "threads=24" "ngl=99" "split=1,1" "ubatch=2048"; do
   command grep -q -- "$want" <<<"$fp" || fail "argv fingerprint missing $want: $fp"
 done
 [[ "$(cap_kv_type "$ARGV")" == "q8_0 (source: argv)" ]] || fail "KV type not read from argv"
+# With no -ctk/-ctv the llama.cpp default is f16 — a fact the reader can act on,
+# where "unavailable" is not. Only inferred once the engine family is identified.
+CAP_LOG="$TMP/end.log" v="$(cap_kv_type 'llama-server -m /m/x.gguf -ngl 99' || true)"
+[[ "$v" == "f16 (engine default; no -ctk/-ctv in argv)" ]] \
+  || fail "a llama.cpp run with no KV flag should report the engine default, got: '$v'"
+CAP_LOG="" CAP_PROPS_TRIED=1 CAP_PROPS="" v="$(cap_kv_type '' 2>/dev/null || echo UNAVAILABLE)"
+[[ "$v" == "UNAVAILABLE" ]] || fail "with no argv and no identifiable engine, KV must stay unavailable, got: '$v'"
 command grep -q 'argv -ot' <<<"$(cap_offload_detected "$ARGV")" || fail "-ot must trigger offload detection"
 command grep -q 'moe_cache_cap=8192' <<<"$(cap_moe_cache_config "$ARGV")" \
   || fail "--moe-cache cap must be captured (the census self-limits below it)"

--- a/scripts/tests/test-bench-capture.sh
+++ b/scripts/tests/test-bench-capture.sh
@@ -1,0 +1,486 @@
+#!/usr/bin/env bash
+# test-bench-capture — guards for scripts/lib/capture.sh and bench.sh's capture layer.
+#
+# Extends the #835 mocked-scrape pattern: TIER 0 checks that can be made from the
+# source text alone, TIER 1 unit tests of every scrape against fixture logs with
+# the REAL line shapes, and TIER 1 end-to-end runs of the actual bench against the
+# fake llama-server.
+#
+# WHAT THIS SUITE IS FOR
+#   The capture layer exists because a bench harness fails by printing a PLAUSIBLE
+#   WRONG NUMBER, not by crashing. Every assertion below corresponds to a defect
+#   that has actually shipped: a 0.00 TPS printed next to a healthy TTFT; a
+#   cumulative hit rate that says a bigger pool is worse; an '[moe-cache] enabled:'
+#   banner that hides a device with no pool (#824); a drafter reporting 0.992
+#   acceptance while firing on a quarter of the requests.
+#
+# So: assert STRUCTURE, STATUS and WARNINGS — never a throughput value. Numbers
+# from a fake server mean nothing.
+#
+# HERMETIC BY CONSTRUCTION — both are load-bearing:
+#   SERVER_PID=<pid>           capture.sh otherwise runs `pgrep -x llama-server`
+#                              and would adopt a production server's argv/env.
+#   PREFLIGHT_NO_AUTODETECT=1  bench.sh otherwise adopts whatever container is up.
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BENCH="$ROOT_DIR/scripts/bench.sh"
+LIB="$ROOT_DIR/scripts/lib/capture.sh"
+FIX="$ROOT_DIR/scripts/tests/fixtures/offload-matrix"
+PORT_BASE="${TEST_PORT:-8147}"
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+for f in "$BENCH" "$LIB" "$FIX/fake-llama-server" "$FIX/fake-nvidia-smi"; do
+  [[ -f "$f" ]] || fail "missing fixture or script: $f"
+done
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"; [[ -n "${SRV_PID:-}" ]] && kill "$SRV_PID" 2>/dev/null; true' EXIT
+mkdir -p "$TMP/bin"
+install -m 0755 "$FIX/fake-nvidia-smi"   "$TMP/bin/nvidia-smi"
+install -m 0755 "$FIX/fake-llama-server" "$TMP/bin/fake-llama-server"
+: > "$TMP/model.gguf"
+
+# ===========================================================================
+# TIER 0 — source-text guards
+# ===========================================================================
+echo "  tier 0: source guards"
+
+bash -n "$BENCH" || fail "bash -n: syntax error in bench.sh"
+bash -n "$LIB"   || fail "bash -n: syntax error in capture.sh"
+python3 -m py_compile "$FIX/fake-llama-server" || fail "py_compile: fake-llama-server"
+# bench.sh's measurement core is a python heredoc; a syntax error in it would only
+# surface at run time, against a real model.
+python3 - "$BENCH" <<'PY' || fail "python heredoc in bench.sh does not parse"
+import ast, re, sys
+src = open(sys.argv[1], encoding="utf-8").read()
+m = re.search(r"<< 'PYEOF'\n(.*?)\nPYEOF\n", src, re.S)
+assert m, "no PYEOF heredoc found in bench.sh"
+ast.parse(m.group(1))
+PY
+# Inline `python3 -c '...'` snippets are the sneakiest syntax hazard in this
+# codebase: a single quote INSIDE the single-quoted shell string silently ends
+# it, python then gets a truncated program, and a `2>/dev/null || true` swallows
+# the error completely — the capture just never prints. Parse every one of them.
+python3 - "$BENCH" "$LIB" <<'PY' || fail "an inline python3 -c snippet does not parse"
+import ast, re, sys
+total = 0
+for path in sys.argv[1:]:
+    src = open(path, encoding="utf-8").read()
+    for m in re.finditer(r"python3 -c '((?:[^']|\n)*?)'\s*[\"$\n]", src):
+        body = m.group(1)
+        if not body.strip():
+            continue
+        total += 1
+        try:
+            ast.parse(body)
+        except SyntaxError as e:
+            sys.exit(f"{path}: inline python3 -c does not parse ({e}):\n{body[:400]}")
+        if "'" in body:
+            sys.exit(f"{path}: inline python3 -c contains a single quote — it would "
+                     f"terminate the shell string early:\n{body[:400]}")
+assert total >= 3, f"only found {total} inline snippets — did the extraction regex rot?"
+print(f"  ✓ {total} inline python3 -c snippets parse and are quote-safe")
+PY
+echo "  ✓ syntax (bash -n x2, py_compile, embedded-python ast)"
+
+# `pgrep -f` / `pkill -f` match against the FULL command line, which includes the
+# harness running the script — they have killed the calling shell (exit 144).
+for f in "$LIB" "$BENCH"; do
+  # `^[^#]*` keeps this to CODE — the rule itself is documented in comments in
+  # both files, and matching those would make the guard unwritable.
+  if command grep -nE '^[^#]*\b(pgrep|pkill) +-[a-zA-Z]*f' "$f"; then
+    fail "$(basename "$f") uses pgrep/pkill -f — self-match footgun; use pgrep -x and kill by pid"
+  fi
+done
+echo "  ✓ no pgrep/pkill -f (self-match footgun)"
+
+# grep is shimmed to ugrep in interactive shells on some rigs, which breaks exact
+# output matching. Every scrape in the lib must use `command grep`.
+bare=$(command grep -nE '(^|[|;&(]|\$\()\s*grep ' "$LIB" || true)
+[[ -z "$bare" ]] || fail "capture.sh uses bare grep (ugrep shim breaks exact matching):
+$bare"
+echo "  ✓ capture.sh uses 'command grep' throughout"
+
+# The degradation contract: ONE line, in a fixed shape, whenever a source is
+# missing. A capture that cannot run must be visibly absent, never silently zero.
+command grep -q 'capture: ${thing} unavailable (${why})' "$LIB" \
+  || fail "capture.sh's degradation notice no longer matches the documented shape"
+echo "  ✓ degradation notice keeps the 'capture: <thing> unavailable (<why>)' shape"
+
+# The deferral is a deliberate decision with an expiry, not an oversight. If the
+# note goes, the reason the duplication is tolerated goes with it.
+command grep -q 'offload-matrix.sh adoption is DEFERRED' "$LIB" \
+  || fail "capture.sh must record WHY offload-matrix.sh still carries its own copies"
+echo "  ✓ offload-matrix adoption deferral is recorded in the lib"
+
+# Sourcing the lib must have no side effects — no output, no exit, and safe to
+# source twice (bench.sh and a future sweep may both pull it in).
+out=$(bash -c "set -euo pipefail; source '$LIB'; source '$LIB'; echo READY" 2>&1)
+[[ "$out" == "READY" ]] || fail "sourcing capture.sh is not side-effect-free / idempotent: $out"
+echo "  ✓ capture.sh sources cleanly and idempotently"
+
+command grep -q 'source "${ROOT_DIR}/scripts/lib/capture.sh"' "$BENCH" \
+  || fail "bench.sh does not source the shared capture lib"
+echo "  ✓ bench.sh consumes the shared lib"
+
+# ===========================================================================
+# TIER 1a — unit tests of every scrape, against the REAL line shapes
+# ===========================================================================
+echo "  tier 1a: scrape units"
+
+# Two snapshots of a log whose hit rate CHANGES: a cold-fill phase followed by a
+# steady state. Constructed so cumulative and marginal DISAGREE — the whole reason
+# the marginal rate exists (item 3b). Also carries the measured per-device
+# asymmetry (~48% / ~58% on a layer-split MoE), which averaging would destroy.
+cat > "$TMP/start.log" <<'EOF'
+llama_context: n_ctx_seq = 262144
+CUDA_Host model buffer size = 98304.00 MiB
+[moe-cache] enabled: reserve=1536 MiB admit=1/64
+[moe-cache] CUDA0 pool[0]: type=mxfp4 expert=4352 KiB slots=3038 total=12911 MiB
+[moe-cache] CUDA0 pool[1]: type=mxfp4 expert=4352 KiB slots=1000 total=4250 MiB
+[moe-cache] CUDA1 pool[0]: type=mxfp4 expert=4352 KiB slots=2500 total=10625 MiB
+[moe-cache] CUDA0 hits=10000/200000 evictions=5 skips=0 fill-fail=0 dispatch-fail=0 collect-fail=0
+[moe-cache] CUDA1 hits=12000/200000 evictions=6 skips=0 fill-fail=0 dispatch-fail=0 collect-fail=0
+EOF
+cp "$TMP/start.log" "$TMP/end.log"
+cat >> "$TMP/end.log" <<'EOF'
+prompt eval time =  5000.00 ms /  10000 tokens (    0.50 ms per token,  2000.00 tokens per second)
+       eval time = 10000.00 ms /    300 tokens (   33.33 ms per token,    30.00 tokens per second)
+       eval time =   500.00 ms /     16 tokens (   31.25 ms per token,    32.00 tokens per second)
+draft acceptance = 0.992 (  248 accepted /   250 generated)
+[moe-cache] CUDA0 hits=58000/300000 evictions=25 skips=0 fill-fail=0 dispatch-fail=0 collect-fail=0
+[moe-cache] CUDA1 hits=70000/300000 evictions=26 skips=0 fill-fail=3 dispatch-fail=0 collect-fail=0
+EOF
+
+# shellcheck source=../lib/capture.sh
+source "$LIB"
+
+# --- census: a device can hold MULTIPLE pools; slots and bytes AGGREGATE ------
+cen=$(cap_moe_parse census "$TMP/end.log") || fail "census scrape returned nothing"
+command grep -q 'CUDA0 pools=2 slots=4038 total_mib=17161' <<<"$cen" \
+  || fail "census must SUM every pool on a device (3038+1000=4038 slots), got:
+$cen"
+command grep -q 'CUDA1 pools=1 slots=2500' <<<"$cen" || fail "census lost CUDA1: $cen"
+command grep -q 'expert_kib=4352' <<<"$cen" || fail "census did not read expert size: $cen"
+echo "  ✓ pool census aggregates multiple pools per device, keeps devices separate"
+
+# --- #824: detection must count DEVICES WITH A POOL, not pool lines ----------
+pd=$(cap_moe_parse pooldev "$TMP/end.log") || fail "pooldev scrape returned nothing"
+command grep -q 'devices=2' <<<"$pd" || fail "pooldev device count wrong: $pd"
+# The generalised trap: two pools on ONE device makes pool_lines >= NGPU while a
+# whole device holds nothing. A count-of-lines detector passes that; only a
+# count-of-devices detector catches it.
+cat > "$TMP/halfcached.log" <<'EOF'
+[moe-cache] enabled: reserve=1536 MiB admit=1/64
+[moe-cache] CUDA0 has no cache budget after 1536 MiB reserve
+[moe-cache] CUDA1 pool[0]: type=mxfp4 expert=4352 KiB slots=3038 total=12911 MiB
+[moe-cache] CUDA1 pool[1]: type=mxfp4 expert=4352 KiB slots=1000 total=4250 MiB
+EOF
+pd2=$(cap_moe_parse pooldev "$TMP/halfcached.log") || fail "pooldev failed on half-cached log"
+command grep -q 'devices=1' <<<"$pd2" \
+  || fail "half-cached log must report devices=1 (only CUDA1 has a pool), got: $pd2"
+command grep -q 'pool_lines=2' <<<"$pd2" || fail "expected pool_lines=2 in: $pd2"
+command grep -q 'enabled=1' <<<"$pd2" \
+  || fail "the 'enabled:' banner must still be reported — that it prints in this state IS the #824 hole"
+echo "  ✓ #824: half-cached run reports devices=1 while pool_lines=2 and enabled=1"
+
+# --- marginal vs cumulative MUST disagree ------------------------------------
+cap_moe_parse counters "$TMP/start.log" > "$TMP/c0" || fail "counters scrape (start) failed"
+cap_moe_parse counters "$TMP/end.log"   > "$TMP/c1" || fail "counters scrape (end) failed"
+mar=$(cap_marginal_rates "$TMP/c0" "$TMP/c1") || fail "marginal-rate derivation failed"
+command grep -q 'CUDA0 marginal=48.0% cumulative=19.3%' <<<"$mar" \
+  || fail "CUDA0 marginal rate wrong (expect 48.0% marginal vs 19.3% cumulative), got:
+$mar"
+command grep -q 'CUDA1 marginal=58.0% cumulative=23.3%' <<<"$mar" \
+  || fail "CUDA1 marginal rate wrong (expect 58.0% vs 23.3%), got:
+$mar"
+# If these ever agree the fixture stopped exercising the defect this exists for.
+python3 - <<PY || fail "marginal and cumulative agree — the fixture no longer covers item 3b"
+import re, sys
+t = """$mar"""
+for ln in t.splitlines():
+    m = re.search(r"marginal=([\d.]+)% cumulative=([\d.]+)%", ln)
+    if m and abs(float(m.group(1)) - float(m.group(2))) < 5:
+        sys.exit(1)
+PY
+echo "  ✓ marginal rate derived per device, and disagrees with cumulative (48/58 vs 19/23)"
+
+# --- health counters: all-zero is the pass condition (item 3c) ---------------
+[[ "$(cap_health_verdict "$TMP/c0")" == PASS* ]] || fail "clean counters should PASS"
+v=$(cap_health_verdict "$TMP/c1")
+[[ "$v" == FAIL* ]] || fail "a non-zero fill-fail must FAIL the health panel, got: $v"
+command grep -q 'CUDA1' <<<"$v" || fail "health verdict must name the offending device: $v"
+echo "  ✓ health counters: all-zero passes, non-zero fails and names the device"
+
+# --- acceptance WITH fire rate ----------------------------------------------
+acc=$(cap_moe_parse acceptance "$TMP/end.log") || fail "acceptance scrape returned nothing"
+command grep -q 'fired=1' <<<"$acc" || fail "acceptance fire count wrong: $acc"
+command grep -q 'mean=0.992' <<<"$acc" || fail "acceptance value wrong: $acc"
+command grep -q 'accepted=248 drafted=250' <<<"$acc" \
+  || fail "drafts-attempted must be captured alongside acceptance: $acc"
+echo "  ✓ acceptance scrape carries fire count AND drafts-attempted"
+
+# --- timings: prefill and decode must not be confused; short runs filtered ----
+tim=$(cap_moe_parse timings "$TMP/end.log") || fail "timings scrape returned nothing"
+command grep -q '^prefill n=1 mean=2000.00' <<<"$tim" || fail "prefill timing mis-parsed: $tim"
+command grep -q '^decode n=2' <<<"$tim" || fail "decode timing mis-parsed: $tim"
+tim2=$(CAP_MIN_DECODE_TOKENS=32 cap_moe_parse timings "$TMP/end.log")
+command grep -q '^decode n=1 ' <<<"$tim2" \
+  || fail "the 16-token completion should be excluded at floor=32: $tim2"
+command grep -q 'dropped_short_decode n=1 floor=32' <<<"$tim2" \
+  || fail "dropping a short completion must be REPORTED, not silent: $tim2"
+echo "  ✓ timings split prefill/decode and report (not hide) short-completion filtering"
+
+# --- always-on fingerprint pieces -------------------------------------------
+ARGV="python3 /x/llama-server -m /models/m.gguf -ot blk.(1|2).ffn_up_exps.weight=CPU -t 24 -ub 2048 -ct q8_0 -ngl 99 -ts 1,1 --moe-cache 8192"
+fp=$(cap_argv_fingerprint "$ARGV") || fail "argv fingerprint returned nothing"
+for want in "kv=q8_0" "threads=24" "ngl=99" "split=1,1" "ubatch=2048"; do
+  command grep -q -- "$want" <<<"$fp" || fail "argv fingerprint missing $want: $fp"
+done
+[[ "$(cap_kv_type "$ARGV")" == "q8_0 (source: argv)" ]] || fail "KV type not read from argv"
+command grep -q 'argv -ot' <<<"$(cap_offload_detected "$ARGV")" || fail "-ot must trigger offload detection"
+command grep -q 'moe_cache_cap=8192' <<<"$(cap_moe_cache_config "$ARGV")" \
+  || fail "--moe-cache cap must be captured (the census self-limits below it)"
+# --n-cpu-moe is the other offload spelling, and a CUDA_Host buffer line is the
+# third signal for a server whose argv we cannot read.
+command grep -q 'n-cpu-moe' <<<"$(cap_offload_detected 'llama-server --n-cpu-moe 20')" \
+  || fail "--n-cpu-moe must trigger offload detection"
+CAP_LOG="$TMP/end.log" && command grep -q 'CUDA_Host' <<<"$(cap_offload_detected '')" \
+  || fail "a CUDA_Host model buffer line must trigger offload detection"
+echo "  ✓ argv/env fingerprint: KV type, offload signals (x3), moe-cache cap"
+
+# --- derived RAM demand + status enum + divergence ---------------------------
+# 94001 misses x 4352 KiB / 1024 / 60 s = 6658 MB/s
+[[ "$(cap_ram_rd_mbps 94001 4352 60)" == "6658" ]] || fail "derived ram_rd arithmetic changed"
+cap_ram_rd_mbps 0 4352 60 >/dev/null 2>&1 && fail "ram_rd must refuse to invent a value from zero misses"
+[[ "$(cap_status_classify 0 0 0 0 1 0)"     == NO_TOKENS ]]      || fail "zero tokens must be NO_TOKENS"
+[[ "$(cap_status_classify 500 0 0 0 1 0)"   == NO_TOKENS ]]      || fail "zero TPS must be NO_TOKENS"
+[[ "$(cap_status_classify 500 30 2 0 1 0)"  == REQ_ERRORS ]]     || fail "request errors must outrank OK"
+[[ "$(cap_status_classify 500 30 0 1 0 0)"  == CACHE_DISABLED ]] || fail "unallocated requested cache must not read OK"
+[[ "$(cap_status_classify 500 30 0 0 1 3)"  == INVALID_BYPASS ]] || fail "bypass>0 must not read OK"
+[[ "$(cap_status_classify 500 30 0 0 1 0)"  == OK ]]             || fail "a clean run must read OK"
+# NO_TOKENS outranks the cache states: a run with no tokens says nothing about a cache.
+[[ "$(cap_status_classify 0 0 0 1 0 5)"     == NO_TOKENS ]]      || fail "NO_TOKENS must outrank the cache states"
+[[ "$(cap_divergence_pct 30 32)" == "6.2" ]] || fail "divergence arithmetic changed"
+echo "  ✓ status enum precedence, derived-demand arithmetic, divergence"
+
+# ===========================================================================
+# TIER 1b — end-to-end bench.sh against the fake server
+# ===========================================================================
+echo "  tier 1b: end-to-end bench runs (no GPU, no model)"
+
+SRV_PID=""
+SRV_LOG=""
+# ⚠ TWO hermeticity traps here, both of which produced a run that measured the
+# RIG'S REAL SERVER instead of the fake:
+#   1. NEVER call this through a command substitution — `$( )` is a subshell, so
+#      SRV_PID would not propagate out.
+#   2. NEVER trust `$!` for the server pid. The shebang plus the `env` prefix
+#      re-execs, and the pid bash recorded can already be gone while the server
+#      runs under another. The fixture writes its OWN pid to FAKE_PID_FILE.
+# Either way, capture.sh with an empty/stale SERVER_PID falls back to
+# `pgrep -x llama-server` and adopts a production server's argv and env.
+start_server() {   # $1=scenario $2=port [extra env as VAR=VAL ...]
+  local scen="$1" port="$2"; shift 2
+  SRV_LOG="$TMP/server-$scen-$port.log"
+  local pidfile="$TMP/server-$scen-$port.pid"
+  rm -f "$pidfile"
+  env FAKE_SCENARIO="$scen" FAKE_NGPU=2 FAKE_TOKENS=40 FAKE_PID_FILE="$pidfile" "$@" \
+      GGML_CUDA_MOE_CACHE_RESERVE_MB=1536 GGML_CUDA_MOE_CACHE_ADMIT_AFTER=1/64 \
+      GGML_CUDA_MOE_CACHE_MAX_BATCH=8 GGML_CUDA_MOE_CACHE_STATS=1000 \
+      "$TMP/bin/fake-llama-server" -m "$TMP/model.gguf" \
+        -ot 'blk.(1|3|5).ffn_.*_exps.weight=CPU' -t 24 -ub 2048 -ct q8_0 -ngl 99 -ts 1,1 \
+        --moe-cache 8192 --host 127.0.0.1 --port "$port" > "$SRV_LOG" 2>&1 &
+  local i
+  for i in $(seq 1 40); do
+    curl -sf -m 1 "http://127.0.0.1:$port/health" >/dev/null 2>&1 && break
+    sleep 0.25
+  done
+  curl -sf -m 1 "http://127.0.0.1:$port/health" >/dev/null 2>&1 \
+    || { sed -n '1,15p' "$SRV_LOG" >&2; fail "$scen: fake server never became ready on $port"; }
+  SRV_PID="$(cat "$pidfile" 2>/dev/null || true)"
+  [[ -n "$SRV_PID" && -r "/proc/$SRV_PID/cmdline" ]] \
+    || fail "$scen: fake server did not report a readable pid — the run would not be hermetic"
+  # let the periodic cache stats emit at least one cumulative sample first, so the
+  # marginal derivation has a genuine "before" to difference against
+  sleep 2
+}
+
+run_bench() {   # $1=scenario $2=port $3=outfile [extra bench env ...]
+  local scen="$1" port="$2" out="$3"; shift 3
+  start_server "$scen" "$port"
+  PATH="$TMP/bin:$PATH" PREFLIGHT_NO_AUTODETECT=1 CONTAINER=none \
+    SERVER_LOG="$SRV_LOG" SERVER_PID="$SRV_PID" URL="http://127.0.0.1:$port" \
+    MODEL=fake-model RUNS=2 WARMUPS=1 PREFILL_PROBE=0 \
+    env "$@" timeout 300 bash "$BENCH" > "$out" 2>"${out}.err" || true
+  kill "$SRV_PID" 2>/dev/null || true; wait "$SRV_PID" 2>/dev/null || true; SRV_PID=""
+  # The fingerprint must describe the server this run actually drove. If the pid
+  # ever fails to reach capture.sh again, this catches it on the next run instead
+  # of silently reporting a production config.
+  # Skipped when the run deliberately disabled /proc inspection (SERVER_PID=none):
+  # there is no pid to adopt, so there is nothing to get wrong.
+  if ! command grep -q 'serving pid    : unknown' "$out" \
+     && command grep -q 'moe-cache cfg' "$out" \
+     && ! command grep -q 'moe_cache_cap=8192' "$out"; then
+    command grep -m1 'moe-cache cfg' "$out" >&2
+    fail "$scen: fingerprint did not describe the FAKE server — the run was not hermetic"
+  fi
+}
+
+# --- 1. healthy: the always-on captures all fire ----------------------------
+run_bench healthy "$((PORT_BASE))" "$TMP/healthy.out"
+H="$TMP/healthy.out"
+for want in \
+  "CONFIG FINGERPRINT" "KV cache type  : q8_0" "CPU offload    : DETECTED" \
+  "moe-cache cfg  : moe_cache_cap=8192" "RESERVE_MB=1536" "ADMIT_AFTER=1/64" \
+  "SYSTEM RAM" "mem_total_gib=" "swap check" \
+  "CAPTURE: PCIe" "CAPTURE: VRAM" "CAPTURE: EXPERT CACHE" "CAPTURE: INTEGRITY" \
+  "serving argv   :" "served ctx     :"; do
+  command grep -q "$want" "$H" || { sed -n '1,40p' "$H" >&2; fail "healthy run missing: $want"; }
+done
+command grep -q 'status: OK' "$H" || fail "healthy run should classify OK: $(command grep -A2 'CAPTURE: INTEGRITY' "$H")"
+# per-device values must survive into the OUTPUT, not just detection (item 3d)
+command grep -q 'CUDA0 marginal=' "$H" || fail "per-device marginal rate missing from output"
+command grep -q 'CUDA1 marginal=' "$H" || fail "the CUDA0/CUDA1 split was averaged away — item 3d"
+command grep -q 'CUDA0 pools=' "$H" || fail "per-device pool census missing from output"
+command grep -q 'DERIVED, NOT A PERF COUNTER' "$H" \
+  || fail "the derived RAM figure must carry its 'not a counter' caveat"
+command grep -q 'MARGINAL' "$H" || fail "the marginal-vs-cumulative caveat is missing"
+echo "  ✓ healthy: fingerprint + RAM + PCIe + VRAM + per-device cache + OK status"
+
+# --- 2. NO_TOKENS: the loud warn, and the engine-side cross-check ------------
+run_bench no_tokens "$((PORT_BASE+1))" "$TMP/notok.out"
+N="$TMP/notok.out"
+command grep -q 'status: NO_TOKENS' "$N" \
+  || { sed -n '/INTEGRITY/,$p' "$N" >&2; fail "a run that produced no tokens must classify NO_TOKENS"; }
+command grep -q 'NO_TOKENS: the run measured' "$N" || fail "NO_TOKENS must warn LOUDLY, not just set a status"
+command grep -q 'SCRAPE failure, not a' "$N" \
+  || fail "the NO_TOKENS warning must name the failure class (scrape, not a slow model)"
+command grep -q 'Do NOT quote any throughput number' "$N" || fail "NO_TOKENS must tell the reader not to quote the run"
+echo "  ✓ no_tokens: NO_TOKENS status + loud warning naming the failure class"
+
+# --- 3. engine-side cross-check divergence (item 1b) ------------------------
+command grep -q 'CAPTURE: ENGINE-SIDE TIMINGS' "$H" || fail "engine-side timing section missing"
+command grep -q 'cross-check: client-observed' "$H" \
+  || fail "SERVER_LOG was set — the engine-side cross-check must run (item 4 + item 1b)"
+command grep -qE 'divergence' "$H" || fail "divergence must be reported"
+# the fake's engine-side rate is deliberately far from the client-observed one
+command grep -q '⚠ WARN: >5% divergence' "$H" \
+  || fail "a >5% client-vs-engine divergence must WARN: $(command grep -A2 'cross-check' "$H")"
+echo "  ✓ engine-side scrape from SERVER_LOG + >5% divergence warning"
+
+# --- 4. short EOS: n-usable per shape (item 2) ------------------------------
+run_bench short_eos "$((PORT_BASE+2))" "$TMP/short.out"
+S="$TMP/short.out"
+command grep -q 'n-usable' "$S" || fail "n-usable must be reported per shape"
+command grep -q 'EOSed well below max_tokens' "$S" \
+  || fail "runs EOSing far below max_tokens must WARN — a 5-run shape silently becomes n=1"
+command grep -q 'treat the CV as unreliable' "$S" || fail "the short-EOS warning must discredit the CV"
+command grep -q '⚠ n-usable' "$S" || fail "n-usable belongs on the integrity panel too"
+echo "  ✓ short_eos: n-usable per shape + warning that the CV is untrustworthy"
+
+# --- 5. acceptance WITH fire rate (item 11a) --------------------------------
+run_bench low_fire "$((PORT_BASE+3))" "$TMP/fire.out"
+F="$TMP/fire.out"
+command grep -q 'CAPTURE: DRAFT ACCEPTANCE' "$F" || fail "acceptance section missing"
+command grep -qE 'mean=0\.99' "$F" || fail "high acceptance value not reported: $(command grep -A3 'DRAFT ACCEPT' "$F")"
+command grep -q 'fire rate: fired on' "$F" \
+  || fail "acceptance without a fire rate is a deception — both must be reported"
+command grep -q 'acceptance WITHOUT a fire rate is a deception' "$F" \
+  || fail "a drafter idle on most requests must WARN: $(command grep -A6 'DRAFT ACCEPT' "$F")"
+# The fire rate is a fraction of requests, so it can never exceed 100%.
+python3 - "$F" <<'PY' || fail "fire rate exceeded 100% — numerator and denominator come from different windows"
+import re, sys
+for ln in open(sys.argv[1], encoding="utf-8"):
+    m = re.search(r"fire rate: fired on (\d+) of (\d+) requests .*?\(([\d.]+)%\)", ln)
+    if m:
+        assert float(m.group(3)) <= 100.0, ln
+        assert int(m.group(1)) <= int(m.group(2)), ln
+PY
+echo "  ✓ low_fire: high acceptance + low fire rate BOTH reported, and warned about"
+
+# --- 6. graceful degradation: none of the sources present -------------------
+# docker-less, GPU-less, no server log, no readable pid. bench.sh must still run
+# end to end and say exactly what it could not capture.
+run_bench healthy "$((PORT_BASE+4))" "$TMP/degraded.out" \
+  SERVER_LOG= SERVER_PID=none PATH="/usr/bin:/bin"
+D="$TMP/degraded.out"
+command grep -q 'CONFIG FINGERPRINT' "$D" || fail "degraded run did not complete its fingerprint section"
+command grep -q 'CAPTURE: INTEGRITY' "$D" \
+  || { tail -25 "$D" "$D.err" >&2; fail "degraded run did not reach the end — degradation is not graceful"; }
+command grep -qE '^capture: .* unavailable \(.*\)$' "$D" \
+  || fail "a missing source must produce a 'capture: <thing> unavailable (<why>)' line"
+# ...and each missing thing exactly once, never in a loop.
+python3 - "$D" <<'PY' || fail "a degradation notice was printed more than once"
+import collections, re, sys
+c = collections.Counter(
+    re.match(r"capture: (.*?) unavailable", ln).group(1)
+    for ln in open(sys.argv[1], encoding="utf-8") if ln.startswith("capture: "))
+dupes = {k: v for k, v in c.items() if v > 1}
+assert not dupes, dupes
+PY
+command grep -q 'no CPU offload detected' "$D" \
+  || fail "with no argv and no log, the moe-cache capture must be SKIPPED with a reason"
+echo "  ✓ degradation: run completes, one notice per missing source, cache capture skipped with a reason"
+
+# --- 7. the historical output shape is untouched ----------------------------
+# Two shipped tests parse bench.sh's BENCH_MOCK output. The capture layer is
+# additive by contract; if the mock branch ever grows a capture line, they break.
+for kind in vllm llamacpp; do
+  out=$(PREFLIGHT_NO_AUTODETECT=1 CONTAINER=none ENGINE_KIND="$kind" BENCH_MOCK=1 bash "$BENCH" 2>/dev/null)
+  command grep -q '^capture:' <<<"$out" && fail "BENCH_MOCK output ($kind) grew a capture line"
+  command grep -q 'CAPTURE:' <<<"$out" && fail "BENCH_MOCK output ($kind) grew a capture section"
+  command grep -qE '(NARRATIVE|PROMPT-PROCESSING)' <<<"$out" || fail "BENCH_MOCK output ($kind) lost its canonical block"
+done
+echo "  ✓ BENCH_MOCK output shape unchanged (test-submit-bench / test-measurement-record)"
+
+# --- 8. CAPTURE=0 disables the whole layer ----------------------------------
+run_bench healthy "$((PORT_BASE+5))" "$TMP/off.out" CAPTURE=0
+command grep -q 'CAPTURE:' "$TMP/off.out" && fail "CAPTURE=0 must suppress the capture sections"
+command grep -q 'summary \[narrative\]' "$TMP/off.out" || fail "CAPTURE=0 broke the normal bench output"
+echo "  ✓ CAPTURE=0 leaves the pre-capture output shape exactly as it was"
+
+# --- 9. ENDPOINT: chat is the historical default; completion is the new mode ---
+run_bench healthy "$((PORT_BASE+6))" "$TMP/chat.out" ONLY=narr RUNS=1 WARMUPS=0
+command grep -q 'mode=chat' "$TMP/chat.out" || fail "ENDPOINT must default to chat (the historical path)"
+command grep -q 'endpoint=/v1/chat/completions' "$SRV_LOG" \
+  || fail "the default run did not drive /v1/chat/completions"
+run_bench healthy "$((PORT_BASE+7))" "$TMP/comp.out" ONLY=narr RUNS=1 WARMUPS=0 ENDPOINT=completion
+command grep -q 'mode=completion' "$TMP/comp.out" || fail "ENDPOINT=completion not reflected in the fingerprint"
+command grep -q 'endpoint=/v1/completions' "$SRV_LOG" \
+  || fail "ENDPOINT=completion did not actually drive the raw completions endpoint"
+command grep -q 'status: OK' "$TMP/comp.out" \
+  || fail "raw completions must still count tokens (choices[0].text, not a delta)"
+echo "  ✓ ENDPOINT: chat default preserved, completion drives the raw endpoint and still counts tokens"
+
+# --- 10. haystacks sized by MEASURED tokens, not words (item 7) --------------
+# The fake tokenizer emits 1.375 tok/word, so the old word-count sizing would
+# overshoot a 2000-token target by ~37% — exactly the "40K that tokenized to 55K".
+run_bench healthy "$((PORT_BASE+8))" "$TMP/ratio.out" \
+  ONLY=narr RUNS=1 WARMUPS=0 PREFILL_PROBE=1 PREFILL_DEPTHS=2000 PREFILL_RUNS=1
+python3 - "$TMP/ratio.out" <<'PY' || fail "prefill warm-up haystack is not sized by a measured token ratio"
+import re, sys
+txt = open(sys.argv[1], encoding="utf-8").read()
+m = re.search(r"warm-1\s+wall=.*?prompt_toks=\s*(\d+)", txt)
+assert m, "no prefill warm-up line found:\n" + txt[-1500:]
+got = int(m.group(1))
+# within 10% of the 2000-token target; the word heuristic lands ~37% over
+assert 1800 <= got <= 2200, f"warm-up haystack was {got} tokens for a 2000-token target"
+PY
+echo "  ✓ prefill warm-up lands on its token target (word-count sizing would overshoot ~37%)"
+
+# --- 11. STREAM triad ceiling is opt-in, and reports how it was measured -----
+command grep -q 'RAM BANDWIDTH CEILING' "$TMP/healthy.out" \
+  && fail "the STREAM calibration must be OPT-IN (it is not free)"
+run_bench healthy "$((PORT_BASE+9))" "$TMP/stream.out" ONLY=narr RUNS=1 WARMUPS=0 STREAM_CALIB=1
+if command grep -q 'RAM BANDWIDTH CEILING' "$TMP/stream.out"; then
+  command grep -qE 'triad ceiling  : [0-9.]+ GB/s  \([0-9]+ concurrent workers' "$TMP/stream.out" \
+    || fail "the triad ceiling must state its worker count — a single-threaded number is not a host ceiling"
+  echo "  ✓ STREAM_CALIB=1 reports a multi-worker sustained ceiling (and is off by default)"
+else
+  # numpy-less rigs are a supported configuration, not a failure.
+  command grep -q 'capture: STREAM triad ceiling unavailable' "$TMP/stream.out" \
+    || fail "STREAM_CALIB=1 produced neither a ceiling nor a degradation notice"
+  echo "  ✓ STREAM_CALIB=1 degrades cleanly where numpy is absent (and is off by default)"
+fi
+
+echo "test-bench-capture: ok"

--- a/scripts/tests/test-bench-card.sh
+++ b/scripts/tests/test-bench-card.sh
@@ -1,0 +1,401 @@
+#!/usr/bin/env bash
+# test-bench-card — guards for scripts/lib/card.sh and bench.sh's CARD= toggle.
+#
+# The card is a DECISION RECORD: it gets pasted into an issue and argued from. So
+# the failure that matters is not "the renderer crashed", it is "the card stated
+# something the run did not measure". These assertions are therefore mostly about
+# what the card must REFUSE to say:
+#   * human judgements stay `<fill: …>` placeholders — never guessed;
+#   * an A/B whose arms differ in a held-constant value renders CONFOUNDED at the
+#     TOP, not buried in a table nobody reads;
+#   * an unparseable baseline fails LOUDLY rather than rendering half a delta;
+#   * a resource-cost row is reported, not scored as good or bad.
+#
+# Plus the round-trip that the whole A/B rests on: the record bench.sh builds
+# in-process and the record card.sh parses back out of a saved log must AGREE.
+# If they drift, an A/B silently compares two different measurements.
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BENCH="$ROOT_DIR/scripts/bench.sh"
+CARDLIB="$ROOT_DIR/scripts/lib/card.sh"
+FIX="$ROOT_DIR/scripts/tests/fixtures/offload-matrix"
+CFIX="$ROOT_DIR/scripts/tests/fixtures/bench-card"
+PORT_BASE="${TEST_PORT:-8171}"
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+for f in "$BENCH" "$CARDLIB" "$CFIX/baseline.log" "$CFIX/baseline-mismatched.log" \
+         "$CFIX/live-offload-run.log" \
+         "$FIX/fake-llama-server" "$FIX/fake-nvidia-smi"; do
+  [[ -f "$f" ]] || fail "missing fixture or script: $f"
+done
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"; [[ -n "${SRV_PID:-}" ]] && kill "$SRV_PID" 2>/dev/null; true' EXIT
+mkdir -p "$TMP/bin"
+install -m 0755 "$FIX/fake-nvidia-smi"   "$TMP/bin/nvidia-smi"
+install -m 0755 "$FIX/fake-llama-server" "$TMP/bin/fake-llama-server"
+: > "$TMP/model.gguf"
+
+# ===========================================================================
+# TIER 0
+# ===========================================================================
+echo "  tier 0: source guards"
+bash -n "$CARDLIB" || fail "bash -n: syntax error in card.sh"
+python3 - "$CARDLIB" <<'PY' || fail "card.sh's embedded python does not parse"
+import ast, re, sys
+src = open(sys.argv[1], encoding="utf-8").read()
+m = re.search(r"<<'PY'\n(.*?)\nPY\n", src, re.S)
+assert m, "no embedded python found in card.sh"
+ast.parse(m.group(1))
+PY
+if command grep -nE '^[^#]*\b(pgrep|pkill) +-[a-zA-Z]*f' "$CARDLIB"; then
+  fail "card.sh uses pgrep/pkill -f"
+fi
+bare=$(command grep -nE '(^|[|;&(]|\$\()\s*grep ' "$CARDLIB" || true)
+[[ -z "$bare" ]] || fail "card.sh uses bare grep (ugrep shim): $bare"
+# JSON is #249's job; if that boundary blurs, the two producers drift.
+command grep -q 'OUT OF SCOPE: machine-parseable JSON' "$CARDLIB" \
+  || fail "card.sh must record that JSON output belongs to #249, not here"
+echo "  ✓ syntax, no pgrep -f, command grep, #249 boundary recorded"
+
+# ===========================================================================
+# TIER 1a — renderer units against fixture records
+# ===========================================================================
+echo "  tier 1a: renderer units"
+# shellcheck source=../lib/card.sh
+source "$CARDLIB"
+
+REC="$TMP/rec.kv"
+cat > "$REC" <<'EOF'
+meta.date=2026-08-01
+meta.endpoint=http://127.0.0.1:8030
+meta.mode=chat
+fp.model=deepseek-v4-flash
+fp.ctx=65536
+fp.slots=1
+fp.ftype=MXFP4 MoE
+fp.drafter=none
+fp.kv=q8_0 (source: argv)
+fp.argv=model=/m/x.gguf offload=blk.*=CPU threads=24 ubatch=2048 ngl=99 split=1,1
+fp.moe=moe_cache_cap=20480 RESERVE_MB=2048 ADMIT_AFTER=1 THROTTLE=64 MAX_BATCH=8 STATS=1000
+fp.offload=DETECTED via argv -ot
+proto.warmups=3
+proto.runs=5
+proto.force_tokens=1000
+proto.thinking=0
+proto.env=RUNS=5 FORCE_TOKENS=1000
+shape.narrative.n=5
+shape.narrative.n_usable=5
+shape.narrative.decode_mean=18.43
+shape.narrative.decode_cv=0.6
+shape.narrative.wall_mean=18.20
+shape.narrative.wall_cv=0.7
+shape.narrative.ttft_mean_ms=507
+shape.narrative.ttft_std_ms=30
+prefill.prefill-10k.n=3
+prefill.prefill-10k.tps_mean=127.20
+prefill.prefill-10k.tps_cv=0.1
+prefill.prefill-10k.ttft_ms=81000
+gpu.vram_idle=23100
+gpu.vram_peak=23800
+gpu.vram_post=23100
+gpu.leak=0
+cache.CUDA0.marginal=48.0
+cache.CUDA0.cumulative=29.6
+cache.CUDA0.cum_start=19.3
+cache.CUDA0.slots=4038
+cache.CUDA1.marginal=58.0
+cache.CUDA1.cumulative=35.3
+cache.CUDA1.cum_start=23.3
+cache.CUDA1.slots=2500
+integrity.status=OK
+integrity.health=PASS (all health counters zero)
+integrity.swap=PASS (no serving-process pages in swap)
+integrity.divergence=2.1
+EOF
+
+snap="$(card_render snapshot "$REC")" || fail "snapshot render failed"
+command grep -q '^## 📊 bench.sh — deepseek-v4-flash' <<<"$snap" || fail "snapshot title wrong"
+for want in "**Config:**" "**Env:** RUNS=5 FORCE_TOKENS=1000" "**Protocol:** 3 warm + 5 measured" \
+            "| narrative | 5 | 18.43 | 0.6% |" "| prefill-10k | 3 | 127.20 |" \
+            "### Integrity" "**One-line verdict:**"; do
+  command grep -qF "$want" <<<"$snap" || fail "snapshot missing: $want"
+done
+# an offload run renders the OFFLOAD BLOCK, per device, never averaged
+command grep -q '^### CPU offload + expert cache' <<<"$snap" \
+  || fail "an offload run must render the CPU offload + expert cache block"
+command grep -q '| CUDA0 | 4038 slots' <<<"$snap" || fail "per-device pool row missing: $snap"
+command grep -q '| CUDA0 |.*\*\*48.0%\*\*' <<<"$snap" || fail "CUDA0 marginal hits missing from the table"
+command grep -q '| CUDA1 |.*\*\*58.0%\*\*' <<<"$snap" \
+  || fail "the CUDA0/CUDA1 asymmetry was averaged away on the card"
+command grep -q 'Quote the \*\*marginal\*\* rate' <<<"$snap" \
+  || fail "the card must tell the reader WHICH hit rate to quote"
+command grep -qF 'The cache config IS the arm identity' <<<"$snap" \
+  || fail "the cache-config line must explain why pool size alone is not the arm"
+command grep -q 'skips.*= admission throttling' <<<"$snap" \
+  || fail "skips must be footnoted as a load signal, not a defect"
+# auto-verified integrity items carry evidence, not just a tick
+command grep -q '\[x\] capture status: OK' <<<"$snap" || fail "status not on the integrity panel"
+command grep -q '\[x\] swap check — PASS' <<<"$snap" || fail "swap check not on the integrity panel"
+command grep -q '\[x\] cache hard-failure counters zero' <<<"$snap" || fail "health counters missing"
+command grep -q '\[x\] n-usable == n for every shape — narrative 5/5' <<<"$snap" || fail "n-usable missing"
+command grep -q '\[x\] VRAM returned after the run — leak delta 0 MiB' <<<"$snap" || fail "leak delta missing"
+echo "  ✓ snapshot: header, shape + prefill tables, per-device cache, integrity panel"
+
+# Human judgement is NEVER guessed.
+for ph in "<fill: config-slug>" "<fill: engine+tag>" "<fill: power cap>" "<fill: confirm>" \
+          "<fill: what this run establishes"; do
+  command grep -qF "$ph" <<<"$snap" || fail "snapshot must keep the placeholder: $ph"
+done
+echo "  ✓ snapshot: every human judgement stays an explicit <fill: …> placeholder"
+
+# A failing run must be visibly unquotable.
+sed -e 's/^integrity.status=OK/integrity.status=NO_TOKENS/' \
+    -e 's/^integrity.health=PASS.*/integrity.health=FAIL — CUDA1: fill_fail=3/' \
+    -e 's/^shape.narrative.n_usable=5/shape.narrative.n_usable=1/' "$REC" > "$TMP/bad.kv"
+badsnap="$(card_render snapshot "$TMP/bad.kv")" || fail "snapshot render failed on a bad run"
+command grep -q '\[ \] capture status: NO_TOKENS' <<<"$badsnap" || fail "a failed status must not be ticked"
+command grep -q 'do not quote a throughput number' <<<"$badsnap" || fail "NO_TOKENS must be called out on the card"
+command grep -q '\[ \] cache hard-failure counters zero .* — FAIL' <<<"$badsnap" || fail "failing health must not be ticked"
+command grep -q 'not trustworthy' <<<"$badsnap" || fail "n-usable shortfall must discredit the CV on the card"
+command grep -q '1/5 ⚠️' <<<"$badsnap" || fail "the shape table must flag the usable-run shortfall"
+echo "  ✓ snapshot: a failed run renders unticked, flagged, and explicitly unquotable"
+
+# ===========================================================================
+# TIER 1b — A/B
+# ===========================================================================
+echo "  tier 1b: A/B render"
+ab="$(KNOB=moe-cache EXPECTATION="bigger pool should raise decode TPS" \
+      BOOT_POLICY="boot-per-arm x1" card_render ab "$REC" "$CFIX/baseline.log")" \
+  || fail "A/B render failed"
+command grep -q '^## ⚖️ bench.sh A/B — moe-cache' <<<"$ab" || fail "A/B title should carry the declared knob"
+command grep -qF "**Pre-registered expectation:** bigger pool should raise decode TPS" <<<"$ab" \
+  || fail "EXPECTATION not rendered"
+command grep -qF "**Boot policy:** boot-per-arm x1" <<<"$ab" || fail "BOOT_POLICY not rendered"
+command grep -q 'decode narrative | 17.30 | 18.43 | +6.5% | outside band — real improvement' <<<"$ab" \
+  || fail "delta row wrong: $(command grep 'decode narrative' <<<"$ab")"
+command grep -q 'TTFT narrative (ms) | 612.00 | 507.00 | -17.2% | outside band — real improvement' <<<"$ab" \
+  || fail "TTFT must be scored lower-is-better: $(command grep 'TTFT narrative' <<<"$ab")"
+command grep -q 'prefill 10k | 119.40 | 127.20' <<<"$ab" || fail "prefill delta row missing"
+# resource rows are REPORTED, not scored — spending pool to buy throughput may be
+# exactly the intended trade, and only the human knows the VRAM budget.
+command grep -q 'pool slots CUDA0 | 2000.00 | 4038.00 | +101.9% | \*\*+101.9% resource spend\*\*' <<<"$ab" \
+  || fail "resource-cost row should report spend, not call it an improvement"
+command grep -qv 'pool slots CUDA0.*improvement' <<<"$ab" || true
+command grep -q 'pool slots CUDA0.*improvement' <<<"$ab" \
+  && fail "a resource row must NOT be scored as an improvement"
+command grep -qF "**Decision:** <fill: ADOPT / REJECT / PARK>" <<<"$ab" || fail "decision must stay a placeholder"
+echo "  ✓ A/B: Δ table, lower-is-better TTFT, resource rows reported not scored"
+
+# the declared knob is attributed, everything else held constant
+command grep -q '🔧 the declared knob' <<<"$ab" || fail "the declared knob should be attributed in the invariants table"
+command grep -q 'CONFOUNDED' <<<"$ab" && fail "a run differing ONLY in the declared knob must not be confounded"
+echo "  ✓ A/B: declaring KNOB attributes that difference instead of confounding the card"
+
+# noise band: derived and SAID SO
+command grep -qE 'Noise band:\*\* ±1\.2% \(derived: 2x the worst decode CV across both arms' <<<"$ab" \
+  || fail "the derived band must state how it was established: $(command grep 'Noise band' <<<"$ab")"
+ab2="$(NOISE_BAND=20 KNOB=moe-cache card_render ab "$REC" "$CFIX/baseline.log")"
+command grep -q 'Noise band:\*\* ±20.0% (NOISE_BAND env' <<<"$ab2" || fail "explicit NOISE_BAND not honoured"
+command grep -q 'decode narrative | 17.30 | 18.43 | +6.5% | within band — no signal' <<<"$ab2" \
+  || fail "a wider band must reclassify the same delta as no-signal"
+echo "  ✓ A/B: band derived from CVs and stated, or taken from NOISE_BAND — and it changes verdicts"
+
+# ===========================================================================
+# TIER 1c — the teeth: confounded arms, and unparseable baselines
+# ===========================================================================
+echo "  tier 1c: confound + failure paths"
+conf="$(card_render ab "$REC" "$CFIX/baseline-mismatched.log")" || fail "confounded A/B failed to render"
+# The banner must be at the TOP — buried it is worthless.
+[[ "$(head -1 <<<"$conf")" == "> ## ⛔ CONFOUNDED" ]] \
+  || fail "the CONFOUNDED banner must be the FIRST line, got: $(head -1 <<<"$conf")"
+# 5: the four the fixture deliberately changes (model, ctx, KV, threads/ubatch in
+# the argv) plus the moe-cache config, which already differed from the record.
+command grep -q 'differ in 5 value(s)' <<<"$conf" || fail "confound count wrong: $(command grep 'differ in' <<<"$conf")"
+# prefix match: some labels carry a parenthetical (e.g. the moe-cache knob list)
+for f in model "served ctx" "KV cache type" "moe-cache config"; do
+  command grep -q "| $f.*⛔ \*\*CONFOUND\*\*" <<<"$conf" || fail "invariant '$f' not flagged as a confound"
+done
+command grep -q '<fill: knob>' <<<"$conf" || fail "with no KNOB declared the knob must stay a placeholder"
+echo "  ✓ confounded arms: banner is line 1, every mismatched invariant flagged"
+
+# A baseline that cannot be parsed must FAIL, not render half a delta.
+for bad in "/nonexistent/path.log" "$TMP/garbage.log" ""; do
+  [[ "$bad" == "$TMP/garbage.log" ]] && echo "this is not a bench log at all" > "$bad"
+  if out="$(card_render ab "$REC" "$bad" 2>&1)"; then
+    fail "an unparseable baseline ('$bad') rendered anyway:\n$out"
+  fi
+  command grep -q 'baseline unparseable:' <<<"$out" \
+    || fail "an unparseable baseline must say 'baseline unparseable: <why>', got: $out"
+done
+# ...and the reason must be specific enough to act on.
+out="$(card_render ab "$REC" "$TMP/garbage.log" 2>&1 || true)"
+command grep -qE 'baseline unparseable:.*(CONFIG FINGERPRINT|summary)' <<<"$out" \
+  || fail "the unparseable reason must name what was missing, got: $out"
+echo "  ✓ unparseable/missing baselines fail loudly, naming what was missing"
+
+# ===========================================================================
+# TIER 1d — end-to-end through bench.sh, incl. the round-trip
+# ===========================================================================
+echo "  tier 1d: end-to-end + record round-trip"
+SRV_PID=""; SRV_LOG=""
+start_server() {   # see test-bench-capture.sh for why $! is not usable here
+  local scen="$1" port="$2"; shift 2
+  SRV_LOG="$TMP/server-$port.log"
+  local pidfile="$TMP/server-$port.pid"; rm -f "$pidfile"
+  env FAKE_SCENARIO="$scen" FAKE_NGPU=2 FAKE_TOKENS=40 FAKE_PID_FILE="$pidfile" "$@" \
+      GGML_CUDA_MOE_CACHE_RESERVE_MB=2048 GGML_CUDA_MOE_CACHE_ADMIT_AFTER=1 \
+      GGML_CUDA_MOE_CACHE_THROTTLE=64 GGML_CUDA_MOE_CACHE_MAX_BATCH=8 \
+      GGML_CUDA_MOE_CACHE_STATS=1000 \
+      "$TMP/bin/fake-llama-server" -m "$TMP/model.gguf" \
+        -ot 'blk.(1|3|5).ffn_.*_exps.weight=CPU' -t 24 -ub 2048 -ct q8_0 -ngl 99 -ts 1,1 \
+        --moe-cache 8192 --host 127.0.0.1 --port "$port" > "$SRV_LOG" 2>&1 &
+  local i
+  for i in $(seq 1 40); do
+    curl -sf -m 1 "http://127.0.0.1:$port/health" >/dev/null 2>&1 && break
+    sleep 0.25
+  done
+  SRV_PID="$(cat "$pidfile" 2>/dev/null || true)"
+  [[ -n "$SRV_PID" && -r "/proc/$SRV_PID/cmdline" ]] || fail "fake server pid unreadable — run not hermetic"
+  sleep 2
+}
+run_bench() {   # $1=port $2=out [extra env ...]
+  local port="$1" out="$2"; shift 2
+  start_server healthy "$port"
+  PATH="$TMP/bin:$PATH" PREFLIGHT_NO_AUTODETECT=1 CONTAINER=none \
+    SERVER_LOG="$SRV_LOG" SERVER_PID="$SRV_PID" URL="http://127.0.0.1:$port" \
+    MODEL=fake-model RUNS=2 WARMUPS=1 PREFILL_PROBE=0 \
+    env "$@" timeout 300 bash "$BENCH" > "$out" 2>"${out}.err" || true
+  kill "$SRV_PID" 2>/dev/null || true; wait "$SRV_PID" 2>/dev/null || true; SRV_PID=""
+}
+
+# CARD unset => no card. The byte-identical guarantee lives in
+# test-bench-capture.sh; this asserts the toggle itself is genuinely off.
+run_bench "$((PORT_BASE))" "$TMP/nocard.out"
+command grep -q 'bench.sh — ' "$TMP/nocard.out" && fail "CARD unset must not render a card"
+command grep -q 'BENCH CARD' "$TMP/nocard.out" && fail "CARD unset must not emit the card section"
+echo "  ✓ CARD unset renders no card at all"
+
+run_bench "$((PORT_BASE+1))" "$TMP/snap.out" CARD=snapshot CARD_RECORD_OUT="$TMP/live-rec.kv"
+command grep -q '## 📊 bench.sh — fake-model' "$TMP/snap.out" \
+  || { tail -30 "$TMP/snap.out" >&2; fail "CARD=snapshot did not render a card"; }
+command grep -q '^```markdown$' "$TMP/snap.out" || fail "the card must be a fenced markdown block, ready to paste"
+command grep -qF '<fill: config-slug>' "$TMP/snap.out" || fail "placeholders must survive the real run"
+command grep -q 'KV cache type\|KV q8_0' "$TMP/snap.out" || fail "fingerprint did not reach the card"
+command grep -q '\[x\] capture status: OK' "$TMP/snap.out" || fail "integrity panel did not reach the card"
+echo "  ✓ CARD=snapshot renders a fenced card from a real run, fingerprint + integrity intact"
+
+# THE ROUND-TRIP. bench.sh builds the record in-process; card.sh parses one back
+# out of a saved log. An A/B compares one of each, so they must agree — otherwise
+# every delta is between two subtly different measurements.
+[[ -s "$TMP/live-rec.kv" ]] || fail "CARD_RECORD_OUT did not write the in-process record"
+card_parse_log "$TMP/snap.out" > "$TMP/parsed-rec.kv" || fail "card.sh cannot parse bench.sh's own output"
+python3 - "$TMP/live-rec.kv" "$TMP/parsed-rec.kv" <<'PY' || exit 1
+import sys
+
+
+def load(p):
+    d = {}
+    for ln in open(p, encoding="utf-8"):
+        if "=" in ln:
+            k, v = ln.rstrip("\n").split("=", 1)
+            d[k.strip()] = v.strip()
+    return d
+
+
+live, parsed = load(sys.argv[1]), load(sys.argv[2])
+# Only fields the LOG can carry are comparable; the record also holds a few the
+# printed output does not render (that asymmetry is fine and expected).
+shared = sorted(set(live) & set(parsed))
+assert len(shared) >= 12, f"only {len(shared)} shared fields — the parser is missing most of the record: {shared}"
+bad = {k: (live[k], parsed[k]) for k in shared if live[k] != parsed[k]}
+assert not bad, "in-process record and parsed-from-log record DISAGREE:\n" + "\n".join(
+    f"  {k}: in-process={v[0]!r} parsed={v[1]!r}" for k, v in bad.items())
+must = {"fp.model", "fp.kv", "fp.moe", "integrity.status"}
+assert must <= set(shared), f"round-trip does not cover {sorted(must - set(shared))}"
+print(f"  ✓ record round-trip: {len(shared)} fields agree between in-process and parsed-from-log")
+PY
+
+# A real saved run used as a BASELINE — the actual user workflow.
+run_bench "$((PORT_BASE+2))" "$TMP/ab.out" CARD=ab BASELINE="$TMP/snap.out" KNOB=nothing
+command grep -q '## ⚖️ bench.sh A/B' "$TMP/ab.out" \
+  || { tail -30 "$TMP/ab.out" "$TMP/ab.out.err" >&2; fail "CARD=ab did not render against a real saved log"; }
+command grep -q 'decode narrative' "$TMP/ab.out" || fail "A/B against a real log produced no delta row"
+echo "  ✓ CARD=ab works against a previous run's saved log (the real workflow)"
+
+# A bad BASELINE must fail the RUN loudly, not print a broken card.
+run_bench "$((PORT_BASE+3))" "$TMP/abbad.out" CARD=ab BASELINE=/nonexistent/nope.log
+command grep -q 'baseline unparseable' "$TMP/abbad.out" "$TMP/abbad.out.err" \
+  || fail "a bad BASELINE must surface 'baseline unparseable' to the operator"
+command grep -q 'summary \[narrative\]' "$TMP/abbad.out" \
+  || fail "a bad BASELINE must not cost the operator the bench run itself"
+echo "  ✓ bad BASELINE fails loudly without discarding the run's own measurements"
+
+# A capture notice must never end up INSIDE a labelled field. Seen live:
+#   'KV cache type  : capture: KV cache type unavailable (…)'
+for f in "$TMP"/*.out; do
+  if command grep -nE '^\s+[A-Za-z][A-Za-z /-]+\s+:\s+capture: ' "$f"; then
+    fail "$(basename "$f"): a degradation notice was rendered inside a labelled field"
+  fi
+done
+echo "  ✓ degradation notices never appear inside a labelled field"
+
+# ===========================================================================
+# TIER 1e — the offload block's conditionality, against a REAL run
+# ===========================================================================
+echo "  tier 1e: offload-block conditionality"
+
+# (a) A real, redacted bare-metal CPU-offload run. A renderer that only ever sees
+#     hand-written records drifts from what bench.sh actually prints.
+real="$(card_parse_log "$CFIX/live-offload-run.log" > "$TMP/real.kv" && card_render snapshot "$TMP/real.kv")" \
+  || fail "could not render a card from the real offload run fixture"
+command grep -q '^### CPU offload + expert cache' <<<"$real" \
+  || fail "the real offload run must render the offload block"
+for want in "**Offload:** DETECTED via argv -ot" "**RSS** 139.2 GiB / 235.9 GiB total" \
+            "**Cache config:** moe_cache_cap=20480" "| CUDA0 | 3038 slots · 12911 MiB · mxfp4" \
+            "**PCIe** (GPU0 gen=4/4 width=16/16)" "**RAM path:** derived miss demand"; do
+  command grep -qF "$want" <<<"$real" || fail "real-run card missing: $want"
+done
+# per-device values survive to the card, including the ones that only differ per card
+command grep -q '| CUDA0 |.*\*\*60.3%\*\*.*| 42171 | 13955 |' <<<"$real" \
+  || fail "CUDA0 row lost evictions/skips: $(command grep '| CUDA0 |' <<<"$real")"
+command grep -q '| CUDA1 |.*\*\*80.4%\*\*' <<<"$real" || fail "CUDA1 marginal hits missing"
+command grep -q 'decode rx 231 / 1941 MB/s' <<<"$real" || fail "decode PCIe phase missing"
+command grep -q 'prefill rx 3031 / 28182 MB/s' <<<"$real" || fail "prefill PCIe phase missing"
+# the ~13x decode-vs-prefill gap is the whole reason for the phase split
+command grep -q 'Prefill PCIe traffic is lopsided: GPU0 5978 MB/s vs GPU1 85 MB/s' <<<"$real" \
+  || fail "a 70x per-device prefill asymmetry must be called out"
+command grep -q 'computed over the \*\*decode window\*\*' <<<"$real" \
+  || fail "the RAM demand must state WHICH window it was computed over"
+# An old log (written before the health-verdict correction) must still parse —
+# users A/B against saved logs from previous versions.
+command grep -q '^proto.warmups=' "$TMP/real.kv" \
+  || fail "protocol counts not recovered from the real log"
+echo "  ✓ real offload run: block filled from an actual bench.sh log (pools, PCIe phases, RAM window)"
+
+# (b) A run with NO offload must render the GENERIC cache line and no block.
+sed -e 's/^fp.offload=.*/fp.offload=not detected (moe-cache captures skipped)/' "$REC" > "$TMP/nooff.kv"
+noff="$(card_render snapshot "$TMP/nooff.kv")" || fail "no-offload snapshot render failed"
+command grep -q '### CPU offload + expert cache' <<<"$noff" \
+  && fail "a run with no offload must NOT render the offload block"
+command grep -q '\*\*Cache (if the engine has one):\*\*' <<<"$noff" \
+  || fail "the non-offload case must keep the generic cache line"
+command grep -q 'CUDA0 hits 19.3% → 29.6%' <<<"$noff" || fail "generic cache line lost its per-device values"
+echo "  ✓ no-offload run: generic cache line, offload block absent"
+
+# (c) A moe-cache config mismatch is a CONFOUND, exactly like a model mismatch.
+sed -e 's/moe_cache_cap=8192/moe_cache_cap=4096/' "$CFIX/baseline.log" > "$TMP/moediff.log"
+mc="$(card_render ab "$REC" "$TMP/moediff.log")" || fail "moe-mismatch A/B failed to render"
+[[ "$(head -1 <<<"$mc")" == "> ## ⛔ CONFOUNDED" ]] \
+  || fail "a moe-cache config mismatch must confound the A/B"
+command grep -q '| moe-cache config.*⛔ \*\*CONFOUND\*\*' <<<"$mc" \
+  || fail "the moe-cache config row must be flagged"
+echo "  ✓ moe-cache config mismatch confounds the A/B"
+
+# (d) With offload in BOTH arms, the Δ table gains the boot-comparable cache rows.
+ab3="$(KNOB=moe-cache card_render ab "$REC" "$CFIX/baseline.log")"
+command grep -q 'marginal hits CUDA0 (%) | 41.00 | 48.00' <<<"$ab3" \
+  || fail "the A/B must compare MARGINAL hit rates per device: $(command grep 'marginal hits' <<<"$ab3")"
+command grep -q 'marginal hits CUDA1 (%)' <<<"$ab3" || fail "per-device marginal rows must not be collapsed"
+echo "  ✓ A/B gains per-device marginal-hit rows when both arms offloaded"
+
+echo "test-bench-card: ok"


### PR DESCRIPTION
Implements the capture backlog in #841: a shared capture library
(`scripts/lib/capture.sh`) plus the `bench.sh` wiring that consumes it, with mocked tests extending
the #835 pattern.

**Everything is additive.** An existing invocation with no new env vars produces everything it
produced before, plus the new always-on captures. `BENCH_MOCK` output is byte-identical — verified by
diffing both mock branches against `master`, and guarded by a new test, because `test-submit-bench`
and `test-measurement-record` parse it.

## Per-item status

| # | Item | Status | Notes |
|---|---|---|---|
| 1 | NO_TOKENS class | ✅ done | Loud warn naming the failure class (scrape, not a slow model) + "do not quote this run". Engine-side cross-check warns above 5% divergence. |
| 2 | Chat-shaped prompts / n-usable | ✅ done | `ENDPOINT=chat\|completion`. **`chat` is the default** — `bench.sh` already drove `/v1/chat/completions`, so the default is unchanged and numbers stay comparable; the knob makes it explicit and adds the raw `/v1/completions` counterpart for base models. n-usable + short-EOS warning fire in **both** modes. |
| 3 | Conditional cache/offload capture | ✅ done | KV type + fingerprint always on; offload gates the moe-cache capture. (a) config fingerprint incl. `--moe-cache` cap + the five `GGML_CUDA_MOE_CACHE_*` vars; (b) marginal rate from start/end snapshots **per device**; (c) health counters, all-zero = pass; (d) per-device rows kept in the **output**. |
| 4 | Bare-metal server scrape | ✅ done | `SERVER_LOG=<path>` scrapes `print_timing` for decode *and* prefill, and feeds the item-1b cross-check. Also fills the summary `PP tok/s` field that previously read "log scrape unavailable". |
| 5 | Config fingerprint in output | ✅ done | `CONFIG FINGERPRINT` block: `/props` (ctx, slots, ftype, drafter) + argv fingerprint from `/proc`. No operator input required. |
| 6 | Live progress | ✅ done | Per-run one-liners, flushed, on **stderr**; stdout keeps its exact historical shape. |
| 7 | Haystack sizing | ✅ done | Token-ratio probe via `/tokenize`, else a tiny `max_tokens=1` request, else the old word heuristic. Test asserts a 2000-token target lands within ±10% where word-sizing overshoots ~37%. |
| 8 | System RAM + swap | ✅ done | Always on. `MemTotal` / `MemAvailable` / server RSS, plus a swap verdict that distinguishes *serving-process* pages in swap (run is suspect) from host-wide swap with no attributable pid. |
| 9 | RAM-bandwidth utilization | ✅ done | (a) derived `ram_rd_mbps` with the "DERIVED, NOT A PERF COUNTER" caveat and its arithmetic printed; (b) `STREAM_CALIB=1` triad ceiling, opt-in. (c) contention probe **deliberately not here** — it perturbs the run by construction and stays a separate opt-in arm, as the item specifies. |
| 10 | PCIe | ✅ done | Unconditional. Per-phase decode/prefill means **and peaks**, per device; link gen/width sampled **under load** with a warn when current < max; utilization against a **stated** denominator. |
| 11 | Import from offload-matrix | ✅ done (lib) / ⏸️ deferred (adoption) | (a)–(e) all landed in the lib and wired into bench. The lib is consumed by `bench.sh` only — see below. |

## Deferred, deliberately

**`offload-matrix.sh` is not touched by this PR** (`git diff` against `master` confirms it).
A 12-commit feature branch (`feat/offload-matrix-prefix-cache`) is in flight on that file; rewiring
it underneath would conflict for no measurement benefit. Until that lands, the sweep keeps its own
inline copies of these scrapes and **the duplication is accepted**. The reason and the expiry are
recorded at the top of `capture.sh`, and a test asserts that note still exists — so the rationale
cannot quietly rot into "why are there two of these?".

Because of that, item 11's "consumed by **both** scripts" clause is not yet satisfied, so this is
**Progress on #841**, not a close. Remaining work on the issue is exactly one step: point
`offload-matrix.sh` at the lib and delete its inline copies (delete, not leave alongside — two copies
of a scrape is how a fixed defect comes back).

Also worth noting: (c) of item 9 is out of scope by the item's own text, not by omission.

## Test evidence

New: `scripts/tests/test-bench-capture.sh` — **27 checks**, three tiers, asserting structure, status
and warnings, never a throughput value (numbers from a fake server mean nothing).

- **Tier 0** — syntax of both scripts plus the embedded python heredoc; no `pgrep`/`pkill -f`;
  `command grep` throughout the lib; the degradation-notice shape; the deferral note; idempotent
  sourcing; and an AST parse of every inline `python3 -c '...'` snippet.
- **Tier 1a** (fixture logs, real telemetry line shapes) — multi-pool-per-device census aggregation;
  the #824 hole; marginal-vs-cumulative constructed to **disagree** (48/58 marginal vs 19/23
  cumulative); health counters; acceptance with fire count and drafts-attempted; prefill/decode
  timing split; status-enum precedence; derived-demand arithmetic.
- **Tier 1b** (end-to-end, real `bench.sh` against the fake server) — healthy; `no_tokens`;
  `short_eos`; `low_fire`; full degradation (no GPU, no log, no pid); `BENCH_MOCK` shape unchanged;
  `CAPTURE=0`; both `ENDPOINT` modes verified against the server's own request log; haystack sizing;
  `STREAM_CALIB` opt-in.

Suites run (no GPU, no model, no tier-2, live services untouched):

| Suite | Result |
|---|---|
| `test-bench-capture` (new) | **PASS** — 27 checks |
| `test-offload-matrix-static` | **PASS** — 9 checks |
| `test-offload-matrix-mocked` | **PASS** — 10 checks |
| `test-measurement-record` | **PASS** — all assertions |
| `test-submit-bench` | **PASS** — 6 synthetic fixtures |

`bash -n` clean on every touched shell script; `py_compile` clean on the fixture. `shellcheck` is not
installed on this rig, so it was not run (advisory only).

The last two are the shipped consumers of `bench.sh`'s output — they are in the list because this PR
touches the script they parse, and they pass unchanged.

## Findings worth their own follow-ups

Four things surfaced while building this that are not in #841:

1. **The #824 detector generalises further than the fix that closed it.** Counting *pool lines*
   against device count is not sufficient: the current census emits one line **per pool**, and a
   device can hold several (`pool[0]`, `pool[1]`). Two pools on one device make `pool_lines >= NGPU`
   while another device holds nothing at all — so a line-count detector scores that half-cached run
   healthy. The lib counts **devices with a pool** instead, and there is a fixture (`multipool`) that
   fails a line-count detector and passes a device-count one. **`offload-matrix.sh` still uses the
   line-count check** and has this latent hole; it should be fixed when the sweep adopts the lib.
2. **Inline `python3 -c '...'` is a silent-failure hazard.** A single quote inside the single-quoted
   shell string ends it early, python receives a truncated program, and a trailing
   `2>/dev/null || true` swallows the error completely — the capture simply never prints. This bit
   this PR once. The new tier-0 guard covers `bench.sh` and `capture.sh`; a repo-wide version would
   be cheap.
3. **`$!` is not the server's pid** when a process is launched through an `env` prefix and a
   `#!/usr/bin/env` shebang — the chain re-execs and the recorded pid can already be gone. Any
   harness pinning `SERVER_PID` from `$!` will silently fall back to `pgrep -x` and adopt whatever
   real server the rig is running. The fixture now reports its own pid, as real servers do with
   `--pid-file`.
4. **A STREAM ceiling must be multi-threaded to be a ceiling.** A single-threaded triad measured
   ~3.7 GB/s on a host that sustains ~35 GB/s across 16 workers while loaded. Reporting the
   single-threaded figure as "the ceiling" would have inflated the derived utilization by ~10×,
   which is worse than reporting nothing. The calibration runs multiple workers and prints the
   worker count next to the number.

## Docs

`docs/BENCH_CARD.md` gains an appended section (the existing templates are untouched): which card
fields now auto-fill, four additions to the integrity panel (status enum incl. `NO_TOKENS`, all-zero
cache health counters, the swap check, n-usable per shape), the provenance rules for the two numbers
easiest to quote wrongly — **quote the marginal hit rate**, **never quote acceptance without its fire
rate** — and the knob table. New env vars are documented in `bench.sh`'s own header block.

Progress on #841.

---

# Update — card rendering + live-run calibration

Two additions since the first review: a **card-render toggle**, and **four fixes from the first live
bare-metal run** against a real CPU-offloaded MoE.

## 1. `CARD=` — the run emits its own BENCH_CARD

Both modes default OFF; with `CARD` unset the output is byte-identical to before (asserted, because
two shipped tests parse it).

```bash
CARD=snapshot bash scripts/bench.sh | tee run-A.log      # Template 1
CARD=ab BASELINE=run-A.log KNOB=moe-cache bash scripts/bench.sh   # Template 2
```

Rendering lives in a new `scripts/lib/card.sh`; `bench.sh` only gains the toggle wiring. A/B knobs:
`KNOB=` (attributes a deliberate difference instead of confounding the card), `NOISE_BAND=`,
`EXPECTATION=`, `BOOT_POLICY=`.

**What it refuses to do is the design.** Human judgement — verdict, A/B decision, knob name, "quiet
box" — stays an explicit `<fill: …>` placeholder. An unparseable baseline fails with
`baseline unparseable: <why>` rather than rendering half a delta (and the run's own numbers still
print). Resource rows (pool slots, VRAM) are **reported, not scored**: spending pool to buy
throughput may be the intended trade, and only the operator knows the VRAM budget.

**The A/B's teeth are the invariants.** Model, ftype, ctx, KV, drafter, moe-cache config, offload
method, argv — plus pool census per device (±5%), checked **only when the cache config matched**
(a different pool is the intended *consequence* of a cache-sizing knob, not a confound). Any
unattributed mismatch renders **⛔ CONFOUNDED as line one**, not buried in a table.

**Two producers, one schema.** The current run's record is built in-process; a baseline is parsed
back out of a saved log. The suite renders a run, re-parses its own log, and diffs the two records
field by field — **50 fields agree**. That guard caught a real disagreement during development
(the printed line and the record used different phrasings for the same fact), which would have made
every A/B compare two subtly different measurements.

JSON stays **out of scope** — that's #249's job. This emits markdown for a human; the record schema
is the seam where the two should meet, and that's noted in the file.

## 2. Live-run calibration — one required fix, three refinements

A real run against a 162 GB CPU-offloaded MoE on 2× consumer GPUs. The capture layer performed well
(0.3% client-vs-engine divergence, correct 90K-depth skip, correct marginal-vs-cumulative split), and
surfaced four cases where a number was right but its **label** was not:

| # | Fix | Why |
|---|---|---|
| **Required** | **Cache-health PASS condition corrected** | The run FAILED health on a healthy server: `skips=13955` / `2330`. `skips` is `insert_skips`, dominated by admission THROTTLE / queue exhaustion — under a low `ADMIT_AFTER` every miss is an insertion candidate and `THROTTLE` caps insertions per step, so non-zero is normal steady-state pressure (0.5% of ~3.0M misses, tracking the per-device miss asymmetry exactly). PASS is now `fill-fail == 0 AND dispatch-fail == 0 AND collect-fail == 0`; `skips`/`admission` report as load metrics with the reason they aren't defects. **The backlog spec (item 3c, "all-zero is the pass condition") was wrong and the measurement corrected it.** |
| 1 | KV type infers the engine default | Printed "unavailable" where llama.cpp's default is f16. Now `f16 (engine default; no -ctk/-ctv in argv)` — and only once the engine family is identified, so no other engine's default is guessed. |
| 2 | Derived RAM demand uses the **decode window** | Dividing whole-run misses by whole-run wall diluted it with prefill (~40% of the wall), where the cache isn't on the hot path. The counters carry no timestamps, so python now records the server-log line position at each phase boundary and the counters are read truncated there. Without `SERVER_LOG` the whole-run figure still prints, explicitly labelled diluted. |
| 3 | "leak delta" → "growth delta" under cache | +1036 MiB on a healthy run: an expert cache allocates its pool and graphs lazily on first inference, so one run grows VRAM by design. Only a monotonic rise across REPEATED runs is a leak. |
| minor | Engine-side prefill split by prompt size | Short canonical prompts (~30 tok/s) and deep haystacks (~127 tok/s) are different populations; one mean over both described neither. |

Also fixed, found by the same run: value-returning capture functions printed their own degradation
notice, which the caller's `$(...)` swallowed into the label — the run literally printed
`KV cache type  : capture: KV cache type unavailable (…)`. Callers now emit the notice, and a test
asserts no notice ever appears inside a labelled field.

### What the live run measured (validating the capture design)

- **Per-phase PCIe split is real and large**: decode rx mean **231 MB/s** vs prefill **3031 MB/s**
  (13×), peaks 1941 vs 28182 MB/s. A whole-run mean would have described neither.
- **Per-device asymmetry is larger still**: prefill rx GPU0 **5978** vs GPU1 **85 MB/s** (70×), and
  cache marginal hits CUDA0 **60.3%** vs CUDA1 **80.4%**. Averaging either away destroys the signal.
- **Client-vs-engine cross-check agreed to 0.3%** once short probe completions were excluded.
- **Derived RAM demand** ~14 GB/s of a ~36 GB/s measured STREAM ceiling.

## 3. Templates grown (supersedes "render only what the template has")

`docs/BENCH_CARD.md` Template 1 gains a **conditional** "CPU offload + expert cache" block —
rendered only when the run offloaded, replacing the generic cache line — with offload method, RSS vs
host RAM, swap, the cache config fingerprint, a per-device pool/marginal/cumulative/evictions/skips
table, per-phase PCIe + link state, and the derived RAM demand with its window stated. Template 2
gains per-device marginal-hit Δ rows and a real invariants table. Template comments mark which fields
auto-fill vs stay `<fill: …>`.

## Test evidence (this update)

| Suite | Result |
|---|---|
| `test-bench-card` (new) | **PASS** — 19 checks |
| `test-bench-capture` | **PASS** — 27 checks |
| `test-offload-matrix-static` | **PASS** — 9 checks |
| `test-offload-matrix-mocked` | **PASS** — 10 checks |
| `test-measurement-record` | **PASS** |
| `test-submit-bench` | **PASS** |

New fixtures: two hand-written baselines pinning the parser's expected shapes, plus
`live-offload-run.log` — the **real** run, redacted. It is deliberately kept in its *pre-correction*
form so the parser stays able to read logs written by older versions, which is exactly what a user
A/B-ing against an old saved log needs.

`scripts/offload-matrix.sh` remains untouched; the adoption deferral is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4LeYTBtjVXgpDgXSNUSgr

