### PR TITLE
docs(p2p): stop overselling the patched-P2P gain; lead with prefill and the risk

### DIFF
--- a/docs/PCIE_P2P.md
+++ b/docs/PCIE_P2P.md
@@ -698,13 +698,29 @@ From cross-rig data on this stack. ⚠️ **The gain is strongly card-dependent*
 
 | Path | Measured gain | Source |
 |---|---|---|
-| `dual.yml` (fp8 KV) — patched P2P vs unpatched | **+2% narrative / +9% code** | [#91](https://github.com/noonghunna/club-3090/issues/91) |
+| ⭐ **Dual 3090, P2P on-vs-off at fixed TP=2 with custom AR OFF IN BOTH ARMS** — the transport alone | **prefill @10K +14.4% · @90K +12.2% · TTFT −13%/−15% · decode INSIDE NOISE** | [#922](https://github.com/noonghunna/club-3090/issues/922) (@juslex) — the only row here that isolates the transport |
+| `dual.yml` (fp8 KV) — patched P2P vs unpatched ⚠️ **custom AR ON** | **+2% narrative / +9% code** | [#91](https://github.com/noonghunna/club-3090/issues/91) |
 | DFlash / spec-decode path — patched P2P | **+19–22%** | [#95](https://github.com/noonghunna/club-3090/issues/95) |
 | **2× RTX 5090, P2P on-vs-off at fixed TP=2** (`qwen-35b-a3b-dual-nvfp4`, same slug, same sitting) | **decode +32.5% · prefill@90K +33.9%** (net, vs a pristine no-dwords system) — the isolated interconnect delta is **+36.9%**, of which ~3% is given back by the `NVreg` override the 50-series path requires. ⚠️ **Ratio is clean, absolutes are not** — that sitting's P2P-off baseline runs 17.7% below the same rig's own earlier measurement of the same slug (BENCHMARKS `⤷ P2P on-vs-off A/B`), so a cross-session read gives only ~+9%. Treat +32.5% as the interconnect delta, **not** as a promised upgrade gain | [#873](https://github.com/noonghunna/club-3090/issues/873) (@paulp83) |
 | NVLink hardware — workload-shaped (same-host A/B) | **decode +3–5% · prefill/long-ctx +35–49%** | [#698](https://github.com/noonghunna/club-3090/issues/698) — supersedes the flat ~+15% from [#77](https://github.com/noonghunna/club-3090/issues/77) (older v7.72.2 image) |
 
-**Translation:** code / spec-decode workloads see a real lift (the K+1 cross-card verify is bandwidth-bound, so it benefits most); narrative decode barely moves. For most users the stock no-P2P PCIe path is already perfectly fine — **P2P is an enthusiast tuning lever, not a requirement.**
+**Translation — read the custom-AR column first.** The decode gains in this table come from **two different
+mechanisms**, and they are not equally available:
 
+- **NCCL peer transport** — the reliable half. It is a **prefill lever**: ~**+12–14%** with TTFT down 13–15%,
+  repeatable at CV ≤1%. It survives `--disable-custom-all-reduce`.
+- **vLLM's custom all-reduce kernel** — where the decode gains live (#91's +9% code, #773's +15%, #873's +32.5%).
+  **On a rig that must turn that kernel off, those numbers are unreachable** — with it neutralised in both arms,
+  decode sits inside run-to-run noise (#922).
+
+⚠️ **Do not quote the +32.5% as an expected upgrade gain.** Its no-P2P baseline was low (17.7%), and a cross-session
+re-read put the honest figure nearer **+9%**. Quote it, if at all, as an upper bound from one Blackwell pair.
+
+⚠️ **And the kernel can be actively harmful**: on at least one Ampere rig it completed fast and returned **wrong
+output** with every indicator green (§7a). `--disable-custom-all-reduce` keeps the prefill win and avoids it.
+
+**Scale check:** at @10K the ladder reads no-P2P ~1253 → PCIe P2P **1434** → NVLink 1975 — so **PCIe P2P delivers
+roughly 30% of NVLink's prefill premium**, about what gen3 x8 should manage against an NV4 bridge.
 ⚠️ **These are DUAL-card measurements — do not extrapolate them to 3+ GPUs.** At world_size > 2 without NVLink, **vLLM force-disables its custom all-reduce kernel** (its gate queries NVML for NVLink and never consults peer access — [#786](https://github.com/noonghunna/club-3090/issues/786)), so whatever P2P is worth at TP=4 arrives **through NCCL peer transfers only** — a lower ceiling than the dual-card custom-kernel path above. An earlier revision claimed the gain "grows with GPU count"; that was a projection, not a measurement, and stays withdrawn. **UPDATE 2026-07-30 — a measured multi-GPU A/B now exists, on ONE rig:** [disc #773](https://github.com/noonghunna/club-3090/discussions/773) (4× 3090, patched P2P, vLLM 0.25.1, MTP n=3, 220 W, one sitting) reports TP=2 → TP=4 as **prefill +55% @10K / +62% @90K, TTFT −38% @90K, decode +4.0% prose / −2.6% code**. Read it as *four cards read faster; they do not write faster* — the win is prefill and TTFT, and the decode column is inside run-to-run noise. It is one rig, one sitting, and it is a **TP-scaling** A/B (2 vs 4 cards, P2P on throughout), **not** a P2P-on-vs-off A/B at fixed TP. **That A/B now exists — see the Blackwell row below.** So: do not extrapolate "P2P scales with GPU count" from it, and do not cite the decode figures as a P2P result.
 
 ---

--- a/scripts/lib/p2p-state.sh
+++ b/scripts/lib/p2p-state.sh
@@ -299,7 +299,10 @@ p2p_opportunity_hint() {
   fi
 
   if p2p_reports_cns; then
-    echo "ℹ interconnect: ${count} GPUs on a P2P-capable layout (same root complex) with peer access OFF — \`topo -p2p\` reports CNS, which is the stock driver refusing P2P on GeForce cards rather than a hardware limit. A patched kernel module can unlock it: gain is strongly card-dependent: +2% narrative / +9% code measured on dual 3090 (#91/#295), but +32% decode on a dual 5090 (#873), so code and spec-decode workloads gain and narrative decode barely moves. It is an optional enthusiast lever, and it ships as a custom DKMS module you rebuild on every driver bump. If you want it: docs/PCIE_P2P.md §5."
+    echo "ℹ interconnect: ${count} GPUs on a P2P-capable layout (same root complex) with peer access OFF — \`topo -p2p\` reports CNS, which is the stock driver refusing P2P on GeForce cards rather than a hardware limit. A patched kernel module can unlock it."
+      echo "  What it reliably buys: PREFILL. Measured +14.4% @10K / +12.2% @90K on dual 3090 with the transport isolated (#922) — repeatable, CV <=1%. DECODE is the unreliable half: it lives in vLLM's custom all-reduce kernel, and with that kernel neutralised the decode delta sits INSIDE run-to-run noise. Older decode figures here (+9% code, +32% on a 5090) were measured with the custom kernel ON and do NOT transfer to a rig that has to turn it off."
+      echo "  ⚠️ It can also return WRONG DATA. On at least one Ampere rig the custom all-reduce over a patched peer path completed fast and emitted garbage on every request, with every indicator green and a plausible TPS (#922). \`--disable-custom-all-reduce\` avoids it and keeps the prefill win. Read real generated output before trusting any verdict line."
+      echo "  It is an optional enthusiast lever shipped as a custom DKMS module you rebuild on every driver bump. If you want it: docs/PCIE_P2P.md §5 (setup) and §7a (failure modes)."
   fi
 }
 

--- a/scripts/tests/test-p2p-state.sh
+++ b/scripts/tests/test-p2p-state.sh
@@ -238,7 +238,16 @@ out="$(hint)"
 assert_contains "$out" "§5"
 assert_contains "$out" "CNS"
 assert_contains "$out" "DKMS"          # the cost is stated, not just the gain
-assert_contains "$out" "+2% narrative" # honest expected gain, so users can decline
+# The advisory must state the gain HONESTLY so a user can decline. This used to
+# assert "+2% narrative" — a custom-all-reduce-dependent decode figure that is
+# unreachable on any rig which has to disable that kernel (#922). The reliable,
+# transport-only gain is PREFILL, so that is what the hint now leads with.
+assert_contains "$out" "PREFILL"
+assert_contains "$out" "14.4%"         # the transport-isolated measurement
+assert_contains "$out" "INSIDE"        # decode sits inside noise without custom AR
+# ...and it must not sell a patched module without its sharpest edge.
+assert_contains "$out" "WRONG DATA"
+assert_contains "$out" "disable-custom-all-reduce"
 
 # (d) BAR1 unreported by the driver -> fail open to the driver-gate message
 mk_smi "$L2" "$TOPO_PHB" "$P2P_CNS" ""


### PR DESCRIPTION
Follow-up to #924. Two independent lines said our P2P gain messaging oversold, so this reworks it end to end — the `report.sh` advisory, the §6 expectations table, and the guard that was pinning the old claim.

## What was wrong

The advisory quoted **"+2% narrative / +9% code"** and **"+32% decode on a dual 5090"**, and framed P2P as a decode / spec-decode lever.

Every one of those decode figures was measured with vLLM's **custom all-reduce kernel ON**. @juslex ([#922](https://github.com/noonghunna/club-3090/issues/922)) ran the first A/B with that kernel neutralised in **both** arms — isolating the transport — and got:

| | transport-isolated |
|---|---|
| prefill @10K | **+14.4%** |
| prefill @90K | **+12.2%** |
| TTFT | **−13% / −15%** |
| decode | **inside run-to-run noise** |

So on any rig that must turn the kernel off, the numbers we advertised are **unreachable**.

The **+32.5%** was separately already known-overstated in our own notes: its no-P2P baseline was low (17.7%) and a cross-session re-read put the honest figure nearer **+9%**. It's now labelled an upper bound from one Blackwell pair, not an expected upgrade gain.

## What was missing, and matters more

**We recommended a patched DKMS module without saying it can return wrong data.** On juslex's rig the custom all-reduce over a patched peer path completed fast and emitted garbage on every request, with every indicator green and a plausible TPS (§7a). Selling a lever without its sharpest edge is the part that actually needed fixing.

## Changes

**Advisory** — leads with prefill as the reliable gain; states plainly that decode lives in the custom kernel and is noise without it; carries the wrong-data warning and `--disable-custom-all-reduce` as the mitigation; keeps the DKMS rebuild cost.

**§6 table** — gains a transport-isolated row (the only one that isolates it) and marks the custom-AR-dependent rows as such. The Translation is rewritten around the two-mechanism split, plus a scale check: **PCIe P2P delivers ~30% of NVLink's prefill premium** (@10K: no-P2P ~1253 → PCIe P2P 1434 → NVLink 1975), about what gen3 x8 should manage against an NV4 bridge.

## The test was pinning the wrong thing

`test-p2p-state` asserted `+2% narrative` — a guard holding the advisory to the *misleading* claim. It now asserts the honest content: `PREFILL`, the `14.4%` measurement, decode `INSIDE` noise, and that the wrong-data warning **and its mitigation** are both present.

A guard should hold the advisory to being **honest**, not to being **unchanged**.

Guards green: `test-p2p-state`, `test-classifier`, `test-detect-nvlink-autop2p`, `test-bench-capture`, `test-report-exit-code`, `test-report-engine-liveness`, `test-locale-utf8`.