### PR TITLE
Unify the spec-decode drafter toggle across all 27 vLLM composes

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -82,6 +82,31 @@ Depends on the arch. The short version:
 
 Full hardware-acceleration matrix (which dtypes/quants run on Tensor Cores natively vs in software, per GPU class) at [DTYPE_MATRIX.md](DTYPE_MATRIX.md), including the weight-only vs weight+activation axis and the NVFP4 / MXFP4 / FP6 Blackwell additions.
 
+### How do I turn the speculative-decoding drafter off?
+
+`SPEC_N=0`, on every compose that ships a drafter:
+
+```bash
+SPEC_N=0 bash scripts/switch.sh vllm/dual    # drafter off
+SPEC_N=6 bash scripts/switch.sh vllm/dual    # depth 6 instead of this compose's default
+```
+
+`SPEC=off` does the same thing and is kept as an alias, so older notes and
+existing `.env` files keep working. A non-numeric `SPEC_N` is a hard boot error
+rather than a silent fall back to "off" — a typo can never quietly leave the
+drafter running, nor quietly disable it.
+
+This is worth stating plainly because turning the drafter off is the documented
+mitigation for [vllm#50021](https://github.com/vllm-project/vllm/pull/50021), and
+until 2026-08-18 the knob was **not** uniform: some composes read `SPEC`, some
+`SPEC_N`, some `SPEC_N_MAX` or `NUM_SPEC_TOKENS`, and ten hardcoded the drafter
+with no runtime escape at all — their header told you to delete a line from the
+YAML. Applying the wrong variable produced a healthy-looking server with the
+drafter still running. `scripts/tests/test-spec-toggle-contract.sh` enforces the
+single contract now, by running each entrypoint and inspecting the argv the
+engine would actually receive.
+
+
 ### What is the W4A8 knob and should I turn it on?
 
 `VLLM_MARLIN_INPUT_DTYPE=int8` on the Qwen vLLM composes (`vllm/dual`, `vllm/minimal`) runs

--- a/models/gemma-4-12b/vllm/compose/single/autoround-int8/mtp.yml
+++ b/models/gemma-4-12b/vllm/compose/single/autoround-int8/mtp.yml
@@ -4,6 +4,7 @@
 #   Engine:    vLLM (vllm/vllm-openai:gemma4-unified — Gemma-4 arch-preview image)
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   assistant external drafter, n=4 default (google/gemma-4-12B-it-assistant ~0.5B)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        bf16 / auto — single kv-dtype (gemma4-unified has no fp8/INT8-PTH path)
 #   Vision:    yes (gemma4_unified is multimodal; served text-only here)
 #   Max ctx:   256K (262144) — MTP fits the FULL ctx on one card (KV pool ~310K tok,
@@ -48,6 +49,10 @@ services:
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
       # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
@@ -78,7 +83,27 @@ services:
       - /bin/bash
       - -c
       - |
-        exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} "$@"
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 4); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-4}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"model\":\"/root/.cache/huggingface/${SPEC_MODEL_SUBDIR:-gemma-4-12b-it-assistant}\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - draft-model ${SPEC_MODEL_SUBDIR:-gemma-4-12b-it-assistant} n=$$_spec_n" >&2
+        else
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
+        exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} "$@" "$${SPEC_ARGS[@]}"
       - --
     command:
       - --model
@@ -99,8 +124,6 @@ services:
       - "${GPU_MEMORY_UTILIZATION:-0.92}"
       - --max-num-seqs
       - "${MAX_NUM_SEQS:-4}"
-      - --speculative-config
-      - '{"model":"/root/.cache/huggingface/${SPEC_MODEL_SUBDIR:-gemma-4-12b-it-assistant}","num_speculative_tokens":${SPEC_N:-4}}'
       - --trust-remote-code
       - --enable-auto-tool-choice
       - --tool-call-parser

--- a/models/gemma-4-12b/vllm/compose/single/qat-w4a16/mtp.yml
+++ b/models/gemma-4-12b/vllm/compose/single/qat-w4a16/mtp.yml
@@ -4,6 +4,7 @@
 #   Engine:    vLLM (vllm/vllm-openai:gemma4-unified — Gemma-4 arch-preview image)
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   assistant external drafter, n=4 default (google/gemma-4-12B-it-assistant ~0.5B)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        bf16 / auto — single kv-dtype (gemma4-unified has no fp8/INT8-PTH path)
 #   Vision:    yes (gemma4_unified is multimodal; served text-only here)
 #   Max ctx:   256K (262144) — MTP fits the FULL ctx on one card (KV pool ~310K tok,
@@ -56,6 +57,10 @@ services:
       # vLLM force-quantizes it because patch_dense is built with quant_config but no prefix=).
       - ../../../patches/gemma4-unified-vision-unquant:/etc/club3090/g4patch:ro
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
       # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
@@ -87,7 +92,27 @@ services:
       - /bin/bash
       - -c
       - |
-        exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} "$@"
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 4); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-4}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"model\":\"/root/.cache/huggingface/${SPEC_MODEL_SUBDIR:-gemma-4-12b-it-assistant}\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - draft-model ${SPEC_MODEL_SUBDIR:-gemma-4-12b-it-assistant} n=$$_spec_n" >&2
+        else
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
+        exec vllm serve ${VLLM_ENFORCE_EAGER:+--enforce-eager} "$@" "$${SPEC_ARGS[@]}"
       - --
     command:
       - --model
@@ -108,8 +133,6 @@ services:
       - "${GPU_MEMORY_UTILIZATION:-0.92}"
       - --max-num-seqs
       - "${MAX_NUM_SEQS:-4}"
-      - --speculative-config
-      - '{"model":"/root/.cache/huggingface/${SPEC_MODEL_SUBDIR:-gemma-4-12b-it-assistant}","num_speculative_tokens":${SPEC_N:-4}}'
       - --trust-remote-code
       - --enable-auto-tool-choice
       - --tool-call-parser

--- a/models/gemma-4-26b-a4b/vllm/compose/single/awq/int8.yml
+++ b/models/gemma-4-26b-a4b/vllm/compose/single/awq/int8.yml
@@ -3,6 +3,7 @@
 #   Model:     Gemma 4 26B-A4B MoE (cyankiwi AWQ-4bit, compressed-tensors)
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   MTP n=4 — google/gemma-4-26B-A4B-it-assistant (external, ~0.97 GB)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        int8_per_token_head (1 byte/token, via vendored PR #40391 overlay)
 #   Vision:    off (limit-mm-per-prompt image=0 audio=0)
 #   Max ctx:   176K default (single-card boot ceiling ~185K WITH the external MTP
@@ -83,6 +84,10 @@ services:
       # whole dir when #40391 merges. See ../../../patches/vllm-pr40391-v0.22.0/README.md.
       - ../../../patches/vllm-pr40391-v0.22.0:/etc/club3090/pr40391:ro
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
       # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
@@ -118,7 +123,27 @@ services:
         # stock v0.22.0 BEFORE vllm imports. Fail-loud: a non-zero exit aborts
         # boot rather than serving a half-patched engine.
         bash /etc/club3090/pr40391/install.sh
-        exec vllm serve "$@"
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 4); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-4}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"model\":\"/root/.cache/huggingface/gemma-4-26b-a4b-it-assistant\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - draft-model gemma-4-26b-a4b-it-assistant n=$$_spec_n" >&2
+        else
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
+        exec vllm serve "$@" "$${SPEC_ARGS[@]}"
       - --
     command:
       - --override-generation-config
@@ -182,6 +207,4 @@ services:
       - "${LONG_PREFILL_TOKEN_THRESHOLD:-2048}"
       # External MTP assistant drafter — n=4 per gemma-26b-it-assistant DrafterProfile.
       # Same external-drafter path as the dual; bypasses MoE expert routing.
-      - --speculative-config
-      - '{"model":"/root/.cache/huggingface/gemma-4-26b-a4b-it-assistant","num_speculative_tokens":4}'
 # Engine-profile: vllm-gemma-stable

--- a/models/gemma-4-31b/vllm/compose/dual/autoround-int4/bf16-mtp.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/autoround-int4/bf16-mtp.yml
@@ -3,6 +3,7 @@
 #   Model:     Gemma 4 31B (Intel AutoRound INT4)
 #   Topology:  Dual 3090 (TP=2, NVLink auto-detected via NVLINK_MODE) — single-card boot-OOMs on 24 GB
 #   Drafter:   MTP n=4 (Google's official `gemma-4-31B-it-assistant`, BF16 0.5B)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        bfloat16 (2 bytes/token)
 #   Vision:    yes
 #   Max ctx:   131K default @ 4 streams (NIAH-validated to 120K) — BF16 KV pool
@@ -89,6 +90,10 @@ services:
       # NVLink auto-detection — runs inside container at boot.
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
       # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
@@ -132,10 +137,30 @@ services:
         bash /etc/club3090/pr42006/install.sh
         # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
         source /etc/club3090/detect_nvlink.sh
-        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve "$$@"
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 4); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-4}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"model\":\"/root/.cache/huggingface/gemma-4-31b-it-assistant\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - draft-model gemma-4-31b-it-assistant n=$$_spec_n" >&2
         else
-          exec vllm serve --disable-custom-all-reduce "$$@"
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve "$$@" "$${SPEC_ARGS[@]}"
+        else
+          exec vllm serve --disable-custom-all-reduce "$$@" "$${SPEC_ARGS[@]}"
         fi
       - --
     command:
@@ -199,5 +224,3 @@ services:
       - gemma4
       - --chat-template
       - /etc/club3090/gemma-canonical-template.jinja
-      - --speculative-config
-      - '{"model":"/root/.cache/huggingface/gemma-4-31b-it-assistant","num_speculative_tokens":4}'

--- a/models/gemma-4-31b/vllm/compose/dual/autoround-int4/int8.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/autoround-int4/int8.yml
@@ -3,6 +3,7 @@
 #   Model:     Gemma 4 31B (Intel AutoRound INT4)
 #   Topology:  Dual 3090 (TP=2, NVLink auto-detected via NVLINK_MODE)
 #   Drafter:   MTP n=4 (Google's official `gemma-4-31B-it-assistant`, BF16 0.5B)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        int8_per_token_head (1 byte/token, via vendored PR #40391 overlay)
 #   Vision:    yes
 #   Max ctx:   262K native default (dual-card max-ctx rule) @ 4-stream cap; INT8 PTH pool ~2× BF16
@@ -151,6 +152,11 @@ services:
       #     minimal overlay surface. Tracked in docs/UPSTREAM.md (re-test trigger:
       #     streaming multi-tool-call regression).
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+      - SPEC_N_MAX=${SPEC_N_MAX:-}
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
       # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
@@ -195,10 +201,30 @@ services:
         bash /etc/club3090/pr42006/install.sh
         # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
         source /etc/club3090/detect_nvlink.sh
-        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve "$$@"
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 4); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-$${SPEC_N_MAX:-4}}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"model\":\"/root/.cache/huggingface/gemma-4-31b-it-assistant\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - draft-model gemma-4-31b-it-assistant n=$$_spec_n" >&2
         else
-          exec vllm serve --disable-custom-all-reduce "$$@"
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve "$$@" "$${SPEC_ARGS[@]}"
+        else
+          exec vllm serve --disable-custom-all-reduce "$$@" "$${SPEC_ARGS[@]}"
         fi
       - --
     command:
@@ -270,5 +296,3 @@ services:
       # qwen3.6-27b/vllm/compose/dual/autoround-int4/int8.yml (Qwen's built-in MTP caps at
       # n=3 architecturally, so the canonical apples-to-apples bench uses
       # SPEC_N_MAX=3 here).
-      - --speculative-config
-      - '{"model":"/root/.cache/huggingface/gemma-4-31b-it-assistant","num_speculative_tokens":${SPEC_N_MAX:-4}}'

--- a/models/gemma-4-31b/vllm/compose/dual/qat-w4a16/int8.yml
+++ b/models/gemma-4-31b/vllm/compose/dual/qat-w4a16/int8.yml
@@ -3,6 +3,7 @@
 #   Model:     Gemma 4 31B — unsloth QAT W4A16 (compressed-tensors int4)
 #   Topology:  Dual 3090 (TP=2, NVLink auto-detected via NVLINK_MODE)
 #   Drafter:   MTP n=3 (Google's official `gemma-4-31B-it-assistant`, BF16 0.5B) — n-swept optimum for this quant
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        int8_per_token_head (1 byte/token, via vendored PR #40391 overlay — compressed-tensors can't do fp8 KV)
 #   Vision:    yes
 #   Max ctx:   262K native default (dual-card max-ctx rule) @ 4-stream cap
@@ -154,6 +155,11 @@ services:
       #     minimal overlay surface. Tracked in docs/UPSTREAM.md (re-test trigger:
       #     streaming multi-tool-call regression).
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+      - SPEC_N_MAX=${SPEC_N_MAX:-}
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
       # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
@@ -198,10 +204,30 @@ services:
         bash /etc/club3090/pr42006/install.sh
         # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
         source /etc/club3090/detect_nvlink.sh
-        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve "$$@"
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-$${SPEC_N_MAX:-3}}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"model\":\"/root/.cache/huggingface/gemma-4-31b-it-assistant\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - draft-model gemma-4-31b-it-assistant n=$$_spec_n" >&2
         else
-          exec vllm serve --disable-custom-all-reduce "$$@"
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve "$$@" "$${SPEC_ARGS[@]}"
+        else
+          exec vllm serve --disable-custom-all-reduce "$$@" "$${SPEC_ARGS[@]}"
         fi
       - --
     command:
@@ -274,5 +300,3 @@ services:
       # n=3 the best balance — top narrative (74.0 TPS), code tied with n=4 (87.7), and
       # ~20% less wasted drafting than n=4. n=2 dips on code; n=4 wastes the low-accept
       # tail. (autoround-int4's slower decay earns its n=4 — see autoround-int4/int8.yml.)
-      - --speculative-config
-      - '{"model":"/root/.cache/huggingface/gemma-4-31b-it-assistant","num_speculative_tokens":${SPEC_N_MAX:-3}}'

--- a/models/gemma-4-31b/vllm/compose/multi4/google-qat-w4a16/base.yml
+++ b/models/gemma-4-31b/vllm/compose/multi4/google-qat-w4a16/base.yml
@@ -3,6 +3,7 @@
 #   Model:     Gemma 4 31B — official Google QAT W4A16 (compressed-tensors INT4)
 #   Topology:  Quad 3090 (TP=4, PCIe; NVLink auto-detected via NVLINK_MODE)
 #   Drafter:   MTP n=2 (Google's official `gemma-4-31B-it-assistant`)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        bf16 (engine-default; overlay-free)
 #   Vision:    yes (live smoke-tested)
 #   Max ctx:   262144 native; MTP recall verified at 257544 prompt tokens
@@ -60,6 +61,11 @@ services:
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
       # No overlay mounts: BF16 KV runs on the pinned stock vLLM image.
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+      - SPEC_N_MAX=${SPEC_N_MAX:-}
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
       # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
@@ -100,10 +106,30 @@ services:
       - |
         # Overlay-free on the pinned stock vLLM image — just NVLink autodetect + serve.
         source /etc/club3090/detect_nvlink.sh
-        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve "$$@"
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 2); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-$${SPEC_N_MAX:-2}}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"model\":\"/root/.cache/huggingface/gemma-4-31b-it-assistant\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - draft-model gemma-4-31b-it-assistant n=$$_spec_n" >&2
         else
-          exec vllm serve --disable-custom-all-reduce "$$@"
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve "$$@" "$${SPEC_ARGS[@]}"
+        else
+          exec vllm serve --disable-custom-all-reduce "$$@" "$${SPEC_ARGS[@]}"
         fi
       - --
     command:
@@ -155,5 +181,3 @@ services:
       - --chat-template
       - /etc/club3090/gemma-canonical-template.jinja
       # Full n=1..4 sweep selects n=2 for this quant. Override only for re-benchmarking.
-      - --speculative-config
-      - '{"model":"/root/.cache/huggingface/gemma-4-31b-it-assistant","num_speculative_tokens":${SPEC_N_MAX:-2}}'

--- a/models/gemma-4-31b/vllm/compose/single/autoround-int4/fp8-mtp.yml
+++ b/models/gemma-4-31b/vllm/compose/single/autoround-int4/fp8-mtp.yml
@@ -3,6 +3,7 @@
 #   Model:     Gemma 4 31B (Intel AutoRound INT4)
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   MTP n=3 (Google's official `gemma-4-31B-it-assistant`)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8_e4m3 (intended) — no fp8 KV path exists for Gemma 4 on Ampere
 #   Vision:    no (image=0)
 #   Max ctx:   8K (config) — never reaches serving on sm_86
@@ -80,6 +81,10 @@ services:
       - ../../../cache/triton:/root/.triton/cache
       # PR #41745 overlay dropped 2026-05-08: merged upstream + nightly contains it.
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
       # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
@@ -110,6 +115,34 @@ services:
     # transformers 5.8.0+ ships in the post-Gemma4-merge nightly (verified
     # 2026-05-08: nightly-1acd67a795... has transformers 5.8.0). Entrypoint
     # upgrade dropped.
+    # The image ENTRYPOINT is ["vllm","serve"]; this wrapper is equivalent to it
+    # and exists only so the drafter can be switched off without editing this file.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 4); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-4}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"model\":\"/root/.cache/huggingface/gemma-4-31b-it-assistant\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - draft-model gemma-4-31b-it-assistant n=$$_spec_n" >&2
+        else
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
+        exec vllm serve "$$@" "$${SPEC_ARGS[@]}"
+      - --
     command:
       - --override-generation-config
       - '{"temperature":${TEMP:-${TEMPERATURE:-1.0}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-64},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
@@ -157,5 +190,3 @@ services:
       - gemma4
       - --chat-template
       - /etc/club3090/gemma-canonical-template.jinja
-      - --speculative-config
-      - '{"model":"/root/.cache/huggingface/gemma-4-31b-it-assistant","num_speculative_tokens":4}'

--- a/models/nemotron-3-puzzle-75b/vllm/compose/multi4/nvfp4/mtp.yml
+++ b/models/nemotron-3-puzzle-75b/vllm/compose/multi4/nvfp4/mtp.yml
@@ -4,6 +4,7 @@
 #              Mamba2-Transformer Hybrid LatentMoE, 512 routed experts + 1 shared)
 #   Topology:  Quad 3090 PCIe (TP=4, no NVLink — auto-detected via NVLINK_MODE)
 #   Drafter:   MTP n=3 (NVIDIA's built-in MTP head — the accelerated path from the card)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        two separate caches (hybrid model):
 #              • Attention layers → fp8_e4m3 (checkpoint declares this scheme; vLLM
 #                auto-selects it, made explicit via --kv-cache-dtype fp8). Storage-only on Ampere.
@@ -91,6 +92,11 @@ services:
       # NVLink auto-detection — runs inside container at boot (sets _NVLINK_ENABLED).
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+      - NUM_SPEC_TOKENS=${NUM_SPEC_TOKENS:-}
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
@@ -128,10 +134,30 @@ services:
         # (the common 4×3090 case) custom all-reduce is disabled — NVLink-assumed
         # allreduce paths break on PCIe.
         source /etc/club3090/detect_nvlink.sh
-        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@"
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-$${NUM_SPEC_TOKENS:-3}}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - mtp n=$$_spec_n" >&2
         else
-          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@"
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@" "$${SPEC_ARGS[@]}"
+        else
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@" "$${SPEC_ARGS[@]}"
         fi
       - --
     command:
@@ -148,8 +174,6 @@ services:
       - --async-scheduling
       # --- MTP speculative decoding (NVIDIA's accelerated path). Comment out the two lines
       # below to run without MTP (no-drafter fallback) if MTP misbehaves on Ampere. ---
-      - --speculative-config
-      - '{"method":"mtp","num_speculative_tokens":${NUM_SPEC_TOKENS:-3}}'
       # --- Mamba2 SSM state cache (NOT the attention KV cache) ---
       # float16 + stochastic rounding is NVIDIA's precision-preserving recurrent-state
       # config. Do NOT lower this to fp8 — SSM state accumulates recurrently and is

--- a/models/qwen3.6-27b/vllm-lmcache/compose/dual/fp8/lmcache.yml
+++ b/models/qwen3.6-27b/vllm-lmcache/compose/dual/fp8/lmcache.yml
@@ -3,6 +3,7 @@
 #   Model:     Qwen3.6-27B FP8 (official e4m3, embedded mtp head)
 #   Topology:  Dual 3090 (TP=2, NVLink auto-detected via NVLINK_MODE)
 #   Drafter:   MTP n=3 (built-in) — survives LMCache, acceptance ~83%
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        int8_per_token_head (1 byte/token) + LMCache tiered prefix cache
 #                (GPU → L1 CPU RAM → optional L2 disk)
 #   Vision:    yes
@@ -114,6 +115,10 @@ services:
       # NVLink auto-detection — runs inside container at boot (same path as dual-max).
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
       # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
@@ -182,10 +187,30 @@ services:
         fi
         lmcache server "$${LM_ARGS[@]}" &
         sleep 6
-        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve "$$@"
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-3}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - mtp n=$$_spec_n" >&2
         else
-          exec vllm serve --disable-custom-all-reduce "$$@"
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve "$$@" "$${SPEC_ARGS[@]}"
+        else
+          exec vllm serve --disable-custom-all-reduce "$$@" "$${SPEC_ARGS[@]}"
         fi
       - --
     command:
@@ -212,8 +237,6 @@ services:
       - "${KV_CACHE_DTYPE:-int8_per_token_head}"
       - --mamba-cache-mode
       - align
-      - --speculative-config
-      - '{"method":"mtp","num_speculative_tokens":3}'
       - --enable-prefix-caching
       - --kv-transfer-config
       - '{"kv_connector":"LMCacheMPConnector","kv_role":"kv_both"}'

--- a/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml
@@ -3,6 +3,7 @@
 #   Model:     Qwen3.6-27B (Lorbus AutoRound INT4 + BF16 mtp.fc preserved)
 #   Topology:  Dual 3090 (TP=2, NVLink auto-detected via NVLINK_MODE)
 #   Drafter:   MTP n=3 (built-in)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8_e4m3 (1 byte/token — more mantissa precision than e5m2; matches dual-max)
 #   Vision:    yes
 #   Max ctx:   262K (237K single-prompt verified)
@@ -118,6 +119,10 @@ services:
       # prefix-off default; protects PREFIX_CACHE_ARG users. See patches.yml.
       - ../../../patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
       # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
@@ -175,10 +180,30 @@ services:
         # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
         source /etc/club3090/detect_nvlink.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
-        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@"
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-3}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - mtp n=$$_spec_n" >&2
         else
-          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@"
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@" "$${SPEC_ARGS[@]}"
+        else
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@" "$${SPEC_ARGS[@]}"
         fi
       - --
     command:
@@ -233,8 +258,6 @@ services:
       # Set LONG_PREFILL_TOKEN_THRESHOLD=0 to disable.
       - --long-prefill-token-threshold
       - "${LONG_PREFILL_TOKEN_THRESHOLD:-2048}"
-      - --speculative-config
-      - '{"method":"mtp","num_speculative_tokens":3}'
       - --override-generation-config
       - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host

--- a/models/qwen3.6-27b/vllm/compose/dual/awq-bf16-int4/int8.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/awq-bf16-int4/int8.yml
@@ -4,6 +4,7 @@
 #              compressed-tensors pack-quantized)
 #   Topology:  Dual 3090 (TP=2, NVLink auto-detected via NVLINK_MODE)
 #   Drafter:   MTP n=3 (built-in — the checkpoint embeds the mtp.* head, BF16)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        int8_per_token_head (1 byte/token, 8-bit — higher KV fidelity than the
 #              fast tier's fp8_e5m2; keeps the full 262K at TP=2)
 #   Vision:    yes
@@ -88,6 +89,10 @@ services:
       # prefix-off default; protects PREFIX_CACHE_ARG users. See patches.yml.
       - ../../../patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
       # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
@@ -139,10 +144,30 @@ services:
         # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
         source /etc/club3090/detect_nvlink.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
-        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@"
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-3}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - mtp n=$$_spec_n" >&2
         else
-          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@"
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@" "$${SPEC_ARGS[@]}"
+        else
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@" "$${SPEC_ARGS[@]}"
         fi
       - --
     command:
@@ -186,8 +211,6 @@ services:
       # v0.25.x. Opt out: PREFIX_CACHE_ARG=--no-enable-prefix-caching
       - "${PREFIX_CACHE_ARG:---enable-prefix-caching}"
       - --enable-chunked-prefill
-      - --speculative-config
-      - '{"method":"mtp","num_speculative_tokens":3}'
       - --override-generation-config
       - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host

--- a/models/qwen3.6-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/fp8/mtp.yml
@@ -3,6 +3,7 @@
 #   Model:     Qwen3.6-27B FP8 (near-lossless 8-bit; embedded mtp.fc head)
 #   Topology:  Dual 3090 (TP=2, NVLink auto-detected via NVLINK_MODE)
 #   Drafter:   MTP n=3 (built-in — the fp8 checkpoint embeds the mtp.* head)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8 → e4m3 (1 byte/token; runs at scale=1.0 — checkpoint is weight-only —
 #              → FlashInfer backend → flat decode at depth). NOT fp8_e5m2 — see "NOT enabled" note.
 #   Vision:    yes
@@ -134,6 +135,10 @@ services:
       # prefix-off default; protects PREFIX_CACHE_ARG users. See patches.yml.
       - ../../../patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
       # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
@@ -193,10 +198,30 @@ services:
         # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
         source /etc/club3090/detect_nvlink.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
-        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@"
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-3}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - mtp n=$$_spec_n" >&2
         else
-          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@"
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@" "$${SPEC_ARGS[@]}"
+        else
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@" "$${SPEC_ARGS[@]}"
         fi
       - --
     command:
@@ -240,8 +265,6 @@ services:
       # v0.25.x. Opt out: PREFIX_CACHE_ARG=--no-enable-prefix-caching
       - "${PREFIX_CACHE_ARG:---enable-prefix-caching}"
       - --enable-chunked-prefill
-      - --speculative-config
-      - '{"method":"mtp","num_speculative_tokens":3}'
       - --override-generation-config
       - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host

--- a/models/qwen3.6-27b/vllm/compose/dual/nvfp4/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/dual/nvfp4/mtp.yml
@@ -10,6 +10,7 @@
 #              2x 3090 sm_86 2026-07-11, ~20% slower than the AutoRound tier).
 #   Drafter:   MTP n=3 (built-in — the checkpoint keeps mtp.* unquantized;
 #              SPEC=off disables it — tight-RAM / spec-dec-fails mitigation, #617)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8 → e4m3 (this checkpoint BAKES FP8 KV scales — modelopt
 #              kv_cache_quant_algo=FP8 — unlike our weight-only fp8 tier which
 #              NVFP4 *KV* not used ON A STOCK PIN (vllm#43562 = no trtllm-gen
@@ -178,6 +179,10 @@ services:
       # NVLink auto-detection — runs inside container at boot.
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
       # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
@@ -211,7 +216,6 @@ services:
       # SPEC=off disables the built-in MTP drafter at boot (bare passthrough;
       # tight-RAM / spec-dec-fails mitigation, #617). Default = MTP on.
       # ⚠️ SPEC=off is ALSO the mitigation for vllm#50021 (see Caveats).
-      - SPEC
       # Optional per-card KV-pool pin (bytes). Unset = stock auto-sizing.
       # See the entrypoint note + Max ctx header block (#838 / vllm#44209).
       - KV_CACHE_MEMORY_BYTES
@@ -246,12 +250,6 @@ services:
         # (unverified on Blackwell — report either way).
         # SPEC=off drops the built-in MTP drafter (--speculative-config) — the
         # tight-system-RAM mitigation (#617), matching the single-nvfp4 toggle.
-        SPEC_ARGS=()
-        if [ "$${SPEC:-on}" != "off" ]; then
-          SPEC_ARGS=(--speculative-config '{"method":"mtp","num_speculative_tokens":3}')
-        else
-          echo "[nvfp4] SPEC=off — MTP drafter disabled (loads lighter; no spec-dec)" >&2
-        fi
         # KV_CACHE_MEMORY_BYTES pins the KV pool per card instead of letting
         # vLLM size it from free memory (#838). vLLM does NOT derive the pool
         # from max_model_len × max_num_seqs, so a 262K/2-seq config can be
@@ -266,6 +264,26 @@ services:
         fi
         # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
         source /etc/club3090/detect_nvlink.sh
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-3}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - mtp n=$$_spec_n" >&2
+        else
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
         if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
           exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@" "$${SPEC_ARGS[@]}" "$${KV_ARGS[@]}"
         else

--- a/models/qwen3.6-27b/vllm/compose/multi4/autoround-int4/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/multi4/autoround-int4/mtp.yml
@@ -3,6 +3,7 @@
 #   Model:     Qwen3.6-27B (Lorbus AutoRound INT4 + BF16 mtp.fc preserved)
 #   Topology:  Quad 3090 (TP=4, NVLink auto-detected via NVLINK_MODE)
 #   Drafter:   MTP n=3 (built-in)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8_e4m3 (1 byte/token)
 #   Vision:    yes
 #   Max ctx:   262K (237K single-prompt verified)
@@ -109,6 +110,10 @@ services:
       # prefix-off default; protects PREFIX_CACHE_ARG users. See patches.yml.
       - ../../../patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
       # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
@@ -159,10 +164,30 @@ services:
         bash /etc/club3090/w4a8/install.sh || exit 1
         source /etc/club3090/detect_nvlink.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
-        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@"
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-3}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - mtp n=$$_spec_n" >&2
         else
-          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@"
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@" "$${SPEC_ARGS[@]}"
+        else
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@" "$${SPEC_ARGS[@]}"
         fi
       - --
     command:
@@ -214,8 +239,6 @@ services:
       # Set LONG_PREFILL_TOKEN_THRESHOLD=0 to disable.
       - --long-prefill-token-threshold
       - "${LONG_PREFILL_TOKEN_THRESHOLD:-2048}"
-      - --speculative-config
-      - '{"method":"mtp","num_speculative_tokens":3}'
       - --override-generation-config
       - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host

--- a/models/qwen3.6-27b/vllm/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/multi4/fp8/mtp.yml
@@ -3,6 +3,7 @@
 #   Model:     Qwen3.6-27B FP8 (near-lossless 8-bit; embedded mtp.fc head)
 #   Topology:  Quad 3090 (TP=4, NVLink auto-detected via NVLINK_MODE)
 #   Drafter:   MTP n=3 (built-in — the fp8 checkpoint embeds the mtp.* head)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8 → e4m3 (1 byte/token; runs at scale=1.0 — checkpoint is weight-only —
 #              → FlashInfer backend → flat decode at depth). Mirrors dual-max (#594). NOT
 #              fp8_e5m2 (hard-rejected with FP8 checkpoints); int8-PTH is TRITON_ATTN-only.
@@ -111,6 +112,10 @@ services:
       # prefix-off default; protects PREFIX_CACHE_ARG users. See patches.yml.
       - ../../../patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
       # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
@@ -164,10 +169,30 @@ services:
         # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
         source /etc/club3090/detect_nvlink.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
-        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@"
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-3}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - mtp n=$$_spec_n" >&2
         else
-          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@"
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@" "$${SPEC_ARGS[@]}"
+        else
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@" "$${SPEC_ARGS[@]}"
         fi
       - --
     command:
@@ -211,8 +236,6 @@ services:
       # v0.25.x. Opt out: PREFIX_CACHE_ARG=--no-enable-prefix-caching
       - "${PREFIX_CACHE_ARG:---enable-prefix-caching}"
       - --enable-chunked-prefill
-      - --speculative-config
-      - '{"method":"mtp","num_speculative_tokens":3}'
       - --override-generation-config
       - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host

--- a/models/qwen3.6-27b/vllm/compose/single/nvfp4/mtp.yml
+++ b/models/qwen3.6-27b/vllm/compose/single/nvfp4/mtp.yml
@@ -11,6 +11,7 @@
 #              config needs >24 GB VRAM regardless.
 #   Drafter:   MTP n=3 (built-in — the checkpoint keeps mtp.* unquantized;
 #              SPEC=off disables it — tight-RAM / spec-dec-fails mitigation, #617)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8 → e4m3 at scale=1.0 (hf_quant_config DECLARES FP8 KV but
 #              ships NO k_scale/v_scale tensors — index-verified 2026-07-06;
 #              hybrid disables calculate_kv_scales → the #594-tied regime).
@@ -137,6 +138,10 @@ services:
       # bugs. See docs/UPSTREAM.md "Community templates / model assets".
       - ../../../patches/froggeric-chat-template/chat_template.jinja:/etc/qwen-froggeric-chat-template.jinja:ro
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       # CUDA-level GPU mask — the runtime-agnostic half of GPU selection
       # (#610): launch.sh --gpus exports GPU UUIDs here. CDI runtimes (NixOS,
@@ -159,7 +164,6 @@ services:
       # set via `SPEC=off bash scripts/switch.sh …` or compose/.env). The
       # mitigation for tight system-RAM rigs (laptop / consumer 5090) where the
       # extra draft-model load OOMs during boot (#617). Default = MTP on.
-      - SPEC
       # ⚠️ WSL/WDDM: set PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False.
       # Expandable segments use CUDA VMM (cuMemCreate/cuMemMap), unsupported
       # under WDDM — every boot dies with "RuntimeError: CUDA driver error:
@@ -189,11 +193,25 @@ services:
         # MTP draft-model load OOM'd during boot; the MTP-off 35B booted fine on
         # the same rig). Default on (spec-dec active). Also honors
         # VLLM_ENFORCE_EAGER=1 (Cliff-2 mitigation at >50K single-prompt).
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-3}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
         SPEC_ARGS=()
-        if [ "$${SPEC:-on}" != "off" ]; then
-          SPEC_ARGS=(--speculative-config '{"method":"mtp","num_speculative_tokens":3}')
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - mtp n=$$_spec_n" >&2
         else
-          echo "[nvfp4] SPEC=off — MTP drafter disabled (loads lighter; no spec-dec)" >&2
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
         fi
         exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@" "$${SPEC_ARGS[@]}"
       - --

--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
@@ -6,6 +6,7 @@
 #              activations ON by default (W4A8=0 for W4A16).
 #   Topology:  Dual 3090 PCIe (TP=2, no NVLink; NVLINK_MODE=auto detects)
 #   Drafter:   MTP n=4 built-in (SPEC_N override; SPEC_N=0 disables)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8 -> e4m3 (KV_CACHE_DTYPE override)
 #   Vision:    ✅ WORKING — image + video INPUT, no extra flags (measured 2026-08-16).
 #              INPUT ONLY: it consumes media and emits TEXT. No image/video
@@ -155,6 +156,10 @@ services:
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
       - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
@@ -169,7 +174,6 @@ services:
       - VLLM_USE_FLASHINFER_SAMPLER=${VLLM_USE_FLASHINFER_SAMPLER:-0}
       - OMP_NUM_THREADS=1
       - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
-      - SPEC_N=${SPEC_N:-4}
       # ⭐ W4A8 (int8 activations) SHIPS ON — set W4A8=0 for the W4A16 path.
       - W4A8=${W4A8:-1}
       # ⚠️⚠️ WHY A SEPARATE BOOLEAN INSTEAD OF `${VLLM_MARLIN_INPUT_DTYPE:-int8}`:
@@ -201,16 +205,29 @@ services:
         bash /etc/club3090/w4a8/install.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
         echo "[w4a8] VLLM_MARLIN_INPUT_DTYPE=$${VLLM_MARLIN_INPUT_DTYPE:-<unset -> W4A16>} (W4A8=$${W4A8:-1})"
-        SPEC=""
-        if [ "$${SPEC_N:-4}" -gt 0 ] 2>/dev/null; then
-          SPEC="--speculative-config {\"method\":\"mtp\",\"num_speculative_tokens\":$${SPEC_N:-4}}"
-          echo "[mtp] SPEC_N=$${SPEC_N:-4}"
-        else
-          echo "[mtp] SPEC_N=0 -> no speculative decoding"
-        fi
         AR=""
         [ "$${_NVLINK_ENABLED:-0}" = "1" ] || AR="--disable-custom-all-reduce"
-        exec vllm serve $$AR $$SPEC "$$@"
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 4); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-4}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - mtp n=$$_spec_n" >&2
+        else
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
+        exec vllm serve $$AR "$$@" "$${SPEC_ARGS[@]}"
       - --
     command:
       - --model

--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
@@ -5,6 +5,7 @@
 #   Topology:  Dual 3090 PCIe (TP=2, no NVLink; NVLink auto-detected via NVLINK_MODE)
 #   Drafter:   MTP n=3 (built-in — the checkpoint ships mtp.safetensors and
 #              text_config.mtp_num_hidden_layers=1). SPEC=off disables it.
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8 -> e4m3 (1 byte/token/elem; runs at scale=1.0 — the checkpoint
 #              is weight-only, no k_scale/v_scale tensors, and vLLM disables
 #              calculate_kv_scales on this hybrid family). NOT fp8_e5m2 — that is
@@ -308,6 +309,10 @@ services:
       # half-wiring it. See patches.yml.
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       # CUDA-level GPU mask — the runtime-agnostic half of GPU selection (#610).
       # CDI runtimes (NixOS, nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so
@@ -348,7 +353,6 @@ services:
       # mitigation for vllm#50021 (see the Caveats / Upstream-risk header) and
       # the fallback if the head turns out net-negative on this model, as the
       # built-in head is on the 35B-A3B MoE sibling. Bare passthrough; default on.
-      - SPEC
       # expandable_segments:True crashes boot on some setups (cuMemMap path):
       # known on NVLink rigs and WSL2/WDDM. Override via .env:
       # PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
@@ -369,16 +373,29 @@ services:
         # VLLM_ENFORCE_EAGER=1 in .env disables CUDA graphs — the mitigation if
         # you see mid-generation hangs at depth on this hybrid family. Costs
         # ~20-30% TPS in exchange for stability. UNTESTED on this model.
-        # SPEC=off drops the built-in MTP drafter — the vllm#50021 mitigation.
-        SPEC_ARGS=()
-        if [ "$${SPEC:-on}" != "off" ]; then
-          SPEC_ARGS=(--speculative-config '{"method":"mtp","num_speculative_tokens":3}')
-        else
-          echo "[qwen38] SPEC=off — built-in MTP drafter disabled (no spec-dec)" >&2
-        fi
         # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
         source /etc/club3090/detect_nvlink.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-3}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - mtp n=$$_spec_n" >&2
+        else
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
         if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
           exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@" "$${SPEC_ARGS[@]}"
         else

--- a/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
@@ -4,6 +4,7 @@
 #              at W4-float/A4-float + 208 at W8-float/A8-float; 20.44 GiB)
 #   Topology:  Dual 3090 PCIe (TP=2, no NVLink; NVLINK_MODE=auto)
 #   Drafter:   MTP n=3 built-in (SPEC_N override; SPEC_N=0 disables)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8 -> e4m3 (KV_CACHE_DTYPE override)
 #   Vision:    ✅ WORKING — image + video INPUT, no extra flags (measured 2026-08-16).
 #              INPUT ONLY: it consumes media and emits TEXT. No image/video
@@ -94,6 +95,10 @@ services:
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
       - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
@@ -116,7 +121,6 @@ services:
       # Raw `docker compose` users on those cards must set it themselves.
       - VLLM_USE_DEEP_GEMM
       - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
-      - SPEC_N=${SPEC_N:-3}
     entrypoint:
       - bash
       - -c
@@ -124,16 +128,29 @@ services:
         set -e
         source /etc/club3090/detect_nvlink.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
-        SPEC=""
-        if [ "$${SPEC_N:-3}" -gt 0 ] 2>/dev/null; then
-          SPEC="--speculative-config {\"method\":\"mtp\",\"num_speculative_tokens\":$${SPEC_N:-3}}"
-          echo "[mtp] SPEC_N=$${SPEC_N:-3}"
-        else
-          echo "[mtp] SPEC_N=0 -> no speculative decoding"
-        fi
         AR=""
         [ "$${_NVLINK_ENABLED:-0}" = "1" ] || AR="--disable-custom-all-reduce"
-        exec vllm serve $$AR $$SPEC "$$@"
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-3}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - mtp n=$$_spec_n" >&2
+        else
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
+        exec vllm serve $$AR "$$@" "$${SPEC_ARGS[@]}"
       - --
     command:
       - --model

--- a/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
@@ -6,6 +6,7 @@
 #              activations ON by default (W4A8=0 for W4A16).
 #   Topology:  Quad 3090 PCIe (TP=4, no NVLink)
 #   Drafter:   MTP n=4 built-in (SPEC_N override; SPEC_N=0 disables)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8 -> e4m3 (KV_CACHE_DTYPE override)
 #   Vision:    ✅ WORKING — image + video INPUT, no extra flags (measured 2026-08-16).
 #              INPUT ONLY: it consumes media and emits TEXT. No image/video
@@ -135,6 +136,10 @@ services:
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
       - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
@@ -149,7 +154,6 @@ services:
       - VLLM_USE_FLASHINFER_SAMPLER=${VLLM_USE_FLASHINFER_SAMPLER:-0}
       - OMP_NUM_THREADS=1
       - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
-      - SPEC_N=${SPEC_N:-4}
       # ⭐ W4A8 (int8 activations) SHIPS ON — set W4A8=0 for the W4A16 path.
       - W4A8=${W4A8:-1}
       # ⚠️⚠️ WHY A SEPARATE BOOLEAN INSTEAD OF `${VLLM_MARLIN_INPUT_DTYPE:-int8}`:
@@ -178,16 +182,29 @@ services:
         bash /etc/club3090/w4a8/install.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
         echo "[w4a8] VLLM_MARLIN_INPUT_DTYPE=$${VLLM_MARLIN_INPUT_DTYPE:-<unset -> W4A16>} (W4A8=$${W4A8:-1})"
-        SPEC=""
-        if [ "$${SPEC_N:-4}" -gt 0 ] 2>/dev/null; then
-          SPEC="--speculative-config {\"method\":\"mtp\",\"num_speculative_tokens\":$${SPEC_N:-4}}"
-          echo "[mtp] SPEC_N=$${SPEC_N:-4}"
-        else
-          echo "[mtp] SPEC_N=0 -> no speculative decoding"
-        fi
         AR=""
         [ "$${_NVLINK_ENABLED:-0}" = "1" ] || AR="--disable-custom-all-reduce"
-        exec vllm serve $$AR $$SPEC "$$@"
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 4); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-4}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - mtp n=$$_spec_n" >&2
+        else
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
+        exec vllm serve $$AR "$$@" "$${SPEC_ARGS[@]}"
       - --
     command:
       - --model

--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
@@ -5,6 +5,7 @@
 #   Topology:  Quad 3090 PCIe (TP=4, no NVLink; NVLink auto-detected via NVLINK_MODE)
 #   Drafter:   MTP n=3 (built-in — the checkpoint ships mtp.safetensors and
 #              text_config.mtp_num_hidden_layers=1). SPEC=off disables it.
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        bf16 (unquantized — `--kv-cache-dtype auto` inherits the pinned
 #              `--dtype bfloat16`). ⚠️ DIVERGES FROM THE DUAL SIBLING, which stays
 #              fp8 e4m3. This is deliberate, not drift: KV bytes/token DOUBLE
@@ -207,6 +208,10 @@ services:
       # than half-wiring it. See patches.yml.
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       # CUDA-level GPU mask — the runtime-agnostic half of GPU selection (#610).
       # CDI runtimes (NixOS, nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so
@@ -245,7 +250,6 @@ services:
       # SPEC=off drops the built-in MTP drafter at boot — the documented
       # mitigation for vllm#50021 (see Caveats / Upstream-risk) and the fallback
       # if the head proves net-negative. Bare passthrough; default on.
-      - SPEC
       # expandable_segments:True crashes boot on some setups (cuMemMap path):
       # known on NVLink rigs and WSL2/WDDM. Override via .env:
       # PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
@@ -266,18 +270,31 @@ services:
         # VLLM_ENFORCE_EAGER=1 in .env disables CUDA graphs — the mitigation if
         # you see mid-generation hangs at depth on this hybrid family. Costs
         # ~20-30% TPS in exchange for stability. UNTESTED on this model.
-        # SPEC=off drops the built-in MTP drafter — the vllm#50021 mitigation.
-        SPEC_ARGS=()
-        if [ "$${SPEC:-on}" != "off" ]; then
-          SPEC_ARGS=(--speculative-config '{"method":"mtp","num_speculative_tokens":3}')
-        else
-          echo "[qwen38] SPEC=off — built-in MTP drafter disabled (no spec-dec)" >&2
-        fi
         # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
         # Without NVLink, custom all-reduce is DISABLED: its NVLink-assumed
         # paths break on PCIe-only multi-GPU, and that matters most at TP=4.
         source /etc/club3090/detect_nvlink.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-3}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - mtp n=$$_spec_n" >&2
+        else
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
         if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
           exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@" "$${SPEC_ARGS[@]}"
         else

--- a/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
@@ -6,6 +6,7 @@
 #              activations ON by default (W4A8=0 for W4A16).
 #   Topology:  Eight 3090 PCIe (TP=8, no NVLink)
 #   Drafter:   MTP n=4 built-in (SPEC_N override; SPEC_N=0 disables)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8 -> e4m3 (KV_CACHE_DTYPE override)
 #   Vision:    ✅ WORKING — image + video INPUT, no extra flags (measured 2026-08-16).
 #              INPUT ONLY: it consumes media and emits TEXT. No image/video
@@ -135,6 +136,10 @@ services:
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
       - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
@@ -149,7 +154,6 @@ services:
       - VLLM_USE_FLASHINFER_SAMPLER=${VLLM_USE_FLASHINFER_SAMPLER:-0}
       - OMP_NUM_THREADS=1
       - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
-      - SPEC_N=${SPEC_N:-4}
       # ⭐ W4A8 (int8 activations) SHIPS ON — set W4A8=0 for the W4A16 path.
       - W4A8=${W4A8:-1}
       # ⚠️⚠️ WHY A SEPARATE BOOLEAN INSTEAD OF `${VLLM_MARLIN_INPUT_DTYPE:-int8}`:
@@ -178,16 +182,29 @@ services:
         bash /etc/club3090/w4a8/install.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
         echo "[w4a8] VLLM_MARLIN_INPUT_DTYPE=$${VLLM_MARLIN_INPUT_DTYPE:-<unset -> W4A16>} (W4A8=$${W4A8:-1})"
-        SPEC=""
-        if [ "$${SPEC_N:-4}" -gt 0 ] 2>/dev/null; then
-          SPEC="--speculative-config {\"method\":\"mtp\",\"num_speculative_tokens\":$${SPEC_N:-4}}"
-          echo "[mtp] SPEC_N=$${SPEC_N:-4}"
-        else
-          echo "[mtp] SPEC_N=0 -> no speculative decoding"
-        fi
         AR=""
         [ "$${_NVLINK_ENABLED:-0}" = "1" ] || AR="--disable-custom-all-reduce"
-        exec vllm serve $$AR $$SPEC "$$@"
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 4); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-4}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - mtp n=$$_spec_n" >&2
+        else
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
+        exec vllm serve $$AR "$$@" "$${SPEC_ARGS[@]}"
       - --
     command:
       - --model

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
@@ -5,6 +5,7 @@
 #   Topology:  8x 3090 PCIe (TP=8, no NVLink; NVLink/PCIe-P2P auto-detected via NVLINK_MODE)
 #   Drafter:   MTP n=3 (built-in — the checkpoint ships mtp.safetensors and
 #              text_config.mtp_num_hidden_layers=1). SPEC=off disables it.
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        bf16 (unquantized — `--kv-cache-dtype auto` inherits the pinned
 #              `--dtype bfloat16`). ⚠️ DIVERGES FROM THE DUAL SIBLING, which stays
 #              fp8 e4m3. Deliberate, not drift: KV bytes/token DOUBLE (32,768 ->
@@ -211,6 +212,10 @@ services:
       # than half-wiring it. See patches.yml.
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       # CUDA-level GPU mask — the runtime-agnostic half of GPU selection (#610).
       # CDI runtimes (NixOS, nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so
@@ -249,7 +254,6 @@ services:
       # SPEC=off drops the built-in MTP drafter at boot — the documented
       # mitigation for vllm#50021 (see Caveats / Upstream-risk) and the fallback
       # if the head proves net-negative. Bare passthrough; default on.
-      - SPEC
       # expandable_segments:True crashes boot on some setups (cuMemMap path):
       # known on NVLink rigs and WSL2/WDDM. Override via .env:
       # PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
@@ -270,18 +274,31 @@ services:
         # VLLM_ENFORCE_EAGER=1 in .env disables CUDA graphs — the mitigation if
         # you see mid-generation hangs at depth on this hybrid family. Costs
         # ~20-30% TPS in exchange for stability. UNTESTED on this model.
-        # SPEC=off drops the built-in MTP drafter — the vllm#50021 mitigation.
-        SPEC_ARGS=()
-        if [ "$${SPEC:-on}" != "off" ]; then
-          SPEC_ARGS=(--speculative-config '{"method":"mtp","num_speculative_tokens":3}')
-        else
-          echo "[qwen38] SPEC=off — built-in MTP drafter disabled (no spec-dec)" >&2
-        fi
         # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
         # Without NVLink, custom all-reduce is DISABLED: its NVLink-assumed
         # paths break on PCIe-only multi-GPU, and that matters most at TP=8.
         source /etc/club3090/detect_nvlink.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-3}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - mtp n=$$_spec_n" >&2
+        else
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
         if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
           exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@" "$${SPEC_ARGS[@]}"
         else

--- a/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
@@ -4,6 +4,7 @@
 #              at W4-float/A4-float + 208 at W8-float/A8-float; 20.44 GiB)
 #   Topology:  Single card (TP=1)
 #   Drafter:   MTP n=3 built-in (SPEC_N override; SPEC_N=0 disables)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8 -> e4m3 (KV_CACHE_DTYPE override)
 #   Vision:    ✅ WORKING — image + video INPUT, no extra flags (measured 2026-08-16).
 #              INPUT ONLY: it consumes media and emits TEXT. No image/video
@@ -115,6 +116,10 @@ services:
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
       - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
@@ -137,7 +142,6 @@ services:
       # Raw `docker compose` users on those cards must set it themselves.
       - VLLM_USE_DEEP_GEMM
       - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
-      - SPEC_N=${SPEC_N:-3}
     entrypoint:
       - bash
       - -c
@@ -145,16 +149,29 @@ services:
         set -e
         source /etc/club3090/detect_nvlink.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
-        SPEC=""
-        if [ "$${SPEC_N:-3}" -gt 0 ] 2>/dev/null; then
-          SPEC="--speculative-config {\"method\":\"mtp\",\"num_speculative_tokens\":$${SPEC_N:-3}}"
-          echo "[mtp] SPEC_N=$${SPEC_N:-3}"
-        else
-          echo "[mtp] SPEC_N=0 -> no speculative decoding"
-        fi
         AR=""
         [ "$${_NVLINK_ENABLED:-0}" = "1" ] || AR="--disable-custom-all-reduce"
-        exec vllm serve $$AR $$SPEC "$$@"
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-3}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - mtp n=$$_spec_n" >&2
+        else
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
+        exec vllm serve $$AR "$$@" "$${SPEC_ARGS[@]}"
       - --
     command:
       - --model

--- a/models/tess-4-27b/vllm/compose/dual/leaderboard-w4a16/fp8-mtp.yml
+++ b/models/tess-4-27b/vllm/compose/dual/leaderboard-w4a16/fp8-mtp.yml
@@ -16,6 +16,7 @@
 #              and n=3 is unbenched here. SPEC_N=5 restores the benched config.
 #              DFlash alternative is upstream-blocked on this hybrid family
 #              (vllm#40898 — mixed layer_types).
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8_e4m3 (validated); prefix caching ON by default (#736 —
 #              vllm#48375 vendored; Tess is a qwen3_5 HYBRID, 48 linear + 16
 #              full attention; hybrid prefix caching via mamba align mode)
@@ -107,6 +108,10 @@ services:
       # off; protects PREFIX_CACHE_ARG users. See patches.yml.
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
       # CUDA-level GPU mask — see #610; UUID form is renumbering-proof and is
       # what CDI runtimes honor. Unset → absent (no masking).
@@ -146,10 +151,30 @@ services:
         # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
         source /etc/club3090/detect_nvlink.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
-        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve "$$@"
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-3}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - mtp n=$$_spec_n" >&2
         else
-          exec vllm serve --disable-custom-all-reduce "$$@"
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve "$$@" "$${SPEC_ARGS[@]}"
+        else
+          exec vllm serve --disable-custom-all-reduce "$$@" "$${SPEC_ARGS[@]}"
         fi
       - --
     command:
@@ -196,8 +221,6 @@ services:
       # n=5 WAS the measured knee, but the default is now 3 — see the
       # precautionary #758 note in the header. n=6/8 REGRESS. SPEC_N=0 is NOT
       # supported here — comment the block out to run spec-off.
-      - --speculative-config
-      - '{"method":"mtp","num_speculative_tokens":${SPEC_N:-3}}'
       - --override-generation-config
       - '{"temperature":${TEMP:-${TEMPERATURE:-0.6}},"top_p":${TOP_P:-0.95},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
       - --host

--- a/models/thinkingcap-27b/vllm/compose/dual/w4a16/w4a8.yml
+++ b/models/thinkingcap-27b/vllm/compose/dual/w4a16/w4a8.yml
@@ -13,6 +13,7 @@
 #              n-sweep knee was n=5: code +64% (65->107 tok/s), prose break-even,
 #              accept-len 4.36-5.0 / 67-80%; n=6/8 regress. SPEC_N=5 restores the
 #              benched config at the documented crash risk; SPEC_N=0 disables spec.
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8_e4m3
 #   Vision:    base is VL-capable (tower resident) — validation is TEXT-ONLY
 #   Max ctx:   262144 (full native — dual card frees the KV headroom the
@@ -111,8 +112,11 @@ services:
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
     environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       - VLLM_MARLIN_INPUT_DTYPE=int8
-      - SPEC_N=${SPEC_N:-3}
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
       - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
@@ -147,16 +151,29 @@ services:
         bash /etc/club3090/w4a8/install.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
         echo "[w4a8] VLLM_MARLIN_INPUT_DTYPE=$${VLLM_MARLIN_INPUT_DTYPE}"
-        SPEC=""
-        if [ "$${SPEC_N:-3}" -gt 0 ] 2>/dev/null; then
-          SPEC="--speculative-config {\"method\":\"mtp\",\"num_speculative_tokens\":$${SPEC_N:-3}}"
-          echo "[mtp] SPEC_N=$${SPEC_N:-3}"
-        else
-          echo "[mtp] SPEC_N=0 -> no speculative decoding"
-        fi
         AR=""
         [ "$${_NVLINK_ENABLED:-0}" = "1" ] || AR="--disable-custom-all-reduce"
-        exec vllm serve $$AR $$SPEC "$$@"
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-3}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - mtp n=$$_spec_n" >&2
+        else
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
+        exec vllm serve $$AR "$$@" "$${SPEC_ARGS[@]}"
       - --
     command:
       - --model

--- a/scripts/lib/profiles/swap_apply.py
+++ b/scripts/lib/profiles/swap_apply.py
@@ -178,14 +178,47 @@ def _gate_spec_via_entrypoint(svc: dict) -> None:
         out.append(cmd[i])
         i += 1
     if spec_val is None:
+        # Since 2026-08-18 the shipped composes already lift the drafter into a
+        # SPEC_N-gated entrypoint, so `command` carries nothing to find — and that
+        # entrypoint ALSO carries NVLink detection and patch installs. Rebuilding
+        # it from scratch (the branch below) would silently drop those, so patch
+        # the existing script in place instead: parameterize the method for the
+        # c3 ② Serve editor and let DRAFTER_N feed the existing SPEC_N default.
+        ep = list(svc.get("entrypoint") or [])
+        idx = next((i for i, x in enumerate(ep)
+                    if isinstance(x, str) and "--speculative-config" in x), None)
+        if idx is None:
+            return
+        script_in = ep[idx]
+        mm = re.search(r'\\?"method\\?"\s*:\s*\\?"([a-z0-9_]+)', script_in)
+        d_method = mm.group(1) if mm else "mtp"
+        script_in = re.sub(
+            r'(\\?"method\\?"\s*:\s*\\?")' + re.escape(d_method),
+            lambda m: m.group(1) + "$${DRAFTER_METHOD:-" + d_method + "}",
+            script_in, count=1)
+        script_in = script_in.replace('_spec_n="$${SPEC_N:-',
+                                      '_spec_n="$${SPEC_N:-$${DRAFTER_N:-', 1)
+        if '$${DRAFTER_N:-' in script_in:            # close the extra brace we opened
+            script_in = re.sub(r'(_spec_n="\$\$\{SPEC_N:-\$\$\{DRAFTER_N:-[^"]*?)"',
+                               r'\1}"', script_in, count=1)
+        ep[idx] = script_in
+        svc["entrypoint"] = ep
+        env_list = list(svc.get("environment") or [])
+        for e in ("SPEC", "SPEC_N", "DRAFTER_METHOD", "DRAFTER_N"):
+            if not any(str(x).split("=", 1)[0] == e for x in env_list):
+                env_list.append(e)
+        svc["environment"] = env_list
+        svc["command"] = out
         return
-    mm = re.search(r'"method"\s*:\s*"([a-z0-9_]+)"', spec_val or "")
+    mm = re.search(r'\\?"method\\?"\s*:\s*\\?"([a-z0-9_]+)', spec_val or "")
     nn = re.search(r'"num_speculative_tokens"\s*:\s*(\d+)', spec_val or "")
+    if nn is None and ep_text:                       # depth lives in _spec_n="${SPEC_N:-N}"
+        nn = re.search(r'_spec_n="\$*\{SPEC_N:-\$*\{?[A-Za-z_]*:?-?(\d+)', ep_text)
     d_method = mm.group(1) if mm else "mtp"
     d_n = nn.group(1) if nn else "3"
     svc["command"] = out
     env_list = list(svc.get("environment") or [])
-    for e in ("SPEC", "DRAFTER_METHOD", "DRAFTER_N"):
+    for e in ("SPEC", "SPEC_N", "DRAFTER_METHOD", "DRAFTER_N"):
         if e not in env_list:
             env_list.append(e)
     svc["environment"] = env_list
@@ -193,15 +226,22 @@ def _gate_spec_via_entrypoint(svc: dict) -> None:
     # printf builds the JSON so the method/n substitute cleanly — no quote-in-YAML
     # escaping hell.  ${DRAFTER_METHOD}/${DRAFTER_N} default to the sibling's.
     script = (
-        "# SPEC=off drops the drafter; DRAFTER_METHOD/DRAFTER_N select the type\n"
-        "# (defaults = the sibling's).  Toggled/selected by the c3 ② Serve editor.\n"
+        "# Same drafter contract as every shipped compose: SPEC_N=<n> sets depth,\n"
+        "# SPEC_N=0 (or SPEC=off) disables. DRAFTER_METHOD/DRAFTER_N additionally\n"
+        "# select the drafter type for the c3 ② Serve editor (defaults = sibling's).\n"
         "SPEC_ARGS=()\n"
-        'if [ "$${SPEC:-on}" != "off" ]; then\n'
+        '_spec_n="$${SPEC_N:-$${DRAFTER_N:-' + d_n + '}}"\n'
+        'case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac\n'
+        'case "$$_spec_n" in ""|*[!0-9]*)\n'
+        '  echo "[brought] SPEC_N=\'$$_spec_n\' is not a non-negative integer." >&2\n'
+        "  exit 1 ;;\n"
+        "esac\n"
+        'if [ "$$_spec_n" -gt 0 ]; then\n'
         "  _cfg=$$(printf '{\"method\":\"%s\",\"num_speculative_tokens\":%s}' "
-        '"$${DRAFTER_METHOD:-' + d_method + '}" "$${DRAFTER_N:-' + d_n + '}")\n'
+        '"$${DRAFTER_METHOD:-' + d_method + '}" "$$_spec_n")\n'
         '  SPEC_ARGS=(--speculative-config "$$_cfg")\n'
         "else\n"
-        '  echo "[brought] SPEC=off — drafter disabled (no spec-dec)" >&2\n'
+        '  echo "[brought] drafter disabled (SPEC_N=0 / SPEC=off)" >&2\n'
         "fi\n"
         'exec vllm serve "$$@" "$${SPEC_ARGS[@]}"'
     )

--- a/scripts/spec-sweep.sh
+++ b/scripts/spec-sweep.sh
@@ -22,8 +22,10 @@
 #     REFUSES rather than emit a fake flat curve — reboot-per-n via
 #     `MTP_DRAFT_N_MAX=<n> bash scripts/switch.sh <slug>` is the fallback.
 #   vLLM — reboot per n (vLLM has no per-request draft-depth knob):
-#     `SPEC_N_MAX=<n> switch.sh <slug>` per arm; `SPEC=off` for the n=0
-#     baseline arm. Slower (~5-8 min/arm, boot-dominated).
+#     `SPEC_N=<n> switch.sh <slug>` for EVERY arm, n=0 included — since
+#     2026-08-18 every drafter-shipping compose honours the same knob, so the
+#     baseline arm no longer needs a different variable. Slower (~5-8 min/arm,
+#     boot-dominated).
 #
 # Usage:
 #   SLUG=llamacpp/tess-dual-mtp SWEEP_N="0 1 2 3 4" bash scripts/spec-sweep.sh
@@ -101,7 +103,7 @@ echo "[spec-sweep] engine=$ENGINE_FAMILY url=$URL n in { $SWEEP_N } gens=$GENS x
 if [[ "$SWEEP_DRY" == "1" ]]; then
   for n in $SWEEP_N; do
     if [[ "$ENGINE_FAMILY" == "vllm" ]]; then
-      echo "[sweep:dry] would: $( [[ "$n" == "0" ]] && echo "SPEC=off" || echo "SPEC_N_MAX=$n" ) switch.sh $SLUG -> measure n=$n"
+      echo "[sweep:dry] would: SPEC_N=$n switch.sh $SLUG -> measure n=$n"
     else
       echo "[sweep:dry] would: per-request speculative.n_max=$n against $URL (no reboot)"
     fi
@@ -171,10 +173,12 @@ _measure_llamacpp_rebooted_arm() {
   local med acc="—"
   med="$(printf '%s\n' "${tps_list[@]}" | sort -n | awk '{a[NR]=$1} END{print a[int((NR+1)/2)]}')"
   if [[ "$n" == "0" && $dn_tot -gt 0 ]]; then
-    # The compose ignored SPEC=off (drafter hardcoded, e.g. tess mtp.yml) —
-    # this "baseline" is actually spec-ON. Mark it rather than lie.
+    # The compose ignored SPEC_N=0 — this "baseline" is actually spec-ON.
+    # Mark it rather than lie. Since 2026-08-18 every shipped compose honours
+    # the knob (test-spec-toggle-contract enforces it), so reaching this means
+    # either a hand-edited compose or a genuine regression in that gate.
     acc="SPEC-OFF-IGNORED"
-    echo "  ⚠ n=0 arm INVALID: drafter still active after SPEC=off (compose lacks a SPEC gate) — baseline requires a SPEC-gated compose"
+    echo "  ⚠ n=0 arm INVALID: drafter still active after SPEC_N=0 — run scripts/tests/test-spec-toggle-contract.sh"
   elif [[ "$n" != "0" && $dn_tot -gt 0 ]]; then
     acc="$(awk -v a="$da_tot" -v d="$dn_tot" 'BEGIN{printf "%.2f", a/d}')"
   fi
@@ -232,6 +236,11 @@ if [[ "$ENGINE_FAMILY" == "llamacpp" ]]; then
     echo "[spec-sweep] per-request speculative NOT honored (probe draft_n: n1=$p1 n4=$p4) — falling back to reboot-per-arm (llama.cpp boots are ~15s, still quick)"
     for n in $SWEEP_N; do
       if [[ "$n" == "0" ]]; then
+        # ⚠️ KNOWN GAP: no llama.cpp compose gates on SPEC, so this does NOT
+        # disable the drafter — the n=0 arm boots spec-ON and the acceptance
+        # guard below marks it INVALID. The vLLM family was unified on SPEC_N
+        # 2026-08-18; the llama.cpp family (MTP_DRAFT_N_MAX / --spec-draft-model)
+        # still needs the same treatment. Left as-is rather than guessed at.
         echo "[spec-sweep] boot $SLUG SPEC=off…"
         SPEC=off bash scripts/switch.sh "$SLUG" >/dev/null
       else
@@ -254,13 +263,8 @@ if [[ "$ENGINE_FAMILY" == "llamacpp" ]]; then
 else
   # --- vLLM: reboot per arm ----------------------------------------------------
   for n in $SWEEP_N; do
-    if [[ "$n" == "0" ]]; then
-      echo "[spec-sweep] boot $SLUG SPEC=off…"
-      SPEC=off bash scripts/switch.sh "$SLUG" >/dev/null
-    else
-      echo "[spec-sweep] boot $SLUG SPEC_N_MAX=$n…"
-      SPEC_N_MAX="$n" bash scripts/switch.sh "$SLUG" >/dev/null
-    fi
+    echo "[spec-sweep] boot $SLUG SPEC_N=$n…"
+    SPEC_N="$n" bash scripts/switch.sh "$SLUG" >/dev/null
     ready=0
     for _ in $(seq 1 240); do curl -sf -m 3 "$URL/v1/models" >/dev/null 2>&1 && { ready=1; break; }; sleep 3; done
     [[ "$ready" == "1" ]] || { echo "  n=$n: boot not ready — skipping"; continue; }

--- a/scripts/tests/test-spec-sweep.sh
+++ b/scripts/tests/test-spec-sweep.sh
@@ -40,12 +40,14 @@ grep -q "per-request speculative.n_max" <<<"$out" || fail "llama.cpp dry plan sh
 grep -q "switch.sh" <<<"$out" && fail "llama.cpp SWEEP_DRY must not plan reboots"
 echo "  ✓ llama.cpp SWEEP_DRY plans per-request arms, no reboots"
 
-# 5. SWEEP_DRY — vLLM slug: reboot-per-arm plans, SPEC=off for the n=0 arm.
+# 5. SWEEP_DRY — vLLM slug: reboot-per-arm plans. Since 2026-08-18 EVERY arm
+#    (n=0 included) uses the one knob every drafter compose honours, so the
+#    baseline arm no longer needs a different variable from the rest.
 out="$(SWEEP_N="0 3" SLUG=vllm/dual SWEEP_DRY=1 bash "$SWEEP" 2>&1)"
 grep -q "engine=vllm" <<<"$out" || fail "vllm/dual should resolve engine=vllm"
-grep -q "SPEC=off switch.sh vllm/dual" <<<"$out" || fail "n=0 arm should plan SPEC=off"
-grep -q "SPEC_N_MAX=3 switch.sh vllm/dual" <<<"$out" || fail "n=3 arm should plan SPEC_N_MAX=3"
-echo "  ✓ vLLM SWEEP_DRY plans reboot-per-arm (SPEC=off baseline)"
+grep -q "SPEC_N=0 switch.sh vllm/dual" <<<"$out" || fail "n=0 arm should plan SPEC_N=0"
+grep -q "SPEC_N=3 switch.sh vllm/dual" <<<"$out" || fail "n=3 arm should plan SPEC_N=3"
+echo "  ✓ vLLM SWEEP_DRY plans reboot-per-arm (one knob, SPEC_N=0 baseline)"
 
 # 6. vLLM without SLUG refused (exit 2) — can't reboot without a target.
 #    (Engine defaults to llamacpp without a slug, so force via a vllm slug

--- a/scripts/tests/test-spec-toggle-contract.sh
+++ b/scripts/tests/test-spec-toggle-contract.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+# Every compose that ships a speculative-decoding drafter must expose the SAME
+# switch, and that switch must actually work.
+#
+# THE CONTRACT
+# ------------
+#   SPEC_N=<n>   drafter depth
+#   SPEC_N=0     drafter off
+#   SPEC=off     drafter off (back-compat alias; also 0/false/no)
+#
+# WHY THIS EXISTS
+# ---------------
+# 2026-08-18: all 27 drafter-shipping composes failed to honour both toggles,
+# in four different ways, because the knob accreted across three generations
+# and was never reconciled:
+#
+#   hardcoded (10)   no env escape at all — vllm/dual, the blessed qwen3.6 dual
+#                    default, told users to "delete the --speculative-config
+#                    line below", i.e. edit a tracked file
+#   SPEC only (5)    SPEC_N=0 silently ignored
+#   SPEC_N only (9)  SPEC=off silently ignored
+#   n=0 passthru (3) flag still sent, with num_speculative_tokens:0
+#
+# The silent half is what makes this a safety bug rather than an annoyance:
+# turning the drafter off is the documented mitigation for vllm#50021 (GDN
+# spec-decode wild write). A user who learns `SPEC=off` on one slug, applies it
+# to another, and sees the server come up healthy has NOT mitigated anything.
+#
+# HOW IT CHECKS
+# -------------
+# It does not grep. It extracts each compose's entrypoint script and `command:`
+# list, applies docker-compose ${VAR:-default} interpolation, runs the script
+# under bash with `vllm` replaced by a stub that prints its argv, and inspects
+# the argv the engine would actually have received. No GPU, no weights, no image.
+
+# SCOPE: vLLM only. `--speculative-config` is a vLLM flag; SGLang
+# (--speculative-algorithm) and llama.cpp (--spec-draft-model / MTP_DRAFT_N_MAX)
+# have their own drafter knobs and are NOT covered. The llama.cpp family has the
+# same class of bug, tracked separately.
+
+set -euo pipefail
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+python3 - "$ROOT_DIR" <<'PY'
+import json, os, pathlib, re, subprocess, sys, tempfile
+
+root = pathlib.Path(sys.argv[1])
+
+FLAG = "--speculative-config"
+
+
+def _interp(v, env):
+    """docker compose interpolation: $$ is a literal $, ${VAR:-default} resolves."""
+    out, i = [], 0
+    while i < len(v):
+        if v[i:i + 2] == "$$":
+            out.append("$"); i += 2; continue
+        m = re.match(r"\$\{([A-Za-z_]\w*)(?::-([^}]*))?\}", v[i:])
+        if m:
+            val = env.get(m.group(1)) or (m.group(2) if m.group(2) is not None else "")
+            out.append(val); i += m.end(); continue
+        out.append(v[i]); i += 1
+    return "".join(out)
+
+
+def _block(lines, key):
+    """Return (start, end, indent) of a `key:` block-scalar body, or None."""
+    for i, l in enumerate(lines):
+        if re.match(rf"^\s*{key}:\s*$", l):
+            j = i + 1
+            while j < len(lines) and not re.match(r"^\s*-\s*\|", lines[j]):
+                if re.match(r"^\s*(command|image|volumes|environment):", lines[j]):
+                    j = None; break
+                j += 1
+            if j is None:
+                continue
+            ind = len(lines[j]) - len(lines[j].lstrip()) + 2
+            k = j + 1
+            while k < len(lines):
+                if lines[k].strip() and (len(lines[k]) - len(lines[k].lstrip())) < ind:
+                    break
+                k += 1
+            return j + 1, k, ind
+    return None
+
+
+def container_env(text, host):
+    """Reproduce docker's env filtering: a var reaches the container ONLY if the
+    compose declares it under `environment:`. This is not a detail — the first
+    version of this gate ran the entrypoint with the host env applied directly,
+    passed 27/27, and every one of those composes was in fact DEAD because the
+    knob was never forwarded. A live boot caught it; this function is why the
+    gate would have."""
+    lines, out = text.split("\n"), {}
+    for i, l in enumerate(lines):
+        if not re.match(r"^\s*environment:\s*$", l):
+            continue
+        ind = len(l) - len(l.lstrip())
+        j = i + 1
+        while j < len(lines):
+            cur = lines[j]
+            if cur.strip() and (len(cur) - len(cur.lstrip())) <= ind:
+                break
+            m = re.match(r"^\s*-\s*([A-Za-z_]\w*)(?:=(.*))?$", cur)
+            if m:
+                name, val = m.group(1), m.group(2)
+                if val is None:                       # bare `- NAME` passthrough
+                    if name in host:
+                        out[name] = host[name]
+                else:
+                    out[name] = _interp(val.strip().strip("'\""), host)
+            j += 1
+        break
+    return out
+
+
+def entrypoint_of(text):
+    lines = text.split("\n")
+    b = _block(lines, "entrypoint")
+    if b is None:
+        return None
+    s, e, ind = b
+    return "\n".join(l[ind:] if len(l) > ind else "" for l in lines[s:e])
+
+
+def command_of(text, env):
+    lines, args = text.split("\n"), []
+    for i, l in enumerate(lines):
+        if not re.match(r"^\s*command:\s*$", l):
+            continue
+        ind = len(l) - len(l.lstrip())
+        j = i + 1
+        while j < len(lines):
+            cur = lines[j]
+            if not cur.strip():
+                j += 1; continue
+            if (len(cur) - len(cur.lstrip())) <= ind:
+                break
+            m = re.match(r"^\s*-\s*(.*)$", cur)
+            if m:
+                v = m.group(1).strip()
+                if len(v) >= 2 and v[0] == v[-1] and v[0] in "'\"":
+                    v = v[1:-1]
+                args.append(_interp(v, env))
+            j += 1
+        break
+    return args
+
+
+def argv_under(text, env):
+    """Run the compose's entrypoint with `vllm` stubbed, under the env docker
+    would actually give the container; return the argv string."""
+    body = entrypoint_of(text)
+    if body is None:
+        return None, ("no block-scalar entrypoint found, so the drafter cannot be "
+                      "switched off at runtime. If this compose uses a flow-style "
+                      "`entrypoint: [...]`, this gate cannot execute it — convert it "
+                      "to `- |` block form (every shipped vLLM compose uses that)")
+    with tempfile.TemporaryDirectory() as d:
+        dp = pathlib.Path(d)
+        stub = dp / "vllm"
+        stub.write_text('#!/bin/bash\nfor a in "$@"; do printf "ARG:%s\\n" "$a"; done\nexit 0\n')
+        stub.chmod(0o755)
+        etc = dp / "etc" / "club3090"
+        etc.mkdir(parents=True, exist_ok=True)
+        (etc / "detect_nvlink.sh").write_text("_NVLINK_ENABLED=0\n")
+        # any `bash /etc/club3090/<x>/install.sh` the entrypoint runs
+        for sub in set(re.findall(r"/etc/club3090/([\w.-]+)/install\.sh", body)):
+            (etc / sub).mkdir(parents=True, exist_ok=True)
+            (etc / sub / "install.sh").write_text("#!/bin/bash\nexit 0\n")
+        script = dp / "ep.sh"
+        script.write_text(body.replace("$$", "$").replace("/etc/club3090", str(etc)))
+        # only what the compose declares crosses into the container
+        e = {k: v for k, v in os.environ.items() if not k.startswith(("SPEC", "NUM_SPEC"))}
+        e.update(container_env(text, env)); e["PATH"] = f"{d}:{os.environ['PATH']}"
+        r = subprocess.run(["bash", str(script), "--", *command_of(text, env)],
+                           capture_output=True, text=True, env=e, timeout=60)
+        args = [l[4:] for l in r.stdout.split("\n") if l.startswith("ARG:")]
+        return (args or None), (r.stderr.strip()[-300:] or "no argv emitted")
+
+
+def spec_payload(args):
+    """The --speculative-config value the engine would receive, or None."""
+    if not args or FLAG not in args:
+        return None
+    i = args.index(FLAG)
+    return args[i + 1] if i + 1 < len(args) else ""
+
+
+def depth(args):
+    """None = no drafter; int = the depth the engine would receive."""
+    p = spec_payload(args)
+    if p is None:
+        return None
+    m = re.search(r"num_speculative_tokens\D*(\d+)", p)
+    return int(m.group(1)) if m else -1
+
+
+def payload_problem(args):
+    """vLLM parses this value as JSON. A payload that only LOOKS right in a regex
+    is how a stray list-item prefix (`- '{...}`) survived review once — it kept a
+    readable token count while being unparseable. Assert the real thing."""
+    p = spec_payload(args)
+    if p is None:
+        return None
+    try:
+        obj = json.loads(p)
+    except Exception as e:
+        return f"--speculative-config is not valid JSON ({e}): {p!r}"
+    if not isinstance(obj, dict):
+        return f"--speculative-config must be a JSON object, got {type(obj).__name__}"
+    if "num_speculative_tokens" not in obj:
+        return f"--speculative-config has no num_speculative_tokens: {p!r}"
+    if not ({"method", "model"} & set(obj)):
+        return f"--speculative-config names neither a method nor a draft model: {p!r}"
+    return None
+
+
+def check(text, label, sink):
+    """Assert the full contract for one compose's text. Appends to sink."""
+    base, err = argv_under(text, {})
+    if base is None:
+        sink.append(f"{label}: {err}"); return
+    bad = payload_problem(base)
+    if bad:
+        sink.append(f"{label}: {bad}")
+    d0 = depth(base)
+    if d0 is None or d0 <= 0:
+        sink.append(f"{label}: ships {FLAG} but the default resolves to no drafter")
+        return
+    for env, desc in [({"SPEC_N": "0"}, "SPEC_N=0"),
+                      ({"SPEC": "off"}, "SPEC=off")]:
+        a, _ = argv_under(text, env)
+        d = depth(a)
+        if d is not None:
+            got = "still passes the flag with n=0" if d == 0 else f"drafter still on at n={d}"
+            sink.append(f"{label}: {desc} does not disable the drafter — {got}")
+    pick = 7 if d0 != 7 else 5
+    a, _ = argv_under(text, {"SPEC_N": str(pick)})
+    if depth(a) != pick:
+        sink.append(f"{label}: SPEC_N={pick} ignored — engine would get n={depth(a)}")
+
+
+# ---------------------------------------------------------------------------
+# SELF-TEST — runs BEFORE the real scan. A gate that only ever passes is
+# indistinguishable from a gate that does nothing. Each case is a real shape
+# this repo shipped.
+# ---------------------------------------------------------------------------
+def _compose(entry, cmd="", env="      - SPEC_N=${SPEC_N:-}\n      - SPEC=${SPEC:-}\n"):
+    return ("services:\n  x:\n    environment:\n" + env
+            + "    entrypoint:\n      - bash\n      - -c\n      - |\n"
+            + "".join(f"        {l}\n" for l in entry.split("\n"))
+            + "      - --\n" + (f"    command:\n{cmd}" if cmd else ""))
+
+GOOD = _compose(
+    '_spec_n="$${SPEC_N:-3}"\n'
+    'case "$${SPEC:-}" in off|0) _spec_n=0 ;; esac\n'
+    'SPEC_ARGS=()\n'
+    '[ "$$_spec_n" -gt 0 ] && SPEC_ARGS=(--speculative-config '
+    '"{\\"method\\":\\"mtp\\",\\"num_speculative_tokens\\":$$_spec_n}")\n'
+    'exec vllm serve "$$@" "$${SPEC_ARGS[@]}"')
+
+HARDCODED = _compose('exec vllm serve "$$@"',
+                     "      - --speculative-config\n"
+                     "      - '{\"method\":\"mtp\",\"num_speculative_tokens\":3}'\n")
+
+SPEC_ONLY = _compose(
+    'SPEC_ARGS=()\n'
+    'if [ "$${SPEC:-on}" != "off" ]; then\n'
+    '  SPEC_ARGS=(--speculative-config '
+    '"{\\"method\\":\\"mtp\\",\\"num_speculative_tokens\\":3}")\n'
+    'fi\n'
+    'exec vllm serve "$$@" "$${SPEC_ARGS[@]}"')
+
+SPECN_ONLY = _compose(
+    'SPEC_ARGS=()\n'
+    '[ "$${SPEC_N:-3}" -gt 0 ] && SPEC_ARGS=(--speculative-config '
+    '"{\\"method\\":\\"mtp\\",\\"num_speculative_tokens\\":$${SPEC_N:-3}}")\n'
+    'exec vllm serve "$$@" "$${SPEC_ARGS[@]}"')
+
+N_ZERO = _compose('exec vllm serve "$$@"',
+                  "      - --speculative-config\n"
+                  "      - '{\"method\":\"mtp\",\"num_speculative_tokens\":${SPEC_N:-3}}'\n")
+
+# entrypoint logic is perfect, but `environment:` declares nothing — the exact
+# bug that shipped past the first version of this gate.
+UNDECLARED = _compose(
+    '_spec_n="$${SPEC_N:-3}"\n'
+    'case "$${SPEC:-}" in off|0) _spec_n=0 ;; esac\n'
+    'SPEC_ARGS=()\n'
+    '[ "$$_spec_n" -gt 0 ] && SPEC_ARGS=(--speculative-config '
+    '"{\\"method\\":\\"mtp\\",\\"num_speculative_tokens\\":$$_spec_n}")\n'
+    'exec vllm serve "$$@" "$${SPEC_ARGS[@]}"',
+    env="      - OTHER=1\n")
+
+MALFORMED = _compose(
+    '_spec_n="$${SPEC_N:-3}"\n'
+    'case "$${SPEC:-}" in off|0) _spec_n=0 ;; esac\n'
+    'SPEC_ARGS=()\n'
+    '[ "$$_spec_n" -gt 0 ] && SPEC_ARGS=(--speculative-config '
+    '"- \'{\\"method\\":\\"mtp\\",\\"num_speculative_tokens\\":$$_spec_n}")\n'
+    'exec vllm serve "$$@" "$${SPEC_ARGS[@]}"')
+
+CASES = [
+    ("honours the full contract",      GOOD,       False),
+    ("payload is not valid JSON",      MALFORMED,  True),
+    ("knob never declared in environment:", UNDECLARED, True),
+    ("hardcoded drafter, no escape",   HARDCODED,  True),
+    ("SPEC only — SPEC_N=0 ignored",   SPEC_ONLY,  True),
+    ("SPEC_N only — SPEC=off ignored", SPECN_ONLY, True),
+    ("n=0 passthrough, flag not removed", N_ZERO,   True),
+]
+
+selffail = []
+for name, text, should_flag in CASES:
+    sink = []
+    check(text, "<self-test>", sink)
+    if bool(sink) != should_flag:
+        selffail.append(f"self-test {name!r}: expected "
+                        f"{'a problem' if should_flag else 'no problem'}, got {sink or 'none'}")
+if selffail:
+    print("test-spec-toggle-contract: FAIL (the gate itself is broken)")
+    for e in selffail:
+        print(f"  ⛔ {e}")
+    sys.exit(1)
+
+# ---------------------------------------------------------------------------
+# The real scan.
+# ---------------------------------------------------------------------------
+errors, checked = [], 0
+for f in sorted(root.glob("models/*/*/compose/**/*.yml")):
+    if "_archive" in str(f):
+        continue
+    text = f.read_text(encoding="utf-8")
+    if not any(FLAG in l and not l.lstrip().startswith("#") for l in text.split("\n")):
+        continue
+    checked += 1
+    check(text, str(f.relative_to(root)), errors)
+
+if errors:
+    print("test-spec-toggle-contract: FAIL")
+    for e in errors:
+        print(f"  ⛔ {e}")
+    print()
+    print(f"  {len(errors)} problem(s) across {checked} drafter-shipping compose(s).")
+    print("  Fix: read SPEC_N (with SPEC=off as an alias) in the entrypoint and build")
+    print("  the flag into a SPEC_ARGS array — see any compose in models/ for the shape.")
+    sys.exit(1)
+
+print(f"test-spec-toggle-contract: ok "
+      f"(self-test {len(CASES)}/{len(CASES)} · {checked} drafter composes honour "
+      f"SPEC_N=<n> / SPEC_N=0 / SPEC=off)")
+PY


### PR DESCRIPTION
## The problem

Turning the speculative-decoding drafter off is the documented mitigation for [vllm#50021](https://github.com/vllm-project/vllm/pull/50021) — the GDN spec-decode wild write that kills workers under sustained multi-turn traffic. It is referenced as such in `DUAL_CARD.md`, `MULTI_CARD.md`, `FAQ.md` and a dozen compose headers.

**On every one of the 27 composes that ship a drafter, that mitigation did not work as documented.** The knob had accreted across three generations and was never reconciled:

| mode | composes | what actually happened |
|---|--:|---|
| hardcoded | 10 | no runtime escape at all — the header told you to *delete a line from the YAML* |
| `SPEC` only | 5 | `SPEC_N=0` silently ignored |
| `SPEC_N` only | 9 | `SPEC=off` silently ignored |
| `n=0` passthrough | 3 | flag still sent, with `num_speculative_tokens:0` |

Two more names were in play beyond those: `SPEC_N_MAX` (3 Gemma composes) and `NUM_SPEC_TOKENS` (Nemotron).

The silent half is what makes this a safety bug rather than an annoyance. A user who learns `SPEC=off` on one slug, applies it to another, and sees a healthy server has **not** mitigated anything. Qwen3.8 is where it surfaced because it is the one model whose slugs span two conventions.

Worst case is `vllm/dual` — the blessed `(qwen3.6-27b, vllm, dual)` default. Its own header read:

> MITIGATION: run the drafter off — delete the `--speculative-config` line below.

That is not scriptable, not `.env`-able, lost on `git pull`, and it dirties the working tree so the next pull conflicts.

## The change

One contract, on all 27:

```bash
SPEC_N=0 bash scripts/switch.sh vllm/dual    # drafter off
SPEC_N=6 bash scripts/switch.sh vllm/dual    # depth 6
SPEC=off bash scripts/switch.sh vllm/dual    # alias, still works
```

- **Every compose keeps its own default depth** — `n=4` where `n=4` was measured (the #1024 knee), `n=3`/`n=2` elsewhere. Asserted per-file before/after; no default moved.
- `SPEC_N_MAX` / `NUM_SPEC_TOKENS` still resolve, so nothing anyone has pinned breaks.
- A **non-numeric `SPEC_N` is a hard boot error**, not a silent fall back to "off". A typo can never quietly leave the drafter running, nor quietly disable it.
- The default lives in the entrypoint only — never duplicated into the `environment:` declaration, so the two cannot drift.

`scripts/spec-sweep.sh` now uses one variable for every arm including `n=0`, replacing the two-variable dance and the `SPEC-OFF-IGNORED` workaround it carried for exactly this bug.

`swap_apply.py` (brought-weights / c3 ② Serve) recovers the drafter from the sibling's entrypoint now that `command:` no longer carries it. It **patches that script in place** rather than rebuilding it — the naive version would have replaced the entrypoint wholesale and silently dropped NVLink detection and patch installs from every brought-weights compose. Verified: `vllm/dual` → `mtp`/n=3 and `vllm/qwen38-27b-dual-fast` → `mtp`/n=4, both retaining `detect_nvlink` and their `install.sh` calls.

## The gate: `test-spec-toggle-contract.sh` (suite 103 → 104)

It does not grep. For each compose it extracts the entrypoint and `command:`, applies compose interpolation, **filters the env exactly as docker does**, runs the script with `vllm` stubbed, and inspects the argv the engine would receive — then parses `--speculative-config` as JSON. No GPU, no weights, no image.

Seven self-tests run **before** the real scan, each a shape this repo actually shipped: hardcoded, `SPEC`-only, `SPEC_N`-only, `n=0` passthrough, undeclared env, malformed payload, plus a passing control. They fail as *"the gate itself is broken"*.

## Two bugs the process caught, worth recording

**1. A green gate over a dead feature.** My first version passed 27/27 while every compose was still broken — it applied env directly to bash, but **docker only forwards variables declared under `environment:`**, and 21 composes declared neither knob. A live boot of `vllm/dual` with `SPEC_N=0` logged `drafter ON n=3` and exposed it. The gate now reproduces docker's filtering, and a self-test covers it.

**2. A payload that looked right and wasn't.** 16 composes briefly carried a stray list-item prefix (`"- '{...}"`) that kept a readable token count under a regex while being unparseable JSON — vLLM would have failed at startup. The gate now `json.loads` the payload and checks its keys.

Both are the same lesson: a check that only ever passes is indistinguishable from no check. Each fix has a negative control that was confirmed to fail before it was trusted.

## Verification

- `test-spec-toggle-contract` — self-test 7/7, 27/27 composes, and confirmed to **fail** when the bug is reintroduced (all three classes tested individually).
- Full suite green.
- **Live**, `vllm/dual` on 2× 3090 — the compose that previously had no escape:
  - `SPEC_N=0` → `[spec] drafter OFF`, no `--speculative-config` in engine argv, serves
  - default → `[spec] drafter ON - mtp n=3`, drafter present, serves
- Behaviour at default settings is unchanged on all 27 — this is additive.

## Not covered

**The llama.cpp family has the same bug and is untouched here.** No llama.cpp compose gates on `SPEC`, so `spec-sweep.sh`'s `n=0` arm for that engine has always booted spec-ON (its acceptance guard flags it). Those use a different mechanism (`MTP_DRAFT_N_MAX` / `--spec-draft-model`) and I could not verify a change without booting them, so it is documented in place rather than guessed at. Tracked as #1049.

The `n=3` vs `n=4` question — `n=4` is measured on the AutoRound tier, `n=3` on fp8/nvfp4 is inherited and unswept — is a separate measurement job, not touched here.
