### PR TITLE
feat(qwen3.8): add Huihui abliterated FP8 dual profile

### DIFF
--- a/models/qwen3.8-27b/vllm/compose/dual/abliterated-fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/abliterated-fp8/mtp.yml
@@ -1,4 +1,4 @@
-# Qwen3.8-27B Huihui abliterated native FP8 — dual RTX 3090 (TP=2)
+# Qwen3.8-27B Huihui abliterated FP8 — dual RTX 3090 (TP=2)
 # Source: munekazu/Huihui-Qwen3.8-27B-abliterated-FP8
 # Engine: stock vllm/vllm-openai:v0.27.1; no GGUF plugin.
 # Quant: FP8 e4m3, dynamic activations, 128x128 blocks; embedded MTP layer.
@@ -17,13 +17,13 @@
 # Abliteration changes behavior; it is not itself a speed optimization.
 
 services:
-  vllm-qwen38-27b-dual-huihui-fp8:
+  vllm-qwen38-27b-dual-abliterated-fp8:
     # Pinned to a vLLM STABLE release (immutable — never purged, unlike
     # nightlies; the #407 pin-drift fix). The launchers resolve the real image
     # from the `vllm-stable` engine profile and inject it over this default,
     # so this literal only bites a raw `docker compose` invocation (#254).
     image: ${VLLM_IMAGE:-vllm/vllm-openai:v0.27.1}
-    container_name: "${ESTATE_CONTAINER:-vllm-qwen38-27b-dual-huihui-fp8}"
+    container_name: "${ESTATE_CONTAINER:-vllm-qwen38-27b-dual-abliterated-fp8}"
     restart: ${CLUB3090_RESTART:-unless-stopped}
     ports:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8091}}:8000"
@@ -143,7 +143,7 @@ services:
       - --model
       - /root/.cache/huggingface/Huihui-Qwen3.8-27B-abliterated-FP8
       - --served-model-name
-      - qwen3.8-27b-huihui-fp8
+      - qwen3.8-27b-abliterated-fp8
       - --quantization
       - fp8
       - --dtype

--- a/models/qwen3.8-27b/vllm/compose/dual/huihui-fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/huihui-fp8/mtp.yml
@@ -1,0 +1,219 @@
+# Qwen3.8-27B Huihui abliterated native FP8 — dual RTX 3090 (TP=2)
+# Source: munekazu/Huihui-Qwen3.8-27B-abliterated-FP8
+# Engine: stock vllm/vllm-openai:v0.27.1; no GGUF plugin.
+# Quant: FP8 e4m3, dynamic activations, 128x128 blocks; embedded MTP layer.
+# Safe defaults: 262144 context, fp8 KV, max-num-seqs=1, thinking=false, MTP off.
+# MTP override: SPEC_N=<n>; SPEC=off or SPEC_N=0 disables it.
+#
+# Measured 2026-08-20 on 2x RTX 3090:
+# - Canonical club bench, SPEC_N=3 / MAX_NUM_SEQS=2:
+#   narrative 67.34 decode tok/s; code 87.80 decode tok/s;
+#   prefill 1553.21 tok/s @10K and 1202.60 tok/s @90K.
+# - Throughput bench, SPEC_N=2 / MAX_NUM_SEQS=8, 8x 1024-in/512-out:
+#   261.56 aggregate output tok/s; 94.71% draft acceptance; 0/8 failures.
+# - MAX_NUM_SEQS=32 entered a restart loop during initialization and is unvalidated.
+# - 262144 was allocated but not filled by a long-context validation.
+#
+# Abliteration changes behavior; it is not itself a speed optimization.
+
+services:
+  vllm-qwen38-27b-dual-huihui-fp8:
+    # Pinned to a vLLM STABLE release (immutable — never purged, unlike
+    # nightlies; the #407 pin-drift fix). The launchers resolve the real image
+    # from the `vllm-stable` engine profile and inject it over this default,
+    # so this literal only bites a raw `docker compose` invocation (#254).
+    image: ${VLLM_IMAGE:-vllm/vllm-openai:v0.27.1}
+    container_name: "${ESTATE_CONTAINER:-vllm-qwen38-27b-dual-huihui-fp8}"
+    restart: ${CLUB3090_RESTART:-unless-stopped}
+    ports:
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8091}}:8000"
+    volumes:
+      - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
+      # torch.compile + Triton kernel caches — first boot warms (~60-90 sec);
+      # subsequent boots reuse the compiled graphs.
+      - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
+      - ../../../cache/triton:/root/.triton/cache
+      # NO chat-template mount. This model serves its OWN chat_template.jinja
+      # from the model dir — see "Chat template" in the header for why the
+      # froggeric override that the qwen3.6/Tess composes carry is WRONG here.
+      # NVLink auto-detection — runs inside the container at boot.
+      - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+      # Vendored vllm#48375 (MambaManager drop_eagle_block) — SHARED from the
+      # qwen3.6-27b tree (same Qwen3-Next hybrid family), exactly as the
+      # Tess-4-27B compose shares it. Load-bearing because this compose ships
+      # BOTH MTP and prefix caching, which is the pair vllm#43559 corrupts.
+      # Anchor drift => the install script REFUSES the boot rather than
+      # half-wiring it. See patches.yml.
+      - ../../../../../qwen3.6-27b/vllm/patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
+    environment:
+      # Drafter toggle — docker only forwards what is declared here. The DEFAULT
+      # lives in the entrypoint, not in these lines, so it cannot drift.
+      - SPEC_N=${SPEC_N:-}
+      - SPEC=${SPEC:-}
+      - NVIDIA_VISIBLE_DEVICES=${ESTATE_GPUS:-${NVIDIA_VISIBLE_DEVICES:-all}}
+      # CUDA-level GPU mask — the runtime-agnostic half of GPU selection (#610).
+      # CDI runtimes (NixOS, nvidia-ctk cdi) IGNORE NVIDIA_VISIBLE_DEVICES, so
+      # this is what actually pins cards there. Unset => absent (no masking).
+      - CUDA_VISIBLE_DEVICES
+      - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
+      - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-${OFFLINE:-0}}
+      - TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-${OFFLINE:-0}}
+      - VLLM_WORKER_MULTIPROC_METHOD=spawn
+      - NVLINK_MODE=${NVLINK_MODE:-auto}
+      # Opt-in transfer check: VLLM_SKIP_P2P_CHECK=0 makes vLLM PROVE peer access
+      # by moving bytes. Bare passthrough — absent unless set. docs/PCIE_P2P.md §7.
+      - VLLM_SKIP_P2P_CHECK
+      - NCCL_CUMEM_ENABLE=0
+      # Safe PCIe-only default (the reference rig has no NVLink and no working
+      # P2P). Rigs with proven working P2P set NCCL_P2P_DISABLE=0.
+      - NCCL_P2P_DISABLE=${NCCL_P2P_DISABLE:-1}
+      - VLLM_NO_USAGE_STATS=1
+      # FlashInfer sampler OFF by default, but env-overridable (the qwen3.6
+      # composes hardcode it, and they disagree with each other: their dual sets
+      # 0, their multi4 sets 1). The reason to default 0 is MECHANISM, not a
+      # measurement on this model: with MTP active, sampling routes through the
+      # rejection-sampler path where the FlashInfer kernel adds overhead rather
+      # than removing it, and it also trims sampler workspace, which is
+      # load-bearing on a 24 GB card at 262K. ⚠️ The -3.0% narrative / -1.7% code
+      # that justified this on qwen3.6-27b is a QWEN3.6 measurement. Nothing has
+      # been benched on 3.8 — re-run the A/B before treating 0 as tuned.
+      - VLLM_USE_FLASHINFER_SAMPLER=${VLLM_USE_FLASHINFER_SAMPLER:-0}
+      - OMP_NUM_THREADS=1
+      # DeepGEMM (vLLM's fp8-GEMM path) is built for Hopper (sm_90) + datacenter
+      # Blackwell. Consumer Blackwell (5090 / PRO 6000 / GB10, sm_120/121) has no
+      # recipe and hard-fails "recipe not found" at boot (disc #571).
+      # switch.sh/launch.sh auto-inject VLLM_USE_DEEP_GEMM=0 there; a raw
+      # `docker compose` user on those cards must set it. Unset = vLLM's arch
+      # default. Irrelevant on the Ampere reference rig (no FP8 compute at all).
+      - VLLM_USE_DEEP_GEMM
+      # SPEC=off drops the built-in MTP drafter at boot. This is the documented
+      # mitigation for vllm#50021 (see the Caveats / Upstream-risk header) and
+      # the fallback if the head turns out net-negative on this model, as the
+      # built-in head is on the 35B-A3B MoE sibling. Bare passthrough; default on.
+      # expandable_segments:True crashes boot on some setups (cuMemMap path):
+      # known on NVLink rigs and WSL2/WDDM. Override via .env:
+      # PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False
+      - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True,max_split_size_mb:512}
+    shm_size: "16gb"
+    ipc: host
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    entrypoint:
+      - bash
+      - -c
+      - |
+        # VLLM_ENFORCE_EAGER=1 in .env disables CUDA graphs — the mitigation if
+        # you see mid-generation hangs at depth on this hybrid family. Costs
+        # ~20-30% TPS in exchange for stability. UNTESTED on this model.
+        # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
+        source /etc/club3090/detect_nvlink.sh
+        bash /etc/club3090/pr48375/install.sh || exit 1
+        # -- Drafter toggle: the same contract on every club-3090 compose --------
+        #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables
+        #   SPEC=off    back-compat alias for SPEC_N=0
+        # Turning the drafter off is the documented mitigation for vllm#50021 and must
+        # never require editing this file. A non-numeric SPEC_N is a hard error, so a
+        # typo can never masquerade as a silent "drafter off".
+        _spec_n="$${SPEC_N:-0}"
+        case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
+        case "$$_spec_n" in ""|*[!0-9]*)
+          echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2
+          echo "[spec] Fix: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables." >&2
+          exit 1 ;;
+        esac
+        SPEC_ARGS=()
+        if [ "$$_spec_n" -gt 0 ]; then
+          SPEC_ARGS=(--speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":$$_spec_n}")
+          echo "[spec] drafter ON - mtp n=$$_spec_n" >&2
+        else
+          echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
+        fi
+        if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@" "$${SPEC_ARGS[@]}"
+        else
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@" "$${SPEC_ARGS[@]}"
+        fi
+      - --
+    command:
+      - --model
+      - /root/.cache/huggingface/Huihui-Qwen3.8-27B-abliterated-FP8
+      - --served-model-name
+      - qwen3.8-27b-huihui-fp8
+      - --quantization
+      - fp8
+      - --dtype
+      - bfloat16
+      - --tensor-parallel-size
+      - "${TP:-2}"
+      - --pipeline-parallel-size
+      - "${PP:-1}"
+      - --max-model-len
+      - "${MAX_MODEL_LEN:-262144}"
+      - --gpu-memory-utilization
+      - "${GPU_MEMORY_UTILIZATION:-0.92}"
+      - --max-num-seqs
+      - "${MAX_NUM_SEQS:-1}"
+      - --max-num-batched-tokens
+      - "${MAX_NUM_BATCHED_TOKENS:-8192}"
+      # fp8 == e4m3 here. NOT fp8_e5m2 — hard-rejected with fp8 checkpoints.
+      - --kv-cache-dtype
+      - "${KV_CACHE_DTYPE:-fp8}"
+      - --trust-remote-code
+      # No --chat-template: the model dir's own chat_template.jinja is used.
+      - --reasoning-parser
+      - qwen3
+      # Stack-wide default: thinking OFF. On this model that ALSO suppresses the
+      # template's xhigh reasoning-effort preamble (it is gated on thinking).
+      # Callers opt in per-request; the server default below is "low", so send
+      # "reasoning_effort":"medium" (un-nudged) or "xhigh" (deliberate) to override.
+      # ⭐ THINKING GATE — flip the server default with ENABLE_THINKING=true.
+      #   Pair it with the card's thinking sampler (see the THINKING MODE block
+      #   in the header); the two are independent and mismatching them is SILENT.
+      - --default-chat-template-kwargs
+      # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
+      # control, so this is only the fallback for callers that send nothing — any
+      # agent still picks its own level per request.
+      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
+      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
+      # "Keep your thinking brief and focused, moving directly to the conclusion
+      # without unnecessary elaboration." The three levels are NOT a scale with a
+      # middle: medium has NO branch and injects nothing (the un-nudged baseline),
+      # xhigh adds "think carefully, validate assumptions, consider alternatives"
+      # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
+      # you want the model un-nudged rather than pushed toward brevity.
+      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
+      # render (`high` included — it does NOT silently remap).
+      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
+      - --enable-auto-tool-choice
+      # The 3.8 template emits the same <tool_call><function=…><parameter=…> XML
+      # as 3.6 (verified by reading the template), so this parser applies.
+      - --tool-call-parser
+      - qwen3_coder
+      # Prefix caching ON, matching the rest of this hybrid family: the
+      # vllm#43559 fix (vllm#48375) is VENDORED here and applied at boot by the
+      # entrypoint, which is what makes MTP + prefix caching safe to pair.
+      # ⚠️ The evidence for the pair being clean is qwen3.6-27b / Tess-4-27B
+      # production data, INHERITED — not measured on 3.8.
+      # Opt out: PREFIX_CACHE_ARG=--no-enable-prefix-caching
+      - "${PREFIX_CACHE_ARG:---enable-prefix-caching}"
+      - --enable-chunked-prefill
+      # SAMPLER = the model card's INSTRUCT row, because this compose ships
+      # thinking OFF. ⚠️ The sampler does NOT follow ENABLE_THINKING: the two are
+      # independent and mismatching them is SILENT. For thinking mode set all
+      # four together — ENABLE_THINKING=true TEMP=1.0 TOP_P=0.95
+      # PRESENCE_PENALTY=0.0 (top_k/min_p/repetition are identical in both rows,
+      # so they need no override). Full rationale + both rows in the "SAMPLER"
+      # header block above.
+      - --override-generation-config
+      - '{"temperature":${TEMP:-${TEMPERATURE:-0.7}},"top_p":${TOP_P:-0.80},"top_k":${TOP_K:-20},"min_p":${MIN_P:-0.0},"presence_penalty":${PRESENCE_PENALTY:-1.5},"repetition_penalty":${REPEAT_PENALTY:-1.0}}'
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8000"

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -1413,6 +1413,17 @@ COMPOSE_REGISTRY = {
     # NO DEFAULTS rows and NOT added to RECOMMENDED_DEFAULT_MODELS — incubating is
     # excluded from the curated walk by design, and an `<engine>/default` row would
     # hand users a never-booted config through the non-status-filtering direct lookup.
+    "vllm/qwen38-27b-dual-huihui-fp8": _entry(
+        model="qwen3.8-27b", weights_variant="huihui-fp8", workload="long-ctx-single", chat_template="native",
+        engine="vllm-stable", drafter="qwen-mtp-builtin", kv_format="fp8_e4m3",
+        tp=2, max_ctx=262144, max_num_seqs=1, mem_util=0.92,
+        compose_path="models/qwen3.8-27b/vllm/compose/dual/huihui-fp8/mtp.yml",
+        default_port=8091,
+        kvcalc_key="SKIP",
+        status="incubating",
+        status_note="Community Huihui abliterated Qwen3.8-27B native FP8 profile for 2x RTX 3090: TP=2, fp8 KV, 262144 context ceiling, prefix caching and chunked prefill enabled. MTP is available through SPEC_N but defaults off for the first stability tests. Abliteration changes behavior, not expected serving speed. BOOTED on 2x RTX 3090 and basic chat/thinking=false passed. Canonical club bench at SPEC_N=3/MAX_NUM_SEQS=2 measured 67.34 narrative and 87.80 code decode tok/s, with 1553.21 tok/s prefill at 10K and 1202.60 tok/s at 90K. SPEC_N=2/MAX_NUM_SEQS=8 measured 261.56 aggregate output tok/s for 8x 1024-input/512-output requests, 94.71% draft acceptance, and 0 failures. MAX_NUM_SEQS=32 entered a restart loop during initialization and is unvalidated. Still incubating pending verify-full, long-context fill, and soak testing.",
+    ),
+
     "vllm/qwen38-27b-dual-max": _entry(
         model="qwen3.8-27b", weights_variant="fp8", workload="long-ctx-single", chat_template="native",
         engine="vllm-stable", drafter="qwen-mtp-builtin", kv_format="fp8_e4m3",

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -1413,11 +1413,11 @@ COMPOSE_REGISTRY = {
     # NO DEFAULTS rows and NOT added to RECOMMENDED_DEFAULT_MODELS — incubating is
     # excluded from the curated walk by design, and an `<engine>/default` row would
     # hand users a never-booted config through the non-status-filtering direct lookup.
-    "vllm/qwen38-27b-dual-huihui-fp8": _entry(
-        model="qwen3.8-27b", weights_variant="huihui-fp8", workload="long-ctx-single", chat_template="native",
+    "vllm/qwen38-27b-dual-abliterated-fp8": _entry(
+        model="qwen3.8-27b", weights_variant="abliterated-fp8", workload="long-ctx-single", chat_template="native",
         engine="vllm-stable", drafter="qwen-mtp-builtin", kv_format="fp8_e4m3",
         tp=2, max_ctx=262144, max_num_seqs=1, mem_util=0.92,
-        compose_path="models/qwen3.8-27b/vllm/compose/dual/huihui-fp8/mtp.yml",
+        compose_path="models/qwen3.8-27b/vllm/compose/dual/abliterated-fp8/mtp.yml",
         default_port=8091,
         kvcalc_key="SKIP",
         status="incubating",

--- a/scripts/lib/profiles/models/qwen3.8-27b.yml
+++ b/scripts/lib/profiles/models/qwen3.8-27b.yml
@@ -102,7 +102,7 @@ weights:
   # Community Huihui abliterated native-FP8 derivative.
   # Kept as a separate weight key and switch profile; it does not replace
   # or modify the official Qwen3.8 FP8 tier.
-  huihui-fp8:
+  abliterated-fp8:
     path: Huihui-Qwen3.8-27B-abliterated-FP8
     local_subdir: Huihui-Qwen3.8-27B-abliterated-FP8
     size_gb: 30.9

--- a/scripts/lib/profiles/models/qwen3.8-27b.yml
+++ b/scripts/lib/profiles/models/qwen3.8-27b.yml
@@ -99,6 +99,21 @@ weights:
     kind: gguf
     verify_glob: "*.gguf"
     manual_note: "Unsloth Dynamic UD-Q8_K_XL (apache-2.0). Dual-3090 max-context tier — drives llamacpp/qwen38-27b-dual-q8kxl (31.5 GB needs both cards; layer-split -sm layer -ts 1,1). ⚠️ size_gb is the HF model-page figure — the download was STILL IN FLIGHT when this entry was authored (2026-08-14), so nothing on this rig has confirmed it. If the landed file differs materially, re-derive the compose's VRAM budget: the IQ4_NL sibling's page figure (16.3) was decimal GB and the real GiB was 15.22, i.e. ~7% smaller than a naive GiB read. Text-only (no mmproj fetched)."
+  # Community Huihui abliterated native-FP8 derivative.
+  # Kept as a separate weight key and switch profile; it does not replace
+  # or modify the official Qwen3.8 FP8 tier.
+  huihui-fp8:
+    path: Huihui-Qwen3.8-27B-abliterated-FP8
+    local_subdir: Huihui-Qwen3.8-27B-abliterated-FP8
+    size_gb: 30.9
+    format: fp8
+    status: experimental
+    hf_repo: munekazu/Huihui-Qwen3.8-27B-abliterated-FP8
+    engine: vllm
+    kind: main
+    verify_glob: "*.safetensors"
+    manual_note: "Community Huihui abliterated Qwen3.8-27B native FP8 checkpoint: e4m3 dynamic activations, 128x128 weight blocks, 262144 context ceiling, and one embedded MTP layer. Abliteration is a behavior modification, not a performance optimization."
+
   # Official Qwen FP8 release — the safetensors/vLLM tier, added 2026-08-14.
   # NO `files:` filter ON PURPOSE: Qwen/Qwen3.8-27B-FP8 is a SINGLE-artifact repo
   # (one quant), not a multi-quant bucket, and serving needs the whole thing —

--- a/scripts/lib/profiles/patches.yml
+++ b/scripts/lib/profiles/patches.yml
@@ -331,6 +331,7 @@ patches:
           - vllm/qwen-27b-multi-fast
           - vllm/qwen-27b-multi-max
           - vllm/tess-dual-w4a16
+          - vllm/qwen38-27b-dual-huihui-fp8
           - vllm/qwen38-27b-dual-max
           - vllm/qwen38-27b-multi4-max
         reason: "Vendored upstream fix vllm#48375 for vllm#43559 (MTP x prefix-caching corrupts recurrent-state KV on Qwen3-Next hybrids; ~20% acc drop reproduced upstream on 35B-A3B): MambaManager.find_longest_cache_hit receives drop_eagle_block but silently ignores it, so the final matched page's Mamba/GDN state snapshot may reflect draft tokens verification later rejected. The 9-line fix lowers the hit-search ceiling by one page. ACTIVE by default since 2026-07-17: the same PR flipped the pair-capable composes back to --enable-prefix-caching (the #720 off-default cost 7.4x TTFT on long prefixes per kevinb361's production data, and the pair-clean evidence stack is now: upstream repro+fix+tests, kevin's 7-day production at 89.5% hit rate on v0.25.x, our 6-arm probe matrix). Opt-out: PREFIX_CACHE_ARG=--no-enable-prefix-caching makes the patched path dormant again. On-rig validation 2026-07-17: no-harm on both hybrid families (27B + 35B-A3B, MTP n=3 + prefix-ON: 12/12 post-agent tool-call probes clean per arm with prefix_cache_hits_total asserted; accept-len 3.2-3.9 intact; ~5% fewer hit tokens = the by-design one-block reduction). Full 6-arm matrix: club-3090#710."

--- a/scripts/lib/profiles/patches.yml
+++ b/scripts/lib/profiles/patches.yml
@@ -331,7 +331,7 @@ patches:
           - vllm/qwen-27b-multi-fast
           - vllm/qwen-27b-multi-max
           - vllm/tess-dual-w4a16
-          - vllm/qwen38-27b-dual-huihui-fp8
+          - vllm/qwen38-27b-dual-abliterated-fp8
           - vllm/qwen38-27b-dual-max
           - vllm/qwen38-27b-multi4-max
         reason: "Vendored upstream fix vllm#48375 for vllm#43559 (MTP x prefix-caching corrupts recurrent-state KV on Qwen3-Next hybrids; ~20% acc drop reproduced upstream on 35B-A3B): MambaManager.find_longest_cache_hit receives drop_eagle_block but silently ignores it, so the final matched page's Mamba/GDN state snapshot may reflect draft tokens verification later rejected. The 9-line fix lowers the hit-search ceiling by one page. ACTIVE by default since 2026-07-17: the same PR flipped the pair-capable composes back to --enable-prefix-caching (the #720 off-default cost 7.4x TTFT on long prefixes per kevinb361's production data, and the pair-clean evidence stack is now: upstream repro+fix+tests, kevin's 7-day production at 89.5% hit rate on v0.25.x, our 6-arm probe matrix). Opt-out: PREFIX_CACHE_ARG=--no-enable-prefix-caching makes the patched path dormant again. On-rig validation 2026-07-17: no-harm on both hybrid families (27B + 35B-A3B, MTP n=3 + prefix-ON: 12/12 post-agent tool-call probes clean per arm with prefix_cache_hits_total asserted; accept-len 3.2-3.9 intact; ~5% fewer hit tokens = the by-design one-block reduction). Full 6-arm matrix: club-3090#710."


### PR DESCRIPTION
<!--
Thanks for the PR. Most reviews stall on missing rig context — this template is
the data we'd ask for individually otherwise. Tick what applies; explain N/A
where it doesn't.

For typo / doc-only changes, ignore everything below the "Summary" section.
-->

## Summary

<!-- One paragraph. What problem does this solve, what's the measured impact,
what existing variant did you compare against, what's the trade-off? -->

## Type of change

- [ ] New compose variant (`models/<model>/<engine>/compose/docker-compose.<name>.yml`)
- [ ] New patch / sidecar (`models/<model>/<engine>/patches/`)
- [ ] New script or tool (`scripts/`, `tools/`)
- [ ] New model (`models/<new-model>/`)
- [ ] Doc-only / typo
- [ ] Other (describe)

## Verification

- [ ] **Full rig + validation report attached** — single command captures everything:
  ```bash
  bash scripts/report.sh --full > my-rig.md
  ```
  Runs hardware + stack + boot log capture **plus** verify-full + verify-stress 7/7 + SOAK_MODE=continuous + canonical bench in one ~35-min pass. Paste contents as a PR comment. See [docs/CLIFFS.md](../docs/CLIFFS.md) for why the soak-continuous step is load-bearing (catches Cliff 2b, which verify-stress doesn't).
- [ ] **Profile header complete** (new/changed compose) — `# Profile (at-a-glance):` block with `Status:` set to one enum value (`✅`/`⚠️`/`🧪`/`👁️`/`⏸️`/`🗑️`) and a `Caveats:` line if `⚠️`/`👁️`/`⏸️`/`🗑️`. Enforced by `test-compose-status-drift`; schema in [CLAUDE.md](../CLAUDE.md).
- [ ] **BENCHMARKS row added** — under the appropriate model section, mirroring existing column shape (incl. `Rig` column).
- [ ] **CHANGELOG entry added** in `models/<model>/CHANGELOG.md`.

If you'd rather run the steps separately:

- `bash scripts/report.sh > my-rig.md` (rig only, ~2 sec)
- `bash scripts/verify-full.sh` — fast functional smoke
- `bash scripts/verify-stress.sh` — 7/7 boundary checks incl. Cliff 2 needles
- `SOAK_MODE=continuous SOAK_SESSIONS=5 SOAK_TURNS=5 bash scripts/soak-test.sh` — required for new single-card composes (catches Cliff 2b)
- `bash scripts/bench.sh` — canonical TPS (3 warmups + 5 measured)

### N/A justifications (if any boxes above are unchecked)

<!-- e.g. "N/A — short-prompt-only path; soak-continuous would not exercise the multi-turn regime"
       or "N/A — doc-only change, no compose touched" -->

## Cross-links

<!-- Issue this PR closes / contributes to. Upstream PRs / issues this depends on.
Sandermage Genesis tickets if relevant. -->

- Closes #
- Related upstream:
