### PR TITLE
feat(scripts): p2p-validate — collective-level P2P check

### DIFF
--- a/scripts/lib/p2p_collective_check.py
+++ b/scripts/lib/p2p_collective_check.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Collective-level P2P validation — the tier below `nvidia-smi topo -p2p` and copy benchmarks.
+
+WHY THIS EXISTS
+  A driver reporting `topo -p2p = OK`, a passing `p2pBandwidthLatencyTest`, and a successful
+  `cuMemSetAccess` do NOT prove NCCL works. All three were true, on the same rig, while every
+  collective deadlocked — and one NCCL setting made them return wrong data instead.
+
+  The reason is structural: a copy benchmark *synchronizes after* the transfer, so it can ride
+  completion-time flushing. NCCL's producer and consumer kernels stay resident and must observe
+  each other's writes while both are still running. Any copy-then-sync test passes on a mapping
+  where NCCL cannot work.
+
+WHAT IT DOES
+  Runs the same tiny all-reduce twice:
+    ARM A — P2P as the driver currently has it
+    ARM B — NCCL_P2P_DISABLE=1 (host-staged control; should ALWAYS pass)
+  Small (4 B) and large (16 MiB) payloads, because NCCL selects different protocols by size
+  (LL vs Simple) and they can fail differently.
+
+  Ranks contribute 1.0 and 2.0, so every element must return exactly 3.0. Correctness is checked,
+  not merely completion — a collective that finishes with the wrong answer is worse than one that
+  hangs, and that failure mode is real (NCCL_P2P_USE_CUDA_MEMCPY=1 produced it).
+
+  Arm B is what makes the result trustworthy: if the control also fails, the verdict is
+  INCONCLUSIVE rather than a false P2P accusation.
+
+SAFETY
+  Read-only. ~16 MiB per GPU. Changes no configuration, writes no files. Each arm runs in its own
+  process group under a hard timeout, so a hang is killed rather than left wedging the machine.
+
+USAGE
+  python3 p2p_collective_check.py            # uses GPUs 0,1
+  GPUS=0,3 TIMEOUT_S=120 python3 p2p_collective_check.py
+
+  Normally invoked via scripts/p2p-validate.sh, which runs it inside a container that has torch.
+
+EXIT CODES
+  0 healthy · 2 collectives hang · 3 collectives return wrong data · 4 inconclusive · 5 unusable
+"""
+
+import os
+import signal
+import subprocess
+import sys
+
+TIMEOUT_S = int(os.environ.get("TIMEOUT_S", "90"))
+GPUS = os.environ.get("GPUS", "0,1")
+BASE_PORT = int(os.environ.get("BASE_PORT", "29517"))
+SIZES = [("4 B    (small -> LL proto)", 1), ("16 MiB (large -> Simple proto)", 4 * 1024 * 1024)]
+
+EXIT_HEALTHY, EXIT_HANG, EXIT_WRONG, EXIT_INCONCLUSIVE, EXIT_UNUSABLE = 0, 2, 3, 4, 5
+
+
+# ----------------------------------------------------------------- worker side
+def _worker(rank, world, port):
+    import torch
+    import torch.distributed as dist
+
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    dist.init_process_group("nccl", rank=rank, world_size=world)
+    torch.cuda.set_device(rank)
+
+    expected = float(world * (world + 1) // 2)  # 1+2 = 3.0 at world=2
+    ok = True
+    for label, n in SIZES:
+        t = torch.full((n,), float(rank + 1), device=f"cuda:{rank}", dtype=torch.float32)
+        dist.all_reduce(t)
+        torch.cuda.synchronize()
+        wrong = int((t != expected).sum().item())
+        if rank == 0:
+            got = t.flatten()[0].item()
+            verdict = "OK" if wrong == 0 else f"WRONG ({wrong}/{n} elements)"
+            print(f"    {label:<34} expect {expected}  got {got}  -> {verdict}", flush=True)
+        ok = ok and wrong == 0
+
+    dist.barrier()
+    dist.destroy_process_group()
+    if rank == 0:
+        print("WORKER_VERDICT=" + ("PASS" if ok else "WRONG_DATA"), flush=True)
+    sys.exit(0 if ok else 2)
+
+
+def _run_worker():
+    import torch.multiprocessing as mp
+    mp.spawn(_worker, args=(2, int(os.environ["P2PCHECK_PORT"])), nprocs=2, join=True)
+
+
+# ----------------------------------------------------------------- driver side
+def _arm(name, extra_env, port):
+    """Run one arm in its own process group. Returns PASS | WRONG | HANG | ERROR."""
+    env = dict(os.environ)
+    env["CUDA_VISIBLE_DEVICES"] = GPUS
+    env["P2PCHECK_WORKER"] = "1"
+    env["P2PCHECK_PORT"] = str(port)          # distinct per arm: a killed arm can hold its port
+    env.update(extra_env)
+
+    print(f"\n  {name}")
+    proc = subprocess.Popen(
+        [sys.executable, os.path.abspath(__file__)],
+        env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        text=True, start_new_session=True,
+    )
+    try:
+        out, _ = proc.communicate(timeout=TIMEOUT_S)
+        rc = proc.returncode
+    except subprocess.TimeoutExpired:
+        # kill the whole group — mp.spawn children outlive a bare proc.kill()
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            proc.kill()
+        proc.communicate()
+        print(f"    HUNG — no result in {TIMEOUT_S}s (killed)")
+        return "HANG"
+
+    for line in out.splitlines():
+        if line.startswith("    ") or "Error" in line or "error" in line:
+            print(line if line.startswith("    ") else f"    {line.strip()[:150]}")
+    if "WORKER_VERDICT=PASS" in out:
+        return "PASS"
+    if "WORKER_VERDICT=WRONG_DATA" in out:
+        return "WRONG"
+    print(f"    (arm did not report a verdict; exit={rc})")
+    return "ERROR"
+
+
+def verdict(a, b):
+    """Pure verdict logic → (message, exit_code). Kept separate and side-effect free
+    because every FAILURE branch is unreachable on a healthy rig — the only way to
+    verify them is a test. See scripts/tests/test-p2p-validate.sh."""
+    if b != "PASS":
+        return ("  INCONCLUSIVE — the P2P-off control also failed, so something unrelated is\n"
+                "  wrong (install / driver / GPU visibility). This is NOT a P2P finding.",
+                EXIT_INCONCLUSIVE)
+    if a == "PASS":
+        return ("  HEALTHY — collectives complete correctly with P2P as configured.",
+                EXIT_HEALTHY)
+    if a == "HANG":
+        return ("  *** BUG — collectives HANG with P2P on, but pass with it off. ***\n"
+                "  Workaround: NCCL_P2P_DISABLE=1 (or NCCL_P2P_LEVEL=PXB), or NVLINK_MODE=force_off.",
+                EXIT_HANG)
+    if a == "WRONG":
+        return ("  *** SERIOUS — collectives COMPLETE WITH WRONG DATA with P2P on. ***\n"
+                "  Silent corruption. Set NCCL_P2P_DISABLE=1 now and treat any multi-GPU output\n"
+                "  from this rig as suspect until it is resolved.",
+                EXIT_WRONG)
+    return (f"  ARM A errored ({a}) — see output above.", EXIT_INCONCLUSIVE)
+
+
+def _sh(cmd):
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=30).stdout.strip()
+    except Exception:
+        return ""
+
+
+def main():
+    bar = "=" * 76
+    print(bar); print("  P2P COLLECTIVE CHECK"); print(bar)
+
+    gpus = _sh(["nvidia-smi", "--query-gpu=index,name", "--format=csv,noheader"])
+    if not gpus:
+        print("\n  ERROR: nvidia-smi unavailable.")
+        return EXIT_UNUSABLE
+    print("\n  " + "\n  ".join(gpus.splitlines()[:8]))
+    if len(gpus.splitlines()) < 2:
+        print("\n  Only one GPU visible — a collective needs two. Nothing to check.")
+        return EXIT_UNUSABLE
+
+    topo = _sh(["nvidia-smi", "topo", "-p2p", "r"])
+    if topo:
+        print("\n  topo -p2p r:")
+        print("  " + "\n  ".join(l for l in topo.splitlines()[:6] if l.strip()))
+    lic = _sh(["modinfo", "-F", "license", "nvidia"])
+    if lic:
+        flavour = "OPEN — P2P-capable" if "MIT" in lic else "proprietary — refuses P2P on GeForce"
+        print(f"\n  driver module license: {lic}   ({flavour})")
+
+    a = _arm("ARM A — P2P as your driver has it", {}, BASE_PORT)
+    b = _arm("ARM B — NCCL_P2P_DISABLE=1 (control)", {"NCCL_P2P_DISABLE": "1"}, BASE_PORT + 1)
+
+    print("\n" + bar)
+    print(f"  ARM A (P2P as-is)        : {a}")
+    print(f"  ARM B (P2P off, control) : {b}")
+    print(bar)
+
+    msg, rc = verdict(a, b)
+    print(msg)
+    print(bar)
+    if rc != EXIT_HEALTHY:
+        print("\n  Why the usual checks miss this: a copy benchmark synchronizes AFTER the")
+        print("  transfer, so it can ride completion-time flushing. NCCL's producer and consumer")
+        print("  kernels stay resident and must observe each other's writes mid-flight. Any")
+        print("  copy-then-sync test therefore passes on a mapping where NCCL cannot work.")
+    print()
+    return rc
+
+
+if __name__ == "__main__":
+    if os.environ.get("P2PCHECK_WORKER"):
+        _run_worker()
+    else:
+        sys.exit(main())

--- a/scripts/p2p-validate.sh
+++ b/scripts/p2p-validate.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# p2p-validate.sh — does this rig actually complete NCCL collectives?
+#
+# The tier BELOW `nvidia-smi topo -p2p` and copy benchmarks. Those can all pass
+# on a rig where every collective deadlocks or silently returns wrong data:
+# a copy test synchronizes AFTER the transfer, while NCCL's kernels stay
+# resident and must observe each other's writes mid-flight — so copy-then-sync
+# can never validate the contract NCCL actually depends on.
+#
+# Runs a tiny all-reduce twice — once with P2P as your driver has it, once with
+# NCCL_P2P_DISABLE=1 as a control — and checks the RESULT VALUES, not just that
+# it finished. Read-only; changes nothing.
+#
+#   bash scripts/p2p-validate.sh
+#   bash scripts/p2p-validate.sh --gpus 0,3 --timeout 120
+#   bash scripts/p2p-validate.sh --image ghcr.io/…   # pick the torch container
+#
+# Exit: 0 healthy · 2 hang · 3 wrong data · 4 inconclusive · 5 unusable
+# ---------------------------------------------------------------------------
+set -uo pipefail
+export PYTHONUTF8="${PYTHONUTF8:-1}"   # #779 — python3 under a C/POSIX locale mangles non-ASCII
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+PAYLOAD="${ROOT_DIR}/scripts/lib/p2p_collective_check.py"
+GPUS="${GPUS:-0,1}"
+TIMEOUT_S="${TIMEOUT_S:-90}"
+IMAGE="${IMAGE:-}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --gpus)    GPUS="$2"; shift 2 ;;
+    --timeout) TIMEOUT_S="$2"; shift 2 ;;
+    --image)   IMAGE="$2"; shift 2 ;;
+    -h|--help) sed -n '2,22p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown arg: $1 (try --help)" >&2; exit 64 ;;
+  esac
+done
+
+[[ -r "$PAYLOAD" ]] || { echo "ERROR: payload not found at $PAYLOAD" >&2; exit 5; }
+
+# ---- 1. host python with torch? then no container needed ----
+if python3 -c 'import torch' >/dev/null 2>&1; then
+  echo "[p2p-validate] using host python3 (torch present)"
+  GPUS="$GPUS" TIMEOUT_S="$TIMEOUT_S" exec python3 "$PAYLOAD"
+fi
+
+# ---- 2. otherwise run inside a container that has torch ----
+command -v docker >/dev/null 2>&1 || {
+  echo "ERROR: no host torch and no docker. Install torch, or run the payload yourself:" >&2
+  echo "       python3 $PAYLOAD" >&2
+  exit 5
+}
+
+if [[ -z "$IMAGE" ]]; then
+  # Any vLLM/SGLang image ships torch + NCCL. Prefer whatever is already local so
+  # the check never triggers a multi-GB pull.
+  IMAGE="$(docker images --format '{{.Repository}}:{{.Tag}}' 2>/dev/null \
+           | grep -E 'vllm|sglang' | grep -v '<none>' | head -1)"
+fi
+if [[ -z "$IMAGE" ]]; then
+  echo "ERROR: no local vLLM/SGLang image found and no --image given." >&2
+  echo "       Pass one you already have:  bash scripts/p2p-validate.sh --image <img>" >&2
+  exit 5
+fi
+
+echo "[p2p-validate] host has no torch — running inside: $IMAGE"
+echo "[p2p-validate] GPUs=$GPUS timeout=${TIMEOUT_S}s (read-only; nothing is changed)"
+
+# --ipc=host: NCCL/torch shared-memory transports need more than docker's 64 MB default.
+docker run --rm --gpus all --ipc=host \
+  -e GPUS="$GPUS" -e TIMEOUT_S="$TIMEOUT_S" \
+  -v "${PAYLOAD}:/p2p_collective_check.py:ro" \
+  --entrypoint python3 "$IMAGE" /p2p_collective_check.py
+exit $?

--- a/scripts/tests/test-p2p-validate.sh
+++ b/scripts/tests/test-p2p-validate.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# test-p2p-validate.sh — guards scripts/p2p-validate.sh + its payload.
+#
+# WHY THIS TEST EARNS ITS KEEP: every FAILURE branch of the verdict matrix is
+# unreachable on a healthy rig. A working machine only ever exercises PASS/PASS,
+# so the hang and silent-corruption paths — the entire reason the tool exists —
+# would otherwise ship having never run once.
+set -uo pipefail
+export PYTHONUTF8="${PYTHONUTF8:-1}"   # #779 — python3 under a C/POSIX locale mangles non-ASCII
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+WRAPPER="${ROOT_DIR}/scripts/p2p-validate.sh"
+PAYLOAD="${ROOT_DIR}/scripts/lib/p2p_collective_check.py"
+fail=0
+pass() { echo "  ok   — $1"; }
+bad()  { echo "  FAIL — $1" >&2; fail=1; }
+
+echo "== test-p2p-validate =="
+
+[[ -r "$WRAPPER" ]] && pass "wrapper present" || bad "wrapper missing"
+[[ -x "$WRAPPER" ]] && pass "wrapper executable" || bad "wrapper not executable"
+[[ -r "$PAYLOAD" ]] && pass "payload present" || bad "payload missing"
+
+bash -n "$WRAPPER" 2>/dev/null && pass "wrapper parses" || bad "wrapper syntax error"
+python3 -m py_compile "$PAYLOAD" 2>/dev/null && pass "payload compiles" || bad "payload syntax error"
+
+# --- the verdict matrix: arm_a arm_b -> expected exit code ---
+# Control-failed MUST outrank everything: never accuse P2P when the baseline is broken.
+python3 - "$PAYLOAD" <<'PY'
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("p2pcheck", sys.argv[1])
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+
+cases = [
+    ("PASS",  "PASS",  m.EXIT_HEALTHY,      "healthy"),
+    ("HANG",  "PASS",  m.EXIT_HANG,         "hang with a good control"),
+    ("WRONG", "PASS",  m.EXIT_WRONG,        "silent corruption"),
+    ("ERROR", "PASS",  m.EXIT_INCONCLUSIVE, "arm A errored"),
+    # control broken -> inconclusive regardless of arm A
+    ("PASS",  "HANG",  m.EXIT_INCONCLUSIVE, "control hung"),
+    ("HANG",  "HANG",  m.EXIT_INCONCLUSIVE, "both hung"),
+    ("WRONG", "ERROR", m.EXIT_INCONCLUSIVE, "control errored"),
+]
+bad = 0
+for a, b, want, name in cases:
+    msg, rc = m.verdict(a, b)
+    if rc != want:
+        print(f"  FAIL — verdict({a},{b}) = {rc}, want {want} ({name})"); bad = 1
+    elif not msg.strip():
+        print(f"  FAIL — verdict({a},{b}) returned an empty message"); bad = 1
+    else:
+        print(f"  ok   — verdict({a},{b}) -> {rc} ({name})")
+
+# the two severe verdicts must name the workaround, or the user is stranded
+for a in ("HANG", "WRONG"):
+    msg, _ = m.verdict(a, "PASS")
+    if "NCCL_P2P_DISABLE" not in msg:
+        print(f"  FAIL — {a} verdict does not tell the user the workaround"); bad = 1
+    else:
+        print(f"  ok   — {a} verdict names NCCL_P2P_DISABLE")
+
+# distinct exit codes: callers must be able to distinguish hang from corruption
+codes = {m.EXIT_HEALTHY, m.EXIT_HANG, m.EXIT_WRONG, m.EXIT_INCONCLUSIVE, m.EXIT_UNUSABLE}
+if len(codes) != 5:
+    print("  FAIL — exit codes are not distinct"); bad = 1
+else:
+    print("  ok   — exit codes distinct")
+sys.exit(bad)
+PY
+[[ $? -eq 0 ]] || fail=1
+
+# --- payload must never mutate the rig ---
+for danger in 'setpci' 'nvidia-smi -[a-z]* [0-9]' 'modprobe' 'rm -rf' 'docker run'; do
+  if command grep -qE "$danger" "$PAYLOAD"; then
+    bad "payload contains a state-changing call: $danger"
+  fi
+done
+pass "payload is read-only (no state-changing calls)"
+
+# --- correctness check must be value-based, not completion-based ---
+command grep -q 'wrong' "$PAYLOAD" && command grep -q 'expected' "$PAYLOAD" \
+  && pass "payload verifies VALUES, not just completion" \
+  || bad "payload does not appear to check result values"
+
+# --- arms must use distinct ports (the bug that broke the first version) ---
+command grep -q 'BASE_PORT + 1' "$PAYLOAD" \
+  && pass "arms use distinct ports (killed arm can hold its port)" \
+  || bad "arms may share a port — a killed arm A will EADDRINUSE arm B"
+
+# --- hang must be killed by process GROUP, not just the parent ---
+command grep -q 'killpg' "$PAYLOAD" \
+  && pass "timeout kills the process group (mp.spawn children outlive proc.kill)" \
+  || bad "timeout does not kill the process group — children would survive"
+
+[[ $fail -eq 0 ]] && echo "== PASS ==" || echo "== FAIL =="
+exit $fail


### PR DESCRIPTION
## Why

`nvidia-smi topo -p2p = OK`, a passing `p2pBandwidthLatencyTest`, and a successful `cuMemSetAccess` can **all be true on a rig where every NCCL collective deadlocks** — or, with one NCCL setting, returns *wrong numbers* instead of hanging.

That isn't a weak test, it's a **weaker contract**. A copy benchmark synchronizes *after* the transfer, so it can ride completion-time flushing. NCCL's producer and consumer kernels stay **resident and mutually dependent** — the consumer must observe the peer's write *before* the producer exits, because the producer is waiting on the reverse direction. So copy-then-sync passes on mappings NCCL cannot use.

## What

Adds the missing fourth rung to the detection ladder:

| tier | answers | tool |
|---|---|---|
| topology | could these cards do P2P? | `report.sh` |
| driver grant | does the driver permit it? | `detect_nvlink.sh` |
| transfer | do bytes move? | `VLLM_SKIP_P2P_CHECK=0` |
| **collective** | **does NCCL actually work?** | **`p2p-validate.sh` ← new** |

```bash
bash scripts/p2p-validate.sh
```

No host torch required — runs inside any local vLLM/SGLang image. Read-only, ~16 MiB per GPU, changes nothing.

## Design

- **Two arms** — P2P as-is, plus `NCCL_P2P_DISABLE=1` as a control. If the control also fails you get `INCONCLUSIVE`, so a broken container can't masquerade as a hardware bug.
- **Checks values, not completion** — ranks contribute 1.0 and 2.0, every element must return 3.0. Silent corruption is a real failure mode and is strictly worse than a hang.
- **4 B and 16 MiB payloads** — NCCL picks LL vs Simple by size and they can fail differently.
- **Distinct exit codes** — `0` healthy · `2` hang · `3` wrong data · `4` inconclusive · `5` unusable, so it is callable from other scripts.

## Testing

- Live run on a 2× 3090 rig: `HEALTHY`, exit 0.
- Full suite green on `master`.

The unit test exists because **every failure branch is unreachable on a healthy rig** — a working machine only ever takes PASS/PASS, so the hang and corruption verdicts would otherwise ship having never executed. It drives the full verdict matrix directly and pins three defects found during development: distinct ports per arm (a killed arm A otherwise `EADDRINUSE`s the control, scoring a broken rig as "inconclusive"), process-**group** kill on timeout (`mp.spawn` children outlive `proc.kill()`), and both severe verdicts naming the `NCCL_P2P_DISABLE` workaround.