### PR TITLE
fix(switch): truncate status_note in terminal warnings (reported via #1036)

### DIFF
--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -973,6 +973,21 @@ export_variant_engine_pin() {
   fi
 }
 
+# Trim a status_note for terminal display. Registry notes are maintainer-facing and
+# long by design (median ~920 chars, worst case 6,116) — dumping a whole one into a
+# user's terminal buries the message it is attached to. Show the opening, cap at
+# ~240 chars, and point at the full text.
+#   Reported via #1036: a --force launch printed ~6 KB of notes ABOVE the real
+#   failure, which was a missing weight shard.
+_note_brief() {
+  local n="${1:-}"
+  [[ -n "$n" ]] || return 0
+  if (( ${#n} <= 240 )); then printf '%s' "$n"; return 0; fi
+  local cut="${n:0:240}"
+  cut="${cut% *}"
+  printf '%s… [truncated — full note: bash scripts/switch.sh --list --all]' "$cut"
+}
+
 status_gate() {
   # Lifecycle gate (PR-A health flag). production → launch silently;
   # caveats → launch with a one-line notice; the (NA) set
@@ -984,17 +999,17 @@ status_gate() {
     production)
       ;;
     caveats)
-      echo "[switch] NOTE: '${v}' is ⚠️ production-with-caveats.${note:+  ${note}}"
+      echo "[switch] NOTE: '${v}' is ⚠️ production-with-caveats.${note:+  $(_note_brief "${note}")}"
       ;;
     *)
       if [[ "${FORCE:-0}" != "1" ]]; then
-        echo "[switch] ERROR: '${v}' is (NA: ${status}) — not a reliable config.${note:+  ${note}}" >&2
+        echo "[switch] ERROR: '${v}' is (NA: ${status}) — not a reliable config.${note:+  $(_note_brief "${note}")}" >&2
         echo "[switch]        It is surfaced for visibility, but won't launch without an explicit override." >&2
         echo "[switch]        Re-run with --force if you know what you're doing:" >&2
         echo "[switch]          bash scripts/switch.sh --force ${v}" >&2
         exit 1
       fi
-      echo "[switch] WARNING: forcing (NA: ${status}) variant '${v}'.${note:+  ${note}}"
+      echo "[switch] WARNING: forcing (NA: ${status}) variant '${v}'.${note:+  $(_note_brief "${note}")}"
       ;;
   esac
 }


### PR DESCRIPTION
[#1036](https://github.com/noonghunna/club-3090/issues/1036) shows a `--force` launch printing **~4 KB of registry notes above the actual failure**. The real error — a missing weight shard — was buried under a wall of maintainer prose the reporter had to scroll past.

## The numbers

`status_note` fields are maintainer-facing and long by design. Dumping one whole into a user's terminal buries the message it's attached to:

| | chars |
|---|--:|
| median `status_note` | 922 |
| **worst — `vllm/qwen38-27b-dual-max`** | **6,116** |

⚠️ **I made that worst case worse.** It was **4,830 before my promotion in #1032 and 6,116 after** — I added 1,286 chars of measurement detail to the single longest note in the registry, and a user hit it the next day. The dump-the-whole-note behaviour is pre-existing; the size is on me.

## Fix — at the display layer, so every slug benefits

New `_note_brief` caps at ~240 chars on a word boundary and points at the full text:

```
6,116 → 293 chars
```

Applied to all three `switch.sh` call sites: the `caveats` NOTE, the non-functional ERROR, and the `--force` WARNING. Notes under 240 chars pass through **byte-identical**; an empty note still yields nothing.

What a user sees now:

```
[switch] WARNING: forcing (NA: experimental) variant 'vllm/qwen38-27b-dual-max'.
Qwen3.8-27B 'max accuracy' tier, 2-card: official Qwen/Qwen3.8-27B-FP8 weights
(e4m3, dynamic act scale, weight_block_size [128,128], embedded mtp.safetensors
head) + fp8/e4m3 KV + MTP n=3, TP=2 @262144, vLLM stable pin. ✅ BOOTED +…
[truncated — full note: bash scripts/switch.sh --list --all]
```

## Verification

Exercised `_note_brief` directly against the real 6,116-char note, plus a short note (passes through unchanged) and an empty note (yields nothing).

**Not** verified by booting — my first attempt tried to launch the slug to compare warnings and just timed out on a 29 GB model load. Unit-testing the function was the right shape.

Green: `test-switch-registry-parity`, `test-launch-registry-parity`, `test-compose-status-drift`, `test-registry-emit-no-yaml`, `test-locale-utf8`, `test-docs-slugs-resolve`. `switch.sh --list` unaffected.

## ⚠️ Not fixed here

`scripts/launch.sh:1346` and `:1349` have the same raw-dump pattern. Left for a follow-up so this stays a one-file change while #1036's reporter is still blocked.