### PR TITLE
test: green test-locale-utf8 — add missing PYTHONUTF8 exports to 4 capture-era suites

### DIFF
--- a/scripts/tests/test-bench-capture.sh
+++ b/scripts/tests/test-bench-capture.sh
@@ -23,6 +23,7 @@
 #   PREFLIGHT_NO_AUTODETECT=1  bench.sh otherwise adopts whatever container is up.
 set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export PYTHONUTF8="${PYTHONUTF8:-1}"   # repo rule: locale must not decide python decoding
 BENCH="$ROOT_DIR/scripts/bench.sh"
 LIB="$ROOT_DIR/scripts/lib/capture.sh"
 FIX="$ROOT_DIR/scripts/tests/fixtures/offload-matrix"

--- a/scripts/tests/test-bench-card.sh
+++ b/scripts/tests/test-bench-card.sh
@@ -16,6 +16,7 @@
 # If they drift, an A/B silently compares two different measurements.
 set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export PYTHONUTF8="${PYTHONUTF8:-1}"   # repo rule: locale must not decide python decoding
 BENCH="$ROOT_DIR/scripts/bench.sh"
 CARDLIB="$ROOT_DIR/scripts/lib/card.sh"
 FIX="$ROOT_DIR/scripts/tests/fixtures/offload-matrix"

--- a/scripts/tests/test-offload-matrix-mocked.sh
+++ b/scripts/tests/test-offload-matrix-mocked.sh
@@ -18,6 +18,7 @@
 # Asserts STRUCTURE and STATUS only — never a throughput value. Numbers from a fake
 # server mean nothing, and real numbers are not portable across rigs.
 set -euo pipefail
+export PYTHONUTF8="${PYTHONUTF8:-1}"   # repo rule: locale must not decide python decoding
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SWEEP="$ROOT_DIR/scripts/offload-matrix.sh"
 REND="$ROOT_DIR/scripts/offload-matrix-render.py"

--- a/scripts/tests/test-offload-matrix-static.sh
+++ b/scripts/tests/test-offload-matrix-static.sh
@@ -9,6 +9,7 @@
 # is not a crash — it is a plausible wrong number. So these assert structure, never
 # throughput values. See issue #824.
 set -euo pipefail
+export PYTHONUTF8="${PYTHONUTF8:-1}"   # repo rule: locale must not decide python decoding
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SWEEP="$ROOT_DIR/scripts/offload-matrix.sh"
 REND="$ROOT_DIR/scripts/offload-matrix-render.py"


### PR DESCRIPTION
The four test scripts that landed with #842/#846 run python3 without the repo-mandated `export PYTHONUTF8` line, leaving `test-locale-utf8` red on master (independently flagged by both harness-cluster reviews). Four one-line insertions, placed above each file's first python3 call per the gate's placement rule; gate green over 97 scripts, both affected suites re-run green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)