### PR TITLE
Gate the Inkling moe-cache slugs + ship a residency sibling (#978)

### DIFF
--- a/models/inkling-small/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/moecache.yml
+++ b/models/inkling-small/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/moecache.yml
@@ -51,7 +51,14 @@
 #              • 1M context does NOT fit: the KV allocates fine, but the prefill
 #                compute buffer wants 9,450 MiB on device 0 and the boot dies.
 #                262K is a deliberate choice, not the model's ceiling.
-#              • Needs ~120 GB of HOST RAM (routed experts live in CPU memory).
+#              • Needs ~121 GB of HOST RAM — a HARD gate, not a recommendation.
+#                The expert cache does NOT reduce it: the cache is a VRAM-side
+#                COPY and the CPU master buffer stays fully allocated, so more
+#                (or bigger) GPUs buy hit rate, never host RAM. If you are host-RAM
+#                bound, use the `residency.yml` sibling instead — it PINS expert
+#                bundles into VRAM and the requirement falls with card size.
+#                preflight REFUSES below it; arithmetic in the
+#                CPU-Offload-Host-RAM-GB block near the bottom of this header.
 #              • Load takes several minutes (--no-mmap).
 #   Quality:   toolcall-15 12/15 · instructfollow-15 12/15 · structoutput-15 14/15
 #              · dataextract-15 13/15 · reasonmath-15 12/15 · bugfind-15 14/15
@@ -94,6 +101,48 @@
 #   against DeepSeek anyway, since the merge conflict sat on its expert-cache
 #   gate path: verify-full all-pass, decode 21.4-21.6 t/s vs 21.91 on v1.
 # ---------------------------------------------------------------------------
+# SIBLING VARIANTS in this directory — pick on HOST RAM first, speed second:
+#
+#   | variant          | expert placement            | host RAM | picked when          |
+#   |------------------|-----------------------------|----------|----------------------|
+#   | moecache.yml     | ALL routed experts on CPU,  | ~121 GB  | ≥128 GB host RAM     |
+#   | (this file)      | cache holds VRAM COPIES     | (fixed)  | ⭐ validated config  |
+#   | residency.yml    | expert bundles PINNED into  | 121 GB   | host-RAM bound, or   |
+#   |                  | VRAM, remainder on CPU      | minus    | >24 GB cards         |
+#   |                  |                             | residency|                      |
+#
+#   The distinction is COPY vs MIGRATE, and it is the whole story: this file's
+#   cache never shrinks the CPU master buffer, `residency.yml`'s `-ot ...=CUDA*`
+#   rules do. On 2×32 GB the sizer pins ~39 GiB of experts, taking the host need
+#   from 121 GB to ~83 GB (club-3090 #978).
+# ---------------------------------------------------------------------------
+#
+# CPU-Offload-Host-RAM-GB: 121
+#   MEASURED (2×3090, `--no-mmap`, all 40 routed-expert layers → CPU, 262K/ub2048;
+#   the buffer is cache- and card-count-independent):
+#       CUDA_Host model buffer   116354.33 MiB = 113.63 GiB   <- the HARD floor
+#     + ~8 GiB   process overhead: the 1,098.86 MiB CUDA_Host compute buffer,
+#                CPU FFN scratch and CUDA host allocations. Same constant the
+#                DeepSeek headers carry (141362 MiB→156 incl. drafter, 80268→86).
+#     = 121.
+#   ⚠️ The 116,354.33 MiB is NOT just the experts. It decomposes exactly as
+#   115,520.00 MiB of routed expert bundles + 834.33 MiB of `token_embd.weight`
+#   (Q8_0), which llama.cpp keeps host-side whatever `-ngl` says. Residency can
+#   move the first term and never the second — see `residency.yml`.
+#   ⚠️ HARD floor, not a recommendation. `--no-mmap` makes the loader
+#   `cudaMallocHost` the whole offloaded set: pinned pages are non-evictable and
+#   cannot be oversubscribed, so a short box does not degrade — it dies inside
+#   the allocation, which presents as "loads the model into RAM, then the
+#   container is OOM-killed" (club-3090 #978: a 123 GB desktop froze outright,
+#   and the RAM gate could not refuse because this header did not exist).
+#   ⚠️ NO residency headers here, DELIBERATELY. This compose's `-ot` is an
+#   unconditional all-experts→CPU catch-all with no ${OT_G*} slots, so the
+#   launcher never pins bundles back onto the GPUs and the gate must NOT
+#   subtract a grant — offload_residency_grant_mib() returns 0 without
+#   CPU-Offload-Bundle-MiB, which is the correct answer here. Adding those
+#   headers would under-gate every rig. `residency.yml` is the compose that
+#   legitimately carries them.
+# ===========================================================================
 services:
   llama-cpp-inkling-small-iq4xs-moecache:
     # Digest-pinned, not tag-pinned: tags move, digests do not (#940 precedent).

--- a/models/inkling-small/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/residency.yml
+++ b/models/inkling-small/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/residency.yml
@@ -1,0 +1,305 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     Inkling-Small (263B MoE, Thinking Machines — unsloth UD-IQ4_XS,
+#              119 GB across 4 shards. ⚠️ MIXED expert precision: iq3_s +
+#              iq4_xs + q6_K, which makes a single scalar bundle size only
+#              approximately true — see the residency block below)
+#   Engine:    llamacpp-club3090-v1.1 (fork: leloch's MoE expert cache + our
+#              L1/L3/E ports and bypass warn-split, PLUS vendored ggml-org#25731
+#              for the inkling arch — a separate pin from the v1 engine)
+#   Topology:  Dual GPU PCIe (layer-split -ts 1,1, no NVLink)
+#   Drafter:   none — the GGUF carries no MTP head and no drafter is converted
+#   KV:        fp16 (llama.cpp default — iSWA keeps it to 7.5 GB even at 262K)
+#   Vision:    no (upstream model is multimodal; this GGUF ships no mmproj)
+#   Max ctx:   262144
+#   Genesis:   N/A — llama.cpp engine
+#   Status:    🧪 Experimental
+#   Caveats:   • ⚠️⚠️ THE RESIDENCY CONSTANTS ARE DERIVED, NOT FIELD-VALIDATED
+#                ON >24 GB CARDS. `CPU-Offload-GPU-Reserve-MiB` and the bundle
+#                size below are MEASURED on 2×24 GB (see the block near the
+#                bottom of this header), and the 2×24 GB grant was booted. The
+#                32 GB / 4-card projections in this header are ARITHMETIC from
+#                those measurements — the reference rig has 2× 24 GB cards
+#                permanently, so a bigger-card grant cannot be booted here.
+#                Treat any non-24 GB number as a starting point to validate.
+#              • ⚠️ PICK THIS ONLY IF YOU ARE HOST-RAM BOUND. Where
+#                `moecache.yml` runs, it is FASTER — measured, not assumed:
+#                same session, same rig, same 300-token prompt, 3 warm-up + 3
+#                measured requests each, this config plateaued at 20.35 t/s
+#                while the cache config was at 25.25 t/s AND STILL CLIMBING
+#                (23.80 → 25.36 → 26.60 across its three measured runs, against
+#                a published canonical 32.01 t/s). The gap is therefore ≥+24%
+#                and understated. Pinning whole layers buys perfect locality on
+#                a FEW layers; the cache spreads slots across ALL 40 by expert
+#                popularity and reaches 76-78% hits. The trade is HOST RAM, not
+#                throughput. See "WHY THIS EXISTS".
+#              • ⏸️ VENDORS AN UNMERGED UPSTREAM PR. The `inkling` architecture
+#                is NOT in llama.cpp mainline — it lives in the open draft
+#                ggml-org/llama.cpp#25731, vendored into the engine this slug
+#                pins (`llamacpp-club3090-v1.1`). Stock llama.cpp fails with
+#                `unknown model architecture: 'inkling'`. When #25731 merges the
+#                vendored copy is dropped and this repoints to the v1 engine.
+#              • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
+#                (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug
+#                packages it. The inkling arch is @danielhanchen's PR, vendored,
+#                not ours — we maintain neither.
+#              • ⚠️ REASONING IS ON BY DEFAULT at effort 0.9. This model reads
+#                `reasoning_effort` (none/minimal/low/medium/high/xhigh/max, or a
+#                float 0.0-0.99) — NOT `enable_thinking`, which it IGNORES
+#                SILENTLY. A client sending a small max_tokens without setting
+#                effort gets an EMPTY answer and no error. Set it explicitly:
+#                  {"reasoning_effort": "none",
+#                   "chat_template_kwargs": {"reasoning_effort": "none"}}
+#                Both are needed: llama.cpp parses the top-level parameter but
+#                only maps the value "none", onto a variable this template does
+#                not read, so the kwargs copy is what actually lands.
+#              • ⚠️ SAMPLING: Unsloth specifies temp 1.0 / top_p 1.0 / min_p 0.0
+#                for this model, NOT the stack-canonical Qwen 0.6/0.95.
+#              • ⚠️ QUALITY IS UNTESTED on this variant. No 8-pack has been run.
+#                The weights are identical to `moecache.yml`, so its 8-pack is
+#                the best available evidence — but placement is not quality-
+#                neutral until shown to be, so do not quote it as this slug's.
+#              • Length-dependent logit scaling engages above 128K context
+#                (`log_scaling_n_floor`), so behaviour at 8K does not
+#                extrapolate to 512K. Do not A/B across that boundary.
+#              • Needs ~121 GB of HOST RAM MINUS whatever residency pins onto
+#                YOUR cards — 99 GB on 2×24 GB, ~83 GB on 2×32 GB. preflight
+#                computes the rig-specific number and REFUSES below it.
+#              • Load takes several minutes (--no-mmap).
+#              • 1M context does NOT fit: the KV allocates fine, but the prefill
+#                compute buffer wants 9,450 MiB on device 0 and the boot dies.
+#                262K is a deliberate choice, not the model's ceiling.
+#   Best for:  Inkling on a rig that cannot afford 121 GB of host RAM. ⭐
+# ---------------------------------------------------------------------------
+# SIBLING VARIANTS in this directory — pick on HOST RAM first, speed second:
+#
+#   | variant          | expert placement            | host RAM | picked when          |
+#   |------------------|-----------------------------|----------|----------------------|
+#   | moecache.yml     | ALL routed experts on CPU,  | ~121 GB  | ≥128 GB host RAM     |
+#   |                  | cache holds VRAM COPIES     | (fixed)  | ⭐ validated config  |
+#   | residency.yml    | expert bundles PINNED into  | 121 GB   | host-RAM bound, or   |
+#   | (this file)      | VRAM, remainder on CPU      | minus    | >24 GB cards         |
+#   |                  |                             | residency|                      |
+# ---------------------------------------------------------------------------
+# WHY THIS EXISTS
+#   COPY vs MIGRATE. `moecache.yml`'s expert cache is a VRAM-side COPY of hot
+#   experts: the CPU master buffer stays fully allocated, so the host-RAM bill is
+#   121 GB no matter how much VRAM you own. A 128 GB desktop therefore cannot run
+#   it at all — it OOM-kills during load and can take the desktop with it
+#   (club-3090 #978, dual 32 GB cards + 128 GB host).
+#
+#   `-ot ...=CUDA<i>` rules MIGRATE instead: an expert bundle named by a device
+#   rule is loaded straight onto that card and never allocated host-side. Host
+#   RAM then falls, one bundle at a time, with the VRAM you can spare:
+#
+#     2×24 GB  4 bundles/card  =  22.25 GiB pinned  ->  99 GB host   (BOOTED)
+#     2×32 GB  7 bundles/card  =  38.94 GiB pinned  ->  83 GB host   (derived)
+#
+#   MEASURED on 2× 24 GB, this compose vs the cache sibling, same session:
+#     CUDA_Host model buffer   116354.33 -> 93570.33 MiB   (−22784.00, EXACTLY
+#                                                           the 8 bundles granted)
+#     peak process RSS             115.39 ->    93.14 GiB
+#     free VRAM after boot                    1525 / 1483 MiB   (margin intact)
+#   The buffer delta is exact, not approximate: because the residency window
+#   excludes the two oversized tail bundles, every pinned layer is 2848 MiB and
+#   the gate's subtraction matches the engine's allocation byte for byte.
+#
+#   ⚠️ THIS IS A MEMORY TRADE, NOT A SPEED WIN — MEASURED. Both mechanisms
+#   compete for the same free VRAM, and on this model the cache uses it better:
+#   76-78% hit rate at 67.5% spatial coverage, because expert popularity is
+#   skewed and the cache follows it across ALL 40 layers. Residency instead makes
+#   a HANDFUL of layers perfectly local and leaves the rest fully remote. A
+#   same-session probe (3 warm-up + 3 measured, 300-token prompt, canonical
+#   sampling) put this config at a FLAT 20.35 t/s — it converges immediately,
+#   having nothing to warm — against 25.25 t/s for the cache config, which was
+#   still climbing on its last run (26.60) toward its published 32.01 t/s.
+#   ⚠️ That is a PROBE, not a canonical bench: N=3 per arm, one prompt, one leg.
+#   It settles the DIRECTION and a lower bound on the gap, nothing finer.
+#   Where both fit, prefer `moecache.yml`.
+#
+#   ⭐ TUNE THE PIN TO YOUR HOST RAM, NOT TO THE MAXIMUM. The sizer is a
+#   floor-conservative maximiser: it pins as many bundles as fit. If your host
+#   RAM is merely tight rather than short, pin the MINIMUM that clears the gate
+#   and leave the rest of the VRAM to the cache, which will spend it better.
+#   OT_G<i> is an explicit override and the launcher NEVER clobbers it — and the
+#   RAM gate prices your ACTUAL pin, so the two stay coherent:
+#
+#     OT_G0='blk\.(2|3)\.ffn_(gate|up|down)_exps\.weight=CUDA0' \
+#     OT_G1='blk\.(39|38)\.ffn_(gate|up|down)_exps\.weight=CUDA1' \
+#       bash scripts/launch.sh llamacpp-club3090/inkling-small-dual-iq4xs-residency
+#
+#   Setting BOTH to a rule matching no layer (blk.99999) degrades this compose to
+#   exactly `moecache.yml`'s behaviour — which is also what a bare
+#   `docker compose up` does, since the defaults below match nothing.
+#
+# ⚠️ -ot IS FIRST-MATCH-WINS. The two device rules MUST precede the catch-all
+#    =CPU rule. Reverse them and every expert silently lands on CPU: no error,
+#    no warning, just a config that quietly isn't what it claims to be.
+#
+# ⚠️ THE RESIDENCY RULES ARE INJECTED, NOT HARDCODED. OT_G0/OT_G1 are resolved by
+#    launch.sh / switch.sh from DETECTED free VRAM. The defaults below
+#    deliberately match NO layer (blk.99999), so a bare `docker compose up`
+#    degrades to all-experts-CPU — the config that runs anywhere — rather than to
+#    one that OOMs.
+# ---------------------------------------------------------------------------
+#
+# CPU-Offload-Host-RAM-GB: 121
+#   ⚠️ MUST stay the ALL-experts-on-CPU worst case — preflight_cpu_offload_ram()
+#   subtracts this rig's detected residency grant itself (offload_residency_grant_mib),
+#   so pre-baking expected residency here would DOUBLE-COUNT it and under-gate.
+#   On a real 2×24 the gate computes 99; on 2×32 it computes 83.
+#   MEASURED (2× 24 GB, `--no-mmap`, zero residency, 262K/ub2048):
+#       CUDA_Host model buffer   116354.33 MiB = 113.63 GiB   <- the HARD floor
+#     + ~8 GiB   process overhead (1,098.86 MiB CUDA_Host compute buffer, CPU FFN
+#                scratch, CUDA host allocations) — the same constant the DeepSeek
+#                headers carry (141362 MiB→156 incl. drafter, 80268 MiB→86).
+#     = 121.
+#   ⚠️ 834.33 MiB OF THAT CAN NEVER BE MIGRATED. The 116,354.33 MiB decomposes as
+#   115,520.00 MiB of routed expert bundles + 834.33 MiB of `token_embd.weight`
+#   (Q8_0), which llama.cpp keeps host-side whatever `-ngl` says and no `-ot` rule
+#   moves. Residency therefore has a floor of ~8-9 GB even with every bundle
+#   pinned; it does not converge to zero.
+#   ⚠️ Hard floor, not a recommendation: `--no-mmap` makes the loader
+#   `cudaMallocHost` the offloaded set, and pinned pages are non-evictable, so a
+#   short box does not degrade — it dies inside the allocation (#978).
+#
+# CPU-Offload-Bundle-MiB: 2848
+#   One MoE layer's routed-expert bundle: `ffn_(gate|up|down)_exps.weight` summed
+#   per layer, read from the GGUF tensor table, NOT derived from the quant name.
+#   ⚠️ The quant is Unsloth *Dynamic* and is NOT uniform. 38 of the 40 MoE layers
+#   are exactly 2848 MiB (iq3_s + iq4_xs); the last two are OUTLIERS:
+#       blk.2 … blk.39   2848 MiB   (38 layers)  <- the residency window
+#       blk.40           3440 MiB   (iq3_s + q6_K)
+#       blk.41           3856 MiB   (iq4_xs + q6_K)
+#   A single scalar cannot describe all three, which is why the window below
+#   excludes blk.40/41 rather than averaging over them.
+#
+# CPU-Offload-MoE-Layers: 38
+# CPU-Offload-First-MoE-Layer: 2
+#   ⚠️⚠️ READ THIS PAIR AS "THE RESIDENCY-ELIGIBLE WINDOW", NOT "the MoE layer
+#   count". The model has 42 blocks = 2 dense + 40 MoE (`dense_block_count = 2`),
+#   so the first MoE layer is 2 — a rule naming a dense layer silently matches
+#   NOTHING, and the host-RAM gate would then subtract a bundle that never landed.
+#   The window is 38, not 40, ON PURPOSE: _offload_layers_for_card() gives the LAST
+#   card outer-edge selection counting DOWN from the top of the window, so a window
+#   of 40 would make card 1 pick blk.41 and blk.40 FIRST — precisely the two
+#   oversized bundles. The gate would price them at 2848 each while the card
+#   actually spends 3856 + 3440, over-pinning that card by 1,600 MiB and eating
+#   the deep-prefill margin (on 2×32 GB it lands at ~856 MiB free, below the
+#   896 MiB that survived a 188K ladder in #931). Excluding the two tail layers
+#   costs 7,296 MiB of eligible residency — 6.3% of the routed set — and buys
+#   EXACT gate arithmetic on every card size. Do not "fix" this to 40.
+#   ⭐ The window also keeps every pin on the card that owns the layer's dense
+#   tensors, with no special-casing: per_card = 38/2 = 19 caps card 0 at blk.2-20
+#   and card 1 at blk.21-39, and `-sm layer` over 42 blocks splits at exactly
+#   0-20 / 21-41. A pin on the wrong card costs a cross-PCIe hop per token.
+#
+# CPU-Offload-GPU-Reserve-MiB: 9758
+# CPU-Offload-First-Card-Extra-MiB: 0
+#   Inputs for resolve_offload_residency(). Sizing is additive from DETECTED
+#   FREE VRAM: fit = (free − reserve − first-card-extra − margin) / bundle.
+#   MEASURED on 2× 24 GB with residency FORCED TO ZERO and the cache OFF — the
+#   same protocol #953 used to recalibrate DeepSeek — at 262K / -ub 2048:
+#       card 0   9116 MiB used   (model 2495.34 + KV 3262.00 + compute 2802.00)
+#       card 1   9758 MiB used   (model 2641.83 + KV 4256.00 + compute 2304.27)
+#   A trivial decode after load added 0 MiB on both cards: there is no
+#   first-decode top-up on this model, everything lands at boot.
+#   ⚠️ CARD 1 IS THE EXPENSIVE ONE HERE — the INVERSE of DeepSeek, and why
+#   first-card-extra is 0 rather than the 768 default. iSWA gives this model 7
+#   full-attention layers among 42; the -ts 1,1 split puts 3 of them on card 0
+#   (3072 MiB KV) and 4 on card 1 (4096 MiB), and that ~1 GB swamps card 0's
+#   larger compute buffer. resolve_offload_residency() has no "last-card extra"
+#   knob, so `reserve` carries the LARGER of the two per-card costs and `extra`
+#   is 0. Card 0 is then charged 642 MiB it does not spend — under-granting is
+#   the safe direction, and OT_G0 exists to out-judge us.
+#   ⚠️ NO CPU-Offload-Draft-Reserve-MiB: this slug loads no drafter (no -md, no
+#   -devd). Absent means 0, which is the correct answer here.
+#   Grants this produces (free VRAM measured at 24123 MiB/card on 2× 24 GB):
+#       2×24 GB   (24123 − 9758 − 1024) / 2848 = 4 bundles/card   BOOTED, serves
+#       2×32 GB   (~32150 − 9758 − 1024) / 2848 = 7 bundles/card  DERIVED
+# ===========================================================================
+services:
+  llama-cpp-inkling-small-iq4xs-residency:
+    # Digest-pinned, not tag-pinned: tags move, digests do not (#940 precedent).
+    # Same image as the moecache sibling — the arch needs vendored #25731 either
+    # way, so there is no mainline option for this model. ⛔ Both collapse back
+    # into the v1 engine when #25731 merges — see engines/llamacpp-club3090-v1.1.yml.
+    image: ${LLAMACPP_CLUB3090_V11_IMAGE:-ghcr.io/noonghunna/llamacpp-club3090@sha256:55f434244cc28d4af99f9fbefdd338b9409dc567d532e7b23bbc7d37f16680f4}
+    container_name: ${ESTATE_CONTAINER:-llama-cpp-inkling-small-iq4xs-residency}
+    restart: unless-stopped
+    ports:
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8086}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+    environment:
+      # Expert-cache tuning — inherited from the 2×24 GB DeepSeek derivation.
+      # ⚠️ On THIS compose the cache is a REMAINDER consumer, not the primary
+      # mechanism: residency is allocated first (at model load) and the pools are
+      # sized from what is left. With a full pin there may be too little left for
+      # even one slab, and that is fine — pin less if you want the cache back.
+      - GGML_CUDA_MOE_CACHE_ADMIT_AFTER=${MOE_ADMIT_AFTER:-64}
+      - GGML_CUDA_MOE_CACHE_RESERVE_MB=${MOE_RESERVE_MB:-1536}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ['${ESTATE_GPUS:-0,1}']
+              capabilities: [gpu]
+    # ⚠️ LIST FORM, NOT a folded `command: >-` string — REQUIRED, not style.
+    # Docker Compose's command-line parser REJECTS `(gate|up|down)` inside a
+    # folded string. The list form skips shell parsing, so the regex — and any
+    # injected OT_G* value — survives byte-for-byte.
+    command:
+      - '-m'
+      - '/models/inkling-small-gguf/UD-IQ4_XS/Inkling-Small-UD-IQ4_XS-00001-of-00004.gguf'
+      - '--host'
+      - '0.0.0.0'
+      - '--port'
+      - '8080'
+      - '--alias'
+      - 'inkling-small'
+      - '-np'
+      - '1'
+      - '-c'
+      - '${CTX:-262144}'
+      - '-ngl'
+      - '99'
+      - '-sm'
+      - 'layer'
+      - '-ts'
+      - '1,1'
+      - '-fa'
+      - 'on'
+      # ⚠️ SINGLE -ot with comma-separated rules. Mainline DEPRECATES repeated
+      # -ot and honours ONLY THE LAST occurrence (#948/#949). FIRST MATCH WINS,
+      # so the two ${OT_G*} device slots MUST stay ahead of the =CPU catch-all.
+      # NOTE the 2 SHARED experts are `_shexp` and do NOT match any of these
+      # rules — they stay GPU-resident by design, which is correct: every token
+      # uses them.
+      - '-ot'
+      - '${OT_G0:-blk\.99999\.ffn_(gate|up|down)_exps\.weight=CUDA0},${OT_G1:-blk\.99999\.ffn_(gate|up|down)_exps\.weight=CUDA1},blk\.[0-9]+\.ffn_(gate|up|down)_exps\.weight=CPU'
+      # ⚠️ The bare-compose default is deliberately conservative. Under the
+      # launchers THREADS is injected; llama.cpp's own default collapses
+      # CPU-offload decode by ~31%, so never leave this to the engine.
+      - '-t'
+      - '${THREADS:-8}'
+      - '-ub'
+      - '${UBATCH:-2048}'
+      - '-b'
+      - '${UBATCH:-2048}'
+      - '--cache-prompt'
+      - '--no-mmap'
+      - '--moe-cache'
+      - '${MOE_CACHE:-auto}'
+      # ⚠️ LOAD-BEARING: `--fit` silently overrides -ngl and places layers itself,
+      # after which the cache reports "kept stock placement" and no-ops. Whenever
+      # -ot is deciding placement, --fit must be off.
+      - '--fit'
+      - 'off'
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 40
+      start_period: 900s

--- a/models/inkling-small/llamacpp-club3090/compose/multi4/unsloth-ud-iq4xs/moecache.yml
+++ b/models/inkling-small/llamacpp-club3090/compose/multi4/unsloth-ud-iq4xs/moecache.yml
@@ -51,7 +51,15 @@
 #              • 1M context does NOT fit: the KV allocates fine, but the prefill
 #                compute buffer wants 9,450 MiB on device 0 and the boot dies.
 #                262K is a deliberate choice, not the model's ceiling.
-#              • Needs ~120 GB of HOST RAM (routed experts live in CPU memory).
+#              • Needs ~121 GB of HOST RAM — a HARD gate, and it does NOT fall
+#                with card count. All 40 routed-expert layers stay on CPU on any
+#                number of cards; more cards buy a bigger expert-cache POOL, not
+#                a smaller CPU buffer, because the cache is a VRAM-side COPY.
+#                preflight REFUSES below it; arithmetic in the
+#                CPU-Offload-Host-RAM-GB block near the bottom of this header.
+#                A host-RAM-bound owner wants the dual `residency.yml` instead,
+#                which PINS bundles into VRAM (no 4-card sibling of it exists —
+#                the reference rig has 2 cards, so nothing 4-card is derivable).
 #              • Load takes several minutes (--no-mmap).
 #              • ⚠️⚠️ NOTHING IN THIS FILE WAS MEASURED ON 4 CARDS. Every number,
 #                and every tuning constant, is INHERITED from the validated dual
@@ -112,6 +120,34 @@
 #   against DeepSeek anyway, since the merge conflict sat on its expert-cache
 #   gate path: verify-full all-pass, decode 21.4-21.6 t/s vs 21.91 on v1.
 # ---------------------------------------------------------------------------
+#
+# CPU-Offload-Host-RAM-GB: 121
+#   ⚠️ IDENTICAL to the dual moe-cache sibling, and that is the POINT: host RAM
+#   here does NOT fall with card count. This compose's `-ot` is an unconditional
+#   all-experts→CPU catch-all, so all 40 routed-expert layers stay in host memory
+#   on any number of cards; the extra VRAM buys expert-cache POOL SLOTS, which
+#   are COPIES, while the CPU master buffer stays whole. (Contrast the DeepSeek
+#   stock multi4 slug, whose need genuinely falls with card count — that one pins
+#   expert bundles back onto the GPUs.)
+#   MEASURED (2×3090 boot log; the buffer is card-count-independent, `--no-mmap`):
+#       CUDA_Host model buffer   116354.33 MiB = 113.63 GiB   <- the HARD floor
+#                                = 115,520.00 MiB routed expert bundles
+#                                + 834.33 MiB `token_embd.weight` (Q8_0), which
+#                                  llama.cpp keeps host-side whatever -ngl says
+#     + ~8 GiB   process overhead (1,098.86 MiB CUDA_Host compute buffer, CPU FFN
+#                scratch, CUDA host allocations) — the same constant the DeepSeek
+#                headers carry.
+#     = 121.
+#   ⚠️ HARD floor, not a recommendation. `--no-mmap` makes the loader
+#   `cudaMallocHost` the whole offloaded set: pinned pages are non-evictable and
+#   cannot be oversubscribed, so a short box does not degrade — it dies inside
+#   the allocation, which presents as "loads the model into RAM, then the
+#   container is OOM-killed" (club-3090 #978).
+#   ⚠️ NO residency headers here, DELIBERATELY — there are no ${OT_G*} slots in
+#   the `-ot` below, so nothing is ever pinned back and the gate must NOT
+#   subtract a grant. offload_residency_grant_mib() returns 0 without
+#   CPU-Offload-Bundle-MiB, which is the correct answer for this compose.
+# ===========================================================================
 services:
   llama-cpp-inkling-small-iq4xs-moecache-multi4:
     # Digest-pinned, not tag-pinned: tags move, digests do not (#940 precedent).

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -1031,10 +1031,48 @@ COMPOSE_REGISTRY = {
         offload="n-cpu-moe",
         # Load-bearing: gates the launch-compat MOE_RESERVE_MB injection.
         moe_cache=True,
-        host_ram_gb=120,
+        # Nominal == the compose header's worst case (121). There is no residency
+        # to subtract on this slug: the `-ot` is an unconditional all-experts->CPU
+        # catch-all with no OT_G* slots, so host RAM does NOT fall with card count
+        # or card size -- the expert cache is a VRAM-side COPY and the CPU master
+        # buffer stays whole. MEASURED CUDA_Host model buffer 116354.33 MiB
+        # (= 115520.00 experts + 834.33 token_embd) = 113.63 GiB, +8 overhead.
+        # The `-residency` sibling is the slug whose need falls with VRAM.
+        host_ram_gb=121,
         required_sm=8.6,
         status="experimental",
         status_note="Validated 2026-08-12 on the fork branch at 262K: verify-full 9/9, soak-continuous PASS (0 MiB growth, 0/25 silent-empty), decode 32.01 narrative / 31.15 code, prefill FLAT 401.6@10K -> 385.7@90K, agentic context 31.4x -> TTFT 4.8x (sub-linear). Expert cache 76-78% hits on ~6,908 resident slots (67.5% of 10,240 routed experts) -- a HIGHER rate than DeepSeek's ~57%, because inkling's resident non-expert weights are only 5.1 GB, leaving more VRAM for the pool. iSWA (7 full-attention + 35 windowed layers) keeps KV to 7.5 GB even at 262K. ⚠️ TTFT at depth is the real cost: 225 s for an 87K prompt -- 262K is a CAPACITY number, not a serving latency. 1M does not fit: KV allocates, but the prefill compute buffer wants 9,450 MiB on device 0. ⏸️ UPSTREAM-GATED on ggml-org#25731: the `inkling` arch is not in mainline, so the published llamacpp-club3090 digest CANNOT load this model (`unknown model architecture: 'inkling'`). Runs only on a self-built fork of stack/club3090-moecachev1.1 until the PR merges and the engine is rebuilt. ⚠️ ATTRIBUTION: the expert cache is leloch's (RFC ggml-org#24528); the arch is @danielhanchen's PR, vendored — we maintain neither. ⚠️ REASONING IS ON BY DEFAULT at effort 0.9: this model reads `reasoning_effort`, NOT `enable_thinking`, and ignores the latter silently — a client sending a small max_tokens without setting effort gets an empty answer and no error. ⚠️ Sampling should be Unsloth's temp 1.0/top_p 1.0/min_p 0.0, not the canonical Qwen values, for any quality work. ⚠️ QUALITY UNTESTED -- no 8-pack. ⚠️ Decode figures are a LOWER BOUND: the expert cache was still filling after 25 soak turns (+49% session 1->5), so short runs understate steady state.",
+        category="frontier",
+    ),
+    # ── The STATIC-RESIDENCY sibling of the dual moe-cache slug (#978). Same
+    # weights, same engine, opposite memory mechanism: `-ot ...=CUDA*` rules MIGRATE
+    # expert bundles into VRAM instead of COPYING them there, so host RAM falls with
+    # card size where the cache slug's never does. Ships because a 128 GB / 2x32 GB
+    # owner cannot run the cache slug at all -- it OOM-killed during load and froze
+    # his desktop. It is a MEMORY trade, not a speed win: prefer the cache slug on
+    # any rig that can feed it.
+    "llamacpp-club3090/inkling-small-dual-iq4xs-residency": _entry(
+        model="inkling-small", weights_variant="unsloth-ud-iq4xs", workload="long-ctx-single",
+        engine="llamacpp-club3090-v1.1", drafter=None, kv_format="fp16",
+        tp=2, max_ctx=262144, max_num_seqs=1, mem_util=None,
+        compose_path="models/inkling-small/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/residency.yml",
+        default_port=8086,
+        kvcalc_key="SKIP",
+        offload="n-cpu-moe",
+        # Load-bearing: gates the launch-compat MOE_RESERVE_MB injection. The cache
+        # is still ON here, but as a REMAINDER consumer -- residency allocates first.
+        moe_cache=True,
+        # NOMINAL, not worst case: the compose header's 121 is the all-experts-on-CPU
+        # figure the gate starts from, and 99 is what it computes after subtracting
+        # the residency grant on 2x24 GB -- the smallest topology this slug supports,
+        # hence the HIGHEST realistic need. Bigger cards go lower (2x32 GB -> ~83,
+        # derived). Do NOT raise this to 121: that would hide the entire point of the
+        # slug in the catalog. Do NOT lower it to the 32 GB figure either -- nominal
+        # must not undershoot what a supported rig actually needs.
+        host_ram_gb=99,
+        required_sm=8.6,
+        status="experimental",
+        status_note="⭐ THE HOST-RAM-BOUND OPTION for Inkling: `-ot ...=CUDA*` residency rules MIGRATE expert bundles into VRAM (the moe-cache slug only COPIES them, so its 121 GB host bill is fixed no matter how much VRAM you own). Host need falls with card size: 99 GB on 2x24 GB (BOOTED on the reference rig -- CUDA_Host model buffer 116354.33 -> 93570.33 MiB, exactly the 4+4 bundles the sizer granted; verify-full not yet run), ~83 GB on 2x32 GB (DERIVED, not booted -- the reference rig has 2x24 GB permanently). ⚠️ THIS IS A MEMORY TRADE, NOT A SPEED WIN, and that is MEASURED: a same-session probe (2x24 GB, 3 warm-up + 3 measured, one 300-token prompt, canonical sampling) put this config at a FLAT 20.35 t/s against 25.25 t/s for the cache sibling, which was STILL CLIMBING on its last run (23.80 -> 25.36 -> 26.60) toward its published canonical 32.01 t/s -- so >=+24% and understated. Residency converges instantly (nothing to warm) but makes only a handful of layers local; the cache follows expert popularity across ALL 40 layers and reaches 76-78% hits at 67.5% coverage. ⚠️ That is a PROBE (N=3/arm, one prompt, one leg) -- it settles direction and a lower bound, not a benchmark row. On a rig that can feed the cache slug, use the cache slug. ⭐ The pin is TUNABLE and the sizer is a maximiser: OT_G0/OT_G1 overrides are never clobbered and the RAM gate prices your ACTUAL pin, so pin the MINIMUM that clears your host RAM and leave the rest to the cache. With both overrides set to a no-match rule this degrades to exactly the moe-cache slug. ⚠️ The residency constants are MEASURED on 2x24 GB (reserve 9758 MiB from a zero-residency cache-off boot; bundle 2848 MiB from the GGUF tensor table) -- every >24 GB projection is ARITHMETIC from those, not a boot. ⚠️ CPU-Offload-MoE-Layers is 38, not the model's 40, ON PURPOSE: blk.40/41 carry oversized mixed-precision bundles (3440/3856 MiB vs 2848) and the last card's outer-edge selection would pick exactly those two first, over-pinning it by 1600 MiB while the gate priced them at 2848. Do not 'fix' it to 40 -- see the compose header. ⏸️ UPSTREAM-GATED on ggml-org#25731 exactly like its sibling: the `inkling` arch is not in mainline, so the published llamacpp-club3090 digest CANNOT load this model. ⚠️ ATTRIBUTION: the expert cache is leloch's (RFC ggml-org#24528); the arch is @danielhanchen's PR, vendored -- we maintain neither. ⚠️ REASONING IS ON BY DEFAULT at effort 0.9: this model reads `reasoning_effort`, NOT `enable_thinking`, and ignores the latter silently. ⚠️ QUALITY UNTESTED on this placement -- the weights are identical to the moe-cache slug but no 8-pack has been run against this config, so do not quote its scores as this slug's.",
         category="frontier",
     ),
     "llamacpp-club3090/inkling-small-multi4-iq4xs-moecache": _entry(
@@ -1046,7 +1084,10 @@ COMPOSE_REGISTRY = {
         kvcalc_key="SKIP",
         offload="n-cpu-moe",
         moe_cache=True,
-        host_ram_gb=120,
+        # Same 121 as the dual sibling, deliberately: the all-experts->CPU `-ot`
+        # is card-count-independent, so 4 cards do NOT lower the host need (they
+        # only buy cache pool slots, which are copies). Do not "scale" this down.
+        host_ram_gb=121,
         required_sm=8.6,
         status="experimental",
         status_note="⚠️⚠️ NEVER BOOTED -- every constant is INHERITED from the validated dual slug (same precedent as the DeepSeek multi4 sibling), and RESERVE_MB/ADMIT_AFTER were derived from a measured compute-buffer swing on 2x24 GB, so they are topology-specific and probably wrong here. Re-derive before trusting any number. HYPOTHESIS worth testing: on this model hit rate tracks spatial coverage (dual = 67.5% of 10,240 routed experts at 76-78% hits), so doubling the pool budget could approach saturation -- but compute buffers and the layer split also change, and this rig has no NVLink. ⏸️ UPSTREAM-GATED on ggml-org#25731: the `inkling` arch is not in mainline, so the published llamacpp-club3090 digest CANNOT load this model (`unknown model architecture: 'inkling'`). Runs only on a self-built fork of stack/club3090-moecachev1.1 until the PR merges and the engine is rebuilt. ⚠️ ATTRIBUTION: the expert cache is leloch's (RFC ggml-org#24528); the arch is @danielhanchen's PR, vendored — we maintain neither. ⚠️ REASONING IS ON BY DEFAULT at effort 0.9: this model reads `reasoning_effort`, NOT `enable_thinking`, and ignores the latter silently — a client sending a small max_tokens without setting effort gets an empty answer and no error. ⚠️ Sampling should be Unsloth's temp 1.0/top_p 1.0/min_p 0.0, not the canonical Qwen values, for any quality work. ⚠️ QUALITY UNTESTED -- no 8-pack. ⚠️ Decode figures are a LOWER BOUND: the expert cache was still filling after 25 soak turns (+49% session 1->5), so short runs understate steady state.",

--- a/scripts/lib/profiles/models/inkling-small.yml
+++ b/scripts/lib/profiles/models/inkling-small.yml
@@ -65,10 +65,30 @@ offload_residency:
     # derive one from "IQ4_XS" — the quant name does not give you the byte size.
     expert_bundle_uniform: false
     expert_types_kib: { iq3_s: 3520, iq4_xs: 4352, q6_K: 6720 }
-    # ⚠️ NOT YET MEASURED: per-layer bundle sizes (the DeepSeek file has these
-    # from tensor-offset deltas; the equivalent pass has not been run here).
-    # Until it is, host-RAM guards must use the totals below, not per-layer math.
-    routed_total_gib: 113.5      # 118.7 GiB total − 5.1 GiB GPU-resident
+    # ⭐ MEASURED 2026-08-14 (#978), read from the GGUF tensor table by summing
+    # `blk.N.ffn_(gate|up|down)_exps.weight` per layer — the pass the previous
+    # revision of this block recorded as "NOT YET MEASURED". Two layers are
+    # OUTLIERS because the Dynamic quant spends q6_K on the model's tail:
+    expert_bundle_mib: 2848                # modal — 38 of the 40 MoE layers
+    per_layer_mib_default: 2848
+    per_layer_mib_overrides: { 40: 3440, 41: 3856 }
+    first_moe_layer: 2                     # 2 dense blocks precede the MoE stack
+    # ⚠️⚠️ THE OUTLIERS ARE AT THE TOP OF THE STACK, WHICH IS EXACTLY WHERE THE
+    # LAST CARD'S RESIDENCY SELECTION STARTS. _offload_layers_for_card() counts
+    # DOWN from the top of the window for the last card, so a residency window
+    # that includes blk.40/41 hands that card the two biggest bundles first while
+    # the scalar gate prices them at 2848 — over-pinning it by 1,600 MiB. The
+    # residency compose therefore declares a window of 38 (blk.2-39), not 40.
+    # Any guard doing per-layer math must respect these overrides.
+    # ⚠️ 113.5 CORRECTED to 112.8 (#978). The old figure was derived as
+    # "118.7 total − 5.1 GPU-resident" and over-counted, because 834.33 MiB of
+    # `token_embd.weight` (Q8_0) is NEITHER routed-expert NOR GPU-resident:
+    # llama.cpp keeps it host-side whatever -ngl says. Measured decomposition of
+    # the CUDA_Host model buffer (116,354.33 MiB at zero residency):
+    #     115,520.00 MiB routed expert bundles  = 112.81 GiB
+    #   +     834.33 MiB token_embd.weight
+    routed_total_gib: 112.8      # 40 layers: 38x2848 + 3440 + 3856 MiB
+    host_pinned_non_expert_mib: 834          # token_embd — no -ot rule moves it
     dense_gpu_gib: 5.0           # measured: CUDA0 2,495 + CUDA1 2,642 MiB
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test-compose-registry-disk.sh
+++ b/scripts/tests/test-compose-registry-disk.sh
@@ -34,8 +34,8 @@ def check(cond, msg):
         print(f"FAIL: {msg}")
         failures.append(msg)
 
-check(len(COMPOSE_REGISTRY) == 77, f"registry has 77 entries (got {len(COMPOSE_REGISTRY)})")
-check(len(disk_paths) == 78, f"disk has 78 compose files (got {len(disk_paths)})")
+check(len(COMPOSE_REGISTRY) == 78, f"registry has 78 entries (got {len(COMPOSE_REGISTRY)})")
+check(len(disk_paths) == 79, f"disk has 79 compose files (got {len(disk_paths)})")
 check(registry_paths <= disk_paths, "all registry compose_path values exist on disk")
 parked_disk_only = disk_paths - registry_paths
 # Disk-only (non-registry) composes allowed: parked SGLang archives, plus the experimental

--- a/scripts/tests/test-preflight-cpu-offload.sh
+++ b/scripts/tests/test-preflight-cpu-offload.sh
@@ -37,10 +37,20 @@ M4=models/deepseek-v4-flash-0731/llama-cpp/compose/multi4/unsloth-q8-kxl/offload
 # cudaMallocHost failure instead of our refusal. Every list below includes them.
 FORK_Q8=models/deepseek-v4-flash-0731/llamacpp-club3090/compose/dual/unsloth-q8-kxl/moecache.yml
 FORK_M4=models/deepseek-v4-flash-0731/llamacpp-club3090/compose/multi4/unsloth-q8-kxl/moecache.yml
+# ── Inkling-Small: the SAME defect, on a second model (#978). Both moe-cache
+# composes carried only prose ("Needs ~120 GB of HOST RAM") and no header, so the
+# gate early-returned again -- this time a dual-5090 / 128 GB owner's container
+# was OOM-killed during load and his desktop froze. Prose is not a gate.
+INK_CACHE=models/inkling-small/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/moecache.yml
+INK_M4=models/inkling-small/llamacpp-club3090/compose/multi4/unsloth-ud-iq4xs/moecache.yml
+# ⭐ the RESIDENCY sibling shipped by #978 -- the answer for a host-RAM-bound rig,
+# and the one Inkling compose that legitimately DOES carry the bundle headers.
+# Its presence is why the no-residency-headers assertions below are per-file.
+INK_RES=models/inkling-small/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/residency.yml
 NONOFF=models/tess-4-27b/llama-cpp/compose/dual/migtissera-q4km/mtp.yml
 
 # ---- detector ----
-for f in "$Q8" "$IQ2" "$M4" "$FORK_Q8" "$FORK_M4"; do
+for f in "$Q8" "$IQ2" "$M4" "$FORK_Q8" "$FORK_M4" "$INK_CACHE" "$INK_M4" "$INK_RES"; do
   is_cpu_offload_compose "$f" && ok "detects offload: $(basename "$(dirname "$f")")/$(basename "$f")" \
     || bad "MISSED offload compose $f"
 done
@@ -80,7 +90,7 @@ command grep -qE "85%|305" <<<"$msg" \
 # ⚠️ EVERY offload compose must declare the header. Without it the gate silently
 # early-returns -- the failure mode is INVISIBLE (no warning, just no refusal),
 # which is exactly how the two moe-cache slugs shipped ungated.
-for f in "$Q8" "$IQ2" "$M4" "$FORK_Q8" "$FORK_M4"; do
+for f in "$Q8" "$IQ2" "$M4" "$FORK_Q8" "$FORK_M4" "$INK_CACHE" "$INK_M4" "$INK_RES"; do
   v="$(compose_meta_get "$f" cpu-offload-host-ram-gb || true)"
   [[ "$v" =~ ^[0-9]+$ ]] && ok "declares CPU-Offload-Host-RAM-GB=$v ($(basename "$(dirname "$f")")/$(basename "$f"))" \
     || bad "$f missing/invalid CPU-Offload-Host-RAM-GB"
@@ -286,7 +296,7 @@ fm4_hdr="$(compose_meta_get "$FORK_M4" cpu-offload-host-ram-gb)"
 # unconditional all-experts->CPU catch-all with no ${OT_G*} slots, so nothing is
 # ever pinned back onto the GPUs. Declaring CPU-Offload-Bundle-MiB would make the
 # gate SUBTRACT a grant that never materialises -- under-gating every rig.
-for f in "$FORK_Q8" "$FORK_M4"; do
+for f in "$FORK_Q8" "$FORK_M4" "$INK_CACHE" "$INK_M4"; do
   b="$(compose_meta_get "$f" cpu-offload-bundle-mib || true)"
   [[ -z "$b" ]] && ok "$(basename "$(dirname "$f")")/moecache.yml declares no bundle header (grant must stay 0)" \
     || bad "$f declares CPU-Offload-Bundle-MiB=$b but has no OT_G* slots — the gate would under-gate"
@@ -295,6 +305,94 @@ for f in "$FORK_Q8" "$FORK_M4"; do
     || ok "$(basename "$(dirname "$f")")/moecache.yml has no OT_G* slots (all experts stay on CPU)"
 done
 
+# the Inkling cache pair: same weights, same all-on-CPU `-ot`, no drafter, and the
+# CUDA_Host buffer is card-count-independent -- so dual and multi4 must AGREE, and
+# the multi4 must NOT be discounted for "more cards". The cache is a COPY.
+ic_hdr="$(compose_meta_get "$INK_CACHE" cpu-offload-host-ram-gb)"
+im_hdr="$(compose_meta_get "$INK_M4" cpu-offload-host-ram-gb)"
+[[ "$ic_hdr" == "$im_hdr" ]] \
+  && ok "inkling dual and multi4 moe-cache headers agree ($ic_hdr GB)" \
+  || bad "inkling headers diverge (dual=$ic_hdr multi4=$im_hdr): a cache slug's host RAM does not fall with card count"
+
+# ---- the RESIDENCY compose is the mirror image: it MUST carry the full set ----
+# A residency compose that declares OT_G* slots but omits the bundle headers gets
+# grant 0 -- the launcher pins nothing, and the slug silently becomes an expensive
+# copy of the cache sibling. Both halves must be present or neither.
+command grep -q 'OT_G[0-9]' "$INK_RES" \
+  && ok "inkling residency.yml has OT_G* slots (the launcher can pin)" \
+  || bad "$INK_RES has no OT_G* slots — nothing will ever be pinned"
+for k in bundle-mib moe-layers first-moe-layer gpu-reserve-mib first-card-extra-mib; do
+  v="$(compose_meta_get "$INK_RES" "cpu-offload-$k" || true)"
+  [[ "$v" =~ ^[0-9]+$ ]] && ok "inkling residency.yml declares CPU-Offload-$k=$v" \
+    || bad "$INK_RES missing/invalid CPU-Offload-$k (grant would silently be 0)"
+done
+# ⚠️ the residency compose's host-RAM header must EQUAL its cache sibling's. It is
+# the ALL-on-CPU worst case for BOTH -- preflight subtracts this rig's grant itself
+# (offload_residency_grant_mib), so pre-baking expected residency here would
+# DOUBLE-COUNT it and under-gate every rig.
+ir_hdr="$(compose_meta_get "$INK_RES" cpu-offload-host-ram-gb)"
+[[ "$ir_hdr" == "$ic_hdr" ]] \
+  && ok "inkling residency header == cache header ($ir_hdr GB — worst case, grant subtracted at runtime)" \
+  || bad "inkling residency header ($ir_hdr) != cache header ($ic_hdr): residency was pre-baked into the header"
+
+# ⭐⭐ THE WINDOW MUST NOT CONTAIN AN OVERSIZED BUNDLE — the subtle one, and the
+# reason CPU-Offload-MoE-Layers is 38 on a model with 40 MoE layers.
+# _offload_layers_for_card() gives the LAST card outer-edge selection counting DOWN
+# from the top of the window, so widening the window to 40 hands that card blk.41
+# (3856 MiB) and blk.40 (3440 MiB) FIRST while the scalar gate prices both at 2848
+# -- over-pinning it by 1,600 MiB and eating the deep-prefill margin. Nothing else
+# would catch that: the compose still boots, the gate still prints a number, and
+# the card just runs closer to the edge than #931's bracket allows.
+# Cross-checked against the MEASURED per-layer table in the model profile.
+while IFS='|' read -r line; do
+  case "$line" in
+    OK\|*)   ok "${line#OK|}" ;;
+    FAIL\|*) bad "${line#FAIL|}" ;;
+  esac
+done < <(python3 - "$INK_RES" <<'PY'
+import re
+import sys
+
+compose = open(sys.argv[1], encoding="utf-8").read()
+
+def hdr(key):
+    m = re.search(rf"^#\s*{key}:\s*(\d+)\s*$", compose, re.M)
+    return int(m.group(1)) if m else None
+
+first, count, scalar = hdr("CPU-Offload-First-MoE-Layer"), hdr("CPU-Offload-MoE-Layers"), hdr("CPU-Offload-Bundle-MiB")
+prof = open("scripts/lib/profiles/models/inkling-small.yml", encoding="utf-8").read()
+m = re.search(r"^\s*per_layer_mib_default:\s*(\d+)", prof, re.M)
+default = int(m.group(1)) if m else None
+m = re.search(r"^\s*per_layer_mib_overrides:\s*\{([^}]*)\}", prof, re.M)
+overrides = {}
+if m:
+    for pair in m.group(1).split(","):
+        if ":" in pair:
+            k, v = pair.split(":")
+            overrides[int(k.strip())] = int(v.strip())
+
+if None in (first, count, scalar, default):
+    print("FAIL|could not read the residency window or the profile's per-layer table")
+    sys.exit(0)
+if scalar != default:
+    print(f"FAIL|compose bundle {scalar} MiB != profile per_layer_mib_default {default} MiB")
+else:
+    print(f"OK|compose bundle ({scalar} MiB) == profile per_layer_mib_default")
+if not overrides:
+    print("FAIL|profile declares no per_layer_mib_overrides — the outlier guard cannot run")
+    sys.exit(0)
+window = range(first, first + count)
+bad_layers = sorted(l for l in overrides if l in window)
+if bad_layers:
+    detail = ", ".join(f"blk.{l}={overrides[l]}MiB" for l in bad_layers)
+    print(f"FAIL|residency window blk.{first}-{first+count-1} contains OVERSIZED bundles ({detail}) "
+          f"but the gate prices every layer at {scalar} MiB — narrow CPU-Offload-MoE-Layers")
+else:
+    print(f"OK|residency window blk.{first}-{first+count-1} holds only uniform {scalar} MiB bundles "
+          f"(outliers {sorted(overrides)} correctly excluded)")
+PY
+)
+
 # registry host_ram_gb is the NOMINAL display figure and must never exceed the
 # header's worst case (nominal = worst case minus residency, on any topology)
 # ⚠️ every deepseek-flash slug carrying host_ram_gb MUST map to a compose here.
@@ -302,8 +400,11 @@ done
 # which is how they kept a copied 146 while their compose needed ~10 GB more.
 while IFS='|' read -r slug reg_gb; do
   case "$slug" in
-    *dual-q8-moecache)   f="$FORK_Q8" ;;
-    *multi4-q8-moecache) f="$FORK_M4" ;;
+    *dual-q8-moecache)      f="$FORK_Q8" ;;
+    *multi4-q8-moecache)    f="$FORK_M4" ;;
+    *dual-iq4xs-moecache)   f="$INK_CACHE" ;;
+    *multi4-iq4xs-moecache) f="$INK_M4" ;;
+    *dual-iq4xs-residency)  f="$INK_RES" ;;
     *dual-q8)   f="$Q8" ;;
     *dual-iq2)  f="$IQ2" ;;
     *multi4-q8) f="$M4" ;;
@@ -317,8 +418,11 @@ done < <(python3 - <<'PY'
 import sys
 sys.path.insert(0, ".")
 from scripts.lib.profiles.compose_registry import COMPOSE_REGISTRY
+# EVERY slug carrying host_ram_gb, not just deepseek-flash: the filter used to be
+# model-scoped, so the inkling slugs sailed past this check entirely and kept a
+# hand-typed 120 that nothing compared against the compose (#978).
 for slug, e in COMPOSE_REGISTRY.items():
-    if "deepseek-flash" in slug and e.get("host_ram_gb"):
+    if e.get("host_ram_gb"):
         print(f"{slug}|{e['host_ram_gb']}")
 PY
 )
@@ -335,10 +439,10 @@ declare -F resolve_offload_threads >/dev/null 2>&1 && ok "resolve_offload_thread
   && ok "no-op on a non-offload compose" || bad "set THREADS on a non-offload compose"
 # the bare-compose fallback must be LOW, not the reference rig's number: over-subscribing
 # measured -69% vs under-subscribing -9.6%, so err low when the core count is unknown.
-for f in "$Q8" "$IQ2" "$M4" "$FORK_Q8" "$FORK_M4"; do
+for f in "$Q8" "$IQ2" "$M4" "$FORK_Q8" "$FORK_M4" "$INK_CACHE" "$INK_M4" "$INK_RES"; do
   fb="$(command grep -oE 'THREADS:-[0-9]+' "$f" | command grep -oE '[0-9]+' | head -1)"
-  [[ -n "$fb" && "$fb" -le 8 ]] && ok "$(basename "$(dirname "$f")"): safe THREADS fallback ($fb)" \
-    || bad "$(basename "$(dirname "$f")"): THREADS fallback '$fb' is too high for an unknown rig"
+  [[ -n "$fb" && "$fb" -le 8 ]] && ok "$(basename "$(dirname "$f")")/$(basename "$f"): safe THREADS fallback ($fb)" \
+    || bad "$(basename "$(dirname "$f")")/$(basename "$f"): THREADS fallback '$fb' is too high for an unknown rig"
 done
 
 # ---- wiring ----


### PR DESCRIPTION
Closes #978.

Two halves, one issue: **why the failure was silent**, and **what we can offer the reporter**.

## 1. The gate that never fired

`preflight_cpu_offload_ram()` early-returns when a compose carries no `CPU-Offload-Host-RAM-GB:` header. Both `inkling-small` moe-cache composes carried only prose — *"Needs ~120 GB of HOST RAM"* — so the hard gate never fired. @paulp83 got a SIGKILL mid-load and, with a desktop running, a frozen machine, instead of a refusal. This is the identical defect #977 just fixed on the DeepSeek pair; the test that caught it there filtered on `"deepseek-flash" in slug`, so these two sailed past.

**Header = 121, measured** (2×3090, `--no-mmap`, 262K / `-ub 2048`):

```
load_tensors: CUDA_Host model buffer size = 116354.33 MiB = 113.63 GiB
  = 115520.00 MiB routed expert bundles
  +    834.33 MiB token_embd.weight (Q8_0) — llama.cpp keeps the input
                  embedding host-side whatever -ngl says
+ ~8 GiB  process overhead (1098.86 MiB CUDA_Host compute buffer, CPU FFN
          scratch, CUDA host allocations) — the constant every shipped
          offload header already carries
= 121
```

Identical on a cache-enabled and a cache-off boot, and card-count-independent: the expert cache is a **VRAM-side COPY**, so the CPU master buffer stays whole. Host RAM does not fall with card count here, which is why the multi4 header is the same 121 and why **neither gets residency headers** (`offload_residency_grant_mib()` must keep returning 0 — the `-ot` is an unconditional all-experts→CPU catch-all with no `${OT_G*}` slots).

On the reporter's rig (123 GB total, ~107 GB available) the gate now takes the `avail_gb < need_gb` branch and refuses cleanly. A 192 GB rig still passes.

## 2. `residency.yml` — the part that actually helps him

Same weights, same engine, opposite memory mechanism: `-ot ...=CUDA*` rules **MIGRATE** expert bundles into VRAM instead of copying them there, so the host bill falls with card size.

| rig | grant | pinned | host need |
|---|---|---|---|
| 2×24 GB | 4 bundles/card | 22.25 GiB | **99 GB** — booted |
| 2×32 GB | 7 bundles/card | 38.94 GiB | **~83 GB** — derived |

**Booted on 2×24 GB**, and the arithmetic is exact rather than approximate:

```
CUDA_Host model buffer   116354.33 -> 93570.33 MiB   (−22784.00 = exactly 8 × 2848)
peak process RSS             115.39 ->    93.14 GiB
free VRAM after boot                     1525 / 1483 MiB   (margin intact)
```

⚠️ **The 32 GB and 4-card figures are arithmetic from the 24 GB measurements, not boots.** The reference rig has 2×24 GB permanently; that limit is stated in the compose header, the registry `status_note`, and here.

### Derived constants (all from measurement)

- **`bundle 2848 MiB`** — per-layer sum of `ffn_(gate|up|down)_exps.weight`, read from the GGUF tensor table. Not from the quant name.
- **`reserve 9758 MiB`** — per-card cost with residency forced to zero and the cache off (card 0 9116, card 1 9758). A trivial decode added 0 MiB: no first-decode top-up on this model.
- **`first-card-extra 0`** — ⚠️ card **1** is the expensive card here, the inverse of DeepSeek. iSWA puts 4 of the 7 full-attention layers on it (4096 vs 3072 MiB KV), swamping card 0's larger compute buffer. There is no last-card knob, so `reserve` carries the larger cost and extra is 0.
- **`window blk.2–39` (38, not the model's 40)** — ⚠️⚠️ the subtle one. `blk.40/41` are 3440/3856 MiB against 2848 for the other 38, and `_offload_layers_for_card()` gives the **last** card outer-edge selection counting **down** from the top — so a window of 40 hands that card both outliers first while the scalar gate prices them at 2848. That over-pins it by 1600 MiB and eats the deep-prefill margin (on 2×32 GB: ~856 MiB free, under the 896 that survived #931's 188K ladder). Excluding them costs 6.3% of the routed set and buys **exact** gate arithmetic. A new test leg cross-checks the window against the measured per-layer table so nobody "fixes" it back to 40.

### It is a memory trade, not a speed win — measured

Same-session probe, 3 warm-up + 3 measured, one 300-token prompt, canonical sampling:

| config | measured runs | verdict |
|---|---|---|
| `residency.yml` | 20.37 / 20.47 / 20.21 | **flat 20.35 t/s** — converges instantly, nothing to warm |
| `moecache.yml` | 23.80 / 25.36 / 26.60 | **25.25 t/s and still climbing** toward its published canonical 32.01 |

Residency makes a handful of layers perfectly local; the cache follows expert popularity across all 40 and reaches 76–78% hits at 67.5% coverage. **On any rig that can feed the cache slug, use the cache slug.** Recorded as a *probe* (N=3/arm, one prompt, one leg) — it settles direction and a lower bound, not a BENCHMARKS row.

The pin is also **tunable**: `OT_G0`/`OT_G1` overrides are never clobbered and the RAM gate prices the *actual* pin, so a user whose host RAM is merely tight can pin the minimum that clears the gate and leave the rest of the VRAM to the cache. With both set to a no-match rule the compose degrades to exactly `moecache.yml`.

## Also

- Registry `host_ram_gb` **120 → 121** on both moe-cache slugs. The old value was hand-typed and nothing compared it against a compose.
- `test-preflight-cpu-offload`: the registry cross-check now covers **every** slug carrying `host_ram_gb`, not just `deepseek-flash`. All three inkling composes are in every list. New legs assert the cache pair agree, that neither declares residency headers, that `residency.yml` declares all five plus `OT_G*` slots, that its host-RAM header **equals** its sibling's (pre-baking residency there would double-count), and the window-vs-outliers guard above.
- `models/inkling-small.yml`: per-layer bundle sizes were recorded as *"NOT YET MEASURED"* — now measured, outliers called out. `routed_total_gib` **113.5 → 112.8**: the old figure was derived as "118.7 total − 5.1 GPU-resident" and over-counted, because `token_embd` is neither routed-expert nor GPU-resident. (This is the 113.5 quoted in the issue.)

## Validation

- Full sweep **102/102 green**.
- `diagnose-profile llamacpp-club3090/inkling-small-dual-iq4xs-residency` → **GREEN** (15/16 constraints, KV projection N/A for llama.cpp).
- `switch.sh --list` shows both dual variants.
- 4 live boots on the reference rig: all-CPU (cache on), all-CPU (cache off, for the reserve), residency+cache, and the A/B arm. GPUs released after each.

## Not verified

- Nothing on 32 GB cards or 4 cards — 2×24 GB is permanent here.
- No `verify-full`, no 8-pack, no soak on `residency.yml`. Weights are identical to the cache sibling, but placement is not quality-neutral until shown to be, so its scores are **not** quoted as this slug's. Status stays `experimental`.
