### PR TITLE
fix(report): capture what we ask users for — CPU topology, DIMM config, P2P status

### DIFF
--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -66,6 +66,10 @@ print_help() {
   sed -n '2,/^set/p' "$0" | sed 's/^# \?//' | head -n -1
 }
 
+# Preserve the invocation so the "re-run with sudo" hint can echo back the SAME
+# flags, rather than a bare command the user has to reconstruct.
+REPORT_ARGS="$*"
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --verify) DO_VERIFY=1; shift ;;
@@ -154,6 +158,29 @@ if [[ $REDACT -eq 1 ]]; then
   printf '\n_Redacted output (paths, host, user, tokens). Re-run with `--no-redact` for full data._\n'
 fi
 
+# Root-gated captures — warn UP FRONT, not per-section.
+#
+# Some of the most decision-relevant hardware facts are root-only: DIMM
+# population + configured memory speed (dmidecode), and ACS state on the
+# upstream bridge (lspci extended config space). Without them a report looks
+# complete while missing the fields that actually explain CPU-offload
+# throughput and whether GPU↔GPU P2P can engage.
+#
+# This is deterministic at start-up, so say it BEFORE the sections rather than
+# leaving a reader to notice three "needs root" lines scattered through a long
+# paste — which they will not, because reports get truncated from the bottom.
+if [[ $EUID -ne 0 ]] && ! sudo -n true 2>/dev/null; then
+  _root_gated=()
+  command -v dmidecode >/dev/null 2>&1 && _root_gated+=("DIMM count / size / configured memory speed")
+  command -v lspci >/dev/null 2>&1     && _root_gated+=("PCIe ACS capability state (LnkSta is still accurate)")
+  if [[ ${#_root_gated[@]} -gt 0 ]]; then
+    printf '\n> ⚠️ **Incomplete — running without root.** These fields were skipped:\n'
+    for _g in "${_root_gated[@]}"; do printf '> - %s\n' "$_g"; done
+    printf '>\n> For a complete report re-run with sudo:\n>\n> ```bash\n> sudo bash scripts/report.sh %s\n> ```\n' "${REPORT_ARGS:-}"
+    printf '>\n> Worth doing before filing a CPU-offload issue: memory channels and speed are the\n> variables that set throughput on those configs, and they cannot be read without root.\n'
+  fi
+fi
+
 # ---------------------------------------------------------------------------
 # System
 # ---------------------------------------------------------------------------
@@ -218,10 +245,44 @@ section "System"
 
 section "CPU + RAM"
 {
+  # ⚠️ This section is load-bearing for the CPU-offload slugs. Their throughput
+  # is set by the HOST — memory channels, memory speed, physical core count —
+  # not by the GPU, which is why those slugs publish no first-party numbers and
+  # ask readers for theirs instead. Reporting only "model name + thread count"
+  # made that ask unanswerable: physical cores are not derivable from the model
+  # string on most vendors, and channels/speed were not collected at all.
   if have lscpu; then
-    cpu_model=$(lscpu 2>/dev/null | awk -F: '/Model name/ {sub(/^ */, "", $2); print $2; exit}')
-    cpu_cores=$(lscpu 2>/dev/null | awk -F: '/^CPU\(s\):/ {gsub(/ /, "", $2); print $2; exit}')
-    echo "- **CPU:** ${cpu_model:-unknown} (${cpu_cores:-?} threads)"
+    # LC_ALL=C — lscpu TRANSLATES its field labels, so every lookup below would
+    # silently return empty on a non-English locale (same class as #779).
+    _lscpu="$(LC_ALL=C lscpu 2>/dev/null)"
+    _lscpu_f() { printf '%s\n' "$_lscpu" | grep -m1 -E "^$1:" | sed -E 's/^[^:]*:[[:space:]]*//'; }
+
+    cpu_model="$(_lscpu_f 'Model name')"
+    cpu_threads="$(_lscpu_f 'CPU\(s\)')"
+    cpu_sockets="$(_lscpu_f 'Socket\(s\)')"
+    cpu_percore="$(_lscpu_f 'Core\(s\) per socket')"
+    cpu_tpc="$(_lscpu_f 'Thread\(s\) per core')"
+    cpu_numa="$(_lscpu_f 'NUMA node\(s\)')"
+    cpu_hyp="$(_lscpu_f 'Hypervisor vendor')"
+
+    echo "- **CPU:** ${cpu_model:-unknown}"
+    cpu_phys=""
+    [[ -n "$cpu_sockets" && -n "$cpu_percore" ]] && cpu_phys=$(( cpu_sockets * cpu_percore ))
+    echo "- **CPU topology:** ${cpu_sockets:-?} socket(s) × ${cpu_percore:-?} core(s) = ${cpu_phys:-?} physical, ${cpu_tpc:-?} thread(s)/core → ${cpu_threads:-?} logical"
+    [[ -n "$cpu_numa" ]] && echo "- **NUMA nodes:** $cpu_numa"
+
+    # nproc honours cgroup/affinity limits and is what the offload `-t` default
+    # halves — so a divergence from lscpu's total changes the thread count the
+    # launcher picks, and is worth surfacing rather than silently disagreeing.
+    if have nproc; then
+      cpu_nproc="$(nproc 2>/dev/null)"
+      if [[ -n "$cpu_nproc" && -n "$cpu_threads" && "$cpu_nproc" != "$cpu_threads" ]]; then
+        echo "- **nproc:** $cpu_nproc ⚠️ differs from lscpu's $cpu_threads — cgroup/affinity limited; offload \`-t\` derives from this"
+      else
+        echo "- **nproc:** ${cpu_nproc:-?}"
+      fi
+    fi
+    [[ -n "$cpu_hyp" ]] && echo "- **Virtualized:** yes — $cpu_hyp ($(_lscpu_f 'Virtualization type'))"
   else
     echo "- **CPU:** lscpu not available"
   fi
@@ -232,6 +293,45 @@ section "CPU + RAM"
     echo "- **RAM:** ${ram_total} total, ${ram_avail} available"
     swap_total=$(free -h 2>/dev/null | awk '/^Swap:/ {print $2}')
     [[ "$swap_total" != "0B" && -n "$swap_total" ]] && echo "- **Swap:** $swap_total"
+  fi
+
+  # DIMM population + configured speed. Needs root, so it is best-effort — but
+  # ALWAYS print a line: an omitted row is indistinguishable from "nothing to
+  # report", and a reader must be able to tell "unknown" from "not collected".
+  _dmi=""
+  if have dmidecode; then
+    if [[ $EUID -eq 0 ]]; then
+      _dmi="$(dmidecode -t memory 2>/dev/null)"
+    elif sudo -n true 2>/dev/null; then
+      _dmi="$(sudo -n dmidecode -t memory 2>/dev/null)"
+    fi
+  fi
+  if [[ -n "$_dmi" ]]; then
+    printf '%s\n' "$_dmi" | awk '
+      BEGIN { RS = ""; FS = "\n" }
+      /Memory Device/ {
+        slots++; size = ""; spd = ""
+        for (i = 1; i <= NF; i++) {
+          if ($i ~ /^[[:space:]]*Size:/)                    { s = $i; sub(/^[^:]*:[[:space:]]*/, "", s); size = s }
+          if ($i ~ /^[[:space:]]*Configured Memory Speed:/) { s = $i; sub(/^[^:]*:[[:space:]]*/, "", s); spd  = s }
+        }
+        if (size != "" && size !~ /No Module/) {
+          pop++; sizes[size]++
+          if (spd != "" && spd !~ /Unknown/) speeds[spd]++
+        }
+      }
+      END {
+        if (slots == 0) { print "- **Memory config:** dmidecode reported no memory devices"; exit }
+        for (s in sizes)  desc = desc (desc ? " + " : "") sizes[s] "× " s
+        for (s in speeds) sp   = sp   (sp   ? ", "   : "") s
+        printf "- **Memory config:** %d of %d slot(s) populated — %s%s\n", pop, slots, desc,
+               (sp != "" ? " @ " sp : " (speed not reported by firmware)")
+        if (pop < slots) print "  - _Populated slot count drives channel width; an unbalanced fill is a real throughput variable for CPU-offload configs._"
+      }'
+  elif have dmidecode; then
+    echo "- **Memory config:** not collected (needs root) — run \`sudo dmidecode -t memory\` for DIMM count / size / configured speed"
+  else
+    echo "- **Memory config:** not collected (\`dmidecode\` not installed)"
   fi
 } | redact
 

--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -330,12 +330,39 @@ else
     # PCIe rig actually has, which every other line in this report leaves
     # unanswered (the verdict below needs a RUNNING container; this doesn't).
     # Tiered + achievability-gated on purpose: see p2p_opportunity_hint.
-    _p2p_hint="$(p2p_opportunity_hint "$(p2p_gpu_count)" "$(p2p_host_capability)" 2>/dev/null || true)"
-    [[ -n "$_p2p_hint" ]] && { echo; echo "$_p2p_hint"; }
+    _p2p_count="$(p2p_gpu_count)"
+    _p2p_cap="$(p2p_host_capability "$_p2p_count" 2>/dev/null || echo none)"
+    if [[ "$_p2p_cap" == "pcie_p2p" ]]; then
+      # ⚠️ The hint below deliberately says NOTHING once peer access is already
+      # granted ("already covered"). That left a rig with working P2P showing no
+      # interconnect status at all — and a reader cannot tell "nothing to say"
+      # from "never ran". State it positively instead, with the caveat that
+      # matters most here: a grant is not proof.
+      echo
+      echo "ℹ interconnect: ${_p2p_count} GPUs, no NVLink, but \`topo -p2p\` reports peer access **enabled on every pair** — P2P is granted on this host."
+      echo
+      echo "  ⚠️ A grant is not proof it works. \`topo -p2p OK\` reflects the driver's *permission*, not a completed transfer: a dual-5090 pair read OK and then hung inside \`ncclCommInitRank\` (#873). Only an actual peer transfer settles it — \`bash scripts/p2p-validate.sh\` runs a real all-reduce, which copy-then-sync benchmarks cannot substitute for. If a multi-GPU engine hangs at init, suspect this first."
+    else
+      _p2p_hint="$(p2p_opportunity_hint "$_p2p_count" "$_p2p_cap" 2>/dev/null || true)"
+      [[ -n "$_p2p_hint" ]] && { echo; echo "$_p2p_hint"; }
+    fi
   fi
 
   subsection "Topology"
   nvidia-smi topo -m 2>&1 | redact | details "PCIe / GPU topology matrix"
+
+  # Peer-access matrix — ALWAYS, not just when lspci is missing.
+  #
+  # This used to be emitted only as an lspci fallback, so any rig with pciutils
+  # installed (i.e. most) filed a report containing no P2P verdict at all — the
+  # one command that answers "is peer access on?" was the one we skipped. It is
+  # a single cheap call and it is the PRIMARY signal; the lspci ACS/LnkSta dump
+  # below is supporting evidence, not a substitute for it.
+  if have nvidia-smi && [[ "$(p2p_gpu_count)" -ge 2 ]]; then
+    if nvidia-smi topo -p2p rw >/dev/null 2>&1; then
+      nvidia-smi topo -p2p rw 2>&1 | redact | details "GPU peer-access matrix (topo -p2p rw)"
+    fi
+  fi
 
   # lspci-based PCIe/P2P detail. nvidia-smi reports negotiated gen/width but
   # cannot show trained link state vs capability side-by-side, ACS state on the
@@ -343,14 +370,9 @@ else
   # actually decide whether GPU↔GPU P2P engages (see issues #137, #351).
   subsection "PCIe / P2P detail (lspci)"
   if ! have lspci; then
-    # Fallback: nvidia-smi topo -p2p doesn't need pciutils and shows P2P capability
-    if have nvidia-smi && nvidia-smi topo -p2p rw >/dev/null 2>&1; then
-      echo "_lspci not available (pciutils not installed) — showing P2P capability matrix instead._"
-      echo
-      nvidia-smi topo -p2p rw | redact
-    else
-      echo "_lspci not available (pciutils not installed) — skipping PCIe/P2P detail._"
-    fi
+    # The peer-access matrix is emitted unconditionally under Topology above, so
+    # there is nothing to fall back to here any more — just say what is missing.
+    echo "_lspci not available (pciutils not installed) — skipping ACS / LnkSta detail. The peer-access matrix under **Topology** above is unaffected; install \`pciutils\` for the link-state and ACS evidence._"
   else
     # sudo lspci -vvv is needed for full capability blocks (ACS lives in the
     # extended config space, root-only). Degrade gracefully if sudo is


### PR DESCRIPTION
`report.sh` did not collect the fields we explicitly ask users for. Three gaps, all surfaced by a real dual-5090 report (#913).

## 1. CPU detail was model-string + thread count only

That's what a user rig actually produced:

```
- **CPU:** AMD Ryzen 9 9950X3D 16-Core Processor (32 threads)
- **RAM:** 123Gi total, 117Gi available
```

Physical cores are **not derivable from the model string** on most vendors (this one happens to embed "16-Core"; Intel's don't). Sockets, threads-per-core, NUMA and virtualization were absent entirely.

Now captured from `lscpu` (with `LC_ALL=C` — it *translates* its field labels, so every lookup would silently return empty on a non-English locale, same class as #779):

```
- **CPU topology:** 1 socket(s) × 32 core(s) = 32 physical, 1 thread(s)/core → 32 logical
- **NUMA nodes:** 1
- **nproc:** 32
- **Virtualized:** yes — KVM (full)
```

`nproc` is reported separately and flagged when it diverges from lscpu's total, because it honours cgroup/affinity limits and is what the offload `-t` default halves.

## 2. RAM channels and speed were not collected at all

The **single biggest variable** for the CPU-offload slugs — whose whole premise is that throughput is set by the host, not the GPU — and we published an announcement asking readers for *"channels populated, speed, core count"* that the tool could not gather.

Now best-effort via `dmidecode`, verified against synthetic multi-DIMM inputs since this rig is a single-DIMM VM:

```
- **Memory config:** 4 of 4 slot(s) populated — 4× 32 GB @ 6000 MT/s
- **Memory config:** 2 of 4 slot(s) populated — 2× 32 GB @ 5600 MT/s
  - _Populated slot count drives channel width; an unbalanced fill is a real throughput variable…_
- **Memory config:** 7 of 8 slot(s) populated — 6× 16 GB + 1× 32 GB @ 3200 MT/s
```

## 3. Root-gated fields failed silently → now warned up front

`dmidecode` and full `lspci` need root. Rather than three "needs root" lines buried mid-report — which readers miss, because reports get truncated from the bottom — the banner is emitted **before** the sections, listing exactly what was skipped and echoing back the same flags:

```
> ⚠️ **Incomplete — running without root.** These fields were skipped:
> - DIMM count / size / configured memory speed
> - PCIe ACS capability state (LnkSta is still accurate)
>
> sudo bash scripts/report.sh --verify
```

It appears **only** when the data is genuinely unreachable — verified silent when passwordless sudo works.

## Also in this PR — P2P status

Two behaviours conspired to leave a dual-5090 report with no interconnect status at all:

- `topo -p2p` was emitted **only as an lspci fallback**, so any rig with pciutils filed a report containing no peer-access verdict. Now unconditional for 2+ GPU rigs.
- `p2p_opportunity_hint` returns empty once P2P is already granted — correct for an *opportunity* hint, but a reader cannot tell "nothing to say" from "never ran". The `pcie_p2p` case now states it positively, with the caveat that matters: `topo -p2p OK` is the driver's *permission*, not a completed transfer — a dual-5090 pair read OK then hung in `ncclCommInitRank` (#873) — and points at `p2p-validate.sh`.

## Testing

Scoped to the guards that touch `report.sh`, per the repo's scoping rule: `test-report-exit-code`, `test-report-engine-liveness`, `test-p2p-state`, `test-bench-capture`, `test-diagnose-estate`, `test-locale-utf8` — **all green**. Both P2P branches exercised (CNS natively; `pcie_p2p` via a stubbed capability, since this rig can't reach it), and the DIMM parser verified against balanced / half-filled / mixed-size inputs.

⚠️ **Unresolved observation, logged not hidden:** two unrelated tests (`test-classifier`, `test-dedup`) came back red in full-suite runs on this branch while a clean-master full sweep was 99/0. They pass in every targeted configuration — alone, after each predecessor individually, and after all predecessors cumulatively — and neither references `report.sh`. I could not reproduce it deterministically and do not have an explanation, so I am not claiming one.