### PR TITLE
feat(qwen3.8-27b): default reasoning_effort to medium when thinking is enabled

### DIFF
--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
@@ -241,7 +241,19 @@ services:
       - --tool-call-parser
       - qwen3_coder
       - --default-chat-template-kwargs
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}}'
+      # ⭐ reasoning_effort default = medium (2026-08-16). It is a PER-REQUEST OpenAI
+      # control, so this is only the fallback for callers that send nothing — any
+      # agent still picks its own level per request.
+      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
+      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ medium is NOT a middle setting — the template has branches for xhigh and
+      # low ONLY, so medium injects NO instruction at all (the un-nudged baseline).
+      # xhigh actively adds "think carefully, validate assumptions, consider
+      # alternatives", which is what makes it slow and timeout-prone.
+      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
+      # render (`high` included — it does NOT silently remap).
+      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-medium}"}'
       # Sampler follows the Qwen3.8 MODEL CARD Instruct row (thinking ships off).
       - --override-generation-config
       - '{"temperature":${TEMP:-0.7},"top_p":${TOP_P:-0.80},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"presence_penalty":${PRESENCE_PENALTY:-1.5}}'

--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
@@ -412,7 +412,19 @@ services:
       #   Pair it with the card's thinking sampler (see the THINKING MODE block
       #   in the header); the two are independent and mismatching them is SILENT.
       - --default-chat-template-kwargs
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}}'
+      # ⭐ reasoning_effort default = medium (2026-08-16). It is a PER-REQUEST OpenAI
+      # control, so this is only the fallback for callers that send nothing — any
+      # agent still picks its own level per request.
+      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
+      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ medium is NOT a middle setting — the template has branches for xhigh and
+      # low ONLY, so medium injects NO instruction at all (the un-nudged baseline).
+      # xhigh actively adds "think carefully, validate assumptions, consider
+      # alternatives", which is what makes it slow and timeout-prone.
+      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
+      # render (`high` included — it does NOT silently remap).
+      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-medium}"}'
       - --enable-auto-tool-choice
       # The 3.8 template emits the same <tool_call><function=…><parameter=…> XML
       # as 3.6 (verified by reading the template), so this parser applies.

--- a/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
@@ -165,7 +165,19 @@ services:
       - --tool-call-parser
       - qwen3_coder
       - --default-chat-template-kwargs
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}}'
+      # ⭐ reasoning_effort default = medium (2026-08-16). It is a PER-REQUEST OpenAI
+      # control, so this is only the fallback for callers that send nothing — any
+      # agent still picks its own level per request.
+      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
+      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ medium is NOT a middle setting — the template has branches for xhigh and
+      # low ONLY, so medium injects NO instruction at all (the un-nudged baseline).
+      # xhigh actively adds "think carefully, validate assumptions, consider
+      # alternatives", which is what makes it slow and timeout-prone.
+      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
+      # render (`high` included — it does NOT silently remap).
+      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-medium}"}'
       - --override-generation-config
       - '{"temperature":${TEMP:-0.7},"top_p":${TOP_P:-0.80},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"presence_penalty":${PRESENCE_PENALTY:-1.5}}'
       - --host

--- a/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
@@ -215,7 +215,19 @@ services:
       - --tool-call-parser
       - qwen3_coder
       - --default-chat-template-kwargs
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}}'
+      # ⭐ reasoning_effort default = medium (2026-08-16). It is a PER-REQUEST OpenAI
+      # control, so this is only the fallback for callers that send nothing — any
+      # agent still picks its own level per request.
+      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
+      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ medium is NOT a middle setting — the template has branches for xhigh and
+      # low ONLY, so medium injects NO instruction at all (the un-nudged baseline).
+      # xhigh actively adds "think carefully, validate assumptions, consider
+      # alternatives", which is what makes it slow and timeout-prone.
+      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
+      # render (`high` included — it does NOT silently remap).
+      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-medium}"}'
       # Sampler follows the Qwen3.8 MODEL CARD Instruct row (thinking ships off).
       - --override-generation-config
       - '{"temperature":${TEMP:-0.7},"top_p":${TOP_P:-0.80},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"presence_penalty":${PRESENCE_PENALTY:-1.5}}'

--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
@@ -326,7 +326,19 @@ services:
       #   Pair it with the card's thinking sampler (see the header); the two are
       #   independent and mismatching them is SILENT.
       - --default-chat-template-kwargs
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}}'
+      # ⭐ reasoning_effort default = medium (2026-08-16). It is a PER-REQUEST OpenAI
+      # control, so this is only the fallback for callers that send nothing — any
+      # agent still picks its own level per request.
+      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
+      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ medium is NOT a middle setting — the template has branches for xhigh and
+      # low ONLY, so medium injects NO instruction at all (the un-nudged baseline).
+      # xhigh actively adds "think carefully, validate assumptions, consider
+      # alternatives", which is what makes it slow and timeout-prone.
+      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
+      # render (`high` included — it does NOT silently remap).
+      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-medium}"}'
       - --enable-auto-tool-choice
       - --tool-call-parser
       - qwen3_coder

--- a/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
@@ -215,7 +215,19 @@ services:
       - --tool-call-parser
       - qwen3_coder
       - --default-chat-template-kwargs
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}}'
+      # ⭐ reasoning_effort default = medium (2026-08-16). It is a PER-REQUEST OpenAI
+      # control, so this is only the fallback for callers that send nothing — any
+      # agent still picks its own level per request.
+      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
+      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ medium is NOT a middle setting — the template has branches for xhigh and
+      # low ONLY, so medium injects NO instruction at all (the un-nudged baseline).
+      # xhigh actively adds "think carefully, validate assumptions, consider
+      # alternatives", which is what makes it slow and timeout-prone.
+      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
+      # render (`high` included — it does NOT silently remap).
+      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-medium}"}'
       # Sampler follows the Qwen3.8 MODEL CARD Instruct row (thinking ships off).
       - --override-generation-config
       - '{"temperature":${TEMP:-0.7},"top_p":${TOP_P:-0.80},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"presence_penalty":${PRESENCE_PENALTY:-1.5}}'

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
@@ -344,7 +344,19 @@ services:
       #   Pair it with the card's thinking sampler (see the header); the two are
       #   independent and mismatching them is SILENT.
       - --default-chat-template-kwargs
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}}'
+      # ⭐ reasoning_effort default = medium (2026-08-16). It is a PER-REQUEST OpenAI
+      # control, so this is only the fallback for callers that send nothing — any
+      # agent still picks its own level per request.
+      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
+      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ medium is NOT a middle setting — the template has branches for xhigh and
+      # low ONLY, so medium injects NO instruction at all (the un-nudged baseline).
+      # xhigh actively adds "think carefully, validate assumptions, consider
+      # alternatives", which is what makes it slow and timeout-prone.
+      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
+      # render (`high` included — it does NOT silently remap).
+      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-medium}"}'
       - --enable-auto-tool-choice
       - --tool-call-parser
       - qwen3_coder

--- a/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
@@ -186,7 +186,19 @@ services:
       - --tool-call-parser
       - qwen3_coder
       - --default-chat-template-kwargs
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}}'
+      # ⭐ reasoning_effort default = medium (2026-08-16). It is a PER-REQUEST OpenAI
+      # control, so this is only the fallback for callers that send nothing — any
+      # agent still picks its own level per request.
+      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
+      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ medium is NOT a middle setting — the template has branches for xhigh and
+      # low ONLY, so medium injects NO instruction at all (the un-nudged baseline).
+      # xhigh actively adds "think carefully, validate assumptions, consider
+      # alternatives", which is what makes it slow and timeout-prone.
+      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
+      # render (`high` included — it does NOT silently remap).
+      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-medium}"}'
       - --override-generation-config
       - '{"temperature":${TEMP:-0.7},"top_p":${TOP_P:-0.80},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"presence_penalty":${PRESENCE_PENALTY:-1.5}}'
       - --host


### PR DESCRIPTION
Servers still ship **instruct** by default — unchanged. This changes what a caller gets when they boot `ENABLE_THINKING=true` and specify no effort: **medium instead of the template's `xhigh`**.

`xhigh` was never a considered choice — it is the template's fallback (`reasoning_effort|default('xhigh')`) for anyone who sends nothing.

### ⭐ medium is not a middle setting

The template has branches for `xhigh` and `low` **only** — `medium` leaves `reasoning_instructions` empty:

| level | injected |
|---|---|
| `xhigh` | *"think carefully through the task, validate key assumptions, consider plausible alternatives…"* |
| **`medium`** | **nothing — the un-nudged baseline** |
| `low` | *"keep your thinking brief and focused…"* |

So this **removes a verbosity nudge** rather than throttling the model — which is what made `xhigh` slow and prone to colliding with cli-40's flat 300 s per-model-call cap.

### Verified end-to-end (live boot, `/tokenize` prompt tokens)

| request | tokens |
|---|--:|
| instruct (shipped default) | 13 |
| **thinking ON, server default** | **11** ← no instruction |
| thinking ON + explicit `xhigh` | **53** ← the 42-token instruction |

An explicit per-request value still wins — `reasoning_effort` is a per-request OpenAI control, so this is only the fallback.

### Also corrects a claim we'd been repeating

`high` does **not** silently remap to `xhigh`. The template **raises**:

```jinja
{%- if resolved_reasoning_effort not in ('xhigh', 'medium', 'low') %}
    {{- raise_exception('Unexpected reasoning effort ...') }}
```

A caller sending `high` gets a hard error, not a quiet downgrade — a very different thing to debug. Headers now say so.

⚠️ **Inert while `enable_thinking` is false** — the template only reads `reasoning_effort` inside `if enable_thinking is undefined or true`. Shipped instruct boots are byte-identical to before.

### Scope

8 vLLM composes, where `--default-chat-template-kwargs` is the mechanism and it's render- and boot-verified. **llama.cpp is not changed** — its composes document `chat_template_kwargs` as a *per-request* field and the pinned image wasn't local to probe for a server-side flag. Filed as follow-up rather than half-done.

Override: `REASONING_EFFORT=low|xhigh` at boot (verified: `low` renders `"reasoning_effort": "low"`).

Guards green: `compose-status-drift`, `compose-mounts-resolve`, `compose-image-drift`, `patch-attribution`, `compose-registry-disk`, `launch-compat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)