### PR TITLE
fix(switch): catch crash-loops and prove generation before declaring ready

### DIFF
--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -67,6 +67,12 @@
 #   FORCE           Set to 1 to skip hardware/free-VRAM preflight
 #   READY_URL       Default: http://localhost:8020/v1/models
 #   READY_TIMEOUT   Default: 600 (seconds — longer for cold cudagraph capture)
+#   READY_PROBE     Default: 1. After /v1/models answers, send ONE max_tokens=1
+#                 completion and require it to succeed before declaring ready
+#                 (#1100) — proves the engine can GENERATE, not just that its
+#                 port is bound, and warms the moe-cache expert pool (allocated
+#                 on first inference). Set 0 to skip.
+#   READY_PROBE_TIMEOUT  Default: 90 (seconds) — hard cap on that one probe.
 #   CLUB3090_THINKING_<MODEL>  .env pin (on|off|inherit) → ENABLE_THINKING at
 #                 launch (#1014 follow-up; set it from the serve-confirm [T]).
 #                 An ENABLE_THINKING exported in the shell wins over the pin.
@@ -1150,12 +1156,104 @@ resolve_ready_url() {
   READY_URL="http://localhost:${port}/v1/models"
 }
 
+ready_probe() {
+  # #1100 — ONE bounded generation call, so "✓ ready" means the engine can
+  # actually produce a token, not merely that its HTTP port is bound.
+  #
+  # Why /v1/models is not enough:
+  #   * it answers the moment the server binds — before a single token has been
+  #     generated, so a server that binds but cannot generate reads as ready and
+  #     the failure only surfaces in the user's first real request;
+  #   * on the moe-cache slugs the expert pool is allocated on the FIRST
+  #     INFERENCE, not at load (~4.9 GB on GPU0). "Ready" therefore meant a cold
+  #     cache, and whatever ran next paid pool allocation inside its own first
+  #     measured request.
+  #
+  # Degrades gracefully — only a dead/erroring server fails the boot:
+  #   transport failure or timeout → FAIL (bound, but cannot serve)
+  #   HTTP 5xx (except 501)        → FAIL (accepted the request, then broke)
+  #   HTTP 4xx / 501 / odd shape   → WARN (different completion shape, missing
+  #                                  chat template, … — NOT a boot failure)
+  # Opt out with READY_PROBE=0; bound it with READY_PROBE_TIMEOUT (default 90s).
+  local container="$1" served="$2"
+  local base body code rc probe_s started snippet has_choices
+  if [[ "${READY_PROBE:-1}" == "0" ]]; then
+    echo "[switch]   generation probe skipped (READY_PROBE=0)"
+    return 0
+  fi
+  if [[ -z "$served" ]]; then
+    echo "[switch] ⚠ generation probe skipped — could not resolve the served model id from ${READY_URL}" >&2
+    return 0
+  fi
+  # http://host:port/v1/models[/] → http://host:port/v1 (a READY_URL override
+  # that is not a /v1/models URL just yields a 404 → WARN, never a false fail).
+  base="${READY_URL%/}"; base="${base%/models}"
+  # Minimal JSON escaping of the served id (it came out of JSON, but never hand
+  # it back unescaped).
+  local served_esc="${served//\\/\\\\}"; served_esc="${served_esc//\"/\\\"}"
+  body="$(mktemp)"
+  started=$SECONDS
+  code="$(curl -s -o "$body" -w '%{http_code}' --max-time "${READY_PROBE_TIMEOUT:-90}" \
+    -X POST "${base}/chat/completions" \
+    -H 'Content-Type: application/json' \
+    -d "{\"model\":\"${served_esc}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":1,\"temperature\":0,\"stream\":false}" \
+    2>/dev/null)" && rc=0 || rc=$?
+  probe_s=$((SECONDS - started))
+  snippet="$(head -c 200 "$body" 2>/dev/null | tr '\n' ' ' || true)"
+  has_choices=0
+  # `if`, not `A && B` — under `set -e` a failing AND-list at statement level
+  # exits the shell.
+  if command grep -q '"choices"' "$body" 2>/dev/null; then has_choices=1; fi
+  rm -f "$body"
+
+  if [[ $rc -ne 0 ]]; then
+    echo "[switch] ERROR: server answered /v1/models but could not generate — the completion" >&2
+    echo "[switch]        probe failed after ${probe_s}s (curl exit ${rc}; cap ${READY_PROBE_TIMEOUT:-90}s)." >&2
+    echo "[switch]        Last 30 log lines:" >&2
+    docker logs --tail 30 "$container" 2>&1 | sed 's/^/[switch]   | /' >&2
+    echo "[switch]        Full logs:  docker logs ${container}" >&2
+    echo "[switch]        Slow-but-healthy engine? raise READY_PROBE_TIMEOUT, or READY_PROBE=0 to skip." >&2
+    return 1
+  fi
+
+  case "$code" in
+    2*)
+      if [[ $has_choices -eq 1 ]]; then
+        echo "[switch]   generation probe ok — 1 token in ${probe_s}s (model: ${served})"
+      else
+        echo "[switch] ⚠ generation probe: HTTP ${code} but no choices[] in the reply — treating as ok." >&2
+        echo "[switch]   ${snippet}" >&2
+      fi
+      return 0
+      ;;
+    501|4*)
+      echo "[switch] ⚠ generation probe skipped — endpoint answered HTTP ${code} on ${base}/chat/completions" >&2
+      echo "[switch]   (different completion shape or missing chat template — NOT a boot failure)" >&2
+      echo "[switch]   ${snippet}" >&2
+      return 0
+      ;;
+    5*)
+      echo "[switch] ERROR: server answered /v1/models but FAILED to generate (HTTP ${code})." >&2
+      echo "[switch]        ${snippet}" >&2
+      echo "[switch]        Last 30 log lines:" >&2
+      docker logs --tail 30 "$container" 2>&1 | sed 's/^/[switch]   | /' >&2
+      echo "[switch]        Full logs:  docker logs ${container}" >&2
+      echo "[switch]        Set READY_PROBE=0 to skip this probe if the engine is known-good." >&2
+      return 1
+      ;;
+    *)
+      echo "[switch] ⚠ generation probe inconclusive (HTTP '${code}') — treating as ok." >&2
+      return 0
+      ;;
+  esac
+}
+
 wait_ready() {
   # Find the container we just brought up so we can detect crashes mid-boot
   # AND surface stage progress markers from its logs while we wait.
   local container
   container="${VARIANT_CONTAINER[$VARIANT]:-}"
-  if [[ -z "$container" ]] || ! docker ps --format '{{.Names}}' 2>/dev/null | grep -Fxq -- "$container"; then
+  if [[ -z "$container" ]] || ! docker ps --format '{{.Names}}' 2>/dev/null | command grep -Fxq -- "$container"; then
     # Compose started but no container is up — almost always a syntax error
     # or env-var issue caught before vLLM even started.
     echo "[switch] ERROR: no container running after 'compose up' — boot failed before vLLM started." >&2
@@ -1165,15 +1263,39 @@ wait_ready() {
 
   echo "[switch] waiting for ${READY_URL} (container=${container}, timeout ${READY_TIMEOUT}s)..."
   local elapsed=0 step=4 last_marker=""
+  # #1099 — baseline the restart counter. Under a restart policy (`restart:
+  # unless-stopped`, which most composes set) docker reports
+  # `.State.Running == true` for a container that is crash-looping, so the old
+  # Running-based check never fired and a boot-guard rejection polled a dead
+  # endpoint for the full READY_TIMEOUT. Baseline instead of assuming 0: `up -d`
+  # can leave an already-running container in place with a non-zero count.
+  local restarts_at_start
+  restarts_at_start="$(docker inspect -f '{{.RestartCount}}' "$container" 2>/dev/null || true)"
+  [[ "$restarts_at_start" =~ ^[0-9]+$ ]] || restarts_at_start=0
+
   until curl -sf -o /dev/null --max-time 3 "${READY_URL}"; do
-    # CRASH DETECTION: if the container died, dump tail and exit fast — don't
-    # silently burn through the full timeout on a dead server.
-    local state
-    state=$(docker inspect -f '{{.State.Running}}' "$container" 2>/dev/null || echo missing)
-    if [[ "$state" != "true" ]]; then
+    # CRASH DETECTION: if the container died OR is crash-looping, dump the tail
+    # and exit fast — don't silently burn through the full timeout on a server
+    # that is never coming up.
+    local state restarts dead=""
+    state="$(docker inspect -f '{{.State.Status}}' "$container" 2>/dev/null || true)"
+    [[ -n "$state" ]] || state="missing"
+    restarts="$(docker inspect -f '{{.RestartCount}}' "$container" 2>/dev/null || true)"
+    [[ "$restarts" =~ ^[0-9]+$ ]] || restarts="$restarts_at_start"
+    if [[ "$state" != "running" ]]; then
+      # exited / dead / restarting / paused / missing — `restarting` is the one
+      # the old .State.Running check could never see.
+      dead="state=${state}"
+    elif [[ "$restarts" -gt "$restarts_at_start" ]]; then
+      # A crash-loop reads `running` in the brief window between two restarts,
+      # so the counter is what makes it visible at an arbitrary sample point.
+      # For a boot-guard rejection even ONE restart means it won't come up.
+      dead="crash-looping (restarts ${restarts_at_start}→${restarts}, state=${state})"
+    fi
+    if [[ -n "$dead" ]]; then
       local exit_code
-      exit_code=$(docker inspect -f '{{.State.ExitCode}}' "$container" 2>/dev/null || echo "?")
-      echo "[switch] ERROR: container '${container}' is no longer running (state=${state}, exit=${exit_code})." >&2
+      exit_code="$(docker inspect -f '{{.State.ExitCode}}' "$container" 2>/dev/null || echo '?')"
+      echo "[switch] ERROR: container '${container}' is not coming up (${dead}, exit=${exit_code})." >&2
       echo "[switch]        Last 30 log lines:" >&2
       docker logs --tail 30 "$container" 2>&1 | sed 's/^/[switch]   | /' >&2
       echo "[switch]        Full logs:  docker logs ${container}" >&2
@@ -1183,13 +1305,16 @@ wait_ready() {
     sleep $step
     elapsed=$((elapsed + step))
 
-    # PROGRESS SIGNAL: surface boot-stage markers so users see WHAT vLLM is
-    # doing, not just that it's "still waiting". The grep is selective — one
-    # line per phase transition, not raw log streaming.
+    # PROGRESS SIGNAL: surface boot-stage markers so users see WHAT the engine
+    # is doing, not just that it's "still waiting". The grep is selective — one
+    # line per phase transition, not raw log streaming. Both engine families are
+    # covered (#1099): vLLM first, then llama.cpp / ik-llama, which emit none of
+    # vLLM's strings and used to show a bare elapsed counter — on exactly the
+    # engines with the longest load times.
     local marker
-    marker=$(docker logs --tail 50 "$container" 2>&1 | grep -oE \
-      'Genesis Results: .* applied|Resolved architecture: \w+|Loading weights|Compilation finished|Memory profiling|Capturing CUDA graphs|Application startup complete' \
-      | tail -1 || true)
+    marker="$(docker logs --tail 50 "$container" 2>&1 | command grep -oE \
+      'Genesis Results: .* applied|Resolved architecture: \w+|Loading weights|Compilation finished|Memory profiling|Capturing CUDA graphs|Application startup complete|load_model: loading model|common_memory_breakdown_print|\[moe-cache\] enabled: first pool allocated|model loaded|listening on http://[^[:space:]]+' \
+      | tail -1 || true)"
     if [[ -n "$marker" && "$marker" != "$last_marker" ]]; then
       echo "[switch]   ${elapsed}s — ${marker}"
       last_marker="$marker"
@@ -1203,7 +1328,7 @@ wait_ready() {
       exit 1
     fi
   done
-  echo "[switch] ✓ ready (${elapsed}s)"
+
   # F3 (CLI parity with c3's serving card): print the USABLE endpoint — the LAN
   # URL an agent/client should point at, the served model id, and the auth
   # status. LANIP's source of truth is the repo .env (#512, loaded above; shell
@@ -1217,8 +1342,16 @@ wait_ready() {
   fi
   _lanip="${_lanip:-localhost}"
   _port="${READY_URL#*://}"; _port="${_port#*:}"; _port="${_port%%/*}"
+  # Resolved BEFORE the ready line now: the generation probe needs the served id
+  # too, and it must come from the endpoint — never a hardcoded name.
   _served="$(curl -sf --max-time 3 "${READY_URL}" \
     | python3 -c 'import json,sys; print(json.load(sys.stdin)["data"][0]["id"])' 2>/dev/null || true)"
+
+  # #1100 — prove generation works (and warm the moe-cache expert pool) before
+  # claiming ready. Only a dead/erroring server fails here; see ready_probe().
+  ready_probe "$container" "$_served" || exit 1
+
+  echo "[switch] ✓ ready (${elapsed}s)"
   echo "[switch] ▶ API:  http://${_lanip}:${_port}/v1   (model: ${_served:-?} · OpenAI-compatible · no auth)"
 }
 

--- a/scripts/tests/test-switch-ready-probe.sh
+++ b/scripts/tests/test-switch-ready-probe.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# Test for switch.sh wait_ready() crash detection + generation readiness probe.
+#
+# Two bugs this locks down:
+#
+#   #1099 — crash detection never fired under a restart policy. Docker reports
+#           `.State.Running == true` for a container in restart backoff, so on
+#           any compose with `restart: unless-stopped` (most of them) a dead
+#           server was polled for the full READY_TIMEOUT while the display said
+#           "still waiting". The check now keys on `.State.Status` (which does
+#           say `restarting`) AND on RestartCount rising during the wait.
+#           Secondary: llama.cpp / ik-llama emit none of the vLLM progress
+#           strings, so those slugs showed a bare elapsed counter.
+#
+#   #1100 — "ready" was declared on a bound-but-cold server: `GET /v1/models`
+#           answers the moment the HTTP server binds. One bounded max_tokens=1
+#           completion now has to succeed first (READY_PROBE=0 opts out).
+#
+# Validates:
+#   1.  Crash-loop under a restart policy (Status=restarting) fails fast.
+#   2.  NEGATIVE CONTROL: a slow-but-healthy boot (Status=running, RestartCount
+#       flat, endpoint binds late) is NOT flagged — a gate that fires on healthy
+#       boots is worse than the bug.
+#   3.  RestartCount rising while Status reads `running` (the between-restarts
+#       sampling window) fails fast.
+#   4.  A plain exited container still fails fast (old behaviour preserved).
+#   5.  The last 30 log lines are dumped on every crash path.
+#   6.  llama.cpp progress markers are surfaced.
+#   7.  Generation probe: HTTP 5xx → boot FAILS (bound but cannot generate).
+#   8.  Generation probe: transport failure / timeout → boot FAILS.
+#   9.  Generation probe: HTTP 2xx with choices[] → ready.
+#   10. Generation probe: HTTP 4xx → WARN only (graceful degrade, not a failure).
+#   11. The probe uses the served model id resolved from /v1/models (no hardcode).
+#   12. READY_PROBE=0 skips the probe entirely (no POST issued).
+#
+# Harness: extract ready_probe()/wait_ready() via sed, source them, and put mock
+# `docker`, `curl` and `sleep` on PATH. Fully offline — no docker, no GPU.
+set -uo pipefail
+
+# wait_ready() parses the served-model id with python3 (via the sourced helper),
+# so carry the repo's UTF-8-mode default here too (#779; test-locale-utf8.sh).
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+PASS=0
+FAIL=0
+_dump() { echo "--- wait_ready output (rc=$2) ---" >&2; printf '%s\n' "$1" >&2; }
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3" rc="${4:-}"
+  if [[ "$haystack" == *"$needle"* ]]; then PASS=$((PASS + 1)); else
+    echo "FAIL: ${label}: expected output to CONTAIN: ${needle}" >&2
+    _dump "$haystack" "$rc"; FAIL=$((FAIL + 1))
+  fi
+}
+assert_not_contains() {
+  local haystack="$1" needle="$2" label="$3" rc="${4:-}"
+  if [[ "$haystack" != *"$needle"* ]]; then PASS=$((PASS + 1)); else
+    echo "FAIL: ${label}: expected output to NOT contain: ${needle}" >&2
+    _dump "$haystack" "$rc"; FAIL=$((FAIL + 1))
+  fi
+}
+assert_rc() {
+  local got="$1" want="$2" label="$3" out="${4:-}"
+  if [[ "$got" == "$want" ]]; then PASS=$((PASS + 1)); else
+    echo "FAIL: ${label}: expected exit ${want}, got ${got}" >&2
+    _dump "$out" "$got"; FAIL=$((FAIL + 1))
+  fi
+}
+
+# --- Extract the functions under test (avoids running switch.sh's main) -------
+HELPERS_FILE="$(mktemp --suffix=.sh)"
+sed -n '/^ready_probe()/,/^}/p' scripts/switch.sh  > "$HELPERS_FILE"
+sed -n '/^wait_ready()/,/^}/p'  scripts/switch.sh >> "$HELPERS_FILE"
+if ! command grep -q '^wait_ready()' "$HELPERS_FILE" || ! command grep -q '^ready_probe()' "$HELPERS_FILE"; then
+  echo "FAIL: could not extract ready_probe()/wait_ready() from scripts/switch.sh" >&2
+  rm -f "$HELPERS_FILE"; exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+cleanup() { rm -rf "$tmp_dir" "$HELPERS_FILE"; }
+trap cleanup EXIT
+
+# --- Mock `docker` ------------------------------------------------------------
+# State is env-driven: DOCKER_MOCK_STATUS (.State.Status), a RestartCount
+# SEQUENCE (successive polls, sticky at the last element), exit code and logs.
+cat > "${tmp_dir}/docker" <<'EOF'
+#!/usr/bin/env bash
+sub="${1:-}"; shift || true
+case "$sub" in
+  ps)
+    for n in ${DOCKER_MOCK_RUNNING:-}; do printf '%s\n' "$n"; done
+    ;;
+  inspect)
+    fmt=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in -f|--format) fmt="${2:-}"; shift 2 || true ;; *) shift ;; esac
+    done
+    case "$fmt" in
+      *State.Status*)   printf '%s\n' "${DOCKER_MOCK_STATUS:-running}" ;;
+      *State.Running*)  printf '%s\n' "${DOCKER_MOCK_RUNNING_FLAG:-true}" ;;
+      *State.ExitCode*) printf '%s\n' "${DOCKER_MOCK_EXIT:-0}" ;;
+      *RestartCount*)
+        read -r -a _seq <<< "${DOCKER_MOCK_RESTARTS:-0}"
+        _i="$(cat "${MOCK_STATE}/rc_idx" 2>/dev/null || echo 0)"
+        [[ "$_i" -lt "${#_seq[@]}" ]] || _i=$(( ${#_seq[@]} - 1 ))
+        printf '%s\n' "${_seq[$_i]}"
+        echo $(( _i + 1 )) > "${MOCK_STATE}/rc_idx"
+        ;;
+    esac
+    ;;
+  logs) printf '%s\n' "${DOCKER_MOCK_LOGS:-}" ;;
+  *) : ;;
+esac
+exit 0
+EOF
+chmod +x "${tmp_dir}/docker"
+
+# --- Mock `curl` --------------------------------------------------------------
+# Three call shapes, all issued by wait_ready/ready_probe:
+#   readiness poll   : -sf -o /dev/null --max-time 3 <models-url>
+#   served-id fetch  : -sf --max-time 3 <models-url>          → JSON on stdout
+#   generation probe : -s -o <file> -w '%{http_code}' -X POST <chat-url>
+cat > "${tmp_dir}/curl" <<'EOF'
+#!/usr/bin/env bash
+is_post=0; out=""; payload=""; url=""
+args=("$@"); i=0
+while [[ $i -lt ${#args[@]} ]]; do
+  case "${args[$i]}" in
+    -X) [[ "${args[$((i+1))]:-}" == "POST" ]] && is_post=1; i=$((i+2)) ;;
+    -o) out="${args[$((i+1))]:-}"; i=$((i+2)) ;;
+    -d) payload="${args[$((i+1))]:-}"; i=$((i+2)) ;;
+    -H|-w|--max-time) i=$((i+2)) ;;
+    http*) url="${args[$i]}"; i=$((i+1)) ;;
+    *) i=$((i+1)) ;;
+  esac
+done
+
+if [[ $is_post -eq 1 ]]; then
+  printf '%s' "$payload" > "${MOCK_STATE}/post_payload"
+  printf '%s' "$url"     > "${MOCK_STATE}/post_url"
+  [[ -n "$out" ]] && printf '%s' "${CURL_MOCK_PROBE_BODY:-}" > "$out"
+  printf '%s' "${CURL_MOCK_PROBE_CODE:-200}"
+  exit "${CURL_MOCK_PROBE_RC:-0}"
+fi
+
+if [[ "$out" == "/dev/null" ]]; then          # readiness poll
+  n="$(cat "${MOCK_STATE}/polls" 2>/dev/null || echo 0)"
+  n=$((n + 1)); echo "$n" > "${MOCK_STATE}/polls"
+  [[ "$n" -ge "${CURL_MOCK_READY_AFTER:-1}" ]] && exit 0
+  exit 22
+fi
+printf '{"data":[{"id":"%s"}]}' "${CURL_MOCK_SERVED:-club-test-model}"
+exit 0
+EOF
+chmod +x "${tmp_dir}/curl"
+
+# --- Mock `sleep`: keep the suite instant (wait_ready polls every 4s) ---------
+printf '#!/usr/bin/env bash\nexit 0\n' > "${tmp_dir}/sleep"
+chmod +x "${tmp_dir}/sleep"
+
+export PATH="${tmp_dir}:$PATH"
+
+# shellcheck source=/dev/null
+source "$HELPERS_FILE"
+
+VARIANT="ik-llama/iq4ks-mtp"
+declare -A VARIANT_CONTAINER=(["ik-llama/iq4ks-mtp"]="ik-llama-qwen36-27b")
+READY_URL="http://localhost:8020/v1/models"
+READY_TIMEOUT=60
+export DOCKER_MOCK_RUNNING="ik-llama-qwen36-27b"
+
+run_wait_ready() {
+  # Fresh mock state per scenario; run under switch.sh's own shell options.
+  export MOCK_STATE="${tmp_dir}/state"
+  rm -rf "$MOCK_STATE"; mkdir -p "$MOCK_STATE"
+  OUT="$( set -euo pipefail; wait_ready 2>&1 )"; RC=$?
+  return 0
+}
+
+# --- 1. Crash-loop under a restart policy (the #1099 bug) ---------------------
+# Docker says Running=true the whole time — only Status/RestartCount betray it.
+export DOCKER_MOCK_STATUS="restarting" DOCKER_MOCK_RUNNING_FLAG="true"
+export DOCKER_MOCK_RESTARTS="29" DOCKER_MOCK_EXIT="1"
+export DOCKER_MOCK_LOGS="ERROR boot-guard: rejected --ctx-size 262144 (needs 30 GiB)"
+export CURL_MOCK_READY_AFTER=9999
+run_wait_ready
+assert_rc "$RC" 1 "crash-loop: fails fast instead of waiting out READY_TIMEOUT" "$OUT"
+assert_contains "$OUT" "is not coming up"         "crash-loop: reports the container is not coming up" "$RC"
+assert_contains "$OUT" "state=restarting"         "crash-loop: names the restarting state" "$RC"
+assert_contains "$OUT" "boot-guard: rejected"     "crash-loop: dumps the log tail with the guard error" "$RC"
+assert_not_contains "$OUT" "timeout — server not ready" "crash-loop: does not burn the full timeout" "$RC"
+
+# --- 2. NEGATIVE CONTROL: slow-but-healthy boot ------------------------------
+# Status stays `running`, RestartCount never moves, the endpoint binds on the
+# 6th poll. Must reach ready — no crash verdict, no false positive.
+export DOCKER_MOCK_STATUS="running" DOCKER_MOCK_RESTARTS="0" DOCKER_MOCK_EXIT="0"
+export DOCKER_MOCK_LOGS="load_model: loading model from /models/qwen.gguf"
+export CURL_MOCK_READY_AFTER=6
+export CURL_MOCK_PROBE_CODE=200 CURL_MOCK_PROBE_RC=0
+export CURL_MOCK_PROBE_BODY='{"choices":[{"message":{"content":"hi"}}]}'
+run_wait_ready
+assert_rc "$RC" 0 "negative control: slow-but-healthy boot is NOT flagged" "$OUT"
+assert_contains "$OUT" "✓ ready"          "negative control: declares ready" "$RC"
+assert_not_contains "$OUT" "ERROR"        "negative control: no crash verdict on a healthy boot" "$RC"
+assert_not_contains "$OUT" "crash-looping" "negative control: no crash-loop verdict" "$RC"
+# 6. llama.cpp progress marker surfaced (used to be vLLM-only strings)
+assert_contains "$OUT" "load_model: loading model" "llama.cpp progress marker is surfaced" "$RC"
+# 11. the probe targets the served id resolved from /v1/models, not a literal
+assert_contains "$(cat "${MOCK_STATE}/post_payload" 2>/dev/null)" '"model":"club-test-model"' \
+  "probe uses the served model id from /v1/models" "$RC"
+assert_contains "$(cat "${MOCK_STATE}/post_url" 2>/dev/null)" "/v1/chat/completions" \
+  "probe posts to the chat-completions endpoint" "$RC"
+assert_contains "$OUT" "generation probe ok"  "probe reports success on a healthy engine" "$RC"
+
+# --- 3. RestartCount rising while Status reads `running` ----------------------
+# A crash-loop reads `running` in the window between two restarts; the counter
+# is what makes it visible at an arbitrary sample point.
+export DOCKER_MOCK_STATUS="running" DOCKER_MOCK_RESTARTS="0 0 3" DOCKER_MOCK_EXIT="1"
+export DOCKER_MOCK_LOGS="CUDA error: out of memory"
+export CURL_MOCK_READY_AFTER=9999
+run_wait_ready
+assert_rc "$RC" 1 "restart-count leg: rising RestartCount fails fast" "$OUT"
+assert_contains "$OUT" "crash-looping"        "restart-count leg: names the crash loop" "$RC"
+assert_contains "$OUT" "CUDA error"           "restart-count leg: dumps the log tail" "$RC"
+
+# --- 4. Plain exited container (pre-existing behaviour preserved) -------------
+export DOCKER_MOCK_STATUS="exited" DOCKER_MOCK_RESTARTS="0" DOCKER_MOCK_EXIT="137"
+export DOCKER_MOCK_LOGS="killed"
+run_wait_ready
+assert_rc "$RC" 1 "exited container still fails fast" "$OUT"
+assert_contains "$OUT" "state=exited"  "exited container: names the state" "$RC"
+assert_contains "$OUT" "exit=137"      "exited container: surfaces the exit code" "$RC"
+
+# --- 7. Generation probe: HTTP 5xx → the boot FAILS (#1100) -------------------
+export DOCKER_MOCK_STATUS="running" DOCKER_MOCK_RESTARTS="0" DOCKER_MOCK_EXIT="0"
+export DOCKER_MOCK_LOGS="AssertionError in sampler"
+export CURL_MOCK_READY_AFTER=1
+export CURL_MOCK_PROBE_CODE=500 CURL_MOCK_PROBE_RC=0
+export CURL_MOCK_PROBE_BODY='{"error":"engine dead"}'
+run_wait_ready
+assert_rc "$RC" 1 "probe: bound but cannot generate (HTTP 500) fails the boot" "$OUT"
+assert_contains "$OUT" "FAILED to generate"   "probe: says generation failed" "$RC"
+assert_contains "$OUT" "AssertionError"       "probe: dumps the log tail" "$RC"
+assert_not_contains "$OUT" "✓ ready"          "probe: does not declare ready on a broken engine" "$RC"
+
+# --- 8. Generation probe: transport failure / timeout → FAILS ----------------
+export CURL_MOCK_PROBE_CODE="000" CURL_MOCK_PROBE_RC=28 CURL_MOCK_PROBE_BODY=""
+run_wait_ready
+assert_rc "$RC" 1 "probe: transport failure / timeout fails the boot" "$OUT"
+assert_contains "$OUT" "could not generate"     "probe: reports the transport failure" "$RC"
+assert_contains "$OUT" "READY_PROBE=0"          "probe: names the opt-out in the error" "$RC"
+
+# --- 10. Generation probe: HTTP 4xx → WARN only ------------------------------
+# A different completion shape / missing chat template must NOT turn a working
+# boot into a false failure.
+export CURL_MOCK_PROBE_CODE=404 CURL_MOCK_PROBE_RC=0
+export CURL_MOCK_PROBE_BODY='{"detail":"Not Found"}'
+run_wait_ready
+assert_rc "$RC" 0 "probe: HTTP 4xx degrades gracefully (not a boot failure)" "$OUT"
+assert_contains "$OUT" "generation probe skipped" "probe: warns on 4xx" "$RC"
+assert_contains "$OUT" "✓ ready"                  "probe: still declares ready on 4xx" "$RC"
+
+# --- 12. READY_PROBE=0 skips the probe entirely ------------------------------
+export CURL_MOCK_PROBE_CODE=500 CURL_MOCK_PROBE_RC=0
+READY_PROBE=0 run_wait_ready
+assert_rc "$RC" 0 "READY_PROBE=0: opt-out keeps the old behaviour" "$OUT"
+assert_contains "$OUT" "probe skipped (READY_PROBE=0)" "READY_PROBE=0: says it skipped" "$RC"
+if [[ -f "${MOCK_STATE}/post_payload" ]]; then
+  echo "FAIL: READY_PROBE=0 still issued a completion request" >&2
+  FAIL=$((FAIL + 1))
+else
+  PASS=$((PASS + 1))
+fi
+
+# --- Summary ------------------------------------------------------------------
+echo "----------------------------------------"
+echo "PASS: $PASS   FAIL: $FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1
+echo "OK: switch.sh crash detection (#1099) + generation readiness probe (#1100)"


### PR DESCRIPTION
Closes #1099. Closes #1100.

Two ways `wait_ready` reported a boot it had not actually verified.

## #1099 — crash detection never fired under a restart policy

```bash
state=$(docker inspect -f '{{.State.Running}}' "$container" ...)
if [[ "$state" != "true" ]]; then
```

**Docker reports `.State.Running == true` for a container in restart backoff**, so this branch was unreachable for every compose that sets `restart: unless-stopped` — which is all 122 of them (`test-compose-restart-policy` mandates it). A boot-guard rejection therefore polled a dead endpoint for the full `READY_TIMEOUT` (600s default) while the display said "still waiting". One user accumulated 29 restarts behind that.

Verified against a real throwaway container:

```
Running=true Status=running     RestartCount=2
Running=true Status=restarting  RestartCount=5
Running=true Status=restarting  RestartCount=7
```

Now judges on `.State.Status` (which does say `restarting`) **plus** a `RestartCount` rising above an at-entry baseline — a crash-loop reads `running` in the window between two restarts, so the counter is what makes it visible at an arbitrary sample point.

| | before | after |
|---|---|---|
| crash-looping container | `timeout — server not ready after 600s`, no verdict, no logs | `ERROR: container is not coming up (state=restarting, exit=1)` + 30-line dump showing the guard's actual error, **at the first poll** |

## #1100 — ready was declared on a bound-but-cold server

`/v1/models` answers the moment the HTTP server binds, before the model has served a token. Two consequences: a server that binds but cannot generate passed silently, and for the moe-cache slugs the expert pool initialises **on first inference**, so "ready" meant a cold cache and anything benchmarking right after ✓ paid pool allocation inside its first measured request.

Adds `ready_probe()`: one bounded `max_tokens=1` completion against the served model id, with a graded verdict — transport failure/timeout or 5xx (except 501) fails; 4xx/501/unfamiliar reply shape warns and passes.

```
before:  /v1/models 200 + /v1/chat/completions 500  ->  ✓ ready (0s), exit 0
after:   ERROR: server answered /v1/models but FAILED to generate (HTTP 500), exit 1
```

**Default on.** The failure it catches is silent and expensive, and the cost is one token on a boot that already took minutes. False-failure risk is bounded by the grading, so an engine with a different completion shape cannot turn a working boot red. Hard-capped by `READY_PROBE_TIMEOUT` (90s) so the probe can never become the hang itself; `READY_PROBE=0` opts out and both failure messages name it.

## Also

The progress-marker grep matched vLLM strings only, so llama.cpp/ik-llama slugs showed a bare elapsed counter — no stage info on exactly the engines with the longest load times. Added `load_model:`, `model loaded`, `listening on`, `[moe-cache] enabled`.

## Verification

New hermetic gate `scripts/tests/test-switch-ready-probe.sh` (32 assertions, mocked `docker`/`curl`/`sleep` — no GPU, no docker daemon).

- **Negative control, the one that matters:** a real slow-but-healthy boot (endpoint binds only after 20s) produces **no** crash verdict; and a container that runs healthily for 10s *then* crashes stays silent through the healthy window and fires on the first restart. A gate that reds healthy boots would be worse than the bug.
- **The gate is not a no-op:** run against the pre-change `wait_ready` it goes 21 FAIL / 11 PASS; against this change, 32 PASS.
- Suite: 119/120 before, 120/121 after — the single failure (`test-bench-capture.sh`) is identical before and after and passes standalone (pre-existing batch-context flake). All 19 gates referencing `switch.sh` re-run green against the final tree.

`--no-wait` is untouched (it never calls `wait_ready`).

This also affects c3, which shells out to `switch.sh <slug>` without `--no-wait` — the cockpit's readiness signal is exactly this probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
