### PR TITLE
feat(c3): surface offload slugs properly + wire setup.sh + fix two #905 regressions

### DIFF
--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -68,6 +68,12 @@ def _entry(
     # PCIe); "prefetch" = vLLM bulk layer prefetch. Surfaced as the c3 catalog
     # "offload" column. First used by the Laguna 118B-MoE offload slugs.
     offload=None,
+    # Minimum HOST RAM in GB for a weight-offload slug — the worst case (all experts
+    # on CPU). This is a HARD GATE, not a recommendation: below it the box thrashes or
+    # OOMs, and preflight_cpu_offload_ram() REFUSES. Surfaced as the c3 catalog
+    # "host RAM" column so a user sees it BEFORE selecting a slug, rather than
+    # discovering it at launch refusal. None = fully VRAM-resident, nothing to warn about.
+    host_ram_gb=None,
     chat_template="native",
     tp,
     max_ctx,
@@ -123,6 +129,7 @@ def _entry(
         "act_format": act_format,
         "act8_capable": act8_capable,
         "offload": offload,
+        "host_ram_gb": host_ram_gb,
         "chat_template": chat_template,
         "tp": tp,
         "pp": 1,
@@ -977,6 +984,8 @@ COMPOSE_REGISTRY = {
         compose_path="models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-q8-kxl/offload.yml",
         default_port=8030,
         kvcalc_key="SKIP",
+        offload="n-cpu-moe",
+        host_ram_gb=146,
         required_sm=8.6,
         status="incubating",
         status_note="A 284B MoE on 2x24 GB. QUALITY TIER of the two DeepSeek-Flash offload slugs. Stock upstream b10236, zero patches. Three levers compose: CPU expert offload (137 GiB of routed experts in host RAM) + partial residency (bundles pinned back onto the GPUs, sized by the launcher from DETECTED free VRAM) + the DSpark drafter. HARD GATE: ~146 GB host RAM worst case -- preflight REFUSES below it. Ships 200K, NOT 262K: at 262K with the drafter it boots READY at 97.4% VRAM, passes a trivial decode, then dies on a ~15.7K-token prefill (CUDA OOM in cuMemCreate, reproduced 2026-08-06). NO PERFORMANCE OR QUALITY NUMBERS ARE PUBLISHED -- incubating; a canonical bench and the 8-pack are both owed. Validated operationally only: boot + a 14,011-token prefill probe + verify-full all checks passed.",
@@ -990,6 +999,8 @@ COMPOSE_REGISTRY = {
         compose_path="models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-iq2-xxs/offload.yml",
         default_port=8031,
         kvcalc_key="SKIP",
+        offload="n-cpu-moe",
+        host_ram_gb=86,
         required_sm=8.6,
         status="incubating",
         status_note="REACH TIER of the two DeepSeek-Flash offload slugs: ~86 GB host RAM worst case vs the Q8 tier's ~146 GB, which is what makes a 284B model fit a constrained box. Stock upstream b10236, zero patches; same three levers (offload + launcher-sized residency + DSpark). ~2.6-bit experts. Scoped to dual 24 GB by design. NO PERFORMANCE OR QUALITY NUMBERS ARE PUBLISHED -- incubating; canonical bench and 8-pack both owed, and quality is the open question on a quant this low. Validated operationally only: boot + a 14,011-token prefill probe + verify-full all checks passed.",
@@ -1004,6 +1015,8 @@ COMPOSE_REGISTRY = {
         compose_path="models/deepseek-v4-flash-0731/llama-cpp/compose/multi4/unsloth-q8-kxl/offload.yml",
         default_port=8032,
         kvcalc_key="SKIP",
+        offload="n-cpu-moe",
+        host_ram_gb=146,
         required_sm=8.6,
         status="incubating",
         status_note="4-card QUALITY tier. NEVER BOOTED BY US -- authored from measured 2-card data plus the ~0.55 residency calibration; every number is an ESTIMATE until a 4-card owner runs it. The argument is NOT throughput: every layer pinned to a GPU is a layer NOT in host RAM, so host RAM FALLS with card count -- ~113 GB (est.) at 4x24 GB vs ~140 GB at 2x24. 128 GB is a very common host config, which the 2-card Q8 slug EXCLUDES and this one FITS, so multi4 is what puts the quality tier inside a mainstream RAM budget. Residency should also be at its best here (~23% of expert traffic on GPU vs 4.7% on two cards). No IQ2 multi slug: on four cards Q8 itself drops into a 128 GB budget, so a low-bit tier is not needed to fit.",

--- a/scripts/lib/profiles/models/deepseek-v4-flash-0731.yml
+++ b/scripts/lib/profiles/models/deepseek-v4-flash-0731.yml
@@ -100,6 +100,25 @@ weights:
     hf_repo: unsloth/DeepSeek-V4-Flash-0731-GGUF
     shards: 3
     manual_note: "Reach tier — substantially lower host-RAM requirement than Q8 (~86 vs ~146 GB worst case), which is what makes the model fit a constrained box. NO published perf/quality numbers — incubating. ⚠️ ~2.6-bit experts; quality is the open question on this tier."
+  dspark:
+    path: deepseek-v4-flash-0731-gguf/dspark
+    local_subdir: deepseek-v4-flash-0731-gguf/dspark
+    size_gb: 11
+    format: gguf
+    status: incubating
+    hf_repo: unsloth/DeepSeek-V4-Flash-0731-GGUF
+    kind: draft
+    verify_glob: "*.gguf"
+    # ⚠️ REQUIRED, not optional — both shipped slugs pass `-md` and will not boot
+    # without it. The main GGUF carries NO embedded nextn/MTP head (unsloth's
+    # conversion drops it; verified 0 nextn tensors across all 5 shards), so
+    # self-speculation is impossible and DSpark is the ONLY speculative path.
+    # ⚠️ Declared HERE as a weights entry with `kind: draft`, NOT under a
+    # `drafters:` block — nothing in the downloader reads that key, so a drafter
+    # declared there is silently never fetched and the guided path yields a model
+    # that cannot start.
+    # Runtime landed in ggml-org#25784; present in server-cuda-b10236, ABSENT in
+    # b9967, so the engine pin is a hard floor.
   # IQ4_NL is on disk but DELIBERATELY NOT a slug (plan D6): slower than Q8 on
   # decode AND slower than IQ2 on prefill, at an intermediate RAM cost — dominated
   # in every workload. Kept for the quality ladder only.
@@ -108,17 +127,3 @@ weights:
   # performance leader. That config can never be a slug (unmerged expert cache +
   # local patches). On stock upstream + DSpark + residency — the shipping regime —
   # IQ4 is dominated. Both readings are correct for their engine.
-
-drafters:
-  dspark:
-    path: deepseek-v4-flash-0731-gguf/dspark/dspark-DeepSeek-V4-Flash-0731-Q8_0.gguf
-    size_gb: 11
-    spec_type: draft-dspark
-    n_max: 5
-    # Runtime landed in ggml-org#25784 ("DeepseekV4 MTP + DSpark", merged 2026-08-02).
-    # VERIFIED present in server-cuda-b10236 (2 `dspark` hits in libllama.so, and
-    # `llama-server --help` advertises it); ABSENT in b9967.
-    # ⚠️ The GGUF carries NO embedded nextn/MTP head — unsloth's conversion dropped it
-    # (verified: 0 nextn-family tensors across all 5 shards), so self-spec is impossible
-    # and DSpark is the only speculative path.
-    requires_engine_min: server-cuda-b10236

--- a/scripts/lib/registry-emit.sh
+++ b/scripts/lib/registry-emit.sh
@@ -682,6 +682,9 @@ for vr in _tui_registry.parse_variant_rows(tab):
             # Weight-offload backend (catalog "offload" column) — None = resident
             # (default) / "uva" / "n-cpu-moe" / "prefetch". Laguna 118B-MoE slugs.
             "offload": (COMPOSE_REGISTRY.get(d["slug"], {}) or {}).get("offload"),
+            # Minimum HOST RAM (GB) for weight-offload slugs — a HARD GATE, surfaced so
+            # c3 can show it BEFORE selection rather than at launch refusal.
+            "host_ram_gb": (COMPOSE_REGISTRY.get(d["slug"], {}) or {}).get("host_ram_gb"),
             # Weights quant_label + FORMAT from the model profile (catalog
             # Weights column fallbacks) — see _weights_meta() above.
             "weights_quant_label": _weights_meta(

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -68,6 +68,7 @@ usage() {
   echo "  qwen3.6-35b-a3b"
   echo "  gemma-4-31b"
   echo "  gemma-4-26b-a4b"
+  echo "  deepseek-v4-flash-0731"
   echo ""
   echo "Exact catalog entry fetch: WEIGHT_KEY=<registry-key> $0 <model-name>"
 }
@@ -76,6 +77,7 @@ model_label() {
   case "$1" in
     qwen3.6-27b) echo "Qwen 3.6 27B" ;;
     qwen3.6-35b-a3b) echo "Qwen 3.6 35B-A3B" ;;
+    deepseek-v4-flash-0731) echo "DeepSeek-V4-Flash-0731 (284B MoE, CPU offload)" ;;
     gemma-4-31b) echo "Gemma 4 31B" ;;
     gemma-4-26b-a4b) echo "Gemma 4 26B-A4B" ;;
     diffusiongemma-26b-a4b) echo "DiffusionGemma 26B-A4B (dLLM)" ;;
@@ -213,6 +215,16 @@ case "${MODEL_NAME}" in
   qwen3.6-35b-a3b)
     PRIMARY_WEIGHT_KEY="qwen3.6-35b-a3b:autoround-int4"
     ;;
+  deepseek-v4-flash-0731)
+    # Defaults to the IQ2 REACH tier (~85 GB on disk, ~86 GB host RAM) rather than
+    # Q8 (~151 GB / ~146 GB host RAM): the reach tier is the one most rigs can
+    # actually run, and a wrong guess here costs the user a 151 GB download.
+    # Q8 instead:  WEIGHT_KEY=deepseek-v4-flash-0731:unsloth-q8-kxl scripts/setup.sh deepseek-v4-flash-0731
+    PRIMARY_WEIGHT_KEY="deepseek-v4-flash-0731:unsloth-iq2-xxs"
+    # ⚠️ NOT optional: both slugs pass -md and will not boot without the drafter.
+    # The main GGUF has no embedded nextn head, so DSpark is the only spec path.
+    ALWAYS_DRAFT_KEY="deepseek-v4-flash-0731:dspark"
+    ;;
   gemma-4-31b)
     PRIMARY_WEIGHT_KEY="gemma-4-31b:autoround-int4"
     ALWAYS_DRAFT_KEY="gemma-4-31b:assistant"
@@ -236,7 +248,7 @@ case "${MODEL_NAME}" in
     # the WEIGHT_KEY override below sets it.
     if [[ -z "${WEIGHT_KEY:-}" ]]; then
       echo "ERROR: unsupported model '${MODEL_NAME}'."
-      echo "Supported: qwen3.6-27b, qwen3.6-35b-a3b, gemma-4-31b, gemma-4-26b-a4b, diffusiongemma-26b-a4b"
+      echo "Supported: qwen3.6-27b, qwen3.6-35b-a3b, gemma-4-31b, gemma-4-26b-a4b, diffusiongemma-26b-a4b, deepseek-v4-flash-0731"
       echo "(To add a new model, extend the model dispatch in scripts/setup.sh and profiles/models/*.yml,"
       echo " or pass WEIGHT_KEY=<model>:<variant> to fetch an exact catalog entry directly.)"
       exit 1

--- a/scripts/tests/test-registry-json.sh
+++ b/scripts/tests/test-registry-json.sh
@@ -85,7 +85,7 @@ VARIANT_KEYS = {
     "act8_capable",
     # c3 catalog offload column: weight-offload backend — None (resident, the
     # default) / "uva" / "n-cpu-moe" / "prefetch".
-    "offload",
+    "offload", "host_ram_gb",
 }
 v0 = d["variants"][0]
 need(set(v0.keys()) == VARIANT_KEYS,

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -240,6 +240,16 @@ def _act_label(e: "CatalogEntry") -> str:
     return (getattr(e.row, "act_format", "") or "") or "—"
 
 
+def _host_ram_label(e: "CatalogEntry") -> str:
+    """Minimum HOST RAM for a weight-offload slug, from the registry ``host_ram_gb``
+    facet. This is the number that decides whether a user can run the slug AT ALL —
+    below it preflight refuses — so it belongs in the catalog next to VRAM, not buried
+    in status_note prose where the user only meets it at launch refusal. "—" for
+    VRAM-resident slugs, which have nothing to warn about."""
+    v = getattr(e.row, "host_ram_gb", None)
+    return f"{v} GB" if v else "—"
+
+
 def _offload_label(e: "CatalogEntry") -> str:
     """Weight-offload backend for the catalog offload column — the registry
     ``offload`` facet (emitted like ``act_format``): "uva" (vLLM demand-paged
@@ -264,6 +274,7 @@ _CATALOG_COLUMNS: "list[tuple[str, str]]" = [
     ("kv", "kv"),
     ("act", "act"),
     ("offload", "offload"),
+    ("host_ram", "host RAM"),
     ("spec", "spec"),
     ("ctx", "ctx"),
     ("tps", "TPS (rig)"),
@@ -324,6 +335,11 @@ def _spec_token(drafter: str) -> str:
         return ""
     if "dflash" in dr:
         return "DFlash"
+    if "dspark" in dr:
+        # Like DFlash, DSpark is ALWAYS an external drafter — the DeepSeek-V4-Flash
+        # GGUF carries no embedded nextn head (unsloth's conversion drops it), so there
+        # is no built-in-vs-external split to disambiguate and it needs no suffix.
+        return "DSpark"
     if "ngram" in dr:
         return "ngram"
     if "assistant" in dr:      # gemma *-it-assistant → spec_method mtp_assistant
@@ -1199,6 +1215,7 @@ class CatalogPane(Container):
                 "kv": _kv_label(e),
                 "act": _act_label(e),
                 "offload": _offload_label(e),
+                "host_ram": _host_ram_label(e),
                 "spec": _spec_label(e),
                 "ctx": e.ctx_label or "—",
                 "tps": tps,

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -4906,6 +4906,9 @@ def _variant_row_from_dict(d: dict[str, Any]) -> VariantRow:
         # Weight-offload backend (catalog offload column) — same pattern;
         # "" when the contract didn't carry it (resident/older emit) → shows "—".
         object.__setattr__(row, "offload", str(d.get("offload") or ""))
+        # Minimum host RAM for offload slugs (hard gate). Kept as int|None rather than
+        # str so the column can render "—" for resident slugs without a magic string.
+        object.__setattr__(row, "host_ram_gb", d.get("host_ram_gb"))
         object.__setattr__(row, "chat_template", str(d.get("chat_template") or "native"))
         # W4A8-int8-activation capability (c3 serve-confirm checkbox, #609).
         object.__setattr__(row, "act8_capable", bool(d.get("act8_capable")))

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -10093,7 +10093,12 @@ class TestProfileTemplateDerivation:
         # Exactly one option per (family, topology); 7 distinct groups today.
         pairs = {(o.topology, o.label.split(" / ")[0]) for o in opts}
         assert len(opts) == len(pairs), "duplicate (family, topology) representative"
-        assert len(opts) == 7, f"expected 7 reps, got {len(opts)}: {[o.slug for o in opts]}"
+        # 8 since #905: the DeepSeek-Flash slugs created a NEW (llamacpp, multi4)
+        # group, whose only member is incubating. That is rule (d) working as
+        # designed — an entirely non-functional group still gets a representative
+        # (cf. the (vllm, multi4) and (beellama, dual) precedents named in the
+        # profile_templates docstring); the custom-slug escape hatch reaches the rest.
+        assert len(opts) == 8, f"expected 8 reps, got {len(opts)}: {[o.slug for o in opts]}"
 
         # The 1-card rig default must be FUNCTIONAL + non-incubating — ideally the
         # registry's curated single default (vllm/minimal).

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -4104,13 +4104,35 @@ class TestServeOverrides:
         assert d["ENGINE"] == "vllm-stable"              # only parsing gives this
         assert d["SPEC_DRAFTER"] == "MTP n=3"            # real drafter, not "on"
 
+    def test_every_registry_drafter_has_a_spec_token(self):
+        """No shipped drafter may fall through to the generic "spec" fallback.
+
+        _spec_token() pattern-matches the drafter id, so a NEW method (dspark was the
+        case) renders as the literal string "spec" in the catalog — technically not
+        wrong, but it tells the user nothing and looks like a bug. Catch it here rather
+        than in a screenshot.
+        """
+        import sys
+        sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts/lib/profiles"))
+        from compose_registry import COMPOSE_REGISTRY
+        from club3090_cockpit.app import _spec_token
+
+        generic = sorted({
+            (e.get("drafter") or "")
+            for e in COMPOSE_REGISTRY.values()
+            if (e.get("drafter") or "") and _spec_token(e.get("drafter")) == "spec"
+        })
+        assert not generic, f"drafters with no _spec_token mapping: {generic}"
+
     def test_engine_kv_formats_is_engine_specific(self):
         repo_root = Path(__file__).resolve().parents[3]
         cd = CockpitData(repo_root, runner=full_runner())
         vk = cd.engine_kv_formats("vllm-stable")
         assert "fp8_e5m2" in vk and "int8_per_token_head" in vk
         # a totally different engine → a totally different KV family
-        assert cd.engine_kv_formats("llama-cpp-mainline") == ["q4_0", "q5_0", "q8_0", "k8v4"]
+        # fp16 is llama.cpp's default KV (no -ctk/-ctv); added to the engine profile in
+        # #905 for the DeepSeek-Flash CPU-offload slugs, which serve on it.
+        assert cd.engine_kv_formats("llama-cpp-mainline") == ["fp16", "q4_0", "q5_0", "q8_0", "k8v4"]
         # the editor's KV options come from the engine, not a generic list
         assert cd.serve_override_defaults("vllm/dual", "org/Foo")["KV_OPTIONS"] == vk
 


### PR DESCRIPTION
#905 shipped the catalog's first **CPU-offload slugs**, but c3 couldn't describe them and `setup.sh` couldn't fetch them. Six gaps, one root cause: an offload slug is a **new kind of thing**, and several hand-maintained tables didn't know it existed.

## Catalog surface

| you saw | cause | fix |
|---|---|---|
| offload column `—` | `offload=None` on the catalog's first offload slugs — the facet and `_offload_label()` already existed for exactly this | `offload="n-cpu-moe"` |
| spec column `spec` | `_spec_token()` pattern-matches drafter ids; `dspark` matched nothing and hit the generic fallback | maps to **`DSpark`** |
| host RAM nowhere | the hard gate lived only in `status_note` prose | new **`host_ram_gb`** facet → registry → emit → `services.py` → c3 column |

Host RAM is the number that decides whether a user can run the slug **at all**. Without a column, a 64 GB box browses, selects, and only meets the gate at launch refusal.

## The setup path didn't work — and would have failed *silently*

**`setup.sh` rejected the model outright.** Its list is hardcoded in **three** places plus a dispatch block, so adding a model to the catalog doesn't register it. Now wired, defaulting to the **IQ2 reach tier (~85 GB)** rather than Q8 (~151 GB) — guessing wrong costs the user a 151 GB download. Q8 via `WEIGHT_KEY=`.

**And the drafter would never have been fetched.** I'd declared DSpark under a `drafters:` key that **nothing reads** — drafters are fetched via `ALWAYS_DRAFT_KEY` pointing at a `weights:` entry with `kind: draft`. As shipped, the guided path would pull 85–151 GB and produce a server that **cannot boot**: both slugs pass `-md`, and with no embedded prediction head DSpark is the only speculative path.

## Two test regressions #905 shipped

Both are legitimate consequences of the catalog change, and both were red on master:

- **`test_engine_kv_formats_is_engine_specific`** — adding `fp16` to the llama.cpp engine broke an exact-equality assertion on a 4-element list.
- **`test_real_registry_reps_are_status_aware`** — the new `(llamacpp, multi4)` group took profile-template reps 7 → 8. I checked this against the picker rather than just bumping the number: the functional-status comment reads as *"reps should never be non-launchable"*, but `profile_templates`' **rule (d)** says an *entirely* non-functional group still gets a representative, naming `(vllm, multi4)` and `(beellama, dual)` as precedents. So **8 is correct behaviour**, not something to code around.

They were missed because **c3's pytest is not covered by `scripts/tests/*.sh`** — AGENTS.md says so explicitly — and #905 ran only the shell sweep.

## Guard

New test walks every registry drafter and fails if one falls through to the generic `"spec"`, so the next new method is caught here instead of in a screenshot.

## Validation

**shell suite 99/0 · c3 suite 877/0.**

> ### ⚠️ c3's suite must run with `cwd = tools/serve-cockpit` in the tree under test
> The venv installs the package **editable against the main checkout**, so running pytest from a worktree root collects the worktree's *tests* while importing master's *code*. That inflated **2 real failures into 495** — and would have hidden a genuine bug in this PR: `_CATALOG_COLUMNS` entries are `(key, label)` and I'd written `("host RAM", "host_ram")` backwards, which crashed the catalog pane with `KeyError('host RAM')`. Every entry I copied from has identical key and label, so the order was invisible.