### PR TITLE
fix(deepseek-flash): gate readiness on the DSpark drafter

### DIFF
--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -982,6 +982,9 @@ COMPOSE_REGISTRY = {
         engine="llama-cpp-local", drafter="dspark", kv_format="fp16",
         tp=2, max_ctx=204800, max_num_seqs=1, mem_util=None,
         compose_path="models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-q8-kxl/offload.yml",
+        # DSpark is REQUIRED, not optional -- the compose passes -md and will not
+        # boot without it, so readiness must gate on it (c3 Start would serve-fail).
+        weights_companions=("dspark",),  # DSpark draft GGUF the compose mounts
         default_port=8030,
         kvcalc_key="SKIP",
         offload="n-cpu-moe",
@@ -997,6 +1000,9 @@ COMPOSE_REGISTRY = {
         engine="llama-cpp-local", drafter="dspark", kv_format="fp16",
         tp=2, max_ctx=204800, max_num_seqs=1, mem_util=None,
         compose_path="models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-iq2-xxs/offload.yml",
+        # DSpark is REQUIRED, not optional -- the compose passes -md and will not
+        # boot without it, so readiness must gate on it (c3 Start would serve-fail).
+        weights_companions=("dspark",),  # DSpark draft GGUF the compose mounts
         default_port=8031,
         kvcalc_key="SKIP",
         offload="n-cpu-moe",
@@ -1013,6 +1019,9 @@ COMPOSE_REGISTRY = {
         engine="llama-cpp-local", drafter="dspark", kv_format="fp16",
         tp=4, max_ctx=204800, max_num_seqs=1, mem_util=None,
         compose_path="models/deepseek-v4-flash-0731/llama-cpp/compose/multi4/unsloth-q8-kxl/offload.yml",
+        # DSpark is REQUIRED, not optional -- the compose passes -md and will not
+        # boot without it, so readiness must gate on it (c3 Start would serve-fail).
+        weights_companions=("dspark",),  # DSpark draft GGUF the compose mounts
         default_port=8032,
         kvcalc_key="SKIP",
         offload="n-cpu-moe",


### PR DESCRIPTION
Third finding from the same audit as #910 / #911.

## What

All three slugs declared `drafter="dspark"` but **no `weights_companions`**. Those are different fields for different jobs:

| field | job |
|---|---|
| `drafter` | display label in the catalog |
| `weights_companions` | what the **readiness check** actually reads |

With it empty, c3 reported the slug **PRESENT** whenever the main quant was on disk — **including when the drafter was not**. Both composes pass `-md`, and the main GGUF carries no embedded prediction head, so the server cannot boot without DSpark. Start would have gone straight to a serve-fail with the catalog claiming the weights were ready.

The companion check exists precisely to stop that — it just had nothing to check.

## Not a new convention

Every other slug mounting a draft or projector GGUF already declares this (`anbeeld-dflash-iq4xs`, `gguf_mmproj_f16`). These three were the exception.

## Verification

Against a synthetic tree with the quant present and the drafter **absent**:

```
quant present, DRAFTER ABSENT:          complete tree:
  dual-q8    -> partial                   dual-q8    -> present
  dual-iq2   -> partial                   dual-iq2   -> present
  multi4-q8  -> partial                   multi4-q8  -> present
```

So Download fires and Start is gated, instead of a confident `present` followed by a boot failure.

Full sweep **99 pass / 0 fail** · c3 full suite (incl. headless) **877 passed**.