### PR TITLE
docs(ik-llama): NP=1 is REQUIRED on the hybrid-GDN slug, not merely defaulted

### DIFF
--- a/models/qwen3.6-35b-a3b/ik-llama/compose/single/byteshape-iq4xs/mtp.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/single/byteshape-iq4xs/mtp.yml
@@ -13,7 +13,29 @@
 #              (narrative 113/116 · code 129/137 wall/decode TPS, CV <2.3%), 8-pack 110/150,
 #              soak-continuous PASS (0 err, 0 VRAM growth, 0/25 silent-empty, 100% retention).
 #              Community intake from PR #293 (@Rhonstin).
-#   Caveats:   Single-rig validation (1× 3090, 370 W) — cross-rig numbers welcome. Agent-pack
+#   Caveats:   ⚠️⚠️ NP=1 IS REQUIRED, NOT A DEFAULT. Raising NP on this engine pin returns
+#              SILENTLY WRONG OUTPUT. Qwen3-Next is a hybrid: 30 of 40 layers are GDN
+#              (recurrent), and on this pin ik_llama's graph-reuse key is shape-based, so a
+#              graph built for one sequence is reused for another without re-pointing the
+#              recurrent state. Every slot then decodes on the first slot's state. No crash,
+#              no error — the server stays healthy and returns fluent text that is simply not
+#              conditioned on that slot's prompt.
+#              Reproduced first-party on THIS digest + quant (2026-08-07), 4 identical greedy
+#              prompts, temperature 0, seed 42, concurrent:
+#                  NP=1 → 1/1 distinct answers ✅        NP=4 → 3/4 distinct ❌
+#              Two of the four slots answered questions that were never asked.
+#              ⚠️ MTP DOES NOT PROTECT YOU. At NP>1 the server logs "MTP is not supported with
+#              parallel slots yet, removing the MTP stage" and boots with n_parallel=4 — NP
+#              wins and MTP is silently DROPPED, so you get the corruption AND lose this
+#              compose's headline drafter.
+#              ⚠️ Do NOT gate this on byte-identity against a sequential reference — batch-shape
+#              FP drift makes correct answers differ, which flags healthy runs and lets a
+#              non-fix look like a fix. Count DISTINCT answers to identical prompts; must be 1.
+#              Fixed upstream by ikawrakow/ik_llama.cpp#2260 (merged 2026-08-05, @ShubhamPriyadarshi),
+#              which this pinned digest PREDATES. Reported as club-3090#896; pin bump tracked in
+#              docs/UPSTREAM.md. Until that bump lands, NP=1 is the only supported value.
+#              ---
+#              Single-rig validation (1× 3090, 370 W) — cross-rig numbers welcome. Agent-pack
 #              scores (hermesagent-20 11/20 = 55%, cli-40 17/40 = 42%) are typical for the
 #              35B-A3B class (the apex sibling scores similarly). Intake fixes vs PR #293:
 #              image cu12→cu13-server, port 8020→8058.
@@ -40,7 +62,7 @@
 #   CTX_SIZE               KV pool size (overrides --fit if set)
 #   BATCH_SIZE             llama.cpp -b        (default: 4096)
 #   UBATCH_SIZE            llama.cpp -ub       (default: 1024)
-#   NP                     parallel slots      (default: 1)
+#   NP                     parallel slots      ⚠️ MUST STAY 1 — see below
 #   KV_TYPE                K and V quant type  (default: q4_0)
 #   MTP_DRAFT_N_MAX        MTP draft tokens    (default: 2)
 #   DRAFT_P_MIN            draft accept floor  (default: 0.0)


### PR DESCRIPTION
Stopgap for #896 while the engine pin catches up.

## The problem

Raising `NP` on this engine pin returns **silently wrong output**. Qwen3-Next is a hybrid — **30 of 40 layers are GDN (recurrent)** — and on this pin ik_llama keys graph reuse on *shape*, not on which sequence the graph was built for. A graph built for one sequence gets reused for another without re-pointing the recurrent state, so every slot decodes on the first slot's state.

No crash, no error. The server stays healthy and returns fluent text that simply isn't conditioned on that slot's prompt.

## Reproduced first-party on this exact digest + quant

4 identical greedy prompts, `temperature 0`, `seed 42`, concurrent:

| NP | distinct answers | |
|---:|---:|---|
| 1 | **1 / 1** | ✅ |
| 4 | **3 / 4** | ❌ |

Two of four slots answered **questions that were never asked** — all four prompts were byte-identical, so there was nothing to bleed *from*.

## MTP does not protect the config

This was the open question in the report — whether MTP forces `n_parallel=1`, making the bug unreachable. It does not:

```
WARN [load_model] MTP is not supported with parallel slots yet, removing the MTP
                  stage to avoid cross-slot corruption.
                  n_parallel=4  stage_chain="mtp"
```

**NP wins; MTP is silently dropped.** Raising NP costs twice — the corruption *and* this compose's headline drafter — with a healthy-looking server either way.

## The metric trap, recorded

Byte-identity against a sequential reference is the **wrong** gate: batch-shape FP drift makes correct answers differ, so it flags healthy runs *and* lets a non-fix look like a fix. Count **distinct answers to identical prompts**; must be 1. Credit to @ShubhamPriyadarshi, who lost time to exactly that and said so.

## This is a stopgap

Fixed upstream by [ikawrakow/ik_llama.cpp#2260](https://github.com/ikawrakow/ik_llama.cpp/pull/2260) (**merged** 2026-08-05), which our pinned digest **predates**. The durable fix is the pin bump, with the distinct-answers metric as its acceptance gate — tracked separately.

## Checks

Single `Caveats:` field preserved (schema requires exactly one); `docker compose config` parses; `test-compose-status-drift`, `test-switch-registry-parity`, `test-launch-registry-parity`, `test-compose-registry-disk`, `test-compose-mounts-resolve` all green. `-np ${NP:-1}` unchanged — this is documentation, not a behaviour change.