### PR TITLE
fix(qwen3.8-27b): accept reasoning_effort "high" on the vLLM slugs

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -348,7 +348,7 @@ Tested via `URL=http://localhost:8004 MODEL=luce-dflash bash scripts/verify-stre
 
 ## Qwen3.8-27B
 
-Dense 27B, Qwen3-Next hybrid (16 full-attention + 48 linear-attention layers, 24 attention heads / 4 KV heads, head_dim 256, 262144 architectural ceiling). Same arch shape as Qwen3.6-27B, different checkpoint. Embedded MTP head. Native chat template (NOT froggeric).
+Dense 27B, Qwen3-Next hybrid (16 full-attention + 48 linear-attention layers, 24 attention heads / 4 KV heads, head_dim 256, 262144 architectural ceiling). Same arch shape as Qwen3.6-27B, different checkpoint. Embedded MTP head. Native chat template (NOT froggeric), vendored with a seven-line `high` -> `medium` reasoning-effort mapping — see `patches.yml` qwen38-reasoning-effort-template.
 
 ### Dual-card (2× RTX 3090, TP=2) — vLLM
 

--- a/docs/QUALITY_TEST.md
+++ b/docs/QUALITY_TEST.md
@@ -152,7 +152,7 @@ the three sampler vars by hand remains the only way to change them.
 | `--max-tokens 4096` | The ~1024 default silently truncates long answers into `token_limit` failures that look like wrong answers. |
 | `--thinking-max-tokens 16384` | The thinking arm needs the headroom. |
 | `--timeout-per-case 600` | 16,384 tokens takes real wall-clock. Too tight a cap produces `timeout` rows that read as content misses. |
-| `REASONING_EFFORT=` | Env only — forwarded as the per-request OpenAI `reasoning_effort`. The qwen3.8 composes default to `low` server-side since #1029; pin it anyway so the run records what it measured. ⚠️ Effort is **not** comparable across runs. ⚠️ `high` **raises** on vLLM — only `xhigh`/`medium`/`low` exist. |
+| `REASONING_EFFORT=` | Env only — forwarded as the per-request OpenAI `reasoning_effort`. The qwen3.8 composes default to `low` server-side since #1029; pin it anyway so the run records what it measured. ⚠️ Effort is **not** comparable across runs. ⚠️ Qwen3.8's own rungs are `xhigh`/`medium`/`low` — there is no `high`. On the **vLLM** slugs the vendored template (`qwen38-reasoning-effort-template`) maps `high` → `medium`, so it is accepted and records as medium — the un-nudged baseline, NOT xhigh; anything else still raises. Elsewhere `high` **raises**. |
 | `--repeat 3` | Add it for anything you'll quote. With `--sampling-from-server` both legs are sampled, so single draws aren't quotable. |
 
 ⚠️⚠️ **Read the failure modes before reading the score.** `timeout` and `token_limit` are **harness

--- a/models/qwen3.8-27b/CHANGELOG.md
+++ b/models/qwen3.8-27b/CHANGELOG.md
@@ -15,6 +15,19 @@ The `dual/fp8/mtp.yml` header has documented two mitigations for the [vllm#50021
 | BENCHMARKS row 2026-08-17 (async ON, MTP n=3) | 67.4 / 85.8 | 1166 / 942 | 152 ms | 2.62 |
 
 Mitigation (1) restores **+53% prose / +95% code** decode over the drafter-off path and is at parity or better with the async-ON catalog row on every column — the header's ~0% cost claim holds. Decode CV 2.1% / 3.3%; VRAM 22.3 GB/card, 0 MiB leak; no Xid / CUDA-error signatures across bench + 8-pack + verify-full on the new config. ⚠️ This bounds the crash *mechanism* the maintainer identified (MTP + prefix-cache + async), not #50021 itself, which is still open — a 10-minute bench is not 44 h of agent traffic. If Xid 31 recurs, `SPEC=off` remains the fallback.
+## 2026-08-23 — every vLLM slug accepts `reasoning_effort: "high"` again (mapped to `medium`)
+
+All 20 Qwen3.8 vLLM slugs returned **HTTP 500** on any thinking-mode request carrying `reasoning_effort: "high"`. Qwen3.8's ladder is `low` / `medium` / `xhigh` — there is **no `high`** — and the stock `chat_template.jinja` `raise_exception()`s on anything else. OpenAI and Anthropic both use `low`/`medium`/`high`, so a generic client sending the standard top rung got a Jinja `TemplateError` surfaced as a 500. Reported on-rig through vLLM's Anthropic-compatible `POST /v1/messages`: a Claude-API client turns thinking **on** and sends `high`, which overrides *both* keys of `--default-chat-template-kwargs` (a fallback for callers that send nothing, never a clamp) and re-arms the raise that the shipped `enable_thinking: false` default otherwise keeps dormant.
+
+⚠️ **Wider than first reported, since the 2026-09-01 thinking flip (#1135):** `ENABLE_THINKING` now defaults to `true` on all 20 slugs, so `reasoning_effort` is read on *every* request and the raise is armed by default — a caller no longer has to opt into thinking to reach it. `ENABLE_THINKING=false` is now the only thing that puts it back to sleep.
+
+⚠️ **The failure mode is the dangerous kind:** `/v1/models` and `/health` keep returning 200 and the model is demonstrably serving, so the endpoint looks healthy while every thinking-mode chat request fails.
+
+New patch [`qwen38-reasoning-effort-template`](vllm/patches/qwen38-reasoning-effort-template/PROVENANCE.md) — the model's own template plus **seven lines** mapping `high` → `medium` before the validation. `medium` is the **un-nudged baseline** (no branch in the template, no injected preamble), deliberately not `xhigh`: `xhigh` injects a "think carefully, validate assumptions, consider alternatives" preamble that is slow and timeout-prone, and a Claude-API client sends `high` on *every* request, which would put all agent traffic in the slowest mode on slugs shipping `max_num_seqs=1`. `xhigh` remains reachable by name; `xhigh`/`medium`/`low` and invalid values are byte-for-byte unchanged.
+
+**Wired mount-only** — bind-mounted *over* the served checkpoint's own `chat_template.jinja`, which vLLM auto-loads from the model dir, so no `--chat-template` argument and the compose `command:` lists are untouched (the carnice override's style, not froggeric's). That is a rebase-surface choice: 11 upstream commits touched these composes in the 7 days to 2026-08-23, and an inserted flag collides with every one of them.
+
+One vendored file covers all 20 slugs: `chat_template.jinja` is sha256 `c3cf9e34…81041` (8,952 bytes) on all three served checkpoints — official FP8, the Frozenlock AutoRound INT4 repack, and the RadixArk NVFP4 export — unchanged by the [#1070](https://github.com/noonghunna/club-3090/pull/1070) weights swap. The DFlash2 drafter repo ships no `chat_template.jinja` at all and is never the render source.
 
 ## 2026-08-23 — dual-fast: FlashInfer decode-buffer unpin merged (#1051) — MTP concurrency unlocked to C=32
 

--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2-fp8.yml
@@ -6,7 +6,8 @@
 #   Drafter:   DFlash2 EXTERNAL block-drafter n=7 (syv-ai W4A16, method=dflash).
 #   KV:        fp8_e4m3 → FlashInfer (fp8 KV can't use FLASH_ATTN on Ampere).
 #   Vision:    ✅ tower present (input-only); untested on this tier.
-#   Template:  native.
+#   Template:  native + club-3090 alias — the model's own chat_template.jinja
+#              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #   Max ctx:   262144 (full arch max — fp8 KV is 2× smaller than bf16, so unlike the
 #              ultrafast/bf16 tier this fits the full 262K).
 #   Genesis:   none
@@ -65,6 +66,22 @@ services:
       # DFlash2DraftModel; refuses boot on apply failure.
       - ../../../patches/vllm-dflash2-backport:/etc/club3090/dflash2:ro
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+      # Chat template: the model's OWN, plus seven lines mapping the standard
+      # OpenAI/Anthropic rung `high` onto `medium`. Qwen3.8's ladder is
+      # low/medium/xhigh with NO `high`, and the stock template
+      # raise_exception()s on anything else, so a client sending the standard top
+      # rung gets HTTP 500 while /v1/models still returns 200. Observed live via
+      # /v1/messages?beta=true.
+      # ⭐ MOUNTED OVER the checkpoint's own chat_template.jinja: vLLM auto-loads
+      # the template from the model dir, so this needs NO --chat-template arg
+      # (the same wiring style as the carnice override -- see patches.yml).
+      # That is deliberate, not incidental: upstream edits the args list
+      # constantly (11 commits touched these composes in the last 7 days), and
+      # every edit there collides with an inserted flag. The volumes block is
+      # quiet by comparison, so wiring here is what keeps this patch rebasable.
+      # DATA-ONLY mount, not an engine-code overlay, so the engine's overlay-free
+      # contract is unaffected. See patches.yml qwen38-reasoning-effort-template.
+      - ../../../patches/qwen38-reasoning-effort-template/chat_template.jinja:/root/.cache/huggingface/qwen3.8-27b-autoround-int4/chat_template.jinja:ro
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
     environment:
@@ -237,8 +254,13 @@ services:
       # xhigh adds "think carefully, validate assumptions, consider alternatives"
       # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
       # you want the model un-nudged rather than pushed toward brevity.
-      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
-      # render (`high` included — it does NOT silently remap).
+      # ⚠️ Valid values are xhigh | medium | low, plus `high`, which THIS REPO
+      # maps onto MEDIUM via the patched chat template mounted above. Upstream
+      # Qwen has no `high` rung and its stock template RAISES on it; the mapping
+      # is the whole point of that mount. medium is the UN-NUDGED baseline (no
+      # branch, no injected preamble), deliberately NOT xhigh — a client sending
+      # the standard top rung gets the neutral setting, not the slowest one.
+      # Anything OUTSIDE that set still RAISES at template render (HTTP 400).
       - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching

--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2.yml
@@ -12,7 +12,8 @@
 #              ONLY bf16/fp16 KV (fp8-KV-in-kernel is FA3/Hopper-only). fp8 KV would
 #              force FlashInfer and cost ~40% decode.
 #   Vision:    ✅ tower present (input-only, text out); untested on this tier.
-#   Template:  native — the repo's own chat_template.jinja.
+#   Template:  native + club-3090 alias — the model's own chat_template.jinja
+#              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #   Max ctx:   204800 (~200K) — MEASURED bf16/FA2 ceiling on 2×3090 @0.90 util
 #              (KV pool 212,977 tok; hard ceiling ~213K). NOT the 262K arch max:
 #              bf16 KV can't fit 262K here (needs ~10.93 GiB vs ~9.1 available).
@@ -100,6 +101,22 @@ services:
       # DFlash2DraftModel; refuses boot on apply failure.
       - ../../../patches/vllm-dflash2-backport:/etc/club3090/dflash2:ro
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+      # Chat template: the model's OWN, plus seven lines mapping the standard
+      # OpenAI/Anthropic rung `high` onto `medium`. Qwen3.8's ladder is
+      # low/medium/xhigh with NO `high`, and the stock template
+      # raise_exception()s on anything else, so a client sending the standard top
+      # rung gets HTTP 500 while /v1/models still returns 200. Observed live via
+      # /v1/messages?beta=true.
+      # ⭐ MOUNTED OVER the checkpoint's own chat_template.jinja: vLLM auto-loads
+      # the template from the model dir, so this needs NO --chat-template arg
+      # (the same wiring style as the carnice override -- see patches.yml).
+      # That is deliberate, not incidental: upstream edits the args list
+      # constantly (11 commits touched these composes in the last 7 days), and
+      # every edit there collides with an inserted flag. The volumes block is
+      # quiet by comparison, so wiring here is what keeps this patch rebasable.
+      # DATA-ONLY mount, not an engine-code overlay, so the engine's overlay-free
+      # contract is unaffected. See patches.yml qwen38-reasoning-effort-template.
+      - ../../../patches/qwen38-reasoning-effort-template/chat_template.jinja:/root/.cache/huggingface/qwen3.8-27b-autoround-int4/chat_template.jinja:ro
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
     environment:
@@ -274,8 +291,13 @@ services:
       # xhigh adds "think carefully, validate assumptions, consider alternatives"
       # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
       # you want the model un-nudged rather than pushed toward brevity.
-      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
-      # render (`high` included — it does NOT silently remap).
+      # ⚠️ Valid values are xhigh | medium | low, plus `high`, which THIS REPO
+      # maps onto MEDIUM via the patched chat template mounted above. Upstream
+      # Qwen has no `high` rung and its stock template RAISES on it; the mapping
+      # is the whole point of that mount. medium is the UN-NUDGED baseline (no
+      # branch, no injected preamble), deliberately NOT xhigh — a client sending
+      # the standard top rung gets the neutral setting, not the slowest one.
+      # Anything OUTSIDE that set still RAISES at template render (HTTP 400).
       - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching

--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
@@ -23,7 +23,8 @@
 #              Video cost ~72.7 tok/s @256x256 (36 tok/frame at default fps=2),
 #              scaling with pixel count: 23 @128px, 263 @512px, 583 @768px.
 #              So ~61 min of 256x256 video fits the 262144 window; ~17 min @512px.
-#   Template:  native — the repo's own chat_template.jinja. NOT froggeric.
+#   Template:  native + club-3090 alias — the model's own chat_template.jinja
+#              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #   Max ctx:   262144 — architectural ceiling, NOT measured on this checkpoint
 #   Genesis:   none
 #   Status:    🧪 Experimental
@@ -173,6 +174,22 @@ services:
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
       - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+      # Chat template: the model's OWN, plus seven lines mapping the standard
+      # OpenAI/Anthropic rung `high` onto `medium`. Qwen3.8's ladder is
+      # low/medium/xhigh with NO `high`, and the stock template
+      # raise_exception()s on anything else, so a client sending the standard top
+      # rung gets HTTP 500 while /v1/models still returns 200. Observed live via
+      # /v1/messages?beta=true.
+      # ⭐ MOUNTED OVER the checkpoint's own chat_template.jinja: vLLM auto-loads
+      # the template from the model dir, so this needs NO --chat-template arg
+      # (the same wiring style as the carnice override -- see patches.yml).
+      # That is deliberate, not incidental: upstream edits the args list
+      # constantly (11 commits touched these composes in the last 7 days), and
+      # every edit there collides with an inserted flag. The volumes block is
+      # quiet by comparison, so wiring here is what keeps this patch rebasable.
+      # DATA-ONLY mount, not an engine-code overlay, so the engine's overlay-free
+      # contract is unaffected. See patches.yml qwen38-reasoning-effort-template.
+      - ../../../patches/qwen38-reasoning-effort-template/chat_template.jinja:/root/.cache/huggingface/qwen3.8-27b-autoround-int4/chat_template.jinja:ro
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
     environment:
@@ -342,8 +359,13 @@ services:
       # xhigh adds "think carefully, validate assumptions, consider alternatives"
       # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
       # you want the model un-nudged rather than pushed toward brevity.
-      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
-      # render (`high` included — it does NOT silently remap).
+      # ⚠️ Valid values are xhigh | medium | low, plus `high`, which THIS REPO
+      # maps onto MEDIUM via the patched chat template mounted above. Upstream
+      # Qwen has no `high` rung and its stock template RAISES on it; the mapping
+      # is the whole point of that mount. medium is the UN-NUDGED baseline (no
+      # branch, no injected preamble), deliberately NOT xhigh — a client sending
+      # the standard top rung gets the neutral setting, not the slowest one.
+      # Anything OUTSIDE that set still RAISES at template render (HTTP 400).
       - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching

--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/dflash2-fp8.yml
@@ -11,7 +11,8 @@
 #              incoai/Qwen3.8-27B-DFlash2 drafter.)
 #   KV:        fp8_e4m3 → FlashInfer.
 #   Vision:    ✅ tower present (input-only, bf16); untested on this tier.
-#   Template:  native.
+#   Template:  native + club-3090 alias — the model's own chat_template.jinja
+#              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #   Max ctx:   262144 (fp8 KV fits the full arch max).
 #   Genesis:   none
 #   Status:    🧪 Experimental
@@ -46,11 +47,28 @@ services:
       # subsequent boots reuse the compiled graphs.
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
-      # NO chat-template mount. This model serves its OWN chat_template.jinja
-      # from the model dir — see "Chat template" in the header for why the
-      # froggeric override that the qwen3.6/Tess composes carry is WRONG here.
+      # The only chat-template mount here is the model's OWN template plus the
+      # club-3090 `high` -> `medium` alias (below) — see "Chat template" in the
+      # header for why the froggeric override that the qwen3.6/Tess composes
+      # carry is WRONG here.
       # NVLink auto-detection — runs inside the container at boot.
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+      # Chat template: the model's OWN, plus seven lines mapping the standard
+      # OpenAI/Anthropic rung `high` onto `medium`. Qwen3.8's ladder is
+      # low/medium/xhigh with NO `high`, and the stock template
+      # raise_exception()s on anything else, so a client sending the standard top
+      # rung gets HTTP 500 while /v1/models still returns 200. Observed live via
+      # /v1/messages?beta=true.
+      # ⭐ MOUNTED OVER the checkpoint's own chat_template.jinja: vLLM auto-loads
+      # the template from the model dir, so this needs NO --chat-template arg
+      # (the same wiring style as the carnice override -- see patches.yml).
+      # That is deliberate, not incidental: upstream edits the args list
+      # constantly (11 commits touched these composes in the last 7 days), and
+      # every edit there collides with an inserted flag. The volumes block is
+      # quiet by comparison, so wiring here is what keeps this patch rebasable.
+      # DATA-ONLY mount, not an engine-code overlay, so the engine's overlay-free
+      # contract is unaffected. See patches.yml qwen38-reasoning-effort-template.
+      - ../../../patches/qwen38-reasoning-effort-template/chat_template.jinja:/root/.cache/huggingface/qwen3.8-27b-fp8/chat_template.jinja:ro
       # Vendored vllm#48375 (MambaManager drop_eagle_block) — SHARED from the
       # qwen3.6-27b tree (same Qwen3-Next hybrid family), exactly as the
       # Tess-4-27B compose shares it. Load-bearing because this compose ships
@@ -229,7 +247,6 @@ services:
       - --kv-cache-dtype
       - "${KV_CACHE_DTYPE:-fp8_e4m3}"
       - --trust-remote-code
-      # No --chat-template: the model dir's own chat_template.jinja is used.
       - --reasoning-parser
       - qwen3
       # Stack-wide default: thinking OFF. On this model that ALSO suppresses the
@@ -255,8 +272,13 @@ services:
       # xhigh adds "think carefully, validate assumptions, consider alternatives"
       # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
       # you want the model un-nudged rather than pushed toward brevity.
-      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
-      # render (`high` included — it does NOT silently remap).
+      # ⚠️ Valid values are xhigh | medium | low, plus `high`, which THIS REPO
+      # maps onto MEDIUM via the patched chat template mounted above. Upstream
+      # Qwen has no `high` rung and its stock template RAISES on it; the mapping
+      # is the whole point of that mount. medium is the UN-NUDGED baseline (no
+      # branch, no injected preamble), deliberately NOT xhigh — a client sending
+      # the standard top rung gets the neutral setting, not the slowest one.
+      # Anything OUTSIDE that set still RAISES at template render (HTTP 400).
       - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       - --enable-auto-tool-choice
       # The 3.8 template emits the same <tool_call><function=…><parameter=…> XML

--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/dflash2.yml
@@ -9,7 +9,8 @@
 #   KV:        bf16 → FLASH_ATTN (the DFlash2 non-causal drafter's preferred path;
 #              on Ampere FLASH_ATTN takes bf16/fp16 KV only — fp8 forces FlashInfer).
 #   Vision:    ✅ tower present (input-only, bf16); untested on this tier.
-#   Template:  native.
+#   Template:  native + club-3090 alias — the model's own chat_template.jinja
+#              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #   Max ctx:   131072 (bf16 KV ceiling — MEASURED at boot; fp8 weights are ~29 GiB so bf16
 #              KV fits LESS than the int4 ultrafast's ~200K. Set from the KV pool.)
 #   Genesis:   none
@@ -46,11 +47,28 @@ services:
       # subsequent boots reuse the compiled graphs.
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
-      # NO chat-template mount. This model serves its OWN chat_template.jinja
-      # from the model dir — see "Chat template" in the header for why the
-      # froggeric override that the qwen3.6/Tess composes carry is WRONG here.
+      # The only chat-template mount here is the model's OWN template plus the
+      # club-3090 `high` -> `medium` alias (below) — see "Chat template" in the
+      # header for why the froggeric override that the qwen3.6/Tess composes
+      # carry is WRONG here.
       # NVLink auto-detection — runs inside the container at boot.
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+      # Chat template: the model's OWN, plus seven lines mapping the standard
+      # OpenAI/Anthropic rung `high` onto `medium`. Qwen3.8's ladder is
+      # low/medium/xhigh with NO `high`, and the stock template
+      # raise_exception()s on anything else, so a client sending the standard top
+      # rung gets HTTP 500 while /v1/models still returns 200. Observed live via
+      # /v1/messages?beta=true.
+      # ⭐ MOUNTED OVER the checkpoint's own chat_template.jinja: vLLM auto-loads
+      # the template from the model dir, so this needs NO --chat-template arg
+      # (the same wiring style as the carnice override -- see patches.yml).
+      # That is deliberate, not incidental: upstream edits the args list
+      # constantly (11 commits touched these composes in the last 7 days), and
+      # every edit there collides with an inserted flag. The volumes block is
+      # quiet by comparison, so wiring here is what keeps this patch rebasable.
+      # DATA-ONLY mount, not an engine-code overlay, so the engine's overlay-free
+      # contract is unaffected. See patches.yml qwen38-reasoning-effort-template.
+      - ../../../patches/qwen38-reasoning-effort-template/chat_template.jinja:/root/.cache/huggingface/qwen3.8-27b-fp8/chat_template.jinja:ro
       # Vendored vllm#48375 (MambaManager drop_eagle_block) — SHARED from the
       # qwen3.6-27b tree (same Qwen3-Next hybrid family), exactly as the
       # Tess-4-27B compose shares it. Load-bearing because this compose ships
@@ -231,7 +249,6 @@ services:
       - --attention-backend
       - "${ATTN_BACKEND:-FLASH_ATTN}"
       - --trust-remote-code
-      # No --chat-template: the model dir's own chat_template.jinja is used.
       - --reasoning-parser
       - qwen3
       # Stack-wide default: thinking OFF. On this model that ALSO suppresses the
@@ -257,8 +274,13 @@ services:
       # xhigh adds "think carefully, validate assumptions, consider alternatives"
       # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
       # you want the model un-nudged rather than pushed toward brevity.
-      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
-      # render (`high` included — it does NOT silently remap).
+      # ⚠️ Valid values are xhigh | medium | low, plus `high`, which THIS REPO
+      # maps onto MEDIUM via the patched chat template mounted above. Upstream
+      # Qwen has no `high` rung and its stock template RAISES on it; the mapping
+      # is the whole point of that mount. medium is the UN-NUDGED baseline (no
+      # branch, no injected preamble), deliberately NOT xhigh — a client sending
+      # the standard top rung gets the neutral setting, not the slowest one.
+      # Anything OUTSIDE that set still RAISES at template render (HTTP 400).
       - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       - --enable-auto-tool-choice
       # The 3.8 template emits the same <tool_call><function=…><parameter=…> XML

--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
@@ -20,7 +20,8 @@
 #              Video cost ~72.7 tok/s @256x256 (36 tok/frame at default fps=2),
 #              scaling with pixel count: 23 @128px, 263 @512px, 583 @768px.
 #              So ~61 min of 256x256 video fits the 262144 window; ~17 min @512px.
-#   Template:  native — the repo's own chat_template.jinja. NOT froggeric.
+#   Template:  native + club-3090 alias — the model's own chat_template.jinja
+#              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #              ⚠️ This is a deliberate break from the qwen3.6-27b composes; see
 #              "Chat template" below. The 3.8 template is a DIFFERENT program.
 #   Max ctx:   262144 — the architectural ceiling (text_config.max_position_embeddings).
@@ -223,6 +224,14 @@
 #       set or after the last query; 3.8: preserve unless explicitly disabled);
 #     - it no longer splits `<think>` out of `content` as a fallback.
 #   Mounting the 3.6/froggeric template here would silently delete all of that.
+#   ⭐ WHAT IS MOUNTED is that same native template plus SEVEN lines: `high` is
+#   mapped onto `medium` immediately before the validation. The standard OpenAI/
+#   Anthropic ladder tops out at `high` and Qwen3.8 has no such rung, so
+#   against the stock file a Claude-API client on /v1/messages — which turns
+#   thinking ON and sends `high` — gets a Jinja TemplateError as HTTP 500 on
+#   every request, while /v1/models and /health keep returning 200. Nothing else
+#   differs from upstream; re-diff with the command in the patch's PROVENANCE.md.
+#   See patches.yml qwen38-reasoning-effort-template.
 #   The tool-call surface is UNCHANGED between the two (the same
 #   `<tool_call><function=…><parameter=…>` XML), which is why
 #   `--tool-call-parser qwen3_coder` still applies; and thinking is still
@@ -327,11 +336,28 @@ services:
       # subsequent boots reuse the compiled graphs.
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
-      # NO chat-template mount. This model serves its OWN chat_template.jinja
-      # from the model dir — see "Chat template" in the header for why the
-      # froggeric override that the qwen3.6/Tess composes carry is WRONG here.
+      # The only chat-template mount here is the model's OWN template plus the
+      # club-3090 `high` -> `medium` alias (below) — see "Chat template" in the
+      # header for why the froggeric override that the qwen3.6/Tess composes
+      # carry is WRONG here.
       # NVLink auto-detection — runs inside the container at boot.
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+      # Chat template: the model's OWN, plus seven lines mapping the standard
+      # OpenAI/Anthropic rung `high` onto `medium`. Qwen3.8's ladder is
+      # low/medium/xhigh with NO `high`, and the stock template
+      # raise_exception()s on anything else, so a client sending the standard top
+      # rung gets HTTP 500 while /v1/models still returns 200. Observed live via
+      # /v1/messages?beta=true.
+      # ⭐ MOUNTED OVER the checkpoint's own chat_template.jinja: vLLM auto-loads
+      # the template from the model dir, so this needs NO --chat-template arg
+      # (the same wiring style as the carnice override -- see patches.yml).
+      # That is deliberate, not incidental: upstream edits the args list
+      # constantly (11 commits touched these composes in the last 7 days), and
+      # every edit there collides with an inserted flag. The volumes block is
+      # quiet by comparison, so wiring here is what keeps this patch rebasable.
+      # DATA-ONLY mount, not an engine-code overlay, so the engine's overlay-free
+      # contract is unaffected. See patches.yml qwen38-reasoning-effort-template.
+      - ../../../patches/qwen38-reasoning-effort-template/chat_template.jinja:/root/.cache/huggingface/qwen3.8-27b-fp8/chat_template.jinja:ro
       # Vendored vllm#48375 (MambaManager drop_eagle_block) — SHARED from the
       # qwen3.6-27b tree (same Qwen3-Next hybrid family), exactly as the
       # Tess-4-27B compose shares it. Load-bearing because this compose ships
@@ -515,7 +541,6 @@ services:
       - --kv-cache-dtype
       - "${KV_CACHE_DTYPE:-fp8}"
       - --trust-remote-code
-      # No --chat-template: the model dir's own chat_template.jinja is used.
       - --reasoning-parser
       - qwen3
       # Stack-wide default: thinking OFF. On this model that ALSO suppresses the
@@ -541,8 +566,13 @@ services:
       # xhigh adds "think carefully, validate assumptions, consider alternatives"
       # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
       # you want the model un-nudged rather than pushed toward brevity.
-      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
-      # render (`high` included — it does NOT silently remap).
+      # ⚠️ Valid values are xhigh | medium | low, plus `high`, which THIS REPO
+      # maps onto MEDIUM via the patched chat template mounted above. Upstream
+      # Qwen has no `high` rung and its stock template RAISES on it; the mapping
+      # is the whole point of that mount. medium is the UN-NUDGED baseline (no
+      # branch, no injected preamble), deliberately NOT xhigh — a client sending
+      # the standard top rung gets the neutral setting, not the slowest one.
+      # Anything OUTSIDE that set still RAISES at template render (HTTP 400).
       - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       - --enable-auto-tool-choice
       # The 3.8 template emits the same <tool_call><function=…><parameter=…> XML

--- a/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
@@ -16,7 +16,8 @@
 #              Video cost ~72.7 tok/s @256x256 (36 tok/frame at default fps=2),
 #              scaling with pixel count: 23 @128px, 263 @512px, 583 @768px.
 #              So ~61 min of 256x256 video fits the 262144 window; ~17 min @512px.
-#   Template:  native — the repo's own chat_template.jinja. NOT froggeric.
+#   Template:  native + club-3090 alias — the model's own chat_template.jinja
+#              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #   Max ctx:   262144
 #   Genesis:   none
 #   Status:    🧪 Experimental
@@ -100,6 +101,22 @@ services:
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
       - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+      # Chat template: the model's OWN, plus seven lines mapping the standard
+      # OpenAI/Anthropic rung `high` onto `medium`. Qwen3.8's ladder is
+      # low/medium/xhigh with NO `high`, and the stock template
+      # raise_exception()s on anything else, so a client sending the standard top
+      # rung gets HTTP 500 while /v1/models still returns 200. Observed live via
+      # /v1/messages?beta=true.
+      # ⭐ MOUNTED OVER the checkpoint's own chat_template.jinja: vLLM auto-loads
+      # the template from the model dir, so this needs NO --chat-template arg
+      # (the same wiring style as the carnice override -- see patches.yml).
+      # That is deliberate, not incidental: upstream edits the args list
+      # constantly (11 commits touched these composes in the last 7 days), and
+      # every edit there collides with an inserted flag. The volumes block is
+      # quiet by comparison, so wiring here is what keeps this patch rebasable.
+      # DATA-ONLY mount, not an engine-code overlay, so the engine's overlay-free
+      # contract is unaffected. See patches.yml qwen38-reasoning-effort-template.
+      - ../../../patches/qwen38-reasoning-effort-template/chat_template.jinja:/root/.cache/huggingface/qwen3.8-27b-nvfp4/chat_template.jinja:ro
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
     environment:
@@ -252,8 +269,13 @@ services:
       # xhigh adds "think carefully, validate assumptions, consider alternatives"
       # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
       # you want the model un-nudged rather than pushed toward brevity.
-      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
-      # render (`high` included — it does NOT silently remap).
+      # ⚠️ Valid values are xhigh | medium | low, plus `high`, which THIS REPO
+      # maps onto MEDIUM via the patched chat template mounted above. Upstream
+      # Qwen has no `high` rung and its stock template RAISES on it; the mapping
+      # is the whole point of that mount. medium is the UN-NUDGED baseline (no
+      # branch, no injected preamble), deliberately NOT xhigh — a client sending
+      # the standard top rung gets the neutral setting, not the slowest one.
+      # Anything OUTSIDE that set still RAISES at template render (HTTP 400).
       - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching

--- a/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/dflash2-fp8.yml
@@ -8,7 +8,8 @@
 #   Drafter:   DFlash2 EXTERNAL block-drafter n=7 (syv-ai W4A16, method=dflash).
 #   KV:        fp8_e4m3 → FlashInfer (fp8 KV can't use FLASH_ATTN on Ampere).
 #   Vision:    ✅ tower present (input-only); untested on this tier.
-#   Template:  native.
+#   Template:  native + club-3090 alias — the model's own chat_template.jinja
+#              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #   Max ctx:   262144 (full arch max — fp8 KV is 2× smaller than bf16, so unlike the
 #              ultrafast/bf16 tier this fits the full 262K).
 #   Genesis:   none
@@ -67,6 +68,22 @@ services:
       # DFlash2DraftModel; refuses boot on apply failure.
       - ../../../patches/vllm-dflash2-backport:/etc/club3090/dflash2:ro
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+      # Chat template: the model's OWN, plus seven lines mapping the standard
+      # OpenAI/Anthropic rung `high` onto `medium`. Qwen3.8's ladder is
+      # low/medium/xhigh with NO `high`, and the stock template
+      # raise_exception()s on anything else, so a client sending the standard top
+      # rung gets HTTP 500 while /v1/models still returns 200. Observed live via
+      # /v1/messages?beta=true.
+      # ⭐ MOUNTED OVER the checkpoint's own chat_template.jinja: vLLM auto-loads
+      # the template from the model dir, so this needs NO --chat-template arg
+      # (the same wiring style as the carnice override -- see patches.yml).
+      # That is deliberate, not incidental: upstream edits the args list
+      # constantly (11 commits touched these composes in the last 7 days), and
+      # every edit there collides with an inserted flag. The volumes block is
+      # quiet by comparison, so wiring here is what keeps this patch rebasable.
+      # DATA-ONLY mount, not an engine-code overlay, so the engine's overlay-free
+      # contract is unaffected. See patches.yml qwen38-reasoning-effort-template.
+      - ../../../patches/qwen38-reasoning-effort-template/chat_template.jinja:/root/.cache/huggingface/qwen3.8-27b-autoround-int4/chat_template.jinja:ro
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
     environment:
@@ -227,8 +244,13 @@ services:
       # xhigh adds "think carefully, validate assumptions, consider alternatives"
       # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
       # you want the model un-nudged rather than pushed toward brevity.
-      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
-      # render (`high` included — it does NOT silently remap).
+      # ⚠️ Valid values are xhigh | medium | low, plus `high`, which THIS REPO
+      # maps onto MEDIUM via the patched chat template mounted above. Upstream
+      # Qwen has no `high` rung and its stock template RAISES on it; the mapping
+      # is the whole point of that mount. medium is the UN-NUDGED baseline (no
+      # branch, no injected preamble), deliberately NOT xhigh — a client sending
+      # the standard top rung gets the neutral setting, not the slowest one.
+      # Anything OUTSIDE that set still RAISES at template render (HTTP 400).
       - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching

--- a/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/dflash2.yml
@@ -13,7 +13,8 @@
 #   KV:        bf16 — MANDATORY (DFlash2 non-causal block attn needs FLASH_ATTN; on
 #              Ampere FLASH_ATTN takes bf16/fp16 KV only). num_kv_heads=4 divides evenly by 4, so KV splits per card.
 #   Vision:    ✅ tower present (input-only); untested.
-#   Template:  native — the repo's own chat_template.jinja.
+#   Template:  native + club-3090 alias — the model's own chat_template.jinja
+#              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #   Max ctx:   262144 (full arch max) — at TP=4 bf16 KV splits/frees enough that
 #              the full 262K fits (the dual's ~200K ceiling is a 2-card bf16 limit,
 #              not the tier's). UNMEASURED here (community-validated).
@@ -78,6 +79,22 @@ services:
       # DFlash2DraftModel; refuses boot on apply failure.
       - ../../../patches/vllm-dflash2-backport:/etc/club3090/dflash2:ro
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+      # Chat template: the model's OWN, plus seven lines mapping the standard
+      # OpenAI/Anthropic rung `high` onto `medium`. Qwen3.8's ladder is
+      # low/medium/xhigh with NO `high`, and the stock template
+      # raise_exception()s on anything else, so a client sending the standard top
+      # rung gets HTTP 500 while /v1/models still returns 200. Observed live via
+      # /v1/messages?beta=true.
+      # ⭐ MOUNTED OVER the checkpoint's own chat_template.jinja: vLLM auto-loads
+      # the template from the model dir, so this needs NO --chat-template arg
+      # (the same wiring style as the carnice override -- see patches.yml).
+      # That is deliberate, not incidental: upstream edits the args list
+      # constantly (11 commits touched these composes in the last 7 days), and
+      # every edit there collides with an inserted flag. The volumes block is
+      # quiet by comparison, so wiring here is what keeps this patch rebasable.
+      # DATA-ONLY mount, not an engine-code overlay, so the engine's overlay-free
+      # contract is unaffected. See patches.yml qwen38-reasoning-effort-template.
+      - ../../../patches/qwen38-reasoning-effort-template/chat_template.jinja:/root/.cache/huggingface/qwen3.8-27b-autoround-int4/chat_template.jinja:ro
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
     environment:
@@ -240,8 +257,13 @@ services:
       # xhigh adds "think carefully, validate assumptions, consider alternatives"
       # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
       # you want the model un-nudged rather than pushed toward brevity.
-      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
-      # render (`high` included — it does NOT silently remap).
+      # ⚠️ Valid values are xhigh | medium | low, plus `high`, which THIS REPO
+      # maps onto MEDIUM via the patched chat template mounted above. Upstream
+      # Qwen has no `high` rung and its stock template RAISES on it; the mapping
+      # is the whole point of that mount. medium is the UN-NUDGED baseline (no
+      # branch, no injected preamble), deliberately NOT xhigh — a client sending
+      # the standard top rung gets the neutral setting, not the slowest one.
+      # Anything OUTSIDE that set still RAISES at template render (HTTP 400).
       - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching

--- a/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
@@ -23,7 +23,8 @@
 #              Video cost ~72.7 tok/s @256x256 (36 tok/frame at default fps=2),
 #              scaling with pixel count: 23 @128px, 263 @512px, 583 @768px.
 #              So ~61 min of 256x256 video fits the 262144 window; ~17 min @512px.
-#   Template:  native — the repo's own chat_template.jinja. NOT froggeric.
+#   Template:  native + club-3090 alias — the model's own chat_template.jinja
+#              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #   Max ctx:   262144 — architectural ceiling, NOT measured on this checkpoint
 #   Genesis:   none
 #   Status:    🧪 Experimental
@@ -148,6 +149,22 @@ services:
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
       - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+      # Chat template: the model's OWN, plus seven lines mapping the standard
+      # OpenAI/Anthropic rung `high` onto `medium`. Qwen3.8's ladder is
+      # low/medium/xhigh with NO `high`, and the stock template
+      # raise_exception()s on anything else, so a client sending the standard top
+      # rung gets HTTP 500 while /v1/models still returns 200. Observed live via
+      # /v1/messages?beta=true.
+      # ⭐ MOUNTED OVER the checkpoint's own chat_template.jinja: vLLM auto-loads
+      # the template from the model dir, so this needs NO --chat-template arg
+      # (the same wiring style as the carnice override -- see patches.yml).
+      # That is deliberate, not incidental: upstream edits the args list
+      # constantly (11 commits touched these composes in the last 7 days), and
+      # every edit there collides with an inserted flag. The volumes block is
+      # quiet by comparison, so wiring here is what keeps this patch rebasable.
+      # DATA-ONLY mount, not an engine-code overlay, so the engine's overlay-free
+      # contract is unaffected. See patches.yml qwen38-reasoning-effort-template.
+      - ../../../patches/qwen38-reasoning-effort-template/chat_template.jinja:/root/.cache/huggingface/qwen3.8-27b-autoround-int4/chat_template.jinja:ro
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
     environment:
@@ -311,8 +328,13 @@ services:
       # xhigh adds "think carefully, validate assumptions, consider alternatives"
       # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
       # you want the model un-nudged rather than pushed toward brevity.
-      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
-      # render (`high` included — it does NOT silently remap).
+      # ⚠️ Valid values are xhigh | medium | low, plus `high`, which THIS REPO
+      # maps onto MEDIUM via the patched chat template mounted above. Upstream
+      # Qwen has no `high` rung and its stock template RAISES on it; the mapping
+      # is the whole point of that mount. medium is the UN-NUDGED baseline (no
+      # branch, no injected preamble), deliberately NOT xhigh — a client sending
+      # the standard top rung gets the neutral setting, not the slowest one.
+      # Anything OUTSIDE that set still RAISES at template render (HTTP 400).
       - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching

--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/dflash2-fp8.yml
@@ -13,7 +13,8 @@
 #              incoai/Qwen3.8-27B-DFlash2 drafter.)
 #   KV:        fp8_e4m3 → FlashInfer.
 #   Vision:    ✅ tower present (input-only, bf16); untested on this tier.
-#   Template:  native.
+#   Template:  native + club-3090 alias — the model's own chat_template.jinja
+#              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #   Max ctx:   262144 (fp8 KV fits the full arch max).
 #   Genesis:   none
 #   Status:    🧪 Experimental
@@ -48,10 +49,27 @@ services:
       # subsequent boots reuse the compiled graphs.
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
-      # NO chat-template mount — this model serves its OWN chat_template.jinja
-      # from the model dir. See the dual sibling's "Chat template" section.
+      # The only chat-template mount here is the model's OWN template plus the
+      # club-3090 `high` -> `medium` alias (below) — NOT froggeric. See the dual
+      # sibling's "Chat template" section.
       # NVLink auto-detection — runs inside the container at boot.
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+      # Chat template: the model's OWN, plus seven lines mapping the standard
+      # OpenAI/Anthropic rung `high` onto `medium`. Qwen3.8's ladder is
+      # low/medium/xhigh with NO `high`, and the stock template
+      # raise_exception()s on anything else, so a client sending the standard top
+      # rung gets HTTP 500 while /v1/models still returns 200. Observed live via
+      # /v1/messages?beta=true.
+      # ⭐ MOUNTED OVER the checkpoint's own chat_template.jinja: vLLM auto-loads
+      # the template from the model dir, so this needs NO --chat-template arg
+      # (the same wiring style as the carnice override -- see patches.yml).
+      # That is deliberate, not incidental: upstream edits the args list
+      # constantly (11 commits touched these composes in the last 7 days), and
+      # every edit there collides with an inserted flag. The volumes block is
+      # quiet by comparison, so wiring here is what keeps this patch rebasable.
+      # DATA-ONLY mount, not an engine-code overlay, so the engine's overlay-free
+      # contract is unaffected. See patches.yml qwen38-reasoning-effort-template.
+      - ../../../patches/qwen38-reasoning-effort-template/chat_template.jinja:/root/.cache/huggingface/qwen3.8-27b-fp8/chat_template.jinja:ro
       # Vendored vllm#48375 (MambaManager drop_eagle_block) — SHARED from the
       # qwen3.6-27b tree (same Qwen3-Next hybrid family). Load-bearing because
       # this compose ships BOTH MTP and prefix caching, the pair vllm#43559
@@ -236,7 +254,6 @@ services:
       - --kv-cache-dtype
       - "${KV_CACHE_DTYPE:-fp8_e4m3}"
       - --trust-remote-code
-      # No --chat-template: the model dir's own chat_template.jinja is used.
       - --reasoning-parser
       - qwen3
       # Stack-wide default: thinking OFF. On this model that ALSO suppresses the
@@ -259,8 +276,13 @@ services:
       # xhigh adds "think carefully, validate assumptions, consider alternatives"
       # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
       # you want the model un-nudged rather than pushed toward brevity.
-      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
-      # render (`high` included — it does NOT silently remap).
+      # ⚠️ Valid values are xhigh | medium | low, plus `high`, which THIS REPO
+      # maps onto MEDIUM via the patched chat template mounted above. Upstream
+      # Qwen has no `high` rung and its stock template RAISES on it; the mapping
+      # is the whole point of that mount. medium is the UN-NUDGED baseline (no
+      # branch, no injected preamble), deliberately NOT xhigh — a client sending
+      # the standard top rung gets the neutral setting, not the slowest one.
+      # Anything OUTSIDE that set still RAISES at template render (HTTP 400).
       - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       - --enable-auto-tool-choice
       - --tool-call-parser

--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/dflash2.yml
@@ -11,7 +11,8 @@
 #   KV:        bf16 → FLASH_ATTN (the DFlash2 non-causal drafter's preferred path;
 #              on Ampere FLASH_ATTN takes bf16/fp16 KV only — fp8 forces FlashInfer).
 #   Vision:    ✅ tower present (input-only, bf16); untested on this tier.
-#   Template:  native.
+#   Template:  native + club-3090 alias — the model's own chat_template.jinja
+#              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #   Max ctx:   131072 → higher at TP≥4 as weights split (MEASURED; community-validated).
 #   Genesis:   none
 #   Status:    🧪 Experimental
@@ -47,10 +48,27 @@ services:
       # subsequent boots reuse the compiled graphs.
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
-      # NO chat-template mount — this model serves its OWN chat_template.jinja
-      # from the model dir. See the dual sibling's "Chat template" section.
+      # The only chat-template mount here is the model's OWN template plus the
+      # club-3090 `high` -> `medium` alias (below) — NOT froggeric. See the dual
+      # sibling's "Chat template" section.
       # NVLink auto-detection — runs inside the container at boot.
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+      # Chat template: the model's OWN, plus seven lines mapping the standard
+      # OpenAI/Anthropic rung `high` onto `medium`. Qwen3.8's ladder is
+      # low/medium/xhigh with NO `high`, and the stock template
+      # raise_exception()s on anything else, so a client sending the standard top
+      # rung gets HTTP 500 while /v1/models still returns 200. Observed live via
+      # /v1/messages?beta=true.
+      # ⭐ MOUNTED OVER the checkpoint's own chat_template.jinja: vLLM auto-loads
+      # the template from the model dir, so this needs NO --chat-template arg
+      # (the same wiring style as the carnice override -- see patches.yml).
+      # That is deliberate, not incidental: upstream edits the args list
+      # constantly (11 commits touched these composes in the last 7 days), and
+      # every edit there collides with an inserted flag. The volumes block is
+      # quiet by comparison, so wiring here is what keeps this patch rebasable.
+      # DATA-ONLY mount, not an engine-code overlay, so the engine's overlay-free
+      # contract is unaffected. See patches.yml qwen38-reasoning-effort-template.
+      - ../../../patches/qwen38-reasoning-effort-template/chat_template.jinja:/root/.cache/huggingface/qwen3.8-27b-fp8/chat_template.jinja:ro
       # Vendored vllm#48375 (MambaManager drop_eagle_block) — SHARED from the
       # qwen3.6-27b tree (same Qwen3-Next hybrid family). Load-bearing because
       # this compose ships BOTH MTP and prefix caching, the pair vllm#43559
@@ -237,7 +255,6 @@ services:
       - --attention-backend
       - "${ATTN_BACKEND:-FLASH_ATTN}"
       - --trust-remote-code
-      # No --chat-template: the model dir's own chat_template.jinja is used.
       - --reasoning-parser
       - qwen3
       # Stack-wide default: thinking OFF. On this model that ALSO suppresses the
@@ -260,8 +277,13 @@ services:
       # xhigh adds "think carefully, validate assumptions, consider alternatives"
       # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
       # you want the model un-nudged rather than pushed toward brevity.
-      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
-      # render (`high` included — it does NOT silently remap).
+      # ⚠️ Valid values are xhigh | medium | low, plus `high`, which THIS REPO
+      # maps onto MEDIUM via the patched chat template mounted above. Upstream
+      # Qwen has no `high` rung and its stock template RAISES on it; the mapping
+      # is the whole point of that mount. medium is the UN-NUDGED baseline (no
+      # branch, no injected preamble), deliberately NOT xhigh — a client sending
+      # the standard top rung gets the neutral setting, not the slowest one.
+      # Anything OUTSIDE that set still RAISES at template render (HTTP 400).
       - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       - --enable-auto-tool-choice
       - --tool-call-parser

--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
@@ -28,7 +28,8 @@
 #              Video cost ~72.7 tok/s @256x256 (36 tok/frame at default fps=2),
 #              scaling with pixel count: 23 @128px, 263 @512px, 583 @768px.
 #              So ~61 min of 256x256 video fits the 262144 window; ~17 min @512px.
-#   Template:  native — the repo's own chat_template.jinja. NOT froggeric.
+#   Template:  native + club-3090 alias — the model's own chat_template.jinja
+#              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #              See the dual sibling's "Chat template" section for the full diff.
 #   Max ctx:   262144 — the architectural ceiling. COMPUTED + inherited, never
 #              measured on this model at ANY topology.
@@ -221,10 +222,27 @@ services:
       # subsequent boots reuse the compiled graphs.
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
-      # NO chat-template mount — this model serves its OWN chat_template.jinja
-      # from the model dir. See the dual sibling's "Chat template" section.
+      # The only chat-template mount here is the model's OWN template plus the
+      # club-3090 `high` -> `medium` alias (below) — NOT froggeric. See the dual
+      # sibling's "Chat template" section.
       # NVLink auto-detection — runs inside the container at boot.
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+      # Chat template: the model's OWN, plus seven lines mapping the standard
+      # OpenAI/Anthropic rung `high` onto `medium`. Qwen3.8's ladder is
+      # low/medium/xhigh with NO `high`, and the stock template
+      # raise_exception()s on anything else, so a client sending the standard top
+      # rung gets HTTP 500 while /v1/models still returns 200. Observed live via
+      # /v1/messages?beta=true.
+      # ⭐ MOUNTED OVER the checkpoint's own chat_template.jinja: vLLM auto-loads
+      # the template from the model dir, so this needs NO --chat-template arg
+      # (the same wiring style as the carnice override -- see patches.yml).
+      # That is deliberate, not incidental: upstream edits the args list
+      # constantly (11 commits touched these composes in the last 7 days), and
+      # every edit there collides with an inserted flag. The volumes block is
+      # quiet by comparison, so wiring here is what keeps this patch rebasable.
+      # DATA-ONLY mount, not an engine-code overlay, so the engine's overlay-free
+      # contract is unaffected. See patches.yml qwen38-reasoning-effort-template.
+      - ../../../patches/qwen38-reasoning-effort-template/chat_template.jinja:/root/.cache/huggingface/qwen3.8-27b-fp8/chat_template.jinja:ro
       # Vendored vllm#48375 (MambaManager drop_eagle_block) — SHARED from the
       # qwen3.6-27b tree (same Qwen3-Next hybrid family). Load-bearing because
       # this compose ships BOTH MTP and prefix caching, the pair vllm#43559
@@ -405,7 +423,6 @@ services:
       - --kv-cache-dtype
       - "${KV_CACHE_DTYPE:-auto}"
       - --trust-remote-code
-      # No --chat-template: the model dir's own chat_template.jinja is used.
       - --reasoning-parser
       - qwen3
       # Stack-wide default: thinking OFF. On this model that ALSO suppresses the
@@ -428,8 +445,13 @@ services:
       # xhigh adds "think carefully, validate assumptions, consider alternatives"
       # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
       # you want the model un-nudged rather than pushed toward brevity.
-      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
-      # render (`high` included — it does NOT silently remap).
+      # ⚠️ Valid values are xhigh | medium | low, plus `high`, which THIS REPO
+      # maps onto MEDIUM via the patched chat template mounted above. Upstream
+      # Qwen has no `high` rung and its stock template RAISES on it; the mapping
+      # is the whole point of that mount. medium is the UN-NUDGED baseline (no
+      # branch, no injected preamble), deliberately NOT xhigh — a client sending
+      # the standard top rung gets the neutral setting, not the slowest one.
+      # Anything OUTSIDE that set still RAISES at template render (HTTP 400).
       - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       - --enable-auto-tool-choice
       - --tool-call-parser

--- a/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/dflash2-fp8.yml
@@ -8,7 +8,8 @@
 #   Drafter:   DFlash2 EXTERNAL block-drafter n=7 (syv-ai W4A16, method=dflash).
 #   KV:        fp8_e4m3 → FlashInfer (fp8 KV can't use FLASH_ATTN on Ampere).
 #   Vision:    ✅ tower present (input-only); untested on this tier.
-#   Template:  native.
+#   Template:  native + club-3090 alias — the model's own chat_template.jinja
+#              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #   Max ctx:   262144 (full arch max — fp8 KV is 2× smaller than bf16, so unlike the
 #              ultrafast/bf16 tier this fits the full 262K).
 #   Genesis:   none
@@ -67,6 +68,22 @@ services:
       # DFlash2DraftModel; refuses boot on apply failure.
       - ../../../patches/vllm-dflash2-backport:/etc/club3090/dflash2:ro
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+      # Chat template: the model's OWN, plus seven lines mapping the standard
+      # OpenAI/Anthropic rung `high` onto `medium`. Qwen3.8's ladder is
+      # low/medium/xhigh with NO `high`, and the stock template
+      # raise_exception()s on anything else, so a client sending the standard top
+      # rung gets HTTP 500 while /v1/models still returns 200. Observed live via
+      # /v1/messages?beta=true.
+      # ⭐ MOUNTED OVER the checkpoint's own chat_template.jinja: vLLM auto-loads
+      # the template from the model dir, so this needs NO --chat-template arg
+      # (the same wiring style as the carnice override -- see patches.yml).
+      # That is deliberate, not incidental: upstream edits the args list
+      # constantly (11 commits touched these composes in the last 7 days), and
+      # every edit there collides with an inserted flag. The volumes block is
+      # quiet by comparison, so wiring here is what keeps this patch rebasable.
+      # DATA-ONLY mount, not an engine-code overlay, so the engine's overlay-free
+      # contract is unaffected. See patches.yml qwen38-reasoning-effort-template.
+      - ../../../patches/qwen38-reasoning-effort-template/chat_template.jinja:/root/.cache/huggingface/qwen3.8-27b-autoround-int4/chat_template.jinja:ro
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
     environment:
@@ -227,8 +244,13 @@ services:
       # xhigh adds "think carefully, validate assumptions, consider alternatives"
       # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
       # you want the model un-nudged rather than pushed toward brevity.
-      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
-      # render (`high` included — it does NOT silently remap).
+      # ⚠️ Valid values are xhigh | medium | low, plus `high`, which THIS REPO
+      # maps onto MEDIUM via the patched chat template mounted above. Upstream
+      # Qwen has no `high` rung and its stock template RAISES on it; the mapping
+      # is the whole point of that mount. medium is the UN-NUDGED baseline (no
+      # branch, no injected preamble), deliberately NOT xhigh — a client sending
+      # the standard top rung gets the neutral setting, not the slowest one.
+      # Anything OUTSIDE that set still RAISES at template render (HTTP 400).
       - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching

--- a/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/dflash2.yml
@@ -14,7 +14,8 @@
 #              Ampere FLASH_ATTN takes bf16/fp16 KV only). num_kv_heads=4 does NOT divide by 8 -> KV heads REPLICATE, so
 #              per-card KV stays ~the TP=4 figure; only weights take the full split.
 #   Vision:    ✅ tower present (input-only); untested.
-#   Template:  native — the repo's own chat_template.jinja.
+#   Template:  native + club-3090 alias — the model's own chat_template.jinja
+#              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #   Max ctx:   262144 (full arch max) — at TP=8 bf16 KV splits/frees enough that
 #              the full 262K fits (the dual's ~200K ceiling is a 2-card bf16 limit,
 #              not the tier's). UNMEASURED here (community-validated).
@@ -79,6 +80,22 @@ services:
       # DFlash2DraftModel; refuses boot on apply failure.
       - ../../../patches/vllm-dflash2-backport:/etc/club3090/dflash2:ro
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+      # Chat template: the model's OWN, plus seven lines mapping the standard
+      # OpenAI/Anthropic rung `high` onto `medium`. Qwen3.8's ladder is
+      # low/medium/xhigh with NO `high`, and the stock template
+      # raise_exception()s on anything else, so a client sending the standard top
+      # rung gets HTTP 500 while /v1/models still returns 200. Observed live via
+      # /v1/messages?beta=true.
+      # ⭐ MOUNTED OVER the checkpoint's own chat_template.jinja: vLLM auto-loads
+      # the template from the model dir, so this needs NO --chat-template arg
+      # (the same wiring style as the carnice override -- see patches.yml).
+      # That is deliberate, not incidental: upstream edits the args list
+      # constantly (11 commits touched these composes in the last 7 days), and
+      # every edit there collides with an inserted flag. The volumes block is
+      # quiet by comparison, so wiring here is what keeps this patch rebasable.
+      # DATA-ONLY mount, not an engine-code overlay, so the engine's overlay-free
+      # contract is unaffected. See patches.yml qwen38-reasoning-effort-template.
+      - ../../../patches/qwen38-reasoning-effort-template/chat_template.jinja:/root/.cache/huggingface/qwen3.8-27b-autoround-int4/chat_template.jinja:ro
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
     environment:
@@ -241,8 +258,13 @@ services:
       # xhigh adds "think carefully, validate assumptions, consider alternatives"
       # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
       # you want the model un-nudged rather than pushed toward brevity.
-      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
-      # render (`high` included — it does NOT silently remap).
+      # ⚠️ Valid values are xhigh | medium | low, plus `high`, which THIS REPO
+      # maps onto MEDIUM via the patched chat template mounted above. Upstream
+      # Qwen has no `high` rung and its stock template RAISES on it; the mapping
+      # is the whole point of that mount. medium is the UN-NUDGED baseline (no
+      # branch, no injected preamble), deliberately NOT xhigh — a client sending
+      # the standard top rung gets the neutral setting, not the slowest one.
+      # Anything OUTSIDE that set still RAISES at template render (HTTP 400).
       - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching

--- a/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
@@ -23,7 +23,8 @@
 #              Video cost ~72.7 tok/s @256x256 (36 tok/frame at default fps=2),
 #              scaling with pixel count: 23 @128px, 263 @512px, 583 @768px.
 #              So ~61 min of 256x256 video fits the 262144 window; ~17 min @512px.
-#   Template:  native — the repo's own chat_template.jinja. NOT froggeric.
+#   Template:  native + club-3090 alias — the model's own chat_template.jinja
+#              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #   Max ctx:   262144 — architectural ceiling, NOT measured on this checkpoint
 #   Genesis:   none
 #   Status:    🧪 Experimental
@@ -148,6 +149,22 @@ services:
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
       - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+      # Chat template: the model's OWN, plus seven lines mapping the standard
+      # OpenAI/Anthropic rung `high` onto `medium`. Qwen3.8's ladder is
+      # low/medium/xhigh with NO `high`, and the stock template
+      # raise_exception()s on anything else, so a client sending the standard top
+      # rung gets HTTP 500 while /v1/models still returns 200. Observed live via
+      # /v1/messages?beta=true.
+      # ⭐ MOUNTED OVER the checkpoint's own chat_template.jinja: vLLM auto-loads
+      # the template from the model dir, so this needs NO --chat-template arg
+      # (the same wiring style as the carnice override -- see patches.yml).
+      # That is deliberate, not incidental: upstream edits the args list
+      # constantly (11 commits touched these composes in the last 7 days), and
+      # every edit there collides with an inserted flag. The volumes block is
+      # quiet by comparison, so wiring here is what keeps this patch rebasable.
+      # DATA-ONLY mount, not an engine-code overlay, so the engine's overlay-free
+      # contract is unaffected. See patches.yml qwen38-reasoning-effort-template.
+      - ../../../patches/qwen38-reasoning-effort-template/chat_template.jinja:/root/.cache/huggingface/qwen3.8-27b-autoround-int4/chat_template.jinja:ro
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
     environment:
@@ -311,8 +328,13 @@ services:
       # xhigh adds "think carefully, validate assumptions, consider alternatives"
       # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
       # you want the model un-nudged rather than pushed toward brevity.
-      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
-      # render (`high` included — it does NOT silently remap).
+      # ⚠️ Valid values are xhigh | medium | low, plus `high`, which THIS REPO
+      # maps onto MEDIUM via the patched chat template mounted above. Upstream
+      # Qwen has no `high` rung and its stock template RAISES on it; the mapping
+      # is the whole point of that mount. medium is the UN-NUDGED baseline (no
+      # branch, no injected preamble), deliberately NOT xhigh — a client sending
+      # the standard top rung gets the neutral setting, not the slowest one.
+      # Anything OUTSIDE that set still RAISES at template render (HTTP 400).
       - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/dflash2-fp8.yml
@@ -13,7 +13,8 @@
 #              incoai/Qwen3.8-27B-DFlash2 drafter.)
 #   KV:        fp8_e4m3 → FlashInfer.
 #   Vision:    ✅ tower present (input-only, bf16); untested on this tier.
-#   Template:  native.
+#   Template:  native + club-3090 alias — the model's own chat_template.jinja
+#              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #   Max ctx:   262144 (fp8 KV fits the full arch max).
 #   Genesis:   none
 #   Status:    🧪 Experimental
@@ -48,10 +49,27 @@ services:
       # subsequent boots reuse the compiled graphs.
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
-      # NO chat-template mount — this model serves its OWN chat_template.jinja
-      # from the model dir. See the dual sibling's "Chat template" section.
+      # The only chat-template mount here is the model's OWN template plus the
+      # club-3090 `high` -> `medium` alias (below) — NOT froggeric. See the dual
+      # sibling's "Chat template" section.
       # NVLink auto-detection — runs inside the container at boot.
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+      # Chat template: the model's OWN, plus seven lines mapping the standard
+      # OpenAI/Anthropic rung `high` onto `medium`. Qwen3.8's ladder is
+      # low/medium/xhigh with NO `high`, and the stock template
+      # raise_exception()s on anything else, so a client sending the standard top
+      # rung gets HTTP 500 while /v1/models still returns 200. Observed live via
+      # /v1/messages?beta=true.
+      # ⭐ MOUNTED OVER the checkpoint's own chat_template.jinja: vLLM auto-loads
+      # the template from the model dir, so this needs NO --chat-template arg
+      # (the same wiring style as the carnice override -- see patches.yml).
+      # That is deliberate, not incidental: upstream edits the args list
+      # constantly (11 commits touched these composes in the last 7 days), and
+      # every edit there collides with an inserted flag. The volumes block is
+      # quiet by comparison, so wiring here is what keeps this patch rebasable.
+      # DATA-ONLY mount, not an engine-code overlay, so the engine's overlay-free
+      # contract is unaffected. See patches.yml qwen38-reasoning-effort-template.
+      - ../../../patches/qwen38-reasoning-effort-template/chat_template.jinja:/root/.cache/huggingface/qwen3.8-27b-fp8/chat_template.jinja:ro
       # Vendored vllm#48375 (MambaManager drop_eagle_block) — SHARED from the
       # qwen3.6-27b tree (same Qwen3-Next hybrid family). Load-bearing because
       # this compose ships BOTH MTP and prefix caching, the pair vllm#43559
@@ -250,7 +268,6 @@ services:
       - --kv-cache-dtype
       - "${KV_CACHE_DTYPE:-fp8_e4m3}"
       - --trust-remote-code
-      # No --chat-template: the model dir's own chat_template.jinja is used.
       - --reasoning-parser
       - qwen3
       # Stack-wide default: thinking OFF. On this model that ALSO suppresses the
@@ -273,8 +290,13 @@ services:
       # xhigh adds "think carefully, validate assumptions, consider alternatives"
       # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
       # you want the model un-nudged rather than pushed toward brevity.
-      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
-      # render (`high` included — it does NOT silently remap).
+      # ⚠️ Valid values are xhigh | medium | low, plus `high`, which THIS REPO
+      # maps onto MEDIUM via the patched chat template mounted above. Upstream
+      # Qwen has no `high` rung and its stock template RAISES on it; the mapping
+      # is the whole point of that mount. medium is the UN-NUDGED baseline (no
+      # branch, no injected preamble), deliberately NOT xhigh — a client sending
+      # the standard top rung gets the neutral setting, not the slowest one.
+      # Anything OUTSIDE that set still RAISES at template render (HTTP 400).
       - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       - --enable-auto-tool-choice
       - --tool-call-parser

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/dflash2.yml
@@ -11,7 +11,8 @@
 #   KV:        bf16 → FLASH_ATTN (the DFlash2 non-causal drafter's preferred path;
 #              on Ampere FLASH_ATTN takes bf16/fp16 KV only — fp8 forces FlashInfer).
 #   Vision:    ✅ tower present (input-only, bf16); untested on this tier.
-#   Template:  native.
+#   Template:  native + club-3090 alias — the model's own chat_template.jinja
+#              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #   Max ctx:   131072 → higher at TP≥4 as weights split (MEASURED; community-validated).
 #   Genesis:   none
 #   Status:    🧪 Experimental
@@ -47,10 +48,27 @@ services:
       # subsequent boots reuse the compiled graphs.
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
-      # NO chat-template mount — this model serves its OWN chat_template.jinja
-      # from the model dir. See the dual sibling's "Chat template" section.
+      # The only chat-template mount here is the model's OWN template plus the
+      # club-3090 `high` -> `medium` alias (below) — NOT froggeric. See the dual
+      # sibling's "Chat template" section.
       # NVLink auto-detection — runs inside the container at boot.
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+      # Chat template: the model's OWN, plus seven lines mapping the standard
+      # OpenAI/Anthropic rung `high` onto `medium`. Qwen3.8's ladder is
+      # low/medium/xhigh with NO `high`, and the stock template
+      # raise_exception()s on anything else, so a client sending the standard top
+      # rung gets HTTP 500 while /v1/models still returns 200. Observed live via
+      # /v1/messages?beta=true.
+      # ⭐ MOUNTED OVER the checkpoint's own chat_template.jinja: vLLM auto-loads
+      # the template from the model dir, so this needs NO --chat-template arg
+      # (the same wiring style as the carnice override -- see patches.yml).
+      # That is deliberate, not incidental: upstream edits the args list
+      # constantly (11 commits touched these composes in the last 7 days), and
+      # every edit there collides with an inserted flag. The volumes block is
+      # quiet by comparison, so wiring here is what keeps this patch rebasable.
+      # DATA-ONLY mount, not an engine-code overlay, so the engine's overlay-free
+      # contract is unaffected. See patches.yml qwen38-reasoning-effort-template.
+      - ../../../patches/qwen38-reasoning-effort-template/chat_template.jinja:/root/.cache/huggingface/qwen3.8-27b-fp8/chat_template.jinja:ro
       # Vendored vllm#48375 (MambaManager drop_eagle_block) — SHARED from the
       # qwen3.6-27b tree (same Qwen3-Next hybrid family). Load-bearing because
       # this compose ships BOTH MTP and prefix caching, the pair vllm#43559
@@ -251,7 +269,6 @@ services:
       - --attention-backend
       - "${ATTN_BACKEND:-FLASH_ATTN}"
       - --trust-remote-code
-      # No --chat-template: the model dir's own chat_template.jinja is used.
       - --reasoning-parser
       - qwen3
       # Stack-wide default: thinking OFF. On this model that ALSO suppresses the
@@ -274,8 +291,13 @@ services:
       # xhigh adds "think carefully, validate assumptions, consider alternatives"
       # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
       # you want the model un-nudged rather than pushed toward brevity.
-      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
-      # render (`high` included — it does NOT silently remap).
+      # ⚠️ Valid values are xhigh | medium | low, plus `high`, which THIS REPO
+      # maps onto MEDIUM via the patched chat template mounted above. Upstream
+      # Qwen has no `high` rung and its stock template RAISES on it; the mapping
+      # is the whole point of that mount. medium is the UN-NUDGED baseline (no
+      # branch, no injected preamble), deliberately NOT xhigh — a client sending
+      # the standard top rung gets the neutral setting, not the slowest one.
+      # Anything OUTSIDE that set still RAISES at template render (HTTP 400).
       - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       - --enable-auto-tool-choice
       - --tool-call-parser

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
@@ -30,7 +30,8 @@
 #              Video cost ~72.7 tok/s @256x256 (36 tok/frame at default fps=2),
 #              scaling with pixel count: 23 @128px, 263 @512px, 583 @768px.
 #              So ~61 min of 256x256 video fits the 262144 window; ~17 min @512px.
-#   Template:  native — the repo's own chat_template.jinja. NOT froggeric.
+#   Template:  native + club-3090 alias — the model's own chat_template.jinja
+#              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #              See the dual sibling's "Chat template" section for the full diff.
 #   Max ctx:   262144 — the architectural ceiling. COMPUTED + inherited, never
 #              measured on this model at ANY topology.
@@ -225,10 +226,27 @@ services:
       # subsequent boots reuse the compiled graphs.
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
-      # NO chat-template mount — this model serves its OWN chat_template.jinja
-      # from the model dir. See the dual sibling's "Chat template" section.
+      # The only chat-template mount here is the model's OWN template plus the
+      # club-3090 `high` -> `medium` alias (below) — NOT froggeric. See the dual
+      # sibling's "Chat template" section.
       # NVLink auto-detection — runs inside the container at boot.
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+      # Chat template: the model's OWN, plus seven lines mapping the standard
+      # OpenAI/Anthropic rung `high` onto `medium`. Qwen3.8's ladder is
+      # low/medium/xhigh with NO `high`, and the stock template
+      # raise_exception()s on anything else, so a client sending the standard top
+      # rung gets HTTP 500 while /v1/models still returns 200. Observed live via
+      # /v1/messages?beta=true.
+      # ⭐ MOUNTED OVER the checkpoint's own chat_template.jinja: vLLM auto-loads
+      # the template from the model dir, so this needs NO --chat-template arg
+      # (the same wiring style as the carnice override -- see patches.yml).
+      # That is deliberate, not incidental: upstream edits the args list
+      # constantly (11 commits touched these composes in the last 7 days), and
+      # every edit there collides with an inserted flag. The volumes block is
+      # quiet by comparison, so wiring here is what keeps this patch rebasable.
+      # DATA-ONLY mount, not an engine-code overlay, so the engine's overlay-free
+      # contract is unaffected. See patches.yml qwen38-reasoning-effort-template.
+      - ../../../patches/qwen38-reasoning-effort-template/chat_template.jinja:/root/.cache/huggingface/qwen3.8-27b-fp8/chat_template.jinja:ro
       # Vendored vllm#48375 (MambaManager drop_eagle_block) — SHARED from the
       # qwen3.6-27b tree (same Qwen3-Next hybrid family). Load-bearing because
       # this compose ships BOTH MTP and prefix caching, the pair vllm#43559
@@ -423,7 +441,6 @@ services:
       - --kv-cache-dtype
       - "${KV_CACHE_DTYPE:-auto}"
       - --trust-remote-code
-      # No --chat-template: the model dir's own chat_template.jinja is used.
       - --reasoning-parser
       - qwen3
       # Stack-wide default: thinking OFF. On this model that ALSO suppresses the
@@ -446,8 +463,13 @@ services:
       # xhigh adds "think carefully, validate assumptions, consider alternatives"
       # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
       # you want the model un-nudged rather than pushed toward brevity.
-      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
-      # render (`high` included — it does NOT silently remap).
+      # ⚠️ Valid values are xhigh | medium | low, plus `high`, which THIS REPO
+      # maps onto MEDIUM via the patched chat template mounted above. Upstream
+      # Qwen has no `high` rung and its stock template RAISES on it; the mapping
+      # is the whole point of that mount. medium is the UN-NUDGED baseline (no
+      # branch, no injected preamble), deliberately NOT xhigh — a client sending
+      # the standard top rung gets the neutral setting, not the slowest one.
+      # Anything OUTSIDE that set still RAISES at template render (HTTP 400).
       - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       - --enable-auto-tool-choice
       - --tool-call-parser

--- a/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
@@ -16,7 +16,8 @@
 #              Video cost ~72.7 tok/s @256x256 (36 tok/frame at default fps=2),
 #              scaling with pixel count: 23 @128px, 263 @512px, 583 @768px.
 #              So ~61 min of 256x256 video fits the 262144 window; ~17 min @512px.
-#   Template:  native — the repo's own chat_template.jinja. NOT froggeric.
+#   Template:  native + club-3090 alias — the model's own chat_template.jinja
+#              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #   Max ctx:   65536 — NOT the architectural ceiling; see the VRAM note
 #   Genesis:   none
 #   Status:    🧪 Experimental
@@ -121,6 +122,22 @@ services:
       - ../../../../../qwen3.6-27b/vllm/patches/vllm-gdn-mtp-async-spec-order:/etc/club3090/gdn-async-order:ro
       - ../../../patches/vllm-flashinfer-decode-pin:/etc/club3090/flashinfer-decode-pin:ro
       - ../../../../../../scripts/detect_nvlink.sh:/etc/club3090/detect_nvlink.sh:ro
+      # Chat template: the model's OWN, plus seven lines mapping the standard
+      # OpenAI/Anthropic rung `high` onto `medium`. Qwen3.8's ladder is
+      # low/medium/xhigh with NO `high`, and the stock template
+      # raise_exception()s on anything else, so a client sending the standard top
+      # rung gets HTTP 500 while /v1/models still returns 200. Observed live via
+      # /v1/messages?beta=true.
+      # ⭐ MOUNTED OVER the checkpoint's own chat_template.jinja: vLLM auto-loads
+      # the template from the model dir, so this needs NO --chat-template arg
+      # (the same wiring style as the carnice override -- see patches.yml).
+      # That is deliberate, not incidental: upstream edits the args list
+      # constantly (11 commits touched these composes in the last 7 days), and
+      # every edit there collides with an inserted flag. The volumes block is
+      # quiet by comparison, so wiring here is what keeps this patch rebasable.
+      # DATA-ONLY mount, not an engine-code overlay, so the engine's overlay-free
+      # contract is unaffected. See patches.yml qwen38-reasoning-effort-template.
+      - ../../../patches/qwen38-reasoning-effort-template/chat_template.jinja:/root/.cache/huggingface/qwen3.8-27b-nvfp4/chat_template.jinja:ro
       - ../../../cache/torch_compile:/root/.cache/vllm/torch_compile_cache
       - ../../../cache/triton:/root/.triton/cache
     environment:
@@ -273,8 +290,13 @@ services:
       # xhigh adds "think carefully, validate assumptions, consider alternatives"
       # which is what makes it slow and timeout-prone. REASONING_EFFORT=medium if
       # you want the model un-nudged rather than pushed toward brevity.
-      # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
-      # render (`high` included — it does NOT silently remap).
+      # ⚠️ Valid values are xhigh | medium | low, plus `high`, which THIS REPO
+      # maps onto MEDIUM via the patched chat template mounted above. Upstream
+      # Qwen has no `high` rung and its stock template RAISES on it; the mapping
+      # is the whole point of that mount. medium is the UN-NUDGED baseline (no
+      # branch, no injected preamble), deliberately NOT xhigh — a client sending
+      # the standard top rung gets the neutral setting, not the slowest one.
+      # Anything OUTSIDE that set still RAISES at template render (HTTP 400).
       - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching

--- a/models/qwen3.8-27b/vllm/patches/qwen38-reasoning-effort-template/PROVENANCE.md
+++ b/models/qwen3.8-27b/vllm/patches/qwen38-reasoning-effort-template/PROVENANCE.md
@@ -1,0 +1,91 @@
+# qwen38-reasoning-effort-template
+
+Vendored copy of Qwen3.8-27B's own `chat_template.jinja` with a **single semantic
+change**: `reasoning_effort: "high"` is mapped onto `medium` instead of raising.
+
+## The defect
+
+Qwen3.8 renamed the conventional top reasoning rung. Its ladder is:
+
+    low  <  medium  <  xhigh        (xhigh is also the default)
+
+There is no `high`. The stock template hard-rejects anything else:
+
+```jinja
+{%- if resolved_reasoning_effort not in ('xhigh', 'medium', 'low') %}
+    {{- raise_exception('Unexpected reasoning effort ...') }}
+```
+
+Both OpenAI and Anthropic use `low` / `medium` / `high`, so a generic client sending
+the standard top rung gets a Jinja `TemplateError` surfaced as **HTTP 500**.
+
+The failure is silent in the worst way: `/v1/models` and `/health` both return 200
+and the model is demonstrably serving, so the endpoint looks healthy while every
+thinking-mode chat request fails. Observed on the reference rig against vLLM's
+Anthropic-compatible `POST /v1/messages?beta=true` — the surface a drop-in
+Claude-API client talks to.
+
+## Scope: all twenty vLLM slugs, one identical template
+
+The template is **byte-identical across every served Qwen3.8 checkpoint** — official
+FP8, the AutoRound INT4 repack, and the NVFP4 export all ship the same 8,952-byte file
+(sha256 `c3cf9e34abf4f9e36c2d72165aa9c132d3e2a725b6c2586aaa3a8af9d7a81041`). Verified
+by fetching each and comparing:
+
+```bash
+for r in Qwen/Qwen3.8-27B-FP8 Frozenlock/Qwen3.8-27B-int4-AutoRound RadixArk/Qwen3.8-27B-NVFP4; do
+  curl -sL "https://huggingface.co/$r/resolve/main/chat_template.jinja" | sha256sum
+done
+```
+
+So one vendored file is correct for every slug, and the quantiser is irrelevant.
+
+**Re-verified 2026-08-21**, on two counts:
+
+| checkpoint | `chat_template.jinja` sha256 | |
+|---|---|---|
+| `Qwen/Qwen3.8-27B-FP8` | `c3cf9e34…81041` | served |
+| `Frozenlock/Qwen3.8-27B-int4-AutoRound` | `c3cf9e34…81041` | served (post-#1070 swap) |
+| `RadixArk/Qwen3.8-27B-NVFP4` | `c3cf9e34…81041` | served |
+| `syvai/Qwen3.8-27B-DFlash2-W4A16` | `f36668dd…ba59` | **drafter — never the render source** |
+
+1. #1070 swapped the FAST tier's weights Avuja → Frozenlock, which would normally
+   invalidate this file's provenance. It does not: the hash is unchanged, so the
+   vendored copy is still the correct base.
+2. #1072 added the DFlash2 super/ultra tiers, taking the slug count 8 → 20. The
+   DFlash2 *drafter* repo ships a different template, but vLLM renders from the
+   **served** model's tokenizer, so that file is deliberately not vendored.
+
+## The change
+
+Seven lines inserted before the validation. `high` maps to **`medium`**, the
+un-nudged baseline — the rung with no template branch and no injected preamble.
+
+`xhigh` was the other candidate, and it is the wrong one here. It is Qwen3.8's
+top rung, so it looks like the intent-preserving choice for a caller asking for
+the standard top rung — but it injects a "think carefully, validate assumptions,
+consider alternatives" system preamble that is slow and timeout-prone, and a
+Claude-API client sends `high` on **every** request. Mapping to the top rung
+would therefore put all agent traffic into the slowest reasoning mode by
+default, on slugs that ship `max_num_seqs=1`. medium keeps the request served
+and un-nudged; a caller who genuinely wants the deep mode can still ask for
+`xhigh` by name.
+
+Everything else is byte-identical to upstream.
+
+Regenerate the diff at any time:
+
+```bash
+diff models-cache/qwen3.8-27b-fp8/chat_template.jinja \
+     models/qwen3.8-27b/vllm/patches/qwen38-reasoning-effort-template/chat_template.jinja
+```
+
+## Drop when
+
+Upstream Qwen accepts `high` as an alias (costs them nothing), **or** vLLM's
+Anthropic router stops forwarding a `high` it cannot know is unsupported. Re-vendor
+from the model dir if Qwen ships a corrected template, and re-run the drift guard.
+
+Source: `Qwen/Qwen3.8-27B-FP8` @ `chat_template.jinja`, fetched 2026-08-16,
+re-diffed against the live upstream file 2026-08-21 — the only difference is the
+seven-line alias block at lines 48–54.

--- a/models/qwen3.8-27b/vllm/patches/qwen38-reasoning-effort-template/chat_template.jinja
+++ b/models/qwen3.8-27b/vllm/patches/qwen38-reasoning-effort-template/chat_template.jinja
@@ -1,0 +1,177 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- set reasoning_instructions = '' %}
+{%- if enable_thinking is undefined or enable_thinking is true %}
+    {%- set resolved_reasoning_effort = reasoning_effort|default('xhigh') %}
+    {#- club-3090 PATCH: Qwen3.8's ladder is low/medium/xhigh with no `high`, so
+        the stock template hard-raises on the value generic OpenAI/Anthropic
+        clients send. Map it onto `medium` -- the un-nudged baseline -- rather
+        than xhigh, whose preamble is slow and timeout-prone. Otherwise upstream. -#}
+    {%- if resolved_reasoning_effort == 'high' %}
+        {%- set resolved_reasoning_effort = 'medium' %}
+    {%- endif %}
+    {%- if resolved_reasoning_effort not in ('xhigh', 'medium', 'low') %}
+        {{- raise_exception('Unexpected reasoning effort ' ~ reasoning_effort ~ '. Supported types are xhigh (default), medium, and low.') }}
+    {%- endif %}
+    {%- if resolved_reasoning_effort == 'xhigh' %}
+        {%- set reasoning_instructions = 'Reasoning effort is set to xhigh. Please think carefully through the task, validate key assumptions, consider plausible alternatives, and prioritize correctness, consistency, and clarity in the final answer.' %}
+    {%- elif resolved_reasoning_effort == 'low' %}
+        {%- set reasoning_instructions = 'Reasoning effort is set to low. Keep your thinking brief and focused, moving directly to the conclusion without unnecessary elaboration.' %}
+    {%- endif %}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {%- if reasoning_instructions %}
+        {{- reasoning_instructions + '\n\n' }}
+    {%- endif %}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '<|im_start|>system\n' + (reasoning_instructions + '\n\n' if reasoning_instructions else '')  + content + '<|im_end|>\n' }}
+        {%- elif reasoning_instructions %}
+            {{- '<|im_start|>system\n' + reasoning_instructions + '<|im_end|>\n' }}
+        {%- endif %}
+    {%- elif reasoning_instructions %}
+        {{- '<|im_start|>system\n' + reasoning_instructions + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- if preserve_thinking is undefined or preserve_thinking is true or loop.index0 > ns.last_query_index %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined and tool_call.arguments != '' %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | string if args_value is string else args_value | tojson | safe %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}

--- a/scripts/lib/profiles/patches.yml
+++ b/scripts/lib/profiles/patches.yml
@@ -314,6 +314,58 @@ patches:
       drop_when: "upstream Qwen ships a corrected default chat template and the pinned engines bundle it, OR the override is re-vendored (the same drift_guard must clear the next re-vendor)"
     status: verified
 
+  - id: qwen38-reasoning-effort-template
+    model: [qwen3.8-27b]
+    files:
+      - models/qwen3.8-27b/vllm/patches/qwen38-reasoning-effort-template/chat_template.jinja
+    load_bearing_when:
+      - composes:
+          - vllm/qwen38-27b-dual-max
+          - vllm/qwen38-27b-multi4-max
+          - vllm/qwen38-27b-multi8-max
+          - vllm/qwen38-27b-dual-supermax
+          - vllm/qwen38-27b-multi4-supermax
+          - vllm/qwen38-27b-multi8-supermax
+          - vllm/qwen38-27b-dual-ultramax
+          - vllm/qwen38-27b-multi4-ultramax
+          - vllm/qwen38-27b-multi8-ultramax
+          - vllm/qwen38-27b-dual-fast
+          - vllm/qwen38-27b-multi4-fast
+          - vllm/qwen38-27b-multi8-fast
+          - vllm/qwen38-27b-dual-superfast
+          - vllm/qwen38-27b-multi4-superfast
+          - vllm/qwen38-27b-multi8-superfast
+          - vllm/qwen38-27b-dual-ultrafast
+          - vllm/qwen38-27b-multi4-ultrafast
+          - vllm/qwen38-27b-multi8-ultrafast
+          - vllm/qwen38-27b-single-nvfp4
+          - vllm/qwen38-27b-dual-nvfp4
+        reason: "Qwen3.8 renamed the conventional top reasoning rung: its ladder is low/medium/xhigh with NO `high`, and the stock template raise_exception()s on any other value. Both OpenAI and Anthropic use low/medium/high, so a generic client sending the standard top rung gets a Jinja TemplateError surfaced as HTTP 500 -- while /v1/models and /health both return 200 and the model is demonstrably serving, which makes the endpoint look healthy while every thinking-mode chat request fails. Observed on the reference rig 2026-08-16 through vLLM's Anthropic-compatible POST /v1/messages?beta=true, i.e. the exact surface a drop-in Claude-API client talks to. Load-bearing on EVERY vLLM slug because the template is byte-identical across all three checkpoints (FP8, AutoRound INT4, NVFP4 -- same 8,952-byte file, sha256 c3cf9e34abf4f9e36c2d72165aa9c132d3e2a725b6c2586aaa3a8af9d7a81041), so the defect and the fix are quantiser-independent. The override is the model's OWN template plus seven lines mapping high -> MEDIUM, bind-mounted OVER the checkpoint's own chat_template.jinja (mount-only, no --chat-template arg -- see delivery_spec.note); the documented xhigh/medium/low behaviour is unchanged and invalid values are still rejected. medium is chosen over xhigh DELIBERATELY: medium is the un-nudged baseline (no template branch, no injected preamble) whereas xhigh injects a 'think carefully, validate assumptions, consider alternatives' preamble that is slow and timeout-prone -- and a Claude-API client sends `high` on EVERY request, so mapping it to the top rung would silently put all agent traffic in the slowest mode on a single-stream rig. SCOPE 2026-08-21: all TWENTY vLLM slugs, not the original eight — #1072 added the DFlash2 super/ultra tiers, and every one of them rendered the stock template. RE-VERIFIED the same day after #1070 swapped the FAST-tier weights Avuja -> Frozenlock: chat_template.jinja is STILL sha256 c3cf9e34…81041 on all three served checkpoints (Qwen/Qwen3.8-27B-FP8, Frozenlock/Qwen3.8-27B-int4-AutoRound, RadixArk/Qwen3.8-27B-NVFP4), so one vendored file still covers every slug. ⚠️ syvai/Qwen3.8-27B-DFlash2-W4A16 ships a DIFFERENT template (f36668dd…ba59) — it is the DFlash2 drafter, never the render source, so it is deliberately not vendored."
+        evidence: "models/qwen3.8-27b/vllm/patches/qwen38-reasoning-effort-template/PROVENANCE.md (carries the regenerable diff and the cross-checkpoint sha256 comparison)"
+    delivery:               # DEPRECATED/READ-ONLY (test-only) -- see header
+      dockerfile_bake: false
+      entrypoint_invoke: true
+      genesis: false
+    delivery_gaps: []
+    delivery_mechanism: chat_template
+    delivery_spec:
+      jinja: models/qwen3.8-27b/vllm/patches/qwen38-reasoning-effort-template/chat_template.jinja
+      mounted_at: /chat_template.jinja
+      mount_mode: ro
+      wired_at: [volumes]
+      note: "MOUNT-ONLY, like the carnice override and unlike froggeric: the vendored .jinja is bind-mounted OVER the served checkpoint's own chat_template.jinja and vLLM auto-loads it from the model dir, so NO --chat-template arg is passed and the compose `command:` list is untouched. That is a deliberate rebase-surface choice -- upstream edits those args constantly (11 commits touched these composes in the 7 days to 2026-08-23, and one of them collided with the arg this patch used to insert), whereas the volumes block is quiet. ⚠️ The container-side target therefore DIFFERS PER WEIGHTS VARIANT and there are three of them: /root/.cache/huggingface/qwen3.8-27b-autoround-int4/chat_template.jinja (9 composes), /root/.cache/huggingface/qwen3.8-27b-fp8/chat_template.jinja (9), /root/.cache/huggingface/qwen3.8-27b-nvfp4/chat_template.jinja (2). `mounted_at` takes ONE string, so it declares the suffix those three share; it is the coverage marker _spec_wiring_present greps for, and it appears only on this patch's mount line. Data-only mount, NOT an engine-code overlay, so vllm-stable's overlay-free CONTRACT-5 status (and its usability as a derived-emission base) is unaffected."
+    drift_guard:
+      kind: behavioral
+      check: "A thinking-mode chat request carrying reasoning_effort='high' must return HTTP 200 (not a 500 TemplateError) with the template mounted; low/medium/xhigh must keep their stock behaviour and an invalid value must still be rejected. Re-diff the jinja against models-cache/qwen3.8-27b-*/chat_template.jinja after any weights re-pull -- a silent upstream template re-push is the drift this guards, and because the file is identical across checkpoints, ONE re-diff covers every slug. Any behavioral/TPS comparison the guard performs MUST use the SELF-CONTAINED symmetric restart+settle protocol: identical `docker restart <container>` on BOTH arms -> wait for /v1/models healthy -> fixed 60s settle -> >=3 bench.sh runs/arm -> compare the GRAND MEAN of the SAME canonical bench segment (NARRATIVE 800-word essay + CODE; never mix segments, never a single run); flag ONLY a deterministic regression reproduced across ALL 3 runs. (An asymmetric-restart harness fabricated a phantom -7% on #150; a non-symmetric guard flaps and gets ignored.)"
+      on_fail: capability-degraded   # serves the stock template, 500-ing every reasoning_effort=high request
+    capability: chat-template-override
+    foundational: false
+    upstream:
+      ref: "Qwen/Qwen3.8-27B-FP8 chat_template.jinja (fetched 2026-08-16); no upstream Qwen issue filed yet; re-diffed against the live upstream file 2026-08-21 — the vendored copy is that 8,952-byte template plus exactly the seven alias lines, nothing else"
+      status: local-vendored
+      drop_when: "upstream Qwen accepts `high` as a valid rung at all (costs them nothing), OR vLLM's Anthropic router stops forwarding a `high` it cannot know is unsupported. Re-vendor from the model dir if Qwen ships a corrected template and re-run the drift guard."
+    status: verified
+
   - id: vllm-pr48375-mamba-drop-eagle-block
     # qwen3.8-27b added 2026-08-14: its two vLLM "max" composes ship the SAME
     # MTP + prefix-caching pair on the same Qwen3-Next hybrid family, and mount

--- a/scripts/lib/profiles/registry.yaml
+++ b/scripts/lib/profiles/registry.yaml
@@ -2846,7 +2846,7 @@ entries:
     offload: null
     moe_cache: false
     host_ram_gb: null
-    chat_template: native
+    chat_template: qwen38-reasoning-effort
     tp: 2
     max_ctx: 262144
     max_num_seqs: 2
@@ -2858,7 +2858,7 @@ entries:
     default_port: 8091
     kvcalc_key: SKIP
     status: experimental
-    status_note: "Qwen3.8-27B 'max accuracy' tier, 2-card: official Qwen/Qwen3.8-27B-FP8 weights (e4m3, dynamic act scale, weight_block_size [128,128], embedded mtp.safetensors head) + fp8/e4m3 KV + MTP n=3, TP=2 @262144, vLLM stable pin. ✅ BOOTED + verify-full PASS on the reference 2x3090 2026-08-17 (8 scored checks; Genesis check skipped — this compose is Genesis-free by design), promoted incubating -> experimental per its own gate. MEASURED same day on stock vllm/vllm-openai:v0.27.1, 3 warm + 5 measured: decode 67.39 narr (CV 1.5%) / 85.75 code (CV 3.5%) tok/s, TTFT 152 ms, prefill 1165.8 @10K / 941.5 @90K tok/s, KV pool 270,930 tok @262144 = 1.03x concurrency, VRAM peak 45,816 MiB total (~22.4 GiB/card), MTP acceptance 2.62 at n=3. ⚠️ The trailing SpecDecoding log lines read 'acceptance length 4.00' — that is a 3-token idle-window artifact at 0.03 tok/s, NOT the serving figure; use 2.62. ⚠️ STILL UNGATED for caveats/production: no verify-stress, no NIAH fill depth (262144 is ALLOCATED not FILLED — the 3.6 sibling fills to ~240K of its 262K, expect the same or worse), no soak-continuous, no 8-pack in either reasoning mode. ⚠️ HISTORICAL NOTE, corrected 2026-08-17: this entry previously read 'NOTHING HAS BOOTED — authored 2026-08-14' while the vllm/qwen38-27b-multi8-max entry simultaneously stated that this slug 'HAS booted and passed verify-full on the reference 2x3090 2026-08-17, with a canonical bench (67.39 narr / 85.75 code tok/s, MTP accept 2.62) — see BENCHMARKS.md'. The registry contradicted itself and the pessimistic side was the one users saw; discussion #993's 'boots + verify-full' claim was correct. The weights have since landed and been measured (66 safetensors = 30,866,866,928 bytes = 30.87 GB decimal / 28.75 GiB, repo revision 017b9c7a == current HEAD, all 66 CRC32-clean against the repo's crc32.txt; three non-weight files — chat_template.jinja, generation_config.json, tokenizer_config.json — do NOT match that manifest but parse fine, almost certainly a stale publisher manifest given its sibling safetensors-md5sum.txt shipped empty). Unvalidated as of 2026-08-17: verify-stress / NIAH / soak / 8-pack (bench and verify-full are DONE, see above). NO TPS, TTFT, accept-length or quality number is claimed anywhere, and the compose deliberately carries no `Quality:` field — the qwen3.6-27b tier's 109/150 is ITS number. What IS verified, from the checkpoint on disk: the architecture matches qwen3.6-27b-FP8 field for field (64 layers, layer_types = 16 full_attention + 48 linear_attention, 4 KV heads, head_dim 256, vocab 248320, max_position 262144, mtp_num_hidden_layers 1, linear k/v head_dim 128, conv_kernel 4), the FFN is DENSE (layer-0 tensor table shows mlp.gate_proj/up_proj/down_proj at 17408, no experts — the mlp.gate / shared_expert_gate names in modules_to_not_convert are export-template artifacts), the vision tower is present and explicitly EXCLUDED from the FP8 quant (preprocessor_config.json + video_preprocessor_config.json ship in-repo, so vision needs no separate projector — but no image request has ever been served), and quantization_config is the same shape as the 3.6 FP8 checkpoint that already loads on this exact pin. The 262144 ceiling is COMPUTED plus a sibling analogy, never filled: KV over the 16 GROWING layers only = 16 x 4 x 256 x 2 = 32,768 elem/token, at fp8 = 32,768 B/token = 8.00 GiB @262K (4.00 GiB/card at TP=2); weights measured at 30.87 GB decimal = 28.75 GiB (~14.4 GiB/card) — and qwen3.6-27b-FP8 measures 30,866,866,928 bytes, the SAME total to the byte (66 files, distinct md5s, so identical arch + quant layout rather than a duplicate dir), with identical KV geometry, and boots 262144 at TP=2 / util 0.92 / 2 seqs on this rig, reporting ~21.4 GB/card and a KV pool only ~1.13x the addressable context, i.e. TIGHT. Allocating is not filling: that 3.6 tier NIAH-fills to ~240K of its 262K; expect the same or worse here. If the first boot OOMs at KV init the levers in order are MAX_MODEL_LEN=196608, then GPU_MEMORY_UTILIZATION, then MAX_NUM_BATCHED_TOKENS=4096. ALSO UNPROVEN: that this checkpoint loads on the v0.25.1 pin at all — the pin predates the model, though it serves the same Qwen3_5ForConditionalGeneration arch (qwen3.6-27b FP8, Tess-4-27B). And a present MTP head is not a working one: accept rate is unmeasured, and on the 35B-A3B MoE sibling the BUILT-IN head is net-negative (-51%) where an external drafter is +49%. KV is fp8 (= e4m3) at scale=1.0 — the checkpoint is weight-only and vLLM disables calculate_kv_scales on Qwen3-Next hybrids; ⚠️ fp8_e5m2 is HARD-REJECTED against an fp8 checkpoint, do not 'simplify' to it. int8-PTH deliberately not offered (TRITON_ATTN-only; decode craters with depth on this family). Chat template is NATIVE, not froggeric — see the block comment above. SAMPLER follows the MODEL CARD, not the stack's Qwen3.6 defaults: the card publishes one row per reasoning mode, and since this compose ships thinking OFF it ships the Instruct row (temp 0.7 / top_p 0.80 / top_k 20 / min_p 0.0 / presence_penalty 1.5 / repetition_penalty 1.0) rather than the usual 0.6/0.95. ⚠️ The sampler does NOT follow the reasoning flag — enabling thinking without also setting TEMP=1.0 TOP_P=0.95 PRESENCE_PENALTY=0.0 is a silent mismatch. Serving defaults only; bench.sh sends its own canonical sampler, so BENCHMARKS rows stay comparable. ⚠️ MTP drafter exposed to OPEN vllm#50021 (GDN spec-decode wild write, quant/topology/depth-independent, live in this pin; v0.26.0 predates the fix). This model has never run so it has never been observed to crash — absence of evidence, not evidence of absence; the exposure is structural. Mitigate with SPEC=off (the compose reads it). Detail + re-test trigger: docs/UPSTREAM.md. Launch requires --force (experimental); VISIBLE in switch.sh --list. Promote to ⚠️/✅ only after verify-stress + soak + 8-pack. Also the on-rig proxy for vllm/qwen38-27b-multi4-max (@ TP=4) — ⚠️ but no longer a clean one: since 2026-08-15 both multi slugs run bf16 KV while this stays fp8 e4m3, so KV-sensitive results (pool size, concurrency) do not transfer in either direction."
+    status_note: "Qwen3.8-27B 'max accuracy' tier, 2-card: official Qwen/Qwen3.8-27B-FP8 weights (e4m3, dynamic act scale, weight_block_size [128,128], embedded mtp.safetensors head) + fp8/e4m3 KV + MTP n=3, TP=2 @262144, vLLM stable pin. ✅ BOOTED + verify-full PASS on the reference 2x3090 2026-08-17 (8 scored checks; Genesis check skipped — this compose is Genesis-free by design), promoted incubating -> experimental per its own gate. MEASURED same day on stock vllm/vllm-openai:v0.27.1, 3 warm + 5 measured: decode 67.39 narr (CV 1.5%) / 85.75 code (CV 3.5%) tok/s, TTFT 152 ms, prefill 1165.8 @10K / 941.5 @90K tok/s, KV pool 270,930 tok @262144 = 1.03x concurrency, VRAM peak 45,816 MiB total (~22.4 GiB/card), MTP acceptance 2.62 at n=3. ⚠️ The trailing SpecDecoding log lines read 'acceptance length 4.00' — that is a 3-token idle-window artifact at 0.03 tok/s, NOT the serving figure; use 2.62. ⚠️ STILL UNGATED for caveats/production: no verify-stress, no NIAH fill depth (262144 is ALLOCATED not FILLED — the 3.6 sibling fills to ~240K of its 262K, expect the same or worse), no soak-continuous, no 8-pack in either reasoning mode. ⚠️ HISTORICAL NOTE, corrected 2026-08-17: this entry previously read 'NOTHING HAS BOOTED — authored 2026-08-14' while the vllm/qwen38-27b-multi8-max entry simultaneously stated that this slug 'HAS booted and passed verify-full on the reference 2x3090 2026-08-17, with a canonical bench (67.39 narr / 85.75 code tok/s, MTP accept 2.62) — see BENCHMARKS.md'. The registry contradicted itself and the pessimistic side was the one users saw; discussion #993's 'boots + verify-full' claim was correct. The weights have since landed and been measured (66 safetensors = 30,866,866,928 bytes = 30.87 GB decimal / 28.75 GiB, repo revision 017b9c7a == current HEAD, all 66 CRC32-clean against the repo's crc32.txt; three non-weight files — chat_template.jinja, generation_config.json, tokenizer_config.json — do NOT match that manifest but parse fine, almost certainly a stale publisher manifest given its sibling safetensors-md5sum.txt shipped empty). Unvalidated as of 2026-08-17: verify-stress / NIAH / soak / 8-pack (bench and verify-full are DONE, see above). NO TPS, TTFT, accept-length or quality number is claimed anywhere, and the compose deliberately carries no `Quality:` field — the qwen3.6-27b tier's 109/150 is ITS number. What IS verified, from the checkpoint on disk: the architecture matches qwen3.6-27b-FP8 field for field (64 layers, layer_types = 16 full_attention + 48 linear_attention, 4 KV heads, head_dim 256, vocab 248320, max_position 262144, mtp_num_hidden_layers 1, linear k/v head_dim 128, conv_kernel 4), the FFN is DENSE (layer-0 tensor table shows mlp.gate_proj/up_proj/down_proj at 17408, no experts — the mlp.gate / shared_expert_gate names in modules_to_not_convert are export-template artifacts), the vision tower is present and explicitly EXCLUDED from the FP8 quant (preprocessor_config.json + video_preprocessor_config.json ship in-repo, so vision needs no separate projector — but no image request has ever been served), and quantization_config is the same shape as the 3.6 FP8 checkpoint that already loads on this exact pin. The 262144 ceiling is COMPUTED plus a sibling analogy, never filled: KV over the 16 GROWING layers only = 16 x 4 x 256 x 2 = 32,768 elem/token, at fp8 = 32,768 B/token = 8.00 GiB @262K (4.00 GiB/card at TP=2); weights measured at 30.87 GB decimal = 28.75 GiB (~14.4 GiB/card) — and qwen3.6-27b-FP8 measures 30,866,866,928 bytes, the SAME total to the byte (66 files, distinct md5s, so identical arch + quant layout rather than a duplicate dir), with identical KV geometry, and boots 262144 at TP=2 / util 0.92 / 2 seqs on this rig, reporting ~21.4 GB/card and a KV pool only ~1.13x the addressable context, i.e. TIGHT. Allocating is not filling: that 3.6 tier NIAH-fills to ~240K of its 262K; expect the same or worse here. If the first boot OOMs at KV init the levers in order are MAX_MODEL_LEN=196608, then GPU_MEMORY_UTILIZATION, then MAX_NUM_BATCHED_TOKENS=4096. ALSO UNPROVEN: that this checkpoint loads on the v0.25.1 pin at all — the pin predates the model, though it serves the same Qwen3_5ForConditionalGeneration arch (qwen3.6-27b FP8, Tess-4-27B). And a present MTP head is not a working one: accept rate is unmeasured, and on the 35B-A3B MoE sibling the BUILT-IN head is net-negative (-51%) where an external drafter is +49%. KV is fp8 (= e4m3) at scale=1.0 — the checkpoint is weight-only and vLLM disables calculate_kv_scales on Qwen3-Next hybrids; ⚠️ fp8_e5m2 is HARD-REJECTED against an fp8 checkpoint, do not 'simplify' to it. int8-PTH deliberately not offered (TRITON_ATTN-only; decode craters with depth on this family). Chat template is the model's NATIVE one plus the club-3090 `high` -> `medium` alias (patches/qwen38-reasoning-effort-template), not froggeric — see the CHAT TEMPLATE section in the compose header. SAMPLER follows the MODEL CARD, not the stack's Qwen3.6 defaults: the card publishes one row per reasoning mode, and since this compose ships thinking OFF it ships the Instruct row (temp 0.7 / top_p 0.80 / top_k 20 / min_p 0.0 / presence_penalty 1.5 / repetition_penalty 1.0) rather than the usual 0.6/0.95. ⚠️ The sampler does NOT follow the reasoning flag — enabling thinking without also setting TEMP=1.0 TOP_P=0.95 PRESENCE_PENALTY=0.0 is a silent mismatch. Serving defaults only; bench.sh sends its own canonical sampler, so BENCHMARKS rows stay comparable. ⚠️ MTP drafter exposed to OPEN vllm#50021 (GDN spec-decode wild write, quant/topology/depth-independent, live in this pin; v0.26.0 predates the fix). This model has never run so it has never been observed to crash — absence of evidence, not evidence of absence; the exposure is structural. Mitigate with SPEC=off (the compose reads it). Detail + re-test trigger: docs/UPSTREAM.md. Launch requires --force (experimental); VISIBLE in switch.sh --list. Promote to ⚠️/✅ only after verify-stress + soak + 8-pack. Also the on-rig proxy for vllm/qwen38-27b-multi4-max (@ TP=4) — ⚠️ but no longer a clean one: since 2026-08-15 both multi slugs run bf16 KV while this stays fp8 e4m3, so KV-sensitive results (pool size, concurrency) do not transfer in either direction."
     weights_companions: []
     gateway: true
     serve_aliases: []
@@ -2891,7 +2891,7 @@ entries:
     offload: null
     moe_cache: false
     host_ram_gb: null
-    chat_template: native
+    chat_template: qwen38-reasoning-effort
     tp: 4
     max_ctx: 262144
     max_num_seqs: 2
@@ -2903,7 +2903,7 @@ entries:
     default_port: 8092
     kvcalc_key: SKIP
     status: experimental
-    status_note: "Qwen3.8-27B 'max accuracy' tier, 4-card (TP=4): official Qwen/Qwen3.8-27B-FP8 weights + bf16 KV + MTP n=3 @262144. Identical to vllm/qwen38-27b-dual-max apart from --tensor-parallel-size, the required gpu-count, and --kv-cache-dtype; keep the first two in lockstep. ⚠️ KV DELIBERATELY DIVERGES from the dual (2026-08-15): this runs bf16 (--kv-cache-dtype auto over the pinned --dtype bfloat16) where the dual runs fp8 e4m3, because only TP>=4 has the per-card headroom — weights fall to ~7.2 GiB/card here vs ~14.4 on the dual, so a 16.00 GiB bf16 pool fits (~4.00 GiB/card) where it would not on 2 cards. Do not 'restore lockstep' by reverting it, and do not propagate it to the dual. TWO independent reasons this is incubating, and only the first is closable. (1) NOTHING HAS BOOTED on any card count — authored 2026-08-14; the weights have since landed and verified (30.87 GB / 28.75 GiB, all 66 safetensors CRC32-clean) but no engine has ever loaded them; no verify-full (0/8), no verify-stress / NIAH / soak / bench / 8-pack, NO TPS number claimed, no `Quality:` field, and the 262144 ceiling is arithmetic plus a qwen3.6-27b analogy rather than a measured fill depth. Engine compatibility is likewise inferred: the v0.25.1 pin predates this model. (2) ⛔ 4-CARD IS COMMUNITY-VALIDATED BY DESIGN and that is PERMANENT, not a TODO: the maintainer rig has exactly two 3090s, so TP=4 can never boot here and should never be filed as pending work. The on-rig proxy is vllm/qwen38-27b-dual-max, which is the same serving config at TP=2 EXCEPT for KV (it runs fp8 e4m3, this runs bf16) — so its numbers transfer on topology but NOT on pool size, concurrency, or any KV-sensitive quality result — and everything TP=4-specific (NCCL across 4 PCIe cards, the 4-way shard, the larger KV pool) is validated by whoever first runs it on 4 cards; that first community boot IS the validation. num_kv_heads=4 divides evenly by 4, so the shard is valid on paper. What TP=4 buys is headroom, not context: 262144 is already the architectural ceiling and the dual is projected to reach it, so the 4 cards convert ~14.4 GiB/card of weights into ~7.2, leaving far more room for KV pool and concurrency — on the qwen3.6-27b equivalent, single-stream decode was ~flat from 2 to 4 cards and the pool is what grew. Expect that shape, expect nothing quantitative. PCIe-only with no NVLink means more ranks = more all-reduce on a slow bus; custom all-reduce stays disabled in the entrypoint. Everything else (dense-not-MoE confirmation, the 16-growing-layer KV math — but DOUBLED for bf16: 65,536 B/token = 16.00 GiB @262K, ~4.00 GiB/card at TP=4, where the dual's note states the fp8 figure of 32,768 B/token, the 30.9 GB decimal / 28.8 GiB unit trap, why fp8_e5m2 is rejected, why the chat template is NATIVE and not froggeric, the MODEL-CARD sampler — Instruct row, temp 0.7 / top_p 0.80 / presence_penalty 1.5, because thinking ships off — and the built-in-MTP caveat) matches the dual sibling's note verbatim. ⚠️ MTP drafter exposed to OPEN vllm#50021 (GDN spec-decode wild write, live in this pin; v0.26.0 predates the fix) — structural exposure inherited from the hybrid-GDN family, never observed here because nothing has run. Mitigate with SPEC=off. Detail + re-test trigger: docs/UPSTREAM.md. Launch requires --force (incubating); hidden from switch.sh --list. Promote to 🧪 only after a clean boot + verify-full on a real 4-card host."
+    status_note: "Qwen3.8-27B 'max accuracy' tier, 4-card (TP=4): official Qwen/Qwen3.8-27B-FP8 weights + bf16 KV + MTP n=3 @262144. Identical to vllm/qwen38-27b-dual-max apart from --tensor-parallel-size, the required gpu-count, and --kv-cache-dtype; keep the first two in lockstep. ⚠️ KV DELIBERATELY DIVERGES from the dual (2026-08-15): this runs bf16 (--kv-cache-dtype auto over the pinned --dtype bfloat16) where the dual runs fp8 e4m3, because only TP>=4 has the per-card headroom — weights fall to ~7.2 GiB/card here vs ~14.4 on the dual, so a 16.00 GiB bf16 pool fits (~4.00 GiB/card) where it would not on 2 cards. Do not 'restore lockstep' by reverting it, and do not propagate it to the dual. TWO independent reasons this is incubating, and only the first is closable. (1) NOTHING HAS BOOTED on any card count — authored 2026-08-14; the weights have since landed and verified (30.87 GB / 28.75 GiB, all 66 safetensors CRC32-clean) but no engine has ever loaded them; no verify-full (0/8), no verify-stress / NIAH / soak / bench / 8-pack, NO TPS number claimed, no `Quality:` field, and the 262144 ceiling is arithmetic plus a qwen3.6-27b analogy rather than a measured fill depth. Engine compatibility is likewise inferred: the v0.25.1 pin predates this model. (2) ⛔ 4-CARD IS COMMUNITY-VALIDATED BY DESIGN and that is PERMANENT, not a TODO: the maintainer rig has exactly two 3090s, so TP=4 can never boot here and should never be filed as pending work. The on-rig proxy is vllm/qwen38-27b-dual-max, which is the same serving config at TP=2 EXCEPT for KV (it runs fp8 e4m3, this runs bf16) — so its numbers transfer on topology but NOT on pool size, concurrency, or any KV-sensitive quality result — and everything TP=4-specific (NCCL across 4 PCIe cards, the 4-way shard, the larger KV pool) is validated by whoever first runs it on 4 cards; that first community boot IS the validation. num_kv_heads=4 divides evenly by 4, so the shard is valid on paper. What TP=4 buys is headroom, not context: 262144 is already the architectural ceiling and the dual is projected to reach it, so the 4 cards convert ~14.4 GiB/card of weights into ~7.2, leaving far more room for KV pool and concurrency — on the qwen3.6-27b equivalent, single-stream decode was ~flat from 2 to 4 cards and the pool is what grew. Expect that shape, expect nothing quantitative. PCIe-only with no NVLink means more ranks = more all-reduce on a slow bus; custom all-reduce stays disabled in the entrypoint. Everything else (dense-not-MoE confirmation, the 16-growing-layer KV math — but DOUBLED for bf16: 65,536 B/token = 16.00 GiB @262K, ~4.00 GiB/card at TP=4, where the dual's note states the fp8 figure of 32,768 B/token, the 30.9 GB decimal / 28.8 GiB unit trap, why fp8_e5m2 is rejected, why the chat template is NATIVE-plus-alias and not froggeric, the MODEL-CARD sampler — Instruct row, temp 0.7 / top_p 0.80 / presence_penalty 1.5, because thinking ships off — and the built-in-MTP caveat) matches the dual sibling's note verbatim. ⚠️ MTP drafter exposed to OPEN vllm#50021 (GDN spec-decode wild write, live in this pin; v0.26.0 predates the fix) — structural exposure inherited from the hybrid-GDN family, never observed here because nothing has run. Mitigate with SPEC=off. Detail + re-test trigger: docs/UPSTREAM.md. Launch requires --force (incubating); hidden from switch.sh --list. Promote to 🧪 only after a clean boot + verify-full on a real 4-card host."
     weights_companions: []
     gateway: false
     serve_aliases: []
@@ -2936,7 +2936,7 @@ entries:
     offload: null
     moe_cache: false
     host_ram_gb: null
-    chat_template: native
+    chat_template: qwen38-reasoning-effort
     tp: 8
     max_ctx: 262144
     max_num_seqs: 2
@@ -2948,7 +2948,7 @@ entries:
     default_port: 8093
     kvcalc_key: SKIP
     status: experimental
-    status_note: "Qwen3.8-27B 'max accuracy' tier, 8-card (TP=8): same serving config as vllm/qwen38-27b-multi4-max with three lines changed — --tensor-parallel-size, the Requires-min-gpu-count header, and the port. ⚠️⚠️ TP=8 IS NOT THE SAME SHARD SHAPE AS TP=2/TP=4 AND DOES NOT SCALE THE SAME WAY: this model has num_kv_heads=4, which divides cleanly by 2 and by 4 but NOT by 8. At TP=8 vLLM REPLICATES KV heads across rank pairs rather than splitting them, so per-card KV stays at roughly the TP=4 figure (~4.00 GiB @262K at this compose's bf16 KV), NOT half of it. Only the WEIGHTS take the full 8-way split (~3.6 GiB/card vs ~7.2 at TP=4). So the 8-card gain over 4 is weight headroom only, bought with more all-reduce traffic on a PCIe bus with no NVLink — and on the qwen3.6-27b equivalent single-stream decode was ALREADY ~flat from 2 cards to 4. Expect flat-or-worse decode; expect nothing quantitative until measured. (1) NOTHING HAS BOOTED on any card count — the weights are on disk and CRC32-verified (66 safetensors, 30.87 GB decimal / 28.75 GiB, revision 017b9c7a) but no engine has loaded them; no verify-full, no bench, no 8-pack, no Quality: field, and 262144 is arithmetic plus a sibling analogy rather than a measured fill. (2) ⛔ 8-CARD IS COMMUNITY-VALIDATED BY DESIGN and that is PERMANENT, not a TODO: the maintainer rig has exactly two 3090s, so TP=8 can never boot here and must never be filed as pending work. The on-rig proxy is vllm/qwen38-27b-dual-max (TP=2, which HAS booted and passed verify-full on the reference 2x3090 2026-08-17, with a canonical bench (67.39 narr / 85.75 code tok/s, MTP accept 2.62) — see BENCHMARKS.md) — but it runs fp8 e4m3 KV where this runs bf16 (--kv-cache-dtype auto), a deliberate 2026-08-15 divergence on headroom grounds, so its pool/concurrency numbers do NOT transfer. Everything TP=8-specific — NCCL across 8 PCIe cards, the 8-way weight shard, KV-head replication — is validated by whoever first runs it on 8 cards; that first community boot IS the validation. Report via numbers-from-your-rig. P2P is NOT hardcoded: scripts/detect_nvlink.sh (NVLINK_MODE=auto) probes the interconnect and, when it finds a fast one, exports NCCL_P2P_LEVEL and UNSETS the compose's NCCL_P2P_DISABLE default — so an 8-card host with working P2P picks it up automatically. ⚠️ A 'topo -p2p OK' line reports a grant, not a working transfer; prove it with a real transfer check. ⚠️ MTP drafter exposed to OPEN vllm#50021 (GDN spec-decode wild write, live in this pin); mitigate with SPEC=off. Detail: docs/UPSTREAM.md. Launch requires --force (incubating); hidden from switch.sh --list. Promote to 🧪 only after a clean boot + verify-full on a real 8-card host. Everything else (dense-not-MoE, the 16-growing-layer KV math, the decimal/GiB unit trap, why fp8_e5m2 is rejected, the NATIVE chat template, the MODEL-CARD sampler) matches the multi4 sibling verbatim."
+    status_note: "Qwen3.8-27B 'max accuracy' tier, 8-card (TP=8): same serving config as vllm/qwen38-27b-multi4-max with three lines changed — --tensor-parallel-size, the Requires-min-gpu-count header, and the port. ⚠️⚠️ TP=8 IS NOT THE SAME SHARD SHAPE AS TP=2/TP=4 AND DOES NOT SCALE THE SAME WAY: this model has num_kv_heads=4, which divides cleanly by 2 and by 4 but NOT by 8. At TP=8 vLLM REPLICATES KV heads across rank pairs rather than splitting them, so per-card KV stays at roughly the TP=4 figure (~4.00 GiB @262K at this compose's bf16 KV), NOT half of it. Only the WEIGHTS take the full 8-way split (~3.6 GiB/card vs ~7.2 at TP=4). So the 8-card gain over 4 is weight headroom only, bought with more all-reduce traffic on a PCIe bus with no NVLink — and on the qwen3.6-27b equivalent single-stream decode was ALREADY ~flat from 2 cards to 4. Expect flat-or-worse decode; expect nothing quantitative until measured. (1) NOTHING HAS BOOTED on any card count — the weights are on disk and CRC32-verified (66 safetensors, 30.87 GB decimal / 28.75 GiB, revision 017b9c7a) but no engine has loaded them; no verify-full, no bench, no 8-pack, no Quality: field, and 262144 is arithmetic plus a sibling analogy rather than a measured fill. (2) ⛔ 8-CARD IS COMMUNITY-VALIDATED BY DESIGN and that is PERMANENT, not a TODO: the maintainer rig has exactly two 3090s, so TP=8 can never boot here and must never be filed as pending work. The on-rig proxy is vllm/qwen38-27b-dual-max (TP=2, which HAS booted and passed verify-full on the reference 2x3090 2026-08-17, with a canonical bench (67.39 narr / 85.75 code tok/s, MTP accept 2.62) — see BENCHMARKS.md) — but it runs fp8 e4m3 KV where this runs bf16 (--kv-cache-dtype auto), a deliberate 2026-08-15 divergence on headroom grounds, so its pool/concurrency numbers do NOT transfer. Everything TP=8-specific — NCCL across 8 PCIe cards, the 8-way weight shard, KV-head replication — is validated by whoever first runs it on 8 cards; that first community boot IS the validation. Report via numbers-from-your-rig. P2P is NOT hardcoded: scripts/detect_nvlink.sh (NVLINK_MODE=auto) probes the interconnect and, when it finds a fast one, exports NCCL_P2P_LEVEL and UNSETS the compose's NCCL_P2P_DISABLE default — so an 8-card host with working P2P picks it up automatically. ⚠️ A 'topo -p2p OK' line reports a grant, not a working transfer; prove it with a real transfer check. ⚠️ MTP drafter exposed to OPEN vllm#50021 (GDN spec-decode wild write, live in this pin); mitigate with SPEC=off. Detail: docs/UPSTREAM.md. Launch requires --force (incubating); hidden from switch.sh --list. Promote to 🧪 only after a clean boot + verify-full on a real 8-card host. Everything else (dense-not-MoE, the 16-growing-layer KV math, the decimal/GiB unit trap, why fp8_e5m2 is rejected, the NATIVE-plus-alias chat template, the MODEL-CARD sampler) matches the multi4 sibling verbatim."
     weights_companions: []
     gateway: false
     serve_aliases: []
@@ -2981,7 +2981,7 @@ entries:
     offload: null
     moe_cache: false
     host_ram_gb: null
-    chat_template: native
+    chat_template: qwen38-reasoning-effort
     tp: 2
     max_ctx: 147456
     max_num_seqs: 1
@@ -3026,7 +3026,7 @@ entries:
     offload: null
     moe_cache: false
     host_ram_gb: null
-    chat_template: native
+    chat_template: qwen38-reasoning-effort
     tp: 4
     max_ctx: 262144
     max_num_seqs: 2
@@ -3071,7 +3071,7 @@ entries:
     offload: null
     moe_cache: false
     host_ram_gb: null
-    chat_template: native
+    chat_template: qwen38-reasoning-effort
     tp: 8
     max_ctx: 262144
     max_num_seqs: 2
@@ -3116,7 +3116,7 @@ entries:
     offload: null
     moe_cache: false
     host_ram_gb: null
-    chat_template: native
+    chat_template: qwen38-reasoning-effort
     tp: 2
     max_ctx: 65536
     max_num_seqs: 1
@@ -3161,7 +3161,7 @@ entries:
     offload: null
     moe_cache: false
     host_ram_gb: null
-    chat_template: native
+    chat_template: qwen38-reasoning-effort
     tp: 4
     max_ctx: 262144
     max_num_seqs: 2
@@ -3206,7 +3206,7 @@ entries:
     offload: null
     moe_cache: false
     host_ram_gb: null
-    chat_template: native
+    chat_template: qwen38-reasoning-effort
     tp: 8
     max_ctx: 262144
     max_num_seqs: 2
@@ -3251,7 +3251,7 @@ entries:
     offload: null
     moe_cache: false
     host_ram_gb: null
-    chat_template: native
+    chat_template: qwen38-reasoning-effort
     tp: 2
     max_ctx: 262144
     max_num_seqs: 1
@@ -3296,7 +3296,7 @@ entries:
     offload: null
     moe_cache: false
     host_ram_gb: null
-    chat_template: native
+    chat_template: qwen38-reasoning-effort
     tp: 4
     max_ctx: 262144
     max_num_seqs: 2
@@ -3341,7 +3341,7 @@ entries:
     offload: null
     moe_cache: false
     host_ram_gb: null
-    chat_template: native
+    chat_template: qwen38-reasoning-effort
     tp: 8
     max_ctx: 262144
     max_num_seqs: 2
@@ -3386,7 +3386,7 @@ entries:
     offload: null
     moe_cache: false
     host_ram_gb: null
-    chat_template: native
+    chat_template: qwen38-reasoning-effort
     tp: 2
     max_ctx: 262144
     max_num_seqs: 1
@@ -3431,7 +3431,7 @@ entries:
     offload: null
     moe_cache: false
     host_ram_gb: null
-    chat_template: native
+    chat_template: qwen38-reasoning-effort
     tp: 4
     max_ctx: 262144
     max_num_seqs: 2
@@ -3476,7 +3476,7 @@ entries:
     offload: null
     moe_cache: false
     host_ram_gb: null
-    chat_template: native
+    chat_template: qwen38-reasoning-effort
     tp: 8
     max_ctx: 262144
     max_num_seqs: 2
@@ -3521,7 +3521,7 @@ entries:
     offload: null
     moe_cache: false
     host_ram_gb: null
-    chat_template: native
+    chat_template: qwen38-reasoning-effort
     tp: 2
     max_ctx: 204800
     max_num_seqs: 1
@@ -3566,7 +3566,7 @@ entries:
     offload: null
     moe_cache: false
     host_ram_gb: null
-    chat_template: native
+    chat_template: qwen38-reasoning-effort
     tp: 4
     max_ctx: 262144
     max_num_seqs: 2
@@ -3611,7 +3611,7 @@ entries:
     offload: null
     moe_cache: false
     host_ram_gb: null
-    chat_template: native
+    chat_template: qwen38-reasoning-effort
     tp: 8
     max_ctx: 262144
     max_num_seqs: 2
@@ -3656,7 +3656,7 @@ entries:
     offload: null
     moe_cache: false
     host_ram_gb: null
-    chat_template: native
+    chat_template: qwen38-reasoning-effort
     tp: 1
     max_ctx: 65536
     max_num_seqs: 1
@@ -3701,7 +3701,7 @@ entries:
     offload: null
     moe_cache: false
     host_ram_gb: null
-    chat_template: native
+    chat_template: qwen38-reasoning-effort
     tp: 2
     max_ctx: 262144
     max_num_seqs: 2


### PR DESCRIPTION
## Summary

`reasoning_effort: "high"` returns HTTP 500 on all 20 Qwen3.8 vLLM slugs. Qwen3.8's ladder is `low`/`medium`/`xhigh` — there's no `high` — and the stock chat template `raise_exception()`s on anything else. OpenAI and Anthropic both use `low`/`medium`/`high`, so any generic client sending the standard top rung hits it. I found it with a Claude-API client on `/v1/messages`, which turns thinking on and sends `high` on every request.

Worth noting how it fails: `/v1/models` and `/health` stay 200 and the model serves fine, so the endpoint looks healthy while every thinking-mode request errors. #1029's server-side default doesn't help — a caller that sends its own value wins.

The fix is the model's own template plus seven lines mapping `high` → `medium`, vendored under `vllm/patches/`. I picked `medium` over `xhigh` because `medium` injects nothing, while `xhigh` adds the "think carefully, validate assumptions" preamble — and since a Claude-API client sends `high` on *every* request, mapping to the top rung would quietly push all agent traffic into the slowest mode on slugs shipping `max_num_seqs=1`. `xhigh` still works by name; every other rung renders byte-identically.

It's mounted over the checkpoint's own `chat_template.jinja` (vLLM auto-loads it) rather than passed with `--chat-template`, so no compose `command:` list changes — same wiring as the carnice override. One file covers all 20 slugs: the template is the same 8,952-byte file, sha256 `c3cf9e34…`, on FP8, Frozenlock INT4 and RadixArk NVFP4.

## Verification

Rendered stock vs vendored through a jinja2 sandbox across the whole ladder: stock raises on `high`, vendored serves it as medium; `xhigh`/`medium`/`low` identical on both, invalid still rejected, and with thinking off neither raises.

On the rig (2×3090, v0.27.1): the vendored file diffs against the checkpoint's own `chat_template.jinja` by exactly those seven lines, and a thinking-mode request with `reasoning_effort: "high"` returns 200 where it used to 500 — measured on `vllm/qwen38-27b-dual-superfast` with the mount wiring exactly as shipped here.

Guards green — `test-patch-attribution`, `test-compose-mounts-resolve`, `test-compose-no-repeated-args`, `test-generate-compose`, `test-compose-registry-disk`. CHANGELOG entry added.

No bench / soak / verify-stress: this is a chat-template mount, not a serving-config change — no engine flag, no memory knob — and every rung but `high` renders byte-identically, so there's no perf or quality claim to make. No BENCHMARKS row for the same reason.