### PR TITLE
docs: the serving tests auto-detect MODEL — correct the stale gotcha

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,7 +258,11 @@ For **entirely new models** under validation (e.g. "let's try MiniMax-M2.7"): ke
 
 **Long-running tests: redirect full output to a log file — NEVER pipe through `tail`/`head`/`grep`.** A pipe buffers until the process exits, so a `--full` quality run piped to `tail -12` is a ~2 h black box: no live `[N/M]` progress, no partial scores, and an interrupt leaves nothing readable (benchlocal also writes its results JSON only at completion — noonghunna/benchlocal-cli#82 tracks scenario-level resume). Do `bash scripts/quality-test.sh --full ... > /path/run.log 2>&1` (or `| tee`) and summarize from the file; `tail -f` the file for live progress. Learned 2026-07-11 on a template A/B.
 
-**Gotcha (all serving tests):** `verify-*`/`bench.sh` default `MODEL=qwen3.6-27b-autoround` — against any other served model that's a silent HTTP 404. Pass `MODEL=<served-name>` explicitly (or use `rebench-full.sh`, which autodetects).
+**Model resolution (all serving tests): they auto-detect — don't hand-pass `MODEL=` out of superstition.** Every serving script resolves the served-model id from `GET /v1/models` when `MODEL` is unset: `verify.sh`, `verify-full.sh`, `verify-stress.sh`, `bench.sh` (via `preflight_autodetect_model`), plus `quality-test.sh`, `soak-test.sh`, `bench-agentic.sh`, `concurrency-probe.sh`, `spec-sweep.sh`, `rebench-full.sh` (each inline). `bench.sh` announces it: `[autodetect] served model='…'`. An explicit `MODEL=` **always wins and is never clobbered**. The `qwen3.6-27b` literal in some of them is a **last-resort fallback for an unreachable endpoint**, not the effective default.
+
+⚠️ **Do pin `MODEL=` on multi-model endpoints** (llama-swap, or a compose registering several `--served-model-name` aliases): detection takes `data[0].id`, which may not be the alias you mean.
+
+> *This paragraph used to read "`verify-*`/`bench.sh` default `MODEL=qwen3.6-27b-autoround` — against any other served model that's a silent HTTP 404." That stopped being true when #372 landed autodetect, and the stale wording caused a wrong support answer on [#873](https://github.com/noonghunna/club-3090/issues/873) (a contributor was told his bench run would 404 when it would have auto-resolved). Verified against all ten scripts 2026-08-04.*
 
 The pipeline is layered: each script has a different question it answers ("does it serve / work / survive / fast / behave correctly / stay healthy"). Skipping any layer can mask regressions.
 


### PR DESCRIPTION
`AGENTS.md` has been telling every agent and contributor:

> **Gotcha (all serving tests):** `verify-*`/`bench.sh` default `MODEL=qwen3.6-27b-autoround` — against any other served model that's a silent HTTP 404.

**That stopped being true when #372 landed `/v1/models` autodetect.**

Verified against all ten serving scripts, not inferred:

| Resolves via | Scripts |
|---|---|
| `preflight_autodetect_model` | `verify.sh`, `verify-full.sh`, `verify-stress.sh`, `bench.sh` |
| inline `/v1/models` | `quality-test.sh`, `soak-test.sh`, `bench-agentic.sh`, `concurrency-probe.sh`, `spec-sweep.sh`, `rebench-full.sh` |

An explicit `MODEL=` always wins and is never clobbered; `bench.sh` announces what it picked (`[autodetect] served model='…'`). The `qwen3.6-27b` literal that survives in some of them is a **fallback for an unreachable endpoint**, not the effective default — which is why grepping for it reads like a footgun when it isn't one.

Kept the one case where pinning genuinely is still required: **multi-model endpoints** (llama-swap, or a compose registering several `--served-model-name` aliases), where detection takes `data[0].id` and may not pick the alias you meant.

## Why this is worth a PR rather than a quiet edit

It wasn't theoretical drift. The stale line produced a **wrong support answer on #873**: a contributor was mid-re-run and got told his `bench.sh` invocation would 404 against his 35B endpoint and to pass `MODEL=` explicitly — when it would have auto-resolved and printed the name. Comment corrected in place; this fixes the source. The correction is recorded inline so nobody re-reverts it from the old habit.
