### PR TITLE
fix(deepseek-flash): declare verify_glob on the GGUF weights entries

### DIFF
--- a/scripts/lib/profiles/models/deepseek-v4-flash-0731.yml
+++ b/scripts/lib/profiles/models/deepseek-v4-flash-0731.yml
@@ -87,6 +87,11 @@ weights:
     status: incubating
     hf_repo: unsloth/DeepSeek-V4-Flash-0731-GGUF
     shards: 5
+    # ⚠️ REQUIRED on every GGUF entry — `verify_glob` defaults to `*.safetensors`,
+    # which matches NOTHING here. Omitting it made c3 report the weights absent
+    # while they sat on disk, and made setup.sh exit 1 after a successful 151 GB
+    # download with "download may have failed" (weights.py:132, setup.sh:114).
+    verify_glob: "*.gguf"
     # MXFP4 experts (~91% of the file) + BF16 attention. ⚠️ The quant NAME does not
     # give you the byte size — 3264 MiB/layer is a MEASUREMENT, not a calculation
     # from "Q8". Every new quant needs measuring, not deriving.
@@ -99,6 +104,7 @@ weights:
     status: incubating
     hf_repo: unsloth/DeepSeek-V4-Flash-0731-GGUF
     shards: 3
+    verify_glob: "*.gguf"          # see the note on unsloth-q8-kxl — not optional
     manual_note: "Reach tier — substantially lower host-RAM requirement than Q8 (~86 vs ~146 GB worst case), which is what makes the model fit a constrained box. NO published perf/quality numbers — incubating. ⚠️ ~2.6-bit experts; quality is the open question on this tier."
   dspark:
     path: deepseek-v4-flash-0731-gguf/dspark

--- a/scripts/tests/test-model-weights-registry.sh
+++ b/scripts/tests/test-model-weights-registry.sh
@@ -82,4 +82,33 @@ assert_lookup carnice-v2-27b-int4-recipe-d-bf16mtp/chat_template.jinja qwen3.6-2
 assert_lookup qwopus3.6-27b-int4-recipe-d-bf16mtp/config.json qwen3.6-27b:qwopus-bf16mtp
 assert_lookup gemma-4-31b-google-qat-w4a16/config.json gemma-4-31b:google-qat-w4a16
 
+# `verify_glob` must match the entry's declared `format`.
+#
+# It DEFAULTS to `*.safetensors` (weights.py), so a GGUF entry that simply omits
+# it gets a glob matching nothing — and both consumers fail SILENTLY-ish in ways
+# that blame the wrong thing: c3 reports the weights absent while they sit on
+# disk, and setup.sh's post-download verify counts zero files and exits with
+# "download may have failed" AFTER a successful multi-hundred-GB pull. Nothing
+# else catches it, because a mismatched glob is valid YAML and a valid glob.
+python3 - <<'PY'
+import pathlib, sys, yaml
+
+bad = []
+for f in sorted(pathlib.Path("scripts/lib/profiles/models").glob("*.yml")):
+    doc = yaml.safe_load(f.read_text(encoding="utf-8")) or {}
+    for key, meta in (doc.get("weights") or {}).items():
+        if not isinstance(meta, dict):
+            continue
+        glob = meta.get("verify_glob") or "*.safetensors"   # weights.py default
+        is_gguf = str(meta.get("format", "")).lower() == "gguf"
+        if is_gguf != glob.endswith(".gguf"):
+            bad.append(f"  {f.name}::{key}  format={meta.get('format')}  "
+                       f"verify_glob={glob}"
+                       f"{'  (DEFAULTED — declare it)' if not meta.get('verify_glob') else ''}")
+
+if bad:
+    print("verify_glob does not match declared format:", *bad, sep="\n", file=sys.stderr)
+    sys.exit(1)
+PY
+
 echo "test-model-weights-registry: ok"


### PR DESCRIPTION
## What

Both DeepSeek-Flash quant entries omitted `verify_glob`, which **defaults to `*.safetensors`** (`weights.py:132`) — a glob that matches nothing in a GGUF directory.

## Why it matters

Two consumers read it, and both fail in ways that blame the wrong thing:

| Consumer | Symptom |
|---|---|
| **c3** | Reports the weights `PARTIAL` ("interrupted / wrong") while all 8 shards sit on disk, and keeps offering Download |
| **`setup.sh`** | Post-download verify counts **zero** files and exits 1 with *"download may have failed"* — **after a successful 151 GB / 85 GB pull** |

The second one is on the path the alpha announcement (#909) tells users to take, so anyone following it downloads for hours and then gets told the download failed.

The drafter entry already declared `verify_glob: "*.gguf"`; the two quants did not. Nothing caught it because a mismatched glob is valid YAML *and* a valid glob.

## The guard

`test-model-weights-registry` now asserts `verify_glob` agrees with each entry's declared `format` across all 68 weights entries, **in both directions**, and calls out the defaulted-not-declared case by name.

## Verification

- `weights_state_for()` (c3's real path, not a reimplementation) returns `partial` → `present` for all three slugs
- Guard goes **red** on the reverted profile, **green** on the fix (mutation-tested)
- Full sweep `scripts/tests/*.sh`: **99 pass / 0 fail**
- c3 `test_services.py` + `test_registry_parser.py`: **264 passed**
- Sweep confirms only these two entries were affected repo-wide