### PR TITLE
fix(qwen3.8-27b): default reasoning_effort low, was medium

### DIFF
--- a/models/qwen3.8-27b/llama-cpp/compose/dual/unsloth-q8kxl/q8kv.yml
+++ b/models/qwen3.8-27b/llama-cpp/compose/dual/unsloth-q8kxl/q8kv.yml
@@ -201,15 +201,26 @@ services:
       # matching the vLLM composes. INERT under the shipped `--reasoning off`:
       # the template only reads reasoning_effort inside
       # `if enable_thinking is undefined or true`, and --reasoning off passes
-      # enable_thinking:false (verified live via /apply-template WITH tools --
-      # without tools the template never emits the instruction at all, so a
-      # no-tools probe proves nothing).
+      # enable_thinking:false.
       # ⚠️ low is an ACTIVE instruction: 'Keep your thinking brief and focused,
       # moving directly to the conclusion without unnecessary elaboration.' It is
       # not "less of medium" -- medium has no branch and injects nothing. xhigh
       # appends 'think carefully, validate key assumptions...', which is what
       # collides with cli-40's flat 300s per-model-call cap on these sub-55 tok/s
-      # configs. ⚠️ xhigh|medium|low ONLY -- `high` RAISES at render.
+      # configs.
+      # ⚠️⚠️ THIS ENGINE DIVERGES FROM vLLM ON `high` -- read before setting it.
+      # The unsloth GGUF's EMBEDDED template (read from the GGUF kv 2026-08-16;
+      # byte-identical in UD-Q8_K_XL and IQ4_NL) carries a branch the HF
+      # safetensors template does NOT:
+      #     {%- if resolved_reasoning_effort == 'high' %}
+      #         {%- set resolved_reasoning_effort = 'xhigh' %}
+      # So here `high` SILENTLY becomes xhigh -- the slowest, most token-hungry
+      # level, and the one that collides with the 300s cap above -- whereas the
+      # vLLM path RAISES on it. Setting REASONING_EFFORT=high on this engine
+      # gets you the opposite of what the name suggests, with no error.
+      # ⚠️ This corrects two claims previously in this header: `high` does NOT
+      # raise on this path, and the template DOES emit the instruction with no
+      # tools present (it has a no-tools else-branch at template line ~90).
       - LLAMA_ARG_CHAT_TEMPLATE_KWARGS=${LLAMA_ARG_CHAT_TEMPLATE_KWARGS:-{"reasoning_effort":"${REASONING_EFFORT:-low}"}}
       - CUDA_VISIBLE_DEVICES=${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0,1}}
     # ⚠ -np 1 is intentional — one decode stream. Extra slots divide throughput

--- a/models/qwen3.8-27b/llama-cpp/compose/dual/unsloth-q8kxl/q8kv.yml
+++ b/models/qwen3.8-27b/llama-cpp/compose/dual/unsloth-q8kxl/q8kv.yml
@@ -197,18 +197,20 @@ services:
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     environment:
-      # ⭐ Default reasoning effort = medium when thinking is on (2026-08-16),
+      # ⭐ Default reasoning effort = low when thinking is on (2026-08-16),
       # matching the vLLM composes. INERT under the shipped `--reasoning off`:
       # the template only reads reasoning_effort inside
       # `if enable_thinking is undefined or true`, and --reasoning off passes
       # enable_thinking:false (verified live via /apply-template WITH tools --
       # without tools the template never emits the instruction at all, so a
       # no-tools probe proves nothing).
-      # ⚠️ medium injects NO instruction: the template branches on xhigh and low
-      # only. xhigh appends 'think carefully, validate key assumptions...', which
-      # is what collides with cli-40's flat 300s per-model-call cap on these
-      # sub-55 tok/s configs. ⚠️ xhigh|medium|low ONLY -- `high` RAISES at render.
-      - LLAMA_ARG_CHAT_TEMPLATE_KWARGS=${LLAMA_ARG_CHAT_TEMPLATE_KWARGS:-{"reasoning_effort":"${REASONING_EFFORT:-medium}"}}
+      # ⚠️ low is an ACTIVE instruction: 'Keep your thinking brief and focused,
+      # moving directly to the conclusion without unnecessary elaboration.' It is
+      # not "less of medium" -- medium has no branch and injects nothing. xhigh
+      # appends 'think carefully, validate key assumptions...', which is what
+      # collides with cli-40's flat 300s per-model-call cap on these sub-55 tok/s
+      # configs. ⚠️ xhigh|medium|low ONLY -- `high` RAISES at render.
+      - LLAMA_ARG_CHAT_TEMPLATE_KWARGS=${LLAMA_ARG_CHAT_TEMPLATE_KWARGS:-{"reasoning_effort":"${REASONING_EFFORT:-low}"}}
       - CUDA_VISIBLE_DEVICES=${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0,1}}
     # ⚠ -np 1 is intentional — one decode stream. Extra slots divide throughput
     #   and each takes its own slice of the KV pool, shrinking the per-slot ctx.

--- a/models/qwen3.8-27b/llama-cpp/compose/single/unsloth-iq4nl/q8kv.yml
+++ b/models/qwen3.8-27b/llama-cpp/compose/single/unsloth-iq4nl/q8kv.yml
@@ -212,15 +212,26 @@ services:
       # matching the vLLM composes. INERT under the shipped `--reasoning off`:
       # the template only reads reasoning_effort inside
       # `if enable_thinking is undefined or true`, and --reasoning off passes
-      # enable_thinking:false (verified live via /apply-template WITH tools --
-      # without tools the template never emits the instruction at all, so a
-      # no-tools probe proves nothing).
+      # enable_thinking:false.
       # ⚠️ low is an ACTIVE instruction: 'Keep your thinking brief and focused,
       # moving directly to the conclusion without unnecessary elaboration.' It is
       # not "less of medium" -- medium has no branch and injects nothing. xhigh
       # appends 'think carefully, validate key assumptions...', which is what
       # collides with cli-40's flat 300s per-model-call cap on these sub-55 tok/s
-      # configs. ⚠️ xhigh|medium|low ONLY -- `high` RAISES at render.
+      # configs.
+      # ⚠️⚠️ THIS ENGINE DIVERGES FROM vLLM ON `high` -- read before setting it.
+      # The unsloth GGUF's EMBEDDED template (read from the GGUF kv 2026-08-16;
+      # byte-identical in UD-Q8_K_XL and IQ4_NL) carries a branch the HF
+      # safetensors template does NOT:
+      #     {%- if resolved_reasoning_effort == 'high' %}
+      #         {%- set resolved_reasoning_effort = 'xhigh' %}
+      # So here `high` SILENTLY becomes xhigh -- the slowest, most token-hungry
+      # level, and the one that collides with the 300s cap above -- whereas the
+      # vLLM path RAISES on it. Setting REASONING_EFFORT=high on this engine
+      # gets you the opposite of what the name suggests, with no error.
+      # ⚠️ This corrects two claims previously in this header: `high` does NOT
+      # raise on this path, and the template DOES emit the instruction with no
+      # tools present (it has a no-tools else-branch at template line ~90).
       - LLAMA_ARG_CHAT_TEMPLATE_KWARGS=${LLAMA_ARG_CHAT_TEMPLATE_KWARGS:-{"reasoning_effort":"${REASONING_EFFORT:-low}"}}
       - CUDA_VISIBLE_DEVICES=${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}
     # ⚠ -np 1 is intentional on a single 24 GB card — do NOT raise it to

--- a/models/qwen3.8-27b/llama-cpp/compose/single/unsloth-iq4nl/q8kv.yml
+++ b/models/qwen3.8-27b/llama-cpp/compose/single/unsloth-iq4nl/q8kv.yml
@@ -208,18 +208,20 @@ services:
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     environment:
-      # ⭐ Default reasoning effort = medium when thinking is on (2026-08-16),
+      # ⭐ Default reasoning effort = low when thinking is on (2026-08-16),
       # matching the vLLM composes. INERT under the shipped `--reasoning off`:
       # the template only reads reasoning_effort inside
       # `if enable_thinking is undefined or true`, and --reasoning off passes
       # enable_thinking:false (verified live via /apply-template WITH tools --
       # without tools the template never emits the instruction at all, so a
       # no-tools probe proves nothing).
-      # ⚠️ medium injects NO instruction: the template branches on xhigh and low
-      # only. xhigh appends 'think carefully, validate key assumptions...', which
-      # is what collides with cli-40's flat 300s per-model-call cap on these
-      # sub-55 tok/s configs. ⚠️ xhigh|medium|low ONLY -- `high` RAISES at render.
-      - LLAMA_ARG_CHAT_TEMPLATE_KWARGS=${LLAMA_ARG_CHAT_TEMPLATE_KWARGS:-{"reasoning_effort":"${REASONING_EFFORT:-medium}"}}
+      # ⚠️ low is an ACTIVE instruction: 'Keep your thinking brief and focused,
+      # moving directly to the conclusion without unnecessary elaboration.' It is
+      # not "less of medium" -- medium has no branch and injects nothing. xhigh
+      # appends 'think carefully, validate key assumptions...', which is what
+      # collides with cli-40's flat 300s per-model-call cap on these sub-55 tok/s
+      # configs. ⚠️ xhigh|medium|low ONLY -- `high` RAISES at render.
+      - LLAMA_ARG_CHAT_TEMPLATE_KWARGS=${LLAMA_ARG_CHAT_TEMPLATE_KWARGS:-{"reasoning_effort":"${REASONING_EFFORT:-low}"}}
       - CUDA_VISIBLE_DEVICES=${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}
     # ⚠ -np 1 is intentional on a single 24 GB card — do NOT raise it to
     #   "parallelize". One GPU is compute-bound: extra slots divide its

--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
@@ -245,19 +245,22 @@ services:
       - --tool-call-parser
       - qwen3_coder
       - --default-chat-template-kwargs
-      # ⭐ reasoning_effort default = medium (2026-08-16). It is a PER-REQUEST OpenAI
+      # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
       # ⚠️ INERT while enable_thinking is false (the shipped default): the template
       # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
       # It takes effect the moment ENABLE_THINKING=true.
-      # ⚠️ medium is NOT a middle setting — the template has branches for xhigh and
-      # low ONLY, so medium injects NO instruction at all (the un-nudged baseline).
-      # xhigh actively adds "think carefully, validate assumptions, consider
-      # alternatives", which is what makes it slow and timeout-prone.
+      # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
+      # "Keep your thinking brief and focused, moving directly to the conclusion
+      # without unnecessary elaboration." The three levels are NOT a scale with a
+      # middle: medium has NO branch and injects nothing (the un-nudged baseline),
+      # xhigh adds "think carefully, validate assumptions, consider alternatives"
+      # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
+      # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-medium}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # Sampler follows the Qwen3.8 MODEL CARD Instruct row (thinking ships off).
       - --override-generation-config
       - '{"temperature":${TEMP:-0.7},"top_p":${TOP_P:-0.80},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"presence_penalty":${PRESENCE_PENALTY:-1.5}}'

--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
@@ -410,24 +410,28 @@ services:
       - qwen3
       # Stack-wide default: thinking OFF. On this model that ALSO suppresses the
       # template's xhigh reasoning-effort preamble (it is gated on thinking).
-      # Callers opt in per-request; add "reasoning_effort":"medium"|"low" there.
+      # Callers opt in per-request; the server default below is "low", so send
+      # "reasoning_effort":"medium" (un-nudged) or "xhigh" (deliberate) to override.
       # ⭐ THINKING GATE — flip the server default with ENABLE_THINKING=true.
       #   Pair it with the card's thinking sampler (see the THINKING MODE block
       #   in the header); the two are independent and mismatching them is SILENT.
       - --default-chat-template-kwargs
-      # ⭐ reasoning_effort default = medium (2026-08-16). It is a PER-REQUEST OpenAI
+      # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
       # ⚠️ INERT while enable_thinking is false (the shipped default): the template
       # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
       # It takes effect the moment ENABLE_THINKING=true.
-      # ⚠️ medium is NOT a middle setting — the template has branches for xhigh and
-      # low ONLY, so medium injects NO instruction at all (the un-nudged baseline).
-      # xhigh actively adds "think carefully, validate assumptions, consider
-      # alternatives", which is what makes it slow and timeout-prone.
+      # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
+      # "Keep your thinking brief and focused, moving directly to the conclusion
+      # without unnecessary elaboration." The three levels are NOT a scale with a
+      # middle: medium has NO branch and injects nothing (the un-nudged baseline),
+      # xhigh adds "think carefully, validate assumptions, consider alternatives"
+      # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
+      # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-medium}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       - --enable-auto-tool-choice
       # The 3.8 template emits the same <tool_call><function=…><parameter=…> XML
       # as 3.6 (verified by reading the template), so this parser applies.

--- a/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
@@ -167,19 +167,22 @@ services:
       - --tool-call-parser
       - qwen3_coder
       - --default-chat-template-kwargs
-      # ⭐ reasoning_effort default = medium (2026-08-16). It is a PER-REQUEST OpenAI
+      # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
       # ⚠️ INERT while enable_thinking is false (the shipped default): the template
       # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
       # It takes effect the moment ENABLE_THINKING=true.
-      # ⚠️ medium is NOT a middle setting — the template has branches for xhigh and
-      # low ONLY, so medium injects NO instruction at all (the un-nudged baseline).
-      # xhigh actively adds "think carefully, validate assumptions, consider
-      # alternatives", which is what makes it slow and timeout-prone.
+      # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
+      # "Keep your thinking brief and focused, moving directly to the conclusion
+      # without unnecessary elaboration." The three levels are NOT a scale with a
+      # middle: medium has NO branch and injects nothing (the un-nudged baseline),
+      # xhigh adds "think carefully, validate assumptions, consider alternatives"
+      # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
+      # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-medium}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       - --override-generation-config
       - '{"temperature":${TEMP:-0.7},"top_p":${TOP_P:-0.80},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"presence_penalty":${PRESENCE_PENALTY:-1.5}}'
       - --host

--- a/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
@@ -219,19 +219,22 @@ services:
       - --tool-call-parser
       - qwen3_coder
       - --default-chat-template-kwargs
-      # ⭐ reasoning_effort default = medium (2026-08-16). It is a PER-REQUEST OpenAI
+      # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
       # ⚠️ INERT while enable_thinking is false (the shipped default): the template
       # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
       # It takes effect the moment ENABLE_THINKING=true.
-      # ⚠️ medium is NOT a middle setting — the template has branches for xhigh and
-      # low ONLY, so medium injects NO instruction at all (the un-nudged baseline).
-      # xhigh actively adds "think carefully, validate assumptions, consider
-      # alternatives", which is what makes it slow and timeout-prone.
+      # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
+      # "Keep your thinking brief and focused, moving directly to the conclusion
+      # without unnecessary elaboration." The three levels are NOT a scale with a
+      # middle: medium has NO branch and injects nothing (the un-nudged baseline),
+      # xhigh adds "think carefully, validate assumptions, consider alternatives"
+      # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
+      # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-medium}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # Sampler follows the Qwen3.8 MODEL CARD Instruct row (thinking ships off).
       - --override-generation-config
       - '{"temperature":${TEMP:-0.7},"top_p":${TOP_P:-0.80},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"presence_penalty":${PRESENCE_PENALTY:-1.5}}'

--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
@@ -326,19 +326,22 @@ services:
       #   Pair it with the card's thinking sampler (see the header); the two are
       #   independent and mismatching them is SILENT.
       - --default-chat-template-kwargs
-      # ⭐ reasoning_effort default = medium (2026-08-16). It is a PER-REQUEST OpenAI
+      # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
       # ⚠️ INERT while enable_thinking is false (the shipped default): the template
       # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
       # It takes effect the moment ENABLE_THINKING=true.
-      # ⚠️ medium is NOT a middle setting — the template has branches for xhigh and
-      # low ONLY, so medium injects NO instruction at all (the un-nudged baseline).
-      # xhigh actively adds "think carefully, validate assumptions, consider
-      # alternatives", which is what makes it slow and timeout-prone.
+      # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
+      # "Keep your thinking brief and focused, moving directly to the conclusion
+      # without unnecessary elaboration." The three levels are NOT a scale with a
+      # middle: medium has NO branch and injects nothing (the un-nudged baseline),
+      # xhigh adds "think carefully, validate assumptions, consider alternatives"
+      # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
+      # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-medium}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       - --enable-auto-tool-choice
       - --tool-call-parser
       - qwen3_coder

--- a/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
@@ -219,19 +219,22 @@ services:
       - --tool-call-parser
       - qwen3_coder
       - --default-chat-template-kwargs
-      # ⭐ reasoning_effort default = medium (2026-08-16). It is a PER-REQUEST OpenAI
+      # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
       # ⚠️ INERT while enable_thinking is false (the shipped default): the template
       # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
       # It takes effect the moment ENABLE_THINKING=true.
-      # ⚠️ medium is NOT a middle setting — the template has branches for xhigh and
-      # low ONLY, so medium injects NO instruction at all (the un-nudged baseline).
-      # xhigh actively adds "think carefully, validate assumptions, consider
-      # alternatives", which is what makes it slow and timeout-prone.
+      # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
+      # "Keep your thinking brief and focused, moving directly to the conclusion
+      # without unnecessary elaboration." The three levels are NOT a scale with a
+      # middle: medium has NO branch and injects nothing (the un-nudged baseline),
+      # xhigh adds "think carefully, validate assumptions, consider alternatives"
+      # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
+      # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-medium}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # Sampler follows the Qwen3.8 MODEL CARD Instruct row (thinking ships off).
       - --override-generation-config
       - '{"temperature":${TEMP:-0.7},"top_p":${TOP_P:-0.80},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"presence_penalty":${PRESENCE_PENALTY:-1.5}}'

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
@@ -344,19 +344,22 @@ services:
       #   Pair it with the card's thinking sampler (see the header); the two are
       #   independent and mismatching them is SILENT.
       - --default-chat-template-kwargs
-      # ⭐ reasoning_effort default = medium (2026-08-16). It is a PER-REQUEST OpenAI
+      # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
       # ⚠️ INERT while enable_thinking is false (the shipped default): the template
       # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
       # It takes effect the moment ENABLE_THINKING=true.
-      # ⚠️ medium is NOT a middle setting — the template has branches for xhigh and
-      # low ONLY, so medium injects NO instruction at all (the un-nudged baseline).
-      # xhigh actively adds "think carefully, validate assumptions, consider
-      # alternatives", which is what makes it slow and timeout-prone.
+      # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
+      # "Keep your thinking brief and focused, moving directly to the conclusion
+      # without unnecessary elaboration." The three levels are NOT a scale with a
+      # middle: medium has NO branch and injects nothing (the un-nudged baseline),
+      # xhigh adds "think carefully, validate assumptions, consider alternatives"
+      # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
+      # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-medium}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       - --enable-auto-tool-choice
       - --tool-call-parser
       - qwen3_coder

--- a/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
@@ -188,19 +188,22 @@ services:
       - --tool-call-parser
       - qwen3_coder
       - --default-chat-template-kwargs
-      # ⭐ reasoning_effort default = medium (2026-08-16). It is a PER-REQUEST OpenAI
+      # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
       # ⚠️ INERT while enable_thinking is false (the shipped default): the template
       # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
       # It takes effect the moment ENABLE_THINKING=true.
-      # ⚠️ medium is NOT a middle setting — the template has branches for xhigh and
-      # low ONLY, so medium injects NO instruction at all (the un-nudged baseline).
-      # xhigh actively adds "think carefully, validate assumptions, consider
-      # alternatives", which is what makes it slow and timeout-prone.
+      # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
+      # "Keep your thinking brief and focused, moving directly to the conclusion
+      # without unnecessary elaboration." The three levels are NOT a scale with a
+      # middle: medium has NO branch and injects nothing (the un-nudged baseline),
+      # xhigh adds "think carefully, validate assumptions, consider alternatives"
+      # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
+      # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-medium}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       - --override-generation-config
       - '{"temperature":${TEMP:-0.7},"top_p":${TOP_P:-0.80},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"presence_penalty":${PRESENCE_PENALTY:-1.5}}'
       - --host


### PR DESCRIPTION
Drops the thinking-mode server default from `medium` to `low` across all 10 qwen3.8-27b composes — **8 vLLM + 2 llama.cpp**.

## The part worth knowing

`low` is **not "less of medium."** The template has branches for `xhigh` and `low` only, so `medium` injected **nothing** — it was the un-nudged baseline. `low` actively injects:

> Reasoning effort is set to low. Keep your thinking brief and focused, moving directly to the conclusion without unnecessary elaboration.

So this is off → on, not a step down a scale. The rationale block in every compose is rewritten accordingly — leaving headers that argue for `medium` while shipping `low` would have been worse than the stale value itself.

## ⚠️ Second commit: two false claims found in the llama.cpp headers

While rewriting those blocks I read the chat template out of the **GGUF kv** instead of trusting the header, and both llama.cpp composes were wrong on two points:

**1. "`high` RAISES at render" — false on this engine.** The unsloth GGUF's embedded template carries a branch the HF safetensors template does not:

```jinja
{%- if resolved_reasoning_effort == 'high' %}
    {%- set resolved_reasoning_effort = 'xhigh' %}
{%- endif %}
```

So on llama.cpp, `high` **silently becomes `xhigh`** — the slowest, most token-hungry level, and the one that collides with cli-40's flat 300s per-model-call cap. The vLLM path genuinely does raise. **The two engines diverge here**, and the header claimed the vLLM behaviour on the llama.cpp side.

**2. "without tools the template never emits the instruction at all" — false.** It has a no-tools else-branch (~line 90) that emits with and without a system message.

Verified by parsing `tokenizer.chat_template` from both GGUFs: `UD-Q8_K_XL` and `IQ4_NL` carry byte-identical 9993-char templates, both with the remap; the HF template has **zero** `== 'high'` branches.

## Unchanged

- **Still a per-request OpenAI control.** Only the fallback for callers that send nothing.
- **Still INERT under the shipped `enable_thinking=false`** — takes effect on `ENABLE_THINKING=true`.
- **`REASONING_EFFORT=medium` restores** the previous un-nudged behaviour.

## Files

| | |
|---|---|
| vLLM (8) | `dual/{autoround-int4,fp8,nvfp4}`, `multi4/{autoround-int4,fp8}`, `multi8/{autoround-int4,fp8}`, `single/nvfp4` |
| llama.cpp (2) | `dual/unsloth-q8kxl`, `single/unsloth-iq4nl` |

`scripts/quality-test.sh` needs no change — no default (`${REASONING_EFFORT:-}`), only forwards when set.

## Verification

- HF template branch read at `chat_template.jinja:45-55`; renders on **both** tools and no-tools paths (`:80-85`).
- GGUF templates extracted and diffed against it — divergence documented above.
- YAML parses on all 10; rendered default confirmed `low` on each.
- `test-thinking-control` (10 assertions), `test-generate-from-profile`, `test-profiles-compat` pass, both before and after the second commit.

Not run: the full 102-test sweep. No catalog shape, status, registry entry or default-resolver target changed.

## Follow-up for the maintainer

The eval commands in #993 and #1024 pass `REASONING_EFFORT=medium` explicitly, so they still run correctly — but they no longer match the shipped default. Whether to update those posts is yours to call.