### PR TITLE
docs: restructure the landing + three audience pages (−59%, zero new pages)

### DIFF
--- a/docs/DUAL_CARD.md
+++ b/docs/DUAL_CARD.md
@@ -1,211 +1,76 @@
 # Dual 3090 — what changes when you add the second card
 
-You have **2× RTX 3090s**. This page is the front door for picking a config and knowing what dual-card unlocks vs single. Model-specific deep dives (quants, Genesis, engine internals) live in the model directory — links at the bottom.
+You have **2× RTX 3090s**. This page gets you to a config and tells you what the second card actually buys. Deep dives are linked at the bottom.
 
-> **Model not in the configs below / want any HF safetensors repo?** → [`docs/PULL.md`](PULL.md): `scripts/pull.sh` evaluates any model against the KV math (honest, no download) and boots it if it passes. The curated configs on this page are the measured path; both work.
+> **Want a model that isn't listed?** → [`PULL.md`](PULL.md): `scripts/pull.sh` evaluates any HF safetensors repo against the KV math without downloading, and boots it if it passes.
 
-**NVLink auto-detection** (since 2026-05-14): the dual-card composes now auto-detect whether an NVLink bridge is present. If you have one, you get the NVLink-optimized path automatically. If not, PCIe mode is used. Override with `NVLINK_MODE=force_on|force_off` in your `.env`. See the "NVLink auto-detection" section below.
+> **Have 3+ GPUs?** → [`MULTI_CARD.md`](MULTI_CARD.md) — deriving TP=4 / TP=8 from `dual.yml`, valid TP values, and what scales vs what doesn't.
 
-> **Have 3+ GPUs?** See [`MULTI_CARD.md`](MULTI_CARD.md) — derivation of TP=4 / TP=8 configs from `dual.yml`, valid TP values for Qwen3.6-27B (1, 2, 4, 5, 8, 10), and what scales vs what doesn't.
-
----
-
-## TL;DR — pick by workload
-
-### Qwen3.6-27B (default model, also runs single-card)
-
-> **Sampling defaults are tuned for coding / tool work.** Every Qwen3.6-27B compose ships `temperature 0.6 · top_p 0.95 · top_k 20 · min_p 0.0` — that's Qwen's own **precise-coding** thinking-mode profile from the model card, and it's also the MTP-accept-sweep winner (a tighter distribution → higher draft acceptance → faster spec-decode, plus more deterministic tool-calls). For **long agentic *reasoning*** runs, the card's **general-task** profile is `temperature 1.0` (same top_p/top_k/min_p) — set `TEMP=1.0` (or send it per-request) when reasoning width matters more than draft throughput. **Best practice: let the agent/harness set temperature per task, not the server default** — a coding agent, a planning loop, and a summarizer each want different sampling, and the calling harness is the only layer that knows which task is running. The compose default is just a sensible coding-biased fallback for clients that send nothing; anything task-aware should override it per-request. `min_p` stays **0.0** in every mode; a non-zero min-p floor (e.g. 0.75) collapses the distribution and traps reasoning models in repetition loops — never set it.
-
-| What you're doing | Compose | Max ctx | Narr / Code TPS | VRAM per card | Why |
-|---|---|---|---|---|---|
-| **Hermes agentic fine-tune** (Carnice tool specialization) | ~~`carnice-bf16mtp.yml`~~ 🗑️ **archived** (`compose/_archive/dual/carnice-bf16mtp/`, no registry slug) — live path: **`beellama/carnice-v2-dual-q8-mtp`** 🧪 (different weights: Carnice-V2 Q8 GGUF + MTP, not the INT4-BF16MTP overlay) | **262K** | see slug header | — | The vLLM INT4-BF16MTP overlay era ended with the compose archive; Carnice serving moved to the beellama lane. Original weights remain on HF: [wasifb/Carnice_V2_27B_INT4_BF16MTP](https://huggingface.co/wasifb/Carnice_V2_27B_INT4_BF16MTP) (#740) |
-| General-purpose default — the **"fast" tier** (vision + tools + long ctx) | [`dual.yml`](../models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml) ⭐ (≡ `vllm/qwen-27b-dual-fast`) | **262K** (237K single-prompt verified) | **72 / 90** ‡ | ~23.6 / 24 GB | AutoRound INT4 + fp8 KV, 2 streams, MTP n=3, full feature set. The proven path. KV pool **622K / 2.37×** — the largest of the dual family (lightest weights). **W4A8 knob:** `VLLM_MARLIN_INPUT_DTYPE=int8` → int8 activations = **prefill +50%** (decode ~neutral), 8-pack-tied on both reasoning legs ([QUANTIZATION.md](QUANTIZATION.md#w4a8--int8-activations-on-the-fast-tier-shipped-as-a-serve-time-knob-2026-07-16) · #609). |
-| ~~**"Balanced" tier**~~ 🗑️ **Deprecated 2026-07-16** | [`dual-balanced`](../models/qwen3.6-27b/vllm/compose/dual/awq-bf16-int4/int8.yml) 🗑️ (`vllm/qwen-27b-dual-balanced`) | 262K | ~67 (probe) | KV pool 370K / 1.41× | **Retired after the tier-space review**: dominated by fast on every measured axis (decode ~67 vs ~89, pool 370K vs 622K, 8-pack tie 105 vs 109 †), and its only reason-to-exist — the int8-PTH KV *fidelity* bet — was **answered against it by [#594](https://github.com/noonghunna/club-3090/pull/594)**: int8-PTH KV craters decode at depth (130.8→50.7 TPS @35K, TRITON-only) while fp8/e4m3→FlashInfer stays flat at equal NIAH recall — the same finding that flipped `dual-max` off int8-PTH. Use `dual.yml` (fast); for weight fidelity use `dual-max`. Hidden from `switch.sh --list` (reveal with `--all`). |
-| **"Max accuracy" tier** (FP8 weights + fp8/e4m3 KV — [#594](https://github.com/noonghunna/club-3090/pull/594)) | [`dual-max`](../models/qwen3.6-27b/vllm/compose/dual/fp8/mtp.yml) 🧪 (`vllm/qwen-27b-dual-max`) | **262K** | **69 / 90** ‡ | KV pool 295K / 1.13× | **FP8** weights (e4m3, Marlin W8A16 on Ampere — memory win, no compute speedup) + **fp8/e4m3** KV (int8-PTH until 2026-07-06 — see the #594 note below; pull if your compose predates it). 8-pack **110/150** (3-way tie †). Decode **83/108** (v0.24.0, 2026-06-30 — corrects the stale ~56 probe); real tradeoffs are the smallest KV pool + slowest prefill/TTFT (158 ms; Marlin dequant is compute-heavy). **KV decode-at-DEPTH ([#594](https://github.com/noonghunna/club-3090/pull/594), 2026-07-06):** int8-PTH KV is `TRITON_ATTN`-only and its single-stream decode **craters with context** (130.8→50.7 TPS @ 35K); swapping the env to **`KV_CACHE_DTYPE=fp8`** (e4m3 → FlashInfer) keeps decode **flat** (~115 @ 35K, ≈2.3×) at ~2× prefill, **equal NIAH recall to 240K**, and **8-pack quality that ties (109 vs 107/150, [#594](https://github.com/noonghunna/club-3090/pull/594))** — quality-neutral despite scale=1.0 (`calculate_kv_scales` is disabled on Qwen3-Next hybrid). **soak-continuous PASS** — the tighter margin holds (509 MB free @ deepest fill, 0 MiB growth, 100% retention, p50 125.5); all #594 gates green. ✅ Production. **Fast-vs-max in one line (revised 2026-07-20 on same-session data ‡):** the tiers are **decode-tied as shipped** (~72/90 fast, ~69/90 max at canonical 262K, boot variance ~5 TPS) — the old 69/89-vs-83/108 spread was cross-session measurement artifact, not a real gap. fast is the *lean* tier (biggest KV pool 2.37×, best prefill, W4A8-eligible, and **48% faster raw decode** with speculation off); max is the *weight-fidelity* tier (8-pack ties within ±5–7). Pick on KV headroom + prefill, not decode. Cross-arch corroboration: 2×5090 scores the identical 109/150 ([#571](https://github.com/noonghunna/club-3090/discussions/571#discussioncomment-17553023)). |
-| Multi-tenant (concurrent agents at full ctx) | ~~`dual-turbo.yml`~~ 🗑️ **archived** (TQ3/TurboQuant KV retirement; `compose/_archive/`, no registry slug) — live answers: **`vllm/qwen-27b-dual-fast`** (622K KV pool handles multi-stream) or, for many agents, **`vllm/qwen-35b-a3b-dual`** (the concurrency pick: ~1,037 tok/s aggregate at N=16, [#669](https://github.com/noonghunna/club-3090/discussions/669)) | **262K** | see slug headers | — | TQ-era row retired with the format (#740) |
-| Peak code TPS (DFlash) | **`beellama/qwen-dflash-dual`** ⏸️ **upstream-gated 2026-07-20** — vLLM `dual-dflash*` ~~deprecated~~ | 262K | ~145 code (historical) | — | ⚠️ vLLM `dual-dflash*` deprecated 2026-05-31 ([#297](https://github.com/noonghunna/club-3090/discussions/297)). The beellama path currently **fails to load current Qwen3.6 GGUFs** (`missing tensor 'hidden_norm.weight'`, [#740](https://github.com/noonghunna/club-3090/issues/740)) and fork-DFlash is broken on Ada ([#693](https://github.com/noonghunna/club-3090/issues/693)) — both fixed by the pending **beellama v0.4.0 pin bump** (upstream-DFlash rewrite, [Anbeeld#91](https://github.com/Anbeeld/beellama.cpp/issues/91)). Un-gates when the bump PR lands. |
-
-‡ **Decode numbers revised 2026-07-20 — same-session, fresh-boot A/B.** The headline figures are **canonical 262K, 2-boot means** (fast 73.1/71.2→72.2 narr, 90.1/90.8→90.4 code; max 67.5/71.1→69.3 narr, 87.2/92.6→89.9 code). Two boots because **single boots swing ~5 TPS on the code leg** (larger than the fast-vs-max gap) — do not re-derive a tier ranking from one draw. The tiers are **decode-tied at 262K** within that boot variance; note max degrades at full context (69 vs 71 narr at 32K) where its 1.13× KV pool is tight, while fast (2.37× pool) does not. The mechanism table below is from the matched 32K on/off A/B:
-
-| tier | MTP **off** (pure weight-bandwidth) | MTP **on** (as shipped, 2 draws) | MTP multiplier (code) | draft accept |
-|---|---|---|---|---|
-| fast (int4, 17.5 GB) | **70.3 / 69.8** | 70.1–71.0 / 89.4–93.7 | ×1.31 | 64.3–66.0% |
-| max (fp8, 35 GB) | 47.5 / 47.4 | 71.2–71.3 / 87.4–94.3 | ×1.92 | 65.6–66.9% |
-
-**Read:** int4 is the far faster *raw* decoder (+48%, exactly as weight-bandwidth predicts), but fp8 extracts nearly twice as much from speculative decoding — because its forward pass is more expensive, each accepted draft token saves more absolute work (accept rates are tied at ~65–66%, so this is *not* an acceptance effect). The two cancel, leaving the tiers decode-tied as shipped. Each tier's code leg swings 4–7 TPS between draws, so single-draw comparisons of these two are meaningless. **The prior 69/89 and 83/108 figures came from different benchmark sessions and should not have been compared** — cross-session TPS comparison is invalid on this rig (a 7%-wide session artifact was separately confirmed on the Tess line the same week).
-
-† **8-pack A/B (`--full`, same harness, 2026-06-07):** fast `109/150` · balanced `105/150` · max `110/150` — a **tie** (deterministic packs 64/64/65; the spread is within ±5–7 8-pack noise). The short-context 8-pack does **not** separate the three quants. Measured KV pools (v0.22.0 @262K, TP=2): **fast 622K/2.37× > balanced 370K/1.41× > max 295K/1.13×** — the fast tier's lighter 17.5 GB autoround weights give it the *biggest* pool too, so it isn't just the quality default, it's also the speed *and* headroom leader. (Earlier `129/150` for the fast tier was the 2026-05-09 harness, before benchlocal-cli verifier fixes — not comparable to today's numbers.) **Resolution (2026-07-16):** the "open follow-up" this note used to point at — does int8-PTH KV *fidelity* justify a tier? — was answered by [#594](https://github.com/noonghunna/club-3090/pull/594): int8-PTH **craters decode at depth** at *equal* NIAH recall, so the fidelity bet lost on both axes. `dual-max` survived by **flipping its KV to fp8/e4m3** (it still owns the real weight-fidelity axis: FP8 weights); `dual-balanced` had nothing left and is **deprecated**. The two-tier map (fast = speed+headroom, max = weight fidelity) is the shipped state. Trade-space background: [`QUANTIZATION.md` §4b](QUANTIZATION.md#4b-the-tier-trade-space--what-fast--balanced--max-actually-optimize).
-
-### Gemma 4 31B (dual-card only on Ampere 24 GB ¹)
-
-| What you're doing | Compose | Max ctx | Narr / Code TPS | VRAM per card | Why |
-|---|---|---|---|---|---|
-| General-purpose default (vision + tools, long ctx) | [`gemma-31b-dual`](../models/gemma-4-31b/vllm/compose/dual/qat-awq-int4/base.yml) ⭐ | **224K** | **~59 decode** | ~23 / 24 GB | cyankiwi QAT-AWQ-int4 + **bf16 KV on stock vLLM v0.24.0, overlay-free** (⚠️ Production w/ caveats). verify-stress→210K (91%, VRAM margin ✓), soak PASS. MTP off — Gemma-4 MTP × tools broken on v0.24.0 ([#39043](https://github.com/vllm-project/vllm/issues/39043) / [#42006](https://github.com/vllm-project/vllm/pull/42006)). |
-| ~~262K int8-PTH / 131K bf16~~ — **deprecated (v0.24.0 consolidation)** | ~~`gemma-int8-mtp` / `gemma-bf16-mtp`~~ (`switch.sh --list --all`) | 262K / 131K | 106 / 139 · 119 / 154 | — | v0.22.0 int8-PTH + PR [#40391](https://github.com/vllm-project/vllm/pull/40391) overlay (262K) / bf16 (131K). Superseded by the overlay-free bf16 default — **int8-PTH silently craters recall on v0.24.0** (#40391 open/unmerged upstream); the 262K int8-PTH path returns overlay-free when #40391 merges. |
-| Peak code TPS (DFlash) | **`beellama/gemma-dflash-dual`** — vLLM Gemma DFlash removed | 262K | ~157 code | — | ⚠️ **vLLM Gemma-4 DFlash removed** — unservable on Ampere ([#40382](https://github.com/vllm-project/vllm/issues/40382)); beellama DFlash (v0.3.0 🧪) replaces it at 262K vs the old 32K. |
-
-¹ Single-card boot OOMs on Ampere 24 GB regardless of KV format. Single-card Gemma 4 is feasible on 32 GB+ GPUs (validated on RTX 5090 32 GB by [@apnar](https://github.com/noonghunna/club-3090/discussions/67#discussioncomment-16832042) — 160/215 TPS at 32K MTP, 150/261 at 12K DFlash). Tracked in [`docs/UPSTREAM.md`](UPSTREAM.md) row 78 + [#67](https://github.com/noonghunna/club-3090/discussions/67).
-
-> **VRAM column is per-card** under TP=2 (each card holds half the weights + half the KV; both cards' totals are nearly identical). For a 2× 20 GB rig (e.g. 2× 3080-20GB / 40 GB combined), `dual.yml` and `dual-turbo` should fit; `dual-dflash*` won't (FP16 KV + DFlash draft pushes per-card past 20 GB). Component breakdown in [`tools/charts/gen-vram.py`](../tools/charts/gen-vram.py).
-
-Run any of these via `bash scripts/launch.sh` (interactive) or `bash scripts/switch.sh <variant>`.
-
----
-
-## Rule of thumb: on dual cards, prioritize context over concurrency
-
-The dual-card composes default to **the largest context the KV pool allows**, with `--max-num-seqs` left as a modest cap (typically 4) — not the other way round. The reasoning:
-
-- **`--max-num-seqs` is a cap, not a reservation.** Setting it to 4 doesn't reserve 4× the context; it caps how many requests run at once. Short/medium requests still pack into the shared KV pool and run concurrently.
-- **The KV pool size is fixed by VRAM, not by `--max-model-len`.** Raising the context ceiling does **not** shrink the pool (e.g. `gemma-bf16-mtp`'s pool is 196,527 tokens whether `--max-model-len` is 32K or 131K). So a higher ceiling is *nearly free* for typical traffic — it only lets a single request go bigger; it doesn't cost short-request concurrency.
-- **Dual cards exist to unlock what single can't.** A 2× 3090 rig's realistic workload is one or two long-context agents, not high-QPS multitenancy. If you want pure concurrency-at-low-ctx, a single-card compose or a replica is the better fit.
-
-**So the default ceiling is set high; lower `--max-num-seqs` (to 2 or 1) only when you need a guarantee** — e.g. two concurrent long-context agents that must never preempt each other, or a single long request that must never be queued. The composes document the per-slug ladder (`gemma-int8-mtp`: 98K/4 → 170K/2 → 262K/1; `gemma-bf16-mtp`: 131K default, drop seqs for guaranteed-long).
-
-> ⚠️ **The one exception is vision.** A large image *at* near-max context can OOM on thin headroom (e.g. `gemma-bf16-mtp` leaves only ~1.4 GB/card free at 120K single-stream). For vision-heavy long-context, lower `--max-num-seqs` or `--gpu-memory-utilization`. Vision at typical context is unaffected.
-
----
-
-## Measured TPS on 2× 3090
-
-![Qwen3.6-27B TPS — 2× 3090 configs (TP=2)](img/performance-dual.png)
-
-Bench protocol: 3 warm + 5 measured runs of the canonical narrative + code prompts on each config. Substrate: vLLM nightly `0.20.1rc1.dev16+g7a1eb8ac2` + Genesis v7.69 dev tip (commit `2db18df`), RTX 3090 sm_86 PCIe-only at 230 W. Cliff 2 doesn't apply on TP=2 (DeltaNet GDN forward state splits across cards — 237K single-prompt verified on `dual.yml`); the v7.69 cutover is mostly a hygiene bump for `dual-turbo.yml` (its old workspace_lock sidecar is now covered by Genesis PN34 env-gate). Per-config run-by-run + VRAM peaks: [models/qwen3.6-27b/CHANGELOG.md](../models/qwen3.6-27b/CHANGELOG.md).
-
----
-
-## VRAM budget on 2× 24 GB (TP=2)
-
-![Per-card VRAM allocation, dual-card section](img/vram-budget-dual.png)
-
-**Tensor parallelism (TP=2) splits weights AND KV symmetrically across both cards.** Each card holds ~7 GB of weights (vs ~14 GB on single-card) plus its half of the KV pool. That's why dual unlocks what single can't:
-
-- 262K context + vision + 2 streams fits at ~23.6 GB / card on `dual.yml` (would need ~33 GB on a hypothetical single-card)
-- DFlash draft adds ~1.75 GB / card (manageable across two cards; would crowd out KV on single)
-- 4 concurrent streams via `dual-turbo` use TQ3 KV's compactness to fit 4 × full-context KV pools
-
-For the single-card picture, see [`SINGLE_CARD.md`](SINGLE_CARD.md).
+**NVLink is auto-detected.** The dual composes probe `nvidia-smi topo -m` at boot and configure themselves; you don't pick a compose for it. Override with `NVLINK_MODE=force_on|force_off|pcie_p2p` in `.env`.
 
 ---
 
 ## Pick a config
 
-### General default — `dual.yml`
+Run any of these with `bash scripts/switch.sh <slug>`, or `bash scripts/launch.sh` for the wizard.
 
-**Workload:** anything. Chat, tool agents, vision, mixed-modal. The recommended default for 2× 3090.
+### Qwen3.8-27B — the newest model
 
-> 🎯 **Don't want to name a slug?** `bash scripts/switch.sh qwen3.6-27b/default` (or a bare `bash scripts/launch.sh`) resolves the blessed dual-card default automatically — on 2× 3090 that's **`vllm/dual`** (the `dual` order in `ENGINE_PREFERENCE` is `vllm > ik-llama > llama.cpp`). Prefer a different config (e.g. `vllm/qwen-35b-a3b-dual` for multi-tenant / agent fleets)? Pin it once with `bash scripts/switch.sh --set-default vllm/qwen-35b-a3b-dual` and bare launches go straight there — see the [FAQ](FAQ.md#how-do-i-set-my-own-default-config).
+| Slug | Weights | KV | Max ctx | Narr / Code TPS | Port | State |
+|---|---|---|--:|---|--:|---|
+| `vllm/qwen38-27b-dual-max` ⭐ | official FP8 | fp8 e4m3 | 262144 | **67.4 / 85.8** | 8091 | 🧪 needs `--force` |
+| `vllm/qwen38-27b-dual-fast` | AutoRound INT4 + int8 act | fp8 e4m3 | 262144 | — | 8095 | 🧪 needs `--force` |
+| `vllm/qwen38-27b-dual-nvfp4` | NVFP4 | fp8 e4m3 | 262144 | — | 8100 | 🧪 needs `--force` |
+| `llamacpp/qwen38-27b-dual-q8kxl` | unsloth Q8_K_XL | q8_0 | 262144 | — | 8087 | 🐣 `--force`, `--list --all` |
 
-262K context, fp8 KV, MTP n=3, 2 streams, vision tower active. **Genesis-less by design** — fp8 KV doesn't trigger the cudagraph bug (#40880) that drove Genesis's existence on single-card. Pure vLLM nightly path. Tool calls work via `--tool-call-parser qwen3_coder` + `--enable-auto-tool-choice`. All `verify-stress.sh` checks pass clean.
+`dual-max` numbers measured 2026-08-17 on stock `vllm/vllm-openai:v0.27.1`, 3 warm + 5 measured: TTFT 152 ms, prefill 1166 @10K / 942 @90K tok/s, KV pool 270,930 tok (1.03× concurrency), MTP acceptance 2.62. verify-full pass. Full row: [`BENCHMARKS.md`](../BENCHMARKS.md).
 
-**When to pick:** the obvious starting point. Unless one of the specialized variants below names your exact workload, this is right. **Strongly recommended for IDE coding agents** (Cline / OpenCode / Roo / Claude Code / Cursor) — fp8 KV avoids the inductor compile-path leak that affects all 4 TQ3-KV variants. See [club-3090#16](https://github.com/noonghunna/club-3090/issues/16).
+⚠️ **262144 is allocated, not filled** — no NIAH ladder has run on this model. The qwen3.6 sibling fills to ~240K of its 262K; expect the same or worse.
 
-### Multi-tenant — `dual-turbo.yml`
+⚠️ **All qwen3.8 slugs ship the MTP drafter on and are exposed to open [vllm#50021](https://github.com/vllm-project/vllm/pull/50021)** (GDN spec-decode wild write — kills workers under sustained multi-turn traffic). Mitigate with `SPEC=off`.
 
-**Workload:** small team or agent farm running 2-4 concurrent sessions. Open WebUI multi-user, GitHub-Actions-with-AI-PRs flows, batch agent runs.
+### Qwen3.6-27B
 
-262K + **TurboQuant 3-bit KV** + Genesis v7.69 PROD env-var stack + 4 streams. TQ3 packs each KV slot to ~3 bits/token (vs fp8's ~8 bits), which is what makes 4 × 262K pools fit on 2 cards. KV pool 1.52M tokens, max concurrency **4.67×**. Per-stream TPS lands at **58 narr / 76 code** (n=5, CV 3-5%), AL 3.39-3.51, MTP avg accept 79-84%, VRAM 19.8 GB / card.
+| Slug | Weights | KV | Max ctx | Narr / Code TPS | Port | State |
+|---|---|---|--:|---|--:|---|
+| `vllm/dual` ⭐ (≡ `qwen-27b-dual-fast`) | AutoRound INT4 | fp8 e4m3 | 262144 | **72 / 90** | 8010 | ⚠️ caveats |
+| `vllm/qwen-27b-dual-max` | FP8 | fp8 e4m3 | 262144 | **69 / 90** | 8013 | ⚠️ caveats |
+| `vllm/qwen-27b-dual-nvfp4` | NVFP4 | fp8 e4m3 | 262144 | — | 8077 | ⚠️ caveats |
 
-**Concurrent throughput** (n=4 streams of the canonical code prompt, 2026-05-01 PM, vLLM v0.20 + Genesis v7.65 dev tip — re-bench against v7.69 pending but decode TPS regime unchanged by the bump): aggregate code TPS 269 across 4 streams (3.63× speedup over single-stream 74 TPS), per-stream mean 74 (CV 3.1%) — true parallel decoding, not interleaved. See `results/v0.20-migration/dual-turbo-concurrent.summary` for the run-by-run.
+`vllm/dual` is the blessed default — `bash scripts/switch.sh qwen3.6-27b/default` resolves to it. **Strongly recommended for IDE coding agents** (Cline / OpenCode / Roo / Claude Code / Cursor): its fp8 KV avoids the inductor compile-path leak that hit the TQ3 variants ([#16](https://github.com/noonghunna/club-3090/issues/16)).
 
-> ⚠️ **Decode-concurrent ≠ long-prefill-overlap** (see [#208](https://github.com/noonghunna/club-3090/discussions/208)). The 269-TPS figure above is *decode-concurrent* — N short-prompt streams decoding together. A **different** regime, a **long prefill** (big tool result, file read, accumulated context) entering while another stream is *already decoding*, can **starve decode** to ~0.1–0.9 TPS until the prefill clears: chunked-prefill co-batches the heavy GDN/Mamba prefill chunk with the decode token into one forward step, and the `align` block floors the chunk at **1568 tokens** so it can't be tuned to zero. Observed on `dual.yml` (fp8); it's architectural to the hybrid model, so expect it on any dual-card chunked-prefill config. **So read 269 TPS as aggregate *throughput*, not a *latency* guarantee under agentic traffic.** Mitigations: lower `--max-num-batched-tokens` toward the 1568 floor to soften it (doesn't eliminate it); **proxy-level admission control** — gate large prefills away from live interactive decodes — is the real fix (`--scheduling-policy priority` does *not* help: it orders admission, not intra-step compute). Per-budget latency numbers pending a community A/B.
+⚠️ **Fast and max are a tie on quality, not a ladder.** 8-pack: 109/150 vs 110/150 — inside noise. And cross-session TPS comparison is invalid on this rig: single boots swing ~5 TPS on the code leg, wider than the gap between the tiers. Same-session A/B only.
 
-**When to pick:** real concurrent load. Solo users won't see the win on the per-stream curve — but per-stream TPS at n=4 is essentially the same as n=1 here (74 vs 76 TPS code), so this is also a viable single-stream config if you want max KV pool. Pick this if you ever serve >1 request at a time, or want the biggest single-card-equivalent context.
+### Other models
 
-### Peak code TPS, with vision — `dual-dflash.yml` ⚠️ DEPRECATED (2026-05-31)
+| Model | Slug | Max ctx | Port | Notes |
+|---|---|--:|--:|---|
+| **Gemma-4-31B** | `vllm/gemma-31b-dual` | 224K | 8032 | QAT-AWQ-int4 + bf16 KV, overlay-free. Dual-only on 24 GB — single-card OOMs regardless of KV format. |
+| **Qwen3.6-35B-A3B** ⭐ concurrency | `vllm/qwen-35b-a3b-dual` | 262K | 8051 | ✅ production. **The multi-agent pick** — flat to N=16 streams where the dense 27B knees at N=2. |
+| **Tess-4-27B** | `llamacpp/tess-dual-mtp` | 262K | 8020 | ✅ production. |
+| **Qwen-AgentWorld-35B-A3B** | `vllm/qwen-agentworld-35b-a3b-dual-awq-int4` | 262K | 8080 | ✅ production. |
 
-> **Deprecated — kept for historical reference.** Pruned 2026-05-31: superseded by `dual.yml` (262K + vision + 2 streams, stable image) and stranded on a [now-purged vLLM nightly](https://github.com/noonghunna/club-3090/discussions/297). **DFlash on dual now lives on beellama** → `bash scripts/switch.sh --force beellama/qwen-dflash-dual` (Qwen3.6-27B, full 262K, v0.3.0 🧪 — pre-release, expect it to move). Full rationale: [#297](https://github.com/noonghunna/club-3090/discussions/297). The numbers below are the original vLLM measurements.
-
-**Workload:** code-heavy single-stream — fast iteration on quicksort-class problems, Cline going through a codebase, Cursor doing inline completions in a heavy file.
-
-185K context (vs 262K — DFlash's draft model takes ~1.75 GB / card), FP16 KV (forced — DFlash's non-causal head_size=256 path requires fp16), DFlash N=5 draft model from Luce z-lab. **Code TPS lands at 125** vs `dual.yml`'s 89 — a real 40% jump on code prompts thanks to DFlash's higher acceptance length (AL ~4.4 vs MTP's 3.4).
-
-**When to pick:** code is the dominant workload, you want TPS over context budget, vision is still required.
-
-**⚠️ Prereq before this compose works:** download the DFlash draft model:
-```bash
-WITH_DFLASH_DRAFT=1 bash scripts/setup.sh qwen3.6-27b
-# OR manually:
-hf download z-lab/Qwen3.6-27B-DFlash --local-dir <MODEL_DIR>/qwen3.6-27b-dflash
-```
-Without it, vLLM falls back silently to baseline bf16 decode (~25 TPS, not 125). Reported by [@lolren in #18](https://github.com/noonghunna/club-3090/discussions/18#discussioncomment-16787831).
-
-**Caveats:**
-- DFlash's per-position acceptance falls off faster than MTP — narrative TPS (82) is good but not dramatically better than `dual.yml`'s 69. The win is concentrated on code/repetitive prompts.
-- The z-lab draft is **still under training** (see [UPSTREAM.md](UPSTREAM.md#luce-dflash-luce-orglucebox-hub--separate-llamacpp-fork-not-our-vllm-dual-dflash)). Published 125 TPS code is against the 2026-04-26 snapshot at peak code-prompt conditions; agent traffic with mixed code + narrative + tool schemas will see lower per-stream TPS until z-lab tags training-complete. **For autonomous coding agents (Cline / OpenCode / Pi / Claude Code) prefer `dual.yml` (FP8 + MTP) until then** — its 89 code TPS is robust across prompt shapes.
-
-### Peak code TPS, no vision — `dual-dflash-noviz.yml` ⚠️ DEPRECATED (2026-05-31)
-
-> **Deprecated** (same as the vision variant) — pruned 2026-05-31, on a purged nightly; DFlash on dual moved to beellama (`beellama/qwen-dflash-dual`). See [#297](https://github.com/noonghunna/club-3090/discussions/297). Numbers below are the original vLLM measurements.
-
-**Workload:** same as above, but no images. Squeezes another 15K of context out of the vision-tower's space.
-
-200K context, FP16 KV, DFlash N=5, `--language-model-only`. Best code TPS in the lineup at **127**. Narrative is 78 (slight drop vs vision variant from compute distribution).
-
-**When to pick:** pure-text code work where you'd rather have 200K than 185K. Drop vision wherever you don't need it.
+Everything launchable: `bash scripts/switch.sh --list` (`--all` includes retired).
 
 ---
 
-## What dual-card unlocks (vs single)
+## Sampling defaults
 
-| Want | Single-card status | Dual-card status |
-|---|---|---|
-| 262K context + vision | Works on `long-vision.yml` (192K) but Cliff 1 fires on big tool prefills | `dual.yml` — clean, 262K, no Cliff 1 |
-| 4 concurrent streams at full context | Single-card serializes; can't fit | `dual-turbo.yml` — 4 streams, 262K each |
-| DFlash N=5 spec-decode | Blocked: DFlash needs head_size=256 + non-causal which doesn't fit single-card head-dim split | `dual-dflash.yml` / `dual-dflash-noviz.yml` |
-| Code TPS >100 | Best single-card is 67 code (default) | 125-127 code (DFlash variants) |
-| Long single prompts safely | Cliff 2 fires at 50-60K on vLLM single-card (forces llama.cpp fallback at 21 TPS) | TP=2 splits activation across cards — **237K single-prompt verified** on `dual.yml` 2026-04-29 (~830 tok/s prefill, no OOM, peak 23.5 GB / card) |
-| Big tool returns at 192K context | Cliff 1 fires on TQ3 paths regardless | `dual.yml` is below the cliff at 262K — activation budget is bigger per-card after split |
+Every Qwen3.6-27B compose ships `temperature 0.6 · top_p 0.95 · top_k 20 · min_p 0.0` — Qwen's precise-coding profile, and the MTP-accept-sweep winner (tighter distribution → higher draft acceptance). For long agentic *reasoning*, use `TEMP=1.0` (same top_p/top_k/min_p).
 
----
+⚠️⚠️ **`min_p` stays `0.0` in every mode.** A non-zero floor (e.g. `0.75`) collapses the distribution and **traps reasoning models in repetition loops**. It looks like a reasonable quality knob. It is not.
 
-## Common pitfalls (dual-card specifics)
-
-### Marlin pad-sub-tile-n patch (vendored, auto-applied)
-
-The dual variants need a one-file patch — our fork of [vllm#40361](https://github.com/vllm-project/vllm/pull/40361) — for AutoRound W4A16 at TP=2, where output-dim shards fall below 64. **It's vendored in the repo and mounted automatically:** `models/qwen3.6-27b/vllm/patches/vllm-marlin-pad/{marlin.py,MPLinearKernel.py}` is overlaid read-only into the stock vLLM image by each dual compose. **No vLLM source clone, no extra setup** — it's in place the moment you launch a dual variant. When the upstream PR lands we'll drop the overlay.
-
-### NVLink auto-detection
-
-The dual-card composes automatically detect whether an NVLink bridge is installed and configure themselves accordingly. No separate compose files needed — `dual.yml`, `dual-turbo.yml`, `dual-dflash.yml`, and `dual-dflash-noviz.yml` all adapt to your hardware.
-
-**How it works:** Each dual compose mounts `scripts/detect_nvlink.sh` and sources it in the entrypoint at container boot. The script checks `nvidia-smi topo -m` for NVLink links between GPUs, sets the correct NCCL env vars, and the entrypoint conditionally passes `--disable-custom-all-reduce` to vLLM.
-
-**Override:** Set `NVLINK_MODE` in your `.env` (passed through to the container):
-- `auto` (default) — detect via `nvidia-smi topo -m`
-- `force_on` — assume NVLink bridge present, enable NVLink mode
-- `force_off` — force PCIe-only path even if NVLink detected
-
-Without NVLink, `--disable-custom-all-reduce` is passed to vLLM and `NCCL_P2P_DISABLE=1` is set. With NVLink, custom all-reduce is enabled and NCCL uses the NVLink path. The gain is **workload-shaped**: small on single-stream **decode** (~2–5% on modern vLLM v0.24+ — the older ~15% figure was the v7.72.2 image), but large on **prefill / long-context** (~35–49%). So NVLink matters most for big-context / agentic movement, not short-prompt decode serving — prefill all-reduces the full activation tensor across TP=2 while decode only moves one token per step (cross-rig data in [BENCHMARKS.md](../BENCHMARKS.md), #698 / #77).
-
-**No NVLink bridge?** You can still enable P2P over the PCIe bus on a patched driver (`NVLINK_MODE=pcie_p2p`) for a workload-dependent gain — and understand what your `nvidia-smi topo -m` output means — in [PCIE_P2P.md](PCIE_P2P.md).
-
-### `dual.yml` is Genesis-less by design
-
-The single-card cliffs (Cliff 1 / Cliff 2) and the cudagraph bug (#40880) that drove Genesis's existence don't fire on `dual.yml` — fp8 KV + 2 streams + 262K has plenty of headroom. So `dual.yml` runs **plain vLLM nightly** without any patch tree. If you want Genesis on dual (e.g. for `dual-turbo`'s TQ3 spec-verify path), it's structurally enabled there but absent from `dual.yml`.
-
-### DFlash variants are FP16 KV (forced)
-
-DFlash's `combine_hidden_states` path needs `head_size=256` + non-causal, which forces FP16 KV on Ampere — there's no fp8 / TurboQuant alternative for this path right now. Tracked at [vllm#40334](https://github.com/vllm-project/vllm/pull/40334). When that lands you can drop `--dtype bfloat16` and let dtype auto-detect.
-
-### DFlash's vision compatibility
-
-The DFlash draft + ViT path is documented and works (`--language-model-only` was historically required, now optional). `dual-dflash.yml` keeps vision; `dual-dflash-noviz.yml` drops it for an extra 15K ctx.
-
-### Single-stream user on dual = small win
-
-If you're solo-using on dual, you're paying for hardware that mostly sits idle on alternate GPUs during single-stream decode. The win shows up at concurrency or when you need DFlash. For solo users, single-card is often the better cost choice.
+Best practice: let the agent/harness set temperature per task. A coding agent, a planning loop and a summarizer each want different sampling, and only the caller knows which is running — the compose default is just a coding-biased fallback.
 
 ---
 
 ## Quick start
 
 ```bash
-# 1. Setup (downloads model + Genesis patches, ~20 min cold). The dual marlin-pad
-#    overlay is vendored in-repo and auto-mounted by the compose — no vLLM clone needed.
+# 1. Setup (downloads weights, ~20 min cold; the Marlin overlay is vendored + auto-mounted)
 bash scripts/setup.sh qwen3.6-27b
 
-# 2. Pick + boot via wizard (asks model + GPUs, projects VRAM budget, auto-picks TP=2 for matched 2× 3090)
+# 2. Pick + boot via wizard (auto-picks TP=2 for matched 2× 3090)
 bash scripts/launch.sh
 
 # 3. Or skip the wizard:
@@ -213,76 +78,76 @@ bash scripts/launch.sh --variant vllm/dual                 # general default    
 bash scripts/launch.sh --variant vllm/qwen-27b-dual-max    # max accuracy (FP8)     :8013
 bash scripts/launch.sh --variant vllm/qwen-35b-a3b-dual    # concurrency / agents   :8051
 
-# 4. Sanity test — port matches the slug you booted (see the table above)
+# 4. Sanity test — port matches the slug you booted
 curl -sf http://localhost:8010/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{"model":"qwen3.6-27b","messages":[{"role":"user","content":"Capital of France?"}],"max_tokens":200}'
 
 # 5. Switch later without re-running setup
 bash scripts/switch.sh vllm/qwen-27b-dual-max   # for example
-bash scripts/switch.sh --list                   # show all variants (--all to include retired)
+bash scripts/switch.sh --list                   # everything launchable (--all includes retired)
 ```
 
 ---
 
-## Performance summary
+## Rule of thumb: prioritize context over concurrency
 
-For variance, AL / accept rates, per-config row docstrings: see each compose YAML, plus the [TPS chart for the full lineup](../README.md#measured-tps-at-a-glance) in the top-level README.
+The dual composes default to **the largest context the KV pool allows**, with `--max-num-seqs` as a modest cap. Why:
 
-| Compose | Max ctx | Narr / Code TPS | TTFT | Concurrency | Vision | Best for |
-|---|---|---|---|---|---|---|
-| `dual.yml` | 262K | 69 / 89 | ~145 ms | 2 | ✅ | general default |
-| `dual-turbo.yml` | 262K | 58 / 76 per stream (269 agg @ 4) | ~110 ms | 4 | ✅ | multi-tenant |
-| `dual-dflash.yml` | 185K | 82 / 125 | ~140 ms | 1 | ✅ | code + vision |
-| `dual-dflash-noviz.yml` | 200K | 78 / 127 | ~145 ms | 1 | ❌ | pure text code |
+- **`--max-num-seqs` is a cap, not a reservation.** Setting it to 4 doesn't reserve 4× the context — it caps how many requests run at once. Short and medium requests still pack into the shared pool and run concurrently.
+- **The KV pool is fixed by VRAM, not by `--max-model-len`.** Raising the ceiling does **not** shrink the pool — `gemma-bf16-mtp`'s pool is 196,527 tokens whether `--max-model-len` is 32K or 131K. So a higher ceiling is nearly free: it lets one request go bigger without costing short-request concurrency.
+- **Dual cards exist to unlock what single can't.** The realistic workload is one or two long-context agents, not high-QPS multitenancy. For pure concurrency at low ctx, a single-card compose or a replica fits better.
 
-All four dual variants re-benched 2026-05-01 PM on the v0.20 + Genesis v7.65 dev tip substrate (n=5 measured + 3 warmup per prompt; v7.69 re-bench pending — decode TPS regime unchanged by the bump, which targets Cliff 2 prefill envelope on single-card):
+Lower `--max-num-seqs` to 2 or 1 only when you need a *guarantee* — two long-context agents that must never preempt each other, or one long request that must never queue.
 
-| Variant | Narr / Code wall_TPS (CV) | vs prior chart |
-|---|---|---|
-| `dual.yml` | 68.61 / 90.71 (CV 1.8% both) | flat (within noise) |
-| `dual-turbo.yml` | 58.33 / 76.01 (n=1) · 269 TPS aggregate at n=4 streams | matches prior |
-| `dual-dflash.yml` | 77.12 / 125.97 (CV 2-4%) | code flat, narr -5.9% (slight) |
-| `dual-dflash-noviz.yml` | 78.94 / 123.18 (CV 2-3%) | flat (within noise) |
-
-Code TPS held within bench variance across all 4 variants — no v0.20 regression on fp8 / FP16 paths. Run-by-run + per-config summaries in [`results/v0.20-migration/`](https://github.com/noonghunna/club-3090/tree/master/results/v0.20-migration).
+> ⚠️ **Vision is the exception.** A large image *at* near-max context can OOM on thin headroom (`gemma-bf16-mtp` leaves only ~1.4 GB/card free at 120K single-stream). For vision-heavy long context, lower `--max-num-seqs` or `--gpu-memory-utilization`. Vision at typical context is unaffected.
 
 ---
 
-## Models supported on dual 3090
+## VRAM budget on 2× 24 GB (TP=2)
 
-- **[Qwen3.6-27B](../models/qwen3.6-27b/)** — primary model. Runs single-card AND dual-card. Quant choices (AutoRound INT4, GGUF Q3_K_XL / Q4_K_M), Genesis patch surface (mostly single-card relevant), engine internals all in the model directory.
-- **[Gemma 4 31B](../models/gemma-4-31b/)** — dual-card only on Ampere 24 GB (single-card boot OOMs even at 8K ctx; needs 32 GB+ per card). Two drafter paths (MTP via Google's official `gemma-4-31B-it-assistant` + DFlash via z-lab) × two KV strategies (bf16 / 32K vs INT8 PTH / 262K) + AWQ-4bit-weights variant. Genesis doesn't apply (Genesis patches are Qwen3-Next-specific).
+![Per-card VRAM allocation, dual-card section](img/vram-budget-dual.png)
 
-As more models land, they'll show up here with their dual-card compose set.
+**TP=2 splits weights AND KV symmetrically.** Each card holds ~7 GB of weights (vs ~14 GB single-card) plus half the KV pool. That's the whole reason dual unlocks what single can't:
+
+- 262K + vision + 2 streams fits at ~23.6 GB/card on `vllm/dual` — it would need ~33 GB on one card
+- Cliff 2 doesn't apply at TP=2: the DeltaNet GDN forward state splits across cards (237K single-prompt verified)
+
+The VRAM column in the tables above is **per card**. On a 2× 20 GB rig (40 GB combined), `vllm/dual` fits. Full math: [`KV_MATH.md`](KV_MATH.md).
 
 ---
 
-## Heads-up: multimodal & image/video models on dual cards
+## Dual-card pitfalls
 
-Two lessons that generalize beyond the LLM composes above (learned wiring up Qwen3-Omni + scoping image generation on 2× 3090):
+### ⚠️ Decode-concurrent ≠ long-prefill-overlap
 
-- **Size the *full pipeline*, not the transformer.** Multimodal and diffusion models bundle a large **text encoder** (8–24 GB: T5-XXL, Qwen3-4B, Qwen3-VL-8B, Mistral-3-24B). A small quantized transformer can still blow a 24 GB card once the encoder + VAE + activations load — so an image model generally **won't co-reside** with an LLM on one card. Give it a dedicated card or **time-share** (run it when the LLM isn't).
-- **Reach full context with fp8/int8 KV on a single card before reaching for TP/PP.** On PCIe-no-NVLink, tensor/pipeline parallelism pays a per-layer cross-card cost; halving the KV (fp8 / int8) often gets a model to its **full native context on *one* card** with zero cross-card traffic — strictly better here. (Qwen3-Omni's thinker reached its full 65 K single-card via fp8 KV — no TP/PP needed.)
-- **Image/video generation → use ComfyUI on a freed card**, not the LLM stack. Sized model shortlist + the Open WebUI → ComfyUI UI pattern: [FAQ.md → Image & video generation](FAQ.md#image--video-generation).
+Aggregate throughput figures are measured with N short-prompt streams decoding together. A **different** regime — a long prefill (big tool result, file read, accumulated context) arriving while another stream is already decoding — can **starve decode to ~0.1–0.9 TPS** until the prefill clears. Chunked prefill co-batches the heavy GDN/Mamba chunk with the decode token into one forward step, and the `align` block **floors the chunk at 1568 tokens**, so it can't be tuned away.
+
+Architectural to the hybrid model — expect it on any dual-card chunked-prefill config. **Read aggregate TPS as throughput, not a latency guarantee under agentic traffic.**
+
+Mitigations: lowering `--max-num-batched-tokens` toward the 1568 floor softens it but doesn't eliminate it. **Proxy-level admission control** — gating large prefills away from live interactive decodes — is the real fix. ⚠️ `--scheduling-policy priority` does *not* help: it orders admission, not intra-step compute. ([#208](https://github.com/noonghunna/club-3090/discussions/208))
+
+### NVLink's gain is workload-shaped
+
+Small on single-stream **decode** (~2–5%), large on **prefill / long context** (~35–49%). Without a bridge, `--disable-custom-all-reduce` and `NCCL_P2P_DISABLE=1` are set automatically. No bridge but want P2P over PCIe? `NVLINK_MODE=pcie_p2p` — see [`PCIE_P2P.md`](PCIE_P2P.md).
+
+### Solo user on dual = small win
+
+Single-stream decode leaves one card mostly idle. The win shows up under concurrency, or when you need the KV pool. **If you're a solo user, single-card is often the better cost choice** — see [`SINGLE_CARD.md`](SINGLE_CARD.md).
+
+### The Marlin overlay is automatic
+
+The pad-sub-tile-n fix for AutoRound W4A16 at TP=2 is vendored in-repo and auto-mounted by the compose. **No vLLM clone, no extra setup.** Rationale: [`INTERNALS.md`](../models/qwen3.6-27b/INTERNALS.md).
 
 ---
 
 ## Deep dives
 
-### Qwen3.6-27B
-- **[Model README](../models/qwen3.6-27b/)** — quant choices (AutoRound INT4 / GGUF), Genesis patch surface (mostly single-card relevant), what's working / what's not.
-- **[INTERNALS.md](../models/qwen3.6-27b/INTERNALS.md)** — engineering rationale: AutoRound vs GPTQ, DFlash forensics, Marlin pad fork, MTP, upstream tracker.
-- **[VRAM allocation diagram](../models/qwen3.6-27b/README.md#vram-allocation-across-configs)** — full per-config breakdown across single + dual.
-
-### Gemma 4 31B
-- **[Model README](../models/gemma-4-31b/)** — quants (BF16 source, AWQ-4bit, INT8 PTH KV via PR #40391 vendored overlay), drafter options (MTP / DFlash), upstream PR tracker.
-- **[Discussion #67](https://github.com/noonghunna/club-3090/discussions/67)** — first Ampere consumer cross-rig data thread. MTP, DFlash, INT8 PTH long-context, single-card 5090 numbers.
-
-### Cross-cutting
-- **[FAQ.md](FAQ.md)** — common questions (NVLink? AMD/Intel? Why fp8 not TQ3 on dual.yml? etc.).
-- **[EXAMPLES.md](EXAMPLES.md)** — Python / TS / curl client snippets + IDE connection settings.
-- **[HARDWARE.md](HARDWARE.md)** — Ampere SM 8.6 specifics, NVLink (declined), power caps, PCIe topology.
-- **[CLIFFS.md](CLIFFS.md)** — single-card Cliff 1 / Cliff 2 mechanisms (mostly Qwen3-Next-specific; Gemma 4 doesn't have these because it's dense attention without DeltaNet).
-- **[UPSTREAM.md](UPSTREAM.md)** — every upstream PR / issue we filed or watch (vLLM, Genesis, lucebox-hub, transformers, llama.cpp, SGLang).
-- **[SINGLE_CARD.md](SINGLE_CARD.md)** — when one card is enough (Qwen3.6-27B only — Gemma 4 needs ≥32 GB single-card).
+- **[MULTI_CARD.md](MULTI_CARD.md)** — 3+ GPUs: replicate-vs-TP, valid TP values, deriving your own config.
+- **[SINGLE_CARD.md](SINGLE_CARD.md)** — what one card can and can't do.
+- **[KV_MATH.md](KV_MATH.md)** — predicting per-card VRAM before you boot.
+- **[PCIE_P2P.md](PCIE_P2P.md)** — topology, P2P enablement, reading `nvidia-smi topo -m`.
+- **[BENCHMARKS.md](../BENCHMARKS.md)** — every measured row, including retired configs.
+- **[FAQ.md](FAQ.md)** — engine choice, why my TPS is low, image/video generation, troubleshooting.
+- **[QUANTIZATION.md](QUANTIZATION.md)** — quant field guide, KV-cache quant trade-offs.
+- **Model detail** — [Qwen3.6-27B](../models/qwen3.6-27b/) · [INTERNALS.md](../models/qwen3.6-27b/INTERNALS.md) · [Gemma 4 31B](../models/gemma-4-31b/)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -223,6 +223,46 @@ Look at the [TPS chart](../README.md#measured-tps-at-a-glance) — single-card v
 2. Wrong compose for your prompt shape (use the `tq3-mtp.yml` 48K single-card default for chat — don't pick `long-vision.yml` if you don't need 198K)
 3. Genesis tree drift — `git pull origin main` between bench runs can change AL by ±15%. We pin to commit `bf667c7` for this reason.
 
+### My TPS is ~5× lower than the table and there is no error — what happened?
+
+You are almost certainly running a **speculative-decoding compose whose draft model was never
+downloaded.** vLLM does not fail in this case: it **silently falls back to baseline decode** and
+serves normally, just far slower. Reported by
+[@lolren in #18](https://github.com/noonghunna/club-3090/discussions/18#discussioncomment-16787831),
+where a DFlash compose ran at ~25 TPS instead of ~125.
+
+```bash
+# Fetch the draft model the compose expects, then reboot the slug:
+WITH_DFLASH_DRAFT=1 bash scripts/setup.sh qwen3.6-27b
+```
+
+Confirm the drafter actually attached — the boot log names it, and an accept-length line appears
+once it has served traffic:
+
+```bash
+docker logs <container> 2>&1 | grep -iE 'speculative|draft|acceptance'
+```
+
+⚠️ This failure mode is **generic to any external-drafter config**, not specific to one compose:
+a missing draft model produces a working server at a fraction of the advertised throughput with no
+error anywhere. If your numbers are off by a large multiple and nothing is logged, check this first.
+
+### Which sampler values matter, and which one will silently ruin output?
+
+Every Qwen3.6-27B compose ships `temperature 0.6 · top_p 0.95 · top_k 20 · min_p 0.0` — Qwen's own
+precise-coding profile, and also the MTP-accept-sweep winner (a tighter distribution raises draft
+acceptance). For long agentic *reasoning*, the card's general-task profile is `temperature 1.0`
+(same top_p/top_k/min_p) — set `TEMP=1.0` or send it per-request.
+
+⚠️⚠️ **`min_p` must stay `0.0` in every mode.** A non-zero min-p floor (e.g. `0.75`) collapses the
+distribution and **traps reasoning models in repetition loops**. It looks like a reasonable quality
+knob and it is not — never set it.
+
+Best practice is to let the agent/harness set temperature per task rather than relying on the server
+default: a coding agent, a planning loop and a summarizer each want different sampling, and only the
+calling harness knows which is running. The compose default is a coding-biased fallback for clients
+that send nothing.
+
 ### My TPS dropped after switching to 198K context. Why?
 
 It shouldn't, much — we measured 50.93 TPS narr at 192K vs 50.53 at 32K (within variance) on `long-vision.yml` pre-fix; the new 198K + 0.98 config is in the same range. If it dropped a lot, you're probably actually decoding *into* a long ctx (not just having KV pool reserved). Loaded-context decode is 2-4× cold short-prompt decode on any LLM. The TPS chart number is short-prompt cold; loaded numbers are in [BENCHMARKS.md](https://github.com/noonghunna/club-3090/blob/master/CHANGELOG.md).

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -424,6 +424,20 @@ This is model-specific but the **shapes apply across hybrid-attention models** (
 - **Single 3090 (24 GB):** Cliff 1 (~25K-token tool prefills, FFN intermediate buffer) closed across all shipped variants since 2026-04-30 PM. **⚠️ Cliff 2 (~50-60K single prompts, DeltaNet GDN forward) regressed under Genesis v7.72.2** — PN59 streaming-GDN was advertised as the structural fix but doesn't engage on the chunked-prefill code path that 24 GB single-card configs are forced to take (`--max-num-batched-tokens 4128` populates `chunk_indices`/`chunk_offsets` which PN59's eligibility check rejects). `long-text.yml` / `long-text-no-mtp.yml` / `long-vision.yml` may OOM at >50K single-prompt context. Filed at [Sandermage/genesis-vllm-patches#22](https://github.com/Sandermage/genesis-vllm-patches/issues/22), pending Sander review. **Workarounds**: `dual.yml` / `dual-turbo.yml` (TP=2 escapes the cliff), or `llamacpp/default` (different engine, no Cliff 2). [See `docs/CLIFFS.md` for the full diagnostic.](CLIFFS.md)
 - **Dual 3090 (48 GB combined):** TP=2 splits activation memory across cards. Cliffs are not active failure modes.
 
+### ⚠️ Peak VRAM ≠ idle VRAM — the "it booted fine, then OOM'd" trap
+
+`nvidia-smi` at boot shows **weights + KV pool reservation**. It does **not** show peak.
+**Peak adds activation buffers during prefill — typically +500–1500 MiB.**
+
+So a card sitting at 23.5 / 24 GB after a clean boot has only ~500 MiB of headroom, which is not
+enough for the 138 MiB-class buffer a long-context prefill allocates. The server starts, serves
+short prompts happily, and dies on the first big one.
+
+**Fix:** drop `--gpu-memory-utilization` by `0.03` and re-boot. That is usually the whole
+intervention — you are buying back activation headroom, not context.
+
+Judge headroom from a **loaded** card, never an idle one.
+
 For visualization of how VRAM splits across single + dual configs, see [vram-budget-combined.svg](img/vram-budget-combined.svg) (or per-page: [single](img/vram-budget-single.svg) · [dual](img/vram-budget-dual.svg)).
 
 ---

--- a/docs/MULTI_CARD.md
+++ b/docs/MULTI_CARD.md
@@ -1,136 +1,28 @@
 # Multi-card (3+ GPUs) — derivation, constraints, scaling recipe
 
-You have **3 or more GPUs** and want to know if club-3090 applies. Short
-answer: yes. We ship a community-validated 4×3090 fp8/MTP baseline (now the
-`vllm/qwen-27b-multi-fast` slug) plus a matching FP8 + fp8/e4m3 "max accuracy"
-variant (`vllm/qwen-27b-multi-max`), and keep other 3+ GPU configs as derivation
-recipes until someone measures them. This page explains what scales (and what
-doesn't) when going beyond TP=2, the constraints to know, and how to derive your
-own compose when the shipped `multi4` composes aren't your topology.
+You have **three or more GPUs**. This page covers the one decision that matters most (replicate or tensor-parallel), the constraints that will stop a config booting, the two shipped 4-card baselines, and how to derive your own TP=N.
 
-> **Model not in the configs here / want any HF safetensors repo?** → [`docs/PULL.md`](PULL.md): `scripts/pull.sh` evaluates any model against the KV math (honest, no download) and boots it if it passes. The recipes on this page are the measured/derivation path; both work.
+> **Two cards?** → [`DUAL_CARD.md`](DUAL_CARD.md). **One?** → [`SINGLE_CARD.md`](SINGLE_CARD.md).
 
-> **Validation note:** the maintainer rig is **2× RTX 3090 PCIe**, but
-> Whamp's 4× RTX 3090 PCIe rig validated the TP=4 fp8/MTP baseline (the config
-> now shipped as `vllm/qwen-27b-multi-fast`) in
-> [discussion #26](https://github.com/noonghunna/club-3090/discussions/26)
-> on 2026-05-03. The TP=8+ sections remain derived expectations. If you
-> have 4× / 8× hardware and run additional configs, please share results via
-> the [Numbers from your rig](https://github.com/noonghunna/club-3090/issues/new?template=numbers-from-your-rig.yml)
-> issue template — `bash scripts/report.sh --full > my-rig.md` captures
-> everything we'd want (verify + stress + soak-continuous + bench, ~35 min).
+## ⛔ This rig has 2 GPUs. Permanently.
 
----
+Nothing above TP=2 is validated here, and nothing above TP=2 ever will be — that is the maintainer's hardware ceiling, not a backlog item. Filing "boot the 4-card slug" as pending work is a category error.
 
-## TL;DR — what scales, what doesn't
+What you get instead: every shipped TP=4 config has been **cross-validated on independent community rigs** — [@Whamp](https://github.com/noonghunna/club-3090) (4× 3090), [@alanspires](https://github.com/noonghunna/club-3090/issues/127) (6× 3090 VFIO), [@ryanmpelletier](https://github.com/noonghunna/club-3090), [@MoppelMat](https://github.com/noonghunna/club-3090), [@alesha-pro](https://github.com/noonghunna/club-3090/discussions/773) — and the derivation recipe below is a three-line diff off the config we run daily.
 
-| Aspect | TP=1 | TP=2 (measured) | TP=4 (measured) | TP=8 (derived) |
-|---|---|---|---|---|
-| Per-card weight share | 100% (~14 GB) | 50% (~7 GB) | 25% (~3.5 GB) | 12.5% (~1.75 GB) |
-| KV pool capacity | smallest | 2× | ~4× | ~8× |
-| Per-card peak VRAM (262K target) | 23.5+ GB tight | 23.6 GB tight | **23.5 GB fp8** (cross-rig) | ~10-12 GB |
-| Cliff 2 single-prompt | fires at ~60K | doesn't fire (verified at 237K) | **passes 91K needle** | shouldn't fire |
-| Per-stream TPS (PCIe-only) | baseline | ~same as TP=1 | **63/76 fp8** (cross-rig = `multi-fast`) | lower still |
-| Concurrent throughput (multi-stream) | 1× | ~1.7-3.6× | KV pre-check **6.77× fp8 @ 262K** (cross-rig) | derived ~3-12× |
-| Marlin pad-sub-tile-n patch | not needed | required | required | required |
+**TP=8 has zero boots anywhere.** Those sections are arithmetic, and labelled as such.
 
-**Two key takeaways:**
-
-1. **More cards = much more headroom**, especially for long-context
-   single-prompt workloads. On TP=4 the 24 GB-per-card pressure that
-   drives Cliff 2 disappears entirely — weights and KV pool both split.
-2. **Per-stream TPS doesn't scale *on our recipes*** — but read the scoping
-   below before treating that as a law of PCIe.
-
-> [!IMPORTANT]
-> **⚠️ Scoped 2026-07-26.** This bullet used to read *"Per-stream TPS doesn't
-> scale without NVLink. PCIe NCCL all-reduce overhead grows with TP count;
-> per-stream decode at TP=4 may be lower than TP=2."* That states a **topology
-> law**, and it isn't one — it's a property of the **recipe** we measure on.
->
-> Every shipped config in the table above runs **MTP K=3 speculative decoding**.
-> [@alesha-pro](https://github.com/noonghunna/club-3090/discussions/773) ran the
-> same TP sweep on 4× 3090 with **no spec decoding at all** and got the opposite
-> result. Decode tok/s, Qwen3.6-27B fp8, single stream:
->
-> | | TP=2 | TP=4 | scaling |
-> |---|--:|--:|--:|
-> | **no spec** (@alesha-pro, 220 W, patched P2P) | 38.07 | 61.60 | **+62%** |
-> | **MTP n=3** (our shipped configs) | 70.7 <sup>a</sup> | 74.76 <sup>b</sup> | **+5.7%** |
->
-> <sup>a</sup> `vllm/qwen-27b-dual-fast`, v0.24.0 · <sup>b</sup> `vllm/qwen-27b-multi-fast`, @ryanmpelletier 4× 3090 all-x16, v0.24.0
->
-> **Both are correct.** vLLM TP scaling is real; our TP=2 baseline just already
-> has ~1.85× of drafter folded into it, so there's nothing left for cards 3 and 4
-> to recover. The decisive number: **his TP=4 (61.60) lands 13% *below* our TP=2
-> (70.7).**
->
-> So the *practical* advice survives — **on a PCIe rig you buy single-stream speed
-> with a drafter, not with more cards** — but the stated *mechanism* (all-reduce
-> overhead growing with TP) is not what either dataset shows. Ours shows TP=4 ≈
-> TP=2, not TP=4 < TP=2.
->
-> **Confirmed by measurement 2026-07-27 — the matched-recipe pair.** The clean
-> test this section was waiting for: same rig, same sitting, same 220 W on every
-> card, same weights and image (v0.25.1), **MTP n=3 on *both* arms**,
-> `switch.sh` + `bench.sh`, ~20 minutes apart
-> ([@alesha-pro again](https://github.com/noonghunna/club-3090/discussions/773)):
->
-> | | TP=2 `dual-fast` | TP=4 `multi-fast` | Δ |
-> |---|--:|--:|--:|
-> | narrative decode TPS | 79.26 (CV 4.1%) | 82.44 (CV 3.2%) | **+4.0%** |
-> | code decode TPS | 106.50 (CV 6.2%) | 103.73 (CV 1.7%) | **−2.6%** |
-> | prefill @10K tok/s | 1556 (CV 0.1%) | 2407 (CV 0.1%) | **+54.6%** |
-> | prefill @90K tok/s | 1202 (CV 0.6%) | 1948 (CV 0.5%) | **+62.0%** |
-> | TTFT @90K | 73.1 s | 45.6 s | **−37.6%** |
->
-> Decode is flat — reproducing the cross-rig +5.7%/−2.9% above within ~2 points,
-> from one rig in one sitting. Recipe-not-topology is now *measured*, not
-> inferred. **And the number that changes the guidance: cards 3 and 4 buy
-> prefill and TTFT, not decode.** A 90K-token prompt starts answering 27 seconds
-> sooner on four cards; the tokens then stream no faster. (Same shape as the
-> NVLink A/B in [#698](https://github.com/noonghunna/club-3090/issues/698) —
-> decode +3–5%, prefill +35–49% — with a larger prefill term.) Two caveats
-> carried from the report: the TP=2 arm runs vLLM's custom all-reduce and the
-> TP=4 arm cannot (engine-gated at >2 PCIe GPUs —
-> [#786](https://github.com/noonghunna/club-3090/issues/786); every
-> dual-vs-multi4 comparison shares this asymmetry, recorded as Rig-cell field 4
-> in BENCHMARKS), and the cross-*version* question is **resolved (2026-07-27)**:
-> our first-party v0.25.1 re-run reproduces the v0.24.0 numbers (decode
-> 68.5/92.1 vs 70.7/93.5, at 230 W vs stock caps — flat within power+CV
-> noise), so the +11–16% by which the #773 rig's dual arm beats ours is
-> **rig-side, not the engine** — their TP=2 runs custom all-reduce +
-> transfer-verified P2P; ours runs neither. That difference matching the ~15%
-> they measured for custom-AR alone is the strongest hint yet of what the
-> interconnect stack is worth at TP=2.
->
-> One engine caveat from the same report: this is a **vLLM** property. On the
-> llama.cpp leg (tensor-split, not TP) the same box gained only 3–13% going 2→4,
-> with a repeat spread wide enough to swamp it (Q8_0 gave 52.9 and 71.8 on
-> identical settings). If you're on a GGUF engine, "more cards ≠ faster per
-> stream" holds much more strongly.
-
-   Aggregate concurrent throughput still scales — see **Replication vs
-   tensor-parallel** below, which is usually the bigger lever.
+If you're running 4+ GPUs you have more relevant hardware than we do. The constraints and the recipe are ours to give; the validation on your card count is the one thing only you can produce. `bash scripts/report.sh --full` — one command, ~35 min, and it becomes the next row in [`BENCHMARKS.md`](../BENCHMARKS.md) with your name on it.
 
 ---
 
 ## ⭐ Decide this first: replicate, or tensor-parallel?
 
-> **If you only read one section of this page, read this one.** Getting it wrong
-> costs up to **3.4×** aggregate throughput, and no amount of TP tuning further
-> down recovers it.
+> **If you read one section of this page, read this one.** Getting it wrong costs up to **3.4×** aggregate throughput, and no amount of TP tuning further down recovers it.
 
-Everything else on this page reasons in the **TP dimension**: how do I split one
-model across N cards? For **aggregate** throughput that is frequently the wrong
-question. If the model fits on one card, running **N independent instances**
-beats splitting it N ways — by a lot.
+Everything else here reasons in the **TP dimension** — how do I split one model across N cards? For **aggregate** throughput that is frequently the wrong question. If the model fits on one card, running **N independent instances** beats splitting it N ways, by a lot.
 
-**The rule: latency wants max TP, throughput wants max instances.**
-
-Measured by [@alesha-pro](https://github.com/noonghunna/club-3090/discussions/773)
-on 4× 3090 PCIe, all arms matched at 220 W, peak aggregate tok/s
-(`--max-num-seqs 256 --enable-chunked-prefill`):
+Measured by [@alesha-pro](https://github.com/noonghunna/club-3090/discussions/773) on 4× 3090 PCIe, all arms matched at 220 W, peak aggregate tok/s:
 
 | Model | TP=4, 1 instance | replicated | gain |
 |---|--:|--:|--:|
@@ -138,253 +30,107 @@ on 4× 3090 PCIe, all arms matched at 220 W, peak aggregate tok/s
 | Qwen3.6-27B INT8-W8A8 | 358 | **741** (TP=2 × 2) | 2.07× |
 | Qwen3.6-27B INT4 | 307 | **737** (TP=2 × 2) | 2.40× |
 
-**The rule of thumb: latency wants max TP, throughput wants max instances.**
-(@alesha-pro's phrasing.) Same cards, same weights, opposite answer depending on
-which you're optimizing.
+**The rule: latency wants max TP, throughput wants max instances.**
 
-The trap is that **the same run flips winner** depending on which number you
-read. AutoRound INT4 on that rig, one sitting, one power cap:
+The trap is that **the same run flips winner** depending which number you read. AutoRound INT4, one rig, one sitting, one power cap:
 
 | | TP=2 | TP=4 |
 |---|--:|--:|
 | single stream (wall) | 53.80 | **69.26** |
 | aggregate peak @ c=64 | **473.1** | 294.8 |
 
-TP=4 is **29% faster for one user and 38% slower for a full queue.** So "which
-TP should I run" has no answer without "for what workload".
+TP=4 is **29% faster for one user and 38% slower for a full queue.** "Which TP should I run" has no answer without "for what workload".
 
-**This agrees with what we measured from the concurrency side.** Our own sweep
-(2026-07-10, 2× 3090, agent-shaped 16K prompts) found the dense 27B's batching
-knee at **N=2** — decode-aggregate *halves* by N=8, because per-stream falls
-faster than N grows. Meanwhile the 35B-A3B MoE holds ~250–270 flat to N=16.
-Same lesson from the other direction: past a low N, stop feeding one big engine
-and start adding engines. See the concurrency sweep in
-[BENCHMARKS.md](../BENCHMARKS.md) and the FAQ entry on serving multiple coding
-agents.
+**Our own concurrency sweep agrees from the other direction:** the dense 27B's batching knee is **N=2** — decode-aggregate *halves* by N=8 because per-stream falls faster than N grows. The 35B-A3B MoE holds ~250–270 flat to N=16. Past a low N, stop feeding one big engine and start adding engines.
 
-**Caveats before you replicate.** Each instance needs its own full weight copy
-(so the model must fit on one card *with* a useful KV pool), its own port, and
-its own KV pool — you lose the pooled-KV benefit that is the main reason to run
-TP=4 for long-context single-prompt work. Replication is the answer for **many
-short-to-medium requests**; TP is the answer for **one very long one**. We don't
-ship a replication compose today — [PODS.md](PODS.md) is the closest thing.
+**Before you replicate:** each instance needs its own full weight copy (the model must fit on one card *with* a useful KV pool), its own port, and its own KV pool — you lose the pooled KV that is the main reason to run TP=4 for long single prompts. Replication wins for **many short-to-medium requests**; TP wins for **one very long one**. No replication compose ships today — [`PODS.md`](PODS.md) is the closest thing.
 
 ---
 
-## Topology classification
+## What scales at TP=4, and what doesn't
 
-The launcher classifies your selected hardware and emits strategy guidance
-when the cards are not matched. You can run the classifier without booting
-anything:
+| Aspect | TP=1 | TP=2 (measured) | TP=4 (measured) | TP=8 (derived) |
+|---|---|---|---|---|
+| Per-card weight share | 100% (~14 GB) | 50% (~7 GB) | 25% (~3.5 GB) | 12.5% (~1.75 GB) |
+| KV pool capacity | smallest | 2× | ~4× | ~8× |
+| Per-card peak VRAM @262K | 23.5+ GB tight | 23.6 GB tight | **23.5 GB fp8** | ~10–12 GB |
+| Cliff 2 single-prompt | fires at ~60K | doesn't fire (237K verified) | **passes 91K needle** | shouldn't fire |
+| Per-stream TPS (PCIe) | baseline | ~same as TP=1 | **63 / 76 fp8** | lower still |
+| Concurrent throughput | 1× | ~1.7–3.6× | **6.77× fp8 @262K** | derived ~3–12× |
+| Marlin pad patch | not needed | required | required | required |
 
-```bash
-bash scripts/launch.sh --topology
-```
+**More cards buy headroom, not per-stream speed.** On TP=4 the 24 GB-per-card pressure that drives Cliff 2 disappears — weights and KV both split.
 
-Use `--gpus 0,1` or `--cards 2` with `--topology` if you only want advice
-for a subset.
+⚠️ **"Per-stream TPS doesn't scale on PCIe" is a property of our recipe, not a law of topology.** Our TP=2 baseline already folds in ~1.85× of MTP drafter, so there's little left for extra cards to add. On a matched-recipe A/B (same rig, same sitting, @alesha-pro): **prefill @90K went 1,202 → 1,948 tok/s (+62%) and TTFT @90K 73.1 s → 45.6 s (−37.6%)**. Cards 3 and 4 buy **prefill and TTFT**, not decode.
 
-| Class | What it means | Example | Recommended |
-|---|---|---|---|
-| `single_card` | 1 GPU detected | 1x RTX 3090 | Run `bash scripts/switch.sh qwen3.6-27b/default` (resolves to `vllm/minimal`). See [SINGLE_CARD.md](SINGLE_CARD.md). |
-| `homogeneous` | All cards have matched VRAM and matched SM | 2x RTX 3090 | TP=N is the optimal default; use the shipped `vllm/dual*` (2-card) or `vllm/qwen-27b-multi-*` (4-card) composes. |
-| `vram_matched_compute_mismatched` | Same VRAM, different compute tier | RTX 3090 + RTX 4090 | TP=N works correctly, but faster cards wait at NCCL allreduce. Estate planner is better for multi-model workloads. |
-| `vram_mismatched` | Different VRAM sizes | RTX 3060 12 GB + RTX 3090 24 GB | Prefer llama.cpp `--tensor-split`, manual PP=N experiments, or estate planner. Avoid TP=N across the full mismatched set. |
-| `heterogeneous_mixed` | Multiple VRAM and compute tiers | RTX 3060 + RTX 3090 + RTX 4090 | Manual selection. Run one model on the largest matched subset or use estate planner for separate endpoints. |
-
-> **Running several models at once** (the "estate planner / separate endpoints" rows above) is a **pod** workload — one model per GPU subset, managed with `pod.sh` or the c3 Operate tab. See **[PODS.md](PODS.md)**.
-
-### Why TP=N is poor on VRAM-mismatched cards
-
-Tensor parallelism splits weights evenly across cards. If one card has 24 GB
-and another has 12 GB, TP=2 still puts roughly half the model on each card.
-The smaller card becomes the hard ceiling for weights, KV cache, activations,
-and fragmentation. For Qwen 3.6 27B INT4, that usually leaves too little KV
-headroom to be useful.
-
-For mismatched VRAM, the practical paths are:
-
-- llama.cpp `--tensor-split` for weighted layer placement.
-- PP=N as a manual vLLM flag flip (`--pipeline-parallel-size N`) when you are
-  deliberately experimenting. club-3090 does not ship a PP compose today.
-- Estate planner: `bash scripts/launch.sh --estate` runs different models on
-  different card subsets without forcing one model across uneven VRAM.
-
-### When compute-mismatched TP is fine
-
-Matched VRAM with different SM, such as RTX 3090 + RTX 4090, is a different
-trade-off. TP=2 works because both cards have enough memory for the same model
-shard and KV budget. The cost is throughput: the faster card waits at NCCL
-allreduce barriers, so effective pair speed caps near the slower card. You
-preserve per-card VRAM capacity, but waste some compute on the faster card.
-
-That is acceptable for one-model serving. If your goal is maximum aggregate
-throughput from two different cards, estate planner usually wins because each
-card runs its own model at full speed.
+⚠️ **Two asymmetries when comparing dual vs multi4 numbers:** TP=2 can run vLLM's custom all-reduce and TP≥3 cannot (engine-gated on PCIe — [#786](https://github.com/noonghunna/club-3090/issues/786)); and on **llama.cpp** (tensor-split, not TP) the same box gained only 3–13% going 2→4, with repeat spread wide enough to swamp it. On a GGUF engine, "more cards ≠ faster per stream" holds much more strongly.
 
 ---
 
-## Valid TP values for Qwen3.6-27B
+## Valid TP values
 
-vLLM asserts that the **attention** head count divides the TP size. KV heads
-do not have to divide it — when there are fewer KV heads than ranks, vLLM
-**replicates** them. Qwen3.6-27B and Qwen3.8-27B are identical here
-(`config.json` → `text_config`):
+vLLM asserts that the **attention** head count divides the TP size. KV heads do not have to divide it — when there are fewer KV heads than ranks, vLLM **replicates** them. Qwen3.6-27B and Qwen3.8-27B are identical here (`config.json` → `text_config`):
 
-- **24 attention heads** (factors: 1, 2, 3, 4, 6, 8, 12, 24) — this is the binding constraint
+- **24 attention heads** (factors: 1, 2, 3, 4, 6, 8, 12, 24) — the binding constraint
 - **4 KV heads** — shard cleanly to TP=4, then replicate above it
 - head_dim 256
 
-Valid TP values are therefore **1, 2, 4, 8** (and 12, 24 on datacenter boards):
-
-| GPUs | Valid TP | Attn heads/card | KV heads/card | Notes |
+| GPUs | Valid TP | Attn/card | KV/card | Notes |
 |---|---|--:|---|---|
-| 1 | TP=1 | 24 | 4 | Standard single-card. See [SINGLE_CARD.md](SINGLE_CARD.md). |
-| 2 | TP=2 | 12 | 2 | Standard dual. See [DUAL_CARD.md](DUAL_CARD.md). |
-| **3** | **TP=2 only** | — | — | 24 ÷ 3 = 8 attention heads is fine, but **4 KV heads across 3 ranks neither divides nor replicates evenly** — vLLM errors at boot. **Use TP=2 with 1 idle card** (`CUDA_VISIBLE_DEVICES=0,1`), or run 2 single-card stacks on different ports. |
-| **4** | **TP=4** | 6 | 1 | The shipped multi-card tier. Production-viable if your rig has the slots + power + cooling. |
+| 1 | TP=1 | 24 | 4 | → [SINGLE_CARD.md](SINGLE_CARD.md) |
+| 2 | TP=2 | 12 | 2 | → [DUAL_CARD.md](DUAL_CARD.md) |
+| **3** | **TP=2 only** | — | — | 24 ÷ 3 = 8 attention heads is fine, but **4 KV heads across 3 ranks neither divides nor replicates evenly** — vLLM errors at boot. Use TP=2 with 1 idle card (`CUDA_VISIBLE_DEVICES=0,1`), or run 2 single-card stacks on different ports. |
+| **4** | **TP=4** | 6 | 1 | The shipped multi-card tier. |
 | **5** | **TP=4 + 1 idle** | — | — | ⚠️ **TP=5 does NOT work** — 24 ÷ 5 is not an integer. |
-| **6 or 7** | **TP=4 + spare cards** | — | — | Neither divides 24 evenly alongside the KV constraint. Use TP=4 and leave the extras idle. |
-| **8** | **TP=8** | 3 | replicated ×2 | Each card holds 3 attention heads; the 4 KV heads replicate, so **per-card KV stays at the TP=4 figure** and only weights shard 8-way. |
+| **6 or 7** | **TP=4 + spares** | — | — | Neither divides 24 evenly alongside the KV constraint. |
+| **8** | **TP=8** | 3 | replicated ×2 | 3 attention heads/card; the 4 KV heads replicate, so **per-card KV stays at the TP=4 figure** and only weights shard 8-way. |
 | **10** | **TP=8 + 2 idle** | — | — | ⚠️ **TP=10 does NOT work** — 24 ÷ 10 is not an integer. |
 
-**Critical: TP=3, 5, 6, 7, 9, 10 do NOT work.** vLLM errors at boot
-("number of attention heads must be divisible by tensor parallel size").
-If you have an awkward GPU count, use the next-lower valid TP and leave
-the extras idle, or run separate stacks on different ports.
+**TP=3, 5, 6, 7, 9, 10 do NOT work.** vLLM errors at boot (*"number of attention heads must be divisible by tensor parallel size"*). Use the next-lower valid TP and leave the extras idle.
 
-> ⚠️ Because KV heads replicate above TP=4, **going from 4 to 8 cards does not
-> shrink per-card KV** — it only shards weights further. Budget accordingly.
+> ⚠️ Because KV heads replicate above TP=4, **going 4 → 8 cards does not shrink per-card KV** — it only shards weights. Budget accordingly.
 
-### Picking which cards to use on awkward counts
+### Picking which cards to use
 
-On a rig with 3 cards (or more, where you only want to use 2 for vLLM),
-**which two you select matters** for both throughput and reliability.
+On awkward counts, pick the **best-connected** pair or quad, not the first N. Inspect with `nvidia-smi topo -m` and prefer `NV#` > `PIX` > `PXB` > `PHB` > `SYS`, then pin with `CUDA_VISIBLE_DEVICES`. Full treatment of link classes, NUMA, slots and BIOS: [`PCIE_P2P.md`](PCIE_P2P.md).
 
-```bash
-# Inspect topology first — connectivity classes affect TP allreduce
-nvidia-smi topo -m
-```
-
-The matrix shows pairwise links between GPUs. Best to worst for TP allreduce:
-
-| Class | Meaning | Implication |
-|---|---|---|
-| `NV#` | NVLink-bonded | Fastest. We don't have it on consumer 3090s by default. |
-| `PIX` | Same PCIe switch (one bridge hop) | Optimal on PCIe-only stacks. |
-| `PXB` | Multiple PCIe bridges, no host bridge | Acceptable; slightly higher latency. |
-| `PHB` | Crosses PCIe Host Bridge (the CPU) | Common on consumer boards; works but ~10-15% allreduce overhead vs PIX. |
-| `SYS` | Crosses NUMA / SMP interconnect | Avoid for TP if there's a same-NUMA pair available. |
-
-**Pick a same-switch pair (`PIX`) if your rig has one** — typically the two
-slots wired into the same PCIe expander on workstation boards. On consumer
-ATX, all GPUs usually traverse the host bridge (`PHB`) so it doesn't matter
-much; on Threadripper / EPYC / dual-CPU server boards, NUMA topology can
-make a measurable difference.
-
-To run TP=2 on cards 1+2 (e.g., card 0 is reserved for ComfyUI / display):
-
-```yaml
-# In your override compose file
-services:
-  vllm-qwen36-27b-dual:
-    environment:
-      - CUDA_VISIBLE_DEVICES=1,2
-```
-
-Cross-rig data: [@lexhoefsloot](https://github.com/noonghunna/club-3090/issues/49)
-runs TP=2 on host GPUs 1+2 of a 3× 3090 rig (same PCIe switch, `PHB` to
-GPU 0) — that's the right pattern for a rig where GPU 0 is doing other
-work or differs in topology.
+⚠️ **TP across VRAM-mismatched cards is poor** — vLLM sizes the KV pool from the *smallest* card, so a 24 GB + 12 GB pair gives you two 12 GB cards. Compute-mismatched (same VRAM, different speed) is fine; the slower card just sets the pace.
 
 ---
 
-## Shipped TP=4 baselines — `vllm/qwen-27b-multi-fast` and `vllm/qwen-27b-multi-max`
+## Shipped TP=4 baselines
 
-For 4× RTX 3090 PCIe, two TP=4 composes mirror the 2-card fast/max tiers (see
-[DUAL_CARD.md](DUAL_CARD.md)). Each is **byte-identical to its 2-card sibling**
-apart from `--tensor-parallel-size` and the gpu-count, so the duals are the
-on-rig validation proxies (the maintainer rig is 2× 3090) — both ship
-🧪 Experimental until re-confirmed on your 4-card host.
+| Slug | Weights | KV | Max ctx | Port | Notes |
+|---|---|---|--:|--:|---|
+| `vllm/qwen-27b-multi-fast` ⭐ | AutoRound INT4 | fp8 e4m3 | 262144 | 8014 | The primary 4-card config. Cross-rig: 74.76 / 90.83 TPS (@ryanmpelletier, all-x16). |
+| `vllm/qwen-27b-multi-max` | FP8 | fp8 e4m3 | 262144 | 8015 | Highest weight fidelity. Cross-rig: 74.10 / 91.30 (@ryanmpelletier) · 79.23 / 101.61 (@MoppelMat). |
+| `vllm/qwen38-27b-multi4-max` | official FP8 | bf16 | 262144 | 8092 | 🐣 Qwen3.8. **Never booted on any card count** — first community boot IS the validation. |
+| `vllm/qwen38-27b-multi4-fast` | AutoRound INT4 | fp8 e4m3 | 262144 | 8096 | 🧪 Qwen3.8. Never booted. |
 
-### `vllm/qwen-27b-multi-fast` — AutoRound INT4 + fp8 KV + MTP (the proven path)
+⚠️ **Both qwen3.6 multi slugs are exposed to open [vllm#50021](https://github.com/vllm-project/vllm/pull/50021)** — a GDN spec-decode wild write that kills workers under sustained agent traffic. Mitigate with `SPEC=off`. Every measured row: [`BENCHMARKS.md`](../BENCHMARKS.md).
 
-```bash
-bash scripts/switch.sh vllm/qwen-27b-multi-fast
-```
+---
 
-`multi4/autoround-int4/mtp.yml` keeps the `dual.yml` (≡ `vllm/qwen-27b-dual-fast`)
-fp8/MTP feature set and changes TP/streams from 2 → 4. This is the exact config
-Whamp measured on a 4× 3090 PCIe rig — **cross-rig numbers** (the compose was
-since renamed `fp8-mtp.yml` → `mtp.yml`; config unchanged):
+## Recipe — derive your own TP=N from `dual.yml`
 
-- boots at `max_model_len=262144`
-- vLLM reports GPU KV cache size **483,200 tokens** and **6.77×** maximum concurrency for 262K-token requests
-- `verify-full.sh` passes
-- `verify-stress.sh` passes 7/7; probe 7 recalls **58,569-token** and **91,070-token** needles
-- `bench.sh`: **63.01 narr / 76.25 code wall TPS**, peak **23,494 MiB/card**
-
-(Validation thread: [discussion #26](https://github.com/noonghunna/club-3090/discussions/26), 2026-05-03.)
-
-### `vllm/qwen-27b-multi-max` — FP8 weights + fp8/e4m3 KV (highest fidelity)
-
-```bash
-bash scripts/switch.sh vllm/qwen-27b-multi-max
-```
-
-`multi4/fp8/mtp.yml` mirrors the 2-card `vllm/qwen-27b-dual-max`: official **FP8**
-weights (Marlin W8A16 on Ampere — memory win, no FP8 compute speedup) + **fp8/e4m3**
-KV (1 byte/token, FlashInfer backend, scale=1.0 on this checkpoint) + MTP n=3 @ 262K.
-**✅ Production** (2026-07-07) — validated on a clean v0.24.0 4-card rig:
-[#584](https://github.com/noonghunna/club-3090/issues/584) (@ryanmpelletier, 4× 3090
-x16) passed verify-full 9/9, verify-stress to 240K, soak-continuous, and the full 8-pack
-at **111/150** (ties the dual-max proxy 109 → quality is TP-invariant), corroborated by a
-2nd independent rig [#625](https://github.com/noonghunna/club-3090/issues/625) (@MoppelMat,
-mixed x4/x8 lanes). The 4 cards relieve the dual-max proxy's tight **295K-tok / 1.13×** KV
-pool → **6.77×** at TP=4; single-stream decode is ~flat vs the 2-card tier.
-
-> **KV decode-at-depth applies here too ([#594](https://github.com/noonghunna/club-3090/pull/594), [#595](https://github.com/noonghunna/club-3090/pull/595)).** `multi-max` now mirrors `dual-max` exactly: FP8 weights + `KV_CACHE_DTYPE=fp8` (e4m3 → FlashInfer). The prior int8-PTH KV was `TRITON_ATTN`-only and cratered at depth on the dual proxy (130.8→50.7 TPS @ 35K); fp8/e4m3 stayed flat (~115 @ 35K), recalled NIAH to 240K, tied the 8-pack (109 vs 107), and passed soak. `multi-max` inherited that one-line KV flip in #595, and it was confirmed at TP=4 on [#584](https://github.com/noonghunna/club-3090/issues/584) (verify-full 9/9, stress to 240K, soak, 8-pack 111/150) + corroborated on [#625](https://github.com/noonghunna/club-3090/issues/625) — hence its promotion to ✅ Production.
-
-> **DFlash on TP=4 was removed.** The former `vllm/dual4-dflash`
-> (`multi4/autoround-int4/dflash.yml`) is gone — DFlash on Qwen3-Next vLLM is blocked
-> by DeltaNet KV rollback ([vllm#39931](UPSTREAM.md), the same block as the dual-card
-> path). DFlash-for-Qwen now lives on beellama (`beellama/qwen-dflash-dual`, v0.3.0 🧪);
-> see [DUAL_CARD.md](DUAL_CARD.md).
-
-## Recipe — derive your own config from `dual.yml`
-
-The 2-card `dual/autoround-int4/fp8-mtp.yml` (`vllm/dual`) is the tested baseline
-and `multi4/autoround-int4/mtp.yml` (`vllm/qwen-27b-multi-fast`) is the measured
-4-card baseline. To scale to another TP=N, copy one of those and change
-**three lines**:
+Copy `dual/autoround-int4/fp8-mtp.yml` (`vllm/dual`, the tested 2-card baseline) or `multi4/autoround-int4/mtp.yml` (`vllm/qwen-27b-multi-fast`, the measured 4-card one) and change **three lines**:
 
 ```diff
   command:
     - --tensor-parallel-size
 -   - "2"
-+   - "4"      # or 8, etc. — must be a valid TP value from the table above
++   - "4"      # must be a valid TP value from the table above
     - --max-num-seqs
 -   - "2"
-+   - "4"      # bump proportional to TP — more cards = more concurrent streams
++   - "4"      # bump proportional to TP
     - --max-num-batched-tokens
 -   - "8192"
-+   - "16384"  # optionally bump proportional to TP for longer prefill chunks
++   - "16384"  # optionally bump for longer prefill chunks
 ```
 
-Everything else stays the same:
-- `--gpu-memory-utilization 0.92` — same per-card budget
-- `--kv-cache-dtype fp8_e5m2` — same KV class
-- `--max-model-len 262144` — same target context (more cards = more
-  total KV pool, but per-request max stays at 262K unless you raise it)
-- `MTP n=3` spec-decode — same
-- The Marlin pad-sub-tile-n patch mount stays — at higher TP, more
-  out-features get sub-tile-split, so the patch is *more* likely to be
-  needed, not less
+Everything else stays: `--gpu-memory-utilization 0.92` (same per-card budget), `--kv-cache-dtype`, `--max-model-len 262144`, MTP n=3, and the Marlin pad patch mount — at higher TP *more* out-features get sub-tile-split, so the patch is more likely to be needed, not less.
 
-Container name + port: pick something distinct so it doesn't collide
-with your other variants. `multi-fast` uses `vllm-qwen36-27b-multi4` on port
-`8014` and `multi-max` uses `vllm-qwen36-27b-multi4-max` on port `8015`;
-reserve a different name/port for further experiments:
+Give it a distinct container name and port so it doesn't collide:
 
 ```yaml
 container_name: vllm-qwen36-27b-octa
@@ -392,115 +138,31 @@ ports:
   - "${PORT:-8016}:8000"
 ```
 
----
-
-## What we measured on TP=4 (4× 3090 PCIe)
-
-Measured 2026-05-03 on Whamp's 4× RTX 3090 PCIe rig:
-
-- **fp8/MTP boot time:** 355s cold after model/image cache populated.
-- **fp8/MTP pre-check:** `max_model_len=262144`, `max_num_seqs=4`, GPU KV
-  cache size 483,200 tokens, max concurrency 6.77× at 262K.
-- **fp8/MTP VRAM:** 21,714 MiB idle after boot; 23,494 MiB/card peak
-  during canonical bench.
-- **fp8/MTP TPS:** 63.01 narrative / 76.25 code wall TPS.
-- **MTP AL:** last three code-bench metrics showed mean acceptance length
-  3.42 / 3.53 / 3.62.
-- **Cliff 2:** canonical `verify-stress.sh` probe 7 passes at both large
-  rungs: ~58.6K tokens and 91K tokens recalled correctly.
-- **Trade-off:** PCIe allreduce makes single-stream decode slower than
-  TP=2, but TP=4 provides more full-context concurrency and the first
-  published 4×3090 Cliff 2 boundary data.
-
-> The same 4×3090 run also measured a **now-removed** DFlash TP=4 variant
-> (64.00 / 104.40 narr/code TPS, AL ~4.4, KV pool 207,264 tok / 2.27× @262K).
-> That compose was dropped — DFlash on Qwen3-Next vLLM is blocked by DeltaNet KV
-> rollback ([vllm#39931](UPSTREAM.md)) — so the numbers are kept only as historical
-> cross-rig context; DFlash-for-Qwen now lives on beellama.
-
----
-
-## What to expect on TP=8 (8× 3090 / A6000)
-
-Server-class setup. Most users at this scale are on rack hardware (DGX,
-4U server chassis, dedicated cooling). The per-card pressure essentially
-disappears:
-
-- **Per-card peak VRAM:** ~10-12 GB. You have headroom to do almost
-  anything — bump max-num-seqs to 8+, push max-model-len higher,
-  experiment with TQ3 + Genesis stack from `dual-turbo.yml`.
-- **Per-stream decode TPS:** without NVLink fabric, likely lower than
-  TP=4. Server-class cards (A6000, A100) often have NVLink — that
-  changes the per-stream calculus dramatically.
-- **Aggregate throughput:** scales near-linearly with N if you have
-  multi-stream load.
-
-If you're on a server-class rig with NVLink: per-stream TPS could
-approach 1.6-1.8× single-card vs the ~1.0× we see on PCIe TP=2. That
-makes TP=8 with NVLink a meaningfully different regime than what we
-measure.
+⚠️ **PCIe-only with no NVLink means more ranks = more all-reduce on a slow bus.** Custom all-reduce stays disabled above TP=2 regardless — it's engine-gated, not a config choice.
 
 ---
 
 ## Cross-rig data we'd love
 
-If you have 4× / 8× hardware and run any config, please share via
-[Numbers from your rig](https://github.com/noonghunna/club-3090/issues/new?template=numbers-from-your-rig.yml).
-The single command that captures everything:
+Anything on 3+ cards, in rough priority order:
+
+1. **A TP=8 boot of anything.** Zero exist. The TP=8 rows above are arithmetic.
+2. **A qwen3.8-27b multi4 or multi8 boot** — `vllm/qwen38-27b-multi4-max` has never run on any card count.
+3. **A replication-vs-TP A/B on your rig** — the single highest-leverage number on this page, and it's cheap to produce.
+4. **Odd card counts** (3, 5, 6) — does the "next-lower valid TP + idle cards" advice actually hold?
 
 ```bash
-bash scripts/report.sh --full > my-rig.md
+bash scripts/report.sh --full     # ~35 min, redacted, paste-ready
 ```
 
-That's verify-full + verify-stress 7/7 + SOAK_MODE=continuous + canonical bench in one ~35-min pass. Use `--bench` instead if you want bench numbers without the soak (faster but doesn't probe Cliff 2b).
-
-Specifically interested in:
-
-- **More TP=4 on 4× 3090 PCIe** — does your motherboard / power cap / PCIe
-  topology match or beat Whamp's 63 / 76 TPS baseline? What's concurrent throughput?
-- **TP=4 with NVLink topology** (e.g. NVLink across pairs) — how does
-  per-stream TPS compare to PCIe-only TP=2?
-- **TP=8 on 8× A6000 / A100** — first server-class data point we'd
-  collect.
-- **TP=4 on mixed cards** (e.g. 2× 3090 + 2× 4090, or 4× modded 3080
-  20GB) — does vLLM's per-card weight balance handle asymmetric VRAM
-  ceilings cleanly? Asymmetric setups need `--gpu-memory-utilization`
-  tuned to the *smallest* card's free VRAM.
-
----
-
-## Why we ship only a fast/max pair of pre-baked 4-card configs
-
-We ship two TP=4 composes — `vllm/qwen-27b-multi-fast` (fp8/MTP) and
-`vllm/qwen-27b-multi-max` (FP8 + fp8/e4m3) — mirroring the 2-card fast/max tiers.
-The `multi-fast` config is here because a community rig validated that exact
-4× RTX 3090 PCIe topology with `verify-full.sh`, `verify-stress.sh`, and
-`bench.sh`; `multi-max` is its higher-fidelity sibling (validated via the
-`dual-max` proxy at TP=2, 🧪 pending a 4-card bench). We still avoid a broad
-matrix of untested 4+ GPU composes:
-
-1. **Hardware combinations explode.** 4× 3090 vs 4× A5000 vs 4× A6000 vs
-   2×3090 + 2×4090 vs 4× modded 3080 — each has different VRAM, topology,
-   power profile, and allreduce characteristics.
-2. **Variant count needs discipline.** A measured fp8/MTP TP=4 baseline
-   (plus its FP8 fidelity sibling) is useful; a directory full of
-   derived-but-unvalidated variants would create false confidence.
-3. **Users at this scale are typically experienced.** If you have a
-   workstation chassis or rack with 4-8 GPUs, you've already done the
-   hardware homework. What you need from us is the methodology, the
-   constraints, and one validated starting point.
-
-If a community member contributes another tested compose for a specific
-topology or workload (with `verify-stress.sh` passing + `bench.sh`
-numbers), we'll ship it with credit and a header noting which rig
-validated it.
+Report via the `numbers-from-your-rig` issue template.
 
 ---
 
 ## See also
 
-- [`SINGLE_CARD.md`](SINGLE_CARD.md) — 1× GPU baseline (where Cliff 2 lives)
-- [`DUAL_CARD.md`](DUAL_CARD.md) — measured 2× GPU configs (your starting point for derivation)
-- [`HARDWARE.md`](HARDWARE.md) — Ampere/Ada/Hopper notes, NVLink, power
-- [`UPSTREAM.md`](UPSTREAM.md) — vLLM PRs we depend on (incl. our [#40361 Marlin pad-sub-tile-n](https://github.com/vllm-project/vllm/pull/40361) which becomes more relevant at higher TP)
-- [`models/qwen3.6-27b/INTERNALS.md`](../models/qwen3.6-27b/INTERNALS.md) — head count + KV head structure (basis for the TP divisibility math above)
+- **[PCIE_P2P.md](PCIE_P2P.md)** — topology classes, NUMA, slots, BIOS, enabling P2P without NVLink.
+- **[KV_MATH.md](KV_MATH.md)** — predicting per-card VRAM before you boot.
+- **[PODS.md](PODS.md)** — running multiple instances on one host (the replication path).
+- **[BENCHMARKS.md](../BENCHMARKS.md)** — every measured row, cross-rig, with attribution.
+- **[DUAL_CARD.md](DUAL_CARD.md)** · **[SINGLE_CARD.md](SINGLE_CARD.md)** — the other topologies.

--- a/docs/MULTI_CARD.md
+++ b/docs/MULTI_CARD.md
@@ -115,12 +115,18 @@ own compose when the shipped `multi4` composes aren't your topology.
 
 ---
 
-## Replication vs tensor-parallel — the fork this page used to ignore
+## ⭐ Decide this first: replicate, or tensor-parallel?
+
+> **If you only read one section of this page, read this one.** Getting it wrong
+> costs up to **3.4×** aggregate throughput, and no amount of TP tuning further
+> down recovers it.
 
 Everything else on this page reasons in the **TP dimension**: how do I split one
 model across N cards? For **aggregate** throughput that is frequently the wrong
 question. If the model fits on one card, running **N independent instances**
 beats splitting it N ways — by a lot.
+
+**The rule: latency wants max TP, throughput wants max instances.**
 
 Measured by [@alesha-pro](https://github.com/noonghunna/club-3090/discussions/773)
 on 4× 3090 PCIe, all arms matched at 220 W, peak aggregate tok/s

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,9 @@ Start here if you want to run a model.
 | Doc | What it is |
 |---|---|
 | [`GETTING_STARTED.md`](GETTING_STARTED.md) | **Start here — 5-minute clone-to-curl path.** No decisions, no menus. |
+| [`LOCAL_AI_PRIMER.md`](LOCAL_AI_PRIMER.md) | New to local AI? Plain-English guide to hardware, engines and quantization before you pick anything. |
+| [`GLOSSARY.md`](GLOSSARY.md) | TPS, KV cache, MTP, TP, prefill vs decode — every term the other pages assume. |
+| [`WSL_SETUP.md`](WSL_SETUP.md) | Windows — running the stack on WSL2 from scratch. |
 | [`SINGLE_CARD.md`](SINGLE_CARD.md) | 1× RTX 3090 — workload → curated config → quick start. |
 | [`DUAL_CARD.md`](DUAL_CARD.md) | 2× RTX 3090 (PCIe / NVLink auto-detected) — workload → config → quick start. |
 | [`MULTI_CARD.md`](MULTI_CARD.md) | 3+ GPUs — TP scaling math, derivation from `dual.yml`, valid TP values. |

--- a/docs/SINGLE_CARD.md
+++ b/docs/SINGLE_CARD.md
@@ -1,14 +1,10 @@
 # Single 3090 — what fits, how to run it
 
-You have **one RTX 3090 (24 GB VRAM)**. This page is the front door for picking a config and knowing what to expect. The model-specific deep dives (quants, Genesis patches, engine internals) live elsewhere — links at the bottom.
+You have **one RTX 3090 (24 GB VRAM)**. This page gets you to a running config and tells you what it can't do. Deep dives (quants, engine internals, cliff mechanisms) are linked at the bottom.
 
-> **Model not in the configs below / want any HF safetensors repo?** → [`docs/PULL.md`](PULL.md): `scripts/pull.sh` evaluates any model against the KV math (honest, no download) and boots it if it passes. The curated configs on this page are the measured path; both work.
+> **Want a model that isn't listed here?** → [`PULL.md`](PULL.md): `scripts/pull.sh` evaluates any HF safetensors repo against the KV math without downloading, and boots it if it passes.
 
-## What actually runs on one 3090 today
-
-**Restructured 2026-08-12.** Every llama.cpp and ik-llama single-card slug was retired that day, and `ik-llama` left every recommendation walk. Those configs are still launchable with `--force` and their measurements are preserved further down — but they are no longer what this page recommends.
-
-On a **single RTX 3090 (sm 8.6)** the functional catalog is now three slugs, all vLLM:
+## What runs on one 3090 today
 
 | Model | Slug | Max ctx | Vision | Status |
 |---|---|--:|---|---|
@@ -16,290 +12,37 @@ On a **single RTX 3090 (sm 8.6)** the functional catalog is now three slugs, all
 | **Gemma-4-26B-A4B** | `vllm/gemma-26ba4b-single` | **176K** | off | ⚠️ caveats |
 | **Qwen3.6-27B** | `vllm/minimal` | **32K** | ❌ none | ✅ production |
 
-⭐ **If you have one 3090 and need long context, you no longer run Qwen — you run Gemma-4-12B.** That is the single biggest change on this page. Qwen3.6-27B's single-card ceiling went from 200K to **32K**, and its vision path is gone.
+⭐ **Need long context on one card? Run Gemma-4-12B, not Qwen.** Qwen3.6-27B's single-card ceiling is 32K and it has no vision path — its 200K llama.cpp / ik-llama routes were retired 2026-08-12 (still launchable, see [Escape hatches](#escape-hatches)).
 
-⚠️ **Two NVFP4 single-card slugs exist and are NOT usable here.** `vllm/qwen-27b-single-nvfp4` (64K) and `vllm/qwen-35b-a3b-single-nvfp4` (128K) both declare `required_sm=9.0`; a 3090 is **sm 8.6**, so the launcher and c3 correctly treat them as hardware-incompatible. They are for Hopper/Blackwell single-card rigs, not this page's hardware.
+⚠️ **The NVFP4 single-card slugs don't work here.** `vllm/qwen-27b-single-nvfp4` and `vllm/qwen-35b-a3b-single-nvfp4` declare `required_sm=9.0`; a 3090 is **sm 8.6**. They're for Hopper/Blackwell.
 
-### ⛔ The Cliff-2 escape is gone
-
-This matters more than the context numbers. Single-card **vLLM is unsafe for accumulating-context agent traffic** — Cliff 2b, validated 2026-05-03, hits at **~21–26K accumulated tokens** across 4–5 turns. The previous guidance routed that workload to `llamacpp/default` precisely because llama.cpp has no such cliff.
-
-**`vllm/minimal` is single-card vLLM.** So on one card there is now **no cliff-immune path for Qwen3.6-27B**. If your workload is hermes / openhands / OpenCode / Cline / Roo / OpenClaw / Aider / Cursor with retained context, the honest answers are:
-
-1. **Two cards** — `vllm/dual` (TP=2 escapes the cliff). See [DUAL_CARD.md](DUAL_CARD.md).
-2. **A different model** — the Gemma single-card slugs above are not Qwen3-Next and do not carry the DeltaNet GDN cliff.
-3. **`--force` a retired llama.cpp slug** — `bash scripts/switch.sh --force llamacpp/default`. It still works and is still cliff-immune; it is simply no longer recommended or maintained as a default.
-
-That third option is a real escape hatch, not a formality — but it is unsupported, so it is listed last.
+Models with **no** functional single-card config: `qwen3.6-40b-deckard`, `tess-4-27b`, `qwen3.8-27b`, `deepseek-v4-flash-0731`, `inkling-small`, `gemma-4-31b` — all dual or multi only.
 
 ---
 
-## ⚠️ Critical — read first if you're running an agentic coding client
+## ⚠️ Read this before you pick: accumulating-context agents
 
-If your workload is **hermes / openhands / OpenCode / Cline / Roo / OpenClaw / Aider / Cursor with retained context**, single-card vLLM is **not safe** as of 2026-05-03. You will hit a hardware-physical cliff at ~21-26K accumulated multi-turn context regardless of which single-card vLLM variant you pick. Validated across all six shipped single-card vLLM composes.
+If your workload is **hermes / openhands / OpenCode / Cline / Roo / OpenClaw / Aider / Cursor with retained context**, single-card vLLM is **not safe**. A hardware-physical cliff ("Cliff 2b") hits at **~21–26K accumulated tokens**, across 4–5 turns, on every single-card vLLM config. Validated 2026-05-03 across all six that shipped at the time — see [#41](https://github.com/noonghunna/club-3090/issues/41).
 
-Symptoms users report: "performance degrades after ~20 turns", "throughput drops to 0", "engine becomes unresponsive then 500s", "OOM after 4-5 turns". Same root cause — see [#41](https://github.com/noonghunna/club-3090/issues/41) for the full validation matrix.
-
-**Two safe paths for these workloads:**
+Symptoms: *"degrades after ~20 turns"*, *"throughput drops to 0"*, *"unresponsive then 500s"*, *"OOM after 4-5 turns"*. Same root cause each time. Mechanism: [`CLIFFS.md`](CLIFFS.md).
 
 | Have | Run | Why it works |
 |---|---|---|
-| 2× 3090 (any topology, NVLink optional) | `bash scripts/switch.sh vllm/dual` | TP=2 splits the failing kernel's working set across both cards. Validated PASS at v2 continuous soak; 111+ TPS p50 decode. |
-| 1× 3090 only — **a different model** | `bash scripts/switch.sh vllm/gemma-12b-single-int8-mtp` | Gemma-4 is not Qwen3-Next: no DeltaNet GDN kernel, so this cliff does not exist on it. **256K** single-card. The straightforward answer if the workload does not specifically need Qwen. |
-| 1× 3090 only — **must be Qwen** | `bash scripts/switch.sh --force llamacpp/default` | ⚠️ **RETIRED 2026-08-12** — needs `--force`, is hidden from `--list`, and is no longer maintained as a default. It still works and is still cliff-immune (different engine, different GDN kernel, different allocator; 200K, ~51 / 60 TPS). Listed because it is a genuine escape hatch, not because it is supported. |
-| 1× 3090 only — supported Qwen path | `bash scripts/switch.sh vllm/minimal` | ⛔ **Does NOT escape the cliff** — this IS single-card vLLM. 32K ctx, no vision. Safe only for workloads that do not accumulate context. |
+| 2× 3090 (any topology) | `bash scripts/switch.sh vllm/dual` | TP=2 splits the failing kernel's working set across both cards. Soak PASS, 111+ TPS p50 decode. → [DUAL_CARD.md](DUAL_CARD.md) |
+| 1× 3090, **a different model** | `bash scripts/switch.sh vllm/gemma-12b-single-int8-mtp` | Gemma-4 isn't Qwen3-Next — no DeltaNet GDN kernel, so the cliff doesn't exist. **256K.** The straightforward answer unless you specifically need Qwen. |
+| 1× 3090, **must be Qwen** | `bash scripts/switch.sh --force llamacpp/default` | Retired but genuinely cliff-immune — different engine, different kernel, different allocator. 200K. Unsupported; see [Escape hatches](#escape-hatches). |
+| 1× 3090, supported Qwen path | `bash scripts/switch.sh vllm/minimal` | ⛔ **Does NOT escape the cliff** — this *is* single-card vLLM. Safe only for workloads that don't accumulate context. |
 
-Neither acceptable? Two single-card vLLM mitigations: (a) cap session context at <15K via app-layer rolling summarization, OR (b) accept periodic engine restarts. **Mem-util tuning, MTP-off, and `max-num-batched-tokens` adjustments do not close it** — all tested. The cliff is in `chunk_gated_delta_rule_fwd`'s simultaneous live-tensor set (~500 MiB at T=4128) which doesn't fit alongside accumulated KV + model + workspace on a 24 GB card.
+⚠️ **Tuning does not close this.** Mem-util, MTP-off and `max-num-batched-tokens` were all tested and none of them work. The only app-layer mitigations are capping session context below ~15K via rolling summarization, or accepting periodic engine restarts.
 
-A Genesis sidecar fix (streaming refactor) is being filed with Sandermage. ETA 2-4 weeks if accepted. This section will be updated when it ships.
-
-> ⚠️ **2026-05-05 update — Genesis v7.72.2's PN59 streaming-GDN doesn't close it.** Sander shipped PN59 advertising it as the structural Cliff 2b fix, but the eligibility check rejects calls with `chunk_indices`/`chunk_offsets` populated — which vLLM's mandatory `--max-num-batched-tokens 4128` always sets on 24 GB single-card configs. PN59 falls through to vanilla code which OOMs at the same site. Filed at [Sandermage/genesis-vllm-patches#22](https://github.com/Sandermage/genesis-vllm-patches/issues/22) with reproducer + 4 fix proposals; pending Sander review. **The two safe paths above remain the recommendation.**
-
-For workloads that **don't** accumulate context across turns (single-shot RAG, simple chat, batch processing), single-card vLLM is fine — see the table below.
-
----
-
-## 📜 Historical — the retired single-card lineup (measurements preserved)
-
-> ⛔ **The four vLLM rows below are struck through — they're pinned to a purged vLLM nightly ([#167](https://github.com/noonghunna/club-3090/issues/167)) and won't boot until the next Genesis-compatible pin lands.** Until then, use the **llama.cpp / ik_llama** rows — they work today and are cliff-immune. (`minimal.yml` is Genesis-free and *can* still run on a current image via `VLLM_IMAGE=vllm/vllm-openai:latest`.)
-
-> 🎯 **Don't want to choose?** `bash scripts/switch.sh qwen3.6-27b/default` resolves the single-card default automatically — since 2026-08-12 that is **`vllm/minimal`** (`ENGINE_PREFERENCE[single]` is now `llamacpp > vllm`; `ik-llama` was removed from every walk when its last functional slug was retired, and llama.cpp has no functional single-card qwen slug left, so the walk falls through to vLLM). ⚠️ `qwen3.6-27b` was also dropped from `RECOMMENDED_DEFAULT_MODELS`, so a bare `bash scripts/launch.sh` no longer auto-selects it on one card. Pin your own with `--set-default <slug>`; see the [FAQ](FAQ.md#how-do-i-set-my-own-default-config).
->
-> 📜 **The table below is a historical record.** Every row in it is either blocked (#167) or retired (2026-08-12). The numbers were really measured and are kept for the audit trail — but for what to actually run, use the three-slug table at the top of this page.
-
-| What you're doing | Compose | Max ctx | Narr / Code TPS | VRAM (24 GB / card) |
-|---|---|---|---|---|
-| ⛔ ~~**Long ctx + vision** (chat, agents, image input)~~ _(vLLM — blocked #167)_ | ~~[`long-vision.yml`](../models/qwen3.6-27b/vllm/compose/single/autoround-int4/long-vision.yml)~~ | ~~145K~~ | ~~50 / 66~~ | ~~23.0 GB~~ |
-| ⛔ ~~**Long ctx, text-only — Balanced MTP** (RAG, codebase, IDE agents)~~ _(vLLM — blocked #167)_ | ~~[`long-text.yml`](../models/qwen3.6-27b/vllm/compose/single/autoround-int4/long-text.yml)~~ | ~~180K~~ | ~~50 / 67~~ | ~~22.3 GB~~ |
-| ⛔ ~~**Long ctx, text-only — Max-context** (long single-shot RAG / codebase analysis)~~ _(vLLM — blocked #167)_ | ~~[`long-text-no-mtp.yml`](../models/qwen3.6-27b/vllm/compose/single/autoround-int4/long-text-no-mtp.yml)~~ | ~~200K~~ | ~~no MTP~~ | ~~21.0 GB~~ |
-| ⛔ ~~**Bounded thinking** (coding agents, structured-CoT — see [STRUCTURED_COT.md](STRUCTURED_COT.md))~~ _(vLLM — blocked #167)_ | ~~[`bounded-thinking.yml`](../models/qwen3.6-27b/vllm/compose/single/autoround-int4/bounded-thinking.yml)~~ | ~~180K~~ | ~~50 / 66~~ | ~~21.7 GB~~ |
-| **Bulletproof, no cliffs** (production service, unpredictable inputs) | [`llamacpp/default`](../models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/mtp.yml) (alias of `llamacpp/mtp`) | **200K** (via `-ub 512`) | 52 / 61 | ~23 GB |
-| **llama.cpp + MTP, fast + long ctx** ⭐ (IDE agents, opencode, Hermes, long-multi-turn agentic; `CTX_SIZE=131072 UBATCH_SIZE=1024` for faster prefill) | [`llamacpp/mtp`](../models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/mtp.yml) | **200K** | **51 / 60** | ~22.5 GB |
-| **llama.cpp + MTP + vision** (multimodal chat, screenshot-debugging, vision-aware review) | [`llamacpp/mtp-vision`](../models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/mtp-vision.yml) | **49K** | **57 / 66** | ~20.5 GB |
-| **ik_llama + IQ4_KS + MTP** ⭐ (fastest single-card + leanest VRAM; advanced-quant track) | [`iq4ks-mtp`](../models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/mtp.yml) | **200K** | **~60 / ~69** | **~22 GB** (leanest) |
-| **ik_llama + IQ4_KS + MTP + vision** | [`iq4ks-mtp-vision`](../models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/mtp-vision.yml) | **160K** | TBD | ~21 GB |
-| **ik_llama + two-stage spec-dec** ⭐ (ngram+MTP, code-optimized) | [`iq4ks-two-stage`](../models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/two-stage.yml) | **200K** | **~59 / ~98** (code +35% vs MTP-only) | ~22 GB |
-| **Small-context vLLM safe path** ([@stiggy2k16](https://github.com/noonghunna/club-3090/issues/43) data point) — IDE agents capped at <60K accumulated, when you need vLLM speed but llama.cpp is too slow. ⚠️ Genesis-free, but its default pin is purged (#167) — run it with `VLLM_IMAGE=vllm/vllm-openai:latest` until the pin's bumped | [`minimal.yml`](../models/qwen3.6-27b/vllm/compose/single/autoround-int4/minimal.yml) at `--gpu-memory-utilization 0.95 --max-model-len 65536` | **64K** | ~32 / ~33 (no MTP) | ~22.4 GB |
-
-Run via `bash scripts/launch.sh` (interactive) or `bash scripts/switch.sh <variant>`.
-
-> ## ⚠️ Two cliffs to know — both same root kernel, different triggers
->
-> ### Cliff 2a — single-prompt OOM (mostly closed on v7.69) ✅
->
-> **Pre-v7.69:** vLLM single-card variants crashed on single prompts >~50K tokens.
->
-> **Post-v7.69 + vllm#35975 + 0.93 mem-util (Balanced MTP) or MTP-off + 0.95 (Max-context):** **60K single-prompt now passes cleanly** (verified HTTP 200, recall correct, AL=4.00 on Balanced MTP). 90K is past wall-clock-feasible on this hardware. For prompts >60K, use `dual-turbo.yml` (TP=2 splits state) or `llamacpp/default` (200K, different engine).
->
-> The fix combines [vllm#35975](https://github.com/vllm-project/vllm/pull/35975) (skip `inputs_embeds` GPU buffer for text-only models, frees ~444 MiB at boot) with mem-util tuning to free activation headroom for the late-stage 50 MiB allocation that previously fired the cliff.
->
-> ### Cliff 2b — accumulated-context OOM under multi-turn agent traffic (NOT closed) ❌
->
-> Same kernel, different trigger. The 50 MiB `chunk_fwd_o → torch.empty_like(v)` allocation also fails when accumulated multi-turn KV cache + GDN forward live-tensor cascade peaks above 24 GiB on a single card. Hits at **~21-26K accumulated tokens** across 4-5 turns of hermes/openhands/OpenCode/Cline/OpenClaw — not just at 50-60K single prompts. Validated 2026-05-03 across all six shipped single-card vLLM composes; only `vllm/dual` (TP=2) and `llamacpp/default` survive. See the critical warning at the top of this page.
->
-> Why this isn't tunable at the config layer: Codex investigation showed the simultaneous live-set of `chunk_gated_delta_rule_fwd` is ~500 MiB at T=4128 (q/k/v/u/v_new/o/w/A/Ai/h tensors all alive at once). Adding accumulated KV + model + workspace + MTP draft puts the per-card peak above 24 GiB. The fix has to be at the kernel level — streaming/pooling these intermediates rather than holding them simultaneously. That's an upstream PR target, not a config knob.
-
-> ### What was Cliff 1 mech B (now closed) ✅
->
-> Earlier in 2026-05 we tracked an inductor compile-path FFN intermediate buffer leak ([club-3090 #16](https://github.com/noonghunna/club-3090/issues/16)) that crashed long-* variants on real IDE-agent prompts. **Closed 2026-05-02** via Genesis PN25 (Inductor-safe `silu_and_mul` opaque op) + PN30 (DS conv state dst-shaped temp fix). Both fixes ship by default in our composes; ChatGPT/Codex CLI cross-check helped land the PN30 dst-shaped temp variant. No user action needed — a fresh `bash scripts/setup.sh qwen3.6-27b` picks up the fixes automatically.
-
----
-
-## Measured TPS on single 3090
-
-![Qwen3.6-27B TPS — single 3090 configs](img/performance-single.png)
-
-Bench protocol: 3 warm + 5 measured runs of the canonical narrative + code prompts on each config. Substrate: vLLM nightly `0.20.1rc1.dev16+g7a1eb8ac2` + Genesis v7.69 dev tip (commit `2db18df`), with local backports `patch_inputs_embeds_optional.py` (vllm#35975) and `patch_tolist_cudagraph.py`. llama.cpp mainline `0d0764dfd`, RTX 3090 sm_86 PCIe-only at 230 W. Per-config run-by-run + VRAM peaks: [models/qwen3.6-27b/CHANGELOG.md](../models/qwen3.6-27b/CHANGELOG.md).
-
----
-
-## VRAM budget on 24 GB
-
-![Per-card VRAM allocation, single-card configs](img/vram-budget-single.png)
-
-What this says about single-card constraints:
-
-- **Model weights** consume ~14 GB (AutoRound INT4 / GGUF Q3_K_XL). Half the card.
-- **KV cache** is the next biggest line; its size depends on `--kv-cache-dtype` × ctx. fp8 ≈ 1 byte/token/(layer×head); TQ3 ≈ 0.4 bytes/token/(layer×head); fp16 ≈ 2 bytes/token/(layer×head).
-- **Vision tower** (mmproj) costs ~0.5–1.0 GB extra when on.
-- **Activations + cudagraph pools** is what's left. **2026-05-02 PM (v7.69 + vllm#35975 backport + Cliff 2 60K closed)** — settled at **180K + 0.93 (long-text Balanced MTP)**, **200K + 0.95 (long-text-no-mtp Max-context)**, **180K + 0.95 (bounded-thinking)**, and **145K + 0.95 (long-vision)** after v7.69 closed three v7.66/v7.68 regressions and the local #35975 backport freed ~444 MiB by skipping the text-only inputs_embeds GPU buffer. Both Cliff 1 mech B AND Cliff 2 60K are now CLOSED on TQ3 single-card. See [`docs/CLIFFS.md`](CLIFFS.md).
-
-For the cross-card TP=2 picture, see [`DUAL_CARD.md`](DUAL_CARD.md).
-
----
-
-## Pick a config
-
-> 📜 **This whole section is historical as of 2026-08-12.** The three vLLM configs below are blocked on [#167](https://github.com/noonghunna/club-3090/issues/167); the llama.cpp and ik_llama configs below them were **retired** and now need `--force`. Nothing here is a current recommendation.
->
-> **For what to run today, see [What actually runs on one 3090 today](#what-actually-runs-on-one-3090-today) at the top.** The per-config detail below is kept because the measurements, VRAM figures and tuning rationale are real and still inform anyone using these configs via `--force`.
-
-### ⛔ Long ctx + vision — `long-vision.yml` _(vLLM — blocked #167)_
-
-**Workload:** chat with images, vision-aware coding agents, multimodal RAG. Anything where the user might paste a screenshot.
-
-145K + vision tower + TQ3 KV + DS layout + Genesis MTP n=3 + full v7.69 patch stack (PN12 + PN17 + PN25 + PN30 part3 + PN26b + P38B + P15B + PN33 + PN32 GDN chunked-prefill) at mem-util 0.95. `verify-stress.sh`: full 7/7 probes pass on text-only paths post-v7.69; vision tower's persistent ~1 GB tightens single-prompt envelope vs long-text. Code 66 / narr 50 TPS (n=5, CV 2-4%), AL 3.40-3.56.
-
-### ⛔ Long ctx, text-only — Balanced MTP — `long-text.yml` _(vLLM — blocked #167)_
-
-**Workload:** RAG ingest, codebase analysis, book/document Q&A, IDE coding agents (Cline / OpenCode / Roo / Claude Code / Cursor), long conversations. _(Was the steady-state default; while #167 blocks it, use `llamacpp/default` below.)_
-
-180K + no vision + TQ3 KV + DS layout + MTP K=3 + same v7.69 patch stack + local vllm#35975 backport at mem-util 0.93. **60K single-prompt PASS @ 623s wall** (HTTP 200, recall correct, AL=4.00). Code 67 / narr 50 TPS (n=5, CV 2.6%), AL 3.34-3.51. **IDE-agent prompts AND big single prompts up to 60K both work cleanly here.**
-
-### ⛔ Long ctx, text-only — Max-context — `long-text-no-mtp.yml` _(vLLM — blocked #167)_
-
-**Workload:** one-shot >50K input where you can wait, don't need MTP, and want maximum KV pool capacity.
-
-200K + no vision + TQ3 KV + DS layout + MTP **off** + same v7.69 patch stack + local vllm#35975 backport at mem-util 0.95. **60K single-prompt PASS @ 537s wall** (HTTP 200, recall correct). Decode is slower without spec-decode (~33 narr / ~40 code TPS estimated; canonical bench pending). Use only when steady-state TPS isn't the priority and you need the extra KV headroom.
-
-### 📜 RETIRED — Bulletproof / no cliffs — `llamacpp/default` _(needs `--force`)_
-
-**Workload:** production service for unpredictable users. Inputs that might be 5K or might be 200K. Tool returns that might be 1K or might be 50K. Anywhere "predictable behavior" beats "peak TPS."
-
-`bash scripts/switch.sh --force llamacpp/default` (alias of `llamacpp/mtp`, collapsed 2026-05-22). Q4_K_M MTP GGUF (`unsloth/Qwen3.6-27B-MTP-GGUF`) + q4_0 KV + MTP `n=2` at **200K** (max-safe — fills cleanly with ~1.1 GB margin; 262K *boots* but walls ~125K, see [`docs/CLIFFS.md`](CLIFFS.md)). No vision — use `llamacpp/mtp-vision` for multimodal. Different attention library entirely (ggml-cuda, not FA2) → no Cliff 1 mechanism, no Cliff 2 mechanism. **~52 / 61 TPS** — slower than vLLM dual but cliff-immune. Quant family validated by [Benjamin Marie's Kaitchup eval](https://kaitchup.substack.com/p/summary-of-qwen36-gguf-evals-updating).
-
-### 📜 RETIRED — llama.cpp + MTP, fast + long ctx — `llamacpp/mtp` _(needs `--force`)_
-
-**Workload:** IDE agents (opencode, Cline), Hermes, multi-turn agentic. The single-card sweet spot for "fast enough + plenty of context + bulletproof."
-
-`bash scripts/switch.sh --force llamacpp/mtp`. Q4_K_M MTP-enabled GGUF (`unsloth/Qwen3.6-27B-MTP-GGUF`) + q4_0 KV + MTP `n=2` + `-ub 1024`. Mainline llama.cpp build 9235 (PR #22673 MTP merged). **~51 narr / ~60 code TPS** — ~2.5× faster than `llamacpp/default`, only marginally slower than vLLM single-card paths *and* without the cliffs. **Quality 102/150 (68%) on the 8-pack matrix beats every Qwen vLLM dual config in [#119](https://github.com/noonghunna/club-3090/discussions/119)**; **aider-polyglot 17/30 exactly matches Qwen vLLM bf16 dual on half the hardware**. **Verify-stress 7/7** including 60K + 91K needle recall — the Cliff 2 narrative is **config-driven, not architectural**: at this config the model walks past 91K cleanly on a single 3090. No vision (mmproj cost trades against KV pool); for multimodal, use `llamacpp/mtp-vision` below.
-
-### 📜 RETIRED — llama.cpp + MTP + vision — `llamacpp/mtp-vision` _(needs `--force`; was the ONLY single-card vision path)_
-
-**Workload:** multimodal chat, screenshot-debugging, vision-aware code review, UI-screenshot agents. The first stack profile combining MTP + vision on a single 3090 (the older "strip mmproj when MTP" rule was obsolete on build 9235 — sweep-verified 2026-05-19).
-
-`bash scripts/switch.sh --force llamacpp/mtp-vision`. Same Q4_K_M MTP GGUF + q4_0 KV + MTP `n=2` + `-ub 1024`, **with `--mmproj mmproj-F16.gguf` mounted**. Ctx 49K is the **speed-optimal** default (vision overhead trades against KV pool). **~57 narr / ~66 code TPS** (text path), vision overhead paid once at image-encode, not per decoded token. Verify-stress 7/7 at this config.
-
-> **Need more context for agentic vision workloads?** Drop `-ub 1024 → 512` and you can push ctx to **192K** with full cliff coverage (verify-stress 7/7 incl. 91K needle), at the cost of ~10% TPS:
-> ```bash
-> UBATCH_SIZE=512 CTX_SIZE=196608 bash scripts/switch.sh --force llamacpp/mtp-vision
-> ```
-> Sweep data + reasoning in [`models/qwen3.6-27b/llama-cpp/README.md`](../models/qwen3.6-27b/llama-cpp/README.md#speed-vs-context--pick-your-trade-off). Surfaced 2026-05-20 by @JensJN in [#170](https://github.com/noonghunna/club-3090/discussions/170).
-
-### 📜 RETIRED — ik_llama + IQ4_KS + MTP — `iq4ks-mtp.yml` _(needs `--force`)_
-
-**Workload:** best quality-per-bit GGUF on a single 3090. Same cliff-immunity as llama.cpp (same ggml memory model), but with fork-exclusive IQK imatrix quants that beat mainline Q4_K_M on perplexity.
-
-ubergarm `Qwen3.6-27B-MTP-IQ4_KS.gguf` (IQK imatrix quant, built-in MTP head) + q4_0 KV + `-khad`/`-vhad` (Hadamard K+V cache transforms) + MTP `n=2` + `--merge-qkv` + `--parallel-tool-calls` (ik-exclusive). **200K context** (max-safe default; native max 262K) on one 3090. At matched 370 W it's **~18–20% faster than `llamacpp/mtp`** on TPS (~60 narr / ~69 code vs ~50 / ~58), quality-tied (8-pack 103 vs 102), and **~0.5–0.8 GB leaner** — the faster *and* leaner single-card path. (A 2026-05-22 "tie" was a wrong-engine measurement artifact — corrected 2026-05-23 via a power-cap-controlled A/B, [#184](https://github.com/noonghunna/club-3090/discussions/184).) Engine: `ghcr.io/ikawrakow/ik-llama-cpp` (digest-pinned `cu13-server` build). See [`docs/engines/IK_LLAMA.md`](engines/IK_LLAMA.md) for the full deep dive.
-
-### 📜 RETIRED — ik_llama + IQ4_KS + MTP + vision — `iq4ks-mtp-vision.yml` _(needs `--force`)_
-
-Same as above with `--mmproj mmproj-F16.gguf` mounted for multimodal input. 160K context (vision tower trades against KV pool).
-
-### 📜 RETIRED — ik_llama + two-stage spec-dec — `iq4ks-two-stage.yml` _(needs `--force`)_
-
-**Workload:** code-heavy agentic workloads where context has repeated patterns (refactoring, test generation, boilerplate).
-
-Chains ngram self-spec (catches repeated code spans, near-zero compute) with the MTP head as fallback for novel tokens. PR [#1789](https://github.com/ikawrakow/ik_llama.cpp/pull/1789) (merged 2026-05-15). **Tuned + measured on 1× 3090 (2026-05-24):** at the shipped defaults `ngram-mod n_max=4` + `MTP n_max=3`, decode is **~59 narr / ~98 code TPS** — narrative tied with `iq4ks-mtp` (~60), code **+35%** (97.8 vs 72.4 in a matched same-session A/B). ngram `n_max` was swept {2,3,4,5,8,16}: code decode is an inverted-U peaking at 4 (16→81.5, 8→90.4, **4→97.8**, 2→78.8) — too-long drafts waste verify compute, too-short ones stop matching code spans. The per-step recurrent checkpoint stays ~0.6 GB at n_max=4 (raising it OOMs → slow gpu-fallback re-decode; see the compose header). **Quality is lossless** (spec-dec): 8-pack 98/150 == MTP-only's 100/150, and aider-polyglot 16/30 == MTP-only's 19/30 — both within single-run noise; verify-full all green. **Ships 200K** (same as `iq4ks-mtp`): verify-stress fills to 183K with correct needle recall at every rung; the ceiling VRAM margin (~833 MB) is just under the 1024 MB sustained-agent-load guard, so for heavy agentic use right at the ceiling set `CTX_SIZE=180224` (~1.4 GB) or `163840` (~1.9 GB). **Use this for code; `iq4ks-mtp` for balanced/prose** — they're the two ⭐ single-card picks, same 200K ctx, two-stage ~0.8 GB leaner. See [`docs/engines/IK_LLAMA.md`](engines/IK_LLAMA.md) "Two-stage spec-dec" section.
-
----
-
-## Other variants in the repo (not recommended for shipping)
-
-These exist for troubleshooting, niche workloads, or historical comparison. Not promoted as primary because the long-* variants now cover their use cases:
-
-- **`tq3-mtp.yml`** — 48K + TQ3 + vision, mem-util 0.92. The "below both cliffs by definition" baseline (engine HTTP-400-rejects requests >48K, so Cliff 2 is unreachable). Useful when you want bulletproof error behavior on a specific small-ctx workload, or as a fast-boot diagnostic. Most users should pick `long-vision` or `llamacpp/default` instead.
-- **`tools-text.yml`** — 75K + FP8 KV + PN8. Was the only Cliff-1-safe single-card path before PN12 anchor fix landed. FP8 KV is closer in quality to FP16 than TQ3 is, so kept around for accuracy-sensitive comparisons. Most IDE-agent workloads now run fine on `long-text.yml`.
-- **`minimal.yml`** — 32K + FP8 + no Genesis + no spec-decode. Stripped-down stack for isolating "is this a Genesis bug?" questions. Half the throughput of any other variant.
-
-## Watch list — Luce DFlash + PFlash (not yet a recommendation)
-
-Re-tested **2026-05-20** against [`Luce-Org/lucebox-hub`](https://github.com/Luce-Org/lucebox-hub) HEAD `248e191` on Qwen3.6-27B Q4_K_M target + the released [`Lucebox/Qwen3.6-27B-DFlash-GGUF`](https://huggingface.co/Lucebox/Qwen3.6-27B-DFlash-GGUF) draft. **The 3.6 draft has shipped and PFlash now exists in the binary — but Luce still loses to [`llamacpp/mtp`](../models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/mtp.yml) (v0.8.3) on every realistic workload except greedy-only code:**
-
-Measured TPS on this rig (RTX 3090, single-stream, n_gen=1000):
-
-| Workload | Luce DFlash @ temp=0.0 (greedy) | Luce DFlash @ temp=0.6 (realistic) | **llamacpp/mtp (any temp)** |
-|---|---|---|---|
-| Narrative essay | 37–47 TPS (mean ~40) | ~20 TPS (DDTree silent → AR-equivalent) | **51 TPS** ⭐ |
-| Code (heap/LRU/AST) | 63–76 TPS (mean ~72) | ~20 TPS | **60 TPS** |
-| AL (code) | 5.9–7.1 | n/a (DDTree off) | 3.4 (MTP) |
-
-What works at HEAD 248e191:
-- ✅ **Tool calls** via native Qwen3 path (no `server_tools.py` patch needed anymore).
-- ✅ **Streaming SSE** with `reasoning_content` deltas.
-- ✅ **Daemon mode** with cache-reuse for fast cold starts.
-- ✅ **PFlash compresses at small source ctx** — verified 2026-05-20: 12K source → 1011 tokens kept (8.2%) → 3.3s response. PFlash drafter (Qwen3-0.6B BF16) loads cleanly when max-ctx ≤ 16K. No truncation when prompt format avoids tight-instruction phrasings.
-
-What still keeps it off the recommended list (re-confirmed 2026-05-20):
-- ❌ **Greedy only.** At temp > 0, DDTree silently disables and decode collapses to ~20 TPS (AR-equivalent). Kills chat / IDE-agent / creative-writing workloads. This is THE shipping gate.
-- ❌ **Loses to llamacpp/mtp at realistic temperatures.** 20 t/s vs 51–60 t/s — AND llamacpp/mtp ships clean via `ghcr.io/ggml-org/llama.cpp:server-cuda` (no source build, no Python+CUDA toolchain).
-- ❌ **PFlash on single 3090 is structurally constrained via the C++ HTTP server.** Drafter (1.43 GB) + target + KV + DDTree workspace = OOM at max-ctx ≥ 32K. Working ceiling is max-ctx=16K → caps source prompts at 16K, far below the headline 128K claim. Luce's published 128K bench is via different binaries (Python `server.py` or `test_dflash`), not the production HTTP server we'd ship. Dual GPU may unlock the C++ HTTP path at long source ctx — untested.
-- ❌ **Verify-stress prompt format triggers premature EOS at long-ctx + greedy.** "Reply with only the phrase, no other text" returns one word; rephrased prompts recall correctly. Same shape as Luce upstream [#121](https://github.com/Luce-Org/lucebox-hub/issues/121) (closed via PR #128, which IS in our build) but extends to the non-PFlash + FP16-KV path. Not a script bug; a Luce + greedy + tight-instruction interaction.
-- ❌ **No vision** tower.
-- ❌ **`enable_thinking` chat_template_kwargs handled differently** than vLLM — verify-full check 6 fails.
-- ❌ **Daemon-mode hang at long source ctx.** Observed 2026-05-20: the first ≥50K request can lock the GPU for minutes, blocking subsequent requests; cleared by server restart.
-- ❌ **Build fragility** — fresh `git clone` of `dflash` requires `git submodule update --init`, plus `-DCMAKE_CUDA_ARCHITECTURES=86 -DDFLASH27B_ENABLE_BSA=ON`. No upstream docker image.
-
-**Re-test triggers (any one would change the verdict):**
-- Luce upstream adds non-greedy sampling support to DDTree (single biggest unblock — opens chat/IDE workloads)
-- Luce-Org publishes an official docker image (removes build/toolchain burden, satisfies the club-3090 "image pulls and runs" substrate)
-- Luce's C++ HTTP server validates source length **after** PFlash compression (would let single 3090 reach the 128K source claim through the production server)
-- We add a dual-GPU compose target and confirm PFlash drafter fits
-
-Track in [`docs/UPSTREAM.md`](UPSTREAM.md#luce-dflash-luce-orglucebox-hub).
-
----
-
-## What single-card can't do
-
-| Want | Why not on 1× | What you'd need |
-|---|---|---|
-| 4 concurrent streams at 262K + vision | KV pool too small for 4 × full ctx | TP=2 (see DUAL_CARD.md) |
-| Peak code TPS (>100 TPS on quicksort prompt) | DFlash N=5 needs head_size=256 + non-causal — vLLM head-dim split | TP=2 + DFlash |
-| Single-prompt >60K tokens on Qwen3.6-27B | Cliff 2 (DeltaNet GDN forward), no fix yet | TP=2 (`vllm/dual`), OR a non-Qwen3-Next model (`vllm/gemma-12b-single-int8-mtp`, 256K), OR `--force llamacpp/default` (retired 2026-08-12, still cliff-immune) |
-
----
-
-## Common pitfalls (single-card specifics)
-
-### Prefill cliffs
-
-- **Cliff 1** — FFN intermediate-buffer activation peak (138 MiB allocate at `intermediate_size × max-num-batched-tokens`). Historically fired on long-ctx composes at >0.95 mem-util when prefill batch needed the buffer. **Closed on `tools-text.yml`** (FP8 KV path) since 2026-04-29 via Genesis PN8. **Closed on TQ3 paths** on v0.20 + Genesis v7.65+ since 2026-05-01 via PN12 + PN17 + P38B in-source hooks. **Mech B closed** 2026-05-02 (v7.66 + PN25 v3 + PN30 dst-shaped) — see [`docs/CLIFFS.md`](CLIFFS.md).
-- **Cliff 2** — DeltaNet GDN forward OOM. **Closed at 60K single-prompt** as of 2026-05-02 PM via Genesis v7.69 (PN32 GDN chunked-prefill + P103 worker self-install) plus a local backport of vllm#35975 (skip text-only `inputs_embeds` GPU buffer, ~444 MiB freed). Two shippable variants: `long-text.yml` (Balanced MTP, 180K + 0.93) and `long-text-no-mtp.yml` (Max-context, 200K + 0.95). >60K still hits the 24 GB hardware-physical wall — for those prompts use dual-card TP=2 (verified 237K) or llama.cpp single-card (200K, different engine).
-
-### VRAM peak vs idle
-
-`nvidia-smi` at boot ≠ peak. Boot shows weights + KV pool reservation. **Peak adds activation buffers during prefill** — typically +500-1500 MiB. If `nvidia-smi` shows 23.5/24 GB at idle, you have ~500 MiB for prefill activations — not enough for the 138 MiB-class buffer at long ctx. Drop mem-util by 0.03 if you need the headroom.
-
-### Tool-call extraction needs `--enable-auto-tool-choice`
-
-vLLM ships this off by default. Our composes set `--tool-call-parser qwen3_coder` + `--enable-auto-tool-choice`. If you're rolling your own compose, both are required.
-
-### Running alongside a desktop / sub-24 GB usable VRAM
-
-The compose defaults are calibrated for **headless** 3090 (no display server, no other GPU consumers). If you're running on a workstation where the same GPU also drives a desktop session — or your card has slightly less effective VRAM (e.g., some 4090s land at ~23.5 GB usable with X server overhead) — the default `max-model-len` may exceed your KV-cache budget at default `gpu-memory-utilization`.
-
-Two env-override knobs available on every vLLM compose (defaults preserved if unset):
-
-```bash
-MAX_MODEL_LEN=32768 \
-GPU_MEMORY_UTILIZATION=0.80 \
-  bash scripts/switch.sh vllm/minimal
-```
-
-- `MAX_MODEL_LEN` — shrink the KV-cache budget; trades long-context for fit. `90000` is a safe value for `long-text.yml` on rigs with ~1 GB of overhead (4090 with display, etc.). Validated on @laurimyllari's 4090 ([disc #62](../../../noonghunna/club-3090/discussions/62)).
-- `GPU_MEMORY_UTILIZATION` — reserve a percentage of VRAM for non-vLLM GPU consumers. **Stay in `0.85-0.92` range** for TQ3 KV paths on 24 GB Ampere. `0.80` is generally too aggressive — vLLM's profiling phase eats more than the saved 0.05 budget and reports `No available memory for the cache blocks` at engine init. fp8 KV paths (`tools-text.yml`, `dual.yml`) tolerate `0.80` better.
-
-Generally prefer **dropping `MAX_MODEL_LEN` first** (clean KV budget reduction, predictable behavior) over `GPU_MEMORY_UTILIZATION` (interacts with profiling overhead in non-obvious ways). Drop both if your envelope is really tight.
-
-### Running two llama.cpp / ik variants at once
-
-Each variant ships a **distinct default `container_name`** (`llamacpp/mtp` → `llama-cpp-qwen36-27b`, `llamacpp/mtp-vision` → `llama-cpp-qwen36-27b-vision`; ik's `iq4ks-mtp` / `-vision` / `-two-stage` likewise), so they no longer collide on the docker name. They **do** still share the default host port `8020`, so give the second one a port with `ESTATE_PORT` (and, if you want a custom name, `ESTATE_CONTAINER`):
-
-```bash
-# text workhorse on :8020 + vision variant on :8030, side by side
-bash scripts/switch.sh --force llamacpp/mtp
-ESTATE_PORT=8030 bash scripts/switch.sh --force llamacpp/mtp-vision
-```
-
-(Whether both fit depends on your VRAM envelope — two full-context single-card servers won't co-reside on one 24 GB card; drop `CTX_SIZE` on one, or use this across two cards.)
+For workloads that **don't** accumulate context — single-shot RAG, simple chat, batch processing — single-card vLLM is fine.
 
 ---
 
 ## Quick start
 
 ```bash
-# 1. Setup (downloads model, clones Genesis, ~20 min cold)
+# 1. Setup (downloads weights, ~20 min cold)
 bash scripts/setup.sh qwen3.6-27b
 
 # 2. Pick + boot via wizard (asks model + GPUs, projects VRAM budget)
@@ -308,8 +51,6 @@ bash scripts/launch.sh
 # 3. Or skip the wizard:
 bash scripts/launch.sh --variant qwen3.6-27b/default  # resolves to vllm/minimal
 bash scripts/launch.sh --variant vllm/minimal         # same thing, named explicitly (32K, no vision)
-# Retired-but-working single-card slugs need --force (see the table at the top of this page):
-#   bash scripts/switch.sh --force llamacpp/default    # 200K, cliff-immune, unmaintained
 
 # 4. Sanity test
 curl -sf http://localhost:8020/v1/chat/completions \
@@ -318,31 +59,91 @@ curl -sf http://localhost:8020/v1/chat/completions \
 
 # 5. Switch later without re-running setup
 bash scripts/switch.sh vllm/minimal        # for example
-bash scripts/switch.sh --list              # show all variants (--all to include retired)
+bash scripts/switch.sh --list              # every launchable variant (--all includes retired)
 ```
+
+Guided 5-minute version, no decisions: [`GETTING_STARTED.md`](GETTING_STARTED.md).
 
 ---
 
-## Models supported on single 3090
+## What single-card can't do
 
-| Model | Single-card slug | Max ctx | Notes |
-|---|---|--:|---|
-| **[Gemma-4-12B](../models/gemma-4-12b/)** ⭐ | `vllm/gemma-12b-single-int8-mtp` | **256K** | The long-context single-card pick. Not Qwen3-Next → no GDN cliff. |
-| **[Gemma-4-26B-A4B](../models/gemma-4-26b-a4b/)** | `vllm/gemma-26ba4b-single` | 176K | Needs the vendored PR #40391 per-token-head-KV overlay. |
-| **[Qwen3.6-27B](../models/qwen3.6-27b/)** | `vllm/minimal` | 32K | ⚠️ 32K only, no vision, and single-card vLLM → Cliff 2b applies. Its 200K llama.cpp / ik-llama paths were retired 2026-08-12. |
+| Want | Why not on 1× | What you'd need |
+|---|---|---|
+| 4 concurrent streams at 262K + vision | KV pool too small for 4 × full ctx | TP=2 → [DUAL_CARD.md](DUAL_CARD.md) |
+| Peak code TPS (>100 on the quicksort prompt) | DFlash needs `head_size=256` + non-causal; vLLM splits the head dim | TP=2 + DFlash |
+| Single prompt >60K tokens on Qwen3.6-27B | Cliff 2 (DeltaNet GDN forward) | TP=2 (`vllm/dual`), a non-Qwen3-Next model (`vllm/gemma-12b-single-int8-mtp`, 256K), or `--force llamacpp/default` |
+| Any Qwen3.8-27B config | 27B FP8/INT4 weights + KV don't fit 24 GB | 2 cards → [DUAL_CARD.md](DUAL_CARD.md) |
 
-⚠️ **NVFP4 single-card slugs require `sm 9.0`** and are unusable on a 3090 (sm 8.6): `vllm/qwen-27b-single-nvfp4`, `vllm/qwen-35b-a3b-single-nvfp4`.
+---
 
-Models with **no** functional single-card config: `qwen3.6-40b-deckard`, `tess-4-27b`, `deepseek-v4-flash-0731`, `inkling-small` (dual/multi only) — and `gemma-4-31b`, whose single-card default was removed 2026-05-31.
+## VRAM budget on 24 GB
+
+![Per-card VRAM allocation, single-card configs](img/vram-budget-single.png)
+
+- **Weights** ~14 GB (AutoRound INT4 / GGUF Q3_K_XL) — over half the card.
+- **KV cache** is next, sized by `--kv-cache-dtype` × ctx: fp8 ≈ 1 byte, TQ3 ≈ 0.4 bytes, fp16 ≈ 2 bytes per token per (layer × head). Full math: [`KV_MATH.md`](KV_MATH.md).
+- **Vision tower** (mmproj) adds ~0.5–1.0 GB when on.
+- **Activations + cudagraph pools** take what's left — and this is where single-card configs actually die. See the peak-vs-idle pitfall below.
+
+Cross-card TP=2 picture: [`DUAL_CARD.md`](DUAL_CARD.md).
+
+---
+
+## Single-card pitfalls
+
+### ⚠️ VRAM peak ≠ idle — the "booted fine, then OOM'd" trap
+
+`nvidia-smi` at boot shows weights + KV reservation, **not peak**. Peak adds activation buffers during prefill, typically **+500–1500 MiB**. A card idling at 23.5 / 24 GB has ~500 MiB of headroom — not enough for the 138 MiB-class buffer a long prefill allocates. The server boots, serves short prompts, and dies on the first big one.
+
+**Fix:** drop `--gpu-memory-utilization` by `0.03`. Judge headroom from a loaded card, never an idle one.
+
+### Tool-call extraction needs `--enable-auto-tool-choice`
+
+vLLM ships it off. Our composes set `--tool-call-parser qwen3_coder` + `--enable-auto-tool-choice`; both are required if you roll your own.
+
+### Prefill cliffs
+
+Cliff 1 (FFN intermediate buffer) and Cliff 2 (DeltaNet GDN forward) are the two OOM shapes on this hardware. Mechanisms, current status and re-test triggers: [`CLIFFS.md`](CLIFFS.md).
+
+### Running alongside a desktop, or sub-24 GB usable VRAM
+
+Compose defaults assume a **headless** card. If the same GPU drives a display, shrink the budget:
+
+```bash
+MAX_MODEL_LEN=32768 GPU_MEMORY_UTILIZATION=0.85 bash scripts/switch.sh vllm/minimal
+```
+
+Prefer dropping `MAX_MODEL_LEN` first — it's a clean KV reduction. `GPU_MEMORY_UTILIZATION` interacts with vLLM's profiling phase in non-obvious ways, and `0.80` is usually too aggressive (profiling eats more than the 0.05 you saved). Card-class detail: [`HARDWARE.md`](HARDWARE.md).
+
+### Running two variants at once
+
+Ports and container names are configurable per instance — see [`PODS.md`](PODS.md). Two full-context single-card servers will not co-reside on one 24 GB card.
+
+---
+
+## Escape hatches
+
+Every llama.cpp and ik-llama single-card slug was retired 2026-08-12, and `ik-llama` left every recommendation walk. **They still work.** They are hidden from `switch.sh --list` and need `--force`:
+
+```bash
+bash scripts/switch.sh --force llamacpp/default   # 200K, cliff-immune, ~51 / 60 TPS
+bash scripts/switch.sh --list --all               # see everything, including retired
+```
+
+This matters because the retirement **removed capability with no replacement**: single-card Qwen3.6-27B went from 200K ctx and 150K vision at ~60 / 72 TPS down to `vllm/minimal` at 32K, no vision, ~32 / 33 TPS. If you need what the retired slugs did, `--force` is the honest answer — unmaintained, but not broken.
+
+Measurements for the retired configs are preserved in [`BENCHMARKS.md`](../BENCHMARKS.md) and [`models/qwen3.6-27b/CHANGELOG.md`](../models/qwen3.6-27b/CHANGELOG.md).
 
 ---
 
 ## Deep dives
 
-- **[Model README](../models/qwen3.6-27b/)** — quant choices (AutoRound INT4 / GGUF Q3_K_XL), Genesis patch surface, what's working / what's not.
-- **[INTERNALS.md](../models/qwen3.6-27b/INTERNALS.md)** — engineering rationale (Genesis P65/P66/PN8, Marlin pad fork, MTP, the cascade bug, upstream tracker).
-- **[VRAM allocation diagram](../models/qwen3.6-27b/README.md#vram-allocation-across-configs)** — full per-config breakdown across single + dual.
-- **[FAQ.md](FAQ.md)** — common questions (4090 / 5090 support, why MTP not EAGLE, Copilot Gateway, what's a cliff, etc.).
-- **[EXAMPLES.md](EXAMPLES.md)** — Python / TS / curl client snippets + IDE connection settings.
-- **[HARDWARE.md](HARDWARE.md)** — Ampere SM 8.6 specifics, NVLink (declined), power caps.
-- **[DUAL_CARD.md](DUAL_CARD.md)** — when you need what single-card can't deliver.
+- **[CLIFFS.md](CLIFFS.md)** — Cliff 1 / 2 / 2b mechanisms, fix landscape, re-test triggers.
+- **[KV_MATH.md](KV_MATH.md)** — predicting per-card VRAM before you boot.
+- **[GLOSSARY.md](GLOSSARY.md)** — TPS, KV, MTP, TP, prefill vs decode.
+- **[FAQ.md](FAQ.md)** — 4090 / 5090, engine choice, why my TPS is low, troubleshooting ladder.
+- **[EXAMPLES.md](EXAMPLES.md)** — Python / TS / curl clients + IDE settings.
+- **[HARDWARE.md](HARDWARE.md)** — card classes, power caps, VRAM ceilings.
+- **[Model README](../models/qwen3.6-27b/)** · **[INTERNALS.md](../models/qwen3.6-27b/INTERNALS.md)** — quant choices, engine internals.
+- **[DUAL_CARD.md](DUAL_CARD.md)** — when you need what one card can't deliver.


### PR DESCRIPTION
Closes the restructure asked for in [#955](https://github.com/noonghunna/club-3090/discussions/955). **The three audience pages go 1,136 → 470 lines (−59%)**, past the 25–50% @Mateleo asked for — with a verified loss register so nothing hard-won goes in the bin.

Separate from [#1031](https://github.com/noonghunna/club-3090/pull/1031) (which fixed commands that couldn't run) and [#1032](https://github.com/noonghunna/club-3090/pull/1032) (the Qwen3.8 promotion).

## What the users said

> *"very clumsy with a lot of LLM slop text… shrink to about 25% to 50%"* — @Mateleo
> *"slop text should live in a different file… human-readable docs should only be a few paragraphs with a link"* — @tomByrer
> *"I'm interested in running Qwen 3.8 27b fp8 on 2x RTX 3090. I have to wade through heaps of incomprehensible technobabble… when there are updates, noone gives a fuck about what was there previously. Get rid of it without a trace. We have git."* — @neuhaus

## Zero new pages

The reference tier already existed and the audience pages were **duplicating** it rather than linking: `PCIE_P2P.md` (930), `KV_MATH.md` (877), `CLIFFS.md` (839), `FAQ.md` (737), `GLOSSARY.md`, and a 41-line `GETTING_STARTED.md` that is the correct novice path. So this is delete-and-link — cheaper and far lower risk than inventing a parallel structure. Every removed chunk has an existing home.

## Per page

| Page | Before | After | Δ |
|---|--:|--:|--:|
| `SINGLE_CARD.md` | 348 | **149** | −57% |
| `DUAL_CARD.md` | 288 | **153** | −47% |
| `MULTI_CARD.md` | 500 | **168** | −66% |
| `FAQ.md` | 737 | 777 | +40 |
| `HARDWARE.md` | 634 | 648 | +14 |
| `docs/README.md` | 92 | 95 | +3 |

**SINGLE_CARD** was **35% tombstones**. #970 correctly *marked* the retired slugs rather than leaving false recommendations — but the gravestones then outweighed live content 3:1 on the page a first-timer lands on, which is precisely @neuhaus's complaint. The 46-line historical lineup, nine per-config `📜 RETIRED` sections, a `## Pick a config` that declared itself historical, and a 38-line third-party watch list all go to `BENCHMARKS.md` / `UPSTREAM.md` / the model CHANGELOG. The agentic-context warning was told **three times in three registers of jargon**; now once.

⚠️ **A named `## Escape hatches` section stays.** The 2026-08-12 retirement removed capability with **no replacement** — single-card Qwen went from 200K ctx + 150K vision at ~60/72 TPS to `vllm/minimal` at 32K, no vision, ~32/33. `--force` is the only route back, so burying it would strand exactly the users who need it.

**DUAL_CARD** now **leads with Qwen3.8-27B**, including numbers measured 2026-08-17 (67.4 / 85.8 TPS on `vllm/qwen38-27b-dual-max`). @neuhaus asked for that exact config; the page had **zero** mentions of the model, which existed only in #993/#1024. Sampling defaults got their own section so the `min_p` trap isn't a clause inside a blockquote attached to a table being deleted.

**MULTI_CARD** had a different disease — ~0% history but **59% reference material**, with the first copy-pasteable command 61% of the way down. **Replicate-vs-tensor-parallel now leads, before any TP content**: it's worth up to **3.4×** aggregate throughput, and a reader who should replicate never needs the rest of the page. Its old heading — *"the fork this page used to ignore"* — read as editorial cruft and invited deletion. The 93-line TL;DR and its 75-line self-correcting retraction became a table plus the two findings, present-tense, with both datasets intact.

The 2-GPU limitation is now stated **once, as permanent fact, immediately reframed as division of labour**, with the five cross-rig validators named. Not an apology, not a TODO.

## Loss register — the safety net

The audit nominated 14 at-risk facts. Grep-checked repo-wide, **10 already had a second home**. The four that didn't were relocated and verified at destination in `d838af7` **before any deletion here** — that ordering is the entire point:

| Fact | Was | Now |
|---|---|---|
| `min_p` must stay 0.0 or reasoning models loop | 1 file, inside a doomed blockquote | `FAQ.md` + own DUAL_CARD section |
| Silent drafter fallback (~25 TPS, not 125, **no error**) | 1 file, under a `⚠️ DEPRECATED` heading | `FAQ.md` with its own Q |
| Replication beats TP for throughput (3.4×) | 1 file, cruft heading | promoted to MULTI_CARD §2 |
| VRAM peak ≠ idle (+500–1500 MiB) | 1 file, flanked by duplicates | kept + mirrored to `HARDWARE.md` |

Also explicitly preserved: the **1568-token decode-starvation floor** ([#208](https://github.com/noonghunna/club-3090/discussions/208)) — it lived inside a section about an *archived* compose, so a slug-driven prune would have deleted it, and it's architectural to the hybrid model rather than specific to that compose. Plus the corrected 24/4 head counts and **all five cross-rig contributor names** — attribution travels with every measurement moved to `BENCHMARKS.md`.

## Verified

- Every backticked slug across all four pages exists in the registry
- **All 55 internal links resolve**
- All four register items present at destination **and** still at origin
- **Full test suite: 102/102 green** on this branch's final content

## Also in this branch

`d838af7` the relocations · `89f74c1` indexing `LOCAL_AI_PRIMER.md`, `WSL_SETUP.md` and `GLOSSARY.md`, which existed but had **no route in from the docs index** — the novice read hit ~40 undefined terms while `GLOSSARY.md` sat unlinked.

## Not in scope

Port collisions (7 ports carry >1 live slug) — may be intentional reuse under `gpu-mode` switching, so it needs a maintainer call rather than a guess.
