### PR TITLE
refactor(offload-matrix): adopt the shared capture lib + PCIe on non-offload cards (closes #841)

### DIFF
--- a/scripts/lib/capture.sh
+++ b/scripts/lib/capture.sh
@@ -15,12 +15,16 @@
 #   bench.sh          = canonical protocol (measures a server someone else booted)
 #   capture.sh        = the common measurement layer
 #
-#   ⚠ offload-matrix.sh adoption is DEFERRED until feat/offload-matrix-prefix-cache
-#   lands — a multi-commit feature branch is in flight on that file and rewiring it
-#   underneath would conflict for no measurement benefit. Until then the sweep keeps
-#   its own inline copies of these scrapes and the duplication is ACCEPTED. When it
-#   is adopted, the sweep's inline versions must be deleted, not left as a second
-#   implementation: two copies of a scrape is how a fixed defect comes back.
+#   BOTH scripts consume this lib. offload-matrix.sh adopted it once
+#   feat/offload-matrix-prefix-cache landed (#826); its inline copies were DELETED
+#   rather than left alongside, because two copies of a scrape is how a fixed
+#   defect comes back — the sweep had been carrying the weaker pool-LINE-count
+#   detector while this lib counted DEVICES-with-a-pool, and a multi-pool device
+#   made the two disagree on whether a run was half-cached.
+#
+#   Where the two callers genuinely need different statistics, the LIB carries both
+#   and each caller picks (e.g. acceptance exposes `last=` for the sweep's per-arm
+#   TSV column and `mean=` for bench.sh). Fork the statistic, never the scrape.
 #
 # CONTRACT FOR EVERY FUNCTION HERE
 #   1. GRACEFUL DEGRADATION IS MANDATORY. A missing source (no GPU, no server log,
@@ -461,8 +465,12 @@ elif mode == "acceptance":
             drafted += int(m2.group(2))
     if not acc:
         sys.exit(1)
-    print(f"fired={len(acc)} mean={sum(acc)/len(acc):.3f} min={min(acc):.3f} "
-          f"max={max(acc):.3f} accepted={accepted} drafted={drafted}")
+    # `last` is the final acceptance the log carries. It exists because the sweep's
+    # TSV `accept` column has always meant exactly that — a per-arm boot ends with
+    # its own last value — and swapping in the mean would silently redefine every
+    # historical row. bench.sh quotes the mean; the sweep quotes last. Same scrape.
+    print(f"fired={len(acc)} last={acc[-1]:.3f} mean={sum(acc)/len(acc):.3f} "
+          f"min={min(acc):.3f} max={max(acc):.3f} accepted={accepted} drafted={drafted}")
 
 elif mode == "timings":
     # llama.cpp per-request print_timing. `prompt eval time` is PREFILL; the bare
@@ -1004,16 +1012,22 @@ PY
 #   REQ_ERRORS      one or more requests errored
 #   CACHE_DISABLED  a cache was REQUESTED but never allocated (incl. per-device)
 #   INVALID_BYPASS  the cache exists but a decode declined it (bypass counter > 0)
-# Precedence is deliberate: NO_TOKENS and REQ_ERRORS outrank the cache states —
-# a run with no tokens has nothing to say about a cache.
+# Precedence is deliberate, strongest last:
+#   INVALID_BYPASS < CACHE_DISABLED < NO_TOKENS < REQ_ERRORS
+# NO_TOKENS outranks the cache states — a run with no tokens has nothing to say
+# about a cache. REQ_ERRORS outranks NO_TOKENS in turn, because a run that errored
+# EXPLAINS why it produced no tokens; reporting NO_TOKENS there would send the
+# reader hunting for a scrape bug that is not the cause. This ordering is the
+# sweep's original one, adopted verbatim so per-arm rows keep their meaning.
 cap_status_classify() {   # $1=tokens $2=tps $3=req_errors $4=cache_requested $5=cache_ok $6=bypass
   local toks="${1:-0}" tps="${2:-0}" errs="${3:-0}" want="${4:-0}" got="${5:-1}" byp="${6:-0}"
   local status=OK
   if (( byp > 0 )); then status=INVALID_BYPASS; fi
   if [[ "$want" == "1" && "$got" != "1" ]]; then status=CACHE_DISABLED; fi
-  if [[ "${errs:-0}" != "0" && -n "${errs:-}" ]]; then status=REQ_ERRORS; fi
   case "${toks:-0}" in ''|'-'|0|0.0|0.00) status=NO_TOKENS ;; esac
   case "${tps:-0}" in ''|'-'|0|0.0|0.00) status=NO_TOKENS ;; esac
+  # LAST, so it outranks NO_TOKENS: a run that errored explains its own zero.
+  if [[ "${errs:-0}" != "0" && -n "${errs:-}" ]]; then status=REQ_ERRORS; fi
   echo "$status"
 }
 

--- a/scripts/lib/card.sh
+++ b/scripts/lib/card.sh
@@ -386,6 +386,41 @@ def cache_judgement(marg, cum):
     return "warming" if m > c else "thrashing"
 
 
+def pcie_slim(rec):
+    """PCIe for a run that did NOT offload.
+
+    Item 10 makes PCIe capture UNCONDITIONAL — TP all-reduce traffic is the
+    interesting part on a GPU-resident multi-card run, and that is exactly the
+    case with no offload block to carry it. Without this the bench output captures
+    PCIe and the card silently drops it, which is the one place a card can be less
+    honest than the run it describes."""
+    link = rec.get("pcie.link", "")
+    warn = rec.get("pcie.link_warn", "")
+    dec_mean, dec_peak = rec.get("pcie.decode.all.rx_mean"), rec.get("pcie.decode.all.rx_peak")
+    pre_mean, pre_peak = rec.get("pcie.prefill.all.rx_mean"), rec.get("pcie.prefill.all.rx_peak")
+    if not (link or dec_mean or pre_mean):
+        return []
+    parts = []
+    if dec_mean:
+        parts.append(f"decode rx {dec_mean} / {dec_peak} MB/s mean/peak")
+    if pre_mean:
+        parts.append(f"prefill rx {pre_mean} / {pre_peak} MB/s mean/peak")
+    pct = rec.get("pcie.link_pct")
+    if pct:
+        parts.append(f"{pct}% of practical link")
+    head = f"**PCIe:** {link or FILL.format('link')}"
+    if warn:
+        head += f" ⚠️ {warn}"
+    out = [head + (" · " + " · ".join(parts) if parts else "")]
+    out.append("")
+    out.append("> No CPU offload on this run, so this is interconnect traffic — on a multi-card "
+               "tensor-parallel run that is the all-reduce path, and it is the number a topology "
+               "change (link width, P2P state) moves. 1 Hz sampling under-reads bursts, so the "
+               "peak sits next to the mean.")
+    out.append("")
+    return out
+
+
 def offload_block(rec, devs):
     """The CPU-offload + expert-cache section. Rendered ONLY when offload is
     detected — on a GPU-resident run every row here would be a dash pretending to
@@ -614,7 +649,9 @@ def render_snapshot(rec):
     devs = cache_devices(rec)
     if is_offload(rec):
         L.extend(offload_block(rec, devs))
-    elif devs:
+    else:
+        L.extend(pcie_slim(rec))
+    if not is_offload(rec) and devs:
         # Non-offload engines with a cache of their own keep the generic line.
         parts = []
         for d in devs:

--- a/scripts/offload-matrix.sh
+++ b/scripts/offload-matrix.sh
@@ -338,7 +338,43 @@ emit_row() {   # $1=status, $2.. = leading values in header order starting at `a
   local IFS=$'\t'; printf '%s\t%s\n' "${f[*]}" "$status" >> "$TSV"
 }
 
-cpu_snap() { awk '/^cpu /{i=$5;t=0;for(j=2;j<=NF;j++)t+=$j;print t,i}' /proc/stat; }
+# kv_fields <key> [<key> ...] — pull named `key=value` fields out of one line of
+# the capture layer's structured output, in order, space-separated for `read`.
+# Missing keys come back empty rather than shifting the rest — a positional read
+# that silently slides one column left is exactly the class of defect this
+# harness exists to prevent.
+kv_fields() {
+  awk -v keys="$*" '{
+    n = split(keys, want, " ")
+    delete got
+    for (i = 1; i <= NF; i++) {
+      p = index($i, "=")
+      if (p > 1) got[substr($i, 1, p - 1)] = substr($i, p + 1)
+    }
+    out = ""
+    for (i = 1; i <= n; i++) out = out (i > 1 ? " " : "") (want[i] in got ? got[want[i]] : "")
+    print out
+  }'
+}
+
+# ---- shared capture layer --------------------------------------------------
+# The scrapes below (pool census, hits/evictions, acceptance, VRAM, dmon, status
+# classification, derived RAM read) live in scripts/lib/capture.sh and are shared
+# with bench.sh. This sweep used to carry its own copies; they DRIFTED — the
+# sweep's #824 detector compared pool-LINE count to device count, which a device
+# holding two pools defeats (pool_lines >= NGPU while another device has none).
+# The lib counts DEVICES-with-a-pool. One scrape, one fix, both callers.
+_OM_LIB="$(dirname "${BASH_SOURCE[0]}")/lib/capture.sh"
+if [[ -r "$_OM_LIB" ]]; then
+  # shellcheck source=lib/capture.sh
+  source "$_OM_LIB"
+else
+  die "missing $_OM_LIB — the sweep consumes the shared capture layer"
+fi
+# These window the lib's log scrapes for bench.sh's single-server protocol. The
+# sweep boots one server PER ARM and scrapes that arm's own log whole, so a value
+# inherited from the environment would silently truncate every scrape.
+unset CAP_LINE_OFFSET CAP_LINE_LIMIT
 
 # depth flag is PER DRAFTER TYPE. Note --draft-max does NOT clamp the ngram family
 # in forks that expose size-m/n-max (their defaults can be 48-64 tokens, which will
@@ -467,32 +503,33 @@ run_arm() {
   (( ok )) || { echo "  BOOT TIMEOUT"; kill "$pid" 2>/dev/null; emit_row TIMEOUT "${idcols[@]}"; return 1; }
 
   local ctx_slot; ctx_slot=$(command grep -oE 'n_ctx_seq *= *[0-9]+|n_ctx_per_seq *= *[0-9]+' "$log" | head -1 | command grep -oE '[0-9]+')
-  # PHASE 1 (before): idle baseline — VRAM after load but before any request, and
-  # a short idle dmon sample so live figures can be read against a floor.
-  local vram_idle="-" dmon_idle="$OUT_DIR/.idle-$arm-r$rep"
-  if (( NGPU > 0 )); then
-    vram_idle=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null | paste -sd+ | bc)
-    timeout 4 nvidia-smi dmon -s ut -d 1 -c 3 > "$dmon_idle" 2>/dev/null || true
-  fi
+  # PHASE 1 (before): idle baseline — VRAM after load but before any request.
+  #
+  # There used to be a 3-sample idle `dmon` here too, described as "so live figures
+  # can be read against a floor". Nothing ever read it: it cost 4 s of every arm and
+  # left a `.idle-*` file in OUT_DIR that no cleanup removed. Deleted rather than
+  # wired up, because the floor it was meant to establish is not actually used by
+  # any column — if a future arm wants one, take it through cap_dmon_phase so it
+  # gets the same treatment as the live sample.
+  local vram_idle="-"
+  (( NGPU > 0 )) && vram_idle="$(cap_vram_used || echo '-')"
   # cache counters BEFORE the measured window, so hits/evictions can be reported as
   # a DELTA (steady state) rather than lifetime-cumulative (which includes the cold
-  # fill storm and understates the hit rate).
-  local h0 m0 e0
-  read -r h0 m0 < <(command grep -oE 'hits=[0-9]+/[0-9]+' "$log" | tail -"${NGPU:-2}" \
-    | command grep -oE '[0-9]+/[0-9]+' | awk -F/ '{h+=$1; t+=$2} END{print h+0, (t-h)+0}')
-  e0=$(command grep -oE 'evictions=[0-9]+' "$log" | tail -"${NGPU:-2}" | command grep -oE '[0-9]+' | paste -sd+ | bc 2>/dev/null)
-  h0="${h0:-0}"; m0="${m0:-0}"; e0="${e0:-0}"
+  # fill storm and understates the hit rate). The lib reads the LAST cumulative
+  # emission PER DEVICE, which is what the old `tail -NGPU` was approximating —
+  # and it stays correct when a device emits at a different cadence.
+  local counters0="$OUT_DIR/.c0-$arm-r$rep"
+  cap_moe_parse counters "$log" > "$counters0" 2>/dev/null || : > "$counters0"
 
   # PHASE 2 (during): telemetry windowed to the MEASURED requests only
   local dmon="$OUT_DIR/.dmon-$arm-r$rep" dpid="" vpid=""
+  local phases="$OUT_DIR/.ph-$arm-r$rep"
   if (( NGPU > 0 )); then
-    nvidia-smi dmon -s ut -d 1 > "$dmon" 2>/dev/null & dpid=$!
-    ( vp=0; while kill -0 "$pid" 2>/dev/null; do
-        v=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null | paste -sd+ | bc 2>/dev/null)
-        [[ -n "$v" && "$v" -gt "$vp" ]] && { vp=$v; echo "$vp" > "$OUT_DIR/.vp-$arm-r$rep"; }; sleep 2
-      done ) & vpid=$!
+    dpid="$(cap_dmon_start "$dmon" || true)"
+    vpid="$(cap_vram_peak_start "$OUT_DIR/.vp-$arm-r$rep" || true)"
   fi
-  read -r c_tot0 c_idle0 < <(cpu_snap); local t0; t0=$(date +%s.%N)
+  local c_snap0; c_snap0="$(cap_cpu_snap)"
+  local t0 t0_epoch; t0=$(date +%s.%N); t0_epoch=$(date +%s)
 
   N="$n" ROUNDS="$ROUNDS" GEN="$GEN" PORT="$PORT" HOST="$HOST" PROMPT_FILE="$PROMPT_FILE" \
   SHAPE="$shape" HETERO="$HETERO" \
@@ -564,8 +601,13 @@ print(len(errs))                                   # line 3: request error count
 print(errs[0] if errs else "-")                    # line 4: first error, for triage
 print(f"shape={SHAPE} hetero={HETERO} prompt[0:120]={mk(0)[:120]!r}")   # line 5: what was actually sent
 PY
-  local t1; t1=$(date +%s.%N); read -r c_tot1 c_idle1 < <(cpu_snap)
-  [[ -n "$dpid" ]] && kill "$dpid" 2>/dev/null; [[ -n "$vpid" ]] && kill "$vpid" 2>/dev/null
+  local t1 t1_epoch; t1=$(date +%s.%N); t1_epoch=$(date +%s)
+  local c_snap1; c_snap1="$(cap_cpu_snap)"
+  cap_stop_pid "$dpid"; cap_stop_pid "$vpid"
+  # One window covering the measured requests. The lib slices its epoch-stamped
+  # dmon stream by window; the sweep has exactly one per arm (bench.sh has several,
+  # split decode vs prefill), so the arm IS the window.
+  printf 'arm %s %s\n' "$t0_epoch" "$t1_epoch" > "$phases"
   local agg ttft elapsed cpu_pct rx tx smp memc
   agg=$(sed -n 1p "$OUT_DIR/.drv-$arm-r$rep"); ttft=$(sed -n 2p "$OUT_DIR/.drv-$arm-r$rep")
   local req_err req_err_msg prompt_dbg
@@ -573,74 +615,115 @@ PY
   prompt_dbg=$(sed -n 5p "$OUT_DIR/.drv-$arm-r$rep")
   { echo "# driver: $prompt_dbg"; echo "# driver: request_errors=${req_err:-?} first=${req_err_msg:--}"; } >> "$log"
   elapsed=$(python3 -c "print(max(0.001,$t1-$t0))")
-  cpu_pct=$(python3 -c "dt=$c_tot1-$c_tot0; di=$c_idle1-$c_idle0; print(f'{(1-di/dt)*100:.1f}' if dt>0 else '-')")
+  cpu_pct="$(cap_cpu_pct "$c_snap0" "$c_snap1" || echo '-')"
+  # MEANS, exactly as before (the TSV columns are means). The lib also carries the
+  # PEAKS, which the console line now shows: 1 Hz sampling under-reads bursts, so a
+  # mean alone hides a transfer spike an offload arm cares about.
+  local rx_peak="-" tx_peak="-"
+  rx=-; tx=-; smp=-; memc=-
   if [[ -s "$dmon" ]]; then
-    read -r rx tx smp memc < <(awk '!/^#/ && NF>=9 {s+=$2;m+=$3;r+=$8;t+=$9;k++} END{if(k)printf "%.0f %.0f %.1f %.1f",r/k,t/k,s/k,m/k; else print "- - - -"}' "$dmon")
-  else rx=-; tx=-; smp=-; memc=-; fi
-  rm -f "$dmon" "$OUT_DIR/.drv-$arm-r$rep"
+    read -r rx rx_peak tx tx_peak smp memc < <(
+      cap_dmon_phase "$dmon" "$phases" arm 2>/dev/null | command grep -m1 ' all ' \
+        | kv_fields rx_mean rx_peak tx_mean tx_peak sm_mean memctl_mean)
+    rx="${rx:--}"; tx="${tx:--}"; smp="${smp:--}"; memc="${memc:--}"
+    rx_peak="${rx_peak:--}"; tx_peak="${tx_peak:--}"
+  fi
+  rm -f "$dmon" "$phases" "$OUT_DIR/.drv-$arm-r$rep"
 
   # PHASE 3 (after): post-run VRAM for a leak check against the idle floor
   local vram_post="-" leak="-"
   if (( NGPU > 0 )); then
-    vram_post=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null | paste -sd+ | bc)
+    vram_post="$(cap_vram_used || echo '')"
     [[ "$vram_idle" != "-" && -n "$vram_post" ]] && leak=$(( vram_post - vram_idle ))
   fi
   local strm acc pool hits ev miss byp vpeak ramrd aexp
   strm=$(command grep -E 'eval time' "$log" | command grep -v 'prompt eval' \
     | command grep -oE '[0-9.]+ tokens per second' | command grep -oE '^[0-9.]+' | tail -$(( n*2 )) \
     | sort -n | awk '{a[NR]=$1} END{if(NR)printf "%.2f",(NR%2)?a[int((NR+1)/2)]:(a[NR/2]+a[NR/2+1])/2; else print "-"}')
-  acc=$(command grep -oE 'draft acceptance = [0-9.]+' "$log" | tail -1 | command grep -oE '[0-9.]+')
-  pool=$(command grep -oE 'slots=[0-9]+' "$log" | command grep -oE '[0-9]+' | paste -sd+ | bc 2>/dev/null)
-  # DELTAS across the measured window (not lifetime): excludes the cold fill storm
-  local h1 m1 e1
-  read -r h1 m1 < <(command grep -oE 'hits=[0-9]+/[0-9]+' "$log" | tail -"${NGPU:-2}" \
-    | command grep -oE '[0-9]+/[0-9]+' | awk -F/ '{h+=$1; t+=$2} END{print h+0, (t-h)+0}')
-  e1=$(command grep -oE 'evictions=[0-9]+' "$log" | tail -"${NGPU:-2}" | command grep -oE '[0-9]+' | paste -sd+ | bc 2>/dev/null)
-  h1="${h1:-0}"; m1="${m1:-0}"; e1="${e1:-0}"
-  miss=$(( m1 - m0 )); (( miss < 0 )) && miss=0
-  ev=$(( ${e1:-0} - ${e0:-0} )); (( ev < 0 )) && ev=0
-  local dh=$(( h1 - h0 )); (( dh < 0 )) && dh=0
+  # `last`, not `mean`: the TSV `accept` column has always meant the arm's final
+  # logged acceptance. The lib carries both; the sweep picks last, bench.sh picks
+  # mean. The FIRE RATE goes to the console line only — acceptance without it is a
+  # deception (a drafter can post 0.99 while firing on a quarter of requests), but
+  # adding a TSV column would change the schema every historical row is read with.
+  local acc_fired="-"
+  read -r acc acc_fired < <(cap_moe_parse acceptance "$log" 2>/dev/null | kv_fields last fired)
+  acc_fired="${acc_fired:--}"
+  # Pool slots: SUM of every pool on every device. Unchanged semantics — the lib's
+  # census aggregates per device and this sums the devices, so a multi-pool device
+  # still contributes all of its pools (the reason a `tail` here would be a defect).
+  local census; census="$(cap_moe_parse census "$log" 2>/dev/null || true)"
+  if [[ -n "$census" ]]; then
+    pool=$(printf '%s\n' "$census" | command grep -oE 'slots=[0-9]+' | cut -d= -f2 \
+           | awk '{s+=$1} END{if(NR) print s}')
+  fi
+  # DELTAS across the measured window (not lifetime): excludes the cold fill storm.
+  local counters1="$OUT_DIR/.c1-$arm-r$rep"
+  cap_moe_parse counters "$log" > "$counters1" 2>/dev/null || : > "$counters1"
+  local dh=0
+  miss=0; ev=0
+  if [[ -s "$counters1" ]]; then
+    read -r dh miss ev < <(cap_marginal_rates "$counters0" "$counters1" 2>/dev/null | awk '{
+      for (i = 1; i <= NF; i++) {
+        if ($i ~ /^dhits=/)      { split($i, a, "="); h += a[2] }
+        if ($i ~ /^dlookups=/)   { split($i, b, "="); t += b[2] }
+        if ($i ~ /^devictions=/) { split($i, c, "="); e += c[2] }
+      }
+    } END { m = t - h; print h+0, (m > 0 ? m : 0), e+0 }')
+  fi
+  dh="${dh:-0}"; miss="${miss:-0}"; ev="${ev:-0}"
   if (( dh + miss > 0 )); then hits=$(python3 -c "print(f'{$dh*100.0/($dh+$miss):.1f}%')"); else hits="-"; fi
-  # derived RAM read on the miss path; expert size read from the pool lines when present
+  # derived RAM read on the miss path; expert size from the census when present
   aexp="$AVG_EXPERT_KIB"
-  [[ -z "$aexp" ]] && aexp=$(command grep -oE 'expert=[0-9]+ KiB' "$log" | command grep -oE '[0-9]+' | awk '{s+=$1;n++} END{if(n)printf "%.0f",s/n}')
-  if [[ -n "$aexp" && -n "$miss" && "$miss" != 0 ]]; then
-    ramrd=$(python3 -c "print(f'{$miss*$aexp/1024/$elapsed:.0f}')" 2>/dev/null)
-  else ramrd="-"; fi
-  byp=$(command grep -c 'bypassing cache' "$log")
+  [[ -z "$aexp" && -n "$census" ]] && aexp=$(printf '%s\n' "$census" \
+    | command grep -oE 'expert_kib=[0-9]+' | cut -d= -f2 | awk '{s+=$1;n++} END{if(n)printf "%.0f",s/n}')
+  ramrd="$(cap_ram_rd_mbps "${miss:-0}" "${aexp:-0}" "$elapsed" 2>/dev/null || echo '-')"
+  byp="$(cap_moe_parse bypass "$log" 2>/dev/null || echo 0)"
   # CACHE-NOT-ALLOCATED detection. Distinct from bypass: bypass means the cache exists
   # but a decode declined it; THIS means the pool was never created at all, so the arm
   # silently measures the no-cache path while every other column looks healthy.
   # Found live 2026-07-30: the engine's DEFAULT reserve (3072 MiB) left no budget at
   # 262K ctx, logging "CUDA0 has no cache budget after 3072 MiB reserve" -- a string the
   # bypass grep does not match. Both arms reported OK and ran ~12-22% slow.
-  local cache_enabled=0 reserve_seen="" pool_lines=0 cache_partial=0
-  command grep -q '\[moe-cache\] enabled:' "$log" && cache_enabled=1
-  # PER-DEVICE budget failure. '[moe-cache] enabled:' still prints when only SOME devices
-  # got a pool, so a presence check scores the arm healthy while it measures a half-cached
-  # path -- measured live 2026-07-30 (CUDA0 no budget, CUDA1 a 69-slot pool, status OK).
-  # The pool-init lines are ground truth: one 'slots=' line per device when fully
-  # allocated. Fewer than NGPU of them means the cache is NOT what was requested.
-  pool_lines=$(command grep -c 'slots=' "$log")
-  if (( cache_enabled == 1 && pool_lines < ${NGPU:-2} )); then
+  # PER-DEVICE budget failure. '[moe-cache] enabled:' still prints when only SOME
+  # devices got a pool, so a presence check scores the arm healthy while it measures
+  # a half-cached path -- measured live 2026-07-30 (CUDA0 no budget, CUDA1 a 69-slot
+  # pool, status OK).
+  #
+  # ⚠ Ground truth is the count of DEVICES THAT HOLD A POOL, never the count of
+  #   pool LINES. A device can hold several pools (`pool[0]`, `pool[1]`), so a
+  #   line-count detector reads pool_lines >= NGPU and passes an arm where an entire
+  #   device got nothing. That is the generalised #824 hole, and it is why this now
+  #   defers to the shared lib instead of re-deriving it here.
+  local cache_enabled=0 reserve_seen="" pool_devs=0 pool_lines=0 cache_partial=0 nobudget=0
+  local pd; pd="$(cap_moe_parse pooldev "$log" 2>/dev/null || true)"
+  read -r cache_enabled pool_devs pool_lines nobudget < <(
+    printf '%s\n' "$pd" | kv_fields enabled devices pool_lines nobudget)
+  cache_enabled="${cache_enabled:-0}"; pool_devs="${pool_devs:-0}"
+  pool_lines="${pool_lines:-0}"; nobudget="${nobudget:-0}"
+  if (( cache_enabled == 1 && pool_devs < ${NGPU:-2} )); then
     cache_enabled=0
     cache_partial=1
   fi
   reserve_seen=$(command grep -oE 'reserve=[0-9]+ MiB|after [0-9]+ MiB reserve' "$log" \
                  | command grep -oE '[0-9]+' | tail -1)
-  local nobudget; nobudget=$(command grep -c 'no cache budget' "$log")
   kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
   vpeak=$(cat "$OUT_DIR/.vp-$arm-r$rep" 2>/dev/null); rm -f "$OUT_DIR/.vp-$arm-r$rep"
 
-  local status=OK
-  (( byp > 0 )) && status="INVALID_BYPASS"
-  # A requested cache that never allocated invalidates the arm for any cache-dimension
-  # conclusion, so it must never read OK.
-  if (( HAS_MOE_CACHE )) && [[ "$cache" != 0 ]] && (( cache_enabled == 0 )); then
-    status="CACHE_DISABLED"
+  # Classification is the lib's: one enum, one precedence order, both callers.
+  # (INVALID_BYPASS < CACHE_DISABLED < NO_TOKENS < REQ_ERRORS — a run that errored
+  # explains its own zero, so REQ_ERRORS outranks NO_TOKENS.)
+  local cache_wanted=0 cache_ok=1
+  if (( HAS_MOE_CACHE )) && [[ "$cache" != 0 ]]; then
+    cache_wanted=1
+    (( cache_enabled == 1 )) || cache_ok=0
+  fi
+  local status
+  status="$(cap_status_classify "${agg:-0}" "${agg:-0}" "${req_err:-0}" \
+                                "$cache_wanted" "$cache_ok" "${byp:-0}")"
+  if (( cache_wanted )) && (( cache_ok == 0 )); then
     echo "  !! expert cache was REQUESTED (--moe-cache $cache) but NEVER ALLOCATED."
     if (( cache_partial )); then
-      echo "     reason: PARTIAL allocation -- only $pool_lines of ${NGPU:-2} devices got a"
+      echo "     reason: PARTIAL allocation -- only $pool_devs of ${NGPU:-2} devices got a"
       echo "     pool (the 'enabled:' line still prints in this state). One GPU ran with no"
       echo "     cache at all, so this arm measured a half-cached path. Lower the reserve"
       echo "     (RESERVE_MB=1536) so every device fits a pool."
@@ -651,11 +734,10 @@ PY
       echo "     no '[moe-cache] enabled:' line in $log -- check the build and flags."
     fi
   fi
-  # zero throughput means every request failed — never let that land as OK (the
-  # first live run reported agg=0.00 with status OK because the prompt builder
-  # rejected an empty SHAPE and the driver exited)
-  case "${agg:-}" in ''|'-'|0|0.0|0.00) status="NO_TOKENS" ;; esac
-  [[ -n "${req_err:-}" && "${req_err:-0}" != 0 ]] && status="REQ_ERRORS"
+  # (zero throughput -> NO_TOKENS and request errors -> REQ_ERRORS are both applied
+  # inside cap_status_classify above; the first live run reported agg=0.00 with
+  # status OK because the prompt builder rejected an empty SHAPE and the driver
+  # exited, which is the case that enum exists for.)
   # Routed through emit_row so the column count comes from $HDR alone. This used to be
   # a hand-written printf with 32 specifiers for 33 arguments -- bash then RE-RAN the
   # format string for the surplus arg, so every arm wrote a short row PLUS a junk row
@@ -665,8 +747,9 @@ PY
     "${admit:--}" "${throttle:--}" "${agg:--}" "${strm:--}" "${ttft:--}" "${acc:--}" "${pool:--}" \
     "${hits:--}" "${miss:--}" "${ev:--}" "${rx:--}" "${tx:--}" "${smp:--}" "${memc:--}" "${cpu_pct:--}" \
     "${ramrd:--}" "${vpeak:--}" "${vram_idle:--}" "${vram_post:--}" "${leak:--}" "$byp" "${req_err:--}"
-  echo "  agg=$agg strm=$strm ttft=${ttft}ms acc=${acc:--} | pcie rx=$rx tx=$tx MB/s sm=${smp}% memctl=${memc}% cpu=${cpu_pct}% ram_rd=${ramrd}MB/s | pool=${pool:--} hits=${hits:--} bypass=$byp req_err=${req_err:-?} [$status]"
+  echo "  agg=$agg strm=$strm ttft=${ttft}ms acc=${acc:--}(fired ${acc_fired}) | pcie rx=$rx/${rx_peak} tx=$tx/${tx_peak} MB/s mean/peak sm=${smp}% memctl=${memc}% cpu=${cpu_pct}% ram_rd=${ramrd}MB/s | pool=${pool:--} hits=${hits:--} bypass=$byp req_err=${req_err:-?} [$status]"
   [[ "${req_err:-0}" != 0 ]] && echo "    first request error: ${req_err_msg:--}   (full context: $log)"
+  rm -f "$counters0" "$counters1"
   sleep 5; echo
 }
 

--- a/scripts/tests/test-bench-capture.sh
+++ b/scripts/tests/test-bench-capture.sh
@@ -106,11 +106,16 @@ command grep -q 'capture: ${thing} unavailable (${why})' "$LIB" \
   || fail "capture.sh's degradation notice no longer matches the documented shape"
 echo "  ✓ degradation notice keeps the 'capture: <thing> unavailable (<why>)' shape"
 
-# The deferral is a deliberate decision with an expiry, not an oversight. If the
-# note goes, the reason the duplication is tolerated goes with it.
-command grep -q 'offload-matrix.sh adoption is DEFERRED' "$LIB" \
-  || fail "capture.sh must record WHY offload-matrix.sh still carries its own copies"
-echo "  ✓ offload-matrix adoption deferral is recorded in the lib"
+# The deferral EXPIRED — offload-matrix.sh adopted the lib. Assert the adoption is
+# recorded and that the old deferral note is gone, so nobody re-reads a stale
+# "duplication is accepted" note as licence to fork a scrape again.
+command grep -q 'adoption is DEFERRED' "$LIB" \
+  && fail "the deferral note outlived the adoption — offload-matrix.sh now consumes the lib"
+command grep -q 'BOTH scripts consume this lib' "$LIB" \
+  || fail "capture.sh must record that both callers consume it (and that copies were DELETED)"
+command grep -q 'Fork the statistic, never the scrape' "$LIB" \
+  || fail "the lib must record the rule that keeps the two callers from re-forking"
+echo "  ✓ lib records the completed adoption (both callers, copies deleted)"
 
 # Sourcing the lib must have no side effects — no output, no exit, and safe to
 # source twice (bench.sh and a future sweep may both pull it in).
@@ -238,7 +243,18 @@ command grep -q 'fired=1' <<<"$acc" || fail "acceptance fire count wrong: $acc"
 command grep -q 'mean=0.992' <<<"$acc" || fail "acceptance value wrong: $acc"
 command grep -q 'accepted=248 drafted=250' <<<"$acc" \
   || fail "drafts-attempted must be captured alongside acceptance: $acc"
-echo "  ✓ acceptance scrape carries fire count AND drafts-attempted"
+# BOTH statistics, because the two callers need different ones: bench.sh quotes the
+# MEAN over its run, while offload-matrix's TSV `accept` column has always meant the
+# arm's LAST logged value. Forking the statistic in the lib is what stops the two
+# from re-forking the whole scrape.
+command grep -q 'last=0.992' <<<"$acc" || fail "acceptance must expose last= for the sweep: $acc"
+cat >> "$TMP/end.log" <<'EOF'
+draft acceptance = 0.500 (  100 accepted /   200 generated)
+EOF
+acc2=$(cap_moe_parse acceptance "$TMP/end.log")
+command grep -q 'last=0.500' <<<"$acc2" || fail "last= must track the FINAL value: $acc2"
+command grep -q 'mean=0.746' <<<"$acc2" || fail "mean= must average both values: $acc2"
+echo "  ✓ acceptance exposes last= (sweep) and mean= (bench) from one scrape"
 
 # --- timings: prefill and decode must not be confused; short runs filtered ----
 tim=$(cap_moe_parse timings "$TMP/end.log") || fail "timings scrape returned nothing"
@@ -293,6 +309,12 @@ cap_ram_rd_mbps 0 4352 60 >/dev/null 2>&1 && fail "ram_rd must refuse to invent 
 [[ "$(cap_status_classify 500 30 0 0 1 0)"  == OK ]]             || fail "a clean run must read OK"
 # NO_TOKENS outranks the cache states: a run with no tokens says nothing about a cache.
 [[ "$(cap_status_classify 0 0 0 1 0 5)"     == NO_TOKENS ]]      || fail "NO_TOKENS must outrank the cache states"
+# ...and REQ_ERRORS outranks NO_TOKENS in turn: a run that errored EXPLAINS its own
+# zero, and reporting NO_TOKENS there sends the reader hunting a scrape bug that is
+# not the cause. This is offload-matrix's original precedence, adopted verbatim so
+# per-arm rows keep their meaning.
+[[ "$(cap_status_classify 0 0 3 0 1 0)"     == REQ_ERRORS ]]     || fail "REQ_ERRORS must outrank NO_TOKENS"
+[[ "$(cap_status_classify 0 0 3 1 0 5)"     == REQ_ERRORS ]]     || fail "REQ_ERRORS must outrank everything"
 [[ "$(cap_divergence_pct 30 32)" == "6.2" ]] || fail "divergence arithmetic changed"
 echo "  ✓ status enum precedence, derived-demand arithmetic, divergence"
 

--- a/scripts/tests/test-bench-card.sh
+++ b/scripts/tests/test-bench-card.sh
@@ -382,6 +382,31 @@ command grep -q '\*\*Cache (if the engine has one):\*\*' <<<"$noff" \
 command grep -q 'CUDA0 hits 19.3% → 29.6%' <<<"$noff" || fail "generic cache line lost its per-device values"
 echo "  ✓ no-offload run: generic cache line, offload block absent"
 
+# (b2) PCIe capture is UNCONDITIONAL (item 10), so a non-offload run must still
+#      show it — on a multi-card TP run the all-reduce traffic IS the interesting
+#      part, and that is precisely the run with no offload block to carry it.
+{
+  sed -e 's/^fp.offload=.*/fp.offload=not detected (moe-cache captures skipped)/' "$REC"
+  printf '%s\n' \
+    'pcie.link=GPU0 gen=4/4 width=16/16' \
+    'pcie.link_pct=31.4' \
+    'pcie.decode.all.rx_mean=812' \
+    'pcie.decode.all.rx_peak=8410' \
+    'pcie.prefill.all.rx_mean=1904' \
+    'pcie.prefill.all.rx_peak=15220'
+} > "$TMP/nooff-pcie.kv"
+np="$(card_render snapshot "$TMP/nooff-pcie.kv")" || fail "no-offload+PCIe snapshot render failed"
+command grep -q '### CPU offload + expert cache' <<<"$np" && fail "still no offload block expected here"
+command grep -qF '**PCIe:** GPU0 gen=4/4 width=16/16' <<<"$np" \
+  || fail "a non-offload card must still render PCIe (capture is unconditional): $np"
+command grep -q 'decode rx 812 / 8410 MB/s mean/peak' <<<"$np" || fail "PCIe means/peaks missing"
+command grep -q '31.4% of practical link' <<<"$np" || fail "link utilisation missing from the slim line"
+command grep -q 'all-reduce path' <<<"$np" \
+  || fail "the non-offload PCIe note should say what the traffic IS on a TP run"
+# a run with no PCIe data at all must not render an empty stub
+command grep -q '\*\*PCIe:\*\*' <<<"$noff" && fail "no PCIe data must render NO PCIe line, not an empty one"
+echo "  ✓ non-offload card keeps PCIe (unconditional capture), and omits it entirely when absent"
+
 # (c) A moe-cache config mismatch is a CONFOUND, exactly like a model mismatch.
 sed -e 's/moe_cache_cap=8192/moe_cache_cap=4096/' "$CFIX/baseline.log" > "$TMP/moediff.log"
 mc="$(card_render ab "$REC" "$TMP/moediff.log")" || fail "moe-mismatch A/B failed to render"

--- a/scripts/tests/test-offload-matrix-mocked.sh
+++ b/scripts/tests/test-offload-matrix-mocked.sh
@@ -110,6 +110,21 @@ st=$(status_of "$tsv")
   "partial_budget must be CACHE_DISABLED, got '$st' — the detector is keying on the presence of '[moe-cache] enabled:' instead of comparing pool-line count to device count (issue #824)"
 echo "  ✓ partial_budget -> CACHE_DISABLED (per-device budget failure is caught)"
 
+# 4b. ⚠️ THE HOLE, ONE LEVEL DEEPER. A device can hold SEVERAL pools, so a run
+#     where CUDA0 got nothing and CUDA1 got two pools has pool_lines(2) >= NGPU(2)
+#     — a line-counting detector scores it healthy while half the model runs
+#     uncached. Only counting DEVICES-with-a-pool catches it. The sweep carried the
+#     line-count form until it adopted scripts/lib/capture.sh; this arm is the
+#     regression guard for that adoption.
+tsv=$(run_scenario multipool); assert_shape "$tsv" multipool
+st=$(status_of "$tsv")
+[[ "$st" == "CACHE_DISABLED" ]] || fail \
+  "multipool must be CACHE_DISABLED, got '$st' — the detector is comparing pool-LINE count to device count, which a device holding two pools defeats (#824 generalised)"
+# ...and the operator must be told WHICH reading failed, in devices not lines.
+grep -q 'only 1 of 2 devices got a' "$TMP/multipool/sweep.log" \
+  || fail "the half-cached message must report DEVICES with a pool, not pool lines"
+echo "  ✓ multipool -> CACHE_DISABLED (two pools on one device no longer masks an uncached device)"
+
 # 5. zero tokens must never read OK — this shipped as agg=0.00/OK once
 tsv=$(run_scenario no_tokens); assert_shape "$tsv" no_tokens
 [[ "$(status_of "$tsv")" == "NO_TOKENS" ]] || fail "no_tokens should be NO_TOKENS, got '$(status_of "$tsv")'"
@@ -148,7 +163,7 @@ PY
 # 9. the renderer must survive every view on real produced rows — one view once died
 #    with KeyError and another rendered '-' forever.
 cat "$TMP"/healthy/r.tsv > "$TMP/all.tsv"
-for s in bypass no_budget_all partial_budget no_tokens boot_fail; do
+for s in bypass no_budget_all partial_budget multipool no_tokens boot_fail; do
   tail -n +2 "$TMP/$s/r.tsv" >> "$TMP/all.tsv"
 done
 for view in --perf --bw --cache --all; do

--- a/scripts/tests/test-offload-matrix-static.sh
+++ b/scripts/tests/test-offload-matrix-static.sh
@@ -12,10 +12,12 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SWEEP="$ROOT_DIR/scripts/offload-matrix.sh"
 REND="$ROOT_DIR/scripts/offload-matrix-render.py"
+LIB="$ROOT_DIR/scripts/lib/capture.sh"
 fail() { echo "FAIL: $1" >&2; exit 1; }
 
 [[ -f "$SWEEP" ]] || fail "missing $SWEEP"
 [[ -f "$REND"  ]] || fail "missing $REND"
+[[ -f "$LIB"   ]] || fail "missing $LIB — the sweep consumes the shared capture layer"
 
 # 1. both halves parse
 bash -n "$SWEEP" || fail "bash -n: syntax error in offload-matrix.sh"
@@ -71,16 +73,26 @@ echo "  ✓ emit_row pads short rows, refuses over-long rows, keeps status last"
 # 5. every status the renderer explains must be one the driver can actually emit,
 #    and vice versa. Drift in either direction means an arm renders with no
 #    explanation, or the renderer documents a state that cannot happen.
-python3 - "$SWEEP" "$REND" <<'PY' || exit 1
+#
+#    The vocabulary now has TWO sources: the sweep still emits its own early-exit
+#    states directly (BOOT_FAIL, TIMEOUT, PORT_BUSY, ...), while the four shared
+#    run-quality states (NO_TOKENS / REQ_ERRORS / CACHE_DISABLED / INVALID_BYPASS)
+#    are classified by scripts/lib/capture.sh, which bench.sh uses too. Scanning
+#    both is the point — one enum, one precedence, two callers.
+python3 - "$SWEEP" "$REND" "$LIB" <<'PY' || exit 1
 import re,sys
 sweep=open(sys.argv[1],encoding="utf-8").read()
 rend =open(sys.argv[2],encoding="utf-8").read()
-emitted=set(re.findall(r'status="([A-Z_]{3,})"',sweep)) | set(re.findall(r'emit_row ([A-Z_]{3,})',sweep))
+lib  =open(sys.argv[3],encoding="utf-8").read()
+def states(src):
+    return (set(re.findall(r'status="?([A-Z_]{3,})"?',src))
+            | set(re.findall(r'emit_row ([A-Z_]{3,})',src)))
+emitted=states(sweep) | states(lib)
 emitted.discard("OK")                      # OK is the default, never explained
 known=set(re.findall(r'"([A-Z_]{3,})":',rend))
 if emitted-known: sys.exit(f"FAIL: driver emits statuses the renderer cannot explain: {sorted(emitted-known)}")
 if known-emitted: sys.exit(f"FAIL: renderer explains statuses the driver never emits: {sorted(known-emitted)}")
-print(f"  ✓ status vocabulary agrees both ways ({len(emitted)} non-OK states)")
+print(f"  ✓ status vocabulary agrees both ways ({len(emitted)} non-OK states, sweep + lib)")
 PY
 
 # 6. every column the renderer reads must exist in the header. One view once
@@ -123,12 +135,13 @@ for must in ("shape","offload","ctx_slot","cache_mb","pcache"):
 print(f"  ✓ pairing key is shape-aware ({len(cols)} dimensions)")
 PY
 
-# 8. pool_slots must sum EVERY 'slots=' line with no tail/head. This looks like a
-#    bug and has been reported as one; it is NOT. 'slots=' appears only in the
-#    pool-init lines, never in the periodic stats emissions, so summing them all is
-#    correct — on a 4-pool run, 742+337+558+279 = 1916, the reported figure. Adding
-#    a `tail -N` would silently DROP two pools and roughly halve the number.
-#    Asserted so nobody "fixes" it back into a defect.
+# 8. pool_slots must sum EVERY pool with no tail/head. This looks like a bug and
+#    has been reported as one; it is NOT. Each pool contributes its own slots, so
+#    summing them all is correct — on a 4-pool run, 742+337+558+279 = 1916, the
+#    reported figure. Adding a `tail -N` would silently DROP two pools and roughly
+#    halve the number. Asserted so nobody "fixes" it back into a defect.
+#    (The slots now come off the shared lib's per-device census rather than a raw
+#    log grep; the invariant is unchanged and so is this guard.)
 pool_line=$(grep -nE 'pool=\$\(' "$SWEEP" | head -1 | cut -d: -f1)
 [[ -n "$pool_line" ]] || fail "could not find the pool_slots extraction"
 pool_expr=$(sed -n "${pool_line}p" "$SWEEP")
@@ -143,5 +156,33 @@ if [[ -n "$doc_n" ]]; then
   [[ "$doc_n" == "$NCOL" ]] || fail "renderer docstring says $doc_n columns, header has $NCOL"
   echo "  ✓ renderer docstring column count matches the header ($NCOL)"
 fi
+
+# 10. THE #824 DETECTOR, GENERALISED. The half-cached check must compare the count
+#     of DEVICES THAT HOLD A POOL against the device count — never the count of
+#     pool LINES. A device can hold several pools (`pool[0]`, `pool[1]`), so a
+#     line-count detector reads pool_lines >= NGPU and passes an arm where an
+#     entire device got no cache at all. That is exactly the state #824 was filed
+#     for, one level deeper, and the sweep carried the weaker form until it adopted
+#     the shared lib. Guarded here so it cannot regress to line-counting.
+grep -qE 'pool_devs *< *\$\{NGPU' "$SWEEP" \
+  || fail "the half-cached detector must compare DEVICES-with-a-pool against NGPU"
+if grep -qE 'pool_lines *< *\$\{?NGPU' "$SWEEP"; then
+  fail "the detector is comparing pool LINE count to device count — a multi-pool device defeats that (#824 generalised)"
+fi
+grep -q 'cap_moe_parse pooldev' "$SWEEP" \
+  || fail "the sweep should get its allocation census from the shared lib, not a private grep"
+echo "  ✓ half-cached detection counts DEVICES with a pool, not pool lines (#824 generalised)"
+
+# 11. the sweep must consume the shared capture layer, and must not have kept a
+#     private copy of a scrape the lib owns. Two copies is how a fixed defect
+#     comes back — it is the reason this adoption happened at all.
+grep -q 'source "\$_OM_LIB"' "$SWEEP" || fail "the sweep no longer sources scripts/lib/capture.sh"
+for fn in cap_moe_parse cap_status_classify cap_vram_used cap_dmon_start cap_cpu_snap cap_ram_rd_mbps; do
+  grep -q "$fn" "$SWEEP" || fail "the sweep stopped using $fn — did a private copy come back?"
+done
+# the private helpers the adoption deleted must stay deleted
+grep -qE '^cpu_snap\(\)' "$SWEEP" && fail "cpu_snap() came back — use cap_cpu_snap from the lib"
+grep -q 'adoption is DEFERRED' "$LIB" && fail "the deferral note outlived the adoption"
+echo "  ✓ sweep consumes the shared lib; the private copies stayed deleted"
 
 echo "test-offload-matrix-static: ok"


### PR DESCRIPTION
The named remainder on #841: **`offload-matrix.sh` adopts `scripts/lib/capture.sh`**, plus the
second remainder from that issue's thread (PCIe on non-offload cards). Unblocked by #826 landing.

## Why this was worth doing: the two copies had already drifted

The sweep and `bench.sh` carried two implementations of the same scrapes, and they disagreed on the
one thing #824 was filed about. The sweep's half-cached detector compared **pool-LINE count** to
device count. A device can hold several pools (`pool[0]`, `pool[1]`), so:

> `pool_lines(2) >= NGPU(2)` — detector satisfied — **while an entire device holds no cache at all.**

The lib counts **DEVICES-with-a-pool**. Verified empirically against the fixture's `multipool` arm:

| | status on the same half-cached run |
|---|---|
| `master` | **OK** — silently measures a half-cached path |
| this branch | **CACHE_DISABLED** |

That is the generalised #824 hole, and it is exactly what "no drifting copy" was meant to prevent.

## Replaced vs kept

**Replaced with lib calls** — pool census · hits/evictions deltas · acceptance · VRAM triplet + peak
sampler · dmon sampling · CPU snapshot/percentage · derived `ram_rd_mbps` · bypass count · allocation
census · status classification.

**Kept deliberately, reason recorded at each site:**

| Kept | Why |
|---|---|
| `strm` (engine-side decode) | The sweep windows to the last `n*2` timings for its N concurrent slots — per-arm windowing. The lib's whole-log median answers a different question. |
| **TSV schema + every column meaning** | Untouched. `accept` still carries the arm's **last** acceptance; `pool_slots` still sums every pool on every device; `rx/tx/sm/memctl` are still **means**. |
| Console line only | The fire rate and the rx/tx **peaks** the lib now provides are printed, not columned — adding columns would change the schema every historical row is read with. |

**Two small lib generalizations** (rather than bending the sweep), each with a test:

1. `acceptance` emits `last=` alongside `mean=`. The sweep's column has always meant the arm's final
   value; `bench.sh` quotes the mean. **Fork the statistic, never the scrape** — now recorded in the
   lib header as the rule.
2. `cap_status_classify` precedence is explicit and adopts the sweep's original order:
   `INVALID_BYPASS < CACHE_DISABLED < NO_TOKENS < REQ_ERRORS`. REQ_ERRORS outranking NO_TOKENS is the
   substantive half — a run that errored **explains its own zero**, and reporting NO_TOKENS there
   sends the reader hunting a scrape bug that is not the cause. `bench.sh` inherits the improvement.

**Also deleted:** a 3-sample idle `dmon` capture that nothing has ever read. It cost 4 s of every arm
and left a `.idle-*` file in `OUT_DIR` that no cleanup removed. Removed rather than wired up — the
"floor" it was meant to establish is not used by any column.

## LOC — honestly, this is not a reduction

| | master | branch | Δ |
|---|--:|--:|--:|
| `offload-matrix.sh` total | 882 | 955 | **+73** |
| `offload-matrix.sh` code (non-comment) | 605 | 642 | **+37** |

61 lines of private scrape logic were deleted, but destructuring the lib's structured output is
bulkier than the one-line greps it replaces, and roughly half the additions are commentary recording
why each site kept or changed its semantics. A `kv_fields` helper pulls named fields out positionally
without column-sliding on a missing key, which claws some of it back.

**The adoption buys correctness and a single source of truth, not brevity** — worth stating plainly
rather than implying a cleanup that didn't happen.

## Second remainder: PCIe on non-offload cards

PCIe capture is unconditional (item 10) but the Snapshot card only rendered it *inside* the offload
block — so a vLLM TP=2 run, where the all-reduce traffic is the interesting part, captured PCIe in
the bench output and dropped it from the card. Non-offload cards now carry a slim standalone PCIe
line (link gen/width + under-load warning, decode/prefill means **and** peaks, link utilisation), with
a note saying what the traffic is on a TP run. A run with no PCIe data renders no line at all rather
than a stub of dashes.

## Tests

| Suite | Result |
|---|---|
| `test-offload-matrix-static` | **PASS** — 11 checks |
| `test-offload-matrix-mocked` | **PASS** — 12 checks |
| `test-bench-capture` | **PASS** — 27 checks |
| `test-bench-card` | **PASS** — 20 checks |
| `test-measurement-record` | **PASS** |
| `test-submit-bench` | **PASS** |

`bash -n` clean on every touched script; `py_compile` clean on the renderer and the fixture.
(`command grep -l 'capture.sh' scripts/tests/*.sh` also matches `test-pull.sh` and
`test-pullemit-capture.sh` — both only reference *their own* filename, neither sources
`scripts/lib/capture.sh`, so they are unrelated.)

New/updated guards, in lockstep with the adoption as the fixture header demands:

- **`multipool` mocked arm** — the regression guard for the motivating fix, and it fails on master.
- **Status-vocabulary drift check now scans the sweep AND the lib**, since the four shared
  run-quality states moved there while the sweep keeps its own early-exit states.
- **New static guards**: the detector must compare DEVICES-with-a-pool against NGPU and never pool
  LINES; the sweep must source the lib and still call each adopted function; the deleted private
  helpers must stay deleted.
- **The deferral-note guard is inverted** — it asserted the deferral was recorded; it now asserts the
  deferral is *gone* and the adoption is recorded, so nobody re-reads a stale "duplication is
  accepted" note as licence to fork a scrape again.

Closes #841.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4LeYTBtjVXgpDgXSNUSgr
