### PR TITLE
feat(concurrency-probe): opt-in WARMUP gate for the live --sweep path

### DIFF
--- a/scripts/concurrency-probe.sh
+++ b/scripts/concurrency-probe.sh
@@ -35,6 +35,10 @@
 #   TPS_FLOOR (0 = report-only) · RETENTION_MIN (0.98) ·
 #   SWEEP ("" = single-N) · SLUG (required for SWEEP) · SWEEP_DRY (0) ·
 #   BOOT_TIMEOUT (360).
+#   Live --sweep warm-up gate (opt-in): WARMUP (0) — when 1, wait for the
+#   server + fire warm-up gens before the ladder (a rung fired at a cold /
+#   not-ready engine reads as a spurious crash); WARMUP_TIMEOUT (900) ·
+#   WARMUP_REQS (3).
 #   --sweep knobs: CTX_SWEEP (1k 4k 8k 16k 32k) · N_LIST (1 2 4 8 16 32) ·
 #   KV_TOKENS (0 = auto from vLLM logs) · N_MAX · CTX_MAX · WALL_BUDGET (15m) ·
 #   EARLY_STOP (1) · CACHE (shared) · SHARE_FRAC (0.75).
@@ -329,8 +333,53 @@ run_probe() {
   python3 "$PROBE_PY"
 }
 
+# --- opt-in readiness + warm-up gate for the live --sweep path ----------------
+# OFF by default (WARMUP=0) so CI / runs against an already-warm server aren't
+# slowed. Set WARMUP=1 when you boot an engine and immediately sweep: cold vLLM
+# needs minutes to load weights + capture CUDA graphs, and a rung fired before
+# it is ready reads as a spurious crash. Waits for /v1/models, re-resolves the
+# served model (the top-of-script autodetect may have fallen back to the default
+# when nothing was serving yet), then fires a few warm-up generations. Returns
+# non-zero only if the server never comes up within WARMUP_TIMEOUT.
+warmup_gate() {
+  [[ "${WARMUP:-0}" == "1" ]] || return 0
+  local timeout="${WARMUP_TIMEOUT:-900}" reqs="${WARMUP_REQS:-3}"
+  echo "[sweep] WARMUP: waiting up to ${timeout}s for ${URL} ..." >&2
+  local ready=0 waited=0
+  for _ in $(seq 1 $(( timeout / 2 )) ); do
+    if curl -s -m 3 "${URL}/v1/models" >/dev/null 2>&1; then ready=1; break; fi
+    sleep 2; waited=$(( waited + 2 ))
+  done
+  if [[ "$ready" != "1" ]]; then
+    echo "[sweep] WARMUP: not ready in ${timeout}s — aborting sweep" >&2
+    return 1
+  fi
+  echo "[sweep] WARMUP: server up after ~${waited}s" >&2
+  # Re-resolve the served model now that the server answers (skip if pinned).
+  if [[ -z "$MODEL_PINNED" ]]; then
+    local det
+    det="$(curl -s -m 5 "${URL}/v1/models" 2>/dev/null \
+      | python3 -c 'import json,sys;print(json.load(sys.stdin)["data"][0]["id"])' 2>/dev/null || true)"
+    if [[ -n "$det" && "$det" != "$MODEL" ]]; then
+      echo "[sweep] WARMUP: served model re-resolved: $det (was: $MODEL)" >&2
+      MODEL="$det"
+    fi
+  fi
+  # Fire warm-up generations to trigger CUDA-graph capture before timing starts.
+  local ok=0 i
+  for i in $(seq 1 "$reqs"); do
+    if curl -s -m 120 "${URL}/v1/chat/completions" \
+         -H 'content-type: application/json' \
+         -d "{\"model\":\"${MODEL}\",\"messages\":[{\"role\":\"user\",\"content\":\"warmup\"}],\"max_tokens\":8}" \
+         >/dev/null 2>&1; then ok=$(( ok + 1 )); fi
+  done
+  echo "[sweep] WARMUP: ${ok}/${reqs} warm-up requests ok" >&2
+  return 0
+}
+
 # --- --sweep: live N×ctx matrix, no reboot ------------------------------------
 if [[ "$MATRIX" == "1" ]]; then
+  if [[ "$SWEEP_DRY" != "1" ]]; then warmup_gate || exit 1; fi
   slots="$(_detect_slots || true)"
   slots_src="undetected"
   if [[ -n "$(_served_seqs || true)" ]]; then slots_src="container max-num-seqs"

--- a/scripts/tests/test-concurrency-probe.sh
+++ b/scripts/tests/test-concurrency-probe.sh
@@ -136,4 +136,23 @@ kv="$(python3 -c 'import sys; sys.path.insert(0,"'"$ROOT_DIR"'/scripts/lib"); fr
 [[ "$kv" == "210000" ]] || fail "parse_kv_tokens_text, got $kv"
 echo "  ✓ KV log parse"
 
+# 10. Live --sweep warm-up gate (WARMUP) — opt-in, dry-run skips it, default is
+#     silent, and a non-dry sweep against an unreachable server aborts BEFORE
+#     slot detection (fails closed instead of sweeping a dead engine). All
+#     offline: point at a dead port; the gate needs no live server to prove.
+out="$(WARMUP=1 URL=http://127.0.0.1:1 bash "$PROBE" --sweep --dry --n 1 2>&1)"
+command grep -q "WARMUP" <<<"$out" && fail "WARMUP=1 + --dry must not fire the gate (dry precedence)"
+set +e
+out="$(URL=http://127.0.0.1:1 MODEL=x bash "$PROBE" --sweep --n 1 2>&1)"; rc=$?
+set -e
+command grep -q "WARMUP" <<<"$out" && fail "gate must stay silent when WARMUP is unset (default off)"
+set +e
+out="$(WARMUP=1 WARMUP_TIMEOUT=2 URL=http://127.0.0.1:1 MODEL=x bash "$PROBE" --sweep --n 1 2>&1)"; rc=$?
+set -e
+[[ "$rc" == "1" ]] || fail "WARMUP=1 against unreachable server should exit 1, got $rc"
+command grep -q "WARMUP: waiting" <<<"$out" || fail "gate should announce it is waiting"
+command grep -q "not ready" <<<"$out" || fail "gate should report the not-ready abort"
+command grep -q "FATAL: --sweep cannot detect" <<<"$out" && fail "gate must abort BEFORE slot detection"
+echo "  ✓ --sweep WARMUP gate: opt-in, dry-skips, default-silent, fails closed"
+
 echo "test-concurrency-probe: ok"


### PR DESCRIPTION
## What

Adds an **opt-in warm-up gate** (`WARMUP=1`) to the live `--sweep` path of `concurrency-probe.sh`.

## Why

The live `--sweep` matrix assumed the server was already up — only the reboot-knee path (`SWEEP=+SLUG`) waited for readiness. When you **boot an engine and immediately sweep**, the first rungs race a cold vLLM (weight load + CUDA-graph capture take minutes), and a rung fired before the engine is ready reads as a **spurious crash** — which is exactly what bit a recent dual-fast concurrency A/B before the runs were re-done with a hand-rolled wait.

Rather than leave that wait in an ad-hoc wrapper, fold it into the canonical tool.

## Behaviour

- **Off by default** (`WARMUP=0`) — CI and runs against an already-warm server are unaffected (verified: default is silent).
- When `WARMUP=1`, **before slot detection** it: waits for `/v1/models`, re-resolves the served model (the top-of-script autodetect can fall back to the default when nothing was serving yet), then fires a few warm-up generations to trigger CUDA-graph capture.
- **Fails closed**: if the server never comes up within `WARMUP_TIMEOUT` (default 900s), it aborts with exit 1 instead of sweeping a dead engine.
- Knobs: `WARMUP_TIMEOUT` (900), `WARMUP_REQS` (3).

## Tests

`test-concurrency-probe.sh` gains offline guards (no live server needed — dead-port based):
- `WARMUP=1 --dry` must **not** fire the gate (dry precedence).
- Gate is **silent** when `WARMUP` is unset.
- `WARMUP=1` against an unreachable URL **aborts before slot detection** (exit 1), proving ordering + fail-closed.

Also validated live against a running engine: gate waits → 3/3 warm-ups → ladder proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
