### PR TITLE
feat(baselines): record vllm/qwen38-27b-dual-fast on the v0.27.1 pin (c3 showed no numbers)

### DIFF
--- a/scripts/lib/profiles/baselines.yml
+++ b/scripts/lib/profiles/baselines.yml
@@ -220,6 +220,29 @@ baselines:
     submitted_by: "noonghunna"
     tier: local
 
+  vllm/qwen38-27b-dual-fast:
+    narr_tps: 72.4
+    code_tps: 105.0
+    prefill_tps:
+      10k: 1780.5
+      90k: 1308.1
+    ttft_ms: 149
+    date: 2026-08-16
+    engine_pin: vllm/vllm-openai:v0.27.1
+    rig: 2x3090-pcie
+    power_cap_w:
+    - 370
+    - 420
+    submitted_by: noonghunna
+    tier: local
+    quality_env:
+      harness: "bench.sh 3 warm + 5 measured on the SHIPPED config (W4A8 default,
+        MTP n=4, max_num_seqs=1, fp8 KV @262144). \u26a0 narr_tps is the mean of a
+        67.7-77.1 spread (13.9%) -- single-stream decode swings with MTP acceptance
+        on this family, so treat it as indicative, not a 5%-resolving figure.
+        code_tps CV 2.7%, prefill CV 0.1% are the tight ones. quality_8pk and
+        ctx_validated deliberately ABSENT: the 8-pack and a NIAH ladder have never
+        been run on this slug."
   vllm/qwen-35b-a3b-dual:
     # BENCHMARKS.md promotion row (#259, decode 182.3/182.3; NIAH-clean 240K).
     # Measured on v0.22.0; the slug now pins v0.24.0 (fast/max-tier era) →


### PR DESCRIPTION
c3's catalog showed no performance numbers for `vllm/qwen38-27b-dual-fast` because `baselines.yml` had **zero** qwen38 records — that file is what the catalog joins against. The slug was benched today but the numbers only ever landed in a PR body.

Recorded from the **shipped** config (W4A8 default, MTP n=4, `max_num_seqs=1`, fp8 KV @262144, stock v0.27.1, 3 warm + 5 measured):

| field | value | CV |
|---|--:|--:|
| `code_tps` | 105.0 | 2.7% |
| `narr_tps` | 72.4 | **13.9%** ⚠️ |
| `prefill_tps` | 10k: 1780.5 · 90k: 1308.1 | 0.1% / 1.4% |
| `ttft_ms` | 149 | 0.7% |

⚠️ **`narr_tps` is indicative, not decisive.** The five runs span 67.67–77.10; single-stream decode swings with MTP acceptance on this family. The `quality_env` note says this inline, so anyone reading the record sees it rather than treating 72.4 as precise.

`quality_8pk` and `ctx_validated` are **deliberately absent** rather than estimated — the 8-pack and a NIAH ladder have never been run on this slug. Partial records are normal (15 of 25 existing ones have gaps).

Worth noting: `prefill_tps` must be a **dict of depth points**, not a scalar. `test-baselines` rejected my first attempt — the guard doing its job.

Guards green: `test-baselines`, `test-catalog-baseline`, `test-bench-card`, `test-registry-json`, `test-quality-baseline`. `registry-emit` confirms the record resolves with `stale=false` against the current pin.

**Not** added to the public repo `BENCHMARKS.md` — that table has no qwen3.8 rows at all today (deliberate, per #993), and publishing on a 🧪 slug with no 8-pack or NIAH is a maintainer call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)