### PR TITLE
Gate the moe-cache DeepSeek slugs: they had no host-RAM header

### DIFF
--- a/models/deepseek-v4-flash-0731/llamacpp-club3090/compose/dual/unsloth-q8-kxl/moecache.yml
+++ b/models/deepseek-v4-flash-0731/llamacpp-club3090/compose/dual/unsloth-q8-kxl/moecache.yml
@@ -42,7 +42,11 @@
 #                at 262K with a GPU-resident drafter), but costs ~8% decode and
 #                445 expert slots, and this model is PREFILL-BOUND at depth.
 #                Set CTX=262144 only if you genuinely need it.
-#              • Needs ~140 GB of HOST RAM (experts live in CPU memory). Hard gate.
+#              • Needs ~156 GB of HOST RAM — a HARD gate, and ~10 GB MORE than
+#                the stock Q8 slug because `-devd none` moves the 10.1 GiB
+#                drafter off the GPU and into host memory. preflight REFUSES
+#                below it; see the CPU-Offload-Host-RAM-GB block near the
+#                bottom of this header for the measured arithmetic.
 #              • Load takes ~8-10 min (--no-mmap).
 #   Quality:   toolcall-15 13/15 (87%) · instructfollow-15 15/15 (100%)
 #              · structoutput-15 14/15 (93%) · dataextract-15 12/15 (80%)
@@ -69,6 +73,35 @@
 #   are DIAGNOSTICS ONLY — three times on this stack a config improved every
 #   cache counter and got slower. Tune on wall-clock.
 # ---------------------------------------------------------------------------
+#
+# CPU-Offload-Host-RAM-GB: 156
+#   ⚠️ HIGHER than the stock Q8 sibling's 146, and the delta IS THE DRAFTER:
+#   `-devd none` puts the DSpark model in HOST memory where the stock slug keeps
+#   it in VRAM. Same weights, different host bill — do not copy 146 over.
+#   MEASURED (2×3090, `--no-mmap`, all 43 expert layers → CPU):
+#       experts    141362.00 MiB   load_tensors: CUDA_Host model buffer size
+#     + drafter     10386.28 MiB   same line, second model (CPU-pinned)
+#     = pinned     151748.28 MiB = 148.19 GiB   <- the HARD floor
+#     + ~8 GiB     process overhead: CUDA_Host compute/output buffers, CPU FFN
+#                  scratch, CUDA host allocations. Measured on this model as
+#                  147 GiB used vs 138.05 GiB pinned; it is also the constant
+#                  both stock headers already carry (141362 MiB→146, 80268→86).
+#     = 156.
+#   ⚠️ HARD floor, not a recommendation. `--no-mmap` makes the loader
+#   `cudaMallocHost` the whole offloaded set: pinned pages are non-evictable and
+#   cannot be oversubscribed, so a short box does not degrade — it dies inside
+#   `cudaMallocHost`, which presents as "loads the model into RAM, then fails to
+#   load". With mmap the same bytes would be file-backed and evictable, and this
+#   number would be a recommendation instead.
+#   ⚠️ NO residency headers here, DELIBERATELY. This compose's `-ot` is an
+#   unconditional all-experts→CPU catch-all with no ${OT_G*} slots, so the
+#   launcher never pins bundles back onto the GPUs and the gate must NOT
+#   subtract a grant — offload_residency_grant_mib() returns 0 without
+#   CPU-Offload-Bundle-MiB, which is the correct answer here. Adding those
+#   headers would under-gate every rig. And the expert cache does not help:
+#   it is a VRAM-side COPY, so the CPU master buffer stays fully allocated
+#   (the 141362 MiB line above is from a cache-ENABLED boot).
+# ===========================================================================
 services:
   llama-cpp-deepseek-flash-q8-moecache:
     # Digest-pinned, not tag-pinned: tags move, digests do not (#940 precedent).

--- a/models/deepseek-v4-flash-0731/llamacpp-club3090/compose/multi4/unsloth-q8-kxl/moecache.yml
+++ b/models/deepseek-v4-flash-0731/llamacpp-club3090/compose/multi4/unsloth-q8-kxl/moecache.yml
@@ -37,7 +37,14 @@
 #                expert pool fills. Do not benchmark it.
 #              • `-devd none` is LOAD-BEARING: with the drafter GPU-resident the
 #                cache records ZERO hits (shared-draft device-list reorder).
-#              • Needs ~140 GB of HOST RAM. Hard gate.
+#              • Needs ~156 GB of HOST RAM — a HARD gate, and it does NOT fall
+#                with card count the way the stock multi4 slug's does: that one
+#                pins expert bundles back onto the GPUs, this one keeps all 43
+#                layers on CPU unconditionally and adds the 10.1 GiB drafter to
+#                host memory as well. A 128 GB box CANNOT run this slug — use
+#                the stock 4-card offload slug (llamacpp/deepseek-flash-multi4-q8)
+#                instead, ~120 GB on a real 4×24. Arithmetic in the
+#                CPU-Offload-Host-RAM-GB block below.
 #   Best for:  Decode-heavy DeepSeek serving on 4 cards — PENDING VALIDATION. ⭐
 # ---------------------------------------------------------------------------
 # WHY THIS EXISTS
@@ -48,6 +55,33 @@
 #   rates has repeatedly been SLOWER. Treat the dual numbers as a hypothesis
 #   for this topology, not a prediction.
 # ---------------------------------------------------------------------------
+#
+# CPU-Offload-Host-RAM-GB: 156
+#   ⚠️ IDENTICAL to the dual moe-cache sibling, and that is the POINT: unlike
+#   the stock multi4 slug, host RAM here does NOT fall with card count. The
+#   stock slug pins expert bundles back onto the GPUs (that is what takes it
+#   from ~146 to ~120 on a real 4×24); this compose's `-ot` is an unconditional
+#   all-experts→CPU catch-all, so all 43 layers stay in host memory on any
+#   number of cards. More cards buy a bigger expert-cache POOL, not a smaller
+#   CPU buffer — the cache is a VRAM-side COPY and the master stays allocated.
+#   MEASURED (2×3090 boot log; the buffer is card-count-independent, `--no-mmap`):
+#       experts    141362.00 MiB   load_tensors: CUDA_Host model buffer size
+#     + drafter     10386.28 MiB   `-devd none` -> DSpark lives in host memory
+#     = pinned     151748.28 MiB = 148.19 GiB   <- the HARD floor
+#     + ~8 GiB     process overhead (CUDA_Host compute/output buffers, CPU FFN
+#                  scratch, CUDA host allocations) — the same constant both
+#                  stock headers carry (141362 MiB→146, 80268 MiB→86).
+#     = 156.
+#   ⚠️ HARD floor, not a recommendation. `--no-mmap` makes the loader
+#   `cudaMallocHost` the whole offloaded set: pinned pages are non-evictable and
+#   cannot be oversubscribed, so a short box does not degrade — it dies inside
+#   `cudaMallocHost`, which presents as "loads the model into RAM, then fails to
+#   load". A 4-card/128 GB owner wants the stock multi4 offload slug instead.
+#   ⚠️ NO residency headers here, DELIBERATELY — there are no ${OT_G*} slots in
+#   the `-ot` below, so nothing is ever pinned back and the gate must NOT
+#   subtract a grant. offload_residency_grant_mib() returns 0 without
+#   CPU-Offload-Bundle-MiB, which is the correct answer for this compose.
+# ===========================================================================
 services:
   llama-cpp-deepseek-flash-q8-moecache-multi4:
     # Digest-pinned, not tag-pinned (#940 precedent). Engine profile is authoritative.

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -1062,7 +1062,13 @@ COMPOSE_REGISTRY = {
         kvcalc_key="SKIP",
         offload="n-cpu-moe",
         moe_cache=True,
-        host_ram_gb=146,
+        # Nominal == the compose header's worst case (156), unlike the stock
+        # multi4 slug where nominal (120) is below the header (146). There is no
+        # residency to subtract here: the `-ot` is an unconditional
+        # all-experts->CPU catch-all with no OT_G* slots, so host RAM does NOT
+        # fall with card count. +10 over the stock sibling is the `-devd none`
+        # drafter (10386.28 MiB) living in host memory instead of VRAM.
+        host_ram_gb=156,
         required_sm=8.6,
         status="experimental",
         status_note="4-card sibling of the dual moe-cache slug. ⚠️ NOT VALIDATED ON ANY RIG — the reference rig has 2 cards, so nothing here has been booted; it ships on the same basis as the stock multi4 slug (off-rig provenance). ⚠️⚠️ THE TUNING IS INHERITED, NOT DERIVED: RESERVE_MB=1536 and -ub 2048 were measured on 2x24 GB against a MEASURED 1,128 MiB compute-buffer swing. On 4 cards the per-card free VRAM, the swing, and the pool/compute balance all differ, and the knee is SHARP (on 2x24 GB the neighbouring reserve value was ~11% slower). Re-derive before trusting: boot with -lv 4 + GGML_CUDA_MOE_CACHE_STATS=50, read the compute-buffer swing, set RESERVE above it, then sweep on WALL-CLOCK (never on hit rate — three times on this stack a config improved every cache counter and got slower). The launch-compat layer raises MOE_RESERVE_MB on cards >24 GB via _moe_cache_env, which covers capacity but not topology. ⚠️ ATTRIBUTION: the expert cache is leloch's work (RFC ggml-org#24528), unmerged in mainline. ⚠️ QUALITY UNTESTED on any topology. Do NOT set GGML_OP_OFFLOAD_MIN_BATCH — at 2 it silently stops the cache allocating (4.2x throughput loss, measured).",
@@ -1082,7 +1088,10 @@ COMPOSE_REGISTRY = {
         # Load-bearing: gates the launch-compat MOE_RESERVE_MB injection
         # (_moe_cache_env). Without it a 96 GB card inherits a 24 GB reserve.
         moe_cache=True,
-        host_ram_gb=146,
+        # 156, NOT the stock sibling's 146: `-devd none` moves the 10386.28 MiB
+        # DSpark drafter off the GPU and into host memory, and this compose pins
+        # no expert bundles back (no OT_G* slots), so nominal == worst case.
+        host_ram_gb=156,
         required_sm=8.6,
         status="experimental",
         status_note="The stock Q8 slug keeps a 10.4 GiB DSpark drafter on the GPU and caches nothing, idling ~9.3 GB of VRAM. This reallocates that: drafter to host (-devd none), ~5,159 experts (~47% of 11,008) resident in VRAM via leloch's expert cache. Measured 2026-08-10, same session vs the stock slug, canonical prompts at temp 0: decode 18.34 -> 23.64 narrative and 23.51 -> 27.01 code (~+29%/+15%), prefill 436 -> ~355 @10K (~-19%), cache hit rate ~56%. The published IMAGE runs ~4% under the local binary (CUDA 12.8 vs 13.2) -- image numbers are the honest ones. ⚠️ ATTRIBUTION: the expert cache is leloch's work (RFC ggml-org#24528), unmerged in mainline; this slug packages it. ⚠️ EXPERIMENTAL: QUALITY IS UNTESTED -- no 8-pack has been run, and both the cache and the CPU drafter sit on the generation path; no soak, no 3-boot. ⚠️ COLD-START TAX: the first request after boot is slow (~50-75 s for 900 tok) while the pool fills -- never benchmark request 1. ⚠️ Tuning is 2x24 GB specific (RESERVE_MB=1536 from a measured 1,128 MiB compute-buffer swing; 1024 was ~11% SLOWER despite a bigger pool and higher hit rate). Do NOT set GGML_OP_OFFLOAD_MIN_BATCH: at 2 it silently stops the cache allocating and costs 4.2x throughput.",

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1903,8 +1903,20 @@ preflight_cpu_offload_ram() {
     echo "            It cannot run here." >&2
     echo "            This is a hard gate, not a tuning knob: below it the box thrashes or OOMs." >&2
     echo "            Fix: use a lower-bit tier (the IQ2 slug needs ~86 GB), add RAM, or pick a" >&2
-    echo "            model that fits VRAM. On a 4-card rig the same model needs LESS host RAM," >&2
-    echo "            because residency moves expert bytes onto the GPUs." >&2
+    echo "            model that fits VRAM." >&2
+    # ⚠️ "more cards => less host RAM" holds ONLY for composes that can pin expert
+    # bundles back onto the GPUs, i.e. ones carrying the residency headers. The
+    # moe-cache composes pin NOTHING (their -ot is an unconditional =CPU catch-all;
+    # the expert cache is a VRAM-side copy, so the CPU master buffer stays whole).
+    # Printing the hint there sends a RAM-short user shopping for GPUs that cannot
+    # help. Key off the same header the sizer uses, not the model name.
+    if [[ "$(compose_meta_get "$compose_file" cpu-offload-bundle-mib || true)" =~ ^[0-9]+$ ]]; then
+      echo "            On a rig with more cards the same model needs LESS host RAM, because" >&2
+      echo "            residency moves expert bytes onto the GPUs." >&2
+    else
+      echo "            NOTE: more GPUs will NOT lower this compose's host-RAM need — it keeps" >&2
+      echo "            every expert on the CPU regardless of card count." >&2
+    fi
     return 1
   fi
   if (( avail_gb < need_gb )); then

--- a/scripts/tests/test-preflight-cpu-offload.sh
+++ b/scripts/tests/test-preflight-cpu-offload.sh
@@ -30,11 +30,18 @@ done
 Q8=models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-q8-kxl/offload.yml
 IQ2=models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-iq2-xxs/offload.yml
 M4=models/deepseek-v4-flash-0731/llama-cpp/compose/multi4/unsloth-q8-kxl/offload.yml
+# The FORK (moe-cache) siblings. They are offload composes too, and they shipped
+# for five days with NO CPU-Offload-Host-RAM-GB header at all -- so the RAM gate
+# early-returned on the two slugs with the LARGEST host footprint in the catalog
+# (they also hold the drafter in host RAM). A 128 GB owner got a raw
+# cudaMallocHost failure instead of our refusal. Every list below includes them.
+FORK_Q8=models/deepseek-v4-flash-0731/llamacpp-club3090/compose/dual/unsloth-q8-kxl/moecache.yml
+FORK_M4=models/deepseek-v4-flash-0731/llamacpp-club3090/compose/multi4/unsloth-q8-kxl/moecache.yml
 NONOFF=models/tess-4-27b/llama-cpp/compose/dual/migtissera-q4km/mtp.yml
 
 # ---- detector ----
-for f in "$Q8" "$IQ2" "$M4"; do
-  is_cpu_offload_compose "$f" && ok "detects offload: $(basename "$(dirname "$f")")" \
+for f in "$Q8" "$IQ2" "$M4" "$FORK_Q8" "$FORK_M4"; do
+  is_cpu_offload_compose "$f" && ok "detects offload: $(basename "$(dirname "$f")")/$(basename "$f")" \
     || bad "MISSED offload compose $f"
 done
 is_cpu_offload_compose "$NONOFF" && bad "FALSE POSITIVE on a non-offload compose" \
@@ -70,9 +77,12 @@ command grep -qE "85%|305" <<<"$msg" \
   && ok "refusal cites the measurement" || bad "refusal has no evidence"
 
 # ---- RAM guard ----
-for f in "$Q8" "$IQ2" "$M4"; do
+# ⚠️ EVERY offload compose must declare the header. Without it the gate silently
+# early-returns -- the failure mode is INVISIBLE (no warning, just no refusal),
+# which is exactly how the two moe-cache slugs shipped ungated.
+for f in "$Q8" "$IQ2" "$M4" "$FORK_Q8" "$FORK_M4"; do
   v="$(compose_meta_get "$f" cpu-offload-host-ram-gb || true)"
-  [[ "$v" =~ ^[0-9]+$ ]] && ok "declares CPU-Offload-Host-RAM-GB=$v" \
+  [[ "$v" =~ ^[0-9]+$ ]] && ok "declares CPU-Offload-Host-RAM-GB=$v ($(basename "$(dirname "$f")")/$(basename "$f"))" \
     || bad "$f missing/invalid CPU-Offload-Host-RAM-GB"
 done
 preflight_cpu_offload_ram "$NONOFF" >/dev/null 2>&1 \
@@ -82,6 +92,20 @@ preflight_cpu_offload_ram "$NONOFF" >/dev/null 2>&1 \
 printf '# CPU-Offload-Host-RAM-GB: 999999\nservices:\n  x:\n    command: >-\n      -ot a=CPU\n' > "$tmp"
 preflight_cpu_offload_ram "$tmp" >/dev/null 2>&1 \
   && bad "impossible RAM requirement was NOT refused" || ok "impossible RAM requirement refused"
+
+# ⚠️ the refusal's "buy more cards" hint must be TRUE for the compose it prints on.
+# It only holds where residency can pin bundles back onto the GPUs — i.e. where the
+# bundle header exists. On an all-experts-on-CPU compose (the moe-cache slugs) more
+# GPUs change nothing, and telling a RAM-short user otherwise sends them shopping.
+msg="$(preflight_cpu_offload_ram "$tmp" 2>&1)"
+command grep -q "more GPUs will NOT lower" <<<"$msg" \
+  && ok "refusal without a bundle header says more GPUs will NOT help" \
+  || bad "no-residency refusal still promises more cards will help: $msg"
+printf '# CPU-Offload-Host-RAM-GB: 999999\n# CPU-Offload-Bundle-MiB: 3264\n# CPU-Offload-MoE-Layers: 43\nservices:\n  x:\n    command: >-\n      -ot a=CPU\n' > "$tmp"
+msg="$(preflight_cpu_offload_ram "$tmp" 2>&1)"
+command grep -q "needs LESS host RAM" <<<"$msg" \
+  && ok "refusal WITH a bundle header keeps the more-cards hint" \
+  || bad "residency-capable refusal lost the more-cards hint: $msg"
 
 # ---- residency-aware RAM gate (the header is the ALL-on-CPU worst case; the ----
 # ---- gate subtracts what THIS rig's VRAM will hold — clort81's #909 report) ----
@@ -242,14 +266,48 @@ m4_hdr="$(compose_meta_get "$M4" cpu-offload-host-ram-gb)"
   && ok "dual-Q8 and multi4-Q8 headers agree ($q8_hdr GB — same quant, same worst case)" \
   || bad "Q8 headers diverge (dual=$q8_hdr multi4=$m4_hdr): residency was pre-baked into one"
 
+# same again for the fork pair: same quant, same all-on-CPU `-ot`, same CPU
+# drafter, and the CUDA_Host buffer is card-count-independent.
+fq8_hdr="$(compose_meta_get "$FORK_Q8" cpu-offload-host-ram-gb)"
+fm4_hdr="$(compose_meta_get "$FORK_M4" cpu-offload-host-ram-gb)"
+[[ "$fq8_hdr" == "$fm4_hdr" ]] \
+  && ok "fork dual and fork multi4 headers agree ($fq8_hdr GB)" \
+  || bad "fork headers diverge (dual=$fq8_hdr multi4=$fm4_hdr)"
+
+# ⭐ the fork slugs must ask for MORE than the stock ones on the same weights.
+# `-devd none` puts the 10386.28 MiB DSpark model in HOST memory (the stock slug
+# keeps it in VRAM), so a header merely COPIED from the stock sibling under-gates
+# by ~10 GB. That copy is what shipped in the registry before this guard existed.
+(( fq8_hdr > q8_hdr )) \
+  && ok "fork Q8 header ($fq8_hdr) > stock Q8 header ($q8_hdr) — the CPU drafter is charged" \
+  || bad "fork Q8 header ($fq8_hdr) does not exceed stock ($q8_hdr): the -devd none drafter is not charged"
+
+# ⚠️ and they must carry NO residency headers. The fork composes' `-ot` is an
+# unconditional all-experts->CPU catch-all with no ${OT_G*} slots, so nothing is
+# ever pinned back onto the GPUs. Declaring CPU-Offload-Bundle-MiB would make the
+# gate SUBTRACT a grant that never materialises -- under-gating every rig.
+for f in "$FORK_Q8" "$FORK_M4"; do
+  b="$(compose_meta_get "$f" cpu-offload-bundle-mib || true)"
+  [[ -z "$b" ]] && ok "$(basename "$(dirname "$f")")/moecache.yml declares no bundle header (grant must stay 0)" \
+    || bad "$f declares CPU-Offload-Bundle-MiB=$b but has no OT_G* slots — the gate would under-gate"
+  command grep -q 'OT_G[0-9]' "$f" \
+    && bad "$f now has OT_G* slots — it needs the residency headers after all" \
+    || ok "$(basename "$(dirname "$f")")/moecache.yml has no OT_G* slots (all experts stay on CPU)"
+done
+
 # registry host_ram_gb is the NOMINAL display figure and must never exceed the
 # header's worst case (nominal = worst case minus residency, on any topology)
+# ⚠️ every deepseek-flash slug carrying host_ram_gb MUST map to a compose here.
+# The `*-moecache` slugs used to fall through the `*)` arm and go UNCHECKED,
+# which is how they kept a copied 146 while their compose needed ~10 GB more.
 while IFS='|' read -r slug reg_gb; do
   case "$slug" in
+    *dual-q8-moecache)   f="$FORK_Q8" ;;
+    *multi4-q8-moecache) f="$FORK_M4" ;;
     *dual-q8)   f="$Q8" ;;
     *dual-iq2)  f="$IQ2" ;;
     *multi4-q8) f="$M4" ;;
-    *) continue ;;
+    *) bad "$slug has host_ram_gb but no compose mapping in this test"; continue ;;
   esac
   hdr="$(compose_meta_get "$f" cpu-offload-host-ram-gb)"
   [[ "$reg_gb" =~ ^[0-9]+$ && "$reg_gb" -le "$hdr" ]] \
@@ -277,7 +335,7 @@ declare -F resolve_offload_threads >/dev/null 2>&1 && ok "resolve_offload_thread
   && ok "no-op on a non-offload compose" || bad "set THREADS on a non-offload compose"
 # the bare-compose fallback must be LOW, not the reference rig's number: over-subscribing
 # measured -69% vs under-subscribing -9.6%, so err low when the core count is unknown.
-for f in "$Q8" "$IQ2" "$M4"; do
+for f in "$Q8" "$IQ2" "$M4" "$FORK_Q8" "$FORK_M4"; do
   fb="$(command grep -oE 'THREADS:-[0-9]+' "$f" | command grep -oE '[0-9]+' | head -1)"
   [[ -n "$fb" && "$fb" -le 8 ]] && ok "$(basename "$(dirname "$f")"): safe THREADS fallback ($fb)" \
     || bad "$(basename "$(dirname "$f")"): THREADS fallback '$fb' is too high for an unknown rig"


### PR DESCRIPTION
## The defect

`preflight_cpu_offload_ram()` early-returns when a compose carries no `CPU-Offload-Host-RAM-GB:` header:

```bash
need_hdr="$(compose_meta_get "$compose_file" cpu-offload-host-ram-gb || true)"
[[ -z "$need_hdr" ]] && return 0                 # not an offload compose we size
```

The two DeepSeek-V4-Flash **moe-cache** composes carried only prose — *"Needs ~140 GB of HOST RAM … Hard gate."* — and no header. So the hard RAM gate **never fired on the two slugs with the largest host footprint in the catalog**, and the failure mode was invisible: no warning, just no refusal.

Reported by a 128 GB / 4×3090 owner, who hit a raw `cudaMallocHost` failure — presenting as *"loads the model into RAM then fails to load"* — instead of our refusal.

The three stock `llama-cpp/` composes were fine (`:63`, `:69`, `:52`). **Five DeepSeek composes exist; two were ungated.**

## The number: 156, not 146

These are the only composes charged for the drafter. `-devd none` puts the DSpark model in **host** memory, where the stock slug keeps it in VRAM.

Measured on 2×3090 under `--no-mmap`, all 43 expert layers → CPU:

| term | MiB | source |
|---|---:|---|
| experts | 141362.00 | `load_tensors: CUDA_Host model buffer size` |
| drafter | 10386.28 | same line, second model (CPU-pinned) |
| **pinned** | **151748.28** | **= 148.19 GiB — the hard floor** |
| + process overhead | ~8 GiB | CUDA_Host compute/output buffers, CPU FFN scratch, CUDA host allocations |
| **= header** | **156** | |

The `+8` is not a fudge — it is measured (147 GiB used vs 138.05 GiB pinned on the drafterless arm) and it is **the constant both shipped headers already carry**, reproducing them exactly:

- Q8 stock: 141362 MiB = 138.05 GiB, +8 → **146** ✔
- IQ2 stock: 80268 MiB = 78.39 GiB, +8 → **86** ✔
- fork: 151748.28 MiB = 148.19 GiB, +8 → **156**

### Hard floor, not a recommendation

All five DeepSeek composes pass `--no-mmap`, so the loader `cudaMallocHost`s the whole offloaded set. Pinned pages are non-evictable and cannot be oversubscribed — a short box does not degrade, it dies inside `cudaMallocHost`. With mmap the same bytes would be file-backed and evictable and this would be advisory. It is not.

### No residency headers on these two, deliberately

Their `-ot` is an unconditional all-experts→CPU catch-all with **no `${OT_G*}` slots**, so nothing is ever pinned back onto the GPUs and `offload_residency_grant_mib()` must keep returning 0. Declaring `CPU-Offload-Bundle-MiB` would make the gate subtract a grant that never materialises — under-gating every rig.

The expert cache does not help either: it is a **VRAM-side copy**, the CPU master buffer stays whole. (The 141362 MiB line above is from a cache-**enabled** boot.) So host RAM here does **not** fall with card count, unlike the stock multi4 slug.

## Also in this PR

- **Registry `host_ram_gb` 146 → 156** on both moe-cache slugs. It was copied from the stock sibling and understated what c3 displays.
- **The refusal's "more cards need less host RAM" hint is now conditional** on the bundle header. It is false for an all-experts-on-CPU compose, and it was about to send a RAM-short user shopping for GPUs that cannot help.
- **`test-preflight-cpu-offload` covered only the three stock composes**, and its registry cross-check silently `continue`d past any slug it had no mapping for — which is exactly how a copied 146 survived. Now: both moe-cache composes are in every list; an unmapped slug **fails** instead of being skipped; and new legs assert the fork header exceeds the stock one, that the pair agree, that neither declares residency headers, and that both hint branches say something true.

## Verification

Gate behaviour, same file, before vs after (no server booted — GPUs in use):

```
### BEFORE (master version of the same file — no header):
  header read = []
  rc=0  <-- silent pass, gate never fired

### AFTER (header 156) on a 196 GiB rig:
[preflight] cpu-offload: RAM ok — needs ~156 GB (worst case), 190 GB available
  rc=0

### AFTER, header rewritten to 197 (rig 1 GiB short):
[preflight] ERROR: this compose offloads experts to host RAM and needs ~197 GB
            (worst case: all experts on CPU), but the machine has only 196 GB TOTAL.
            ...
            NOTE: more GPUs will NOT lower this compose's host-RAM need — it keeps
            every expert on the CPU regardless of card count.
  rc=1  <-- REFUSED

### grant on the fork compose: 0  (no residency to subtract — correct)
```

`grant = 0` means `need_gb` stays the full 156 on any rig, so a 128 GB box (`total_gb` ≈ 122–126) takes the same `total_gb < need_gb` branch shown above, and `switch.sh:1047` turns it into `exit 1`.

Full sweep: **102/102 green**. c3 has no code change here (registry field value only), so its separate suite was not re-run.
