### PR TITLE
test(list-topology-filter): neutralize per-model default pins

### DIFF
--- a/scripts/tests/test-list-topology-filter.sh
+++ b/scripts/tests/test-list-topology-filter.sh
@@ -27,6 +27,17 @@ cd "$ROOT_DIR"
 # topology rank, not weights on disk.
 export MODEL_DIR="${MODEL_DIR:-/mnt/models/huggingface}"
 
+# A per-model default pin (CLUB3090_DEFAULT_<MODELID>) makes the Defaults view print
+# that slug by name — including the "your pin <slug> was ignored" note a topology-
+# mismatched pin produces — which trips the assertions below on correct behavior.
+# Exporting empty beats the .env file because switch.sh's loader tests `+x`.
+while IFS= read -r pin_key; do
+  export "${pin_key}="
+done < <(
+  compgen -v | grep '^CLUB3090_DEFAULT_' || true   # no match must not abort the subshell
+  [[ -f "$ROOT_DIR/.env" ]] && sed -n 's/^[[:space:]]*\(CLUB3090_DEFAULT_[A-Za-z0-9_]*\)=.*/\1/p' "$ROOT_DIR/.env"
+)
+
 SWITCH="$ROOT_DIR/scripts/switch.sh"
 
 fail=0


### PR DESCRIPTION
## Summary

`test-list-topology-filter.sh` fails on any rig whose `.env` pins a per-model default whose topology doesn't match the detected one — and it fails *because the product code is correct*. The 1-GPU leg asserts `switch.sh --list` never mentions a dual slug, over a capture that includes the Defaults view. When a pin's topology mismatches, `model_default_target` correctly refuses it and prints `(your pin vllm/dual was ignored ...)` — and that slug name satisfies the substring assertion. The test's own header already claims independence from "a stray `.env` pin" and pins `MODEL_DIR` for exactly this reason; this extends the claim to `CLUB3090_DEFAULT_<MODELID>`. **Test-only, 11 lines; no product code changes.** Trade-off: none — it removes a false red without weakening any assertion.

## Type of change

- [ ] New compose variant
- [ ] New patch / sidecar
- [x] **New script or tool** (`scripts/` — test-only change)
- [ ] New model
- [ ] Doc-only / typo
- [ ] Other

## Verification

- [x] **Red-then-green proven.** With a dual pin in `.env`, the test fails before this change and passes after.
- [x] Passes with the pin in `.env`, in the shell env, in **both**, and with **no `.env`** at all.
- [x] `test-locale-utf8.sh` passes.
- [ ] verify-full / verify-stress / report.sh — see N/A below.

<details><summary>Reproduction + result (click)</summary>

```
# Before — .env contains CLUB3090_DEFAULT_QWEN3_6_27B=vllm/dual
$ bash scripts/tests/test-list-topology-filter.sh
FAIL: 1-GPU hides dual slugs: output unexpectedly contains 'vllm/dual'
[list-topology-filter] FAIL

# The line that trips it — note the product behaviour is correct:
  qwen3.6-27b   vllm/minimal   [curated]  (your pin vllm/dual was ignored — invalid/mismatched)

# After
no .env at all .......... test-list-topology-filter: ok
dual pin in .env ........ test-list-topology-filter: ok
dual pin in shell env ... test-list-topology-filter: ok
both .................... test-list-topology-filter: ok
```
</details>

Implementation note: exporting the key **empty** is sufficient to beat the file, because
`switch.sh`'s `.env` loader skips a key that is already set using `+x` rather than `-n` — so
one mechanism clears a shell-inherited pin and a repo `.env` pin alike. The `|| true` on the
`compgen` leg is load-bearing, not decoration: under `set -e` a no-match `grep` aborts the
process-substitution subshell before the `.env` scan runs, which would silently leave only
the shell-env case covered. Verified in isolation.

### N/A justifications

- **verify-full / verify-stress / soak-continuous / bench.sh / `report.sh`** — N/A. This changes one test script's environment setup. It touches no compose, no serving path, no engine flag, and cannot affect what the server does or its TPS.
- **Profile header / BENCHMARKS row / CHANGELOG** — N/A, no compose or model touched.

## Cross-links

- Closes # — none; found while reconciling a branch against master. Filing directly since it is a self-contained test fix well under the "open an issue first" bar, but happy to convert.
- Context: the Defaults view and the pin resolver come from the `<model>/default` resolver work; the resolver itself is **unchanged and not at fault** here.
