### PR TITLE
fix(report): capture memory CHANNELS and MEASURED bandwidth, not slots and rated MT/s

### DIFF
--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -239,6 +239,71 @@ section "System"
   echo "- **Uptime:** $(uptime -p 2>/dev/null || echo unknown)"
 } | redact
 
+# _report_mem_bandwidth — MEASURED memory bandwidth, because the rated figure is
+# blind to the failure that matters.
+#
+# ⚠️ Firmware's "Configured Memory Speed" does NOT move when a channel is lost.
+# This rig read 3200 MT/s both before and after a DIMM went missing, while real
+# STREAM Triad fell ~100 -> 59.9 GB/s (2026-08-07). The spec number is exactly
+# the one that cannot detect the problem; the measured one is the only witness.
+# Our own learnings already say "the bandwidth number must be MEASURED, not spec"
+# — this implements it.
+#
+# Cheap and honest: ~1.5 GB, a few hundred ms, skipped when RAM is tight or no
+# compiler exists, and it SAYS SO rather than omitting the line (a missing row
+# reads as "nothing to report"). Disable with REPORT_NO_BANDWIDTH=1.
+_report_mem_bandwidth() {
+  [[ "${REPORT_NO_BANDWIDTH:-0}" == "1" ]] && return 0
+  local cc=""
+  for c in cc gcc clang; do command -v "$c" >/dev/null 2>&1 && { cc="$c"; break; }; done
+  if [[ -z "$cc" ]]; then
+    echo "- **Memory bandwidth:** not measured (no C compiler) — install \`gcc\` for a STREAM Triad figure"
+    return 0
+  fi
+  local free_mb; free_mb=$(free -m 2>/dev/null | awk '/^Mem:/{print $7}')
+  if [[ -n "$free_mb" && "$free_mb" -lt 4096 ]]; then
+    echo "- **Memory bandwidth:** not measured (only ${free_mb} MiB available; probe needs ~1.5 GB)"
+    return 0
+  fi
+  local d; d="$(mktemp -d 2>/dev/null)" || return 0
+  cat > "$d/t.c" <<'CEOF'
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <time.h>
+#define N (64L*1024*1024)          /* 3 x 512 MiB */
+static double *a,*b,*c; static int NT;
+static void *w(void *p){ long id=(long)p, lo=N*id/NT, hi=N*(id+1)/NT;
+  for(long i=lo;i<hi;i++) c[i]=a[i]+3.0*b[i]; return 0; }
+int main(int argc,char**argv){
+  NT=atoi(argv[1]); if(NT<1)NT=1;
+  a=malloc(N*8); b=malloc(N*8); c=malloc(N*8);
+  if(!a||!b||!c){ printf("0\n"); return 1; }
+  for(long i=0;i<N;i++){a[i]=1.0;b[i]=2.0;c[i]=0.0;}
+  double best=0; pthread_t th[512];
+  for(int r=0;r<3;r++){
+    struct timespec s,e; clock_gettime(CLOCK_MONOTONIC,&s);
+    for(long i=0;i<NT;i++) pthread_create(&th[i],0,w,(void*)i);
+    for(long i=0;i<NT;i++) pthread_join(th[i],0);
+    clock_gettime(CLOCK_MONOTONIC,&e);
+    double dt=(e.tv_sec-s.tv_sec)+(e.tv_nsec-s.tv_nsec)/1e9;
+    double gbs=(3.0*N*8)/dt/1e9; if(gbs>best) best=gbs;
+  }
+  printf("%.1f\n",best); return 0;
+}
+CEOF
+  local gbs=""
+  if "$cc" -O2 -o "$d/t" "$d/t.c" -lpthread >/dev/null 2>&1; then
+    gbs="$("$d/t" "$(nproc 2>/dev/null || echo 4)" 2>/dev/null)"
+  fi
+  rm -rf "$d"
+  if [[ -n "$gbs" && "$gbs" != "0" ]]; then
+    echo "- **Memory bandwidth (measured):** ${gbs} GB/s STREAM Triad — *this*, not the rated MT/s above, is what sets CPU-offload decode throughput"
+  else
+    echo "- **Memory bandwidth:** probe failed to build/run — rated speed above is NOT a substitute"
+  fi
+}
+
 # ---------------------------------------------------------------------------
 # CPU + RAM
 # ---------------------------------------------------------------------------
@@ -310,26 +375,40 @@ section "CPU + RAM"
     printf '%s\n' "$_dmi" | awk '
       BEGIN { RS = ""; FS = "\n" }
       /Memory Device/ {
-        slots++; size = ""; spd = ""
+        slots++; size = ""; spd = ""; ch = ""
         for (i = 1; i <= NF; i++) {
           if ($i ~ /^[[:space:]]*Size:/)                    { s = $i; sub(/^[^:]*:[[:space:]]*/, "", s); size = s }
           if ($i ~ /^[[:space:]]*Configured Memory Speed:/) { s = $i; sub(/^[^:]*:[[:space:]]*/, "", s); spd  = s }
+          if ($i ~ /^[[:space:]]*Bank Locator:/)            { s = $i; sub(/^[^:]*:[[:space:]]*/, "", s); ch   = s }
         }
+        # ⚠️ CHANNEL identity, not just a slot tally. Slots != channels — boards
+        # commonly carry 2 DIMMs per channel, so "7 of 8 slots" can mean four fully
+        # populated channels, a completely different bandwidth story. It is CHANNEL
+        # population that sets the interleave, and the interleave is what moves GB/s.
+        if (ch != "") { if (!(ch in seen_ch)) { seen_ch[ch] = 1; nch++ } }
         if (size != "" && size !~ /No Module/) {
           pop++; sizes[size]++
+          if (ch != "") full_ch[ch] = 1
           if (spd != "" && spd !~ /Unknown/) speeds[spd]++
-        }
+        } else if (ch != "") { empty_list = empty_list (empty_list ? ", " : "") ch }
       }
       END {
         if (slots == 0) { print "- **Memory config:** dmidecode reported no memory devices"; exit }
         for (s in sizes)  desc = desc (desc ? " + " : "") sizes[s] "× " s
         for (s in speeds) sp   = sp   (sp   ? ", "   : "") s
+        nfull = 0; for (c in full_ch) nfull++
         printf "- **Memory config:** %d of %d slot(s) populated — %s%s\n", pop, slots, desc,
-               (sp != "" ? " @ " sp : " (speed not reported by firmware)")
-        if (pop < slots) print "  - _Populated slot count drives channel width; an unbalanced fill is a real throughput variable for CPU-offload configs._"
+               (sp != "" ? " @ " sp " (rated — NOT measured; see bandwidth below)" : " (speed not reported by firmware)")
+        if (nch > 0)
+          printf "- **Memory channels:** %d of %d populated%s\n", nfull, nch,
+                 (empty_list != "" ? " — EMPTY: " empty_list : "")
+        if (nfull < nch)
+          print "  - ⚠️ _An unpopulated channel forces a coarser interleave. Measured on this stack: losing ONE of eight channels cost ~**30% of bandwidth** (~100 → 69.8 GB/s idle; 59.9 under load) — 2.4× worse than the 12.5% a naive share implies._"
       }'
+    _report_mem_bandwidth
   elif have dmidecode; then
     echo "- **Memory config:** not collected (needs root) — run \`sudo dmidecode -t memory\` for DIMM count / size / configured speed"
+    _report_mem_bandwidth
   else
     echo "- **Memory config:** not collected (\`dmidecode\` not installed)"
   fi


### PR DESCRIPTION
A decode regression on the reference rig took hours to track down, and `report.sh` captured **neither** field that would have shown it.

## 1. We counted slots, not channels

The section said *"N of M slots populated."* **Slots are not channels** — boards commonly carry 2 DIMMs per channel, so "7 of 8 slots" can mean four fully-populated channels, a completely different bandwidth story. **Channel** population sets the interleave, and the interleave is what moves GB/s.

Now parsed from `Bank Locator`, naming the empty ones. Verified against the real host output:

```
- **Memory config:** 7 of 8 slot(s) populated — 7× 32 GB @ 3200 MT/s (rated — NOT measured)
- **Memory channels:** 7 of 8 populated — EMPTY: P0 CHANNEL H
  - ⚠️ An unpopulated channel forces a coarser interleave…
```

## 2. We captured the one field blind to the failure

| | before the DIMM went missing | after |
|---|---|---|
| `Configured Memory Speed` (captured) | 3200 MT/s | **3200 MT/s** |
| STREAM Triad (not captured) | ~100 GB/s | **69.8 GB/s** |

**The firmware number did not move at all.** Adds a small pthreads Triad probe (~1.5 GB, sub-second), which skips with an explicit message when there's no compiler or RAM is tight, and is disabled by `REPORT_NO_BANDWIDTH=1`. It never silently omits the row — a missing line reads as "nothing to report".

The repo's own learnings already said *"the bandwidth number must be MEASURED, not spec."* This implements it.

## Why this section specifically

The CPU-offload slugs are **not GPU-bound** — host memory sets their throughput, which is why they ship without first-party TPS figures and ask readers for theirs. This is the report's most load-bearing section for those configs, and it was its thinnest.

## The number worth remembering

**Losing ONE of eight channels cost ~30% of bandwidth, not 12.5%** — 2.4× worse than a naive share, because unbalanced population forces a coarser interleave. The warning says so explicitly.

## Verification

- Real 7-of-8 host `dmidecode` → correctly reports `7 of 8 populated — EMPTY: P0 CHANNEL H`
- Live on the reference rig → the KVM guest reports **one synthetic DIMM**, which is itself worth knowing: **DIMM detail is informative on bare metal and useless on any VM**, including ours
- Scoped to the 6 guards touching `report.sh` (`test-report-exit-code`, `test-report-engine-liveness`, `test-p2p-state`, `test-bench-capture`, `test-diagnose-estate`, `test-locale-utf8`) — all green