### PR TITLE
fix(bench): dLLM decode window, PP-scrape plausibility gate, --quick preset (#809 bench half, #817, #832)

### DIFF
--- a/docs/BENCH_CARD.md
+++ b/docs/BENCH_CARD.md
@@ -183,6 +183,19 @@ The baseline is any previously saved `bench.sh` log. Parsing is strict: a log th
 fingerprint or summary blocks fails with `baseline unparseable: <why>` rather than rendering half a
 delta — and the run's own measurements are still printed.
 
+**`--quick` runs cannot be carded.** `bash scripts/bench.sh --quick` is a preset over existing knobs
+(`WARMUPS=1 RUNS=1 ONLY=narr PREFILL_PROBE=0 QUIET=1`) for A/B sweeps where the canonical protocol
+dominates wall-clock and only a direction is needed. It is n=1, so it has **no CV** — and the A/B
+card's noise band *defaults to 2× the worst decode CV across both arms*, which would then be zero and
+render every delta as significant. `CARD=` under `--quick` is refused for that reason. Card the arms
+you intend to publish; use `--quick` to find out which ones those are.
+
+And the caveat that outlives the flag: **`--quick` removes *within-boot* samples, not the need for
+≥2 boots.** Pool allocation on the CPU-offload MoE path swings ~20% between boots of a
+byte-identical config (4949 vs 3942 slots) and throughput tracked it (−12%) — enough to flip a
+same-day "22L is the best no-spec config" from first to last once the arm was confirmed at 2 reps.
+A cheaper arm makes that mistake easier to make, not harder.
+
 ## What `bench.sh` now fills in for you
 
 `bench.sh` carries a capture layer (`scripts/lib/capture.sh`) that auto-fills most of the

--- a/docs/BENCH_CARD.md
+++ b/docs/BENCH_CARD.md
@@ -261,6 +261,26 @@ Two numbers on the card need their provenance stated, because both are easy to q
 - **Draft acceptance — never without its fire rate.** A drafter measured at 0.992 acceptance that
   fired on 5 of ~20 requests contributes almost nothing end-to-end. The run prints both.
 
+### `PP tok/s` — which prefill number belongs on a card
+
+Two different things have carried this label, and only one of them is a measurement:
+
+| Line | What it is | Card-worthy |
+|---|---|---|
+| `prefill tok/s` (in a `[prefill-<N>k]` summary) | **Client-side**: `prompt_tokens / TTFT` over a cache-busted haystack at a stated depth. CV 0.3–1.5%. | **Yes — this is the prefill number.** |
+| `PP tok/s` / `PP tok/s (engine log, windowed …)` | **Scraped** from the engine's own stats log — vLLM's `Avg prompt throughput`, averaged over its ~10 s logging window. | Only with its depth and the "indicative only" label, and only when the run printed it. |
+
+On the canonical bench prompts (~15 tokens) the windowed average is mostly idle time, and it renders
+as `PP tok/s mean=2.00 CV=55.9%` — shaped exactly like a measurement. Three community reports pasted
+it as one (#817, #769, #822). The run now prints it only when it could be a rate at all — prompt
+≥ 1000 tok **and** mean ≥ 50 tok/s **and** CV ≤ 100% — and otherwise says
+`n/a (engine-log scrape suppressed: <reason>)` and points at the client-side line. All three
+conditions are load-bearing: the windowed variant inside a prefill section clears the first two at
+`mean=1127.30 CV=171.9%` (min 13 / max 8044) and is still not a rate.
+
+Thresholds: `CAP_PP_MIN_PROMPT_TOKS` / `CAP_PP_MIN_TPS` / `CAP_PP_MAX_CV` (defined in
+`scripts/lib/capture.sh`; raise them, don't remove the gate).
+
 ### Knobs worth setting
 
 | Env | Why |

--- a/docs/BENCH_CARD.md
+++ b/docs/BENCH_CARD.md
@@ -221,6 +221,36 @@ Add these four lines to the checklist in both templates. Each is printed by the 
 - [ ] **VRAM growth / leak delta** — labelled *growth* when an expert cache is active (its pool and
       graphs allocate lazily on first inference, so one run grows VRAM by design) and *leak*
       otherwise. Only a monotonic rise across REPEATED runs is evidence of a leak.
+- [ ] **no `⚠ decode-win` line** — a run carrying one measured at least one **zero-width decode
+      window**, so `decode_TPS` for that shape is over fewer runs than `n` says (or, when *every*
+      run was zero-width, is `wall_TPS` under a `decode_TPS` label). See below.
+
+### Canvas-granularity models: quote `wall_TPS`, not `decode_TPS`
+
+`decode_TPS = tokens / (wall − TTFT)` assumes token-by-token autoregressive streaming. A
+**block-diffusion (dLLM) model denoises a whole canvas in parallel** and the SSE endpoint emits
+roughly one chunk per completed canvas — so any response that fits in one canvas arrives as a single
+chunk, `TTFT == wall`, and the decode window is zero-width. Dividing by it produced
+`decode_TPS=690000000.00` and a shape summary reading `mean=2728143.37 CV=223.6%`, which three
+community reports pasted as measurements (#809, #822).
+
+The run now handles this itself:
+
+| Situation | What the run prints |
+|---|---|
+| One run's decode window is zero-width | `decode_TPS=   n/a  (decode window … % of wall — single-block emission …)`. Never a number. |
+| Some runs degenerate, some not | The degenerate runs are **excluded** from `decode_TPS`, and the exclusion is stated: `decode-window  unmeasurable on 1/5 run(s) …`. |
+| Every run degenerate | `decode_TPS` is **derived** as completion/wall — which *is* `wall_TPS` by construction — and is labelled `DERIVED, NOT MEASURED` on the next line. It includes prefill. |
+| The shape reads canvas-granularity | `⚠ CANVAS GRANULARITY` names the class and points at `wall_TPS` as the headline. |
+
+**On a card for one of these models, put `wall_TPS` in the throughput row and say `decode: n/a
+(canvas granularity)`.** A `decode_TPS` copied off such a run is either a divide-by-noise artifact or
+`wall_TPS` wearing the wrong label; neither is comparable to an autoregressive row.
+
+Set `DECODE_GRANULARITY=canvas` to declare the class up front rather than waiting for the run to
+classify it, or `=token` to suppress the classification on a model you know is autoregressive. The
+per-run `n/a` guard is **not** overridable — a zero-width window has no decode rate whatever the
+label says.
 
 Two numbers on the card need their provenance stated, because both are easy to quote wrongly:
 
@@ -239,4 +269,5 @@ Two numbers on the card need their provenance stated, because both are easy to q
 | `ENDPOINT=chat` \| `completion` | `chat` (default) applies the model's template — the historical behaviour, so numbers stay comparable. `completion` drives raw `/v1/completions` with no template, for base models. Numbers are **not** comparable across modes. |
 | `STREAM_CALIB=1` | ~3 s STREAM-triad ceiling on the host, so the derived miss-path RAM demand can be stated as a fraction ("~29 of ~99 GB/s"). Off by default. The *contention* probe (co-running STREAM during decode) is deliberately not included — it perturbs the run by construction. |
 | `FORCE_TOKENS=<n>` | The fix when `n-usable < n`. |
+| `DECODE_GRANULARITY=canvas` \| `token` \| `auto` | Declares whether `decode_TPS` means anything for this model (see above). `auto` (default) classifies from the measured runs. |
 | `CAPTURE=0` | Suppress the capture layer entirely (for a harness parsing the older output shape). |

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -39,6 +39,18 @@
 #   QUIET              Set to 1 to skip per-run lines (just print summary)
 #   PP                 Set to 1 to add the long-prompt PP fallback probe.
 #                      llama.cpp containers enable this automatically.
+#                      NOTE (#817): the `PP tok/s` line scraped from the ENGINE
+#                      LOG is a ~10 s window average, and on the canonical ~15-tok
+#                      prompts it is not a prefill rate at all — it rendered as
+#                      `mean=2.00 CV=55.9%` and three community reports pasted it
+#                      as data. It now prints only when it could be a rate
+#                      (prompt >= 1000 tok, mean >= 50 tok/s, CV <= 100%) and is
+#                      labelled `(engine log, windowed — indicative only)` when it
+#                      does; otherwise it says n/a WITH THE REASON and points at
+#                      the client-side `prefill tok/s`, which is trustworthy at
+#                      CV 0.3-1.5%. Thresholds live in scripts/lib/capture.sh and
+#                      are overridable via CAP_PP_MIN_PROMPT_TOKS /
+#                      CAP_PP_MIN_TPS / CAP_PP_MAX_CV.
 #   PP_FALLBACK_TOKENS Approximate filler-token target for PP=1. Default: 10000
 #   PP_MAX_TOKENS      Completion cap for the PP fallback request. Default: 16
 #   PREFILL_PROBE      Set to 0 to skip the canonical two-depth prefill/TTFT
@@ -162,6 +174,9 @@ if [[ -f "${ROOT_DIR}/scripts/preflight.sh" ]]; then
   source "${ROOT_DIR}/scripts/preflight.sh"
   preflight_autodetect_endpoint || true
 fi
+# The measurement heredoc shells out to the lib for the #817 PP plausibility gate,
+# so it needs the path even when the capture layer itself is off (CAPTURE=0).
+export BENCH_CAPTURE_LIB="${ROOT_DIR}/scripts/lib/capture.sh"
 URL="${URL:-http://localhost:8020}"
 # Resolve the served model from /v1/models when MODEL is unset (#372). The qwen
 # literal below is only a last resort if detection no-ops (endpoint unreachable).
@@ -700,6 +715,43 @@ def fmt(label, wall, ttft, toks):
     line = f"  {label:<10s} wall={wall:6.2f}s  ttft={ttft*1000:6.0f}ms  toks={toks:>4d}  wall_TPS={wtps:6.2f}  {dcol}"
     return wtps, dtps, ttft, line
 
+# --- prompt-processing plausibility gate (#817) -----------------------------
+# The policy and its three thresholds live in ONE place — capture.sh's
+# cap_pp_plausible. Shelling out to it is deliberate: bench.sh has two print
+# sites for this scrape, and a second copy of the rule in python is exactly how
+# two callers of a shared scrape drift apart.
+CAPTURE_LIB = os.environ.get("BENCH_CAPTURE_LIB", "")
+
+
+def pp_pointer():
+    if os.environ.get("PREFILL_PROBE", "1") == "1":
+        return ("the trustworthy prefill number is the client-side `prefill tok/s` "
+                "summary (prompt_tokens/TTFT, cache-busted)")
+    return ("run with PREFILL_PROBE=1 (the default) or PP=1 for a client-side "
+            "prefill measurement")
+
+
+def pp_verdict(vals, prompt_tokens):
+    """(plausible?, reason) for a scraped PP sample. Fails CLOSED."""
+    if not vals:
+        return False, "no values scraped"
+    m = s.mean(vals)
+    cv = (s.stdev(vals) / m * 100) if len(vals) > 1 and m > 0 else 0.0
+    if not CAPTURE_LIB or not os.path.exists(CAPTURE_LIB):
+        # Without the gate we cannot tell a measurement from an artifact, and the
+        # artifact is the one that gets pasted into an issue. Refuse to print.
+        return False, "plausibility gate unavailable (scripts/lib/capture.sh not found)"
+    try:
+        p = subprocess.run(
+            ["bash", "-c", 'source "$1"; cap_pp_plausible "$2" "$3" "$4"', "_",
+             CAPTURE_LIB, f"{m:.4f}", f"{cv:.4f}", str(int(prompt_tokens))],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            text=True, timeout=20, check=False)
+    except Exception as e:
+        return False, f"plausibility gate failed to run ({e})"
+    return (p.returncode == 0), p.stdout.strip()
+
+
 def fmt_pp(label, wall, ttft, prompt_tokens):
     pp = prompt_tokens / max(ttft, 1e-6)
     line = f"  {label:<10s} wall={wall:6.2f}s  ttft={ttft*1000:6.0f}ms  prompt_toks={prompt_tokens:>6d}  PP_tok/s={pp:7.2f}"
@@ -867,8 +919,16 @@ def run_set(label, prompt, max_tokens):
                      f"(short EOS) — see the summary block")
         if PP_MODE == "log":
             pp_vals = scrape_prompt_throughput(CONTAINER, len(walls))
-            if pp_vals:
-                print(stats("PP tok/s", pp_vals))
+            # #817: the canonical narrative/code prompts are ~15 tokens, and the
+            # engine's windowed prompt-throughput average over them is not a
+            # prefill rate. Print it only when it could be one.
+            pp_prompt = int(s.mean(ptoks_seen)) if ptoks_seen else 0
+            pp_ok, pp_why = pp_verdict(pp_vals, pp_prompt)
+            if pp_vals and pp_ok:
+                print(stats("PP tok/s", pp_vals) + "   (engine log, windowed — indicative only)")
+            elif pp_vals:
+                print(f"  PP tok/s       n/a (engine-log scrape suppressed: {pp_why})")
+                print(f"                 {pp_pointer()}")
             else:
                 print("  PP tok/s       n/a (engine log scrape unavailable; use PP=1 for the "
                       "long-prompt fallback, or SERVER_LOG=<path> on bare metal)")
@@ -976,7 +1036,7 @@ def run_prefill_probe():
                 continue
             print(f"  warm-1     FAIL: {e}")
         print(f"\n=== measured ({n}) ===")
-        pps, ttfts = [], []
+        pps, ttfts, ptoks_seen = [], [], []
         phase_t0 = phase_start()
         for i in range(n):
             try:
@@ -988,6 +1048,7 @@ def run_prefill_probe():
                          f"{pp:.1f} prefill tok/s, ttft {ttft*1000:.0f}ms")
                 pps.append(pp)
                 ttfts.append(ttft)
+                ptoks_seen.append(ptoks)
             except Exception as e:
                 print(f"  run-{i+1}    FAIL: {e}")
                 progress(f"[bench] {label} run {i+1}/{n}: FAIL: {e}")
@@ -1009,8 +1070,17 @@ def run_prefill_probe():
             if PP_MODE == "log":
                 vals = scrape_prompt_throughput(CONTAINER, len(pps) * 2)
                 vals = [v for v in vals if v > 0][-len(pps):]
-                if vals:
-                    print(stats("PP tok/s (engine log, windowed)", vals))
+                # #817: the prompt IS long here, so the depth condition passes —
+                # but this variant still renders `mean=1127.30 CV=171.9%` (min 13
+                # / max 8044) when the sampled windows straddle idle and busy.
+                # Same gate, same single definition.
+                w_ok, w_why = pp_verdict(vals, int(s.mean(ptoks_seen)) if ptoks_seen else 0)
+                if vals and w_ok:
+                    print(stats("PP tok/s (engine log, windowed — indicative only)", vals))
+                elif vals:
+                    print(f"  PP tok/s (engine log, windowed) n/a (suppressed: {w_why})")
+                    print("                 the `prefill tok/s` line above is the client-side "
+                          "measurement for this depth")
             _pm = s.mean(pps)
             SUMMARY["shapes"][label] = {
                 "n": len(pps), "n_usable": len(pps), "errors": 0,

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -62,6 +62,22 @@
 #                      generation — you must force the length to measure sustained
 #                      throughput. vLLM-oriented (ignore_eos/min_tokens). 0 = off
 #                      (model decides length). Default: 0.
+#   DECODE_GRANULARITY How this model emits tokens, which decides whether
+#                      `decode_TPS` means anything at all (#809).
+#                        auto   (default) classify from the measured runs
+#                        token  autoregressive — decode_TPS is a decode rate
+#                        canvas block diffusion (dLLM): the model denoises a whole
+#                               canvas in parallel and the SSE endpoint emits ~one
+#                               chunk per canvas, so TTFT == wall on any response
+#                               that fits in one block and the decode window is
+#                               zero-width. decode_TPS is NOT a decode rate for
+#                               this class; the headline number is wall_TPS.
+#   BENCH_DEGEN_WINDOW_FRAC
+#                      A run whose decode window is below this fraction of its own
+#                      wall time has no measurable decode rate and prints n/a
+#                      rather than a number. Default: 0.05 — an AR decode window
+#                      is ~the whole wall, so this sits ~20x away from any AR run
+#                      and cannot fire on one.
 #
 # Capture knobs (the always-on capture layer — scripts/lib/capture.sh):
 #   SERVER_LOG         Path to a BARE-METAL server log. CONTAINER=none runs used to
@@ -171,6 +187,14 @@ PREFILL_RUNS="${PREFILL_RUNS:-3}"
 export PREFILL_PROBE PREFILL_DEPTHS PREFILL_RUNS
 ENABLE_THINKING="${ENABLE_THINKING:-0}"
 FORCE_TOKENS="${FORCE_TOKENS:-0}"
+# --- decode-granularity knobs (#809) ----------------------------------------
+DECODE_GRANULARITY="${DECODE_GRANULARITY:-auto}"
+case "$DECODE_GRANULARITY" in
+  auto|token|canvas) : ;;
+  *) echo "ERROR: DECODE_GRANULARITY must be 'auto', 'token' or 'canvas' (got '$DECODE_GRANULARITY')" >&2; exit 1 ;;
+esac
+BENCH_DEGEN_WINDOW_FRAC="${BENCH_DEGEN_WINDOW_FRAC:-0.05}"
+export DECODE_GRANULARITY BENCH_DEGEN_WINDOW_FRAC
 # --- capture layer knobs (see the header block) -----------------------------
 CAPTURE="${CAPTURE:-1}"
 ENDPOINT="${ENDPOINT:-chat}"
@@ -619,11 +643,61 @@ def run_once(prompt, max_tokens):
         prompt_tokens = max(1, len(prompt.split()))
     return wall, ttft, completion_tokens, prompt_tokens
 
+# --- decode-window guard (#809) ---------------------------------------------
+# `decode_TPS = toks / (wall - TTFT)` assumes token-by-token AR streaming. A
+# canvas-granularity (block-diffusion) model denoises a whole canvas in parallel
+# and the SSE endpoint emits roughly ONE chunk per completed canvas: any response
+# that fits in a single canvas arrives as one chunk, TTFT == wall, and the decode
+# window is zero-width. The old `max(wall - ttft, 1e-6)` then divided by an
+# epsilon and printed `decode_TPS=690000000.00` as though it were a throughput
+# (#822, real output from a 2x5090 diffusiongemma run).
+#
+# The guard is a RATIO, not an absolute threshold, and that is what makes it safe
+# for AR models: a real AR decode window IS essentially the whole wall (TTFT is a
+# few percent of it), so 5% sits ~20x away from any autoregressive run and cannot
+# fire on one. When it does fire there is no decode rate to report — not a small
+# one, not a large one — so the column prints n/a and the run is excluded from the
+# decode statistics. wall_TPS is the honest number for such a run.
+try:
+    DEGEN_WINDOW_FRAC = float(os.environ.get("BENCH_DEGEN_WINDOW_FRAC", "0.05"))
+except ValueError:
+    DEGEN_WINDOW_FRAC = 0.05
+GRANULARITY = (os.environ.get("DECODE_GRANULARITY", "auto") or "auto").strip().lower()
+if GRANULARITY not in ("auto", "token", "canvas"):
+    GRANULARITY = "auto"
+
+
+def decode_window(wall, ttft):
+    """(decode_seconds, degenerate?). Degenerate means UNMEASURABLE, not slow."""
+    dt = wall - ttft
+    return dt, (wall <= 0 or dt <= 0 or dt < DEGEN_WINDOW_FRAC * wall)
+
+
+def classify_granularity(n_runs, degen_runs):
+    """(granularity, why). Declared wins; otherwise classify from the runs."""
+    if GRANULARITY in ("token", "canvas"):
+        return GRANULARITY, f"declared: DECODE_GRANULARITY={GRANULARITY}"
+    # A single degenerate run can be a fluke (a scheduler hiccup, an EOS on the
+    # first chunk). A MAJORITY of them across a shape is a property of the model.
+    if n_runs >= 2 and degen_runs * 2 >= n_runs:
+        return "canvas", (f"auto-detected: {degen_runs}/{n_runs} runs emitted their whole "
+                          f"completion inside one block, TTFT == wall")
+    return "token", ""
+
+
 def fmt(label, wall, ttft, toks):
-    decode_t = max(wall - ttft, 1e-6)
+    dt, degen = decode_window(wall, ttft)
     wtps = toks / wall if wall > 0 else 0
-    dtps = toks / decode_t
-    line = f"  {label:<10s} wall={wall:6.2f}s  ttft={ttft*1000:6.0f}ms  toks={toks:>4d}  wall_TPS={wtps:6.2f}  decode_TPS={dtps:6.2f}"
+    if degen:
+        # Never a number here. The historical divide-by-1e-6 is the defect (#809).
+        dtps = None
+        pct = (dt / wall * 100) if wall > 0 else 0.0
+        dcol = (f"decode_TPS={'n/a':>6s}  (decode window {max(dt, 0.0):.3f}s = {pct:.1f}% of wall "
+                f"— single-block emission, no measurable decode rate; quote wall_TPS)")
+    else:
+        dtps = toks / dt
+        dcol = f"decode_TPS={dtps:6.2f}"
+    line = f"  {label:<10s} wall={wall:6.2f}s  ttft={ttft*1000:6.0f}ms  toks={toks:>4d}  wall_TPS={wtps:6.2f}  {dcol}"
     return wtps, dtps, ttft, line
 
 def fmt_pp(label, wall, ttft, prompt_tokens):
@@ -694,19 +768,29 @@ def run_set(label, prompt, max_tokens):
             print(f"  warm-{i+1}  FAIL: {e}")
     print(f"\n=== measured ({RUNS}) ===")
     walls, decodes, ttfts, toks_seen = [], [], [], []
+    ptoks_seen = []          # prompt size per run — the #817 plausibility gate needs it
+    degen_runs = 0           # runs with a zero-width decode window (#809)
     errors = 0
     mt = FORCE if FORCE > 0 else max_tokens
     phase_t0 = phase_start()
     for i in range(RUNS):
         try:
-            w, t, k, _ = run_once(prompt, max_tokens)
+            w, t, k, ptk = run_once(prompt, max_tokens)
             wtps, dtps, ttft, line = fmt(f"run-{i+1}", w, t, k)
             if not QUIET:
                 print(line)
+            rate = f"{dtps:.2f} decode TPS" if dtps is not None else f"{wtps:.2f} wall TPS (no decode window)"
             progress(f"[bench] {label} run {i+1}/{RUNS}: {k} tok in {w:.1f}s "
-                     f"({dtps:.2f} decode TPS, ttft {ttft*1000:.0f}ms)")
-            walls.append(wtps); decodes.append(dtps); ttfts.append(ttft)
-            toks_seen.append(k)
+                     f"({rate}, ttft {ttft*1000:.0f}ms)")
+            walls.append(wtps); ttfts.append(ttft)
+            # A degenerate run contributes NO decode value. Averaging in a
+            # divide-by-epsilon is how `decode_TPS mean=2728143.37 CV=223.6%`
+            # reached three community reports (#809).
+            if dtps is None:
+                degen_runs += 1
+            else:
+                decodes.append(dtps)
+            toks_seen.append(k); ptoks_seen.append(ptk)
         except Exception as e:
             errors += 1
             print(f"  run-{i+1}  FAIL: {e}")
@@ -724,21 +808,51 @@ def run_set(label, prompt, max_tokens):
         m = s.mean(xs)
         return (s.stdev(xs) / m * 100) if m > 0 else 0.0
 
+    gran, gran_why = classify_granularity(len(walls), degen_runs)
+    # Derived == "every run had a zero-width decode window", so the only rate
+    # available is completion/wall, which IS wall_TPS by construction.
+    derived = bool(walls) and not decodes
     SUMMARY["shapes"][label] = {
         "n": len(walls), "n_usable": len(usable), "errors": errors,
         "max_tokens": mt, "short_eos_floor": floor,
         "tokens": toks_seen,
         "wall_tps_mean": (s.mean(walls) if walls else 0.0),
         "wall_tps_cv": _cv(walls),
-        "decode_tps_mean": (s.mean(decodes) if decodes else 0.0),
-        "decode_tps_cv": _cv(decodes),
+        "decode_tps_mean": (s.mean(decodes) if decodes else (s.mean(walls) if walls else 0.0)),
+        "decode_tps_cv": (_cv(decodes) if decodes else _cv(walls)),
+        "decode_degenerate": degen_runs,
+        "decode_derived": derived,
+        "decode_granularity": gran,
         "ttft_mean_ms": (s.mean(ttfts) * 1000 if ttfts else 0.0),
         "ttft_std_ms": (s.stdev(ttfts) * 1000 if len(ttfts) > 1 else 0.0),
     }
     if walls:
         print(f"\n=== summary [{label}] (n={len(walls)}) ===")
         print(stats("wall_TPS",   walls))
-        print(stats("decode_TPS", decodes))
+        if decodes:
+            print(stats("decode_TPS", decodes))
+        else:
+            # #809 proposal item 1: DERIVE, don't zero — and never present the
+            # derived value bare. Printing nothing here would also strand the
+            # measurement-record producer, which keys off a `decode_TPS mean=`
+            # line and refuses to write a record without one.
+            print(stats("decode_TPS", walls))
+            print(f"  ⚠ decode_TPS above is DERIVED, NOT MEASURED: all {len(walls)} run(s) had a "
+                  f"zero-width decode")
+            print("    window, so it is completion/wall = wall_TPS by construction. It INCLUDES "
+                  "prefill and")
+            print("    must never be quoted as a decode rate (#809).")
+        if degen_runs and decodes:
+            print(f"  decode-window  unmeasurable on {degen_runs}/{len(walls)} run(s) "
+                  f"(decode window < {DEGEN_WINDOW_FRAC:.0%} of wall); "
+                  f"decode_TPS above is over the {len(decodes)} measured run(s)")
+        if gran == "canvas":
+            print(f"  ⚠ CANVAS GRANULARITY ({gran_why})")
+            print("    dLLM: block emission, decode window undefined. decode_TPS is NOT a decode "
+                  "rate for")
+            print("    this model class — the HEADLINE number is wall_TPS (#809).")
+            if GRANULARITY == "auto":
+                print("    Set DECODE_GRANULARITY=token if this model really is autoregressive.")
         print(f"  TTFT          mean={s.mean(ttfts)*1000:6.0f}ms  std={s.stdev(ttfts)*1000 if len(ttfts) > 1 else 0:5.0f}ms  min={min(ttfts)*1000:.0f}ms  max={max(ttfts)*1000:.0f}ms")
         print(f"  n-usable      {len(usable)}/{len(walls)}  (runs with >= {floor} tokens, "
               f"{SHORT_EOS_FRAC:.0%} of max_tokens={mt})")
@@ -1080,7 +1194,9 @@ try:
     d = json.load(open(sys.argv[1], encoding="utf-8"))
 except Exception:
     sys.exit(1)
-xs = [v.get("decode_tps_mean", 0) for v in d.get("shapes", {}).values() if v.get("decode_tps_mean")]
+shapes = d.get("shapes", {}).values()
+xs = [v.get("decode_tps_mean", 0) for v in shapes
+      if v.get("decode_tps_mean") and not v.get("decode_derived")]
 print(f"{sum(xs)/len(xs):.2f}" if xs else "")
 ' "$CAP_WORK/summary.json" 2>/dev/null || true)"
       if [[ -n "$_eng" && -n "$_cli" ]]; then
@@ -1237,7 +1353,25 @@ except Exception:
     sys.exit(1)
 print(d.get("total_errors", 0))
 ' "$CAP_WORK/summary.json" 2>/dev/null || echo 0)"
-  CAP_TPS="${_cli:-0}"
+  # The status enum keys on A tps, and `_cli` only exists when an engine-side log
+  # was available to cross-check against. With no log — CONTAINER=none and no
+  # SERVER_LOG — a perfectly healthy run classified NO_TOKENS purely because the
+  # cross-check had nothing to compare with. Same hole now reachable a second way:
+  # a canvas-granularity run's decode mean is DERIVED and deliberately excluded
+  # from the cross-check (#809), which empties `_cli` on a run that measured fine.
+  # Fall back to the client-measured wall rate, which every successful run has.
+  CAP_TPS="${_cli:-}"
+  if [[ -z "$CAP_TPS" || "$CAP_TPS" == "0" ]]; then
+    CAP_TPS="$(python3 -c '
+import json, sys
+try:
+    d = json.load(open(sys.argv[1], encoding="utf-8"))
+except Exception:
+    sys.exit(1)
+xs = [v.get("wall_tps_mean", 0) for v in d.get("shapes", {}).values() if v.get("wall_tps_mean")]
+print(f"{sum(xs)/len(xs):.2f}" if xs else "0")
+' "$CAP_WORK/summary.json" 2>/dev/null || echo 0)"
+  fi
   CAP_STATUS="$(cap_status_classify "${CAP_TOKENS:-0}" "${CAP_TPS:-0}" "${CAP_ERRS:-0}" \
                   "$CAP_CACHE_WANTED" "${CAP_CACHE_OK:-1}" "${_byp:-0}")"
   echo "  status: ${CAP_STATUS}"
@@ -1278,6 +1412,14 @@ for name, v in d.get("shapes", {}).items():
     if n and u < n:
         print(f"  ⚠ n-usable   : {name} {u}/{n} runs above the short-EOS floor "
               f"({floor} tok) - the CV for this shape is not trustworthy")
+    dg = v.get("decode_degenerate", 0)
+    if n and dg:
+        gran = v.get("decode_granularity", "token")
+        tag = ("canvas granularity - dLLM block emission, decode window undefined"
+               if gran == "canvas" else "zero-width decode window")
+        note = " decode_TPS is DERIVED (= wall_TPS)." if v.get("decode_derived") else ""
+        print(f"  ⚠ decode-win : {name} {dg}/{n} run(s) unmeasurable - {tag}.{note}"
+              f" Quote wall_TPS, not decode_TPS (#809)")
 ' "$CAP_WORK/summary.json" || true
 
   # ---- BENCH CARD (opt-in: CARD=snapshot | ab) ----------------------------

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -146,8 +146,22 @@
 #     CARD=snapshot bash scripts/bench.sh | tee run-A.log
 #     CARD=ab BASELINE=run-A.log KNOB=moe-cache bash scripts/bench.sh
 #
+# Presets (#832 — `--help` prints the same text):
+#   --quick / QUICK=1  WARMUPS=1 RUNS=1 ONLY=narr PREFILL_PROBE=0 QUIET=1
+#                      A preset over existing knobs; no new measurement code. For
+#                      A/B sweeps where the canonical protocol dominates wall-clock
+#                      and only a direction is needed. NOT CANONICAL: no CV, no code
+#                      shape, no prefill anchor, not a BENCHMARKS.md row, and CARD
+#                      rendering is refused. An explicitly-set env var wins over the
+#                      preset and the banner says which.
+#                      ⚠ It removes WITHIN-boot samples only. Any comparison that
+#                      requires a reboot still needs >=2 BOOTS per arm — pool
+#                      allocation on the CPU-offload MoE path swings ~20% between
+#                      boots of a byte-identical config.
+#
 # Usage:
 #   bash scripts/bench.sh
+#   bash scripts/bench.sh --quick             # directional A/B arm (non-canonical)
 #   ONLY=code bash scripts/bench.sh
 #   PP=1 bash scripts/bench.sh
 #   RUNS=10 bash scripts/bench.sh
@@ -165,6 +179,90 @@ set -euo pipefail
 # case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
 # processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
 export PYTHONUTF8="${PYTHONUTF8:-1}"
+
+# ===========================================================================
+# CLI arguments (#832)
+# ===========================================================================
+# Everything else about this script is env-driven. `--quick` is a PRESET over
+# those same knobs and adds NO measurement code — the point of the issue was
+# discoverability, not capability: composing `WARMUPS=1 RUNS=1 ONLY=narr
+# PREFILL_PROBE=0 QUIET=1` by hand requires reading ~40 lines of the env block
+# and knowing that PREFILL_PROBE defaults to 1 and silently adds two long-prompt
+# requests (10K and 90K), the 90K of which is plausibly the single largest term
+# in a "quick" run.
+#
+# Parsed HERE, before the env defaults below, so "was this knob set explicitly?"
+# is still answerable — and before preflight.sh is sourced, since a sourced
+# script inherits our positional parameters.
+QUICK="${QUICK:-0}"
+# The documented expansion. This array IS the contract: --help prints it, the
+# banner prints it, and the suite asserts the run behaves as exactly this set.
+QUICK_PRESET=(WARMUPS=1 RUNS=1 ONLY=narr PREFILL_PROBE=0 QUIET=1)
+
+bench_usage() {
+  cat <<USAGE
+Usage: bash scripts/bench.sh [--quick] [--help]
+
+bench.sh is env-driven; see the header block of this file for the full knob list.
+
+  --quick    ${QUICK_PRESET[*]}
+             1 warmup + 1 measured run, narrative only, no prefill probe.
+             Directional signal for A/B sweeps. Equivalent to QUICK=1.
+
+             NOT CANONICAL. It gives up:
+               * the 4 other measured runs, so there is NO CV and no way to tell
+                 a real delta from noise within the arm;
+               * the code shape (MTP/drafter acceptance differs sharply between
+                 prose and code — one half is not the pair);
+               * both prefill depths, so no prefill/TTFT anchor at all.
+             Single-run TPS is NOT comparable across boots, and the output is
+             not a BENCHMARKS.md row. CARD rendering is refused under --quick.
+
+             --quick removes WITHIN-boot samples. It does NOT remove the need
+             for >=2 BOOTS per arm on any comparison that requires a reboot
+             (-ub, -b, KV type, offload layout). Pool allocation on the
+             CPU-offload MoE path swings ~20% between boots of a byte-identical
+             config (4949 vs 3942 slots) and throughput tracked it (-12%); that
+             flipped "22L is the best no-spec config" from first to last once
+             the arm was confirmed at 2 reps.
+
+  -h, --help Print this and exit.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --quick)   QUICK=1 ;;
+    -h|--help) bench_usage; exit 0 ;;
+    --)        shift; break ;;
+    *) echo "ERROR: unknown argument '$1'. bench.sh is env-driven — see --help." >&2; exit 2 ;;
+  esac
+  shift
+done
+
+QUICK_APPLIED=(); QUICK_KEPT=()
+if [[ "$QUICK" == "1" ]]; then
+  for _kv in "${QUICK_PRESET[@]}"; do
+    _k="${_kv%%=*}"; _v="${_kv#*=}"
+    # An explicit env var wins over the preset, and the banner says so — silently
+    # overriding what the operator typed is how a "quick" run turns into a
+    # different protocol than either of them intended.
+    if [[ -n "${!_k+x}" ]]; then
+      QUICK_KEPT+=("${_k}=${!_k} (preset wanted ${_v})")
+    else
+      printf -v "$_k" '%s' "$_v"
+      export "${_k?}"
+      QUICK_APPLIED+=("$_kv")
+    fi
+  done
+  if [[ -n "${CARD:-}" ]]; then
+    echo "ERROR: --quick and CARD=${CARD} are incompatible." >&2
+    echo "  A --quick run is n=1, so it has no CV — and the A/B card's noise band" >&2
+    echo "  DEFAULTS to 2x the worst decode CV across both arms, which is then zero." >&2
+    echo "  Every delta would render as significant. Render cards from canonical runs." >&2
+    exit 2
+  fi
+fi
 
 # Auto-detect running container + port (URL/CONTAINER env vars still win).
 # See scripts/preflight.sh::preflight_autodetect_endpoint.
@@ -280,6 +378,36 @@ if ! curl -sf "${URL}/v1/models" >/dev/null; then
   echo "  Start with: cd compose && docker compose up -d" >&2
   exit 1
 fi
+
+# --- --quick banner (#832) --------------------------------------------------
+# Deliberately AFTER the BENCH_MOCK branch, so mock output stays byte-identical
+# for the harnesses that parse it. On stdout, so it lands in a tee'd log next to
+# the numbers it qualifies — a caveat that only exists in the operator's terminal
+# is a caveat that does not survive being pasted into an issue.
+quick_banner() {
+  echo "=============================================================================="
+  echo "⚠ QUICK MODE — NOT CANONICAL. Directional signal only."
+  if (( ${#QUICK_APPLIED[@]} )); then
+    echo "  preset applied : ${QUICK_APPLIED[*]}"
+  else
+    echo "  preset applied : (none — every knob was already set explicitly)"
+  fi
+  if (( ${#QUICK_KEPT[@]} )); then
+    echo "  your env kept  : ${QUICK_KEPT[*]}"
+  fi
+  echo "  gives up       : 4 measured runs (so NO CV — a single-run delta cannot be"
+  echo "                   told from noise), the code shape, both prefill depths."
+  echo "  ⚠⚠ --quick removes WITHIN-boot samples. It does NOT remove the need for"
+  echo "     >=2 BOOTS per arm on any reboot-requiring comparison (-ub, -b, KV type,"
+  echo "     offload layout). Pool allocation on the CPU-offload MoE path swings ~20%"
+  echo "     between boots of a byte-identical config (4949 vs 3942 slots) and"
+  echo "     throughput tracked it (-12%) — that flipped a same-day \"22L is the best"
+  echo "     no-spec config\" from first to last once the arm was confirmed at 2 reps."
+  echo "  Single-run TPS is NOT comparable across boots. This output is NOT a"
+  echo "  BENCHMARKS.md row — do not paste it into one."
+  echo "=============================================================================="
+}
+if [[ "$QUICK" == "1" ]]; then quick_banner; fi
 
 server_reasoning_on() {
   if curl -sf -m 3 "${URL}/props" 2>/dev/null | python3 -c '
@@ -1637,4 +1765,14 @@ if [[ "${CONTAINER:-}" != "none" ]] && command -v docker >/dev/null 2>&1 \
   echo ""
   echo "=== Last 3 SpecDecoding metrics ==="
   docker logs "${CONTAINER}" 2>&1 | grep "SpecDecoding metrics" | tail -3 || true
+fi
+
+# Repeated at the END on purpose (#832): a reader who tails the log, or who
+# scrolls to the summary and copies it, never sees the opening banner.
+if [[ "$QUICK" == "1" ]]; then
+  echo ""
+  echo "⚠ QUICK MODE — the numbers above are NOT canonical: n=1, no CV, narrative only,"
+  echo "  no prefill anchor. Not a BENCHMARKS.md row. For any comparison that needed a"
+  echo "  reboot, run >=2 BOOTS per arm — --quick cut the within-boot samples, not the"
+  echo "  between-boot variance. Drop --quick for the canonical protocol."
 fi

--- a/scripts/lib/capture.sh
+++ b/scripts/lib/capture.sh
@@ -1031,6 +1031,68 @@ cap_status_classify() {   # $1=tokens $2=tps $3=req_errors $4=cache_requested $5
   echo "$status"
 }
 
+# ---------------------------------------------------------------------------
+# Prompt-processing plausibility gate (#817)
+# ---------------------------------------------------------------------------
+# The `PP tok/s` line in bench.sh's summaries is SCRAPED from the engine's own
+# stats log — vLLM's `Avg prompt throughput`, which is averaged over its ~10 s
+# logging window (llama.cpp's `prompt eval time` equivalent goes through the same
+# path). That is a windowed figure over whatever the engine happened to be doing,
+# and on the canonical bench prompts — ~15 tokens — most of the window contains no
+# prefill at all. It renders as `PP tok/s  mean=2.00  CV=55.9%` (#769) or
+# `mean=6.88  CV=19.7%` (#822): shaped exactly like a measurement, and not one.
+# Three community reports have now pasted it as data.
+#
+# The trustworthy prefill number is the CLIENT-side one bench.sh already prints by
+# default: prompt_tokens / TTFT over a cache-busted haystack (`prefill tok/s`,
+# CV 0.3-1.5% on the very same runs).
+#
+# So the scrape only prints when it could be a prefill rate at all. Three
+# conditions, each one an observed failure shape rather than a guess:
+#   prompt >= 1000 tok   a ~15-token prompt cannot fill a 10 s window (#769, #822)
+#   mean   >= 50 tok/s   below that it is window dilution, not prefill compute
+#   CV     <= 100%       the windowed variant inside the prefill sections reads
+#                        `mean=1127.30 CV=171.9%`, min 13 / max 8044 — a sample
+#                        straddling idle and busy windows is not a rate
+# ALL THREE must hold. The CV condition is load-bearing on its own: the prefill-
+# section variant passes the first two and is still garbage.
+#
+# The caller prints the reason whenever the gate refuses — a number that vanishes
+# without explanation is its own defect, and the next report would just ask where
+# `PP tok/s` went.
+#
+# ONE DEFINITION, ON PURPOSE. bench.sh has two print sites and shells out to this
+# function for both rather than reimplementing the thresholds; two copies of a
+# rule is how the two callers of a shared scrape drifted apart before (see the
+# pool-LINE-count vs DEVICES-with-a-pool split at the top of this file).
+CAP_PP_MIN_PROMPT_TOKS="${CAP_PP_MIN_PROMPT_TOKS:-1000}"
+CAP_PP_MIN_TPS="${CAP_PP_MIN_TPS:-50}"
+CAP_PP_MAX_CV="${CAP_PP_MAX_CV:-100}"
+
+# cap_pp_plausible <mean_tok_s> <cv_pct> <prompt_tokens>
+#   exit 0 — plausible; prints nothing
+#   exit 1 — suppress; prints the reason on stdout
+cap_pp_plausible() {
+  awk -v m="${1:-0}" -v cv="${2:-0}" -v pt="${3:-0}" \
+      -v minpt="${CAP_PP_MIN_PROMPT_TOKS:-1000}" \
+      -v mintps="${CAP_PP_MIN_TPS:-50}" \
+      -v maxcv="${CAP_PP_MAX_CV:-100}" 'BEGIN{
+    if (pt + 0 < minpt + 0) {
+      printf "prompt is %d tok (< %d) - the engine averages prompt throughput over a ~10 s window, and a prompt this short cannot fill one\n", pt, minpt
+      exit 1
+    }
+    if (m + 0 < mintps + 0) {
+      printf "scraped mean %.2f tok/s (< %d) - window dilution, not prefill compute\n", m, mintps
+      exit 1
+    }
+    if (cv + 0 > maxcv + 0) {
+      printf "scraped CV %.1f%% (> %d%%) - the sample straddles idle and busy windows, which is not a rate\n", cv, maxcv
+      exit 1
+    }
+    exit 0
+  }'
+}
+
 # cap_divergence_pct <a> <b> — |a-b| / max(a,b) as a percentage; the engine-side
 # vs client-observed cross-check (item 1b). Anything over 5% means one of the two
 # numbers is not measuring what its label says.

--- a/scripts/tests/fixtures/offload-matrix/fake-llama-server
+++ b/scripts/tests/fixtures/offload-matrix/fake-llama-server
@@ -43,6 +43,15 @@ FAKE_SCENARIO:
                   census line shape (type=/expert=/slots=/total=) -> per-device
                   aggregation, and the #824 detector must key on DEVICES-with-a
                   -pool, not on the raw pool-line count
+  canvas          CANVAS GRANULARITY (block diffusion / dLLM, #809): the whole
+                  completion is denoised in parallel and emitted as ONE SSE chunk
+                  after the block's compute, so TTFT == wall and the decode window
+                  is zero-width. On master this divides by 1e-6 and prints an
+                  8-digit decode_TPS (real: 690000000.00 in #822)
+  canvas_mixed    the #822 SHAPE: odd requests fit one canvas (zero-width window),
+                  even requests span two (a genuine, measurable window). Four runs
+                  read plausibly, one printed 690000000.00, and the shape mean came
+                  out at 2728143.37 with CV=223.6%
   probefail       the n_layer line NEVER appears, so the layer probe times out --
                   and the process IGNORES SIGTERM, the way a real server does
                   while still inside model load. Only a probe that escalates past
@@ -79,6 +88,9 @@ EXPERT_KIB   = int(os.environ.get("FAKE_EXPERT_KIB", "1536"))
 # needs a measured phase LONGER than the 1 Hz dmon sample period raises it, since
 # a phase shorter than the sample period genuinely contains no samples.
 TOK_DELAY    = float(os.environ.get("FAKE_TOKEN_DELAY", "0.002"))
+# Per-canvas denoise cost for the canvas/canvas_mixed scenarios. Spent BEFORE the
+# block becomes visible, which is what collapses the decode window to zero width.
+CANVAS_DELAY = float(os.environ.get("FAKE_CANVAS_DELAY", "0.05"))
 _req_n       = [0]
 
 
@@ -270,6 +282,16 @@ class H(BaseHTTPRequestHandler):
         else:
             emit = min(gen, TOKS)
 
+        # Canvas granularity (#809). A block-diffusion model denoises a whole
+        # canvas in parallel, so the endpoint emits ~ONE chunk per canvas instead
+        # of one per token -- and the block's compute happens BEFORE any of it is
+        # visible, so a response that fits in a single canvas has TTFT == wall.
+        canvas = 0
+        if SC == "canvas":
+            canvas = max(emit, 1)                       # everything in one block
+        elif SC == "canvas_mixed":
+            canvas = max(emit, 1) if _req_n[0] % 2 == 1 else max(emit // 2, 1)
+
         self.send_response(200)
         self.send_header("Content-Type", "text/event-stream")
         self.send_header("Transfer-Encoding", "chunked")
@@ -278,7 +300,20 @@ class H(BaseHTTPRequestHandler):
             b = s.encode()
             self.wfile.write(f"{len(b):X}\r\n".encode() + b + b"\r\n"); self.wfile.flush()
         try:
-            for i in range(emit):
+            if canvas:
+                i = 0
+                while i < emit:
+                    blk = min(canvas, emit - i)
+                    time.sleep(TOK_DELAY * blk + CANVAS_DELAY)   # the denoise
+                    text = "".join(f"tok{j} " for j in range(i, i + blk))
+                    d = ({"choices": [{"text": text}]} if raw_completion
+                         else {"choices": [{"delta": {"content": text}}]})
+                    chunk("data: " + json.dumps(d) + "\n\n")
+                    i += blk
+                emit_loop = range(0)
+            else:
+                emit_loop = range(emit)
+            for i in emit_loop:
                 if raw_completion:
                     d = {"choices": [{"text": f"tok{i} "}]}
                 else:

--- a/scripts/tests/fixtures/offload-matrix/fake-llama-server
+++ b/scripts/tests/fixtures/offload-matrix/fake-llama-server
@@ -91,6 +91,12 @@ TOK_DELAY    = float(os.environ.get("FAKE_TOKEN_DELAY", "0.002"))
 # Per-canvas denoise cost for the canvas/canvas_mixed scenarios. Spent BEFORE the
 # block becomes visible, which is what collapses the decode window to zero width.
 CANVAS_DELAY = float(os.environ.get("FAKE_CANVAS_DELAY", "0.05"))
+# #817: the engine-log prompt-throughput scrape is a ~10 s WINDOW average. On a
+# rig where those windows straddle idle and busy the sample reads min 13 / max
+# 8044 (CV 137-221%) while looking exactly like a rate, and three community
+# reports pasted it as one. A CSV here cycles the logged rate through such a
+# sample so the plausibility gate can be driven end to end.
+PP_JITTER    = [float(x) for x in os.environ.get("FAKE_PP_JITTER", "").split(",") if x.strip()]
 _req_n       = [0]
 
 
@@ -337,8 +343,9 @@ class H(BaseHTTPRequestHandler):
             pass
         # per-request timings the sweep scrapes for server-side decode TPS
         ptoks = fake_tokens(str(prompt_text or ""))
+        pp_rate = PP_JITTER[(_req_n[0] - 1) % len(PP_JITTER)] if PP_JITTER else ptoks * 1.0
         log(f"print_timing: prompt eval time = 1000.00 ms / {ptoks} tokens "
-            f"( 1.00 ms per token, {ptoks * 1.0:.2f} tokens per second)")
+            f"( 1.00 ms per token, {pp_rate:.2f} tokens per second)")
         log(f"print_timing: eval time = 1000.00 ms / {max(emit,1)} tokens "
             f"( 1.00 ms per token, {max(emit,1)*2.5:.2f} tokens per second)")
         # low_fire: HIGH acceptance, but the drafter only fires on a minority of

--- a/scripts/tests/test-bench-capture.sh
+++ b/scripts/tests/test-bench-capture.sh
@@ -93,6 +93,18 @@ for f in "$LIB" "$BENCH"; do
 done
 echo "  ✓ no pgrep/pkill -f (self-match footgun)"
 
+# #809: the decode window must never be floored to an epsilon and divided by.
+# `max(wall - ttft, 1e-6)` is the exact expression that printed
+# `decode_TPS=690000000.00` on a block-diffusion model (#822).
+# `^[^#]*` keeps this to CODE — the defect is quoted verbatim in the comment that
+# explains it, and matching that would make the guard unwritable.
+if command grep -nE '^[^#]*max\(wall ?- ?ttft, ?1e-6\)' "$BENCH"; then
+  fail "bench.sh still floors the decode window to 1e-6 and divides by it (#809)"
+fi
+command grep -q 'DEGEN_WINDOW_FRAC' "$BENCH" \
+  || fail "bench.sh must guard the decode window by RATIO (#809)"
+echo "  ✓ no divide-by-epsilon decode window (#809)"
+
 # grep is shimmed to ugrep in interactive shells on some rigs, which breaks exact
 # output matching. Every scrape in the lib must use `command grep`.
 bare=$(command grep -nE '(^|[|;&(]|\$\()\s*grep ' "$LIB" || true)
@@ -537,5 +549,100 @@ else
     || fail "STREAM_CALIB=1 produced neither a ceiling nor a degradation notice"
   echo "  ✓ STREAM_CALIB=1 degrades cleanly where numpy is absent (and is off by default)"
 fi
+
+# --- 12. canvas granularity: no divide-by-epsilon decode rate (#809) --------
+# A block-diffusion model denoises a whole canvas in parallel and the endpoint
+# emits ~one chunk per canvas, so TTFT == wall and the decode window is zero
+# width. master divided by 1e-6 and printed 8- and 9-digit "throughputs"
+# (decode_TPS=690000000.00, shape mean=2728143.37 CV=223.6% — #822, real).
+#
+# The realism bound below is the assertion that matters: NO decode figure
+# anywhere in the output, per-run or aggregate, may exceed it.
+REALISM_BOUND=100000
+
+assert_no_absurd_decode() {   # $1=file $2=context
+  python3 - "$1" "$2" "$REALISM_BOUND" <<'PY' || fail "an absurd decode figure was printed"
+import re, sys
+path, ctx, bound = sys.argv[1], sys.argv[2], float(sys.argv[3])
+bad = []
+for ln in open(path, encoding="utf-8"):
+    for m in re.finditer(r"decode_TPS[= ]\s*(?:mean=\s*)?([0-9]+(?:\.[0-9]+)?)", ln):
+        if float(m.group(1)) > bound:
+            bad.append(ln.rstrip())
+if bad:
+    sys.exit(f"{ctx}: decode figure above the realism bound ({bound:.0f}):\n" + "\n".join(bad))
+PY
+}
+
+run_bench canvas "$((PORT_BASE+10))" "$TMP/canvas.out" ONLY=narr
+C="$TMP/canvas.out"
+assert_no_absurd_decode "$C" "canvas run"
+command grep -q 'decode_TPS=   n/a' "$C" \
+  || { command grep -m2 'run-' "$C" >&2; fail "a zero-width decode window must print n/a, never a number"; }
+command grep -q 'single-block emission' "$C" \
+  || fail "the n/a must name WHY the window is unmeasurable"
+command grep -q '⚠ CANVAS GRANULARITY' "$C" \
+  || fail "an all-degenerate shape must be classified canvas-granularity (#809)"
+command grep -q 'HEADLINE number is wall_TPS' "$C" \
+  || fail "the canvas marker must name wall_TPS as the headline"
+command grep -q 'DERIVED, NOT MEASURED' "$C" \
+  || fail "with no measurable run the decode figure is derived and must say so"
+command grep -q '⚠ decode-win : narrative' "$C" \
+  || fail "the integrity panel must state the unmeasurable-window split"
+# ...and the run must not be mistaken for a failed one. A canvas run's decode mean
+# is DERIVED, so it is excluded from the engine cross-check — which used to leave
+# the status enum with no TPS at all and classify a healthy run NO_TOKENS.
+command grep -q 'status: NO_TOKENS' "$C" \
+  && { command grep -A3 'CAPTURE: INTEGRITY' "$C" >&2; fail "a healthy canvas run must not classify NO_TOKENS"; }
+# The record producer refuses to write a measured record without a parseable
+# `decode_TPS mean=` line, so suppressing the column outright would break it.
+command grep -qE '^\s+decode_TPS\s+mean=' "$C" \
+  || fail "the decode_TPS summary line must stay parseable (measurement_record.py keys off it)"
+echo "  ✓ canvas: n/a per run, derived+labelled aggregate, canvas marker, no absurd figure"
+
+# --- 13. the #822 SHAPE: some runs degenerate, some measurable --------------
+# Four plausible runs and one 690000000.00 is what produced mean=2728143.37.
+# The degenerate run must be EXCLUDED from the statistic, and the exclusion said
+# out loud — a quietly-dropped sample is its own defect.
+run_bench canvas_mixed "$((PORT_BASE+11))" "$TMP/mixed.out" ONLY=narr
+M="$TMP/mixed.out"
+assert_no_absurd_decode "$M" "canvas_mixed run"
+command grep -qE 'decode-window  unmeasurable on [0-9]+/[0-9]+ run\(s\)' "$M" \
+  || fail "excluding a run from decode_TPS must be stated, not silent"
+command grep -q 'decode_TPS above is over the' "$M" \
+  || fail "the summary must say how many runs the decode statistic actually rests on"
+python3 - "$M" <<'PY' || fail "the mixed shape did not produce a finite, interpretable decode CV"
+import re, sys
+txt = open(sys.argv[1], encoding="utf-8").read()
+m = re.search(r"^\s+decode_TPS\s+mean=\s*([\d.]+)\s+std=\s*([\d.]+)\s+CV=\s*([\d.]+)%", txt, re.M)
+assert m, "no decode_TPS summary line"
+mean, cv = float(m.group(1)), float(m.group(3))
+# master on this same scenario: mean=81584.17 CV=140.7%
+assert mean < 100000, f"decode mean {mean} is not interpretable"
+assert cv < 100, f"decode CV {cv}% — the degenerate run is still in the sample"
+PY
+echo "  ✓ canvas_mixed: degenerate run excluded from the statistic, and the exclusion is stated"
+
+# --- 14. AR models are untouched, and the guard is not overridable ----------
+# The healthy (autoregressive) run must carry NONE of the canvas machinery.
+for unwanted in 'decode_TPS=   n/a' 'CANVAS GRANULARITY' 'decode-win :' 'DERIVED, NOT MEASURED'; do
+  command grep -qF "$unwanted" "$H" \
+    && fail "an autoregressive run grew canvas output: $unwanted"
+done
+echo "  ✓ AR run carries none of the canvas machinery (output unchanged)"
+
+# DECODE_GRANULARITY=canvas declares the class on a model whose runs look AR.
+run_bench healthy "$((PORT_BASE+12))" "$TMP/declared.out" ONLY=narr RUNS=1 WARMUPS=0 \
+  DECODE_GRANULARITY=canvas
+command grep -q 'declared: DECODE_GRANULARITY=canvas' "$TMP/declared.out" \
+  || fail "DECODE_GRANULARITY=canvas must declare the class without waiting for auto-detection"
+# ...and declaring `token` must NOT buy back the divide-by-epsilon. The per-run
+# guard is unconditional: there is no decode rate to print, whatever the label.
+run_bench canvas "$((PORT_BASE+13))" "$TMP/forced.out" ONLY=narr RUNS=1 WARMUPS=0 \
+  DECODE_GRANULARITY=token
+assert_no_absurd_decode "$TMP/forced.out" "canvas run with DECODE_GRANULARITY=token"
+command grep -q 'CANVAS GRANULARITY' "$TMP/forced.out" \
+  && fail "DECODE_GRANULARITY=token must suppress the canvas classification"
+echo "  ✓ DECODE_GRANULARITY declares the class, and cannot re-enable the epsilon divide"
 
 echo "test-bench-capture: ok"

--- a/scripts/tests/test-bench-capture.sh
+++ b/scripts/tests/test-bench-capture.sh
@@ -110,8 +110,10 @@ echo "  ✓ no divide-by-epsilon decode window (#809)"
 # exactly how the two callers of a shared scrape drifted apart before.
 command grep -q 'cap_pp_plausible' "$LIB" || fail "capture.sh must define the PP plausibility gate (#817)"
 command grep -q 'cap_pp_plausible' "$BENCH" || fail "bench.sh must CALL the lib gate, not reimplement it (#817)"
+# `^[^#]*` keeps this to CODE — the header block names the three knobs so an
+# operator can find them, which is documentation, not a second implementation.
 for thresh in CAP_PP_MIN_PROMPT_TOKS CAP_PP_MIN_TPS CAP_PP_MAX_CV; do
-  command grep -q "$thresh" "$BENCH" \
+  command grep -qE "^[^#]*${thresh}" "$BENCH" \
     && fail "bench.sh carries a copy of the PP threshold $thresh — it must live only in the lib"
 done
 [[ "$(command grep -c '^cap_pp_plausible()' "$LIB")" == "1" ]] \
@@ -746,5 +748,81 @@ assert "indicative only" in m.string[m.start():m.string.find("\n", m.start())], 
     "the plausible line must still carry its 'indicative only' qualifier"
 PY
 echo "  ✓ a plausible PP line keeps the shape measurement_record/rebench-report parse"
+
+# --- 18. --quick is a PRESET over existing knobs, and nothing more (#832) ----
+# Deliberately NOT run through run_bench: that helper exports RUNS/WARMUPS/
+# PREFILL_PROBE itself, which the preset would (correctly) refuse to overwrite,
+# so the test would prove nothing. This one sets only what hermeticity needs.
+QUICK_EXPANSION='WARMUPS=1 RUNS=1 ONLY=narr PREFILL_PROBE=0 QUIET=1'
+command grep -qF "QUICK_PRESET=($QUICK_EXPANSION)" "$BENCH" \
+  || fail "the --quick preset array drifted from the documented expansion (#832)"
+bash "$BENCH" --help > "$TMP/help.out" 2>&1 || fail "--help must exit 0"
+command grep -qF "$QUICK_EXPANSION" "$TMP/help.out" \
+  || fail "--help must print the exact knob set --quick expands to"
+for want in "NOT CANONICAL" "NO CV" "comparable across boots" "BENCHMARKS.md row" \
+            ">=2 BOOTS per arm"; do
+  command grep -qF "$want" "$TMP/help.out" \
+    || fail "--help is missing the guardrail text: $want"
+done
+echo "  ✓ --help documents --quick and every guardrail the issue asks for"
+
+run_bench_bare() {   # $1=scenario $2=port $3=outfile $4=script args (may be "") [VAR=VAL ...]
+  local scen="$1" port="$2" out="$3" argstr="$4"; shift 4
+  local -a bargs=(); read -r -a bargs <<< "$argstr"
+  start_server "$scen" "$port"
+  PATH="$TMP/bin:$PATH" PREFLIGHT_NO_AUTODETECT=1 CONTAINER=none \
+    SERVER_LOG="$SRV_LOG" SERVER_PID="$SRV_PID" \
+    URL="http://127.0.0.1:$port" MODEL=fake-model \
+    env "$@" timeout 300 bash "$BENCH" ${bargs[@]+"${bargs[@]}"} > "$out" 2>"${out}.err" || true
+  kill "$SRV_PID" 2>/dev/null || true; wait "$SRV_PID" 2>/dev/null || true; SRV_PID=""
+}
+
+run_bench_bare healthy "$((PORT_BASE+17))" "$TMP/quick.out" "--quick"
+Q="$TMP/quick.out"
+command grep -q '⚠ QUICK MODE — NOT CANONICAL' "$Q" || fail "--quick must print a non-canonical banner"
+command grep -qF "preset applied : $QUICK_EXPANSION" "$Q" \
+  || { command grep -n 'preset applied' "$Q" >&2; fail "--quick did not expand to exactly the documented knob set"; }
+# ...and each knob must actually have taken effect, not merely been announced.
+command grep -q '=== warmups (1) ===' "$Q"  || fail "--quick did not set WARMUPS=1"
+command grep -q '=== measured (1) ===' "$Q" || fail "--quick did not set RUNS=1"
+command grep -q 'summary \[narrative\]' "$Q" || fail "--quick lost the narrative shape"
+command grep -q 'summary \[code\]' "$Q"      && fail "--quick did not set ONLY=narr"
+command grep -q 'PREFILL-' "$Q"              && fail "--quick did not set PREFILL_PROBE=0"
+command grep -qE '^  (run|warm)-[0-9]+ ' "$Q" && fail "--quick did not set QUIET=1 (per-run lines printed)"
+# The banner must survive a tail: a reader who scrolls to the summary and copies
+# it never sees the opening one.
+tail -8 "$Q" | command grep -q 'QUICK MODE' \
+  || fail "the non-canonical warning must be repeated at the END of the run"
+echo "  ✓ --quick expands to exactly the documented set, and every knob took effect"
+
+# --- 19. --quick guardrails: no card, explicit env wins, QUICK=1 parity -----
+if out="$(CARD=snapshot bash "$BENCH" --quick 2>&1)"; then
+  fail "CARD under --quick must be refused (a card from n=1 data has a zero noise band)"
+fi
+command grep -q 'incompatible' <<<"$out" || fail "the CARD refusal must say why: $out"
+command grep -q 'noise band' <<<"$out" \
+  || fail "the CARD refusal must name the degenerate-noise-band reason"
+# An explicitly-set knob wins over the preset AND is reported — silently
+# overriding what the operator typed makes the run a third protocol.
+run_bench_bare healthy "$((PORT_BASE+18))" "$TMP/quickov.out" "--quick" RUNS=3
+command grep -q 'your env kept  : RUNS=3 (preset wanted 1)' "$TMP/quickov.out" \
+  || { command grep -n 'preset\|env kept' "$TMP/quickov.out" >&2; fail "an explicit knob must win over the preset and be REPORTED"; }
+command grep -q '=== measured (3) ===' "$TMP/quickov.out" || fail "the explicit RUNS=3 did not take effect"
+# QUICK=1 must be the same thing as --quick (the issue offers both spellings).
+run_bench_bare healthy "$((PORT_BASE+19))" "$TMP/quickenv.out" "" QUICK=1
+command grep -qF "preset applied : $QUICK_EXPANSION" "$TMP/quickenv.out" \
+  || fail "QUICK=1 must behave exactly like --quick"
+# Unknown arguments are rejected rather than silently ignored.
+bash "$BENCH" --not-a-flag >/dev/null 2>&1 && fail "an unknown argument must be rejected"
+echo "  ✓ --quick guardrails: card refused, explicit env wins + reported, QUICK=1 parity"
+
+# --- 20. --quick is additive: a default run carries none of it --------------
+for unwanted in 'QUICK MODE' 'preset applied'; do
+  command grep -qF "$unwanted" "$H" && fail "a default run grew --quick output: $unwanted"
+done
+out=$(PREFLIGHT_NO_AUTODETECT=1 CONTAINER=none BENCH_MOCK=1 bash "$BENCH" --quick 2>/dev/null)
+command grep -q 'QUICK MODE' <<<"$out" \
+  && fail "BENCH_MOCK output must stay byte-identical even under --quick (two shipped tests parse it)"
+echo "  ✓ --quick is additive: default runs and BENCH_MOCK output are untouched"
 
 echo "test-bench-capture: ok"

--- a/scripts/tests/test-bench-capture.sh
+++ b/scripts/tests/test-bench-capture.sh
@@ -105,6 +105,19 @@ command grep -q 'DEGEN_WINDOW_FRAC' "$BENCH" \
   || fail "bench.sh must guard the decode window by RATIO (#809)"
 echo "  ✓ no divide-by-epsilon decode window (#809)"
 
+# #817: bench.sh has TWO print sites for the engine-log PP scrape. Both must go
+# through the lib's gate — a copy of the thresholds in the python heredoc is
+# exactly how the two callers of a shared scrape drifted apart before.
+command grep -q 'cap_pp_plausible' "$LIB" || fail "capture.sh must define the PP plausibility gate (#817)"
+command grep -q 'cap_pp_plausible' "$BENCH" || fail "bench.sh must CALL the lib gate, not reimplement it (#817)"
+for thresh in CAP_PP_MIN_PROMPT_TOKS CAP_PP_MIN_TPS CAP_PP_MAX_CV; do
+  command grep -q "$thresh" "$BENCH" \
+    && fail "bench.sh carries a copy of the PP threshold $thresh — it must live only in the lib"
+done
+[[ "$(command grep -c '^cap_pp_plausible()' "$LIB")" == "1" ]] \
+  || fail "cap_pp_plausible must be defined exactly once"
+echo "  ✓ PP plausibility policy defined once, in the lib (#817)"
+
 # grep is shimmed to ugrep in interactive shells on some rigs, which breaks exact
 # output matching. Every scrape in the lib must use `command grep`.
 bare=$(command grep -nE '(^|[|;&(]|\$\()\s*grep ' "$LIB" || true)
@@ -329,6 +342,34 @@ cap_ram_rd_mbps 0 4352 60 >/dev/null 2>&1 && fail "ram_rd must refuse to invent 
 [[ "$(cap_status_classify 0 0 3 1 0 5)"     == REQ_ERRORS ]]     || fail "REQ_ERRORS must outrank everything"
 [[ "$(cap_divergence_pct 30 32)" == "6.2" ]] || fail "divergence arithmetic changed"
 echo "  ✓ status enum precedence, derived-demand arithmetic, divergence"
+
+# --- PP plausibility gate against the REAL reported samples (#817) -----------
+# Every row below is a figure a human actually pasted into an issue as data.
+pp_case() {   # $1=expect(plausible|suppress) $2=mean $3=cv $4=prompt_toks $5=source
+  local out rc
+  # `set -e` aborts on a failing command substitution in an assignment, and this
+  # gate signals "suppress" with a non-zero exit BY DESIGN.
+  out="$(cap_pp_plausible "$2" "$3" "$4")" && rc=0 || rc=$?
+  if [[ "$1" == "plausible" ]]; then
+    (( rc == 0 )) || fail "$5: mean=$2 CV=$3% prompt=$4 should PRINT, gate said: $out"
+    [[ -z "$out" ]] || fail "$5: a plausible sample must print no reason, got: $out"
+  else
+    (( rc == 1 )) || fail "$5: mean=$2 CV=$3% prompt=$4 must be SUPPRESSED — it was printed as data"
+    [[ -n "$out" ]] || fail "$5: a suppressed sample must say WHY (a number that vanishes silently is its own defect)"
+  fi
+}
+pp_case suppress  2.00    55.9  15     "#769 — 65-char prompt"
+pp_case suppress  6.88    19.7  15     "#822 [code] shape"
+pp_case suppress  7.60    40.9  15     "#822 [narrative] shape"
+pp_case suppress  6.07    49.5  10000  "#822 prefill-10k windowed — long prompt, absurd rate"
+pp_case suppress  1127.30 171.9 90000  "#817 windowed-in-prefill — passes mean AND depth, CV is the only tell"
+pp_case plausible 9968.67 14.0  90000  "#822 prefill-90k windowed — the one that IS a rate"
+pp_case plausible 3950.40 0.0   9876   "PP fallback shape"
+# ...and the CV condition must be load-bearing on its own, or the #817 case above
+# would print: it clears both the depth and the rate floor.
+[[ "$(CAP_PP_MAX_CV=1000 cap_pp_plausible 1127.30 171.9 90000; echo rc=$?)" == "rc=0" ]] \
+  || fail "the CV condition is not what suppresses the windowed-in-prefill sample"
+echo "  ✓ PP gate: every figure pasted as data in #769/#822 is suppressed, with a reason"
 
 # ===========================================================================
 # TIER 1b — end-to-end bench.sh against the fake server
@@ -644,5 +685,66 @@ assert_no_absurd_decode "$TMP/forced.out" "canvas run with DECODE_GRANULARITY=to
 command grep -q 'CANVAS GRANULARITY' "$TMP/forced.out" \
   && fail "DECODE_GRANULARITY=token must suppress the canvas classification"
 echo "  ✓ DECODE_GRANULARITY declares the class, and cannot re-enable the epsilon divide"
+
+# --- 15. PP scrape end-to-end: suppressed where meaningless (#817) ----------
+# The canonical narrative prompt is ~11 tokens on this fixture. The engine's
+# windowed prompt-throughput average over it is not a prefill rate and must not
+# render as one — `PP tok/s mean=2.00 CV=55.9%` reached three community reports.
+run_bench healthy "$((PORT_BASE+14))" "$TMP/pp.out" ONLY=narr RUNS=2 WARMUPS=1 \
+  PREFILL_PROBE=1 PREFILL_DEPTHS=2000 PREFILL_RUNS=2
+P="$TMP/pp.out"
+command grep -q 'PP tok/s       n/a (engine-log scrape suppressed:' "$P" \
+  || { command grep -n 'PP tok/s' "$P" >&2; fail "the short-prompt PP scrape must be suppressed (#817)"; }
+command grep -q 'a prompt this short cannot fill one' "$P" \
+  || fail "the suppression must state WHY, not just vanish"
+command grep -q 'client-side `prefill tok/s`' "$P" \
+  || fail "the suppression must point at the number that IS trustworthy"
+# The short-prompt shape must not print a numeric PP line at all.
+python3 - "$P" <<'PY' || fail "a short-prompt shape still printed a numeric PP tok/s"
+import re, sys
+blocks = re.split(r"^=== summary \[([^\]]+)\] \(n=\d+\) ===$", open(sys.argv[1], encoding="utf-8").read(), flags=re.M)
+for name, body in zip(blocks[1::2], blocks[2::2]):
+    if name.startswith("prefill-"):
+        continue
+    bad = re.search(r"^\s+PP tok/s\s+mean=", body, re.M)
+    assert not bad, f"shape [{name}] printed a numeric PP tok/s line: {bad.group(0)}"
+PY
+# ...while the DEEP probe, where the figure can be a rate, still prints — labelled.
+command grep -q 'PP tok/s (engine log, windowed — indicative only) mean=' "$P" \
+  || { command grep -n 'windowed' "$P" >&2; fail "a plausible windowed scrape must still print, labelled indicative"; }
+echo "  ✓ PP scrape: suppressed with a reason on short prompts, printed+labelled at depth"
+
+# --- 16. the CV condition fires at depth too (#817's second named case) -----
+# min 13 / max 8044 across the sampled windows: passes the depth and rate floors,
+# and is still not a rate.
+# Exported, not passed through run_bench: this one configures the SERVER, which
+# start_server launches from the ambient environment.
+export FAKE_PP_JITTER=13,8044,13,8044
+run_bench healthy "$((PORT_BASE+15))" "$TMP/ppcv.out" ONLY=narr RUNS=1 WARMUPS=1 \
+  PREFILL_PROBE=1 PREFILL_DEPTHS=2000 PREFILL_RUNS=2
+unset FAKE_PP_JITTER
+command grep -q 'PP tok/s (engine log, windowed) n/a (suppressed: scraped CV' "$TMP/ppcv.out" \
+  || { command grep -n 'windowed' "$TMP/ppcv.out" >&2; fail "a CV>100% windowed sample must be suppressed at depth (#817)"; }
+command grep -q 'is the client-side measurement for this depth' "$TMP/ppcv.out" \
+  || fail "the depth suppression must point at the client-side prefill line"
+echo "  ✓ windowed-in-prefill scrape suppressed on CV, pointing at the client-side number"
+
+# --- 17. a PLAUSIBLE short-shape scrape keeps the parseable line shape -------
+# measurement_record.py and rebench-report.py both key on `^\s+PP tok/s\s+mean=`.
+# The `(engine log, windowed — indicative only)` label is appended as a SUFFIX so
+# the number stays where the parsers look for it.
+LONGP="$(python3 -c 'print("calibration filler sentence with stable token shape. " * 200)')"
+run_bench healthy "$((PORT_BASE+16))" "$TMP/pplong.out" ONLY=narr RUNS=1 WARMUPS=1 \
+  PREFILL_PROBE=0 "PROMPT_NARR=$LONGP"
+python3 - "$TMP/pplong.out" <<'PY' || fail "a plausible PP line no longer matches the shipped parsers"
+import re, sys
+txt = open(sys.argv[1], encoding="utf-8").read()
+m = re.search(r"^\s+PP tok/s\s+mean=\s*([0-9.]+)\s+std=\s*([0-9.]+)\s+CV=\s*([0-9.]+)%", txt, re.M)
+assert m, "no parseable PP tok/s line on a long-prompt shape:\n" + "\n".join(
+    l for l in txt.splitlines() if "PP tok/s" in l)
+assert "indicative only" in m.string[m.start():m.string.find("\n", m.start())], \
+    "the plausible line must still carry its 'indicative only' qualifier"
+PY
+echo "  ✓ a plausible PP line keeps the shape measurement_record/rebench-report parse"
 
 echo "test-bench-capture: ok"


### PR DESCRIPTION
The bench/capture cluster: three self-reported issues on `scripts/bench.sh` and its shared lib.
Audited each against what #842 (capture layer) and #846 (offload-matrix adoption) already landed
this week before writing any code — every one had a genuine remainder.

## Per-issue verdict

| Issue | Verdict | What #842 already covered | What this PR adds |
|---|---|---|---|
| **#809** (bench half) | **Fixed (bench half)** | The client-vs-engine cross-check *flags* a divergence — but only when a server log exists, and only after the fact | bench still **printed** the number. `max(wall - ttft, 1e-6)` is gone; a zero-width window prints `n/a` and leaves the statistic |
| **#817** | **Fixed** | Nothing. #842 changed the *fallback* message and added the bare-metal scrape source; the unconditional print was untouched | Plausibility gate, defined once in `capture.sh`, consumed by **both** print sites |
| **#832** | **Fixed** | Nothing — bench.sh had no argument parsing at all | `--quick` / `QUICK=1` preset, `--help`, banners, guardrails |

`soak-test.sh` / `soak-helper.py` are **not touched** — the soak half of #809 is a sibling PR.
`scripts/offload-matrix.sh`, `report.sh`, `pull.sh` and the downloaders are untouched.

---

## #809 — bench half: never divide by an epsilon decode window

`decode_TPS = tokens / (wall − TTFT)` assumes token-by-token autoregressive streaming. A
block-diffusion (dLLM) model denoises a whole canvas in parallel and the SSE endpoint emits ~one
chunk per completed canvas, so any response that fits in one canvas arrives as a single chunk,
`TTFT == wall`, and the decode window is zero-width. Dividing by `1e-6` printed:

```
run-1  wall=  3.04s  ttft= 3039ms  toks= 690  wall_TPS=227.06  decode_TPS=690000000.00
decode_TPS  mean=138000225.71  std=308577254.72  CV=223.6%  min=164.45  max=690000000.00
```

**The guard is a ratio, not an absolute, and that is what makes it safe.** A real AR decode window
*is* essentially the whole wall, so the 5% floor sits ~20× away from any autoregressive run and
cannot fire on one.

| Situation | Now prints |
|---|---|
| One run's window is zero-width | `decode_TPS=   n/a  (decode window 0.001s = 0.0% of wall — single-block emission …)`. Never a number, and **not overridable** by `DECODE_GRANULARITY`. |
| Some runs degenerate | Those runs leave the sample **and the exclusion is stated** — a quietly-dropped sample is its own defect. |
| Every run degenerate | Derived rather than zeroed (issue proposal item 1): completion/wall, which *is* `wall_TPS` by construction, labelled `DERIVED, NOT MEASURED` on the next line. |
| Shape reads canvas-granularity | `⚠ CANVAS GRANULARITY (…)` names the class and points at `wall_TPS` as the headline. Repeated on the integrity panel. |

Declared via `DECODE_GRANULARITY=canvas|token`, else auto-classified from a majority of degenerate
runs.

**One design call worth stating.** The decode column is **labelled, not suppressed**. Removing the
`decode_TPS mean=` line entirely would make `measurement_record.py` raise `MeasuredRecordError`
blaming "bench.sh output drift" on a perfectly legitimate dLLM run — a confusing failure in a file
this PR does not own. Labelling satisfies the issue's acceptance criterion (a *finite, interpretable*
summary) without breaking a downstream contract.

**Also fixed, because #809 made it reachable a second way:** the status enum keyed on `_cli`, which
only exists when an engine-side log was available — so a healthy run with `CONTAINER=none` and no
`SERVER_LOG` classified `NO_TOKENS`. A canvas run's derived decode mean is excluded from the
cross-check, which empties `_cli` the same way. It now falls back to the client-measured wall rate.

### Evidence

Fixture `canvas_mixed` reproduces the defect class on `master` before the fix:

| | `master` | this branch |
|---|---|---|
| per-run | `decode_TPS=162727.60` | `decode_TPS=   n/a  (…)` |
| shape summary | `mean=81584.17  CV=140.7%` | `mean=440.31  CV=0.0%` + the exclusion line |

### Not in this PR (bench half only)

- `bench-agentic.sh` carries the same `max(wall - ttft, 1e-6)` pattern (issue root-cause table, ~L300). Not owned here.
- `soak-helper.py` — sibling PR.
- Issue item 3 asks to promote `decode_granularity` / `canvas_tokens` into
  `scripts/lib/profiles/models/diffusiongemma-26b-a4b.yml`. **Deliberately not done here:** it is a
  shared surface the soak half wants too, and two PRs editing it would conflict. `bench.sh` reads
  `DECODE_GRANULARITY`, so a launcher that exports it from the profile lights this up with no
  further change.
- `verify-full` step 5 (issue item 6) is a different script.

---

## #817 — gate the log-scraped `PP tok/s`

`PP tok/s` is scraped from the engine's own stats log — vLLM's `Avg prompt throughput`, averaged over
its **~10 s logging window**. On the canonical bench prompts (~15 tokens) most of that window
contains no prefill at all, so it renders as `mean=2.00 CV=55.9%` (#769) or `mean=6.88 CV=19.7%`
(#822): shaped exactly like a measurement, and not one. The trustworthy figure — client-side
`prompt_tokens / TTFT`, cache-busted — is already printed by default at CV 0.3–1.5%.

Issue option 2, plus a third condition the issue's own second case requires:

| Condition | Why |
|---|---|
| `prompt >= 1000 tok` | a ~15-token prompt cannot fill a 10 s window |
| `mean >= 50 tok/s` | below that it is window dilution, not prefill compute |
| `CV <= 100%` | **load-bearing on its own** — the windowed variant *inside the prefill sections* clears both other conditions at `mean=1127.30 CV=171.9%` (min 13 / max 8044) and is still not a rate |

All three must hold. When they do, the line prints **with** `(engine log, windowed — indicative
only)`. When they do not it prints `n/a (engine-log scrape suppressed: <reason>)` and points at
`prefill tok/s`. **The reason is mandatory** — a number that vanishes with no explanation is its own
defect, and the next report just asks where `PP tok/s` went.

**One definition, on purpose.** bench.sh has *two* print sites for this scrape. Both shell out to
`cap_pp_plausible` in `scripts/lib/capture.sh` rather than reimplementing the thresholds — a copy of
a rule in the caller is how the two consumers of a shared scrape drifted apart before (the
pool-LINE-count vs DEVICES-with-a-pool split #846 had to unpick). A test asserts bench.sh contains
none of the three threshold names outside comments.

Gate verdicts on every figure actually pasted into an issue as data:

| Sample | Source | Verdict |
|---|---|---|
| `mean=2.00 CV=55.9% prompt=15` | #769 | suppressed (depth) |
| `mean=6.88 CV=19.7% prompt=15` | #822 `[code]` | suppressed (depth) |
| `mean=6.07 CV=49.5% prompt=10000` | #822 prefill-10k | suppressed (rate) |
| `mean=1127.30 CV=171.9% prompt=90000` | #817 | suppressed (**CV only**) |
| `mean=9968.67 CV=14.0% prompt=90000` | #822 prefill-90k | **printed**, labelled indicative |

**Parser contract preserved**: on the plausible path the label is appended as a *suffix*, so
`^\s+PP tok/s\s+mean=` still matches — `measurement_record.py` and `rebench-report.py` both key on
it, and both already tolerate the line's absence (the `n/a (long-prompt fallback below)` case has
always existed).

---

## #832 — `--quick`

`WARMUPS=1 RUNS=1 ONLY=narr PREFILL_PROBE=0 QUIET=1` behind one flag. A **preset over knobs that
already exist** — no new measurement code — because the ask was discoverability: composing it by
hand takes reading ~40 lines of the env block and knowing that `PREFILL_PROBE` defaults to **1** and
silently adds a 10K and a 90K request.

bench.sh had no argument parsing at all, so this adds a small one plus `--help`. Unknown arguments
are now rejected rather than silently ignored, and parsing happens **before `preflight.sh` is
sourced**, so a sourced script no longer inherits our positional parameters.

The guardrails are the point:

- non-canonical banner at the **start and again at the end** — a reader who tails the log, or scrolls
  to the summary and copies it, never sees the opening one;
- **`CARD=` is refused.** A `--quick` run is n=1, so it has no CV — and the A/B card's noise band
  *defaults to 2× the worst decode CV across both arms*, which would then be zero and render every
  delta as significant;
- `--help` and both banners state that CV is not computed, that single-run TPS is not comparable
  across boots, and that this is not a BENCHMARKS.md row.

And the caveat that matters more than the flag, carried in `--help`, in both banners and in
`docs/BENCH_CARD.md`: **`--quick` removes *within-boot* samples, not the need for ≥2 boots.** Pool
allocation on the CPU-offload MoE path swings ~20% between boots of a byte-identical config
(4949 vs 3942 slots) and throughput tracked it (−12%) — enough to flip a same-day "22L is the best
no-spec config" from first to last once the arm was confirmed at 2 reps. A cheaper arm makes that
mistake *easier*, which is why it is documented at the point of use.

An explicitly-set env var **wins** over the preset and the banner reports which — silently overriding
what the operator typed makes the run a third protocol neither of them chose:

```
  preset applied : WARMUPS=1 PREFILL_PROBE=0 QUIET=1
  your env kept  : RUNS=3 (preset wanted 1) ONLY=code (preset wanted narr)
```

---

## Additivity

The standing requirement, checked rather than asserted: a `healthy` (autoregressive) run was diffed
against `master` with numbers and the tmpdir normalised. **The only difference in the whole output is
the #817 PP line** — the deliberate, issue-sanctioned change. `BENCH_MOCK` output is byte-identical
on both branches (guarded, because `test-submit-bench` and `test-measurement-record` parse it),
including under `--quick`.

## Tests

| Suite | Result |
|---|---|
| `test-bench-capture` (extended: 21 → 30 checks) | **PASS** |
| `test-bench-card` | **PASS** |
| `test-offload-matrix-static` | **PASS** |
| `test-offload-matrix-mocked` | **PASS** |
| `test-measurement-record` | **PASS** |
| `test-submit-bench` | **PASS** |
| `test-bench-agentic-ramp` · `test-report-calib` · `test-artifact-inventory` · `test-scenario-sets` · `test-quality-baseline` | **PASS** |

`bash -n` clean on both touched shell scripts; `py_compile` clean on the fixture; the embedded python
heredoc and all five inline `python3 -c` snippets AST-parse.

New fixture scenarios on the fake server (additive — the sweep's own suites stay green):
`canvas`, `canvas_mixed`, and a `FAKE_PP_JITTER` knob reproducing the min 13 / max 8044 window
sample.

No GPU, no model, no tier-2, live services untouched.

### ⚠ Pre-existing failure, NOT from this branch

`test-locale-utf8` fails **on `origin/master`** with the identical file list — four test scripts run
`python3` without exporting `PYTHONUTF8` (#779):

```
scripts/tests/test-bench-capture.sh
scripts/tests/test-bench-card.sh
scripts/tests/test-offload-matrix-mocked.sh
scripts/tests/test-offload-matrix-static.sh
```

Two of those sit outside this cluster's ownership, and fixing only the other two would leave the gate
red, so it is flagged rather than half-fixed. The fix the test itself prescribes is one line at the
top of each: `export PYTHONUTF8="${PYTHONUTF8:-1}"`.

---

Closes #817, #832.
Bench half of #809 — the soak half is a sibling PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4LeYTBtjVXgpDgXSNUSgr
