### PR TITLE
test: add test-docs-slugs-resolve — assert documented commands can actually run

### DIFF
--- a/docs/ADDING_MODELS.md
+++ b/docs/ADDING_MODELS.md
@@ -61,9 +61,10 @@ Use these rules when you touch anything that changes version, branch, overlay se
 | You changed… | Tests that catch incoherence |
 |---|---|
 | Engine pin (`install.spec`) | `test-launch-compat` · `test-compose-image-drift` · `test-diagnose-profile` |
-| Deprecated an engine / compose | `test-compose-status-drift` · `test-switch-registry-parity` · `test-launch-registry-parity` |
+| Deprecated an engine / compose | `test-compose-status-drift` · `test-switch-registry-parity` · `test-launch-registry-parity` · **`test-docs-slugs-resolve`** (docs may still tell users to run the slug you just retired) |
 | Added / changed a patch or overlay | `test-patch-attribution` · `test-compose-image-drift` |
 | Added a model / new `(model, engine, KV)` combo | `test-profiles-compat` · `test-patch-attribution` · `test-compose-registry-disk` |
+| Renamed / removed a slug, or edited a documented command | **`test-docs-slugs-resolve`** — asserts every slug named in a `switch.sh`/`launch.sh` command exists, and that non-functional ones carry `--force` |
 
 ## Workflow at a glance
 

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -57,7 +57,7 @@ On 20 GB cards (modded 3080) the cudagraph-profiling overhead is a meaningful sl
 **4090s with attached display — env-override the compose defaults.** Some 4090 rigs land at ~23.5 GB usable VRAM with X server + driver overhead, vs the headless 3090s the composes are calibrated for. Boot may fail with `No available memory for the cache blocks` at default `max-model-len`. Cross-rig data: @laurimyllari's 4090 single-card on `long-text.yml` needed `MAX_MODEL_LEN=90000` (down from 180K default) to fit cleanly ([disc #62](../../../noonghunna/club-3090/discussions/62) / [issue #71](../../../noonghunna/club-3090/issues/71)). **Newer driver shrinks the budget the same way even on a headless 3090:** @sethbrasile's controlled 9-run matrix on a headless 3090 with driver 595.71.05 / CUDA 13.2 capped `long-text.yml` at `MAX_MODEL_LEN=105000` — the newer driver's activation-profile reserve measured ~2.87 GiB vs ~1.5 GiB on the bare-metal reference rig, shrinking the KV pool by the difference ([issue #149](../../../noonghunna/club-3090/issues/149)). On a newer-driver 3090, start at `MAX_MODEL_LEN=105000` rather than the 180K default. Pattern:
 
 ```bash
-MAX_MODEL_LEN=90000 bash scripts/switch.sh vllm/long-text
+MAX_MODEL_LEN=32768 GPU_MEMORY_UTILIZATION=0.85 bash scripts/switch.sh vllm/minimal
 ```
 
 Same `MAX_MODEL_LEN` / `GPU_MEMORY_UTILIZATION` env overrides apply for any setup running vLLM alongside other GPU consumers on the same card. See [SINGLE_CARD.md "Running alongside a desktop"](SINGLE_CARD.md#running-alongside-a-desktop--sub-24-gb-usable-vram) for safe ranges.

--- a/docs/STRUCTURED_COT.md
+++ b/docs/STRUCTURED_COT.md
@@ -66,7 +66,7 @@ After the Phase 3 grammar A/B (2026-05-04, full HE+ 164 + LCB v6 50, 5 grammars 
 On vLLM, we ship one compose, with the DeepSeek scratchpad as the recommended grammar:
 
 ```bash
-bash scripts/switch.sh vllm/bounded-thinking
+bash scripts/switch.sh vllm/dual        # 🗑️ vllm/bounded-thinking is archived; any vLLM slug works
 # Then send requests with:
 #   extra_body={"structured_outputs": {"grammar": <deepseek-scratchpad GBNF>}}
 ```
@@ -91,7 +91,7 @@ The combined-accuracy spread is within noise (87.4% / 86.9% / 86.4% over 214 pro
 
 ```bash
 cd /path/to/club-3090
-bash scripts/switch.sh vllm/bounded-thinking
+bash scripts/switch.sh vllm/dual        # 🗑️ vllm/bounded-thinking is archived; any vLLM slug works
 # Or directly:
 cd models/qwen3.6-27b/vllm/compose
 docker compose -f single/autoround-int4/bounded-thinking.yml up -d

--- a/scripts/tests/test-docs-slugs-resolve.sh
+++ b/scripts/tests/test-docs-slugs-resolve.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# Every slug named in a DOCUMENTED COMMAND must exist in the registry, and
+# non-functional slugs must be shown with --force.
+#
+# WHY THIS EXISTS
+# ---------------
+# 2026-08-17: six separate places told users to run commands that could not
+# work. None was caught by any gate, because nothing asserted that a slug
+# appearing in prose still exists:
+#
+#   README.md            first explicit command was `beellama/dflash` — deprecated,
+#                        labelled "single-card BLESSED default"
+#   SINGLE_CARD.md       Quick start ran ik-llama/iq4ks-mtp + llamacpp/default
+#                        (both deprecated, no --force); vllm/minimal — the only
+#                        production single-card slug — was absent entirely
+#   DUAL_CARD.md         3 of 4 --variant lines named absent slugs
+#   MULTI_CARD.md        topology table named vllm/default + vllm/long-text
+#   FAQ.md               `--set-default vllm/dual-turbo` told users to PERSIST a
+#                        broken default; the 5-step troubleshooting ladder had
+#                        3 of 5 rungs on absent slugs
+#   discussion #17       onboarding path used a compose path the restructure removed
+#
+# `launch.sh` exits 2 with "unknown compose variant", so the failure is clean —
+# but a new user cannot tell a stale doc from their own mistake.
+#
+# SCOPE — deliberately narrow, so the gate stays trustworthy
+# ----------------------------------------------------------
+# Only lines invoking `switch.sh` or `launch.sh` are inspected. That is what makes
+# this checkable at all: the repo has 106 `vllm/pull`, 51 `vllm/issues`, 30
+# `vllm/patches` and 27 `vllm/vllm-openai` strings in prose, all GitHub URLs or
+# paths that happen to match a slug shape. None of them appear inside a launch
+# command. A gate that scanned all prose would be noise and would get disabled.
+#
+# Resolver tokens are legal and NOT slugs: `<engine>/default` and `<model>/default`
+# are resolved by model_default_target(), documented in FAQ.md.
+
+set -euo pipefail
+
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs — repo
+# docs are full of unicode (— × → ⚠) and a non-UTF-8, non-C locale otherwise
+# decodes reads/stdout/argv with the locale codec (#779). Guarded by
+# test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+python3 - "$ROOT_DIR" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+sys.path.insert(0, str(root))
+from scripts.lib.profiles.compose_registry import (
+    COMPOSE_REGISTRY,
+    FUNCTIONAL_STATUSES,
+)
+
+# Engine prefixes and model ids are DERIVED from the registry, never hardcoded —
+# a new engine or model must not silently fall outside the gate.
+ENGINES = sorted({k.split("/", 1)[0] for k in COMPOSE_REGISTRY})
+MODELS = sorted({e["model"] for e in COMPOSE_REGISTRY.values() if e.get("model")})
+
+# Which docs a user actually follows. Contributor-track and diagnostics prose are
+# out of scope on purpose; those aren't copy-paste onboarding paths.
+TARGETS = [
+    "README.md",
+    "CONTRIBUTING.md",
+    *sorted(str(p.relative_to(root)) for p in (root / "docs").glob("*.md")),
+]
+
+# Match a launcher invocation and capture only what sits in ARGUMENT position.
+# Matching the whole line over-fires: tables and retirement notes mention slugs in
+# prose while also containing a launcher call elsewhere on the same line, and
+# `VLLM_IMAGE=vllm/vllm-openai:latest` is an image reference, not a slug.
+ARG = re.compile(
+    r"\b(?:switch|launch)\.sh\b"                 # the launcher
+    r"((?:\s+(?:--[\w-]+(?:=\S+)?|[A-Z_]+=\S+))*)"  # intervening flags / env
+    r"\s+([A-Za-z0-9][\w./-]*)"                    # the argument we care about
+)
+# --variant / --set-default take the slug as the NEXT token.
+FLAG_ARG = re.compile(r"--(?:variant|set-default)\s+([A-Za-z0-9][\w./-]*)")
+# A trailing :tag means it's a container image, never a slug.
+IMAGEISH = re.compile(r"^\S+:[\w.-]+$")
+
+def check_line(rel, lineno, line, sink, counters):
+    """Classify one line. Appends problems to `sink`. Pure — used by the self-test."""
+    if "switch.sh" not in line and "launch.sh" not in line:
+        return
+    has_force = "--force" in line or "FORCE=1" in line
+
+    cands = set()
+    for m in ARG.finditer(line):
+        cands.add(m.group(2))
+    for m in FLAG_ARG.finditer(line):
+        cands.add(m.group(1))
+
+    for tok in cands:
+        if IMAGEISH.match(tok):          # vllm/vllm-openai:latest
+            continue
+        if "/" not in tok:               # `switch.sh --list`, a bare model id
+            continue
+        prefix, _, name = tok.partition("/")
+
+        # ⚠️ REGISTRY LOOKUP MUST COME FIRST. `llamacpp/default` is BOTH a real
+        # (deprecated) slug AND matches the `<engine>/default` resolver shape.
+        # Checking the resolver pattern first made this gate SKIP it — and it is the
+        # most-referenced deprecated slug in the docs (29 mentions), so that bug
+        # would have defeated the main thing this test exists for. It was caught by
+        # the self-test below, not by reading the code. Do not reorder these.
+        entry = COMPOSE_REGISTRY.get(tok)
+
+        if entry is None and name == "default":
+            if prefix in ENGINES or prefix in MODELS:
+                continue
+            sink.append(
+                f"{rel}:{lineno}: `{tok}` names neither an engine nor a model "
+                f"in the registry — the resolver will reject it"
+            )
+            continue
+
+        if prefix not in ENGINES:
+            continue                     # not a slug shape we own
+
+        counters["checked"] += 1
+        if entry is None:
+            sink.append(
+                f"{rel}:{lineno}: `{tok}` is NOT in compose_registry.py — "
+                f"this command cannot run (launch.sh exits 2)"
+            )
+            continue
+
+        status = entry.get("status", "production")
+        if status not in FUNCTIONAL_STATUSES and not has_force:
+            sink.append(
+                f"{rel}:{lineno}: `{tok}` is status={status} (non-functional) "
+                f"but the command has no --force — it will be refused"
+            )
+        elif status not in FUNCTIONAL_STATUSES:
+            counters["force_ok"] += 1
+
+
+# ---------------------------------------------------------------------------
+# SELF-TEST — a gate that silently stops catching things is worse than no gate.
+# Each case below is one the real docs got wrong at some point.
+# ---------------------------------------------------------------------------
+_dep = next((k for k, v in COMPOSE_REGISTRY.items()
+             if v.get("status") == "deprecated" and k.endswith("/default")), None)
+_prod = next((k for k, v in COMPOSE_REGISTRY.items()
+              if v.get("status") == "production"), None)
+
+CASES = [
+    ("absent slug",                 "bash scripts/switch.sh vllm/does-not-exist",              True),
+    ("--variant absent",            "bash scripts/launch.sh --variant vllm/nope",              True),
+    ("--set-default absent",        "bash scripts/switch.sh --set-default vllm/nope",          True),
+    ("bogus <model>/default",       "bash scripts/switch.sh not-a-real-model/default",         True),
+    ("production slug",             f"bash scripts/switch.sh {_prod}",                         False),
+    ("<engine>/default resolver",   "bash scripts/switch.sh vllm/default",                     False),
+    ("docker image, not a slug",
+     "VLLM_IMAGE=vllm/vllm-openai:latest bash scripts/launch.sh --variant " + str(_prod),      False),
+    ("slug in prose beside a call",
+     "The retired `llamacpp/mtp` is listed by `bash scripts/switch.sh --list`.",               False),
+]
+if _dep:
+    CASES += [
+        ("deprecated, no --force",  f"bash scripts/switch.sh {_dep}",                          True),
+        ("deprecated with --force", f"bash scripts/switch.sh --force {_dep}",                  False),
+    ]
+
+_self_fail = []
+for label, line, should_flag in CASES:
+    sink, ctr = [], {"checked": 0, "force_ok": 0}
+    check_line("<self-test>", 0, line, sink, ctr)
+    if bool(sink) != should_flag:
+        _self_fail.append(
+            f"self-test '{label}': expected {'a problem' if should_flag else 'no problem'}, "
+            f"got {sink or 'none'}"
+        )
+if _self_fail:
+    print("test-docs-slugs-resolve: FAIL (the gate itself is broken)")
+    for e in _self_fail:
+        print(f"  ⛔ {e}")
+    sys.exit(1)
+
+errors = []
+counters = {"checked": 0, "force_ok": 0}
+
+for rel in TARGETS:
+    path = root / rel
+    if not path.exists():
+        continue
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").split("\n"), 1):
+        check_line(rel, lineno, line, errors, counters)
+
+checked = counters["checked"]
+force_ok = counters["force_ok"]
+
+if errors:
+    print("test-docs-slugs-resolve: FAIL")
+    for e in errors:
+        print(f"  ⛔ {e}")
+    print()
+    print(f"  {len(errors)} problem(s) across {len(TARGETS)} doc(s).")
+    print("  Fix: name a slug that exists (`bash scripts/switch.sh --list`), add")
+    print("  --force for a non-functional one, or use the `<model>/default` resolver.")
+    sys.exit(1)
+
+print(
+    f"test-docs-slugs-resolve: ok "
+    f"self-test {len(CASES)}/{len(CASES)} · {checked} slug refs in launcher commands across {len(TARGETS)} docs, "
+    f"{force_ok} non-functional correctly gated behind --force)"
+)
+PY


### PR DESCRIPTION
Closes the gap that let **six separate broken-command bugs** ship this week. Nothing asserted that a slug named in a doc still exists, so every one of these passed a green 102/102 suite:

| Where | What it told users to run |
|---|---|
| `README.md` | `beellama/dflash` — deprecated, labelled *"single-card BLESSED default"*, and the repo's **first explicit command** |
| `SINGLE_CARD.md` | two deprecated slugs with no `--force`; `vllm/minimal` — the only production single-card slug — absent entirely |
| `DUAL_CARD.md` | **3 of 4** `--variant` lines named absent slugs |
| `MULTI_CARD.md` | topology table named `vllm/default` + `vllm/long-text` |
| `FAQ.md` | `--set-default vllm/dual-turbo` — told users to **persist** a broken default; troubleshooting ladder had **3 of 5** rungs on absent slugs |
| discussion #17 | onboarding used a compose path the restructure removed |

## What it asserts

For every line invoking `switch.sh` or `launch.sh` across `README.md`, `CONTRIBUTING.md` and all of `docs/*.md`:

1. a slug in **argument position** exists in `COMPOSE_REGISTRY`
2. a non-functional slug (status ∉ `FUNCTIONAL_STATUSES`) carries `--force`
3. `<engine>/default` and `<model>/default` resolver tokens name something real

Engine prefixes, model ids and `FUNCTIONAL_STATUSES` are all **derived from the registry**, never hardcoded — a new engine or model can't silently fall outside the gate.

## Why the scope is narrow (deliberately)

Only argument position, only launcher lines. The repo has **106 `vllm/pull`, 51 `vllm/issues`, 30 `vllm/patches`, 27 `vllm/vllm-openai`** strings that match a slug shape — all GitHub URLs, paths or image refs. A gate that scanned prose would be pure noise and would get switched off inside a week.

Matching the whole *line* also over-fired: tables and retirement notes mention slugs in prose while containing a launcher call elsewhere on the same line. Argument-position matching is what makes this trustworthy.

## It found 3 more real bugs on first run

```
docs/HARDWARE.md:60       switch.sh vllm/long-text         (absent)
docs/STRUCTURED_COT.md:69 switch.sh vllm/bounded-thinking  (absent)
docs/STRUCTURED_COT.md:94 switch.sh vllm/bounded-thinking  (absent)
```

All three fixed here. **These are docs I had not swept manually** — which is the whole argument for having the gate rather than doing it by hand.

## Self-test — because a gate that stops catching things is worse than none

Ten cases run *before* the real scan: absent slug, `--variant` absent, `--set-default` absent, bogus `<model>/default`, production slug, resolver token, docker image, slug-in-prose, deprecated-without-`--force`, deprecated-with-`--force`. A wrong verdict on any of them fails as **"the gate itself is broken"**.

⚠️ **That self-test immediately caught a real bug in my own gate.** `llamacpp/default` is **both** a deprecated slug **and** matches the `<engine>/default` resolver shape — so checking the resolver pattern first made the gate **skip it**, and it's the most-referenced deprecated slug in the docs (29 mentions). Registry lookup now comes first, with a comment explaining the ordering. Verified by reintroducing the bug and watching the self-test fail:

```
test-docs-slugs-resolve: FAIL (the gate itself is broken)
  ⛔ self-test 'deprecated, no --force': expected a problem, got none
```

Fixing it raised real coverage from **48 → 52** slug refs and **8 → 12** verified `--force` gates.

## Registered so it's discoverable

`docs/ADDING_MODELS.md` change-type → tests table, under both *"deprecated an engine / compose"* and a new *"renamed / removed a slug, or edited a documented command"* row.

## Verification

**Full suite 103/103 green** (was 102 tests). Gate output on current master:

```
test-docs-slugs-resolve: ok self-test 10/10 · 52 slug refs in launcher
commands across 41 docs, 12 non-functional correctly gated behind --force
```