### PR TITLE
fix(deepseek-flash): map host port to container 8080, restoring endpoint autodetect

### DIFF
--- a/models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-iq2-xxs/offload.yml
+++ b/models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-iq2-xxs/offload.yml
@@ -69,7 +69,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-llama-cpp-deepseek-flash-iq2}"
     restart: unless-stopped
     ports:
-      - "${BIND_HOST:-0.0.0.0}:${PORT:-8031}:${PORT:-8031}"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8031}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     shm_size: "16g"
@@ -99,7 +99,7 @@ services:
       - '--host'
       - '0.0.0.0'
       - '--port'
-      - '${PORT:-8031}'
+      - '8080'
       - '--alias'
       - 'deepseek-v4-flash'
       - '-np'

--- a/models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-q8-kxl/offload.yml
+++ b/models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-q8-kxl/offload.yml
@@ -75,7 +75,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-llama-cpp-deepseek-flash-q8}"
     restart: unless-stopped
     ports:
-      - "${BIND_HOST:-0.0.0.0}:${PORT:-8030}:${PORT:-8030}"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8030}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     shm_size: "16g"
@@ -105,7 +105,7 @@ services:
       - '--host'
       - '0.0.0.0'
       - '--port'
-      - '${PORT:-8030}'
+      - '8080'
       - '--alias'
       - 'deepseek-v4-flash'
       - '-np'

--- a/models/deepseek-v4-flash-0731/llama-cpp/compose/multi4/unsloth-q8-kxl/offload.yml
+++ b/models/deepseek-v4-flash-0731/llama-cpp/compose/multi4/unsloth-q8-kxl/offload.yml
@@ -72,7 +72,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-llama-cpp-deepseek-flash-q8-multi4}"
     restart: unless-stopped
     ports:
-      - "${BIND_HOST:-0.0.0.0}:${PORT:-8032}:${PORT:-8032}"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8032}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     shm_size: "16g"
@@ -102,7 +102,7 @@ services:
       - '--host'
       - '0.0.0.0'
       - '--port'
-      - '${PORT:-8032}'
+      - '8080'
       - '--alias'
       - 'deepseek-v4-flash'
       - '-np'


### PR DESCRIPTION
Found by @paulp83 on #913 — he booted successfully, then reported `report.sh --full` couldn't reach the server and suspected the port. He was right.

## The defect

All three DeepSeek composes published the container-**internal** port as `${PORT}` rather than the catalog's fixed `8080`:

```
ours:       "${BIND_HOST:-0.0.0.0}:${PORT:-8031}:${PORT:-8031}"
other 24:   "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8020}}:8080"
```

`preflight_autodetect_endpoint` extracts the host port by matching `->(8000|8080|30000)/tcp`. A mapping of `->8031/tcp` matches **nothing**, so every serving script — `report.sh --full`, `bench.sh`, `verify-*`, `quality-test.sh` — silently fell back to its default endpoint and missed the running server.

The container was healthy the entire time. The tooling just couldn't find it.

## Second defect in the same line

The **`ESTATE_PORT` hook was missing**. Every other compose carries `${ESTATE_PORT:-${PORT:-NNNN}}`, and the add-a-model checklist requires it — so estate/pod orchestration had no way to override the port on these slugs.

## Fix

Adopt the convention: host `${ESTATE_PORT:-${PORT:-80NN}}` → container `8080`, with `--port 8080` inside. Host-side defaults (8030/8031/8032) are unchanged, so registry `default_port` parity is unaffected.

The catalog was **24 composes on internal 8080 and these 3 on `${PORT}`** — now 27/27.

## Verified live, not just by diff

```
before:  0.0.0.0:8031->8031/tcp     autodetect → nothing
after:   0.0.0.0:8031->8080/tcp     autodetect → URL=http://localhost:8031
                                                 CONTAINER=llama-cpp-deepseek-flash-iq2
```

Guards green: `test-compose-bind-host`, `test-switch-registry-parity`, `test-launch-registry-parity`, `test-compose-status-drift`, `test-compose-registry-disk`, `test-compose-mounts-resolve`, `test-parallel-boot`.