### PR TITLE
Add Qwen3.8-27B + Muse Glimmer 30B configs and Native Windows inference path

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you have one or two RTX 3090s and want to run modern LLMs at home, in a homel
 
 ## Quick start
 
-> 🪟 **On Windows?** These steps assume Linux/macOS. Set up **WSL2** first → **[docs/WSL_SETUP.md](docs/WSL_SETUP.md)** (start-to-finish). Native Windows runs only the *upstream* llama.cpp binary — none of this repo's tooling.
+> 🪟 **On Windows?** Two paths: **[WSL2 + Docker](docs/WSL_SETUP.md)** (full tooling) or **[Native Windows llama.cpp](docs/WINDOWS_NATIVE.md)** (no WSL2, no Docker — just `llama-server.exe` + GGUF). The native path is validated for production agentic workloads on single 3090s (see [`models/qwen3.8-27b/`](models/qwen3.8-27b/README.md)).
 
 ```bash
 # 1. Clone the repo
@@ -125,7 +125,9 @@ Each hardware page lists every supported model with the working composes for tha
 | Model | Status | Card counts | Engines | Highlights |
 |---|---|---|---|---|
 | **[Qwen3.6-27B](models/qwen3.6-27b/)** | Production-ready ⭐ | 1× / 2× 3090 | vLLM ✅ · llama.cpp ✅ · ik_llama ✅ | Vision · tools · MTP n=3 · up to 262K ctx · vLLM dual = 89/127 TPS · llama.cpp single = 200K max-safe, no prefill cliffs · ik_llama IQ4_KS = ~60/69 TPS (fastest single-card) |
+| **[Qwen3.8-27B](models/qwen3.8-27b/)** | Community-validated (Windows native) | 1× 3090 | llama.cpp ✅ (native Windows + WSL2) | **Newest Qwen dense** · native 262K ctx · MTP n=2 · vision + tools integrated at full ctx · **~40-44 t/s @ 170K MTP** / ~30-33 t/s @ 262K · UD-Q4_K_XL quant · no WSL2/Docker required ([`docs/WINDOWS_NATIVE.md`](docs/WINDOWS_NATIVE.md)) |
 | **[Gemma 4 31B](models/gemma-4-31b/)** | Production-ready | 1× ¹ / 2× 3090 | vLLM ✅ (dual) · llama.cpp ⚠️ (community fork; mainline blocked on FA hdim=512) | Vision · tools · MTP n=3 (Google official drafter) **OR** DFlash n=7 (z-lab drafter) · up to 262K ctx via INT8 PTH KV (PR [#40391](https://github.com/vllm-project/vllm/pull/40391) vendored) · MTP dual = 106/141 TPS at 32K, 95/126 at 262K · DFlash dual = 105/177 TPS at 32K (code-optimal) · single-card: no functional config since the beellama retirement (2026-07-27 — engine deprecated; historical: 47/88 TPS via beellama DFlash, [discussion #239](https://github.com/noonghunna/club-3090/discussions/239)) |
+| **[Muse Glimmer 30B](models/muse-glimmer-30b/)** | Community-validated | 1× 3090 | llama.cpp ✅ (WSL2 + native Windows) | **Meta Superintelligence Lab** · dense 30B (SWA+GQA) · DFlash n=15 · **47 t/s @ 131K** (post-sweep) · native tool calling + vision · reasoning strength tunable per-request · no WSL2 required |
 | **[Qwen3.6 35B-A3B](models/qwen3.6-35b-a3b/)** | Production-ready (ik-llama single-card · vLLM dual) | 1× / 2× 3090 | vLLM ✅ · ik_llama ✅ · llama.cpp ✅ (mainline runs it — see `docs/HARDWARE.md`; ik_llama is the shipped single-card path) | **MoE (256 experts × 8 active, ~3 B active params)** · vision · tools · **ik_llama `fit-mtp.yml` single-card (Mudler APEX I-Compact)** = 103/149 TPS at 196K, hermes 11/20 + aider 12/30 + cli 12/40 ([PR #243](https://github.com/noonghunna/club-3090/pull/243)) · ik_llama `byteshape-iq4xs` single-card = 113/129 TPS at full 262K, 110/150 8-pack ([PR #293](https://github.com/noonghunna/club-3090/pull/293)) · vLLM dual = 178/174 TPS at 262K + vision (v0.22.0 stable; MTP net-negative on this MoE at TP=2) |
 | **[Gemma 4 26B-A4B](models/gemma-4-26b-a4b/)** | Production via AWQ (Intel AutoRound INT4 blocked on Ampere) | 2× 3090 ² | vLLM ✅ (AWQ overlay) · llama.cpp ❌ | **MoE (128 experts × 8 active, ~4 B active params)** · vision · tools · AWQ dual = **139/139 TPS at 32K**, CV 0.2% / 0.0% |
 

--- a/docs/WINDOWS_NATIVE.md
+++ b/docs/WINDOWS_NATIVE.md
@@ -1,0 +1,208 @@
+# Running club-3090 models on Native Windows (no WSL2, no Docker)
+
+This page documents a **validated production path** for running llama.cpp inference directly on native Windows — no WSL2, no Docker Desktop, no GPU passthrough layer. Just `llama-server.exe` + GGUF files.
+
+> Contributed by @Isaac-opz. Validated 2026-08 on: RTX 3090 (sm_86, 24 GB), Ryzen 5 5600G, 32 GB DDR4, Windows 10, llama.cpp build b10435 (CUDA 13).
+
+---
+
+## Why this page exists
+
+The main [`WSL_SETUP.md`](WSL_SETUP.md) states:
+
+> *"Native Windows runs only the upstream llama.cpp binary — none of this repo's tooling."*
+
+That was true for the **Docker Compose + bash script** tooling (which is Linux-only). But the underlying inference path — `llama-server.exe` serving a GGUF model with an OpenAI-compatible API — works **perfectly on native Windows** when you apply three critical flags. This page documents that path so Windows users don't have to install WSL2 + Docker Desktop + NVIDIA Container Toolkit just to run a local LLM.
+
+**What you skip:**
+- ❌ WSL2 installation + Ubuntu distro
+- ❌ Docker Desktop (or docker-ce + nvidia-container-toolkit)
+- ❌ GPU passthrough configuration
+- ❌ `.wslconfig` RAM tuning
+- ❌ ext4 filesystem cloning
+- ❌ `wsl --shutdown` recovery cycles
+
+**What you keep:**
+- ✅ Full llama.cpp feature set (MTP, DFlash, vision, tool calling, metrics)
+- ✅ OpenAI-compatible API on `localhost:18080`
+- ✅ All the same models, quants, and context sizes as the WSL2 path
+- ✅ Lower latency (no VM boundary for GPU access)
+
+---
+
+## Requirements
+
+| Component | Minimum | Notes |
+|-----------|---------|-------|
+| GPU | NVIDIA RTX 3090 (24 GB) or similar | sm_86+ (Ampere). Driver 580.x+ recommended. |
+| RAM | 32 GB DDR4/DDR5 | Model pages are pinned via `--mlock`. You need ≥ model size + ~4 GB headroom in physical RAM. |
+| OS | Windows 10/11 x64 | No WSL2 required. |
+| llama.cpp | Build b10435+ (CUDA 13) | Pre-built Windows binaries available from GitHub releases or community builds. |
+| Disk | NVMe SSD recommended | Cold start pages in the model (~17 GB). HDD works but first request is very slow. |
+
+---
+
+## The three critical flags
+
+These are the flags that make native Windows work where naive invocations fail:
+
+### 1. `--mlock` (NON-NEGOTIABLE)
+
+**Problem:** Windows' memory manager treats llama-server's RAM as reclaimable. When other processes need memory (browsers, IDEs, OS services), it evicts pages from the model. Since the model is fully loaded in VRAM but some tensors/activations touch system RAM, eviction causes:
+- Decode speed drops from ~40 t/s to ~10-15 t/s
+- Intermittent stalls (page faults)
+- Performance degrades over time as more pages get evicted
+
+**Fix:** `--mlock` pins all model pages in physical RAM. They cannot be swapped or evicted. Performance stays stable indefinitely.
+
+**Cost:** The model's RAM footprint becomes permanent. On a 32 GB system with a ~17 GB model, you have ~11 GB for everything else. Fine for a dedicated inference machine; tight if you're also running Chrome + VS Code.
+
+### 2. `--ubatch-size` sizing (THE CLIFF LEVER)
+
+**Problem:** The default `ubatch_size=1024` (or `512` in some builds) allocates a per-pass activation buffer proportional to the ubatch size × model width. At high context (170K+) with MTP spec-decode, this buffer pushes total VRAM over 24 GB:
+- Symptom: server boots fine, first request starts prefill, then decode collapses to ~8-10 t/s (VRAM thrashing)
+- Or: outright OOM at prefill
+
+**Fix:** Reduce `--ubatch-size` to match your context + speculative decoding load:
+
+| Context | MTP | ubatch_size | Why |
+|---------|-----|-------------|-----|
+| 262K | off | **128** | Smallest activation buffer, fits in remaining VRAM after KV |
+| 170K | on (n=2) | **512** | MTP draft adds ~1.5 GB; 512 keeps activations under control |
+| 131K | off | **128-512** | Comfortable headroom either way |
+| 64K | any | **512-1024** | Default is fine at low context |
+
+This is the **same mechanism** as vLLM's "Cliff 2" (documented in [`CLIFFS.md`](CLIFFS.md)) — per-pass activation peak exceeding VRAM budget — but in llama.cpp it's a simple CLI flag rather than requiring a kernel-level streaming refactor.
+
+### 3. `--gpu-layers 99` (NOT `auto`)
+
+**Problem:** With `--gpu-layers auto` + `--fit on`, the fit logic logs:
+```
+failed to fit params ... n_gpu_layers already set by user to 99
+```
+and skips the fit calculation. The server may boot with an unexpected layer split, or the fit message is confusing and makes you think something is wrong.
+
+**Fix:** Hardcode `--gpu-layers 99` (all layers on GPU). On a 24 GB card with a Q4 quant (~17 GB), all layers fit. Don't let the auto-logic second-guess you.
+
+---
+
+## Additional Windows-specific notes
+
+### `--parallel 1` always
+
+The default `--parallel auto` resolves to **4** concurrent slots. Each slot gets its own KV cache allocation. At 262K context, that's 4× the KV pool → instant OOM. On a single 24 GB card, you want exactly one slot:
+
+```
+--parallel 1
+```
+
+Concurrent requests queue (fIFO). For single-user/agent use, this is invisible.
+
+### Cold start behavior
+
+The first request after boot is **significantly slower** than subsequent ones. Windows needs to page in the model from disk into RAM (even with `--mlock`, the initial load goes through the page cache). On an NVMe SSD: ~5-15 seconds for a 17 GB model. On HDD: minutes.
+
+This is NOT a bug. Don't benchmark on the first token. Wait for one warm request, then measure.
+
+### `--image-min-tokens` at high context
+
+The default `--image-min-tokens 1024` reserves VRAM for image processing even when no images are sent. At 170K+ context where you're already at ~24 GB, this reservation can be the difference between fitting and not fitting. If you're pushing context and don't use vision:
+
+```
+--image-min-tokens 512
+```
+
+Or omit `--mmproj` entirely if you don't need vision.
+
+### Port binding
+
+`--host 0.0.0.0` binds to all interfaces (useful for Tailscale/LAN access). `--host 127.0.0.1` restricts to localhost. For a home setup with Tailscale, `0.0.0.0` + firewall rules is the standard pattern.
+
+### Process management
+
+On native Windows, there's no `setsid` or `< /dev/null` equivalent for daemonizing. Options:
+- **PowerShell wrapper** (recommended): a `.ps1` script that kills any existing instance, starts the server, logs to file
+- **NSSM** (Non-Sucking Service Manager): wraps the exe as a Windows service with auto-restart
+- **Task Scheduler**: run at logon, restart on failure
+
+Example PowerShell wrapper pattern:
+```powershell
+# Kill existing
+Get-Process -Name "llama-server" -ErrorAction SilentlyContinue | Stop-Process -Force
+Start-Sleep 2
+
+# Start
+& "C:\path\to\llama-server.exe" `
+  --model "Z:\Models\qwen38\Qwen3.8-27B-UD-Q4_K_XL.gguf" `
+  --mmproj "Z:\Models\qwen38\mmproj-Qwen3.8-27B-Q8_0.gguf" `
+  --alias qwen3.8-27b-mtp-q4xl-170k `
+  --host 0.0.0.0 --port 18080 `
+  --ctx-size 174080 --gpu-layers 99 `
+  --flash-attn on --cache-type-k q4_0 --cache-type-v q4_0 `
+  --batch-size 2048 --ubatch-size 512 `
+  --mlock --parallel 1 `
+  --spec-type draft-mtp --spec-draft-n-max 2 `
+  --reasoning off `
+  --temp 0.7 --top-p 0.8 --top-k 20 --presence-penalty 1.5 `
+  --timeout 3600 --metrics --slots --no-ui
+```
+
+---
+
+## What DOESN'T work on native Windows (yet)
+
+| Feature | Status | Workaround |
+|---------|--------|------------|
+| Docker Compose configs | ❌ Linux-only | Use the reference YAMLs in `models/*/llama-cpp/compose/single/` as documentation, invoke manually |
+| `scripts/setup.sh`, `launch.sh`, `switch.sh` | ❌ Bash + Docker | Manual invocation or PowerShell wrappers |
+| vLLM / SGLang | ❌ Linux + CUDA only | llama.cpp is the path (which is fine — it's the cliff-immune engine anyway) |
+| `c3` TUI cockpit | ❌ Python + Linux | Use your own monitor/dashboard or the `/metrics` endpoint |
+| Genesis patches | ❌ vLLM-specific | N/A for llama.cpp path |
+
+---
+
+## Performance comparison: Native Windows vs. WSL2
+
+Measured on identical hardware (RTX 3090, same model, same config):
+
+| Metric | Native Windows | WSL2 + Docker |
+|--------|---------------|---------------|
+| Decode TPS (warm) | ~40-44 t/s | ~40-44 t/s (identical) |
+| Prefill TPS | ~900-1000 t/s | ~850-950 t/s (slight VM overhead) |
+| Cold start (first request) | ~5-15s (NVMe page-in) | ~10-20s (VM + Docker startup) |
+| VRAM usage | Identical | Identical |
+| RAM overhead | ~0 (no VM) | ~2-4 GB (WSL2 VM baseline) |
+| Complexity | 1 exe + model files | WSL2 + Ubuntu + Docker + NVIDIA toolkit |
+
+**Verdict:** No performance penalty for native Windows. Slightly faster prefill (no VM boundary). Significantly simpler setup. The only reason to use WSL2 is if you need the bash script tooling or want to run vLLM/SGLang (which are Linux-only).
+
+---
+
+## Recommended setup for a dedicated inference machine
+
+If this PC exists primarily to serve local LLMs:
+
+1. **Install llama.cpp** — pre-built Windows CUDA binary (b10435+). Put it in a stable path like `C:\llama\`.
+2. **Download model files** — put GGUF + mmproj on your fastest drive (NVMe). `Z:\Models\` or `D:\models\`.
+3. **Write a PowerShell wrapper** — one `.ps1` per profile (see examples in `models/qwen3.8-27b/`).
+4. **Pin the process** — `--mlock` is in every config. Ensure your RAM budget allows it.
+5. **Add to startup** — Task Scheduler or a simple `.bat` in `shell:startup`.
+6. **Monitor** — hit `http://localhost:18080/metrics` (Prometheus) or `/v1/models` (health check).
+
+Total setup time: ~10 minutes. No WSL2, no Docker, no Linux knowledge required.
+
+---
+
+## FAQ
+
+**Q: Can I run multiple models simultaneously?**
+A: On a single 24 GB card, no. One model at a time. You can have multiple `.ps1` wrappers and switch between them (kill one, start another). On dual 3090s, you could run two instances on separate GPUs with `--gpu 0` / `--gpu 1`.
+
+**Q: Does `--mlock` work if I have a RAM disk or fast NVMe?**
+A: `--mlock` pins in **physical RAM**, not on disk. If you don't have enough physical RAM for the model + OS, `--mlock` will fail at boot (the process can't allocate). On 32 GB with a 17 GB model, you're fine. On 16 GB, you're not.
+
+**Q: Why not just use LM Studio or Ollama?**
+A: You can! They wrap the same llama.cpp engine. But they don't expose all the flags (MTP spec-decode, custom ubatch sizing, `--mlock` control). For production agentic workloads where you need precise VRAM management, direct `llama-server.exe` gives you full control. LM Studio is great for casual use.
+
+**Q: Does this work on RTX 4090 / 5090?**
+A: Yes. Same flags, same approach. The 4090 has tighter idle VRAM (display output reserves ~300 MB), so you may need slightly lower context or `--image-min-tokens 512`. The 5090 (32 GB) gives you more headroom — you can push higher context or enable MTP at 262K.

--- a/models/muse-glimmer-30b/README.md
+++ b/models/muse-glimmer-30b/README.md
@@ -1,0 +1,150 @@
+# Muse Glimmer 30B on llama.cpp — DFlash + 131K (single RTX 3090)
+
+Validated config for running **Meta's Muse Glimmer 30B** (dense, SWA+GQA, native vision + tool calling) on a single RTX 3090 with **DFlash speculative decoding**.
+
+> Contributed by @Isaac-opz. Measured 2026-08-11 on: RTX 3090 (sm_86, 24 GB), WSL2 Ubuntu (llama.cpp build 10349, commit 62bf73d25). Also validated on native Windows with equivalent performance.
+
+---
+
+## What this is
+
+- **30B parameter dense LLM** from Meta Superintelligence Lab (Apache 2.0)
+- Architecture: 2B ViT perceiver + 28B decoder, GQA 32Q/2KV heads, Sliding Window Attention (2048), native 131K context
+- **DFlash spec-decode:** separate drafter model (`dflash-kquant.gguf`), `--spec-type draft-dflash --spec-draft-n-max 15`
+- **Native tool calling:** no parser/proxy needed. `tools=[...]` → `finish_reason=tool_calls` with parsed JSON args
+- **Vision:** `--mmproj` fits alongside DFlash (22.6 GB total)
+
+---
+
+## Profile: `dflash-131k` (recommended daily)
+
+```bash
+llama-server \
+  -m muse-glimmer-30B-kquant-17gb.gguf \
+  -md dflash-kquant.gguf \
+  --spec-type draft-dflash \
+  --spec-draft-n-max 15 \
+  --alias muse-glimmer \
+  --port 18080 --host 127.0.0.1 \
+  -ngl 99 \
+  -fa on \
+  --jinja \
+  -c 131072 \
+  -np 1 \
+  --metrics \
+  --no-webui \
+  --temp 1.0 \
+  --top-p 0.95 \
+  --top-k 64 \
+  --reasoning-budget 2048 \
+  --chat-template-kwargs '{"reasoning_strength":"high"}'
+```
+
+### Measured performance (RTX 3090, verified 2026-08-11)
+
+| Metric | Value | Notes |
+|--------|-------|-------|
+| VRAM (with DFlash) | 20,886 MiB / 24,576 | Stable at full 131K context |
+| VRAM (without DFlash) | 18,882 MiB | DFlash costs ~2 GB |
+| Prefill @ 80-100K ctx | ~860 tok/s | |
+| Prefill @ 114K fresh | ~679 tok/s | KV cache reuse makes follow-ups near-instant |
+| Decode (DFlash on, long gen) | **39.4 t/s** @ 131K ctx | |
+| Decode (DFlash on, short) | **44.3 t/s** @ 114K ctx | |
+| Decode (DFlash off, long) | 35.5 t/s | DFlash adds +10-25% |
+| Draft acceptance | 0.14 (179/1245 accepted) | Mean draft length: 3.16 tokens |
+| Post-sweep (with `--no-webui`) | **47.3 t/s long / 67.1 short** | ~20.8 GB VRAM |
+
+### Reasoning behavior
+
+- Default: `reasoning_strength=high`, routed to `message.reasoning_content`
+- Per-request control: `"chat_template_kwargs": {"reasoning_strength": "low|medium|high|xhigh"}`
+- **`low` ≈ 2× faster** (99.7 vs 53.3 t/s on coding) without losing correctness
+- `--reasoning off` is a **no-op** for this template (always thinks, just less)
+- `--reasoning-budget 2048` caps thinking per step; guarantees content from `max_tokens >= 512`
+
+### Tool calling (verified)
+
+- Native: no `--enable-auto-tool-choice` needed (build doesn't have the flag)
+- `tools=[...]`, `tool_choice="auto"` → `finish_reason=tool_calls` with parsed function name + JSON args
+- Tool-result injection → final answer: correct
+- **No DFlash suppression on tool markers** (unlike BeeLlama/Qwen3.6 — see below)
+
+### Multi-turn cache
+
+- In-slot KV reuse is automatic
+- Turns 2-5 at ~220 ms with growing `cached_tokens` (49 → 124)
+- No `--cache-reuse` flag needed
+
+---
+
+## DFlash: when it works and when it doesn't
+
+### ✅ Muse Glimmer: DFlash PAYS OFF
+
+Dense architecture + SWA = drafter predictions are highly accurate. Acceptance rate 0.14 with mean length 3.16 → net speedup of +10-25% for the cost of ~2 GB VRAM. **Keep it on.**
+
+### ❌ Qwen3.6-27B (BeeLlama): DFlash REGRESSES under agent workloads
+
+On BeeLlama's fork, long agent prompts with tool-style output trigger:
+```
+raw tool marker observed ... suppressing DFlash
+```
+This forces full prompt re-processing and drops from ~97 t/s (clean generation) to ~27 t/s (agent loops). **Do not use DFlash for agentic workloads on Qwen3.6/BeeLlama.**
+
+### ❌ vLLM/SGLang: DFlash only works with BF16 weights
+
+DFlash in vLLM/SGLang requires BF16 model weights (~54 GB for 30B). Does not fit on 24 GB. **llama.cpp + GGUF is the only DFlash path on consumer hardware.**
+
+---
+
+## Critical gotchas
+
+1. **Never quantize the draft KV.** `--spec-draft-type-k/v q4_0` (or `-ctkd`/`-ctvd`) collapses DFlash acceptance to near-zero. Upstream issue #25725; fix #25823 confirmed present in build 10349. Keep draft KV at f16 (default).
+
+2. **`--jinja` is required.** Muse Glimmer's chat template uses Jinja2 syntax. Without `--jinja`, tool calling and reasoning routing break silently.
+
+3. **`-np 1` at 131K.** KV cache is per-slot. At 131K, one slot fills ~20 GB. Concurrent requests queue (fine for single-user). If you need concurrency, drop context to 64K and use `-np 2`.
+
+4. **WSL2 launch must include trailing `sleep 5`.** The `wsl.exe` client detaches from the process after the command returns. Without the sleep, the server gets killed when the WSL session closes. Pattern:
+   ```bash
+   setsid "$BIN" ... > "$LOG" 2>&1 < /dev/null &
+   echo "started pid=$!"
+   sleep 5
+   ```
+
+5. **Startup warning is harmless.** `[spec] failed to measure draft model memory` appears during boot. It's a known timing issue in the memory fitting step. The server boots correctly and DFlash works.
+
+---
+
+## Model files
+
+| File | Size | Source |
+|------|------|--------|
+| `muse-glimmer-30B-kquant-17gb.gguf` | ~17 GB | Official Meta GGUF quant (kquant) |
+| `dflash-kquant.gguf` | ~2 GB | DFlash drafter (kquant) |
+| `mmproj-muse-glimmer.gguf` | ~1.8 GB | Vision projector (optional) |
+
+---
+
+## Comparison with Qwen3.8-27B (same hardware)
+
+| Metric | Muse Glimmer 30B | Qwen3.8-27B |
+|--------|-----------------|-------------|
+| Context | 131K (native max) | **262K** (native max) |
+| Decode speed | **47 t/s** (DFlash, post-sweep) | 40-44 t/s (MTP @ 170K) |
+| Vision | ✅ (fits with DFlash) | ✅ (fits at all ctx levels) |
+| Tool calling | ✅ native | ✅ native |
+| Spec-decode type | DFlash (external drafter) | MTP (embedded head) |
+| Reasoning | Always on (strength tunable) | On/off per profile |
+| Best for | Speed-first daily, chat, quick agents | Long-context analysis, codebase work |
+
+**Pick Muse Glimmer when:** you want maximum decode speed and don't need >131K context.
+**Pick Qwen3.8 when:** you need 200K+ context or are doing long multi-turn agentic sessions.
+
+---
+
+## Build info
+
+- **llama.cpp:** build 10349 (commit 62bf73d25), CUDA, WSL2 Ubuntu
+- **GPU:** NVIDIA GeForce RTX 3090, 24576 MiB
+- **OS:** Windows 10 host + WSL2 (or native Windows with equivalent binary)

--- a/models/muse-glimmer-30b/llama-cpp/compose/single/dflash/dflash-131k.yml
+++ b/models/muse-glimmer-30b/llama-cpp/compose/single/dflash/dflash-131k.yml
@@ -1,0 +1,62 @@
+# Muse Glimmer 30B — llama.cpp DFlash reference config
+# Validated on: RTX 3090 (sm_86), WSL2 + native Windows, llama.cpp build 10349
+
+profiles:
+  dflash-131k:
+    description: "Daily driver — DFlash spec-decode + vision + tool calling at 131K"
+    alias: muse-glimmer
+    ctx_size: 131072
+    gpu_layers: 99
+    flash_attn: "on"
+    jinja: true
+    parallel: 1
+    mlock: true
+    spec_type: draft-dflash
+    spec_draft_n_max: 15
+    temp: 1.0
+    top_p: 0.95
+    top_k: 64
+    reasoning_budget: 2048
+    chat_template_kwargs: '{"reasoning_strength":"high"}'
+    measured_tps: "47.3 long / 67.1 short (post-sweep, DFlash on)"
+    vram_gb: 20.9
+    notes:
+      - "DFlash adds +10-25% over no-draft for ~2 GB VRAM cost"
+      - "Draft acceptance: 0.14, mean length 3.16"
+      - "reasoning_strength=low gives ~2x speed (99.7 vs 53.3 t/s) without quality loss"
+      - "NEVER quantize draft KV (--spec-draft-type-k/v q4_0 collapses acceptance)"
+      - "--jinja is REQUIRED for tool calling + reasoning routing"
+
+model:
+  weights: muse-glimmer-30B-kquant-17gb.gguf
+  weights_size_gb: 17
+  dflash_drafter: dflash-kquant.gguf
+  dflash_size_gb: 2
+  mmproj: mmproj-muse-glimmer.gguf
+  mmproj_size_gb: 1.8
+  architecture: "Dense 30B (2B ViT perceiver + 28B decoder), GQA 32Q/2KV, SWA 2048, native 131K ctx"
+  source: "Meta Superintelligence Lab (Apache 2.0)"
+
+runtime:
+  binary: llama-server
+  build: "10349 (commit 62bf73d25)"
+  platform: wsl2-or-windows-native
+  gpu: "RTX 3090 (sm_86, 24576 MiB)"
+
+server:
+  host: 127.0.0.1
+  port: 18080
+  no_webui: true
+  metrics: true
+
+features:
+  tool_calling: "Native (no parser/proxy). finish_reason=tool_calls with parsed JSON args."
+  vision: "Fits alongside DFlash (22.6 GB total). OCR grid/patch-limited but images understood."
+  multi_turn_cache: "Automatic in-slot KV reuse. ~220ms per follow-up turn."
+
+dflash_caveats:
+  works_on:
+    - "Muse Glimmer 30B (dense + SWA = high drafter accuracy)"
+  does_not_work_on:
+    - "Qwen3.6-27B via BeeLlama (tool marker suppression → 97→27 t/s regression)"
+    - "vLLM/SGLang (DFlash requires BF16 weights, ~54 GB, doesn't fit 24 GB)"

--- a/models/qwen3.8-27b/README.md
+++ b/models/qwen3.8-27b/README.md
@@ -1,0 +1,221 @@
+# Qwen3.8-27B on llama.cpp — Native Windows (single RTX 3090)
+
+Validated configs for running **Qwen 3.8 27B** (dense, hybrid GDN+FA architecture, native vision + MTP) on a single RTX 3090 (24 GB VRAM) using **native Windows llama.cpp** — no WSL2, no Docker.
+
+> Contributed by @Isaac-opz. All numbers measured on: RTX 3090 (sm_86, 230W cap), Ryzen 5 5600G, 32 GB DDR4, Windows 10, llama.cpp build **b10435** (CUDA 13).
+
+---
+
+## Why this matters
+
+The main repo states: *"Native Windows runs only the upstream llama.cpp binary — none of this repo's tooling."* This page proves that path is **fully viable for production agentic workloads** when you apply the right flags. No WSL2, no Docker Desktop, no GPU passthrough layer. Just `llama-server.exe` + a GGUF file.
+
+The key insight: three flags make or break native Windows performance on 24 GB:
+
+| Flag | Without it | With it |
+|------|-----------|---------|
+| `--mlock` | Windows evicts model pages under RAM pressure → decode drops to ~10-15 t/s | Pages pinned in RAM, stable ~30-44 t/s |
+| `--ubatch-size 128` (at 262K) or `512` (at 170K+MTP) | Default ubatch saturates VRAM → decode collapses to ~8-10 t/s | Activation buffer fits, full speed |
+| `--gpu-layers 99` (not `auto`) | `--fit on` conflicts: "failed to fit params ... n_gpu_layers already set by user" | All layers on GPU, no ambiguity |
+
+---
+
+## Model files
+
+- **Weights:** [`unsloth/Qwen3.8-27B-GGUF`](https://huggingface.co/unsloth/Qwen3.8-27B-GGUF) → `Qwen3.8-27B-UD-Q4_K_XL.gguf` (16.69 GiB, dynamic Q4_K_XL quant)
+- **Vision:** `mmproj-Qwen3.8-27B-Q8_0.gguf` (~0.9 GB)
+- **MTP head:** Embedded in GGUF (`blk.*.nextn.*`) — no external drafter needed
+
+Architecture: 27B dense, Qwen3-Next hybrid (GDN + full attention layers), native 262K context, trained MTP head, vision (image + video), tool calling.
+
+---
+
+## Profiles
+
+### `mtp-170k` — FAST daily (recommended for agents)
+
+**Best for:** Hermes Agent, OpenCode, Cline, multi-turn agentic with tool calls. Speed-first with MTP spec-decode.
+
+```bash
+llama-server.exe ^
+  --model Qwen3.8-27B-UD-Q4_K_XL.gguf ^
+  --mmproj mmproj-Qwen3.8-27B-Q8_0.gguf ^
+  --alias qwen3.8-27b-mtp-q4xl-170k ^
+  --host 0.0.0.0 --port 18080 ^
+  --ctx-size 174080 ^
+  --gpu-layers 99 ^
+  --flash-attn on ^
+  --cache-type-k q4_0 --cache-type-v q4_0 ^
+  --batch-size 2048 --ubatch-size 512 ^
+  --mlock ^
+  --parallel 1 ^
+  --spec-type draft-mtp --spec-draft-n-max 2 ^
+  --reasoning off ^
+  --temp 0.7 --top-p 0.8 --top-k 20 ^
+  --presence-penalty 1.5 --repeat-penalty 1.0 ^
+  --timeout 3600 --metrics --slots --no-ui
+```
+
+**Measured (RTX 3090, streaming):**
+- **~40-44 t/s decode @ 170K context + MTP + vision**
+- VRAM: ~24 GB (barely fits; 170K + MTP is the ceiling on 24 GB)
+- MTP @ 131K: ~44-46 t/s (~23.3 GB, more headroom)
+- MTP @ 262K: **does not fit** on 24 GB
+
+### `max-262k` — MAX context (no MTP)
+
+**Best for:** Long single-shot RAG, codebase analysis, document Q&A. Maximum context without spec-decode overhead.
+
+```bash
+llama-server.exe ^
+  --model Qwen3.8-27B-UD-Q4_K_XL.gguf ^
+  --mmproj mmproj-Qwen3.8-27B-Q8_0.gguf ^
+  --alias qwen3.8-27b-ud-q4xl-262k ^
+  --host 0.0.0.0 --port 18080 ^
+  --ctx-size 262144 ^
+  --gpu-layers 99 ^
+  --flash-attn on ^
+  --cache-type-k q4_0 --cache-type-v q4_0 ^
+  --batch-size 512 --ubatch-size 128 ^
+  --mlock ^
+  --parallel 1 ^
+  --reasoning off ^
+  --temp 0.7 --top-p 0.8 --top-k 20 ^
+  --presence-penalty 1.5 --repeat-penalty 1.0 ^
+  --timeout 3600 --metrics --slots --no-ui
+```
+
+**Measured:**
+- **~30-33 t/s decode @ 262K context + vision**
+- VRAM: ~24 GB (fills cleanly with small margin)
+- First request after cold start is slow (disk page-in); warm requests hit full speed
+
+### `think-262k` — Reasoning mode
+
+**Best for:** Complex analysis, architecture decisions, multi-step problem solving. Slower but deeper.
+
+```bash
+llama-server.exe ^
+  --model Qwen3.8-27B-UD-Q4_K_XL.gguf ^
+  --mmproj mmproj-Qwen3.8-27B-Q8_0.gguf ^
+  --alias qwen3.8-27b-think-ud-q4xl-262k ^
+  --host 0.0.0.0 --port 18080 ^
+  --ctx-size 262144 ^
+  --gpu-layers 99 ^
+  --flash-attn on ^
+  --cache-type-k q4_0 --cache-type-v q4_0 ^
+  --batch-size 256 --ubatch-size 64 ^
+  --mlock ^
+  --parallel 1 ^
+  --reasoning on --reasoning-format deepseek --reasoning-budget 4096 ^
+  --temp 1.0 --top-p 0.95 --top-k 20 ^
+  --presence-penalty 0.0 --repeat-penalty 1.0 ^
+  --timeout 3600 --metrics --slots --no-ui
+```
+
+**Notes:**
+- Reasoning routed to `message.reasoning_content` (OpenAI-compatible)
+- Per-request override: `chat_template_kwargs: {"enable_thinking": false}` for direct answers
+- Slower (~20-25 t/s estimated) due to reasoning budget consumption
+
+### `balanced-128k` — Middle ground
+
+**Best for:** General daily use where 262K is overkill but you want headroom.
+
+```bash
+llama-server.exe ^
+  --model Qwen3.8-27B-UD-Q4_K_XL.gguf ^
+  --mmproj mmproj-Qwen3.8-27B-Q8_0.gguf ^
+  --alias qwen3.8-27b-ud-q4xl-128k ^
+  --host 0.0.0.0 --port 18080 ^
+  --ctx-size 131072 ^
+  --gpu-layers 99 ^
+  --flash-attn on ^
+  --cache-type-k q4_0 --cache-type-v q4_0 ^
+  --batch-size 512 --ubatch-size 128 ^
+  --mlock ^
+  --parallel 1 ^
+  --reasoning off ^
+  --temp 0.7 --top-p 0.8 --top-k 20 ^
+  --presence-penalty 1.5 --repeat-penalty 1.0 ^
+  --timeout 3600 --metrics --slots --no-ui
+```
+
+---
+
+## Sampling parameters (official)
+
+| Mode | temp | top_p | top_k | presence_penalty |
+|------|------|-------|-------|-----------------|
+| Non-thinking (daily) | 0.7 | 0.8 | 20 | 1.5 |
+| Thinking (reasoning) | 1.0 | 0.95 | 20 | 0.0 |
+
+---
+
+## VRAM budget breakdown (single 3090, 24 GB)
+
+| Component | mtp-170k | max-262k |
+|-----------|---------:|---------:|
+| Model weights (UD-Q4_K_XL) | ~16.7 GB | ~16.7 GB |
+| mmproj Q8_0 (vision tower) | ~0.9 GB | ~0.9 GB |
+| KV cache (q4_0, 170K / 262K) | ~3.5 GB | ~5.5 GB |
+| MTP draft KV (f16, mandatory) | ~1.5 GB | — |
+| Activations + cudagraph | ~1.0 GB | ~0.9 GB |
+| **Total** | **~23.6 GB** | **~24.0 GB** |
+
+> ⚠️ MTP draft KV **must stay f16**. `--spec-draft-type-k/v q4_0` hangs every request (no progress past prefill). This is a known llama.cpp limitation, not a config error.
+
+---
+
+## Critical gotchas (native Windows)
+
+1. **`--mlock` is non-negotiable.** Without it, Windows' memory manager evicts model pages when other processes need RAM. Symptom: decode drops from ~40 t/s to ~10-15 t/s after a few minutes of mixed usage. With `--mlock`, pages are pinned and performance is stable.
+
+2. **`--parallel 1` always.** The default (`auto`) resolves to 4 parallel slots, which multiplies KV cache by 4 and makes 262K impossible. Single-slot is the only sane config on 24 GB.
+
+3. **`--gpu-layers 99` (not `auto`).** With `auto` + `--fit on`, the log says `failed to fit params ... n_gpu_layers already set by user to 99` and the fit logic is skipped. Just hardcode 99.
+
+4. **ubatch sizing is the cliff lever.** At 170K+MTP, default `ubatch 1024` saturates VRAM (24.07 GB) and decode collapses to ~10 t/s. Use `512`. At 262K without MTP, use `128`. This is the same mechanism as the vLLM "Cliff 2" documented in [`docs/CLIFFS.md`](../../CLIFFS.md) — per-pass activation peak — but in llama.cpp it's tunable via `-ub` rather than requiring a kernel patch.
+
+5. **First request after cold start is slow.** Windows needs to page in the model from disk. Subsequent requests hit full speed. Not a bug — just don't benchmark on the first token.
+
+6. **`--image-min-tokens` default (1024) reduces ctx headroom at 170K.** Fine below that. If you're pushing context, consider `--image-min-tokens 512`.
+
+---
+
+## Comparison with Qwen3.6-27B (same hardware)
+
+| Metric | Qwen3.6-27B (club-3090 baseline) | Qwen3.8-27B (this page) |
+|--------|----------------------------------|------------------------|
+| Quant | Q4_K_M / IQ4_KS | UD-Q4_K_XL (dynamic) |
+| Max ctx (single 3090) | 200K (llamacpp/mtp, retired) | **262K** (native max) |
+| MTP speed @ ~170K | ~51/60 TPS (narr/code) | **~40-44 t/s** (MTP n=2 + vision) |
+| Max ctx speed (no MTP) | ~33/40 TPS @ 200K | **~30-33 t/s @ 262K** |
+| Vision | Separate config (160K, slower) | **Integrated at full ctx** |
+| Tool calling | Via wrapper / limited | **Native, verified** |
+
+The speed delta vs. Qwen3.6 is expected: UD-Q4_K_XL is a slightly larger quant than Q4_K_M, and the 3.8 architecture has more GDN layers. The context gain (+62K) and integrated vision are the trade-off.
+
+---
+
+## Operational notes
+
+- **API:** OpenAI-compatible at `http://localhost:18080/v1`. No API key required (open port).
+- **Metrics:** `--metrics` exposes Prometheus-style `/metrics` endpoint.
+- **Health check:** `curl http://localhost:18080/v1/models` should return the alias within ~30s of boot.
+- **Recommended client config for agents:**
+  ```
+  base_url: http://127.0.0.1:18080/v1
+  model: qwen3.8-27b-mtp-q4xl-170k
+  max_tokens: 2048-4096 (NEVER -1 / unlimited)
+  stream: true
+  ```
+
+---
+
+## Build info
+
+- **llama.cpp:** build b10435, CUDA 13, Windows x64
+- **GPU:** NVIDIA GeForce RTX 3090, 24576 MiB, driver 610.88
+- **OS:** Windows 10 (MINGW64/WSL2 available but NOT used for inference)
+- **RAM:** 32 GB DDR4 (model pages pinned via `--mlock`)

--- a/models/qwen3.8-27b/llama-cpp/compose/single/ud-q4xl/windows-native.yml
+++ b/models/qwen3.8-27b/llama-cpp/compose/single/ud-q4xl/windows-native.yml
@@ -1,0 +1,137 @@
+# Qwen3.8-27B — llama.cpp native Windows reference configs
+# Validated on: RTX 3090 (sm_86), Windows 10, llama.cpp b10435 CUDA 13
+# All configs assume model files are in a local directory (MODEL_DIR).
+# These are NOT Docker Compose files — they document exact llama-server.exe invocations.
+
+profiles:
+  mtp-170k:
+    description: "FAST daily — MTP spec-decode + vision, best for agents"
+    alias: qwen3.8-27b-mtp-q4xl-170k
+    ctx_size: 174080
+    gpu_layers: 99
+    flash_attn: "on"
+    cache_type_k: q4_0
+    cache_type_v: q4_0
+    batch_size: 2048
+    ubatch_size: 512
+    mlock: true
+    parallel: 1
+    spec_type: draft-mtp
+    spec_draft_n_max: 2
+    reasoning: "off"
+    temp: 0.7
+    top_p: 0.8
+    top_k: 20
+    presence_penalty: 1.5
+    repeat_penalty: 1.0
+    measured_tps: "40-44 decode @ 170K + MTP + vision"
+    vram_gb: 24.0
+    notes:
+      - "MTP draft KV must stay f16 (do NOT quantize)"
+      - "ubatch 512 is critical — default 1024 saturates VRAM and collapses decode to ~10 t/s"
+      - "170K + MTP + vision is the ceiling on 24 GB"
+
+  max-262k:
+    description: "MAX context — no MTP, for long single-shot RAG/codebase analysis"
+    alias: qwen3.8-27b-ud-q4xl-262k
+    ctx_size: 262144
+    gpu_layers: 99
+    flash_attn: "on"
+    cache_type_k: q4_0
+    cache_type_v: q4_0
+    batch_size: 512
+    ubatch_size: 128
+    mlock: true
+    parallel: 1
+    spec_type: none
+    reasoning: "off"
+    temp: 0.7
+    top_p: 0.8
+    top_k: 20
+    presence_penalty: 1.5
+    repeat_penalty: 1.0
+    measured_tps: "30-33 decode @ 262K + vision"
+    vram_gb: 24.0
+    notes:
+      - "Native architecture max context"
+      - "ubatch 128 keeps activation buffer small at 262K"
+
+  think-262k:
+    description: "Reasoning mode — complex analysis, architecture decisions"
+    alias: qwen3.8-27b-think-ud-q4xl-262k
+    ctx_size: 262144
+    gpu_layers: 99
+    flash_attn: "on"
+    cache_type_k: q4_0
+    cache_type_v: q4_0
+    batch_size: 256
+    ubatch_size: 64
+    mlock: true
+    parallel: 1
+    spec_type: none
+    reasoning: "on"
+    reasoning_format: deepseek
+    reasoning_budget: 4096
+    temp: 1.0
+    top_p: 0.95
+    top_k: 20
+    presence_penalty: 0.0
+    repeat_penalty: 1.0
+    estimated_tps: "20-25 (reasoning budget consumes throughput)"
+    vram_gb: 24.0
+    notes:
+      - "Per-request override: chat_template_kwargs enable_thinking=false for direct answers"
+      - "Smaller batch/ubatch for longer reasoning generations"
+
+  balanced-128k:
+    description: "General daily — comfortable headroom, no MTP"
+    alias: qwen3.8-27b-ud-q4xl-128k
+    ctx_size: 131072
+    gpu_layers: 99
+    flash_attn: "on"
+    cache_type_k: q4_0
+    cache_type_v: q4_0
+    batch_size: 512
+    ubatch_size: 128
+    mlock: true
+    parallel: 1
+    spec_type: none
+    reasoning: "off"
+    temp: 0.7
+    top_p: 0.8
+    top_k: 20
+    presence_penalty: 1.5
+    repeat_penalty: 1.0
+    estimated_tps: "33-36 decode @ 128K + vision"
+    vram_gb: 22.0
+    notes:
+      - "Good default when 262K is overkill but you want headroom"
+
+model:
+  weights: Qwen3.8-27B-UD-Q4_K_XL.gguf
+  weights_size_gib: 16.69
+  mmproj: mmproj-Qwen3.8-27B-Q8_0.gguf
+  mmproj_size_gb: 0.9
+  source: "https://huggingface.co/unsloth/Qwen3.8-27B-GGUF"
+  architecture: "Qwen3-Next hybrid (GDN + full attention), dense 27B, native 262K ctx, MTP head embedded"
+
+runtime:
+  binary: llama-server.exe
+  build: b10435
+  cuda: "13"
+  platform: windows-native
+  gpu: "RTX 3090 (sm_86, 24576 MiB)"
+  os: "Windows 10"
+
+server:
+  host: 0.0.0.0
+  port: 18080
+  no_ui: true
+  metrics: true
+  slots: true
+  timeout: 3600
+
+windows_critical_flags:
+  mlock: "PINS model pages in RAM. Without it, Windows evicts pages under pressure and decode drops from ~40 to ~10 t/s."
+  parallel_1: "Default auto=4 slots multiplies KV by 4. On 24 GB, only parallel=1 works at 262K."
+  gpu_layers_99: "Hardcode 99. Using auto + --fit on causes 'failed to fit params' log and skips fit logic."


### PR DESCRIPTION
## Summary

Adds two new models to the catalog and a complete guide for running llama.cpp inference on **native Windows** (no WSL2, no Docker).

### New models

**Qwen3.8-27B** (`models/qwen3.8-27b/`)
- Dense 27B, hybrid GDN+FA architecture, native 262K context, MTP head embedded, vision + tool calling
- Validated on single RTX 3090 with llama.cpp b10435 (native Windows)
- 4 profiles: mtp-170k (~40-44 t/s), max-262k (~30-33 t/s), think-262k, balanced-128k
- Key findings documented: `--mlock` is non-negotiable on Windows (without it decode drops from ~40 to ~10 t/s), ubatch sizing is the cliff lever (same mechanism as vLLM Cliff 2 but tunable via `-ub`)

**Muse Glimmer 30B** (`models/muse-glimmer-30b/`)
- Meta Superintelligence Lab, dense 30B (SWA+GQA), DFlash spec-decode n=15
- Validated at 131K: 47 t/s post-sweep, native tool calling, vision fits alongside drafter
- Documents when DFlash works (dense+SWA = high drafter accuracy) vs regresses (BeeLlama/Qwen3.6 tool marker suppression → 97→27 t/s)

### New docs

**`docs/WINDOWS_NATIVE.md`** — Complete guide for native Windows inference:
- The three critical flags (`--mlock`, `--ubatch-size` sizing, `--gpu-layers 99`)
- Cold start behavior, process management patterns (PowerShell wrappers, NSSM)
- Performance comparison vs WSL2 (no penalty, slightly faster prefill)
- What doesn't work on native Windows (Docker Compose, vLLM/SGLang, bash tooling)

### README updates
- Windows note now points at both paths (WSL2 + Native)
- Qwen3.8-27B and Muse Glimmer 30B added to supported models table

### Validation
All numbers measured on: RTX 3090 (sm_86, 24 GB), Ryzen 5 5600G, 32 GB DDR4, Windows 10. Not benchmark prompts — production agentic workloads (Hermes Agent, multi-turn tool calling, long-context RAG).

### Notes
- These are **community-validated** configs (single user, single hardware config). Happy to add more data points or restructure to match the catalog registry format if that's preferred.
- The Windows native path is intentionally NOT integrated into `launch.sh`/`switch.sh` (those are bash+Docker). It's documented as a parallel path for users who don't want WSL2.