### PR TITLE
feat(litellm): add OrcaRouter cloud reference routes

### DIFF
--- a/docs/QUALITY_TEST.md
+++ b/docs/QUALITY_TEST.md
@@ -254,7 +254,7 @@ Quality:   ToolCall-15 14/15 (93%) · InstructFollow-15 13/15 (87%) · StructOut
 
 ## Cloud / proxy endpoints
 
-`quality-test.sh` runs the same 8-pack against any **cloud or proxied OpenAI-compatible endpoint** — a managed API (DashScope, OpenRouter, together, DeepInfra), a router, or your own hosted model — for a like-for-like local-vs-cloud comparison (identical prompts, identical verifiers). Cloud support shipped in [#746](https://github.com/noonghunna/club-3090/pull/746); the underlying knobs live in [benchlocal-cli → Running against a cloud / managed endpoint](https://github.com/noonghunna/benchlocal-cli#running-against-a-cloud--managed-endpoint).
+`quality-test.sh` runs the same 8-pack against any **cloud or proxied OpenAI-compatible endpoint** — a managed API (DashScope, OpenRouter, OrcaRouter, together, DeepInfra), a router, or your own hosted model — for a like-for-like local-vs-cloud comparison (identical prompts, identical verifiers). Cloud support shipped in [#746](https://github.com/noonghunna/club-3090/pull/746); the underlying knobs live in [benchlocal-cli → Running against a cloud / managed endpoint](https://github.com/noonghunna/benchlocal-cli#running-against-a-cloud--managed-endpoint).
 
 Three env vars (or flags) point the wrapper at a remote endpoint:
 
@@ -289,6 +289,18 @@ URL=http://localhost:4000 API_KEY="$LITELLM_KEY" MODEL=qwen3.8-max \
   bash scripts/quality-test.sh --full --enable-thinking --save-json qwen38max-on.json
 URL=http://localhost:4000 API_KEY="$LITELLM_KEY" MODEL=qwen3.8-max-nothink \
   bash scripts/quality-test.sh --full --no-thinking --save-json qwen38max-off.json
+```
+
+### Worked example — OrcaRouter (AI gateway)
+
+A second named cloud reference ([services/litellm/config.yaml](../services/litellm/config.yaml)): `orcarouter-auto` and `orcarouter-fusion-flash` route through the same LiteLLM proxy to [OrcaRouter](https://www.orcarouter.ai) (`https://api.orcarouter.ai/v1`). Unlike DashScope's single upstream, the gateway exposes a provider/model namespace — `orcarouter/auto` picks a model dynamically, `orcarouter/fusion-flash` is a fixed model id — so both a routing and a concrete model are available for like-for-like comparison. No `rpm`/`tpm` pacing is set: no rate limits are prescribed to us. The key comes from `ORCAROUTER_API_KEY` (see `services/litellm/docker-compose.yml`).
+
+```bash
+# via the proxy routes (services/litellm/config.yaml)
+URL=http://localhost:4000 API_KEY="$LITELLM_KEY" MODEL=orcarouter-auto \
+  bash scripts/quality-test.sh --full --enable-thinking --save-json orca-on.json
+URL=http://localhost:4000 API_KEY="$LITELLM_KEY" MODEL=orcarouter-fusion-flash \
+  bash scripts/quality-test.sh --full --no-thinking --save-json orca-off.json
 ```
 
 ## Scenario-level probes (selection, incremental, resume)

--- a/services/litellm/config.yaml
+++ b/services/litellm/config.yaml
@@ -137,3 +137,21 @@ model_list:
       rpm: 110
       tpm: 480000
       extra_body: {"thinking_budget": 1}
+
+  # === Cloud reference endpoint (OrcaRouter AI gateway, OpenAI-compatible) ===
+  # Second named cloud reference for benchlocal-cli quality runs. OrcaRouter is a
+  # multi-model AI gateway: it exposes a provider/model namespace (orcarouter/auto,
+  # orcarouter/fusion-flash, …) across many upstream models, so one endpoint serves
+  # as a drop-in cloud comparison the same way DashScope does. No rpm/tpm set — no
+  # rate limits prescribed to us, so let LiteLLM pass through untuned.
+  - model_name: orcarouter-auto
+    litellm_params:
+      model: openai/orcarouter/auto
+      api_base: https://api.orcarouter.ai/v1
+      api_key: os.environ/ORCAROUTER_API_KEY
+  # A concrete, stable model id (orcarouter/auto routes dynamically).
+  - model_name: orcarouter-fusion-flash
+    litellm_params:
+      model: openai/orcarouter/fusion-flash
+      api_base: https://api.orcarouter.ai/v1
+      api_key: os.environ/ORCAROUTER_API_KEY

--- a/services/litellm/docker-compose.yml
+++ b/services/litellm/docker-compose.yml
@@ -9,8 +9,10 @@ services:
       - ./config.yaml:/app/config.yaml
     environment:
       - LITELLM_MASTER_KEY=sk-litellm-master-key
-      # Cloud reference route (qwen3.8-max*) — referenced as os.environ/DASHSCOPE_API_KEY
+      # Cloud reference routes — referenced as os.environ/DASHSCOPE_API_KEY and
+      # os.environ/ORCAROUTER_API_KEY in config.yaml
       - DASHSCOPE_API_KEY=${DASHSCOPE_API_KEY:-}
+      - ORCAROUTER_API_KEY=${ORCAROUTER_API_KEY:-}
     command: ["--config", "/app/config.yaml", "--port", "4000", "--host", "0.0.0.0", "--num_workers", "1"]
     extra_hosts:
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
## Summary

club-3090 is a recipes-and-configs stack for serving LLMs on RTX 3090s, and its LiteLLM gateway (`services/litellm/config.yaml`) already ships one named cloud reference endpoint — DashScope's `qwen3.8-max` — so `quality-test.sh` can grade a managed API against the local composes with the identical 8-pack. This PR adds a second named cloud reference, [OrcaRouter](https://www.orcarouter.ai), wired in exact parallel to the DashScope block.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class cloud reference means this project's users can run `quality-test.sh` against that stack directly, without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Type of change

- [ ] New compose variant (`models/<model>/<engine>/compose/docker-compose.<name>.yml`)
- [ ] New patch / sidecar (`models/<model>/<engine>/patches/`)
- [ ] New script or tool (`scripts/`, `tools/`)
- [ ] New model (`models/<new-model>/`)
- [x] Doc-only / config (LiteLLM cloud reference routes)
- [ ] Other (describe)

## Changes

- **`services/litellm/config.yaml`** — added two routes mirroring the DashScope block below it: `orcarouter-auto` (model `openai/orcarouter/auto`, the gateway's dynamic routing model) and `orcarouter-fusion-flash` (model `openai/orcarouter/fusion-flash`, a concrete stable model id). Both point at `https://api.orcarouter.ai/v1` with `api_key: os.environ/ORCAROUTER_API_KEY`. No `rpm`/`tpm` pacing — OrcaRouter prescribes no rate limits to us.
- **`services/litellm/docker-compose.yml`** — added `ORCAROUTER_API_KEY=${ORCAROUTER_API_KEY:-}` next to the existing `DASHSCOPE_API_KEY`, so the key reaches LiteLLM the same way DashScope's does.
- **`docs/QUALITY_TEST.md`** — added OrcaRouter to the managed-API list and a "Worked example — OrcaRouter (AI gateway)" subsection beside the DashScope one, with the `quality-test.sh` invocation for both routes.

## Verification

This is a config/docs change (cloud reference route), so the compose-verification gates (`report.sh --full`, `verify-full`, `verify-stress`, soak, bench) don't apply — there's no local serving config touched and no TPS surface. What I did run:

- **LiteLLM gate tests, both green:**
  - `bash scripts/tests/test-litellm-generate.sh` — PASS (emit idempotent, `--check` green, hand/cloud blocks preserved — the generated LOCAL block and my hand-maintained cloud routes coexist cleanly).
  - `bash scripts/tests/test-litellm-ports-resolve.sh` — PASS ("all 12 local litellm entries resolve to real registry default_ports"); the OrcaRouter routes are `https://` cloud entries and are correctly exempt, same as DashScope.
  - `bash scripts/lib/litellm-emit.sh --check` — PASS; a re-run leaves `config.yaml` byte-identical (cloud block untouched by the generator).
- **Live endpoint round-trip** through the exact route the config resolves: `api_base https://api.orcarouter.ai/v1` + `Authorization: Bearer $ORCAROUTER_API_KEY` + `model orcarouter/auto` / `orcarouter/fusion-flash` → **HTTP 200**, `finish_reason: stop`, valid content. No BENCHMARKS row added — a full 8-pack quality run with n≥3 is the honest bar for that, and I haven't produced those numbers.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
