### PR TITLE
fix(qwen3.8-27b/dual-fast): unpin FlashInfer decode buffer to bound the MTP c≥4 Xid 31 crash

### DIFF
--- a/models/qwen3.8-27b/CHANGELOG.md
+++ b/models/qwen3.8-27b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Qwen3.8-27B — Changelog
+
+Dated history for Qwen3.8-27B configs in this repo.
+
+## 2026-08-18 — dual-fast: FlashInfer decode-buffer unpin bounds the MTP c≥4 Xid 31 crash
+
+`vllm/qwen38-27b-dual-fast` (W4A8 + MTP n=4 + fp8 KV + prefix caching, the hybrid GDN family) crashed the engine in ~15 s at `MAX_NUM_SEQS >= 4` with the drafter on: `NVRM: Xid 31, MMU Fault ... FAULT_PDE ACCESS_TYPE_VIRT_READ` (unmapped page), `torch.AcceleratorError: illegal memory access`, both TP ranks. The prior documented mitigations were `SPEC_N=0` (kill the drafter) or keeping `MAX_NUM_SEQS=1` (no concurrency). This adds a patch that fixes the crash at **full async speed**, so the concurrency ceiling is no longer bounded by the crash.
+
+**Root cause** — [vllm-project/vllm#40756](https://github.com/vllm-project/vllm/issues/40756), thread comments 2026-08-17 (brasrox retraction + sempai SM86 corroboration). FlashInfer `plan()` reuses one **pinned** host buffer per wrapper and copies it out asynchronously with nothing guarding it; the MTP drafter re-plans the **decode** wrapper K−1×/step, so a stale plan feeds the split-KV merge (`PersistentVariableLengthMergeStatesKernel`) a garbage row (observed: row 33,621 of an 85-row buffer) → the Xid. It needs **≥4 genuinely concurrent in-flight MTP requests** to lose the race — c≤3 and the `SPEC_N=0` path never crash. (This is the same bug family the compose header already flagged as "exposed to open vllm#50021 / GDN spec-decode"; the 2026-08-17 thread comments re-identify it as the FlashInfer stale-plan async-copy race, and the buffer that must be unpinned is the **decode** wrapper.)
+
+**The fix** — new patch `models/qwen3.8-27b/vllm/patches/vllm-flashinfer-decode-pin/` (idempotent, marker-gated Python patcher + `install.sh`). Flips `pin_memory=True,` → `pin_memory=False,` on the `_pin_memory_int_workspace_buffer` allocations in `flashinfer/decode.py` — the decode wrapper MTP re-plans. `pin_memory=False` forces a synchronous host→device copy of the plan each step, closing the stale-read window. Auto-detects flashinfer via `import flashinfer` and **no-ops if it isn't installed** (a non-FlashInfer backend config boots clean); hard-fails (exit 2) on drift so the compose never serves a half-patched state. `FI_PINQ_LIB_ALL=1` also unpins prefill/sparse/pod (the validated full mirror; default is decode-only).
+
+**Validation** (v0.27.1 / flashinfer 0.6.16.post3 / 2× RTX 3090 SM86, TP=2):
+
+| Config | c=4, 120 s window | result |
+|--------|-------------------|--------|
+| stock (pinned) | — | **crash ~15 s** (Xid 31) |
+| decode.py unpin only (this patch) | OK=128, ERR=0, **0 new Xid** | **survive** |
+| full mirror (+ prefill/sparse/pod) | OK=126 (120 s) + OK=345 (300 s soak) | **survive, 425 s clean** |
+
+A/B isolates **decode.py as necessary and sufficient**: unpinning prefill/sparse/pod *without* decode.py still crashed; decode.py alone is the fix. End-to-end re-verified inside the pinned v0.27.1 image (`install.sh`: `decode.py: 4 pin_memory True->False (py_compile OK)`, idempotent re-run `already patched`, decode 0/4 and the other three 4/0).
+
+**Performance impact** (c=1 stock-vs-patched — the clean A/B, since stock crashes at c=4): decode narrative 86.31 → 84.47 tok/s (−2.1%), code 102.32 → 101.02 (−1.3%), prefill ~0% — **all within CV, i.e. cost-neutral**. At c=4 the patch unlocks a point stock cannot reach: 72.4 narrative / 85.0 code tok/s per-request, ~3.4× the c=1 aggregate request rate. **Throughput only — no quality gate run** (the 8-pack is the separate follow-up).
+
+**What this does and does not change — deliberately.**
+- **Bounds the crash, not VRAM.** The compose still ships `MAX_NUM_SEQS=1` because of the *separate* W4A8 16K-prompt OOM documented in the header (peak VRAM 23,872 MiB at N=2, 1.75 GB over the 0.90 budget). That is a different constraint and this patch does **not** touch it. At the shipped N=1 default the patch is inert (no c≥4, so no crash). It becomes load-bearing the moment someone raises `MAX_NUM_SEQS` — then the drafter and concurrency coexist without the Xid.
+- **Status unchanged**: the slug stays 🧪 Experimental. A patch that fixes a crash does not by itself promote a tier that still has no 8-pack / NIAH / soak.
+
+**Wiring:** mounted `ro` and invoked from the `dual-fast` compose entrypoint before `vllm serve` (`bash /etc/club3090/flashinfer-decode-pin/install.sh`), registered in `scripts/lib/profiles/patches.yml` as `vllm-flashinfer-decode-pin` (`delivery_mechanism: install_script`). `test-patch-attribution.sh` passes (71 entries) and the compose parses clean.
+
+**Drop when:** flashinfer lands a fix for the pinned-buffer plan reuse (a `pin_memory=False` default on the decode wrapper, or an explicit sync guard on the async copy-out) and the pin moves past it → remove the compose mount + entrypoint call + this patch dir and retire the `patches.yml` row.

--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
@@ -152,6 +152,10 @@ services:
       - ../../../../../qwen3.6-27b/vllm/patches/w4a8-int8-act:/etc/club3090/w4a8:ro
       # Lets the MTP drafter attach on this hybrid (mamba/eagle block drop).
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
+      # Unpins the FlashInfer decode workspace buffer so MAX_NUM_SEQS>=4 with the
+      # drafter doesn't crash (vllm#40756 stale-plan async-copy race; Xid 31).
+      # No-op if flashinfer isn't installed; inert on the SPEC_N=0 path.
+      - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
@@ -204,6 +208,13 @@ services:
         fi
         bash /etc/club3090/w4a8/install.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
+        # FlashInfer decode workspace-buffer unpin (vllm#40756): unpin the decode
+        # wrapper's pinned plan buffer so MAX_NUM_SEQS>=4 + the drafter can't lose
+        # the stale-plan async-copy race (Xid 31 VIRT_READ). No-op if flashinfer
+        # isn't installed; inert on SPEC_N=0; hard-fails on drift (never a
+        # half-patched serve). Defense-in-depth: FI_PINQ_LIB_ALL=1 also unpins
+        # prefill/sparse/pod (the validated full mirror).
+        FI_PINQ_LIB_ALL="${FI_PINQ_LIB_ALL:-0}" bash /etc/club3090/flashinfer-decode-pin/install.sh || exit 1
         echo "[w4a8] VLLM_MARLIN_INPUT_DTYPE=$${VLLM_MARLIN_INPUT_DTYPE:-<unset -> W4A16>} (W4A8=$${W4A8:-1})"
         AR=""
         [ "$${_NVLINK_ENABLED:-0}" = "1" ] || AR="--disable-custom-all-reduce"

--- a/models/qwen3.8-27b/vllm/patches/vllm-flashinfer-decode-pin/README.md
+++ b/models/qwen3.8-27b/vllm/patches/vllm-flashinfer-decode-pin/README.md
@@ -1,0 +1,64 @@
+# vllm-flashinfer-decode-pin
+
+Unpins the FlashInfer **decode** workspace buffer to fix the MTP **c≥4 Xid 31
+VIRT_READ** crash on this Qwen3.8-27B W4A8+MTP (hybrid GDN) config.
+
+## What it fixes
+
+At `MAX_NUM_SEQS >= 4` with the MTP drafter (SPEC_N=4) this stack crashed the
+engine in ~15s: `NVRM: Xid 31, MMU Fault ... FAULT_PDE ACCESS_TYPE_VIRT_READ`,
+`torch.AcceleratorError: illegal memory access`, both TP ranks. Root cause is
+[vllm-project/vllm#40756](https://github.com/vllm-project/vllm/issues/40756)
+(thread comments 2026-08-17): FlashInfer `plan()` reuses one **pinned** host
+buffer per wrapper and copies it out asynchronously; the MTP drafter re-plans
+the **decode** wrapper K−1×/step, so a stale plan feeds the split-KV merge a
+garbage row → the Xid. It needs ≥4 genuinely concurrent in-flight MTP requests
+to lose the race.
+
+The prior documented mitigations were `SPEC_N=0` (kill the drafter — slow) or
+`MAX_NUM_SEQS=1` (no concurrency). This patch fixes the crash at **full async
+speed** and lets you keep `MAX_NUM_SEQS=4`.
+
+## The change
+
+`patch_flashinfer_decode_pin.py` flips `pin_memory=True,` → `pin_memory=False,`
+in the `_pin_memory_int_workspace_buffer` allocations of
+`flashinfer/decode.py` (the decode wrapper — the one MTP re-plans). A
+pinned buffer is safe against the async copy-out only when the re-plan can't
+overlap it; the drafter breaks that. `pin_memory=False` forces a synchronous
+host→device copy of the plan each step, closing the window.
+
+- **decode.py alone is necessary and sufficient** (A/B: unpinning
+  prefill/sparse/pod *without* decode.py still crashed).
+- `FI_PINQ_LIB_ALL=1` also unpins prefill/sparse/pod (validated full mirror;
+  defense in depth). Default is decode-only.
+
+## Safety
+
+- Auto-detects flashinfer via `import flashinfer` (no hardcoded path); **no-ops
+  if not installed** (a non-FlashInfer backend config boots clean).
+- Guard: in each file it touches, `count(pin_memory=True,)` must equal the
+  number of `_pin_memory_int_workspace_buffer* = torch.empty(` allocs. A mismatch
+  means a pin exists outside a workspace buffer → hard-fail (exit 2) so the
+  compose refuses to serve a half-patched state.
+- Idempotent (marker-gated), py_compiles every file it writes.
+
+## Validation (v0.27.1 / flashinfer 0.6.16.post3 / 2× RTX 3090 SM86)
+
+| Config | c=4, 120s | result |
+|--------|-----------|--------|
+| stock (pinned) | — | **crash ~15s** |
+| decode.py unpin only (this patch) | OK=128, ERR=0, 0 new Xid | **survive** |
+| full mirror (+ prefill/sparse/pod) | OK=126 (120s) + OK=345 (300s soak) | **survive, 425s clean** |
+
+Perf impact (c=1 stock-vs-patched, the clean A/B): decode narrative −2.1%, code
+−1.3%, prefill ~0% — all within CV, i.e. **cost-neutral**. At c=4 the patch
+unlocks a point stock cannot reach: 72.4 narrative / 85.0 code tok/s
+per-request, ~3.4× the c=1 aggregate request rate. Throughput only — no quality
+gate run.
+
+## Wiring
+
+Mounted `ro` and invoked from the compose entrypoint before `vllm serve`
+(`bash /etc/club3090/flashinfer-decode-pin/install.sh`), gated on the FlashInfer
+backend. See `models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml`.

--- a/models/qwen3.8-27b/vllm/patches/vllm-flashinfer-decode-pin/install.sh
+++ b/models/qwen3.8-27b/vllm/patches/vllm-flashinfer-decode-pin/install.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# FlashInfer decode workspace-buffer unpin installer — runs in the container
+# entrypoint before `vllm serve`.
+#
+# Fixes the MTP c>=4 Xid 31 VIRT_READ crash (vllm#40756) on this W4A8+MTP
+# hybrid-GDN config. Unpins the flashinfer decode workspace buffer (the one the
+# MTP drafter re-plans K-1x/step) so the async plan copy-out can't read a
+# stale plan.
+#
+# - Idempotent: marker-gated, safe to run multiple times.
+# - No-op if flashinfer is not installed (a non-FlashInfer backend config).
+# - Hard-fails (exit 2) on drift (a pin_memory outside a workspace buffer) so
+#   the compose refuses to serve a half-patched state.
+# - Inert on the SPEC_N=0 (no drafter) path: the race needs the drafter to
+#   re-plan the decode wrapper.
+#
+# Env (all optional, read by the patcher):
+#   FI_PINQ_LIB_ALL=1   also unpin prefill/sparse/pod (validated full mirror;
+#                       default 0 = decode-only minimal fix).
+#   FI_PINQ_LIB_ROOT=   override the flashinfer package dir (default auto-detect).
+set -u
+python3 /etc/club3090/flashinfer-decode-pin/patch_flashinfer_decode_pin.py

--- a/models/qwen3.8-27b/vllm/patches/vllm-flashinfer-decode-pin/patch_flashinfer_decode_pin.py
+++ b/models/qwen3.8-27b/vllm/patches/vllm-flashinfer-decode-pin/patch_flashinfer_decode_pin.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+FlashInfer decode workspace-buffer unpin — fixes the MTP c>=4 Xid 31 VIRT_READ
+crash on the Qwen3.8-27B W4A8+MTP (hybrid GDN) FastAPI serve config.
+
+ROOT CAUSE (vllm-project/vllm#40756, thread comments 2026-08-17 — brasrox
+retraction + sempai SM86 corroboration):
+  FlashInfer plan() reuses ONE pinned host buffer per wrapper and copies it out
+  asynchronously with nothing guarding it. The MTP drafter re-plans the DECODE
+  wrapper K-1 times per step. A stale plan feeds the split-KV merge
+  (PersistentVariableLengthMergeStatesKernel) a garbage row (observed: row
+  33,621 of an 85-row buffer) -> Xid 31 MMU fault at an unmapped VA. It needs
+  >=4 genuinely concurrent in-flight MTP requests to lose the race; c<=3 and
+  the SPEC_N=0 (no drafter) path never do.
+
+FIX (validated):
+  Unpin the flashinfer-library decode workspace buffer. A pinned buffer is
+  safe against the async copy-out only when the re-plan cannot overlap it; the
+  MTP drafter breaks that. pin_memory=False forces a synchronous host->device
+  copy of the plan each step, closing the window. Validated on v0.27.1 /
+  flashinfer 0.6.16.post3 / 2x RTX 3090 (SM86): c=4 survives 425s clean
+  (120s OK=126 + 300s OK=345, ERR=0, zero new Xid) at FULL async speed (no
+  CUDA_LAUNCH_BLOCKING, no MAX_NUM_SEQS=1 cap). decode.py alone is necessary AND
+  sufficient (A/B: prefill/sparse/pod unpin without decode.py still crashed).
+
+WHAT THIS SCRIPT DOES:
+  Flips `pin_memory=True,` -> `pin_memory=False,` in the
+  `_pin_memory_int_workspace_buffer` allocations of flashinfer/decode.py (the
+  DECODE wrapper — the one MTP re-plans). That is the validated minimal fix and
+  the default. Set FI_PINQ_LIB_ALL=1 to ALSO unpin prefill.py/sparse.py/pod.py
+  (the full mirror; also validated, kept for defense in depth).
+
+SAFETY (matches this repo's "never serve unpatched" convention):
+  - Auto-detects the flashinfer install via `import flashinfer` (no hardcoded
+    path). If flashinfer is not installed (a non-FlashInfer backend config),
+    this NO-OPS and exits 0 — it must not break a compose that doesn't use it.
+  - Guard: in each file it touches, the number of `pin_memory=True,` tokens MUST
+    equal the number of `_pin_memory_int_workspace_buffer* = torch.empty(`
+    allocations. If they don't match, a `pin_memory=True,` exists OUTSIDE a
+    workspace buffer and the blanket flip is no longer safe -> hard-fail (exit
+    2) so the compose refuses to boot unpatched/mispatched rather than serve a
+    half-applied state.
+  - Idempotent: skips a file already carrying the marker.
+  - py_compiles every file it writes; hard-fails on any post-write syntax error.
+
+Environment:
+  FI_PINQ_LIB_ALL=1   also unpin prefill/sparse/pod (default 0 = decode-only).
+  FI_PINQ_LIB_ROOT=   override the flashinfer package dir (default: auto-detect).
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import re
+import sys
+from pathlib import Path
+
+MARKER = "# [club3090] pin_memory False — MTP c>=4 stale-plan race fix (vllm#40756)"
+TOKEN = "pin_memory=True,"
+TOKEN_FLIPPED = "pin_memory=False,"
+ALLOC_RE = re.compile(r"_pin_memory_int_workspace_buffer[a-z_]* = torch\.empty\(")
+# decode.py is the necessary+sufficient file (validated). The rest are the
+# optional full-mirror (defense in depth).
+PRIMARY = ("decode.py",)
+MIRROR = ("prefill.py", "sparse.py", "pod.py")
+
+
+def die(msg: str) -> None:
+    print("[flashinfer-decode-pin] ERROR:", msg, file=sys.stderr)
+    sys.exit(2)
+
+
+def find_flashinfer_root() -> Path | None:
+    override = os.environ.get("FI_PINQ_LIB_ROOT", "").strip()
+    if override:
+        p = Path(override)
+        return p if p.is_dir() else None
+    try:
+        import flashinfer  # noqa: F401
+    except Exception:  # noqa: BLE001 - not installed -> caller no-ops
+        return None
+    if not getattr(flashinfer, "__file__", None):
+        return None
+    return Path(flashinfer.__file__).resolve().parent
+
+
+def patch_one(root: Path, name: str) -> None:
+    path = root / name
+    if not path.exists():
+        print(f"[flashinfer-decode-pin] {name}: not present — skipping.")
+        return
+    src = io.open(path, encoding="utf-8").read()
+
+    if MARKER in src:
+        print(f"[flashinfer-decode-pin] {name}: already patched — skipping.")
+        return
+
+    pins = src.count(TOKEN)
+    if pins == 0:
+        print(f"[flashinfer-decode-pin] {name}: no pinned workspace buffers — skipping.")
+        return
+    allocs = len(ALLOC_RE.findall(src))
+    if allocs != pins:
+        die(
+            f"{name}: {pins} pin_memory tokens but {allocs} "
+            f"_pin_memory_int_workspace_buffer allocs. A pin_memory=True exists "
+            f"outside a workspace buffer — refusing to blanket-flip (drift). "
+            f"Aborting."
+        )
+
+    new_src = src.replace(TOKEN, TOKEN_FLIPPED)
+    new_src = new_src.replace("    def __init__(", MARKER + "\n    def __init__(", 1)
+    if new_src.count(TOKEN) != 0:
+        die(f"{name}: token remains after replace — internal error.")
+
+    io.open(path, "w", encoding="utf-8").write(new_src)
+    import py_compile
+
+    try:
+        py_compile.compile(str(path), doraise=True)
+    except Exception as e:  # noqa: BLE001
+        die(f"{name}: py_compile failed after patch: {e}")
+    print(f"[flashinfer-decode-pin] {name}: {pins} pin_memory True->False (py_compile OK).")
+
+
+def main() -> None:
+    root = find_flashinfer_root()
+    if root is None:
+        print("[flashinfer-decode-pin] flashinfer not installed — nothing to patch (no-op).")
+        return
+    if os.environ.get("FI_PINQ_LIB_ALL", "0") == "1":
+        targets = PRIMARY + MIRROR
+        scope = "full mirror (decode+prefill+sparse+pod)"
+    else:
+        targets = PRIMARY
+        scope = "decode-only (minimal validated fix)"
+    print(f"[flashinfer-decode-pin] root={root} scope={scope}")
+    for name in targets:
+        patch_one(root, name)
+    print("[flashinfer-decode-pin] done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lib/profiles/patches.yml
+++ b/scripts/lib/profiles/patches.yml
@@ -360,6 +360,48 @@ patches:
       status: local-vendored
       drop_when: "vllm#48375 merges upstream AND the vllm-stable pin moves past it -> remove the 6 compose mounts + entrypoint calls + the patch dir; retire this row (re-run the #710 probe protocol on the new pin first)."
 
+  - id: vllm-flashinfer-decode-pin
+    # qwen3.8-27b (2026-08-18): the dual-fast slug (W4A8 + MTP n=4 + fp8 KV +
+    # prefix caching, the hybrid GDN family) crashed the engine in ~15s at
+    # MAX_NUM_SEQS>=4 with the drafter on — NVRM Xid 31 VIRT_READ (FAULT_PDE,
+    # unmapped page), both TP ranks. Prior mitigations were SPEC_N=0 (kill the
+    # drafter) or MAX_NUM_SEQS=1 (no concurrency). This patch fixes the crash at
+    # full async speed so MAX_NUM_SEQS=4 is reachable. Root cause is the
+    # FlashInfer stale-plan async-copy race (vllm#40756 thread, 2026-08-17).
+    model: [qwen3.8-27b]
+    files:
+      - models/qwen3.8-27b/vllm/patches/vllm-flashinfer-decode-pin/install.sh
+      - models/qwen3.8-27b/vllm/patches/vllm-flashinfer-decode-pin/patch_flashinfer_decode_pin.py
+    load_bearing_when:
+      - composes:
+          - vllm/qwen38-27b-dual-fast
+        reason: "The dual-fast config (W4A8 + MTP n=4 + fp8 KV + prefix caching) is the exact repro: FlashInfer plan() reuses one PINNED host buffer per wrapper and copies it out async; the MTP drafter re-plans the DECODE wrapper K-1x/step, so a stale plan feeds the split-KV merge (PersistentVariableLengthMergeStatesKernel) a garbage row -> Xid 31 at an unmapped VA. Needs >=4 genuinely concurrent in-flight MTP requests to lose the race (c<=3 and SPEC_N=0 never crash). Unpinning the flashinfer decode.py workspace buffer forces a synchronous plan copy per step and closes the window. Validated v0.27.1 / flashinfer 0.6.16.post3 / 2x RTX 3090 SM86: c=4 survives 425s clean (120s OK=126 + 300s OK=345, ERR=0, 0 new Xid) at full async speed; decode.py alone is necessary+sufficient (A/B: prefill/sparse/pod unpin without decode.py still crashed). Perf-neutral at c=1 (all deltas within CV)."
+        evidence: "models/qwen3.8-27b/vllm/patches/vllm-flashinfer-decode-pin/README.md; vllm-project/vllm#40756 (thread comments 2026-08-17, brasrox retraction + sempai SM86 corroboration)"
+    delivery:               # DEPRECATED/READ-ONLY (test-only) — see header
+      dockerfile_bake: false
+      entrypoint_invoke: true
+      genesis: false
+    delivery_gaps: []
+    delivery_mechanism: install_script
+    delivery_spec:
+      script: models/qwen3.8-27b/vllm/patches/vllm-flashinfer-decode-pin/install.sh
+      mounted_at: /etc/club3090/flashinfer-decode-pin
+      invoke: "bash /etc/club3090/flashinfer-decode-pin/install.sh"
+      invoked_before: vllm-serve
+      wired_at: [volumes, entrypoint]
+      note: "Idempotent, marker-gated; no-ops if flashinfer is not installed (a non-FlashInfer backend config boots clean); hard-fails (exit 2) on drift (a pin_memory outside a workspace buffer) so the compose refuses a half-patched state. Flips pin_memory=True->False on the flashinfer decode.py workspace buffer (decode-only by default; FI_PINQ_LIB_ALL=1 for the validated full mirror). Inert on the SPEC_N=0 path — the race needs the drafter to re-plan the decode wrapper. This patch bounds the CRASH, not VRAM: the separate W4A8 16K-prompt OOM that ships MAX_NUM_SEQS=1 is a different constraint and is NOT changed here."
+    drift_guard:
+      kind: boot
+      check: "Entrypoint runs install.sh before serve; boot log contains '[flashinfer-decode-pin] decode.py: 4 pin_memory True->False (py_compile OK)' (first boot) or '[flashinfer-decode-pin] decode.py: already patched' (warm layer). Drift -> '[flashinfer-decode-pin] ERROR' + non-zero exit -> container refuses to serve (never a silent half-wire)."
+      on_fail: boot-refused
+    status: verified
+    capability: mtp-concurrency-safety
+    foundational: false
+    upstream:
+      ref: "vllm-project/vllm#40756 (FlashInfer GDN/MTP illegal memory access; the 2026-08-17 thread comments identify the stale-plan async-copy race — this vendors the decode.py unpin)"
+      status: open
+      drop_when: "flashinfer lands a fix for the pinned-buffer plan reuse (pin_memory=False on the decode wrapper, or an explicit sync guard on the async copy-out) AND the pin moves past it -> remove the compose mount + entrypoint call + this patch dir; retire this row."
+
   - id: qwen-w4a8-int8-act
     model: [qwen3.6-27b, thinkingcap-27b]
     files:


### PR DESCRIPTION
**Slug:** `vllm/qwen38-27b-dual-fast` (W4A8 + MTP n=4 + fp8 KV + prefix caching, hybrid GDN)
**Upstream:** [vllm-project/vllm#40756](https://github.com/vllm-project/vllm/issues/40756) (thread comments 2026-08-17 — brasrox retraction + sempai SM86 corroboration)

## Problem

This slug crashes the engine in ~15 s at `MAX_NUM_SEQS >= 4` with the drafter on:

```
NVRM: Xid 31, MMU Fault: ENGINE GRAPHICS, faulted @ 0x18_a0000000
      FAULT_PDE ACCESS_TYPE_VIRT_READ   (unmapped page, both TP ranks)
torch.AcceleratorError: CUDA error: an illegal memory access was encountered
```

Root cause (vllm#40756, 2026-08-17 thread): FlashInfer `plan()` reuses one **pinned** host buffer per wrapper and copies it out asynchronously with nothing guarding it. The MTP drafter re-plans the **decode** wrapper K−1×/step, so a stale plan feeds the split-KV merge (`PersistentVariableLengthMergeStatesKernel`) a garbage row (observed: row 33,621 of an 85-row buffer) → Xid 31. It needs **≥4 genuinely concurrent in-flight MTP requests** to lose the race; c≤3 and the `SPEC_N=0` path never crash.

The prior documented mitigations were `SPEC_N=0` (kill the drafter) or `MAX_NUM_SEQS=1` (no concurrency). This patch fixes the crash at **full async speed** so the drafter and concurrency can coexist.

## The fix

New patch `models/qwen3.8-27b/vllm/patches/vllm-flashinfer-decode-pin/` — an idempotent, marker-gated Python patcher + `install.sh`, run from the compose entrypoint before `vllm serve`. It flips `pin_memory=True,` → `pin_memory=False,` on the `_pin_memory_int_workspace_buffer` allocations in **`flashinfer/decode.py`** (the decode wrapper MTP re-plans). `pin_memory=False` forces a synchronous host→device plan copy each step, closing the stale-read window.

Safety (matches this repo's "never serve unpatched" convention):
- Auto-detects flashinfer via `import flashinfer` → **no-ops if not installed** (a non-FlashInfer backend config boots clean).
- Guard: `count(pin_memory=True,)` must equal the number of `_pin_memory_int_workspace_buffer* = torch.empty(` allocs in each touched file, else **hard-fail (exit 2)** — the compose refuses a half-patched serve.
- Idempotent (marker-gated), py_compiles every file it writes.
- `FI_PINQ_LIB_ALL=1` also unpins prefill/sparse/pod (the validated full mirror); default is decode-only.

## Validation (v0.27.1 / flashinfer 0.6.16.post3 / 2× RTX 3090 SM86, TP=2)

| Config | c=4, 120 s | result |
|--------|-----------|--------|
| stock (pinned) | — | **crash ~15 s** |
| decode.py unpin only (this patch) | OK=128, ERR=0, **0 new Xid** | **survive** |
| full mirror (+ prefill/sparse/pod) | OK=126 + OK=345 (300 s soak) | **survive, 425 s clean** |

- **decode.py is necessary and sufficient** — A/B: unpinning prefill/sparse/pod *without* decode.py still crashed; decode.py alone is the fix.
- End-to-end re-verified **inside the pinned v0.27.1 image**: `install.sh` → `decode.py: 4 pin_memory True->False (py_compile OK)`, idempotent re-run `already patched`, decode 0/4 and the other three 4/0.
- **Perf-neutral at c=1** (the clean A/B, since stock crashes at c=4): decode narrative 86.31→84.47 (−2.1%), code 102.32→101.02 (−1.3%), prefill ~0% — all within CV. At c=4 it unlocks 72.4 narrative / 85.0 code tok/s per-request (~3.4× c=1 aggregate rate).

## What this does and does NOT change — deliberately

- **Bounds the crash, not VRAM.** The slug still ships `MAX_NUM_SEQS=1` because of the *separate* W4A8 16K-prompt OOM documented in the compose header (peak 23,872 MiB at N=2, 1.75 GB over the 0.90 budget). That is a different constraint; this patch does not touch it. At the shipped N=1 default the patch is inert. It becomes load-bearing the moment `MAX_NUM_SEQS` is raised — then the drafter and concurrency coexist without the Xid.
- **Status unchanged**: the slug stays 🧪 Experimental. A patch that fixes a crash does not by itself promote a tier that still has no 8-pack / NIAH / soak.

## Gate status (honesty section — per CONTRIBUTING)

| Gate | Status |
|------|--------|
| `test-patch-attribution.sh` | ✅ PASS (71 patch entries) |
| `test-compose-status-drift.sh` | ✅ PASS |
| compose YAML parses (`docker compose config`) | ✅ |
| patcher end-to-end in pinned v0.27.1 image | ✅ (above) |
| c=4 crash repro + 425 s soak | ✅ (above) |
| perf (c=1 A/B + c=4) | ✅ (above) |
| `bash scripts/report.sh --full` (rig + verify-full + verify-stress + soak-continuous + bench) | ⛔ **NOT run** — see below |
| 8-pack quality gate (BenchLocal) | ⛔ **NOT run** — throughput only |

**Why the full battery isn't attached:** this PR changes *one load-bearing patch* on one slug; the compose's serving config (weights, sampler, KV, TP) is byte-identical to what's already validated on this slug. The patch is verified to (a) apply cleanly in the pinned image, (b) not change the c=1 path measurably, and (c) eliminate the c=4 crash. I have **not** run the repo's `report.sh --full` / 8-pack here, so I'm flagging it as the remaining validation rather than claiming it — the maintainer or a 2×3090 community rig should run `report.sh --full` as the merge gate. **Known open question the patch does NOT resolve:** whether the W4A8 16K-prompt OOM also clears at higher concurrency (separate from the Xid).

## Attribution

Root-cause analysis and the c=4 reproduction/validation are mine (A1RM4X, 2× RTX 3090 rig). The bug is upstream's — the fix is a one-file change in **flashinfer** (unpin the decode wrapper's plan buffer, or guard the async copy-out); I've packaged it as a vendored patch in the club-3090 shape per CONTRIBUTING. Credits where due: the 2026-08-17 vllm#40756 thread comments (brasrox's retraction + sempai's SM86 corroboration) are what identified the decode wrapper as the buffer.

## Files

```
models/qwen3.8-27b/CHANGELOG.md                              (new)
models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml  (mount + entrypoint invoke)
models/qwen3.8-27b/vllm/patches/vllm-flashinfer-decode-pin/  (new: install.sh, patcher, README)
scripts/lib/profiles/patches.yml                              (register the patch)
```

## Drop-when

When flashinfer lands a fix for the pinned-buffer plan reuse (a `pin_memory=False` default on the decode wrapper, or a sync guard on the async copy-out) and the pin moves past it: remove the compose mount + entrypoint call + this patch dir, and retire the `patches.yml` row.