### PR TITLE
Print applied residency (and its source) at launch

### DIFF
--- a/scripts/lib/compose-meta.sh
+++ b/scripts/lib/compose-meta.sh
@@ -473,7 +473,7 @@ resolve_offload_residency() {
   (( n >= 2 )) || return 0
 
   local per_card=$(( layers / n ))
-  local i fit rule var
+  local i fit rule var applied=""
   for (( i=0; i<n; i++ )); do
     # An explicit OT_G<i> from the user/env ALWAYS WINS and is never clobbered —
     # same contract as THREADS (resolve_offload_threads). This is the supported
@@ -497,14 +497,26 @@ resolve_offload_residency() {
         echo "            bundle sizes differ per quant tier; a layer count sized for one tier over-pins another)." >&2
         echo "            Expect a boot OOM; reduce the pin." >&2
       fi
+      applied="${applied}${applied:+ · }card${i}: USER pin, ${ucount} bundles"
       continue
     fi
     fit="$(_offload_fit_count "${totals[i]}" "$reserve" "$bundle" "$per_card")"
-    (( fit < 1 )) && continue                     # leave this card's no-op default
+    if (( fit < 1 )); then                        # leave this card's no-op default
+      applied="${applied}${applied:+ · }card${i}: none (0 fit)"
+      continue
+    fi
     rule="$(_offload_layers_for_card "$i" "$n" "$first" "$layers" "$fit")"
-    [[ -z "$rule" ]] && continue
+    if [[ -z "$rule" ]]; then
+      applied="${applied}${applied:+ · }card${i}: none (0 fit)"
+      continue
+    fi
     export "OT_G${i}=blk\.(${rule})\.ffn_(gate|up|down)_exps\.weight=CUDA${i}"
+    applied="${applied}${applied:+ · }card${i}: auto ${fit} bundles (blk ${rule})"
   done
+  # Say what will actually be pinned and WHO decided it. Three community
+  # debugging rounds in two days (#931 twice, milano's multi4 boot) needed
+  # docker-inspect forensics to answer exactly this — one boot line ends that.
+  [[ -n "$applied" ]] && echo "[residency] ${applied}" >&2
   return 0
 }
 

--- a/scripts/tests/test-preflight-cpu-offload.sh
+++ b/scripts/tests/test-preflight-cpu-offload.sh
@@ -183,6 +183,20 @@ command grep -q "WARN" <<<"$w" \
   && bad "sane 1-bundle pin wrongly warned" \
   || ok "sane pin stays silent"
 
+# the boot line must SAY what was pinned and who decided it — three community
+# debugging rounds (#931 twice, the multi4 first boot) needed docker-inspect
+# forensics to answer exactly this
+w="$(PATH="$stub:$PATH" resolve_offload_residency "$Q8" 2>&1 >/dev/null)"
+command grep -q "card0: auto 1 bundles (blk 0)" <<<"$w" \
+  && command grep -q "card1: auto 1 bundles (blk 42)" <<<"$w" \
+  && ok "boot line reports auto residency per card" \
+  || bad "no auto-residency boot line (got: $w)"
+w="$(export OT_G0='blk\.(0|1|2|3)\.ffn_(gate|up|down)_exps\.weight=CUDA0'
+     PATH="$stub:$PATH" resolve_offload_residency "$Q8" 2>&1 >/dev/null)"
+command grep -q "card0: USER pin, 4 bundles" <<<"$w" \
+  && ok "boot line marks a user pin as USER" \
+  || bad "user pin not marked in the boot line (got: $w)"
+
 # the gate must SUBTRACT the grant: worst-case 999999 minus 6528 MiB -> ~999993
 printf '# CPU-Offload-Host-RAM-GB: 999999\n# CPU-Offload-Bundle-MiB: 3264\n# CPU-Offload-MoE-Layers: 43\n# CPU-Offload-First-MoE-Layer: 0\n# CPU-Offload-GPU-Reserve-MiB: 18000\nservices:\n  x:\n    command: >-\n      -ot a=CPU\n' > "$tmp"
 msg="$(PATH="$stub:$PATH" preflight_cpu_offload_ram "$tmp" 2>&1)"


### PR DESCRIPTION
Promised in #931: the third community debugging round in two days came down to "what residency actually applied, and who decided it" — answerable only by `docker inspect` on the live container. Now the launcher prints it at boot:

```
[residency] card0: auto 5 bundles (blk 0|1|2|3|4) · card1: auto 5 bundles (blk 42|41|40|39|38)
[residency] card0: USER pin, 8 bundles · card1: USER pin, 8 bundles
```

Cards that fit nothing say `none (0 fit)` instead of staying silent. Guards added for both shapes; suite 56/56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)