### PR TITLE
Retire two ubergarm-iq4ks and all four mudler-apex slugs

### DIFF
--- a/models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/mtp-vision.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/mtp-vision.yml
@@ -17,9 +17,16 @@
 #              ceiling (~160K) sits below the text profile's 200K, and shrinking images
 #              does NOT raise it (180K still OOMs at fill) — gated by KV + fill-time
 #              runtime overhead, not the image-encode buffer.
-#   Status:    ✅ Production — config validated 2026-05-25 (full verify-stress [8/8]
-#              at the 160K + 1M-px default; graduated from EVAL #402). switch.sh /
-#              compose_registry wiring tracked as a follow-up. Sibling of iq4ks-mtp.yml.
+#   Status:    🗑️ Deprecated
+#   Caveats:   Retired 2026-08-12 to keep the single-card ik-llama variant set
+#              lean — NOT because it regressed. Its measured result stands
+#              (verify-stress 8/8 @ 160K + 1M-px, recalls to 147K, vision
+#              functional). The surface consolidates onto iq4ks-mtp.yml, which
+#              REMAINS production and the shipped single-card default. For
+#              single-card vision use llamacpp/mtp-vision (150K).
+#              ⚠ NO weights are reclaimed: all three ubergarm-iq4ks slugs share
+#              one GGUF, still in use by iq4ks-mtp. Still launchable by name
+#              with --force, and visible in c3 via --all.
 #   Best for:  Multimodal chat / screenshot-debugging on ik_llama IQ4_KS.
 # ---------------------------------------------------------------------------
 # This is the VISION sibling of iq4ks-mtp.yml. Everything matches that file

--- a/models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/two-stage.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/two-stage.yml
@@ -22,15 +22,16 @@
 #              agentic use right at the ceiling, set CTX_SIZE=180224 (~1.4 GB
 #              margin) or 163840 (~1.9 GB). The ngram stage's 0.6 GB per-step
 #              checkpoint is what costs the top slice vs MTP-only's clean 200K.
-#   Status:    ✅ Production — code-optimized single-card pick (sits alongside iq4ks-mtp.yml,
-#              the balanced/long-ctx ⭐). Tuned + validated on 1× 3090 @ 370 W
-#              (2026-05-24). ngram n_max swept {2,3,4,5,8,16}: code decode is an
-#              inverted-U peaking at n_max=4. At (ngram 4, MTP 3): code 97.8 TPS
-#              vs 72.4 for MTP-only (iq4ks-mtp.yml) = +35%; narrative ~tie
-#              (59 vs 60). Spec-dec is lossless: 8-pack 98/150 == MTP-only's
-#              100/150 and aider-polyglot 16/30 == MTP-only's 19/30, both within
-#              noise; verify-full all green. Same 200K ctx as iq4ks-mtp, ~0.8 GB
-#              leaner at idle. Use this for code; iq4ks-mtp for balanced/prose.
+#   Status:    🗑️ Deprecated
+#   Caveats:   Retired 2026-08-12 to keep the single-card ik-llama variant set
+#              lean — NOT because it regressed. Its measured result stands
+#              (code decode ~97.8 vs 72.4 MTP-only, +35%; 8-pack 98/150 ≈ tie).
+#              The surface consolidates onto iq4ks-mtp.yml, which REMAINS
+#              production and the shipped single-card default (~18–20% faster
+#              than llamacpp/mtp at matched 370 W — discussions/184).
+#              ⚠ NO weights are reclaimed: all three ubergarm-iq4ks slugs share
+#              one GGUF, still in use by iq4ks-mtp. Still launchable by name
+#              with --force, and visible in c3 via --all.
 #   Best for:  Code-heavy agentic workloads where context has repeated patterns
 #              (refactoring, test generation, boilerplate, import blocks).
 # ---------------------------------------------------------------------------

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/dual/mudler-apex-quality/mtp.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/dual/mudler-apex-quality/mtp.yml
@@ -7,7 +7,14 @@
 #   KV:        q8_0 K + q8_0 V
 #   Vision:    NO
 #   Default ctx: 196608
-#   Status:    🧪 EVAL ONLY — dual-card APEX quality bring-up lane
+#   Status:    🗑️ Deprecated
+#   Caveats:   Superseded by later quants; no production role remains. Weights
+#              reclaimed. ⚠️ NOTE both mudler-apex-compact and
+#              mudler-apex-quality resolve to the SAME path
+#              (qwen3.6-35b-a3b-gguf/mudler-apex-mtp) — neither is
+#              independently deletable, which is why all four slugs retire
+#              together. Still launchable by name with --force, and visible in
+#              c3 via --all.
 #   Best for:  Long-context dual-card MoE testing of mudler's APEX-MTP Quality
 #              GGUF on the ik-llama path while keeping full-context q8 KV on the
 #              paired 3090 rig.

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/fit-mtp.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/fit-mtp.yml
@@ -7,13 +7,17 @@
 #   KV:        q8_0 K + q5_0 V (asymmetric, K-high/V-low) + -khad/-vhad
 #   Vision:    NO
 #   Default ctx: 196608
-#   Status:    ✅ Production — captures @laurimyllari's --fit + asymmetric-KV
-#              config (discussion #241) on top of the APEX I-Compact GGUF.
-#              All gates clean: verify-full 8/8, verify-stress 8/8 (incl. 180K
-#              NIAH), bench n=5 (CV 1.5-3.0%), soak-continuous PASS (0 errors,
-#              0 silent_empty, 0 VRAM growth, 100% retention), full quality
-#              measured post-fix.
-#   Caveats:   3090 power-sensitive: numbers below at 370 W; expect lower at 230 W.
+#   Status:    🗑️ Deprecated
+#   Caveats:   Superseded by later quants. ⚠️ This slug was PRODUCTION (its three
+#              mudler siblings were already experimental), so retiring it IS a
+#              user-visible change — it leaves `--list` and now needs --force.
+#              It was not a DEFAULTS target, and no functional mudler slug
+#              remains. Weights reclaimed. ⚠️ NOTE both mudler-apex-compact and
+#              mudler-apex-quality resolve to the SAME path
+#              (qwen3.6-35b-a3b-gguf/mudler-apex-mtp) — neither is
+#              independently deletable, which is why all four slugs retire
+#              together. Still launchable by name with --force, and visible in
+#              c3 via --all.
 #   Quality:   toolcall-15 14/15 (93%) · instructfollow-15 15/15 (100%) ·
 #              structoutput-15 14/15 (93%) · dataextract-15 11/15 (73%) ·
 #              reasonmath-15 12/15 (80%) · bugfind-15 10/15 (67%) ·

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/long.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/long.yml
@@ -7,7 +7,14 @@
 #   KV:        q8_0 K + q8_0 V + -khad/-vhad Hadamard
 #   Vision:    NO
 #   Default ctx: 262144
-#   Status:    🧪 EVAL ONLY — single-card APEX compact long-context lane
+#   Status:    🗑️ Deprecated
+#   Caveats:   Superseded by later quants; no production role remains. Weights
+#              reclaimed. ⚠️ NOTE both mudler-apex-compact and
+#              mudler-apex-quality resolve to the SAME path
+#              (qwen3.6-35b-a3b-gguf/mudler-apex-mtp) — neither is
+#              independently deletable, which is why all four slugs retire
+#              together. Still launchable by name with --force, and visible in
+#              c3 via --all.
 #   Best for:  Great single-card APEX throughput while still stretching the fit
 #              path toward the largest stable context that stayed fast here.
 # ---------------------------------------------------------------------------

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/mtp.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/mtp.yml
@@ -7,7 +7,14 @@
 #   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
 #   Vision:    NO
 #   Default ctx: 200000
-#   Status:    🧪 EVAL ONLY — single-card APEX compact bring-up lane
+#   Status:    🗑️ Deprecated
+#   Caveats:   Superseded by later quants; no production role remains. Weights
+#              reclaimed. ⚠️ NOTE both mudler-apex-compact and
+#              mudler-apex-quality resolve to the SAME path
+#              (qwen3.6-35b-a3b-gguf/mudler-apex-mtp) — neither is
+#              independently deletable, which is why all four slugs retire
+#              together. Still launchable by name with --force, and visible in
+#              c3 via --all.
 #   Best for:  Fast single-card testing of mudler's APEX-MTP compact MoE GGUF
 #              on the ik-llama path when the 23.5 GB Quality file is too tight
 #              for a practical 24 GB single-card context budget.

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -409,6 +409,8 @@ COMPOSE_REGISTRY = {
         kvcalc_key="SKIP",
     ),
     "ik-llama/iq4ks-mtp-vision": _entry(
+        status="deprecated",
+        status_note="Retired 2026-08-12: consolidating the single-card ik-llama surface onto ik-llama/iq4ks-mtp, which STAYS production and remains the shipped single-card default (~18-20% faster decode than llamacpp/mtp at matched 370 W, verified by a set-and-readback power-cap A/B -- discussions/184). This variant was validated and is not broken; it is retired to keep the variant set lean per the compose conventions. NOTE: NO disk is reclaimed -- all three ubergarm-iq4ks slugs share ONE weights file, still in use by ik-llama/iq4ks-mtp. Entry KEPT (deprecated != deleted) so the slug resolves and the launch-compat tests keep asserting on its hardware fields. Launchable with --force; c3 --all.",
         model="qwen3.6-27b", weights_variant="ubergarm-iq4ks", workload="vision-coding", chat_template="froggeric",
         engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q4_0",
         tp=1, max_ctx=163840, max_num_seqs=1, mem_util=None,
@@ -418,6 +420,8 @@ COMPOSE_REGISTRY = {
         kvcalc_key="SKIP",
     ),
     "ik-llama/iq4ks-two-stage": _entry(
+        status="deprecated",
+        status_note="Retired 2026-08-12: consolidating the single-card ik-llama surface onto ik-llama/iq4ks-mtp, which STAYS production and remains the shipped single-card default (~18-20% faster decode than llamacpp/mtp at matched 370 W, verified by a set-and-readback power-cap A/B -- discussions/184). This variant was validated and is not broken; it is retired to keep the variant set lean per the compose conventions. NOTE: NO disk is reclaimed -- all three ubergarm-iq4ks slugs share ONE weights file, still in use by ik-llama/iq4ks-mtp. Entry KEPT (deprecated != deleted) so the slug resolves and the launch-compat tests keep asserting on its hardware fields. Launchable with --force; c3 --all.",
         model="qwen3.6-27b", weights_variant="ubergarm-iq4ks", workload="fast-chat",
         engine="llama-cpp-local", drafter="qwen-mtp-builtin", kv_format="q4_0",
         tp=1, max_ctx=200000, max_num_seqs=1, mem_util=None,
@@ -561,8 +565,8 @@ COMPOSE_REGISTRY = {
         compose_path="models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/mtp.yml",
         default_port=8054,
         kvcalc_key="SKIP",
-        status="experimental",
-        status_note="APEX-MTP community MoE GGUF — eval-only bring-up lane, not yet validated.",
+        status="deprecated",
+        status_note="Retired 2026-08-12: superseded by later quants, no production role; was already 'experimental' (hidden from --list, --force to launch), so this is a status change with no new user-visible restriction. Weights reclaimed (17 GB). WARNING: mudler-apex-compact and mudler-apex-quality resolve to the SAME path (qwen3.6-35b-a3b-gguf/mudler-apex-mtp), so neither was independently deletable -- all three slugs retire together. Entry KEPT (deprecated != deleted). Launchable with --force; c3 --all.",
     ),
     "ik-llama/byteshape-iq4xs-mtp": _entry(
         model="qwen3.6-35b-a3b", weights_variant="byteshape-iq4xs", workload="fast-chat",
@@ -581,8 +585,8 @@ COMPOSE_REGISTRY = {
         compose_path="models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/long.yml",
         default_port=8056,
         kvcalc_key="SKIP",
-        status="experimental",
-        status_note="APEX-MTP community MoE GGUF — eval-only bring-up lane, not yet validated.",
+        status="deprecated",
+        status_note="Retired 2026-08-12: superseded by later quants, no production role; was already 'experimental' (hidden from --list, --force to launch), so this is a status change with no new user-visible restriction. Weights reclaimed (17 GB). WARNING: mudler-apex-compact and mudler-apex-quality resolve to the SAME path (qwen3.6-35b-a3b-gguf/mudler-apex-mtp), so neither was independently deletable -- all three slugs retire together. Entry KEPT (deprecated != deleted). Launchable with --force; c3 --all.",
     ),
     # @laurimyllari's --fit + asymmetric q8_0(K)/q5_0(V) KV config from
     # discussion #241, retuned + measured on 1× 3090. +7% narr / +4% code
@@ -595,6 +599,8 @@ COMPOSE_REGISTRY = {
         compose_path="models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/fit-mtp.yml",
         default_port=8057,
         kvcalc_key="SKIP",
+        status="deprecated",
+        status_note="Retired 2026-08-12: consolidating the mudler-apex surface. ATTENTION this slug was PRODUCTION (not experimental like its three siblings), so this IS a user-visible change: it leaves --list and now needs --force. It is not a DEFAULTS target, and no functional mudler slug remains. Superseded by later quants. WARNING all four mudler slugs resolve to the SAME weights path (qwen3.6-35b-a3b-gguf/mudler-apex-mtp) -- none was independently deletable, which is why they retire together and why the 17 GB is only reclaimable now. Entry KEPT (deprecated != deleted). Launchable with --force; c3 --all.",
     ),
     "ik-llama/apex-mtp-quality-dual": _entry(
         model="qwen3.6-35b-a3b", weights_variant="mudler-apex-quality", workload="long-ctx-single",
@@ -603,8 +609,8 @@ COMPOSE_REGISTRY = {
         compose_path="models/qwen3.6-35b-a3b/ik-llama/compose/dual/mudler-apex-quality/mtp.yml",
         default_port=8055,
         kvcalc_key="SKIP",
-        status="experimental",
-        status_note="APEX-MTP community MoE GGUF — eval-only bring-up lane, not yet validated.",
+        status="deprecated",
+        status_note="Retired 2026-08-12: superseded by later quants, no production role; was already 'experimental' (hidden from --list, --force to launch), so this is a status change with no new user-visible restriction. Weights reclaimed (17 GB). WARNING: mudler-apex-compact and mudler-apex-quality resolve to the SAME path (qwen3.6-35b-a3b-gguf/mudler-apex-mtp), so neither was independently deletable -- all three slugs retire together. Entry KEPT (deprecated != deleted). Launchable with --force; c3 --all.",
     ),
     "llamacpp/hauhaucs-35ba3b-dual": _entry(
         model="qwen3.6-35b-a3b", weights_variant="morikomorizz-q6kp", workload="fast-chat",


### PR DESCRIPTION
Retires six superseded slugs — the two non-default `ubergarm-iq4ks` variants and all four `mudler-apex` variants.

## What does NOT change

⭐ **`ik-llama/iq4ks-mtp` stays `production` and remains the shipped single-card default for `qwen3.6-27b`.** The `DEFAULTS[("qwen3.6-27b", "ik-llama", "single")]` row is untouched, so `ik-llama/default` and the curated `<model>/default` walk resolve exactly as before. No user-facing doc needs to change, and no `--set-default` pin breaks.

That is a deliberate correction to this PR's original scope — see "A rationale I had to retract" below.

## What changes

| Slug | Was | Now | User-visible? |
|---|---|---|---|
| `ik-llama/iq4ks-mtp-vision` | production | 🗑️ deprecated | yes — leaves `--list`, needs `--force` |
| `ik-llama/iq4ks-two-stage` | production | 🗑️ deprecated | yes — leaves `--list`, needs `--force` |
| `ik-llama/apex-fit-q8q5` | **production** | 🗑️ deprecated | yes — leaves `--list`, needs `--force` |
| `ik-llama/apex-mtp-compact` | experimental | 🗑️ deprecated | no — already hidden, already `--force` |
| `ik-llama/apex-mtp-compact-long` | experimental | 🗑️ deprecated | no |
| `ik-llama/apex-mtp-quality-dual` | experimental | 🗑️ deprecated | no |

Every entry is **kept, not deleted** — the slugs still resolve, and the launch-compat / pull-gate tests keep asserting on their hardware fields. All six stay launchable by name with `--force`, and visible in c3 via `--all`.

**Neither retirement is a regression report.** Both ubergarm variants keep their measured results (`iq4ks-two-stage`: code decode ~97.8 vs 72.4 MTP-only, +35%; `iq4ks-mtp-vision`: verify-stress 8/8 @ 160K + 1M-px, recalls to 147K). They are retired to keep the single-card variant set lean, per the compose conventions — three overlapping single-card ik slugs is the case that convention exists to prevent.

## Disk — only the mudler half reclaims anything

⚠️ **Retiring the two ubergarm slugs frees zero bytes.** All three `ubergarm-iq4ks` slugs share **one** GGUF, still in use by the live `iq4ks-mtp`.

**17 GB** is reclaimable from `mudler-apex-mtp`, and only now: `mudler-apex-compact` and `mudler-apex-quality` are two `weights_variant` names resolving to the **same path**, so neither was ever independently deletable — which is why all four mudler slugs had to retire together.

## A rationale I had to retract

This branch originally retired `ik-llama/iq4ks-mtp` too, on the stated grounds that *"the +18% over llamacpp was a power artifact; at matched power ik IQ4_KS is a tie."*

**That is wrong, and it was already known to be wrong.** It restates a 2026-05-22 finding that was itself overturned the next day: a set-and-readback power-cap A/B (4 cells: {ik, mainline} × {230 W, 370 W}) plus 5 independent ik runs showed the *tie* was the artifact — that bench had hit a stale mainline container on the shared port, and its "ik ~50/58" is exactly mainline@370, a number ik produces at no power setting. See [discussions/184](https://github.com/noonghunna/club-3090/discussions/184) and the `BENCHMARKS.md` row.

At matched 370 W, `ik-llama/iq4ks-mtp` measures **59.67 / 68.78** wall (60.39 / 72.40 decode) against `llamacpp/mtp`'s **49.69 / 57.50** — ~18–20% faster, ~0.5–0.8 GB leaner, quality tied (8-pack 107/150), soak PASS, verify-stress 8/8, plus an independent 4090 cross-rig run. Retiring it would have demoted the single-card default to a measurably slower config and orphaned the ⭐ recommendation in eight user-facing docs.

The false rationale had been written into six registry `status_note`s and two compose `Caveats:` blocks; all are rewritten here.

## Two traps worth recording

**A `weights_variant` name is not a weights identity.** Deletability has to be decided on the *resolved path* — two names can share one directory (mudler), and one directory can back three slugs of which only some retire (ubergarm).

**A production slug can hide in a set you believe is uniformly experimental.** Three of the four mudler slugs were `experimental`; `ik-llama/apex-fit-q8q5` was **production** on the same weights. Deleting on the strength of "they're all experimental" would have broken a live config.

## Validation

Full suite green (a status change is a catalog-shape change, so the whole sweep, not a subset) — `test-compose-status-drift` in particular asserts the compose header emoji matches the registry status for all six.

Weights deletion is **not** part of this PR; the 17 GB comes out after it merges.
