### PR TITLE
Probe the unlisted scene ports in gpu-mode status (#865 follow-up)

### DIFF
--- a/scripts/gpu-mode.sh
+++ b/scripts/gpu-mode.sh
@@ -450,6 +450,24 @@ show_status() {
         m=$(curl -sf -m 2 http://localhost:8038/v1/models | python3 -c "import sys,json;d=json.load(sys.stdin);print(', '.join(x['id'] for x in d.get('data',[])))" 2>/dev/null)
         echo -e "  ${GREEN}▶${NC} gemma-12b @ :8038        → ${m:-unknown} (gemma4_unified, INT8 + bf16 KV + MTP, single card)"
     fi
+    if curl -sf -m 2 http://localhost:8033/v1/models >/dev/null 2>&1; then
+        _endpoint_up=1
+        local m
+        m=$(curl -sf -m 2 http://localhost:8033/v1/models | python3 -c "import sys,json;d=json.load(sys.stdin);print(', '.join(x['id'] for x in d.get('data',[])))" 2>/dev/null)
+        echo -e "  ${GREEN}▶${NC} gemma-qat @ :8033        → ${m:-unknown} (QAT W4A16 + INT8 PTH KV)"
+    fi
+    if curl -sf -m 2 http://localhost:8099/v1/models >/dev/null 2>&1; then
+        _endpoint_up=1
+        local m
+        m=$(curl -sf -m 2 http://localhost:8099/v1/models | python3 -c "import sys,json;d=json.load(sys.stdin);print(', '.join(x['id'] for x in d.get('data',[])))" 2>/dev/null)
+        echo -e "  ${GREEN}▶${NC} thinkingcap @ :8099      → ${m:-unknown} (AutoRound W4A16 served W4A8 + built-in MTP + 262K)"
+    fi
+    if curl -sf -m 2 http://localhost:8199/v1/models >/dev/null 2>&1; then
+        _endpoint_up=1
+        local m
+        m=$(curl -sf -m 2 http://localhost:8199/v1/models | python3 -c "import sys,json;d=json.load(sys.stdin);print(', '.join(x['id'] for x in d.get('data',[])))" 2>/dev/null)
+        echo -e "  ${GREEN}▶${NC} deckard @ :8199          → ${m:-unknown} (llama.cpp Q6_K + MTP, dual)"
+    fi
     if curl -sf -m 2 http://localhost:8090/v1/models >/dev/null 2>&1; then
         _endpoint_up=1
         echo -e "  ${GREEN}▶${NC} studio director @ :8090  → qwen3.5-4b-uncensored (prompt crafter, GPU0, llama.cpp)"


### PR DESCRIPTION
Follow-up to #865, rebased onto `0cf0dd78`.

**Scope changed after 0cf0dd78 landed.** This PR originally carried the same structural fix you shipped there — the `_endpoint_up` flag replacing the second hardcoded port list. That half is yours now and I've dropped it; the branch is rebased onto your commit and keeps only the part 0cf0dd78 explicitly left open.

## What's left

0cf0dd78 fixed the *drift* but not the *coverage*, and flagged that gap itself. The consequence on the reference rig is that the reporting case from #865 still shows nothing:

```
# at 0cf0dd78
  ▶ LiteLLM @ :4000  → qwen3.6-27b, …, thinkingcap-27b
        ← thinkingcap-27b is live on :8099, Up 2h, both cards at 100%

# with this PR
  ▶ thinkingcap @ :8099  → thinkingcap-27b (AutoRound W4A16 served W4A8 + built-in MTP + 262K)
  ▶ LiteLLM @ :4000      → qwen3.6-27b, …, thinkingcap-27b
```

The warning is correctly suppressed either way now (`:4000` sets the flag), so the failure is quieter than before but the operator still can't see what's serving — which was the original question that led to the issue.

Adds probe blocks for the three functional scene ports a rig in this repo can actually be serving on today, in the same shape as the twelve already present:

| Port | Model | Compose |
|---|---|---|
| `:8033` | gemma-4-31b | `dual/qat-w4a16/int8.yml` |
| `:8099` | thinkingcap-27b | `dual/w4a16/w4a8.yml` |
| `:8199` | qwen3.6-40b-deckard | `llama-cpp dual/piehsoft-q6k/mtp.yml` |

## This is a stopgap, and I agree it isn't the fix

Your note on 0cf0dd78 is right: 34 of 53 functional slugs are unprobed, and a hardcoded list cannot track a 53-slug catalog. Registry-derived discovery from `compose_registry.py`'s `default_port` is the durable answer.

I'm proposing this anyway on the narrow grounds that it costs 18 lines, unblocks the three ports that are live on real rigs now, and doesn't make the rewrite harder — discovery deletes these blocks wholesale along with the other twelve. **If you'd rather hold out for the registry-derived version, close this** and I'll take a run at that instead; I'd just want your read on one design question first: whether `status` should probe all 53 declared ports on every invocation (~53 curls, though they can be parallelised) or narrow the set first from `docker ps` port bindings and only probe those.

I dropped `:11434` (ollama) from the earlier revision of this branch — the old guard referenced it with nothing printing it, but that stack retired 2026-06-22 and reviving a line for it seemed like the wrong direction.

## Verification

Live on the reference rig (2× 3090, thinkingcap-27b on `:8099` under systemd): reports as shown above. `bash -n` clean. `test-gpu-mode-list`, `test-locale-utf8`, `test-studio-derig`, `test-setup-ai-studio-skip-path` all pass. Scoped-change guards only per AGENTS.md — one script, not a catalog-shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
