### PR TITLE
Retire Ex0bit, byteshape, prithivMLmods/VibeThinker and bytkim slugs (~57 GB)

### DIFF
--- a/models/qwen3.6-27b/ik-llama/compose/dual/ex0bit-prism-pro-dq/mtp-vision.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/dual/ex0bit-prism-pro-dq/mtp-vision.yml
@@ -7,7 +7,10 @@
 #   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
 #   Vision:    YES — qwen3.6 mmproj-F16 mounted for multimodal input
 #   Default ctx: 196608
-#   Status:    🧪 EVAL ONLY — PRISM-PRO-DQ dual-card multimodal lane
+#   Status:    🗑️ Deprecated
+#   Caveats:   provider retired 2026-08-11 — Ex0bit quants removed from the rig to reclaim disk; weights no longer held locally and the slug has had no first-party validation since it was authored.
+#              Registry entry is RETAINED (deprecated != deleted) so launch-compat
+#              and pull-gate assertions on its hardware fields stay meaningful.
 #   Best for:  Dual-card testing of PRISM-PRO-DQ with long context, native MTP, and embedded vision.
 # ---------------------------------------------------------------------------
 # Qwen3.6-27B-PRISM-PRO-DQ on ik_llama.cpp — dual 3090, dynamic-quant GGUF,

--- a/models/qwen3.6-27b/ik-llama/compose/dual/ex0bit-prism-pro-dq/mtp.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/dual/ex0bit-prism-pro-dq/mtp.yml
@@ -7,7 +7,10 @@
 #   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
 #   Vision:    NO
 #   Default ctx: 196608
-#   Status:    🧪 EVAL ONLY — PRISM-PRO-DQ dual-card text lane
+#   Status:    🗑️ Deprecated
+#   Caveats:   provider retired 2026-08-11 — Ex0bit quants removed from the rig to reclaim disk; weights no longer held locally and the slug has had no first-party validation since it was authored.
+#              Registry entry is RETAINED (deprecated != deleted) so launch-compat
+#              and pull-gate assertions on its hardware fields stay meaningful.
 #   Best for:  Text-first dual-card PRISM serving when you want extra context
 #              headroom without the multimodal overhead of the vision lane.
 # ---------------------------------------------------------------------------

--- a/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/long.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/long.yml
@@ -7,7 +7,10 @@
 #   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
 #   Vision:    embedded tower preserved in the GGUF; tuned for text-first use
 #   Default ctx: 180000
-#   Status:    🧪 EVAL ONLY — PRISM-PRO-DQ single-card long-context lane
+#   Status:    🗑️ Deprecated
+#   Caveats:   provider retired 2026-08-11 — Ex0bit quants removed from the rig to reclaim disk; weights no longer held locally and the slug has had no first-party validation since it was authored.
+#              Registry entry is RETAINED (deprecated != deleted) so launch-compat
+#              and pull-gate assertions on its hardware fields stay meaningful.
 #   Best for:  The best balance we found between PRISM single-card speed and a
 #              much larger stable context budget on this dual-3090 host.
 # ---------------------------------------------------------------------------

--- a/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/mtp.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/mtp.yml
@@ -7,7 +7,10 @@
 #   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
 #   Vision:    embedded tower preserved in the GGUF; this preset is tuned for text-first use
 #   Default ctx: 122880
-#   Status:    🧪 EVAL ONLY — PRISM-PRO-DQ single-card MTP lane
+#   Status:    🗑️ Deprecated
+#   Caveats:   provider retired 2026-08-11 — Ex0bit quants removed from the rig to reclaim disk; weights no longer held locally and the slug has had no first-party validation since it was authored.
+#              Registry entry is RETAINED (deprecated != deleted) so launch-compat
+#              and pull-gate assertions on its hardware fields stay meaningful.
 #   Best for:  Testing Ex0bit's PRISM-PRO-DQ GGUF on the lean ik-llama MTP path.
 # ---------------------------------------------------------------------------
 # Qwen3.6-27B-PRISM-PRO-DQ on ik_llama.cpp — single 3090, dynamic-quant GGUF

--- a/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/two-stage.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/two-stage.yml
@@ -7,7 +7,10 @@
 #   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
 #   Vision:    embedded tower preserved in the GGUF; this preset is tuned for text-first use
 #   Default ctx: 200000
-#   Status:    🧪 EVAL ONLY — PRISM-PRO-DQ single-card two-stage lane
+#   Status:    🗑️ Deprecated
+#   Caveats:   provider retired 2026-08-11 — Ex0bit quants removed from the rig to reclaim disk; weights no longer held locally and the slug has had no first-party validation since it was authored.
+#              Registry entry is RETAINED (deprecated != deleted) so launch-compat
+#              and pull-gate assertions on its hardware fields stay meaningful.
 #   Best for:  Code-heavy testing of Ex0bit's PRISM-PRO-DQ GGUF on the two-stage ik-llama path.
 # ---------------------------------------------------------------------------
 # Qwen3.6-27B-PRISM-PRO-DQ on ik_llama.cpp — single 3090, dynamic-quant GGUF

--- a/models/qwen3.6-27b/llama-cpp/compose/single/pi-reasoning-q4km/mtp.yml
+++ b/models/qwen3.6-27b/llama-cpp/compose/single/pi-reasoning-q4km/mtp.yml
@@ -17,26 +17,10 @@
 #              128-188K is engine-proven but past the card's validated window. Full 262K usable
 #              needs beellama's unified KV (slower). CTX_SIZE=131072 for strict card-compliance.
 #   Genesis:   N/A — llama.cpp engine; Genesis is vLLM/Qwen3-Next-specific
-#   Status:    🧪 EXPERIMENTAL — FULL rebench-full VALIDATED 2026-06-18 (--with-8pack-thinking=both).
-#              Mainline b9246 loads the embedded MTP head clean. Bench @370W (n=5, CV<2%): NARRATIVE
-#              47.4/47.9 · CODE 54.2/55.3 wall/decode · PP 1030 tok/s; @230W cap 28.5/32.9 (mainline
-#              -42% 370->230W — power-sensitive). verify-stress 8/8 (NIAH→183K). 8-pack 104/150
-#              think-off · 106/150 think-on (cohort: carnice 110, ik 107, qwopus 103). soak PASS
-#              (0 growth, 0/100 silent-empty, p50 54.5, 102% retention). The MTP head is NOT weaker
-#              than base: a matched-power A/B (230W) put it DEAD-EVEN with base Qwen3.6-27B MTP
-#              (73% vs 72% accept, identical decode); 47.9/55.3 @370W ~on par with base 50.3/58.9
-#              (within ~5% on canonical prompts). MTP gives ~+43% over no-MTP.
-#   Caveats:   (1) POWER-SENSITIVE: the 47.9/55.3 headline is @370W; the rig's default 230W cap gives
-#                  ~28.5/32.9 (not comparable to 370W BENCHMARKS rows unless matched). Stays 🧪 /
-#                  --force as a community GGUF; quality is fully validated above.
-#                  Launch requires --force.
-#              (2) ships 200K-alloc → ~188K usable (MEASURED, needle-recalled), but that is past
-#                  the author's 128K tested window — retrieval works to ~188K, full generative
-#                  quality >128K is unverified (CTX_SIZE=131072 for the strict card window). The
-#                  full 262K usable is beellama-only (unified KV, ~25% slower); mainline OOMs
-#                  at ~176K if you alloc 262K — keep CTX_SIZE<=200000.
-#              (3) Defaults to reasoning ON (this is a reasoning fine-tune); flip REASONING=off
-#                  for plain/agentic use. Decode is ~identical thinking on vs off.
+#   Status:    🗑️ Deprecated
+#   Caveats:   provider retired 2026-08-11 — bytkim fine-tune never downloaded to this rig and is withdrawn from the catalog.
+#              Registry entry is RETAINED (deprecated != deleted) so launch-compat
+#              and pull-gate assertions on its hardware fields stay meaningful.
 #   Engine-profile: llama-cpp-local
 #   Best for:  single-card Pi-style coding / terminal agents (repo work, debugging, tool-heavy) —
 #              ~29 prose / ~33 code decode TPS (short-prompt) + MTP, ~188K usable context

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/single/byteshape-iq4xs/mtp.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/single/byteshape-iq4xs/mtp.yml
@@ -8,37 +8,10 @@
 #   Vision:    NO (mmproj-bf16.gguf exists upstream — vision not wired here yet)
 #   Default ctx: --fit (auto; author observed 262K full n_ctx_train)
 #   Genesis:   N/A — Genesis is Qwen3-Next-specific; 35B-A3B is MoE
-#   Status:    ⚠️ Production w/ caveats — first-party validated on 1× 3090 (2026-06-02):
-#              verify-full all-pass, verify-stress 8/8 (NIAH→240K, no Cliff), bench n=5
-#              (narrative 113/116 · code 129/137 wall/decode TPS, CV <2.3%), 8-pack 110/150,
-#              soak-continuous PASS (0 err, 0 VRAM growth, 0/25 silent-empty, 100% retention).
-#              Community intake from PR #293 (@Rhonstin).
-#   Caveats:   ⚠️⚠️ NP=1 IS REQUIRED, NOT A DEFAULT. Raising NP on this engine pin returns
-#              SILENTLY WRONG OUTPUT. Qwen3-Next is a hybrid: 30 of 40 layers are GDN
-#              (recurrent), and on this pin ik_llama's graph-reuse key is shape-based, so a
-#              graph built for one sequence is reused for another without re-pointing the
-#              recurrent state. Every slot then decodes on the first slot's state. No crash,
-#              no error — the server stays healthy and returns fluent text that is simply not
-#              conditioned on that slot's prompt.
-#              Reproduced first-party on THIS digest + quant (2026-08-07), 4 identical greedy
-#              prompts, temperature 0, seed 42, concurrent:
-#                  NP=1 → 1/1 distinct answers ✅        NP=4 → 3/4 distinct ❌
-#              Two of the four slots answered questions that were never asked.
-#              ⚠️ MTP DOES NOT PROTECT YOU. At NP>1 the server logs "MTP is not supported with
-#              parallel slots yet, removing the MTP stage" and boots with n_parallel=4 — NP
-#              wins and MTP is silently DROPPED, so you get the corruption AND lose this
-#              compose's headline drafter.
-#              ⚠️ Do NOT gate this on byte-identity against a sequential reference — batch-shape
-#              FP drift makes correct answers differ, which flags healthy runs and lets a
-#              non-fix look like a fix. Count DISTINCT answers to identical prompts; must be 1.
-#              Fixed upstream by ikawrakow/ik_llama.cpp#2260 (merged 2026-08-05, @ShubhamPriyadarshi),
-#              which this pinned digest PREDATES. Reported as club-3090#896; pin bump tracked in
-#              docs/UPSTREAM.md. Until that bump lands, NP=1 is the only supported value.
-#              ---
-#              Single-rig validation (1× 3090, 370 W) — cross-rig numbers welcome. Agent-pack
-#              scores (hermesagent-20 11/20 = 55%, cli-40 17/40 = 42%) are typical for the
-#              35B-A3B class (the apex sibling scores similarly). Intake fixes vs PR #293:
-#              image cu12→cu13-server, port 8020→8058.
+#   Status:    🗑️ Deprecated
+#   Caveats:   provider retired 2026-08-11 — byteshape quants removed from the rig to reclaim disk (/mnt/models was at 100%). Config was sound at 262K; it is retired for storage, not for a defect.
+#              Registry entry is RETAINED (deprecated != deleted) so launch-compat
+#              and pull-gate assertions on its hardware fields stay meaningful.
 #   Quality:   toolcall-15 15/15 (100%) · instructfollow-15 14/15 (93%) · structoutput-15 14/15 (93%) · dataextract-15 13/15 (87%) · reasonmath-15 13/15 (87%) · bugfind-15 13/15 (87%) · hermesagent-20 11/20 (55%) · cli-40 17/40 (42%) (--full, our 1× 3090, 2026-06-02 — 110/150 total)
 #   Best for:  Single-card Qwen3.6-35B-A3B — author's best overall 8-pack on the rig (111/150, 74%)
 # ---------------------------------------------------------------------------

--- a/models/vibethinker-3b/llama-cpp/compose/single/prithivmlmods-q8/q8kv.yml
+++ b/models/vibethinker-3b/llama-cpp/compose/single/prithivmlmods-q8/q8kv.yml
@@ -10,7 +10,10 @@
 #   Template:  native (GGUF-embedded) via --jinja
 #   Max ctx:   131072 (full native)
 #   Genesis:   N/A — llama.cpp engine
-#   Status:    🐣 Incubating  (pre-experimental — hidden from `switch.sh --list`; see `--list --all`)
+#   Status:    🗑️ Deprecated
+#   Caveats:   provider retired 2026-08-11 — VibeThinker-3B withdrawn from the catalog and its weights removed to reclaim disk.
+#              Registry entry is RETAINED (deprecated != deleted) so launch-compat
+#              and pull-gate assertions on its hardware fields stay meaningful.
 #   Engine-profile: llama-cpp-local
 #   Quality:   tool-free packs (benchlocal, temp 0.6, 2026-06-16, thinking-ON = the model's only
 #              real mode). Reasoning/math: gsm-symbolic-30 30/30 (100%) · reasonmath-15 12/15 (80%).

--- a/models/vibethinker-3b/vllm/compose/single/bf16/fp8.yml
+++ b/models/vibethinker-3b/vllm/compose/single/bf16/fp8.yml
@@ -10,12 +10,10 @@
 #   Vision:    no (text-only)
 #   Max ctx:   131072 (full native; RL-trained at a 64K window) — fits a 24 GB card with room
 #   Genesis:   N/A — Genesis is Qwen3-Next-specific; VibeThinker is Qwen2 dense
-#   Status:    🐣 Incubating  (pre-experimental — hidden from `switch.sh --list`; see `--list --all`)
-#   Caveats:   Does NOT pass the standard functional gate (verify-full 5/9): an always-reasoning
-#              model (emits <think> before every answer, no way to disable) that FAILS fixed-small-
-#              budget checks + has NO tool-calling. Niche math/code/STEM reasoning specialist, not a
-#              general/agentic serve. temp 1.0 (card default) is unstable on short prompts — TEMP=0.6
-#              is steadier. Kept in the catalog for the co-resident-reasoner experiment (#403-adjacent).
+#   Status:    🗑️ Deprecated
+#   Caveats:   model withdrawn 2026-08-11 — VibeThinker-3B removed from the catalog; bf16 safetensors deleted from the rig to reclaim disk.
+#              Registry entry is RETAINED (deprecated != deleted) so launch-compat
+#              and pull-gate assertions on its hardware fields stay meaningful.
 #   Best for:  single-card verifiable reasoning — competition math / coding / STEM
 #              (AIME, LiveCodeBench, LeetCode). NOT an open-domain-knowledge or
 #              prose model (the authors say so) — pick a larger general model for that.

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -497,7 +497,7 @@ COMPOSE_REGISTRY = {
         compose_path="models/qwen3.6-27b/llama-cpp/compose/single/pi-reasoning-q4km/mtp.yml",
         default_port=8063,
         kvcalc_key="SKIP",
-        status="experimental",
+        status="deprecated",
         status_note="Qwen3.6-27B-MTP-pi-reasoning (bytkim — 'Pi-style' reasoning-supervised CODING/terminal-agent fine-tune of Qwen3.6-27B) Q4_K_M GGUF + EMBEDDED MTP head (--spec-type draft-mtp, n=2) + q4_0/q4_0 KV, single 3090, reasoning-ON, on MAINLINE llama.cpp (server-cuda-b9246, PR #22673). Launch with --force (experimental). CONFIG FOLLOWS THE MODEL CARD: temp 1.0 / top-p 0.95 / top-k 0 / min-p 0 (NOT the stack's 0.6/20), reasoning ON, q4_0/q4_0 KV. Card recommends MTP n=3; on-rig A/B found n=2 marginally faster (within noise) — kept n=2, MTP_DRAFT_N_MAX=3 matches the card. Card notes presence-penalty 1.5 for DIRECT/instruct (REASONING=off) mode. CONTEXT (measured 2026-06-17): 200K-alloc fills ~188K usable with correct needle recall (22.7 GB / ~1.8 GB free); decode ~23 t/s at ~188K depth. Do NOT alloc 262K — FA scratch grows with alloc, so 262K OOMs at ~176K (LESS usable than 200K); full 262K usable is beellama-only. Author TESTED only 128K, so 128-188K is engine-proven but past the card's validated window (CTX_SIZE=131072 for strict compliance). FULL REBENCH-FULL VALIDATED 2026-06-18 (--with-8pack-thinking=both): bench @370W NARRATIVE 47.4/47.9, CODE 54.2/55.3 wall/decode, PP 1030 tok/s (n=5, CV<2%); @230W cap 28.5/32.9 (mainline -42% 370->230W — power-sensitive). verify-stress 8/8 (NIAH recall to 183K @ 91% of the 200K pool). 8-pack 104/150 think-off / 106/150 think-on (cohort: carnice 110, ik 107, qwopus 103). soak PASS (0 MiB growth, 0/100 silent-empty, p50 54.5, 102% retention). The MTP head is NOT weaker than base: a matched-power A/B (230W) put it DEAD-EVEN with base Qwen3.6-27B MTP (73% vs 72% accept, identical decode), and 47.9/55.3 @370W is ~on par with base 50.3/58.9 (within ~5% on canonical prompts). Verbose even thinking-off (a few deterministic-pack misses were finish_reason=length truncations — give it generous max_tokens). MTP gives ~+43% over no-MTP. Mainline llama.cpp = no patches, follows upstream.",
     ),
 
@@ -509,7 +509,7 @@ COMPOSE_REGISTRY = {
         compose_path="models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/mtp.yml",
         default_port=8020,
         kvcalc_key="SKIP",
-        status="experimental",
+        status="deprecated",
         status_note="PRISM-PRO-DQ community dynamic-quant GGUF — eval-only, not yet validated.",
     ),
     "ik-llama/prism-pro-dq-long": _entry(
@@ -519,7 +519,7 @@ COMPOSE_REGISTRY = {
         compose_path="models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/long.yml",
         default_port=8052,
         kvcalc_key="SKIP",
-        status="experimental",
+        status="deprecated",
         status_note="PRISM-PRO-DQ community dynamic-quant GGUF — eval-only, not yet validated.",
     ),
     "ik-llama/prism-pro-dq-two-stage": _entry(
@@ -529,7 +529,7 @@ COMPOSE_REGISTRY = {
         compose_path="models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/two-stage.yml",
         default_port=8020,
         kvcalc_key="SKIP",
-        status="experimental",
+        status="deprecated",
         status_note="PRISM-PRO-DQ community dynamic-quant GGUF — eval-only, not yet validated.",
     ),
     "ik-llama/prism-pro-dq-dual": _entry(
@@ -539,7 +539,7 @@ COMPOSE_REGISTRY = {
         compose_path="models/qwen3.6-27b/ik-llama/compose/dual/ex0bit-prism-pro-dq/mtp.yml",
         default_port=8053,
         kvcalc_key="SKIP",
-        status="experimental",
+        status="deprecated",
         status_note="PRISM-PRO-DQ community dynamic-quant GGUF — eval-only, not yet validated.",
     ),
     "ik-llama/prism-pro-dq-dual-vision": _entry(
@@ -550,7 +550,7 @@ COMPOSE_REGISTRY = {
         weights_companions=("gguf_mmproj_f16",),  # mmproj vision projector the compose mounts
         default_port=8010,
         kvcalc_key="SKIP",
-        status="experimental",
+        status="deprecated",
         status_note="PRISM-PRO-DQ community dynamic-quant GGUF — eval-only, not yet validated.",
     ),
     # Qwen3.6-35B-A3B APEX-MTP (mudler MoE GGUF — Compact + Quality) — community-experimental, ik-llama.
@@ -571,7 +571,7 @@ COMPOSE_REGISTRY = {
         compose_path="models/qwen3.6-35b-a3b/ik-llama/compose/single/byteshape-iq4xs/mtp.yml",
         default_port=8058,
         kvcalc_key="SKIP",
-        status="caveats",
+        status="deprecated",
         status_note="byteshape IQ4_XS 4.19bpw MoE GGUF (embedded MTP head) — community intake from PR #293 (@Rhonstin). Single-card 35B-A3B, q4_0 KV + --fit → 262K. First-party validated 2026-06-02 on 1× 3090: verify-full all-pass, verify-stress 8/8 (NIAH→240K, no Cliff), bench n=5 (narrative 113/116 · code 129/137 wall/decode TPS, CV<2.3%), 8-pack 110/150 (≈ author's 111/150), soak-continuous PASS (0 err, 0 VRAM growth, 0/25 silent-empty). Caveat: single-rig; agent packs modest (hermes 55%, cli 42%) as typical for the class. Intake fixes vs #293: image cu13, port 8058.",
     ),
     "ik-llama/apex-mtp-compact-long": _entry(
@@ -1230,7 +1230,7 @@ COMPOSE_REGISTRY = {
         compose_path="models/vibethinker-3b/vllm/compose/single/bf16/fp8.yml",
         default_port=8074,
         kvcalc_key="SKIP",
-        status="incubating",
+        status="deprecated",
         status_note="VibeThinker-3B (WeiboAI) — bf16 Qwen2 dense verifiable-reasoning model (SFT+RL fine-tune of Qwen2.5-Coder-3B) on a single 3090, vLLM v0.22.0 (vllm-stable). bf16 weights (~5.8 GB) + fp8_e5m2 KV (storage-only A/B'd 2026-06-16 — math/code answers identical to bf16 KV; halves cache, quality-neutral). full 131072 ctx, ~110 TPS. Single-concurrency sized: max_num_seqs=1 + mem_util 0.40 → ~9.8 GB total (174K-token / 1.33x KV pool, full 131K kept), freeing ~14 GB to co-reside with a 27B; ~9.8 GB is near the floor (5.8 GB bf16 weights immovable). Output quality is temp-governed not mem-governed: temp 0.6 coherent, the card's temp 1.0 is unstable on short prompts (degenerate loops) — overridable via TEMP. fp8 WEIGHTS rejected (break this quant-sensitive 3B: non-terminating empty output). Sampling per the tech report: temp 1.0 / top_p 0.95 / top_k -1. Live-validated 2026-06-16: serves clean, correct reasoning + code (verify-full output-quality + thinking-mode PASS); --reasoning-parser qwen3 splits <think> blocks correctly. ⚠️ ALWAYS-REASONING: it emits a <think> trace before every answer with NO way to disable it (system prompt / /no_think ignored; authors document no controls). Omit max_tokens (vLLM's large default → reasons briefly then answers) or set generously (8K-40K; authors use up to 40960); a small explicit max_tokens truncates mid-reason with no answer. NO tool-calling (emits bare JSON not <tool_call>; authors don't support it — intentionally unwired). Consequence: FAILS verify-full's fixed-small-budget checks (basic 30 / streaming 120 / tool 200-256 tok) → 5/9 — a harness-vs-always-reasoning mismatch, NOT a serving defect. Stays 🐣 incubating: does not pass the standard functional gate; math/code/STEM reasoning only, not general/agentic.",
     ),
     "llamacpp/vibethinker-3b-single": _entry(
@@ -1240,7 +1240,7 @@ COMPOSE_REGISTRY = {
         compose_path="models/vibethinker-3b/llama-cpp/compose/single/prithivmlmods-q8/q8kv.yml",
         default_port=8075,
         kvcalc_key="SKIP",
-        status="incubating",
+        status="deprecated",
         status_note="VibeThinker-3B (WeiboAI) — prithivMLmods Q8_0 GGUF on a single 3090, mainline llama.cpp (server-cuda). Q8 weights + q8_0/q8_0 KV, full 131072 ctx, -b 4096 -ub 2048. The PERFORMANCE-MAX VibeThinker path: live-validated 2026-06-16 ~166 TPS decode (vs ~110 vLLM bf16), prefill ~6,630 tok/s (-b 4096/-ub 2048 = +20% over 2048/512; -ub is the lever, -b 8192 adds nothing), ~6.2 GB at full 131K (3.3 GB Q8 + ~2.6 GB q8_0 KV), CV 0.1%, stable at temp 0.6 AND 1.0. KEY: llama.cpp Q8_0 is near-lossless → quality INTACT, where vLLM's fp8 weight-quant broke this quant-sensitive 3B (non-terminating empty output) — so on llama.cpp you get the quantization win with no quality cost. NO MTP head in this GGUF (plain qwen2 conversion) → no self-spec-dec (not needed at this speed). Reasoning: emits <think>...</think> but llama.cpp's deepseek parser does NOT split it (Qwen2.5 template doesn't declare reasoning) → trace stays inline in content (answer after </think> clean). ⚠️ ALWAYS-REASONING + NO tool-calling → FAILS verify-full's fixed-small-budget + tool checks (5/9, same as the vLLM sibling) — by design, not a serving defect. 🐣 incubating: math/code/STEM reasoning specialist, not general/agentic. Better-performing sibling to vllm/vibethinker-3b-single. Tool-free quality (benchlocal, temp 0.6, 2026-06-16, thinking-ON): gsm-symbolic-30 30/30 (100%), reasonmath-15 12/15 (80%); one-shot coding (sandbox executes, no tool-calls) humaneval-plus-30 29/30 (97%) + lcb-v6-30 25/30 (83%, 2 losses=token_limit on hardest); instructfollow-15 15/15 (100%), structoutput-15 12/15 (80%), dataextract-15 6/15 (40%). The packs' thinking-OFF defaults had zeroed dataextract / capped structoutput at 60% via token_limit truncation (always-reasoning vs bounded budget); --enable-thinking restores them. dataextract's residual 40% is genuine — full config sweep {temp 0/0.6/1.0 x budget 16K/32K} all land 27-40% (0.6 is the sweet spot; greedy and 1.0 both = 27%), same value-mismatch + type-coercion failures → config can NOT recover it; valid JSON, field-level extraction errors (reasoning specialist, not an extractor). Sweep also validates the compose default temp 0.6 (beats 0 and 1.0). toolcall/hermes/cli N/A (no tool-calling).",
     ),
 }


### PR DESCRIPTION
Retires nine slugs across five providers to reclaim disk — the models volume was at **100% (10 GB free)**.

| Provider | Slugs | Prior status | Weights on disk |
|---|---|---|--:|
| Ex0bit | `ik-llama/prism-pro-dq-{mtp,long,two-stage,dual,dual-vision}` | 🧪 experimental ×5 | 13 GB |
| byteshape | `ik-llama/byteshape-iq4xs-mtp` | ⚠️ Production w/ caveats | 18 GB |
| WeiboAI | `vllm/vibethinker-3b-single` | 🐣 incubating | 5.8 GB |
| prithivMLmods | `llamacpp/vibethinker-3b-single` | 🐣 incubating | 3.1 GB |
| bytkim | `llamacpp/qwen27b-pi-reasoning-single` | 🧪 experimental | **never downloaded** |

**~40 GB** once the weights are removed.

### Deprecation checklist

- **Compose headers** — `Status: 🗑️ Deprecated` + a required `Caveats:` line on all nine, each stating the concrete reason.
- **Registry** — `status="deprecated"`; **slugs and hardware fields retained**. Deprecated is not deleted, and the launch-compat / pull-gate assertions on those fields stay meaningful.
- **`DEFAULTS`** — none of the nine was a target, so no row needed repointing or removing.
- **`scripts/`** — grepped for all four slug families; **zero** hand-written references in `launch.sh`, `setup.sh` or `preflight.sh`.
- **Gate** — **full suite: 101 pass, 0 fail**, including `test-compose-status-drift` (header emoji ↔ registry status must match exactly).

`switch.sh --list` now hides all nine by default; they remain launchable by name with `--force`.

### On byteshape specifically

Not experimental cleanup — it was **⚠️ Production w/ caveats**, a working 262K config. Its `Caveats:` line says so:

> *retired for storage, not for a defect. Config was sound at 262K.*

### ⚠️ Correction — `mudler-apex-mtp` is NOT orphaned

An earlier revision of this description claimed `qwen3.6-35b-a3b-gguf/mudler-apex-mtp` (17 GB) was unreferenced and could be deleted alongside these. **That was wrong.** Both mudler variants resolve to that single directory:

```
variant 'mudler-apex-compact' → path: qwen3.6-35b-a3b-gguf/mudler-apex-mtp
variant 'mudler-apex-quality' → path: qwen3.6-35b-a3b-gguf/mudler-apex-mtp
```

One of them backs **`ik-llama/apex-fit-q8q5`**, which is **functional** (no status caveat, 197K ctx). Deleting those 17 GB would have broken a working slug.

The mistake was comparing registry `weights_variant` *keys* against on-disk *directory names*, instead of resolving the `path:` / `local_subdir:` fields that actually map catalog → disk. **No mudler slug is touched by this PR and no mudler weights were deleted.**

### Weights removal — separate, and partially done

Removal of the five providers' weights above is **not** in this commit; it follows the merge.

Unrelated to this PR, a separate sweep of genuinely unreferenced directories freed **36 GB** (`qwen3.5-4b-poc-*` ×8 plus `qwen3.5-4b-gguf/unsloth-mtp-q4kxl`), taking the volume from 10 GB to 46 GB free. That sweep also *nearly* removed three live paths — the mudler directory above, `qwen3.5-4b` (the AI Studio Director's model), and `hauhaucs-uncensored-q4km`. All three were caught by a final reference gate.

Every one of those near-misses had the same cause: **matching names instead of resolving indirection** — variant keys vs `path:`, drafters referenced by HF repo rather than local path, and substring collisions between `qwen3.5-4b` and `qwen3.5-4b-poc-*`. A resolver-backed helper that asks `weights.py` what it considers live and diffs it against disk would catch all of them automatically, and is worth building before any further cleanup.
