### PR TITLE
fix(deepseek-flash): derive multi4's residency constants for 4 cards, not 2

### DIFF
--- a/models/deepseek-v4-flash-0731/llama-cpp/compose/multi4/unsloth-q8-kxl/offload.yml
+++ b/models/deepseek-v4-flash-0731/llama-cpp/compose/multi4/unsloth-q8-kxl/offload.yml
@@ -48,7 +48,20 @@
 #    Defaults match NO layer (blk.99999), so an unset env degrades to all-experts-CPU
 #    rather than to an OOM. Asymmetric counts fall out for free, which is what mixed
 #    rigs (e.g. 5090 + 3090) need.
-# CPU-Offload-Host-RAM-GB: 146
+# ⚠️ THESE TWO CONSTANTS ARE 4-CARD-DERIVED — do NOT copy them from the dual compose.
+# This slug originally shipped with the dual's values (reserve 18000 / host 146) because
+# it was authored by copying that file, and neither was re-derived for four cards. Both
+# were wrong in the same direction and the slug contradicted its own purpose:
+#   • reserve 18000 was sized for a 2-WAY dense split. On four cards each card carries a
+#     quarter of the dense stack, so the budget was far too conservative — the sizer
+#     granted 1 bundle/card where 2 fit, i.e. HALF the residency the hardware holds.
+#   • host 146 GB then followed from those 4 resident layers — and the registry note for
+#     this very slug sells it as "what puts the quality tier inside a mainstream RAM
+#     budget", naming 128 GB. So preflight REFUSED the exact box the slug exists for.
+# Corrected from a real 4x3090 + 128 GB boot by @milano (Discord, 2026-08-07), and the
+# pair is self-consistent with our own residency math: reserve 12000 -> 2 bundles/card ->
+# 8 resident -> 137.1 GiB routed - 8x3.19 GiB = 111.6 GiB = ~120 GB host.
+# CPU-Offload-Host-RAM-GB: 120
 #   Worst case: ALL experts on CPU. Residency only MOVES bytes onto the GPUs, so the
 #   real requirement is LOWER — the guard is conservative by construction, which is the
 #   safe direction. Read by preflight_cpu_offload_ram(); measured, not computed (the
@@ -59,7 +72,7 @@
 #   0 = no dense prefix on this model (all 43 layers are MoE). Models WITH one
 #   (Laguna=1, Inkling=2) must set it: a residency rule naming a dense layer
 #   silently matches nothing, so fewer layers land resident than we granted.
-# CPU-Offload-GPU-Reserve-MiB: 18000
+# CPU-Offload-GPU-Reserve-MiB: 12000
 #   Inputs for resolve_offload_residency(). The RESERVE is what the naive
 #   free-VRAM/bundle arithmetic forgets: dense stack + compute reserve + drafter.
 #   A ~0.55 calibration is applied on top — naive sizing overestimates ~2x and

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -1025,10 +1025,10 @@ COMPOSE_REGISTRY = {
         default_port=8032,
         kvcalc_key="SKIP",
         offload="n-cpu-moe",
-        host_ram_gb=146,
+        host_ram_gb=120,
         required_sm=8.6,
         status="incubating",
-        status_note="4-card QUALITY tier. NEVER BOOTED BY US -- authored from measured 2-card data plus the ~0.55 residency calibration; every number is an ESTIMATE until a 4-card owner runs it. The argument is NOT throughput: every layer pinned to a GPU is a layer NOT in host RAM, so host RAM FALLS with card count -- ~113 GB (est.) at 4x24 GB vs ~140 GB at 2x24. 128 GB is a very common host config, which the 2-card Q8 slug EXCLUDES and this one FITS, so multi4 is what puts the quality tier inside a mainstream RAM budget. Residency should also be at its best here (~23% of expert traffic on GPU vs 4.7% on two cards). No IQ2 multi slug: on four cards Q8 itself drops into a 128 GB budget, so a low-bit tier is not needed to fit.",
+        status_note="4-card QUALITY tier. NEVER BOOTED BY US. 2026-08-07: a 4x3090 + 128 GB owner (@milano, Discord) BOOTED it after correcting two constants this compose had COPIED from the dual file and never re-derived for four cards -- reserve 18000 (a 2-way dense split) granted 1 bundle/card where 2 fit, and the 146 GB gate then REFUSED the 128 GB box this slug exists to serve. Now reserve 12000 / host 120, self-consistent with our residency math. STILL UNVALIDATED BEYOND BOOT: no real prefill probe yet, and on this model boot is NOT sufficient -- the 262K config booted, passed a trivial decode, then died on the first ~15.7K prefill. Prefill probe requested. The argument is NOT throughput: every layer pinned to a GPU is a layer NOT in host RAM, so host RAM FALLS with card count -- **120 GB MEASURED** at 4x24 GB (was ~113 est.) vs ~146 at 2x24 -- first 4-card boot by @milano 2026-08-07. 128 GB is a very common host config, which the 2-card Q8 slug EXCLUDES and this one FITS, so multi4 is what puts the quality tier inside a mainstream RAM budget. Residency should also be at its best here (~23% of expert traffic on GPU vs 4.7% on two cards). No IQ2 multi slug: on four cards Q8 itself drops into a 128 GB budget, so a low-bit tier is not needed to fit.",
         category="frontier",
     ),
 


### PR DESCRIPTION
First 4-card boot of a slug we shipped without ever running it — by @milano on Discord (4×3090, 128 GB DDR5, PCIe 3.0). He had to edit two constants to get in, and **they weren't a workaround: they're the values our own math produces.**

## What was wrong

The multi4 compose was authored by **copying the dual file**, and two constants were never re-derived for four cards:

```
CPU-Offload-GPU-Reserve-MiB: 18000 -> 12000
CPU-Offload-Host-RAM-GB:       146 -> 120     (registry host_ram_gb too)
```

**Reserve 18000 was sized for a 2-way dense split.** On four cards each card carries a *quarter* of the dense stack, so the budget was far too conservative — the sizer granted **1 bundle/card where 2 fit**, i.e. half the residency the hardware holds.

**The 146 GB gate then followed from those 4 resident layers** — and this slug's own registry note sells it as *"what puts the quality tier inside a mainstream RAM budget,"* naming **128 GB** explicitly. So preflight refused the exact box the slug exists to serve.

## His numbers are the coherent pair

| reserve | fit/card | resident | host RAM |
|---:|---:|---:|---:|
| 18000 | 1 | 4 | 133.5 GB |
| **12000** | **2** | **8** | **119.8 GB** ← his 120 |

`137.1 GiB routed − 8 × 3.19 GiB = 111.6 GiB ≈ 120 GB`. He didn't tune two numbers independently; he found the self-consistent pair empirically, on hardware we don't have.

## ⚠️ Still unvalidated beyond boot

He reported *"you are good to go"* after a successful boot. On **this model** that isn't sufficient, and the `status_note` now says so: the 262K config booted, reported healthy, passed a trivial decode, then **died on the first ~15.7K-token prefill** with a CUDA OOM in `cuMemCreate`. Reserve 12000 leaves *less* headroom — exactly where that failure lives.

A real ≥10K prefill probe has been requested. Until then the slug stays honest about what is and isn't known.

## Note on the change itself

While editing, a `sed` hit **both** q8 slugs — dual-q8 also carried `host_ram_gb=146`. Caught and reverted; dual-q8 genuinely needs 146 at 2 resident layers. Verified after: dual-q8=146, dual-iq2=86, multi4=120.

Guards green: `test-compose-status-drift`, `test-compose-registry-disk`, `test-switch-registry-parity`, `test-launch-registry-parity`, `test-preflight-cpu-offload`, `test-compose-mounts-resolve`.