### PR TITLE
fix(c3): only require reconcile for GPU-holding services in service_start

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -3228,10 +3228,10 @@ class CockpitData:
           - ``--env-file .env`` (when present) resolves repo vars like
             ``${MODEL_DIR}`` / ``${HF_TOKEN}`` that some composes (comfyui) need.
 
-        Reconcile-gated: a GPU-holding service (ComfyUI / Step-Audio) can't
-        silently collide with whatever holds the cards, while a non-GPU web
-        service (litellm / qdrant / …) clears the gate immediately.  Tolerates the
-        ``.yml`` / ``.yaml`` spelling."""
+        Reconcile-gated for GPU-holding services only (ComfyUI / Step-Audio) so
+        they can't silently collide with whatever holds the cards; non-GPU web
+        services (litellm / qdrant / searxng / open-webui) skip the gate entirely.
+        Tolerates the ``.yml`` / ``.yaml`` spelling."""
         resolved = self._resolve_service_compose(name)
         rel, project = resolved if resolved is not None else (
             f"services/{name}/docker-compose.yml",
@@ -3247,11 +3247,15 @@ class CockpitData:
         # `env K=V …` (process env) wins over --env-file for compose interpolation.
         if name == STUDIO_DIRECTOR_CONTAINER:
             cmd = ["env", *(f"{k}={v}" for k, v in self.director_compose_env().items()), *cmd]
+        # Reconcile-gated for GPU-holding services only: they can't silently
+        # collide with whatever holds the cards; non-GPU web services clear
+        # the gate immediately.
+        is_gpu_holder = _classify_container_kind(name) is not None
         return ActionPlan(
             kind="service-up",
             cmd=cmd,
             description=f"docker compose up {name}",
-            requires_reconcile=True,
+            requires_reconcile=is_gpu_holder,
         )
 
     def service_start_or_restart(self, name: str) -> ActionPlan:

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -1745,7 +1745,8 @@ class TestServiceStart:
         assert plan.cmd == [
             "docker", "compose", "-f",
             "services/litellm/docker-compose.yml", "-p", "litellm", "up", "-d"]
-        assert plan.requires_reconcile is True
+        # litellm is a non-GPU web service → skips the reconcile gate
+        assert plan.requires_reconcile is False
         assert plan.kind == "service-up"
 
     def test_env_file_included_when_present(self, tmp_path):
@@ -1761,6 +1762,12 @@ class TestServiceStart:
         (d / "docker-compose.yaml").write_text("services: {}\n")
         plan = CockpitData(tmp_path).service_start("x")
         assert "services/x/docker-compose.yaml" in plan.cmd
+
+    def test_gpu_service_requires_reconcile(self, tmp_path):
+        """comfyui is a GPU holder → reconcile is required."""
+        _seed_service_dirs(tmp_path, ["comfyui"])
+        plan = CockpitData(tmp_path).service_start("comfyui")
+        assert plan.requires_reconcile is True
 
 
 class TestComfyuiImagePresent:


### PR DESCRIPTION
## Problem

Starting a non-GPU web service (open-webui, litellm, qdrant, searxng) from c3's Containers tab would warn about tearing down the current vLLM container. The reconcile gate assumed every service wanted both GPUs.

## Fix

`service_start()` now uses `_classify_container_kind(name)` to determine if a service is a GPU holder. Only GPU-holding services (ComfyUI, Step-Audio, engine containers, estate containers) go through the reconcile gate. Non-GPU web services skip it entirely.

## Changes

- **services.py:3253** — `requires_reconcile=True` becomes `requires_reconcile=is_gpu_holder`
- Updated docstring to reflect the new behavior

## Testing

- Non-GPU services (open-webui, litellm, qdrant, searxng) start without reconcile warning
- GPU-holding services (ComfyUI, Step-Audio) still go through the reconcile gate as before