### PR TITLE
p2p: scope the runtime messages to the card they apply to (#873 follow-up)

### DIFF
--- a/scripts/detect_nvlink.sh
+++ b/scripts/detect_nvlink.sh
@@ -213,7 +213,7 @@ if [ "$_NVLINK_ENABLED" -eq 1 ]; then
   if [ "$NCCL_P2P_LEVEL" != "NVL" ]; then
     _BAR1_BAD="$(_bar1_undersized)"
     if [ -n "$_BAR1_BAD" ]; then
-      echo "[nvlink] WARNING: enabling PCIe P2P, but BAR1 is far smaller than VRAM on: ${_BAR1_BAD}— the patched-driver P2P path maps the FULL VRAM aperture through BAR1 (static BAR1 mapping), which a BAR1 this small cannot back. Peer access can still be ADVERTISED by the driver (topo -p2p: OK) while transfers fail, and NCCL then HANGS during init rather than falling back — if this boot stops right after 'using nccl', this is why. Fix: enable Above 4G Decoding + Re-Size BAR in BIOS (some cards need a ReBAR VBIOS; some driver branches need the static-BAR1 registry override) — docs/PCIE_P2P.md §4-§5. To boot now without P2P: NVLINK_MODE=force_off." >&2
+      echo "[nvlink] WARNING: enabling PCIe P2P, but BAR1 is far smaller than VRAM on: ${_BAR1_BAD}— the patched-driver P2P path maps the FULL VRAM aperture through BAR1 (static BAR1 mapping), which a BAR1 this small cannot back. Peer access can still be ADVERTISED by the driver (topo -p2p: OK) while transfers fail, and NCCL then HANGS during init rather than falling back — if this boot stops right after 'using nccl', this is why. Fix: enable Above 4G Decoding + Re-Size BAR in BIOS; if lspci says the card's Physical Resizable BAR tops out at 256MB it is a VBIOS ceiling, not a BIOS setting (docs/PCIE_P2P.md §4). NOTE: the NVreg static-BAR1 override in §5 does NOT help here — that addresses a driver refusing to USE a full-size aperture, not an aperture that is too small. To boot now without P2P: NVLINK_MODE=force_off." >&2
     fi
     unset _BAR1_BAD
   fi

--- a/scripts/lib/p2p-state.sh
+++ b/scripts/lib/p2p-state.sh
@@ -277,7 +277,7 @@ p2p_opportunity_hint() {
   fi
 
   if p2p_reports_cns; then
-    echo "ℹ interconnect: ${count} GPUs on a P2P-capable layout (same root complex) with peer access OFF — \`topo -p2p\` reports CNS, which is the stock driver refusing P2P on GeForce cards rather than a hardware limit. A patched kernel module can unlock it: measured +2% narrative / +9% code on dual rigs (#91/#295), so code and spec-decode workloads gain and narrative decode barely moves. It is an optional enthusiast lever, and it ships as a custom DKMS module you rebuild on every driver bump. If you want it: docs/PCIE_P2P.md §5."
+    echo "ℹ interconnect: ${count} GPUs on a P2P-capable layout (same root complex) with peer access OFF — \`topo -p2p\` reports CNS, which is the stock driver refusing P2P on GeForce cards rather than a hardware limit. A patched kernel module can unlock it: gain is strongly card-dependent: +2% narrative / +9% code measured on dual 3090 (#91/#295), but +32% decode on a dual 5090 (#873), so code and spec-decode workloads gain and narrative decode barely moves. It is an optional enthusiast lever, and it ships as a custom DKMS module you rebuild on every driver bump. If you want it: docs/PCIE_P2P.md §5."
   fi
 }
 


### PR DESCRIPTION
#880 fixed the doc. These are the messages users actually **see** — at boot and in `report.sh` — which carried the same over-generalisation.

## 1. `detect_nvlink.sh` BAR1 warning suggested a fix that cannot work

It said *"some driver branches need the static-BAR1 registry override"*. That warning fires on **any** small-BAR1 PCIe rig — but the override addresses a driver refusing to **use** a full-size aperture. It cannot help an aperture that is **too small**, which is exactly the firmware-capped 3090 case (#734) this warning actually catches.

Replaced with the VBIOS-ceiling check, plus an explicit note that the §5 override does **not** apply here.

## 2. The opportunity hint quoted a 3090-era gain as universal

It cited **+2% narrative / +9% code** — dual-3090 numbers from #91/#295. @paulp83's dual 5090 measured **+32% decode** (#873).

A Blackwell owner reading "+2% narrative" would reasonably conclude that patching a kernel module is not worth it, when for them it is a **16x larger win**. Now states card-dependence with both datapoints.

## Why these matter more than the doc

Both strings reach users who never open `PCIE_P2P.md` — one at boot, one in the report people paste into issues. Getting them wrong is worse than getting the doc wrong.

`test-p2p-state`, `test-detect-nvlink-autop2p`, `test-detect-nvlink-alloc-conf` green.
