### PR TITLE
residency: split the drafter out of the static reserve (#953)

### DIFF
--- a/models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-q8-kxl/offload.yml
+++ b/models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-q8-kxl/offload.yml
@@ -72,13 +72,37 @@
 #   0 = no dense prefix on this model (all 43 layers are MoE). Models WITH one
 #   (Laguna=1, Inkling=2) must set it: a residency rule naming a dense layer
 #   silently matches nothing, so fewer layers land resident than we granted.
-# CPU-Offload-GPU-Reserve-MiB: 18000
-#   Inputs for resolve_offload_residency(). RESERVE = this compose's true
-#   per-card engine cost (dense split + drafter half + compute buffers + KV).
-#   Sizing is additive from DETECTED FREE VRAM (#931 recalibration):
-#     fit = (free − reserve − first-card-extra − margin) / bundle
-#   This value survived the re-derivation unchanged (grants 1/card on 2x24 GB,
-#   the field-validated count). No ×0.55 is applied any more.
+# CPU-Offload-GPU-Reserve-MiB: 11432
+# CPU-Offload-Draft-Reserve-MiB: 8154
+# CPU-Offload-First-Card-Extra-MiB: 444
+#   Inputs for resolve_offload_residency(). Sizing is additive from DETECTED
+#   FREE VRAM (#931 recalibration):
+#     fit = (free − reserve − draft-reserve − first-card-extra − margin) / bundle
+#
+#   ⚠️ RECALIBRATED 2026-08-12 FROM MEASUREMENT (#953). The previous single
+#   constant was 18000, documented as covering "dense split + drafter half +
+#   compute buffers + KV". It could not: the drafter loads AFTER the launcher
+#   resolves residency, so free VRAM is read before ~8-9 GB of draft model
+#   allocates. Measured on 2x3090 (this compose, same session, only residency
+#   varied):
+#     grant 0+0 (forced): 20030 / 19586 MiB used   <- TRUE per-card cost
+#     grant 1+1 (as shipped): 23280 / 22838 used, 845 / 1287 free
+#     delta 3250 / 3252 vs a 3264 MiB bundle -> the bundles DID place
+#   So the grant was honoured, and the failure was quieter than "experts stay on
+#   CPU": card 0 ended at 845 MiB free, BELOW the 1024 MiB margin the model is
+#   meant to guarantee and below the 896 MiB that survived a 188K prefill ladder
+#   in #931 (556 MiB died at ~90K). The sizer was silently spending its own
+#   safety margin, which is a deep-prefill OOM risk on exactly the config whose
+#   header already documents a 262K prefill OOM.
+#
+#   The three terms now mean what they say and reproduce the measurement:
+#     reserve      11432  drafter-FREE per-card base (dense split + buffers + KV)
+#     draft        8154   the smaller drafter half (card 1)
+#     first-card   444    card 0's measured excess (20030 − 19586)
+#   -> grants 0 on card 0, 1 on card 1 on 2x24 GB. Asymmetric because card 1
+#      carries the smaller drafter half and takes no first-card extra; a fix that
+#      simply zeroed residency whenever a drafter is present would leave card 1's
+#      bundle on the table.
 # ===========================================================================
 
 services:

--- a/scripts/lib/compose-meta.sh
+++ b/scripts/lib/compose-meta.sh
@@ -371,9 +371,22 @@ compose_hw_model_status() {
 #    worth +19% decode — #931). The overhead it absorbed is ADDITIVE (dense split
 #    + drafter half + compute buffers + KV don't scale with card size), so the
 #    model now subtracts it explicitly:
-#      reserve           per-compose header (true per-card engine cost)
+#      reserve           per-compose header (true per-card engine cost, DRAFTER-FREE)
+#      draft_reserve     per-card VRAM the DRAFT MODEL will take (default 0 — see below)
 #      first_card_extra  card 0 carries the larger drafter half + compute buffer
 #                        (measured 660 MiB on 2x5090; default 768)
+#
+#    ⚠️ WHY draft_reserve IS ITS OWN TERM (#953). `reserve` is a STATIC per-compose
+#    constant, and it used to be documented as already covering the "drafter half".
+#    It cannot: the drafter loads AFTER this resolves, so FREE_i is read before the
+#    draft model allocates, and a static number set before that cost was measured
+#    silently understates it. On DeepSeek-Flash-Q8 (2x24 GB) the constant said
+#    18000 MiB while the true per-card cost measured 19586-20028 — which is exactly
+#    enough to flip fit from 0 to 1 on card 0. The sizer then granted a bundle the
+#    engine could not place, and the experts silently stayed on CPU while the RAM
+#    gate priced a bundle that never landed.
+#    Defaults to 0, so every compose WITHOUT the header is bit-identical to before
+#    and the #931 calibration points keep reproducing untouched.
 #      margin            deep-prefill spike headroom. #931 brackets it: a card at
 #                        556 MiB free DIED on a ~90K prefill; 896 MiB survived a
 #                        full 188K NIAH ladder. Default 1024 (RESIDENCY_MARGIN_MB).
@@ -485,6 +498,14 @@ resolve_offload_residency() {
   [[ "$first" =~ ^[0-9]+$ ]] || first=0
   local extra; extra="$(compose_meta_get "$compose_file" cpu-offload-first-card-extra-mib || true)"
   [[ "$extra" =~ ^[0-9]+$ ]] || extra=768
+  # Per-card DRAFT-MODEL VRAM (#953). 0 when absent => no behaviour change for any
+  # compose that does not declare it. Overridable for A/B via RESIDENCY_DRAFT_MB.
+  local draft; draft="$(compose_meta_get "$compose_file" cpu-offload-draft-reserve-mib || true)"
+  [[ "$draft" =~ ^[0-9]+$ ]] || draft=0
+  # ⚠️ plain `if`, NOT `[[ ]] && assign`: the latter returns non-zero when the
+  # condition is false, and every caller runs under `set -e` — that aborts the
+  # launcher mid-resolve. Same trap documented in preflight.sh.
+  if [[ "${RESIDENCY_DRAFT_MB:-}" =~ ^[0-9]+$ ]]; then draft="$RESIDENCY_DRAFT_MB"; fi
 
   local -a frees=()
   while read -r m; do [[ "$m" =~ ^[0-9]+$ ]] && frees+=("$m"); done \
@@ -495,7 +516,7 @@ resolve_offload_residency() {
   local per_card=$(( layers / n ))
   local i fit rule var applied="" res_i
   for (( i=0; i<n; i++ )); do
-    res_i=$(( reserve + (i == 0 ? extra : 0) ))
+    res_i=$(( reserve + draft + (i == 0 ? extra : 0) ))
     # An explicit OT_G<i> from the user/env ALWAYS WINS and is never clobbered —
     # same contract as THREADS (resolve_offload_threads). This is the supported
     # way to pin more residency than the sizer grants (the grant is deliberately
@@ -571,6 +592,14 @@ offload_residency_grant_mib() {
   [[ "$first" =~ ^[0-9]+$ ]] || first=0
   local extra; extra="$(compose_meta_get "$compose_file" cpu-offload-first-card-extra-mib || true)"
   [[ "$extra" =~ ^[0-9]+$ ]] || extra=768
+  # Per-card DRAFT-MODEL VRAM (#953). 0 when absent => no behaviour change for any
+  # compose that does not declare it. Overridable for A/B via RESIDENCY_DRAFT_MB.
+  local draft; draft="$(compose_meta_get "$compose_file" cpu-offload-draft-reserve-mib || true)"
+  [[ "$draft" =~ ^[0-9]+$ ]] || draft=0
+  # ⚠️ plain `if`, NOT `[[ ]] && assign`: the latter returns non-zero when the
+  # condition is false, and every caller runs under `set -e` — that aborts the
+  # launcher mid-resolve. Same trap documented in preflight.sh.
+  if [[ "${RESIDENCY_DRAFT_MB:-}" =~ ^[0-9]+$ ]]; then draft="$RESIDENCY_DRAFT_MB"; fi
 
   local -a frees=()
   local m
@@ -583,7 +612,7 @@ offload_residency_grant_mib() {
   local i fit rule total_mib=0 var ucount res_i
   local -a lays
   for (( i=0; i<n; i++ )); do
-    res_i=$(( reserve + (i == 0 ? extra : 0) ))
+    res_i=$(( reserve + draft + (i == 0 ? extra : 0) ))
     # A user-set OT_G<i> is what will ACTUALLY be pinned (the injector never
     # clobbers it) — price ITS layer count, not the auto fit, so the gate and
     # the boot describe the same config. First hit in the wild: a 123 GB box


### PR DESCRIPTION
Closes #953. Boot-validated on 2× 3090.

## ⚠️ First: #953's stated mechanism is refuted

Booted this compose three ways in one session, only residency varied:

| arm | card 0 used | card 1 used | free |
|---|--:|--:|---|
| grant 1+1 (as shipped) | **23,280** | **22,838** | 845 / 1,287 |
| grant 0+0 (forced via `RESIDENCY_MARGIN_MB`) | 20,030 | 19,586 | 4,095 / 4,539 |
| **delta** | **3,250** | **3,252** | bundle = 3,264 |

⇒ **the bundles DID place.** *"The sizer grants 1/card; the engine cannot honour it; experts silently stay on CPU"* is not what happens.

The issue's own arithmetic already implied it — `10,920 + 9,108 + 3,252 = 23,280` and `11,432 + 8,154 + 3,252 = 22,838`, both exact. The bundle was inside the as-shipped totals all along.

(The as-shipped row is also a clean cross-rig reproduction: byte-identical to the figures reported from different hardware.)

## The real defect is quieter, and worse

Card 0 boots with **845 MiB free**. The model exists to leave `RESIDENCY_MARGIN_MB` (default **1024**) for deep-prefill spikes — so the sizer was **silently spending its own safety margin**. #931 brackets the cost: **556 MiB died** on a ~90K prefill; **896 MiB survived** a 188K NIAH ladder. 845 sits between them, nearer the fatal end — on a config whose header already documents a 262K prefill OOM.

So this is not *"residency quietly does nothing"* (harmless) but *"residency quietly removes the OOM guard"* (a latent crash at depth). That is why it's worth fixing even though nothing visibly broke.

## Cause

`CPU-Offload-GPU-Reserve-MiB: 18000` was a **static** constant documented as covering the *"drafter half"*. It cannot: the drafter loads **after** the launcher resolves residency, so `FREE_i` is read before ~8–9 GB of draft model allocates. The forced-zero arm measures true per-card cost at **20,030 / 19,586** — understating by ~2 GB, exactly enough to flip `fit` from 0 to 1 on card 0.

## Fix — calibrated from the measurement, not reasoned

| term | value | meaning |
|---|--:|---|
| `CPU-Offload-GPU-Reserve-MiB` | 11,432 | drafter-**free** per-card base |
| `CPU-Offload-Draft-Reserve-MiB` *(new)* | 8,154 | smaller drafter half (card 1) |
| `CPU-Offload-First-Card-Extra-MiB` | 444 | card 0's measured excess (20,030 − 19,586) |

`draft_reserve` **defaults to 0**, so every compose that doesn't declare it is bit-identical and the #931 calibration points (IQ2 7+8 on 2×32, Q8-multi4 2/card, 0 on 16 GB) reproduce untouched. Applied at **both** call sites — the residency injector *and* the RAM gate — so they can never disagree about how many bundles a card holds.

## Boot-validated

| card | before | after |
|---|--:|--:|
| 0 free | 845 ⚠️ | **4,101** ✅ |
| 1 free | 1,287 | **1,281** ✅ — bundle still placed (22,844 − 19,586 = 3,258) |

`verify-full` **all-pass** on the fixed config.

⭐ The honest grant is **asymmetric — 0 on card 0, 1 on card 1**. Card 1 genuinely has room: it carries the smaller drafter half and takes no first-card extra. A fix that simply zeroed residency whenever a drafter is present would have thrown that legitimate bundle away.

## Two things found while validating

**The grant is knife-edge on transient free VRAM.** Immediately after a container stops, `nvidia-smi` reported 23,805 MiB free and the sizer granted **0+0**; once settled at 24,123 it granted **0+1**. ~300 MiB of *timing* flips the result. Sizing from live free VRAM is the right design — it makes desktops and other consumers fall out automatically — but it means **residency is only reproducible when the GPUs are idle at resolve time**. Probably deserves its own issue and a docs line.

**A `set -e` hazard in my own first draft:** `[[ cond ]] && assign` returns non-zero when the condition is false, which aborts every caller (all run under `set -euo pipefail`). Rewritten as a plain `if` and proven under `set -e` — the same trap already documented in `preflight.sh`.

## Not available: moving the drafter off-GPU

The obvious alternative — reclaim the ~9 GB by relocating the draft model — is blocked by [ggml-org/llama.cpp#26475](https://github.com/ggml-org/llama.cpp/issues/26475) (our #954): a draft model alone on its device crashes speculative init, and the one workaround is reported upstream as *"a massive slow down"*. Tracked in `docs/UPSTREAM.md`.

## Validation

Full suite green — **102/102**, plus `test-preflight-cpu-offload` and `test-offload-matrix-static` individually.
