### PR TITLE
litellm: add qwen3.8-27b routes for the live :8091 scene

### DIFF
--- a/services/litellm/config.yaml
+++ b/services/litellm/config.yaml
@@ -31,6 +31,25 @@ model_list:
       api_base: http://host.docker.internal:8010/v1
       api_key: EMPTY
 
+  # Qwen 3.8 27B — dual-max fp8 KV + MTP n=3, 262K. Started by
+  # club3090-vllm-dual.service (drop-in zzzz-qwen38-27b-fp8-current.conf) →
+  # vllm-qwen38-27b-dual-max at :8091, which is a registry default_port for this
+  # model. Serves TWO ids: the neutral primary below + the quant alias after it.
+  # Added 2026-08-19 (#1062): the scene moved here during the dual-max promotion
+  # but the gateway was never told, so every client got a deterministic 400.
+  - model_name: qwen3.8-27b
+    litellm_params:
+      model: openai/qwen3.8-27b
+      api_base: http://host.docker.internal:8091/v1
+      api_key: EMPTY
+
+  # Quant-specific alias (same container, second --served-model-name).
+  - model_name: qwen3.8-27b-fp8
+    litellm_params:
+      model: openai/qwen3.8-27b-fp8
+      api_base: http://host.docker.internal:8091/v1
+      api_key: EMPTY
+
   # Agents-A1 — InternScience 35B agentic MoE (⚠️ caveats; the agentic thinking-ON
   # specialist). Launched via `switch.sh vllm/agents-a1-dual` → vllm-agents-a1-dual
   # at :8072 (own port — never share a sibling's; see the slug-masquerade note).


### PR DESCRIPTION
## Summary

`services/litellm/config.yaml` had no entry for the locally-served **`qwen3.8-27b`** on `:8091`, so every client routing through the gateway — the documented pattern for LAN clients — got a deterministic `400`:

```
ProxyModelNotFoundError: 400: Invalid model name passed in model=qwen3.8-27b.
POST /v1/chat/completions HTTP/1.1" 400 Bad Request
```

The only `qwen3.8-*` entries were `qwen3.8-max` / `-max-nothink`, both pointing at Alibaba's cloud endpoint, not the rig. When the live scene moved to `qwen3.8-27b` on `:8091` during the dual-max promotion, the gateway catalog was never updated alongside it.

**Impact:** a 400 on an unknown model name is deterministic, so retries cannot help — it surfaces to clients as an upstream *provider* failure while the model is perfectly healthy. Direct to `:8091` throughout: 82 tok in 1.28 s (~64 tok/s), `finish_reason=stop`. Cost of the fix is two routes; trade-off is none, since `:8091` is a registry `default_port` for this model.

**Deliberately narrow.** The other seven local backends point at currently-closed ports, and I checked each against `scripts/lib/profiles/compose_registry.py` before touching anything:

| model_name | port | valid registry `default_port`? |
|---|---|---|
| `deepseek-v4-flash` | 8030 | ✅ |
| `qwen3.6-27b` / `-autoround` | 8010 | ✅ |
| `agents-a1` | 8072 | ✅ |
| `qwen3.6-35b-a3b-autoround` | 8051 | ✅ |
| `gemma-4-31b` / `-autoround` | 8032 | ✅ |
| `gemma-4-12b-int8` | 8038 | ✅ |
| `deckard-40b` | 8199 | ✅ |

They are **inactive scenes, not stale routes** — one scene occupies the cards at a time and the gateway lists the full catalog regardless, exactly as the config's own header comment states. Removing them would break scene switching, so this PR leaves them alone.

## Type of change

- [ ] New compose variant
- [ ] New patch / sidecar
- [ ] New script or tool
- [ ] New model
- [ ] Doc-only / typo
- [x] **Other** — service gateway config (`services/litellm/config.yaml`), 19 lines added, no compose/model/script touched.

## Verification

Gateway probes before and after, all through `:4000` with the master key:

| Probe | Before | After |
|---|---|---|
| `qwen3.8-27b` (the call that failed) | `400 Invalid model name` | **`200` · `'GATEWAY OK'` · 0.78 s** |
| `qwen3.8-27b-fp8` | not registered | **`200` · `'Hi there! How can'`** |
| `qwen3.6-27b` (inactive scene) | `500` connection error | **`500` connection error — unchanged** |

That last row is the regression check that matters: the inactive route still resolves its *model group* and fails only on the closed backend, confirming scene switching is untouched. YAML parses clean (13 models).

### N/A justifications

- **Full rig + validation report** — N/A. No compose, engine, model, or serving flag changed; `report.sh --full` measures a serving path this PR does not touch. The model's own health was confirmed independently (direct `:8091`, ~64 tok/s) and is unchanged by a gateway route.
- **Profile header** — N/A, no compose touched.
- **BENCHMARKS row** — N/A, no TPS-affecting change. Routing through the gateway adds no measurable overhead to a decode-bound request.
- **CHANGELOG entry** — N/A for `models/<model>/CHANGELOG.md`; this is service-level config, not a per-model change. Happy to add a cross-cutting `CHANGELOG.md` entry if maintainers prefer.

## Cross-links

- Closes #1062
- Related upstream: none

### Note for maintainers

The branch name predates the content — it was cut for the dual-max promotion, which has since landed on master via #1032. This PR carries only the gateway fix.

Issue #1062 also flags a wider pattern worth a separate decision: there are three independently hand-maintained copies of "where is the model" (`config.yaml` here, `hermes-autoselect.sh`'s `SCENE_PORTS`, `gpu-mode.sh status`), none derived from `docker ps` or the registry. Each drifts silently and fails looking like something else. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
