### PR TITLE
fix: remove leaked absolute paths (username committed to a public repo)

### DIFF
--- a/tools/grammar-eval/smoke-test.py
+++ b/tools/grammar-eval/smoke-test.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
+import os
 import pathlib
 import re
 import subprocess
@@ -17,7 +18,12 @@ import urllib.request
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 DEFAULT_GRAMMAR = REPO_ROOT / "tools/grammar-eval/holiday-tagline.gbnf"
-STRUCTURED_COT_DIR = pathlib.Path("/home/wasif/structured-cot")
+# Override with STRUCTURED_COT_DIR=/path/to/structured-cot. The default is
+# ~/structured-cot so this works on any machine; it used to be a hardcoded
+# absolute path from the author's box, which leaked a username into a public repo.
+STRUCTURED_COT_DIR = pathlib.Path(
+    os.environ.get("STRUCTURED_COT_DIR", pathlib.Path.home() / "structured-cot")
+)
 
 HOLIDAY_SYSTEM = (
     "You are an expert Python programmer. Think only inside the required "

--- a/tools/grammar-eval/subset-bench.py
+++ b/tools/grammar-eval/subset-bench.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
+import os
 import pathlib
 import random
 import re
@@ -16,7 +17,12 @@ from types import SimpleNamespace
 
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
-DEFAULT_STRUCTURED_COT_DIR = pathlib.Path("/home/wasif/structured-cot")
+# Override with STRUCTURED_COT_DIR=/path/to/structured-cot. The default is
+# ~/structured-cot so this works on any machine; it used to be a hardcoded
+# absolute path from the author's box, which leaked a username into a public repo.
+DEFAULT_STRUCTURED_COT_DIR = pathlib.Path(
+    os.environ.get("STRUCTURED_COT_DIR", pathlib.Path.home() / "structured-cot")
+)
 DEFAULT_PRIOR = DEFAULT_STRUCTURED_COT_DIR / "runs/full-humaneval-2026-04-30/results.jsonl"
 DEFAULT_CURRENT_GRAMMAR = DEFAULT_STRUCTURED_COT_DIR / "grammars/fsm_grammar_no_open.gbnf"
 DEFAULT_TAGLINE_GRAMMAR = REPO_ROOT / "tools/grammar-eval/holiday-tagline.gbnf"


### PR DESCRIPTION
Four hardcoded `/home/wasif/...` paths were committed. Two also made the scripts unrunnable for anyone else; one is a markdown link pointing into the author's personal Claude memory directory.

| File | What |
|---|---|
| `tools/grammar-eval/smoke-test.py:20` | `STRUCTURED_COT_DIR` hardcoded to an absolute path |
| `tools/grammar-eval/subset-bench.py:19` | same |
| `docs/diagnostics/grammar-eval-codex-brief.md:24` | `results.jsonl` path |
| `docs/diagnostics/grammar-eval-codex-brief.md:69` | harness location |
| `docs/diagnostics/grammar-eval-codex-brief.md:55` | a link to `../../../home/wasif/.claude/projects/-opt-ai/memory/<file>.md` |

## The Python fix is portability, not a re-point

Swapping one absolute path for another would have left the tools broken for everyone but the author. They now take an env override with a machine-independent default:

```python
STRUCTURED_COT_DIR = pathlib.Path(
    os.environ.get("STRUCTURED_COT_DIR", pathlib.Path.home() / "structured-cot")
)
```

**Verified:** `STRUCTURED_COT_DIR=/tmp/probe-cot` resolves to the override; unset resolves to `~/structured-cot`. Both files still parse.

## Verification

Repo-wide `/home/wasif` count is **0** (excluding `.venv` and worktrees). The one remaining `/home/...` match is `docs/ai-studio/README.md`'s `/home/me/models`, a deliberate generic example.

`test-locale-utf8`, `test-artifact-inventory`, `test-docs-slugs-resolve` all green.

## ⚠️ Gate-scope note

`docs/diagnostics/` is **not** in `test-docs-slugs-resolve`'s TARGETS — it globs `docs/*.md`, top level only. So this brief's reference to the archived `vllm/bounded-thinking` slug isn't caught. Left as-is (it's a historical brief, not an onboarding path), but flagged in case the gate's scope is ever widened.