### PR TITLE
fix(deepseek-flash): scope the weight fetch to the quant we serve

### DIFF
--- a/scripts/lib/profiles/models/deepseek-v4-flash-0731.yml
+++ b/scripts/lib/profiles/models/deepseek-v4-flash-0731.yml
@@ -79,32 +79,56 @@ vram_sizing:
   drafter_dspark_mib: { cuda0: 9054, cuda1: 8104 }   # model + compute, both cards
 
 weights:
+  # ⚠️⚠️ THIS REPO HOLDS 13 QUANTS — 1,537 GB. `files:` is what scopes the fetch.
+  # With no `files:`, setup.sh runs `hf download <repo> --local-dir <subdir>` and
+  # pulls the WHOLE repo (every quant) — verified against the HF API 2026-08-07.
+  #
+  # ⚠️ And `--local-dir` PRESERVES repo folder structure (verified empirically,
+  # not assumed): a file at `UD-Q8_K_XL/x.gguf` lands at `<local_dir>/UD-Q8_K_XL/
+  # x.gguf`. So `local_subdir` must be the BUCKET and `files:` must carry the
+  # quant-folder prefix — pointing local_subdir at the quant dir would nest it
+  # twice (`…/UD-Q8_K_XL/UD-Q8_K_XL/`), which no compose points at.
+  # `path:` stays the QUANT dir: it is the physical weights location and keeps
+  # key-resolution precise (weights.py `_resolve_key`), while `local_subdir` is
+  # the download target. They are deliberately different here — don't "fix" it.
   unsloth-q8-kxl:
     path: deepseek-v4-flash-0731-gguf/UD-Q8_K_XL
-    local_subdir: deepseek-v4-flash-0731-gguf/UD-Q8_K_XL
+    local_subdir: deepseek-v4-flash-0731-gguf
     size_gb: 151
     format: gguf
     status: incubating
     hf_repo: unsloth/DeepSeek-V4-Flash-0731-GGUF
     shards: 5
+    files:
+      - UD-Q8_K_XL/DeepSeek-V4-Flash-0731-UD-Q8_K_XL-00001-of-00005.gguf
+      - UD-Q8_K_XL/DeepSeek-V4-Flash-0731-UD-Q8_K_XL-00002-of-00005.gguf
+      - UD-Q8_K_XL/DeepSeek-V4-Flash-0731-UD-Q8_K_XL-00003-of-00005.gguf
+      - UD-Q8_K_XL/DeepSeek-V4-Flash-0731-UD-Q8_K_XL-00004-of-00005.gguf
+      - UD-Q8_K_XL/DeepSeek-V4-Flash-0731-UD-Q8_K_XL-00005-of-00005.gguf
     # ⚠️ REQUIRED on every GGUF entry — `verify_glob` defaults to `*.safetensors`,
     # which matches NOTHING here. Omitting it made c3 report the weights absent
     # while they sat on disk, and made setup.sh exit 1 after a successful 151 GB
     # download with "download may have failed" (weights.py:132, setup.sh:114).
-    verify_glob: "*.gguf"
+    # Globbed relative to `local_subdir`, so it carries the quant prefix too —
+    # which also makes each match a valid REPO path for the hash check.
+    verify_glob: "UD-Q8_K_XL/*.gguf"
     # MXFP4 experts (~91% of the file) + BF16 attention. ⚠️ The quant NAME does not
     # give you the byte size — 3264 MiB/layer is a MEASUREMENT, not a calculation
     # from "Q8". Every new quant needs measuring, not deriving.
     manual_note: "Quality tier. NO published perf/quality numbers — incubating. Ships 200K, NOT 262K: at 262K with the drafter attached it boots READY at 97.4% VRAM, survives a trivial decode, then dies on a ~15.7K-token prefill with CUDA OOM in cuMemCreate (reproduced 2026-08-06)."
   unsloth-iq2-xxs:
     path: deepseek-v4-flash-0731-gguf/UD-IQ2_XXS
-    local_subdir: deepseek-v4-flash-0731-gguf/UD-IQ2_XXS
+    local_subdir: deepseek-v4-flash-0731-gguf
     size_gb: 85
     format: gguf
     status: incubating
     hf_repo: unsloth/DeepSeek-V4-Flash-0731-GGUF
     shards: 3
-    verify_glob: "*.gguf"          # see the note on unsloth-q8-kxl — not optional
+    files:                          # see the note on unsloth-q8-kxl — without this
+      - UD-IQ2_XXS/DeepSeek-V4-Flash-0731-UD-IQ2_XXS-00001-of-00003.gguf   # the fetch
+      - UD-IQ2_XXS/DeepSeek-V4-Flash-0731-UD-IQ2_XXS-00002-of-00003.gguf   # is the
+      - UD-IQ2_XXS/DeepSeek-V4-Flash-0731-UD-IQ2_XXS-00003-of-00003.gguf   # whole repo
+    verify_glob: "UD-IQ2_XXS/*.gguf"
     manual_note: "Reach tier — substantially lower host-RAM requirement than Q8 (~86 vs ~146 GB worst case), which is what makes the model fit a constrained box. NO published perf/quality numbers — incubating. ⚠️ ~2.6-bit experts; quality is the open question on this tier."
   dspark:
     path: deepseek-v4-flash-0731-gguf/dspark
@@ -113,6 +137,15 @@ weights:
     format: gguf
     status: incubating
     hf_repo: unsloth/DeepSeek-V4-Flash-0731-GGUF
+    # ⚠️ The Q8_0 drafter we serve lives at the REPO ROOT, while the repo's
+    # `dspark/` FOLDER holds a different artifact (the BF16). Our local `dspark/`
+    # dir is therefore a root file placed into a folder of our own naming — the
+    # two `dspark` names are unrelated. Root files land flat under --local-dir
+    # (verified), so this yields `…-gguf/dspark/dspark-…-Q8_0.gguf`, which is
+    # exactly the `-md` path both composes pass. Unfiltered, the repo's own
+    # dspark/ would nest a BF16 at `…/dspark/dspark/` and serve nothing.
+    files:
+      - dspark-DeepSeek-V4-Flash-0731-Q8_0.gguf
     kind: draft
     verify_glob: "*.gguf"
     # ⚠️ REQUIRED, not optional — both shipped slugs pass `-md` and will not boot

--- a/scripts/tests/test-model-weights-registry.sh
+++ b/scripts/tests/test-model-weights-registry.sh
@@ -111,4 +111,69 @@ if bad:
     sys.exit(1)
 PY
 
+# `files:` scopes the fetch, and `verify_glob` must agree with it.
+#
+# An entry with no `files:` downloads the ENTIRE hf_repo. That is correct for a
+# whole-repo bucket, and catastrophic for one quant of a multi-quant repo — the
+# DeepSeek repo holds 13 quants / 1,537 GB, so the unscoped form would pull all
+# of it to serve one. Two entries sharing a local_subdir is the tell: they are
+# slices of one repo, so each MUST name its files or they fetch the same superset
+# into the same directory.
+#
+# And because `hf download --local-dir` PRESERVES repo folder structure, a file
+# in a repo subfolder lands under that subfolder — so verify_glob has to carry
+# the same prefix the files do. If the two ever drift, verification looks in a
+# directory the download never wrote to and reports a good pull as a failure.
+python3 - <<'PY'
+import collections, fnmatch, pathlib, sys, yaml
+
+
+def gmatch(name: str, pattern: str) -> bool:
+    """Glob semantics as the CONSUMERS apply them, not fnmatch's.
+
+    Both readers (`for f in $verify_glob` in bash, `Path.glob()` in c3) treat
+    `*` as NOT crossing a `/`. Plain fnmatch does cross it, so `*.gguf` would
+    falsely appear to match `UD-IQ2_XXS/x.gguf` and this guard would pass a
+    prefix drift it exists to catch. Match segment-wise instead.
+    """
+    n, p = name.split("/"), pattern.split("/")
+    return len(n) == len(p) and all(fnmatch.fnmatch(a, b) for a, b in zip(n, p))
+
+
+bad = []
+for f in sorted(pathlib.Path("scripts/lib/profiles/models").glob("*.yml")):
+    doc = yaml.safe_load(f.read_text(encoding="utf-8")) or {}
+    # Only FETCHABLE entries can misfetch. An entry with no `hf_repo` is a local
+    # bucket placeholder (e.g. qwen3.6-27b::gguf) — it downloads nothing, so it
+    # neither needs a files: filter nor makes a shared subdir dangerous.
+    weights = {
+        k: m for k, m in (doc.get("weights") or {}).items()
+        if isinstance(m, dict) and m.get("hf_repo")
+    }
+
+    shared = collections.Counter(
+        str(m.get("local_subdir") or m.get("path") or "") for m in weights.values()
+    )
+    for key, meta in weights.items():
+        files = meta.get("files") or []
+        if isinstance(files, str):
+            files = [files]
+        subdir = str(meta.get("local_subdir") or meta.get("path") or "")
+
+        if not files and shared[subdir] > 1:
+            bad.append(f"  {f.name}::{key}  shares local_subdir '{subdir}' with "
+                       f"{shared[subdir] - 1} other entry(s) but declares no files: "
+                       f"— it would fetch the whole repo into a shared dir")
+            continue
+
+        glob = meta.get("verify_glob") or "*.safetensors"
+        if files and not any(gmatch(name, glob) for name in files):
+            bad.append(f"  {f.name}::{key}  verify_glob={glob} matches NONE of its "
+                       f"{len(files)} declared file(s) (e.g. {files[0]})")
+
+if bad:
+    print("files:/verify_glob inconsistency:", *bad, sep="\n", file=sys.stderr)
+    sys.exit(1)
+PY
+
 echo "test-model-weights-registry: ok"


### PR DESCRIPTION
Follow-up to #910. Same audit, worse bug.

## What

The weights entries declared no `files:`, so `setup.sh` ran `hf download <repo> --local-dir <subdir>` **with no filter**. That repo holds **13 quants / 1,537 GB**:

| folder | size |
|---|---|
| UD-Q8_K_XL | 161.9 GB |
| UD-Q4_K_XL | 155.1 GB |
| …11 more quants… | ~1,200 GB |
| dspark | 11.3 GB |

Asking for the **85 GB reach tier** would have tried to pull **all 1,537 GB**.

## And it would not have served even if it finished

`--local-dir` **preserves repo folder structure** — verified empirically, not assumed:

```
hf download <repo> UD-IQ2_XXS/…-00001-of-00003.gguf --local-dir X
  ->  X/UD-IQ2_XXS/…-00001-of-00003.gguf     # subfolder preserved
hf download <repo> README.md --local-dir X
  ->  X/README.md                            # root file lands flat
```

With `local_subdir` pointing at the quant dir, that nests twice — `…-gguf/UD-IQ2_XXS/UD-IQ2_XXS/` — and **no compose points there**.

## Fix

`local_subdir` becomes the bucket; `files:` carries the quant-folder prefix; `verify_glob` carries it too (it globs relative to `local_subdir`, which also keeps every match a valid **repo** path for the hash check). `path:` stays the quant dir — the physical location, and it keeps key resolution precise.

**The drafter needed a different shape.** The Q8_0 we serve is at the **repo root**, while the repo's own `dspark/` folder holds an unrelated **BF16**. Root files land flat, so naming the file yields exactly the `-md` path both composes pass. Unfiltered, it would have nested a BF16 and served nothing.

## Why nothing caught it

The weights were placed **by hand** on the maintainer rig, so the `setup.sh` path had never been exercised for this model — the same reason #910 went unnoticed.

## Guard

Two new legs on `test-model-weights-registry`:
1. a **fetchable** entry sharing a `local_subdir` must scope its fetch;
2. `verify_glob` must match at least one declared file.

Leg 2 needs **consumer glob semantics, not `fnmatch`'s**: `*` must not cross `/`, or `*.gguf` falsely matches `UD-IQ2_XXS/x.gguf` and the guard passes the exact drift it exists to catch. That defect was in my first version of the guard and was caught by mutation-testing the guard itself. Both legs are scoped to entries with an `hf_repo` — a bucket placeholder that downloads nothing cannot misfetch (this removed a false positive on `qwen3.6-27b::gguf`).

## Verification

- Resolved fetch for all three entries lands **exactly** where each compose points
- c3 `weights_state_for()` still `present` for all three slugs
- Every `verify_glob` match resolves to a real repo path **with a published etag** — so the hash check will actually verify
- Guard **red** on both mutations (dropped `files:`, drifted glob prefix), green on the fix
- Full sweep `scripts/tests/*.sh`: **99 pass / 0 fail** · c3: **264 passed**