### PR TITLE
Let explicit OT_G<i> env win over auto-sized residency

### DIFF
--- a/scripts/lib/compose-meta.sh
+++ b/scripts/lib/compose-meta.sh
@@ -429,6 +429,26 @@ _offload_layers_for_card() {
   printf '%s' "$rule"
 }
 
+# _offload_rule_layer_count <ot_rule>
+#
+# Prints the number of layers named in an OT_G-style rule's `blk\.(a|b|c)\.`
+# group; 0 if the rule doesn't have that shape. 0-on-unparseable is the safe
+# direction: a malformed user rule most likely matches nothing at boot, so the
+# RAM gate should price that card at worst case, not at what the user intended.
+_offload_rule_layer_count() {
+  local rule="$1" group
+  case "$rule" in
+    *'blk\.('*')'*) ;;
+    *) printf '0'; return 0 ;;
+  esac
+  group="${rule#*'blk\.('}"
+  group="${group%%')'*}"
+  [[ -z "$group" ]] && { printf '0'; return 0; }
+  local -a lays
+  IFS='|' read -ra lays <<<"$group"
+  printf '%s' "${#lays[@]}"
+}
+
 resolve_offload_residency() {
   local compose_file="$1"
   [[ -f "$compose_file" ]] || return 0
@@ -459,11 +479,26 @@ resolve_offload_residency() {
     # same contract as THREADS (resolve_offload_threads). This is the supported
     # way to pin more residency than the calibrated sizer grants (the 0.55 was
     # calibrated on 24 GB cards and under-fills larger ones — club-3090 #931).
-    # ⚠️ RAM-gate interaction: the gate subtracts the AUTO grant. A user pinning
-    # MORE layers needs LESS host RAM than gated (conservative, fine); pinning
-    # FEWER on a RAM-tight box could under-gate — exotic, accepted.
+    # The RAM gate prices the user's ACTUAL pin (offload_residency_grant_mib
+    # counts the rule's layers), so the two stay coherent.
     var="OT_G${i}"
-    [[ -n "${!var:-}" ]] && continue
+    if [[ -n "${!var:-}" ]]; then
+      # Sanity: a pin that exceeds even the card's NAIVE free space (total minus
+      # reserve — the OPTIMISTIC bound; true usable is ~half of it) is a certain
+      # boot OOM. Warn loudly, don't block: the override exists to out-judge us.
+      # First community hit: 8/card of Q8's 3264 MiB bundles — an IQ2-sized
+      # recipe applied to the fat quant (#931).
+      local ucount upin_mib
+      ucount="$(_offload_rule_layer_count "${!var}")"
+      upin_mib=$(( ucount * bundle ))
+      if (( upin_mib > totals[i] - reserve )); then
+        echo "[residency] WARN: OT_G${i} pins ${ucount} bundles = ~$(( upin_mib / 1024 )) GiB of experts, but card ${i}" >&2
+        echo "            has only ~$(( (totals[i] > reserve ? totals[i] - reserve : 0) / 1024 )) GiB beyond the reserve (bundle=${bundle} MiB on THIS quant —" >&2
+        echo "            bundle sizes differ per quant tier; a layer count sized for one tier over-pins another)." >&2
+        echo "            Expect a boot OOM; reduce the pin." >&2
+      fi
+      continue
+    fi
     fit="$(_offload_fit_count "${totals[i]}" "$reserve" "$bundle" "$per_card")"
     (( fit < 1 )) && continue                     # leave this card's no-op default
     rule="$(_offload_layers_for_card "$i" "$n" "$first" "$layers" "$fit")"
@@ -511,9 +546,20 @@ offload_residency_grant_mib() {
   (( n >= 2 )) || { printf '0'; return 0; }
 
   local per_card=$(( layers / n ))
-  local i fit rule total_mib=0
+  local i fit rule total_mib=0 var ucount
   local -a lays
   for (( i=0; i<n; i++ )); do
+    # A user-set OT_G<i> is what will ACTUALLY be pinned (the injector never
+    # clobbers it) — price ITS layer count, not the auto fit, so the gate and
+    # the boot describe the same config. First hit in the wild: a 123 GB box
+    # gated on the auto grant (~12 GB) while the user was pinning 4x that
+    # (#931). Unparseable user rule counts 0 = worst case, the safe direction.
+    var="OT_G${i}"
+    if [[ -n "${!var:-}" ]]; then
+      ucount="$(_offload_rule_layer_count "${!var}")"
+      total_mib=$(( total_mib + ucount * bundle ))
+      continue
+    fi
     fit="$(_offload_fit_count "${totals[i]}" "$reserve" "$bundle" "$per_card")"
     (( fit < 1 )) && continue
     rule="$(_offload_layers_for_card "$i" "$n" "$first" "$layers" "$fit")"

--- a/scripts/lib/compose-meta.sh
+++ b/scripts/lib/compose-meta.sh
@@ -453,8 +453,17 @@ resolve_offload_residency() {
   (( n >= 2 )) || return 0
 
   local per_card=$(( layers / n ))
-  local i fit rule
+  local i fit rule var
   for (( i=0; i<n; i++ )); do
+    # An explicit OT_G<i> from the user/env ALWAYS WINS and is never clobbered —
+    # same contract as THREADS (resolve_offload_threads). This is the supported
+    # way to pin more residency than the calibrated sizer grants (the 0.55 was
+    # calibrated on 24 GB cards and under-fills larger ones — club-3090 #931).
+    # ⚠️ RAM-gate interaction: the gate subtracts the AUTO grant. A user pinning
+    # MORE layers needs LESS host RAM than gated (conservative, fine); pinning
+    # FEWER on a RAM-tight box could under-gate — exotic, accepted.
+    var="OT_G${i}"
+    [[ -n "${!var:-}" ]] && continue
     fit="$(_offload_fit_count "${totals[i]}" "$reserve" "$bundle" "$per_card")"
     (( fit < 1 )) && continue                     # leave this card's no-op default
     rule="$(_offload_layers_for_card "$i" "$n" "$first" "$layers" "$fit")"

--- a/scripts/tests/test-preflight-cpu-offload.sh
+++ b/scripts/tests/test-preflight-cpu-offload.sh
@@ -136,11 +136,52 @@ _mkstub '24576\n24576\n'
 # pin more residency than the calibrated sizer grants — #931), and the OTHER
 # card's slot must still be auto-sized
 ( export OT_G0='blk\.(0|1|2|3)\.ffn_(gate|up|down)_exps\.weight=CUDA0'
-  PATH="$stub:$PATH" resolve_offload_residency "$Q8"
+  PATH="$stub:$PATH" resolve_offload_residency "$Q8" 2>/dev/null
   [[ "$OT_G0" == 'blk\.(0|1|2|3)\.ffn_(gate|up|down)_exps\.weight=CUDA0' ]] \
     && [[ "${OT_G1:-}" == 'blk\.(42)\.ffn_(gate|up|down)_exps\.weight=CUDA1' ]] ) \
   && ok "user OT_G0 wins; OT_G1 still auto-sized" \
   || bad "user OT_G override was clobbered (or blocked the other card's auto-size)"
+
+# ---- user pins and the RAM gate must describe the SAME config (#931: paul's ----
+# ---- Q8 attempt was gated on the auto ~12 GB while pinning 4x that)         ----
+
+declare -F _offload_rule_layer_count >/dev/null 2>&1 && ok "_offload_rule_layer_count defined" \
+  || bad "_offload_rule_layer_count missing"
+[[ "$(_offload_rule_layer_count 'blk\.(0|1|2|3|4|5|6|7)\.ffn_(gate|up|down)_exps\.weight=CUDA0')" == "8" ]] \
+  && ok "rule parser: 8-layer rule -> 8" || bad "rule parser miscounted an 8-layer rule"
+[[ "$(_offload_rule_layer_count 'blk\.(42)\.ffn_(gate|up|down)_exps\.weight=CUDA1')" == "1" ]] \
+  && ok "rule parser: single layer -> 1" || bad "rule parser miscounted a 1-layer rule"
+[[ "$(_offload_rule_layer_count 'not-an-ot-rule')" == "0" ]] \
+  && ok "rule parser: garbage -> 0 (worst case, safe)" || bad "rule parser did not zero on garbage"
+
+# gate prices the user's ACTUAL pin: 4+4 layers = 8x3264 = 26112 MiB -> ~25 GB
+# subtracted from the 999999 worst case
+g="$(export OT_G0='blk\.(0|1|2|3)\.ffn_(gate|up|down)_exps\.weight=CUDA0' \
+            OT_G1='blk\.(42|41|40|39)\.ffn_(gate|up|down)_exps\.weight=CUDA1'
+     PATH="$stub:$PATH" offload_residency_grant_mib "$Q8")"
+[[ "$g" == "26112" ]] && ok "grant follows user pins (8 layers = 26112 MiB, auto would say 6528)" \
+  || bad "grant '$g' ignored user pins (expected 26112)"
+printf '# CPU-Offload-Host-RAM-GB: 999999\n# CPU-Offload-Bundle-MiB: 3264\n# CPU-Offload-MoE-Layers: 43\n# CPU-Offload-First-MoE-Layer: 0\n# CPU-Offload-GPU-Reserve-MiB: 18000\nservices:\n  x:\n    command: >-\n      -ot a=CPU\n' > "$tmp"
+msg="$(export OT_G0='blk\.(0|1|2|3)\.ffn_(gate|up|down)_exps\.weight=CUDA0' \
+              OT_G1='blk\.(42|41|40|39)\.ffn_(gate|up|down)_exps\.weight=CUDA1'
+       PATH="$stub:$PATH" preflight_cpu_offload_ram "$tmp" 2>&1)"
+command grep -q "999974" <<<"$msg" \
+  && ok "gate subtracts the USER grant (999999 - 25 GB)" \
+  || bad "gate did not price the user pin (no 999974 in: $(head -1 <<<"$msg"))"
+
+# an over-pin beyond even the card's naive free space must WARN (certain OOM —
+# e.g. an IQ2-sized 8/card recipe applied to Q8's 3264 MiB bundles), and a sane
+# pin must stay silent
+w="$(export OT_G0='blk\.(0|1|2|3|4|5|6|7)\.ffn_(gate|up|down)_exps\.weight=CUDA0'
+     PATH="$stub:$PATH" resolve_offload_residency "$Q8" 2>&1 >/dev/null)"
+command grep -q "WARN: OT_G0 pins 8" <<<"$w" \
+  && ok "over-pin (8x3264 on a 24 GB card) warns of certain OOM" \
+  || bad "no WARN for a pin that cannot fit the card"
+w="$(export OT_G0='blk\.(0)\.ffn_(gate|up|down)_exps\.weight=CUDA0'
+     PATH="$stub:$PATH" resolve_offload_residency "$Q8" 2>&1 >/dev/null)"
+command grep -q "WARN" <<<"$w" \
+  && bad "sane 1-bundle pin wrongly warned" \
+  || ok "sane pin stays silent"
 
 # the gate must SUBTRACT the grant: worst-case 999999 minus 6528 MiB -> ~999993
 printf '# CPU-Offload-Host-RAM-GB: 999999\n# CPU-Offload-Bundle-MiB: 3264\n# CPU-Offload-MoE-Layers: 43\n# CPU-Offload-First-MoE-Layer: 0\n# CPU-Offload-GPU-Reserve-MiB: 18000\nservices:\n  x:\n    command: >-\n      -ot a=CPU\n' > "$tmp"

--- a/scripts/tests/test-preflight-cpu-offload.sh
+++ b/scripts/tests/test-preflight-cpu-offload.sh
@@ -132,6 +132,16 @@ _mkstub '24576\n24576\n'
   && ok "injector: 2x24 Q8 pins blk.0->CUDA0 + blk.42->CUDA1 (outer-edge)" \
   || bad "injector OT_G rules drifted from the known-good 2x24 placement"
 
+# an explicit OT_G<i> from the user must NEVER be clobbered (the supported way to
+# pin more residency than the calibrated sizer grants — #931), and the OTHER
+# card's slot must still be auto-sized
+( export OT_G0='blk\.(0|1|2|3)\.ffn_(gate|up|down)_exps\.weight=CUDA0'
+  PATH="$stub:$PATH" resolve_offload_residency "$Q8"
+  [[ "$OT_G0" == 'blk\.(0|1|2|3)\.ffn_(gate|up|down)_exps\.weight=CUDA0' ]] \
+    && [[ "${OT_G1:-}" == 'blk\.(42)\.ffn_(gate|up|down)_exps\.weight=CUDA1' ]] ) \
+  && ok "user OT_G0 wins; OT_G1 still auto-sized" \
+  || bad "user OT_G override was clobbered (or blocked the other card's auto-size)"
+
 # the gate must SUBTRACT the grant: worst-case 999999 minus 6528 MiB -> ~999993
 printf '# CPU-Offload-Host-RAM-GB: 999999\n# CPU-Offload-Bundle-MiB: 3264\n# CPU-Offload-MoE-Layers: 43\n# CPU-Offload-First-MoE-Layer: 0\n# CPU-Offload-GPU-Reserve-MiB: 18000\nservices:\n  x:\n    command: >-\n      -ot a=CPU\n' > "$tmp"
 msg="$(PATH="$stub:$PATH" preflight_cpu_offload_ram "$tmp" 2>&1)"


### PR DESCRIPTION
Enables the supported answer to #931 (@paulp83's 2×5090 report: ~6 GB/card idle after residency sizing).

The launcher's `resolve_offload_residency` exported `OT_G*` unconditionally — a user-set value was silently clobbered, unlike `THREADS` which has always had a user-wins guard. With this, `OT_G0=... OT_G1=... bash scripts/switch.sh --force <slug>` pins exactly what the user asks; unset slots still auto-size per card.

Context: the `0.55` fit calibration is a multiplicative guard for an additive overhead, measured on 24 GB cards — correct there, increasingly conservative on larger cards (paul's 32 GB pair holds the 5 granted bundles/card while his NIAH ladder shows ~5.4 GB free *through a 188K prefill*). Hand-pinning is the escape hatch until a 32 GB datapoint recalibrates the sizer — that recalibration is deliberately NOT in this PR (needs paul's stepwise probe first).

Guard added: preset `OT_G0` survives the injector, `OT_G1` still auto-sizes. Suite: test-preflight-cpu-offload 41/41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)