### PR TITLE
c3: add [w] downloaded-only catalog filter

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -1249,12 +1249,21 @@ class CatalogPane(Container):
         # [w] gets its OWN hint, not a third bit in the [h] list: it is a
         # separate toggle, so folding it in would tell the user to press h to
         # reveal rows that only w can bring back (#963).
-        abs_n = self._absent_hidden_count()
+        #
+        # The hint renders in BOTH states, which is what makes the toggle
+        # discoverable at all — [h] gets this for free (it always has deprecated
+        # rows to report), but an OFF [w] with nothing on screen is invisible:
+        # there is no way to learn the filter exists without already knowing.
+        #   OFF → "+N not on disk — w"   (an invitation to narrow)
+        #   ON  → "downloaded only (+N hidden) — w"  (state + how to undo)
+        abs_n = self._absent_count_in_pool()
         if self._downloaded_only:
             dep_note += (
                 f"  ·  [dim]downloaded only (+{abs_n} not on disk hidden) — w[/dim]"
                 if abs_n else "  ·  [dim]downloaded only — w[/dim]"
             )
+        elif abs_n:
+            dep_note += f"  ·  [dim]+{abs_n} not on disk — w[/dim]"
         if self._filter or self._model_filter:
             tail = f"  ·  filter: {self._filter!r}" if self._filter else ""
             status_label.update(
@@ -1459,11 +1468,14 @@ class CatalogPane(Container):
         return (getattr(e, "weights_state", "") or "") == WEIGHTS_ABSENT
 
     def _absent_hidden_count(self) -> int:
-        """How many not-downloaded slugs [w] is currently hiding (0 when off).
-        Counted over the SAME pool the filter narrows — i.e. excluding rows
-        already hidden by [h] — so the two hints never double-count one row."""
-        if not self._downloaded_only:
-            return 0
+        """How many not-downloaded slugs [w] is currently HIDING (0 when off)."""
+        return self._absent_count_in_pool() if self._downloaded_only else 0
+
+    def _absent_count_in_pool(self) -> int:
+        """How many not-downloaded slugs are in the [h]-filtered pool, regardless
+        of whether [w] is on.  Counted over the SAME pool the filter narrows — i.e.
+        excluding rows already hidden by [h] — so the two hints never double-count
+        one row.  Drives the hint in BOTH states (see _render_rows)."""
         pool = (
             self._entries
             if self._show_deprecated

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -1041,6 +1041,10 @@ class CatalogPane(Container):
         self._model_filter: str = ""
         # [h] toggle: hide 🗑️ deprecated slugs by default (mirrors `switch.sh --list`).
         self._show_deprecated: bool = False
+        # [w] toggle (#963): narrow to slugs whose weights are already on disk.
+        # OFF by default so the catalog still answers "what COULD I run?" — this
+        # is opt-in for "what can I run right now, without a download?".
+        self._downloaded_only: bool = False
         # Distinct model names (registry order) backing the dropdown — refreshed on load.
         self._models: list[str] = []
         # N3: the slug currently live-serving (from the estate's matched_slug),
@@ -1242,6 +1246,15 @@ class CatalogPane(Container):
             f"  ·  [dim]{' · '.join(_hidden_bits)} hidden — h[/dim]"
             if _hidden_bits else ""
         )
+        # [w] gets its OWN hint, not a third bit in the [h] list: it is a
+        # separate toggle, so folding it in would tell the user to press h to
+        # reveal rows that only w can bring back (#963).
+        abs_n = self._absent_hidden_count()
+        if self._downloaded_only:
+            dep_note += (
+                f"  ·  [dim]downloaded only (+{abs_n} not on disk hidden) — w[/dim]"
+                if abs_n else "  ·  [dim]downloaded only — w[/dim]"
+            )
         if self._filter or self._model_filter:
             tail = f"  ·  filter: {self._filter!r}" if self._filter else ""
             status_label.update(
@@ -1349,6 +1362,16 @@ class CatalogPane(Container):
                 and not self._hw_incompatible(e)
             ]
         )
+        # [w] downloaded-only (#963): an INDEPENDENT narrowing, AND-combined with
+        # the [h] bucket above — the two answer different questions, so neither
+        # subsumes the other. Hides ONLY `absent`; `partial` and `downloading`
+        # stay (bytes exist on disk, and a broken/half download is exactly what
+        # you want visible), and `unknown` stays because it means "we could not
+        # tell" — most often a self-grabbed GGUF that IS present. Hiding on a
+        # guess is the worse failure here: a false hide looks like the slug
+        # vanished from the catalog.
+        if self._downloaded_only:
+            pool = [e for e in pool if not self._weights_absent(e)]
         # Model-scope dropdown first — AND-combined with the text filter below.
         base = (
             [e for e in pool if e.model == self._model_filter]
@@ -1421,6 +1444,36 @@ class CatalogPane(Container):
         now-widened / narrowed set)."""
         self._show_deprecated = not self._show_deprecated
         self._render_rows()
+
+    def toggle_downloaded_only(self) -> None:
+        """[w] show only slugs whose weights are already on disk (#963).  OFF by
+        default.  Re-renders (cursor resets to the top of the narrowed set)."""
+        self._downloaded_only = not self._downloaded_only
+        self._render_rows()
+
+    @staticmethod
+    def _weights_absent(e: CatalogEntry) -> bool:
+        """Weights are known-missing (the ⬇ glyph).  Deliberately NOT true for
+        partial / downloading / unknown — see the [w] filter note in
+        _filtered_entries for why those stay visible."""
+        return (getattr(e, "weights_state", "") or "") == WEIGHTS_ABSENT
+
+    def _absent_hidden_count(self) -> int:
+        """How many not-downloaded slugs [w] is currently hiding (0 when off).
+        Counted over the SAME pool the filter narrows — i.e. excluding rows
+        already hidden by [h] — so the two hints never double-count one row."""
+        if not self._downloaded_only:
+            return 0
+        pool = (
+            self._entries
+            if self._show_deprecated
+            else [
+                e for e in self._entries
+                if (e.status or "").strip().lower() != "deprecated"
+                and not self._hw_incompatible(e)
+            ]
+        )
+        return sum(1 for e in pool if self._weights_absent(e))
 
     @staticmethod
     def _hw_incompatible(e: CatalogEntry) -> bool:
@@ -6627,6 +6680,7 @@ _PALETTE_COMMANDS: tuple[tuple[str, str, str], ...] = (
     ("explain", "Explain selected slug", "Catalog — detail + cross-rig benchmarks"),
     ("filter_catalog", "Filter catalog", "Catalog — filter by slug / engine / status"),
     ("toggle_catalog_deprecated", "Show/hide deprecated", "Catalog — reveal 🗑️ deprecated slugs (hidden by default)"),
+    ("toggle_catalog_downloaded", "Show only downloaded", "Catalog — narrow to slugs whose weights are already on disk"),
     ("copy_endpoint", "Copy the serving API URL", "Run & Operate — copy http://<lan>:<port>/v1 for your agent/client (no auth by default)"),
     ("set_default", "Set default", "Catalog — pin the selected slug as model default"),
     ("clear_default", "Clear default", "Catalog — clear the model default pin"),
@@ -6781,6 +6835,8 @@ class CockpitApp(App):
         Binding("slash", "filter_catalog", "Filter", show=False),
         Binding("backslash", "toggle_catalog_model", "Model", show=False),
         Binding("h", "toggle_catalog_deprecated", "Deprecated", show=False),
+        # #963 — [w] narrow the catalog to slugs whose weights are already on disk.
+        Binding("w", "toggle_catalog_downloaded", "Downloaded", show=False),
         # #724 — [|] catalog column picker (show/hide + reorder, persisted).
         Binding("vertical_bar", "catalog_columns", "Columns", show=False),
         Binding("u", "copy_endpoint", "API URL", show=False),
@@ -6991,6 +7047,7 @@ class CockpitApp(App):
         # Merged mode 0 · Catalog tab
         "filter_catalog":   ({0}, {"tab-catalog"}),  # Catalog
         "toggle_catalog_deprecated": ({0}, {"tab-catalog"}),  # Catalog — [h] hide/show deprecated
+        "toggle_catalog_downloaded": ({0}, {"tab-catalog"}),  # Catalog — [w] downloaded-only (#963)
         # [u] copy the serving API URL — the endpoint is rig-global, so it's
         # live on EVERY merged-mode tab (F3; guards inside the action when
         # nothing is serving).
@@ -9964,6 +10021,14 @@ class CockpitApp(App):
         if self._active_mode == 0 and self._current_subtab() == "tab-catalog":
             try:
                 self.query_one("#catalog-pane", CatalogPane).toggle_deprecated()
+            except Exception:
+                pass
+
+    def action_toggle_catalog_downloaded(self) -> None:
+        """[w] show only slugs whose weights are on disk (merged mode 0 · Catalog)."""
+        if self._active_mode == 0 and self._current_subtab() == "tab-catalog":
+            try:
+                self.query_one("#catalog-pane", CatalogPane).toggle_downloaded_only()
             except Exception:
                 pass
 

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -1191,6 +1191,76 @@ class TestCatalogWired:
             assert single.topology == "single"
 
     @pytest.mark.asyncio
+    async def test_catalog_downloaded_only_filter(self):
+        """#963: [w] narrows the catalog to slugs whose weights are on disk.
+
+        The predicate hides ONLY `absent`.  `partial` and `downloading` have
+        bytes on disk (and a half-finished download is exactly what you want to
+        see), and `unknown` means "couldn't tell" — usually a self-grabbed GGUF
+        that IS present — so hiding those would make rows silently vanish."""
+        from club3090_cockpit.data import (
+            CatalogEntry as _CE,
+            WEIGHTS_ABSENT, WEIGHTS_PRESENT, WEIGHTS_PARTIAL,
+            WEIGHTS_UNKNOWN, WEIGHTS_DOWNLOADING,
+        )
+        from club3090_tui_core import VariantRow as _VR
+
+        def _entry(slug: str, weights_state: str, status: str = "production") -> _CE:
+            cp = "models/m/vllm/compose/dual/q/base.yml"
+            return _CE(
+                row=_VR(
+                    slug=slug, switch_engine="vllm", launch_engine="vllm",
+                    compose_dir=cp.rsplit("/", 1)[0], file="base.yml", port=8000,
+                    model="m", engine="vllm-stable", kvcalc_key="m:dual",
+                    container="c", compose_path=cp, status=status,
+                    ctx_label="262K", status_note="",
+                ),
+                weights_state=weights_state,
+            )
+
+        present = _entry("v/present", WEIGHTS_PRESENT)
+        absent = _entry("v/absent", WEIGHTS_ABSENT)
+        partial = _entry("v/partial", WEIGHTS_PARTIAL)
+        unknown = _entry("v/unknown", WEIGHTS_UNKNOWN)
+        downloading = _entry("v/downloading", WEIGHTS_DOWNLOADING)
+        dep_absent = _entry("v/dep-absent", WEIGHTS_ABSENT, status="deprecated")
+
+        app, _, _ = make_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            pane = app.query_one("#catalog-pane", CatalogPane)
+            pane.populate(
+                [present, absent, partial, unknown, downloading, dep_absent], None
+            )
+
+            # OFF by default — the catalog still answers "what COULD I run?".
+            assert pane._downloaded_only is False
+            assert "v/absent" in {e.slug for e in pane._filtered_entries()}
+            assert pane._absent_hidden_count() == 0
+
+            # ON — only the known-missing row goes.
+            pane.toggle_downloaded_only()
+            got = {e.slug for e in pane._filtered_entries()}
+            assert got == {"v/present", "v/partial", "v/unknown", "v/downloading"}
+            # dep-absent was ALREADY hidden by [h]; it must not be double-counted.
+            assert pane._absent_hidden_count() == 1
+
+            # [w] and [h] are independent and AND-combine: revealing deprecated
+            # must NOT bring back a deprecated row whose weights are absent.
+            pane.toggle_deprecated()
+            got = {e.slug for e in pane._filtered_entries()}
+            assert "v/dep-absent" not in got
+            assert got == {"v/present", "v/partial", "v/unknown", "v/downloading"}
+            # now both absent rows are in the [w] pool → counted.
+            assert pane._absent_hidden_count() == 2
+
+            # toggling back restores everything (idempotent).
+            pane.toggle_downloaded_only()
+            pane.toggle_deprecated()
+            assert pane._downloaded_only is False
+            assert len(pane._filtered_entries()) == 5   # dep-absent hidden by [h]
+
+    @pytest.mark.asyncio
     async def test_catalog_multiword_filter_is_and(self):
         """Round-4 CHANGE 2: a multi-word filter ("gemma dual") is AND-of-substrings
         across the searchable text (slug + topology + engine + model + status +

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -1237,6 +1237,11 @@ class TestCatalogWired:
             assert pane._downloaded_only is False
             assert "v/absent" in {e.slug for e in pane._filtered_entries()}
             assert pane._absent_hidden_count() == 0
+            # ...but the count is still reported while OFF, because that is what
+            # makes the toggle discoverable: the hint renders in BOTH states, the
+            # same way [h] is only findable via its own always-on hint.  An OFF
+            # [w] with nothing on screen cannot be learned about at all.
+            assert pane._absent_count_in_pool() == 1   # v/absent (dep-absent is [h]-hidden)
 
             # ON — only the known-missing row goes.
             pane.toggle_downloaded_only()
@@ -1259,6 +1264,8 @@ class TestCatalogWired:
             pane.toggle_deprecated()
             assert pane._downloaded_only is False
             assert len(pane._filtered_entries()) == 5   # dep-absent hidden by [h]
+            assert pane._absent_hidden_count() == 0     # hiding nothing again
+            assert pane._absent_count_in_pool() == 1    # ...but still advertised
 
     @pytest.mark.asyncio
     async def test_catalog_multiword_filter_is_and(self):


### PR DESCRIPTION
Closes #963.

Adds an opt-in `[w]` filter narrowing the catalog to slugs whose weights are already on disk — so the catalog can answer **"what can I run right now, without a download?"** alongside the **"what could I run?"** it answers today.

**OFF by default**, so the current view is unchanged until you press it.

## The one real decision: what counts as "downloaded"

The predicate hides **only** `weights_state == absent`. Everything else stays:

| state | shown under `[w]`? | why |
|---|---|---|
| `present` | ✅ | the point of the filter |
| `partial` | ✅ | bytes ARE on disk — and a half-finished/wrong download is exactly what you want visible, not hidden |
| `downloading` | ✅ | on disk shortly; hiding an in-flight download would make the row vanish mid-transfer |
| `unknown` | ✅ | means "we couldn't tell" — most often a self-grabbed GGUF that IS present |
| `absent` | ❌ | the only state we actually know is missing |

Hiding on a guess is the worse failure mode: a false hide reads as *the slug disappeared from the catalog*, with no glyph left to explain why. So `[w]` only ever hides what carries the `⬇` glyph.

## How it composes with `[h]`

`[w]` and `[h]` are **independent** and AND-combine — they answer different questions, so neither subsumes the other. Revealing deprecated slugs does **not** bring back a deprecated row whose weights are absent (asserted in the test).

Two details that follow from that:

- The hidden-count is computed over the **same pool the filter narrows** (i.e. excluding rows already hidden by `[h]`), so the two status-line hints never double-count a row.
- `[w]` gets its **own** hint rather than a third bit in the `[h]` list — folding it in would tell the user to press `h` to reveal rows only `w` can bring back.

## Implementation

Mirrors the existing `_show_deprecated` machinery one-for-one: `_downloaded_only` flag → `toggle_downloaded_only()` → `_absent_hidden_count()` → context-scoped action + binding + command-palette entry.

The `[w]` key is shared with `power_cap_sweep`, which is scoped to `tab-doctor` while this is scoped to `tab-catalog`. Context-gated duplicate keys are the established pattern in this app (`k`×4, `d`×3, and `v`/`u`/`r`/`m`/`e` already ×2).


## Discoverability — the part the first cut got wrong

The initial version showed **nothing** until you pressed `w`: the binding is `show=False` (matching `[h]`), and the hint only rendered once the filter was active. There was no way to learn the filter existed without already knowing about it — and #963 asked for something surfaced *alongside the filter*. It was reported as "still can't see it" against a green test suite.

`[h]` is discoverable for free because it always has deprecated rows to report. `[w]` now gets the same treatment — the hint renders in **both** states:

```
… 42 / 58 variants  ·  +9 deprecated hidden — h  ·  +14 not on disk — w
```

| state | hint |
|---|---|
| OFF | `+N not on disk — w` — an invitation to narrow |
| ON | `downloaded only (+N hidden) — w` — state, plus how to undo |

The original tests passed while the feature was unreachable, because they asserted the **predicate** rather than whether anyone could find it. The test now asserts the count is reported while OFF — the property that actually makes it usable.

## Validation

Full c3 suite green — **879 passed** (re-run after the discoverability fix), run from the main checkout (a worktree would have silently tested master's code through the editable install's absolute paths).

New test covers: default-off, each of the five weights states, the `[h]`×`[w]` interaction in both directions, the no-double-count property, and toggle idempotency.