### PR TITLE
report: tell 2-card PCIe rigs which P2P gate they are behind (#873)

### DIFF
--- a/docs/PCIE_P2P.md
+++ b/docs/PCIE_P2P.md
@@ -117,6 +117,8 @@ A 3-slot (triple-width) card like most 3090s covers its own slot **plus the two 
 
 ## 5. Enabling P2P on consumer GPUs
 
+> **Not sure whether your rig is even a candidate?** `bash scripts/report.sh` answers that under *GPU hardware → NVLink*. On a 2+-card PCIe rig with peer access off it prints one line naming **which gate you're actually behind**: cards on separate root complexes (unreachable regardless of driver — §1–§2), a BAR1 too small to back the static full-VRAM mapping (fix §4 / the VBIOS **first**; this section can't help until then), or the stock driver's `CNS` refusal — which is the one case this section fixes. It stays silent on single-card rigs, NVLink rigs, and rigs where P2P is already on, so a line appearing means there's something real to decide.
+
 Two hard truths set expectations before you start:
 
 1. **The stock NVIDIA driver refuses P2P on GeForce cards over `PHB`.** Even with perfect topology and BIOS, the consumer driver disables peer access. Enabling it requires a **patched kernel module** — the community [`aikitoria/open-gpu-kernel-modules`](https://github.com/aikitoria/open-gpu-kernel-modules) fork ([Sam McLeod's walkthrough](https://smcleod.net/2026/02/patching-nvidias-driver-and-vllm-to-enable-p2p-on-consumer-gpus/)). This is a custom DKMS module — weigh the maintenance cost. (Should the walkthrough link ever rot, the shape of it: clone the fork matching your driver branch → build + install via DKMS in place of the stock `nvidia` kernel module → reboot → `nvidia-smi topo -p2p r` should now report `OK` between your GPUs.)

--- a/scripts/lib/p2p-state.sh
+++ b/scripts/lib/p2p-state.sh
@@ -196,3 +196,88 @@ p2p_transfer_verdict() {
     echo "⚠ interconnect WARN: P2P transfer check has only ${ok}/${total} directed pairs OK — peer access is advertised but BROKEN on some pairs (vLLM cache: ${src}). NCCL silently falls back on failing pairs → throughput ≈ P2P-off there. Guide: docs/PCIE_P2P.md"
   fi
 }
+# ── P2P opportunity hint (#873) ──────────────────────────────────────────────
+# Everything above answers "is P2P on?". This answers the question a user with
+# two cards and no P2P actually has: "could it be, and is it worth it?".
+#
+# Deliberately tiered rather than one line, because the naive "you could enable
+# P2P!" is WRONG for most rigs that would see it: cards on separate root
+# complexes can never peer regardless of driver, and a BAR1 smaller than VRAM
+# cannot back the patched module's static full-VRAM mapping (#734) — telling
+# either of those users to build a DKMS module wastes their evening. The
+# reference 2x3090 is itself the BAR1 case, which is why B outranks A.
+#
+# Prints ONE informational line, or nothing. Never a warning: not having P2P is
+# not a fault, and this must never read as "your rig is misconfigured".
+
+# GPU-GPU link class from `topo -m`: "same_root" (PHB/PIX/PXB — peer traffic can
+# stay below the CPU) | "split" (SYS/NODE — crosses the SMP/host-bridge boundary,
+# unreachable for P2P) | "unknown". Off-diagonal cells only.
+p2p_topology_class() {
+  nvidia-smi topo -m 2>/dev/null | awk '
+    NR == 1 { for (i = 1; i <= NF; i++) if ($i ~ /^GPU[0-9]+$/) ngpu++; next }
+    $1 ~ /^GPU[0-9]+$/ {
+      for (i = 2; i <= ngpu + 1; i++) {
+        if ($i == "X") continue
+        if ($i ~ /^(PHB|PIX|PXB)$/) near = 1
+        else if ($i ~ /^(SYS|NODE)$/) far = 1
+      }
+    }
+    END {
+      if (far) print "split"
+      else if (near) print "same_root"
+      else print "unknown"
+    }'
+}
+
+# Smallest BAR1 and its card's VRAM, as "<bar1MiB> <fbMiB>"; empty when the
+# driver does not report the fields. Mirrors detect_nvlink.sh _bar1_undersized,
+# but reports the numbers rather than a verdict (report.sh wants to print them).
+p2p_bar1_min() {
+  nvidia-smi -q -d MEMORY 2>/dev/null | awk '
+    /^GPU /             { idx++; sect = ""; next }
+    /FB Memory Usage/   { sect = "fb";   next }
+    /BAR1 Memory Usage/ { sect = "bar1"; next }
+    /Memory Usage/      { sect = "";     next }
+    sect != "" && $1 == "Total" && $3 ~ /^[0-9]+$/ {
+      if (sect == "fb") fb[idx] = $3; else bar1[idx] = $3
+      sect = ""
+    }
+    END {
+      for (i = 1; i <= idx; i++)
+        if (fb[i] > 0 && bar1[i] > 0 && (best == 0 || bar1[i] < best)) { best = bar1[i]; bfb = fb[i] }
+      if (best > 0) printf "%d %d\n", best, bfb
+    }'
+}
+
+# True (0) when `topo -p2p r` reports CNS on any pair — the stock GeForce
+# driver's software refusal, the one gate a patched module actually lifts.
+p2p_reports_cns() {
+  nvidia-smi topo -p2p r 2>/dev/null | grep -qE '(^|[[:space:]])CNS([[:space:]]|$)'
+}
+
+# p2p_opportunity_hint <gpu_count> <host_capability>
+# One line when there is something true to say; silent otherwise.
+p2p_opportunity_hint() {
+  local count="${1:-0}" cap="${2:-none}"
+  [[ "${count:-0}" -ge 2 ]] || return 0        # single card: meaningless
+  [[ "$cap" == "none" ]] || return 0           # nvlink / pcie_p2p: already covered
+
+  local topo; topo="$(p2p_topology_class)"
+  if [[ "$topo" == "split" ]]; then
+    echo "ℹ interconnect: ${count} GPUs, but they sit on SEPARATE root complexes (topo -m: SYS/NODE) — peer-to-peer is unreachable on this layout regardless of driver or BIOS, so there is nothing to enable here. If you can re-slot them onto the same root complex, docs/PCIE_P2P.md §1-§2 covers what to aim for."
+    return 0
+  fi
+  [[ "$topo" == "same_root" ]] || return 0     # unknown topology: say nothing
+
+  local bar1 fb; read -r bar1 fb <<<"$(p2p_bar1_min)"
+  if [[ -n "${bar1:-}" ]] && [[ "${bar1:-0}" -gt 0 ]] && (( bar1 * 2 < fb )); then
+    echo "ℹ interconnect: ${count} GPUs on a P2P-capable layout (same root complex) with peer access OFF, and BAR1 is ${bar1} MiB against ${fb} MiB of VRAM. The patched-driver P2P path maps the FULL VRAM aperture through BAR1, so it cannot work until that changes — this is the gate to fix first, not the driver. Check which one you're behind: the BIOS toggles (Above 4G Decoding + Re-Size BAR, docs/PCIE_P2P.md §4), or a pre-ReBAR VBIOS ceiling — \`sudo lspci -vv -s <bus> | grep -A4 'Physical Resizable BAR'\`, and if \`supported:\` tops out at 256MB it is firmware (#734)."
+    return 0
+  fi
+
+  if p2p_reports_cns; then
+    echo "ℹ interconnect: ${count} GPUs on a P2P-capable layout (same root complex) with peer access OFF — \`topo -p2p\` reports CNS, which is the stock driver refusing P2P on GeForce cards rather than a hardware limit. A patched kernel module can unlock it: measured +2% narrative / +9% code on dual rigs (#91/#295), so code and spec-decode workloads gain and narrative decode barely moves. It is an optional enthusiast lever, and it ships as a custom DKMS module you rebuild on every driver bump. If you want it: docs/PCIE_P2P.md §5."
+  fi
+}
+

--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -326,6 +326,12 @@ else
     nvidia-smi nvlink --status 2>&1 | redact | details "NVLink link status"
   else
     echo "_No NVLink detected (PCIe-only)_"
+    # "Could P2P be on here, and is it worth it?" — the question a 2-card
+    # PCIe rig actually has, which every other line in this report leaves
+    # unanswered (the verdict below needs a RUNNING container; this doesn't).
+    # Tiered + achievability-gated on purpose: see p2p_opportunity_hint.
+    _p2p_hint="$(p2p_opportunity_hint "$(p2p_gpu_count)" "$(p2p_host_capability)" 2>/dev/null || true)"
+    [[ -n "$_p2p_hint" ]] && { echo; echo "$_p2p_hint"; }
   fi
 
   subsection "Topology"

--- a/scripts/tests/test-p2p-state.sh
+++ b/scripts/tests/test-p2p-state.sh
@@ -69,6 +69,7 @@ case "\$*" in
   -L) printf '%b' "$1" ;;
   "topo -m") printf '%b' "$2" ;;
   "topo -p2p r") printf '%b' "$3" ;;
+  "-q -d MEMORY") printf '%b' "${4:-}" ;;
 esac
 EOF
 chmod +x "$TMP/nvidia-smi"; }
@@ -204,5 +205,52 @@ assert_contains "$out" "WARN"
 assert_contains "$out" "3/4"
 assert_empty "$(p2p_transfer_verdict 0 0 x)"                          # no data -> silent
 echo "  ✓ transfer-cache parse + verdict: full OK / partial WARN / garbage silent"
+
+# ── 9. P2P opportunity hint (#873): tiered, achievability-gated, never nags ──
+# The naive "you could enable P2P!" is WRONG for most rigs that would see it.
+# What matters here is that each rig class gets the message that is TRUE for it,
+# and that the firmware gate outranks the driver gate — the reference 2x3090 is
+# CNS *and* BAR1-capped, so a precedence bug would tell the maintainer's own rig
+# to go build a DKMS module that provably cannot work.
+TOPO_SYS='\tGPU0\tGPU1\nGPU0\t X \tSYS\nGPU1\tSYS\t X \n'
+_mem() { printf 'GPU 00000000:0%d:00.0\n    FB Memory Usage\n        Total : 24576 MiB\n        Used  : 1 MiB\n    BAR1 Memory Usage\n        Total : %d MiB\n        Used  : 4 MiB\n    Conf Compute Protected Memory Usage\n        Total : 0 MiB\n' "$1" "$2"; }
+MEM_SMALL="$(_mem 1 256)$(_mem 3 256)"      # aperture never grew (ReBAR off / capped VBIOS)
+MEM_BIG="$(_mem 1 32768)$(_mem 3 32768)"    # full-size aperture
+
+hint() { PATH="$TMP:$PATH" bash -c 'source scripts/lib/p2p-state.sh; p2p_opportunity_hint "$(p2p_gpu_count)" "$(p2p_host_capability)"'; }
+
+# (a) separate root complexes -> unreachable; must NOT sell the patched module
+mk_smi "$L2" "$TOPO_SYS" "$P2P_CNS" "$MEM_BIG"
+out="$(hint)"
+assert_contains "$out" "SEPARATE root complexes"
+[[ "$out" != *"§5"* ]] || fail "split-topology hint must not point at the patched-module path"
+
+# (b) same root + CNS + SMALL BAR1 -> firmware gate wins over the driver gate
+mk_smi "$L2" "$TOPO_PHB" "$P2P_CNS" "$MEM_SMALL"
+out="$(hint)"
+assert_contains "$out" "BAR1 is 256 MiB against 24576 MiB"
+assert_contains "$out" "§4"
+[[ "$out" != *"§5"* ]] || fail "BAR1-capped hint must not recommend the patched module (it cannot work)"
+
+# (c) same root + CNS + full-size BAR1 -> the one actionable case
+mk_smi "$L2" "$TOPO_PHB" "$P2P_CNS" "$MEM_BIG"
+out="$(hint)"
+assert_contains "$out" "§5"
+assert_contains "$out" "CNS"
+assert_contains "$out" "DKMS"          # the cost is stated, not just the gain
+assert_contains "$out" "+2% narrative" # honest expected gain, so users can decline
+
+# (d) BAR1 unreported by the driver -> fail open to the driver-gate message
+mk_smi "$L2" "$TOPO_PHB" "$P2P_CNS" ""
+assert_contains "$(hint)" "§5"
+
+# (e) silence where there is nothing to say
+mk_smi "$L2" "$TOPO_PHB" "$P2P_OK" "$MEM_BIG"
+assert_empty "$(hint)"                                  # P2P already on
+mk_smi "$L2" "$TOPO_NV" "$P2P_CNS" "$MEM_BIG"
+assert_empty "$(hint)"                                  # NVLink rig
+mk_smi 'GPU 0: RTX 3090\n' "$TOPO_PHB" "$P2P_CNS" "$MEM_SMALL"
+assert_empty "$(hint)"                                  # single card
+echo "  ✓ opportunity hint: split/firmware/driver tiers, BAR1 outranks CNS, silent when moot"
 
 echo "test-p2p-state: ok"


### PR DESCRIPTION
Every interconnect line in the report answers *"is P2P on?"*. None answered the question a user with two cards and no P2P actually has: **"could it be, and is it worth it?"** — and the existing verdict needs a *running container*, so a rig with nothing up got nothing at all.

## Why it's tiered instead of one line

The naive "you could enable P2P!" is **wrong for most rigs that would see it**. Cards on separate root complexes can never peer regardless of driver, and a BAR1 smaller than VRAM cannot back the patched module's static full-VRAM mapping (#734). Telling either of those users to go build a DKMS kernel module wastes their evening.

| Detected | Message |
|---|---|
| Separate root complexes (`SYS`/`NODE`) | unreachable on this layout, nothing to enable → §1–§2 |
| BAR1 < VRAM | **firmware/BIOS gate — fix that first**, §5 can't help yet → §4 + #734 |
| `CNS` + full-size BAR1 | the stock driver's refusal; the patched module lifts it → §5 |

**The firmware tier deliberately outranks the driver tier.** The reference 2×3090 is `CNS` **and** BAR1-capped at 256 MiB, so a precedence bug would tell the maintainer's own rig to install a module that provably cannot work. Live-verified there — it prints the firmware line, not the driver one:

```
### NVLink

_No NVLink detected (PCIe-only)_

ℹ interconnect: 2 GPUs on a P2P-capable layout (same root complex) with peer access OFF,
and BAR1 is 256 MiB against 24576 MiB of VRAM. The patched-driver P2P path maps the FULL
VRAM aperture through BAR1, so it cannot work until that changes — this is the gate to fix
first, not the driver. …
```

## UX rules it follows

- **Informational (`ℹ`), never a warning.** Not having P2P is not a fault and must not read as a misconfiguration.
- **States the cost, not just the gain** — `+2% narrative / +9% code` (#91/#295) *and* "a custom DKMS module you rebuild on every driver bump", so users can decline on the facts. §6 already frames P2P as an enthusiast lever, not a requirement; this matches.
- **Silent** on single-card, NVLink, and P2P-already-on rigs — preserving the existing "silence means nothing to gain, not check-failed" contract.
- **Placed in the container-independent NVLink subsection**, not preflight/launch: those run on every boot, and a recurring "have you considered patching your driver" line is nagging.

## Doc tie-in

Bidirectional: each tier points at the § that fixes it, and §5 gains a lead-in telling users to run `report.sh` to find out which gate they're behind before starting.

## Test

`test-p2p-state` gains 9 cases covering all three tiers, the BAR1-outranks-CNS precedence, fail-open when the driver doesn't report BAR1, and silence in all three moot cases. The shared `nvidia-smi` mock gained a `-q -d MEMORY` arm (optional 4th arg — existing 3-arg callers unaffected).

Green: `test-p2p-state`, `test-report-calib`, `test-report-engine-liveness`, `test-report-exit-code`, `test-detect-nvlink-autop2p`, `test-detect-nvlink-alloc-conf`, `test-locale-utf8`. Targeted rather than the full sweep — no compose, registry, or profile shape changed.
