### PR TITLE
Retire all single-card llama.cpp + ik-llama qwen slugs and diffusiongemma

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ bash scripts/launch.sh
 #      bash scripts/launch.sh --variant qwen3.6-27b/default # YOUR default for this model
 #    Or skip the wizard with an explicit config:
 #      bash scripts/launch.sh --variant beellama/dflash     # single-card BLESSED default — code-fast (~100 code / 50 narr TPS), DFlash spec-dec (⚠️ unofficial multi-arch image; sm_89/120 unvalidated — see docs/INFERENCE_ENGINES.md)
-#      bash scripts/launch.sh --variant ik-llama/iq4ks-mtp  # single-card BALANCED alt — ~63/69 TPS, 200K ctx + vision, leanest VRAM (ik_llama IQK quant)
-#      bash scripts/launch.sh --variant llamacpp/default    # single-card cliff-immune ALT — 200K @ -ub 512, ~51/60 TPS
-#      bash scripts/launch.sh --variant llamacpp/mtp-vision # single-card 49K + MTP + vision
+#      bash scripts/launch.sh --variant vllm/minimal       # single-card qwen — the ONLY functional path since 2026-08-12 (32K ctx, no vision, ~32/33 TPS)
+#      # ⚠️ RETIRED 2026-08-12 (all --force-only now): ik-llama/iq4ks-mtp (200K + vision, ~63/69 TPS),
+#      #    llamacpp/default (200K, cliff-immune), llamacpp/mtp-vision. See docs/SINGLE_CARD.md banner.
 #      bash scripts/launch.sh --variant vllm/dual           # dual-card 262K + vision (vLLM single-card paths blocked on #167)
 #    Or partial flags (wizard fills the rest):
 #      bash scripts/launch.sh --model qwen3.6-27b --gpus 0,1
@@ -48,7 +48,7 @@ bash scripts/launch.sh
 #      bash scripts/switch.sh --list          # runnable here
 #      bash scripts/switch.sh --list --all    # everything
 #    Pin your own default so bare `launch.sh` goes straight there:
-#      bash scripts/switch.sh --set-default ik-llama/iq4ks-mtp   # e.g. prefer the balanced ik-llama path over the beellama default; clear: --clear-default qwen3.6-27b
+#      bash scripts/switch.sh --set-default vllm/dual            # e.g. pin a dual-card default; clear: --clear-default qwen3.6-27b
 
 # 4. Sanity test (launcher already printed this curl)
 curl -sf http://localhost:8020/v1/chat/completions \
@@ -82,7 +82,7 @@ c3                                              # launch  (also: python -m club3
 
 **First run:** press **`S`** → set your **Model Dir** (where weights download) + **HuggingFace token** → **`Ctrl+S`** to save; then **`r`** to browse the catalog and serve one. **`c3 --lean`** (or **`[C]`** in-app) hides the producer lane for a consumer-only view. After a `git pull`, re-run the install to pick up new deps + UI changes. Full keybindings + details → [`tools/serve-cockpit/`](tools/serve-cockpit/).
 
-> ⚠️ **Single-card long-context note:** Cliff 2 (GDN prefill OOM at >~50K single-prompt) is **open** on 24 GB single-card vLLM. Genesis v7.72.2 PN59 was intended as the fix but doesn't engage on chunked-prefill. **Workarounds:** [`vllm/dual`](docs/DUAL_CARD.md) (TP=2 escapes it) or [`llamacpp/default`](docs/SINGLE_CARD.md#bulletproof-no-cliffs) (different engine, no cliff). Full diagnosis at [`docs/CLIFFS.md`](docs/CLIFFS.md).
+> ⚠️ **Single-card long-context note:** Cliff 2 (GDN prefill OOM at >~50K single-prompt) is **open** on 24 GB single-card vLLM. Genesis v7.72.2 PN59 was intended as the fix but doesn't engage on chunked-prefill. **Workarounds:** [`vllm/dual`](docs/DUAL_CARD.md) (TP=2 escapes it). ⚠️ The former single-card escape `llamacpp/default` was **retired 2026-08-12** (`--force` only) — on one card there is no longer a cliff-immune qwen path. Full diagnosis at [`docs/CLIFFS.md`](docs/CLIFFS.md).
 
 ---
 

--- a/docs/BRING_YOUR_OWN.md
+++ b/docs/BRING_YOUR_OWN.md
@@ -66,8 +66,9 @@ Copy the one closest to your target engine + topology as a starting point:
 
 | Engine | Single-GPU starting point | Dual-GPU starting point |
 |---|---|---|
-| ik-llama | `ik-llama/iq4ks-mtp` | `ik-llama/apex-mtp-quality-dual` |
-| llama.cpp | `llamacpp/mtp` | (multi-GPU via `--list --all`) |
+| ik-llama | ⚠️ none functional (all slugs `--force` only since 2026-08-12) | ⚠️ none functional |
+| llama.cpp | ⚠️ none functional single-card since 2026-08-12 | `llamacpp/tess-dual-mtp` |
+| vLLM | `vllm/minimal` | `vllm/dual` |
 | beellama | `beellama/dflash` | `beellama/qwen-dflash-dual` |
 
 Then point it at your weights and boot directly — no registry or profile entry

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -24,10 +24,10 @@ vLLM Genesis patches work cleanly on Ada.
 
 **Watch out for the context derate.** A 24 GB 4090 carries more idle desktop + driver VRAM than a headless 3090, so single-card context ceilings land **~15–20% lower**. Observed: `long-text.yml` 180K → 90K, ik two-stage 200K → 160K, `dual-dflash-noviz` 200K → 180K. Start below the 3090 number and verify with `verify-stress.sh` (watch its ceiling VRAM-margin line).
 
-**⚠ UPDATE 2026-07-27: `beellama/dflash` is no longer the default — the beellama engine is retired** (all its slugs deprecated; Anbeeld closed the DFlash VRAM-regression report #98 as won't-fix, and the pin was unmaintained). The single-card walk now resolves to `ik-llama/iq4ks-mtp` automatically, which also takes the Ada gibberish below off the default path. Historical context: beellama's DFlash speculative path returns gibberish (`//////`) on sm_89 — reproduced on a 4090 in [#693](https://github.com/noonghunna/club-3090/issues/693) (the same weights serve fine under mainline llama.cpp and ik-llama on the same rig, so it's the DFlash path, not your setup). Until it's fixed, use **`ik-llama/iq4ks-mtp`** (keeps spec-dec via MTP, which works on Ada) or **`llamacpp/default`**, and pin your choice so `launch.sh` doesn't re-select the broken default:
+**⚠ UPDATE 2026-07-27: `beellama/dflash` is no longer the default — the beellama engine is retired** (all its slugs deprecated; Anbeeld closed the DFlash VRAM-regression report #98 as won't-fix, and the pin was unmaintained). ⚠️ **Superseded 2026-08-12:** `ik-llama/iq4ks-mtp` has itself been retired, along with every llama.cpp single-card qwen slug. The single-card walk now resolves to **`vllm/minimal`** (32K ctx, no vision). The Ada gibberish below is still off the default path. Historical context: beellama's DFlash speculative path returns gibberish (`//////`) on sm_89 — reproduced on a 4090 in [#693](https://github.com/noonghunna/club-3090/issues/693) (the same weights serve fine under mainline llama.cpp and ik-llama on the same rig, so it's the DFlash path, not your setup). Until it's fixed, use **`ik-llama/iq4ks-mtp`** (keeps spec-dec via MTP, which works on Ada) or **`llamacpp/default`**, and pin your choice so `launch.sh` doesn't re-select the broken default:
 
 ```bash
-./scripts/switch.sh --set-default ik-llama/iq4ks-mtp
+./scripts/switch.sh --set-default vllm/minimal   # ik-llama/iq4ks-mtp retired 2026-08-12
 ```
 
 Tracking + status: the beellama row in [`UPSTREAM.md`](UPSTREAM.md).
@@ -387,7 +387,7 @@ There are **two layers of "default"**, with different owners:
 | `<engine>/default` (e.g. `vllm/default`) | the repo's recommended config for that engine, on the detected topology | club-3090 (changes by PR) |
 | `<model>/default` (e.g. `qwen3.6-27b/default`) | **your** preferred way to run that model | **you** (`--set-default`) |
 
-By default `<model>/default` resolves to the *curated* pick — the first engine in `ENGINE_PREFERENCE` for your topology that has a healthy config (single-card Qwen → `ik-llama/iq4ks-mtp`; dual → `vllm/dual`). To make it resolve to **your** choice instead, pin a slug:
+By default `<model>/default` resolves to the *curated* pick — the first engine in `ENGINE_PREFERENCE` for your topology that has a healthy config (single-card Qwen → **`vllm/minimal`** since the 2026-08-12 retirements; dual → `vllm/dual`). To make it resolve to **your** choice instead, pin a slug:
 
 ```bash
 bash scripts/switch.sh --set-default vllm/dual-turbo   # pin (writes .env)
@@ -541,7 +541,7 @@ For a one-off bump: `GENESIS_PIN=<new-commit-sha> bash scripts/setup.sh qwen3.6-
 
 ### My hermes / openhands / OpenCode / Cline / OpenClaw / Cursor session OOMs after a few turns. What do I do?
 
-**Short answer:** route to `bash scripts/switch.sh vllm/dual` (if you have 2× 3090s) or `bash scripts/switch.sh llamacpp/default` (if 1× only). Single-card vLLM is **not safe** for accumulating-context multi-turn agent traffic on Qwen3.6-27B. We validated this 2026-05-03 across all six shipped single-card vLLM composes; only TP=2 and llama.cpp survive cleanly.
+**Short answer:** route to `bash scripts/switch.sh vllm/dual` (if you have 2× 3090s). ⚠️ **The single-card escape is gone as of 2026-08-12** — `llamacpp/default` and every other llama.cpp / ik-llama single-card qwen slug was retired (`--force` only), so on one card there is no longer a cliff-immune qwen path; `vllm/minimal` is functional but is single-card vLLM, which this answer warns about. Single-card vLLM is **not safe** for accumulating-context multi-turn agent traffic on Qwen3.6-27B. We validated this 2026-05-03 across all six shipped single-card vLLM composes; only TP=2 and llama.cpp survive cleanly.
 
 Symptoms users report: "performance degrades after 20 turns", "throughput drops to 0", "engine becomes unresponsive at ~30K tokens", "OOM after 4-5 turns of hermes", `chunk_fwd_o → torch.empty_like(v) → CUDA OOM`. All same root cause — Cliff 2b in [`docs/CLIFFS.md`](CLIFFS.md). Hardware-physical limit; not a tuning issue.
 
@@ -561,9 +561,12 @@ Symptoms users report: "performance degrades after 20 turns", "throughput drops 
 bash scripts/switch.sh vllm/dual    # 111+ TPS p50, 0 errors, 0 MiB growth across 5 sessions
 
 # 1× 3090 — different engine, different kernels, different allocator
-bash scripts/switch.sh llamacpp/default      # 21 TPS, 262K context, cliff-immune, vision
-bash scripts/switch.sh llamacpp/mtp          # ~60 code TPS, 131K, MTP, 7/7 verify-stress (incl. 91K needle)
-bash scripts/switch.sh llamacpp/mtp-vision   # ~66 code TPS, 49K + vision (multimodal MTP — drop UBATCH_SIZE to 512 + raise CTX_SIZE to 196608 if you need long ctx; see SINGLE_CARD.md)
+# ⚠️ ALL THREE RETIRED 2026-08-12 — `--force` only, not in `--list`. Kept for reference:
+bash scripts/switch.sh --force llamacpp/default      # 21 TPS, 262K context, cliff-immune, vision
+bash scripts/switch.sh --force llamacpp/mtp          # ~60 code TPS, 131K, MTP, 7/7 verify-stress (incl. 91K needle)
+bash scripts/switch.sh --force llamacpp/mtp-vision   # ~66 code TPS, 49K + vision
+# Functional single-card qwen path today:
+bash scripts/switch.sh vllm/minimal                  # 32K ctx, no vision, ~32/33 TPS
 ```
 
 **Want to verify your rig hits the same class:**

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -13,7 +13,7 @@ cd club-3090
 bash scripts/setup.sh qwen3.6-27b
 
 # 3. Boot the default config for this model on your hardware
-#    (auto-picks: single-card → ik-llama/iq4ks-mtp; dual → vllm/dual)
+#    (auto-picks: single-card → vllm/minimal; dual → vllm/dual)
 bash scripts/launch.sh --variant qwen3.6-27b/default
 
 # 4. Test it

--- a/docs/QUANTIZATION.md
+++ b/docs/QUANTIZATION.md
@@ -24,11 +24,11 @@ GGUF is the llama.cpp-family weight format. Roughly in order of quality-per-bit 
 | Family | Examples | Calibrated? | Where | Notes |
 |---|---|---|---|---|
 | **Legacy** | `Q4_0`, `Q4_1`, `Q5_0`, `Q8_0` | ❌ | mainline | Simple round-to-nearest, one scale/block. `Q8_0` is still a great near-lossless choice; the low-bit legacy ones are superseded. |
-| **K-quants** | `Q3_K_M`, **`Q4_K_M`**, `Q5_K_M`, `Q6_K` | ❌ (data-free) | mainline | Mixed precision per tensor-type + 2-level block scales. The mainstream default. **`Q4_K_M` is what our shipped `llamacpp/mtp` runs.** Good, but data-free — no calibration. |
+| **K-quants** | `Q3_K_M`, **`Q4_K_M`**, `Q5_K_M`, `Q6_K` | ❌ (data-free) | mainline | Mixed precision per tensor-type + 2-level block scales. The mainstream default. **`Q4_K_M` is what `llamacpp/mtp` ran** (retired 2026-08-12 — `--force` only). Good, but data-free — no calibration. |
 | **i-quants** | `IQ2_XXS` … `IQ3_M`, `IQ4_XS` | ✅ imatrix | mainline | Non-linear lattice codebooks + importance matrix. Clearly better quality-per-bit than k-quants, *especially below 4 bpw*. Slightly slower dequant than k-quants. |
 | **IQK quants** ⭐ | **`IQ4_KS`**, `IQ5_KS`, `IQ4_K`, `IQ2_K` … | ✅ imatrix | **[ik_llama.cpp](engines/IK_LLAMA.md) only** | Refined grids + imatrix + **kernels co-designed for those grids**. Best quality-per-bit in the GGUF world *and* fast (the dequant path is hand-tuned). Fork-exclusive. |
 
-**The progression that matters:** `Q4_K_M` (data-free) → `IQ4_XS` (imatrix, mainline) → `IQ4_KS` (imatrix + co-designed kernels, ik fork). Each step is better quality at similar bpw. Our shipped `llamacpp/mtp` is at the *first* rung (`Q4_K_M`); the [ik_llama track](engines/IK_LLAMA.md) is at the *last* (`IQ4_KS`).
+**The progression that matters:** `Q4_K_M` (data-free) → `IQ4_XS` (imatrix, mainline) → `IQ4_KS` (imatrix + co-designed kernels, ik fork). Each step is better quality at similar bpw. `llamacpp/mtp` sat at the *first* rung (`Q4_K_M`) and the [ik_llama track](engines/IK_LLAMA.md) at the *last* (`IQ4_KS`) — ⚠️ both retired 2026-08-12, so neither ships as a recommended single-card path today.
 
 ---
 

--- a/docs/SINGLE_CARD.md
+++ b/docs/SINGLE_CARD.md
@@ -1,5 +1,29 @@
 # Single 3090 — what fits, how to run it
 
+> ## ⚠️⚠️ RETIREMENT NOTICE — 2026-08-12: this page's recommendations are out of date
+>
+> **Every llama.cpp and ik-llama single-card `qwen3.6-27b` slug was retired on 2026-08-12** —
+> `llamacpp/default`, `llamacpp/mtp`, `llamacpp/mtp-vision`, `llamacpp/bounded-thinking` and
+> `ik-llama/iq4ks-mtp`. They remain launchable with `--force` and visible in c3 via `--all`, but they
+> are **no longer recommended, no longer in `switch.sh --list`, and no longer resolvable as a default**.
+>
+> **The only FUNCTIONAL single-card qwen3.6-27b path is now `vllm/minimal`.** ⚠️ That is a genuine
+> capability drop, not a like-for-like swap:
+>
+> | | retired path | `vllm/minimal` |
+> |---|---|---|
+> | max ctx | **200K** | **32K** |
+> | vision | ✅ `llamacpp/mtp-vision` @150K | ❌ none |
+> | decode | ~60 / ~72 TPS (ik) · ~50 / ~58 (llamacpp) | ~32 / ~33 TPS |
+>
+> `qwen3.6-27b` was also removed from `RECOMMENDED_DEFAULT_MODELS`, so a bare `launch.sh` no longer
+> auto-selects it on a single card.
+>
+> **Everything below this banner still describes the retired configs.** The measurements are real and
+> are kept as the historical record — treat the *recommendations* as superseded, not the numbers.
+> The deeper rewrite of this page is tracked separately.
+
+
 You have **one RTX 3090 (24 GB VRAM)**. This page is the front door for picking a config and knowing what to expect. The model-specific deep dives (quants, Genesis patches, engine internals) live elsewhere — links at the bottom.
 
 > **Model not in the configs below / want any HF safetensors repo?** → [`docs/PULL.md`](PULL.md): `scripts/pull.sh` evaluates any model against the KV math (honest, no download) and boots it if it passes. The curated configs on this page are the measured path; both work.

--- a/docs/WSL_SETUP.md
+++ b/docs/WSL_SETUP.md
@@ -166,8 +166,8 @@ Two WSL2-specific failure modes, both fixed on the **Windows** side, both docume
 Then it's the normal [Quick start](../README.md#quick-start). On a single 24 GB card under WSL2, the **llama.cpp / ik_llama** paths are the most forgiving (no prefill cliffs, smaller VRAM footprint):
 
 ```bash
-bash scripts/launch.sh --variant ik-llama/iq4ks-mtp   # single-card, leanest VRAM — fits WSL2 at defaults
-bash scripts/launch.sh --variant llamacpp/default     # single-card, cliff-immune (drop CTX_SIZE if tight)
+bash scripts/launch.sh --variant vllm/minimal         # single-card qwen — the only functional path since 2026-08-12 (32K, no vision)
+# ⚠️ RETIRED 2026-08-12 (--force only): ik-llama/iq4ks-mtp (leanest VRAM), llamacpp/default (cliff-immune)
 bash scripts/launch.sh --variant vllm/dual            # 2 cards — WSL2 overhead is noise at TP=2
 ```
 
@@ -243,7 +243,7 @@ You still do steps **1–3** (WSL + driver/passthrough + `.wslconfig` RAM) and *
 
 | Hardware | Recommended | Why |
 |---|---|---|
-| 1× 24 GB (3090/4090) | `ik-llama/iq4ks-mtp` (GGUF) | Leanest VRAM — fits at defaults despite the ~1.3 GiB overhead; no prefill cliffs |
+| 1× 24 GB (3090/4090) | `vllm/minimal` | ⚠️ `ik-llama/iq4ks-mtp` (leanest VRAM, no prefill cliffs) was RETIRED 2026-08-12 → `--force` only. `vllm/minimal` is the functional path (32K, no vision). |
 | 1× 24 GB, want vLLM | `vllm/single` + `GPU_MEMORY_UTILIZATION=0.94` `.env` | Full feature stack; needs the WSL2 VRAM + TDR tuning (steps 8–9) |
 | 2× 24 GB | `vllm/dual` | TP=2; the ~1.3 GiB overhead is noise at ~17 GB/card |
 

--- a/docs/engines/IK_LLAMA.md
+++ b/docs/engines/IK_LLAMA.md
@@ -1,5 +1,23 @@
 # ik_llama.cpp — the advanced-quant engine
 
+> ## ⚠️⚠️ ENGINE RETIREMENT NOTICE — 2026-08-12: no FUNCTIONAL ik-llama slug remains
+>
+> `ik-llama/iq4ks-mtp` — this engine's last functional slug — was **retired 2026-08-12**, following
+> `iq4ks-mtp-vision` and `iq4ks-two-stage` earlier the same day. The remaining ik-llama slugs
+> (`ornith9b-single`, `ornith35b-dual`) are `experimental`, i.e. also non-functional.
+>
+> Consequently **`ik-llama` was removed from every `ENGINE_PREFERENCE` walk** — it can no longer
+> resolve a curated default on any topology. Same precedent as the beellama retirement (2026-07-27).
+>
+> Every ik-llama slug stays **launchable by name with `--force`** and visible in c3 via `--all`; the
+> engine profile and image pin are untouched. This is a removal from *automatic recommendation*, not
+> a deletion — and it reverses the moment a functional ik-llama slug ships.
+>
+> **The performance findings below remain accurate and are deliberately preserved** — in particular
+> that IQ4_KS measured ~18–20% faster than `llamacpp/mtp` at matched 370 W. The engine was not retired
+> for being slow; its qwen slugs were retired when the single-card surface consolidated onto vLLM.
+
+
 **Role on this stack:** the engine you reach for when you want **newer, higher-quality-per-bit quants** than mainline llama.cpp ships — specifically the **IQK imatrix family** (`IQ4_KS`, `IQ5_KS`, …) that exists *only* in this fork. It's a llama.cpp fork (ikawrakow), so it inherits llama.cpp's cliff-immune memory model and broad hardware support, then adds a co-designed quant + kernel stack on top.
 
 > **In one line:** llama.cpp's robustness + fork-exclusive IQK quants + fused CUDA kernels → **MTP, clean to 262K on one card, quality on par with `llamacpp/mtp`** (8-pack 103 vs 102), at a **~0.5–0.8 GB leaner VRAM footprint**. It's also **~18–20% faster** than `llamacpp/mtp` on decode TPS at matched 370 W (~60 narr / ~69 code vs ~50 / ~58 on a 3090) — so it's the faster *and* leaner single-card path. The trade is a second engine to maintain + the IQK quant. Full matched-power write-up: [discussions/184](https://github.com/noonghunna/club-3090/discussions/184).

--- a/models/diffusiongemma-26b-a4b/vllm/compose/dual/fp8/base.yml
+++ b/models/diffusiongemma-26b-a4b/vllm/compose/dual/fp8/base.yml
@@ -8,9 +8,16 @@
 #   Vision:    no (text diffusion)
 #   Max ctx:   262144 (NIAH retrieval validated to ~250K)
 #   Genesis:   N/A — Genesis is Qwen3-Next-specific
-#   Status:    🧪 Experimental — runs on STOCK vllm/vllm-openai:v0.24.0 (arch native #45163) +
-#              3 vendored Ampere/TP fix-mounts; under active validation, eager-only.
-#              Launch needs --force (non-functional status).
+#   Status:    🗑️ Deprecated
+#   Caveats:   Retired 2026-08-12 (maintainer decision) — superseded, no
+#              production role. Was already 🧪 Experimental (hidden from --list,
+#              --force to launch), so no NEW user-visible restriction. Sole slug
+#              for diffusiongemma-26b-a4b and no DEFAULTS row, so nothing else
+#              moves. Its fp8 weights resolve to their OWN path
+#              (diffusiongemma-26b-a4b-it-fp8-dynamic, 25.3 GB) — the shared
+#              'fp8' variant NAME is not a shared path, so they are
+#              independently reclaimable.
+#              Still launchable by name with --force, and visible in c3 via --all.
 #   Quality:   8-pack 100/150 (67%) — toolcall 13/15 · instructfollow 13-15/15 ·
 #              structoutput 14/15 · dataextract 10/15 · reasonmath 11/15 ·
 #              bugfind 11/15 · hermesagent-20 14/20 (agentic tool-use works) ·

--- a/models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/mtp.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/mtp.yml
@@ -27,8 +27,19 @@
 #              the ceiling; 210K fills 193K leaving 863 MB — both under the 1024 MB
 #              agent-safety margin. 200000 (≈1131 MB at ceiling) is the safe default. -ub 512 @ 262144
 #              → 21.5 GB if you need the extra ~1 GB back.
-#   Status:    ✅ Production (advanced-quant track, #180). In the wizard +
-#              `bash scripts/switch.sh ik-llama/iq4ks-mtp`.
+#   Status:    🗑️ Deprecated
+#   Caveats:   Retired 2026-08-12 (maintainer decision) — consolidating the
+#              single-card qwen3.6-27b surface onto vLLM. NOT a regression
+#              report: this config's measured results stand.
+#              ⚠️ This removes capability. With every llama.cpp + ik-llama
+#              single-card qwen slug retired, single-card qwen3.6-27b drops to
+#              vllm/minimal: 200K → 32K ctx, single-card vision (mtp-vision
+#              @150K) → none, ~60/72 → ~32/33 TPS. Both DEFAULTS rows
+#              (llamacpp/single, ik-llama/single) were REMOVED, not repointed —
+#              no functional sibling remains in either engine — and
+#              qwen3.6-27b left RECOMMENDED_DEFAULT_MODELS so a bare launch.sh
+#              no longer auto-lands single-card users on a debugging baseline.
+#              Still launchable by name with --force, and visible in c3 via --all.
 #   Perf:      ~18-20% FASTER decode TPS than shipped llamacpp/mtp Q4_K_M
 #              (~60 narr / ~69 code vs ~50/58, at set-and-readback matched 370 W
 #              same card), quality-tied (8-pack 103 vs 102), AND ~0.5-0.8 GB

--- a/models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/bounded-thinking.yml
+++ b/models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/bounded-thinking.yml
@@ -8,7 +8,19 @@
 #   Vision:    no
 #   Template:  native GGUF + --jinja + --reasoning on --reasoning-format deepseek
 #   Max ctx:   200000 default (@ -ub 512, same max-safe fill profile as mtp.yml)
-#   Status:    🧪 Experimental — new structured-CoT port; live grammar + MTP validation pending
+#   Status:    🗑️ Deprecated
+#   Caveats:   Retired 2026-08-12 (maintainer decision) — consolidating the
+#              single-card qwen3.6-27b surface onto vLLM. NOT a regression
+#              report: this config's measured results stand.
+#              ⚠️ This removes capability. With every llama.cpp + ik-llama
+#              single-card qwen slug retired, single-card qwen3.6-27b drops to
+#              vllm/minimal: 200K → 32K ctx, single-card vision (mtp-vision
+#              @150K) → none, ~60/72 → ~32/33 TPS. Both DEFAULTS rows
+#              (llamacpp/single, ik-llama/single) were REMOVED, not repointed —
+#              no functional sibling remains in either engine — and
+#              qwen3.6-27b left RECOMMENDED_DEFAULT_MODELS so a bare launch.sh
+#              no longer auto-lands single-card users on a debugging baseline.
+#              Still launchable by name with --force, and visible in c3 via --all.
 #   Engine-profile: llama-cpp-local
 #   Best for:  bounded-thinking coding/reasoning workloads on the llama.cpp
 #              engine that boots today. Client sends a per-request GBNF grammar.

--- a/models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/mtp-vision.yml
+++ b/models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/mtp-vision.yml
@@ -8,7 +8,19 @@
 #   Vision:    YES (mmproj-F16 mounted — multimodal input enabled)
 #   Max ctx:   150000 (150K) default @ 1M-px images. Higher OOMs at fill — see below.
 #   Genesis:   N/A — llama.cpp engine
-#   Status:    ✅ Production
+#   Status:    🗑️ Deprecated
+#   Caveats:   Retired 2026-08-12 (maintainer decision) — consolidating the
+#              single-card qwen3.6-27b surface onto vLLM. NOT a regression
+#              report: this config's measured results stand.
+#              ⚠️ This removes capability. With every llama.cpp + ik-llama
+#              single-card qwen slug retired, single-card qwen3.6-27b drops to
+#              vllm/minimal: 200K → 32K ctx, single-card vision (mtp-vision
+#              @150K) → none, ~60/72 → ~32/33 TPS. Both DEFAULTS rows
+#              (llamacpp/single, ik-llama/single) were REMOVED, not repointed —
+#              no functional sibling remains in either engine — and
+#              qwen3.6-27b left RECOMMENDED_DEFAULT_MODELS so a bare launch.sh
+#              no longer auto-lands single-card users on a debugging baseline.
+#              Still launchable by name with --force, and visible in c3 via --all.
 #   Engine-profile: llama-cpp-local
 #   Best for:  Multimodal chat, screenshot-debugging, vision-aware code review.
 #              ~51/60 TPS text + vision overhead paid once at image-encode.

--- a/models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/mtp.yml
+++ b/models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/mtp.yml
@@ -10,7 +10,19 @@
 #   Max ctx:   200000 default (@ -ub 512, fills ~183K w/ ~1.1 GB margin); 262144 boots but
 #              walls ~125K (FA scratch at fill — see CTX_SIZE note); 131072 = faster prefill @ -ub 1024
 #   Genesis:   N/A — llama.cpp engine; Genesis is vLLM/Qwen3-Next-specific
-#   Status:    ✅ Production
+#   Status:    🗑️ Deprecated
+#   Caveats:   Retired 2026-08-12 (maintainer decision) — consolidating the
+#              single-card qwen3.6-27b surface onto vLLM. NOT a regression
+#              report: this config's measured results stand.
+#              ⚠️ This removes capability. With every llama.cpp + ik-llama
+#              single-card qwen slug retired, single-card qwen3.6-27b drops to
+#              vllm/minimal: 200K → 32K ctx, single-card vision (mtp-vision
+#              @150K) → none, ~60/72 → ~32/33 TPS. Both DEFAULTS rows
+#              (llamacpp/single, ik-llama/single) were REMOVED, not repointed —
+#              no functional sibling remains in either engine — and
+#              qwen3.6-27b left RECOMMENDED_DEFAULT_MODELS so a bare launch.sh
+#              no longer auto-lands single-card users on a debugging baseline.
+#              Still launchable by name with --force, and visible in c3 via --all.
 #   Engine-profile: llama-cpp-local
 #   Best for:  IDE agents, opencode, Hermes, long-multi-turn agentic — the
 #              speed + ctx workhorse. ~51 narr / ~60 code TPS, 7/7 verify-stress

--- a/scripts/launch.sh
+++ b/scripts/launch.sh
@@ -873,18 +873,24 @@ profile_filter_candidates() {
 suggest_default_variant() {
   local cards="${#CARD_INDICES[@]}"
   if [[ "$MODEL_NAME" == "qwen3.6-27b" ]]; then
+    # ⚠️ 2026-08-12: every llama.cpp + ik-llama single-card qwen slug is deprecated,
+    # so there is no functional llamacpp suggestion left to make here — suggesting
+    # one would hand the user a slug that needs --force. Fall through to vLLM.
     if [[ "$ENGINE" == "llamacpp" ]] || { ! model_has_engine "$MODEL_NAME" "vllm" && model_has_engine "$MODEL_NAME" "llamacpp"; }; then
-      echo "llamacpp/default"
+      echo "vllm/minimal"
     elif (( cards >= 4 )); then
       echo "vllm/dual4"
     elif (( cards >= 2 )); then
       echo "vllm/dual"
     else
-      # Single card: llamacpp/default is the recommended path — full 262K, cliff-immune,
-      # and no purged-nightly dependency. The old vllm/long-text suggestion is dead
-      # (#167 image purge + single-card Cliff 2b); vLLM single-card users can still pick
-      # vllm/tools-text explicitly.
-      echo "llamacpp/default"
+      # Single card: vllm/minimal, as of the 2026-08-12 retirement of every
+      # llama.cpp + ik-llama single-card qwen slug. ⚠️ This is a genuine downgrade
+      # from the llamacpp/default it replaces (32K vs 200K ctx, no vision, ~32 vs
+      # ~50 TPS) — it is the only FUNCTIONAL single-card qwen path left, not a
+      # like-for-like substitute. Revisit if a long-context single-card qwen slug
+      # returns. (Earlier history: the vllm/long-text suggestion died with the #167
+      # image purge + single-card Cliff 2b.)
+      echo "vllm/minimal"
     fi
   elif [[ "$MODEL_NAME" == "qwen3.6-40b-deckard" ]]; then
     # Deckard: only one compose (dual llama.cpp MTP). Dual-only (31 GB > 24 GB).

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -365,6 +365,8 @@ COMPOSE_REGISTRY = {
         compose_path="models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/mtp.yml",
         default_port=8020,
         kvcalc_key="SKIP",
+        status="deprecated",
+        status_note="Retired 2026-08-12 (maintainer decision): consolidating the single-card qwen3.6-27b surface onto vLLM. NOT a regression report -- this slug's measured results stand. WARNING this retirement REMOVES capability: with all llama.cpp + ik-llama single-card qwen slugs gone, single-card qwen3.6-27b drops from 200K ctx (and 150K vision via llamacpp/mtp-vision) to vllm/minimal at 32K with NO vision, ~32/33 TPS vs ~60/72. Both DEFAULTS rows (llamacpp/single, ik-llama/single) are REMOVED, not repointed -- no functional sibling remains in either engine -- and qwen3.6-27b is dropped from RECOMMENDED_DEFAULT_MODELS so a bare launch.sh no longer auto-lands single-card users on a debugging baseline. Entry KEPT (deprecated != deleted). Launchable with --force; c3 --all.",
     ),
     "llamacpp/mtp": _entry(
         model="qwen3.6-27b", weights_variant="unsloth-q4km", workload="fast-chat", chat_template="froggeric",
@@ -373,6 +375,8 @@ COMPOSE_REGISTRY = {
         compose_path="models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/mtp.yml",
         default_port=8020,
         kvcalc_key="SKIP",
+        status="deprecated",
+        status_note="Retired 2026-08-12 (maintainer decision): consolidating the single-card qwen3.6-27b surface onto vLLM. NOT a regression report -- this slug's measured results stand. WARNING this retirement REMOVES capability: with all llama.cpp + ik-llama single-card qwen slugs gone, single-card qwen3.6-27b drops from 200K ctx (and 150K vision via llamacpp/mtp-vision) to vllm/minimal at 32K with NO vision, ~32/33 TPS vs ~60/72. Both DEFAULTS rows (llamacpp/single, ik-llama/single) are REMOVED, not repointed -- no functional sibling remains in either engine -- and qwen3.6-27b is dropped from RECOMMENDED_DEFAULT_MODELS so a bare launch.sh no longer auto-lands single-card users on a debugging baseline. Entry KEPT (deprecated != deleted). Launchable with --force; c3 --all.",
     ),
     "llamacpp/bounded-thinking": _entry(
         model="qwen3.6-27b", weights_variant="unsloth-q4km", workload="tool-heavy",
@@ -381,8 +385,8 @@ COMPOSE_REGISTRY = {
         compose_path="models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/bounded-thinking.yml",
         default_port=8020,
         kvcalc_key="SKIP",
-        status="experimental",
-        status_note="New structured-CoT port; live grammar + MTP validation pending.",
+        status="deprecated",
+        status_note="Retired 2026-08-12 (maintainer decision): consolidating the single-card qwen3.6-27b surface onto vLLM. NOT a regression report -- this slug's measured results stand. WARNING this retirement REMOVES capability: with all llama.cpp + ik-llama single-card qwen slugs gone, single-card qwen3.6-27b drops from 200K ctx (and 150K vision via llamacpp/mtp-vision) to vllm/minimal at 32K with NO vision, ~32/33 TPS vs ~60/72. Both DEFAULTS rows (llamacpp/single, ik-llama/single) are REMOVED, not repointed -- no functional sibling remains in either engine -- and qwen3.6-27b is dropped from RECOMMENDED_DEFAULT_MODELS so a bare launch.sh no longer auto-lands single-card users on a debugging baseline. Entry KEPT (deprecated != deleted). Launchable with --force; c3 --all.",
     ),
     "llamacpp/mtp-vision": _entry(
         model="qwen3.6-27b", weights_variant="unsloth-q4km", workload="vision-coding", chat_template="froggeric",
@@ -394,6 +398,8 @@ COMPOSE_REGISTRY = {
         weights_companions=("gguf_mmproj_f16",),  # mmproj vision projector the compose mounts
         default_port=8020,
         kvcalc_key="SKIP",
+        status="deprecated",
+        status_note="Retired 2026-08-12 (maintainer decision): consolidating the single-card qwen3.6-27b surface onto vLLM. NOT a regression report -- this slug's measured results stand. WARNING this retirement REMOVES capability: with all llama.cpp + ik-llama single-card qwen slugs gone, single-card qwen3.6-27b drops from 200K ctx (and 150K vision via llamacpp/mtp-vision) to vllm/minimal at 32K with NO vision, ~32/33 TPS vs ~60/72. Both DEFAULTS rows (llamacpp/single, ik-llama/single) are REMOVED, not repointed -- no functional sibling remains in either engine -- and qwen3.6-27b is dropped from RECOMMENDED_DEFAULT_MODELS so a bare launch.sh no longer auto-lands single-card users on a debugging baseline. Entry KEPT (deprecated != deleted). Launchable with --force; c3 --all.",
     ),
 
     # ik_llama.cpp — IQ4_KS (ubergarm). Same engine family as llamacpp, but the
@@ -407,6 +413,8 @@ COMPOSE_REGISTRY = {
         compose_path="models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/mtp.yml",
         default_port=8020,
         kvcalc_key="SKIP",
+        status="deprecated",
+        status_note="Retired 2026-08-12 (maintainer decision): consolidating the single-card qwen3.6-27b surface onto vLLM. NOT a regression report -- this slug's measured results stand. WARNING this retirement REMOVES capability: with all llama.cpp + ik-llama single-card qwen slugs gone, single-card qwen3.6-27b drops from 200K ctx (and 150K vision via llamacpp/mtp-vision) to vllm/minimal at 32K with NO vision, ~32/33 TPS vs ~60/72. Both DEFAULTS rows (llamacpp/single, ik-llama/single) are REMOVED, not repointed -- no functional sibling remains in either engine -- and qwen3.6-27b is dropped from RECOMMENDED_DEFAULT_MODELS so a bare launch.sh no longer auto-lands single-card users on a debugging baseline. Entry KEPT (deprecated != deleted). Launchable with --force; c3 --all.",
     ),
     "ik-llama/iq4ks-mtp-vision": _entry(
         status="deprecated",
@@ -883,8 +891,8 @@ COMPOSE_REGISTRY = {
         compose_path="models/diffusiongemma-26b-a4b/vllm/compose/dual/fp8/base.yml",
         default_port=8042,
         kvcalc_key="SKIP",
-        status="experimental",
-        status_note="DiffusionGemma dLLM (vLLM's first) on Ampere via the OFFICIAL vllm/vllm-openai:gemma image (digest-pinned; dgemma arch baked in) + 3 bind-mounted Ampere/TP fixes (marlin-K-pad x2 + diffusion_gemma TP-vocab/dtype) — NOT in :gemma since vLLM tests H100/TP=1. Eager-only, gemma4 tool+reasoning parsers. 262K (NIAH->250K), 8-pack 100/150 (5-pack 84%), ~177/180 TPS typical (peak ~1100 low-entropy). max_new_tokens lifted 256->16384 (the model self-terminates ~1.2-1.8K words; no one-shot 10K). Experimental: visible in --list (NA), launch needs --force. Supersedes the 123-file sideload (PR #358); re-pin+rebase the 3 fixes if :gemma is re-pushed. 2026-06-11.",
+        status="deprecated",
+        status_note="Retired 2026-08-12 (maintainer decision): superseded, no production role. Was already 'experimental' (hidden from --list, --force to launch), so no new user-visible restriction. Sole slug for model diffusiongemma-26b-a4b, no DEFAULTS row, and its fp8 weights resolve to their OWN path (diffusiongemma-26b-a4b-it-fp8-dynamic, 25.3 GB) -- the shared 'fp8' variant NAME is not a shared path, so those weights are independently reclaimable. Entry KEPT (deprecated != deleted). Launchable with --force; c3 --all.",
     ),
     # DEFAULTS: intentionally NOT added — 'experimental' is non-functional, so it
     # degrades out of the curated <model>/default walk; reachable only by explicit
@@ -1287,8 +1295,21 @@ COMPOSE_REGISTRY = {
 DEFAULTS = {
     ("qwen3.6-27b", "vllm", "single"): "vllm/minimal",
     ("qwen3.6-27b", "vllm", "dual"): "vllm/dual",
-    ("qwen3.6-27b", "llamacpp", "single"): "llamacpp/default",
-    ("qwen3.6-27b", "ik-llama", "single"): "ik-llama/iq4ks-mtp",
+    # ("qwen3.6-27b", "llamacpp", "single") and ("qwen3.6-27b", "ik-llama", "single")
+    # REMOVED 2026-08-12 — every llama.cpp and ik-llama single-card qwen slug was
+    # deprecated (maintainer decision: consolidate single-card qwen onto vLLM), so
+    # NEITHER engine has a functional target left. Per the deprecation checklist the
+    # rows are REMOVED rather than repointed: the direct `<engine>/default` lookup
+    # does NOT status-filter, so leaving them would hand users a deprecated slug.
+    # Both now error loudly ("no default for model=qwen3.6-27b engine=…"), which is
+    # the intended degradation. The curated `<model>/default` walk DOES filter, so
+    # ENGINE_PREFERENCE[single] = [ik-llama, llamacpp, vllm] falls through to
+    # vllm/minimal.
+    # ⚠️ That is a real capability drop, not a like-for-like move: 200K → 32K ctx,
+    # single-card vision (llamacpp/mtp-vision @150K) → none, ~60/72 → ~32/33 TPS.
+    # qwen3.6-27b is dropped from RECOMMENDED_DEFAULT_MODELS in the same change so a
+    # bare `launch.sh` does not silently land single-card users on vllm/minimal,
+    # whose own header calls it a debugging baseline / 20 GB Ampere fallback.
     # No vLLM single-card Gemma default: fp8 KV is hardware-impossible on Ampere
     # sm_86 (vllm/gemma-mtp-tp1 deprecated 2026-05-31) and no bf16 single compose
     # ships. Single-card Gemma → beellama/gemma-dflash (the curated walk picks it).
@@ -1330,7 +1351,13 @@ DEFAULTS = {
 #   - New models are NOT auto-added. Adding a model touches nothing here;
 #     promote one explicitly only when desired.
 #   - Order within the (short) list = the tiebreak for "first installed".
-RECOMMENDED_DEFAULT_MODELS = ["qwen3.6-27b", "gemma-4-31b"]
+# ⚠️ qwen3.6-27b REMOVED 2026-08-12 (was first). With all its llama.cpp + ik-llama
+# single-card slugs deprecated, its single-card `<model>/default` resolves to
+# vllm/minimal — 32K ctx, no vision, a self-described debugging baseline. Leaving it
+# first here would make that the bare-`launch.sh` landing spot on any single-card rig.
+# It stays fully runnable by name; it is just no longer auto-selected. Revisit if a
+# functional long-context single-card qwen slug returns.
+RECOMMENDED_DEFAULT_MODELS = ["gemma-4-31b"]
 
 # Which engine wins, per detected topology, when resolving `<model>/default`
 # with no user pin. The resolver walks this list in order and picks the FIRST
@@ -1349,10 +1376,17 @@ RECOMMENDED_DEFAULT_MODELS = ["qwen3.6-27b", "gemma-4-31b"]
 # slugs deprecated — Anbeeld #98 won't-fix upstream DFlash VRAM regression;
 # pin v0.3.2-preview unmaintained). Slugs stay launchable by name with --force.
 # Re-add if the llama-cpp-mainline migration ever revives a beellama build.
+# ⚠️ `ik-llama` REMOVED from every walk 2026-08-12 — same precedent as beellama
+# (2026-07-27). Its last FUNCTIONAL slug was ik-llama/iq4ks-mtp; with that
+# deprecated, every remaining ik-llama slug is non-functional (the ornith pair is
+# `experimental`), so the engine can never resolve a curated default and was pure
+# dead weight at the head of the single-card walk. Its slugs stay launchable by
+# name with --force and visible in c3 via --all — this only removes it from
+# automatic recommendation. Re-add it the moment a functional ik-llama slug ships.
 ENGINE_PREFERENCE = {
-    "single": ["ik-llama", "llamacpp", "vllm"],
-    "dual": ["vllm", "ik-llama", "llamacpp"],
-    "multi": ["vllm", "ik-llama", "llamacpp"],
+    "single": ["llamacpp", "vllm"],
+    "dual": ["vllm", "llamacpp"],
+    "multi": ["vllm", "llamacpp"],
 }
 
 

--- a/scripts/lib/profiles/estate_cli.py
+++ b/scripts/lib/profiles/estate_cli.py
@@ -785,7 +785,9 @@ def wizard_instance(slot: int, gpus: list[GpuInfo], existing: InstanceSpec | Non
     print("[estate] Available composes:")
     for name, entry in sorted(COMPOSE_REGISTRY.items()):
         print(f"  {name:28s} model={entry['model']} tp={entry['tp']} port={entry['default_port']}")
-    default_compose = existing.compose_name if existing else "llamacpp/default"
+    # llamacpp/default was deprecated 2026-08-12 (all single-card qwen llama.cpp +
+    # ik-llama slugs retired); vllm/minimal is the functional single-card fallback.
+    default_compose = existing.compose_name if existing else "vllm/minimal"
     compose = prompt_default("Compose", default_compose)
     if compose not in COMPOSE_REGISTRY:
         raise EstateCliError(f"unknown compose `{compose}`")

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -265,8 +265,14 @@ _preflight_hardware_suggestions() {
     echo "[preflight]   - Single 24 GB card: no functional Gemma-4-31B single config (beellama retired 2026-07-27) — nearest: bash scripts/switch.sh vllm/gemma-12b-single-int8-mtp (12B), or run the 31B dual" >&2
     echo "[preflight]   - On 2x 24 GB cards, use:  bash scripts/switch.sh vllm/gemma-31b-dual" >&2
   fi
-  echo "[preflight]   - On a single 24 GB card, start with:  bash scripts/switch.sh beellama/dflash  (single-card default)" >&2
-  echo "[preflight]   - For maximum compatibility, use:  bash scripts/switch.sh llamacpp/default" >&2
+  # ⚠️ Both suggestions here were stale/dead and are repointed 2026-08-12:
+  #   - beellama/dflash: the beellama engine was RETIRED 2026-07-27 (all 10 slugs
+  #     deprecated) — this line had been advertising a --force-only slug as "the
+  #     single-card default" ever since. Pre-existing bug, fixed here.
+  #   - llamacpp/default: deprecated 2026-08-12 with every other llama.cpp +
+  #     ik-llama single-card qwen slug.
+  # vllm/minimal is now the only FUNCTIONAL single-card qwen path (32K, no vision).
+  echo "[preflight]   - On a single 24 GB card, start with:  bash scripts/switch.sh vllm/minimal  (single-card default; 32K ctx, no vision)" >&2
   echo "[preflight]   - Explicit bypass:  bash scripts/switch.sh --force ${variant:-<variant>}" >&2
 }
 

--- a/scripts/tests/test-default-resolver.sh
+++ b/scripts/tests/test-default-resolver.sh
@@ -48,7 +48,7 @@ assert_contains "$out" "bringing up: vllm/dual"
 # 2026-07-27 beellama retirement — engine removed from every walk);
 # dual → vllm/dual.
 out="$(CLUB3090_FAKE_GPUS="$fake_one" SWITCH=/bin/echo bash scripts/launch.sh --no-preflight --no-verify --no-projection --variant qwen3.6-27b/default 2>&1)"
-assert_contains "$out" "selected variant: ik-llama/iq4ks-mtp"
+assert_contains "$out" "selected variant: vllm/minimal"
 out="$(CLUB3090_FAKE_GPUS="$fake_two" SWITCH=/bin/echo bash scripts/launch.sh --no-preflight --no-verify --no-projection --variant qwen3.6-27b/default 2>&1)"
 assert_contains "$out" "selected variant: vllm/dual"
 # gemma-4-31b/default dual → vllm/gemma-31b-dual (model token overrides PRIMARY_MODEL).

--- a/scripts/tests/test-list-topology-filter.sh
+++ b/scripts/tests/test-list-topology-filter.sh
@@ -44,7 +44,7 @@ assert_not_contains() {
 # Count rows whose slug column matches a topology by grepping for the
 # topology's compose-file path segment in the *visible* listing. We assert on
 # slugs we know are bound to each topology in the shipped registry.
-SINGLE_SLUG="ik-llama/iq4ks-mtp"      # single
+SINGLE_SLUG="vllm/minimal"            # single (ik-llama/iq4ks-mtp retired 2026-08-12)
 DUAL_SLUG="vllm/dual"                 # dual
 # NOTE: multi4 vLLM tier is empty post-#327 (dual4 + dual4-dflash archived); no MULTI_SLUG to assert.
 

--- a/scripts/tests/test-model-default-resolver.sh
+++ b/scripts/tests/test-model-default-resolver.sh
@@ -42,11 +42,13 @@ assert_contains() {
 source "$ROOT_DIR/scripts/lib/registry-emit.sh"
 
 # --- curated walk (no pin) ---------------------------------------------------
-# qwen3.6-27b: single → ik-llama (#1 in ENGINE_PREFERENCE since the 2026-07-27
-# beellama retirement — engine removed from every walk, all its slugs
-# deprecated); dual → vllm; multi4 → vllm.
+# qwen3.6-27b: single → vllm. ⚠️ 2026-08-12: ik-llama was removed from every walk
+# (same treatment as beellama on 2026-07-27) once its last functional slug,
+# ik-llama/iq4ks-mtp, was deprecated; every llama.cpp single-card qwen slug went
+# with it, so llamacpp has no functional single target either. The walk is now
+# ["llamacpp", "vllm"] and lands on vllm/minimal. dual → vllm; multi4 → vllm.
 assert_eq "$(model_default_target "$ROOT_DIR" qwen3.6-27b single 2>/dev/null)" \
-  "ik-llama/iq4ks-mtp" "qwen single curated"
+  "vllm/minimal" "qwen single curated (ik-llama + llamacpp single slugs retired 2026-08-12)"
 assert_eq "$(model_default_target "$ROOT_DIR" qwen3.6-27b dual 2>/dev/null)" \
   "vllm/dual" "qwen dual curated"
 out="$(model_default_target "$ROOT_DIR" qwen3.6-27b multi4 2>&1)"
@@ -78,18 +80,19 @@ assert_eq "$(model_default_target "$ROOT_DIR" gemma-4-31b multi4 2>/dev/null)" \
   "vllm/gemma-31b-dual" "gemmamulti4 degrades to dual slug"
 
 # --- arch-gate: beellama DFlash default steers off non-sm_86 (#693) ----------
-# On sm_8.6 (RTX 3090) the beellama DFlash default is unchanged; on any other
-# DETECTED arch the curated walk skips it (DFlash returns gibberish on Ada) and
-# falls through to the next functional engine. sm empty/unknown → fail-open (so
-# CI / headless keep today's behavior — the 3-arg calls above prove that).
+# ⚠️ Largely MOOT for qwen since 2026-08-12: with ik-llama and llamacpp holding no
+# functional single-card qwen slug, every arch resolves to vllm/minimal, so these
+# rows now assert arch-INVARIANCE rather than a steer. They are kept because the
+# helper itself (warn_if_default_arch_gated) is still live for other models, and
+# because a future functional ik/llamacpp single slug must re-establish the steer.
 assert_eq "$(model_default_target "$ROOT_DIR" qwen3.6-27b single 8.6 2>/dev/null)" \
-  "ik-llama/iq4ks-mtp" "qwen single sm_8.6 → ik-llama (beellama retired; gate moot on-default)"
+  "vllm/minimal" "qwen single sm_8.6 → vllm/minimal (ik-llama retired from the walk 2026-08-12)"
 assert_eq "$(model_default_target "$ROOT_DIR" qwen3.6-27b single 8.9 2>/dev/null)" \
-  "ik-llama/iq4ks-mtp" "qwen single sm_8.9 (Ada) → steers to ik-llama (#693)"
+  "vllm/minimal" "qwen single sm_8.9 (Ada) → vllm/minimal; the #693 ik-llama steer is moot, ik-llama has no functional slug"
 assert_eq "$(model_default_target "$ROOT_DIR" qwen3.6-27b single 12.0 2>/dev/null)" \
-  "ik-llama/iq4ks-mtp" "qwen single sm_12.0 (Blackwell) → steers to ik-llama"
+  "vllm/minimal" "qwen single sm_12.0 (Blackwell) → vllm/minimal"
 assert_eq "$(model_default_target "$ROOT_DIR" qwen3.6-27b single '' 2>/dev/null)" \
-  "ik-llama/iq4ks-mtp" "qwen single sm unknown → ik-llama (no arch gate on the ik default)"
+  "vllm/minimal" "qwen single sm unknown → vllm/minimal"
 # gemma single has no other single default → off-arch degrades to pick-explicitly.
 if model_default_target "$ROOT_DIR" gemma-4-31b single 8.6 >/dev/null 2>&1; then
   note "gemma single sm_8.6 unexpectedly resolved (beellama retired, no functional single)"
@@ -101,9 +104,9 @@ assert_contains "$(model_default_target "$ROOT_DIR" gemma-4-31b single 8.9 2>&1)
   "pick a config explicitly" "gemma single sm_8.9 → pick-explicitly"
 # X/default dispatch threads the sm too.
 assert_eq "$(x_default_dispatch "$ROOT_DIR" qwen3.6-27b/default single qwen3.6-27b 8.9 2>/dev/null)" \
-  "ik-llama/iq4ks-mtp" "qwen/default X-dispatch on sm_8.9 → ik-llama"
+  "vllm/minimal" "qwen/default X-dispatch on sm_8.9 → vllm/minimal"
 assert_eq "$(x_default_dispatch "$ROOT_DIR" qwen3.6-27b/default single qwen3.6-27b 8.6 2>/dev/null)" \
-  "ik-llama/iq4ks-mtp" "qwen/default X-dispatch on sm_8.6 → ik-llama (beellama retired)"
+  "vllm/minimal" "qwen/default X-dispatch on sm_8.6 → vllm/minimal"
 
 # --- helpers: primary_sm_from_gpu_spec + warn_if_default_arch_gated -----------
 assert_eq "$(primary_sm_from_gpu_spec '0|NVIDIA GeForce RTX 4090|24564|8.9;1|x|24564|8.9')" \
@@ -111,23 +114,34 @@ assert_eq "$(primary_sm_from_gpu_spec '0|NVIDIA GeForce RTX 4090|24564|8.9;1|x|2
 assert_eq "$(primary_sm_from_gpu_spec '')" "" "primary_sm_from_gpu_spec empty → empty"
 warn_out="$(warn_if_default_arch_gated "$ROOT_DIR" beellama/dflash 8.9 2>&1 >/dev/null)"
 assert_contains "$warn_out" "arch-gate" "warn fires for beellama/dflash on sm_8.9"
-assert_contains "$warn_out" "ik-llama/iq4ks-mtp" "warn recommends ik-llama for qwen"
+assert_contains "$warn_out" "vllm/minimal" "warn recommends the functional single-card qwen slug"
 assert_contains "$(warn_if_default_arch_gated "$ROOT_DIR" beellama/gemma-dflash 8.9 2>&1 >/dev/null)" \
   "No validated single-card default" "gemma warn → no-fallback message"
 assert_eq "$(warn_if_default_arch_gated "$ROOT_DIR" beellama/dflash 8.6 2>&1)" \
   "" "warn silent for beellama/dflash on sm_8.6 (on-arch)"
-assert_eq "$(warn_if_default_arch_gated "$ROOT_DIR" ik-llama/iq4ks-mtp 8.9 2>&1)" \
+assert_eq "$(warn_if_default_arch_gated "$ROOT_DIR" vllm/minimal 8.9 2>&1)" \
   "" "warn silent for a non-gated slug"
 
 # --- X/default dispatch ------------------------------------------------------
 # engine name → engine recommendation (back-compat).
 assert_eq "$(x_default_dispatch "$ROOT_DIR" vllm/default single qwen3.6-27b 2>/dev/null)" \
   "vllm/minimal" "vllm/default single → vllm/minimal (Genesis tq3-mtp deprecated 2026-05-31)"
-assert_eq "$(x_default_dispatch "$ROOT_DIR" ik-llama/default single qwen3.6-27b 2>/dev/null)" \
-  "ik-llama/iq4ks-mtp" "ik-llama/default engine dispatch"
+# ik-llama/default must now FAIL LOUDLY: every ik-llama qwen slug was deprecated
+# 2026-08-12, and the DIRECT engine lookup does not status-filter — so the row was
+# removed rather than repointed, and this must error instead of handing back a
+# --force-only slug.
+if out="$(x_default_dispatch "$ROOT_DIR" ik-llama/default single qwen3.6-27b 2>&1)"; then
+  fail "ik-llama/default should error (no functional ik-llama single qwen slug), got: $out"
+else
+  # engine_set() = DEFAULTS engines ∪ ENGINE_PREFERENCE engines. Removing ik-llama
+  # from BOTH drops it out of that set, so the token is rejected as unknown rather
+  # than resolving-then-failing. Same shape as beellama/default since 2026-07-27.
+  assert_contains "$out" "is neither a known engine nor a known model" \
+    "ik-llama/default errors after the 2026-08-12 retirement (out of engine_set)"
+fi
 # model-id → model default (model token overrides the passed model).
 assert_eq "$(x_default_dispatch "$ROOT_DIR" qwen3.6-27b/default single qwen3.6-27b 2>/dev/null)" \
-  "ik-llama/iq4ks-mtp" "qwen3.6-27b/default model dispatch"
+  "vllm/minimal" "qwen3.6-27b/default model dispatch"
 # unknown → error, lists both sets.
 if out="$(x_default_dispatch "$ROOT_DIR" bogus/default single qwen3.6-27b 2>&1)"; then
   note "bogus/default unexpectedly resolved to '${out}'"
@@ -148,7 +162,9 @@ PIN=CLUB3090_DEFAULT_QWEN3_6_27B
 ( export "$PIN=ik-llama/prism-pro-dq-dual"
   out="$(model_default_target "$ROOT_DIR" qwen3.6-27b dual 2>&1 1>/dev/null)"
   slug="$(model_default_target "$ROOT_DIR" qwen3.6-27b dual 2>/dev/null)"
-  assert_contains "$out" "(NA: experimental)" "(NA) pin warns"
+  # prism-pro-dq-dual is `deprecated` (since #956), not `experimental` — this
+  # assertion was stale on master and failed there independently of this change.
+  assert_contains "$out" "(NA: deprecated)" "(NA) pin warns"
   assert_eq "$slug" "vllm/dual" "(NA) pin falls back to curated" )
 # wrong-model pin → warn + fall back.
 ( export "$PIN=vllm/gemma-bf16-mtp"
@@ -161,7 +177,7 @@ PIN=CLUB3090_DEFAULT_QWEN3_6_27B
   out="$(model_default_target "$ROOT_DIR" qwen3.6-27b single 2>&1 1>/dev/null)"
   slug="$(model_default_target "$ROOT_DIR" qwen3.6-27b single 2>/dev/null)"
   assert_contains "$out" "this rig is single" "topology-mismatch pin warns"
-  assert_eq "$slug" "ik-llama/iq4ks-mtp" "topology-mismatch pin falls back to single curated" )
+  assert_eq "$slug" "vllm/minimal" "topology-mismatch pin falls back to single curated" )
 # unknown-slug pin → warn + fall back.
 ( export "$PIN=vllm/nope"
   out="$(model_default_target "$ROOT_DIR" qwen3.6-27b dual 2>&1 1>/dev/null)"

--- a/scripts/tests/test-setup-picker.sh
+++ b/scripts/tests/test-setup-picker.sh
@@ -200,8 +200,8 @@ mkdir -p "${TMP_DIR}/models/qwen3.6-27b-gguf"
 out="$(MODEL_DIR="${TMP_DIR}/models" CLUB3090_FAKE_GPUS='0:RTX_3090:24576:8.6' \
   SWITCH="${TMP_DIR}/switch-mock" bash "${ROOT_DIR}/scripts/launch.sh" \
   --no-preflight --no-verify --model qwen3.6-27b --gpus 0 --stable --no-projection 2>&1)"
-assert_contains "$out" "[launch] selected variant: llamacpp/default"
-assert_contains "$out" "SWITCHED llamacpp/default CUDA=0 NVD=0 TP=1 PP=1"
+assert_contains "$out" "[launch] selected variant: vllm/minimal"
+assert_contains "$out" "SWITCHED vllm/minimal CUDA=0 NVD=0 TP=1 PP=1"
 
 if out="$(MODEL_DIR="${TMP_DIR}/models" CLUB3090_FAKE_GPUS='0:RTX_3090:24576:8.6' \
   SWITCH="${TMP_DIR}/switch-mock" bash "${ROOT_DIR}/scripts/launch.sh" \


### PR DESCRIPTION
Consolidates the single-card `qwen3.6-27b` surface onto vLLM, and retires the sole diffusiongemma slug.

## What's retired

| Slug | Was | User-visible? |
|---|---|---|
| `llamacpp/default` | production | yes — leaves `--list`, needs `--force` |
| `llamacpp/mtp` | production | yes |
| `llamacpp/mtp-vision` | production | yes |
| `llamacpp/bounded-thinking` | experimental | no — already hidden |
| `ik-llama/iq4ks-mtp` | production | yes |
| `vllm/diffusiongemma-dual` | experimental | no — already hidden |

All entries are **kept, not deleted**: the slugs still resolve, the launch-compat tests keep asserting on their hardware fields, and every one stays launchable with `--force` and visible in c3 via `--all`.

## ⚠️ This removes capability — read before merging

This is **not** a like-for-like consolidation. Single-card `qwen3.6-27b` becomes `vllm/minimal`:

| | retired path | `vllm/minimal` |
|---|---|---|
| max ctx | **200K** | **32K** |
| vision | ✅ `mtp-vision` @150K | ❌ none |
| decode | ~60 / ~72 (ik) · ~50 / ~58 (llamacpp) | ~32 / ~33 |
| cliff-immunity | ✅ llama.cpp has no GDN prefill cliff | ❌ single-card vLLM — Cliff 2 applies |

That last row is the one to weigh. `docs/FAQ.md` routed accumulating-context agent traffic to `llamacpp/default` *precisely because* single-card vLLM is unsafe past ~21–26K accumulated context (Cliff 2b). **After this, there is no single-card escape from that cliff for this model.**

**None of these slugs regressed.** `iq4ks-mtp`'s ~18–20% matched-power lead, `mtp-vision`'s 8/8 verify-stress at 160K — all still stand and stay in `BENCHMARKS.md`. This is a catalog-surface decision, not a quality verdict.

## Structural consequences

**Both `DEFAULTS` rows REMOVED, not repointed** (`llamacpp/single`, `ik-llama/single`) — no functional sibling exists in either engine. The direct `<engine>/default` lookup does **not** status-filter, so repointing would have handed users a `--force`-only slug. Both now error loudly; the curated `<model>/default` walk *does* filter and lands on `vllm/minimal`.

**`ik-llama` removed from every `ENGINE_PREFERENCE` walk.** `iq4ks-mtp` was its **last functional slug** (the ornith pair is `experimental`), so the engine could never resolve a curated default — it was dead weight at the head of the single-card walk. Same precedent as the beellama retirement (2026-07-27).

> Behavioural note: `engine_set()` is built from `DEFAULTS` ∪ `ENGINE_PREFERENCE`, so `ik-llama/default` now fails as an **unknown token** ("neither a known engine nor a known model") rather than "no default". That's identical to `beellama/default` since its own retirement — consistent, though arguably a worse message for an engine that still has `--force`-able slugs.

**`qwen3.6-27b` dropped from `RECOMMENDED_DEFAULT_MODELS`**, so a bare `launch.sh` no longer auto-lands single-card users on `vllm/minimal` — whose own header calls it a *"debugging baseline / 20 GB Ampere fallback"*. `gemma-4-31b` is now the sole entry. The model stays fully runnable by name.

**llama.cpp keeps only its DUAL qwen slugs** (`tess-dual-mtp`, `deckard40B-dual-mtp`).

## diffusiongemma — clean, and a near-miss worth recording

One slug, already experimental, no `DEFAULTS` row, so nothing moves. Its **25.3 GB is independently reclaimable** — but note its `weights_variant` is named `fp8`, the *same name* three live qwen slugs use. The name is not the identity: it resolves to `diffusiongemma-26b-a4b-it-fp8-dynamic` while qwen's resolves to `qwen3.6-27b-fp8`. Deleting on the shared **name** would have destroyed live qwen weights; deleting on the resolved **path** is safe.

## Two pre-existing bugs fixed in passing

- **`preflight.sh` still advertised `beellama/dflash` as "the single-card default"** — that engine was retired 2026-07-27, so it had been recommending a `--force`-only slug for weeks. Found because the retirement touched the same block.
- **A stale assertion in `test-model-default-resolver`** (`prism-pro-dq-dual` is `deprecated`, not `experimental`) — verified failing on `master` independently of this branch.

## Docs — correctness-only pass

Retirement banners on `SINGLE_CARD.md` and `engines/IK_LLAMA.md` (both are guides whose every recommendation is now `--force`-only), and repointed the **active routing advice** in `README`, `GETTING_STARTED`, `FAQ`, `QUANTIZATION`, `WSL_SETUP`, `BRING_YOUR_OWN`.

Measurement tables, benchmark history and prose are deliberately **left intact** — the numbers are real and remain the historical record; only the *recommendations* are superseded. A deeper restructure of `SINGLE_CARD.md` (33 slug references) and the two SVG charts is tracked separately.

## Validation

Full suite green — **102/102**. Four fixtures hard-asserted the old slugs and were updated; they are hand-written, so only running the suite reveals them.

Resolver verified by hand: `qwen3.6-27b/default single` → `vllm/minimal`; `ik-llama/default` and `llamacpp/default` both error.
