### PR TITLE
fix(preflight): see list-form compose args, so the deps guard stops false-greening

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -886,6 +886,44 @@ _preflight_compose_model_dir() {
   printf '%s' "$model_dir"
 }
 
+# _preflight_compose_flag_paths <flag-alternation> <compose-file>... — emit every
+# `/models/...` value passed to one of the given flags, in BOTH compose spellings.
+#
+# ⚠️ Compose command args come in two forms, and matching only one is a SILENT
+# hole — the guard returns green for a compose it never actually read:
+#
+#     command: -m /models/x.gguf          # inline: flag + value on one line
+#     command:                            # list: flag and value are SEPARATE items
+#       - '-m'
+#       - '/models/x.gguf'
+#
+# Every extractor here was inline-only, so all three DeepSeek-Flash composes
+# (list form) were invisible: the path came back empty, the qwen fallback took
+# over, and `switch.sh` validated *Qwen's* files while launching DeepSeek. That
+# is how paulp83 got three container restarts and a cryptic in-container
+# "failed to open GGUF file" instead of one clear "weights missing" (#913).
+_preflight_compose_flag_paths() {
+  local flags="$1"
+  shift
+  [[ $# -gt 0 ]] || return 0
+
+  # (a) inline — flag and value on the same line.
+  grep -hoE -- "(^|[[:space:]])(${flags})[[:space:]]+/models/[^[:space:]]+" "$@" 2>/dev/null \
+    | awk '{print $NF}' || true
+
+  # (b) YAML list — the value is the NEXT list item after the flag item.
+  # `q` carries the single quote so the program stays single-quotable in bash.
+  awk -v flagre="^(${flags})$" -v q="'" '
+    FNR == 1 { pending = 0 }                       # never span two files
+    {
+      line = $0
+      sub(/^[[:space:]]*-[[:space:]]*/, "", line)  # strip the list dash
+      gsub("^[\"" q "]|[\"" q "],?$", "", line)    # strip quotes / trailing comma
+      if (pending && line ~ /^\/models\//) { print line; pending = 0; next }
+      pending = (line ~ flagre) ? 1 : 0
+    }' "$@" 2>/dev/null || true
+}
+
 _preflight_compose_path_default() {
   local value="$1"
   value="$(_preflight_trim "$value")"
@@ -1134,8 +1172,7 @@ preflight_compose_deps() {
     while IFS= read -r token; do
       path="$(_preflight_compose_path_default "$token")"
       [[ -n "$path" ]] && gguf_paths+=("$path")
-    done < <(grep -hoE -- '(^|[[:space:]])(-m|--model)[[:space:]]+/models/[^[:space:]]+' "${compose_files[@]}" \
-      | awk '{print $NF}' || true)
+    done < <(_preflight_compose_flag_paths '-m|--model' "${compose_files[@]}")
 
     # Speculative drafter: beellama --spec-draft-model, llama.cpp -md/--model-draft.
     # A missing drafter GGUF otherwise surfaces only as a cryptic in-container
@@ -1143,14 +1180,12 @@ preflight_compose_deps() {
     while IFS= read -r token; do
       path="$(_preflight_compose_path_default "$token")"
       [[ -n "$path" ]] && draft_paths+=("$path")
-    done < <(grep -hoE -- '(^|[[:space:]])(--spec-draft-model|--model-draft|-md)[[:space:]]+/models/[^[:space:]]+' "${compose_files[@]}" \
-      | awk '{print $NF}' || true)
+    done < <(_preflight_compose_flag_paths '--spec-draft-model|--model-draft|-md' "${compose_files[@]}")
 
     while IFS= read -r token; do
       path="$(_preflight_compose_path_default "$token")"
       [[ -n "$path" ]] && mmproj_paths+=("$path")
-    done < <(grep -hoE -- '(^|[[:space:]])--mmproj[[:space:]]+/models/[^[:space:]]+' "${compose_files[@]}" \
-      | awk '{print $NF}' || true)
+    done < <(_preflight_compose_flag_paths '--mmproj' "${compose_files[@]}")
 
     # Env overrides mirror the compose knobs (GGUF_FILE / DRAFT_FILE / MMPROJ_FILE),
     # each replacing only its own path class.


### PR DESCRIPTION
Found while diagnosing #913.

## The hole

`preflight_compose_deps` is a **hard gate** in `switch.sh` (`|| exit 1`). Its entire job is to refuse when a compose mounts a model file that isn't on the host. It never fired for the DeepSeek-Flash slugs.

Compose args come in two spellings, and every extractor matched only one:

```yaml
command: -m /models/x.gguf     # inline — matched
command:
  - '-m'                       # list — INVISIBLE
  - '/models/x.gguf'
```

With the path unextractable, the code fell through to its **hardcoded qwen fallback** — so `switch.sh` validated *Qwen's* files while launching DeepSeek, and returned green.

**3 of 12 llama.cpp composes were affected — all three DeepSeek slugs.** A guard that reports on a model it never looked at is worse than no guard at all.

## What the reporter saw instead

Three container restarts and a cryptic in-container `failed to open GGUF file (No such file or directory)` — with a preflight that had just said everything was fine.

## Fix

`_preflight_compose_flag_paths` extracts a flag's `/models/...` values in **both** forms; all three call sites rewired (`-m|--model`, `-md|--model-draft|--spec-draft-model`, `--mmproj`). The awk leg resets its pending flag on `FNR == 1` so a flag in one compose can never bind to a value in the next.

## Verification

Reconstructed the reporter's on-disk layout (shards one level too deep, from the pre-#911 fetch bug):

```
[preflight] ERROR: compose '…/dual/unsloth-iq2-xxs/offload.yml' expects model files that aren't on host.
[preflight]   missing: …/UD-IQ2_XXS/…-00001-of-00003.gguf (llama.cpp GGUF weights)
[preflight]   missing: …/dspark/dspark-…-Q8_0.gguf (speculative drafter GGUF)
[preflight] Fix: …hf download … --local-dir $MODEL_DIR/deepseek-v4-flash-0731-gguf
exit=1
```

It now catches **both** the weights and the drafter, and the `hf download` line it prints is correct (it reads the #911-fixed `files:`/`local_subdir`). Still exits **0** on a complete tree. Extraction verified across every llama.cpp compose — none blind. Full sweep **99 pass / 0 fail**.