### PR TITLE
fix: resolve 8020/8032 cross-model port collisions

### DIFF
--- a/docs/DUAL_CARD.md
+++ b/docs/DUAL_CARD.md
@@ -47,7 +47,7 @@ Run any of these with `bash scripts/switch.sh <slug>`, or `bash scripts/launch.s
 |---|---|--:|--:|---|
 | **Gemma-4-31B** | `vllm/gemma-31b-dual` | 224K | 8032 | QAT-AWQ-int4 + bf16 KV, overlay-free. Dual-only on 24 GB — single-card OOMs regardless of KV format. |
 | **Qwen3.6-35B-A3B** ⭐ concurrency | `vllm/qwen-35b-a3b-dual` | 262K | 8051 | ✅ production. **The multi-agent pick** — flat to N=16 streams where the dense 27B knees at N=2. |
-| **Tess-4-27B** | `llamacpp/tess-dual-mtp` | 262K | 8020 | ✅ production. |
+| **Tess-4-27B** | `llamacpp/tess-dual-mtp` | 262K | 8115 | ✅ production. |
 | **Qwen-AgentWorld-35B-A3B** | `vllm/qwen-agentworld-35b-a3b-dual-awq-int4` | 262K | 8080 | ✅ production. |
 
 Everything launchable: `bash scripts/switch.sh --list` (`--all` includes retired).

--- a/models/deepseek-v4-flash-0731/llama-cpp/compose/multi4/unsloth-q8-kxl/offload.yml
+++ b/models/deepseek-v4-flash-0731/llama-cpp/compose/multi4/unsloth-q8-kxl/offload.yml
@@ -96,7 +96,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-llama-cpp-deepseek-flash-q8-multi4}"
     restart: unless-stopped
     ports:
-      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8032}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8116}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     shm_size: "16g"
@@ -202,7 +202,7 @@ services:
       - '--fit'
       - 'off'
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:${PORT:-8032}/health || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:${PORT:-8116}/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 40

--- a/models/deepseek-v4-flash-0731/llamacpp-club3090/compose/multi4/unsloth-q8-kxl/moecache.yml
+++ b/models/deepseek-v4-flash-0731/llamacpp-club3090/compose/multi4/unsloth-q8-kxl/moecache.yml
@@ -92,7 +92,7 @@ services:
     container_name: ${ESTATE_CONTAINER:-llama-cpp-deepseek-flash-q8-moecache-multi4}
     restart: unless-stopped
     ports:
-      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8032}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8116}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     environment:

--- a/models/tess-4-27b/llama-cpp/compose/dual/migtissera-q4km/mtp.yml
+++ b/models/tess-4-27b/llama-cpp/compose/dual/migtissera-q4km/mtp.yml
@@ -112,7 +112,7 @@ services:
     container_name: "${ESTATE_CONTAINER:-llama-cpp-tess-4-27b}"
     restart: unless-stopped
     ports:
-      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8020}}:8080"
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8115}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     # ⚠ -np 1 is intentional — do NOT raise it. One decode stream per dual-card

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -1099,7 +1099,7 @@ COMPOSE_REGISTRY = {
         tp=4, max_ctx=204800, max_num_seqs=1, mem_util=None,
         compose_path="models/deepseek-v4-flash-0731/llamacpp-club3090/compose/multi4/unsloth-q8-kxl/moecache.yml",
         weights_companions=("dspark",),
-        default_port=8032,
+        default_port=8116,
         kvcalc_key="SKIP",
         offload="n-cpu-moe",
         moe_cache=True,
@@ -1183,7 +1183,7 @@ COMPOSE_REGISTRY = {
         # DSpark is REQUIRED, not optional -- the compose passes -md and will not
         # boot without it, so readiness must gate on it (c3 Start would serve-fail).
         weights_companions=("dspark",),  # DSpark draft GGUF the compose mounts
-        default_port=8032,
+        default_port=8116,
         kvcalc_key="SKIP",
         offload="n-cpu-moe",
         host_ram_gb=120,
@@ -1198,7 +1198,7 @@ COMPOSE_REGISTRY = {
         engine="llama-cpp-local", drafter="tess-mtp-gguf", kv_format="q4_0",
         tp=2, max_ctx=262144, max_num_seqs=1, mem_util=None,
         compose_path="models/tess-4-27b/llama-cpp/compose/dual/migtissera-q4km/mtp.yml",
-        default_port=8020,
+        default_port=8115,
         kvcalc_key="SKIP",
         status="production",
         status_note="Tess-4-27B (migtissera Q4_K_M GGUF, 16 GB) — Qwen3.5-based dense 27B instruct/agentic fine-tune on dual 3090 llama.cpp. Arch qwen35-dense (dense = non-MoE; HYBRID attention, 48 linear + 16 full — corrected 2026-07-11) — same family as Deckard-40B. EXTERNAL MTP n=2 (separate mtp-*.gguf draft via --spec-draft-model, spec_method mtp_gguf) — first external-draft compose in the catalog. q4_0 KV, 262K ctx. Live-validated 2026-07-09 on server-cuda-b9246: decode ~52 narrative / 68 code tok/s (TTFT 233 ms), prefill ~1.3K tok/s; verify-stress 8/8 (NIAH ladder clean to 240,634 tok = 91% of 262K, ~5.9 GB free at deepest fill); soak-continuous PASS (0 err, 0/100 silent-empty, p50 66.4 tok/s, 96.3% retention). Quality (benchlocal --full): core 8-pack 115/150 (77%) think-off, 118/150 (79%) think-on — ties-to-edges the qwen3.6-27b dual-max reference (109) and LEADS the agentic packs (hermesagent 15/20 vs 9, cli-40 25/40 vs 20). PROMOTED caveats->production 2026-07-12: the streaming+thinking finish=length caveat does NOT reproduce on the shipped b9967 + 16K-reasoning-budget config (3/3 clean incl. parallel 2-tool) and the shipped-config quality refresh passed both modes (OFF 116 / ON 117 single-draw, no pack regression). Trades ~1/2 the qwen-dual throughput for a quality tie/edge + vision-capable base + smaller footprint (~12.7+17.2 GB layer-split vs ~22 GB/card TP=2).",

--- a/scripts/tests/test-compose-port-conflicts.sh
+++ b/scripts/tests/test-compose-port-conflicts.sh
@@ -34,9 +34,11 @@ from scripts.lib.profiles.compose_registry import COMPOSE_REGISTRY as R
 # Pre-existing cross-model collisions, tracked for a separate port-hygiene PR.
 # Burn these down and DELETE them from here — the gate fails if a listed port
 # stops colliding, so a stale entry can't hide.
-#   8020 — vllm/minimal (qwen3.6-27b) + llamacpp/tess-dual-mtp (tess-4-27b)
-#   8032 — vllm/gemma-31b-dual (gemma-4-31b) + deepseek-flash-multi4 (deepseek-v4-flash)
-ALLOW = {8020, 8032}
+# (Empty — the two pre-existing cross-model collisions were resolved in this
+#  port-hygiene PR: tess-dual-mtp -> 8115, deepseek-flash-multi4 -> 8116. Re-add a
+#  port here only as a *tracked* temporary exception for a NEW pre-existing overlap;
+#  the gate fails if a listed port no longer collides.)
+ALLOW = set()
 
 byport = collections.defaultdict(list)
 for slug, e in R.items():


### PR DESCRIPTION
## Summary

Follow-up hygiene to #1072, which added `test-compose-port-conflicts.sh` and **allowlisted** two pre-existing cross-model `default_port` overlaps (8020, 8032) pending a separate fix. This is that fix.

## The two collisions

| Port | Was (cross-model) | Fix |
|---|---|---|
| **8020** | `vllm/minimal` (qwen3.6-27b) + `llamacpp/tess-dual-mtp` (tess-4-27b) | **tess-dual-mtp → 8115** — qwen3.6 owns the 8020 single-card slot (its whole single-card family sits there) |
| **8032** | `vllm/gemma-31b-dual` (gemma-4-31b) + `deepseek-flash-multi4-q8` ×2 (deepseek-v4-flash) | **both deepseek-flash-multi4 variants → 8116** — gemma owns the 8030-8032 block |

The two `deepseek-flash-multi4` variants (`moecache` + `offload`) are the same model / mutually exclusive, so they keep sharing one port (8116) — which the gate allows.

## Changes
- Registry `default_port`: tess-dual-mtp 8020→8115; deepseek-flash-multi4 {moecache, offload} 8032→8116.
- Composes: the `${PORT:-}` defaults (+ the offload healthcheck).
- `docs/DUAL_CARD.md`: tess row port.
- **`test-compose-port-conflicts.sh` `ALLOW` → empty** — both debts paid. (The gate's negative-control fails if a listed port stops colliding, so the allowlist can't go stale.)

## Validation
- Port-conflict gate ✅ — `ALLOW=[]`, 0 cross-model collisions across 64 active slug-ports.
- Affected gates ✅ — parity ×2, launch-compat, diagnose, registry-disk, status-drift, mounts-resolve.
- c3 suite ✅ — 265 passed.

Target ports 8115/8116 verified free against both the registry and the service ports (4000/6333/6334/8080/8088/8188/8189).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
