### PR TITLE
docs: fix commands that cannot run + the TP head counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,9 @@ bash scripts/launch.sh
 #    Or let the resolver pick for your model + hardware (.env pin ‖ curated default):
 #      bash scripts/launch.sh --variant qwen3.6-27b/default # YOUR default for this model
 #    Or skip the wizard with an explicit config:
-#      bash scripts/launch.sh --variant beellama/dflash     # single-card BLESSED default — code-fast (~100 code / 50 narr TPS), DFlash spec-dec (⚠️ unofficial multi-arch image; sm_89/120 unvalidated — see docs/INFERENCE_ENGINES.md)
-#      bash scripts/launch.sh --variant vllm/minimal       # single-card qwen — the ONLY functional path since 2026-08-12 (32K ctx, no vision, ~32/33 TPS)
-#      # ⚠️ RETIRED 2026-08-12 (all --force-only now): ik-llama/iq4ks-mtp (200K + vision, ~63/69 TPS),
-#      #    llamacpp/default (200K, cliff-immune), llamacpp/mtp-vision. See docs/SINGLE_CARD.md banner.
-#      bash scripts/launch.sh --variant vllm/dual           # dual-card 262K + vision (vLLM single-card paths blocked on #167)
+#      bash scripts/launch.sh --variant vllm/minimal        # single-card qwen (32K ctx, no vision, ~32/33 TPS)
+#      bash scripts/launch.sh --variant vllm/dual           # dual-card 262K + vision
+#    Retired single-card slugs still launch with --force; see docs/SINGLE_CARD.md "Escape hatches".
 #    Or partial flags (wizard fills the rest):
 #      bash scripts/launch.sh --model qwen3.6-27b --gpus 0,1
 #      bash scripts/launch.sh --tp 2 --pp 1               # override vLLM parallelism
@@ -59,7 +57,8 @@ curl -sf http://localhost:8020/v1/chat/completions \
 bash scripts/bench.sh
 
 # 6. Switch later without re-clicking through the wizard:
-bash scripts/switch.sh vllm/long-vision   # for example
+bash scripts/switch.sh vllm/dual          # for example
+bash scripts/switch.sh --list             # every launchable variant (--all to include retired)
 
 # 7. Keep your install up-to-date as the stack moves (Genesis pin bumps,
 #    new compose variants, vendored patch updates):

--- a/docs/DUAL_CARD.md
+++ b/docs/DUAL_CARD.md
@@ -94,7 +94,7 @@ For the single-card picture, see [`SINGLE_CARD.md`](SINGLE_CARD.md).
 
 **Workload:** anything. Chat, tool agents, vision, mixed-modal. The recommended default for 2× 3090.
 
-> 🎯 **Don't want to name a slug?** `bash scripts/switch.sh qwen3.6-27b/default` (or a bare `bash scripts/launch.sh`) resolves the blessed dual-card default automatically — on 2× 3090 that's **`vllm/dual`** (the `dual` order in `ENGINE_PREFERENCE` is `vllm > ik-llama > llama.cpp`). Prefer a different config (e.g. `vllm/dual-turbo` for multi-tenant)? Pin it once with `bash scripts/switch.sh --set-default vllm/dual-turbo` and bare launches go straight there — see the [FAQ](FAQ.md#how-do-i-set-my-own-default-config).
+> 🎯 **Don't want to name a slug?** `bash scripts/switch.sh qwen3.6-27b/default` (or a bare `bash scripts/launch.sh`) resolves the blessed dual-card default automatically — on 2× 3090 that's **`vllm/dual`** (the `dual` order in `ENGINE_PREFERENCE` is `vllm > ik-llama > llama.cpp`). Prefer a different config (e.g. `vllm/qwen-35b-a3b-dual` for multi-tenant / agent fleets)? Pin it once with `bash scripts/switch.sh --set-default vllm/qwen-35b-a3b-dual` and bare launches go straight there — see the [FAQ](FAQ.md#how-do-i-set-my-own-default-config).
 
 262K context, fp8 KV, MTP n=3, 2 streams, vision tower active. **Genesis-less by design** — fp8 KV doesn't trigger the cudagraph bug (#40880) that drove Genesis's existence on single-card. Pure vLLM nightly path. Tool calls work via `--tool-call-parser qwen3_coder` + `--enable-auto-tool-choice`. All `verify-stress.sh` checks pass clean.
 
@@ -209,19 +209,18 @@ bash scripts/setup.sh qwen3.6-27b
 bash scripts/launch.sh
 
 # 3. Or skip the wizard:
-bash scripts/launch.sh --variant vllm/dual              # general default
-bash scripts/launch.sh --variant vllm/dual-turbo        # 4 streams
-bash scripts/launch.sh --variant vllm/dual-dflash       # peak code + vision
-bash scripts/launch.sh --variant vllm/dual-dflash-noviz # peak code, no vision
+bash scripts/launch.sh --variant vllm/dual                 # general default        :8010
+bash scripts/launch.sh --variant vllm/qwen-27b-dual-max    # max accuracy (FP8)     :8013
+bash scripts/launch.sh --variant vllm/qwen-35b-a3b-dual    # concurrency / agents   :8051
 
-# 4. Sanity test
-curl -sf http://localhost:8020/v1/chat/completions \
+# 4. Sanity test — port matches the slug you booted (see the table above)
+curl -sf http://localhost:8010/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{"model":"qwen3.6-27b","messages":[{"role":"user","content":"Capital of France?"}],"max_tokens":200}'
 
 # 5. Switch later without re-running setup
-bash scripts/switch.sh vllm/dual-dflash    # for example
-bash scripts/switch.sh --list              # show all variants
+bash scripts/switch.sh vllm/qwen-27b-dual-max   # for example
+bash scripts/switch.sh --list                   # show all variants (--all to include retired)
 ```
 
 ---

--- a/docs/MULTI_CARD.md
+++ b/docs/MULTI_CARD.md
@@ -180,7 +180,7 @@ for a subset.
 
 | Class | What it means | Example | Recommended |
 |---|---|---|---|
-| `single_card` | 1 GPU detected | 1x RTX 3090 | Use the largest single-card compose that fits (`vllm/default`, `vllm/long-text`, `llamacpp/default`). |
+| `single_card` | 1 GPU detected | 1x RTX 3090 | Run `bash scripts/switch.sh qwen3.6-27b/default` (resolves to `vllm/minimal`). See [SINGLE_CARD.md](SINGLE_CARD.md). |
 | `homogeneous` | All cards have matched VRAM and matched SM | 2x RTX 3090 | TP=N is the optimal default; use the shipped `vllm/dual*` (2-card) or `vllm/qwen-27b-multi-*` (4-card) composes. |
 | `vram_matched_compute_mismatched` | Same VRAM, different compute tier | RTX 3090 + RTX 4090 | TP=N works correctly, but faster cards wait at NCCL allreduce. Estate planner is better for multi-model workloads. |
 | `vram_mismatched` | Different VRAM sizes | RTX 3060 12 GB + RTX 3090 24 GB | Prefer llama.cpp `--tensor-split`, manual PP=N experiments, or estate planner. Avoid TP=N across the full mismatched set. |
@@ -220,30 +220,35 @@ card runs its own model at full speed.
 
 ## Valid TP values for Qwen3.6-27B
 
-vLLM's tensor parallelism splits attention heads across cards. The TP
-value must divide both the attention head count AND the KV head count
-cleanly. Qwen3.6-27B has:
+vLLM asserts that the **attention** head count divides the TP size. KV heads
+do not have to divide it — when there are fewer KV heads than ranks, vLLM
+**replicates** them. Qwen3.6-27B and Qwen3.8-27B are identical here
+(`config.json` → `text_config`):
 
-- **80 attention heads** (factors: 1, 2, 4, 5, 8, 10, 16, 20, 40, 80)
-- **5 KV heads** (factors: 1, 5)
+- **24 attention heads** (factors: 1, 2, 3, 4, 6, 8, 12, 24) — this is the binding constraint
+- **4 KV heads** — shard cleanly to TP=4, then replicate above it
+- head_dim 256
 
-The intersection — TP values that work — is **1, 2, 4, 5, 8, 10**. So:
+Valid TP values are therefore **1, 2, 4, 8** (and 12, 24 on datacenter boards):
 
-| GPUs | Valid TP | Notes |
-|---|---|---|
-| 1 | TP=1 | Standard single-card. See [SINGLE_CARD.md](SINGLE_CARD.md). |
-| 2 | TP=2 | Standard dual. See [DUAL_CARD.md](DUAL_CARD.md). |
-| **3** | **TP=2 only** | TP=3 would split 5 KV heads as 5/3 = 1.67 per card — vLLM errors at boot. **Use TP=2 with 1 idle card** (set `CUDA_VISIBLE_DEVICES=0,1`), or run 2 single-card stacks on different ports. |
-| **4** | **TP=4** | Each card gets 20 attention heads + 1.25 KV heads — vLLM splits with replication for fractional KV (handled internally). Production-viable if your rig has the slots + power + cooling. |
-| **5** | **TP=5** | Theoretically valid (1 KV head per card, 16 attention heads per card). Unusual rig count; not common. |
-| **6 or 7** | **TP=4 or TP=5 + spare cards** | TP=6/7 don't divide head count. Use TP=4 (idle 2-3 cards) or TP=5 (idle 1-2 cards). |
-| **8** | **TP=8** | Datacenter-class. Each card gets 10 attention heads, splits KV heads via vLLM's internal handling. |
-| **10** | **TP=10** | Server-class. Production-viable on data-center boards. |
+| GPUs | Valid TP | Attn heads/card | KV heads/card | Notes |
+|---|---|--:|---|---|
+| 1 | TP=1 | 24 | 4 | Standard single-card. See [SINGLE_CARD.md](SINGLE_CARD.md). |
+| 2 | TP=2 | 12 | 2 | Standard dual. See [DUAL_CARD.md](DUAL_CARD.md). |
+| **3** | **TP=2 only** | — | — | 24 ÷ 3 = 8 attention heads is fine, but **4 KV heads across 3 ranks neither divides nor replicates evenly** — vLLM errors at boot. **Use TP=2 with 1 idle card** (`CUDA_VISIBLE_DEVICES=0,1`), or run 2 single-card stacks on different ports. |
+| **4** | **TP=4** | 6 | 1 | The shipped multi-card tier. Production-viable if your rig has the slots + power + cooling. |
+| **5** | **TP=4 + 1 idle** | — | — | ⚠️ **TP=5 does NOT work** — 24 ÷ 5 is not an integer. |
+| **6 or 7** | **TP=4 + spare cards** | — | — | Neither divides 24 evenly alongside the KV constraint. Use TP=4 and leave the extras idle. |
+| **8** | **TP=8** | 3 | replicated ×2 | Each card holds 3 attention heads; the 4 KV heads replicate, so **per-card KV stays at the TP=4 figure** and only weights shard 8-way. |
+| **10** | **TP=8 + 2 idle** | — | — | ⚠️ **TP=10 does NOT work** — 24 ÷ 10 is not an integer. |
 
-**Critical: TP=3, TP=6, TP=7, TP=9 do NOT work.** vLLM errors at boot
+**Critical: TP=3, 5, 6, 7, 9, 10 do NOT work.** vLLM errors at boot
 ("number of attention heads must be divisible by tensor parallel size").
 If you have an awkward GPU count, use the next-lower valid TP and leave
 the extras idle, or run separate stacks on different ports.
+
+> ⚠️ Because KV heads replicate above TP=4, **going from 4 to 8 cards does not
+> shrink per-card KV** — it only shards weights further. Budget accordingly.
 
 ### Picking which cards to use on awkward counts
 

--- a/docs/SINGLE_CARD.md
+++ b/docs/SINGLE_CARD.md
@@ -306,8 +306,10 @@ bash scripts/setup.sh qwen3.6-27b
 bash scripts/launch.sh
 
 # 3. Or skip the wizard:
-bash scripts/launch.sh --variant ik-llama/iq4ks-mtp   # single-card default (MTP, fastest + leanest)
-bash scripts/launch.sh --variant llamacpp/default  # easy mode
+bash scripts/launch.sh --variant qwen3.6-27b/default  # resolves to vllm/minimal
+bash scripts/launch.sh --variant vllm/minimal         # same thing, named explicitly (32K, no vision)
+# Retired-but-working single-card slugs need --force (see the table at the top of this page):
+#   bash scripts/switch.sh --force llamacpp/default    # 200K, cliff-immune, unmaintained
 
 # 4. Sanity test
 curl -sf http://localhost:8020/v1/chat/completions \
@@ -315,8 +317,8 @@ curl -sf http://localhost:8020/v1/chat/completions \
   -d '{"model":"qwen3.6-27b","messages":[{"role":"user","content":"Capital of France?"}],"max_tokens":200}'
 
 # 5. Switch later without re-running setup
-bash scripts/switch.sh vllm/long-vision    # for example
-bash scripts/switch.sh --list              # show all variants
+bash scripts/switch.sh vllm/minimal        # for example
+bash scripts/switch.sh --list              # show all variants (--all to include retired)
 ```
 
 ---

--- a/models/qwen3.6-27b/vllm/compose/single/autoround-int4/minimal.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/autoround-int4/minimal.yml
@@ -5,7 +5,7 @@
 #   Drafter:   none (no spec-decode — simplest path)
 #   KV:        fp8_e4m3 (no TQ3 to avoid cudagraph cascade bugs)
 #   Vision:    no
-#   Max ctx:   65K (mem-util 0.95)
+#   Max ctx:   32K (MAX_MODEL_LEN default 32768; raise it explicitly if headroom allows)
 #   Genesis:   none — bare vLLM, isolation control
 #   Status:    ✅ Production
 #   Best for:  Debugging baseline / 20 GB Ampere fallback when TQ3 paths
@@ -17,11 +17,15 @@
 #   - You want the simplest possible stack (fewer moving parts to debug)
 #   - You don't need MTP / spec-decode speedup
 #   - You're OK with ~32 TPS instead of the ~50-70 TPS of the spec-decode variants
-#   - You want vision + tool calls to "just work" without any patches
+#   - You want tool calls to "just work" without any patches
 #
-# Trade-off vs the default `docker-compose.yml`:
-#   - This: no MTP, no Genesis → 32/33 TPS narr/code, 32K ctx, vision ✓, tools ✓
-#   - Default: MTP + Genesis P65 + TQ3 KV → 51/68 TPS, 48K ctx, vision ✓, tools ✓
+# What you get: no MTP, no Genesis → ~32/33 TPS narr/code, 32K ctx, tools ✓,
+# no vision (matches the `Vision: no` schema line above — vLLM single-card
+# vision on this model is blocked by #167).
+#
+# ⚠️ This block previously claimed 65K ctx and `vision ✓`, and compared against a
+# "MTP + Genesis P65 + TQ3 KV" default that no longer exists (Genesis retired
+# stack-wide 2026-07-06; the TQ3 composes are in `compose/_archive/`).
 #
 # This file exists because community feedback (predecessor repo issue #1)
 # showed users sometimes hit the spec-decode tool-call cascade by booting


### PR DESCRIPTION
Correctness-only pass on the four main pages, split out from the docs restructure discussed in #955. **No sections deleted, no content moved, no restructure** — that is a separate change.

## 1. Ten documented commands could not work

Six slugs printed as runnable commands don't exist in the registry; three exist but are `deprecated` and were shown without `--force`. `launch.sh` exits 2 with `unknown compose variant`, so anyone copy-pasting got a clean failure and no explanation.

| Site | Slug | Reality |
|---|---|---|
| `README.md:38` | `beellama/dflash` | **deprecated** — labelled *"single-card BLESSED default"*, and the retirement footnote directly below names three *other* slugs |
| `README.md:62` | `vllm/long-vision` | absent |
| `SINGLE_CARD.md:309` | `ik-llama/iq4ks-mtp` | deprecated — labelled *"single-card default"* |
| `SINGLE_CARD.md:310` | `llamacpp/default` | deprecated — labelled *"easy mode"* |
| `SINGLE_CARD.md:318` | `vllm/long-vision` | absent |
| `DUAL_CARD.md:97` | `vllm/dual-turbo` | absent — inside a `--set-default` recommendation, so it would persist the breakage |
| `DUAL_CARD.md:213-215` | `vllm/dual-turbo`, `vllm/dual-dflash`, `vllm/dual-dflash-noviz` | all absent |
| `DUAL_CARD.md:223` | `vllm/dual-dflash` | absent |
| `MULTI_CARD.md:183` | `vllm/default`, `vllm/long-text` | absent |

**Three of the four** `--variant` lines in DUAL_CARD's Quick start were dead. And `vllm/minimal` — the only `production` single-card slug — did not appear in SINGLE_CARD's Quick start at all.

Found while fixing that block: DUAL_CARD's sanity-test `curl` hits **:8020** while the slug it tells you to boot (`vllm/dual`) serves on **:8010**.

Retired-but-working slugs are **kept**, now shown with `--force`. The 2026-08-12 single-card retirement removed capability with no replacement (200K + vision → 32K, no vision), so `--force` is the only route back and deleting the mention would strand those users.

## 2. The TP table was built on fabricated head counts

`MULTI_CARD.md` claimed **80 attention heads / 5 KV heads**. Both qwen3.6-27b and qwen3.8-27b ship **24 and 4** (`config.json` → `text_config`). Every verdict downstream came from the wrong numbers:

- **`TP=5` was called "theoretically valid"** — 24 ÷ 5 isn't an integer; vLLM refuses to boot. Same for the `TP=10` row. A reader with 5 or 10 GPUs provisions hardware for a config that cannot start.
- `TP=4` was described as *"1.25 KV heads"* — not a real mechanism.
- The constraint was stated as "TP must divide both counts". vLLM asserts on **attention** heads and **replicates** KV heads when there are fewer than ranks.

Corrected to 24/4, valid set **1/2/4/8**, with per-card head counts and a note that KV replicates above TP=4 — so going 4 → 8 cards does **not** shrink per-card KV, only shards weights further.

⚠️ `learnings/qwen3.8-27b.md` gotcha #7 already recorded the correct 24/4 and the correct valid set. Two in-repo sources disagreed and the user-facing one was wrong — the same shape as #1029.

## 3. `minimal.yml` contradicted itself

| | Header | Body prose | Actual flag | SINGLE_CARD table |
|---|---|---|---|---|
| Max ctx | **65K** | 32K | `MAX_MODEL_LEN:-32768` | 32K |
| Vision | **no** | **vision ✓** | — | ❌ none |

Header ctx corrected to 32K (the flag is ground truth). Vision resolves to "no" — header and doc table agree, and the dissenting prose block is demonstrably stale in other respects: it compares against a *"MTP + Genesis P65 + TQ3 KV"* default that no longer exists (Genesis retired stack-wide 2026-07-06; TQ3 composes are in `compose/_archive/`).

## Verification

Every `launch.sh` / `switch.sh` invocation across the four pages now resolves — **35 tokens** checked against `compose_registry.py`: 30 live slugs, 5 resolver tokens, **0 absent, 0 deprecated-without-`--force`**.

Green: `test-compose-status-drift`, `test-compose-registry-disk`, `test-switch-registry-parity`, `test-launch-registry-parity`, `test-artifact-inventory`, `test-profiles-compat`. `minimal.yml` still parses.

Not run: the full 102-test sweep — no catalog shape, status, registry entry or resolver target changed.

## Deliberately not in this PR

- **Qwen3.8-27B is absent from all four pages** (0 mentions; qwen3.6: 78). Adding it needs a decision first: its recommended slugs are `incubating`, and `switch.sh --list` hides that status by default, so the model reads as less supported than qwen3.6 in the CLI too.
- **Seven ports carry more than one live slug**, including two `production` slugs on 8020. May be intentional reuse under `gpu-mode` switching.
- **The restructure itself** — 34% of the corpus is history or duplication.