### PR TITLE
Give the llama.cpp lineage the same drafter toggle

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -96,15 +96,26 @@ existing `.env` files keep working. A non-numeric `SPEC_N` is a hard boot error
 rather than a silent fall back to "off" — a typo can never quietly leave the
 drafter running, nor quietly disable it.
 
+It works on **every engine** — vLLM, mainline llama.cpp, ik-llama, beellama and
+llamacpp-club3090 — despite each using a different drafter grammar underneath.
+
+On the llama.cpp side `SPEC_N=0` **removes** the drafter flags rather than setting
+the count to zero, and that distinction is worth real memory: llama.cpp at
+`--spec-draft-n-max 0` stops drafting but still builds the draft context (and still
+loads an external draft GGUF when one is named). Measured on
+`llamacpp/qwen38-27b-single-iq4nl`, 1× 3090: **21,444 MiB with the drafter on vs
+20,174 MiB with `SPEC_N=0`** — 1,270 MiB that zeroing the count would have left
+allocated.
+
 This is worth stating plainly because turning the drafter off is the documented
 mitigation for [vllm#50021](https://github.com/vllm-project/vllm/pull/50021), and
-until 2026-08-18 the knob was **not** uniform: some composes read `SPEC`, some
-`SPEC_N`, some `SPEC_N_MAX` or `NUM_SPEC_TOKENS`, and ten hardcoded the drafter
-with no runtime escape at all — their header told you to delete a line from the
-YAML. Applying the wrong variable produced a healthy-looking server with the
-drafter still running. `scripts/tests/test-spec-toggle-contract.sh` enforces the
-single contract now, by running each entrypoint and inspecting the argv the
-engine would actually receive.
+until 2026-08-18 the knob was **not** uniform: composes read `SPEC`, `SPEC_N`,
+`SPEC_N_MAX`, `NUM_SPEC_TOKENS`, `MTP_DRAFT_N_MAX` or `DRAFT_N_MAX` depending on
+vintage, and ten hardcoded the drafter with no runtime escape at all — their header
+told you to delete a line from the YAML. Applying the wrong variable produced a
+healthy-looking server with the drafter still running.
+`scripts/tests/test-spec-toggle-contract.sh` enforces the single contract now, by
+running each entrypoint and inspecting the argv the engine would actually receive.
 
 
 ### What is the W4A8 knob and should I turn it on?

--- a/models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-iq2-xxs/offload.yml
+++ b/models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-iq2-xxs/offload.yml
@@ -5,6 +5,8 @@
 #   Engine:    llama.cpp (mainline server-cuda-b10236, external DSpark drafter)
 #   Topology:  Dual 3090 PCIe (layer-split -ts 1,1, no NVLink)
 #   Drafter:   DSpark n=5 external (--spec-type draft-dspark) — REQUIRES b10236+
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        fp16 (llama.cpp default — MLA + a 4,352-cell SWA window keep it tiny)
 #   Vision:    no
 #   Max ctx:   204800
@@ -101,6 +103,48 @@ services:
     # by bisection; `blk\.[0-9]+\.ffn_exps\.weight=CPU` parses fine, adding the group
     # breaks it). The list form skips shell parsing altogether, so the regex — and any
     # injected OT_G* value — survives byte-for-byte.
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command:
       - '-m'
       - '/models/deepseek-v4-flash-0731-gguf/UD-IQ2_XXS/DeepSeek-V4-Flash-0731-UD-IQ2_XXS-00001-of-00003.gguf'

--- a/models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-q8-kxl/offload.yml
+++ b/models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-q8-kxl/offload.yml
@@ -6,6 +6,8 @@
 #   Topology:  Dual 3090 PCIe (layer-split -ts 1,1, no NVLink)
 #   Drafter:   DSpark n=5 external (--spec-type draft-dspark) — runtime landed in
 #              ggml-org#25784; ABSENT in b9967, so this slug REQUIRES b10236+
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        fp16 (llama.cpp default — MLA + a 4,352-cell SWA window keep it tiny)
 #   Vision:    no
 #   Max ctx:   204800  (⚠️ NOT 262144 — see Caveats)
@@ -135,6 +137,48 @@ services:
     # by bisection; `blk\.[0-9]+\.ffn_exps\.weight=CPU` parses fine, adding the group
     # breaks it). The list form skips shell parsing altogether, so the regex — and any
     # injected OT_G* value — survives byte-for-byte.
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command:
       - '-m'
       - '/models/deepseek-v4-flash-0731-gguf/UD-Q8_K_XL/DeepSeek-V4-Flash-0731-UD-Q8_K_XL-00001-of-00005.gguf'

--- a/models/deepseek-v4-flash-0731/llama-cpp/compose/multi4/unsloth-q8-kxl/offload.yml
+++ b/models/deepseek-v4-flash-0731/llama-cpp/compose/multi4/unsloth-q8-kxl/offload.yml
@@ -4,6 +4,8 @@
 #   Engine:    llama.cpp (mainline server-cuda-b10236, external DSpark drafter)
 #   Topology:  4× 24 GB PCIe (layer-split -ts 1,1,1,1)
 #   Drafter:   DSpark n=5 external (--spec-type draft-dspark) — REQUIRES b10236+
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        fp16 (llama.cpp default)
 #   Vision:    no
 #   Max ctx:   204800
@@ -118,6 +120,48 @@ services:
     # by bisection; `blk\.[0-9]+\.ffn_exps\.weight=CPU` parses fine, adding the group
     # breaks it). The list form skips shell parsing altogether, so the regex — and any
     # injected OT_G* value — survives byte-for-byte.
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command:
       - '-m'
       - '/models/deepseek-v4-flash-0731-gguf/UD-Q8_K_XL/DeepSeek-V4-Flash-0731-UD-Q8_K_XL-00001-of-00005.gguf'

--- a/models/deepseek-v4-flash-0731/llamacpp-club3090/compose/dual/unsloth-q8-kxl/moecache.yml
+++ b/models/deepseek-v4-flash-0731/llamacpp-club3090/compose/dual/unsloth-q8-kxl/moecache.yml
@@ -6,6 +6,8 @@
 #              ports, bypass warn-split, and multi-row top-k batching)
 #   Topology:  Dual 3090 PCIe (layer-split -ts 1,1, no NVLink)
 #   Drafter:   DSpark n=5 external, PINNED TO CPU (-devd none) — see Caveats
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        fp16 (llama.cpp default — MLA + a 4,352-cell SWA window keep it tiny)
 #   Vision:    no
 #   Max ctx:   204800  (262144 boots on this config — see Caveats)
@@ -115,6 +117,9 @@ services:
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       # Expert-cache tuning — every value MEASURED on 2×24 GB, see Caveats.
       - GGML_CUDA_MOE_CACHE_ADMIT_AFTER=${MOE_ADMIT_AFTER:-64}
       - GGML_CUDA_MOE_CACHE_RESERVE_MB=${MOE_RESERVE_MB:-1536}
@@ -129,6 +134,44 @@ services:
     # Docker Compose's command-line parser REJECTS `(gate|up|down)` inside a
     # folded string. The list form skips shell parsing, so the regex survives
     # byte-for-byte.
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command:
       - '-m'
       - '/models/deepseek-v4-flash-0731-gguf/UD-Q8_K_XL/DeepSeek-V4-Flash-0731-UD-Q8_K_XL-00001-of-00005.gguf'

--- a/models/deepseek-v4-flash-0731/llamacpp-club3090/compose/multi4/unsloth-q8-kxl/moecache.yml
+++ b/models/deepseek-v4-flash-0731/llamacpp-club3090/compose/multi4/unsloth-q8-kxl/moecache.yml
@@ -6,6 +6,8 @@
 #              ports, bypass warn-split, and multi-row top-k batching)
 #   Topology:  4× CUDA (layer-split -ts 1,1,1,1)
 #   Drafter:   DSpark n=5 external, PINNED TO CPU (-devd none)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        fp16
 #   Vision:    no
 #   Max ctx:   204800
@@ -94,6 +96,9 @@ services:
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       # ⚠️ PLACEHOLDER VALUES inherited from the 2-card sibling. Re-derive.
       - GGML_CUDA_MOE_CACHE_ADMIT_AFTER=${MOE_ADMIT_AFTER:-64}
       - GGML_CUDA_MOE_CACHE_RESERVE_MB=${MOE_RESERVE_MB:-1536}
@@ -106,6 +111,44 @@ services:
               capabilities: [gpu]
     # ⚠️ LIST FORM, NOT a folded string — compose rejects `(gate|up|down)` in a
     # folded `command: >-`.
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command:
       - '-m'
       - '/models/deepseek-v4-flash-0731-gguf/UD-Q8_K_XL/DeepSeek-V4-Flash-0731-UD-Q8_K_XL-00001-of-00005.gguf'

--- a/models/gemma-4-31b/beellama/compose/dual/beellama-q4ks-dflash/dflash.yml
+++ b/models/gemma-4-31b/beellama/compose/dual/beellama-q4ks-dflash/dflash.yml
@@ -4,6 +4,8 @@
 #   Engine:    beellama.cpp (Anbeeld llama.cpp fork — DFlash spec-dec + SWA windowed KV)
 #   Topology:  Dual 3090 (layer-split across both cards, PCIe — no NVLink needed)
 #   Drafter:   DFlash (--spec-type dflash, Anbeeld DFlash-IQ4_XS GGUF)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q5_0 K + q4_1 V (Anbeeld's long-ctx precision default)
 #   Vision:    no (mmproj NOT mounted; set MMPROJ_FILE + --mmproj for vision)
 #   Template:  native (GGUF-embedded) via --jinja
@@ -75,6 +77,48 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8062}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080

--- a/models/gemma-4-31b/beellama/compose/dual/beellama-q8kxl-dflash/dflash.yml
+++ b/models/gemma-4-31b/beellama/compose/dual/beellama-q8kxl-dflash/dflash.yml
@@ -5,6 +5,8 @@
 #   Topology:  Dual 3090 (layer-split across both cards, PCIe — no NVLink needed)
 #   Drafter:   DFlash (--spec-type dflash, Anbeeld DFlash-IQ4_XS — separate draft model; pinned
 #              to ONE card, drafter=1 device + GPU cross ring — NOT split across cards.)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q5_0 K + q4_1 V
 #   Vision:    no (mmproj NOT mounted; set MMPROJ_FILE + --mmproj for vision)
 #   Template:  native (GGUF-embedded) via --jinja
@@ -68,6 +70,48 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8066}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080

--- a/models/gemma-4-31b/beellama/compose/single/beellama-q4ks-dflash/dflash.yml
+++ b/models/gemma-4-31b/beellama/compose/single/beellama-q4ks-dflash/dflash.yml
@@ -4,6 +4,8 @@
 #   Engine:    beellama.cpp (Anbeeld llama.cpp fork — DFlash spec-dec + SWA windowed KV)
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   DFlash (--spec-type dflash, Anbeeld DFlash-IQ4_XS GGUF, adaptive draft-max)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q5_0 K + q4_1 V (Anbeeld's long-ctx precision default)
 #   Vision:    no (mmproj NOT mounted; for vision pass MMPROJ_FILE + --mmproj — CPU-offloaded)
 #   Template:  native (GGUF-embedded) via --jinja
@@ -114,6 +116,48 @@ services:
     # server target ENTRYPOINT is /app/llama-server — args only below.
     # ⚠ -np 1 is intentional on a single 24 GB card — DFlash is single-slot by
     #   default and extra slots divide a compute-bound GPU's throughput.
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080

--- a/models/ornith-1.0-9b/ik-llama/compose/single/deepreinforce-q4km/ngram.yml
+++ b/models/ornith-1.0-9b/ik-llama/compose/single/deepreinforce-q4km/ngram.yml
@@ -9,6 +9,8 @@
 #              baked default-on below. ~0.59 accept, +30% warm decode on copy-heavy
 #              gen, output-lossless. Works DESPITE the DeltaNet hybrid (DFlash/EAGLE
 #              are KV-rollback-blocked on Qwen3-Next; drafter-free ngram is not).
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q8_0 K + q8_0 V. Hybrid attention → only 8/32 layers carry GQA KV
 #              (full_attention_interval=4), so the full 262K fits at just 4.25 GiB KV.
 #   Vision:    no
@@ -46,6 +48,48 @@ services:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # ENTRYPOINT is /app/llama-server — args only. The ngram self-spec stage is
     # baked in (this is ngram.yml); tune via NGRAM_NMAX / NGRAM_MIN_HITS.
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080

--- a/models/qwen3.6-27b/beellama/compose/dual/beellama-q8kxl-dflash/dflash.yml
+++ b/models/qwen3.6-27b/beellama/compose/dual/beellama-q8kxl-dflash/dflash.yml
@@ -6,6 +6,8 @@
 #   Drafter:   DFlash (--spec-type dflash, Anbeeld DFlash-IQ4_XS — separate draft model, ~4.4 GB
 #              in VRAM incl. its 1024-token K/V projection cache; pinned to ONE card, drafter=1
 #              device + GPU cross ring — NOT split across cards. Footprint is CTX-INDEPENDENT.)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q5_0 K + q4_1 V
 #   Vision:    no (mmproj NOT mounted; set MMPROJ_FILE + --mmproj for vision)
 #   Template:  native (GGUF-embedded) via --jinja
@@ -100,6 +102,48 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8065}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080

--- a/models/qwen3.6-27b/beellama/compose/dual/beellama-q8kxl-mtp/mtp.yml
+++ b/models/qwen3.6-27b/beellama/compose/dual/beellama-q8kxl-mtp/mtp.yml
@@ -4,6 +4,8 @@
 #   Engine:    beellama.cpp v0.3.0 (Anbeeld llama.cpp fork — MTP spec-dec)
 #   Topology:  Dual 3090 (layer-split across both cards, PCIe — no NVLink needed)
 #   Drafter:   MTP (--spec-type draft-mtp, embedded head — NO separate draft model)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q5_0 K + q4_1 V
 #   Vision:    no (mmproj NOT mounted; set MMPROJ_FILE + --mmproj for vision)
 #   Template:  native (GGUF-embedded) via --jinja
@@ -56,12 +58,54 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8064}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
       -m /models/${GGUF_FILE:-qwen3.6-27b-gguf/unsloth-mtp-q8kxl/Qwen3.6-27B-UD-Q8_K_XL.gguf}
       --spec-type draft-mtp
-      --spec-draft-n-max ${DRAFT_N_MAX:-3}
+      --spec-draft-n-max ${SPEC_N:-${DRAFT_N_MAX:-3}}
       -ngl all
       --split-mode ${SPLIT_MODE:-layer}
       --main-gpu ${MAIN_GPU:-0}

--- a/models/qwen3.6-27b/beellama/compose/dual/carnice-v2-q8/mtp-q8kv.yml
+++ b/models/qwen3.6-27b/beellama/compose/dual/carnice-v2-q8/mtp-q8kv.yml
@@ -6,6 +6,8 @@
 #   Topology:  Dual 3090 (layer-split, -ts 0.55,0.45)
 #   Drafter:   MTP (--spec-type draft-mtp, embedded head — NO separate draft model).
 #              n_max=1 default (the head is mtp_num_hidden_layers=1); n=2 = +13% opt-in (see Caveats).
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q8_0 K + q8_0 V (standard quantized KV — high fidelity; chosen over kvarn6 after a
 #              measured A/B, see "Why q8_0 not kvarn6").
 #   Vision:    no (text-only fine-tune; no mmproj)
@@ -77,12 +79,54 @@ services:
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # server target ENTRYPOINT is /app/llama-server — args only below.
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
       -m /models/${GGUF_FILE:-carnice-v2-27b-gguf/stuchapin-q8/Carnice-V2-27B-Q8_0-mtp.gguf}
       --spec-type draft-mtp
-      --spec-draft-n-max ${DRAFT_N_MAX:-1}
+      --spec-draft-n-max ${SPEC_N:-${DRAFT_N_MAX:-1}}
       -ngl all
       --split-mode ${SPLIT_MODE:-layer}
       --main-gpu ${MAIN_GPU:-0}

--- a/models/qwen3.6-27b/beellama/compose/single/beellama-q5ks-dflash/dflash.yml
+++ b/models/qwen3.6-27b/beellama/compose/single/beellama-q5ks-dflash/dflash.yml
@@ -4,6 +4,8 @@
 #   Engine:    beellama.cpp (Anbeeld llama.cpp fork — DFlash spec-dec + windowed KV)
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   DFlash (--spec-type dflash, Anbeeld DFlash-Q4_K_M GGUF, adaptive draft-max)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q5_0 K + q4_1 V (Anbeeld's long-ctx precision default — better
 #              quality/size than turbo KV per his KV-quant benchmarks)
 #   Vision:    no (mmproj NOT mounted; for vision pass MMPROJ_FILE + --mmproj — CPU-offloaded)
@@ -121,6 +123,48 @@ services:
     # server target ENTRYPOINT is /app/llama-server — args only below.
     # ⚠ -np 1 is intentional on a single 24 GB card — DFlash is single-slot by
     #   default and extra slots divide a compute-bound GPU's throughput.
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080

--- a/models/qwen3.6-27b/beellama/compose/single/carnice-v2-q5km/mtp-kvarn4.yml
+++ b/models/qwen3.6-27b/beellama/compose/single/carnice-v2-q5km/mtp-kvarn4.yml
@@ -6,6 +6,8 @@
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   MTP (--spec-type draft-mtp, embedded head — NO separate draft model).
 #              n_max=1 (NOT 3 — see Caveats: this head is mtp_num_hidden_layers=1).
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        kvarn4 K + kvarn4 V (KVarN — q5-class quality at ~28% bf16 memory; disc #329).
 #              Author's card ships q4_0/q4_0; we use kvarn4 (better quality, similar memory →
 #              bigger window) per the qwopus-coder KVarN result.
@@ -129,12 +131,54 @@ services:
     # -np 1 is intentional on a single 24 GB card (extra slots divide a compute-bound GPU).
     # --no-context-shift: author-recommended — errors instead of silently shifting when the
     # window fills (context-shift can corrupt MTP draft alignment at long ctx).
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
       -m /models/${GGUF_FILE:-carnice-v2-27b-gguf/stuchapin-q5km/Carnice-V2-27B-Q5_K_M-mtp.gguf}
       --spec-type draft-mtp
-      --spec-draft-n-max ${DRAFT_N_MAX:-1}
+      --spec-draft-n-max ${SPEC_N:-${DRAFT_N_MAX:-1}}
       -ngl all
       --ctx-size ${CTX_SIZE:-163840}
       -b ${BATCH_SIZE:-2048}

--- a/models/qwen3.6-27b/beellama/compose/single/qwopus-coder-mtp-q5km/mtp.yml
+++ b/models/qwen3.6-27b/beellama/compose/single/qwopus-coder-mtp-q5km/mtp.yml
@@ -5,6 +5,8 @@
 #   Engine:    beellama.cpp v0.3.2-preview (Anbeeld fork — MTP spec-dec + KVarN KV-compression)
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   MTP (--spec-type draft-mtp, embedded head — NO separate draft model)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        kvarn4 K + kvarn4 V (KVarN — q5-class quality at ~28% bf16 memory; disc #329)
 #   Vision:    no (mmproj NOT mounted; repo ships mmproj-F32.gguf — set MMPROJ_FILE
 #              + it's CPU-offloaded — but it's not downloaded by default)
@@ -98,12 +100,54 @@ services:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # server target ENTRYPOINT is /app/llama-server — args only below.
     # -np 1 is intentional on a single 24 GB card (extra slots divide a compute-bound GPU).
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
       -m /models/${GGUF_FILE:-qwopus3.6-27b-coder-gguf/jackrong-mtp-q5km/Qwopus3.6-27B-Coder-MTP-Q5_K_M.gguf}
       --spec-type draft-mtp
-      --spec-draft-n-max ${DRAFT_N_MAX:-3}
+      --spec-draft-n-max ${SPEC_N:-${DRAFT_N_MAX:-3}}
       -ngl all
       --ctx-size ${CTX_SIZE:-163840}
       -b ${BATCH_SIZE:-2048}

--- a/models/qwen3.6-27b/ik-llama/compose/dual/ex0bit-prism-pro-dq/mtp-vision.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/dual/ex0bit-prism-pro-dq/mtp-vision.yml
@@ -4,6 +4,8 @@
 #   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp@sha256:5f914f1ccade922417af58c94bd1cbb558052c8852d86678ead3fe693eec0143)
 #   Topology:  Dual 3090 (TP=2)
 #   Drafter:   MTP n=5, p-min 0.0
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
 #   Vision:    YES — qwen3.6 mmproj-F16 mounted for multimodal input
 #   Default ctx: 196608
@@ -56,6 +58,48 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8010}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -75,7 +119,7 @@ services:
       -khad
       -vhad
       -ngld 99
-      --spec-type mtp:n_max=${MTP_DRAFT_N_MAX:-5},p_min=${DRAFT_P_MIN:-0.0}
+      --spec-type mtp:n_max=${SPEC_N:-${MTP_DRAFT_N_MAX:-5}},p_min=${DRAFT_P_MIN:-0.0}
       --recurrent-ckpt-mode auto
       --merge-qkv
       -fa on

--- a/models/qwen3.6-27b/ik-llama/compose/dual/ex0bit-prism-pro-dq/mtp.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/dual/ex0bit-prism-pro-dq/mtp.yml
@@ -4,6 +4,8 @@
 #   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp@sha256:5f914f1ccade922417af58c94bd1cbb558052c8852d86678ead3fe693eec0143)
 #   Topology:  Dual 3090 (TP=2)
 #   Drafter:   MTP n=4, p-min 0.0
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
 #   Vision:    NO
 #   Default ctx: 196608
@@ -43,6 +45,48 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8053}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -59,7 +103,7 @@ services:
       -khad
       -vhad
       -ngld 99
-      --spec-type mtp:n_max=${MTP_DRAFT_N_MAX:-4},p_min=${DRAFT_P_MIN:-0.0}
+      --spec-type mtp:n_max=${SPEC_N:-${MTP_DRAFT_N_MAX:-4}},p_min=${DRAFT_P_MIN:-0.0}
       --recurrent-ckpt-mode auto
       --merge-qkv
       -fa on

--- a/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/long.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/long.yml
@@ -4,6 +4,8 @@
 #   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp@sha256:5f914f1ccade922417af58c94bd1cbb558052c8852d86678ead3fe693eec0143)
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   MTP n=5, p-min 0.0
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
 #   Vision:    embedded tower preserved in the GGUF; tuned for text-first use
 #   Default ctx: 180000
@@ -43,6 +45,48 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8052}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -57,7 +101,7 @@ services:
       -khad
       -vhad
       -ngld 99
-      --spec-type mtp:n_max=${MTP_DRAFT_N_MAX:-5},p_min=${DRAFT_P_MIN:-0.0}
+      --spec-type mtp:n_max=${SPEC_N:-${MTP_DRAFT_N_MAX:-5}},p_min=${DRAFT_P_MIN:-0.0}
       --recurrent-ckpt-mode auto
       --merge-qkv
       -fa on

--- a/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/mtp.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/mtp.yml
@@ -4,6 +4,8 @@
 #   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp@sha256:5f914f1ccade922417af58c94bd1cbb558052c8852d86678ead3fe693eec0143)
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   MTP n=4, p-min 0.0 (best code TPS on the latest 1x3090 retune)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
 #   Vision:    embedded tower preserved in the GGUF; this preset is tuned for text-first use
 #   Default ctx: 122880
@@ -49,6 +51,48 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8020}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -63,7 +107,7 @@ services:
       -khad
       -vhad
       -ngld 99
-      --spec-type mtp:n_max=${MTP_DRAFT_N_MAX:-4},p_min=${DRAFT_P_MIN:-0.0}
+      --spec-type mtp:n_max=${SPEC_N:-${MTP_DRAFT_N_MAX:-4}},p_min=${DRAFT_P_MIN:-0.0}
       --recurrent-ckpt-mode auto
       --merge-qkv
       -fa on

--- a/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/two-stage.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/ex0bit-prism-pro-dq/two-stage.yml
@@ -4,6 +4,8 @@
 #   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp@sha256:5f914f1ccade922417af58c94bd1cbb558052c8852d86678ead3fe693eec0143)
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   TWO-STAGE ngram-mod + MTP fallback
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
 #   Vision:    embedded tower preserved in the GGUF; this preset is tuned for text-first use
 #   Default ctx: 200000
@@ -52,6 +54,48 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8020}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -67,7 +111,7 @@ services:
       -vhad
       -ngld 99
       --spec-type ngram-mod:n_max=${NGRAM_N_MAX:-4},n_min=${NGRAM_N_MIN:-2},ngram_size_n=${NGRAM_SIZE_N:-16}
-      --spec-type mtp:n_max=${MTP_N_MAX:-3},p_min=${MTP_P_MIN:-0.0}
+      --spec-type mtp:n_max=${SPEC_N:-${MTP_N_MAX:-3}},p_min=${MTP_P_MIN:-0.0}
       --recurrent-ckpt-mode auto
       --merge-qkv
       -fa on

--- a/models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/mtp-vision.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/mtp-vision.yml
@@ -4,6 +4,8 @@
 #   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp@sha256:5f914f1ccade922417af58c94bd1cbb558052c8852d86678ead3fe693eec0143)
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   MTP n=2, p-min 0.0 (built-in MTP head)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q4_0 K + q4_0 V
 #   Template:  native (GGUF-embedded) — froggeric (pinned) A/B'd on the text sibling,
 #              native won the 8-pack 103 vs 99 (toolcall TIED); see iq4ks-mtp.yml
@@ -134,6 +136,48 @@ services:
     #   timeouts (aider ran 1/30) — and -np>1 also auto-disables MTP and
     #   can OOM the spec-context buffer. On a higher-throughput card (e.g.
     #   5090) or multi-GPU the trade may flip — re-validate before raising.
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -151,7 +195,7 @@ services:
       -khad
       -vhad
       -ngld 99
-      --spec-type mtp:n_max=${MTP_DRAFT_N_MAX:-2},p_min=${DRAFT_P_MIN:-0.0}
+      --spec-type mtp:n_max=${SPEC_N:-${MTP_DRAFT_N_MAX:-2}},p_min=${DRAFT_P_MIN:-0.0}
       --recurrent-ckpt-mode auto
       --merge-qkv
       -fa on

--- a/models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/mtp.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/mtp.yml
@@ -4,6 +4,8 @@
 #   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp@sha256:5f914f1ccade922417af58c94bd1cbb558052c8852d86678ead3fe693eec0143)
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   MTP n=2, p-min 0.0 (built-in MTP head)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q4_0 K + q4_0 V (default — max-context-first; -khad/-vhad
 #              Hadamard transforms on K and V caches for quantized-KV accuracy,
 #              no VRAM cost. KV_TYPE=q8_0 = ampersandru's, higher KV fidelity,
@@ -133,6 +135,48 @@ services:
     #   timeouts (aider ran 1/30) — and -np>1 also auto-disables MTP and
     #   can OOM the spec-context buffer. On a higher-throughput card (e.g.
     #   5090) or multi-GPU the trade may flip — re-validate before raising.
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -147,7 +191,7 @@ services:
       -khad
       -vhad
       -ngld 99
-      --spec-type mtp:n_max=${MTP_DRAFT_N_MAX:-2},p_min=${DRAFT_P_MIN:-0.0}
+      --spec-type mtp:n_max=${SPEC_N:-${MTP_DRAFT_N_MAX:-2}},p_min=${DRAFT_P_MIN:-0.0}
       --recurrent-ckpt-mode auto
       --merge-qkv
       -fa on

--- a/models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/two-stage.yml
+++ b/models/qwen3.6-27b/ik-llama/compose/single/ubergarm-iq4ks/two-stage.yml
@@ -11,6 +11,8 @@
 #              (ngram n_max TUNED to 4 on this rig — the PR's default of 64
 #               OOMs the per-step checkpoint on a 24 GB card. See Status + the
 #               RECURRENT CHECKPOINT MODE note below.)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard (same as iq4ks-mtp.yml)
 #   Template:  native (GGUF-embedded) — see iq4ks-mtp.yml for A/B rationale
 #   Vision:    NO (text-only; mmproj is a separate axis → iq4ks-mtp-vision.yml)
@@ -110,6 +112,48 @@ services:
     #   timeouts (aider ran 1/30) — and -np>1 also auto-disables MTP and
     #   can OOM the spec-context buffer. On a higher-throughput card (e.g.
     #   5090) or multi-GPU the trade may flip — re-validate before raising.
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -125,7 +169,7 @@ services:
       -vhad
       -ngld 99
       --spec-type ngram-mod:n_max=${NGRAM_N_MAX:-4},n_min=${NGRAM_N_MIN:-2},ngram_size_n=${NGRAM_SIZE_N:-16}
-      --spec-type mtp:n_max=${MTP_N_MAX:-3},p_min=${MTP_P_MIN:-0.0}
+      --spec-type mtp:n_max=${SPEC_N:-${MTP_N_MAX:-3}},p_min=${MTP_P_MIN:-0.0}
       --recurrent-ckpt-mode auto
       --merge-qkv
       -fa on

--- a/models/qwen3.6-27b/llama-cpp/compose/single/pi-reasoning-q4km/mtp.yml
+++ b/models/qwen3.6-27b/llama-cpp/compose/single/pi-reasoning-q4km/mtp.yml
@@ -6,6 +6,8 @@
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   MTP n=2 (--spec-type draft-mtp; our on-rig A/B peak. Card recommends n=3 — within
 #              noise of 2 here; MTP_DRAFT_N_MAX=3 matches the card exactly)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q4_0 K + q4_0 V (per card; densest mainline, Ampere-fast)
 #   Vision:    no (text-only; repo ships no mmproj)
 #   Template:  native (GGUF-embedded) via --jinja
@@ -80,6 +82,48 @@ services:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # -np 1 is intentional on a single 24 GB card — extra slots divide a compute-bound GPU
     # and -np>1 auto-disables MTP + can OOM the spec-context buffer.
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -93,7 +137,7 @@ services:
       --cache-type-v ${KV_TYPE:-q4_0}
       -np ${NP:-1}
       --spec-type draft-mtp
-      --spec-draft-n-max ${MTP_DRAFT_N_MAX:-2}
+      --spec-draft-n-max ${SPEC_N:-${MTP_DRAFT_N_MAX:-2}}
       --jinja
       --reasoning ${REASONING:-on}
       --reasoning-format ${REASONING_FORMAT:-deepseek}

--- a/models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/bounded-thinking.yml
+++ b/models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/bounded-thinking.yml
@@ -4,6 +4,8 @@
 #   Engine:    llama.cpp mainline (server-cuda-b9246 pin, same as mtp.yml)
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   MTP n=2 (--spec-type draft-mtp, inherited from mtp.yml)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q4_0 K + q4_0 V
 #   Vision:    no
 #   Template:  native GGUF + --jinja + --reasoning on --reasoning-format deepseek
@@ -79,6 +81,48 @@ services:
     #   timeouts (aider ran 1/30) — and -np>1 also auto-disables MTP and
     #   can OOM the spec-context buffer. On a higher-throughput card (e.g.
     #   5090) or multi-GPU the trade may flip — re-validate before raising.
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -92,7 +136,7 @@ services:
       --cache-type-v ${KV_TYPE:-q4_0}
       -np ${NP:-1}
       --spec-type draft-mtp
-      --spec-draft-n-max ${MTP_DRAFT_N_MAX:-2}
+      --spec-draft-n-max ${SPEC_N:-${MTP_DRAFT_N_MAX:-2}}
       --jinja
       --reasoning ${REASONING:-on}
       --reasoning-format ${REASONING_FORMAT:-deepseek}

--- a/models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/mtp-vision.yml
+++ b/models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/mtp-vision.yml
@@ -4,6 +4,8 @@
 #   Engine:    llama.cpp (local MTP-enabled build, build 9235)
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   MTP n=2 (--spec-type draft-mtp, sweet spot)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q4_0 K + q4_0 V
 #   Vision:    YES (mmproj-F16 mounted — multimodal input enabled)
 #   Max ctx:   150000 (150K) default @ 1M-px images. Higher OOMs at fill — see below.
@@ -118,6 +120,48 @@ services:
     #   timeouts (aider ran 1/30) — and -np>1 also auto-disables MTP and
     #   can OOM the spec-context buffer. On a higher-throughput card (e.g.
     #   5090) or multi-GPU the trade may flip — re-validate before raising.
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -134,7 +178,7 @@ services:
       --cache-type-v ${KV_TYPE:-q4_0}
       -np ${NP:-1}
       --spec-type draft-mtp
-      --spec-draft-n-max ${MTP_DRAFT_N_MAX:-2}
+      --spec-draft-n-max ${SPEC_N:-${MTP_DRAFT_N_MAX:-2}}
       --jinja
       --reasoning ${REASONING:-off}
       --reasoning-format ${REASONING_FORMAT:-deepseek}

--- a/models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/mtp.yml
+++ b/models/qwen3.6-27b/llama-cpp/compose/single/unsloth-q4km/mtp.yml
@@ -4,6 +4,8 @@
 #   Engine:    llama.cpp (local MTP-enabled build, build 9235)
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   MTP n=2 (--spec-type draft-mtp, sweet spot — see BENCHMARKS.md)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q4_0 K + q4_0 V (densest mainline, Ampere-fast)
 #   Vision:    no (mmproj NOT mounted — for vision, see mtp-vision.yml)
 #   Template:  native (GGUF-embedded) — froggeric A/B'd here, regressed 8-pack 102→95
@@ -109,6 +111,48 @@ services:
     #   timeouts (aider ran 1/30) — and -np>1 also auto-disables MTP and
     #   can OOM the spec-context buffer. On a higher-throughput card (e.g.
     #   5090) or multi-GPU the trade may flip — re-validate before raising.
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -122,7 +166,7 @@ services:
       --cache-type-v ${KV_TYPE:-q4_0}
       -np ${NP:-1}
       --spec-type draft-mtp
-      --spec-draft-n-max ${MTP_DRAFT_N_MAX:-2}
+      --spec-draft-n-max ${SPEC_N:-${MTP_DRAFT_N_MAX:-2}}
       --jinja
       --reasoning ${REASONING:-off}
       --reasoning-format ${REASONING_FORMAT:-deepseek}

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/dual/mudler-apex-quality/mtp.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/dual/mudler-apex-quality/mtp.yml
@@ -4,6 +4,8 @@
 #   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp@sha256:5f914f1ccade922417af58c94bd1cbb558052c8852d86678ead3fe693eec0143)
 #   Topology:  Dual 3090 (TP=2)
 #   Drafter:   MTP n=5, p-min 0.0
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q8_0 K + q8_0 V
 #   Vision:    NO
 #   Default ctx: 196608
@@ -49,6 +51,48 @@ services:
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
       - ../../../patches/apex-qwen-chat-template.jinja:/etc/apex-qwen-chat-template.jinja:ro
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -63,7 +107,7 @@ services:
       -np ${NP:-1}
       -ctk ${KV_TYPE:-q8_0}
       -ctv ${KV_TYPE:-q8_0}
-      --spec-type mtp:n_max=${MTP_DRAFT_N_MAX:-5},p_min=${DRAFT_P_MIN:-0.0}
+      --spec-type mtp:n_max=${SPEC_N:-${MTP_DRAFT_N_MAX:-5}},p_min=${DRAFT_P_MIN:-0.0}
       --merge-qkv
       -fa on
       --jinja

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/single/byteshape-iq4xs/mtp.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/single/byteshape-iq4xs/mtp.yml
@@ -4,6 +4,8 @@
 #   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp@sha256:5f914f1ccade922417af58c94bd1cbb558052c8852d86678ead3fe693eec0143)
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   MTP n=2, p-min 0.0 (built-in MTP head — byteshape/Qwen3.6-35B-A3B-MTP-GGUF)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
 #   Vision:    NO (mmproj-bf16.gguf exists upstream — vision not wired here yet)
 #   Default ctx: --fit (auto; author observed 262K full n_ctx_train)
@@ -53,6 +55,48 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8058}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -68,7 +112,7 @@ services:
       -khad
       -vhad
       -ngld 99
-      --spec-type mtp:n_max=${MTP_DRAFT_N_MAX:-2},p_min=${DRAFT_P_MIN:-0.0}
+      --spec-type mtp:n_max=${SPEC_N:-${MTP_DRAFT_N_MAX:-2}},p_min=${DRAFT_P_MIN:-0.0}
       --recurrent-ckpt-mode auto
       --merge-qkv
       -fa on

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/fit-mtp.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/fit-mtp.yml
@@ -4,6 +4,8 @@
 #   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp@sha256:5f914f1ccade922417af58c94bd1cbb558052c8852d86678ead3fe693eec0143)
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   MTP n=4, p-min 0.0
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q8_0 K + q5_0 V (asymmetric, K-high/V-low) + -khad/-vhad
 #   Vision:    NO
 #   Default ctx: 196608
@@ -88,6 +90,48 @@ services:
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
       - ../../../patches/apex-qwen-chat-template.jinja:/etc/apex-qwen-chat-template.jinja:ro
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -104,7 +148,7 @@ services:
       -khad
       -vhad
       -ngld 99
-      --spec-type mtp:n_max=${MTP_DRAFT_N_MAX:-4},p_min=${DRAFT_P_MIN:-0.0}
+      --spec-type mtp:n_max=${SPEC_N:-${MTP_DRAFT_N_MAX:-4}},p_min=${DRAFT_P_MIN:-0.0}
       --recurrent-ckpt-mode auto
       --merge-qkv
       -fa on

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/long.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/long.yml
@@ -4,6 +4,8 @@
 #   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp@sha256:5f914f1ccade922417af58c94bd1cbb558052c8852d86678ead3fe693eec0143)
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   MTP n=2, p-min 0.0
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q8_0 K + q8_0 V + -khad/-vhad Hadamard
 #   Vision:    NO
 #   Default ctx: 262144
@@ -47,6 +49,48 @@ services:
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
       - ../../../patches/apex-qwen-chat-template.jinja:/etc/apex-qwen-chat-template.jinja:ro
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -63,7 +107,7 @@ services:
       -khad
       -vhad
       -ngld 99
-      --spec-type mtp:n_max=${MTP_DRAFT_N_MAX:-4},p_min=${DRAFT_P_MIN:-0.0}
+      --spec-type mtp:n_max=${SPEC_N:-${MTP_DRAFT_N_MAX:-4}},p_min=${DRAFT_P_MIN:-0.0}
       --recurrent-ckpt-mode auto
       --merge-qkv
       -fa on

--- a/models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/mtp.yml
+++ b/models/qwen3.6-35b-a3b/ik-llama/compose/single/mudler-apex-compact/mtp.yml
@@ -4,6 +4,8 @@
 #   Engine:    ik_llama.cpp (ghcr.io/ikawrakow/ik-llama-cpp@sha256:5f914f1ccade922417af58c94bd1cbb558052c8852d86678ead3fe693eec0143)
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   MTP n=2, p-min 0.0
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q4_0 K + q4_0 V + -khad/-vhad Hadamard
 #   Vision:    NO
 #   Default ctx: 200000
@@ -53,6 +55,48 @@ services:
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
       - ../../../patches/apex-qwen-chat-template.jinja:/etc/apex-qwen-chat-template.jinja:ro
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -69,7 +113,7 @@ services:
       -khad
       -vhad
       -ngld 99
-      --spec-type mtp:n_max=${MTP_DRAFT_N_MAX:-5},p_min=${DRAFT_P_MIN:-0.0}
+      --spec-type mtp:n_max=${SPEC_N:-${MTP_DRAFT_N_MAX:-5}},p_min=${DRAFT_P_MIN:-0.0}
       --recurrent-ckpt-mode auto
       --merge-qkv
       -fa on

--- a/models/qwen3.6-35b-a3b/llama-cpp/compose/dual/morikomorizz-q6kp/mtp.yml
+++ b/models/qwen3.6-35b-a3b/llama-cpp/compose/dual/morikomorizz-q6kp/mtp.yml
@@ -4,6 +4,8 @@
 #   Engine:    llama.cpp (mainline server-cuda-b9570, draft-mtp)
 #   Topology:  Dual 3090 (layer-split -ts 0.55,0.45 — rebalances the MTP draft card)
 #   Drafter:   MTP n=3 (--spec-type draft-mtp; embedded nextn head, 1 layer)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q8_0 K + q8_0 V
 #   Vision:    no (mmproj not fetched)
 #   Template:  native (GGUF-embedded, qwen3 im_start)
@@ -97,6 +99,48 @@ services:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # ⚠ -np 1 is intentional — one decode stream per dual-card config; extra
     #   slots divide throughput and can OOM the spec-context buffer at 262K.
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -112,7 +156,7 @@ services:
       --cache-type-v ${KV_TYPE:-q8_0}
       -np ${NP:-1}
       --spec-type draft-mtp
-      --spec-draft-n-max ${MTP_DRAFT_N_MAX:-3}
+      --spec-draft-n-max ${SPEC_N:-${MTP_DRAFT_N_MAX:-3}}
       --jinja
       --reasoning ${REASONING:-on}
       --reasoning-format ${REASONING_FORMAT:-deepseek}

--- a/models/qwen3.6-40b-deckard/llama-cpp/compose/dual/piehsoft-q6k/mtp.yml
+++ b/models/qwen3.6-40b-deckard/llama-cpp/compose/dual/piehsoft-q6k/mtp.yml
@@ -4,6 +4,8 @@
 #   Engine:    llama.cpp (mainline server-cuda-b9570, draft-mtp)
 #   Topology:  Dual 3090 (layer-split -ts 1,1)
 #   Drafter:   MTP n=2 (--spec-type draft-mtp, sweet-spot — see BENCHMARKS.md)
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q8_0 K + q8_0 V
 #   Vision:    no
 #   Template:  native (GGUF-embedded)
@@ -89,6 +91,48 @@ services:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # ⚠ -np 1 is intentional — do NOT raise it. One decode stream per dual-card
     #   config; extra slots divide throughput and can OOM the spec-context buffer.
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -104,7 +148,7 @@ services:
       --cache-type-v ${KV_TYPE:-q8_0}
       -np ${NP:-1}
       --spec-type draft-mtp
-      --spec-draft-n-max ${MTP_DRAFT_N_MAX:-2}
+      --spec-draft-n-max ${SPEC_N:-${MTP_DRAFT_N_MAX:-2}}
       --jinja
       --reasoning ${REASONING:-off}
       --reasoning-format ${REASONING_FORMAT:-deepseek}

--- a/models/qwen3.8-27b/llama-cpp/compose/dual/unsloth-q8kxl/q8kv.yml
+++ b/models/qwen3.8-27b/llama-cpp/compose/dual/unsloth-q8kxl/q8kv.yml
@@ -6,6 +6,8 @@
 #              all-reduce; the skew rebalances the pinned MTP draft card, see TOPOLOGY)
 #   Drafter:   MTP n=2 built-in (--spec-type draft-mtp; the head is EMBEDDED in this GGUF)
 #              ⚠️ n=2 is the house default for Qwen 27B on llama.cpp, NOT measured for 3.8.
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q8_0 K + q8_0 V (serving-grade KV floor — see "KV choice" below)
 #   Vision:    no (base is VL-capable; mmproj NOT fetched, NOT mounted — text-only ship)
 #   Template:  native (GGUF-embedded) via --jinja
@@ -197,6 +199,9 @@ services:
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       # ⭐ Default reasoning effort = low when thinking is on (2026-08-16),
       # matching the vLLM composes. INERT under the shipped `--reasoning off`:
       # the template only reads reasoning_effort inside
@@ -304,6 +309,44 @@ services:
     #         -m /nonexistent.gguf --temp 0.11 --temp 0.99 2>&1 | grep -i 'multiple times'
     #     Expect the DEPRECATED/last-value warning. If it is gone, verify last-wins still holds
     #     (or convert this to a sibling thinking.yml compose, which needs no such guarantee).
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -320,7 +363,7 @@ services:
       --cache-type-v ${KV_TYPE:-q8_0}
       -np ${NP:-1}
       --spec-type draft-mtp
-      --spec-draft-n-max ${MTP_DRAFT_N_MAX:-2}
+      --spec-draft-n-max ${SPEC_N:-${MTP_DRAFT_N_MAX:-2}}
       --jinja
       --reasoning ${REASONING:-off}
       --reasoning-format ${REASONING_FORMAT:-deepseek}

--- a/models/qwen3.8-27b/llama-cpp/compose/single/unsloth-iq4nl/q8kv.yml
+++ b/models/qwen3.8-27b/llama-cpp/compose/single/unsloth-iq4nl/q8kv.yml
@@ -5,6 +5,8 @@
 #   Topology:  Single 3090 (TP=1)
 #   Drafter:   MTP n=2 built-in (--spec-type draft-mtp; the head is EMBEDDED in this GGUF)
 #              ⚠️ n=2 is the house default for Qwen 27B on llama.cpp, NOT measured for 3.8.
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q8_0 K + q8_0 V (serving-grade KV floor — see "KV choice" below)
 #   Vision:    no (base is VL-capable; mmproj NOT fetched, NOT mounted — text-only ship)
 #   Template:  native (GGUF-embedded) via --jinja
@@ -208,6 +210,9 @@ services:
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
       # ⭐ Default reasoning effort = low when thinking is on (2026-08-16),
       # matching the vLLM composes. INERT under the shipped `--reasoning off`:
       # the template only reads reasoning_effort inside
@@ -317,6 +322,44 @@ services:
     #         -m /nonexistent.gguf --temp 0.11 --temp 0.99 2>&1 | grep -i 'multiple times'
     #     Expect the DEPRECATED/last-value warning. If it is gone, verify last-wins still holds
     #     (or convert this to a sibling thinking.yml compose, which needs no such guarantee).
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -331,7 +374,7 @@ services:
       --cache-type-v ${KV_TYPE:-q8_0}
       -np ${NP:-1}
       --spec-type draft-mtp
-      --spec-draft-n-max ${MTP_DRAFT_N_MAX:-2}
+      --spec-draft-n-max ${SPEC_N:-${MTP_DRAFT_N_MAX:-2}}
       --jinja
       --reasoning ${REASONING:-off}
       --reasoning-format ${REASONING_FORMAT:-deepseek}

--- a/models/tess-4-27b/llama-cpp/compose/dual/migtissera-q4km/mtp.yml
+++ b/models/tess-4-27b/llama-cpp/compose/dual/migtissera-q4km/mtp.yml
@@ -4,6 +4,8 @@
 #   Engine:    llama.cpp (mainline server-cuda-b10236, external draft-mtp)
 #   Topology:  Dual 3090 (layer-split -ts 1,1)
 #   Drafter:   MTP n=2 external (n-sweep sweet spot 2026-07-09) — --spec-draft-model mtp-Tess-*.gguf + --spec-type draft-mtp
+#              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
+#              (removes the flags — n-max=0 would leave the draft context allocated)
 #   KV:        q4_0 K + q4_0 V
 #   Vision:    no (base is VL-capable; mmproj on disk, not mounted — text-only ship)
 #   Template:  native (GGUF-embedded, Qwen-style)
@@ -115,6 +117,48 @@ services:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # ⚠ -np 1 is intentional — do NOT raise it. One decode stream per dual-card
     #   config; extra slots divide throughput and can OOM the spec-context buffer.
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth; SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Disabling REMOVES the drafter flags rather than passing n=0. At
+        # --spec-draft-n-max 0 llama.cpp sets drafting=false but still builds the
+        # draft context (server-context.cpp), and still loads an external draft
+        # model when one is named -- so the memory stays spent. Removing the
+        # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-1}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        if [ "$$_spec_n" -gt 0 ]; then
+          echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          exec /app/llama-server "$$@"
+        fi
+        ARGS=(); _skip=0
+        for _a in "$$@"; do
+          if [ "$$_skip" = 1 ]; then _skip=0; continue; fi
+          case "$$_a" in
+            --spec-type|--spec-draft-model|--spec-draft-n-max|--spec-draft-n-min|-md|--model-draft) _skip=1; continue ;;
+          esac
+          ARGS+=("$$_a")
+        done
+        echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - drafter flags removed" >&2
+        exec /app/llama-server "$${ARGS[@]}"
+      - --
     command: >-
       --host 0.0.0.0
       --port 8080
@@ -131,7 +175,7 @@ services:
       -np ${NP:-1}
       --spec-draft-model /models/${MTP_DRAFT_FILE:-tess-4-27b-gguf/migtissera-q4km/mtp-Tess-4-27B-Q4_K_M.gguf}
       --spec-type draft-mtp
-      --spec-draft-n-max ${MTP_DRAFT_N_MAX:-2}
+      --spec-draft-n-max ${SPEC_N:-${MTP_DRAFT_N_MAX:-2}}
       --jinja
       --reasoning ${REASONING:-off}
       --reasoning-format ${REASONING_FORMAT:-deepseek}

--- a/scripts/spec-sweep.sh
+++ b/scripts/spec-sweep.sh
@@ -20,7 +20,7 @@
 #     A capability probe guards this: if the server ignores the field
 #     (timings.draft_n missing or identical across differing n), the sweep
 #     REFUSES rather than emit a fake flat curve — reboot-per-n via
-#     `MTP_DRAFT_N_MAX=<n> bash scripts/switch.sh <slug>` is the fallback.
+#     `SPEC_N=<n> bash scripts/switch.sh <slug>` is the fallback.
 #   vLLM — reboot per n (vLLM has no per-request draft-depth knob):
 #     `SPEC_N=<n> switch.sh <slug>` for EVERY arm, n=0 included — since
 #     2026-08-18 every drafter-shipping compose honours the same knob, so the
@@ -235,18 +235,12 @@ if [[ "$ENGINE_FAMILY" == "llamacpp" ]]; then
   elif [[ -n "$SLUG" ]]; then
     echo "[spec-sweep] per-request speculative NOT honored (probe draft_n: n1=$p1 n4=$p4) — falling back to reboot-per-arm (llama.cpp boots are ~15s, still quick)"
     for n in $SWEEP_N; do
-      if [[ "$n" == "0" ]]; then
-        # ⚠️ KNOWN GAP: no llama.cpp compose gates on SPEC, so this does NOT
-        # disable the drafter — the n=0 arm boots spec-ON and the acceptance
-        # guard below marks it INVALID. The vLLM family was unified on SPEC_N
-        # 2026-08-18; the llama.cpp family (MTP_DRAFT_N_MAX / --spec-draft-model)
-        # still needs the same treatment. Left as-is rather than guessed at.
-        echo "[spec-sweep] boot $SLUG SPEC=off…"
-        SPEC=off bash scripts/switch.sh "$SLUG" >/dev/null
-      else
-        echo "[spec-sweep] boot $SLUG MTP_DRAFT_N_MAX=$n…"
-        MTP_DRAFT_N_MAX="$n" bash scripts/switch.sh "$SLUG" >/dev/null
-      fi
+      # One knob for every arm, n=0 included — the llama.cpp family was unified
+      # on SPEC_N 2026-08-18 (#1049), so the baseline arm no longer needs a
+      # different variable, and SPEC_N=0 genuinely REMOVES the drafter flags
+      # rather than passing n-max=0 (which leaves the draft context allocated).
+      echo "[spec-sweep] boot $SLUG SPEC_N=$n…"
+      SPEC_N="$n" bash scripts/switch.sh "$SLUG" >/dev/null
       ready=0
       for _ in $(seq 1 90); do curl -sf -m 3 "$URL/v1/models" >/dev/null 2>&1 && { ready=1; break; }; sleep 2; done
       [[ "$ready" == "1" ]] || { echo "  n=$n: boot not ready — skipping"; continue; }

--- a/scripts/tests/test-spec-toggle-contract.sh
+++ b/scripts/tests/test-spec-toggle-contract.sh
@@ -33,10 +33,10 @@
 # under bash with `vllm` replaced by a stub that prints its argv, and inspects
 # the argv the engine would actually have received. No GPU, no weights, no image.
 
-# SCOPE: vLLM only. `--speculative-config` is a vLLM flag; SGLang
-# (--speculative-algorithm) and llama.cpp (--spec-draft-model / MTP_DRAFT_N_MAX)
-# have their own drafter knobs and are NOT covered. The llama.cpp family has the
-# same class of bug, tracked separately.
+# SCOPE: vLLM (`--speculative-config`) and the llama.cpp lineage (mainline,
+# ik-llama, beellama, llamacpp-club3090 — `--spec-type` / `--spec-draft-model` /
+# `--spec-draft-n-max` / `-md`). SGLang (--speculative-algorithm) is not covered;
+# its two composes ship no drafter today.
 
 set -euo pipefail
 export PYTHONUTF8="${PYTHONUTF8:-1}"
@@ -49,7 +49,13 @@ import json, os, pathlib, re, subprocess, sys, tempfile
 
 root = pathlib.Path(sys.argv[1])
 
-FLAG = "--speculative-config"
+FLAG = "--speculative-config"                      # vLLM
+# llama.cpp lineage: four grammars (mainline `--spec-type draft-mtp
+# --spec-draft-n-max N`, ik-llama `--spec-type mtp:n_max=N,...`, beellama
+# `--spec-type dflash` + external GGUF, deepseek `-md <path>`). All that matters
+# for the contract is that NONE of them survive SPEC_N=0.
+LC_FLAGS = ("--spec-type", "--spec-draft-model", "--spec-draft-n-max",
+            "--spec-draft-n-min", "-md", "--model-draft")
 
 
 def _interp(v, env):
@@ -127,6 +133,26 @@ def entrypoint_of(text):
 
 
 def command_of(text, env):
+    """`command:` as a list, or as a folded/literal scalar that docker splits."""
+    lines = text.split("\n")
+    for i, l in enumerate(lines):
+        m = re.match(r"^(\s*)command:\s*(>-|>|\||\|-)\s*$", l)
+        if not m:
+            continue
+        ind = len(m.group(1))
+        j, buf = i + 1, []
+        while j < len(lines):
+            cur = lines[j]
+            if cur.strip() and (len(cur) - len(cur.lstrip())) <= ind:
+                break
+            buf.append(cur.strip())
+            j += 1
+        import shlex
+        return shlex.split(_interp(" ".join(buf), env))
+    return _command_list(text, env)
+
+
+def _command_list(text, env):
     lines, args = text.split("\n"), []
     for i, l in enumerate(lines):
         if not re.match(r"^\s*command:\s*$", l):
@@ -161,6 +187,10 @@ def argv_under(text, env):
                       "to `- |` block form (every shipped vLLM compose uses that)")
     with tempfile.TemporaryDirectory() as d:
         dp = pathlib.Path(d)
+        (dp / "app").mkdir(exist_ok=True)
+        srv = dp / "app" / "llama-server"
+        srv.write_text('#!/bin/bash\nfor a in "$@"; do printf "ARG:%s\\n" "$a"; done\nexit 0\n')
+        srv.chmod(0o755)
         stub = dp / "vllm"
         stub.write_text('#!/bin/bash\nfor a in "$@"; do printf "ARG:%s\\n" "$a"; done\nexit 0\n')
         stub.chmod(0o755)
@@ -172,7 +202,9 @@ def argv_under(text, env):
             (etc / sub).mkdir(parents=True, exist_ok=True)
             (etc / sub / "install.sh").write_text("#!/bin/bash\nexit 0\n")
         script = dp / "ep.sh"
-        script.write_text(body.replace("$$", "$").replace("/etc/club3090", str(etc)))
+        script.write_text(body.replace("$$", "$")
+                              .replace("/etc/club3090", str(etc))
+                              .replace("/app/llama-server", str(srv)))
         # only what the compose declares crosses into the container
         e = {k: v for k, v in os.environ.items() if not k.startswith(("SPEC", "NUM_SPEC"))}
         e.update(container_env(text, env)); e["PATH"] = f"{d}:{os.environ['PATH']}"
@@ -217,6 +249,28 @@ def payload_problem(args):
     if not ({"method", "model"} & set(obj)):
         return f"--speculative-config names neither a method nor a draft model: {p!r}"
     return None
+
+
+def lc_drafter_args(args):
+    return [a for a in (args or []) if a in LC_FLAGS]
+
+
+def check_llamacpp(text, label, sink):
+    """Same contract, llama.cpp lineage: SPEC_N=0 must REMOVE the drafter flags.
+    Zeroing the count is not enough — llama.cpp still builds the draft context
+    (and still loads an external draft model) at --spec-draft-n-max 0."""
+    base, err = argv_under(text, {})
+    if base is None:
+        sink.append(f"{label}: {err}"); return
+    if not lc_drafter_args(base):
+        sink.append(f"{label}: ships drafter flags but the default resolves to none")
+        return
+    for env, desc in [({"SPEC_N": "0"}, "SPEC_N=0"), ({"SPEC": "off"}, "SPEC=off")]:
+        a, _ = argv_under(text, env)
+        left = lc_drafter_args(a)
+        if left:
+            sink.append(f"{label}: {desc} does not disable the drafter — "
+                        f"{' '.join(sorted(set(left)))} still passed to the engine")
 
 
 def check(text, label, sink):
@@ -335,10 +389,14 @@ for f in sorted(root.glob("models/*/*/compose/**/*.yml")):
     if "_archive" in str(f):
         continue
     text = f.read_text(encoding="utf-8")
-    if not any(FLAG in l and not l.lstrip().startswith("#") for l in text.split("\n")):
-        continue
-    checked += 1
-    check(text, str(f.relative_to(root)), errors)
+    live = [l for l in text.split("\n") if not l.lstrip().startswith("#")]
+    if any(FLAG in l for l in live):
+        checked += 1
+        check(text, str(f.relative_to(root)), errors)
+    elif any(re.search(r"(?<![\w-])" + re.escape(fl) + r"(?![\w-])", l)
+             for l in live for fl in LC_FLAGS):
+        checked += 1
+        check_llamacpp(text, str(f.relative_to(root)), errors)
 
 if errors:
     print("test-spec-toggle-contract: FAIL")


### PR DESCRIPTION
Closes #1049.

## The defect

`scripts/spec-sweep.sh` booted its **n=0 baseline arm** for llama.cpp slugs with `SPEC=off`. **No llama.cpp compose gated on `SPEC`** — zero of the 37 referenced it. So that arm booted with the drafter on, the sweep's own acceptance guard flagged it `SPEC-OFF-IGNORED`, and the llama.cpp n=0 baseline has never actually measured a no-drafter configuration. Every speedup computed against it was computed against the wrong thing.

Behind that, the same accretion as the vLLM side: **six env names** for one knob — `MTP_DRAFT_N_MAX`, `DRAFT_N_MAX`, `MTP_N_MAX`, `NGRAM_N_MAX`, `NGRAM_NMAX`, and `SPEC_N` on the deepseek composes only.

## What "off" actually has to mean here

#1049 asked whether `MTP_DRAFT_N_MAX=0` is a real off switch. It isn't, and the source says why:

- `server-context.cpp` guards drafting on `if (n_draft_max > 0)`, so **n-max=0 does stop speculation**.
- But the draft context is built regardless, and an external draft model is loaded on `speculative.has_dft()` — **neither is gated on n_max**.

So zeroing the count stops the drafting and keeps paying for it. Measured on `llamacpp/qwen38-27b-single-iq4nl`, 1× 3090:

| | draft context | VRAM |
|---|---|--:|
| drafter on | `common_speculative_init_result: creating MTP draft context…` | 21,444 MiB |
| `SPEC_N=0` | *(line absent)* | 20,174 MiB |

**1,270 MiB** that zeroing the count would have left allocated. `SPEC_N=0` therefore **removes** the drafter flags.

## Design: strip, don't rewrite

Four engine binaries ship here with four different drafter grammars:

```
mainline    --spec-type draft-mtp --spec-draft-n-max N
ik-llama    --spec-type mtp:n_max=N,p_min=0.0        (depth inside the type string; two-stage passes it twice)
beellama    --spec-type dflash --spec-draft-model <gguf>   (no depth at all)
deepseek    -md <gguf> --spec-type draft-dspark --spec-draft-n-max N
```

Rebuilding those per-shape is where a silent break would come from, so the entrypoint **strips the drafter flags from argv** when disabled instead. It only needs to know which flags take a value — grammar-agnostic, and each compose's flags stay byte-identical whenever the drafter is on. Only four flags exist across the catalog: `--spec-type`, `--spec-draft-n-max`, `--spec-draft-model`, `-md`.

Depth still routes through each compose's own variable, with `SPEC_N` fronting it: `${SPEC_N:-${MTP_DRAFT_N_MAX:-2}}`. Legacy names keep working. `NGRAM_*` is deliberately **not** aliased — the two-stage ik-llama composes have two independent depths and one knob driving both would be wrong.

All 37 composes needed an entrypoint (none had one) and 33 needed an `environment:` block created. The image `ENTRYPOINT` is `["/app/llama-server"]` on **all seven** pinned images — verified by pulling each config blob from the registry, not assumed from the two I had locally.

## Verification

- **Gate** `test-spec-toggle-contract` extended to the llama.cpp lineage: **64 composes** now (27 vLLM + 37 llama.cpp), self-test 7/7. Before the change it failed all 37 — a live negative control on real files, not synthetic ones.
- **No default moved**: every one of the 37 resolves to **byte-identical** drafter argv against `HEAD` at default env, checked mechanically.
- `docker compose config` **37/37** clean.
- Docker's folded-`command:` splitting verified explicitly (45 separate argv items), since the strip loop depends on it.
- **Live**, `llamacpp/qwen38-27b-single-iq4nl` on 1× 3090:
  - `SPEC_N=0` → `[spec] drafter OFF … flags removed`, **0** drafter flags in engine argv, no draft context, serves
  - default → `[spec] drafter ON`, **2** flags, draft context created, serves
- `spec-sweep.sh` now uses `SPEC_N=<n>` for every arm on **both** engine families; the `SPEC-OFF-IGNORED` workaround is retired.

## Not covered

**SGLang** (`--speculative-algorithm`) is a third grammar. Its two composes are `🧪 Experimental` and ship no drafter today, so there is nothing to gate; the gate's scope note says so.

Of the 37, one was boot-verified. The other 36 are covered by the argv-level gate, the byte-identical-defaults check and `docker compose config` — the same evidence standard as #1048, and the strip-don't-rewrite design is what keeps that standard adequate across four grammars rather than one.
