### PR TITLE
fix(p2p): classify user-disabled custom-AR; document the wrong-data failure mode

### DIFF
--- a/docs/PCIE_P2P.md
+++ b/docs/PCIE_P2P.md
@@ -757,8 +757,21 @@ Read the **"Interconnect verdict"** line under *Boot log highlights* — the rep
 
 Everything below was hit for real. Start from the symptom.
 
+> ### ⚠️⚠️ A green verdict line is not a correctness check — and neither is TPS
+>
+> This doc says a copy test is weaker than a collective. #922 goes one further: a rig where the
+> **collective itself completed, fast, and was still wrong.** Every indicator was green —
+> `topo -p2p rw` = OK, 6.60 GB/s peer with bytes verified by a Driver-API comparison, clean boot,
+> zero Xid, VRAM on reference — and the throughput was *plausible* at 29.7 tok/s, a number you could
+> rationalise as "Ampere is just slower."
+>
+> **Only reading the generated text caught it.** That is strictly worse than a hang, which at least
+> announces itself. Before trusting any verdict in §7, generate real output and read it.
+
+
 | symptom | cause | fix |
 |---|---|---|
+| ⚠️⚠️ Collectives **complete**, at a plausible TPS, but the model emits **garbage on every request** (e.g. `!!!!!!!!!!!!` at 18 prompt tokens) over a patched peer path | vLLM's **custom all-reduce** over BAR1 P2P returns WRONG DATA — NCCL itself is fine. aikitoria [#21](https://github.com/aikitoria/open-gpu-kernel-modules/issues/21) class; related `vllm#28334` (IMA in custom AR during graph capture with spec-decode). **NOT universal on Ampere** — a configuration interaction, not "Ampere is broken" | **`--disable-custom-all-reduce`** — keeps NCCL P2P *and* its prefill gain. `NVLINK_MODE=force_off` also works but discards the win. Reported by @juslex ([#922](https://github.com/noonghunna/club-3090/issues/922), 2×3090 + aikitoria `610.43.03-p2p`, measured A/B) |
 | `topo -p2p` = **`CNS`** in a VM | Emulated front host bridge isn't in the driver's chipset table (§4a) | `x-nv-gpudirect-clique` (§4a). **Not** a BAR, driver-flavour or topology problem |
 | `CNS` persists after a **large BAR1** + **open driver** | BAR/driver were never the gate; the chipset table is | Same — clique. Measured: 32 GB BAR1 + `nvidia-open` still `CNS` |
 | `CNS` persists after `NVreg_RegistryDwords` | Those keys relax peer *mapping*, not the chipset verdict | Refuted on-rig. Don't retry |

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -10,6 +10,26 @@
 #     + prompt-processing throughput (`PP tok/s`)
 #   - shows MTP SpecDecoding metrics from docker logs at the end
 #
+# ⚠️⚠️ NEVER COMPARE A COLD BOOT AGAINST A HEAT-SOAKED ONE.
+#   The 3 warmups above settle the ENGINE (cudagraphs, caches). They do NOT settle
+#   the HARDWARE. A rig can take ~1 hour to reach thermal steady state, and a cold
+#   card measures materially faster on decode — @juslex reported ~4% on 2x3090
+#   (#922: rack air 29.6 -> 35.6 C over ~55 min, cores 80/82 -> 82/84 C). No
+#   throttling was involved: power sat pinned at the cap the whole time, so the
+#   CAP binds, not temperature — which is exactly why it does not show up as a
+#   clock drop you would notice.
+#
+#   That is larger than most deltas worth reporting. Their first read put one cold
+#   boot against three soaked ones and inflated a decode delta; it cost a day.
+#   Shubham independently hit the same shape on ik_llama (whichever arm ran SECOND
+#   was ~1% faster regardless of which arm it was).
+#
+#   ⇒ For any A/B: pre-warm both arms, or interleave A/B/A/B and compare like with
+#     like. A single sequential pair — the thing this script makes easiest — is the
+#     one design that cannot distinguish the patch from the position.
+#   ⇒ Prefill is far more robust (CV <=0.1% within a boot, <=1% across boots);
+#     decode is where this bites.
+#
 # Why two TPS metrics:
 #   - wall_TPS  = "user-perceived speed" (includes prefill cost)
 #   - decode_TPS = "model decode rate" (excludes prefill)
@@ -1862,7 +1882,7 @@ bench_interconnect_block() {
   eng_text=""
   if [[ "${CONTAINER:-}" != "none" ]] && command -v docker >/dev/null 2>&1 \
      && docker inspect "${CONTAINER}" >/dev/null 2>&1; then
-    eng_text="$(docker logs "$CONTAINER" 2>&1 | command grep -E '\[nvlink\]|Custom allreduce is disabled' | head -8 || true)"
+    eng_text="$(docker logs "$CONTAINER" 2>&1 | command grep -E '\[nvlink\]|Custom allreduce is disabled|disable_custom_all_reduce=True' | head -8 || true)"
   fi
   if [[ "$ENGINE_KIND" == "llamacpp" || "${CONTAINER:-}" == "none" ]]; then
     # llama.cpp/ik-llama split layers across cards with plain copies — there is
@@ -1872,7 +1892,7 @@ bench_interconnect_block() {
   else
     case "$(printf '%s\n%s' "$eng_text" "$nccl_line" | p2p_classify_engagement 2>/dev/null || echo unknown)" in
       on)        l3="ENGAGED — engine reports its custom all-reduce ON" ;;
-      nccl_only) l3="engine-VETOED — vLLM disabled its custom all-reduce (NVLink-only gate at world>2, #786); P2P still live via NCCL peer transfers" ;;
+      nccl_only) l3="custom-AR OFF, P2P LIVE — the engine is not using its custom all-reduce; peer transfers still go via NCCL. Cause is either vLLM's own NVLink-only gate at world>2 (#786) or an operator-supplied --disable-custom-all-reduce (#922). Check the engine log to tell which; both are healthy states" ;;
       off)       l3="OFF — the serving container resolved to PCIe/no-P2P mode" ;;
       requested) l3="REQUESTED but UNVERIFIED — P2P forced on without a driver grant (#688)" ;;
       *)         l3="unknown — no [nvlink] boot line and no engine gate line in the log" ;;

--- a/scripts/lib/p2p-state.sh
+++ b/scripts/lib/p2p-state.sh
@@ -97,6 +97,28 @@ p2p_classify_engagement() {
   case "$text" in
     *"P2P REQUESTED (UNVERIFIED)"*) echo requested; return 0 ;;
   esac
+  # ⚠️ USER-disabled is a THIRD state, and it used to read as "on" (#922, juslex).
+  # When the operator passes `--disable-custom-all-reduce`, vLLM does NOT emit
+  # "Custom allreduce is disabled" — that string is its OWN world>2 veto (#786).
+  # It emits the config-dump form `disable_custom_all_reduce=True` and dispatches
+  # through PYNCCL. Meanwhile the [nvlink] trail still says P2P is up, so the
+  # classifier fell through to "on" and the report asserted the OPPOSITE of what
+  # was running — on precisely the configuration where that flag is the remedy for
+  # silent WRONG OUTPUT over a patched peer path. Checked BEFORE the "on" match.
+  # NB the flag is injected into the entrypoint AFTER detect_nvlink.sh runs, so
+  # the [nvlink] heuristic cannot see it either way — only the engine's own log can.
+  case "$text" in
+    *"disable_custom_all_reduce=True"*|*"--disable-custom-all-reduce"*)
+      # Same refinement the veto branch needs: custom-AR off says nothing about
+      # whether the PEER TRANSPORT is also off. If P2P itself is disabled this is
+      # plain "off", not "custom-AR off but P2P live". Dropping this check made
+      # the `veto + P2P disabled` fixture regress nccl_only — the guard caught it.
+      case "$text" in
+        *"P2P off"*|*"using PCIe mode"*|*"forcing PCIe mode"*|*NCCL_P2P_DISABLE=1*)
+          echo off; return 0 ;;
+      esac
+      echo nccl_only; return 0 ;;
+  esac
   # vLLM runtime veto (#786): at world_size>2 without NVLink, vLLM disables its
   # custom all-reduce regardless of peer access — its gate queries NVML for
   # NVLink only. A pre-#786 boot trail still asserts "custom all-reduce ON" in


### PR DESCRIPTION
Three findings from @juslex ([#922](https://github.com/noonghunna/club-3090/issues/922)) — 2×3090 on the aikitoria patched-P2P driver, with a measured A/B and a positive control.

## 1. The verdict line said the opposite of what was running

`p2p_classify_engagement` matched only vLLM's **own** veto strings (`Custom allreduce is disabled`), which it emits at `world_size > 2` — the #786 case. When the **operator** passes `--disable-custom-all-reduce` at TP=2, vLLM logs the config-dump form `disable_custom_all_reduce=True` and dispatches through `PYNCCL`, matching neither pattern.

The `[nvlink]` trail still reports P2P up, so we fell through to `on` and printed:

```
layer 3  engine custom-AR : ENGAGED — engine reports its custom all-reduce ON
```

…while it was off. **§7 points readers at that line as authoritative**, and this is precisely the configuration where the flag is the remedy for silent wrong output.

Worth noting *why* the heuristic can't help: the flag is injected into the entrypoint **after** `detect_nvlink.sh` runs. Only the engine's own log can see it — and `bench.sh` wasn't grepping for it.

Now classified `nccl_only`, with the same P2P-off refinement the veto branch carries. Dropping that refinement regressed the `veto + P2P disabled` fixture and **the guard caught it** — which is the argument for the guard. The rendered message is cause-neutral now: it names both routes and points at the engine log.

| input | before | after |
|---|---|---|
| user flag, P2P live | `on` ❌ | `nccl_only` ✅ |
| user flag, P2P off | `on` ❌ | `off` ✅ |
| vLLM veto, P2P live | `nccl_only` | `nccl_only` |
| vLLM veto, P2P off | `off` | `off` |
| genuine on | `on` | `on` |

## 2. A third failure mode for §7a

The doc's two documented modes are both **hangs**. This one **completes, fast, and returns wrong data** — garbage on 100% of requests over a patched peer path. Custom AR is the culprit; NCCL is fine. `--disable-custom-all-reduce` keeps the NCCL half of the win, which `NVLINK_MODE=force_off` discards.

## 3. TPS is not a correctness check

Added above the §7a table, because this is the part that generalises:

> Every indicator was green — `topo -p2p rw` OK, 6.60 GB/s peer with bytes verified by a Driver-API comparison, clean boot, zero Xid, VRAM on reference — **and the throughput was plausible** at 29.7 tok/s, a number you could rationalise as "Ampere is just slower." Only reading the generated text caught it. Strictly worse than a hang, which announces itself.

## Also: a measurement trap in `bench.sh`

The 3 warmups settle the **engine**, not the **hardware**. A ~1 h thermal ramp makes a **cold card ~4% faster on decode** with *no throttling* — power pinned at the cap throughout, so the cap binds, which is why it doesn't show as a clock drop you'd notice. That's larger than most deltas worth reporting, and it cost juslex a day.

@ShubhamPriyadarshi hit the same shape independently on ik_llama (whichever arm ran **second** was ~1% faster, regardless of which arm). A single sequential pair — the thing this script makes easiest — is the one design that cannot separate the patch from the position.

## Testing

Scoped to the guards touching these files: `test-p2p-state`, `test-classifier`, `test-detect-nvlink-autop2p`, `test-bench-capture`, `test-bench-card`, `test-report-exit-code`, `test-report-engine-liveness`, `test-locale-utf8` — all green.