### PR TITLE
feat(model-switch): self-healing control plane — watchdog, rollback, /pull

### DIFF
--- a/scripts/control-api.sh
+++ b/scripts/control-api.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# control-api.sh — start/stop/status the model-switch HTTP control plane (dev / non-systemd path).
+#
+# The PRODUCTION path is the systemd unit (scripts/systemd/club3090-model-switch.service), which
+# reads the same repo-root .env. This wrapper is the equivalent for a foreground rig without
+# systemd: it loads .env, launches tools/model-switch/server.py detached, and manages a pidfile +
+# log — so you never hand-type the env incantation. All config still comes from .env + the
+# server's own MODEL_SWITCH_* defaults.
+#
+# Usage:
+#   bash scripts/control-api.sh start      # launch (detached); waits for /healthz
+#   bash scripts/control-api.sh stop
+#   bash scripts/control-api.sh restart
+#   bash scripts/control-api.sh status     # UP/DOWN (+ /status JSON if a token is set)
+#   bash scripts/control-api.sh logs       # tail -f the server log
+set -euo pipefail
+
+# Force Python's UTF-8 mode (PEP 540) for the server we launch below. Repo sources are full of
+# unicode (— × → ⚠), and without this a rig on a real non-UTF-8 locale (de_DE.iso88591 and
+# friends) decodes reads, stdout AND argv with the locale codec, which crashes the launcher/emit
+# paths the server shells out to (#779). Exported, so the detached server and every switch.sh /
+# setup.sh it spawns inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# Load repo-root .env, shell env winning (matches switch.sh precedence) so the daemon, downloads,
+# and serving all agree on VLLM_API_KEY / PORT / MODEL_DIR.
+if [[ -f "$ROOT_DIR/.env" ]]; then
+  while IFS= read -r _line; do
+    _line="${_line%%#*}"; _line="${_line#export }"
+    [[ "$_line" == *=* ]] || continue
+    _k="${_line%%=*}"; _k="${_k//[[:space:]]/}"; _v="${_line#*=}"
+    [[ "$_k" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+    if [[ -z "${!_k:-}" ]]; then                         # shell env wins
+      _v="${_v#"${_v%%[![:space:]]*}"}"; _v="${_v%"${_v##*[![:space:]]}"}"
+      _v="${_v%\"}"; _v="${_v#\"}"; _v="${_v%\'}"; _v="${_v#\'}"
+      export "$_k=$_v"
+    fi
+  done < "$ROOT_DIR/.env"
+fi
+
+PORT_API="${MODEL_SWITCH_PORT:-8099}"
+BIND="${MODEL_SWITCH_BIND:-127.0.0.1}"
+export MODEL_SWITCH_PORT="$PORT_API" MODEL_SWITCH_BIND="$BIND"
+export MODEL_SWITCH_WATCHDOG="${MODEL_SWITCH_WATCHDOG:-1}"
+export CLUB3090_API_TOKEN="${CLUB3090_API_TOKEN:-${VLLM_API_KEY:-}}"   # server + our status curl
+TOKEN="$CLUB3090_API_TOKEN"
+
+RUN_DIR="${MODEL_SWITCH_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/club3090-model-switch}"
+export MODEL_SWITCH_STATE_DIR="$RUN_DIR"
+mkdir -p "$RUN_DIR"
+PIDFILE="$RUN_DIR/server.pid"
+LOG="$RUN_DIR/server.log"
+BASE="http://$BIND:$PORT_API"
+
+_healthz() { curl -s -o /dev/null -w '%{http_code}' "$BASE/healthz" 2>/dev/null; }
+# `|| true`: with `set -o pipefail`, grep finding no listener (port free) would otherwise make
+# this exit non-zero and trip `set -e` in callers.
+_listener_pid() { ss -tlnHp "sport = :$PORT_API" 2>/dev/null | grep -oP 'pid=\K[0-9]+' | head -1 || true; }
+_running_pid() {
+  local p; p="$(cat "$PIDFILE" 2>/dev/null || true)"
+  if [[ -n "$p" ]] && kill -0 "$p" 2>/dev/null; then echo "$p"; else _listener_pid; fi
+}
+
+start() {
+  local p; p="$(_running_pid)"
+  if [[ -n "$p" ]]; then echo "already running (pid $p) on $BASE"; return 0; fi
+  echo "starting model-switch on $BASE  (watchdog=$MODEL_SWITCH_WATCHDOG, MODEL_DIR=${MODEL_DIR:-<repo>/models-cache})"
+  nohup python3 tools/model-switch/server.py >"$LOG" 2>&1 < /dev/null &
+  echo "$!" > "$PIDFILE"
+  disown 2>/dev/null || true
+  for _ in $(seq 1 40); do
+    [[ "$(_healthz)" == "200" ]] && { echo "up (pid $(cat "$PIDFILE"))   log: $LOG"; return 0; }
+    sleep 0.25
+  done
+  echo "started but /healthz isn't answering — check $LOG" >&2
+  return 1
+}
+
+stop() {
+  local p; p="$(_running_pid)"
+  if [[ -z "$p" ]]; then echo "not running"; rm -f "$PIDFILE"; return 0; fi
+  kill "$p" 2>/dev/null || true
+  rm -f "$PIDFILE"
+  echo "stopped (pid $p)"
+}
+
+status() {
+  if [[ "$(_healthz)" != "200" ]]; then echo "DOWN  ($BASE)"; return 1; fi
+  echo "UP    ($BASE, pid $(_running_pid))"
+  if [[ -n "$TOKEN" ]]; then
+    curl -s -H "Authorization: Bearer $TOKEN" "$BASE/status" \
+      | { command -v jq >/dev/null 2>&1 && jq . || cat; }
+  fi
+}
+
+case "${1:-}" in
+  start)   start ;;
+  stop)    stop ;;
+  restart) stop; sleep 1; start ;;
+  status)  status ;;
+  logs)    tail -n "${LINES:-40}" -f "$LOG" ;;
+  *) echo "usage: bash scripts/control-api.sh {start|stop|restart|status|logs}" >&2; exit 2 ;;
+esac

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -3,7 +3,7 @@
 # Switch between club-3090 compose variants.
 #
 # Brings down whatever's currently running, brings up the new variant,
-# and (optionally) waits for the server to report ready on /v1/models.
+# and (optionally) waits for the server to report ready on /health.
 # Stateless — re-run any time you want a different config.
 #
 # Usage:
@@ -65,7 +65,8 @@
 #   COMPOSE_BIN     Default: "docker compose" (set to e.g. "podman compose" if needed)
 #   CLUB3090_GPU    Single-card GPU index override, e.g. "1" on a hetero rig
 #   FORCE           Set to 1 to skip hardware/free-VRAM preflight
-#   READY_URL       Default: http://localhost:8020/v1/models
+#   READY_URL       Default: http://localhost:8020/health  (unauthenticated — works with
+#                   or without VLLM_API_KEY set on the compose)
 #   READY_TIMEOUT   Default: 600 (seconds — longer for cold cudagraph capture)
 
 set -euo pipefail
@@ -1062,12 +1063,18 @@ up_variant() {
 resolve_ready_url() {
   # Precedence: $READY_URL (full override) → $PORT (port only, host=localhost)
   # → per-variant default port from VARIANT_DEFAULT_PORT.
+  #
+  # Default probe is /health, NOT /v1/models: /health is unauthenticated and only returns
+  # 200 once the engine has loaded, so readiness works whether or not the compose sets
+  # VLLM_API_KEY. An auth-gated /v1/models probe returns 401 forever when a key is set →
+  # the server never looks "ready" and we burn the full READY_TIMEOUT on a healthy model.
+  # Override READY_URL to probe a different path.
   local variant="$1"
   if [[ -n "${READY_URL:-}" ]]; then
     return 0
   fi
   local port="${PORT:-${VARIANT_DEFAULT_PORT[$variant]:-8020}}"
-  READY_URL="http://localhost:${port}/v1/models"
+  READY_URL="http://localhost:${port}/health"
 }
 
 wait_ready() {
@@ -1249,4 +1256,8 @@ if [[ "$OWUI_REGISTER" -eq 1 && "$WAIT" -eq 1 ]]; then
   _owui_port="${READY_URL##*:}"; _owui_port="${_owui_port%%/*}"
   bash "$(dirname "$0")/lib/owui-register.sh" "$_owui_port" || true
 fi
-echo "[switch] done. Try:  curl -s ${READY_URL%/v1/models}/v1/models | jq ."
+# Derive scheme://host:port from READY_URL (whatever its path) so the hint is correct
+# regardless of whether the probe path is /health or an override.
+_ready_rest="${READY_URL#*://}"
+_ready_origin="${READY_URL%%://*}://${_ready_rest%%/*}"
+echo "[switch] done. Try:  curl -s ${_ready_origin}/v1/models | jq ."

--- a/scripts/systemd/club3090-model-switch.service
+++ b/scripts/systemd/club3090-model-switch.service
@@ -13,6 +13,13 @@
 # The token + model port are read from the repo-root .env via EnvironmentFile
 # (CLUB3090_API_TOKEN / VLLM_API_KEY, PORT, MODEL_DIR, …), so switch.sh's child
 # `docker compose` inherits the same environment the CLI uses.
+#
+# Self-healing knobs (all optional; defaults are sensible) can go in .env too:
+#   MODEL_SWITCH_WATCHDOG=1  MODEL_SWITCH_WATCH_INTERVAL_S=15  MODEL_SWITCH_HEAL_GRACE_S=60
+#   MODEL_SWITCH_BOOT_GRACE_S=300  MODEL_SWITCH_MAX_HEAL_FAILURES=3  (see the README).
+# StateDirectory= gives the service /var/lib/club3090-model-switch (owned by User=) and
+# exports $STATE_DIRECTORY, which server.py uses to persist the desired-model state so
+# healing survives a service restart.
 [Unit]
 Description=club-3090 model-switch HTTP control plane
 After=docker.service
@@ -26,6 +33,9 @@ WorkingDirectory=/opt/club-3090
 # Leading '-' = optional: a fresh checkout has no root .env yet (loopback + a
 # token passed another way still works). Add the token/port here for the tailnet.
 EnvironmentFile=-/opt/club-3090/.env
+# Persisted desired-model state (server.py reads $STATE_DIRECTORY) →
+# /var/lib/club3090-model-switch, so self-healing survives a restart.
+StateDirectory=club3090-model-switch
 ExecStart=/usr/bin/python3 /opt/club-3090/tools/model-switch/server.py
 Restart=on-failure
 RestartSec=3

--- a/scripts/tests/test-model-switch-unit.py
+++ b/scripts/tests/test-model-switch-unit.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+"""Unit tests for the model-switch self-healing state machine.
+
+Drives server.py's functions directly (monkeypatching `_observe` / `do_switch` / the
+`--down` subprocess) so the watchdog, rollback, force-consent, crash-loop budget, and
+persistence logic are tested DETERMINISTICALLY — no HTTP, no sleeps, no timing races.
+The HTTP contract itself is covered by test-model-switch.sh.
+
+Run: python3 scripts/tests/test-model-switch-unit.py   (invoked by test-model-switch.sh)
+"""
+import importlib.util
+import os
+import subprocess as _sp
+import sys
+import tempfile
+from pathlib import Path
+
+# Some tests stub `m.subprocess.run` — but that's the SHARED subprocess module, so the patch
+# leaks across every later module (e.g. breaking weights.py list --json). Reset it per load().
+_REAL_SP_RUN = _sp.run
+
+REPO = Path(__file__).resolve().parents[2]
+SERVER = REPO / "tools" / "model-switch" / "server.py"
+sys.path.insert(0, str(REPO))
+import scripts.lib.profiles.compose_registry as reg  # noqa: E402
+
+FAILS = []
+
+
+def check(name, cond):
+    print(f"  {'ok  ' if cond else 'FAIL'} {name}")
+    if not cond:
+        FAILS.append(name)
+
+
+def load(state_dir=None, **env):
+    """Import a FRESH copy of server.py with a clean state dir + deterministic env."""
+    _sp.run = _REAL_SP_RUN  # undo any prior test's global subprocess.run monkeypatch
+    os.environ["MODEL_SWITCH_WATCHDOG"] = "0"
+    os.environ["MODEL_SWITCH_GPU_COUNT"] = "2"
+    os.environ["CLUB3090_TOPOLOGY"] = "dual"
+    os.environ["MODEL_SWITCH_HEAL_GRACE_S"] = "0"
+    os.environ["MODEL_SWITCH_BOOT_GRACE_S"] = "0"
+    os.environ["MODEL_SWITCH_STABILITY_WINDOW_S"] = "1000"
+    os.environ["MODEL_SWITCH_HEAL_BUDGET_WINDOW_S"] = "100000"
+    os.environ["MODEL_SWITCH_MAX_HEAL_FAILURES"] = "3"
+    os.environ["CLUB3090_API_TOKEN"] = ""   # hermetic auth: default no token (override via **env)
+    os.environ["VLLM_API_KEY"] = ""
+    os.environ.pop("MODEL_DIR", None)       # hermetic: resolve fresh (override via **env)
+    os.environ.pop("SETUP_SCRIPT", None)
+    os.environ["MODEL_SWITCH_STATE_DIR"] = state_dir or tempfile.mkdtemp()
+    os.environ.update(env)
+    spec = importlib.util.spec_from_file_location("ms_%d" % id(state_dir or object()), SERVER)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+# Pick representative real slugs from the registry.
+def _pick(m):
+    func_dual = [s for s, e in reg.COMPOSE_REGISTRY.items()
+                 if m._raw_topology(s) == "dual" and e["status"] in reg.FUNCTIONAL_STATUSES]
+    exp_dual = [s for s, e in reg.COMPOSE_REGISTRY.items()
+                if m._raw_topology(s) == "dual" and e["status"] not in reg.FUNCTIONAL_STATUSES]
+    multi = [s for s in reg.COMPOSE_REGISTRY if (m._raw_topology(s) or "").startswith("multi")]
+    return func_dual, exp_dual, multi
+
+
+def obs(state, slug=None, port=8000):
+    return {"state": state, "slug": slug, "container": "c", "port": port,
+            "restart_count": 0, "started_at": None}
+
+
+def recorder(m, fail_for=()):
+    calls = []
+
+    def do_switch(slug, force=False):
+        calls.append((slug, force))
+        if slug in fail_for:
+            raise m.SwitchError(500, "switch failed", slug=slug)  # this module's class
+        return {"ok": True, "slug": slug, "model": "m", "took_s": 0}
+
+    return calls, do_switch
+
+
+# --------------------------------------------------------------------------
+def test_force_consent_and_propagation():
+    m = load()
+    func, exp, _ = _pick(m)
+    A, E = func[0], (exp[0] if exp else None)
+    m._observe = lambda: obs("absent")
+    calls, m.do_switch = recorder(m)
+
+    # production slug: no consent needed, no FORCE
+    payload, code = m.perform_switch(A, force_requested=False)
+    check("functional slug switches without force (200)", code == 200)
+    check("functional slug not forced", (A, False) in calls)
+
+    if E:
+        # experimental slug: 400 without consent
+        payload, code = m.perform_switch(E, force_requested=False)
+        check("experimental slug needs consent (400)", code == 400 and "force" in payload.get("error", ""))
+        # with consent: FORCE=1 propagated + persisted
+        calls.clear()
+        payload, code = m.perform_switch(E, force_requested=True)
+        check("experimental slug switches with force (200)", code == 200)
+        check("experimental slug forced (FORCE=1)", (E, True) in calls)
+        check("force authorization persisted", m._state["force_authorized"] is True)
+
+
+def test_gpu_eligibility():
+    m = load()
+    func, _, multi = _pick(m)
+    check("dual slug eligible on 2 GPUs", m._gpu_eligible(func[0]) is True)
+    check("dual slug not requires_force", m.requires_force(func[0]) is False)
+    if multi:
+        M = next((s for s in multi if (m._required_gpus(s) or 0) > 2), None)
+        if M:
+            check("multi>2 slug ineligible on 2 GPUs", m._gpu_eligible(M) is False)
+            check("multi>2 slug requires_force", m.requires_force(M) is True)
+    # fail-open: unknown gpu count -> eligible None, no forced consent on a functional slug
+    m2 = load(MODEL_SWITCH_GPU_COUNT="")
+    m2._gpu_count = lambda: None
+    check("unknown gpu count -> eligible None (fail-open)", m2._gpu_eligible(func[0]) is None)
+
+
+def test_rollback():
+    m = load()
+    func, _, _ = _pick(m)
+    A, B = func[0], func[1]
+    m._state["desired_slug"] = A
+    m._observe = lambda: obs("healthy", slug=A)  # A currently healthy
+    calls, m.do_switch = recorder(m, fail_for=(B,))
+    payload, code = m.perform_switch(B, force_requested=False)
+    check("failed switch returns 500", code == 500)
+    check("rolled back to previous healthy slug", payload.get("rolled_back_to") == A)
+    check("switch attempted B then restored A", [c[0] for c in calls] == [B, A])
+
+    # rollback_failed: both fail -> honest 'rig may be empty'
+    m._observe = lambda: obs("healthy", slug=A)
+    _, m.do_switch = recorder(m, fail_for=(A, B))
+    payload, code = m.perform_switch(B, force_requested=False)
+    check("rollback_failed reported (may be empty)", "rollback_failed" in payload)
+
+
+def test_models_hardware_filter():
+    m = load()
+    _, exp, multi = _pick(m)
+    M = next((s for s in multi if (m._required_gpus(s) or 0) > 2), None)
+    default = {r["slug"] for r in m.models_payload(False)["available"]}
+    allrows = {r["slug"]: r for r in m.models_payload(True)["available"]}
+    if M:
+        check("multi>2 hidden from default /models", M not in default)
+        check("multi>2 present under ?all=1", M in allrows)
+        check("multi>2 flagged gpu_eligible false", allrows[M]["gpu_eligible"] is False)
+    # incubating hidden by default
+    inc = [s for s, e in reg.COMPOSE_REGISTRY.items() if e["status"] == "incubating"]
+    if inc:
+        check("incubating hidden from default /models", inc[0] not in default)
+
+
+def test_slug_from_config_file_exact():
+    m = load()
+    func, _, _ = _pick(m)
+    A = func[0]
+    cp = reg.COMPOSE_REGISTRY[A]["compose_path"]
+    abs_ok = str(REPO / cp)
+    check("exact compose path resolves the slug", m._slug_from_config_file(abs_ok) == A)
+    # a path that merely SHARES a suffix but isn't the repo file must NOT match
+    check("non-repo suffix path does not match", m._slug_from_config_file("/somewhere/else/" + cp) is None)
+
+
+def test_watchdog_adopt_external():
+    m = load()
+    func, _, _ = _pick(m)
+    A, B = func[0], func[1]
+    m._state["desired_slug"] = A
+    m._observe = lambda: obs("healthy", slug=B)  # a DIFFERENT model is running (external switch)
+    calls, m.do_switch = recorder(m)
+    m._watchdog_tick()
+    check("adopts externally-running slug as desired", m._state["desired_slug"] == B)
+    check("adoption does not relaunch (no do_switch)", calls == [])
+
+
+def test_watchdog_unknown_no_heal():
+    m = load()
+    func, _, _ = _pick(m)
+    m._state["desired_slug"] = func[0]
+    m._observe = lambda: obs("unknown")
+    calls, m.do_switch = recorder(m)
+    m._watchdog_tick()
+    check("docker unknown -> no heal", calls == [])
+    check("docker unknown -> not degraded", m._state["degraded"] is False)
+
+
+def test_watchdog_heal_then_degrade():
+    m = load()
+    # This test is about the heal BUDGET, not about weights. do_switch() short-circuits on the
+    # presence pre-check before any heal is attempted, so without this stub the assertions would
+    # depend on the rig actually having A's weights under MODEL_DIR (passing here, failing in a
+    # fresh clone / CI). weights_missing has its own coverage in
+    # test_watchdog_weights_missing_degrades.
+    m._weights_present = lambda slug: True
+    func, _, _ = _pick(m)
+    A = func[0]
+    m._state["desired_slug"] = A
+    m._wd["last_healthy_ts"] = 0.0
+    m._wd["launch_ts"] = 0.0  # booting=False -> HEAL_GRACE(0)
+    m._observe = lambda: obs("absent")           # desired is down
+    calls, m.do_switch = recorder(m, fail_for=(A,))  # every heal fails
+    downs = []
+    _orig_run = m.subprocess.run
+
+    def fake_run(cmd, **kw):
+        if "--down" in cmd:
+            downs.append(cmd)
+            class R:  # noqa
+                returncode = 0
+                stdout = stderr = ""
+            return R()
+        return _orig_run(cmd, **kw)
+
+    m.subprocess.run = fake_run
+    for _ in range(3):
+        m._watchdog_tick()
+    check("heals up to the budget (3 attempts)", len(calls) == 3)
+    check("not degraded before budget spent", m._state["degraded"] is False)
+    m._watchdog_tick()  # 4th: budget spent
+    check("degrades after budget spent", m._state["degraded"] is True)
+    check("teardown (--down) called on degrade", len(downs) == 1)
+    check("no 4th heal attempt", len(calls) == 3)
+
+
+def test_watchdog_stability_reset():
+    m = load()
+    func, _, _ = _pick(m)
+    A = func[0]
+    m._state["desired_slug"] = A
+    m._state["heal_history"] = [1.0, 2.0]
+    m._observe = lambda: obs("healthy", slug=A)
+    # STABILITY_WINDOW=1000 -> transient health must NOT reset the budget
+    m._watchdog_tick()
+    check("transient health keeps heal_history", m._state["heal_history"] == [1.0, 2.0])
+    # window=0 -> health clears it
+    m2 = load(MODEL_SWITCH_STABILITY_WINDOW_S="0")
+    m2._state["desired_slug"] = A
+    m2._state["heal_history"] = [1.0, 2.0]
+    m2._observe = lambda: obs("healthy", slug=A)
+    m2._watchdog_tick()
+    check("stable health resets heal_history", m2._state["heal_history"] == [])
+
+
+def test_persisted_heal_history_survives_restart():
+    d = tempfile.mkdtemp()
+    m = load(state_dir=d)
+    m._weights_present = lambda slug: True   # budget persistence, not weights — see above
+    func, _, _ = _pick(m)
+    A = func[0]
+    m._state["desired_slug"] = A
+    m._wd["last_healthy_ts"] = m._wd["launch_ts"] = 0.0
+    m._observe = lambda: obs("absent")
+    _, m.do_switch = recorder(m, fail_for=(A,))
+    m._watchdog_tick(); m._watchdog_tick()  # 2 failed heals, persisted
+    check("2 heals recorded", len(m._state["heal_history"]) == 2)
+
+    # "restart": fresh import, SAME state dir -> _load_state() (as main() does) must
+    # rehydrate the budget so it survives across the daemon restart.
+    m2 = load(state_dir=d)
+    m2._weights_present = lambda slug: True
+    m2._load_state()
+    check("heal_history reloaded after restart", len(m2._state["heal_history"]) == 2)
+    m2._state["desired_slug"] = A
+    m2._wd["last_healthy_ts"] = m2._wd["launch_ts"] = 0.0
+    m2._observe = lambda: obs("absent")
+    calls, m2.do_switch = recorder(m2, fail_for=(A,))
+    downs = []
+    m2.subprocess.run = lambda cmd, **kw: type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+    m2._watchdog_tick()  # 3rd attempt (reaches budget=3)
+    m2._watchdog_tick()  # budget spent -> degrade
+    check("degrades at 3 across a restart (budget survived)", m2._state["degraded"] is True)
+
+
+def test_state_load_corrupt_and_unknown():
+    d = tempfile.mkdtemp()
+    (Path(d) / "state.json").write_text("{ not json ]")
+    m = load(state_dir=d)
+    check("corrupt state -> desired None", m._state["desired_slug"] is None)
+    d2 = tempfile.mkdtemp()
+    (Path(d2) / "state.json").write_text('{"desired_slug": "__nope__", "force_authorized": true}')
+    m2 = load(state_dir=d2)
+    check("unknown persisted slug dropped", m2._state["desired_slug"] is None)
+    check("force not carried for dropped slug", m2._state["force_authorized"] is False)
+
+
+def test_routes_table_contract():
+    m = load()
+    expected = {("GET", "/healthz"), ("GET", "/"), ("GET", "/status"), ("GET", "/models"),
+                ("POST", "/switch"), ("POST", "/heal"), ("POST", "/pull"), ("POST", "/down")}
+    pairs = [(r["method"], r["path"]) for r in m.ROUTES]
+    check("exactly the 8 expected (method,path) pairs", set(pairs) == expected)
+    check("route pairs are unique (8)", len(pairs) == len(set(pairs)) == 8)
+    check("every handler is a callable Handler method",
+          all(callable(getattr(m.Handler, r["handler"], None)) for r in m.ROUTES))
+    d = m.discovery_payload()
+    check("no 'handler' key leaks into discovery endpoints",
+          not any("handler" in e for e in d["endpoints"]))
+    open_paths = {r["path"] for r in m.ROUTES if not r["auth"]}
+    check("open (auth=False) routes are exactly /healthz and /", open_paths == {"/healthz", "/"})
+    check("all other routes require auth",
+          all(r["auth"] for r in m.ROUTES if r["path"] not in ("/healthz", "/")))
+    # auth.configured reflects token presence — 3 hermetic cases (load() resets both vars)
+    check("auth.configured False with no token", d["auth"]["configured"] is False)
+    check("auth.configured True with CLUB3090_API_TOKEN",
+          load(CLUB3090_API_TOKEN="tok1").discovery_payload()["auth"]["configured"] is True)
+    check("auth.configured True via VLLM_API_KEY fallback",
+          load(VLLM_API_KEY="tok2").discovery_payload()["auth"]["configured"] is True)
+
+
+def test_models_recommended():
+    m = load()
+    rows = m.models_payload(True)["available"]  # ?all=1 -> includes lower-state entries
+    bad = [r["slug"] for r in rows if r["recommended"] != (r["status"] in reg.FUNCTIONAL_STATUSES)]
+    check("recommended == (status in FUNCTIONAL_STATUSES) for every row", bad == [])
+    check("covers a recommended (production/caveats) row", any(r["recommended"] for r in rows))
+    check("covers a non-recommended (experimental/…) row", any(not r["recommended"] for r in rows))
+
+
+def _materialize(m, slug, model_dir, variants=None):
+    """Create each artifact's subdir + a verify_glob-matching file (subset via `variants`)."""
+    for a in m._slug_artifacts(slug):
+        if not a["subdir"] or (variants is not None and a["variant"] not in variants):
+            continue
+        d = os.path.join(model_dir, a["subdir"])
+        os.makedirs(d, exist_ok=True)
+        open(os.path.join(d, (a["verify_glob"].replace("*", "x") or "x")), "w").close()
+
+
+def test_model_dir_precedence():
+    check("shell/systemd MODEL_DIR wins", load(MODEL_DIR="/tmp/msx-explicit").MODEL_DIR == "/tmp/msx-explicit")
+    md = load().MODEL_DIR  # no env var -> repo .env's MODEL_DIR, else <repo>/models-cache
+    check("fallback MODEL_DIR is a non-empty absolute path", bool(md) and os.path.isabs(md))
+
+
+def test_weights_presence_and_companions():
+    # Part A: a safetensors slug is always subdir-verifiable — guaranteed presence coverage.
+    d = tempfile.mkdtemp()
+    m = load(MODEL_DIR=d)
+    check("safetensors slug absent -> not present", m._weights_present("vllm/dual") is False)
+    _materialize(m, "vllm/dual", d)
+    check("safetensors slug materialized -> present", m._weights_present("vllm/dual") is True)
+
+    # Part B: companion counting — a slug whose core + companion are BOTH subdir-verifiable
+    # (some GGUF cores aren't in the subdir index; skip cleanly if none qualify).
+    def verifiable(sl):
+        arts = m._slug_artifacts(sl)
+        return len(arts) >= 2 and all(a["subdir"] for a in arts)
+    cands = [s for s, e in reg.COMPOSE_REGISTRY.items() if e.get("weights_companions") and verifiable(s)]
+    check("companions are modeled as extra artifacts",
+          any(len(m._slug_artifacts(s)) >= 2 for s, e in reg.COMPOSE_REGISTRY.items() if e.get("weights_companions")))
+    if not cands:
+        check("(skip) no fully-subdir-verifiable companion slug in catalog", True)
+        return
+    d2 = tempfile.mkdtemp()
+    m2 = load(MODEL_DIR=d2)
+    s = cands[0]
+    core = reg.COMPOSE_REGISTRY[s]["weights_variant"]
+    check("nothing on disk -> not present", m2._weights_present(s) is False)
+    _materialize(m2, s, d2, variants={core})  # core only
+    check("core present but companion missing -> not present", m2._weights_present(s) is False)
+    _materialize(m2, s, d2)  # core + companions
+    check("core + companion present -> present", m2._weights_present(s) is True)
+
+
+def test_do_switch_weights_missing_no_rollback():
+    m = load()
+    m._weights_present = lambda slug: False
+    func = _pick(m)[0]
+    A, B = func[0], func[1]
+    raised = False
+    try:
+        m.do_switch(A)
+    except m.SwitchError as e:
+        raised = e.payload.get("error") == "weights_missing"
+    check("do_switch raises weights_missing when absent", raised)
+    # perform_switch uses the REAL do_switch, which short-circuits on the presence check before
+    # switch.sh runs. A different model is healthy, so a *normal* failure would roll back — this
+    # must NOT (nothing was torn down).
+    m._observe = lambda: obs("healthy", slug=B)
+    payload, code = m.perform_switch(A, force_requested=False)
+    check("perform_switch surfaces weights_missing (409)", code == 409 and payload.get("error") == "weights_missing")
+    check("no rollback on weights_missing", "rolled_back_to" not in payload and "rollback_failed" not in payload)
+
+
+def test_watchdog_weights_missing_degrades():
+    m = load()
+    A = _pick(m)[0][0]
+    m._state["desired_slug"] = A
+    m._weights_present = lambda slug: False
+    m._observe = lambda: obs("absent")
+    m._wd["last_healthy_ts"] = m._wd["launch_ts"] = 0.0
+    calls, m.do_switch = recorder(m)  # must NOT be called
+    m._watchdog_tick()
+    check("watchdog degrades on weights_missing", m._state["degraded"] is True)
+    check("no heal budget burned / no switch attempted", m._state["heal_history"] == [] and calls == [])
+    check("last_error notes weights_missing", "weights_missing" in (m._wd["last_error"] or ""))
+
+
+def test_run_pull_env_and_state():
+    d = tempfile.mkdtemp()
+    envlog = os.path.join(d, "env.txt")
+    stub = os.path.join(d, "setup.sh")
+    with open(stub, "w") as f:
+        f.write("#!/usr/bin/env bash\nenv > %r\nexit 0\n" % envlog)
+    os.chmod(stub, 0o755)
+    s = [sl for sl, e in reg.COMPOSE_REGISTRY.items() if e.get("weights_companions")][0]
+    m = load(MODEL_DIR=d, SETUP_SCRIPT=stub)
+    m._pull_lock.acquire()      # _run_pull assumes the caller holds it, then releases
+    m._run_pull(s)
+    check("pull reaches 'ready' after a clean setup.sh", m._pull["state"] == "ready")
+    check("pull lock released after run", m._pull_lock.acquire(blocking=False))
+    m._pull_lock.release()
+    envtxt = open(envlog).read()
+    check("child env has MODEL_DIR", ("MODEL_DIR=%s" % d) in envtxt)
+    check("child env has WEIGHT_KEY", "\nWEIGHT_KEY=" in envtxt)
+    check("child env has WEIGHT_EXTRA_KEYS (companion)", "\nWEIGHT_EXTRA_KEYS=" in envtxt)
+    check("child env pins HF_HOME to the model disk",
+          ("HF_HOME=%s" % os.path.join(d, ".cache", "huggingface")) in envtxt)
+
+
+def test_disk_helpers():
+    m = load()
+    fb = m._free_bytes("/nonexistent/deeply/nested/path")
+    check("_free_bytes walks up to an existing ancestor", isinstance(fb, int) and fb > 0)
+    sz = m._slug_total_size_gb(_pick(m)[0][0])
+    check("_slug_total_size_gb returns a number or None", sz is None or isinstance(sz, (int, float)))
+
+
+def test_watchdog_exception_survives():
+    m = load()
+    m._state["desired_slug"] = _pick(m)[0][0]
+
+    def boom():
+        raise RuntimeError("kaboom")
+
+    m._observe = boom
+    m._watchdog_safe_tick()  # must NOT raise
+    check("watchdog tick exception is contained", True)
+    check("last_error records the exception", "kaboom" in (m._wd["last_error"] or ""))
+
+
+def main():
+    for fn in [
+        test_force_consent_and_propagation, test_gpu_eligibility, test_rollback,
+        test_models_hardware_filter, test_slug_from_config_file_exact,
+        test_watchdog_adopt_external, test_watchdog_unknown_no_heal,
+        test_watchdog_heal_then_degrade, test_watchdog_stability_reset,
+        test_persisted_heal_history_survives_restart, test_state_load_corrupt_and_unknown,
+        test_watchdog_exception_survives, test_routes_table_contract, test_models_recommended,
+        test_model_dir_precedence, test_weights_presence_and_companions,
+        test_do_switch_weights_missing_no_rollback, test_watchdog_weights_missing_degrades,
+        test_run_pull_env_and_state, test_disk_helpers,
+    ]:
+        print(f"# {fn.__name__}")
+        fn()
+    print()
+    if FAILS:
+        print(f"test-model-switch-unit: FAIL ({len(FAILS)}): {', '.join(FAILS)}")
+        sys.exit(1)
+    print("test-model-switch-unit: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test-model-switch.sh
+++ b/scripts/tests/test-model-switch.sh
@@ -27,22 +27,53 @@ SRV_PID=""
 cleanup() { [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null; rm -rf "$TMP"; }
 trap cleanup EXIT
 
-# Stub switch.sh: record the slug, sleep briefly (so the single-flight lock is
-# observable), succeed.
+# Stub switch.sh: record arg1 + the FORCE env (so we can assert force propagation) +
+# the full args, sleep briefly (so the single-flight lock is observable), succeed.
 cat > "$TMP/stub-switch.sh" <<EOF
 #!/usr/bin/env bash
-echo "\$@" >> "$STUB_LOG"
+echo "arg1=\$1 FORCE=\${FORCE:-unset} all=\$*" >> "$STUB_LOG"
 sleep 2
 exit 0
 EOF
 chmod +x "$TMP/stub-switch.sh"
 
+# Stub setup.sh (for /pull): record the invocation, exit 0 fast (no real download).
+cat > "$TMP/stub-setup.sh" <<EOF
+#!/usr/bin/env bash
+echo "setup arg1=\$1 WEIGHT_KEY=\${WEIGHT_KEY:-} EXTRA=\${WEIGHT_EXTRA_KEYS:-} HF_HOME=\${HF_HOME:-}" >> "$TMP/setup.log"
+exit 0
+EOF
+chmod +x "$TMP/stub-setup.sh"
+
+# Hermetic MODEL_DIR: materialize fake weights so the do_switch weights pre-check passes and the
+# STUB switch runs (else those switches would 409 weights_missing). Presence re-checks disk live,
+# so slugs discovered later (e.g. the force-required one) can be materialized after server start.
+MDIR="$TMP/models"; mkdir -p "$MDIR"
+materialize() {
+  MODEL_DIR="$MDIR" python3 - "$@" <<'PY'
+import sys, os, importlib.util
+spec = importlib.util.spec_from_file_location("ms", "tools/model-switch/server.py")
+os.environ["MODEL_SWITCH_WATCHDOG"] = "0"
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+for s in sys.argv[1:]:
+    for a in m._slug_artifacts(s):
+        if a["subdir"]:
+            d = os.path.join(m.MODEL_DIR, a["subdir"]); os.makedirs(d, exist_ok=True)
+            open(os.path.join(d, (a["verify_glob"].replace("*", "x") or "x")), "w").close()
+PY
+}
+materialize vllm/dual vllm/gemma-31b-dual
+
 PORT="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
 TOKEN="test-token-123"
 BASE="http://127.0.0.1:$PORT"
 
+# MODEL_SWITCH_GPU_COUNT=2 makes hardware eligibility deterministic; WATCHDOG=0 keeps
+# the background healer out of the HTTP contract tests; STATE_DIR is a throwaway.
 CLUB3090_API_TOKEN="$TOKEN" MODEL_SWITCH_PORT="$PORT" MODEL_SWITCH_BIND=127.0.0.1 \
-  SWITCH_SCRIPT="$TMP/stub-switch.sh" DOCKER_BIN=/bin/true CLUB3090_TOPOLOGY=dual \
+  SWITCH_SCRIPT="$TMP/stub-switch.sh" SETUP_SCRIPT="$TMP/stub-setup.sh" \
+  DOCKER_BIN=/bin/true CLUB3090_TOPOLOGY=dual MODEL_DIR="$MDIR" \
+  MODEL_SWITCH_GPU_COUNT=2 MODEL_SWITCH_WATCHDOG=0 MODEL_SWITCH_STATE_DIR="$TMP/state" \
   VLLM_API_KEY="" \
   python3 tools/model-switch/server.py >"$TMP/server.out" 2>&1 &
 SRV_PID=$!
@@ -76,8 +107,37 @@ assert_code 200 "$(code "$BASE/healthz")" "/healthz open"
 assert_code 401 "$(code "$BASE/status")" "/status without token -> 401"
 assert_code 401 "$(code -H 'Authorization: Bearer wrong' "$BASE/status")" "/status wrong token -> 401"
 assert_code 200 "$(code "${auth[@]}" "$BASE/status")" "/status with token -> 200"
+# 2c. auth-first preserved: unknown routes require auth BEFORE revealing a 404.
+assert_code 401 "$(code "$BASE/__nope__")" "unknown GET route without token -> 401 (auth-first)"
+assert_code 404 "$(code "${auth[@]}" "$BASE/__nope__")" "unknown GET route with token -> 404"
+assert_code 401 "$(code -XPOST "$BASE/__nope__")" "unknown POST route without token -> 401"
 # 3. /models lists the registry.
 assert_contains "$(curl -s "${auth[@]}" "$BASE/models")" '"vllm/dual"'
+# 3a1. GET / self-discovery: OPEN (no auth), valid JSON manifest, lists routes, no handler leak.
+assert_code 200 "$(code "$BASE/")" "GET / discovery open (no auth) -> 200"
+disc="$(curl -s "$BASE/")"
+echo "$disc" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+paths={(e['method'],e['path']) for e in d['endpoints']}
+assert ('POST','/switch') in paths and ('POST','/heal') in paths, 'missing routes'
+assert not any('handler' in e for e in d['endpoints']), 'handler leaked'
+assert d['auth']['configured'] is True, 'auth.configured should be true (token set)'
+assert d['auth']['token_env']==['CLUB3090_API_TOKEN','VLLM_API_KEY'], 'token_env'
+print('discovery-manifest: ok')
+" || { echo 'FAIL: GET / discovery manifest' >&2; echo "$disc" >&2; exit 1; }
+# 3b. /heal with no target and no desired model yet (fresh state) -> 400.
+assert_code 400 "$(code "${auth[@]}" -XPOST "$BASE/heal" -d '{}')" "/heal no-body, no desired -> 400"
+
+# Discover representative slugs from the live registry so tests aren't brittle to
+# specific slug names: a functional one, one that needs force by STATUS, and a
+# GPU-ineligible one (multi>2 on our forced gpu_count=2).
+allmodels="$(curl -s "${auth[@]}" "$BASE/models?all=1")"
+pick() { echo "$allmodels" | python3 -c "import sys,json;print(next((r['slug'] for r in json.load(sys.stdin)['available'] if $1),''))"; }
+FORCE_SLUG="$(pick "r['requires_force'] and r['gpu_eligible'] is not False")"   # non-functional status
+INELIGIBLE_SLUG="$(pick "r['gpu_eligible'] is False")"                          # needs >2 GPUs
+# Materialize the force-required slug's weights so 6b reaches the stub switch (not weights_missing).
+[[ -n "$FORCE_SLUG" ]] && materialize "$FORCE_SLUG"
 # 4. unknown slug -> 400 (registry validation, no switch attempted).
 assert_code 400 "$(code "${auth[@]}" -XPOST "$BASE/switch" -d '{"slug":"__bogus__"}')" "bad slug -> 400"
 # 4b. valid JSON, wrong shape -> 400 (not a 500 / dropped connection).
@@ -89,6 +149,48 @@ assert_contains "$(cat "$STUB_LOG")" "vllm/dual"
 # 6. model id -> resolves to its curated default slug (gemma-4-31b -> vllm/gemma-31b-dual).
 assert_code 200 "$(code "${auth[@]}" -XPOST "$BASE/switch" -d '{"model":"gemma-4-31b"}')" "model switch -> 200"
 assert_contains "$(cat "$STUB_LOG")" "vllm/gemma-31b-dual"
+# functional slug switched without force -> stub saw FORCE=unset.
+assert_contains "$(grep 'arg1=vllm/dual ' "$STUB_LOG" | head -1)" "FORCE=unset"
+
+# 6b. force consent (real FORCE env plumbing through switch.sh).
+if [[ -n "$FORCE_SLUG" ]]; then
+  assert_code 400 "$(code "${auth[@]}" -XPOST "$BASE/switch" -d "{\"slug\":\"$FORCE_SLUG\"}")" "force-required slug w/o force -> 400"
+  assert_code 200 "$(code "${auth[@]}" -XPOST "$BASE/switch" -d "{\"slug\":\"$FORCE_SLUG\",\"force\":true}")" "force-required slug w/ force -> 200"
+  assert_contains "$(grep "arg1=$FORCE_SLUG " "$STUB_LOG" | tail -1)" "FORCE=1"
+fi
+# 6c. hardware filter: a GPU-ineligible slug is hidden by default, shown under ?all=1.
+if [[ -n "$INELIGIBLE_SLUG" ]]; then
+  assert_contains "$allmodels" "\"$INELIGIBLE_SLUG\""
+  if curl -s "${auth[@]}" "$BASE/models" | grep -q "\"$INELIGIBLE_SLUG\""; then
+    echo "FAIL: GPU-ineligible slug $INELIGIBLE_SLUG should be hidden from default /models" >&2; exit 1
+  fi
+  # ...and switching to it without force is refused (400).
+  assert_code 400 "$(code "${auth[@]}" -XPOST "$BASE/switch" -d "{\"slug\":\"$INELIGIBLE_SLUG\"}")" "ineligible slug w/o force -> 400"
+fi
+# 6d. /heal with an explicit slug -> 200; /down -> 200 + stub called with --down.
+assert_code 200 "$(code "${auth[@]}" -XPOST "$BASE/heal" -d '{"slug":"vllm/dual"}')" "/heal slug -> 200"
+assert_code 200 "$(code "${auth[@]}" -XPOST "$BASE/down")" "/down -> 200"
+assert_contains "$(cat "$STUB_LOG")" "arg1=--down"
+
+# 6e. weights_missing: a functional slug whose weights aren't materialized -> /switch 409.
+MISSING="$(echo "$allmodels" | python3 -c "import sys,json;print(next((r['slug'] for r in json.load(sys.stdin)['available'] if not r['requires_force'] and r['slug'] not in ('vllm/dual','vllm/gemma-31b-dual')),''))")"
+if [[ -n "$MISSING" ]]; then
+  assert_contains "$(curl -s "${auth[@]}" -XPOST "$BASE/switch" -d "{\"slug\":\"$MISSING\"}")" '"weights_missing"'
+  assert_code 409 "$(code "${auth[@]}" -XPOST "$BASE/switch" -d "{\"slug\":\"$MISSING\"}")" "missing weights -> /switch 409"
+  # /pull the missing slug: 202 (started) or 507 (disk) — both valid; if 202, stub setup runs.
+  pc="$(code "${auth[@]}" -XPOST "$BASE/pull" -d "{\"slug\":\"$MISSING\"}")"
+  [[ "$pc" == "202" || "$pc" == "507" ]] || { echo "FAIL: /pull missing -> $pc (want 202 or 507)" >&2; exit 1; }
+  if [[ "$pc" == "202" ]]; then
+    for _ in $(seq 1 20); do
+      ds="$(curl -s "${auth[@]}" "$BASE/status" | python3 -c "import sys,json;print(json.load(sys.stdin)['download']['state'])")"
+      [[ "$ds" != "downloading" ]] && break; sleep 0.3
+    done
+    assert_contains "$(cat "$TMP/setup.log")" "WEIGHT_KEY="
+  fi
+fi
+# 6f. /status exposes model_dir + download; /pull an already-present slug -> 200 ready.
+assert_contains "$(curl -s "${auth[@]}" "$BASE/status")" "\"model_dir\": \"$MDIR\""
+assert_code 200 "$(code "${auth[@]}" -XPOST "$BASE/pull" -d '{"slug":"vllm/dual"}')" "/pull present -> 200 ready"
 # 7. single-flight: a 2nd switch while the (sleeping) stub holds the lock -> 409.
 curl -s -o /dev/null "${auth[@]}" -XPOST "$BASE/switch" -d '{"slug":"vllm/dual"}' &
 BG_PID=$!
@@ -107,5 +209,10 @@ set -e
 if [ "$rc" -eq 0 ] || [ "$rc" -eq 124 ]; then
   echo "FAIL: unauthenticated non-loopback bind should be refused (rc=$rc)" >&2; exit 1
 fi
+
+# 9. Deterministic state-machine unit tests (watchdog, rollback, crash-loop budget,
+#    persistence, force consent) — driven directly against server.py's functions.
+echo "--- state-machine unit tests ---"
+python3 "$ROOT_DIR/scripts/tests/test-model-switch-unit.py" || exit 1
 
 echo "test-model-switch: ok"

--- a/tools/model-switch/README.md
+++ b/tools/model-switch/README.md
@@ -3,43 +3,125 @@
 **Status: 🧪 experimental** (opt-in; validate on your rig before relying on it).
 
 A tiny stdlib HTTP service that wraps [`scripts/switch.sh`](../../scripts/switch.sh) so an
-experiment harness can swap the running model programmatically instead of shelling out.
-Only one model fits in VRAM at a time on a 1–2 GPU rig, so this is the "now serve model X,
-tell me when it's ready" primitive.
+experiment harness can swap the running model programmatically instead of shelling out —
+and, because much of the catalog is experimental, **keep the desired model alive**. Only one
+model fits in VRAM at a time on a 1–2 GPU rig, so this is the "now serve model X, keep it
+healthy, tell me when it's ready" primitive.
 
 It adds **no orchestration logic** — `switch.sh` stays the single source of truth (registry
 lookup, down→up, readiness probe). This is the HTTP analogue of what `tools/serve-cockpit`
 does as a TUI. **stdlib only, no pip installs.**
+
+## What it does beyond a raw switch
+- **Hardware-aware listing** — `/models` hides slugs that can't fit this GPU count (e.g.
+  `multi4` on a 2-GPU host) and tombstoned statuses; `?all=1` shows everything.
+- **Explicit-consent force** — a non-production or oversized slug requires `{"force": true}`
+  (mirrors `switch.sh --force`). See the caution below.
+- **Rollback** — if a switch fails, the previously-healthy model is restored.
+- **Self-healing watchdog** — re-launches a crashed/wedged desired model; on a crash-loop it
+  tears the model down and marks the service `degraded` instead of thrashing forever.
 
 ## Endpoints
 
 | Method | Path | Auth | Returns |
 |---|---|---|---|
 | GET | `/healthz` | no | `{"ok": true}` |
-| GET | `/status` | yes | `{"current_model","ready","port","container"}` |
-| GET | `/models` | yes | `{"available":[{"slug","model","status","port"}, …]}` |
-| POST | `/switch` | yes | blocks until ready → `{"ok","slug","model","took_s"}` |
+| GET | `/` | no | **self-discovery manifest** — every route, method, auth policy, and body shape (point an agent here) |
+| GET | `/status` | yes | current/desired slug, `docker_state`, `degraded`, `watchdog{…}` |
+| GET | `/models` | yes | `{"host_topology","gpu_count","available":[{slug,…,gpu_eligible,requires_force,recommended}]}` |
+| POST | `/switch` | yes | blocks until ready → `{"ok","slug","model","took_s"}`; rolls back on failure |
+| POST | `/heal` | yes | recover to a slug (`{"slug"\|"model"}`) or re-launch the current desired model |
+| POST | `/pull` | yes | **download** a model's weights + companions (async; poll `GET /status .download`) |
+| POST | `/down` | yes | `switch.sh --down` + stand the watchdog down |
 
-`POST /switch` body accepts either an exact registry slug or a model id:
+> This table is human-facing convenience. The **authoritative** endpoint list is the `ROUTES`
+> table in `server.py`, served unauthenticated at `GET /` — so a client/agent can learn the whole
+> API in one call, and it can't drift from the code. On `/models`, `recommended` = the slug is
+> `production` or production-with-`caveats` (vs experimental/preview/incubating/upstream-gated/
+> deprecated); `status` is the exact lifecycle, `requires_force` the switching-consent signal.
+
+`POST /switch` / `/heal` body accepts an exact registry slug or a model id, plus optional force:
 ```json
-{"slug": "vllm/gemma-31b-dual"}      // any slug from GET /models
-{"model": "gemma-4-31b"}             // resolved to the model's curated default slug
+{"slug": "vllm/gemma-31b-dual"}          // any slug from GET /models
+{"model": "gemma-4-31b"}                 // resolved to the model's curated default slug
+{"slug": "vllm/qwen-27b-multi-fast", "force": true}   // required for non-prod / oversized slugs
 ```
-Errors: `400` unknown/ambiguous slug-or-model · `401` bad token · `409` a switch is already
-in progress · `500` `{ok:false, detail:<switch.sh log tail>}`.
+Errors: `400` unknown/ambiguous, or **force required without `"force": true`** ·
+`401` bad token · `409` a transition is already in progress · `500`
+`{ok:false, detail:<switch.sh log tail>}` (with `rolled_back_to` / `rollback_failed`).
 
-## Run
+### ⚠️ `force` disables safety checks
+`{"force": true}` sets `FORCE=1` for `switch.sh`, which bypasses its free-VRAM, SM, and
+hardware-fit preflights — not just the status gate. Only force a slug you know fits. The
+authorization is **persisted**, so the watchdog re-launches a force-authorized model the same
+way; an *externally* CLI-switched experimental model is adopted but **not** auto-forced (heal
+it via `POST /heal {"slug":…,"force":true}` if you want that).
+
+## Downloading weights (`/pull`)
+`/switch` to a model whose weights aren't on disk returns **`409 {"error":"weights_missing",
+"pull":"POST /pull {...}"}`** (the same check fires for watchdog heals — a missing-weights model
+degrades instead of thrashing). Fetch them with `/pull`, which wraps `scripts/setup.sh` (core
+weights **+** every `weights_companions` — mmproj / DFlash the compose mounts):
 
 ```bash
-# Foreground (dev):
-python3 tools/model-switch/server.py
+curl -s -H "$AUTH" -XPOST $BASE/pull -d '{"slug":"ik-llama/ornith9b-single"}'   # → 202, async
+curl -s -H "$AUTH" $BASE/status | jq .download    # {state: downloading|ready|error, last_line, ...}
+```
+- **Async & coarse:** returns `202` immediately; poll `GET /status .download`. `200 {state:ready,
+  already:true}` if already present; `507` if the disk hasn't room.
+- **`{model}` resolves only a *functional curated default*** — experimental/non-default catalog
+  entries (e.g. Ornith) must be pulled by **`{"slug": …}`** (same rule as `/switch`).
+- **Runs concurrently** with a serving model (disk/network, not GPU); a service restart interrupts
+  it — re-`POST /pull` resumes (`setup.sh` idempotent + HF resume). One download at a time (`409`).
 
-# Or as a systemd service (survives reboots, auto-restarts):
-#   edit scripts/systemd/club3090-model-switch.service (User=, repo path), then:
-sudo cp scripts/systemd/club3090-model-switch.service /etc/systemd/system/
+### Where weights land — `MODEL_DIR`
+Everything (`/pull`, the weights pre-check, `/status.model_dir`) uses **`MODEL_DIR`**, the same
+knob `setup.sh`/`switch.sh`/the composes read. Precedence: shell/systemd env `MODEL_DIR` >
+repo-root `.env` `MODEL_DIR=` > `<repo>/models-cache` (default). Set it once in `.env`
+(e.g. `MODEL_DIR=/mnt/ssd/models`) so the service, downloads, and serving all agree. `HF_HOME` is
+pinned to `$MODEL_DIR/.cache/huggingface` so HF staging lands on the same disk.
+
+## Self-healing model
+The watchdog polls the desired model's `/health`. If it stays down past `HEAL_GRACE_S` (or
+`BOOT_GRACE_S` while first booting) it re-launches it. Repeated failures spend a rolling
+budget (`MAX_HEAL_FAILURES` within `HEAL_BUDGET_WINDOW_S`, persisted across restarts); once
+spent, the service `--down`s the model and goes `degraded` — clear it with `POST /heal`. A
+docker-daemon outage reads as `docker_state:"unknown"` and **never** triggers healing.
+
+## Run the rig
+
+The control API is the entry point — it drives the model **and** keeps it alive. Two steps:
+start the API, then tell it which model to serve. All config comes from the repo-root `.env`
+(`VLLM_API_KEY`, `PORT`, `MODEL_DIR`); you never hand-type env vars.
+
+**Dev / no systemd** — the `control-api.sh` wrapper loads `.env` and manages a pidfile + log:
+```bash
+bash scripts/control-api.sh start          # launch the API (detached, watchdog on)
+TOKEN=$(grep -E '^VLLM_API_KEY=' .env | cut -d= -f2)
+curl -s --max-time 420 -H "Authorization: Bearer $TOKEN" \
+     -XPOST localhost:8099/switch -d '{"slug":"vllm/dual"}'   # bring up the model (~3 min)
+bash scripts/control-api.sh status         # UP + /status
+# control-api.sh {start|stop|restart|status|logs}
+```
+
+**Production — systemd** (survives reboots; the desired model is persisted, so the watchdog
+restores it on boot):
+```bash
+sed -e "s|/opt/club-3090|$PWD|g" -e "s|User=youruser|User=$USER|" \
+    scripts/systemd/club3090-model-switch.service | sudo tee /etc/systemd/system/club3090-model-switch.service
 sudo systemctl daemon-reload
 sudo systemctl enable --now club3090-model-switch.service
+# then bring the model up once (persisted; watchdog keeps/restores it thereafter):
+curl -s --max-time 420 -H "Authorization: Bearer $VLLM_API_KEY" \
+     -XPOST localhost:8099/switch -d '{"slug":"vllm/dual"}'
 ```
+
+**From another device** (over a VPN — do not expose the port directly): point the base at the
+tailnet HTTPS front, e.g. `BASE=https://<host>.ts.net:8443` (`tailscale serve --https=8443 8099`).
+
+> `switch.sh`'s readiness probe defaults to the unauthenticated `/health`, so the CLI
+> (`bash scripts/switch.sh vllm/dual`) also works with `VLLM_API_KEY` set — but the API path
+> above is preferred: one entry point, and the watchdog then keeps the model up.
 
 ## Config (env — systemd loads them from the repo-root `.env`)
 
@@ -48,8 +130,17 @@ sudo systemctl enable --now club3090-model-switch.service
 | `CLUB3090_API_TOKEN` | — | Control-endpoint bearer token. Falls back to `VLLM_API_KEY`. If neither is set, the endpoint is **unauthenticated** (loopback only). |
 | `MODEL_SWITCH_PORT` | `8099` | Listen port. |
 | `MODEL_SWITCH_BIND` | `127.0.0.1` | Bind address. Keep on loopback; expose via a VPN, not `0.0.0.0`. |
+| `MODEL_SWITCH_WATCHDOG` | `1` | Background self-healing on/off. |
+| `MODEL_SWITCH_WATCH_INTERVAL_S` | `15` | Watchdog poll period. |
+| `MODEL_SWITCH_HEAL_GRACE_S` | `60` | Down time before healing a previously-healthy model. |
+| `MODEL_SWITCH_BOOT_GRACE_S` | `300` | Unready time allowed while a model is booting. |
+| `MODEL_SWITCH_STABILITY_WINDOW_S` | `300` | Continuous health before the heal budget resets. |
+| `MODEL_SWITCH_HEAL_BUDGET_WINDOW_S` | `600` | Rolling window for the crash-loop budget. |
+| `MODEL_SWITCH_MAX_HEAL_FAILURES` | `3` | Heals allowed in-window before degrading. |
+| `MODEL_SWITCH_STATE_DIR` | `$STATE_DIRECTORY`/XDG | Where the desired-model state persists. |
+| `MODEL_SWITCH_GPU_COUNT` | `nvidia-smi -L` | Override the detected GPU count. |
 | `PORT` | slug default | Model http port used for the `/health` readiness probe. |
-| `SWITCH_SCRIPT` | `scripts/switch.sh` | Overridable (used by the test to stub the switch). |
+| `SWITCH_SCRIPT` / `DOCKER_BIN` | `scripts/switch.sh` / `docker` | Overridable (used by the test to stub them). |
 
 ## Example
 
@@ -65,9 +156,3 @@ curl -s -XPOST -H "Authorization: Bearer $TOKEN" localhost:8099/switch -d '{"mod
 Bind to loopback (default) and set a token. To reach it from other devices, front it with a
 VPN — e.g. Tailscale on its own HTTPS port: `tailscale serve --https=8443 8099`. Do **not**
 expose the port directly to the internet; a model-switch endpoint is a control plane.
-
-## Readiness note
-
-The service probes the **unauthenticated `/health`** endpoint (not the auth-gated
-`/v1/models`) when waiting for a switch, so it works whether or not the model is protected
-with `VLLM_API_KEY`. It requires no change to `switch.sh`.

--- a/tools/model-switch/server.py
+++ b/tools/model-switch/server.py
@@ -1,46 +1,59 @@
-"""model-switch — a tiny host HTTP wrapper around scripts/switch.sh.
+"""model-switch — a self-healing host HTTP control plane around scripts/switch.sh.
 
-Only one model fits in VRAM at a time on a 1–2 GPU rig, so switching between
-models (e.g. Qwen3.6-27B <-> Gemma-4-31B) for cross-model experiments means
-tearing one down and booting another. This exposes that over HTTP so a harness
-can POST /switch and block until the new model is serving.
+Only one model fits in VRAM at a time on a 1–2 GPU rig, so switching between models
+means tearing one down and booting another. This exposes that over HTTP so a harness
+can POST /switch and block until the new model is serving — and, because much of the
+catalog is experimental, it also *keeps the desired model alive*:
 
-It adds NO orchestration logic: `scripts/switch.sh` remains the single source of
-truth (registry lookup, down->up, readiness). This is a thin wrapper — the same
-role `tools/serve-cockpit` plays as a TUI, done as an HTTP endpoint. stdlib-only
-(http.server), matching services/studio/*/server.py.
+  - hardware-aware /models (hides slugs that can't fit this GPU count),
+  - explicit-consent force (non-production / oversized slugs need {"force": true}),
+  - rollback if a switch fails (restore the previously-healthy model),
+  - a background watchdog that re-launches a crashed/wedged model and, on a crash-loop,
+    tears it down and marks the service `degraded` instead of thrashing forever.
 
-Endpoints (Bearer auth on all but /healthz, when a token is configured):
-  GET  /healthz   -> {"ok": true}
-  GET  /status    -> {"current_model", "ready", "port", "container"}
-  GET  /models    -> {"available": [{"slug","model","status","port"}, ...]}
-  POST /switch    -> body {"slug": "<registry-slug>"} OR {"model": "<model-id>"}
-                     blocks until ready; 200 {"ok","slug","model","took_s"}
-                     400 unknown/ambiguous · 401 bad token · 409 in-progress · 500 {ok:false,detail}
+It adds NO orchestration logic: scripts/switch.sh remains the single source of truth
+(registry lookup, down->up, readiness). stdlib-only (http.server), matching
+services/studio/*/server.py; the watchdog thread is the only new shape.
 
-Config (env; systemd loads them from the repo-root .env):
-  CLUB3090_API_TOKEN  control-endpoint bearer token (falls back to VLLM_API_KEY).
-                      If neither is set, the endpoint is UNAUTHENTICATED (loopback only).
-  MODEL_SWITCH_PORT   listen port (default 8099)
-  MODEL_SWITCH_BIND   bind address (default 127.0.0.1)
-  PORT                model http port used for the readiness probe / status (else the
-                      target slug's registry default_port)
-  SWITCH_SCRIPT       path to switch.sh (default <repo>/scripts/switch.sh; overridable for tests)
+Endpoints: the authoritative list is the ROUTES table below (also served, unauthenticated,
+at GET / for self-discovery). Bearer auth on all but /healthz and / when a token is configured.
+
+Force: a slug is `requires_force` when its status is not production/caveats OR it needs
+more GPUs than this host has. Switching to it needs an explicit {"force": true}; that
+authorization is persisted so healing re-launches it the same way. FORCE=1 also bypasses
+switch.sh's VRAM/SM/hardware-fit preflights, so it is deliberately a user act — never inferred.
+
+Config (env; systemd loads them from the repo-root .env). All new vars are MODEL_SWITCH_*:
+  CLUB3090_API_TOKEN / VLLM_API_KEY   control-endpoint bearer token (empty => open, loopback)
+  MODEL_SWITCH_BIND (127.0.0.1) / MODEL_SWITCH_PORT (8099)
+  MODEL_SWITCH_WATCHDOG (1)            background self-healing on/off
+  MODEL_SWITCH_WATCH_INTERVAL_S (15)   watchdog poll period
+  MODEL_SWITCH_HEAL_GRACE_S (60)       down time before healing a previously-healthy model
+  MODEL_SWITCH_BOOT_GRACE_S (300)      unready time allowed while a model is booting
+  MODEL_SWITCH_STABILITY_WINDOW_S (300) continuous health before the heal budget resets
+  MODEL_SWITCH_HEAL_BUDGET_WINDOW_S (600) rolling window for the crash-loop budget
+  MODEL_SWITCH_MAX_HEAL_FAILURES (3)   heals allowed in-window before degrading
+  MODEL_SWITCH_STATE_DIR               desired-state dir (default $STATE_DIRECTORY else XDG)
+  MODEL_SWITCH_GPU_COUNT               override GPU count (else nvidia-smi -L)
+  PORT                                 model http port for readiness/status (else registry)
+  SWITCH_SCRIPT / DOCKER_BIN           overridable for tests
 
 Run:  python3 tools/model-switch/server.py     (or the club3090-model-switch systemd unit)
 """
 from __future__ import annotations
 
-import functools
+import glob
 import hmac
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import threading
 import time
 import urllib.request
+from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
@@ -48,26 +61,98 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 from scripts.lib.profiles.compose_registry import (  # noqa: E402
     COMPOSE_REGISTRY,
+    FUNCTIONAL_STATUSES,
     curated_default_target,
     model_of_slug,
 )
 
+# ---- config --------------------------------------------------------------
 BIND = os.environ.get("MODEL_SWITCH_BIND", "127.0.0.1")
 PORT = int(os.environ.get("MODEL_SWITCH_PORT", "8099"))
-# Control-endpoint token: dedicated var first, then reuse VLLM_API_KEY so a
-# secured rig needs no second secret. Empty -> endpoint is open (loopback only).
-CONTROL_TOKEN = os.environ.get("CLUB3090_API_TOKEN") or os.environ.get("VLLM_API_KEY", "")
-# Token for talking to the MODEL's own OpenAI API (/v1/models is auth-gated when set).
-MODEL_TOKEN = os.environ.get("VLLM_API_KEY", "")
+TOKEN_ENV = ("CLUB3090_API_TOKEN", "VLLM_API_KEY")   # control-endpoint bearer-token sources, in order
+CONTROL_TOKEN = next((v for v in (os.environ.get(k) for k in TOKEN_ENV) if v), "")
 SWITCH_SCRIPT = os.environ.get("SWITCH_SCRIPT") or str(REPO_ROOT / "scripts" / "switch.sh")
 SWITCH_TIMEOUT_S = int(os.environ.get("MODEL_SWITCH_TIMEOUT_S", "600"))
-DOCKER_BIN = os.environ.get("DOCKER_BIN", "docker")  # overridable for tests
+DOCKER_BIN = os.environ.get("DOCKER_BIN", "docker")
+SETUP_SCRIPT = os.environ.get("SETUP_SCRIPT") or str(REPO_ROOT / "scripts" / "setup.sh")
+WEIGHTS_READER = str(REPO_ROOT / "scripts" / "lib" / "profiles" / "weights.py")
 LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1", "::ffff:127.0.0.1"}
 
-# Only one switch may run at a time (a switch tears down + boots a model).
-_switch_lock = threading.Lock()
+
+def _resolve_model_dir() -> str:
+    """MODEL_DIR with setup.sh/switch.sh precedence: shell/systemd env wins, else the repo-root
+    .env's MODEL_DIR= line, else <repo>/models-cache. A bare `python3 server.py` foreground run
+    doesn't auto-load .env, so without this /pull would use models-cache while switch.sh (which
+    loads .env) serves from the .env path — re-creating the missing-weights failure."""
+    v = os.environ.get("MODEL_DIR")
+    if v:
+        return v
+    try:
+        for line in (REPO_ROOT / ".env").read_text().splitlines():
+            s = line.strip()
+            if s.startswith("MODEL_DIR=") and not s.startswith("#"):
+                val = s.split("=", 1)[1].strip().strip('"').strip("'")
+                if val:
+                    return val
+    except OSError:
+        pass
+    return str(REPO_ROOT / "models-cache")
+
+
+MODEL_DIR = _resolve_model_dir()
+
+WATCHDOG_ENABLED = os.environ.get("MODEL_SWITCH_WATCHDOG", "1") == "1"
+WATCH_INTERVAL_S = int(os.environ.get("MODEL_SWITCH_WATCH_INTERVAL_S", "15"))
+HEAL_GRACE_S = int(os.environ.get("MODEL_SWITCH_HEAL_GRACE_S", "60"))
+BOOT_GRACE_S = int(os.environ.get("MODEL_SWITCH_BOOT_GRACE_S", "300"))
+STABILITY_WINDOW_S = int(os.environ.get("MODEL_SWITCH_STABILITY_WINDOW_S", "300"))
+HEAL_BUDGET_WINDOW_S = int(os.environ.get("MODEL_SWITCH_HEAL_BUDGET_WINDOW_S", "600"))
+MAX_HEAL_FAILURES = int(os.environ.get("MODEL_SWITCH_MAX_HEAL_FAILURES", "3"))
+
+
+def _default_state_dir() -> Path:
+    d = os.environ.get("MODEL_SWITCH_STATE_DIR") or os.environ.get("STATE_DIRECTORY")
+    if d:
+        return Path(d)
+    base = os.environ.get("XDG_STATE_HOME") or os.path.expanduser("~/.local/state")
+    return Path(base) / "club3090-model-switch"
+
+
+STATE_DIR = _default_state_dir()
+STATE_FILE = STATE_DIR / "state.json"
 
 MODEL_IDS = sorted({e["model"] for e in COMPOSE_REGISTRY.values()})
+
+# ---- serialized state ----------------------------------------------------
+# One lock serializes every mutation (/switch, /heal, /down, watchdog heal) and every
+# state write. Reads (status/models) are lock-free snapshot reads.
+_transition_lock = threading.Lock()
+
+
+class _TryLock:
+    """Non-blocking `with` for _transition_lock: `with _TryLock(lock) as got:` — `got` is True iff
+    acquired, and the lock is released on exit ONLY if we acquired it. Replaces the repeated
+    acquire(blocking=False) / try / finally-release boilerplate."""
+    def __init__(self, lock):
+        self._lock, self._held = lock, False
+
+    def __enter__(self):
+        self._held = self._lock.acquire(blocking=False)
+        return self._held
+
+    def __exit__(self, *exc):
+        if self._held:
+            self._lock.release()
+
+
+_state: dict = {"desired_slug": None, "force_authorized": False, "degraded": False, "heal_history": []}
+
+# in-memory watchdog timers (grace is re-timed after a restart; only heal_history persists)
+_wd = {
+    "launch_ts": 0.0, "last_healthy_ts": 0.0, "down_since": 0.0, "healthy_streak_start": 0.0,
+    "last_action": None, "last_action_ts": 0.0, "last_error": None,
+}
+_wd_thread: threading.Thread | None = None
 
 
 class SwitchError(Exception):
@@ -77,21 +162,134 @@ class SwitchError(Exception):
         self.payload = {"error": message, **extra}
 
 
+# ---- state persistence (atomic) ------------------------------------------
+def _save_state() -> None:
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        tmp = STATE_FILE.with_name(STATE_FILE.name + ".tmp")
+        tmp.write_text(json.dumps(_state))
+        os.replace(tmp, STATE_FILE)
+    except OSError as e:
+        _wd["last_error"] = f"state save failed: {e}"
+
+
+def _set_state(**kw) -> None:
+    """Update + persist state. Caller MUST hold _transition_lock."""
+    _state.update(kw)
+    _save_state()
+
+
+def _load_state() -> None:
+    data: dict = {}
+    try:
+        loaded = json.loads(STATE_FILE.read_text())
+        if isinstance(loaded, dict):
+            data = loaded
+    except (OSError, ValueError):
+        data = {}  # missing or corrupt -> empty
+    slug = data.get("desired_slug")
+    if slug is not None and slug not in COMPOSE_REGISTRY:
+        _wd["last_error"] = f"dropped unknown persisted slug {slug!r}"
+        slug = None
+    _state["desired_slug"] = slug
+    _state["force_authorized"] = bool(data.get("force_authorized", False)) if slug else False
+    _state["degraded"] = bool(data.get("degraded", False))
+    _state["heal_history"] = [
+        float(t) for t in data.get("heal_history", []) if isinstance(t, (int, float))
+    ]
+
+
+def _pruned_heals(now: float | None = None) -> list[float]:
+    now = now if now is not None else time.time()
+    cutoff = now - HEAL_BUDGET_WINDOW_S
+    return [t for t in _state.get("heal_history", []) if t >= cutoff]
+
+
+# ---- topology / GPU eligibility ------------------------------------------
 def _topology() -> str:
-    """dual/single from visible GPU count (overridable via CLUB3090_TOPOLOGY)."""
+    """single/dual/multi family from GPU count (override CLUB3090_TOPOLOGY). For slug resolution."""
     forced = os.environ.get("CLUB3090_TOPOLOGY")
     if forced:
         return forced
-    try:
-        out = subprocess.run(["nvidia-smi", "-L"], capture_output=True, text=True, timeout=10).stdout
-        n = sum(1 for line in out.splitlines() if line.startswith("GPU "))
-    except Exception:
-        n = 2
+    n = _gpu_count()
+    if n is None:
+        return "dual"
     return "single" if n <= 1 else ("dual" if n == 2 else "multi")
 
 
+def _raw_topology(slug: str) -> str | None:
+    """The concrete topology dir from compose_path (single/dual/multiN) — keeps the N."""
+    entry = COMPOSE_REGISTRY.get(slug) or {}
+    cp = entry.get("compose_path", "")
+    if "/compose/" not in cp:
+        return None
+    return cp.split("/compose/", 1)[1].split("/", 1)[0]
+
+
+def _required_gpus(slug: str) -> int | None:
+    topo = _raw_topology(slug)
+    if topo == "single":
+        return 1
+    if topo == "dual":
+        return 2
+    if topo and topo.startswith("multi"):
+        m = re.match(r"multi(\d+)", topo)
+        return int(m.group(1)) if m else None
+    return None
+
+
+_gpu_count_cache: int | None = None
+
+
+def _gpu_count() -> int | None:
+    """Visible GPU count. Override MODEL_SWITCH_GPU_COUNT; None if undetectable (fail-open)."""
+    global _gpu_count_cache
+    override = os.environ.get("MODEL_SWITCH_GPU_COUNT")
+    if override:
+        try:
+            return int(override)
+        except ValueError:
+            return None
+    if _gpu_count_cache is not None:
+        return _gpu_count_cache
+    try:
+        out = subprocess.run(["nvidia-smi", "-L"], capture_output=True, text=True, timeout=10)
+        if out.returncode != 0:
+            return None
+        n = sum(1 for line in out.stdout.splitlines() if line.startswith("GPU "))
+        if n:
+            _gpu_count_cache = n  # cache only a positive result
+        return n or None
+    except Exception:
+        return None
+
+
+def _gpu_eligible(slug: str) -> bool | None:
+    """True/False fit, or None when either side is unknown (fail-open: don't block)."""
+    req = _required_gpus(slug)
+    cnt = _gpu_count()
+    if req is None or cnt is None:
+        return None
+    return req <= cnt
+
+
+def requires_force(slug: str) -> bool:
+    """Consent needed? Non-functional status OR positively GPU-ineligible. Derived, never stored."""
+    entry = COMPOSE_REGISTRY.get(slug) or {}
+    if entry.get("status", "production") not in FUNCTIONAL_STATUSES:
+        return True
+    return _gpu_eligible(slug) is False
+
+
+def _force_reason(slug: str) -> str:
+    entry = COMPOSE_REGISTRY.get(slug) or {}
+    if entry.get("status", "production") not in FUNCTIONAL_STATUSES:
+        return f"status={entry.get('status')}"
+    return f"needs {_required_gpus(slug)} GPUs, host has {_gpu_count()}"
+
+
+# ---- slug resolution -----------------------------------------------------
 def _as_str(body: dict, key: str) -> str:
-    """Return body[key] as a stripped string, or '' — 400 on a non-string value."""
     v = body.get(key)
     if v is None:
         return ""
@@ -101,7 +299,6 @@ def _as_str(body: dict, key: str) -> str:
 
 
 def resolve_slug(body) -> str:
-    """Resolve a request body to a concrete registry slug, or raise SwitchError(400)."""
     if not isinstance(body, dict):
         raise SwitchError(400, "request body must be a JSON object")
     slug = _as_str(body, "slug")
@@ -126,73 +323,37 @@ def resolve_slug(body) -> str:
     raise SwitchError(400, "provide 'slug' or 'model'")
 
 
-def _docker_ps() -> list[dict]:
-    try:
-        out = subprocess.run(
-            [DOCKER_BIN, "ps", "--format", "{{.Names}}\t{{.Image}}\t{{.Ports}}"],
-            capture_output=True, text=True, timeout=10,
-        ).stdout
-    except Exception:
-        return []
-    rows = []
-    for line in out.splitlines():
-        parts = line.split("\t")
-        if len(parts) == 3:
-            rows.append({"name": parts[0], "image": parts[1], "ports": parts[2]})
-    return rows
-
-
-def _running_model() -> tuple[str | None, int | None]:
-    """(container_name, host_port) of the running model server, or (None, None)."""
-    for r in _docker_ps():
-        if "vllm" in r["image"] or "llama" in r["image"] or r["name"].startswith(
-            ("vllm-", "llama-cpp-", "beellama-", "ik-llama-")
-        ):
-            # Ports like "127.0.0.1:8010->8000/tcp" or "0.0.0.0:8010->8000/tcp".
-            for chunk in r["ports"].split(","):
-                if "->" in chunk:
-                    hostpart = chunk.split("->", 1)[0].strip()
-                    try:
-                        return r["name"], int(hostpart.rsplit(":", 1)[-1])
-                    except ValueError:
-                        continue
-            return r["name"], None
-    return None, None
-
-
-@functools.lru_cache(maxsize=None)
-def _compose_container(slug: str) -> str | None:
-    """The default container_name a slug's compose creates (for same-config detection)."""
-    entry = COMPOSE_REGISTRY.get(slug) or {}
-    try:
-        txt = (REPO_ROOT / entry.get("compose_path", "")).read_text()
-    except OSError:
-        return None
-    m = re.search(r'container_name:\s*"?(?:\$\{[^:}]*:-)?([A-Za-z0-9._-]+)\}?"?', txt)
-    return m.group(1) if m else None
-
-
-def _slug_of_container(name: str | None) -> str | None:
-    if not name:
-        return None
-    for slug in COMPOSE_REGISTRY:
-        if _compose_container(slug) == name:
-            return slug
+# ---- docker observation --------------------------------------------------
+def _parse_host_port(ports: str) -> int | None:
+    for chunk in (ports or "").split(","):
+        if "->" in chunk:
+            hostpart = chunk.split("->", 1)[0].strip()
+            try:
+                return int(hostpart.rsplit(":", 1)[-1])
+            except ValueError:
+                continue
     return None
 
 
-def _get_json(url: str, token: str = "") -> dict | None:
-    req = urllib.request.Request(url)
-    if token:
-        req.add_header("Authorization", f"Bearer {token}")
-    try:
-        with urllib.request.urlopen(req, timeout=3) as r:
-            return json.loads(r.read() or b"{}")
-    except Exception:
-        return None
+def _slug_from_config_file(cfgfile: str) -> str | None:
+    """Map a compose config-files label (absolute path(s)) to the exact registry slug."""
+    for part in (cfgfile or "").split(","):
+        p = part.strip()
+        if not p:
+            continue
+        try:
+            rel = os.path.relpath(os.path.realpath(p), str(REPO_ROOT)).replace(os.sep, "/")
+        except (OSError, ValueError):
+            continue
+        for slug, entry in COMPOSE_REGISTRY.items():
+            if entry.get("compose_path") == rel:  # exact normalized match, not suffix
+                return slug
+    return None
 
 
-def _is_ready(port: int) -> bool:
+def _is_ready(port: int | None) -> bool:
+    if not port:
+        return False
     try:
         with urllib.request.urlopen(f"http://localhost:{port}/health", timeout=3) as r:
             return r.status == 200
@@ -200,35 +361,228 @@ def _is_ready(port: int) -> bool:
         return False
 
 
-def status() -> dict:
-    container, port = _running_model()
-    if not container:
-        return {"current_model": None, "current_slug": None, "ready": False, "port": None, "container": None}
-    ready = _is_ready(port) if port else False
-    current_model = None
-    if port:
-        data = _get_json(f"http://localhost:{port}/v1/models", MODEL_TOKEN)
-        if data and data.get("data"):
-            current_model = data["data"][0].get("id")
-    return {"current_model": current_model, "current_slug": _slug_of_container(container),
-            "ready": ready, "port": port, "container": container}
+def _observe() -> dict:
+    """Observe the running model. state in {healthy, unready, absent, unknown}.
+
+    'unknown' means docker itself is unreachable (never triggers healing); 'absent' means
+    docker is fine but no model container is up.
+    """
+    base = {"slug": None, "container": None, "port": None, "restart_count": None, "started_at": None}
+    try:
+        ps = subprocess.run(
+            [DOCKER_BIN, "ps", "--format", "{{.Names}}\t{{.Image}}\t{{.Ports}}"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except Exception:
+        return {**base, "state": "unknown"}
+    if ps.returncode != 0:
+        return {**base, "state": "unknown"}
+
+    name = ports = None
+    for line in ps.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 3:
+            continue
+        n, img, prts = parts[0], parts[1], parts[2]
+        if "vllm" in img or "llama" in img or n.startswith(
+            ("vllm-", "llama-cpp-", "beellama-", "ik-llama-", "sglang-")
+        ):
+            name, ports = n, prts
+            break
+    if not name:
+        return {**base, "state": "absent"}
+
+    try:
+        insp = subprocess.run(
+            [DOCKER_BIN, "inspect", "-f",
+             '{{index .Config.Labels "com.docker.compose.project.config_files"}}\t'
+             '{{.RestartCount}}\t{{.State.StartedAt}}', name],
+            capture_output=True, text=True, timeout=10,
+        )
+    except Exception:
+        return {**base, "state": "unknown"}
+    if insp.returncode != 0:
+        return {**base, "state": "unknown"}
+    cfgfile, restart, started = (insp.stdout.strip().split("\t") + ["", "", ""])[:3]
+    port = _parse_host_port(ports)
+    try:
+        rc = int(restart)
+    except (TypeError, ValueError):
+        rc = None
+    return {"slug": _slug_from_config_file(cfgfile), "container": name, "port": port,
+            "restart_count": rc, "started_at": started or None,
+            "state": "healthy" if _is_ready(port) else "unready"}
 
 
-def do_switch(slug: str) -> dict:
-    """Run switch.sh <slug>, blocking until ready. Raises SwitchError on failure."""
+def _uptime_s(started_at: str | None) -> int | None:
+    if not started_at:
+        return None
+    try:
+        dt = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+        return max(0, int((datetime.now(timezone.utc) - dt).total_seconds()))
+    except (ValueError, TypeError):
+        return None
+
+
+# ---- weights presence + download (reuses weights.py + setup.sh) ----------
+# Mirrors serve-cockpit's Download action: a slug's weights = its core `weights_variant`
+# PLUS every `weights_companions` (mmproj / DFlash the compose mounts). All must be on disk
+# under MODEL_DIR/<subdir> for the slug to actually serve.
+_weights_index_cache: dict | None = None
+
+
+def _weights_index() -> dict:
+    """(model, variant) -> {subdir, size_gb, verify_glob} from `weights.py list --json`. Cached."""
+    global _weights_index_cache
+    if _weights_index_cache is not None:
+        return _weights_index_cache
+    idx: dict = {}
+    try:
+        out = subprocess.run(["python3", WEIGHTS_READER, "list", "--json"],
+                             capture_output=True, text=True, timeout=15)
+        if out.returncode == 0:
+            for row in json.loads(out.stdout or "[]"):
+                idx[(row.get("model"), row.get("variant"))] = {
+                    "subdir": row.get("subdir") or "",
+                    "size_gb": row.get("size_gb"),
+                    "verify_glob": row.get("verify_glob") or "*.safetensors",
+                }
+    except Exception:
+        pass
+    _weights_index_cache = idx
+    return idx
+
+
+def _companion_keys(entry: dict) -> list[str]:
+    """weights_companions as fully-qualified <model>:<variant> keys (qualify with model if bare)."""
+    model = entry.get("model")
+    return [c if ":" in c else f"{model}:{c}" for c in (entry.get("weights_companions") or []) if c]
+
+
+def _slug_artifacts(slug: str) -> list[dict]:
+    """Core weights variant + companions, each as {model, variant, subdir, size_gb, verify_glob}."""
+    entry = COMPOSE_REGISTRY.get(slug) or {}
+    model, core = entry.get("model"), entry.get("weights_variant")
+    idx = _weights_index()
+    arts = []
+    keys = ([f"{model}:{core}"] if core else []) + _companion_keys(entry)
+    for key in keys:
+        m, v = key.split(":", 1)
+        meta = idx.get((m, v)) or {"subdir": "", "size_gb": None, "verify_glob": "*"}
+        arts.append({"model": m, "variant": v, **meta})
+    return arts
+
+
+def _weights_present(slug: str) -> bool:
+    """True if every artifact's subdir exists under MODEL_DIR with a verify_glob match. Artifacts
+    with no known subdir can't be verified here and are skipped (switch.sh preflight still guards)."""
+    arts = _slug_artifacts(slug)
+    if not arts:
+        return True  # unknown slug shape -> don't block
+    for a in arts:
+        sub = a["subdir"]
+        if not sub:
+            continue
+        d = os.path.join(MODEL_DIR, sub)
+        if not os.path.isdir(d) or not glob.glob(os.path.join(d, a["verify_glob"])):
+            return False
+    return True
+
+
+def _slug_total_size_gb(slug: str) -> float | None:
+    """Summed download size, or None if ANY artifact size is unknown/variable (skip disk preflight)."""
+    total = 0.0
+    for a in _slug_artifacts(slug):
+        s = a["size_gb"]
+        if not isinstance(s, (int, float)):
+            return None
+        total += s
+    return total
+
+
+def _free_bytes(path: str) -> int | None:
+    """Free bytes at path, walking up to the nearest existing ancestor first (path may not exist
+    yet — mirrors preflight.sh's disk check)."""
+    p = path
+    while p and not os.path.isdir(p):
+        p = os.path.dirname(p)
+    try:
+        return shutil.disk_usage(p or "/").free
+    except OSError:
+        return None
+
+
+def _weights_missing_error(slug: str) -> SwitchError:
+    core = (COMPOSE_REGISTRY.get(slug) or {}).get("weights_variant")
+    model = model_of_slug(slug)
+    return SwitchError(409, "weights_missing", slug=slug, model=model, model_dir=MODEL_DIR,
+                       weight_key=f"{model}:{core}" if core else None,
+                       pull=f'POST /pull {{"slug": "{slug}"}}')
+
+
+# One download at a time; independent of _transition_lock (disk/network, not GPU) so a pull can
+# run while a model serves. The pull thread releases _pull_lock when it finishes.
+_pull_lock = threading.Lock()
+_pull: dict = {"state": "idle", "model": None, "slug": None, "weight_key": None,
+               "extra_keys": None, "model_dir": None, "started_ts": 0.0, "last_line": None, "error": None}
+
+
+def _run_pull(slug: str) -> None:
+    """Background: shell out to setup.sh (mirrors serve-cockpit) to fetch core + companions.
+    Caller holds _pull_lock; this releases it when the download finishes."""
+    try:
+        entry = COMPOSE_REGISTRY[slug]
+        model, core = entry["model"], entry["weights_variant"]
+        comp = _companion_keys(entry)
+        env = dict(os.environ)
+        env["WEIGHT_KEY"] = f"{model}:{core}"
+        env["MODEL_DIR"] = MODEL_DIR
+        if comp:
+            env["WEIGHT_EXTRA_KEYS"] = " ".join(comp)
+        env.setdefault("HF_HOME", os.path.join(MODEL_DIR, ".cache", "huggingface"))
+        _pull.update({"state": "downloading", "model": model, "slug": slug,
+                      "weight_key": env["WEIGHT_KEY"], "extra_keys": env.get("WEIGHT_EXTRA_KEYS"),
+                      "model_dir": MODEL_DIR, "started_ts": time.time(), "last_line": None, "error": None})
+        try:
+            p = subprocess.Popen(["bash", SETUP_SCRIPT, model], cwd=str(REPO_ROOT), env=env,
+                                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+            for line in p.stdout:  # stream: keep last non-empty line as coarse progress
+                ln = line.rstrip()
+                if ln:
+                    _pull["last_line"] = ln[-300:]
+            rc = p.wait()
+            if rc == 0:
+                _pull["state"] = "ready"
+            else:
+                _pull["state"], _pull["error"] = "error", f"setup.sh exit {rc}: {_pull['last_line']}"
+        except Exception as e:
+            _pull["state"], _pull["error"] = "error", f"{type(e).__name__}: {e}"
+    finally:
+        _pull_lock.release()
+
+
+# ---- switch primitive ----------------------------------------------------
+def do_switch(slug: str, force: bool = False) -> dict:
+    """Run switch.sh <slug>, blocking until ready. env FORCE=1 iff force. Raises SwitchError.
+
+    Weights presence is checked HERE (the single choke point both perform_switch and the watchdog
+    heal use) so a missing-weights model surfaces `weights_missing` instead of a doomed boot."""
+    if not _weights_present(slug):
+        raise _weights_missing_error(slug)
     entry = COMPOSE_REGISTRY[slug]
     port = os.environ.get("PORT") or str(entry["default_port"])
     env = dict(os.environ)
-    # Probe the unauthenticated /health (not the auth-gated /v1/models) so readiness
-    # works whether or not the model has VLLM_API_KEY set.
-    env["READY_URL"] = f"http://localhost:{port}/health"
+    env["READY_URL"] = f"http://localhost:{port}/health"  # unauth probe: survives VLLM_API_KEY
     env.setdefault("READY_TIMEOUT", str(SWITCH_TIMEOUT_S))
+    if force:
+        env["FORCE"] = "1"
+    else:
+        env.pop("FORCE", None)
     t0 = time.time()
     try:
         p = subprocess.run(
-            ["bash", SWITCH_SCRIPT, slug],
-            cwd=str(REPO_ROOT), env=env, capture_output=True, text=True,
-            timeout=SWITCH_TIMEOUT_S + 60,
+            ["bash", SWITCH_SCRIPT, slug], cwd=str(REPO_ROOT), env=env,
+            capture_output=True, text=True, timeout=SWITCH_TIMEOUT_S + 60,
         )
     except subprocess.TimeoutExpired:
         raise SwitchError(500, "switch timed out", slug=slug)
@@ -237,6 +591,253 @@ def do_switch(slug: str) -> dict:
     return {"ok": True, "slug": slug, "model": model_of_slug(slug), "took_s": round(time.time() - t0, 1)}
 
 
+def _reset_timers(launched: bool = False) -> None:
+    if launched:
+        _wd["launch_ts"] = time.time()
+    _wd["down_since"] = 0.0
+    _wd["healthy_streak_start"] = 0.0
+
+
+# ---- switch + rollback (holds the lock) ----------------------------------
+def perform_switch(target: str, force_requested: bool) -> tuple[dict, int]:
+    if requires_force(target) and not force_requested:
+        return ({"ok": False, "error": "slug requires explicit force consent",
+                 "slug": target, "reason": _force_reason(target),
+                 "hint": 'resend with {"force": true}'}, 400)
+
+    obs = _observe()
+    # no-op fast path: exact slug already healthy
+    if obs["state"] == "healthy" and obs["slug"] == target:
+        _set_state(desired_slug=target, force_authorized=force_requested, degraded=False, heal_history=[])
+        _reset_timers(launched=True)
+        return ({"ok": True, "slug": target, "model": model_of_slug(target),
+                 "status": "already-running", "took_s": 0}, 200)
+
+    rollback_to = obs["slug"] if obs["state"] == "healthy" else None
+    rollback_force = _state.get("force_authorized", False) if rollback_to == _state.get("desired_slug") else False
+
+    try:
+        result = do_switch(target, force=force_requested)
+    except SwitchError as e:
+        if e.payload.get("error") == "weights_missing":
+            # do_switch raised before any teardown — nothing to roll back; surface the pull hint.
+            return ({"ok": False, **e.payload}, e.code)
+        if rollback_to and rollback_to != target:
+            try:
+                do_switch(rollback_to, force=rollback_force)
+                _set_state(desired_slug=rollback_to, force_authorized=rollback_force,
+                           degraded=False, heal_history=[])
+                _reset_timers(launched=True)
+                return ({"ok": False, "error": str(e), "attempted": target,
+                         "rolled_back_to": rollback_to, **e.payload}, e.code)
+            except SwitchError as e2:
+                return ({"ok": False, "error": str(e), "attempted": target,
+                         "rollback_failed": str(e2), "detail": "rig may be empty", **e.payload}, e.code)
+        return ({"ok": False, "error": str(e), "attempted": target, "rolled_back_to": None,
+                 **e.payload}, e.code)
+
+    _set_state(desired_slug=target, force_authorized=force_requested, degraded=False, heal_history=[])
+    _reset_timers(launched=True)
+    return (result, 200)
+
+
+# ---- watchdog ------------------------------------------------------------
+def _degrade(desired: str) -> None:
+    """Caller holds the lock. Mark degraded + best-effort teardown to stop the crash-loop."""
+    _set_state(degraded=True)
+    _wd["last_action"], _wd["last_action_ts"] = f"degrade:{desired}", time.time()
+    try:
+        subprocess.run(["bash", SWITCH_SCRIPT, "--down"], cwd=str(REPO_ROOT),
+                       env=dict(os.environ), capture_output=True, text=True, timeout=120)
+    except Exception as e:  # teardown failure is logged, not retried (avoid a loop)
+        _wd["last_error"] = f"teardown during degrade failed: {e}"
+
+
+def _attempt_heal(desired: str, now: float) -> None:
+    with _TryLock(_transition_lock) as got:
+        if not got:
+            return  # a user op or another heal is running; try next tick
+        # Missing weights is permanent-until-pull, not a crash-loop: don't spend heal budget or
+        # invoke switch.sh — degrade with the reason so /status shows it. Recover via /pull + /heal.
+        if not _weights_present(desired):
+            _set_state(degraded=True)
+            _wd["last_action"], _wd["last_action_ts"] = f"blocked:weights_missing:{desired}", now
+            _wd["last_error"] = f"weights_missing: {desired}"
+            return
+        recent = _pruned_heals(now)
+        if len(recent) >= MAX_HEAL_FAILURES:
+            _degrade(desired)
+            return
+        _set_state(heal_history=recent + [now])
+        _wd["last_action"], _wd["last_action_ts"] = f"heal:{desired}", now
+        try:
+            do_switch(desired, force=_state.get("force_authorized", False))
+            _reset_timers(launched=True)
+        except SwitchError as e:
+            _wd["last_error"] = f"heal failed: {e}"
+
+
+def _watchdog_tick() -> None:
+    desired = _state.get("desired_slug")
+    if not desired or _state.get("degraded"):
+        return
+    obs = _observe()
+    st, observed, now = obs["state"], obs["slug"], time.time()
+
+    if st == "unknown":
+        return  # docker outage: never take destructive action
+
+    # Adopt any present container that isn't the desired one (external CLI switch, even
+    # mid-boot). This makes the just-launched model the new intent, so we never restore
+    # the old desired *under* a booting external launch.
+    if observed and observed != desired:
+        with _TryLock(_transition_lock) as got:
+            if got:
+                _set_state(desired_slug=observed, force_authorized=False)
+                _reset_timers(launched=True)
+        return
+
+    if st == "healthy":
+        if not _wd["healthy_streak_start"]:
+            _wd["healthy_streak_start"] = now
+        _wd["last_healthy_ts"], _wd["down_since"] = now, 0.0
+        if now - _wd["healthy_streak_start"] >= STABILITY_WINDOW_S and _state.get("heal_history"):
+            with _TryLock(_transition_lock) as got:
+                if got:
+                    _set_state(heal_history=[])
+        return
+
+    # st in {unready, absent} for the desired model
+    _wd["healthy_streak_start"] = 0.0
+    if not _wd["down_since"]:
+        _wd["down_since"] = now
+    booting = _wd["last_healthy_ts"] < _wd["launch_ts"]  # never healthy since last launch
+    grace = BOOT_GRACE_S if booting else HEAL_GRACE_S
+    anchor = _wd["launch_ts"] if booting else _wd["down_since"]
+    if now - anchor >= grace:
+        _attempt_heal(desired, now)
+
+
+def _watchdog_safe_tick() -> None:
+    """One watchdog tick with exception containment — a bad tick must never kill the thread."""
+    try:
+        _watchdog_tick()
+    except Exception as e:
+        _wd["last_error"] = f"watchdog tick: {type(e).__name__}: {e}"
+
+
+def _watchdog_loop() -> None:
+    while True:
+        time.sleep(WATCH_INTERVAL_S)
+        _watchdog_safe_tick()
+
+
+# ---- payloads ------------------------------------------------------------
+def status_payload() -> dict:
+    obs = _observe()
+    return {
+        "current_slug": obs["slug"],
+        "current_model": model_of_slug(obs["slug"]) if obs["slug"] else None,
+        "desired_slug": _state.get("desired_slug"),
+        "force_authorized": _state.get("force_authorized", False),
+        "docker_state": obs["state"],
+        "healthy": obs["state"] == "healthy",
+        "port": obs["port"],
+        "container": obs["container"],
+        "restart_count": obs["restart_count"],
+        "uptime_s": _uptime_s(obs["started_at"]),
+        "gpu_count": _gpu_count(),
+        "model_dir": MODEL_DIR,
+        "download": dict(_pull),  # snapshot copy for a clean lock-free read
+        "degraded": _state.get("degraded", False),
+        "watchdog": {
+            "enabled": WATCHDOG_ENABLED,
+            "thread_alive": _wd_thread.is_alive() if _wd_thread else False,
+            "heals_in_window": len(_pruned_heals()),
+            "last_action": _wd["last_action"],
+            "last_action_ts": _wd["last_action_ts"],
+            "last_error": _wd["last_error"],
+        },
+    }
+
+
+def models_payload(show_all: bool) -> dict:
+    avail = []
+    for slug, entry in sorted(COMPOSE_REGISTRY.items()):
+        st = entry["status"]
+        elig = _gpu_eligible(slug)
+        row = {"slug": slug, "model": entry["model"], "status": st, "port": entry["default_port"],
+               "topology": _raw_topology(slug), "gpu_eligible": elig,
+               "requires_force": requires_force(slug),
+               "recommended": st in FUNCTIONAL_STATUSES}
+        if not show_all:
+            if st in ("deprecated", "upstream-gated", "incubating"):
+                continue
+            if elig is False:  # None (unknown) stays visible under fail-open detection
+                continue
+        avail.append(row)
+    return {"host_topology": _topology(), "gpu_count": _gpu_count(), "available": avail}
+
+
+# ---- routes: single runtime source of truth for dispatch AND self-discovery ----
+# Add/change an endpoint by editing ONE entry here (+ its h_* method). Dispatch, the 404
+# set, the auth gate, and GET / all derive from this list, so they cannot drift apart.
+ROUTES = [
+    {"method": "GET", "path": "/healthz", "auth": False, "summary": "liveness",
+     "handler": "h_healthz"},
+    {"method": "GET", "path": "/", "auth": False, "summary": "this API manifest (self-discovery)",
+     "handler": "h_discover"},
+    {"method": "GET", "path": "/status", "auth": True,
+     "summary": "current + desired model, health, watchdog", "handler": "h_status"},
+    {"method": "GET", "path": "/models", "auth": True,
+     "summary": "available models (+ recommended / status / requires_force / gpu_eligible)",
+     "query": {"all": "1 -> include hidden (deprecated/upstream-gated/incubating) + GPU-ineligible"},
+     "handler": "h_models"},
+    {"method": "POST", "path": "/switch", "auth": True,
+     "summary": "switch model; rolls back to the previous healthy model on failure",
+     "body": {"slug": "registry slug (see /models)", "model": "model id -> its curated default slug",
+              "force": "bool, optional; consent for non-production or GPU-oversized slugs"},
+     "body_note": "provide at least one of slug|model; if both are given, slug wins (model ignored)",
+     "handler": "h_switch"},
+    {"method": "POST", "path": "/heal", "auth": True,
+     "summary": "recover a model (or re-launch the current desired model)",
+     "body": {"slug": "optional", "model": "optional", "force": "bool, optional"},
+     "body_note": "omit slug+model to re-launch the current desired model; slug wins if both given",
+     "handler": "h_heal"},
+    {"method": "POST", "path": "/pull", "auth": True,
+     "summary": "download a model's weights + companions (async; poll GET /status .download)",
+     "body": {"slug": "registry slug (see /models)", "model": "model id (functional curated default only)"},
+     "body_note": "slug|model like /switch, but {model} resolves ONLY to a functional curated "
+                  "default — use slug for experimental/non-default entries. Returns 202 immediately; "
+                  "poll GET /status .download for state (downloading|ready|error). Weights land under "
+                  "MODEL_DIR (see /status.model_dir).",
+     "handler": "h_pull"},
+    {"method": "POST", "path": "/down", "auth": True,
+     "summary": "stop the model + stand the watchdog down", "handler": "h_down"},
+]
+
+
+def discovery_payload() -> dict:
+    """Self-description built from ROUTES — one call tells a client/agent the whole API.
+
+    Per-route `auth` is the POLICY (protected when a token is configured); `auth.configured`
+    reports whether auth is actually enforced right now (a token is set).
+    """
+    return {
+        "service": "model-switch",
+        "version": 1,
+        "auth": {
+            "scheme": "Bearer",
+            "configured": bool(CONTROL_TOKEN),
+            "token_env": list(TOKEN_ENV),
+            "note": ("auth=true routes require the Bearer token WHEN configured; if neither env "
+                     "var is set the service is unauthenticated (loopback only)"),
+        },
+        "endpoints": [{k: v for k, v in r.items() if k != "handler"} for r in ROUTES],
+    }
+
+
+# ---- HTTP handler --------------------------------------------------------
 class Handler(BaseHTTPRequestHandler):
     def _json(self, code: int, obj: dict) -> None:
         body = json.dumps(obj).encode()
@@ -248,72 +849,158 @@ class Handler(BaseHTTPRequestHandler):
 
     def _authed(self) -> bool:
         if not CONTROL_TOKEN:
-            return True  # open (warned at startup); loopback bind is the guard
+            return True
         got = self.headers.get("Authorization", "")
         pfx = "Bearer "
         return got.startswith(pfx) and hmac.compare_digest(got[len(pfx):], CONTROL_TOKEN)
 
+    def _body(self) -> dict:
+        n = int(self.headers.get("Content-Length") or 0)
+        return json.loads(self.rfile.read(n) or b"{}")
+
+    def _dispatch(self, method: str) -> None:
+        route = self.path.split("?", 1)[0]
+        entry = next((r for r in ROUTES if r["method"] == method and r["path"] == route), None)
+        # Auth-first: unknown routes and auth:true routes require the token BEFORE we reveal a
+        # 404. Only explicitly-open routes (/healthz, /) skip auth.
+        if entry is None or entry["auth"]:
+            if not self._authed():
+                return self._json(401, {"error": "unauthorized"})
+        if entry is None:
+            return self._json(404, {"error": "not found"})
+        getattr(self, entry["handler"])()
+
     def do_GET(self):
-        if self.path == "/healthz":
-            return self._json(200, {"ok": True})
-        if not self._authed():
-            return self._json(401, {"error": "unauthorized"})
-        if self.path == "/status":
-            return self._json(200, status())
-        if self.path == "/models":
-            avail = [
-                {"slug": s, "model": e["model"], "status": e["status"], "port": e["default_port"]}
-                for s, e in sorted(COMPOSE_REGISTRY.items())
-            ]
-            return self._json(200, {"available": avail})
-        return self._json(404, {"error": "not found"})
+        self._dispatch("GET")
 
     def do_POST(self):
-        if not self._authed():
-            return self._json(401, {"error": "unauthorized"})
-        if self.path != "/switch":
-            return self._json(404, {"error": "not found"})
+        self._dispatch("POST")
+
+    # -- handlers (one per ROUTES entry) --
+    def h_healthz(self):
+        self._json(200, {"ok": True})
+
+    def h_discover(self):
+        self._json(200, discovery_payload())
+
+    def h_status(self):
+        self._json(200, status_payload())
+
+    def h_models(self):
+        self._json(200, models_payload("all=1" in self.path))
+
+    def h_switch(self):
+        self._transition("/switch")
+
+    def h_heal(self):
+        self._transition("/heal")
+
+    def h_down(self):
+        self._handle_down()
+
+    def h_pull(self):
         try:
-            n = int(self.headers.get("Content-Length") or 0)
-            body = json.loads(self.rfile.read(n) or b"{}")
+            body = self._body()
         except Exception as e:
             return self._json(400, {"error": f"bad body: {e}"})
         try:
-            slug = resolve_slug(body)
+            target = resolve_slug(body)
         except SwitchError as e:
             return self._json(e.code, e.payload)
-        # Fast no-op ONLY when the requested slug's compose is the exact one already
-        # running + ready — compared by container, so a different quant/topology/engine
-        # of the same model id still triggers a real switch (no silent skip).
-        cur = status()
-        if cur["ready"] and cur["container"] and _compose_container(slug) == cur["container"]:
-            return self._json(200, {"ok": True, "slug": slug, "model": model_of_slug(slug),
-                                    "status": "already-running", "took_s": 0})
-        if not _switch_lock.acquire(blocking=False):
-            return self._json(409, {"error": "a switch is already in progress"})
+        if _weights_present(target):
+            return self._json(200, {"state": "ready", "already": True, "slug": target,
+                                    "model": model_of_slug(target), "model_dir": MODEL_DIR})
+        # disk preflight (skip when total size is unknown/variable)
+        need_gb = _slug_total_size_gb(target)
+        free = _free_bytes(MODEL_DIR)
+        if need_gb is not None and free is not None and free < need_gb * (1024 ** 3):
+            return self._json(507, {"error": "insufficient_disk", "slug": target,
+                                    "needed_gb": round(need_gb, 1), "free_gb": round(free / 1024 ** 3, 1),
+                                    "model_dir": MODEL_DIR})
+        if not _pull_lock.acquire(blocking=False):
+            return self._json(409, {"error": "a download is already in progress",
+                                    "download": dict(_pull)})
+        started = False
         try:
-            result = do_switch(slug)
-        except SwitchError as e:
-            return self._json(e.code, {"ok": False, **e.payload})
+            threading.Thread(target=_run_pull, args=(target,), name="model-switch-pull",
+                             daemon=True).start()
+            started = True
         finally:
-            _switch_lock.release()
-        return self._json(200, result)
+            if not started:
+                _pull_lock.release()
+        self._json(202, {"state": "downloading", "slug": target, "model": model_of_slug(target),
+                         "model_dir": MODEL_DIR, "needed_gb": need_gb})
 
-    def log_message(self, *a):  # quiet; systemd journal captures stderr
+    def _transition(self, route):
+        try:
+            body = self._body()
+        except Exception as e:
+            return self._json(400, {"error": f"bad body: {e}"})
+        try:
+            target = self._resolve_target(body, route)
+        except SwitchError as e:
+            return self._json(e.code, e.payload)
+        force_requested = bool(isinstance(body, dict) and body.get("force"))
+        with _TryLock(_transition_lock) as got:
+            if not got:
+                return self._json(409, {"error": "a transition is already in progress"})
+            # /switch and /heal share one path: perform_switch clears degraded + heal_history on
+            # every success, so a heal recovers a degraded service too. The only difference — heal
+            # may omit a target and re-launch the desired model — is handled in _resolve_target.
+            payload, code = perform_switch(target, force_requested)
+        self._json(code, payload)
+
+    def _resolve_target(self, body, route):
+        # /heal with no slug/model -> recover the persisted desired
+        if route == "/heal" and isinstance(body, dict) and not body.get("slug") and not body.get("model"):
+            desired = _state.get("desired_slug")
+            if not desired:
+                raise SwitchError(400, "no desired model to heal; provide 'slug' or 'model'")
+            return desired
+        return resolve_slug(body)
+
+    def _handle_down(self):
+        with _TryLock(_transition_lock) as got:
+            if not got:
+                return self._json(409, {"error": "a transition is already in progress"})
+            try:
+                p = subprocess.run(["bash", SWITCH_SCRIPT, "--down"], cwd=str(REPO_ROOT),
+                                   env=dict(os.environ), capture_output=True, text=True, timeout=180)
+                if p.returncode != 0:
+                    return self._json(500, {"ok": False, "error": "down failed",
+                                            "detail": (p.stderr or p.stdout or "")[-400:]})
+                _set_state(desired_slug=None, force_authorized=False, degraded=False)  # stand watchdog down
+                return self._json(200, {"ok": True, "status": "down"})
+            except Exception as e:
+                return self._json(500, {"ok": False, "error": f"down failed: {e}"})
+
+    def log_message(self, *a):
         pass
 
 
 def main() -> None:
+    global _wd_thread
+    if not CONTROL_TOKEN and BIND not in LOOPBACK_HOSTS:
+        raise SystemExit(
+            f"model-switch: REFUSING to start — MODEL_SWITCH_BIND={BIND!r} is non-loopback and "
+            "no CLUB3090_API_TOKEN/VLLM_API_KEY is set; that would expose the destructive "
+            "/switch endpoint unauthenticated. Set a token, or bind to 127.0.0.1.")
+    _load_state()
+    # Adopt the currently-running model as desired if we have no persisted intent.
+    if not _state.get("desired_slug"):
+        obs = _observe()
+        if obs["state"] == "healthy" and obs["slug"]:
+            _state["desired_slug"] = obs["slug"]
+            _save_state()
     if not CONTROL_TOKEN:
-        if BIND not in LOOPBACK_HOSTS:
-            raise SystemExit(
-                f"model-switch: REFUSING to start — MODEL_SWITCH_BIND={BIND!r} is non-loopback and "
-                "no CLUB3090_API_TOKEN/VLLM_API_KEY is set; that would expose the destructive "
-                "/switch endpoint unauthenticated. Set a token, or bind to 127.0.0.1.")
-        print("model-switch: WARNING — no CLUB3090_API_TOKEN/VLLM_API_KEY set; "
-              "control endpoint is UNAUTHENTICATED (loopback only).", flush=True)
+        print("model-switch: WARNING — no token set; control endpoint is UNAUTHENTICATED "
+              "(loopback only).", flush=True)
+    if WATCHDOG_ENABLED:
+        _wd_thread = threading.Thread(target=_watchdog_loop, name="model-switch-watchdog", daemon=True)
+        _wd_thread.start()
     srv = ThreadingHTTPServer((BIND, PORT), Handler)
-    print(f"model-switch: serving on {BIND}:{PORT} (auth={'on' if CONTROL_TOKEN else 'OFF'})", flush=True)
+    print(f"model-switch: serving on {BIND}:{PORT} (auth={'on' if CONTROL_TOKEN else 'OFF'}, "
+          f"watchdog={'on' if WATCHDOG_ENABLED else 'off'})", flush=True)
     srv.serve_forever()
 
 


### PR DESCRIPTION
## Summary

`tools/model-switch` (added in #549) wraps `switch.sh` for one-shot swaps. An unattended harness needs more: only one model fits in VRAM on a 1–2 GPU rig, much of the catalog is experimental, and a wedged model strands the rig until a human notices. This adds a watchdog that re-launches a crashed/wedged model, rollback to the previously-healthy model on a failed switch, a crash-loop budget that degrades instead of thrashing, `POST /pull` for missing weights, and a `ROUTES`-driven `GET /` manifest so an agent can learn the API in one call. **No TPS impact** — the serving path, composes and KV config are untouched; this is host-side control plane only. Trade-off: ~1.6k lines of new host code and a background thread, in exchange for the rig staying up unattended. Compared against the existing `tools/model-switch` on master (the only prior art) and `tools/serve-cockpit`, which does the same job as a TUI.

## Type of change

- [ ] New compose variant
- [ ] New patch / sidecar
- [x] **New script or tool** (`scripts/`, `tools/`)
- [ ] New model
- [ ] Doc-only / typo
- [ ] Other

## Verification

- [x] **`verify-full.sh` PASS** — 8 checks pass, Genesis skipped (not in this compose).
- [x] **`verify-stress.sh`** — boundary **5/5**, recall ladder **3/3**, all 6 ceiling rungs to 240,633 tok (91% of n_ctx=262144).
- [x] Tool's own suite — `test-model-switch.sh` (live HTTP) + `test-model-switch-unit.py`, green **with and without weights on disk**.
- [x] `test-locale-utf8.sh` — 106 scripts (this PR adds `control-api.sh`, which carries the `PYTHONUTF8` export per #779).
- [ ] Full `report.sh --full` — see N/A below.
- [ ] Profile header / BENCHMARKS row / CHANGELOG — see N/A below.

<details><summary><code>verify-full.sh</code> (click)</summary>

```
[1/9] Server reachable on /v1/models ...      ✓ server is serving
[2/9] Genesis patches applied ...             ⊘ no Genesis marker (skipped)
[3/9] Basic completion — capital of France ✓ reply contains 'Paris'
[4/9] Tool calling ...                        ✓ tool_calls[] populated with get_weather
[5/9] Streaming (SSE) ...                     ✓ streamed 15 chunks, 113 chars
[6/9] Streaming tool-calls (thinking-on) ...  ✓ delta.tool_calls + finish_reason=tool_calls, no <tool_call> leak
[7/9] Thinking / reasoning mode ...           ✓ reasoning 636 chars, content 3 chars (finish=stop)
[8/9] Output quality / cascade detection ...  ✓ 9968 chars, variety=0.665, max_line_repeat=0
[9/9] MTP acceptance length threshold ...     ✓ AL = 2.79 (>=2.0 — spec-decode contributing)

All checks passed. Stack is ready for full-functionality use.
```
</details>

<details><summary><code>verify-stress.sh</code> (click)</summary>

```
[7/8] Long-context needle large rungs (60K / 90K — Cliff 2 territory) ...
    ✓  58569 tokens: recalled 'silver platypus 64'   prefill=1831.8 t/s (32s)
    ✓  91070 tokens: recalled 'crimson capybara 13'  prefill=1907.1 t/s (48s)
[8/8] Context ceiling ladder (~95000 → 0.92 × n_ctx) ...
    ✓ rung 1/6: 94K tok (36%)   prefill=2360.9 t/s  VRAM_free=588MB
    ✓ rung 2/6: 124K tok (47%)  prefill=1822.5 t/s  VRAM_free=588MB
    ✓ rung 3/6: 154K tok (59%)  prefill=1749.8 t/s  VRAM_free=588MB
    ✓ rung 4/6: 184K tok (70%)  prefill=1667.2 t/s  VRAM_free=588MB
    ✓ rung 5/6: 214K tok (81%)  prefill=1504.0 t/s  VRAM_free=588MB
    ✓ rung 6/6: 240K tok (91%)  prefill=1505.2 t/s  VRAM_free=588MB

  boundary checks  5/5 passed
  recall ladder    3/3 passed
```

⚠️ The run prints `1 stress check(s) failed` despite 5/5 and 3/3. That counter is the
**VRAM-margin advisory** at `verify-stress.sh:1515` — 588 MB free at 91% fill, under the
1024 MB threshold — which prints a `⚠` but increments `FAILED`. It is a property of the
`vllm/dual` compose that was already running, not a functional failure, and this PR
touches no compose, serving path or KV config. Flagging rather than hiding it.

Note: CONTRIBUTING says "verify-stress 7/7"; since #1018 the script reports split
boundary/recall verdicts instead. The above is the equivalent full pass.
</details>

### N/A justifications

- **`report.sh --full` (~35 min: soak-continuous + bench)** — N/A. That pass exists to validate a *serving* config. This PR adds a host-side control plane and changes no compose, engine flag, or KV setting, so soak-continuous and `bench.sh` would measure the unmodified `vllm/dual` config. `verify-full` + `verify-stress` were still run (above) to prove the tool doesn't perturb the running stack.
- **Profile header** — N/A, no compose added or changed.
- **BENCHMARKS row** — N/A, no TPS claim. Nothing here can move TPS.
- **CHANGELOG entry** — N/A. `models/<model>/CHANGELOG.md` is the per-model gate and no model is touched; consistent with recent `scripts/`+`tools/` changes on master, none of which carry a CHANGELOG entry.

## Cross-links

- Closes # — none; no tracking issue exists. Filed as a draft to scope it, per CONTRIBUTING's "open an issue first" — happy to convert to an issue instead if you'd prefer to align on shape before reviewing code.
- Related: **#1042** (*Launch should catch a missing weight shard before the engine does*). This PR's pre-check is **adjacent but does not close it.** `_weights_present()` verifies the subdir exists and that *some* file matches `verify_glob`, so it catches "weights never downloaded" but **not** #1042's case. Tested explicitly: with 65 of 66 shards on disk it returns `True`. A shard-level `index.json` check is the separate fix #1042 describes.
- Builds on #549 (the original thin wrapper).
- `control-api.sh` carries the `PYTHONUTF8` export required by #779 / #782.
