### PR TITLE
feat(qwen3.8-27b): seqs=8 fast-tier default + crash-fixes on all vLLM composes

### DIFF
--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2-fp8.yml
@@ -55,6 +55,7 @@ services:
       # (our #1052 / upstream #52873 + #50021 thread). Ours, not an upstream PR;
       # validated 3/3 boots on the reference 2×3090. Anchor drift → boot refused.
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
+      - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
       # DFlash2 external-drafter support — vLLM PR#52816 backport (syv-ai). Adds
       # DFlash2DraftModel; refuses boot on apply failure.
       - ../../../patches/vllm-dflash2-backport:/etc/club3090/dflash2:ro
@@ -123,6 +124,7 @@ services:
         bash /etc/club3090/w4a8/install.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
         bash /etc/club3090/gdn-async-order/install.sh || exit 1
+        FI_PINQ_LIB_ALL="${FI_PINQ_LIB_ALL:-0}" bash /etc/club3090/flashinfer-decode-pin/install.sh || exit 1
         bash /etc/club3090/dflash2/install.sh || exit 1
         echo "[w4a8] VLLM_MARLIN_INPUT_DTYPE=$${VLLM_MARLIN_INPUT_DTYPE:-<unset -> W4A16>} (W4A8=$${W4A8:-1})"
         AR=""

--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2.yml
@@ -90,6 +90,7 @@ services:
       # (our #1052 / upstream #52873 + #50021 thread). Ours, not an upstream PR;
       # validated 3/3 boots on the reference 2×3090. Anchor drift → boot refused.
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
+      - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
       # DFlash2 external-drafter support — vLLM PR#52816 backport (syv-ai). Adds
       # DFlash2DraftModel; refuses boot on apply failure.
       - ../../../patches/vllm-dflash2-backport:/etc/club3090/dflash2:ro
@@ -158,6 +159,7 @@ services:
         bash /etc/club3090/w4a8/install.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
         bash /etc/club3090/gdn-async-order/install.sh || exit 1
+        FI_PINQ_LIB_ALL="${FI_PINQ_LIB_ALL:-0}" bash /etc/club3090/flashinfer-decode-pin/install.sh || exit 1
         bash /etc/club3090/dflash2/install.sh || exit 1
         echo "[w4a8] VLLM_MARLIN_INPUT_DTYPE=$${VLLM_MARLIN_INPUT_DTYPE:-<unset -> W4A16>} (W4A8=$${W4A8:-1})"
         AR=""

--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
@@ -66,15 +66,19 @@
 #   which is what the vendored negscale fold assumes; a compressed-tensors
 #   pack-quantized checkpoint hard-fails that fold (LEARNINGS.md 2026-08-16).
 #
-# ⚠️⚠️ CONCURRENCY vs THE DRAFTER — the measured conflict, now ON THE DEFAULT PATH.
-#   At MAX_NUM_SEQS=2 with 16K prompts, MTP n=4 **UNDER W4A8** pushed peak VRAM to
-#   23,872 MiB/card — 1.75 GB OVER the 0.90 budget — and requests began failing
-#   while ~535K KV tokens sat free. SPEC_N=0 at the same concurrency ran clean.
-#   ⭐ W4A8 used to be opt-in, so this was a warning for people who turned it on.
-#      It is now the DEFAULT, which is why MAX_NUM_SEQS ships at **1** rather than
-#      2 — shipping N=2 would ship the measured failure.
-#   → For concurrency, set SPEC_N=0 (or W4A8=0) and then raise MAX_NUM_SEQS. The
-#     drafter and multi-stream do not coexist under int8 on 24 GB.
+# ⚠️ CONCURRENCY — the ENGINE CRASH is fixed; a VRAM caveat remains for LONG ctx.
+#   MTP-under-concurrency used to CRASH the engine (Xid 31): the #40756 FlashInfer
+#   decode-plan race + the async wild-write. Both are now closed by the patches
+#   wired below (vllm-flashinfer-decode-pin + vllm-gdn-mtp-async-spec-order), so
+#   MAX_NUM_SEQS now DEFAULTS to **8** (was 1). Validated 2026-08-23 (2x3090,
+#   v0.27.1): clean to C=32 at ~1K-tok prompts, MTP accept ~2.8; spec-decode wins
+#   per-stream latency to ~C=8, batch aggregate peaks with SPEC_N=0 (~306 tok/s).
+#   ⚠️ SEPARATE, STILL-REAL LIMIT — VRAM, NOT the crash, and the patches do NOT
+#     change it: at 16K-tok prompts MTP n=4 UNDER W4A8 hit 23,872 MiB/card (1.75 GB
+#     over the 0.90 budget) already at N=2. Many LONG-context concurrent streams
+#     can still OOM. seqs=8 is validated at short/moderate context only.
+#   → If you OOM under long-context concurrency: lower MAX_NUM_SEQS, or SPEC_N=0
+#     (drops the drafter → ~+27% batch aggregate anyway), or W4A8=0.
 #   → The drafter also costs ~13% of the KV pool (652,346 -> 567,737 tokens).
 #
 # ⚠️ GPU_MEMORY_UTILIZATION IS 0.90 HERE, NOT THE TIER'S 0.92 — DELIBERATE, AND
@@ -288,7 +292,7 @@ services:
       # ⚠️ 1, NOT 2 — see the CONCURRENCY vs THE DRAFTER block in the header.
       # W4A8 + MTP n=4 at N=2 is the combination that OOM'd on 24 GB cards, and
       # W4A8 is now the shipped default, so N=2 would ship a measured failure.
-      - "${MAX_NUM_SEQS:-1}"
+      - "${MAX_NUM_SEQS:-8}"
       - --max-num-batched-tokens
       - "${MAX_NUM_BATCHED_TOKENS:-8192}"
       # Head-of-line-blocking mitigation (Zylone's vLLM tip; qwen3.6 dual-fast precedent).

--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/dflash2-fp8.yml
@@ -53,6 +53,8 @@ services:
       # Anchor drift => the install script REFUSES the boot rather than
       # half-wiring it. See patches.yml.
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
+      - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
+      - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
       # DFlash2 external-drafter support — vLLM PR#52816 backport (syv-ai).
       - ../../../patches/vllm-dflash2-backport:/etc/club3090/dflash2:ro
     environment:
@@ -137,6 +139,8 @@ services:
         # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
         source /etc/club3090/detect_nvlink.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
+        bash /etc/club3090/gdn-async-order/install.sh || exit 1
+        FI_PINQ_LIB_ALL="${FI_PINQ_LIB_ALL:-0}" bash /etc/club3090/flashinfer-decode-pin/install.sh || exit 1
         bash /etc/club3090/dflash2/install.sh || exit 1
         # -- Drafter toggle: the same contract on every club-3090 compose --------
         #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables

--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/dflash2.yml
@@ -53,6 +53,8 @@ services:
       # Anchor drift => the install script REFUSES the boot rather than
       # half-wiring it. See patches.yml.
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
+      - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
+      - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
       # DFlash2 external-drafter support — vLLM PR#52816 backport (syv-ai).
       - ../../../patches/vllm-dflash2-backport:/etc/club3090/dflash2:ro
     environment:
@@ -137,6 +139,8 @@ services:
         # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
         source /etc/club3090/detect_nvlink.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
+        bash /etc/club3090/gdn-async-order/install.sh || exit 1
+        FI_PINQ_LIB_ALL="${FI_PINQ_LIB_ALL:-0}" bash /etc/club3090/flashinfer-decode-pin/install.sh || exit 1
         bash /etc/club3090/dflash2/install.sh || exit 1
         # -- Drafter toggle: the same contract on every club-3090 compose --------
         #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables

--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
@@ -307,6 +307,8 @@ services:
       # Anchor drift => the install script REFUSES the boot rather than
       # half-wiring it. See patches.yml.
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
+      - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
+      - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
     environment:
       # Drafter toggle — docker only forwards what is declared here. The DEFAULT
       # lives in the entrypoint, not in these lines, so it cannot drift.
@@ -389,6 +391,8 @@ services:
         # NVLink auto-detection (sets NCCL env vars, _NVLINK_ENABLED).
         source /etc/club3090/detect_nvlink.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
+        bash /etc/club3090/gdn-async-order/install.sh || exit 1
+        FI_PINQ_LIB_ALL="${FI_PINQ_LIB_ALL:-0}" bash /etc/club3090/flashinfer-decode-pin/install.sh || exit 1
         # -- Drafter toggle: the same contract on every club-3090 compose --------
         #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables
         #   SPEC=off    back-compat alias for SPEC_N=0

--- a/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
@@ -92,6 +92,8 @@ services:
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
+      - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
+      - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
@@ -141,6 +143,8 @@ services:
         set -e
         source /etc/club3090/detect_nvlink.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
+        bash /etc/club3090/gdn-async-order/install.sh || exit 1
+        FI_PINQ_LIB_ALL="${FI_PINQ_LIB_ALL:-0}" bash /etc/club3090/flashinfer-decode-pin/install.sh || exit 1
         AR=""
         [ "$${_NVLINK_ENABLED:-0}" = "1" ] || AR="--disable-custom-all-reduce"
         # -- Drafter toggle: the same contract on every club-3090 compose --------

--- a/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/dflash2-fp8.yml
@@ -57,6 +57,7 @@ services:
       # (our #1052 / upstream #52873 + #50021 thread). Ours, not an upstream PR;
       # validated 3/3 boots on the reference 2×3090. Anchor drift → boot refused.
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
+      - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
       # DFlash2 external-drafter support — vLLM PR#52816 backport (syv-ai). Adds
       # DFlash2DraftModel; refuses boot on apply failure.
       - ../../../patches/vllm-dflash2-backport:/etc/club3090/dflash2:ro
@@ -125,6 +126,7 @@ services:
         bash /etc/club3090/w4a8/install.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
         bash /etc/club3090/gdn-async-order/install.sh || exit 1
+        FI_PINQ_LIB_ALL="${FI_PINQ_LIB_ALL:-0}" bash /etc/club3090/flashinfer-decode-pin/install.sh || exit 1
         bash /etc/club3090/dflash2/install.sh || exit 1
         echo "[w4a8] VLLM_MARLIN_INPUT_DTYPE=$${VLLM_MARLIN_INPUT_DTYPE:-<unset -> W4A16>} (W4A8=$${W4A8:-1})"
         AR=""

--- a/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/dflash2.yml
@@ -68,6 +68,7 @@ services:
       # (our #1052 / upstream #52873 + #50021 thread). Ours, not an upstream PR;
       # validated 3/3 boots on the reference 2×3090. Anchor drift → boot refused.
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
+      - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
       # DFlash2 external-drafter support — vLLM PR#52816 backport (syv-ai). Adds
       # DFlash2DraftModel; refuses boot on apply failure.
       - ../../../patches/vllm-dflash2-backport:/etc/club3090/dflash2:ro
@@ -136,6 +137,7 @@ services:
         bash /etc/club3090/w4a8/install.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
         bash /etc/club3090/gdn-async-order/install.sh || exit 1
+        FI_PINQ_LIB_ALL="${FI_PINQ_LIB_ALL:-0}" bash /etc/club3090/flashinfer-decode-pin/install.sh || exit 1
         bash /etc/club3090/dflash2/install.sh || exit 1
         echo "[w4a8] VLLM_MARLIN_INPUT_DTYPE=$${VLLM_MARLIN_INPUT_DTYPE:-<unset -> W4A16>} (W4A8=$${W4A8:-1})"
         AR=""

--- a/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
@@ -62,12 +62,14 @@
 #   It works only because this checkpoint is auto-round-packed [k/8,n], which is
 #   what the vendored negscale fold assumes; a compressed-tensors pack-quantized
 #   checkpoint hard-fails that fold (LEARNINGS.md 2026-08-16).
-#   ⚠️ MAX_NUM_SEQS stays at 2 here while the dual dropped to 1: the dual's cap is
-#      the W4A8 + n=4 OOM on 24 GB cards, and at TP=4/8 weights fall far enough
-#      that the headroom should be ample — but THAT IS UNTESTED. If you hit it,
-#      lower MAX_NUM_SEQS or set SPEC_N=0 (or W4A8=0) and report it.
+#   ⚠️ MAX_NUM_SEQS defaults to 8 (was 2): the MTP-under-concurrency ENGINE CRASH
+#      is fixed by the patches wired below; the dual sibling is validated crash-
+#      clean to C=32 at short ctx (2026-08-23). UNTESTED here (no 4/8-card host on
+#      the reference rig — community-validated by transfer). SEPARATE VRAM limit,
+#      unchanged by the patches: many LONG-context streams can still OOM (W4A8 +
+#      n=4); if so, lower MAX_NUM_SEQS or SPEC_N=0 (or W4A8=0) and report it.
 #
-# ⚠️⚠️ The dual sibling caps MAX_NUM_SEQS at 1 because MTP n=4 OOM'd at N=2 on 24 GB cards. At TP=4 weights fall to ~4.6 GiB/card, so the headroom that caused it is far larger and MAX_NUM_SEQS defaults to 2 — but THIS IS UNTESTED: no 4-card host exists on the reference rig. If you hit the same OOM, drop MAX_NUM_SEQS or set SPEC_N=0, and please report it.
+# ⚠️⚠️ MAX_NUM_SEQS defaults to 8 (was 2): the MTP-under-concurrency ENGINE CRASH (#40756 FlashInfer decode-plan race + the async wild-write) is now fixed by vllm-flashinfer-decode-pin + vllm-gdn-mtp-async-spec-order (wired below); the dual sibling is validated crash-clean to C=32 at ~1K-tok prompts (2026-08-23). At TP=4 weights fall to ~4.6 GiB/card so per-card headroom exceeds the dual — but THIS IS UNTESTED: no 4-card host exists on the reference rig (community-validated by transfer). SEPARATE VRAM limit unchanged by the patches: many LONG-context concurrent streams can still OOM (W4A8 + n=4). If you hit it, drop MAX_NUM_SEQS or set SPEC_N=0, and please report it.
 #
 #
 # ⚠️⚠️ CONSUMER BLACKWELL (5090, sm_120) — READ BEFORE RUNNING THIS THERE.
@@ -138,6 +140,8 @@ services:
       - ../../../../../qwen3.6-27b/vllm/patches/w4a8-int8-act:/etc/club3090/w4a8:ro
       # Lets the MTP drafter attach on this hybrid (mamba/eagle block drop).
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
+      - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
+      - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
@@ -199,6 +203,8 @@ services:
         fi
         bash /etc/club3090/w4a8/install.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
+        bash /etc/club3090/gdn-async-order/install.sh || exit 1
+        FI_PINQ_LIB_ALL="${FI_PINQ_LIB_ALL:-0}" bash /etc/club3090/flashinfer-decode-pin/install.sh || exit 1
         echo "[w4a8] VLLM_MARLIN_INPUT_DTYPE=$${VLLM_MARLIN_INPUT_DTYPE:-<unset -> W4A16>} (W4A8=$${W4A8:-1})"
         AR=""
         [ "$${_NVLINK_ENABLED:-0}" = "1" ] || AR="--disable-custom-all-reduce"
@@ -255,7 +261,7 @@ services:
       - --gpu-memory-utilization
       - "${GPU_MEMORY_UTILIZATION:-0.95}"
       - --max-num-seqs
-      - "${MAX_NUM_SEQS:-2}"
+      - "${MAX_NUM_SEQS:-8}"
       - --max-num-batched-tokens
       - "${MAX_NUM_BATCHED_TOKENS:-8192}"
       # Head-of-line-blocking mitigation (Zylone's vLLM tip; qwen3.6 dual-fast precedent).

--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/dflash2-fp8.yml
@@ -53,6 +53,8 @@ services:
       # corrupts. Anchor drift => the install script REFUSES the boot rather
       # than half-wiring it. See patches.yml.
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
+      - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
+      - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
       # DFlash2 external-drafter support — vLLM PR#52816 backport (syv-ai).
       - ../../../patches/vllm-dflash2-backport:/etc/club3090/dflash2:ro
     environment:
@@ -137,6 +139,8 @@ services:
         # paths break on PCIe-only multi-GPU, and that matters most at TP=4.
         source /etc/club3090/detect_nvlink.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
+        bash /etc/club3090/gdn-async-order/install.sh || exit 1
+        FI_PINQ_LIB_ALL="${FI_PINQ_LIB_ALL:-0}" bash /etc/club3090/flashinfer-decode-pin/install.sh || exit 1
         bash /etc/club3090/dflash2/install.sh || exit 1
         # -- Drafter toggle: the same contract on every club-3090 compose --------
         #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables

--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/dflash2.yml
@@ -52,6 +52,8 @@ services:
       # corrupts. Anchor drift => the install script REFUSES the boot rather
       # than half-wiring it. See patches.yml.
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
+      - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
+      - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
       # DFlash2 external-drafter support — vLLM PR#52816 backport (syv-ai).
       - ../../../patches/vllm-dflash2-backport:/etc/club3090/dflash2:ro
     environment:
@@ -136,6 +138,8 @@ services:
         # paths break on PCIe-only multi-GPU, and that matters most at TP=4.
         source /etc/club3090/detect_nvlink.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
+        bash /etc/club3090/gdn-async-order/install.sh || exit 1
+        FI_PINQ_LIB_ALL="${FI_PINQ_LIB_ALL:-0}" bash /etc/club3090/flashinfer-decode-pin/install.sh || exit 1
         bash /etc/club3090/dflash2/install.sh || exit 1
         # -- Drafter toggle: the same contract on every club-3090 compose --------
         #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables

--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
@@ -208,6 +208,8 @@ services:
       # corrupts. Anchor drift => the install script REFUSES the boot rather
       # than half-wiring it. See patches.yml.
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
+      - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
+      - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
     environment:
       # Drafter toggle — docker only forwards what is declared here. The DEFAULT
       # lives in the entrypoint, not in these lines, so it cannot drift.
@@ -290,6 +292,8 @@ services:
         # paths break on PCIe-only multi-GPU, and that matters most at TP=4.
         source /etc/club3090/detect_nvlink.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
+        bash /etc/club3090/gdn-async-order/install.sh || exit 1
+        FI_PINQ_LIB_ALL="${FI_PINQ_LIB_ALL:-0}" bash /etc/club3090/flashinfer-decode-pin/install.sh || exit 1
         # -- Drafter toggle: the same contract on every club-3090 compose --------
         #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables
         #   SPEC=off    back-compat alias for SPEC_N=0

--- a/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/dflash2-fp8.yml
@@ -57,6 +57,7 @@ services:
       # (our #1052 / upstream #52873 + #50021 thread). Ours, not an upstream PR;
       # validated 3/3 boots on the reference 2×3090. Anchor drift → boot refused.
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
+      - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
       # DFlash2 external-drafter support — vLLM PR#52816 backport (syv-ai). Adds
       # DFlash2DraftModel; refuses boot on apply failure.
       - ../../../patches/vllm-dflash2-backport:/etc/club3090/dflash2:ro
@@ -125,6 +126,7 @@ services:
         bash /etc/club3090/w4a8/install.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
         bash /etc/club3090/gdn-async-order/install.sh || exit 1
+        FI_PINQ_LIB_ALL="${FI_PINQ_LIB_ALL:-0}" bash /etc/club3090/flashinfer-decode-pin/install.sh || exit 1
         bash /etc/club3090/dflash2/install.sh || exit 1
         echo "[w4a8] VLLM_MARLIN_INPUT_DTYPE=$${VLLM_MARLIN_INPUT_DTYPE:-<unset -> W4A16>} (W4A8=$${W4A8:-1})"
         AR=""

--- a/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/dflash2.yml
@@ -69,6 +69,7 @@ services:
       # (our #1052 / upstream #52873 + #50021 thread). Ours, not an upstream PR;
       # validated 3/3 boots on the reference 2×3090. Anchor drift → boot refused.
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
+      - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
       # DFlash2 external-drafter support — vLLM PR#52816 backport (syv-ai). Adds
       # DFlash2DraftModel; refuses boot on apply failure.
       - ../../../patches/vllm-dflash2-backport:/etc/club3090/dflash2:ro
@@ -137,6 +138,7 @@ services:
         bash /etc/club3090/w4a8/install.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
         bash /etc/club3090/gdn-async-order/install.sh || exit 1
+        FI_PINQ_LIB_ALL="${FI_PINQ_LIB_ALL:-0}" bash /etc/club3090/flashinfer-decode-pin/install.sh || exit 1
         bash /etc/club3090/dflash2/install.sh || exit 1
         echo "[w4a8] VLLM_MARLIN_INPUT_DTYPE=$${VLLM_MARLIN_INPUT_DTYPE:-<unset -> W4A16>} (W4A8=$${W4A8:-1})"
         AR=""

--- a/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
@@ -62,12 +62,14 @@
 #   It works only because this checkpoint is auto-round-packed [k/8,n], which is
 #   what the vendored negscale fold assumes; a compressed-tensors pack-quantized
 #   checkpoint hard-fails that fold (LEARNINGS.md 2026-08-16).
-#   ⚠️ MAX_NUM_SEQS stays at 2 here while the dual dropped to 1: the dual's cap is
-#      the W4A8 + n=4 OOM on 24 GB cards, and at TP=4/8 weights fall far enough
-#      that the headroom should be ample — but THAT IS UNTESTED. If you hit it,
-#      lower MAX_NUM_SEQS or set SPEC_N=0 (or W4A8=0) and report it.
+#   ⚠️ MAX_NUM_SEQS defaults to 8 (was 2): the MTP-under-concurrency ENGINE CRASH
+#      is fixed by the patches wired below; the dual sibling is validated crash-
+#      clean to C=32 at short ctx (2026-08-23). UNTESTED here (no 4/8-card host on
+#      the reference rig — community-validated by transfer). SEPARATE VRAM limit,
+#      unchanged by the patches: many LONG-context streams can still OOM (W4A8 +
+#      n=4); if so, lower MAX_NUM_SEQS or SPEC_N=0 (or W4A8=0) and report it.
 #
-# ⚠️⚠️ The dual sibling caps MAX_NUM_SEQS at 1 because MTP n=4 OOM'd at N=2 on 24 GB cards. At TP=8 weights fall to ~2.3 GiB/card, so the headroom that caused it is far larger and MAX_NUM_SEQS defaults to 2 — but THIS IS UNTESTED: no 8-card host exists on the reference rig. If you hit the same OOM, drop MAX_NUM_SEQS or set SPEC_N=0, and please report it.
+# ⚠️⚠️ MAX_NUM_SEQS defaults to 8 (was 2): the MTP-under-concurrency ENGINE CRASH (#40756 FlashInfer decode-plan race + the async wild-write) is now fixed by vllm-flashinfer-decode-pin + vllm-gdn-mtp-async-spec-order (wired below); the dual sibling is validated crash-clean to C=32 at ~1K-tok prompts (2026-08-23). At TP=8 weights fall to ~2.3 GiB/card so per-card headroom exceeds the dual — but THIS IS UNTESTED: no 8-card host exists on the reference rig (community-validated by transfer). SEPARATE VRAM limit unchanged by the patches: many LONG-context concurrent streams can still OOM (W4A8 + n=4). If you hit it, drop MAX_NUM_SEQS or set SPEC_N=0, and please report it.
 #
 #
 # ⚠️⚠️ CONSUMER BLACKWELL (5090, sm_120) — READ BEFORE RUNNING THIS THERE.
@@ -138,6 +140,8 @@ services:
       - ../../../../../qwen3.6-27b/vllm/patches/w4a8-int8-act:/etc/club3090/w4a8:ro
       # Lets the MTP drafter attach on this hybrid (mamba/eagle block drop).
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
+      - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
+      - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
@@ -199,6 +203,8 @@ services:
         fi
         bash /etc/club3090/w4a8/install.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
+        bash /etc/club3090/gdn-async-order/install.sh || exit 1
+        FI_PINQ_LIB_ALL="${FI_PINQ_LIB_ALL:-0}" bash /etc/club3090/flashinfer-decode-pin/install.sh || exit 1
         echo "[w4a8] VLLM_MARLIN_INPUT_DTYPE=$${VLLM_MARLIN_INPUT_DTYPE:-<unset -> W4A16>} (W4A8=$${W4A8:-1})"
         AR=""
         [ "$${_NVLINK_ENABLED:-0}" = "1" ] || AR="--disable-custom-all-reduce"
@@ -255,7 +261,7 @@ services:
       - --gpu-memory-utilization
       - "${GPU_MEMORY_UTILIZATION:-0.95}"
       - --max-num-seqs
-      - "${MAX_NUM_SEQS:-2}"
+      - "${MAX_NUM_SEQS:-8}"
       - --max-num-batched-tokens
       - "${MAX_NUM_BATCHED_TOKENS:-8192}"
       # Head-of-line-blocking mitigation (Zylone's vLLM tip; qwen3.6 dual-fast precedent).

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/dflash2-fp8.yml
@@ -53,6 +53,8 @@ services:
       # corrupts. Anchor drift => the install script REFUSES the boot rather
       # than half-wiring it. See patches.yml.
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
+      - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
+      - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
       # DFlash2 external-drafter support — vLLM PR#52816 backport (syv-ai).
       - ../../../patches/vllm-dflash2-backport:/etc/club3090/dflash2:ro
     environment:
@@ -137,6 +139,8 @@ services:
         # paths break on PCIe-only multi-GPU, and that matters most at TP=8.
         source /etc/club3090/detect_nvlink.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
+        bash /etc/club3090/gdn-async-order/install.sh || exit 1
+        FI_PINQ_LIB_ALL="${FI_PINQ_LIB_ALL:-0}" bash /etc/club3090/flashinfer-decode-pin/install.sh || exit 1
         bash /etc/club3090/dflash2/install.sh || exit 1
         # -- Drafter toggle: the same contract on every club-3090 compose --------
         #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/dflash2.yml
@@ -52,6 +52,8 @@ services:
       # corrupts. Anchor drift => the install script REFUSES the boot rather
       # than half-wiring it. See patches.yml.
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
+      - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
+      - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
       # DFlash2 external-drafter support — vLLM PR#52816 backport (syv-ai).
       - ../../../patches/vllm-dflash2-backport:/etc/club3090/dflash2:ro
     environment:
@@ -136,6 +138,8 @@ services:
         # paths break on PCIe-only multi-GPU, and that matters most at TP=8.
         source /etc/club3090/detect_nvlink.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
+        bash /etc/club3090/gdn-async-order/install.sh || exit 1
+        FI_PINQ_LIB_ALL="${FI_PINQ_LIB_ALL:-0}" bash /etc/club3090/flashinfer-decode-pin/install.sh || exit 1
         bash /etc/club3090/dflash2/install.sh || exit 1
         # -- Drafter toggle: the same contract on every club-3090 compose --------
         #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
@@ -212,6 +212,8 @@ services:
       # corrupts. Anchor drift => the install script REFUSES the boot rather
       # than half-wiring it. See patches.yml.
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
+      - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
+      - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
     environment:
       # Drafter toggle — docker only forwards what is declared here. The DEFAULT
       # lives in the entrypoint, not in these lines, so it cannot drift.
@@ -294,6 +296,8 @@ services:
         # paths break on PCIe-only multi-GPU, and that matters most at TP=8.
         source /etc/club3090/detect_nvlink.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
+        bash /etc/club3090/gdn-async-order/install.sh || exit 1
+        FI_PINQ_LIB_ALL="${FI_PINQ_LIB_ALL:-0}" bash /etc/club3090/flashinfer-decode-pin/install.sh || exit 1
         # -- Drafter toggle: the same contract on every club-3090 compose --------
         #   SPEC_N=<n>  drafter depth (this compose defaults to 3); SPEC_N=0 disables
         #   SPEC=off    back-compat alias for SPEC_N=0

--- a/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
@@ -113,6 +113,8 @@ services:
     volumes:
       - ${MODEL_DIR:-../../../../../../models-cache}:/root/.cache/huggingface
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-pr48375-mamba-drop-eagle-block:/etc/club3090/pr48375:ro
+      - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
+      - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
@@ -162,6 +164,8 @@ services:
         set -e
         source /etc/club3090/detect_nvlink.sh
         bash /etc/club3090/pr48375/install.sh || exit 1
+        bash /etc/club3090/gdn-async-order/install.sh || exit 1
+        FI_PINQ_LIB_ALL="${FI_PINQ_LIB_ALL:-0}" bash /etc/club3090/flashinfer-decode-pin/install.sh || exit 1
         AR=""
         [ "$${_NVLINK_ENABLED:-0}" = "1" ] || AR="--disable-custom-all-reduce"
         # -- Drafter toggle: the same contract on every club-3090 compose --------

--- a/scripts/lib/profiles/patches.yml
+++ b/scripts/lib/profiles/patches.yml
@@ -414,6 +414,8 @@ patches:
     load_bearing_when:
       - composes:
           - vllm/qwen38-27b-dual-fast
+          - vllm/qwen38-27b-multi4-fast
+          - vllm/qwen38-27b-multi8-fast
         reason: "The dual-fast config (W4A8 + MTP n=4 + fp8 KV + prefix caching) is the exact repro: FlashInfer plan() reuses one PINNED host buffer per wrapper and copies it out async; the MTP drafter re-plans the DECODE wrapper K-1x/step, so a stale plan feeds the split-KV merge (PersistentVariableLengthMergeStatesKernel) a garbage row -> Xid 31 at an unmapped VA. Needs >=4 genuinely concurrent in-flight MTP requests to lose the race (c<=3 and SPEC_N=0 never crash). Unpinning the flashinfer decode.py workspace buffer forces a synchronous plan copy per step and closes the window. Validated v0.27.1 / flashinfer 0.6.16.post3 / 2x RTX 3090 SM86: c=4 survives 425s clean (120s OK=126 + 300s OK=345, ERR=0, 0 new Xid) at full async speed; decode.py alone is necessary+sufficient (A/B: prefill/sparse/pod unpin without decode.py still crashed). Perf-neutral at c=1 (all deltas within CV)."
         evidence: "models/qwen3.8-27b/vllm/patches/vllm-flashinfer-decode-pin/README.md; vllm-project/vllm#40756 (thread comments 2026-08-17, brasrox retraction + sempai SM86 corroboration)"
     delivery:               # DEPRECATED/READ-ONLY (test-only) — see header
@@ -453,6 +455,8 @@ patches:
     load_bearing_when:
       - composes:
           - vllm/qwen38-27b-dual-fast
+          - vllm/qwen38-27b-multi4-fast
+          - vllm/qwen38-27b-multi8-fast
         reason: "Our own 2-line fix for the async wild-write crash (club-3090#1052 / vllm#52873 + the vllm#50021 thread): on a Qwen3-Next hybrid with MTP + prefix caching + async scheduling (vLLM v0.27.1 default), gpu_model_runner.py::synchronize_input_prep waits prepare_inputs_event (recorded BEFORE the forward + spec-decode fused-align postprocess) but not num_accepted_tokens_event (recorded AFTER it), so the next step's _update_states block-table mutation raced the still-in-flight postprocess -> stale state-block index -> wild GPU write (CUDA illegal access / Xid 31 VIRT_WRITE) within 6-13k generated tokens of agent traffic. The fix also waits the postprocess event, closing the write-after-read window; it relocates a wait align-mode already did later, so TPS is neutral. Distinct from vllm#50021 (its in-kernel bounds do NOT fix this - built its head, crashed 2/2) and from vllm#43559/#48375. On-rig validation 2026-08-19 (reference 2x3090, v0.27.1): async-ON survived 3/3 boots to 33-36k generated tokens each (crossing ctx 32k + a compaction) where 5/5 unpatched arms died 6-13k; real delivery path confirmed (switch.sh -> compose mount -> entrypoint install.sh logs '[gdn-async-order] applied'); bench 79.1 narr / 108.5 code / 1756 prefill >= baseline. Does NOT address the separate acceptance-collapse bug (vllm#52873 / Bug A)."
         evidence: "models/qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order/README.md; club-3090#1052; vllm#52873; docs/UPSTREAM.md"
     delivery:


### PR DESCRIPTION
Standardizes concurrency safety across the whole Qwen3.8-27B vLLM family and raises the fast-tier default now that #1051 (`vllm-flashinfer-decode-pin`, merged via #1089) makes MTP concurrency crash-safe.

## Changes

- **Both spec-decode crash-fixes on all 20 vLLM composes** (defense-in-depth; both idempotent, no-op-safe where inapplicable, TPS-neutral, hard-fail-on-drift):
  - `vllm-flashinfer-decode-pin` (#40756 decode-plan race) — added to 19
  - `vllm-gdn-mtp-async-spec-order` (async wild-write) — added to 13
  - each was previously wired on only a subset; now uniform
- **`MAX_NUM_SEQS` default 1/2 → 8** on the three W4A8-int4 MTP fast composes (`dual`/`multi4`/`multi8`) **only**. DFlash2 (OOMs at C=8 — proven), fp8 (~2× the weight VRAM), and nvfp4 (esp. single-card) keep lower defaults — 8 there would ship an OOM. Override per-launch with `MAX_NUM_SEQS=` anywhere.
- `patches.yml` `load_bearing_when` extended to the fast trio for both patches; fast-compose comments rewritten (crash fixed → seqs=8; the **separate** long-context VRAM OOM preserved as a caveat).

## Validation (2026-08-23, 2×3090, v0.27.1, dual-fast, real delivery path)

`switch.sh → compose mount → entrypoint install.sh`:
- boots at default `--max-num-seqs 8`; both patches applied via entrypoint
- **C=8 @ 1024-tok: agg 218, clean; C=8 @ 8192-tok: agg 62, clean** (chunked prefill bounds the activation peak)
- conformance tests green (`patch-attribution`, status/image/arch drift, `concurrency-probe`); all 20 composes YAML-parse

`multi4`/`multi8` are community-validated *by transfer* (topology-agnostic patches; no 4/8-GPU host on the reference rig). 16K+ prompts × high concurrency can still OOM — caveated in each fast compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
