### PR TITLE
Download resilience: >50 GB refusal ladder (#804) + verify-in-place & announce-why (#812)

### DIFF
--- a/scripts/lib/profiles/downloader.py
+++ b/scripts/lib/profiles/downloader.py
@@ -20,10 +20,14 @@ Public API (stable for E3/E4)
     #                                   HF API lfs.sha256)
     #     .failure      -> None | "no-etag" | "sha-mismatch" | "gated-401"
     #                          | "disk" | "hf-cli-missing" | "in-progress"
-    #     .detail       -> str  (actionable message for "hf-cli-missing", or
-    #                            the adoption summary on a #812 skip)
+    #                          | "fallback-failed" | "fallback-unavailable"
+    #     .detail       -> str  (actionable message for "hf-cli-missing",
+    #                            the ladder's reason for a fallback-* failure,
+    #                            or the adoption summary on a #812 skip)
     #     .adopted      -> list[str]  (#812 — files verified in place and NOT
     #                                  re-downloaded)
+    #     .rung         -> str  (#804 — which ladder rung delivered the bytes:
+    #                            "classic" | "xet" | "raw-resolve")
     #     .local_dir    -> str         (the CONTRACT-2 host --model dir, or
     #                                   the .incomplete path on failure)
 
@@ -74,7 +78,17 @@ CONTRACT-3 invariants enforced here
   recorded-fixture fetcher / mocked subprocess; NO live multi-GB network
   in CI).
 
-Later addition, implemented in `hf_fetch.py` (see its docstring) and wired here:
+Two later additions, both in `hf_fetch.py` (see its docstring for the full
+rationale) and both wired here:
+
+* **#804 — the download resilience ladder.** The classic `hf download` above
+  is rung 1 and stays FIRST and unchanged. When (and only when) it exits with
+  huggingface_hub's client-side too-large refusal — a hard policy wall for
+  files over 50 GB, not flakiness — `HubFetcher.snapshot` escalates: rung 2
+  (Xet) if the operator opted in AND `hf_xet` is already importable, else
+  rung 3 (single-stream resumable `curl` against the resolve endpoint). Both
+  fallback rungs run a mandatory independent sha256 gate and DELETE a
+  mismatching artifact. No parallel-chunk downloader is ever used.
 
 * **#812 — verify-in-place + announce WHY.** Before any bytes move,
   `_download_model_impl` announces, per already-present file, what was found
@@ -119,6 +133,7 @@ class DownloadResult:
     sha_verified: bool = False
     # None | "no-etag" | "sha-mismatch" | "gated-401" | "disk"
     #      | "hf-cli-missing" | "in-progress"
+    #      | "fallback-failed" | "fallback-unavailable"   (#804 ladder)
     failure: Optional[str] = None
     local_dir: str = ""
     # Actionable detail (populated for "hf-cli-missing"; the canonical
@@ -128,6 +143,9 @@ class DownloadResult:
     # #812 — files that were already on disk, verified in place, and NOT
     # re-downloaded. Empty on every pre-existing path.
     adopted: list[str] = field(default_factory=list)
+    # #804 — which ladder rung delivered the bytes ("classic" unless the
+    # too-large refusal forced an escalation). "" when nothing was fetched.
+    rung: str = ""
 
 
 # The canonical actionable message when NEITHER `hf` nor `huggingface-cli`
@@ -284,6 +302,26 @@ class HubFetcher:
 
     timeout = _NET_TIMEOUT
 
+    def __init__(self, api: Optional[dict] = None, *,
+                 log: Optional[Any] = None):
+        # `api` = the deriver's already-fetched /api/models?blobs=true payload.
+        # The #804 ladder prefers it for sha256/size (free + redirect-immune)
+        # and only hits the repo-tree API when it is absent.
+        self.api = api or {}
+        self.log = log or HF.default_log
+        # Filenames the fallback ladder ALREADY sha256-verified, so
+        # download_model doesn't re-read a 96 GB file to compute the same hash
+        # against the same source.
+        self.ladder_verified: set = set()
+        self.rung = "classic"
+        # Injection seams for the #804 ladder, so its rungs are testable with
+        # NO network and NO multi-GB transfer (same discipline as the fixture
+        # fetcher). Production leaves every one of them None.
+        self.xet_runner = None        # (repo, dir, includes, xet) -> (rc, blob)
+        self.curl_runner = None       # (argv, dest_path) -> rc
+        self.xet_available = None     # () -> bool
+        self.tree_fn = None           # () -> repo-tree payload
+
     def snapshot(
         self, repo_id: str, local_dir: str, allow_patterns: list[str]
     ) -> list[str]:
@@ -308,7 +346,35 @@ class HubFetcher:
             text=True,
         )
         if proc.returncode != 0:
-            blob = f"{proc.stdout or ''}\n{proc.stderr or ''}".lower()
+            raw = f"{proc.stdout or ''}\n{proc.stderr or ''}"
+            blob = raw.lower()
+            # --- #804 rung 1 -> rung 2/3 escalation -----------------------
+            # ONLY on huggingface_hub's client-side too-large refusal. That is
+            # a hard policy wall (files over 50 GB on the plain HTTP path), so
+            # retrying rung 1 cannot succeed; every OTHER non-zero exit keeps
+            # its pre-existing mapping below, byte-unchanged.
+            if HF.is_xet_refusal(raw):
+                try:
+                    res = HF.escalate(
+                        repo_id, Path(local_dir), list(allow_patterns),
+                        classic_error=raw,
+                        meta=HF.api_meta(self.api) if self.api else None,
+                        log=self.log,
+                        xet_runner=self.xet_runner,
+                        curl_runner=self.curl_runner,
+                        xet_available=self.xet_available,
+                        tree_fn=self.tree_fn,
+                    )
+                except HF.LadderError as exc:
+                    raise LadderFailure(exc.token, exc.detail) from exc
+                self.ladder_verified = set(res.verified)
+                self.rung = res.rung
+                out: list[str] = []
+                root = Path(local_dir)
+                for p in sorted(root.rglob("*")):
+                    if p.is_file():
+                        out.append(str(p.relative_to(root)))
+                return out
             # Map non-zero exit to the EXISTING structured failure tokens,
             # exactly as the fixture fetcher would have raised.
             if (
@@ -459,8 +525,18 @@ class DiskError(RuntimeError):
     """Out-of-space / staging IO failure surfaced by the fetcher."""
 
 
-# ---------------------------------------------------------------------------
-# THE download stage.
+class LadderFailure(RuntimeError):
+    """#804: rung 1 hit the too-large refusal AND the escalation could not
+    deliver a verified artifact. `.token` is the structured failure the
+    DownloadResult carries ("sha-mismatch" / "no-etag" / "fallback-failed" /
+    "fallback-unavailable"); `.detail` is the operator-facing reason. Raised
+    (never swallowed) so `.incomplete` cleanup runs on the way out."""
+
+    def __init__(self, token: str, detail: str = ""):
+        super().__init__(detail or token)
+        self.token = token
+        self.detail = detail
+
 
 # ---------------------------------------------------------------------------
 # THE download stage.
@@ -554,6 +630,12 @@ def _download_model_impl(einput, *, fetcher: Optional[Any] = None) -> DownloadRe
                                        -> failure="hf-cli-missing"
         (STRUCTURED, with actionable .detail — NEVER a bare
         ModuleNotFoundError; the on-rig E5 regression this closes)
+      * #804 ladder exhausted           -> failure="fallback-failed" /
+                                           "fallback-unavailable" (or the
+                                           existing "sha-mismatch"/"no-etag"
+                                           when a fallback artifact fails the
+                                           mandatory hash gate — the artifact
+                                           is deleted either way)
 
     #812 — BEFORE any of that, the already-present contents of the final dir
     are announced file-by-file and (with VERIFY_IN_PLACE=1) sha256-checked
@@ -566,7 +648,9 @@ def _download_model_impl(einput, *, fetcher: Optional[Any] = None) -> DownloadRe
     allow = D.download_set(api)
 
     if fetcher is None:
-        fetcher = HubFetcher()
+        # Hand the deriver's already-fetched API payload to the fetcher so the
+        # #804 ladder can price/verify files without a second network round.
+        fetcher = HubFetcher(api)
 
     hf_home = Path(einput.hf_home)
     final_dir = pull_dir(hf_home, slug)
@@ -611,7 +695,7 @@ def _download_model_impl(einput, *, fetcher: Optional[Any] = None) -> DownloadRe
                 ok=True, files=list(allow), bytes=total,
                 # honest: only a computed hash counts as verification here.
                 sha_verified=bool(hashed) and len(hashed) == len(allow),
-                local_dir=str(final_dir), adopted=adopted,
+                local_dir=str(final_dir), adopted=adopted, rung="",
                 detail=f"adopted {len(adopted)} file(s) in place",
             )
 
@@ -624,6 +708,16 @@ def _download_model_impl(einput, *, fetcher: Optional[Any] = None) -> DownloadRe
         f"({len(allow)} file(s); reason: {', '.join(reasons)}"
         + (f"; {len(adopted)} already verified and kept" if adopted else "")
         + ")")
+
+    # #804 preflight: say up front when the classic path CANNOT serve this
+    # repo, instead of letting the operator watch a doomed rung-1 attempt.
+    try:
+        verdict, note = HF.preflight_transport(
+            [n for n in allow if n not in adopted], HF.api_meta(api))
+        if verdict == "needs-fallback":
+            log(f"[download] preflight: {note}")
+    except Exception:                    # pragma: no cover - advisory only
+        pass
 
     # Fresh staging tree (never reuse a prior partial — aria2c lesson).
     _rmtree(staging)
@@ -682,6 +776,15 @@ def _download_model_impl(einput, *, fetcher: Optional[Any] = None) -> DownloadRe
         return DownloadResult(
             ok=False, failure="disk", local_dir=str(staging), files=[]
         )
+    except LadderFailure as exc:
+        # #804: the too-large refusal was real and the escalation could not
+        # deliver a VERIFIED artifact. Same cleanup discipline as every other
+        # failure — no corrupt residue for anyone to serve.
+        _rmtree(staging)
+        return DownloadResult(
+            ok=False, failure=exc.token, local_dir=str(staging), files=[],
+            detail=exc.detail,
+        )
 
     written_set = sorted(set(written) | set(pre_staged))
 
@@ -701,7 +804,13 @@ def _download_model_impl(einput, *, fetcher: Optional[Any] = None) -> DownloadRe
     # longer a failure by itself: verifiability is decided by the API hash.
     sha_ok = True
     lfs_sha = _lfs_sha_map(api)
-    safetensors = [n for n in written_set if n.endswith(".safetensors")]
+    # #804: files the fallback ladder ALREADY hashed against the SAME published
+    # sha256 are not re-read here — re-hashing a 96 GB artifact to recompute an
+    # identical comparison is pure cost, not extra assurance. Anything the
+    # ladder did NOT verify still goes through the loop below.
+    ladder_verified = set(getattr(fetcher, "ladder_verified", ()) or ())
+    safetensors = [n for n in written_set
+                   if n.endswith(".safetensors") and n not in ladder_verified]
     for name in safetensors:
         # HEAD retained ONLY to surface HF gated-401 mid-verify (the
         # injectable-fetcher seam; its hash value is intentionally ignored).
@@ -775,6 +884,11 @@ def _download_model_impl(einput, *, fetcher: Optional[Any] = None) -> DownloadRe
             files=written_set,
         )
 
+    rung = str(getattr(fetcher, "rung", "") or "")
+    if rung and rung != "classic":
+        log(f"[download] delivered via the #804 fallback ladder "
+            f"(rung={rung}) — every fetched file sha256-verified against the "
+            f"hub's published hashes.")
     return DownloadResult(
         ok=True,
         files=written_set,
@@ -783,4 +897,5 @@ def _download_model_impl(einput, *, fetcher: Optional[Any] = None) -> DownloadRe
         failure=None,
         local_dir=str(final_dir),
         adopted=pre_staged,
+        rung=rung,
     )

--- a/scripts/lib/profiles/downloader.py
+++ b/scripts/lib/profiles/downloader.py
@@ -19,8 +19,11 @@ Public API (stable for E3/E4)
     #     .sha_verified -> bool        (every *.safetensors verified vs the
     #                                   HF API lfs.sha256)
     #     .failure      -> None | "no-etag" | "sha-mismatch" | "gated-401"
-    #                          | "disk" | "hf-cli-missing"
-    #     .detail       -> str  (actionable message for "hf-cli-missing")
+    #                          | "disk" | "hf-cli-missing" | "in-progress"
+    #     .detail       -> str  (actionable message for "hf-cli-missing", or
+    #                            the adoption summary on a #812 skip)
+    #     .adopted      -> list[str]  (#812 — files verified in place and NOT
+    #                                  re-downloaded)
     #     .local_dir    -> str         (the CONTRACT-2 host --model dir, or
     #                                   the .incomplete path on failure)
 
@@ -70,6 +73,15 @@ CONTRACT-3 invariants enforced here
   'huggingface_hub'")`. The fetcher is injectable so tests are hermetic (a
   recorded-fixture fetcher / mocked subprocess; NO live multi-GB network
   in CI).
+
+Later addition, implemented in `hf_fetch.py` (see its docstring) and wired here:
+
+* **#812 — verify-in-place + announce WHY.** Before any bytes move,
+  `_download_model_impl` announces, per already-present file, what was found
+  and what will happen to it. With `VERIFY_IN_PLACE=1` a metadata-less local
+  file is sha256'd against the hub and ADOPTED on a match (0 bytes
+  re-downloaded, HF metadata stub written) instead of silently re-pulled.
+  Size agreement alone is never called "verified".
 """
 
 from __future__ import annotations
@@ -88,6 +100,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from . import deriver as D
+from . import hf_fetch as HF
 
 _HF_RESOLVE = "https://huggingface.co"
 _NET_TIMEOUT = 60  # seconds (HEAD for etag is cheap; weight bytes via hub)
@@ -105,13 +118,16 @@ class DownloadResult:
     bytes: int = 0
     sha_verified: bool = False
     # None | "no-etag" | "sha-mismatch" | "gated-401" | "disk"
-    #      | "hf-cli-missing"
+    #      | "hf-cli-missing" | "in-progress"
     failure: Optional[str] = None
     local_dir: str = ""
     # Actionable detail (populated for "hf-cli-missing"; the canonical
     # PEP-668-aware install hint, in sync with setup.sh `ensure_hf_cli`).
     # Optional / additive — existing failure paths leave it "".
     detail: str = ""
+    # #812 — files that were already on disk, verified in place, and NOT
+    # re-downloaded. Empty on every pre-existing path.
+    adopted: list[str] = field(default_factory=list)
 
 
 # The canonical actionable message when NEITHER `hf` nor `huggingface-cli`
@@ -445,6 +461,9 @@ class DiskError(RuntimeError):
 
 # ---------------------------------------------------------------------------
 # THE download stage.
+
+# ---------------------------------------------------------------------------
+# THE download stage.
 # ---------------------------------------------------------------------------
 def download_model(einput, *, fetcher: Optional[Any] = None) -> DownloadResult:
     """Public entry — serialize per-repo via an atomic pull-dir lock, then run
@@ -535,18 +554,76 @@ def _download_model_impl(einput, *, fetcher: Optional[Any] = None) -> DownloadRe
                                        -> failure="hf-cli-missing"
         (STRUCTURED, with actionable .detail — NEVER a bare
         ModuleNotFoundError; the on-rig E5 regression this closes)
-    """
-    if fetcher is None:
-        fetcher = HubFetcher()
 
+    #812 — BEFORE any of that, the already-present contents of the final dir
+    are announced file-by-file and (with VERIFY_IN_PLACE=1) sha256-checked
+    against the hub. A fully-verified pull dir returns ok WITHOUT touching the
+    network. Nothing here starts a transfer without first printing why.
+    """
     slug = einput.slug
     api = _selected_files_api(einput)
     # The ONE shared allowlist — identical object [C2a] sized + E3 will smoke.
     allow = D.download_set(api)
 
+    if fetcher is None:
+        fetcher = HubFetcher()
+
     hf_home = Path(einput.hf_home)
     final_dir = pull_dir(hf_home, slug)
     staging = final_dir / ".incomplete"
+    log = getattr(fetcher, "log", None) or HF.default_log
+
+    # --- #812: announce, and verify in place, BEFORE any bytes move --------
+    # The silent re-pull of a present 160 GB file is the bug being fixed. The
+    # announcement is unconditional; the *adoption* needs VERIFY_IN_PLACE=1
+    # because hashing a multi-GB file costs a full read — but a size match
+    # alone is NEVER treated as (or called) verification.
+    adopted: list[str] = []
+    plan: list = []
+    if allow:
+        try:
+            plan = HF.plan_and_announce(
+                final_dir, allow, HF.api_meta(api),
+                do_hash=HF.verify_in_place_enabled(), log=log,
+                prefix="[download]",
+                commit=str((api or {}).get("sha") or ""),
+            )
+        except Exception as exc:   # a planning failure must never block a pull
+            log(f"[download] could not check the existing files ({exc!r}) — "
+                f"proceeding with a full download")
+            plan = []
+        adopted = [e.name for e in plan if e.action == "adopt"]
+        if plan and len(adopted) == len(allow):
+            hashed = [e.name for e in plan if e.hashed]
+            total = 0
+            for name in allow:
+                try:
+                    total += (final_dir / name).stat().st_size
+                except OSError:
+                    pass
+            log(f"[download] SKIPPED — all {len(allow)} file(s) already "
+                f"present and accounted for in {final_dir} "
+                f"({len(hashed)} sha256-verified in place, "
+                f"{len(adopted) - len(hashed)} matched by the downloader's "
+                f"own record). 0 bytes re-downloaded.")
+            _rmtree(staging)
+            return DownloadResult(
+                ok=True, files=list(allow), bytes=total,
+                # honest: only a computed hash counts as verification here.
+                sha_verified=bool(hashed) and len(hashed) == len(allow),
+                local_dir=str(final_dir), adopted=adopted,
+                detail=f"adopted {len(adopted)} file(s) in place",
+            )
+
+    # Announce WHY the download starts — #812 acceptance: "No code path starts
+    # a download without printing why."
+    reasons = sorted({e.reason for e in plan if e.action == "download"})
+    if not plan:
+        reasons = ["no-local-copy"]
+    log(f"[download] starting: {slug} -> {final_dir} "
+        f"({len(allow)} file(s); reason: {', '.join(reasons)}"
+        + (f"; {len(adopted)} already verified and kept" if adopted else "")
+        + ")")
 
     # Fresh staging tree (never reuse a prior partial — aria2c lesson).
     _rmtree(staging)
@@ -560,12 +637,31 @@ def _download_model_impl(einput, *, fetcher: Optional[Any] = None) -> DownloadRe
             files=[],
         )
 
-    # --- fetch EXACTLY the shared download_set ----------------------------
+    # --- #812: carry the already-verified files INTO the staging tree ------
+    # A rename inside the same pull dir, so an adopted 96 GB shard is not
+    # re-fetched just because a sibling file is missing. Only files whose
+    # sha256 was matched above get here, and they are still hashed again in
+    # the SHA stage below unless the ladder already did it.
+    pre_staged: list[str] = []
+    for name in adopted:
+        src, dst = final_dir / name, staging / name
+        try:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(str(src), str(dst))
+            pre_staged.append(name)
+        except OSError:
+            pass                      # fall back to fetching it
+    fetch_set = [n for n in allow if n not in pre_staged]
+    if pre_staged:
+        log(f"[download] keeping {len(pre_staged)} verified file(s); "
+            f"fetching only the remaining {len(fetch_set)}")
+
+    # --- fetch EXACTLY the shared download_set (minus anything adopted) ----
     try:
         written = fetcher.snapshot(
             repo_id=slug,
             local_dir=str(staging),
-            allow_patterns=list(allow),
+            allow_patterns=list(fetch_set),
         )
     except _MissingHfCli as exc:
         # NEITHER `hf` nor `huggingface-cli` resolvable. STRUCTURED failure
@@ -587,7 +683,7 @@ def _download_model_impl(einput, *, fetcher: Optional[Any] = None) -> DownloadRe
             ok=False, failure="disk", local_dir=str(staging), files=[]
         )
 
-    written_set = sorted(set(written))
+    written_set = sorted(set(written) | set(pre_staged))
 
     # --- SHA: every *.safetensors via the HF API lfs.sha256 ---------------
     # E2-fix-2 (on-rig E5): the trusted hash now comes from the HF model API
@@ -686,4 +782,5 @@ def _download_model_impl(einput, *, fetcher: Optional[Any] = None) -> DownloadRe
         sha_verified=sha_ok,
         failure=None,
         local_dir=str(final_dir),
+        adopted=pre_staged,
     )

--- a/scripts/lib/profiles/hf_fetch.py
+++ b/scripts/lib/profiles/hf_fetch.py
@@ -1,0 +1,459 @@
+"""Verify-in-place for metadata-less local files + announce WHY (club-3090 #812).
+
+A file placed by hand has no ``.cache/huggingface/download/<f>.metadata`` beside
+it, so the downloader cannot tell "complete" from "half-copied 40 GB" and
+re-pulls it — silently, for hours (Discord report: setup/pull re-downloading a
+model that was already at the target path). The instinct is right; the silence
+is the bug. So:
+
+* **The announcement is unconditional.** Nothing here starts a transfer without
+  first printing one honest line per present file saying what was found and
+  what will happen to it.
+* **Adoption requires a real hash.** ``VERIFY_IN_PLACE=1`` opts into hashing
+  (it costs a full read of a multi-GB file); on a sha256 match the file is
+  adopted and the HF metadata stub written, so ``hf download`` skips it
+  forever after. Size agreement alone is NEVER called "verified" — a wrapper
+  on this rig once printed "DONE (hash-verified)" over silent corruption at the
+  correct size, and that is exactly the failure this module refuses to repeat.
+
+Wording contract (asserted by ``test-pull-verify-in-place.sh``): the token
+``verified`` appears in an announcement **only** when a sha256 was actually
+computed and compared. A size-only observation says "size matches" and nothing
+stronger.
+
+The hub-metadata plumbing here (repo tree API, the non-redirect resolve HEAD,
+the sha256 helpers) is deliberately generic — the download resilience ladder
+(#804) is built on the same three primitives.
+
+Stdlib only — this runs under the bare ``python3`` that ``scripts/pull.sh``
+uses, where ``huggingface_hub`` is NOT importable (it exists on this rig only as
+a ``uv tool`` exposing the ``hf`` CLI).
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import json
+import os
+import time
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable, Optional
+
+_HF = "https://huggingface.co"
+_NET_TIMEOUT = 60
+_SHA_CHUNK = 8 * 1024 * 1024
+
+
+# ---------------------------------------------------------------------------
+# announcement plumbing
+# ---------------------------------------------------------------------------
+def default_log(msg: str) -> None:
+    """Announcements go to stderr so they interleave with `hf`'s own progress
+    bars and never pollute a `--json` stdout contract."""
+    print(msg, file=sys.stderr, flush=True)
+
+
+def human_bytes(n: Optional[int]) -> str:
+    if n is None:
+        return "unknown size"
+    f = float(n)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if f < 1024.0 or unit == "TB":
+            return f"{f:.0f} {unit}" if unit == "B" else f"{f:.2f} {unit}"
+        f /= 1024.0
+    return f"{f:.2f} TB"  # pragma: no cover - unreachable
+
+
+def short_sha(s: Optional[str]) -> str:
+    return f"{s[:12]}…" if s else "?"
+
+
+def verify_in_place_enabled(env: Optional[dict] = None) -> bool:
+    """Opt-in for hashing an already-present file instead of re-downloading it.
+    The *announcement* is unconditional and does not consult this — only the
+    decision to spend a full read of a multi-GB file does."""
+    e = os.environ if env is None else env
+    return (e.get("CLUB3090_VERIFY_IN_PLACE") or e.get("VERIFY_IN_PLACE")
+            or "") == "1"
+
+
+# ---------------------------------------------------------------------------
+# HF metadata: repo tree + the non-redirect resolve HEAD
+# ---------------------------------------------------------------------------
+@dataclass
+class FileMeta:
+    """What the hub publishes about one file. `sha256` is the canonical LFS
+    hash (`x-linked-etag` on the non-redirected resolve hop == the model API's
+    `siblings[].lfs.sha256`); None means genuinely unverifiable."""
+    name: str
+    size: Optional[int] = None
+    sha256: Optional[str] = None
+    commit: Optional[str] = None
+    source: str = ""          # "api" | "resolve-head" | ""
+
+
+def _token(env: Optional[dict] = None) -> Optional[str]:
+    """HF token from the env, else the CLI's token file. nohup/cron/non-login
+    shells don't source a profile, so an unexported token silently degrades to
+    anonymous -> rate-limited -> looks exactly like a stall (the rig wrapper
+    learned this the slow way)."""
+    e = os.environ if env is None else env
+    tok = e.get("HF_TOKEN") or e.get("HUGGING_FACE_HUB_TOKEN")
+    if tok:
+        return tok.strip()
+    for p in (
+        Path(e.get("HF_HOME", "")) / "token" if e.get("HF_HOME") else None,
+        Path.home() / ".cache" / "huggingface" / "token",
+    ):
+        if p is None:
+            continue
+        try:
+            t = p.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if t:
+            return t
+    return None
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Do NOT follow the 302 into the CAS bridge.
+
+    Following it is the trap: the post-redirect CAS response carries a
+    CAS-*blob* ETag (the xet hash) and NO `x-linked-etag`, so a redirect-
+    following HEAD reads as "no hash published" on every Xet-backed repo. The
+    sha256 lives on the FIRST hop."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def resolve_head(repo_id: str, filename: str, *, revision: str = "main",
+                 token: Optional[str] = None,
+                 timeout: int = _NET_TIMEOUT,
+                 opener: Optional[Any] = None) -> FileMeta:
+    """Non-redirect-following HEAD on the resolve endpoint -> size + sha256.
+
+    Reads `x-linked-etag` (canonical LFS sha256) / `x-linked-size` /
+    `x-repo-commit` off the 302 itself. `opener` is injectable so tests never
+    touch the network."""
+    url = f"{_HF}/{repo_id}/resolve/{revision}/{urllib.parse.quote(filename)}"
+    req = urllib.request.Request(url, method="HEAD")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    op = opener or urllib.request.build_opener(_NoRedirect())
+    hdrs = None
+    try:
+        with op.open(req, timeout=timeout) as resp:
+            hdrs = resp.headers          # 200 (a small non-LFS file)
+    except urllib.error.HTTPError as exc:
+        if exc.code in (301, 302, 303, 307, 308):
+            hdrs = exc.headers           # the hop we actually want
+        else:
+            return FileMeta(name=filename)
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError):
+        return FileMeta(name=filename)
+    if hdrs is None:                     # pragma: no cover - defensive
+        return FileMeta(name=filename)
+
+    def _h(*names: str) -> Optional[str]:
+        for n in names:
+            v = hdrs.get(n)
+            if v:
+                return v.strip().strip('"')
+        return None
+
+    sha = _h("x-linked-etag", "X-Linked-Etag")
+    size = _h("x-linked-size", "X-Linked-Size") or _h("content-length")
+    try:
+        size_i = int(size) if size is not None else None
+    except ValueError:
+        size_i = None
+    return FileMeta(
+        name=filename, size=size_i,
+        sha256=sha.lower() if sha else None,
+        commit=_h("x-repo-commit", "X-Repo-Commit"),
+        source="resolve-head" if sha else "",
+    )
+
+
+def repo_tree(repo_id: str, *, revision: str = "main",
+              token: Optional[str] = None, timeout: int = _NET_TIMEOUT,
+              urlopen: Optional[Callable] = None) -> list[dict]:
+    """`/api/models/<repo>/tree/<rev>?recursive=1` — path + size + lfs.oid for
+    every file. Needed to expand `--include` globs for rung 3 (curl fetches one
+    named file at a time) and to price/verify an on-disk file. Returns [] on any
+    failure; the caller degrades to "no metadata to verify against" rather than
+    inventing one."""
+    url = (f"{_HF}/api/models/{repo_id}/tree/{revision}"
+           f"?recursive=1&expand=1")
+    req = urllib.request.Request(url)
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    fn = urlopen or urllib.request.urlopen
+    try:
+        with fn(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except Exception:
+        return []
+    return [e for e in data if isinstance(e, dict)] if isinstance(data, list) else []
+
+
+def tree_meta(tree: Iterable[dict]) -> dict[str, FileMeta]:
+    """`{path: FileMeta}` from a repo-tree payload. `lfs.oid`/`lfs.sha256` is
+    the canonical sha256 for LFS files; a plain (non-LFS) file publishes only a
+    size, and stays hash-unverifiable — which the announcement says out loud
+    instead of implying otherwise."""
+    out: dict[str, FileMeta] = {}
+    for e in tree or []:
+        if e.get("type") not in (None, "file"):
+            continue
+        name = e.get("path")
+        if not name:
+            continue
+        lfs = e.get("lfs") if isinstance(e.get("lfs"), dict) else {}
+        sha = lfs.get("sha256") or lfs.get("oid")
+        size = lfs.get("size") if lfs.get("size") is not None else e.get("size")
+        try:
+            size_i = int(size) if size is not None else None
+        except (TypeError, ValueError):
+            size_i = None
+        out[name] = FileMeta(
+            name=name, size=size_i,
+            sha256=str(sha).lower() if sha else None,
+            source="api" if sha else "",
+        )
+    return out
+
+
+def api_meta(api: dict) -> dict[str, FileMeta]:
+    """`{path: FileMeta}` from the `/api/models/<repo>?blobs=true` payload the
+    deriver already fetched and stashed at `der.profile['_hf_api']` — free, and
+    redirect-immune. Preferred over a network round-trip when present."""
+    out: dict[str, FileMeta] = {}
+    for s in (api or {}).get("siblings", []) or []:
+        if not isinstance(s, dict):
+            continue
+        name = s.get("rfilename")
+        if not name:
+            continue
+        lfs = s.get("lfs") if isinstance(s.get("lfs"), dict) else {}
+        sha = lfs.get("sha256")
+        size = lfs.get("size") if lfs.get("size") is not None else s.get("size")
+        try:
+            size_i = int(size) if size is not None else None
+        except (TypeError, ValueError):
+            size_i = None
+        out[name] = FileMeta(
+            name=name, size=size_i,
+            sha256=str(sha).strip().strip('"').lower() if sha else None,
+            source="api" if sha else "",
+        )
+    return out
+
+
+def expand_includes(names: Iterable[str], patterns: Iterable[str]) -> list[str]:
+    """Resolve `--include` globs against a repo file list, preserving pattern
+    order and de-duplicating. Exact filenames are valid globs, so the
+    single-file case falls out for free."""
+    all_names = list(names)
+    out: list[str] = []
+    seen: set[str] = set()
+    for pat in patterns:
+        for n in all_names:
+            if n == pat or fnmatch.fnmatch(n, pat):
+                if n not in seen:
+                    seen.add(n)
+                    out.append(n)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# hashing + the HF local-dir metadata stub
+# ---------------------------------------------------------------------------
+def sha256_file(path: Path, *, chunk: int = _SHA_CHUNK) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        while True:
+            b = fh.read(chunk)
+            if not b:
+                break
+            h.update(b)
+    return h.hexdigest()
+
+
+def metadata_path(local_dir: Path, filename: str) -> Path:
+    """The path `huggingface_hub._local_folder.get_local_download_paths`
+    computes, so a stub we write is the same file `hf download` reads."""
+    return (Path(local_dir) / ".cache" / "huggingface" / "download"
+            / f"{os.path.join(*filename.split('/'))}.metadata")
+
+
+def read_metadata(local_dir: Path, filename: str) -> Optional[dict]:
+    """`{'commit': …, 'etag': …, 'timestamp': float}` or None.
+
+    Mirrors `_local_folder.read_download_metadata`, INCLUDING its staleness
+    rule: metadata older than the file's mtime is ignored (the file changed
+    after the record was written, so the record no longer describes it)."""
+    mp = metadata_path(local_dir, filename)
+    try:
+        lines = mp.read_text(encoding="utf-8").splitlines()
+        commit, etag, ts = lines[0].strip(), lines[1].strip(), float(lines[2])
+    except (OSError, IndexError, ValueError):
+        return None
+    try:
+        st = (Path(local_dir) / filename).stat()
+    except OSError:
+        return None
+    if st.st_mtime - 1 > ts:
+        return None                      # outdated record — do not trust it
+    return {"commit": commit, "etag": etag.strip('"'), "timestamp": ts}
+
+
+def write_metadata(local_dir: Path, filename: str, *, commit: str,
+                   etag: str) -> Path:
+    """Write the 3-line stub (`commit_hash` / `etag` / `timestamp`) that makes
+    `hf download` treat the file as already-fetched.
+
+    ONLY ever called after a full sha256 match — this is the adoption receipt
+    for a byte-verified file, never a shortcut around verification."""
+    mp = metadata_path(local_dir, filename)
+    mp.parent.mkdir(parents=True, exist_ok=True)
+    mp.write_text(f"{commit or ''}\n{etag}\n{time.time()}\n", encoding="utf-8")
+    return mp
+
+
+# ---------------------------------------------------------------------------
+# #812 — verify-in-place decisions + the unconditional announcement
+# ---------------------------------------------------------------------------
+@dataclass
+class PlanEntry:
+    name: str
+    action: str        # "adopt" | "download"
+    reason: str        # machine token
+    message: str       # the honest human line (announced verbatim)
+    local_size: Optional[int] = None
+    remote_size: Optional[int] = None
+    hashed: bool = False
+
+
+def plan_local_file(local_dir: Path, name: str, meta: Optional[FileMeta], *,
+                    do_hash: bool,
+                    hasher: Callable[[Path], str] = sha256_file) -> PlanEntry:
+    """Decide — and phrase — what happens to one already-present file.
+
+    Order is deliberate: size first (a cheap, certain reject that needs no
+    read), then the downloader's own metadata record, then the opt-in hash.
+    ``adopt`` is reachable ONLY through a computed sha256 match or a metadata
+    record the downloader itself wrote; a bare size agreement is reported as
+    "size matches" and still re-downloads, because size agreement is exactly
+    what silent corruption looks like."""
+    fp = Path(local_dir) / name
+    try:
+        lsize = fp.stat().st_size
+    except OSError:
+        return PlanEntry(name, "download", "absent",
+                         f"{name}: not present — downloading")
+
+    rsize = meta.size if meta else None
+    rsha = meta.sha256 if meta else None
+    h = human_bytes(lsize)
+
+    # 1. size mismatch -> certain reject, names BOTH sizes, no read needed.
+    if rsize is not None and lsize != rsize:
+        return PlanEntry(
+            name, "download", "size-mismatch",
+            f"found {name} ({h}, {lsize} bytes) but the repo publishes "
+            f"{human_bytes(rsize)} ({rsize} bytes) — truncated or stale, "
+            f"re-downloading",
+            local_size=lsize, remote_size=rsize)
+
+    # 2. the downloader's own record (what `hf download` itself consults).
+    md = read_metadata(local_dir, name)
+    if md and md.get("etag") and rsha and md["etag"].lower() == rsha:
+        return PlanEntry(
+            name, "adopt", "metadata-match",
+            f"found {name} ({h}) with an HF download record for sha256 "
+            f"{short_sha(rsha)} — already fetched by the downloader, skipping",
+            local_size=lsize, remote_size=rsize)
+
+    # 3. nothing published to check against -> say so, and say the cost.
+    if rsha is None:
+        extra = (f" and the size matches ({h})"
+                 if rsize is not None and lsize == rsize else "")
+        return PlanEntry(
+            name, "download", "no-remote-hash",
+            f"found {name} ({h}) but the repo publishes no sha256 for it, so "
+            f"it cannot be verified{extra} — re-downloading ({h} over the "
+            f"wire)",
+            local_size=lsize, remote_size=rsize)
+
+    # 4. verifiable, but hashing is opt-in (a full read of a multi-GB file).
+    if not do_hash:
+        return PlanEntry(
+            name, "download", "verify-not-enabled",
+            f"found {name} ({h}) but cannot verify it without hashing "
+            f"(no HF metadata beside it) — re-downloading ({h} over the wire). "
+            f"Set VERIFY_IN_PLACE=1 (or pull.sh --verify-in-place) to sha256 "
+            f"the local copy instead and adopt it on a match",
+            local_size=lsize, remote_size=rsize)
+
+    # 5. the real check.
+    try:
+        actual = hasher(fp)
+    except OSError as exc:
+        return PlanEntry(
+            name, "download", "hash-unreadable",
+            f"found {name} ({h}) but it could not be read for hashing "
+            f"({exc}) — re-downloading",
+            local_size=lsize, remote_size=rsize)
+    if actual.lower() == rsha:
+        return PlanEntry(
+            name, "adopt", "hash-match",
+            f"verified in place: {name} ({h}) sha256 {short_sha(rsha)} "
+            f"matches the repo — adopting, 0 bytes re-downloaded",
+            local_size=lsize, remote_size=rsize, hashed=True)
+    return PlanEntry(
+        name, "download", "hash-mismatch",
+        f"found {name} ({h}) but its sha256 {short_sha(actual)} does NOT "
+        f"match the repo's {short_sha(rsha)} — corrupt, re-downloading",
+        local_size=lsize, remote_size=rsize, hashed=True)
+
+
+def plan_and_announce(local_dir: Path, names: Iterable[str],
+                      meta: dict[str, FileMeta], *, do_hash: bool,
+                      log: Callable[[str], None] = default_log,
+                      prefix: str = "[verify]",
+                      hasher: Callable[[Path], str] = sha256_file,
+                      commit: str = "") -> list[PlanEntry]:
+    """Announce, unconditionally, what happens to every target file — then
+    write the adoption receipt for each verified one.
+
+    This is #812's rule "no code path starts a download without printing why"
+    made mechanical: the caller cannot obtain the plan without the lines being
+    emitted."""
+    entries: list[PlanEntry] = []
+    for name in names:
+        e = plan_local_file(local_dir, name, meta.get(name), do_hash=do_hash,
+                            hasher=hasher)
+        entries.append(e)
+        if e.reason == "absent":
+            continue                     # summarised by the caller, not spammed
+        log(f"{prefix} {e.message}")
+        if e.action == "adopt" and e.reason == "hash-match":
+            m = meta.get(name)
+            try:
+                write_metadata(local_dir, name, commit=commit,
+                               etag=(m.sha256 if m and m.sha256 else ""))
+            except OSError as exc:       # pragma: no cover - defensive
+                log(f"{prefix} (could not write the adoption record for "
+                    f"{name}: {exc} — it will be re-checked next time)")
+    return entries
+
+

--- a/scripts/lib/profiles/hf_fetch.py
+++ b/scripts/lib/profiles/hf_fetch.py
@@ -1,10 +1,55 @@
-"""Verify-in-place for metadata-less local files + announce WHY (club-3090 #812).
+"""Download resilience ladder + verify-in-place (club-3090 #804 / #812).
 
+Two jobs, one module, because they share the same plumbing (the HF repo tree
+API, the non-redirect resolve HEAD, and the sha256 gate):
+
+#804 — the three-rung ladder
+----------------------------
+``huggingface_hub`` **client-side refuses** the classic (non-Xet) HTTP path for
+any file whose published size exceeds ``constants.MAX_HTTP_DOWNLOAD_SIZE``
+(50 GB, hard-coded, no env override) — verbatim, from
+``file_download.py::http_get`` on hf 1.25.1::
+
+    The file is too large to be downloaded using the regular download method.
+     Install `hf_xet` with `pip install hf_xet` for xet-powered downloads.
+
+Retrying is futile; it is a policy wall, not flakiness. Meanwhile the server
+serves the bytes fine: the resolve endpoint 302s to the CAS bridge, plain HTTP
+200, resumable, and hands back the canonical sha256 in ``x-linked-etag``.
+
+    rung 1  classic LFS   the current default — UNCHANGED, always first
+                          (resume via .incomplete + the best reliability record)
+    rung 2  Xet           OPT-IN ONLY (``ALLOW_XET=1`` / ``pull.sh --allow-xet``)
+                          and only when ``hf_xet`` is ALREADY importable — this
+                          module NEVER installs it. Xet has a stall/corruption
+                          history on this stack, so a mandatory INDEPENDENT
+                          sha256 gate runs afterwards.
+    rung 3  raw resolve   single-stream ``curl -L -C - --retry-all-errors``
+                          against the *resolve* endpoint, stall watchdog, then
+                          the same mandatory sha256 gate.
+
+Guardrails that are not negotiable here:
+
+* **No parallel-chunk downloaders.** ``aria2c`` silently corrupts multi-GB
+  files (right size, wrong bytes) — it must never appear in any rung. Guarded
+  by ``test-pull-download-ladder.sh``.
+* **Rung 2 never engages silently.** No opt-in -> announce why it was skipped
+  and fall to rung 3.
+* **Re-resolve per retry.** The 302 target is a *signed* CAS URL that expires
+  (``Expires=`` ~3600 s). Resume must therefore go through
+  ``huggingface.co/<repo>/resolve/<rev>/<file>`` on every attempt and let curl
+  follow the redirect afresh — caching the signed URL turns a 6-hour resume
+  into a 403. Guarded by a test on the curl argv.
+* **A rung-2/rung-3 artifact that fails sha256 is DELETED**, not left on disk
+  for someone to serve.
+* Every rung announces which rung ran and what was verified, so logs are
+  auditable.
+
+#812 — verify-in-place + announce WHY
+-------------------------------------
 A file placed by hand has no ``.cache/huggingface/download/<f>.metadata`` beside
 it, so the downloader cannot tell "complete" from "half-copied 40 GB" and
-re-pulls it — silently, for hours (Discord report: setup/pull re-downloading a
-model that was already at the target path). The instinct is right; the silence
-is the bug. So:
+re-pulls. The instinct is right; the silence is the bug. So:
 
 * **The announcement is unconditional.** Nothing here starts a transfer without
   first printing one honest line per present file saying what was found and
@@ -16,14 +61,9 @@ is the bug. So:
   on this rig once printed "DONE (hash-verified)" over silent corruption at the
   correct size, and that is exactly the failure this module refuses to repeat.
 
-Wording contract (asserted by ``test-pull-verify-in-place.sh``): the token
-``verified`` appears in an announcement **only** when a sha256 was actually
-computed and compared. A size-only observation says "size matches" and nothing
-stronger.
-
-The hub-metadata plumbing here (repo tree API, the non-redirect resolve HEAD,
-the sha256 helpers) is deliberately generic — the download resilience ladder
-(#804) is built on the same three primitives.
+Wording contract (asserted by the tests): the token ``verified`` appears in an
+announcement **only** when a sha256 was actually computed and compared. A
+size-only observation says "size matches" and nothing stronger.
 
 Stdlib only — this runs under the bare ``python3`` that ``scripts/pull.sh``
 uses, where ``huggingface_hub`` is NOT importable (it exists on this rig only as
@@ -36,18 +76,35 @@ import fnmatch
 import hashlib
 import json
 import os
-import time
+import re
+import shutil
+import subprocess
 import sys
+import threading
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Iterable, Optional
 
 _HF = "https://huggingface.co"
 _NET_TIMEOUT = 60
 _SHA_CHUNK = 8 * 1024 * 1024
+
+# The verbatim client-side refusal (hf 1.25.1 file_download.py). Matched on a
+# lowercased haystack; both markers must be present so an unrelated "too large"
+# from the filesystem or a proxy cannot false-trigger an escalation.
+_XET_REFUSAL_MARKERS = (
+    "too large to be downloaded using the regular download method",
+    "hf_xet",
+)
+
+# The wall's real trigger, for the honest announcement (NOT a Xet property per
+# se: any file over this size is refused on the classic HTTP path, Xet-backed
+# repo or not). huggingface_hub constants.MAX_HTTP_DOWNLOAD_SIZE.
+MAX_HTTP_DOWNLOAD_SIZE = 50 * 1000 * 1000 * 1000
 
 
 # ---------------------------------------------------------------------------
@@ -74,10 +131,61 @@ def short_sha(s: Optional[str]) -> str:
     return f"{s[:12]}…" if s else "?"
 
 
+# ---------------------------------------------------------------------------
+# Xet refusal signature
+# ---------------------------------------------------------------------------
+def is_xet_refusal(blob: str) -> bool:
+    """True iff `blob` (a merged stdout+stderr of a failed `hf download`) is the
+    client-side too-large refusal, NOT ordinary flakiness. Both markers are
+    required — retrying this is futile, so a false positive would send a
+    recoverable network error down the slow fallback and a false negative would
+    burn 30 opaque retries on a hard policy wall."""
+    low = (blob or "").lower()
+    return all(m in low for m in _XET_REFUSAL_MARKERS)
+
+
+def hf_xet_importable(python: Optional[str] = None) -> bool:
+    """Is `hf_xet` ALREADY importable in the environment the `hf` CLI runs under?
+
+    Deliberately a probe, never an install: rung 2 is opt-in *and* BYO-package.
+    The `hf` CLI on this rig is a `uv tool` / pipx venv, so we probe the
+    interpreter that sits beside the resolved `hf` binary; failing that, our
+    own. A probe failure reads as "not importable" (fall to rung 3), never as
+    an exception."""
+    cands: list[str] = []
+    if python:
+        cands.append(python)
+    hf_bin = shutil.which("hf") or shutil.which("huggingface-cli")
+    if hf_bin:
+        sibling = Path(hf_bin).resolve().parent / "python3"
+        if sibling.exists():
+            cands.append(str(sibling))
+    cands.append(sys.executable or "python3")
+    for exe in cands:
+        try:
+            proc = subprocess.run(
+                [exe, "-c", "import hf_xet"],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                timeout=30,
+            )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if proc.returncode == 0:
+            return True
+    return False
+
+
+def allow_xet_enabled(env: Optional[dict] = None) -> bool:
+    """Operator opt-in for rung 2. `pull.sh --allow-xet` exports
+    CLUB3090_ALLOW_XET; the bare ALLOW_XET=1 from the issue is honoured too."""
+    e = os.environ if env is None else env
+    return (e.get("CLUB3090_ALLOW_XET") or e.get("ALLOW_XET") or "") == "1"
+
+
 def verify_in_place_enabled(env: Optional[dict] = None) -> bool:
-    """Opt-in for hashing an already-present file instead of re-downloading it.
-    The *announcement* is unconditional and does not consult this — only the
-    decision to spend a full read of a multi-GB file does."""
+    """Opt-in for hashing an already-present file instead of re-downloading it
+    (#812 item 2). The *announcement* (item 1) is unconditional and does not
+    consult this."""
     e = os.environ if env is None else env
     return (e.get("CLUB3090_VERIFY_IN_PLACE") or e.get("VERIFY_IN_PLACE")
             or "") == "1"
@@ -457,3 +565,474 @@ def plan_and_announce(local_dir: Path, names: Iterable[str],
     return entries
 
 
+# ---------------------------------------------------------------------------
+# #804 — the ladder
+# ---------------------------------------------------------------------------
+def preflight_transport(names: Iterable[str],
+                        meta: dict[str, FileMeta]) -> tuple[str, str]:
+    """Will the classic path be REFUSED for this pull? `(verdict, message)`.
+
+    Answered from published sizes BEFORE a byte moves, so the operator sees
+    "this repo needs Xet or the fallback" up front instead of watching a
+    doomed rung-1 attempt (#804 acceptance bullet 3). `verdict` is "classic"
+    (nothing over the wall) or "needs-fallback"."""
+    over = [(n, meta[n].size) for n in names
+            if meta.get(n) and (meta[n].size or 0) > MAX_HTTP_DOWNLOAD_SIZE]
+    if not over:
+        return "classic", ""
+    listed = ", ".join(f"{n} ({human_bytes(s)})" for n, s in over[:3])
+    more = f" (+{len(over) - 3} more)" if len(over) > 3 else ""
+    # Say "50 GB" — upstream defines the constant decimally (50 * 1000**3), so
+    # rendering it in binary units ("46.57 GB") would not match the number in
+    # anyone's error message or in huggingface_hub's own source.
+    return "needs-fallback", (
+        f"{len(over)} file(s) exceed the 50 GB ceiling huggingface_hub "
+        f"enforces on the classic HTTP path — "
+        f"{listed}{more}. Rung 1 will be REFUSED client-side (a policy wall, "
+        f"not flakiness, so retries cannot help). This will escalate: rung 3 "
+        f"(single-stream resumable curl, ~5 MB/s, always works), or rung 2 "
+        f"(Xet, faster) if you pass --allow-xet and hf_xet is installed.")
+
+
+class LadderError(RuntimeError):
+    """A rung failed in a way the ladder cannot escalate past. `.token` maps to
+    the caller's structured failure vocabulary."""
+
+    def __init__(self, token: str, detail: str = ""):
+        super().__init__(detail or token)
+        self.token = token
+        self.detail = detail
+
+
+@dataclass
+class LadderResult:
+    ok: bool
+    rung: str = ""                 # "classic" | "xet" | "raw-resolve"
+    files: list[str] = field(default_factory=list)
+    verified: list[str] = field(default_factory=list)
+    hash_source: str = ""          # "api" | "resolve-head" | ""
+    failure: Optional[str] = None
+    detail: str = ""
+    notes: list[str] = field(default_factory=list)
+
+
+def _curl_bin() -> Optional[str]:
+    return shutil.which("curl")
+
+
+def curl_argv(repo_id: str, filename: str, dest: Path, *,
+              revision: str = "main", token: Optional[str] = None,
+              connect_timeout: int = 30, curl: str = "curl") -> list[str]:
+    """Rung 3's exact command line, as its own function so a test can assert
+    the shape without running it.
+
+    Two properties are load-bearing:
+      * the URL is the **resolve endpoint**, never a signed CAS URL — curl
+        re-follows the 302 on every invocation, so a resume hours later gets a
+        fresh signature instead of a 403 on an `Expires`d one;
+      * `-C -` + a single stream. No `-Z`, no range splitting, no aria2c —
+        parallel-chunk fetchers have silently corrupted multi-GB files on this
+        rig (right size, wrong bytes)."""
+    url = f"{_HF}/{repo_id}/resolve/{revision}/{urllib.parse.quote(filename)}"
+    argv = [
+        curl, "-L",                       # follow the 302 afresh each attempt
+        "-C", "-",                        # resume from whatever is on disk
+        "--retry-all-errors", "--retry", "5", "--retry-delay", "5",
+        "--connect-timeout", str(connect_timeout),
+        "--fail",                         # an HTTP error is a non-zero exit
+        "-sS",                            # no \r progress spam; the watchdog
+                                          # reports growth on its own line
+        "-o", str(dest),
+    ]
+    if token:
+        argv += ["-H", f"Authorization: Bearer {token}"]
+    argv.append(url)
+    return argv
+
+
+def _run_with_stall_watchdog(argv: list[str], watch: Path, *,
+                             stall_timeout: int,
+                             log: Callable[[str], None],
+                             runner: Optional[Callable] = None,
+                             progress_every: int = 60) -> int:
+    """Run `argv`, killing it if `watch` stops growing for `stall_timeout`.
+
+    A silent hang (rate-limit, dead peer, a lock wait) produces no error on its
+    own — only a watchdog turns it into a retryable failure. The same thread
+    emits a periodic line-oriented progress note, because curl runs with `-sS`
+    (a `\\r` progress meter would shred the c3 lane's line reader, and a
+    multi-hour download that prints nothing is the opaque-download complaint
+    this whole change exists to fix). `runner` is injectable so tests exercise
+    the ladder without spawning curl."""
+    if runner is not None:
+        return int(runner(argv, watch))
+    proc = subprocess.Popen(argv, stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT, text=True,
+                            encoding="utf-8")
+    stop = threading.Event()
+
+    def _watch() -> None:
+        last, flat, since_report = -1, 0, 0
+        while not stop.wait(15):
+            try:
+                cur = watch.stat().st_size
+            except OSError:
+                cur = 0
+            if cur > last:
+                last, flat = cur, 0
+            else:
+                flat += 15
+            since_report += 15
+            if since_report >= progress_every:
+                since_report = 0
+                log(f"[hf-fetch]   {watch.name}: {human_bytes(cur)} on disk")
+            if stall_timeout > 0 and flat >= stall_timeout:
+                log(f"[hf-fetch] no byte growth for {stall_timeout}s "
+                    f"({human_bytes(cur)} on disk) — killing the stalled "
+                    f"attempt; the retry resumes from here")
+                try:
+                    proc.kill()
+                except OSError:          # pragma: no cover - defensive
+                    pass
+                return
+
+    t = threading.Thread(target=_watch, daemon=True)
+    t.start()
+    try:
+        out, _ = proc.communicate()
+    finally:
+        stop.set()
+    if proc.returncode != 0 and out:
+        log(f"[hf-fetch] curl: {out.strip()[-400:]}")
+    return int(proc.returncode)
+
+
+def raw_resolve_fetch(repo_id: str, filename: str, local_dir: Path, *,
+                      revision: str = "main", token: Optional[str] = None,
+                      stall_timeout: int = 300, max_retries: int = 6,
+                      expected_size: Optional[int] = None,
+                      log: Callable[[str], None] = default_log,
+                      runner: Optional[Callable] = None) -> Path:
+    """Rung 3 for ONE file: single-stream resumable curl against the resolve
+    endpoint, re-resolved on every attempt, with a stall watchdog.
+
+    Raises `LadderError` on exhaustion. Does NOT verify — the caller runs the
+    mandatory sha256 gate over everything the rung produced, so verification
+    can never be skipped per-file by accident."""
+    curl = _curl_bin()
+    if curl is None and runner is None:
+        raise LadderError(
+            "fallback-unavailable",
+            "the raw-resolve fallback needs `curl` on PATH (install it, or "
+            "opt into rung 2 with --allow-xet if hf_xet is installed)")
+    dest = Path(local_dir) / filename
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    argv = curl_argv(repo_id, filename, dest, revision=revision, token=token,
+                     curl=curl or "curl")
+    for attempt in range(1, max_retries + 1):
+        # `-C -` against an already-complete file gets a 416 and `--fail` turns
+        # that into a non-zero exit — a resume that finished on the previous
+        # attempt would otherwise look like a failure. Size agreement is NOT
+        # trust: the mandatory sha256 gate still runs over this file.
+        if expected_size is not None:
+            try:
+                if dest.stat().st_size == expected_size:
+                    return dest
+            except OSError:
+                pass
+        rc = _run_with_stall_watchdog(argv, dest, stall_timeout=stall_timeout,
+                                      log=log, runner=runner)
+        if rc == 0:
+            return dest
+        if attempt >= max_retries:
+            raise LadderError(
+                "fallback-failed",
+                f"curl gave up on {filename} after {max_retries} attempts "
+                f"(last rc={rc})")
+        log(f"[hf-fetch] rung 3: {filename} attempt {attempt}/{max_retries} "
+            f"failed (rc={rc}) — retrying in 8s (re-resolving the URL; the "
+            f"signed CAS link expires, the resolve endpoint does not)")
+        time.sleep(8 if runner is None else 0)
+    raise LadderError("fallback-failed", filename)  # pragma: no cover
+
+
+def verify_fetched(local_dir: Path, names: Iterable[str],
+                   meta: dict[str, FileMeta], *,
+                   log: Callable[[str], None] = default_log,
+                   rung: str,
+                   hasher: Callable[[Path], str] = sha256_file) -> list[str]:
+    """The MANDATORY sha256 gate for rungs 2 and 3.
+
+    Rung 1 delegates integrity to `hf download` (which hashes as it writes);
+    rungs 2 and 3 do not get that for free, and both have a corruption story on
+    this rig, so every file they produce is hashed here against the hub's
+    published sha256. A mismatch DELETES the artifact and raises — a corrupt
+    multi-GB weight left on disk is worse than no weight, because someone will
+    serve it.
+
+    A file the hub publishes no sha256 for is an unverifiable-artifact hard
+    fail on these rungs; it is NOT quietly waved through."""
+    verified: list[str] = []
+    for name in names:
+        fp = Path(local_dir) / name
+        m = meta.get(name)
+        if m is None or not m.sha256:
+            try:
+                fp.unlink()
+            except OSError:
+                pass
+            raise LadderError(
+                "no-etag",
+                f"rung {rung} fetched {name} but the hub publishes no sha256 "
+                f"for it — refusing to trust an unverifiable artifact "
+                f"(deleted)")
+        actual = hasher(fp)
+        if actual.lower() != m.sha256:
+            try:
+                fp.unlink()
+            except OSError:
+                pass
+            raise LadderError(
+                "sha-mismatch",
+                f"rung {rung} fetched {name} but sha256 {short_sha(actual)} "
+                f"!= the hub's {short_sha(m.sha256)} — artifact DELETED")
+        verified.append(name)
+        log(f"[hf-fetch] sha256 OK: {name} ({short_sha(m.sha256)}, "
+            f"source={m.source or 'hub'})")
+    return verified
+
+
+def escalate(repo_id: str, local_dir: Path, includes: list[str], *,
+             classic_error: str,
+             meta: Optional[dict[str, FileMeta]] = None,
+             revision: str = "main",
+             allow_xet: Optional[bool] = None,
+             token: Optional[str] = None,
+             log: Callable[[str], None] = default_log,
+             xet_runner: Optional[Callable] = None,
+             curl_runner: Optional[Callable] = None,
+             xet_available: Optional[Callable[[], bool]] = None,
+             tree_fn: Optional[Callable] = None,
+             stall_timeout: int = 300) -> LadderResult:
+    """Rungs 2 and 3, entered ONLY after rung 1 hit the too-large refusal.
+
+    Each rung announces why the previous one could not deliver, so a log shows
+    the whole decision chain rather than a bare "downloading (again)"."""
+    token = token if token is not None else _token()
+    allow = allow_xet_enabled() if allow_xet is None else allow_xet
+    notes: list[str] = []
+
+    log("[hf-fetch] rung 1 (classic LFS) REFUSED this repo: huggingface_hub "
+        "client-side blocks the plain HTTP path for files over 50 GB. This is "
+        "a hard policy wall, not flakiness — retrying it cannot succeed.")
+    if classic_error:
+        log(f"[hf-fetch]   hub said: {classic_error.strip()[:300]}")
+
+    # --- enumerate the concrete files (curl fetches one named file at a time)
+    metas: dict[str, FileMeta] = dict(meta or {})
+    if not metas:
+        tf = tree_fn or (lambda: repo_tree(repo_id, revision=revision,
+                                           token=token))
+        metas = tree_meta(tf())
+    names = expand_includes(metas.keys(), includes) if metas else []
+    if not names:
+        # No tree -> fall back to treating literal (non-glob) includes as names
+        # and pricing them from a per-file resolve HEAD.
+        names = [p for p in includes if not any(c in p for c in "*?[")]
+        for n in names:
+            metas.setdefault(n, resolve_head(repo_id, n, revision=revision,
+                                             token=token))
+    if not names:
+        raise LadderError(
+            "fallback-failed",
+            "could not enumerate the repo tree, so the fallback has no "
+            "concrete filenames to fetch (network down, or the repo is gated)")
+    log(f"[hf-fetch] escalating for {len(names)} file(s): "
+        f"{', '.join(names[:4])}{' …' if len(names) > 4 else ''}")
+
+    # --- rung 2: Xet, opt-in only, never auto-installed --------------------
+    avail_fn = xet_available or hf_xet_importable
+    if not allow:
+        notes.append("rung 2 (Xet) skipped: not opted in")
+        log("[hf-fetch] rung 2 (Xet) SKIPPED — operator opt-in required "
+            "(ALLOW_XET=1 or pull.sh --allow-xet). Xet has a stall/restart-"
+            "from-zero history on this stack, so it never engages silently.")
+    elif not avail_fn():
+        notes.append("rung 2 (Xet) skipped: hf_xet not importable")
+        log("[hf-fetch] rung 2 (Xet) SKIPPED — opted in, but `hf_xet` is not "
+            "importable in the hf CLI's environment. This never auto-installs "
+            "it; run `uv tool install --with hf_xet huggingface-hub` (or "
+            "`pipx inject huggingface-hub hf_xet`) yourself to enable it.")
+    else:
+        log("[hf-fetch] rung 2 (Xet) — opted in and hf_xet is importable; "
+            "retrying the SAME `hf download` with Xet enabled. An independent "
+            "sha256 gate runs afterwards regardless of what it reports.")
+        rc, blob = _hf_download(repo_id, local_dir, includes, xet=True,
+                               runner=xet_runner)
+        if rc == 0:
+            verified = verify_fetched(local_dir, names, metas, log=log,
+                                      rung="2 (Xet)")
+            src = next((metas[n].source for n in verified if metas.get(n)), "")
+            log(f"[hf-fetch] DONE via rung 2 (Xet) — {len(verified)} file(s), "
+                f"sha256-verified against the hub's published hashes "
+                f"({src or 'hub'}).")
+            return LadderResult(ok=True, rung="xet", files=list(names),
+                                verified=verified, hash_source=src,
+                                notes=notes)
+        notes.append(f"rung 2 (Xet) failed rc={rc}")
+        log(f"[hf-fetch] rung 2 (Xet) FAILED (rc={rc}) — falling through to "
+            f"the raw-resolve fallback. {blob.strip()[:200]}")
+
+    # --- rung 3: raw resolve + curl ---------------------------------------
+    log("[hf-fetch] rung 3 (raw resolve + curl) — single-stream, resumable, "
+        "re-resolved per retry. Slower than either rung above (~5 MB/s "
+        "observed) but universal. No parallel-chunk downloader is used: they "
+        "have corrupted multi-GB files on this stack at the correct size.")
+    for n in names:
+        m = metas.get(n)
+        log(f"[hf-fetch] rung 3: fetching {n} ({human_bytes(m.size if m else None)})")
+        raw_resolve_fetch(repo_id, n, local_dir, revision=revision,
+                          token=token, log=log, runner=curl_runner,
+                          stall_timeout=stall_timeout,
+                          expected_size=(m.size if m else None))
+    verified = verify_fetched(local_dir, names, metas, log=log,
+                              rung="3 (raw resolve)")
+    src = next((metas[n].source for n in verified if metas.get(n)), "")
+    log(f"[hf-fetch] DONE via rung 3 (raw resolve) — {len(verified)} file(s), "
+        f"sha256-verified against the hub's published hashes "
+        f"({src or 'hub'}).")
+    return LadderResult(ok=True, rung="raw-resolve", files=list(names),
+                        verified=verified, hash_source=src, notes=notes)
+
+
+def _hf_download(repo_id: str, local_dir: Path, includes: list[str], *,
+                 xet: bool, runner: Optional[Callable] = None) -> tuple[int, str]:
+    """One `hf download` invocation. `xet=False` is the classic path
+    (HF_HUB_DISABLE_XET=1); `xet=True` is rung 2. Returns (rc, stdout+stderr)."""
+    if runner is not None:
+        return runner(repo_id, str(local_dir), list(includes), xet)
+    hf = shutil.which("hf") or shutil.which("huggingface-cli")
+    if hf is None:
+        return 127, "neither `hf` nor `huggingface-cli` is on PATH"
+    argv = [hf, "download", repo_id, "--local-dir", str(local_dir)]
+    for pat in includes:
+        argv += ["--include", pat]
+    env = dict(os.environ)
+    env["HF_HUB_DISABLE_XET"] = "0" if xet else "1"
+    env.setdefault("HF_HUB_DOWNLOAD_TIMEOUT", "30")
+    tok = _token()
+    if tok:
+        env.setdefault("HF_TOKEN", tok)
+    proc = subprocess.run(argv, env=env, stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE, text=True, encoding="utf-8")
+    return proc.returncode, f"{proc.stdout or ''}\n{proc.stderr or ''}"
+
+
+def fetch(repo_id: str, local_dir: Path, includes: list[str], *,
+          revision: str = "main", allow_xet: Optional[bool] = None,
+          do_verify_in_place: Optional[bool] = None,
+          token: Optional[str] = None,
+          log: Callable[[str], None] = default_log) -> LadderResult:
+    """The whole thing, for callers that are NOT `downloader.download_model`:
+    preflight -> announce/verify-in-place -> rung 1 -> escalate on the refusal.
+
+    `download_model` drives the rungs itself (it owns atomic staging and the
+    CONTRACT-3 failure vocabulary); this is the standalone entry the module CLI
+    exposes so a GGUF pull or a shell script gets the same ladder + the same
+    honest announcements without reimplementing either."""
+    token = token if token is not None else _token()
+    allow = allow_xet_enabled() if allow_xet is None else allow_xet
+    do_hash = (verify_in_place_enabled() if do_verify_in_place is None
+               else do_verify_in_place)
+    local_dir = Path(local_dir)
+    local_dir.mkdir(parents=True, exist_ok=True)
+
+    metas = tree_meta(repo_tree(repo_id, revision=revision, token=token))
+    names = expand_includes(metas.keys(), includes) if metas else list(includes)
+    if metas and not names:
+        return LadderResult(ok=False, failure="fallback-failed",
+                            detail=f"no file in {repo_id} matches {includes}")
+
+    verdict, note = preflight_transport(names, metas)
+    if verdict == "needs-fallback":
+        log(f"[hf-fetch] preflight: {note}")
+
+    plan = plan_and_announce(local_dir, names, metas, do_hash=do_hash, log=log,
+                             prefix="[hf-fetch]")
+    todo = [e.name for e in plan if e.action == "download"]
+    adopted = [e.name for e in plan if e.action == "adopt"]
+    if not todo:
+        log(f"[hf-fetch] SKIPPED — all {len(names)} file(s) already present "
+            f"and accounted for. 0 bytes re-downloaded.")
+        return LadderResult(ok=True, rung="", files=list(names),
+                            verified=[e.name for e in plan if e.hashed])
+    log(f"[hf-fetch] starting: {repo_id} -> {local_dir} "
+        f"({len(todo)} file(s) to fetch"
+        + (f", {len(adopted)} kept" if adopted else "") + ")")
+
+    rc, blob = _hf_download(repo_id, local_dir, todo, xet=False)
+    if rc == 0:
+        log(f"[hf-fetch] DONE via rung 1 (classic LFS) — {len(todo)} file(s); "
+            f"`hf download` hashes as it writes, so no separate gate is run "
+            f"on this rung.")
+        return LadderResult(ok=True, rung="classic", files=list(names))
+    if not is_xet_refusal(blob):
+        return LadderResult(ok=False, failure="fallback-failed",
+                            detail=f"rung 1 failed (rc={rc}): "
+                                   f"{blob.strip()[-400:]}")
+    try:
+        return escalate(repo_id, local_dir, todo, classic_error=blob,
+                        meta=metas, revision=revision, allow_xet=allow,
+                        token=token, log=log)
+    except LadderError as exc:
+        log(f"[hf-fetch] FAILED: {exc.detail or exc.token}")
+        return LadderResult(ok=False, failure=exc.token, detail=exc.detail)
+
+
+def _main(argv: list[str]) -> int:
+    """`python3 scripts/lib/profiles/hf_fetch.py <repo> --local-dir DIR ...`
+
+    A thin CLI over `fetch()` / `preflight_transport()`, so surfaces that
+    shell out to `hf download` directly can adopt the ladder + the honest
+    announcements without importing anything."""
+    import argparse
+
+    ap = argparse.ArgumentParser(
+        prog="hf_fetch.py",
+        description="HF download with the #804 resilience ladder and the "
+                    "#812 verify-in-place / announce-why preflight.")
+    ap.add_argument("repo")
+    ap.add_argument("--local-dir", required=True)
+    ap.add_argument("--include", action="append", default=[],
+                    help="glob or exact filename; repeatable (default: all)")
+    ap.add_argument("--revision", default="main")
+    ap.add_argument("--allow-xet", action="store_true",
+                    help="permit rung 2 (needs hf_xet already installed; "
+                         "this never installs it)")
+    ap.add_argument("--verify-in-place", action="store_true",
+                    help="sha256 an already-present file and adopt it on a "
+                         "match instead of re-downloading")
+    ap.add_argument("--preflight", action="store_true",
+                    help="report whether the classic path can serve this "
+                         "pull, then exit")
+    args = ap.parse_args(argv)
+
+    includes = args.include or ["*"]
+    if args.preflight:
+        metas = tree_meta(repo_tree(args.repo, revision=args.revision,
+                                    token=_token()))
+        names = expand_includes(metas.keys(), includes)
+        verdict, note = preflight_transport(names, metas)
+        print(f"transport: {verdict}")
+        if note:
+            print(note)
+        return 0
+
+    res = fetch(args.repo, Path(args.local_dir), includes,
+                revision=args.revision, allow_xet=args.allow_xet or None,
+                do_verify_in_place=args.verify_in_place or None)
+    return 0 if res.ok else 1
+
+
+if __name__ == "__main__":       # pragma: no cover - CLI wrapper
+    sys.exit(_main(sys.argv[1:]))

--- a/scripts/pull.sh
+++ b/scripts/pull.sh
@@ -32,10 +32,25 @@
 #
 # Opts: --yes  --force-download  --experimental-arch  --trust-remote-code
 #       --hf-home DIR  --out FILE (Path A)  --hardware SM (override nvidia-smi)
-#       --verify-in-place                (download behaviour — see below)
+#       --allow-xet  --verify-in-place   (download behaviour — see below)
 #
-# Download behaviour flag (club-3090 #812)
+# Download behaviour flags (club-3090 #804 / #812)
 # -------------------------------------------------------------------------
+#   --allow-xet         Permit rung 2 of the download ladder. The classic LFS
+#                       path (rung 1) is always tried first; if huggingface_hub
+#                       CLIENT-SIDE refuses it ("The file is too large to be
+#                       downloaded using the regular download method" — a hard
+#                       policy wall for files over 50 GB, not flakiness), this
+#                       flag lets the retry run with Xet enabled, but ONLY if
+#                       `hf_xet` is already importable. Nothing here ever
+#                       installs it. Xet has a stall / restart-from-zero history
+#                       on this stack, so it never engages without this flag,
+#                       and an independent sha256 gate runs afterwards either
+#                       way. Without the flag the ladder falls straight to
+#                       rung 3 (single-stream resumable curl against the
+#                       resolve endpoint) — slower, but universal.
+#                       Env equivalent: ALLOW_XET=1.
+#
 #   --verify-in-place   When a target file is ALREADY at the destination with no
 #                       HF download metadata beside it (hand-placed weights),
 #                       sha256 it against the hub instead of re-downloading, and
@@ -90,14 +105,17 @@ export PYTHONUTF8="${PYTHONUTF8:-1}"
 
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# Download-behaviour flag (#812). Stripped HERE and turned into env, so every
-# downstream path — the gate, --json, --apply-swap — sees an argv it already
-# understands and `pull.py`'s parser is untouched. The bare VERIFY_IN_PLACE env
-# var from the issue keeps working on its own; the flag just sets it for one
-# invocation. Default OFF: in-place hashing costs a full read of a multi-GB file.
+# Download-behaviour flags (#804 / #812). Stripped HERE and turned into env, so
+# every downstream path — the gate, --json, --apply-swap — sees an argv it
+# already understands and `pull.py`'s parser is untouched. The bare ALLOW_XET /
+# VERIFY_IN_PLACE env vars from the issues keep working on their own; the flags
+# just set them for one invocation. Both default OFF: Xet is opt-in because of
+# its stall history here, and in-place hashing is opt-in because it costs a full
+# read of a multi-GB file.
 _pull_dlargs=()
 for _a in "$@"; do
     case "$_a" in
+        --allow-xet)        export CLUB3090_ALLOW_XET=1 ;;
         --verify-in-place)  export CLUB3090_VERIFY_IN_PLACE=1 ;;
         *)                  _pull_dlargs+=("$_a") ;;
     esac

--- a/scripts/pull.sh
+++ b/scripts/pull.sh
@@ -32,6 +32,20 @@
 #
 # Opts: --yes  --force-download  --experimental-arch  --trust-remote-code
 #       --hf-home DIR  --out FILE (Path A)  --hardware SM (override nvidia-smi)
+#       --verify-in-place                (download behaviour — see below)
+#
+# Download behaviour flag (club-3090 #812)
+# -------------------------------------------------------------------------
+#   --verify-in-place   When a target file is ALREADY at the destination with no
+#                       HF download metadata beside it (hand-placed weights),
+#                       sha256 it against the hub instead of re-downloading, and
+#                       adopt it on a match (0 bytes over the wire). Off by
+#                       default because hashing a 40 GB file costs a full read.
+#                       The *announcement* of what was found and why a download
+#                       is (or isn't) starting is UNCONDITIONAL — this flag only
+#                       controls whether the hash is computed. A size match
+#                       alone is never treated as, or reported as, verification.
+#                       Env equivalent: VERIFY_IN_PLACE=1.
 #
 # All decision logic lives in scripts/lib/profiles/pull.py (this is a thin
 # argv pass-through, matching the generate-compose.sh / diagnose-profile.sh
@@ -75,6 +89,20 @@ set -euo pipefail
 export PYTHONUTF8="${PYTHONUTF8:-1}"
 
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Download-behaviour flag (#812). Stripped HERE and turned into env, so every
+# downstream path — the gate, --json, --apply-swap — sees an argv it already
+# understands and `pull.py`'s parser is untouched. The bare VERIFY_IN_PLACE env
+# var from the issue keeps working on its own; the flag just sets it for one
+# invocation. Default OFF: in-place hashing costs a full read of a multi-GB file.
+_pull_dlargs=()
+for _a in "$@"; do
+    case "$_a" in
+        --verify-in-place)  export CLUB3090_VERIFY_IN_PLACE=1 ;;
+        *)                  _pull_dlargs+=("$_a") ;;
+    esac
+done
+set -- "${_pull_dlargs[@]+"${_pull_dlargs[@]}"}"
 
 # Intercept --json (strictly additive). Absent -> the original exec path,
 # byte-identical. Present -> strip it and hand the remaining argv to the

--- a/scripts/tests/test-pull-download-ladder.sh
+++ b/scripts/tests/test-pull-download-ladder.sh
@@ -1,0 +1,500 @@
+#!/usr/bin/env bash
+# test-pull-download-ladder.sh — the #804 download resilience ladder.
+#
+# The ladder exists because huggingface_hub CLIENT-SIDE refuses the classic
+# (non-Xet) HTTP path for files over 50 GB — verbatim, from hf 1.25.1:
+#
+#   The file is too large to be downloaded using the regular download method.
+#    Install `hf_xet` with `pip install hf_xet` for xet-powered downloads.
+#
+# ...while the server serves the bytes fine (resolve 302 -> CAS, HTTP 200,
+# resumable, sha256 in x-linked-etag). Hit in the wild on a 96 GB single-file
+# GGUF. Retrying rung 1 cannot succeed, so the ladder escalates instead.
+#
+# Asserted here (all hermetic — NO network, NO multi-GB transfer, every rung's
+# transport injected):
+#   1. the refusal signature is recognised, and ordinary flakiness is NOT
+#      (a false positive sends a recoverable error down the slow path; a false
+#      negative burns 30 opaque retries on a hard wall);
+#   2. rung 1 success does NOT escalate — the classic path stays first and
+#      unchanged, and Xet is never touched;
+#   3. NO opt-in -> rung 2 is SKIPPED with the reason announced, rung 3 runs;
+#   4. opt-in but hf_xet not importable -> skipped, and NOTHING auto-installs;
+#   5. opt-in + hf_xet importable -> rung 2 runs, followed by the MANDATORY
+#      independent sha256 gate;
+#   6. a rung-2/rung-3 artifact whose sha256 mismatches HARD-FAILS and is
+#      DELETED (a corrupt weight left on disk is worse than none — someone
+#      will serve it);
+#   7. a file the hub publishes no sha256 for is an unverifiable-artifact hard
+#      fail on the fallback rungs, never waved through;
+#   8. rung 3's curl argv is single-stream + resumable and points at the
+#      RESOLVE endpoint, never a signed CAS URL (those expire in ~3600 s, so a
+#      cached one turns a long resume into a 403);
+#   9. NO parallel-chunk downloader appears anywhere in the executable path —
+#      aria2c has silently corrupted multi-GB files on this rig at the correct
+#      size, so it is banned by test, not by convention;
+#  10. end-to-end through downloader.download_model: the refusal escalates,
+#      the result reports which rung delivered, and the ladder's verification
+#      is not silently re-done on a 96 GB file.
+set -euo pipefail
+
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+export PYTHONPATH="$ROOT_DIR${PYTHONPATH:+:$PYTHONPATH}"
+
+python3 - "$ROOT_DIR" <<'PY'
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+import sys
+import tempfile
+import tokenize
+from pathlib import Path
+from types import SimpleNamespace
+
+root = Path(sys.argv[1])
+sys.path.insert(0, str(root))
+
+from scripts.lib.profiles import downloader as DL     # noqa: E402
+from scripts.lib.profiles import hf_fetch as HF       # noqa: E402
+from scripts.lib.profiles.einput import EInput        # noqa: E402
+
+failures: list[str] = []
+
+
+def check(cond, msg: str) -> None:
+    if cond:
+        print(f"PASS: {msg}")
+    else:
+        print(f"FAIL: {msg}", file=sys.stderr)
+        failures.append(msg)
+
+
+# The verbatim refusal, as `hf download` surfaces it (issue #804 body).
+REFUSAL = (
+    "Error: Invalid value. The file is too large to be downloaded using the "
+    "regular download method. Install hf_xet with pip install hf_xet for "
+    "xet-powered downloads."
+)
+BIG = "laguna-s-2.1-Q4_K_M.gguf"
+BODY = b"NINETY-SIX-GIGABYTES-PRETEND"
+SHA = hashlib.sha256(BODY).hexdigest()
+TREE = [{"type": "file", "path": BIG, "size": len(BODY),
+         "lfs": {"sha256": SHA, "size": len(BODY)}}]
+
+
+class Log:
+    """Capture the announcements; the ladder's auditability IS the feature."""
+
+    def __init__(self):
+        self.lines: list[str] = []
+
+    def __call__(self, msg: str) -> None:
+        self.lines.append(str(msg))
+
+    def text(self) -> str:
+        return "\n".join(self.lines)
+
+
+def curl_runner_ok(body=BODY):
+    """Stand in for curl: honour `-o <dest>` and write `body`. Records argv."""
+    seen = {"argv": None, "calls": 0}
+
+    def _run(argv, dest):
+        seen["argv"] = list(argv)
+        seen["calls"] += 1
+        Path(dest).parent.mkdir(parents=True, exist_ok=True)
+        Path(dest).write_bytes(body)
+        return 0
+
+    _run.seen = seen
+    return _run
+
+
+# ---------------------------------------------------------------------------
+# 1. refusal signature — precise, both directions.
+# ---------------------------------------------------------------------------
+check(HF.is_xet_refusal(REFUSAL),
+      "the verbatim too-large refusal is recognised as a hard wall")
+check(HF.is_xet_refusal(REFUSAL.upper()),
+      "signature match is case-insensitive (CLI casing varies)")
+for transient in (
+    "ConnectionResetError: [Errno 104] Connection reset by peer",
+    "requests.exceptions.ReadTimeout: HTTPSConnectionPool(...)",
+    "OSError: [Errno 28] No space left on device",
+    "the file is too large for this filesystem",     # 'too large', no hf_xet
+    "Xet Storage is enabled for this repo, but the 'hf_xet' package is not "
+    "installed.",                                     # a WARNING, not the wall
+):
+    check(not HF.is_xet_refusal(transient),
+          f"ordinary failure is NOT mistaken for the wall: {transient[:44]!r}")
+
+# ---------------------------------------------------------------------------
+# 2. rung 1 success does not escalate (classic stays first and untouched).
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    f = DL.HubFetcher()
+    f.xet_available = lambda: (_ for _ in ()).throw(
+        AssertionError("Xet must not even be probed on a rung-1 success"))
+    _orig_which, _orig_run = DL.shutil.which, DL.subprocess.run
+    DL.shutil.which = lambda n: "/usr/bin/hf" if n == "hf" else None
+
+    def _run_ok(argv, **kw):
+        d = Path(argv[argv.index("--local-dir") + 1])
+        (d / BIG).parent.mkdir(parents=True, exist_ok=True)
+        (d / BIG).write_bytes(BODY)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    DL.subprocess.run = _run_ok
+    try:
+        out = f.snapshot(repo_id="org/Repo", local_dir=td, allow_patterns=[BIG])
+    finally:
+        DL.shutil.which, DL.subprocess.run = _orig_which, _orig_run
+    check(out == [BIG] and f.rung == "classic",
+          f"rung 1 (classic LFS) success returns without escalating "
+          f"(rung={f.rung!r} files={out})")
+
+# ---------------------------------------------------------------------------
+# 3. NO opt-in -> rung 2 skipped WITH a reason; rung 3 delivers + verifies.
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    log, curl = Log(), curl_runner_ok()
+    res = HF.escalate(
+        "poolside/Laguna-S-2.1-GGUF", Path(td), [BIG],
+        classic_error=REFUSAL, allow_xet=False, token=None, log=log,
+        curl_runner=curl,
+        xet_runner=lambda *a: (_ for _ in ()).throw(
+            AssertionError("rung 2 must NOT run without an opt-in")),
+        xet_available=lambda: True,      # available, but NOT permitted
+        tree_fn=lambda: TREE,
+    )
+    check(res.ok and res.rung == "raw-resolve",
+          f"no opt-in -> rung 3 (raw resolve) delivers (rung={res.rung!r})")
+    check(res.verified == [BIG],
+          f"rung 3 output is sha256-verified, not merely fetched "
+          f"({res.verified})")
+    check("rung 2 (Xet) SKIPPED" in log.text()
+          and "opt-in required" in log.text(),
+          "rung 2 skip is ANNOUNCED with its reason (never silent)")
+    check("rung 1" in log.text() and "policy wall" in log.text(),
+          "the announcement explains WHY rung 1 could not be retried")
+    check("DONE via rung 3" in log.text()
+          and "sha256-verified" in log.text(),
+          "the completion line names the rung AND what was verified")
+
+# ---------------------------------------------------------------------------
+# 4. opt-in but hf_xet missing -> skipped, and the ladder NEVER installs it.
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    log, curl = Log(), curl_runner_ok()
+    res = HF.escalate(
+        "org/Big", Path(td), [BIG], classic_error=REFUSAL, allow_xet=True,
+        token=None, log=log, curl_runner=curl,
+        xet_runner=lambda *a: (_ for _ in ()).throw(
+            AssertionError("rung 2 must NOT run when hf_xet is unavailable")),
+        xet_available=lambda: False,
+        tree_fn=lambda: TREE,
+    )
+    check(res.ok and res.rung == "raw-resolve",
+          "opted in but hf_xet unimportable -> falls through to rung 3")
+    check("not importable" in log.text()
+          and "never auto-installs" in log.text(),
+          "the skip says hf_xet is missing AND that we will not install it")
+
+# ---------------------------------------------------------------------------
+# 5. opt-in + hf_xet importable -> rung 2 runs, THEN the mandatory sha gate.
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    log = Log()
+    xet_calls = {"n": 0, "xet": None}
+
+    def _xet(repo, local_dir, includes, xet):
+        xet_calls["n"] += 1
+        xet_calls["xet"] = xet
+        p = Path(local_dir) / BIG
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(BODY)
+        return 0, ""
+
+    res = HF.escalate(
+        "org/Big", Path(td), [BIG], classic_error=REFUSAL, allow_xet=True,
+        token=None, log=log, xet_runner=_xet, xet_available=lambda: True,
+        curl_runner=lambda *a: (_ for _ in ()).throw(
+            AssertionError("rung 3 must not run after a rung-2 success")),
+        tree_fn=lambda: TREE,
+    )
+    check(res.ok and res.rung == "xet" and xet_calls["n"] == 1,
+          f"rung 2 runs when opted in AND available (rung={res.rung!r})")
+    check(xet_calls["xet"] is True,
+          "rung 2 re-runs the SAME hf download with Xet ENABLED")
+    check(res.verified == [BIG],
+          "rung 2's artifact still goes through the INDEPENDENT sha256 gate "
+          "(a wrapper-reported 'verified' has lied on this rig before)")
+
+# ---------------------------------------------------------------------------
+# 6. sha mismatch on a fallback rung -> hard fail + the artifact is DELETED.
+# ---------------------------------------------------------------------------
+def _xet_corrupt(repo, local_dir, includes, xet):
+    p = Path(local_dir) / BIG
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(b"CORRUPT")
+    return 0, ""
+
+
+for rung_name, kwargs in (
+    ("rung 3", dict(allow_xet=False, curl_runner=curl_runner_ok(b"CORRUPT"),
+                    xet_available=lambda: False)),
+    ("rung 2", dict(allow_xet=True, xet_available=lambda: True,
+                    xet_runner=_xet_corrupt)),
+):
+    with tempfile.TemporaryDirectory() as td:
+        log = Log()
+        err = None
+        try:
+            HF.escalate("org/Big", Path(td), [BIG], classic_error=REFUSAL,
+                        token=None, log=log, tree_fn=lambda: TREE, **kwargs)
+        except HF.LadderError as exc:
+            err = exc
+        check(err is not None and err.token == "sha-mismatch",
+              f"{rung_name}: sha256 mismatch is a HARD fail "
+              f"(token={getattr(err, 'token', None)!r})")
+        check(not (Path(td) / BIG).exists(),
+              f"{rung_name}: the mismatching artifact is DELETED, not left "
+              f"on disk for someone to serve")
+
+# ---------------------------------------------------------------------------
+# 7. no published sha256 -> unverifiable artifact, hard fail + delete.
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    log = Log()
+    no_hash_tree = [{"type": "file", "path": BIG, "size": len(BODY)}]
+    err = None
+    try:
+        HF.escalate("org/Big", Path(td), [BIG], classic_error=REFUSAL,
+                    allow_xet=False, token=None, log=log,
+                    curl_runner=curl_runner_ok(), xet_available=lambda: False,
+                    tree_fn=lambda: no_hash_tree)
+    except HF.LadderError as exc:
+        err = exc
+    check(err is not None and err.token == "no-etag",
+          f"a fallback artifact with no published sha256 hard-fails "
+          f"(token={getattr(err, 'token', None)!r}) — never waved through")
+    check(not (Path(td) / BIG).exists(),
+          "the unverifiable artifact is deleted too")
+
+# ---------------------------------------------------------------------------
+# 8. rung 3's curl argv: single stream, resumable, RESOLVE endpoint.
+# ---------------------------------------------------------------------------
+argv = HF.curl_argv("poolside/Laguna-S-2.1-GGUF", BIG, Path("/tmp/x.gguf"))
+joined = " ".join(argv)
+check(argv[0].endswith("curl"), f"rung 3 transport is curl (got {argv[0]!r})")
+check("-L" in argv, "curl follows the 302 (-L) — afresh on every attempt")
+check("-C" in argv and argv[argv.index("-C") + 1] == "-",
+      "curl resumes from whatever is on disk (-C -)")
+check("--retry-all-errors" in argv, "curl retries transient errors")
+url = argv[-1]
+check(url.startswith("https://huggingface.co/poolside/Laguna-S-2.1-GGUF/"
+                     "resolve/main/"),
+      f"the URL is the RESOLVE endpoint, re-signed per attempt — NOT a "
+      f"cached CAS link that expires in ~3600s (got {url})")
+check("cas-bridge" not in url and "X-Xet-Cas-Uid" not in url
+      and "Expires=" not in url,
+      "no signed/expiring CAS URL is ever baked into the retry command")
+for parallel in ("-Z", "--parallel", "--parallel-max"):
+    check(parallel not in argv,
+          f"rung 3 is SINGLE-STREAM: no {parallel} (parallel-chunk fetchers "
+          f"have corrupted multi-GB files on this rig at the correct size)")
+
+# ---------------------------------------------------------------------------
+# 9. no parallel-chunk downloader anywhere in the EXECUTABLE path.
+#    Comments/docstrings may name aria2c (they explain the ban); code may not.
+# ---------------------------------------------------------------------------
+for mod in ("scripts/lib/profiles/hf_fetch.py",
+            "scripts/lib/profiles/downloader.py"):
+    src = (root / mod).read_text(encoding="utf-8")
+    code = []
+    for tok in tokenize.generate_tokens(io.StringIO(src).readline):
+        if tok.type in (tokenize.COMMENT, tokenize.STRING):
+            continue
+        code.append(tok.string)
+    blob = " ".join(code).lower()
+    check("aria2" not in blob,
+          f"{mod}: aria2c appears only in prose, never in executable code")
+
+# ---------------------------------------------------------------------------
+# 10. END TO END through download_model: refusal -> escalation -> reported.
+# ---------------------------------------------------------------------------
+API = {
+    "sha": "cafebabe",
+    "siblings": [
+        {"rfilename": "config.json", "size": 12},
+        {"rfilename": "model.safetensors", "size": len(BODY),
+         "lfs": {"sha256": SHA, "size": len(BODY)}},
+    ],
+}
+
+
+def mk_einput(slug, hf_home, api):
+    der = SimpleNamespace(slug=slug, profile={"_hf_api": api})
+    return EInput(
+        slug=slug, terminal="proceed", is_override_accepted=False, der=der,
+        runtime={}, selected_files=[], hf_home=Path(hf_home), c2a=None,
+        hardware_sm=8.6, visible_gpu_count=1, per_gpu_vram_mib=[24576],
+        selected_gpu_indices=[0], selected_gpu_vram_mib=[24576],
+        topology_summary="(RTX 3090, 24576)", club3090_commit="deadbeef",
+        diagnostics={},
+    )
+
+
+with tempfile.TemporaryDirectory() as td:
+    log = Log()
+    ei = mk_einput("org/Huge", td, API)
+    fetcher = DL.HubFetcher(API, log=log)
+    fetcher.xet_available = lambda: False
+    hashed = {"n": 0}
+    _orig_sha = DL._sha256_file
+
+    def _counting_sha(p):
+        hashed["n"] += 1
+        return _orig_sha(p)
+
+    def _curl(argv, dest):
+        Path(dest).parent.mkdir(parents=True, exist_ok=True)
+        Path(dest).write_bytes(BODY)
+        return 0
+
+    fetcher.curl_runner = _curl
+    _orig_which, _orig_run = DL.shutil.which, DL.subprocess.run
+    DL.shutil.which = lambda n: "/usr/bin/hf" if n == "hf" else None
+    DL._sha256_file = _counting_sha
+
+    def _run_refuse(argv, **kw):
+        return SimpleNamespace(returncode=1, stdout="", stderr=REFUSAL)
+
+    DL.subprocess.run = _run_refuse
+    try:
+        # config.json is not LFS -> rung 3 fetches it too; give it bytes.
+        def _curl_multi(argv, dest):
+            Path(dest).parent.mkdir(parents=True, exist_ok=True)
+            Path(dest).write_bytes(
+                BODY if Path(dest).name.endswith(".safetensors") else b"{}")
+            return 0
+
+        fetcher.curl_runner = _curl_multi
+        # only the safetensors publishes a sha256; a non-LFS metadata file has
+        # none, which on a fallback rung is (correctly) a hard fail -> restrict
+        # the pull to the weight so the happy path is what we assert.
+        API_W = {"sha": "cafebabe", "siblings": [API["siblings"][1]]}
+        ei = mk_einput("org/Huge", td, API_W)
+        fetcher.api = API_W
+        r = DL.download_model(ei, fetcher=fetcher)
+    finally:
+        DL.shutil.which, DL.subprocess.run = _orig_which, _orig_run
+        DL._sha256_file = _orig_sha
+
+    check(r.ok and r.failure is None,
+          f"end-to-end: the too-large refusal ESCALATES instead of failing "
+          f"(ok={r.ok} failure={r.failure!r})")
+    check(r.rung == "raw-resolve",
+          f"the result reports WHICH rung delivered the bytes "
+          f"(rung={r.rung!r}) — logs stay auditable")
+    check(hashed["n"] == 0,
+          f"the ladder's own sha256 is not re-computed by the stage that "
+          f"follows it (a 96 GB re-read for an identical comparison); "
+          f"extra hashes={hashed['n']}")
+    check("delivered via the #804 fallback ladder" in log.text(),
+          "the completion announcement names the ladder + the rung")
+    final = DL.pull_dir(Path(td), "org/Huge")
+    check(final.is_dir() and not (final / ".incomplete").exists(),
+          "atomic move + .incomplete cleanup are unchanged on the ladder path")
+
+# ---------------------------------------------------------------------------
+# 11. a NON-refusal rung-1 failure keeps its pre-existing mapping (no
+#     escalation, no behaviour change for the 99% case).
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    f = DL.HubFetcher()
+    f.curl_runner = lambda *a: (_ for _ in ()).throw(
+        AssertionError("a transient error must NOT trigger the fallback"))
+    _orig_which, _orig_run = DL.shutil.which, DL.subprocess.run
+    DL.shutil.which = lambda n: "/usr/bin/hf" if n == "hf" else None
+    DL.subprocess.run = lambda argv, **kw: SimpleNamespace(
+        returncode=1, stdout="", stderr="401 Client Error: Unauthorized")
+    err = None
+    try:
+        f.snapshot(repo_id="org/Gated", local_dir=td, allow_patterns=[BIG])
+    except BaseException as exc:
+        err = exc
+    finally:
+        DL.shutil.which, DL.subprocess.run = _orig_which, _orig_run
+    check(isinstance(err, DL.GatedError),
+          f"a 401 still maps to GatedError — the ladder ONLY intercepts the "
+          f"too-large refusal (got {type(err).__name__})")
+
+# ---------------------------------------------------------------------------
+# 12. PREFLIGHT: say "this repo needs Xet or the fallback" BEFORE the doomed
+#     rung-1 attempt, not after 30 opaque retries (#804 acceptance bullet 3).
+# ---------------------------------------------------------------------------
+small = {"a.safetensors": HF.FileMeta("a.safetensors", size=8 * 1024**3,
+                                      sha256="a" * 64)}
+verdict, note = HF.preflight_transport(["a.safetensors"], small)
+check(verdict == "classic" and note == "",
+      f"a normal repo preflights as 'classic' with no noise ({verdict!r})")
+
+huge = {BIG: HF.FileMeta(BIG, size=96 * 1024**3, sha256=SHA)}
+verdict, note = HF.preflight_transport([BIG], huge)
+check(verdict == "needs-fallback",
+      f"a >50 GB file preflights as needs-fallback ({verdict!r})")
+check("50 GB" in note,
+      f"the ceiling is quoted the way upstream defines it (decimal 50 GB, "
+      f"not a binary 46.57 GB nobody will recognise): {note}")
+check("policy wall" in note and "retries cannot help" in note,
+      "the preflight says retrying is futile, so nobody sits through 30 of them")
+check("--allow-xet" in note and "rung 3" in note,
+      f"the preflight names BOTH escape routes: {note}")
+check(BIG in note and "89" in note or "96" in note,
+      f"the offending file and its size are named: {note}")
+
+# The same warning reaches the operator through download_model's own log.
+with tempfile.TemporaryDirectory() as td:
+    log = Log()
+    BIG_API = {"siblings": [
+        {"rfilename": "model.safetensors", "size": 96 * 1024**3,
+         "lfs": {"sha256": SHA, "size": 96 * 1024**3}}]}
+    ei = mk_einput("org/Big", td, BIG_API)
+    f = DL.HubFetcher(BIG_API, log=log)
+
+    def _snap(repo_id, local_dir, allow_patterns):
+        raise DL.DiskError("stop here — the preflight line is what we assert")
+
+    f.snapshot = _snap
+    DL.download_model(ei, fetcher=f)
+    check("[download] preflight:" in log.text() and "50 GB" in log.text(),
+          f"download_model announces the transport verdict BEFORE fetching "
+          f"(pull.sh streams this straight into c3's lane):\n{log.text()}")
+
+# ---------------------------------------------------------------------------
+# 13. the module CLI exists and is self-describing (so a surface that shells
+#     out to `hf download` today can adopt the ladder without importing).
+# ---------------------------------------------------------------------------
+check(callable(getattr(HF, "_main", None)) and callable(getattr(HF, "fetch", None)),
+      "hf_fetch exposes a standalone fetch() + a CLI entry point")
+
+if failures:
+    print(f"\n{len(failures)} assertion(s) failed.", file=sys.stderr)
+    sys.exit(1)
+print("\nAll #804 download-ladder assertions passed.")
+PY
+
+echo "test-pull-download-ladder.sh OK"

--- a/scripts/tests/test-pull-verify-in-place.sh
+++ b/scripts/tests/test-pull-verify-in-place.sh
@@ -1,0 +1,383 @@
+#!/usr/bin/env bash
+# test-pull-verify-in-place.sh — #812: verify-in-place for metadata-less local
+# files, and announce WHY a re-download starts.
+#
+# The reported failure (Discord, lifeform): setup/pull re-downloads a model on
+# first run even though the file is already at the target path. Mechanism: it
+# was placed by hand, so no `.cache/huggingface/download/<f>.metadata` sits
+# beside it, the skip check cannot prove completeness, and a full re-pull starts
+# — silently, for hours. The instinct is right (a half-copied 40 GB file must
+# never be silently trusted); the silence is the bug.
+#
+# Asserted here (hermetic — no network, no real transfer):
+#   1. a correct, metadata-less file is ADOPTED after a hash match, with ZERO
+#      bytes re-downloaded (the fetcher is not called at all);
+#   2. adoption writes the HF metadata stub in huggingface_hub's exact 3-line
+#      format at its exact path, so `hf download` skips the file from now on;
+#   3. a TRUNCATED file is rejected with a message naming BOTH sizes, then
+#      re-downloaded;
+#   4. a corrupt-but-right-sized file is caught by the hash and re-downloaded
+#      (this is the exact shape of the silent-corruption incident this rig has
+#      already been burned by: correct size, wrong bytes);
+#   5. without VERIFY_IN_PLACE the file is still re-downloaded — but the reason
+#      is stated, along with how to opt into verifying instead;
+#   6. NO code path starts a download without printing why;
+#   7. the word "verified" NEVER appears for a size-only observation. A wrapper
+#      on this rig once printed "DONE (hash-verified)" over silent corruption;
+#      this suite makes that phrasing a test failure, not a style note;
+#   8. a partially-present pull dir adopts what it can and fetches only the
+#      remainder (one missing sibling must not re-pull three good shards).
+set -euo pipefail
+
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+export PYTHONPATH="$ROOT_DIR${PYTHONPATH:+:$PYTHONPATH}"
+
+python3 - "$ROOT_DIR" <<'PY'
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+root = Path(sys.argv[1])
+sys.path.insert(0, str(root))
+
+from scripts.lib.profiles import downloader as DL     # noqa: E402
+from scripts.lib.profiles import hf_fetch as HF       # noqa: E402
+from scripts.lib.profiles.einput import EInput        # noqa: E402
+
+failures: list[str] = []
+
+
+def check(cond, msg: str) -> None:
+    if cond:
+        print(f"PASS: {msg}")
+    else:
+        print(f"FAIL: {msg}", file=sys.stderr)
+        failures.append(msg)
+
+
+WEIGHT = "model.safetensors"
+CONF = "config.json"
+BODY = b"FORTY-GIGABYTES-OF-WEIGHTS-PRETEND" * 4
+CONF_BODY = b'{"architectures":["Qwen3NextForCausalLM"]}'
+SHA = hashlib.sha256(BODY).hexdigest()
+CONF_SHA = hashlib.sha256(CONF_BODY).hexdigest()
+
+API = {
+    "sha": "1234567890abcdef1234567890abcdef12345678",
+    "siblings": [
+        {"rfilename": WEIGHT, "size": len(BODY),
+         "lfs": {"sha256": SHA, "size": len(BODY)}},
+        {"rfilename": CONF, "size": len(CONF_BODY),
+         "lfs": {"sha256": CONF_SHA, "size": len(CONF_BODY)}},
+    ],
+}
+
+
+class Log:
+    def __init__(self):
+        self.lines: list[str] = []
+
+    def __call__(self, msg):
+        self.lines.append(str(msg))
+
+    def text(self):
+        return "\n".join(self.lines)
+
+
+class CountingFetcher:
+    """Records whether — and for what — the network was engaged."""
+
+    def __init__(self, log=None):
+        self.calls = 0
+        self.allow_seen = None
+        self.log = log or HF.default_log
+        self.rung = "classic"
+        self.ladder_verified = set()
+
+    def snapshot(self, repo_id, local_dir, allow_patterns):
+        self.calls += 1
+        self.allow_seen = list(allow_patterns)
+        out = []
+        for name in allow_patterns:
+            p = Path(local_dir) / name
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_bytes(BODY if name == WEIGHT else CONF_BODY)
+            out.append(name)
+        return out
+
+    def head_etag(self, repo_id, filename):
+        return None
+
+
+def mk_einput(slug, hf_home):
+    der = SimpleNamespace(slug=slug, profile={"_hf_api": API})
+    return EInput(
+        slug=slug, terminal="proceed", is_override_accepted=False, der=der,
+        runtime={}, selected_files=[], hf_home=Path(hf_home), c2a=None,
+        hardware_sm=8.6, visible_gpu_count=1, per_gpu_vram_mib=[24576],
+        selected_gpu_indices=[0], selected_gpu_vram_mib=[24576],
+        topology_summary="(RTX 3090, 24576)", club3090_commit="deadbeef",
+        diagnostics={},
+    )
+
+
+def place(pull: Path, name: str, body: bytes) -> None:
+    """Hand-place a file exactly as a user would: bytes only, no metadata."""
+    pull.mkdir(parents=True, exist_ok=True)
+    (pull / name).write_bytes(body)
+
+
+def env(**kw):
+    """Scoped env for the VERIFY_IN_PLACE opt-in."""
+    class _Ctx:
+        def __enter__(self):
+            self.old = {k: os.environ.get(k) for k in kw}
+            for k, v in kw.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+
+        def __exit__(self, *a):
+            for k, v in self.old.items():
+                if v is None:
+                    os.environ.pop(k, None)
+                else:
+                    os.environ[k] = v
+    return _Ctx()
+
+
+# ---------------------------------------------------------------------------
+# 1 + 2. correct metadata-less files + VERIFY_IN_PLACE=1 -> adopted, 0 bytes,
+#        HF metadata stub written in the exact format at the exact path.
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td, env(VERIFY_IN_PLACE="1",
+                                              CLUB3090_VERIFY_IN_PLACE=None):
+    ei = mk_einput("org/Placed", td)
+    pull = DL.pull_dir(Path(td), "org/Placed")
+    place(pull, WEIGHT, BODY)
+    place(pull, CONF, CONF_BODY)
+    log = Log()
+    f = CountingFetcher(log)
+    r = DL.download_model(ei, fetcher=f)
+
+    check(r.ok and f.calls == 0,
+          f"a hand-placed, CORRECT model is adopted — the fetcher is never "
+          f"called (ok={r.ok} snapshot_calls={f.calls})")
+    check(sorted(r.adopted) == sorted([WEIGHT, CONF]),
+          f"every file is reported as adopted ({r.adopted})")
+    check(r.sha_verified is True,
+          "sha_verified is True only because an actual sha256 was computed")
+    check("verified in place" in log.text(),
+          f"the adoption is ANNOUNCED as verified in place:\n{log.text()}")
+    check("0 bytes re-downloaded" in log.text(),
+          "the announcement states that nothing went over the wire")
+
+    mp = HF.metadata_path(pull, WEIGHT)
+    check(mp == pull / ".cache" / "huggingface" / "download"
+          / f"{WEIGHT}.metadata",
+          f"the stub lands where huggingface_hub looks for it ({mp})")
+    lines = mp.read_text(encoding="utf-8").splitlines()
+    check(len(lines) >= 3 and lines[0] == API["sha"] and lines[1] == SHA,
+          f"the stub is huggingface_hub's 3-line format "
+          f"(commit / etag=sha256 / timestamp); got {lines[:3]}")
+    check(float(lines[2]) >= (pull / WEIGHT).stat().st_mtime - 1,
+          "the stub's timestamp is not older than the file, or hf would "
+          "discard it as outdated and re-download anyway")
+    md = HF.read_metadata(pull, WEIGHT)
+    check(md is not None and md["etag"] == SHA,
+          f"the stub reads back through the same rules hf applies ({md})")
+
+    # Re-running now takes the cheap path: the record exists, no re-hash.
+    log2 = Log()
+    f2 = CountingFetcher(log2)
+    hashed = {"n": 0}
+    _orig = HF.sha256_file
+    HF.sha256_file = lambda p, **kw: (hashed.__setitem__("n", hashed["n"] + 1)
+                                      or _orig(p, **kw))
+    try:
+        r2 = DL.download_model(ei, fetcher=f2)
+    finally:
+        HF.sha256_file = _orig
+    check(r2.ok and f2.calls == 0 and hashed["n"] == 0,
+          f"the SECOND run costs neither a download nor a re-hash "
+          f"(calls={f2.calls} hashes={hashed['n']})")
+
+# ---------------------------------------------------------------------------
+# 3. truncated file -> rejected naming BOTH sizes, then re-downloaded.
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td, env(VERIFY_IN_PLACE="1",
+                                              CLUB3090_VERIFY_IN_PLACE=None):
+    ei = mk_einput("org/Truncated", td)
+    pull = DL.pull_dir(Path(td), "org/Truncated")
+    half = BODY[: len(BODY) // 2]
+    place(pull, WEIGHT, half)
+    place(pull, CONF, CONF_BODY)
+    log = Log()
+    f = CountingFetcher(log)
+    r = DL.download_model(ei, fetcher=f)
+
+    txt = log.text()
+    check(str(len(half)) in txt and str(len(BODY)) in txt,
+          f"the size-mismatch message names BOTH sizes "
+          f"(local={len(half)} remote={len(BODY)}):\n{txt}")
+    check("truncated or stale" in txt,
+          "the message says what a size mismatch means, not just that it is one")
+    check(f.calls == 1 and r.ok,
+          f"the truncated file IS re-downloaded (calls={f.calls} ok={r.ok})")
+    check(WEIGHT in (f.allow_seen or []),
+          f"the re-fetch includes the truncated file ({f.allow_seen})")
+    check(CONF not in (f.allow_seen or []),
+          f"...and NOT the sibling that verified clean ({f.allow_seen}) — "
+          f"one bad file must not re-pull the good ones")
+
+# ---------------------------------------------------------------------------
+# 4. right size, WRONG bytes -> the hash catches it (the silent-corruption
+#    shape this rig has already been burned by).
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td, env(VERIFY_IN_PLACE="1",
+                                              CLUB3090_VERIFY_IN_PLACE=None):
+    ei = mk_einput("org/Corrupt", td)
+    pull = DL.pull_dir(Path(td), "org/Corrupt")
+    corrupt = b"X" * len(BODY)          # correct size, wrong content
+    place(pull, WEIGHT, corrupt)
+    place(pull, CONF, CONF_BODY)
+    log = Log()
+    f = CountingFetcher(log)
+    r = DL.download_model(ei, fetcher=f)
+    txt = log.text()
+    check("does NOT match" in txt and "corrupt" in txt.lower(),
+          f"a right-sized, wrong-bytes file is caught BY HASH and named as "
+          f"corrupt:\n{txt}")
+    check(f.calls == 1 and WEIGHT in (f.allow_seen or []),
+          "the corrupt file is re-downloaded")
+
+# ---------------------------------------------------------------------------
+# 5 + 6 + 7. no opt-in -> still re-downloads, but says why, says how to opt in,
+#            and NEVER calls a size check "verified".
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td, env(VERIFY_IN_PLACE=None,
+                                              CLUB3090_VERIFY_IN_PLACE=None):
+    ei = mk_einput("org/NoOptIn", td)
+    pull = DL.pull_dir(Path(td), "org/NoOptIn")
+    place(pull, WEIGHT, BODY)          # byte-perfect, but unhashed
+    place(pull, CONF, CONF_BODY)
+    log = Log()
+    f = CountingFetcher(log)
+    r = DL.download_model(ei, fetcher=f)
+    txt = log.text()
+
+    check(f.calls == 1,
+          "without the opt-in the file is re-downloaded (a half-copy must "
+          "never be silently trusted)")
+    check("cannot verify it without hashing" in txt,
+          f"the reason is stated in plain words:\n{txt}")
+    check("VERIFY_IN_PLACE=1" in txt and "--verify-in-place" in txt,
+          "the announcement names BOTH the env var and the pull.sh flag")
+    check(re.search(r"re-downloading \(.*over the wire\)", txt) is not None,
+          "the announcement states the cost of proceeding")
+    check("verified" not in txt.lower(),
+          f"the word 'verified' NEVER appears for a size-only observation — "
+          f"a wrapper on this rig once printed 'DONE (hash-verified)' over "
+          f"silent corruption, and that must be untellable here:\n{txt}")
+    check(r.sha_verified is True,
+          "the completed download is still hash-verified by the normal stage")
+
+# ---------------------------------------------------------------------------
+# 6b. the announce-WHY rule holds even with an EMPTY destination: no code path
+#     starts a download without printing why.
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td, env(VERIFY_IN_PLACE=None,
+                                              CLUB3090_VERIFY_IN_PLACE=None):
+    ei = mk_einput("org/Fresh", td)
+    log = Log()
+
+    class OrderedFetcher(CountingFetcher):
+        def snapshot(self, repo_id, local_dir, allow_patterns):
+            # capture what had been announced BEFORE the first byte moved
+            self.pre = list(self.log.lines) if hasattr(self.log, "lines") else []
+            return super().snapshot(repo_id, local_dir, allow_patterns)
+
+    f = OrderedFetcher(log)
+    r = DL.download_model(ei, fetcher=f)
+    pre = "\n".join(getattr(f, "pre", []))
+    check(r.ok and f.calls == 1, "a fresh pull still downloads normally")
+    check("[download] starting:" in pre,
+          f"the 'starting' announcement is emitted BEFORE the fetch, not "
+          f"after:\n{pre}")
+    check("reason:" in pre and str(ei.slug) in pre,
+          f"the announcement names the repo and the reason:\n{pre}")
+
+# ---------------------------------------------------------------------------
+# 8. partial presence -> adopt what verifies, fetch only the remainder.
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td, env(VERIFY_IN_PLACE="1",
+                                              CLUB3090_VERIFY_IN_PLACE=None):
+    ei = mk_einput("org/Partial", td)
+    pull = DL.pull_dir(Path(td), "org/Partial")
+    place(pull, WEIGHT, BODY)          # the expensive one is already correct
+    log = Log()
+    f = CountingFetcher(log)
+    r = DL.download_model(ei, fetcher=f)
+    check(r.ok and f.allow_seen == [CONF],
+          f"only the MISSING file is fetched; the verified multi-GB weight is "
+          f"kept (allow_seen={f.allow_seen})")
+    check(r.adopted == [WEIGHT],
+          f"the kept file is reported as adopted ({r.adopted})")
+    check((DL.pull_dir(Path(td), "org/Partial") / WEIGHT).read_bytes() == BODY,
+          "the adopted file survives the atomic move into the final dir")
+    check("keeping 1 verified file" in log.text(),
+          f"the split is announced:\n{log.text()}")
+
+# ---------------------------------------------------------------------------
+# 9. plan_local_file phrasing contract, in isolation.
+# ---------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as td:
+    d = Path(td)
+    (d / WEIGHT).write_bytes(BODY)
+    meta_ok = HF.FileMeta(WEIGHT, size=len(BODY), sha256=SHA, source="api")
+    meta_nohash = HF.FileMeta(WEIGHT, size=len(BODY), sha256=None)
+
+    e = HF.plan_local_file(d, WEIGHT, meta_ok, do_hash=True)
+    check(e.action == "adopt" and e.hashed and "verified in place" in e.message,
+          f"hash match -> adopt, and only then is it called verified ({e})")
+
+    e = HF.plan_local_file(d, WEIGHT, meta_nohash, do_hash=True)
+    check(e.action == "download" and e.reason == "no-remote-hash"
+          and "verified" not in e.message.replace("cannot be verified", ""),
+          f"no published hash -> honest 'cannot be verified', re-download "
+          f"({e.message})")
+
+    e = HF.plan_local_file(d, "absent.bin", meta_ok, do_hash=True)
+    check(e.action == "download" and e.reason == "absent",
+          f"a missing file is simply 'absent' ({e.reason})")
+
+    e = HF.plan_local_file(d, WEIGHT, meta_ok, do_hash=False)
+    check(e.action == "download" and e.reason == "verify-not-enabled"
+          and not e.hashed,
+          f"size agreement alone NEVER adopts ({e.reason}) — silent "
+          f"corruption looks exactly like this")
+
+if failures:
+    print(f"\n{len(failures)} assertion(s) failed.", file=sys.stderr)
+    sys.exit(1)
+print("\nAll #812 verify-in-place / announce-why assertions passed.")
+PY
+
+echo "test-pull-verify-in-place.sh OK"


### PR DESCRIPTION
Two downloader issues from the maintainer's own reports. One commit each; the second builds on the first's hub-metadata plumbing.

## Per-issue verdict

| Issue | Verdict | What landed | Acceptance |
|---|---|---|---|
| **#812** — verify-in-place + announce WHY | ✅ **Fully implemented** | Unconditional per-file announcement before any transfer; opt-in sha256 verify-in-place with adoption + HF metadata stub; partial-presence adoption | 3/3 |
| **#804** — download resilience ladder | ⚠️ **Implemented on the surfaces this PR owns** (`pull.sh` / `downloader.py` / `--apply-swap`), plus a preflight that reaches c3's Bring lane for free on the safetensors path. **c3's GGUF Bring path still shells `hf download` directly** and does not go through the ladder — see "Remaining" | 2.5/3 |

### #812 acceptance, line by line

- **"A manually-placed, correct file is adopted after hash match — zero bytes re-downloaded."** ✅ `test-pull-verify-in-place.sh` case 1 asserts the fetcher is never called (`snapshot_calls=0`) and that the adoption survives the atomic move.
- **"A truncated file is rejected with a size-mismatch message naming both sizes, then re-downloaded."** ✅ Case 3 asserts both byte counts appear in the message and that only the bad file is re-fetched — a clean sibling is kept.
- **"No code path starts a download without printing why."** ✅ Case 6b captures the log as it stood at the moment `snapshot()` was entered and asserts `[download] starting: … reason: …` was already there.

### #804 acceptance, line by line

- **"The exact refusal signature triggers escalation (test with a mocked stderr)."** ✅ Signature matched on the verbatim hf 1.25.1 text, both directions (5 negative cases, including the `hf_xet`-mentioning *warning* that is **not** the wall).
- **"A file fetched via rung 2 or 3 with a mismatched sha256 hard-fails and deletes the artifact."** ✅ Asserted for both rungs, plus the no-published-sha256 case.
- **"c3's download preflight surfaces 'this repo needs Xet or fallback' instead of 30 opaque retries."** ⚠️ Partial — the preflight exists and `download_model` prints it, so it reaches c3's Bring lane on the **safetensors** path (c3 streams `pull.sh`). c3's **GGUF** path builds its own `hf download` argv in `services.py` and is untouched here (outside this PR's file ownership).

## What the ladder actually is

I read the wall in huggingface_hub's source rather than inferring it, and one detail changes how it should be described:

> `file_download.py::http_get` raises when `expected_size > constants.MAX_HTTP_DOWNLOAD_SIZE` (**50 GB, hard-coded, no env override**) **and** `resume_size == 0`.

So it is not a Xet property — it is a **size ceiling on the classic HTTP path**, which fires on Xet-backed and non-Xet repos alike. The error text recommends `hf_xet` regardless, which on a non-Xet repo would not help. Rung 3 covers both, so the behaviour is right either way; the announcements say "files over 50 GB", not "Xet repos".

```
rung 1  classic LFS   unchanged, always first. ONLY the exact refusal escalates —
                      every other non-zero exit keeps its pre-existing mapping.
rung 2  Xet           opt-in ONLY (ALLOW_XET=1 / --allow-xet) AND only if hf_xet is
                      already importable. Never auto-installed, never silent.
rung 3  raw resolve   single-stream `curl -L -C - --retry-all-errors` on the resolve
                      endpoint, stall watchdog + line-oriented progress, retry loop.
```

Both fallback rungs run a **mandatory independent sha256** against the hub's published hash and **delete** a mismatching or unverifiable artifact.

Verified against the live hub while writing this (metadata requests only, no weights):

- non-redirect-following HEAD on `resolve/main/<file>` → `x-linked-etag: "<sha256>"` + `x-linked-size` + `x-repo-commit`
- redirect-**following** HEAD → ends at the CAS blob with the *xet* hash in `etag`, no `x-linked-etag` (the trap the repo already documented; the module uses a no-redirect opener)
- `/api/models/<repo>/tree/<rev>?recursive=1&expand=1` → `lfs.sha256` per file, identical to the header value

## Guardrails held

- **aria2c is banned by test, not by convention.** `test-pull-download-ladder.sh` tokenizes `hf_fetch.py` and `downloader.py`, strips comments and docstrings, and asserts `aria2` appears nowhere in executable code. It is also asserted that rung 3 carries no `-Z` / `--parallel`.
- **Re-resolve per retry.** The 302 target is a signed CAS URL with `Expires=` ~3600 s. Caching it turns a long resume into a 403, so every attempt goes through `huggingface.co/.../resolve/...` and lets curl re-follow. A test asserts the argv URL shape and that no signature parameters are baked in.
- **"verified" is a load-bearing word.** It appears in an announcement only when a sha256 was actually computed and compared. A size match reports "size matches" and still re-downloads. `test-pull-verify-in-place.sh` asserts the token is absent from the entire size-only log — this is the direct descendant of the wrapper that once printed `DONE (hash-verified)` over silent corruption at the correct size.
- **Rung 1 is untouched for everything that is not the wall.** A 401 still raises `GatedError`, ENOSPC still maps to `disk`, and `test-pullgate-download.sh` (the CONTRACT-3 spec test) passes unmodified.

## New flags

```bash
scripts/pull.sh <repo> --profile-like <slug> --verify-in-place   # or VERIFY_IN_PLACE=1
scripts/pull.sh <repo> --profile-like <slug> --allow-xet         # or ALLOW_XET=1
```

Both are stripped in the `pull.sh` wrapper and turned into env, so `pull.py`'s parser is untouched and `--json` / `--apply-swap` behave identically.

Standalone entry point, for surfaces that shell out to `hf download` today:

```bash
python3 scripts/lib/profiles/hf_fetch.py <repo> --local-dir DIR --include '*.gguf' --preflight
# transport: needs-fallback
# 1 file(s) exceed the 50 GB ceiling huggingface_hub enforces on the classic HTTP
# path — laguna-s-2.1-Q4_K_M.gguf (89.44 GB). Rung 1 will be REFUSED client-side …
```

## Tests

| Test | Result |
|---|---|
| `test-pull-download-ladder.sh` (new, 47 assertions) | ✅ |
| `test-pull-verify-in-place.sh` (new, 33 assertions) | ✅ |
| `test-pullgate-download.sh` (CONTRACT-3 spec, unmodified) | ✅ |
| `test-download-lock.sh`, `test-pull.sh`, `test-pull-swap.sh`, `test-pullemit-capture.sh`, `test-pullgate-deriver/gates.sh`, `test-submit-pull.sh` | ✅ |
| Full `scripts/tests/*.sh` sweep | 90/92 |

Both sweep failures are **pre-existing on `origin/master`**, confirmed by running them in a pristine `origin/master` worktree:

- `test-locale-utf8` — `test-bench-capture.sh`, `test-bench-card.sh`, `test-offload-matrix-mocked.sh`, `test-offload-matrix-static.sh` run `python3` without `export PYTHONUTF8="${PYTHONUTF8:-1}"`. One line each; those files belong to other clusters so I left them alone.
- `test-offload-matrix-mocked` — flaky, not deterministic: `a fixture from an earlier case is still running: <pid>`. Passed on re-run and in an earlier sweep.

Everything is hermetic: no network beyond a handful of metadata HEAD/tree requests during development, no multi-GB transfer, every rung's transport injected.

## Remaining for full #804 closure

`tools/serve-cockpit/club3090_cockpit/services.py::run_bring_download` builds a bare `hf download` argv for the GGUF route (the `gguf_includes` branch) — that is the path the 96 GB Laguna pull actually took, and it still hits the wall. Repointing it at `python3 scripts/lib/profiles/hf_fetch.py <repo> --local-dir <pull> --include <pat>…` is a ~4-line change plus an update to `test_gguf_includes_build_hf_download_cmd`; the module CLI was added specifically so that stays a one-liner. Left out here because c3 is outside this PR's file ownership.

## One thing worth flagging in the existing downloader

`setup.sh::_verify_downloaded_files` (line ~670) prints `SKIP (no etag)` and **does not count a failure** when the `x-linked-etag` lookup comes back empty — then `[done] N file(s) SHA-verified` counts that file among the N. `downloader.py` deliberately hard-fails the same case (`failure="no-etag"`, documented as the opposite of setup.sh), so the two surfaces disagree about what "verified" means, and the weaker one is the one that prints the reassuring line. Worse, its lookup is a **redirect-following** `curl -sfI`, which on any Xet-backed repo lands on the CAS blob with no `x-linked-etag` — so on a modern repo that SKIP is the *normal* outcome, not the rare one. Not touched here (out of scope, and it is `setup.sh`), but it is the same failure shape as the "DONE (hash-verified)" incident and probably wants its own issue.

Closes #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)