### PR TITLE
feat(c3): Containers log-follow ([f]) — live tail with pause/resume

### DIFF
--- a/docs/superpowers/specs/2026-08-16-c3-container-log-follow-design.md
+++ b/docs/superpowers/specs/2026-08-16-c3-container-log-follow-design.md
@@ -1,0 +1,229 @@
+# c3 Containers log-follow (`[f]`) — design
+
+Date: 2026-08-16
+Status: approved in brainstorming (user, 2026-08-16) — ready for an implementation plan
+Surface: `tools/serve-cockpit` (c3) + `tools/tui-core` (`LivePane`)
+
+## Problem
+
+In c3's Operate · Containers view, the Logs drill (`#drill-logs` `LivePane`) shows a
+**one-shot** `docker logs --tail 200` snapshot: `action_container_logs()` →
+`stream_container_logs()` (app.py:10452 / 10551) reads the tail exactly once. New log
+lines only appear if the user re-presses `[l]`. There is no way to watch a container's
+log live, and no way to pause a live view.
+
+## Decisions (and why)
+
+| Question | Decision | Rationale |
+|---|---|---|
+| Stream transport | **Periodic poll** of the existing `container_logs(name, tail=200)` service read, ~2s cadence | Reuses the injected one-shot `Runner` (fully `FakeRunner`-mocked in tests → headless tests stay subprocess-free); no long-lived subprocess lifecycle across pause / container-switch / tab-switch / app-quit; transient docker errors can't wedge a follow process. 2s granularity is imperceptible for a log-tail. True `docker logs -f` (Approach B) was considered and rejected on process-lifecycle surface (single-flight `SubprocessRunner` needs a 3rd instance, `start_raw` assumes a parser, new streaming test fake, orphan risk on quit). |
+| Default state | **Snapshot first, opt-in to stream** | `[l]` keeps today's semantics exactly; streaming is armed deliberately. Protects against log-spammy containers. |
+| Toggle key | **`[f]`** (follow, matching `docker logs -f`) | Lowercase `f` is free at app level; the `f` = force-start binding (app.py:1976) lives only on the staged-write **modal** screen, which owns its keys — no conflict. |
+| Stream scope | **Follows the selection** | Follow is a property of the Logs pane, not of a container. Moving the cursor re-snapshots (existing nav path, app.py:11992) and polling continues on the new container. |
+| New-line marking | **Persistent subtle tint: brighter default foreground** | Lines arriving on a poll tick render in a brighter default-foreground style; snapshot/tail lines stay normal. Copy stays clean for free: `LivePane.append_line` buffers `Text.from_markup(line).plain` for `[Y]` (live_pane.py:266–277), so markup is stripped from the copy. Decaying-flash and leading-marker options were considered; flash needs re-styling off-screen `RichLog` lines + timers, marker needs a new display-vs-copy API. |
+| Disarm on tab/mode leave | Yes, silently | No background polling; preserves the invariant "a periodic poll never starts docker logs for a container the user didn't actively select" (app.py:8273). |
+
+## Behavior & state
+
+`[f]` is a toggle, active **only** in mode 0 · Containers tab (same context gate as
+`l`/`t`). Footer binding shown in that context; palette entry added.
+
+State (on `CockpitApp`) — three distinct states: **off** (never armed / disarmed),
+**following**, **paused**. Paused is *not* the same as off: it keeps the anchor and the
+"this pane was a live view" context, and resumes incrementally.
+
+- `_log_follow_armed: bool` — True in following **and** paused.
+- `_log_follow_paused: bool` — True only in paused.
+- `_log_follow_timer` — the `set_interval` handle (or `None`; None while paused).
+- `_log_follow_anchor: Optional[str]` — last displayed line of the current tail.
+- `_log_follow_name: str` — container the anchor belongs to.
+
+**Arming (`[f]` while off):**
+
+1. No container selected, or selected service stopped → warn notify (same as `[l]`), no state change.
+2. Activate the Logs drill tab (`#drill-tabs` → `drill-tab-logs`).
+3. `_log_follow_armed = True`; `_log_follow_name = name` — set **before** the snapshot
+   so the snapshot path's rebase (below) applies.
+4. Load the initial `--tail 200` snapshot via the existing
+   `stream_container_logs(name)` (`@work(group="container-logs", exclusive=True)`) —
+   normal color; on success it rebases the anchor to the last line.
+5. `_log_follow_timer = self.set_interval(2.0, self._log_follow_tick)`.
+6. Pane title → live indicator (see UI below); notify once: `Log follow armed — [f] to pause` (timeout ~3s).
+
+**Pausing (`[f]` while following):** stop the timer, `_log_follow_timer = None`,
+`_log_follow_paused = True` (anchor/name kept), pane title → paused indicator, append
+one dim **display-only** note (`buffer=False`, so it never enters the `[Y]` copy
+buffer): `follow paused`.
+
+**Resuming (`[f]` while paused):** `_log_follow_paused = False`; run one poll
+**immediately, incrementally** against the stored anchor — a quiet log shows no change;
+lines emitted during the pause arrive tinted — then restart the interval, title → live.
+
+**"Disarm"** (used throughout): stop the timer if running, `_log_follow_armed = False`,
+`_log_follow_paused = False`, clear the anchor/name, title → `Live`.
+
+**Container change while armed:** the existing row-highlight → `_load_active_drill_tab`
+path (app.py:11992) re-snapshots the new running container; `stream_container_logs`
+rebases the anchor (see below), so the next tick dedupes against the new container.
+
+**A stopped row is selected while armed.** The pane shows the existing "stopped · no
+live logs/stats" placeholder (`_clear_drill_for_stopped`); the mode **stays armed** —
+ticks no-op while the selection is stopped or unselected, and follow resumes when the
+next running row is selected. **Exception:** the container that was *being followed*
+itself stopped or vanished (selected row stopped/absent **and**
+`selection.name == _log_follow_name`) → dim note + **disarm** — without this the live
+indicator would lie about a dead container (`docker logs` on a stopped container still
+succeeds, just with no new lines).
+
+**Leaving the Containers tab / switching modes:** the app disarms on leave (timer
+stopped, state reset). Re-entering starts in OFF.
+
+## Polling & dedupe
+
+- Cadence constant: `_LOG_FOLLOW_PERIOD = 2.0` (module level, next to the other poll constants).
+- The interval callback is a **sync** `def _log_follow_tick(self)` that calls an
+  `async def _log_follow_poll()` decorated
+  `@work(group="container-logs", exclusive=True)` — same group as
+  `stream_container_logs`, so a tick and a manual `[l]` can never interleave (exclusive
+  cancels the in-flight), and the existing `workers.cancel_group(self, "container-logs")`
+  paths (app.py:12029) cover it with no change. (Matches the established idiom: sync
+  interval callback → `@work` coroutine, e.g. the estate poll.)
+
+**Tick guards** (local, free, in order): `_log_follow_armed` → `_active_mode == 0` →
+active operate tab == `tab-containers` → active drill tab == `drill-tab-logs` → a
+container is selected. Any miss → return.
+
+**Local liveness check** (per Behavior): the selected `ContainerInfo.status` (from the
+periodic estate poll — no extra docker call) is `stopped`, or the selected container is
+no longer listed →
+
+- selection differs from `_log_follow_name` (user browsed to a stopped row) → no-op;
+  the mode stays armed;
+- selection **is** `_log_follow_name` (the followed container died) → dim display-only
+  note (`▸ <name> — stopped · follow stopped`) + **disarm**.
+
+**Dedupe — single-line anchor.** After any successful full-tail render, set
+`anchor = lines[-1]` (or `None` if the tail is empty). Each tick:
+
+1. `res = await self._data.container_logs(name, tail=200)` — existing service method
+   (services.py:2228); **no new service surface**.
+2. `res["error"]` → dim display-only note `follow stopped: <err>` + **disarm**.
+3. Empty `lines` → no-op (keep anchor).
+4. `_log_follow_name != name` (shouldn't happen — navigation rebases — but guard) → resync.
+5. **Anchor found** in the new tail (last occurrence) → append only the lines after it,
+   each tinted; anchor = new tail's last line.
+6. **Anchor missing** (≥200 new lines, container restart, in-place `\r` progress-bar
+   line) → **resync**: `clear_log()`, re-render the fresh tail in **normal** color,
+   rebase anchor. Resync is "a new look at the tail" — the same semantic as a snapshot.
+
+The anchor is deliberately a single line: minimal state that makes quiet logs
+append-zero and active logs append-exactly-the-new-lines, with a bounded, visible
+resync as the only failure mode.
+
+**Self-heal:** the exclusive `container-logs` group means a tick can cancel an
+in-flight navigation snapshot (or a manual `[l]` cancel a tick). Either way the
+pane ends up showing a consistent tail and the next tick either dedupes normally or
+hits the name-guard/resync (step 4) and rebases — no stuck or half-rendered state.
+
+**Snapshot path gets one awareness:** in `stream_container_logs`, after a successful
+load, rebase anchor + name **when `_log_follow_armed` is True** (covers the arm
+snapshot — armed is set before the call — navigation snapshots, and manual `[l]`
+while following). Consequences:
+
+- manual `[l]` while following = natural "resync now" (clear + re-tail, normal color, polling continues);
+- navigation snapshots (app.py:11992) rebase for free.
+
+Reconsidered and rejected: `docker logs --since` + timestamp cursor (changes on-screen
+line format; host/container clock dependence) and true `docker logs -f` (see Decisions).
+
+## UI
+
+**Pane title** (`#drill-logs`'s `.live-title` `Label`; this pane never calls
+`set_run_header`, so `update_elapsed_timer` never fights it):
+
+- off (never armed / disarmed by leaving) → `Live` (unchanged)
+- armed → `Live  ●  following`
+- paused → `Live  …  paused` (dim)
+
+Glyph/spacing exact forms at implementation; no U+FE0F variation-selector emoji (c3
+convention), `●` is a text-default glyph.
+
+**Hint line** (`#containers-hint`): static copy gains `\ [f] follow` next to the existing
+`\ [l] logs   \ [t] top …`.
+
+**Toast:** arm only (`notify(..., title="Logs", timeout=3)`); pause is legible from the
+title + in-pane note.
+
+**Scroll-follow (tui-core `LivePane`).** Today `append_line` auto-scrolls to the bottom
+on every append whenever the widget's `_follow` flag is True — and nothing ever turns it
+off (the `toggle_follow()` at live_pane.py:335 is dormant). With a live stream, the user
+could not scroll up to read history. Add to `LivePane`:
+
+- on user scroll of `#live-log`: not at the bottom → auto-follow **off**; at the bottom
+  → auto-follow **on**.
+- No new key; standard tail-reader behavior; improves every `LivePane` consumer (c3
+  Run/Gate output, c3t). While follow is **paused**, nothing appends, so the pane is
+  readable at any scroll position; this only matters while actively streaming.
+
+## Keybindings / palette
+
+- `Binding("f", "container_follow", "Follow", show=False)` at app level, context-restricted
+  to `{tab-containers}` in mode 0 (same context-map pattern as `container_logs`).
+- Palette entry: `("container_follow", "Container log follow", "Containers — [f] arm/pause the live log tail for the selected container")`.
+- The modal's `f` (force-start) is unaffected: modal screens own their keys.
+
+## Testing
+
+**tui-core** (`tools/tui-core/tests/test_live_pane.py`):
+
+- scroll-up disables auto-follow; scroll-to-bottom re-enables; append while scrolled up
+  does not move the scroll offset.
+
+**c3** (`tools/serve-cockpit/tests/test_app_headless.py`) — all headless; `conftest`
+already blocks real subprocesses; ticks driven by direct `_log_follow_tick()` calls (no
+real 2s waits):
+
+1. `[f]` arms: timer set, title indicator, snapshot loaded; wrong tab/mode → no-op.
+2. Tick appends **only** new lines (fake: L1–L3, then L1–L5 → L4, L5 exactly once).
+3. Quiet log (same tail again) → zero new lines.
+4. Anchor-missing → resync: clear + full tail, no duplicated tail content.
+5. `[f]` pauses: timer cleared, no further runner calls, `follow paused` note absent from
+   `tail_text()`.
+6. Resume: one immediate incremental poll + timer re-armed (quiet log → no change;
+   paused-window lines arrive tinted).
+7. Navigation to another running container while armed → snapshot re-bases; ticks stream
+   the new container.
+8. The followed container stops/vanishes (selection == `_log_follow_name`) → note +
+   disarm; browsing to a *different* stopped row while armed → stays armed, tick no-ops.
+9. Runner error → note + disarm.
+10. Copy stays clean: tick-appended tinted lines' `tail_text()` returns unmarked plain
+    text.
+11. Tint markup present on-screen for tick lines only (snapshot lines un-tinted).
+
+Both suites run (CLAUDE.md: the c3 suite is not in `scripts/tests/*.sh`):
+`tools/serve-cockpit/.venv/bin/python -m pytest tools/serve-cockpit/tests/ -q` plus
+tui-core's suite.
+
+## Docs
+
+- `tools/serve-cockpit/README.md` keybindings table: add an `f` row, noting the context
+  split (`f` = log-follow on the Containers tab; `f` = force-start only inside the
+  staged-write modal, where it shadows app keys).
+- No new top-level doc.
+
+## Open at implementation (decide, don't re-debate)
+
+- **Tint token:** brighter default-foreground as a single Rich style — candidate
+  `bold` (portable "brighter") vs `bright_white` (hue-neutral; zero effect on themes
+  whose default fg is already bright white). Pick whichever reads as "brighter default"
+  in both a light and a dark terminal; record the choice in the commit message.
+- Exact title glyphs/spacing (above: `●` vs alternatives, dim treatment of "paused").
+
+## Out of scope (explicit)
+
+- c3t views (no container-log drill there).
+- True `docker logs -f` streaming.
+- Tinting the initial snapshot; changing `[Y]` copy semantics.
+- The pre-existing `from_markup` edge for docker lines containing `[brackets]`
+  (both display and copy paths parse the raw line today; wrapping in a color tag is no
+  worse — logged, not fixed here).

--- a/tools/serve-cockpit/README.md
+++ b/tools/serve-cockpit/README.md
@@ -62,6 +62,7 @@ own location; override with **`C3_REPO_ROOT=/path/to/club-3090`** if you install
 | `⏎` | primary action for the focused row (serve / start / download / confirm) |
 | `k` | stop a service / cancel a download |
 | `f` | force-start (experimental — skips the fit gate) |
+| `f` | Containers — log follow: arm/pause the live log tail for the selected container (Containers tab only; inside the staged-write modal `f` = force-start, which shadows app keys) |
 | `r` | refresh the catalog (re-reads the registry) |
 | `S` | settings — set Model Dir + HF token (`Ctrl+S` saves) |
 | `N` | new pod — Operate · Orchestration: compose a model + GPU set (fit-checked, gated) |

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -10604,10 +10604,70 @@ class CockpitApp(App):
 
     @work(group="container-logs", exclusive=True)
     async def _log_follow_poll(self) -> None:
-        """One follow tick — the read + anchor dedupe lands in Task 4.  The
-        guards already make a disarmed/paused tick a no-op."""
+        """One follow tick: re-read the tail, append only the NEW lines
+        (tinted), resync if the anchor is gone.  Guards in order — any miss
+        is a no-op (the mode stays armed; see the spec's stopped-row rule)."""
         if not self._log_follow_armed or self._log_follow_paused:
             return
+        if self._active_mode != 0 or self._active_operate_tab() != "tab-containers":
+            return
+        if self._active_drill_tab() != "drill-tab-logs":
+            return
+        con = self._selected_container()
+        if con is None:
+            return
+        # Local liveness check (from the periodic estate poll — no extra
+        # docker call).  A stopped selection no-ops while armed (browsing to
+        # a different stopped row keeps the mode armed; follow resumes when
+        # the next running row is selected) — EXCEPT when the container that
+        # was being followed itself stopped: the live indicator would lie
+        # about a dead container, so note + disarm.
+        if self._is_stopped_service(con):
+            if con.name == self._log_follow_name:
+                self._log_follow_death_note(con.name)
+                self._log_follow_disarm()
+            return
+        try:
+            live = self.query_one("#drill-logs", LivePane)
+        except Exception:
+            return
+        res = await self._data.container_logs(con.name, tail=200)
+        if res.get("error"):
+            live.append_line(f"[dim]follow stopped: {res['error']}[/dim]", buffer=False)
+            self._log_follow_disarm()
+            return
+        lines = res.get("lines", [])
+        if not lines:
+            return  # quiet container — keep the anchor, append nothing
+        # The anchor must belong to THIS container: navigation re-snapshots +
+        # rebases, but a lost race falls back to a full resync ("a new look
+        # at the tail" — normal color, the same semantic as a snapshot).
+        if con.name != self._log_follow_name or self._log_follow_anchor is None:
+            live.clear_log()
+            for ln in lines:
+                live.append_line(ln)
+            self._log_follow_anchor = lines[-1]
+            self._log_follow_name = con.name
+            return
+        anchor = self._log_follow_anchor
+        idx = -1
+        for j in range(len(lines) - 1, -1, -1):  # LAST occurrence
+            if lines[j] == anchor:
+                idx = j
+                break
+        if idx < 0:
+            # Anchor missing (≥200 new lines / restart / in-place progress-bar
+            # line) — resync.
+            live.clear_log()
+            for ln in lines:
+                live.append_line(ln)
+        else:
+            # Only the lines after the anchor are new — tinted (brighter
+            # default foreground).  Display-only: LivePane's [Y]-copy buffer
+            # strips the markup (Text.from_markup(...).plain).
+            for ln in lines[idx + 1:]:
+                live.append_line(f"[bold]{ln}[/bold]")
+        self._log_follow_anchor = lines[-1]
 
     def action_s_key(self) -> None:
         """[s] is context-sensitive:
@@ -10708,6 +10768,13 @@ class CockpitApp(App):
             return
         for ln in res.get("lines", []):
             live.append_line(ln)
+        # Follow-awareness: while armed, EVERY successful full-tail render
+        # rebases the anchor + name — the arm snapshot, navigation snapshots
+        # (row-highlight → _load_active_drill_tab), and a manual [l] while
+        # following (= a natural "resync now"; polling continues untouched).
+        if self._log_follow_armed:
+            self._log_follow_anchor = res.get("lines")[-1] if res.get("lines") else None
+            self._log_follow_name = name
 
     def action_container_rm(self) -> None:
         """[X] on the merged mode's Containers tab: reconcile-gated `docker rm

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -10542,17 +10542,23 @@ class CockpitApp(App):
         self._set_log_follow_title()
         try:
             live = self.query_one("#drill-logs", LivePane)
-            # Display-only note — never enters the [Y]-copy tail.
-            live.append_line("[dim]follow paused[/dim]", buffer=False)
+            # Display-only note — never enters the [Y]-copy tail.  Yellow
+            # (intermediate-state color) so the paused state reads at a glance.
+            live.append_line("[yellow]follow paused — press f to resume[/yellow]", buffer=False)
         except Exception:
             pass
 
     def _log_follow_resume(self) -> None:
         """paused → following: one immediate incremental poll against the
         stored anchor (quiet log → no change; lines emitted during the pause
-        arrive tinted), then restart the interval.  (Task 4's poll makes the
-        immediate call meaningful; until then it is a guarded no-op.)"""
+        arrive tinted), then restart the interval."""
         self._log_follow_paused = False
+        try:
+            live = self.query_one("#drill-logs", LivePane)
+            # Display-only note — never enters the [Y]-copy tail.
+            live.append_line("[green]follow resumed[/green]", buffer=False)
+        except Exception:
+            pass
         self._log_follow_tick()
         self._log_follow_timer = self.set_interval(_LOG_FOLLOW_PERIOD, self._log_follow_tick)
         self._set_log_follow_title()
@@ -10582,8 +10588,10 @@ class CockpitApp(App):
             pass
 
     def _set_log_follow_title(self) -> None:
-        """#drill-logs' pane title: `Live` (off) · `Live  ●  following` ·
-        `Live  …  paused` (dim).  This pane never calls set_run_header, so
+        """#drill-logs' pane title: `Live` (off) · `Live  ●  following`
+        (green) · `Live  …  paused` (yellow) — the state colors follow the
+        rig's running/intermediate conventions so the follow state reads at a
+        glance.  This pane never calls set_run_header, so
         update_elapsed_timer never fights it."""
         try:
             pane = self.query_one("#drill-logs", LivePane)
@@ -10591,9 +10599,9 @@ class CockpitApp(App):
             return
         if self._log_follow_armed:
             if self._log_follow_paused:
-                pane.set_title("Live  …  [dim]paused[/dim]")
+                pane.set_title("Live  [yellow]…  paused[/yellow]")
             else:
-                pane.set_title("Live  ●  following")
+                pane.set_title("Live  [green]●  following[/green]")
         else:
             pane.set_title("Live")
 
@@ -10666,7 +10674,7 @@ class CockpitApp(App):
             # default foreground).  Display-only: LivePane's [Y]-copy buffer
             # strips the markup (Text.from_markup(...).plain).
             for ln in lines[idx + 1:]:
-                live.append_line(f"[bold]{ln}[/bold]")
+                live.append_line(f"[underline]{ln}[/underline]")
         self._log_follow_anchor = lines[-1]
 
     def action_s_key(self) -> None:

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -9521,6 +9521,10 @@ class CockpitApp(App):
         except Exception:
             pass
         self._active_mode = index
+        if index != 0:
+            # Leaving the merged mode — log-follow can only be armed in mode 0;
+            # disarm on leave (no background polling; re-entry starts in OFF).
+            self._log_follow_disarm()
         # Refresh the footer so bindings shown/hidden update immediately.
         self._sync_footer_labels()
         self.refresh_bindings()
@@ -10489,10 +10493,120 @@ class CockpitApp(App):
         self.stream_container_logs(con.name)
 
     def action_container_follow(self) -> None:
-        """[f] on the Containers tab: arm/pause/resume the live log tail
-        (full arm/pause/resume logic lands with the tick; the context guard
-        matches l/t)."""
+        """[f] on the Containers tab — the log-follow toggle.
+
+        off → following: arm — activate the Logs drill, take the
+        `--tail 200` snapshot, start the 2s poll (armed/name are set BEFORE
+        the snapshot so the snapshot path's anchor rebase applies).
+        following → paused: stop the timer; anchor/name survive so the
+        resume can pick up incrementally (paused is NOT the same as off).
+        paused → following: one immediate incremental poll + restart."""
         if self._active_mode != 0 or self._active_operate_tab() != "tab-containers":
+            return
+        if self._log_follow_armed and self._log_follow_paused:
+            self._log_follow_resume()
+            return
+        if self._log_follow_armed:
+            self._log_follow_pause()
+            return
+        con = self._selected_container()
+        if con is None:
+            self.notify("No container selected.", title="Logs", severity="warning", timeout=3)
+            return
+        if self._is_stopped_service(con):
+            self.notify(f"{con.name} is not running.", title="Logs", severity="warning", timeout=3)
+            return
+        try:
+            tabs = self.query_one("#drill-tabs", TabbedContent)
+            tabs.active = "drill-tab-logs"
+        except Exception:
+            pass
+        self._log_follow_armed = True
+        self._log_follow_paused = False
+        self._log_follow_name = con.name
+        self.stream_container_logs(con.name)  # snapshot — rebases the anchor (Task 4)
+        self._log_follow_timer = self.set_interval(_LOG_FOLLOW_PERIOD, self._log_follow_tick)
+        self._set_log_follow_title()
+        self.notify("Log follow armed — [f] to pause", title="Logs", timeout=3)
+
+    def _log_follow_pause(self) -> None:
+        """following → paused: stop the timer (anchor/name kept)."""
+        timer = self._log_follow_timer
+        if timer is not None:
+            try:
+                timer.stop()
+            except Exception:
+                pass
+        self._log_follow_timer = None
+        self._log_follow_paused = True
+        self._set_log_follow_title()
+        try:
+            live = self.query_one("#drill-logs", LivePane)
+            # Display-only note — never enters the [Y]-copy tail.
+            live.append_line("[dim]follow paused[/dim]", buffer=False)
+        except Exception:
+            pass
+
+    def _log_follow_resume(self) -> None:
+        """paused → following: one immediate incremental poll against the
+        stored anchor (quiet log → no change; lines emitted during the pause
+        arrive tinted), then restart the interval.  (Task 4's poll makes the
+        immediate call meaningful; until then it is a guarded no-op.)"""
+        self._log_follow_paused = False
+        self._log_follow_tick()
+        self._log_follow_timer = self.set_interval(_LOG_FOLLOW_PERIOD, self._log_follow_tick)
+        self._set_log_follow_title()
+
+    def _log_follow_disarm(self) -> None:
+        """Stop the follow and forget it: timer stopped, both flags cleared,
+        anchor/name cleared, title back to `Live` (re-entry starts in OFF)."""
+        timer = self._log_follow_timer
+        if timer is not None:
+            try:
+                timer.stop()
+            except Exception:
+                pass
+        self._log_follow_timer = None
+        self._log_follow_armed = False
+        self._log_follow_paused = False
+        self._log_follow_anchor = None
+        self._log_follow_name = ""
+        self._set_log_follow_title()
+
+    def _log_follow_death_note(self, name: str) -> None:
+        """Display-only note for the followed container dying mid-follow."""
+        try:
+            live = self.query_one("#drill-logs", LivePane)
+            live.append_line(f"[dim]▸ {name} — stopped · follow stopped[/dim]", buffer=False)
+        except Exception:
+            pass
+
+    def _set_log_follow_title(self) -> None:
+        """#drill-logs' pane title: `Live` (off) · `Live  ●  following` ·
+        `Live  …  paused` (dim).  This pane never calls set_run_header, so
+        update_elapsed_timer never fights it."""
+        try:
+            pane = self.query_one("#drill-logs", LivePane)
+        except Exception:
+            return
+        if self._log_follow_armed:
+            if self._log_follow_paused:
+                pane.set_title("Live  …  [dim]paused[/dim]")
+            else:
+                pane.set_title("Live  ●  following")
+        else:
+            pane.set_title("Live")
+
+    def _log_follow_tick(self) -> None:
+        """Sync interval callback → @work coroutine (same exclusive group as
+        the snapshot, so a tick and a manual [l] can never interleave)."""
+        self._log_follow_poll()
+
+    @work(group="container-logs", exclusive=True)
+    async def _log_follow_poll(self) -> None:
+        """One follow tick — the read + anchor dedupe lands in Task 4.  The
+        guards already make a disarmed/paused tick a no-op."""
+        if not self._log_follow_armed or self._log_follow_paused:
             return
 
     def action_s_key(self) -> None:
@@ -11741,6 +11855,10 @@ class CockpitApp(App):
         # Strip the Textual internal prefix if present.
         _PREFIX = "--content-tab-"
         tab_id = raw_tab_id[len(_PREFIX):] if raw_tab_id.startswith(_PREFIX) else raw_tab_id
+        if tab_id != "tab-containers":
+            # Leaving the Containers tab — disarm the log-follow (no background
+            # polling).  No-op when the follow is already off (e.g. mode-1 tabs).
+            self._log_follow_disarm()
         # N9 — entering ② Serve re-arms it from the cached ① Bring fit-check so the
         # resolved target is shown WITHOUT re-entering ① Bring (the pipeline flows).
         if tab_id == "tab-serve":

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -3285,7 +3285,7 @@ class OperateContainersPane(Container):
                 yield Static("[dim]highlight a container (move cursor) to load its config[/dim]", id="drill-config")
         yield Label(
             "[dim]move cursor or \\[l]/\\[t] to load detail · \\[l] logs   \\[t] top   "
-            "\\[s] restart · start if stopped (gated)   \\[x] stop (gated)   "
+            "\\[f] follow   \\[s] restart · start if stopped (gated)   \\[x] stop (gated)   "
             "\\[X] rm (reconcile-gated)[/dim]",
             id="containers-hint",
         )
@@ -6706,6 +6706,7 @@ _PALETTE_COMMANDS: tuple[tuple[str, str, str], ...] = (
     ("power_cap", "Power cap…", "Orchestration — power-cap menu: default 230W / clear / custom W (gated)"),
     ("power_cap_sweep", "Power cap sweep", "Doctor — sweep power caps + bench at each (gated)"),
     ("container_logs", "Container logs", "Containers — stream the selected container's logs"),
+    ("container_follow", "Container log follow", "Containers — [f] arm/pause the live log tail for the selected container"),
     ("doctor_rerun", "Re-run Doctor health", "Doctor — re-run the live health read (read-only)"),
     ("doctor_verify", "Verify serving", "Doctor — send a test query to the model (verify.sh · read)"),
     ("doctor_verify_full", "Verify-full battery", "Doctor — functional battery (verify-full.sh · ~1-2 min · read)"),
@@ -6794,6 +6795,10 @@ class CockpitCommands(Provider):
 
 # ── Main application ──────────────────────────────────────────────────────────────
 
+# Containers log-follow ([f]) — docker-logs poll cadence while armed.  2s is
+# imperceptible for a log tail and keeps the read-runner calls cheap.
+_LOG_FOLLOW_PERIOD = 2.0
+
 
 class CockpitApp(App):
     """club3090 serve cockpit — both modes (Run & Operate · Bring & Validate) wired to the live data layer."""
@@ -6868,6 +6873,8 @@ class CockpitApp(App):
         # rewritten by `_sync_footer_labels`.  show=True so check_action can surface
         # it when the action is live (phase 1.3).
         Binding("l", "container_logs", "Logs", show=False),
+        # [f] = log-follow toggle (Containers tab).  The modal force-start 'f' lives on the staged-write modal screen, which owns its keys — no conflict.
+        Binding("f", "container_follow", "Follow", show=False),
         Binding("s", "s_key", "Restart / Submit", show=True),
         Binding("x", "container_stop", "Stop", show=False),
         Binding("X", "container_rm", "Remove", show=False),
@@ -7096,6 +7103,7 @@ class CockpitApp(App):
         "doctor_verify_full": ({0}, {"tab-doctor"}),
         # Merged mode 0 · Containers tab
         "container_logs":   ({0}, {"tab-containers"}),
+        "container_follow": ({0}, {"tab-containers"}),
         # [s] is handled by a DEDICATED branch in check_action (FIX 2) — Containers
         # (restart) on mode 0 + the lane's ④ Measure (submit) on mode 1 — so it is
         # NOT listed here (the old `({0, 1}, None)` entry was over-broad: it showed
@@ -7434,6 +7442,17 @@ class CockpitApp(App):
         self._c3_log_enabled = False
         self._c3_log_env_override = False
         self._active_mode = 0  # 0=Run & Operate (merged) · 1=Bring & Validate
+        # Containers log-follow ([f]) — three states: off / following / paused.
+        #   _log_follow_armed   True in BOTH following and paused
+        #   _log_follow_paused  True only in paused
+        #   _log_follow_timer   set_interval handle (None while paused)
+        #   _log_follow_anchor  last displayed line of the current tail (dedupe)
+        #   _log_follow_name    container the anchor belongs to
+        self._log_follow_armed = False
+        self._log_follow_paused = False
+        self._log_follow_timer = None
+        self._log_follow_anchor: Optional[str] = None
+        self._log_follow_name = ""
         # Cache the last-loaded variants so detect/match + containers can match
         # running engines back to registry slugs.
         self._variants: list[VariantRow] = []
@@ -10468,6 +10487,13 @@ class CockpitApp(App):
         except Exception:
             pass
         self.stream_container_logs(con.name)
+
+    def action_container_follow(self) -> None:
+        """[f] on the Containers tab: arm/pause/resume the live log tail
+        (full arm/pause/resume logic lands with the tick; the context guard
+        matches l/t)."""
+        if self._active_mode != 0 or self._active_operate_tab() != "tab-containers":
+            return
 
     def action_s_key(self) -> None:
         """[s] is context-sensitive:

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -60,6 +60,7 @@ from textual.widgets import (
     Header,
     Input,
     Label,
+    RichLog,
     Select,
     Static,
     Switch,
@@ -6798,6 +6799,10 @@ class CockpitCommands(Provider):
 # Containers log-follow ([f]) — docker-logs poll cadence while armed.  2s is
 # imperceptible for a log tail and keeps the read-runner calls cheap.
 _LOG_FOLLOW_PERIOD = 2.0
+# Display-model cap for the follow pane — mirrors LivePane's own 2000-line
+# [Y]-copy buffer cap so a log-spammy container can't grow the model without
+# bound (the pane re-render trims to this too).
+_LOG_FOLLOW_ENTRIES_MAX = 2000
 
 
 class CockpitApp(App):
@@ -7448,11 +7453,18 @@ class CockpitApp(App):
         #   _log_follow_timer   set_interval handle (None while paused)
         #   _log_follow_anchor  last displayed line of the current tail (dedupe)
         #   _log_follow_name    container the anchor belongs to
+        #   _log_follow_entries the follow pane's display model: (kind, text)
+        #       with kind "line" (plain, in the [Y] copy) / "fresh" (the
+        #       LATEST tick's lines — underlined) / "note" (state note,
+        #       display-only).  Each tick promotes fresh→line, so the
+        #       underline tracks only the newest batch; the pane is
+        #       re-rendered from this while the user sits at the tail.
         self._log_follow_armed = False
         self._log_follow_paused = False
         self._log_follow_timer = None
         self._log_follow_anchor: Optional[str] = None
         self._log_follow_name = ""
+        self._log_follow_entries: list[tuple[str, str]] = []
         # Cache the last-loaded variants so detect/match + containers can match
         # running engines back to registry slugs.
         self._variants: list[VariantRow] = []
@@ -10540,25 +10552,17 @@ class CockpitApp(App):
         self._log_follow_timer = None
         self._log_follow_paused = True
         self._set_log_follow_title()
-        try:
-            live = self.query_one("#drill-logs", LivePane)
-            # Display-only note — never enters the [Y]-copy tail.  Yellow
-            # (intermediate-state color) so the paused state reads at a glance.
-            live.append_line("[yellow]follow paused — press f to resume[/yellow]", buffer=False)
-        except Exception:
-            pass
+        # Yellow (intermediate-state color) so the paused state reads at a
+        # glance.  Recorded in the display model so a resume-tick re-render
+        # re-emits it instead of dropping it.
+        self._log_follow_note("[yellow]follow paused — press f to resume[/yellow]")
 
     def _log_follow_resume(self) -> None:
         """paused → following: one immediate incremental poll against the
         stored anchor (quiet log → no change; lines emitted during the pause
         arrive tinted), then restart the interval."""
         self._log_follow_paused = False
-        try:
-            live = self.query_one("#drill-logs", LivePane)
-            # Display-only note — never enters the [Y]-copy tail.
-            live.append_line("[green]follow resumed[/green]", buffer=False)
-        except Exception:
-            pass
+        self._log_follow_note("[green]follow resumed[/green]")
         self._log_follow_tick()
         self._log_follow_timer = self.set_interval(_LOG_FOLLOW_PERIOD, self._log_follow_tick)
         self._set_log_follow_title()
@@ -10577,6 +10581,7 @@ class CockpitApp(App):
         self._log_follow_paused = False
         self._log_follow_anchor = None
         self._log_follow_name = ""
+        self._log_follow_entries = []
         self._set_log_follow_title()
 
     def _log_follow_death_note(self, name: str) -> None:
@@ -10586,6 +10591,37 @@ class CockpitApp(App):
             live.append_line(f"[dim]▸ {name} — stopped · follow stopped[/dim]", buffer=False)
         except Exception:
             pass
+
+    def _log_follow_note(self, text: str) -> None:
+        """Display-only state note in #drill-logs — recorded in the display
+        model too, so a follow-tick re-render re-emits it in place instead of
+        dropping it (never enters the [Y]-copy tail)."""
+        try:
+            live = self.query_one("#drill-logs", LivePane)
+            live.append_line(text, buffer=False)
+        except Exception:
+            return
+        self._log_follow_entries.append(("note", text))
+
+    def _log_follow_rerender(self, pane: LivePane) -> None:
+        """Re-render #drill-logs from _log_follow_entries: plain history, the
+        LATEST tick's lines underlined, state notes in place.  RichLog is
+        append-only, so 'the previous batch loses its underline' can only
+        mean a rewrite; when the user is reading history (not at the tail)
+        the scroll offset is restored so the rewrite doesn't yank them."""
+        log = pane.query_one("#live-log", RichLog)
+        at_bottom = pane.at_bottom
+        y = log.scroll_y if not at_bottom else 0.0
+        pane.clear_log()
+        for kind, text in self._log_follow_entries:
+            if kind == "fresh":
+                pane.append_line(f"[underline]{text}[/underline]")
+            elif kind == "note":
+                pane.append_line(text, buffer=False)
+            else:
+                pane.append_line(text)
+        if not at_bottom:
+            log.scroll_to(0, y, immediate=True, animate=False)
 
     def _set_log_follow_title(self) -> None:
         """#drill-logs' pane title: `Live` (off) · `Live  ●  following`
@@ -10612,9 +10648,11 @@ class CockpitApp(App):
 
     @work(group="container-logs", exclusive=True)
     async def _log_follow_poll(self) -> None:
-        """One follow tick: re-read the tail, append only the NEW lines
-        (tinted), resync if the anchor is gone.  Guards in order — any miss
-        is a no-op (the mode stays armed; see the spec's stopped-row rule)."""
+        """One follow tick: re-read the tail, show only the NEW lines
+        underlined (the previous batch drops back to plain — the pane is
+        re-rendered from the display model while the user is at the tail),
+        resync if the anchor is gone.  Guards in order — any miss is a no-op
+        (the mode stays armed; see the spec's stopped-row rule)."""
         if not self._log_follow_armed or self._log_follow_paused:
             return
         if self._active_mode != 0 or self._active_operate_tab() != "tab-containers":
@@ -10654,6 +10692,7 @@ class CockpitApp(App):
             live.clear_log()
             for ln in lines:
                 live.append_line(ln)
+            self._log_follow_entries = [("line", ln) for ln in lines]
             self._log_follow_anchor = lines[-1]
             self._log_follow_name = con.name
             return
@@ -10669,12 +10708,29 @@ class CockpitApp(App):
             live.clear_log()
             for ln in lines:
                 live.append_line(ln)
+            self._log_follow_entries = [("line", ln) for ln in lines]
         else:
-            # Only the lines after the anchor are new — tinted (brighter
-            # default foreground).  Display-only: LivePane's [Y]-copy buffer
-            # strips the markup (Text.from_markup(...).plain).
-            for ln in lines[idx + 1:]:
-                live.append_line(f"[underline]{ln}[/underline]")
+            new = lines[idx + 1 :]
+            if not new:
+                return  # same tail as the last read — the underline stays put
+            # The underline tracks ONLY the newest batch: earlier "fresh"
+            # lines drop back to plain, the new ones take the underline
+            # (display-only: LivePane's [Y]-copy buffer strips the markup).
+            self._log_follow_entries = [
+                ("line", t) if k == "fresh" else (k, t)
+                for k, t in self._log_follow_entries
+            ]
+            self._log_follow_entries.extend(("fresh", ln) for ln in new)
+            if len(self._log_follow_entries) > _LOG_FOLLOW_ENTRIES_MAX:
+                del self._log_follow_entries[: -_LOG_FOLLOW_ENTRIES_MAX]
+            if live.at_bottom:
+                self._log_follow_rerender(live)
+            else:
+                # Reading history — append the new lines plain (the highlight
+                # is a tail affordance); the next at-tail tick re-renders with
+                # the underline on the right lines.
+                for ln in new:
+                    live.append_line(ln)
         self._log_follow_anchor = lines[-1]
 
     def action_s_key(self) -> None:
@@ -10773,16 +10829,28 @@ class CockpitApp(App):
             return
         if res.get("error"):
             live.append_line(f"[red]logs unavailable:[/red] {res['error']}")
+            if self._log_follow_armed:
+                # Mirror the pane so a follow-tick re-render keeps the error
+                # line (and doesn't resurrect stale tail content).
+                self._log_follow_entries = [
+                    ("line", f"[dim]$ docker logs --tail 200 {name}[/dim]"),
+                    ("line", f"[red]logs unavailable:[/red] {res['error']}"),
+                ]
             return
         for ln in res.get("lines", []):
             live.append_line(ln)
         # Follow-awareness: while armed, EVERY successful full-tail render
         # rebases the anchor + name — the arm snapshot, navigation snapshots
         # (row-highlight → _load_active_drill_tab), and a manual [l] while
-        # following (= a natural "resync now"; polling continues untouched).
+        # following (= a natural "resync now"; polling continues untouched) —
+        # and mirrors the pane's content (command prompt + tail) in the
+        # display model so the next tick's re-render matches the [Y] copy.
         if self._log_follow_armed:
             self._log_follow_anchor = res.get("lines")[-1] if res.get("lines") else None
             self._log_follow_name = name
+            self._log_follow_entries = [
+                ("line", f"[dim]$ docker logs --tail 200 {name}[/dim]")
+            ] + [("line", ln) for ln in res.get("lines", [])]
 
     def action_container_rm(self) -> None:
         """[X] on the merged mode's Containers tab: reconcile-gated `docker rm

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -30,7 +30,7 @@ from typing import Any, Optional
 
 import pytest
 
-from textual.widgets import Button, DataTable, Input, Select, Static, Switch, TabbedContent, TabPane, Label, Tabs
+from textual.widgets import Button, DataTable, Input, RichLog, Select, Static, Switch, TabbedContent, TabPane, Label, Tabs
 from textual.widgets._footer import FooterKey
 from textual.widgets._tabbed_content import ContentTabs
 
@@ -6374,6 +6374,22 @@ class TestContainerLogFollow:
 
     Ticks are driven by direct app._log_follow_tick() calls — no real 2s waits."""
 
+    class _StepLogsRunner(FakeRunner):
+        """docker logs responses step through a list of tails: first call gets
+        the first tail, every later call gets the last (steady state)."""
+
+        def __init__(self, tails):
+            super().__init__(fake_responses(**{"docker ps": ok(DOCKER_PS_ENGINE)}))
+            self._tails = list(tails)
+
+        async def run(self, cmd, *, cwd, timeout=30.0):
+            joined = " ".join(cmd)
+            if "docker logs" in joined:
+                self.calls.append(list(cmd))
+                tail = self._tails.pop(0) if len(self._tails) > 1 else self._tails[0]
+                return ok(tail)
+            return await super().run(cmd, cwd=cwd, timeout=timeout)
+
     async def test_follow_binding_gated_to_containers_tab(self):
         responses = fake_responses(**{"docker ps": ok(DOCKER_PS_ENGINE)})
         app, _, _ = make_app(responses=responses)
@@ -6493,6 +6509,243 @@ class TestContainerLogFollow:
             await pilot.pause()
             assert app._log_follow_armed is False
             assert app._log_follow_timer is None
+
+    async def test_tick_appends_only_new_lines(self):
+        runner = TestContainerLogFollow._StepLogsRunner(["L1\nL2\nL3\n", "L1\nL2\nL3\nL4\nL5\n"])
+        app, runner, _ = make_app(runner=runner)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot, tab="tab-containers")
+            app.query_one("#operate-containers-pane", OperateContainersPane).query_one(
+                "#containers-table", DataTable
+            ).move_cursor(row=0)
+            await pilot.pause()
+            await pilot.press("f")
+            await _settle(pilot)
+            assert app._log_follow_anchor == "L3"  # snapshot rebased the anchor
+            calls_before = len(runner.calls)
+            app._log_follow_tick()
+            await _settle(pilot)
+            assert len(runner.calls) == calls_before + 1  # exactly one docker-logs read
+            text = app.query_one("#drill-logs", LivePane).tail_text()
+            assert text.count("L4") == 1 and text.count("L5") == 1
+            assert "L1" in text  # snapshot lines kept — no resync
+
+    async def test_tick_quiet_log_appends_nothing(self):
+        runner = TestContainerLogFollow._StepLogsRunner(["L1\nL2\nL3\n"])
+        app, runner, _ = make_app(runner=runner)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot, tab="tab-containers")
+            app.query_one("#operate-containers-pane", OperateContainersPane).query_one(
+                "#containers-table", DataTable
+            ).move_cursor(row=0)
+            await pilot.pause()
+            await pilot.press("f")
+            await _settle(pilot)
+            calls_before = len(runner.calls)
+            app._log_follow_tick()
+            await _settle(pilot)
+            assert len(runner.calls) == calls_before + 1
+            text = app.query_one("#drill-logs", LivePane).tail_text()
+            assert text.count("L3") == 1  # nothing appended on the same tail
+
+    async def test_tick_anchor_missing_resyncs(self):
+        # The tail scrolled past 200 lines: the anchor line is gone → clear +
+        # full fresh tail in normal color (no duplicated tail content).
+        runner = TestContainerLogFollow._StepLogsRunner(["L1\nL2\nL3\n", "L4\nL5\nL6\n"])
+        app, runner, _ = make_app(runner=runner)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot, tab="tab-containers")
+            app.query_one("#operate-containers-pane", OperateContainersPane).query_one(
+                "#containers-table", DataTable
+            ).move_cursor(row=0)
+            await pilot.pause()
+            await pilot.press("f")
+            await _settle(pilot)
+            app._log_follow_tick()
+            await _settle(pilot)
+            pane = app.query_one("#drill-logs", LivePane)
+            text = pane.tail_text()
+            assert "L1" not in text and "L2" not in text  # old tail cleared
+            assert text.count("L4") == 1 and text.count("L6") == 1  # fresh tail, once each
+            assert app._log_follow_anchor == "L6"
+
+    async def test_tick_tints_only_new_lines_and_copy_stays_clean(self):
+        runner = TestContainerLogFollow._StepLogsRunner(["L1\nL2\nL3\n", "L1\nL2\nL3\nL4\nL5\n"])
+        app, runner, _ = make_app(runner=runner)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot, tab="tab-containers")
+            app.query_one("#operate-containers-pane", OperateContainersPane).query_one(
+                "#containers-table", DataTable
+            ).move_cursor(row=0)
+            await pilot.pause()
+            await pilot.press("f")
+            await _settle(pilot)
+            written: list[str] = []
+            log = app.query_one("#drill-logs", LivePane).query_one("#live-log", RichLog)
+            real_write = log.write
+
+            def spy(content, *a, **kw):
+                written.append(str(content))
+                return real_write(content, *a, **kw)
+
+            log.write = spy
+            app._log_follow_tick()
+            await _settle(pilot)
+            pane = app.query_one("#drill-logs", LivePane)
+            # Tinted markup on screen for the tick lines ONLY…
+            assert "[bold]L4[/bold]" in written and "[bold]L5[/bold]" in written
+            # …and the [Y]-copy tail is unmarked plain text either way.
+            text = pane.tail_text()
+            assert "[bold]" not in text and "L4" in text and "L5" in text
+
+    async def test_navigation_to_another_container_rebases(self):
+        class _PerNameLogsRunner(FakeRunner):
+            """docker logs keyed by the container name in the command."""
+
+            def __init__(self, by_name):
+                super().__init__(fake_responses(**{"docker ps": ok(DOCKER_PS_TWO)}))
+                self._by_name = by_name
+
+            async def run(self, cmd, *, cwd, timeout=30.0):
+                joined = " ".join(cmd)
+                if "docker logs" in joined:
+                    self.calls.append(list(cmd))
+                    for name, tail in self._by_name.items():
+                        if name in joined:
+                            return ok(tail)
+                    return ok("")
+                return await super().run(cmd, cwd=cwd, timeout=timeout)
+
+        runner = _PerNameLogsRunner(
+            {
+                "vllm-qwen36-27b-dual": "A1\nA2\n",
+                "vllm-gemma-4-31b-dual": "B1\nB2\n",
+            }
+        )
+        app, runner, _ = make_app(runner=runner)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot, tab="tab-containers")
+            pane = app.query_one("#operate-containers-pane", OperateContainersPane)
+            pane.query_one("#containers-table", DataTable).move_cursor(row=0)
+            await pilot.pause()
+            await pilot.press("f")
+            await _settle(pilot)
+            assert app._log_follow_anchor == "A2"
+            # User browses to the other running engine → navigation snapshot
+            # (existing path) re-snapshots AND rebases the anchor.
+            pane.query_one("#containers-table", DataTable).move_cursor(row=1)
+            await pilot.pause(0.35)  # let the 0.25s drill-debounce timer fire
+            await _settle(pilot)
+            assert app._log_follow_anchor == "B2"
+            assert app._log_follow_name == "vllm-gemma-4-31b-dual"
+            text = app.query_one("#drill-logs", LivePane).tail_text()
+            assert "A1" not in text and "B1" in text
+            # A tick now streams the NEW container's tail (quiet → nothing new).
+            app._log_follow_tick()
+            await _settle(pilot)
+            assert app.query_one("#drill-logs", LivePane).tail_text().count("B2") == 1
+
+    async def test_followed_container_stops_notes_and_disarms(self):
+        responses = fake_responses(
+            **{"docker ps": ok(DOCKER_PS_ENGINE), "docker logs": ok("L1\nL2\nL3\n")}
+        )
+        app, _, _ = make_app(responses=responses)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot, tab="tab-containers")
+            pane = app.query_one("#operate-containers-pane", OperateContainersPane)
+            pane.query_one("#containers-table", DataTable).move_cursor(row=0)
+            await pilot.pause()
+            await pilot.press("f")
+            await _settle(pilot)
+            assert app._log_follow_armed is True
+            # The followed container itself stopped (estate poll would surface
+            # this; simulate by flipping the live row's status).
+            pane._containers[0].status = "stopped"
+            app._log_follow_tick()
+            await _settle(pilot)
+            assert app._log_follow_armed is False
+            assert app._log_follow_timer is None
+            assert app._log_follow_anchor is None
+
+    async def test_browsing_to_other_stopped_row_stays_armed(self):
+        responses = fake_responses(
+            **{
+                "docker ps": ok(DOCKER_PS_TWO),
+                "docker container ls -a": ok("studio-step-voice\n"),
+                "docker logs": ok("L1\nL2\nL3\n"),
+            }
+        )
+        app, _, _ = make_app(responses=responses)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot, tab="tab-containers")
+            pane = app.query_one("#operate-containers-pane", OperateContainersPane)
+            pane.query_one("#containers-table", DataTable).move_cursor(row=0)
+            await pilot.pause()
+            await pilot.press("f")
+            await _settle(pilot)
+            assert app._log_follow_armed is True
+            assert app._log_follow_name == "vllm-qwen36-27b-dual"
+            # Browse to a DIFFERENT stopped row (the studio stack row).
+            stopped = [c for c in pane._containers if c.status == "stopped"]
+            assert stopped, "test setup: expected a stopped studio row"
+            idx = [c.name for c in pane._containers].index(stopped[0].name)
+            pane.query_one("#containers-table", DataTable).move_cursor(row=idx)
+            await _settle(pilot)
+            app._log_follow_tick()
+            await _settle(pilot)
+            assert app._log_follow_armed is True  # mode stays armed, tick no-ops
+            assert app._log_follow_timer is not None
+            assert app._log_follow_name == "vllm-qwen36-27b-dual"
+
+    async def test_follow_runner_error_notes_and_disarms(self):
+        class _ErrLogsRunner(FakeRunner):
+            def __init__(self):
+                super().__init__(fake_responses(**{"docker ps": ok(DOCKER_PS_ENGINE)}))
+
+            async def run(self, cmd, *, cwd, timeout=30.0):
+                joined = " ".join(cmd)
+                if "docker logs" in joined:
+                    self.calls.append(list(cmd))
+                    return RunResult(returncode=1, stdout="", stderr="No such container: x")
+                return await super().run(cmd, cwd=cwd, timeout=timeout)
+
+        app, _, _ = make_app(runner=_ErrLogsRunner())
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot, tab="tab-containers")
+            app.query_one("#operate-containers-pane", OperateContainersPane).query_one(
+                "#containers-table", DataTable
+            ).move_cursor(row=0)
+            await pilot.pause()
+            await pilot.press("f")
+            await _settle(pilot)
+            app._log_follow_tick()
+            await _settle(pilot)
+            assert app._log_follow_armed is False
+            assert app._log_follow_timer is None
+            # The 'follow stopped' note is display-only.
+            assert "follow stopped" not in app.query_one("#drill-logs", LivePane).tail_text()
+
+    async def test_f_resumes_with_immediate_incremental_poll(self):
+        runner = TestContainerLogFollow._StepLogsRunner(["L1\nL2\nL3\n", "L1\nL2\nL3\nL4\nL5\n"])
+        app, runner, _ = make_app(runner=runner)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot, tab="tab-containers")
+            app.query_one("#operate-containers-pane", OperateContainersPane).query_one(
+                "#containers-table", DataTable
+            ).move_cursor(row=0)
+            await pilot.pause()
+            await pilot.press("f")  # arm — snapshot L1-L3
+            await _settle(pilot)
+            await pilot.press("f")  # pause
+            await pilot.pause()
+            calls_before = len(runner.calls)
+            await pilot.press("f")  # resume → ONE immediate incremental poll
+            await _settle(pilot)
+            assert app._log_follow_paused is False
+            assert app._log_follow_timer is not None
+            assert len(runner.calls) == calls_before + 1
+            text = app.query_one("#drill-logs", LivePane).tail_text()
+            assert text.count("L4") == 1 and text.count("L5") == 1  # pause-window lines arrived
 
 
 class TestEscClosesFilter:

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -6598,6 +6598,123 @@ class TestContainerLogFollow:
             text = pane.tail_text()
             assert "[underline]" not in text and "L4" in text and "L5" in text
 
+    async def test_tick_underline_tracks_only_newest_batch(self):
+        # Moving highlight: when a 2nd tick arrives, the 1st tick's
+        # underlined lines drop back to plain and only the newest lines
+        # keep the underline (the pane is re-rendered from the model).
+        runner = TestContainerLogFollow._StepLogsRunner(
+            ["L1\nL2\nL3\n", "L1\nL2\nL3\nL4\nL5\n", "L1\nL2\nL3\nL4\nL5\nL6\nL7\n"]
+        )
+        app, runner, _ = make_app(runner=runner)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot, tab="tab-containers")
+            app.query_one("#operate-containers-pane", OperateContainersPane).query_one(
+                "#containers-table", DataTable
+            ).move_cursor(row=0)
+            await pilot.pause()
+            await pilot.press("f")
+            await _settle(pilot)
+            written: list[str] = []
+            log = app.query_one("#drill-logs", LivePane).query_one("#live-log", RichLog)
+            real_write = log.write
+
+            def spy(content, *a, **kw):
+                written.append(str(content))
+                return real_write(content, *a, **kw)
+
+            log.write = spy
+            app._log_follow_tick()  # L4/L5 new
+            await _settle(pilot)
+            app._log_follow_tick()  # L6/L7 new — L4/L5 must lose the underline
+            await _settle(pilot)
+            # Each re-render starts with the command prompt — isolate the last.
+            starts = [i for i, w in enumerate(written) if "$ docker logs" in w]
+            assert len(starts) == 2, f"expected two re-renders, saw {len(starts)}"
+            last_batch = written[starts[-1] :]
+            assert "[underline]L6[/underline]" in last_batch
+            assert "[underline]L7[/underline]" in last_batch
+            assert "[underline]L4[/underline]" not in last_batch
+            assert "[underline]L5[/underline]" not in last_batch
+            assert "L4" in last_batch  # still on screen, plain now
+            # No content duplication from the re-renders.
+            text = app.query_one("#drill-logs", LivePane).tail_text()
+            for ln in ("L1", "L2", "L3", "L4", "L5", "L6", "L7"):
+                assert text.count(ln) == 1
+
+    async def test_state_notes_survive_rerender(self):
+        # The pause/resume notes live in the display model — the resume-tick
+        # re-render re-emits them in chronological order, and they stay out
+        # of the [Y] copy.
+        runner = TestContainerLogFollow._StepLogsRunner(["L1\nL2\nL3\n", "L1\nL2\nL3\nL4\nL5\n"])
+        app, runner, _ = make_app(runner=runner)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot, tab="tab-containers")
+            app.query_one("#operate-containers-pane", OperateContainersPane).query_one(
+                "#containers-table", DataTable
+            ).move_cursor(row=0)
+            await pilot.pause()
+            await pilot.press("f")
+            await _settle(pilot)
+            await pilot.press("f")  # pause
+            await pilot.pause()
+            written: list[str] = []
+            log = app.query_one("#drill-logs", LivePane).query_one("#live-log", RichLog)
+            real_write = log.write
+
+            def spy(content, *a, **kw):
+                written.append(str(content))
+                return real_write(content, *a, **kw)
+
+            log.write = spy
+            await pilot.press("f")  # resume → immediate tick → re-render
+            await _settle(pilot)
+            starts = [i for i, w in enumerate(written) if "$ docker logs" in w]
+            assert starts, "resume-tick re-render did not rewrite the pane"
+            last_batch = written[starts[-1] :]
+            i_paused = last_batch.index("[yellow]follow paused — press f to resume[/yellow]")
+            i_resumed = last_batch.index("[green]follow resumed[/green]")
+            i_l4 = last_batch.index("[underline]L4[/underline]")
+            assert i_paused < i_resumed < i_l4  # chronological: notes, then fresh lines
+            text = app.query_one("#drill-logs", LivePane).tail_text()
+            assert "follow paused" not in text and "follow resumed" not in text
+
+    async def test_tick_scrolled_up_appends_plain(self):
+        # Reading history: a tick appends the new lines plain (no underline,
+        # no rewrite) — the moving highlight is a tail affordance.
+        base = "".join(f"K{i:03d}\n" for i in range(60))
+        runner = TestContainerLogFollow._StepLogsRunner(
+            [base, base + "K060\nK061\n", base + "K060\nK061\nK062\n"]
+        )
+        app, runner, _ = make_app(runner=runner)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot, tab="tab-containers")
+            app.query_one("#operate-containers-pane", OperateContainersPane).query_one(
+                "#containers-table", DataTable
+            ).move_cursor(row=0)
+            await pilot.pause()
+            await pilot.press("f")
+            await _settle(pilot)
+            app._log_follow_tick()  # K060/K061 new — re-render at the tail
+            await _settle(pilot)
+            pane = app.query_one("#drill-logs", LivePane)
+            log = pane.query_one("#live-log", RichLog)
+            log.scroll_up(immediate=True, animate=False)
+            await pilot.pause()
+            assert pane.at_bottom is False
+            written: list[str] = []
+            real_write = log.write
+
+            def spy(content, *a, **kw):
+                written.append(str(content))
+                return real_write(content, *a, **kw)
+
+            log.write = spy
+            app._log_follow_tick()  # K062 new
+            await _settle(pilot)
+            assert written == ["K062"]  # plain append only — no rewrite, no tint
+            text = pane.tail_text()
+            assert text.count("K062") == 1 and "[underline]" not in text
+
     async def test_navigation_to_another_container_rebases(self):
         class _PerNameLogsRunner(FakeRunner):
             """docker logs keyed by the container name in the command."""

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -35,6 +35,7 @@ from textual.widgets._footer import FooterKey
 from textual.widgets._tabbed_content import ContentTabs
 
 from club3090_tui_core.detect import GpuInfo, ServingTarget
+from club3090_tui_core.widgets.live_pane import LivePane
 
 from club3090_cockpit.app import (
     CockpitApp,
@@ -6366,6 +6367,29 @@ class TestContainerClampDoesNotAutoloadDrill:
                     and other in " ".join(c)
                     for c in runner.calls
                 ), f"a drill spuriously loaded for {other}: {runner.calls}"
+
+
+class TestContainerLogFollow:
+    """[f] log-follow (live tail) — spec docs/superpowers/specs/2026-08-16-c3-container-log-follow-design.md.
+
+    Ticks are driven by direct app._log_follow_tick() calls — no real 2s waits."""
+
+    async def test_follow_binding_gated_to_containers_tab(self):
+        responses = fake_responses(**{"docker ps": ok(DOCKER_PS_ENGINE)})
+        app, _, _ = make_app(responses=responses)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot)  # lands on Orchestration
+            assert app.check_action("container_follow", ()) is False
+            app.query_one("#operate-tabs", TabbedContent).active = "tab-containers"
+            await pilot.pause()
+            assert app.check_action("container_follow", ()) is True
+
+    async def test_containers_hint_mentions_follow(self):
+        app, _, _ = make_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot, tab="tab-containers")
+            hint = app.query_one("#containers-hint", Label)
+            assert "[f] follow" in hint.content
 
 
 class TestEscClosesFilter:

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -6425,7 +6425,7 @@ class TestContainerLogFollow:
             assert app._log_follow_timer is not None
             assert app._log_follow_name == "vllm-qwen36-27b-dual"
             title = app.query_one("#drill-logs", LivePane).query_one(".live-title", Label)
-            assert title.content == "Live  ●  following"
+            assert title.content == "Live  [green]●  following[/green]"
 
     async def test_f_with_no_selection_warns_and_stays_off(self):
         # Default responses: docker ps empty → no selectable running row.
@@ -6463,7 +6463,7 @@ class TestContainerLogFollow:
             await _settle(pilot)
             assert len(runner.calls) == calls_before
             title = app.query_one("#drill-logs", LivePane).query_one(".live-title", Label)
-            assert title.content == "Live  …  [dim]paused[/dim]"
+            assert title.content == "Live  [yellow]…  paused[/yellow]"
             # The 'follow paused' note is display-only — never in the [Y] tail.
             pane = app.query_one("#drill-logs", LivePane)
             assert "follow paused" not in pane.tail_text()
@@ -6593,10 +6593,10 @@ class TestContainerLogFollow:
             await _settle(pilot)
             pane = app.query_one("#drill-logs", LivePane)
             # Tinted markup on screen for the tick lines ONLY…
-            assert "[bold]L4[/bold]" in written and "[bold]L5[/bold]" in written
+            assert "[underline]L4[/underline]" in written and "[underline]L5[/underline]" in written
             # …and the [Y]-copy tail is unmarked plain text either way.
             text = pane.tail_text()
-            assert "[bold]" not in text and "L4" in text and "L5" in text
+            assert "[underline]" not in text and "L4" in text and "L5" in text
 
     async def test_navigation_to_another_container_rebases(self):
         class _PerNameLogsRunner(FakeRunner):
@@ -6744,8 +6744,13 @@ class TestContainerLogFollow:
             assert app._log_follow_paused is False
             assert app._log_follow_timer is not None
             assert len(runner.calls) == calls_before + 1
-            text = app.query_one("#drill-logs", LivePane).tail_text()
+            pane = app.query_one("#drill-logs", LivePane)
+            text = pane.tail_text()
             assert text.count("L4") == 1 and text.count("L5") == 1  # pause-window lines arrived
+            # The 'follow resumed' note is display-only — never in the [Y] tail.
+            assert "follow resumed" not in text
+            title = pane.query_one(".live-title", Label)
+            assert title.content == "Live  [green]●  following[/green]"
 
 
 class TestEscClosesFilter:

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -6391,6 +6391,109 @@ class TestContainerLogFollow:
             hint = app.query_one("#containers-hint", Label)
             assert "[f] follow" in hint.content
 
+    async def test_f_arms_follow(self):
+        responses = fake_responses(
+            **{"docker ps": ok(DOCKER_PS_ENGINE), "docker logs": ok("L1\nL2\nL3\n")}
+        )
+        app, _, _ = make_app(responses=responses)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot, tab="tab-containers")
+            app.query_one("#operate-containers-pane", OperateContainersPane).query_one(
+                "#containers-table", DataTable
+            ).move_cursor(row=0)
+            await pilot.pause()
+            await pilot.press("f")
+            await _settle(pilot)
+            assert app._log_follow_armed is True
+            assert app._log_follow_paused is False
+            assert app._log_follow_timer is not None
+            assert app._log_follow_name == "vllm-qwen36-27b-dual"
+            title = app.query_one("#drill-logs", LivePane).query_one(".live-title", Label)
+            assert title.content == "Live  ●  following"
+
+    async def test_f_with_no_selection_warns_and_stays_off(self):
+        # Default responses: docker ps empty → no selectable running row.
+        app, _, _ = make_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot, tab="tab-containers")
+            await pilot.pause()
+            await pilot.press("f")
+            await pilot.pause()
+            assert app._log_follow_armed is False
+            assert app._log_follow_timer is None
+
+    async def test_f_pauses_follow(self):
+        responses = fake_responses(
+            **{"docker ps": ok(DOCKER_PS_ENGINE), "docker logs": ok("L1\nL2\nL3\n")}
+        )
+        app, runner, _ = make_app(responses=responses)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot, tab="tab-containers")
+            app.query_one("#operate-containers-pane", OperateContainersPane).query_one(
+                "#containers-table", DataTable
+            ).move_cursor(row=0)
+            await pilot.pause()
+            await pilot.press("f")
+            await _settle(pilot)
+            assert app._log_follow_armed is True  # paused is NOT off
+            calls_before = len(runner.calls)
+            await pilot.press("f")
+            await pilot.pause()
+            assert app._log_follow_armed is True
+            assert app._log_follow_paused is True
+            assert app._log_follow_timer is None
+            # A tick while paused performs NO read.
+            app._log_follow_tick()
+            await _settle(pilot)
+            assert len(runner.calls) == calls_before
+            title = app.query_one("#drill-logs", LivePane).query_one(".live-title", Label)
+            assert title.content == "Live  …  [dim]paused[/dim]"
+            # The 'follow paused' note is display-only — never in the [Y] tail.
+            pane = app.query_one("#drill-logs", LivePane)
+            assert "follow paused" not in pane.tail_text()
+
+    async def test_follow_disarms_on_operate_tab_leave(self):
+        responses = fake_responses(
+            **{"docker ps": ok(DOCKER_PS_ENGINE), "docker logs": ok("L1\nL2\nL3\n")}
+        )
+        app, _, _ = make_app(responses=responses)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot, tab="tab-containers")
+            app.query_one("#operate-containers-pane", OperateContainersPane).query_one(
+                "#containers-table", DataTable
+            ).move_cursor(row=0)
+            await pilot.pause()
+            await pilot.press("f")
+            await _settle(pilot)
+            assert app._log_follow_armed is True
+            app.query_one("#operate-tabs", TabbedContent).active = "tab-orchestration"
+            await pilot.pause()
+            assert app._log_follow_armed is False
+            assert app._log_follow_paused is False
+            assert app._log_follow_timer is None
+            assert app._log_follow_anchor is None
+            title = app.query_one("#drill-logs", LivePane).query_one(".live-title", Label)
+            assert title.content == "Live"
+
+    async def test_follow_disarms_on_mode_switch(self):
+        responses = fake_responses(
+            **{"docker ps": ok(DOCKER_PS_ENGINE), "docker logs": ok("L1\nL2\nL3\n")}
+        )
+        app, _, _ = make_app(responses=responses)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot, tab="tab-containers")
+            app.query_one("#operate-containers-pane", OperateContainersPane).query_one(
+                "#containers-table", DataTable
+            ).move_cursor(row=0)
+            await pilot.pause()
+            await pilot.press("f")
+            await _settle(pilot)
+            assert app._log_follow_armed is True
+            await pilot.press("2")  # Bring & Validate lane
+            await pilot.pause()
+            assert app._log_follow_armed is False
+            assert app._log_follow_timer is None
+
 
 class TestEscClosesFilter:
     """Esc closes an open filter Input + refocuses the table (it was a dead key

--- a/tools/tui-core/club3090_tui_core/widgets/live_pane.py
+++ b/tools/tui-core/club3090_tui_core/widgets/live_pane.py
@@ -286,6 +286,13 @@ class LivePane(Static):
         except Exception:
             pass
 
+    @property
+    def at_bottom(self) -> bool:
+        """Whether the user is at the tail (scroll-follow on).  Hosts gate
+        tail-specific rendering on this (e.g. c3's log-follow highlight,
+        which only makes sense at the tail)."""
+        return self._follow
+
     def append_line(self, line: str, buffer: bool = True) -> None:
         """Append a raw log line.  ``buffer=False`` writes display-only lines
         (idle/stopped notes) that must NOT appear in the [Y]-copy tail."""

--- a/tools/tui-core/club3090_tui_core/widgets/live_pane.py
+++ b/tools/tui-core/club3090_tui_core/widgets/live_pane.py
@@ -262,6 +262,29 @@ class LivePane(Static):
         if self._placeholder:
             log = self.query_one("#live-log", RichLog)
             log.write(f"[dim]{self._placeholder}[/dim]")
+        self._attach_scroll_follow()
+
+    def _attach_scroll_follow(self) -> None:
+        """Tail-reader scroll-follow (standard `tail -f` UX, for EVERY
+        LivePane consumer): user scroll away from the bottom turns
+        auto-follow OFF (history stays readable while new lines stream in);
+        scroll back to the bottom turns it ON.  Gated on BOTH the append-time
+        scroll_end flag and RichLog's own auto_scroll var (which otherwise
+        yanks the pane to the end on every write regardless)."""
+        try:
+            log = self.query_one("#live-log", RichLog)
+            log.watch(log, "scroll_y", self._on_log_scrolled, init=True)
+        except Exception:
+            pass
+
+    def _on_log_scrolled(self, y: float) -> None:
+        try:
+            log = self.query_one("#live-log", RichLog)
+            at_bottom = y + log.region.height >= log.virtual_size.height - 0.5
+            self._follow = at_bottom
+            log.auto_scroll = at_bottom
+        except Exception:
+            pass
 
     def append_line(self, line: str, buffer: bool = True) -> None:
         """Append a raw log line.  ``buffer=False`` writes display-only lines
@@ -277,6 +300,7 @@ class LivePane(Static):
                 del self._raw_lines[: self._RAW_LINES_MAX // 2]
         try:
             log = self.query_one("#live-log", RichLog)
+            log.auto_scroll = self._follow
             log.write(line)
             if self._follow:
                 log.scroll_end(animate=False)
@@ -304,6 +328,14 @@ class LivePane(Static):
             log.clear()
             header = self.query_one("#structured-header", StructuredHeader)
             header.clear()
+        except Exception:
+            pass
+
+    def set_title(self, text: str) -> None:
+        """Update the pane's .live-title label (Rich markup allowed).  Hosts
+        use this for status indicators (e.g. c3's log-follow `● following`)."""
+        try:
+            self.query_one(".live-title", Label).update(text)
         except Exception:
             pass
 

--- a/tools/tui-core/tests/test_live_pane.py
+++ b/tools/tui-core/tests/test_live_pane.py
@@ -7,6 +7,9 @@ standalone.
 
 from __future__ import annotations
 
+from textual.app import App, ComposeResult
+from textual.widgets import Label, RichLog
+
 from club3090_tui_core.widgets.live_pane import LivePane
 
 
@@ -52,3 +55,69 @@ class TestLivePaneTailBuffer:
         assert LivePane()._placeholder == "Ready."
         assert LivePane(placeholder="")._placeholder == ""
         assert LivePane(placeholder="logs stream here")._placeholder == "logs stream here"
+
+
+class _Host(App):
+    """Minimal host so the RichLog is mounted (scroll-follow needs layout)."""
+
+    CSS = "LivePane { width: 1fr; height: 1fr; }"
+
+    def compose(self) -> ComposeResult:
+        yield LivePane(id="lp")
+
+
+class TestLivePaneScrollFollow:
+    async def test_scrolling_up_disables_auto_follow(self):
+        async with _Host().run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            lp = pilot.app.query_one("#lp", LivePane)
+            log = pilot.app.query_one("#live-log", RichLog)
+            for i in range(40):
+                lp.append_line(f"line {i}")
+                await pilot.pause()
+            assert lp._follow is True
+            log.scroll_up(immediate=True, animate=False)
+            await pilot.pause()
+            assert lp._follow is False
+            assert log.auto_scroll is False  # write() must stop auto-scrolling too
+
+    async def test_scrolling_to_bottom_re_enables(self):
+        async with _Host().run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            lp = pilot.app.query_one("#lp", LivePane)
+            log = pilot.app.query_one("#live-log", RichLog)
+            for i in range(40):
+                lp.append_line(f"line {i}")
+                await pilot.pause()
+            log.scroll_up(immediate=True, animate=False)
+            await pilot.pause()
+            assert lp._follow is False
+            log.scroll_end(immediate=True, animate=False)
+            await pilot.pause()
+            assert lp._follow is True
+            assert log.auto_scroll is True
+
+    async def test_append_while_scrolled_up_does_not_move_offset(self):
+        async with _Host().run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            lp = pilot.app.query_one("#lp", LivePane)
+            log = pilot.app.query_one("#live-log", RichLog)
+            for i in range(40):
+                lp.append_line(f"line {i}")
+                await pilot.pause()
+            log.scroll_up(immediate=True, animate=False)
+            await pilot.pause()
+            before = log.scroll_y
+            lp.append_line("line 40")
+            await pilot.pause()
+            assert log.scroll_y == before  # reading history is not yanked away
+
+    async def test_set_title_updates_live_title_label(self):
+        lp = LivePane()
+        lp.set_title("whatever")  # unmounted — must not raise
+        async with _Host().run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            lp = pilot.app.query_one("#lp", LivePane)
+            lp.set_title("Live  ●  [bold]following[/bold]")
+            title = pilot.app.query_one(".live-title", Label)
+            assert title.content == "Live  ●  [bold]following[/bold]"

--- a/tools/tui-core/tests/test_live_pane.py
+++ b/tools/tui-core/tests/test_live_pane.py
@@ -97,6 +97,23 @@ class TestLivePaneScrollFollow:
             assert lp._follow is True
             assert log.auto_scroll is True
 
+    async def test_at_bottom_property_tracks_follow(self):
+        async with _Host().run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            lp = pilot.app.query_one("#lp", LivePane)
+            log = pilot.app.query_one("#live-log", RichLog)
+            assert lp.at_bottom is True
+            for i in range(40):
+                lp.append_line(f"line {i}")
+                await pilot.pause()
+            assert lp.at_bottom is True
+            log.scroll_up(immediate=True, animate=False)
+            await pilot.pause()
+            assert lp.at_bottom is False
+            log.scroll_end(immediate=True, animate=False)
+            await pilot.pause()
+            assert lp.at_bottom is True
+
     async def test_append_while_scrolled_up_does_not_move_offset(self):
         async with _Host().run_test(size=(80, 24)) as pilot:
             await pilot.pause()


### PR DESCRIPTION
## What

Adds a `[f]` log-follow (live tail) to c3's Containers view Logs drill: new `docker logs` lines appear every ~2 s without re-pressing `[l]`, with pause/resume and a live state indicator.

## How

- **Poll, not stream** — a 2.0 s interval re-reads the existing one-shot `container_logs(name, tail=200)` service call. No `docker logs -f` subprocess, no new service surface (`services.py` untouched).
- **Anchor dedupe** — after any full-tail render the anchor is the last displayed line; each tick appends only the lines after the anchor's last occurrence. Anchor missing (tail scrolled past 200 lines, restart, in-place progress-bar line) or container changed → resync: clear + full fresh tail.
- **No interleaving** — ticks share the exclusive `container-logs` worker group with `stream_container_logs`, so a tick and a manual `[l]`/navigation snapshot never interleave; cancellation races self-heal via resync.
- **Moving underline** — new lines render underlined; each tick the previous batch drops back to plain and only the newest batch keeps the underline. `RichLog` is append-only, so the tick keeps a chronological display model (plain / newest-batch / state-note) and re-renders the pane from it while the user sits at the tail; while reading history (scrolled up) ticks append plain with no rewrite, and the next at-tail tick re-renders correctly.
- **State** — three explicit states: off / following / paused. Pane title: `Live` / `Live  ●  following` (green) / `Live  …  paused` (yellow); pause/resume notes are display-only.
- **Invariants** — the `[Y]`-copy tail stays plain text (markup stripped by the existing buffer; notes use `buffer=False`); no background polling when leaving the Containers tab or mode 0 (disarm on leave, re-entry starts off); the followed container dying → death note + disarm; browsing to a different stopped row keeps the mode armed (tick no-ops).

## tui-core

`LivePane` gains tail-reader scroll-follow for every consumer: scrolling up stops auto-scroll (history stays readable while lines stream in), scrolling back to the bottom resumes it — gated on both the append-time `scroll_end` and `RichLog.auto_scroll` (which otherwise yanks the pane on every write). Plus `set_title()` and an `at_bottom` property.

## Tests

- 19 headless tests in `TestContainerLogFollow` (subprocess-free — injected `FakeRunner`, ticks driven by direct `_log_follow_tick()` calls, no real 2 s waits): binding/context gating, arm/pause/resume/disarm, tick dedupe + quiet-log no-op, resync, moving-underline batch tracking, note survival across re-render, scrolled-up plain append, navigation rebase, death/error disarms.
- tui-core scroll-follow + `at_bottom` tests.
- README keybindings row for `f`.

Verified on a live rig: full c3 suite green (896 passed; the two failures are a pre-existing registry-reps count mismatch that fails at pre-feature commits, and a tab-bar focus timing flake that passes in isolation), plus a read-only live smoke test driving the production app against real docker (arm → 3 real ticks on an actively-logging container → pause → resume → navigate to a quiet container → disarm-on-tab-leave).

Design spec: `docs/superpowers/specs/2026-08-16-c3-container-log-follow-design.md`.
