### PR TITLE
feat(qwen3.8-27b): default reasoning_effort to medium on the llama.cpp slugs (closes the #1020 asymmetry)

### DIFF
--- a/models/qwen3.8-27b/llama-cpp/compose/dual/unsloth-q8kxl/q8kv.yml
+++ b/models/qwen3.8-27b/llama-cpp/compose/dual/unsloth-q8kxl/q8kv.yml
@@ -197,6 +197,18 @@ services:
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     environment:
+      # ⭐ Default reasoning effort = medium when thinking is on (2026-08-16),
+      # matching the vLLM composes. INERT under the shipped `--reasoning off`:
+      # the template only reads reasoning_effort inside
+      # `if enable_thinking is undefined or true`, and --reasoning off passes
+      # enable_thinking:false (verified live via /apply-template WITH tools --
+      # without tools the template never emits the instruction at all, so a
+      # no-tools probe proves nothing).
+      # ⚠️ medium injects NO instruction: the template branches on xhigh and low
+      # only. xhigh appends 'think carefully, validate key assumptions...', which
+      # is what collides with cli-40's flat 300s per-model-call cap on these
+      # sub-55 tok/s configs. ⚠️ xhigh|medium|low ONLY -- `high` RAISES at render.
+      - LLAMA_ARG_CHAT_TEMPLATE_KWARGS=${LLAMA_ARG_CHAT_TEMPLATE_KWARGS:-{"reasoning_effort":"${REASONING_EFFORT:-medium}"}}
       - CUDA_VISIBLE_DEVICES=${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0,1}}
     # ⚠ -np 1 is intentional — one decode stream. Extra slots divide throughput
     #   and each takes its own slice of the KV pool, shrinking the per-slot ctx.

--- a/models/qwen3.8-27b/llama-cpp/compose/single/unsloth-iq4nl/q8kv.yml
+++ b/models/qwen3.8-27b/llama-cpp/compose/single/unsloth-iq4nl/q8kv.yml
@@ -208,6 +208,18 @@ services:
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     environment:
+      # ⭐ Default reasoning effort = medium when thinking is on (2026-08-16),
+      # matching the vLLM composes. INERT under the shipped `--reasoning off`:
+      # the template only reads reasoning_effort inside
+      # `if enable_thinking is undefined or true`, and --reasoning off passes
+      # enable_thinking:false (verified live via /apply-template WITH tools --
+      # without tools the template never emits the instruction at all, so a
+      # no-tools probe proves nothing).
+      # ⚠️ medium injects NO instruction: the template branches on xhigh and low
+      # only. xhigh appends 'think carefully, validate key assumptions...', which
+      # is what collides with cli-40's flat 300s per-model-call cap on these
+      # sub-55 tok/s configs. ⚠️ xhigh|medium|low ONLY -- `high` RAISES at render.
+      - LLAMA_ARG_CHAT_TEMPLATE_KWARGS=${LLAMA_ARG_CHAT_TEMPLATE_KWARGS:-{"reasoning_effort":"${REASONING_EFFORT:-medium}"}}
       - CUDA_VISIBLE_DEVICES=${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}
     # ⚠ -np 1 is intentional on a single 24 GB card — do NOT raise it to
     #   "parallelize". One GPU is compute-bound: extra slots divide its


### PR DESCRIPTION
#1020 defaulted thinking boots to `medium` on the 8 vLLM composes. The 2 llama.cpp ones still fell back to the template's `xhigh` — and they are the slugs that need it **most**, sitting below the ~55 tok/s break-even where a 16,384-token thinking answer cannot finish inside cli-40's flat 300 s per-model-call cap.

### Mechanism

`LLAMA_ARG_CHAT_TEMPLATE_KWARGS` — the env form of `--chat-template-kwargs`, present in the pinned `server-cuda-b10236` build. The env form avoids nested JSON quoting inside the shell-expanded `${THINKING:+…}` command line. Malformed JSON **fails the boot loudly**, so a typo can't silently disable it.

Set unconditionally rather than THINKING-gated: the template only reads `reasoning_effort` inside `if enable_thinking is undefined or true`.

### ⚠️ The risk this could have introduced

If `--chat-template-kwargs` **replaced** rather than merged, it would have dropped `enable_thinking` → `undefined` — and `undefined` takes the **same branch as `true`**, injecting `xhigh` into the **instruct** path. A silent quality and token regression on the default config.

### Verified — three live boots, all probing `/apply-template` **with tools**

| arm | chars | `xhigh` | |
|---|--:|---|---|
| instruct (`--reasoning off`) + medium | 1118 | `False` | ✅ no clobber |
| `THINKING=1` + medium default | 1107 | `False` | ✅ the fix |
| `THINKING=1` + explicit `xhigh` | **1316** | **`True`** | ✅ reachable |

The third arm is load-bearing: without it, "no `xhigh` instruction" is satisfied equally by *the fix working* and by *the setting being ignored*.

⚠️ **Tools are required in the probe.** The template only emits `reasoning_instructions` inside its `{% if tools %}` branch, so a no-tools probe renders clean regardless — that confound produced a false pass earlier in this session before it was caught.

Override: `REASONING_EFFORT=low|xhigh` at boot (verified: `low` renders `{"reasoning_effort":"low"}`).

**Both engines now agree** — instruct by default, `medium` when thinking is on.

Guards green: `compose-status-drift`, `compose-mounts-resolve`, `compose-image-drift`, `compose-registry-disk`, `launch-compat`, `patch-attribution`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)