### PR TITLE
fix(verify-stress): split the summary into boundary vs recall verdicts

### DIFF
--- a/scripts/verify-stress.sh
+++ b/scripts/verify-stress.sh
@@ -152,12 +152,34 @@ fi
 
 pass() { printf "  \033[32m✓\033[0m %s\n" "$1"; }
 fail() { printf "  \033[31m✗\033[0m %s\n" "$1"; printf "    \033[33m→\033[0m %s\n" "$2"; return 1; }
-skip() { printf "  \033[33m⊘\033[0m %s (skipped)\n" "$1"; }
+_SKIPPED=0
+skip() { printf "  \033[33m⊘\033[0m %s (skipped)\n" "$1"; _SKIPPED=1; }
 
 FAILED=0
+# The summary is split into two verdicts because this script answers two
+# DIFFERENT questions and they carry different weight (#1017):
+#   BOUNDARY — does the deployed config survive its edges (tool-prefill OOM,
+#              agent shapes, reasoning-heavy, VRAM ceiling)? Unambiguous.
+#   RECALL   — does the needle come back at depth? Real, but measured against a
+#              haystack built from ONE repeated block (~0.03% unique content at
+#              380K), so it establishes ADDRESSABILITY, not retrieval quality,
+#              and must not be quoted next to published NIAH/RULER scores.
+# One green line for both let a uniform-haystack pass read as "recall validated".
+_RECALL_CHECKS=" longctx longctx_large ceiling_ladder "
+RECALL_RUN=0;   RECALL_FAIL=0
+BOUND_RUN=0;    BOUND_FAIL=0
 run_check() {
   local label="$1"; shift
-  if "$@"; then :; else FAILED=$((FAILED + 1)); fi
+  local rc=0
+  _SKIPPED=0
+  if "$@"; then :; else rc=1; FAILED=$((FAILED + 1)); fi
+  if [[ "$_SKIPPED" == "1" ]]; then return 0; fi   # skipped checks count in neither bucket
+  if [[ "$_RECALL_CHECKS" == *" $label "* ]]; then
+    RECALL_RUN=$((RECALL_RUN + 1)); [[ "$rc" == "1" ]] && RECALL_FAIL=$((RECALL_FAIL + 1))
+  else
+    BOUND_RUN=$((BOUND_RUN + 1));  [[ "$rc" == "1" ]] && BOUND_FAIL=$((BOUND_FAIL + 1))
+  fi
+  return 0
 }
 
 # ---- Engine detection (parallel to verify-full.sh::detect_engine, see #87) ---
@@ -1525,6 +1547,21 @@ EOF
 run_check "ceiling_ladder" check_ceiling_ladder
 ensure_engine_alive "probe 8 (ceiling ladder)" || true
 
+echo ""
+_c_ok=$'\033[32m'; _c_bad=$'\033[31m'; _c_dim=$'\033[2m'; _c_off=$'\033[0m'
+_b_col="$_c_ok"; [[ "$BOUND_FAIL"  == "0" ]] || _b_col="$_c_bad"
+_r_col="$_c_ok"; [[ "$RECALL_FAIL" == "0" ]] || _r_col="$_c_bad"
+if [[ "$BOUND_RUN" != "0" ]]; then
+  printf "  %sboundary checks%s  %d/%d passed  %s(tool-prefill OOM, agent shapes, reasoning-heavy, VRAM ceiling)%s\n" \
+    "$_b_col" "$_c_off" "$((BOUND_RUN - BOUND_FAIL))" "$BOUND_RUN" "$_c_dim" "$_c_off"
+fi
+if [[ "$RECALL_RUN" != "0" ]]; then
+  printf "  %srecall ladder%s    %d/%d passed  %s(uniform-haystack: ADDRESSABILITY, not retrieval%s\n" \
+    "$_r_col" "$_c_off" "$((RECALL_RUN - RECALL_FAIL))" "$RECALL_RUN" "$_c_dim" "$_c_off"
+  printf "                     %squality — do not quote beside NIAH/RULER scores. #1017)%s\n" "$_c_dim" "$_c_off"
+else
+  printf "  %srecall ladder%s    skipped (SKIP_LONGCTX / SKIP_CEILING)%s\n" "$_c_dim" "$_c_off" "$_c_off"
+fi
 echo ""
 if [[ "$FAILED" == "0" ]]; then
   printf "\033[32mAll stress / boundary checks passed.\033[0m KV-cache and prefill paths are sound for the deployed config.\n"


### PR DESCRIPTION
`verify-stress` answers **two different questions** and printed one green line for both.

| half | checks | strength |
|---|---|---|
| **boundary** | tool-response prefill OOM, IDE-agent / multi-turn / LCB shapes, reasoning-heavy, VRAM ceiling | unambiguous pass/fail |
| **recall** | needle at 10K/30K, 60K/90K, ceiling ladder | real, but see below |

The recall half runs against a haystack built from **one repeated 65-token block**. At 381K that is the same block ~5,862 times — **~0.033% unique content**. The needle is the only non-repeating span in a uniform field, which is a *saliency* task, not a retrieval one.

Collapsing both into `All stress / boundary checks passed` lets a uniform-haystack pass read as "recall validated". **It nearly did here**: a clean ladder to 452K on `vllm/qwen38-27b-dual-fast` was about to be written up as "recall clean to 381K" when the defensible claim is "*addressable* to 381K".

### New output

```
  boundary checks  6/6 passed  (tool-prefill OOM, agent shapes, reasoning-heavy, VRAM ceiling)
  recall ladder    5/5 passed  (uniform-haystack: ADDRESSABILITY, not retrieval
                                quality — do not quote beside NIAH/RULER scores. #1017)

All stress / boundary checks passed. KV-cache and prefill paths are sound…
```

### Mechanics

`run_check` buckets by check name (`_RECALL_CHECKS` = `longctx`, `longctx_large`, `ceiling_ladder`). `skip()` now sets a flag so skipped checks land in **neither** bucket rather than silently counting as passes — which also surfaces the existing `SKIP_LONGCTX` / `SKIP_CEILING` knobs in the output for the first time.

`FAILED` and the exit code are **untouched**, so nothing consuming the exit status changes.

Bucketing verified against a synthetic harness: `boundary 1/2 · recall 2/3 · FAILED=2`, one skip in neither.

### Scope

Does **not** fix the haystack — #1017 tracks both the prefix-cache contamination of the per-rung prefill numbers (32.6% cache hit rate measured; 130–160K byte-identical prefix between consecutive rungs) and the corpus weakness. This only stops the report over-claiming while that's open.

Guards green: `test-verify-stress-ceiling`, `test-report-exit-code`, `test-report-engine-liveness`, `test-submit-bench`, `test-catalog-baseline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)