### PR TITLE
Detect the model's reasoning switch instead of assuming Qwen's

### DIFF
--- a/scripts/bench-agentic.sh
+++ b/scripts/bench-agentic.sh
@@ -129,8 +129,37 @@ if [[ -z "$MODEL" ]]; then
   exit 1
 fi
 
+# Which request field controls reasoning is model-specific, and an unrecognised
+# one is silently ignored — the model then reasons at full effort while the run
+# reports itself thinking-off. Resolved once by preflight.sh
+# ::preflight_detect_thinking_control and exported as final JSON.
+if declare -F preflight_detect_thinking_control >/dev/null; then
+  preflight_detect_thinking_control
+else
+  THINK_OFF_KW='{"enable_thinking": false}'; THINK_ON_KW='{"enable_thinking": true}'
+  THINK_OFF_EFFORT=''; THINK_ON_EFFORT=''
+fi
+export THINK_OFF_KW THINK_ON_KW THINK_OFF_EFFORT THINK_ON_EFFORT
+
 python3 - "$URL" "$MODEL" "$SESSIONS" "$TURNS" "$QUIET" "$FIXTURE" << 'PYEOF'
 import json, os, sys, time, urllib.request, statistics as s, pathlib
+
+# Reasoning switch resolved by the shell (see preflight.sh header) — WHICH key
+# works is model-specific and an unrecognised one is silently ignored. Returns
+# the payload fragment: the kwargs object plus, when the model uses an effort
+# dial, the OpenAI-standard top-level parameter alongside it.
+def _think(on=False):
+    import os as _o, json as _j
+    raw = _o.environ.get("THINK_ON_KW" if on else "THINK_OFF_KW")
+    try:
+        frag = {"chat_template_kwargs": _j.loads(raw) if raw else {"enable_thinking": on}}
+    except Exception:
+        frag = {"chat_template_kwargs": {"enable_thinking": on}}
+    eff = _o.environ.get("THINK_ON_EFFORT" if on else "THINK_OFF_EFFORT") or ""
+    if eff:
+        frag["reasoning_effort"] = eff
+    return frag
+
 sys.stdout.reconfigure(line_buffering=True)  # flush after every \n
 
 URL, MODEL, SESSIONS, TURNS, QUIET, FIXTURE_PATH = sys.argv[1:7]
@@ -224,7 +253,7 @@ def run_turn(messages, fixture_turn, session_id, turn_idx):
         "temperature": 0.3,
         "stream": True,
         "stream_options": {"include_usage": True},
-        "chat_template_kwargs": {"enable_thinking": False},
+        **_think(),
     }).encode()
 
     req = urllib.request.Request(

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -384,8 +384,22 @@ if [[ "$PP" == "1" || "$ENGINE_KIND" == "llamacpp" ]]; then
   PP_MODE="fallback"
 fi
 
+# Which request field turns reasoning off is model-specific, and an unrecognised
+# one is silently ignored — the model then reasons at full effort and the run
+# measures reasoning-heavy generation while reporting itself as thinking-off.
+# See preflight.sh::preflight_detect_thinking_control.
+if declare -F preflight_detect_thinking_control >/dev/null; then
+  preflight_detect_thinking_control
+else
+  THINK_CONTROL="enable_thinking"
+  THINK_OFF_KW='{"enable_thinking": false}'; THINK_ON_KW='{"enable_thinking": true}'
+  THINK_OFF_EFFORT=''; THINK_ON_EFFORT=''
+fi
 if [[ "$ENABLE_THINKING" == "1" ]]; then
-  echo "[bench] thinking: enabled (request chat_template_kwargs.enable_thinking=true)" >&2
+  export BENCH_THINK_KW="$THINK_ON_KW"  BENCH_THINK_EFFORT="$THINK_ON_EFFORT"
+  echo "[bench] thinking: enabled (${THINK_CONTROL} → ${THINK_ON_KW})" >&2
+else
+  export BENCH_THINK_KW="$THINK_OFF_KW" BENCH_THINK_EFFORT="$THINK_OFF_EFFORT"
 fi
 
 if [[ "${BENCH_MOCK:-0}" == "1" ]]; then
@@ -487,7 +501,17 @@ sys.exit(0 if walk(obj) else 1)
 }
 
 if [[ "$ENABLE_THINKING" != "1" ]] && server_reasoning_on; then
-  echo "[bench] WARN: server appears to have reasoning enabled, but bench requests send enable_thinking=false. Use ENABLE_THINKING=1 for reasoning-on TPS." >&2
+  echo "[bench] WARN: server appears to have reasoning enabled, but bench requests send thinking-off. Use ENABLE_THINKING=1 for reasoning-on TPS." >&2
+fi
+# server_reasoning_on() is blind twice over: it needs a docker CONTAINER (so a
+# bare-metal llama-server is skipped entirely) and it looks for an explicit
+# `--reasoning on` flag, which a model that reasons BY DEFAULT never needs. Both
+# were true on Inkling-Small 2026-08-12 — the run measured reasoning-on
+# generation, reported itself thinking-off, and this guard never fired. The
+# detected control closes that gap: no switch means reasoning cannot be turned
+# off at all, whatever the flags say.
+if [[ "$ENABLE_THINKING" != "1" && "${THINK_CONTROL:-}" == none* ]]; then
+  echo "[bench] WARN: no reasoning off-switch detected for this model — a thinking-off run is NOT possible and these numbers include reasoning tokens. Set VERIFY_THINK_OFF='{\"<key>\": <value>}' if the template uses a switch this harness doesn't know." >&2
 fi
 
 # ===========================================================================
@@ -654,6 +678,11 @@ WARMUPS = int(WARMUPS); RUNS = int(RUNS); QUIET = int(QUIET) == 1
 MAX_NARR = int(MAX_NARR); MAX_CODE = int(MAX_CODE)
 PP_FALLBACK_TOKENS = int(PP_FALLBACK_TOKENS); PP_MAX_TOKENS = int(PP_MAX_TOKENS)
 ENABLE_THINKING = ENABLE_THINKING == "1"
+try:
+    THINK_KW = json.loads(os.environ.get("BENCH_THINK_KW") or "")
+except Exception:
+    THINK_KW = {"enable_thinking": ENABLE_THINKING}
+THINK_EFFORT = os.environ.get("BENCH_THINK_EFFORT") or ""
 FORCE = int(FORCE)   # >0: force EXACTLY this many output tokens (max+min+ignore_eos)
 
 # --- capture-layer plumbing (all optional; absent => historical behaviour) ---
@@ -786,7 +815,17 @@ def run_once(prompt, max_tokens):
         path = "/v1/completions"
     else:
         req_body["messages"] = [{"role": "user", "content": prompt}]
-        req_body["chat_template_kwargs"] = {"enable_thinking": ENABLE_THINKING}
+        # The reasoning switch is resolved by the shell (preflight.sh
+        # ::preflight_detect_thinking_control) and handed over as final JSON,
+        # because WHICH key works is model-specific and an unrecognised one is
+        # silently ignored — which would make a "thinking off" run silently
+        # measure reasoning-heavy generation.
+        req_body["chat_template_kwargs"] = THINK_KW
+        if THINK_EFFORT:
+            # The OpenAI-standard top-level parameter, sent alongside for
+            # engines that implement it (llama.cpp currently does not forward it
+            # into the template — see the preflight.sh block header).
+            req_body["reasoning_effort"] = THINK_EFFORT
         path = "/v1/chat/completions"
     if FORCE > 0:
         req_body["min_tokens"] = FORCE

--- a/scripts/power-cap-sweep.sh
+++ b/scripts/power-cap-sweep.sh
@@ -435,6 +435,22 @@ if [ -z "${CONTAINER:-}" ]; then
   CONTAINER="none"
 fi
 
+# Which request field turns reasoning off is model-specific and an unrecognised
+# one is silently ignored, so a sweep on such a model would compare power caps
+# against reasoning-heavy generation while reporting itself thinking-off. The
+# load generator below splats THINK_FRAG_OFF via its _think() helper.
+# See preflight.sh::preflight_detect_thinking_control.
+if [[ -f "$REPO_ROOT/scripts/preflight.sh" ]] && ! declare -F preflight_detect_thinking_control >/dev/null; then
+  # shellcheck source=preflight.sh
+  source "$REPO_ROOT/scripts/preflight.sh"
+fi
+if declare -F preflight_detect_thinking_control >/dev/null; then
+  preflight_detect_thinking_control "${URL:-}" "${MODEL:-}"
+fi
+export THINK_OFF_KW="${THINK_OFF_KW:-{\"enable_thinking\": false\}}"
+export THINK_ON_KW="${THINK_ON_KW:-{\"enable_thinking\": true\}}"
+export THINK_OFF_EFFORT="${THINK_OFF_EFFORT:-}" THINK_ON_EFFORT="${THINK_ON_EFFORT:-}"
+
 if [ -z "${URL:-}" ] || [ -z "${MODEL:-}" ]; then
   echo "[error] could not auto-detect a running URL + MODEL." >&2
   echo "[hint]  start a model server first (bash scripts/switch.sh <variant>)" >&2
@@ -512,6 +528,23 @@ bench_decode_single_request() {
 
   python3 - "$URL" "$MODEL" "$prompt" "$max_tokens" "$kind" "$phase" "$cap" "$log_file" <<'PY'
 import json
+
+# Reasoning switch resolved by the shell (see preflight.sh header) — WHICH key
+# works is model-specific and an unrecognised one is silently ignored. Returns
+# the payload fragment: the kwargs object plus, when the model uses an effort
+# dial, the OpenAI-standard top-level parameter alongside it.
+def _think(on=False):
+    import os as _o, json as _j
+    raw = _o.environ.get("THINK_ON_KW" if on else "THINK_OFF_KW")
+    try:
+        frag = {"chat_template_kwargs": _j.loads(raw) if raw else {"enable_thinking": on}}
+    except Exception:
+        frag = {"chat_template_kwargs": {"enable_thinking": on}}
+    eff = _o.environ.get("THINK_ON_EFFORT" if on else "THINK_OFF_EFFORT") or ""
+    if eff:
+        frag["reasoning_effort"] = eff
+    return frag
+
 import sys
 import time
 import urllib.request
@@ -525,7 +558,7 @@ body = json.dumps({
     "top_p": 0.95,
     "stream": True,
     "stream_options": {"include_usage": True},
-    "chat_template_kwargs": {"enable_thinking": False},
+    **_think(),
 }).encode()
 request = urllib.request.Request(
     f"{url}/v1/chat/completions",

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1503,6 +1503,170 @@ except Exception:
   return 0
 }
 
+# ---------------------------------------------------------------------------
+# Resolve WHICH chat_template_kwargs key controls reasoning on the served model.
+# Sets THINK_CONTROL / THINK_OFF_KW / THINK_ON_KW in the caller's scope.
+#
+# The key is NOT universal, and the whole script layer had the Qwen one baked in:
+#   Qwen3.x + most families → {"enable_thinking": false|true}
+#   Inkling (TML)           → {"reasoning_effort": "none"|"high"} — a DIAL
+#                             (none/minimal/low/medium/high/xhigh/max, or a
+#                             float), defaulting to 0.9 "high", NOT a boolean
+#   neither                 → {} (caller decides whether to add budget headroom)
+#
+# Why this exists (found on Inkling-Small 2026-08-12): an unrecognised kwarg is
+# silently IGNORED — no error, no warning. The model then reasons at full effort,
+# and a short-budget check spends its entire allowance on the reasoning preamble
+# before emitting a single content token. verify-full's [3/9] and [5/9] failed
+# structurally on such a model, reporting "Model may be loading badly or wrong
+# chat template" — sending you to debug a template that was in fact correct.
+#
+# ⚠️ Both switches must go in chat_template_kwargs. llama-server does NOT map the
+# top-level OpenAI-standard `reasoning_effort` request parameter into the
+# template; passing it there is silently ignored (measured, same session).
+#
+# ⚠️ THINK_*_KW hold FINAL JSON text, not backslash-escaped source. Callers
+# interpolate them into a double-quoted payload, and bash processes \" escapes
+# BEFORE parameter expansion — an escaped value reaches curl with its
+# backslashes intact and every request 400s.
+#
+# Detection order is deliberate: enable_thinking is checked FIRST so that a
+# template supporting both keeps the exact request shape it has today. This can
+# only add coverage, never change an existing model's result.
+#
+# No-ops when THINK_CONTROL is already set, or when there's no URL / curl /
+# python3 — callers keep working defaults. Overridden by VERIFY_THINK_OFF /
+# VERIFY_THINK_ON (plain JSON objects).
+_preflight_probe_thinking_key() {
+  # Echo the content length a trivial question returns under the given kwargs.
+  # A working off-switch answers in a few tokens; an ignored one burns the whole
+  # budget reasoning and returns empty content.
+  local url="$1" model="$2" kwargs="$3"
+  curl -sf -m 90 "${url%/}/v1/chat/completions" \
+    -H "Content-Type: application/json" \
+    -d "{\"model\": \"${model}\", \"messages\": [{\"role\": \"user\", \"content\": \"Say OK.\"}], \"max_tokens\": 24, \"temperature\": 0.0, \"chat_template_kwargs\": ${kwargs}}" 2>/dev/null \
+    | python3 -c "import sys,json; print(len((json.load(sys.stdin)['choices'][0]['message'].get('content') or '').strip()))" 2>/dev/null \
+    || echo 0
+}
+
+preflight_detect_thinking_control() {
+  [[ -n "${THINK_CONTROL:-}" ]] && return 0
+  local url="${1:-${URL:-}}"
+  local model="${2:-${MODEL:-}}"
+  THINK_CONTROL="enable_thinking"   # safe default = today's behaviour
+  if [[ -n "$url" ]] && command -v curl >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1; then
+    local tmpl
+    # 1. Exact — read the live chat template when the engine exposes it
+    #    (llama.cpp /props). Free, and needs no inference.
+    tmpl="$(curl -sf -m 5 "${url%/}/props" 2>/dev/null \
+      | python3 -c "import sys,json; print(json.load(sys.stdin).get('chat_template') or '')" 2>/dev/null || true)"
+    if [[ -n "$tmpl" ]]; then
+      case "$tmpl" in
+        *enable_thinking*)  THINK_CONTROL="enable_thinking"  ;;
+        *reasoning_effort*) THINK_CONTROL="reasoning_effort" ;;
+        *)                  THINK_CONTROL="none"             ;;
+      esac
+    elif [[ "${THINK_PROBE:-0}" == "1" ]] && [[ -n "$model" ]] && curl -sf -m 5 "${url%/}/v1/models" >/dev/null 2>&1; then
+      # 2. Behavioural probe for engines that don't expose the template (vLLM,
+      #    SGLang). At most two tiny requests, and only when step 1 no-ops.
+      #
+      # ⚠️ OPT-IN via THINK_PROBE=1, and deliberately so: this fires REAL
+      # inference requests. Functional checks (verify / verify-full) opt in
+      # because one extra request is harmless there. MEASUREMENT scripts
+      # (bench, soak, power-cap-sweep, quality-test) must NOT, for two reasons:
+      # it puts uncontrolled requests on the server before warmup, and against
+      # a scripted/mocked endpoint it consumes responses the run expects —
+      # which is exactly how it broke the soak fixtures, silently shifting
+      # every turn's response by two.
+      #
+      # ⚠️ The /v1/models reachability gate above is load-bearing. The probe
+      # reads "empty content" as "this switch is ignored", and a request that
+      # never reached the server also returns empty — so without the gate an
+      # unreachable or still-warming endpoint is misread as "model has no
+      # reasoning switch", which both changes the request shape and (in
+      # verify-full) inflates token budgets by 64×. Unreachable must fall
+      # through to the safe default instead, and let the caller's own
+      # reachability check surface the real outage.
+      if [[ "$(_preflight_probe_thinking_key "$url" "$model" '{"enable_thinking": false}')" != "0" ]]; then
+        THINK_CONTROL="enable_thinking"
+      elif [[ "$(_preflight_probe_thinking_key "$url" "$model" '{"reasoning_effort": "none"}')" != "0" ]]; then
+        THINK_CONTROL="reasoning_effort"
+      else
+        THINK_CONTROL="none"
+      fi
+    fi
+  fi
+  # THINK_*_STD is the OpenAI-standard TOP-LEVEL parameter, emitted as a JSON
+  # fragment (trailing comma included) to sit alongside the kwargs object.
+  #
+  # `reasoning_effort` IS the standard, and Thinking Machines' own API takes it
+  # top-level (tinker-docs "compatible-apis/openai"): none/minimal/low/medium/
+  # high/xhigh or a float in [0.0, 0.99], default 0.9. We send it — but we
+  # cannot send it ALONE, because llama.cpp only half-implements it:
+  #
+  #   server-common.cpp: if (reasoning_effort == "none") inputs.enable_thinking = false;
+  #                      // other reasoning_effort values are model-specific and not yet handled
+  #
+  # i.e. the one handled value is mapped onto `enable_thinking`, a template
+  # variable this family does NOT read, and every other value is dropped
+  # silently. So on llama.cpp the chat_template_kwargs copy is what actually
+  # reaches the template. Sending both is verified non-conflicting (measured
+  # 2026-08-12: none → 10 tok / 0 reasoning; high → 45 tok / 152 chars) and
+  # makes the request correct on engines that DO implement the standard.
+  # Drop the kwargs fallback once llama.cpp forwards the value into the template.
+  # THINK_*_EFFORT are the same top-level value as a PLAIN string (empty when the
+  # model has no effort dial), for consumers that build their payload in Python
+  # rather than by string-splicing JSON — they set req["reasoning_effort"] from
+  # it directly instead of parsing the fragment above.
+  THINK_OFF_STD=''
+  THINK_ON_STD=''
+  THINK_OFF_EFFORT=''
+  THINK_ON_EFFORT=''
+  case "$THINK_CONTROL" in
+    reasoning_effort)
+      THINK_OFF_KW='{"reasoning_effort": "none"}'
+      THINK_ON_KW='{"reasoning_effort": "high"}'
+      THINK_OFF_STD='"reasoning_effort": "none", '
+      THINK_ON_STD='"reasoning_effort": "high", '
+      THINK_OFF_EFFORT='none'
+      THINK_ON_EFFORT='high' ;;
+    none)
+      THINK_OFF_KW='{}'
+      THINK_ON_KW='{}' ;;
+    *)
+      THINK_OFF_KW='{"enable_thinking": false}'
+      THINK_ON_KW='{"enable_thinking": true}' ;;
+  esac
+  # An explicit override is the full statement of intent — it replaces the
+  # detected kwargs AND suppresses the top-level fragment, so the two can't
+  # disagree in the same request.
+  [[ -n "${VERIFY_THINK_OFF:-}" ]] && { THINK_OFF_KW="${VERIFY_THINK_OFF}"; THINK_OFF_STD=''; THINK_OFF_EFFORT=''; THINK_CONTROL="${THINK_CONTROL} (off overridden)"; }
+  [[ -n "${VERIFY_THINK_ON:-}"  ]] && { THINK_ON_KW="${VERIFY_THINK_ON}";   THINK_ON_STD='';  THINK_ON_EFFORT='';  THINK_CONTROL="${THINK_CONTROL} (on overridden)"; }
+  # THINK_FRAG_* is the COMPLETE request fragment as one JSON object — the kwargs
+  # plus, when applicable, the top-level standard parameter. Python consumers
+  # splat it into their payload in a single uniform line:
+  #   **json.loads(os.environ.get("THINK_FRAG_OFF") or '{"chat_template_kwargs": {"enable_thinking": false}}')
+  # ⚠️ Build these with plain assignments, NEVER `X="$(cond && printf …)"`. Under
+  # `set -e` (every caller) a command substitution whose last command fails makes
+  # the ASSIGNMENT return non-zero, which aborts the function mid-way — leaving
+  # THINK_* half-set and taking the calling script down with it. That is not
+  # theoretical: it broke 10 test suites in one commit.
+  local _off_extra='' _on_extra=''
+  if [[ -n "$THINK_OFF_EFFORT" ]]; then _off_extra=", \"reasoning_effort\": \"${THINK_OFF_EFFORT}\""; fi
+  if [[ -n "$THINK_ON_EFFORT"  ]]; then _on_extra=", \"reasoning_effort\": \"${THINK_ON_EFFORT}\""; fi
+  THINK_FRAG_OFF="{\"chat_template_kwargs\": ${THINK_OFF_KW}${_off_extra}}"
+  THINK_FRAG_ON="{\"chat_template_kwargs\": ${THINK_ON_KW}${_on_extra}}"
+  # Announce ONLY when the answer is non-default. For every model that already
+  # used the Qwen key this function is now completely silent, so output-drift
+  # guards (test-soak-decode-basis compares stdout against origin/master) and
+  # anything else parsing these logs stay byte-identical. A surprising answer is
+  # worth a line; confirming the status quo is not.
+  if [[ "$THINK_CONTROL" != "enable_thinking" ]]; then
+    echo "[autodetect] thinking-control='${THINK_CONTROL}' off=${THINK_OFF_KW} (set VERIFY_THINK_OFF/ON to override)" >&2
+  fi
+  return 0
+}
+
 # ── #633 — ik-llama cu13/cu12 driver-aware image selection ────────────────────
 # The pinned cu13 ik-llama image has a CUDA 13.2 runtime; on a driver whose
 # supported CUDA < 13.2 the forward-compat path fails on GeForce (CUDA error

--- a/scripts/quality-test.sh
+++ b/scripts/quality-test.sh
@@ -758,6 +758,40 @@ if [[ "$NO_THINKING" == "1" ]]; then
   CLI_ARGS+=(--no-thinking)
   echo "[quality-test] thinking: disabled for every pack, ignoring per-pack defaults (non-canonical)"
 fi
+# ---- reasoning switch: benchlocal-cli only knows the Qwen key ---------------
+# benchlocal-cli builds its own request bodies and drives thinking via
+# chat_template_kwargs.enable_thinking. A model whose template reads a different
+# variable IGNORES that silently, so --no-thinking and --enable-thinking would
+# produce two IDENTICAL reasoning-on runs and the 8-pack would report a clean
+# off-vs-on comparison that never happened. Found on Inkling-Small 2026-08-12
+# (effort dial, default 0.9). Detect the real switch and hand it over through
+# --extra-body, which benchlocal-cli merges into every request body.
+#
+# Only injected when the model does NOT use the Qwen key, so runs on every
+# existing model stay byte-identical. Only injected when the arm is pinned
+# (--no-thinking / --enable-thinking): without a pin, packs choose per-pack, and
+# a single --extra-body would force one setting across all of them.
+if declare -F preflight_detect_thinking_control >/dev/null; then
+  preflight_detect_thinking_control "$URL" "$MODEL"
+fi
+if [[ "${THINK_CONTROL:-enable_thinking}" != enable_thinking* ]]; then
+  _tfrag=""
+  [[ "$NO_THINKING"     == "1" ]] && _tfrag="${THINK_FRAG_OFF:-}"
+  [[ "$ENABLE_THINKING" == "1" ]] && _tfrag="${THINK_FRAG_ON:-}"
+  if [[ -n "$_tfrag" ]]; then
+    if [[ -n "${EXTRA_BODY:-}" ]]; then
+      echo "[quality-test] WARN: EXTRA_BODY is already set — NOT injecting the reasoning switch (${THINK_CONTROL}). Merge '${_tfrag}' into it yourself or the thinking arm is a no-op." >&2
+    else
+      CLI_ARGS+=(--extra-body "$_tfrag")
+      echo "[quality-test] thinking switch: ${THINK_CONTROL} → --extra-body ${_tfrag}"
+      echo "[quality-test]   (benchlocal-cli's enable_thinking flag does not apply to this model)"
+    fi
+  else
+    echo "[quality-test] WARN: this model's reasoning switch is '${THINK_CONTROL:-unknown}', which benchlocal-cli's --enable-thinking/--no-thinking cannot drive." >&2
+    echo "[quality-test]   Packs will run at the model's DEFAULT reasoning level regardless of pack metadata." >&2
+    echo "[quality-test]   Pin the arm with --no-thinking or --enable-thinking so the correct switch is injected." >&2
+  fi
+fi
 if [[ -n "$THINKING_MAX_TOKENS" ]]; then
   CLI_ARGS+=(--thinking-max-tokens "$THINKING_MAX_TOKENS")
   echo "[quality-test] thinking max tokens: $THINKING_MAX_TOKENS (applies to thinking-enabled packs)"

--- a/scripts/quality-test.sh
+++ b/scripts/quality-test.sh
@@ -234,6 +234,7 @@ SANDBOX_LOG_DIR="${SANDBOX_LOG_DIR:-}"
 SAMPLING_FROM_SERVER="${SAMPLING_FROM_SERVER:-0}"
 ENABLE_THINKING="${ENABLE_THINKING:-0}"
 NO_THINKING="${NO_THINKING:-0}"
+REASONING_EFFORT="${REASONING_EFFORT:-}"
 THINKING_MAX_TOKENS="${THINKING_MAX_TOKENS:-}"
 MAX_TOKENS="${MAX_TOKENS:-}"
 # #252: passthroughs to benchlocal-cli for the quality-baseline corpus —
@@ -758,39 +759,31 @@ if [[ "$NO_THINKING" == "1" ]]; then
   CLI_ARGS+=(--no-thinking)
   echo "[quality-test] thinking: disabled for every pack, ignoring per-pack defaults (non-canonical)"
 fi
-# ---- reasoning switch: benchlocal-cli only knows the Qwen key ---------------
-# benchlocal-cli builds its own request bodies and drives thinking via
-# chat_template_kwargs.enable_thinking. A model whose template reads a different
-# variable IGNORES that silently, so --no-thinking and --enable-thinking would
-# produce two IDENTICAL reasoning-on runs and the 8-pack would report a clean
-# off-vs-on comparison that never happened. Found on Inkling-Small 2026-08-12
-# (effort dial, default 0.9). Detect the real switch and hand it over through
-# --extra-body, which benchlocal-cli merges into every request body.
+# ---- reasoning switch: resolved by benchlocal-cli itself (its #131) ---------
+# WHICH request field turns reasoning off is model-specific, and an unrecognised
+# one is silently ignored — so on such a model --no-thinking and --enable-thinking
+# produce two IDENTICAL reasoning-on runs, and the 8-pack reports an off-vs-on
+# comparison that never happened. Found on Inkling-Small 2026-08-12 (effort dial,
+# default 0.9; reads `reasoning_effort`, not `enable_thinking`).
 #
-# Only injected when the model does NOT use the Qwen key, so runs on every
-# existing model stay byte-identical. Only injected when the arm is pinned
-# (--no-thinking / --enable-thinking): without a pin, packs choose per-pack, and
-# a single --extra-body would force one setting across all of them.
-if declare -F preflight_detect_thinking_control >/dev/null; then
-  preflight_detect_thinking_control "$URL" "$MODEL"
+# This wrapper used to work around it by injecting the switch via --extra-body.
+# That is GONE: benchlocal-cli#131 resolves the control itself and — crucially —
+# forwards it through the Hermes and Aider SANDBOXES, which an --extra-body from
+# out here never reached. Two detectors would only drift; theirs is complete.
+# See noonghunna/benchlocal-cli#130 (report) and #131 (fix, merged 2026-08-12).
+#
+# ⚠️ The capability check below is the guard that matters: a benchlocal-cli older
+# than #131 fails SILENTLY on such a model — no error, just a null A/B.
+if ! benchlocal-cli run --help 2>/dev/null | grep -q -- "--reasoning-effort"; then
+  echo "[quality-test] WARN: this benchlocal-cli predates the model-specific thinking fix (#131)." >&2
+  echo "[quality-test]   On a model that does not use chat_template_kwargs.enable_thinking (e.g. an" >&2
+  echo "[quality-test]   effort-dial model), --no-thinking and --enable-thinking are BOTH ignored and" >&2
+  echo "[quality-test]   the two arms are the same reasoning-on run — a silently invalid A/B." >&2
+  echo "[quality-test]   Upgrade: pip install --upgrade git+https://github.com/noonghunna/benchlocal-cli.git" >&2
 fi
-if [[ "${THINK_CONTROL:-enable_thinking}" != enable_thinking* ]]; then
-  _tfrag=""
-  [[ "$NO_THINKING"     == "1" ]] && _tfrag="${THINK_FRAG_OFF:-}"
-  [[ "$ENABLE_THINKING" == "1" ]] && _tfrag="${THINK_FRAG_ON:-}"
-  if [[ -n "$_tfrag" ]]; then
-    if [[ -n "${EXTRA_BODY:-}" ]]; then
-      echo "[quality-test] WARN: EXTRA_BODY is already set — NOT injecting the reasoning switch (${THINK_CONTROL}). Merge '${_tfrag}' into it yourself or the thinking arm is a no-op." >&2
-    else
-      CLI_ARGS+=(--extra-body "$_tfrag")
-      echo "[quality-test] thinking switch: ${THINK_CONTROL} → --extra-body ${_tfrag}"
-      echo "[quality-test]   (benchlocal-cli's enable_thinking flag does not apply to this model)"
-    fi
-  else
-    echo "[quality-test] WARN: this model's reasoning switch is '${THINK_CONTROL:-unknown}', which benchlocal-cli's --enable-thinking/--no-thinking cannot drive." >&2
-    echo "[quality-test]   Packs will run at the model's DEFAULT reasoning level regardless of pack metadata." >&2
-    echo "[quality-test]   Pin the arm with --no-thinking or --enable-thinking so the correct switch is injected." >&2
-  fi
+if [[ -n "$REASONING_EFFORT" ]]; then
+  CLI_ARGS+=(--reasoning-effort "$REASONING_EFFORT")
+  echo "[quality-test] reasoning effort: $REASONING_EFFORT (forwarded to benchlocal-cli)"
 fi
 if [[ -n "$THINKING_MAX_TOKENS" ]]; then
   CLI_ARGS+=(--thinking-max-tokens "$THINKING_MAX_TOKENS")

--- a/scripts/soak-helper.py
+++ b/scripts/soak-helper.py
@@ -62,8 +62,23 @@ def base_req(model, messages, max_tokens, temp=0.4, thinking=False, tools=False)
     # `chat_template_kwargs.enable_thinking` is a Qwen3-family feature.
     # Other model families (Gemma 4, etc.) reject it with 400. Skip via:
     #   SOAK_NO_CHAT_TEMPLATE_KWARGS=1
+    #
+    # WHICH key controls reasoning is model-specific, and a family that uses a
+    # different one IGNORES this silently — no 400, no warning — so the model
+    # reasons at full effort for the whole soak while the run believes thinking
+    # is off. soak-test.sh resolves the real key via preflight.sh
+    # ::preflight_detect_thinking_control and exports it as final JSON.
     if os.environ.get("SOAK_NO_CHAT_TEMPLATE_KWARGS") != "1":
-        req["chat_template_kwargs"] = {"enable_thinking": thinking}
+        raw = os.environ.get("THINK_ON_KW" if thinking else "THINK_OFF_KW")
+        try:
+            req["chat_template_kwargs"] = (
+                json.loads(raw) if raw else {"enable_thinking": thinking})
+        except Exception:
+            req["chat_template_kwargs"] = {"enable_thinking": thinking}
+        # The OpenAI-standard top-level parameter, for engines that honour it.
+        effort = os.environ.get("THINK_ON_EFFORT" if thinking else "THINK_OFF_EFFORT")
+        if effort:
+            req["reasoning_effort"] = effort
     if tools:
         req["tools"] = TOOLS
         req["tool_choice"] = "auto"

--- a/scripts/soak-test.sh
+++ b/scripts/soak-test.sh
@@ -353,6 +353,23 @@ curl -sf -m 10 "${ENDPOINT}/v1/models" -o "$MODELS_JSON" \
   || die "no response from ${ENDPOINT}/v1/models"
 MODEL="${MODEL:-$(python3 "$HELPER" model "$MODELS_JSON")}"
 
+# Which request field turns reasoning off is model-specific, and an unrecognised
+# one is silently ignored — so a family that uses a different switch would reason
+# at full effort for the ENTIRE soak while the run reports itself thinking-off.
+# Resolve it once here and hand soak-helper.py the final JSON via the
+# environment. See preflight.sh::preflight_detect_thinking_control.
+if [[ -f "${REPO_ROOT}/scripts/preflight.sh" ]]; then
+  # shellcheck source=preflight.sh
+  source "${REPO_ROOT}/scripts/preflight.sh"
+fi
+if declare -F preflight_detect_thinking_control >/dev/null; then
+  preflight_detect_thinking_control "$ENDPOINT" "$MODEL"
+else
+  THINK_OFF_KW='{"enable_thinking": false}'; THINK_ON_KW='{"enable_thinking": true}'
+  THINK_OFF_EFFORT=''; THINK_ON_EFFORT=''
+fi
+export THINK_OFF_KW THINK_ON_KW THINK_OFF_EFFORT THINK_ON_EFFORT
+
 TURN_LOG="${SOAK_OUTPUT}/turn-log.csv"
 GPU_LOG="${SOAK_OUTPUT}/gpu-log.csv"
 SUMMARY_MD="${SOAK_OUTPUT}/summary.md"

--- a/scripts/stream-toolcall-probe.py
+++ b/scripts/stream-toolcall-probe.py
@@ -31,6 +31,7 @@ Usage:
 """
 import argparse
 import json
+import os
 import sys
 import urllib.request
 
@@ -93,8 +94,19 @@ def stream_request(url, model, messages, tool_choice, thinking, temperature, max
         "max_tokens": max_tokens,
     }
     if thinking:
-        # vLLM Qwen3 thinking gate.
-        body["chat_template_kwargs"] = {"enable_thinking": True}
+        # The thinking gate. WHICH key it is varies by model family and an
+        # unrecognised one is silently ignored, so the caller resolves it via
+        # preflight.sh::preflight_detect_thinking_control and exports the final
+        # JSON; the Qwen literal is the fallback when nothing was exported.
+        raw = os.environ.get("THINK_ON_KW")
+        try:
+            body["chat_template_kwargs"] = (
+                json.loads(raw) if raw else {"enable_thinking": True})
+        except Exception:
+            body["chat_template_kwargs"] = {"enable_thinking": True}
+        effort = os.environ.get("THINK_ON_EFFORT")
+        if effort:
+            body["reasoning_effort"] = effort
     req = urllib.request.Request(
         url.rstrip("/") + "/v1/chat/completions",
         data=json.dumps(body).encode(),

--- a/scripts/tests/test-thinking-control.sh
+++ b/scripts/tests/test-thinking-control.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-thinking-control.sh — the reasoning-switch detection contract.
+#
+# WHICH request field turns a model's reasoning off is not universal, and an
+# unrecognised one is silently ignored — no error, no warning. The whole script
+# layer had the Qwen key (`chat_template_kwargs.enable_thinking`) baked in, so
+# on a model that uses a different one the switch did nothing, the model reasoned
+# at full effort, and every short-budget check spent its entire allowance on the
+# reasoning preamble before emitting a content token. verify-full's [3/9] and
+# [5/9] then failed reporting "Model may be loading badly or wrong chat
+# template" — sending you to debug a template that was in fact correct.
+# Found on Inkling-Small 2026-08-12, whose template takes an effort DIAL
+# (`reasoning_effort`: none/minimal/low/medium/high/xhigh, default 0.9).
+#
+# Why this test exists rather than a live model run: any single served model
+# exercises exactly ONE branch of the detector. Inkling covers the template-scan
+# reasoning_effort path and nothing else — in particular the behavioural-probe
+# path, which is what EVERY vLLM/SGLang model takes (they ship no /props), would
+# never execute. This drives all of them against a mock endpoint, deterministic
+# and GPU-free.
+#
+# Asserts, per scenario: the detected control, the chat_template_kwargs object,
+# and the top-level OpenAI `reasoning_effort` fragment.
+#
+#   template scan (llama.cpp /props)
+#     1. template mentions enable_thinking      → enable_thinking
+#     2. template mentions reasoning_effort     → reasoning_effort + std param
+#     3. template mentions BOTH                 → enable_thinking  ← no-regression
+#     4. template mentions neither              → none, empty kwargs
+#   behavioural probe (vLLM / SGLang — no /props)
+#     5. enable_thinking yields content         → enable_thinking
+#     6. only reasoning_effort yields content   → reasoning_effort + std param
+#     7. neither yields content                 → none
+#   safety
+#     8. endpoint unreachable                   → enable_thinking (today's shape)
+#     9. env override wins AND suppresses the top-level param
+#
+# Scenario 3 is the load-bearing one: it is what guarantees this change can only
+# ADD coverage. Every model passing today keeps its exact request shape.
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
+PASS=0
+fail() { echo "ASSERTION FAILED: $*" >&2; exit 1; }
+ok()   { PASS=$((PASS + 1)); printf '  ok  %s\n' "$*"; }
+
+command -v python3 >/dev/null 2>&1 || { echo "python3 unavailable — skipping"; exit 0; }
+command -v curl    >/dev/null 2>&1 || { echo "curl unavailable — skipping";    exit 0; }
+
+TMP="$(mktemp -d)"
+MOCK_PID=""
+cleanup() {
+  [[ -n "$MOCK_PID" ]] && kill "$MOCK_PID" 2>/dev/null || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+# --- mock endpoint --------------------------------------------------------
+# MODE selects the served behaviour:
+#   props:<text>   → /props returns that chat_template; completions always 200
+#   noprops:<key>  → /props 404s; completions return content ONLY when the
+#                    request's chat_template_kwargs carries <key> ("-" = never)
+cat > "$TMP/mock.py" <<'PY'
+import json, os, sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+MODE = os.environ["MOCK_MODE"]
+
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def _send(self, code, obj):
+        body = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path == "/props":
+            if MODE.startswith("props:"):
+                return self._send(200, {"chat_template": MODE.split(":", 1)[1]})
+            return self._send(404, {"error": "not found"})
+        if self.path.endswith("/v1/models"):
+            return self._send(200, {"data": [{"id": "mock-model"}]})
+        return self._send(404, {"error": "not found"})
+
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length", 0))
+        try:
+            body = json.loads(self.rfile.read(n) or b"{}")
+        except Exception:
+            body = {}
+        content = "OK"
+        if MODE.startswith("noprops:"):
+            want = MODE.split(":", 1)[1]
+            kw = body.get("chat_template_kwargs") or {}
+            # Empty content = the model reasoned the budget away, which is
+            # exactly what an ignored switch looks like from the client side.
+            content = "OK" if (want != "-" and want in kw) else ""
+        self._send(200, {"choices": [{"message": {"content": content}}]})
+
+
+HTTPServer(("127.0.0.1", int(sys.argv[1])), H).serve_forever()
+PY
+
+free_port() { python3 -c "import socket;s=socket.socket();s.bind(('127.0.0.1',0));print(s.getsockname()[1]);s.close()"; }
+
+start_mock() {
+  [[ -n "$MOCK_PID" ]] && { kill "$MOCK_PID" 2>/dev/null || true; wait "$MOCK_PID" 2>/dev/null || true; }
+  PORT="$(free_port)"
+  MOCK_MODE="$1" python3 "$TMP/mock.py" "$PORT" >/dev/null 2>&1 &
+  MOCK_PID=$!
+  for _ in $(seq 1 50); do
+    curl -sf -m 1 "http://127.0.0.1:${PORT}/v1/models" >/dev/null 2>&1 && return 0
+    sleep 0.1
+  done
+  fail "mock endpoint did not come up on port ${PORT}"
+}
+
+# Run detection in a clean subshell so no scenario leaks state into the next.
+# Echoes: <control>|<kwargs>|<top-level fragment>
+detect() {
+  local url="$1"
+  env -u THINK_CONTROL -u THINK_OFF_KW -u THINK_ON_KW -u THINK_OFF_STD -u THINK_ON_STD \
+      -u VERIFY_THINK_OFF -u VERIFY_THINK_ON "${@:2}" \
+      bash -c '
+        set -euo pipefail
+        source scripts/preflight.sh >/dev/null 2>&1 || true
+        declare -F preflight_detect_thinking_control >/dev/null \
+          || { echo "MISSING||"; exit 0; }
+        URL="'"$url"'" MODEL="mock-model"
+        preflight_detect_thinking_control "'"$url"'" "mock-model" 2>/dev/null
+        printf "%s|%s|%s\n" "${THINK_CONTROL:-}" "${THINK_OFF_KW:-}" "${THINK_OFF_STD:-}"
+      '
+}
+
+expect() {
+  local label="$1" url="$2" want="$3"; shift 3
+  local got
+  got="$(detect "$url" "$@" | tail -1)"
+  [[ "$got" == "$want" ]] || fail "${label}: expected '${want}', got '${got}'"
+  ok "$label"
+}
+
+KW_QWEN='{"enable_thinking": false}'
+KW_EFFORT='{"reasoning_effort": "none"}'
+STD_EFFORT='"reasoning_effort": "none", '
+
+echo "--- template scan (llama.cpp /props)"
+start_mock 'props:{%- if enable_thinking %}<think>{%- endif %}'
+expect "1. template declares enable_thinking"  "http://127.0.0.1:${PORT}" "enable_thinking|${KW_QWEN}|"
+
+start_mock 'props:Thinking effort level: {{ reasoning_effort }}'
+expect "2. template declares reasoning_effort" "http://127.0.0.1:${PORT}" "reasoning_effort|${KW_EFFORT}|${STD_EFFORT}"
+
+start_mock 'props:{{ reasoning_effort }} and {%- if enable_thinking %}'
+expect "3. BOTH → keeps today's shape"         "http://127.0.0.1:${PORT}" "enable_thinking|${KW_QWEN}|"
+
+start_mock 'props:{{ messages }} plain template, no switch at all'
+expect "4. template declares neither"          "http://127.0.0.1:${PORT}" "none|{}|"
+
+echo "--- behavioural probe (vLLM / SGLang — no /props; opt-in via THINK_PROBE=1)"
+start_mock 'noprops:enable_thinking'
+expect "5. probe finds enable_thinking"        "http://127.0.0.1:${PORT}" "enable_thinking|${KW_QWEN}|" THINK_PROBE=1
+
+start_mock 'noprops:reasoning_effort'
+expect "6. probe finds reasoning_effort"       "http://127.0.0.1:${PORT}" "reasoning_effort|${KW_EFFORT}|${STD_EFFORT}" THINK_PROBE=1
+
+start_mock 'noprops:-'
+expect "7. probe finds no working switch"      "http://127.0.0.1:${PORT}" "none|{}|" THINK_PROBE=1
+
+start_mock 'noprops:reasoning_effort'
+expect "7b. probe NOT run without opt-in → safe default" "http://127.0.0.1:${PORT}" "enable_thinking|${KW_QWEN}|"
+
+echo "--- safety"
+DEAD_PORT="$(free_port)"
+expect "8. unreachable endpoint → safe default" "http://127.0.0.1:${DEAD_PORT}" "enable_thinking|${KW_QWEN}|"
+
+start_mock 'props:Thinking effort level: {{ reasoning_effort }}'
+expect "9. env override wins + suppresses std param" "http://127.0.0.1:${PORT}" \
+  'reasoning_effort (off overridden)|{"enable_thinking": false}|' \
+  VERIFY_THINK_OFF='{"enable_thinking": false}'
+
+echo ""
+echo "test-thinking-control: ${PASS} assertions passed"

--- a/scripts/verify-full.sh
+++ b/scripts/verify-full.sh
@@ -36,6 +36,19 @@
 #   SKIP_TOOLS   Set to 1 to skip the tool-call test entirely (useful when
 #                running against the default config which is known to fail
 #                tool calls — see README "Known issue" section).
+#   VERIFY_THINK_OFF / VERIFY_THINK_ON
+#                Raw JSON objects for chat_template_kwargs, overriding the
+#                auto-detected reasoning switch. Example for a model whose
+#                template uses an effort dial rather than a boolean:
+#                  VERIFY_THINK_OFF='{"reasoning_effort": "none"}'
+#                Auto-detection handles the known families — set these only for
+#                a template this harness does not recognise. Setting one also
+#                suppresses the matching top-level OpenAI `reasoning_effort`
+#                parameter, so an override fully specifies the request.
+#   VERIFY_TOK_SCALE
+#                Multiplier for the two short scored checks' token budgets.
+#                Applied ONLY when no reasoning off-switch was detected
+#                (default 64); models with a working switch are unaffected.
 #
 # Optional flag:
 #   --bench      After all correctness checks pass, run scripts/bench.sh
@@ -111,6 +124,39 @@ detect_engine() {
 }
 ENGINE_KIND="$(detect_engine)"
 
+# ---- Thinking-control detection -----------------------------------------
+# WHICH chat_template_kwargs key controls reasoning is model-specific, and an
+# unrecognised one is silently ignored. Detection lives in preflight.sh so the
+# whole script layer shares one implementation; see the block header there for
+# the failure mode and the escaping rule. Sets THINK_CONTROL / THINK_OFF_KW /
+# THINK_ON_KW; override with VERIFY_THINK_OFF / VERIFY_THINK_ON.
+if declare -F preflight_detect_thinking_control >/dev/null; then
+  THINK_PROBE=1   # functional check: one extra request is harmless, coverage matters
+  preflight_detect_thinking_control
+else
+  # preflight.sh not found — keep the historical request shape.
+  THINK_CONTROL="enable_thinking"
+  THINK_OFF_KW='{"enable_thinking": false}'
+  THINK_ON_KW='{"enable_thinking": true}'
+  THINK_OFF_STD=''; THINK_ON_STD=''
+fi
+
+# Token budgets AND request timeouts for the two short scored checks. An
+# always-reasoning model whose switch this harness doesn't know needs room for
+# the preamble as well as the answer — and raising the budget alone is a trap,
+# because the extra tokens take extra wall-clock and the curl caps (30s/45s)
+# would then fire instead. Scale both together. Every model with a detected
+# switch is unaffected: the multiplier is 1 and the timeouts are unchanged.
+TOK_SCALE=1
+[[ "$THINK_CONTROL" == none* ]] && TOK_SCALE="${VERIFY_TOK_SCALE:-64}"
+MT_BASIC=$(( 30 * TOK_SCALE ))
+MT_STREAM=$(( 120 * TOK_SCALE ))
+if (( TOK_SCALE > 1 )); then
+  TMO_BASIC=300; TMO_STREAM=300
+else
+  TMO_BASIC=30;  TMO_STREAM=45
+fi
+
 FAILED=0
 run_check() {
   local label="$1"; shift
@@ -119,6 +165,7 @@ run_check() {
 
 echo "Running FULL functional test against ${URL}"
 echo "  model=${MODEL}  container=${CONTAINER}  engine=${ENGINE_KIND}"
+echo "  thinking-control=${THINK_CONTROL}  off=${THINK_OFF_KW}  on=${THINK_ON_KW}"
 echo ""
 
 # --------------------------------------------------------------------
@@ -201,7 +248,7 @@ curl -sf -m 180 "${URL}/v1/chat/completions" \
     \"messages\": [{\"role\": \"user\", \"content\": \"ping\"}],
     \"max_tokens\": 1,
     \"temperature\": 0.0,
-    \"chat_template_kwargs\": {\"enable_thinking\": false}
+    ${THINK_OFF_STD}\"chat_template_kwargs\": ${THINK_OFF_KW}
   }" >/dev/null 2>&1 && echo "[warmup] engine warm" || echo "[warmup] warmup request did not return in 180s — [3/9] will surface a real outage if present"
 
 # --------------------------------------------------------------------
@@ -210,14 +257,14 @@ curl -sf -m 180 "${URL}/v1/chat/completions" \
 check_basic() {
   echo "[3/9] Basic completion — capital of France ..."
   local resp
-  resp="$(curl -sf -m 30 "${URL}/v1/chat/completions" \
+  resp="$(curl -sf -m ${TMO_BASIC} "${URL}/v1/chat/completions" \
     -H "Content-Type: application/json" \
     -d "{
       \"model\": \"${MODEL}\",
       \"messages\": [{\"role\": \"user\", \"content\": \"What is the capital of France? One short sentence.\"}],
-      \"max_tokens\": 30,
+      \"max_tokens\": ${MT_BASIC},
       \"temperature\": 0.6,
-      \"chat_template_kwargs\": {\"enable_thinking\": false}
+      ${THINK_OFF_STD}\"chat_template_kwargs\": ${THINK_OFF_KW}
     }")" || { fail "completion request failed" "Check docker logs ${CONTAINER}"; return 1; }
   local content
   content="$(echo "$resp" | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0]['message']['content'])" 2>/dev/null || true)"
@@ -247,7 +294,7 @@ check_tools() {
       \"messages\": [{\"role\": \"user\", \"content\": \"What is the weather in San Francisco? Use the get_weather tool.\"}],
       \"tools\": [{\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"description\":\"Get weather for a city.\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}}}],
       \"tool_choice\": \"auto\", \"max_tokens\": 200, \"temperature\": 0.3,
-      \"chat_template_kwargs\": {\"enable_thinking\": false}
+      ${THINK_OFF_STD}\"chat_template_kwargs\": ${THINK_OFF_KW}
     }")" || { fail "tool-call request failed" "Check docker logs"; return 1; }
   local tool_calls
   tool_calls="$(echo "$resp" | python3 -c "
@@ -284,15 +331,15 @@ check_streaming() {
   echo "[5/9] Streaming (SSE) ..."
   # Collect streamed chunks for 15 seconds max
   local stream_out
-  stream_out="$(curl -sf -m 45 --no-buffer "${URL}/v1/chat/completions" \
+  stream_out="$(curl -sf -m ${TMO_STREAM} --no-buffer "${URL}/v1/chat/completions" \
     -H "Content-Type: application/json" \
     -d "{
       \"model\": \"${MODEL}\",
       \"messages\": [{\"role\": \"user\", \"content\": \"Write a three-sentence haiku about debugging.\"}],
-      \"max_tokens\": 120,
+      \"max_tokens\": ${MT_STREAM},
       \"temperature\": 0.6,
       \"stream\": true,
-      \"chat_template_kwargs\": {\"enable_thinking\": false}
+      ${THINK_OFF_STD}\"chat_template_kwargs\": ${THINK_OFF_KW}
     }" 2>/dev/null)" || { fail "streaming request failed" "Check docker logs"; return 1; }
 
   local text chunks
@@ -357,7 +404,7 @@ check_streaming_tools() {
       \"tools\": [{\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"description\":\"Get weather for a city.\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}}}],
       \"tool_choice\": \"auto\", \"max_tokens\": 256, \"temperature\": 0.3,
       \"stream\": true,
-      \"chat_template_kwargs\": {\"enable_thinking\": true}
+      ${THINK_ON_STD}\"chat_template_kwargs\": ${THINK_ON_KW}
     }" 2>/dev/null)" || { fail "streaming tool-call request failed" "Check docker logs"; return 1; }
   local verdict
   verdict="$(echo "$stream_out" | python3 -c "
@@ -409,7 +456,7 @@ check_thinking() {
       \"messages\": [{\"role\": \"user\", \"content\": \"What is 2+2? One-line answer.\"}],
       \"max_tokens\": 4000,
       \"temperature\": 0.3,
-      \"chat_template_kwargs\": {\"enable_thinking\": true}
+      ${THINK_ON_STD}\"chat_template_kwargs\": ${THINK_ON_KW}
     }")" || { fail "thinking request failed" "Check docker logs"; return 1; }
   local analyzed
   analyzed="$(echo "$resp" | python3 -c "
@@ -462,7 +509,7 @@ check_output_quality() {
       \"messages\": [{\"role\": \"user\", \"content\": \"Write a detailed 1500-word essay explaining how transformer attention works. Cover: query/key/value projections, scaled dot-product attention, softmax, multi-head attention, positional encodings, and a brief comparison with RNN-based attention.\"}],
       \"max_tokens\": 2000,
       \"temperature\": 0.6,
-      \"chat_template_kwargs\": {\"enable_thinking\": false}
+      ${THINK_OFF_STD}\"chat_template_kwargs\": ${THINK_OFF_KW}
     }")" || { fail "output quality request failed" "Check docker logs ${CONTAINER}"; return 1; }
 
   local analysis
@@ -552,7 +599,7 @@ check_mtp_acceptance() {
       \"messages\": [{\"role\": \"user\", \"content\": \"Count from 1 to 80, one number per line.\"}],
       \"max_tokens\": 500,
       \"temperature\": 0.0,
-      \"chat_template_kwargs\": {\"enable_thinking\": false}
+      ${THINK_OFF_STD}\"chat_template_kwargs\": ${THINK_OFF_KW}
     }" >/dev/null 2>&1 || { fail "metrics-trigger request failed" "Check docker logs"; return 1; }
   sleep 3  # let log line flush
 

--- a/scripts/verify-stress.sh
+++ b/scripts/verify-stress.sh
@@ -114,6 +114,20 @@ URL="${URL:-http://localhost:8020}"
 # literal below is only a last resort if detection no-ops (endpoint unreachable).
 declare -F preflight_autodetect_model >/dev/null && preflight_autodetect_model
 MODEL="${MODEL:-qwen3.6-27b}"
+
+# Which request field turns reasoning off is model-specific, and an unrecognised
+# one is silently ignored — a family using a different switch would reason at
+# full effort through the whole longctx ladder, blowing the tight token budgets
+# (the needle checks cap at 30 tokens) for reasons that look like recall
+# failures. See preflight.sh::preflight_detect_thinking_control. THINK_FRAG_*
+# is the complete request fragment, splatted by the python blocks below.
+if declare -F preflight_detect_thinking_control >/dev/null; then
+  preflight_detect_thinking_control
+else
+  THINK_FRAG_OFF='{"chat_template_kwargs": {"enable_thinking": false}}'
+  THINK_FRAG_ON='{"chat_template_kwargs": {"enable_thinking": true}}'
+fi
+export THINK_FRAG_OFF THINK_FRAG_ON
 CONTAINER="${CONTAINER:-vllm-qwen36-27b}"
 
 # Detect VLLM_ENFORCE_EAGER=1 in the running container's env. Eager-mode
@@ -382,7 +396,7 @@ req = {
     "messages": [{"role": "user", "content": content}],
     "max_tokens": 30,
     "temperature": 0.0,
-    "chat_template_kwargs": {"enable_thinking": False},
+    **json.loads(os.environ.get("THINK_FRAG_OFF") or '{"chat_template_kwargs": {"enable_thinking": false}}'),
 }
 with open(os.environ['SECRET_FILE'], 'w') as f:
     f.write(secret)
@@ -531,7 +545,7 @@ payload = {
     "tool_choice": "auto",
     "max_tokens": 500,
     "temperature": 0.6,
-    "chat_template_kwargs": {"enable_thinking": False},
+    **json.loads(os.environ.get("THINK_FRAG_OFF") or '{"chat_template_kwargs": {"enable_thinking": false}}'),
 }
 with open(os.environ['REQ_FILE'], 'w') as f:
     json.dump(payload, f)
@@ -548,7 +562,7 @@ EOF
     200)
       local content_len tc_count finish
       read -r content_len tc_count finish < <(python3 -c "
-import json
+import json, os
 try:
     d = json.load(open('${resp_file}'))
     msg = d['choices'][0]['message']
@@ -1238,7 +1252,7 @@ print(' '.join(str(r) for r in rungs))
   cal_req="$(mktemp --suffix=.json)"
   cal_result="$(mktemp --suffix=.json)"
   python3 -c "
-import json
+import json, os
 block = (
     'This section describes the history of computing in detail. '
     'Transistors were invented in 1947 at Bell Labs. The integrated circuit came a decade later. '
@@ -1249,7 +1263,7 @@ req = {
     'model': '${MODEL}',
     'messages': [{'role': 'user', 'content': block + '\n\nHi.'}],
     'max_tokens': 5, 'temperature': 0.0,
-    'chat_template_kwargs': {'enable_thinking': False},
+    **json.loads(os.environ.get('THINK_FRAG_OFF') or '{\"chat_template_kwargs\": {\"enable_thinking\": false}}'),
 }
 with open('${cal_req}', 'w') as f:
     json.dump(req, f)
@@ -1322,7 +1336,7 @@ req = {
     "messages": [{"role": "user", "content": content}],
     "max_tokens": 30,
     "temperature": 0.0,
-    "chat_template_kwargs": {"enable_thinking": False},
+    **json.loads(os.environ.get("THINK_FRAG_OFF") or '{"chat_template_kwargs": {"enable_thinking": false}}'),
 }
 with open(os.environ['SECRET_FILE'], 'w') as f:
     f.write(secret)

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -43,6 +43,24 @@ declare -F preflight_autodetect_model >/dev/null && preflight_autodetect_model
 MODEL="${MODEL:-qwen3.6-27b}"
 CONTAINER="${CONTAINER:-vllm-qwen36-27b}"
 
+# Which chat_template_kwargs key turns reasoning off is model-specific, and an
+# unrecognised one is silently ignored — the model then reasons at full effort
+# and a 30-token budget is gone before any content token. See preflight.sh
+# ::preflight_detect_thinking_control. Falls back to today's shape if absent.
+if declare -F preflight_detect_thinking_control >/dev/null; then
+  THINK_PROBE=1   # functional check: one extra request is harmless, coverage matters
+  preflight_detect_thinking_control
+else
+  THINK_CONTROL="enable_thinking"
+  THINK_OFF_KW='{"enable_thinking": false}'
+  THINK_OFF_STD=''
+fi
+# Budget + timeout headroom when no switch was detected (see verify-full.sh).
+TOK_SCALE=1
+[[ "$THINK_CONTROL" == none* ]] && TOK_SCALE="${VERIFY_TOK_SCALE:-64}"
+MT_BASIC=$(( 30 * TOK_SCALE ))
+if (( TOK_SCALE > 1 )); then TMO_BASIC=300; else TMO_BASIC=30; fi
+
 pass() { printf "  \033[32m✓\033[0m %s\n" "$1"; }
 fail() { printf "  \033[31m✗\033[0m %s\n" "$1"; printf "    \033[33m→\033[0m %s\n" "$2"; exit 1; }
 
@@ -92,14 +110,14 @@ fi
 # 3. Basic completion — Paris sanity
 # --------------------------------------------------------------------
 echo "[3/4] Basic completion — capital of France ..."
-resp="$(curl -sf -m 30 "${URL}/v1/chat/completions" \
+resp="$(curl -sf -m ${TMO_BASIC} "${URL}/v1/chat/completions" \
   -H "Content-Type: application/json" \
   -d "{
     \"model\": \"${MODEL}\",
     \"messages\": [{\"role\": \"user\", \"content\": \"What is the capital of France? Reply in one short sentence.\"}],
-    \"max_tokens\": 30,
+    \"max_tokens\": ${MT_BASIC},
     \"temperature\": 0.6,
-    \"chat_template_kwargs\": {\"enable_thinking\": false}
+    ${THINK_OFF_STD}\"chat_template_kwargs\": ${THINK_OFF_KW}
   }")" || fail "completion request failed" "Check docker logs ${CONTAINER}"
 
 content="$(echo "$resp" | python3 -c "import sys,json; print(json.load(sys.stdin)['choices'][0]['message']['content'])" 2>/dev/null || true)"
@@ -141,7 +159,7 @@ tool_resp="$(curl -sf -m 60 "${URL}/v1/chat/completions" \
     \"tool_choice\": \"auto\",
     \"max_tokens\": 200,
     \"temperature\": 0.3,
-    \"chat_template_kwargs\": {\"enable_thinking\": false}
+    ${THINK_OFF_STD}\"chat_template_kwargs\": ${THINK_OFF_KW}
   }")" || fail "tool-call request failed" "Check docker logs ${CONTAINER}"
 
 tool_calls="$(echo "$tool_resp" | python3 -c "


### PR DESCRIPTION
## The bug

The whole script layer had **one vendor's reasoning switch hardcoded as if it were universal**:

```json
"chat_template_kwargs": {"enable_thinking": false}
```

That is the Qwen convention. A model whose template reads a different variable **ignores it silently** — no error, no warning, no 400. The model then reasons at full effort while the run believes thinking is off.

Surfaced by Inkling-Small, whose template takes an effort **dial** rather than a boolean: `reasoning_effort` ∈ `none|minimal|low|medium|high|xhigh` or a float, **defaulting to 0.9 ("high")**. At that default it spends ~1,600 output tokens reasoning about a haiku.

What that cost, concretely:

- **`verify-full`** failed *structurally* — `[3/9]` and `[5/9]`, both reporting *"Model may be loading badly or wrong chat template"*. The template was correct. A 30-token budget was simply gone before the first content token.
- **`bench`** measured reasoning-heavy generation and reported itself thinking-off. Its existing guard for this is blind twice over: `server_reasoning_on()` needs a docker `CONTAINER` (so a bare-metal server is skipped entirely) *and* looks for an explicit `--reasoning on` flag, which a model that reasons by default never needs.
- **`quality-test`** was the worst case: benchlocal-cli drives thinking via the same Qwen key, so `--no-thinking` and `--enable-thinking` would have produced **two identical reasoning-on runs**, and the 8-pack would have reported a clean off-vs-on comparison that never happened.

## The fix

One detector in `preflight.sh::preflight_detect_thinking_control`, consumed by every serving script:

1. **Template scan** — read the live template from `/props` (llama.cpp). Exact, free, no inference.
2. **Behavioural probe** — for engines that don't expose the template (vLLM, SGLang): ask which switch actually yields content. **Opt-in via `THINK_PROBE=1`.**

Sets `THINK_CONTROL`, `THINK_OFF_KW` / `THINK_ON_KW` (kwargs object), `THINK_OFF_STD` / `THINK_ON_STD` (top-level fragment for shell splicing), `THINK_OFF_EFFORT` / `THINK_ON_EFFORT` (plain value) and `THINK_FRAG_OFF` / `THINK_FRAG_ON` (complete request fragment, for Python consumers to splat in one line). Override with `VERIFY_THINK_OFF` / `VERIFY_THINK_ON`.

### Why the probe is opt-in

It fires **real inference requests**. Functional checks (`verify`, `verify-full`) opt in — one extra request is harmless. Measurement scripts (`bench`, `soak`, `power-cap-sweep`, `quality-test`) deliberately do **not**: it would put uncontrolled requests on the server before warmup, and against a scripted endpoint it consumes responses the run expects. That is not hypothetical — it silently shifted every soak turn's response by two until it was gated.

### Three invariants that keep this from changing existing behaviour

- **`enable_thinking` is checked first**, so a template declaring both keeps the shape it has today.
- **The detector is silent when the answer is the default**, so output-drift guards and log parsers stay byte-identical.
- **Unreachable endpoint → safe default**, never "no switch" (which would also inflate budgets 64×).

### Standards note — the OpenAI parameter is sent, with a fallback

`reasoning_effort` **is** the OpenAI standard, and Thinking Machines' own API takes it top-level, so we send it there. It cannot be sent alone, because llama.cpp only half-implements it — `tools/server/server-common.cpp`:

```c
// Parse also the OAI "reasoning_effort": "none" specific value
if (body.contains("reasoning_effort")) {
    auto reasoning_effort = json_value(body, "reasoning_effort", std::string(""));
    if (reasoning_effort == "none") {
        inputs.enable_thinking = false;
    } // other reasoning_effort values are model-specific and not yet handled
}
```

The one handled value is mapped onto `enable_thinking` — a variable this family's template does not read — and every other value is dropped. So on llama.cpp the kwargs copy is what reaches the template. Sending both is verified non-conflicting (`none` → 10 tok / 0 reasoning; `high` → 45 tok / 152 chars). **Drop the kwargs half once llama.cpp forwards the value into the template.**

## Scope

| File | Change |
|---|---|
| `preflight.sh` | the shared detector |
| `verify.sh`, `verify-full.sh` | detector + probe opt-in + budget/timeout headroom |
| `verify-stress.sh` | 4 payload sites via `THINK_FRAG_OFF` |
| `bench.sh` | payload + a second guard that fires when no off-switch exists |
| `bench-agentic.sh`, `power-cap-sweep.sh` | payload via a `_think()` helper |
| `soak-test.sh` + `soak-helper.py` | detector exported into the helper's environment |
| `quality-test.sh` | injects the switch through benchlocal-cli's `--extra-body`, or warns loudly when it can't |
| `stream-toolcall-probe.py` | payload |
| `scripts/tests/test-thinking-control.sh` | **new gate, 10 assertions** |

`quality-test.sh` only injects when the model does **not** use the Qwen key and the arm is pinned (`--no-thinking` / `--enable-thinking`) — without a pin, packs choose per-pack and one `--extra-body` would force a single setting across all of them. If the user already set `EXTRA_BODY`, it warns instead of clobbering.

## Validation

**Live, against the model that exposed it** — harness only, no model or compose change:

| | before | after |
|---|---|---|
| `verify-full` | **7/9** (`[3/9]`, `[5/9]` fail) | **9/9 — all checks passed** |
| `verify.sh` | n/a | **all checks passed** |

**Live, against a real Qwen model** (Qwen3.5-4B Q4_K_M on GPU, real Qwen chat template) — the arm that had to prove *nothing changed*:

| run | this branch | `origin/master` |
|---|---|---|
| 1 | 7 pass / 0 fail / 2 skip | 7 pass / 0 fail / 2 skip |
| 2 | 7 pass / 0 fail / 2 skip | 7 pass / 0 fail / 2 skip |

Detection returns `enable_thinking` from the live template, **structural output is byte-identical between the two arms**, and the detector prints nothing at all — it only speaks when the answer is non-default.

**Regression control** — forcing the legacy shape via `VERIFY_THINK_OFF` reproduces the old result *exactly* (same two failures, every switch-independent check still passing), isolating the cause and proving existing payloads still construct correctly.

**Real-world tie-break check.** DeepSeek-V4-Flash's chat template declares **both** keys — `thinking` falling back to `enable_thinking`, plus `reasoning_effort` — so it is a live instance of scenario 3. `enable_thinking` wins, and that model's request shape is unchanged.

**New gate — `scripts/tests/test-thinking-control.sh`, 10 assertions** against a mock endpoint. It exists because any single served model exercises exactly one branch: the probe path that every vLLM/SGLang model takes never executes against a llama.cpp model. Deterministic, GPU-free.

```
--- template scan (llama.cpp /props)
  ok  1. template declares enable_thinking
  ok  2. template declares reasoning_effort
  ok  3. BOTH → keeps today's shape
  ok  4. template declares neither
--- behavioural probe (vLLM / SGLang — no /props; opt-in via THINK_PROBE=1)
  ok  5. probe finds enable_thinking
  ok  6. probe finds reasoning_effort
  ok  7. probe finds no working switch
  ok  7b. probe NOT run without opt-in → safe default
--- safety
  ok  8. unreachable endpoint → safe default
  ok  9. env override wins + suppresses std param
```

**Full suite green.**

### Three bugs the suite caught during development

Worth recording, because each was silent and each would have shipped:

1. **`X="$(cond && printf …)"` under `set -e`.** A command substitution whose last command fails makes the *assignment* return non-zero, aborting the function mid-way and taking the calling script down. Broke 10 suites in one commit. Now built with plain assignments.
2. **The probe consuming scripted responses**, as above — now opt-in.
3. **An unreachable endpoint classified as "no switch"** — empty probe response is indistinguishable from an ignored switch — which would have changed the request shape *and* inflated budgets on a transient blip. Now gated on a `/v1/models` reachability check.

## Not in this PR

- **benchlocal-cli** (separate repo) still drives thinking by the Qwen key. `quality-test.sh` works around it via `--extra-body`; the real fix belongs upstream in that repo.
- **`verify.sh` step 2 is broken for host builds, independently of this change** — `docker inspect none` returns **0** (Docker ships a *network* named `none`), so the guard never fires and `docker logs none` dies under `set -e`. `CONTAINER=none` is the repo's own documented convention for host engines. Reproduces on `origin/master`. Deserves its own issue.
- **`bench.sh` sends only `temperature` and `top_p`**, so `top_k`/`min_p` fall through to engine defaults that **differ between llama.cpp and vLLM** — the "canonical protocol" is not actually identical across engines. Its own issue.
