### PR TITLE
DeepSeek-V4-Flash-Vision-Exp catalog, portable -t defaults, VRAM component split

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -252,3 +252,11 @@
 # CLUB3090_API_TOKEN=
 # MODEL_SWITCH_PORT=8099
 # MODEL_SWITCH_BIND=127.0.0.1
+
+# --- CPU-offload thread count (llamacpp-club3090 moe-cache slugs) ---
+# The composes default to nproc/2, which matches the launcher and is portable.
+# ⚠️ nproc/2 is a FLOOR, not the optimum. The useful zone is an ABSOLUTE
+# ~24-32 threads, NOT a fraction of your core count — on a 32c/8-channel host
+# `-t 28` measured ~20% faster than nproc/2=16, and llama.cpp's own default
+# collapses CPU-offload decode outright. Tune it for YOUR box and pin it here.
+# THREADS=28

--- a/models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-iq2-xxs/offload.yml
+++ b/models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-iq2-xxs/offload.yml
@@ -104,6 +104,10 @@ services:
     # breaks it). The list form skips shell parsing altogether, so the regex — and any
     # injected OT_G* value — survives byte-for-byte.
     environment:
+      # Bare passthrough — docker forwards ONLY what is declared here, so without
+      # this line the entrypoint's THREADS branch can never fire and the knob is
+      # inert. Never write `- THREADS=${THREADS:-}`: that sets it EMPTY.
+      - THREADS
       # Drafter toggle - docker forwards only what is declared here.
       - SPEC_N=${SPEC_N:-}
       - SPEC=${SPEC:-}
@@ -132,6 +136,23 @@ services:
         esac
         if [ "$$_spec_n" -gt 0 ]; then
           echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          # -- Threads -------------------------------------------------------------
+          # Resolved HERE, not as a `-t` CLI arg: CLI beats env, so a command-line -t
+          # silently overrides anything set below. PORTABLE DEFAULT = nproc/2, matching
+          # the launcher's resolve_offload_threads so both paths agree. The old `-t 8`
+          # was far below optimum on any capable host; nproc/2 is the safe choice when
+          # the operator's core count is unknown. ⚠️ Still a FLOOR, not the optimum --
+          # the useful zone is an ABSOLUTE ~24-32 threads. Set THREADS=<n> to tune.
+          if [ -n "$${THREADS:-}" ]; then
+            export LLAMA_ARG_THREADS="$${THREADS}"
+            echo "[threads] -t $${LLAMA_ARG_THREADS} (THREADS set explicitly)" >&2
+          else
+            _np=$$(nproc 2>/dev/null || echo 8)
+            _half=$$(( _np / 2 )); [ "$$_half" -lt 1 ] && _half=1
+            export LLAMA_ARG_THREADS="$$_half"
+            echo "[threads] -t $${LLAMA_ARG_THREADS} (auto = nproc/2, nproc=$$_np)" >&2
+          fi
+
           exec /app/llama-server "$$@"
         fi
         ARGS=(); _skip=0
@@ -173,8 +194,6 @@ services:
       - 'on'
       - '-ot'
       - '${OT_G0:-blk\.99999\.ffn_(gate|up|down)_exps\.weight=CUDA0},${OT_G1:-blk\.99999\.ffn_(gate|up|down)_exps\.weight=CUDA1},blk\.[0-9]+\.ffn_(gate|up|down)_exps\.weight=CPU'
-      - '-t'
-      - '${THREADS:-8}'
       - '-ub'
       - '4096'
       - '-b'

--- a/models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-q8-kxl/offload.yml
+++ b/models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-q8-kxl/offload.yml
@@ -138,6 +138,10 @@ services:
     # breaks it). The list form skips shell parsing altogether, so the regex — and any
     # injected OT_G* value — survives byte-for-byte.
     environment:
+      # Bare passthrough — docker forwards ONLY what is declared here, so without
+      # this line the entrypoint's THREADS branch can never fire and the knob is
+      # inert. Never write `- THREADS=${THREADS:-}`: that sets it EMPTY.
+      - THREADS
       # Drafter toggle - docker forwards only what is declared here.
       - SPEC_N=${SPEC_N:-}
       - SPEC=${SPEC:-}
@@ -166,6 +170,23 @@ services:
         esac
         if [ "$$_spec_n" -gt 0 ]; then
           echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          # -- Threads -------------------------------------------------------------
+          # Resolved HERE, not as a `-t` CLI arg: CLI beats env, so a command-line -t
+          # silently overrides anything set below. PORTABLE DEFAULT = nproc/2, matching
+          # the launcher's resolve_offload_threads so both paths agree. The old `-t 8`
+          # was far below optimum on any capable host; nproc/2 is the safe choice when
+          # the operator's core count is unknown. ⚠️ Still a FLOOR, not the optimum --
+          # the useful zone is an ABSOLUTE ~24-32 threads. Set THREADS=<n> to tune.
+          if [ -n "$${THREADS:-}" ]; then
+            export LLAMA_ARG_THREADS="$${THREADS}"
+            echo "[threads] -t $${LLAMA_ARG_THREADS} (THREADS set explicitly)" >&2
+          else
+            _np=$$(nproc 2>/dev/null || echo 8)
+            _half=$$(( _np / 2 )); [ "$$_half" -lt 1 ] && _half=1
+            export LLAMA_ARG_THREADS="$$_half"
+            echo "[threads] -t $${LLAMA_ARG_THREADS} (auto = nproc/2, nproc=$$_np)" >&2
+          fi
+
           exec /app/llama-server "$$@"
         fi
         ARGS=(); _skip=0
@@ -207,8 +228,6 @@ services:
       - 'on'
       - '-ot'
       - '${OT_G0:-blk\.99999\.ffn_(gate|up|down)_exps\.weight=CUDA0},${OT_G1:-blk\.99999\.ffn_(gate|up|down)_exps\.weight=CUDA1},blk\.[0-9]+\.ffn_(gate|up|down)_exps\.weight=CPU'
-      - '-t'
-      - '${THREADS:-8}'
       - '-ub'
       - '4096'
       - '-b'

--- a/models/deepseek-v4-flash-0731/llama-cpp/compose/multi4/unsloth-q8-kxl/offload.yml
+++ b/models/deepseek-v4-flash-0731/llama-cpp/compose/multi4/unsloth-q8-kxl/offload.yml
@@ -121,6 +121,10 @@ services:
     # breaks it). The list form skips shell parsing altogether, so the regex — and any
     # injected OT_G* value — survives byte-for-byte.
     environment:
+      # Bare passthrough — docker forwards ONLY what is declared here, so without
+      # this line the entrypoint's THREADS branch can never fire and the knob is
+      # inert. Never write `- THREADS=${THREADS:-}`: that sets it EMPTY.
+      - THREADS
       # Drafter toggle - docker forwards only what is declared here.
       - SPEC_N=${SPEC_N:-}
       - SPEC=${SPEC:-}
@@ -149,6 +153,23 @@ services:
         esac
         if [ "$$_spec_n" -gt 0 ]; then
           echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          # -- Threads -------------------------------------------------------------
+          # Resolved HERE, not as a `-t` CLI arg: CLI beats env, so a command-line -t
+          # silently overrides anything set below. PORTABLE DEFAULT = nproc/2, matching
+          # the launcher's resolve_offload_threads so both paths agree. The old `-t 8`
+          # was far below optimum on any capable host; nproc/2 is the safe choice when
+          # the operator's core count is unknown. ⚠️ Still a FLOOR, not the optimum --
+          # the useful zone is an ABSOLUTE ~24-32 threads. Set THREADS=<n> to tune.
+          if [ -n "$${THREADS:-}" ]; then
+            export LLAMA_ARG_THREADS="$${THREADS}"
+            echo "[threads] -t $${LLAMA_ARG_THREADS} (THREADS set explicitly)" >&2
+          else
+            _np=$$(nproc 2>/dev/null || echo 8)
+            _half=$$(( _np / 2 )); [ "$$_half" -lt 1 ] && _half=1
+            export LLAMA_ARG_THREADS="$$_half"
+            echo "[threads] -t $${LLAMA_ARG_THREADS} (auto = nproc/2, nproc=$$_np)" >&2
+          fi
+
           exec /app/llama-server "$$@"
         fi
         ARGS=(); _skip=0
@@ -190,8 +211,6 @@ services:
       - 'on'
       - '-ot'
       - '${OT_G0:-blk\.99999\.ffn_(gate|up|down)_exps\.weight=CUDA0},${OT_G1:-blk\.99999\.ffn_(gate|up|down)_exps\.weight=CUDA1},${OT_G2:-blk\.99999\.ffn_(gate|up|down)_exps\.weight=CUDA2},${OT_G3:-blk\.99999\.ffn_(gate|up|down)_exps\.weight=CUDA3},blk\.[0-9]+\.ffn_(gate|up|down)_exps\.weight=CPU'
-      - '-t'
-      - '${THREADS:-8}'
       - '-ub'
       - '4096'
       - '-b'

--- a/models/deepseek-v4-flash-0731/llamacpp-club3090/compose/multi4/unsloth-q8-kxl/moecache.yml
+++ b/models/deepseek-v4-flash-0731/llamacpp-club3090/compose/multi4/unsloth-q8-kxl/moecache.yml
@@ -101,6 +101,10 @@ services:
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     environment:
+      # Bare passthrough — docker forwards ONLY what is declared here, so without
+      # this line the entrypoint's THREADS branch can never fire and the knob is
+      # inert. Never write `- THREADS=${THREADS:-}`: that sets it EMPTY.
+      - THREADS
       # Drafter toggle - docker forwards only what is declared here.
       - SPEC_N=${SPEC_N:-}
       - SPEC=${SPEC:-}
@@ -184,6 +188,23 @@ services:
             exit 1
           fi
           echo "[spec] drafter ON (SPEC_N=$$_spec_n)" >&2
+          # -- Threads -------------------------------------------------------------
+          # Resolved HERE, not as a `-t` CLI arg: CLI beats env, so a command-line -t
+          # silently overrides anything set below. PORTABLE DEFAULT = nproc/2, matching
+          # the launcher's resolve_offload_threads so both paths agree. The old `-t 8`
+          # was far below optimum on any capable host; nproc/2 is the safe choice when
+          # the operator's core count is unknown. ⚠️ Still a FLOOR, not the optimum --
+          # the useful zone is an ABSOLUTE ~24-32 threads. Set THREADS=<n> to tune.
+          if [ -n "$${THREADS:-}" ]; then
+            export LLAMA_ARG_THREADS="$${THREADS}"
+            echo "[threads] -t $${LLAMA_ARG_THREADS} (THREADS set explicitly)" >&2
+          else
+            _np=$$(nproc 2>/dev/null || echo 8)
+            _half=$$(( _np / 2 )); [ "$$_half" -lt 1 ] && _half=1
+            export LLAMA_ARG_THREADS="$$_half"
+            echo "[threads] -t $${LLAMA_ARG_THREADS} (auto = nproc/2, nproc=$$_np)" >&2
+          fi
+
           exec /app/llama-server "$$@"
         fi
         ARGS=(); _skip=0
@@ -227,8 +248,6 @@ services:
       # -ot occurrence. All experts to CPU; the cache decides residency.
       - '-ot'
       - 'blk\.[0-9]+\.ffn_(gate|up|down)_exps\.weight=CPU'
-      - '-t'
-      - '${THREADS:-8}'
       - '-ub'
       - '${UBATCH:-2048}'
       - '-b'

--- a/models/deepseek-v4-flash-vision-exp/llamacpp-club3090/compose/dual/unsloth-ud-q8kxl/moecache.yml
+++ b/models/deepseek-v4-flash-vision-exp/llamacpp-club3090/compose/dual/unsloth-ud-q8kxl/moecache.yml
@@ -1,0 +1,283 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     DeepSeek-V4-Flash-Vision-Exp (deepseek4 MoE, unsloth UD-Q8_K_XL —
+#              MXFP4 experts + BF16 attention, 161.9 GB across 5 shards)
+#   Engine:    llamacpp-club3090-v1.6 (fork: leloch's MoE expert cache v2 + our
+#              L1/L3/E ports, plus @danielhanchen's indexer key-cache commits)
+#   Topology:  Dual 3090 PCIe (layer-split -ts 1,1, no NVLink)
+#   Drafter:   none wired — DSpark 0731 is tokenizer-compatible, acceptance UNMEASURED
+#   KV:        fp16 (llama.cpp default — MLA + single KV head keep it small)
+#   Vision:    ⛔ NO — despite the model name. See Caveats.
+#   Max ctx:   204800  (1,048,576 native; rope original 65,536)
+#   Genesis:   N/A — llama.cpp engine
+#   Status:    🧪 Experimental
+#   Caveats:   • ⚠️⚠️ **"Vision" IS IN THE NAME BUT NOT IN THE WEIGHTS.** Gated
+#                2026-08-31 before download: the repo ships NO mmproj/projector
+#                file, the GGUF carries NO clip/vision metadata keys, and a scan
+#                of all 1,328 tensors across shards 2-5 found ZERO vision
+#                tensors (only `blk`, `output*`, `token_embd`). This serves
+#                TEXT-ONLY. If unsloth later publishes a projector, revisit.
+#              • ✅ VALIDATED 2026-08-31 — FIRST BOOT PASSED. verify-full 10/10
+#                (tool-calling, streaming tool-calls, thinking, 2K output quality,
+#                all clean). Booted in 100 s. Bench, canonical 3 warm + 5 measured,
+#                at the SHIPPED default (THREADS unset -> -t 16) and DRAFTER-FREE:
+#                  decode  22.94 narrative (CV 1.5%) · 21.29 code (CV 0.5%)
+#                  prefill 407.3 @10K (CV 1.0%) · 343.9 @90K
+#                  depth   20.82 @10K · 19.69 @90K  ⇒ only −14% shallow→90K
+#                  TTFT    157-173 ms short · hit rate 63.1% / 60.2% per card
+#                  pool    5,360 slots of 11,008 experts (48.7%), 1 allocation
+#                ⚠️ A FLOOR, not a ceiling: 16 threads is ~20% below this rig's
+#                measured optimum of 28, and no drafter was mounted. Code decode
+#                is the leg that shows it (0731 with DSpark records 27.01).
+#              • ⚠️ NO DRAFTER WIRED — but not because none can work. The 0731
+#                sibling's DSpark (`dspark-DeepSeek-V4-Flash-0731-Q8_0.gguf`,
+#                arch `dflash`) has an **IDENTICAL tokenizer** to this target:
+#                gpt2, vocab 129,280, bos 0 / eos 1, same special tokens
+#                (verified 2026-08-31 from both GGUFs). Same base model plus
+#                vision training, so it is a plausible drafter. What is NOT
+#                measured is ACCEPTANCE against this checkpoint — the drafter was
+#                trained on 0731's weights. Wire it with `-md` + `--spec-type
+#                draft-dspark` and read the acceptance rate before trusting it;
+#                the 0731 slug reports 0.41-0.73. Until then nothing is mounted
+#                and SPEC_N is absent rather than inert.
+#              • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
+#                (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug
+#                packages it; it does not originate it.
+#              • UNMERGED ENGINE. The cache is not in mainline llama.cpp. This
+#                slug pins a fork image; it cannot be reproduced with stock.
+#              • QUALITY IS UNTESTED. No 8-pack, no soak, no verify-full.
+#              • ⚠️ COLD-START TAX: the FIRST request after boot is slow while
+#                the expert pool fills. Do not benchmark the first request.
+#              • Tuning is 2× 24 GB SPECIFIC and INHERITED from the 0731
+#                sibling — `RESERVE_MB=1536`, `-ub/-b 4096`. Re-derive
+#                before trusting any of them on other hardware.
+#              • `-t` defaults to **nproc/2**, matching the launcher so both
+#                paths agree. ⚠️ nproc/2 is a FLOOR, not the optimum — on our
+#                32c/8-channel reference host `-t 28` measured ~20% faster.
+#                That 28 lives in the OPERATOR's .env, deliberately NOT in the
+#                shipped default: pinning it would hand a 32-core-tuned value
+#                to every user and oversubscribe smaller boxes. Set THREADS=<n>;
+#                the useful zone is an ABSOLUTE ~24-32, not a fraction of cores.
+#   Best for:  long-context text on CPU-offload, when 0731's DSpark drafter is
+#              not wanted and a newer base is preferred
+# ---------------------------------------------------------------------------
+# Architecturally IDENTICAL to DeepSeek-V4-Flash-0731: arch `deepseek4`,
+# 43 blocks (all MoE, no dense prefix), 256 routed experts top-6 + 1 shared,
+# MLA with a single KV head, DSA indexer (64 heads). Verified from THIS GGUF's
+# metadata by HTTP range read, not assumed from the sibling.
+# ⚠️ `general.file_type = 38`; experts are ggml type 39 = **MXFP4**, IDENTICAL
+# to the UD-Q4_K_XL tier in the same repo. The Q4/Q8 in unsloth's names refers
+# to the NON-EXPERT path only (Q8_0 vs BF16 attention/dense) — which is why the
+# two tiers are only 4% apart in size. For a moe-cache rig this means the tier
+# choice does NOT change expert residency; it changes on-GPU dense bytes, and
+# BF16 dense COSTS pool slots under free-minus-reserve. Chosen deliberately.
+# ===========================================================================
+services:
+  llama-cpp-deepseek-flash-vision-q8-moecache:
+    # Digest-pinned, not tag-pinned: tags move, digests do not (#940 precedent).
+    # The engine profile is authoritative for this pin; keep them in step.
+    # v1.6 (revision d9cc8af98, moecachev1.6-rc0): mainline base b10675 +
+    # leloch's expert cache + @danielhanchen's indexer key-cache commits.
+    # ⚠️ NO VALIDATION CLAIM FOR THIS SLUG. The sibling compose carries a
+    # boot+verify+acceptance line here; it was deliberately NOT carried over,
+    # because it was measured on deepseek-v4-flash-0731 with a drafter this slug
+    # does not ship. First boot 2026-08-31: verify-full 10/10 (see header). The release ledger
+    # records what the IMAGE was validated against — not this compose.
+    image: ${LLAMACPP_CLUB3090_IMAGE:-ghcr.io/noonghunna/llamacpp-club3090@sha256:69b833eea9266707cd9853fc8041348a59e2403a1e763822db5c2a46484db72b}
+    container_name: ${ESTATE_CONTAINER:-llama-cpp-deepseek-flash-vision-q8-moecache}
+    restart: unless-stopped
+    # Reap orphaned children. Without this, a wedged llama-server becomes a
+    # <defunct> PID 1 child that docker CANNOT kill ("PID N is zombie and can
+    # not be killed. Use the --init option"), and it keeps holding GPU memory
+    # AND ~117 GB of host RAM — after which preflight correctly refuses every
+    # later boot ("needs ~156 GB; only 39 GB AVAILABLE"). Cost 8 of 9 A/B arms
+    # on 2026-08-25 before it was diagnosed.
+    init: true
+    ports:
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8128}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      # Expert-cache tuning — every value MEASURED on 2×24 GB, see Caveats.
+      - GGML_CUDA_MOE_CACHE_ADMIT_AFTER=${MOE_ADMIT_AFTER:-64}
+      - GGML_CUDA_MOE_CACHE_RESERVE_MB=${MOE_RESERVE_MB:-1536}
+      # Cache hit/miss telemetry. DEFAULT ON (emit every N collect calls per
+      # device) because without it the engine's `stats_every` is 0 and NO
+      # `CUDA<n> hits=…` line is ever produced — see moe-cache.cu:169 (default 0)
+      # and :2795 (`stats_every > 0` gate). It is NOT gated on log verbosity.
+      # ⚠️ This var was previously ABSENT from this block entirely, so docker
+      # never forwarded it and the value was unreachable through the shipped
+      # slug no matter what the caller exported. Every community bench filed
+      # against this compose therefore carried zero cache telemetry, and
+      # bench.sh rendered that absence as a measured `0.0% dhits=0 dlookups=0`
+      # — indistinguishable from "the cache did nothing" (club-3090 #1105/#1106).
+      # ⚠️⚠️ THIS VAR ALONE IS NOT ENOUGH — telemetry needs BOTH knobs. Measured
+      # on a live 2-arm boot 2026-08-26 with one variable between the arms:
+      #   STATS=200, default verbosity -> 0 `[moe-cache]` lines of ANY kind
+      #   STATS=200, LLAMA_ARG_LOG_VERBOSITY=4 -> 228 lines / 211 stats lines
+      # MOE_CACHE_LOG is GGML_LOG_INFO (moe-cache.cu:46) and the server's verbosity
+      # threshold drops it below 4, so without `-lv 4` the whole cache subsystem is
+      # silent. Verbosity is left to the caller (bare passthrough below) because 4
+      # is loud for a serving deployment — but a bench/report run wanting cache
+      # numbers MUST set it. bench.sh now says so when the counters do not advance.
+      # ⚠️ DEFAULT IS 0 (OFF) — telemetry is OPT-IN so instrumentation does not run
+      # when nothing reads it. Set MOE_STATS=200 (plus LLAMA_ARG_LOG_VERBOSITY=4)
+      # for a bench/report run. ⚠️ The counter-gating behaviour was characterised
+      # on the old v1.2-era image; it has NOT been re-checked on v1.5.
+      # ✅ The `=${VAR:-N}` form is SAFE here (unlike the bare-passthrough vars
+      # below): `moe_cache_env_i64` rejects unset AND empty (`!text || !text[0]`,
+      # moe-cache.cu:509) before parsing, so it cannot hit the atoi("")==0 trap.
+      - GGML_CUDA_MOE_CACHE_STATS=${MOE_STATS:-0}
+      # Prefill expert-prefetch and log verbosity.
+      #
+      # ⚠️ STATUS ON THIS PIN IS UNVERIFIED — rewritten 2026-08-29 with the v1.5
+      # migration. The previous text said the knob was INERT because the pinned
+      # digest (sha256:17824d44 / revision e0a208949) predated the prefetch work.
+      # That digest is no longer pinned here: this compose now runs v1.5-rc0
+      # (7104d5f4e, base b10675), and whether the ring exists in THAT binary has
+      # not been checked. A ring WAS observed on rc2 — but rc2 is the ROLLBACK
+      # digest (bf2776f7), not rc0, so it does not settle this.
+      #
+      # ⛔ The "+14.5% / +15.0% prefill" justification is WITHDRAWN regardless: it
+      # was measured on a build carrying the n_copies==1 scheduler race (fixed in
+      # ce8743a05) and is unquotable until re-measured
+      # (moecache-engine-playbook.md section 6). The COST is not withdrawn — a
+      # 2,176 MiB ring on the FIRST CUDA device only, allocated lazily on first
+      # prefill AFTER the pool is sized, so nothing budgets for it.
+      #
+      # ⚠️ BARE PASS-THROUGH FORM ON PURPOSE — do NOT rewrite these as
+      # `- GGML_EXPERT_PREFETCH=${PREFETCH:-}`. The engine tests
+      # `if (on && atoi(on) == 0) return nullptr;` (expert-prefetch.cu:126) and
+      # atoi("") == 0, so an empty-string default would set the var to "" and
+      # SILENTLY DISABLE the prefetch for every user. Bare form leaves the var
+      # UNSET in the container unless the caller exports it, which is the only
+      # spelling that preserves default-ON.
+      #   GGML_EXPERT_PREFETCH=0  stock (no ring; frees ~484 CUDA0 cache slots)
+      #                       =2  BALLAST (ring allocated, every node declined) —
+      #                           the pool-matched control for mechanism A/Bs
+      #   LLAMA_ARG_LOG_VERBOSITY=4  resolved pools + moe-cache statistics
+      - GGML_EXPERT_PREFETCH
+      - GGML_EXPERT_PREFETCH_SLOTS
+      - LLAMA_ARG_LOG_VERBOSITY
+      # Prefix reuse via KV shifting (default 0 = OFF). The between-turn TTFT
+      # lever for agent traffic — the llama.cpp analogue of the vLLM
+      # mamba-align work on the qwen3.8 MTP composes (#1093), though a
+      # different mechanism (KV shift, not SSM-state alignment).
+      # ⚠️ The server force-disables it when the memory layout cannot shift
+      # (server-context.cpp: "cache_reuse is not supported by this context")
+      # — MLA + SWA is a plausible refusal case, so CHECK THE BOOT LOG rather
+      # than assuming it engaged.
+      - LLAMA_ARG_CACHE_REUSE
+      # Thread count. Resolved in the entrypoint (see [threads]) because a
+      # fixed compose default cannot be right on two different rigs.
+      - THREADS
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ['${ESTATE_GPUS:-0,1}']
+              capabilities: [gpu]
+    # ⚠️ LIST FORM, NOT a folded `command: >-` string — REQUIRED, not style.
+    # Docker Compose's command-line parser REJECTS `(gate|up|down)` inside a
+    # folded string. The list form skips shell parsing, so the regex survives
+    # byte-for-byte.
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- No drafter on this slug ---------------------------------------------
+        # The SPEC_N/SPEC toggle that every other club-3090 compose carries is
+        # deliberately ABSENT here: no drafter exists for DeepSeek-V4-Flash-Vision-Exp
+        # (0731's DSpark is built against THAT model), so the knob would be inert.
+        # Shipping an env var that does nothing is the exact defect
+        # test-spec-toggle-contract exists to catch -- so it is not shipped.
+        # `--spec-type ngram-mod` needs no drafter file and is the obvious candidate;
+        # unmeasured on deepseek4, so not enabled.
+        # -- Threads ------------------------------------------------------------
+        # llama.cpp's own default collapses CPU-offload decode (-31% measured on
+        # this workload), and the old `-t ${THREADS:-8}` compose default was worse
+        # still for anyone running `docker compose` directly. Resolve here instead:
+        # THREADS if the caller set it, else nproc/2 -- which MATCHES what the
+        # launcher already computes (scripts/lib/compose-meta.sh
+        # resolve_offload_threads), so the two paths agree instead of diverging.
+        # ⚠️ nproc/2 is a floor, NOT the optimum: on the 32c/8-channel reference
+        # host `-t 28` measured ~20% faster than the launcher's nproc/2=16, which
+        # is why .env pins 28 there. Under the launcher THREADS is always already
+        # set, so this branch only serves direct-compose users.
+        # Exported as LLAMA_ARG_THREADS -- the `-t` flag is therefore NOT in the
+        # command list; adding one back would override this (CLI beats env).
+        if [ -n "$${THREADS:-}" ]; then
+          export LLAMA_ARG_THREADS="$${THREADS}"
+          echo "[threads] -t $${LLAMA_ARG_THREADS} (THREADS set explicitly)" >&2
+        else
+          # PORTABLE DEFAULT = nproc/2, matching the launcher's resolve_offload_threads
+          # so both paths agree. ⚠️ nproc/2 is a FLOOR, not the optimum: on our 32c/
+          # 8-channel reference host `-t 28` measured ~20% faster than nproc/2=16. That
+          # 28 belongs in the OPERATOR's .env, NOT in the shipped default -- pinning it
+          # here handed a 32-core-tuned value to every user and oversubscribed smaller
+          # boxes. Set THREADS=<n> to tune; the useful zone is an ABSOLUTE ~24-32.
+          _np=$$(nproc 2>/dev/null || echo 8)
+          _half=$$(( _np / 2 )); [ "$$_half" -lt 1 ] && _half=1
+          export LLAMA_ARG_THREADS="$$_half"
+          echo "[threads] -t $${LLAMA_ARG_THREADS} (auto = nproc/2, nproc=$$_np; set THREADS to tune)" >&2
+        fi
+
+        exec /app/llama-server "$$@"
+      - --
+    command:
+      - '-m'
+      - '/models/deepseek-v4-flash-vision-exp-gguf/unsloth-ud-q8kxl/UD-Q8_K_XL/DeepSeek-V4-Flash-Vision-Exp-UD-Q8_K_XL-00001-of-00005.gguf'
+      - '--host'
+      - '0.0.0.0'
+      - '--port'
+      - '8080'
+      - '--alias'
+      - 'deepseek-v4-flash'
+      # Slots. ⚠️ `-np N` SPLITS `-c` into ctx/N per slot, so the pool and the
+      # compute buffer change with it — a concurrency A/B must re-measure, not
+      # reuse single-stream rows. Default 1 keeps shipped behaviour identical.
+      # ⚠️ LLAMA_ARG_N_PARALLEL cannot override this: common/arg.cpp applies env
+      #    BEFORE argv (~L783 vs ~L808), so the command line always wins.
+      - '-np'
+      - '${NPARALLEL:-1}'
+      - '-c'
+      - '${CTX:-204800}'
+      - '-ngl'
+      - '99'
+      - '-sm'
+      - 'layer'
+      - '-ts'
+      - '1,1'
+      - '-fa'
+      - 'on'
+      # ⚠️ SINGLE -ot with comma-separated rules. Current mainline DEPRECATES
+      # repeated -ot and honours ONLY THE LAST occurrence — passing it three
+      # times silently drops the GPU pins. All experts to CPU here; the cache
+      # decides residency dynamically, so static pins are counter-productive.
+      - '-ot'
+      - 'blk\.[0-9]+\.ffn_(gate|up|down)_exps\.weight=CPU'
+      - '-ub'
+      - '${UBATCH:-4096}'
+      - '-b'
+      - '${UBATCH:-4096}'
+      - '--cache-prompt'
+      - '--no-mmap'
+      # ⛔ NO DRAFTER. 0731's DSpark is built against THAT model and is not
+      #    known valid here, so nothing is mounted and SPEC_N is inert.
+      #    `--spec-type ngram-mod` needs no drafter file and is the obvious
+      #    candidate — UNMEASURED on deepseek4, so deliberately not enabled.
+      - '--moe-cache'
+      - '${MOE_CACHE:-auto}'
+      - '--fit'
+      - 'off'
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 40
+      start_period: 900s

--- a/models/deepseek-v4-flash-vision-exp/llamacpp-club3090/compose/multi4/unsloth-ud-q8kxl/moecache.yml
+++ b/models/deepseek-v4-flash-vision-exp/llamacpp-club3090/compose/multi4/unsloth-ud-q8kxl/moecache.yml
@@ -1,0 +1,196 @@
+# ===========================================================================
+# Profile (at-a-glance):
+#   Model:     DeepSeek-V4-Flash-Vision-Exp (deepseek4 MoE, unsloth UD-Q8_K_XL —
+#              MXFP4 experts + BF16 attention, 161.9 GB across 5 shards)
+#   Engine:    llamacpp-club3090-v1.6 (fork: leloch's MoE expert cache v2 + our
+#              L1/L3/E ports, plus @danielhanchen's indexer key-cache commits)
+#   Topology:  4x 24 GB (layer-split, no NVLink) - not bootable on this 2-GPU rig
+#   Drafter:   none wired - DSpark 0731 is tokenizer-compatible, acceptance UNMEASURED
+#   KV:        fp16 (llama.cpp default - MLA + single KV head keep it small)
+#   Vision:    NO - despite the model name. See Caveats.
+#   Max ctx:   204800  (1,048,576 native; rope original 65,536)
+#   Genesis:   N/A - llama.cpp engine
+#   Status:    🧪 Experimental
+#   Caveats:   • ⚠️⚠️ **"Vision" IS IN THE NAME BUT NOT IN THE WEIGHTS.** Gated
+#                2026-08-31 before download: the repo ships NO mmproj/projector
+#                file, the GGUF carries NO clip/vision metadata keys, and a scan
+#                of all 1,328 tensors across shards 2-5 found ZERO vision
+#                tensors (only `blk`, `output*`, `token_embd`). This serves
+#                TEXT-ONLY. If unsloth later publishes a projector, revisit.
+#              • ⚠️ NO DRAFTER WIRED — but not because none can work. The 0731
+#                sibling's DSpark (`dspark-DeepSeek-V4-Flash-0731-Q8_0.gguf`,
+#                arch `dflash`) has an **IDENTICAL tokenizer** to this target:
+#                gpt2, vocab 129,280, bos 0 / eos 1, same special tokens
+#                (verified 2026-08-31 from both GGUFs). Same base model plus
+#                vision training, so it is a plausible drafter. What is NOT
+#                measured is ACCEPTANCE against this checkpoint — the drafter was
+#                trained on 0731's weights. Wire it with `-md` + `--spec-type
+#                draft-dspark` and read the acceptance rate before trusting it;
+#                the 0731 slug reports 0.41-0.73. Until then nothing is mounted
+#                and SPEC_N is absent rather than inert.
+#              • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
+#                (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug
+#                packages it; it does not originate it.
+#              • UNMERGED ENGINE. The cache is not in mainline llama.cpp. This
+#                slug pins a fork image; it cannot be reproduced with stock.
+#              • QUALITY IS UNTESTED. No 8-pack, no soak, no verify-full.
+#              • ⚠️ COLD-START TAX: the FIRST request after boot is slow while
+#                the expert pool fills. Do not benchmark the first request.
+#              • Tuning is 4× 24 GB SPECIFIC and INHERITED from the 0731
+#                sibling — `RESERVE_MB=1536`, `-ub/-b 2048`. Re-derive
+#                before trusting any of them on other hardware.
+#              • `-t` defaults to **nproc/2**, matching the launcher so both
+#                paths agree. ⚠️ nproc/2 is a FLOOR, not the optimum — on our
+#                32c/8-channel reference host `-t 28` measured ~20% faster.
+#                That 28 lives in the OPERATOR's .env, deliberately NOT in the
+#                shipped default: pinning it would hand a 32-core-tuned value
+#                to every user and oversubscribe smaller boxes. Set THREADS=<n>;
+#                the useful zone is an ABSOLUTE ~24-32, not a fraction of cores.
+#   Best for:  long-context text on CPU-offload, when 0731's DSpark drafter is
+#              not wanted and a newer base is preferred
+# ---------------------------------------------------------------------------
+# Architecturally IDENTICAL to DeepSeek-V4-Flash-0731: arch `deepseek4`,
+# 43 blocks (all MoE, no dense prefix), 256 routed experts top-6 + 1 shared,
+# MLA with a single KV head, DSA indexer (64 heads). Verified from THIS GGUF's
+# metadata by HTTP range read, not assumed from the sibling.
+# ⚠️ `general.file_type = 38`; experts are ggml type 39 = **MXFP4**, IDENTICAL
+# to the UD-Q4_K_XL tier in the same repo. The Q4/Q8 in unsloth's names refers
+# to the NON-EXPERT path only (Q8_0 vs BF16 attention/dense) — which is why the
+# two tiers are only 4% apart in size. For a moe-cache rig this means the tier
+# choice does NOT change expert residency; it changes on-GPU dense bytes, and
+# BF16 dense COSTS pool slots under free-minus-reserve. Chosen deliberately.
+# ===========================================================================
+services:
+  llama-cpp-deepseek-flash-vision-q8-moecache-multi4:
+    # Digest-pinned, not tag-pinned (#940 precedent). Engine profile is authoritative.
+    # v1.6 (revision d9cc8af98, moecachev1.6-rc0): mainline base b10675 +
+    # leloch's expert cache + @danielhanchen's indexer key-cache commits.
+    # ⚠️ NO VALIDATION CLAIM FOR THIS SLUG. The sibling compose carries a
+    # boot+verify+acceptance line here; it was deliberately NOT carried over,
+    # because it was measured on deepseek-v4-flash-0731 with a drafter this slug
+    # does not ship. Nothing in THIS config has ever booted. The release ledger
+    # records what the IMAGE was validated against — not this compose.
+    image: ${LLAMACPP_CLUB3090_IMAGE:-ghcr.io/noonghunna/llamacpp-club3090@sha256:69b833eea9266707cd9853fc8041348a59e2403a1e763822db5c2a46484db72b}
+    container_name: ${ESTATE_CONTAINER:-llama-cpp-deepseek-flash-vision-q8-moecache-multi4}
+    restart: unless-stopped
+    ports:
+      - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8129}}:8080"
+    volumes:
+      - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+    environment:
+      # Drafter toggle - docker forwards only what is declared here.
+      # ⚠️ PLACEHOLDER VALUES inherited from the 2-card sibling. Re-derive.
+      - GGML_CUDA_MOE_CACHE_ADMIT_AFTER=${MOE_ADMIT_AFTER:-64}
+      - GGML_CUDA_MOE_CACHE_RESERVE_MB=${MOE_RESERVE_MB:-1536}
+      # Cache hit/miss telemetry. Needs BOTH knobs — measured on a live 2-arm boot
+      # 2026-08-26: STATS alone at default verbosity emitted 0 `[moe-cache]` lines of
+      # ANY kind; STATS + verbosity 4 emitted 228. `stats_every` defaults to 0
+      # (moe-cache.cu:169, gate at :2795) and MOE_CACHE_LOG is GGML_LOG_INFO, which the
+      # server's verbosity threshold drops below 4.
+      # ⚠️ Both were previously ABSENT here, so docker forwarded neither and NO caller
+      # could switch telemetry on (club-3090 #1105/#1106 were filed with no usable
+      # cache data for exactly this reason).
+      # `=${VAR:-N}` is safe for STATS: moe_cache_env_i64 rejects unset AND empty
+      # before parsing (moe-cache.cu:509), so it cannot hit the atoi("")==0 trap.
+      # ⚠️ DEFAULT IS 0 (OFF) — telemetry is OPT-IN, on principle rather than on a
+      # measured cost: instrumentation should not run when nothing reads it.
+      # ⛔ An earlier version of this comment claimed the counters cost ~6% decode.
+      # That is RETRACTED (2026-08-26). Two A/B runs could not support it — the
+      # SHIPPED image itself measured 20.05 then 18.36 narrative TPS across runs
+      # with no code change, so run-to-run variance swamps the effect. Arithmetic
+      # agrees: ~175 bypassed nodes per bench x ~4 atomics is ~1e-4 % of wall time.
+      # The old v1.2-era engine did NOT gate these counters; UNVERIFIED on v1.5, so this
+      # knob controls EMISSION only.
+      # Turn it on for a bench/report run: MOE_STATS=200 LLAMA_ARG_LOG_VERBOSITY=4.
+      # Verbosity stays BARE (caller-owned): 4 is loud for a serving deployment.
+      - GGML_CUDA_MOE_CACHE_STATS=${MOE_STATS:-0}
+      - LLAMA_ARG_LOG_VERBOSITY
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ['${ESTATE_GPUS:-0,1,2,3}']
+              capabilities: [gpu]
+    # ⚠️ LIST FORM, NOT a folded string — compose rejects `(gate|up|down)` in a
+    # folded `command: >-`.
+    # The image ENTRYPOINT is ["/app/llama-server"] on every engine we ship
+    # (mainline, ik-llama, beellama, llamacpp-club3090 — all verified). This
+    # wrapper is equivalent to it plus the drafter toggle.
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # -- No drafter on this slug ---------------------------------------------
+        # The SPEC_N/SPEC toggle every other club-3090 compose carries is deliberately
+        # ABSENT: no drafter exists for DeepSeek-V4-Flash-Vision-Exp (0731's DSpark is
+        # built against THAT model), so the knob would be inert. Shipping an env var
+        # that does nothing is the defect test-spec-toggle-contract exists to catch.
+        # -- Threads -------------------------------------------------------------
+        # Resolved HERE, not as a `-t` CLI arg: CLI beats env, so a command-line -t
+        # would silently override this. PORTABLE DEFAULT = nproc/2, matching the
+        # launcher's resolve_offload_threads so both paths agree. A FLOOR, not the
+        # optimum -- 28 measured ~20% faster on our 32c host and belongs in the
+        # operator's .env, not the shipped default.
+        if [ -n "$${THREADS:-}" ]; then
+          export LLAMA_ARG_THREADS="$${THREADS}"
+          echo "[threads] -t $${LLAMA_ARG_THREADS} (THREADS set explicitly)" >&2
+        else
+          _np=$$(nproc 2>/dev/null || echo 8)
+          _half=$$(( _np / 2 )); [ "$$_half" -lt 1 ] && _half=1
+          export LLAMA_ARG_THREADS="$$_half"
+          echo "[threads] -t $${LLAMA_ARG_THREADS} (auto = nproc/2, nproc=$$_np)" >&2
+        fi
+        
+        exec /app/llama-server "$$@"
+      - --
+    command:
+      - '-m'
+      - '/models/deepseek-v4-flash-vision-exp-gguf/unsloth-ud-q8kxl/UD-Q8_K_XL/DeepSeek-V4-Flash-Vision-Exp-UD-Q8_K_XL-00001-of-00005.gguf'
+      - '--host'
+      - '0.0.0.0'
+      - '--port'
+      - '8080'
+      - '--alias'
+      - 'deepseek-v4-flash'
+      # Slots. ⚠️ `-np N` SPLITS `-c` into ctx/N per slot, so the pool and the
+      # compute buffer change with it — a concurrency A/B must re-measure, not
+      # reuse single-stream rows. Default 1 keeps shipped behaviour identical.
+      # ⚠️ LLAMA_ARG_N_PARALLEL cannot override this: common/arg.cpp applies env
+      #    BEFORE argv (~L783 vs ~L808), so the command line always wins.
+      - '-np'
+      - '${NPARALLEL:-1}'
+      - '-c'
+      - '${CTX:-204800}'
+      - '-ngl'
+      - '99'
+      - '-sm'
+      - 'layer'
+      - '-ts'
+      - '${TENSOR_SPLIT:-1,1,1,1}'
+      - '-fa'
+      - 'on'
+      # ⚠️ SINGLE -ot, comma-separated: current mainline honours ONLY THE LAST
+      # -ot occurrence. All experts to CPU; the cache decides residency.
+      - '-ot'
+      - 'blk\.[0-9]+\.ffn_(gate|up|down)_exps\.weight=CPU'
+      - '-ub'
+      - '${UBATCH:-2048}'
+      - '-b'
+      - '${UBATCH:-2048}'
+      - '--cache-prompt'
+      - '--no-mmap'
+      # ⛔ NO DRAFTER. 0731's DSpark is built against THAT model and is not
+      #    known valid here, so nothing is mounted and SPEC_N is inert.
+      #    `--spec-type ngram-mod` needs no drafter file and is the obvious
+      #    candidate — UNMEASURED on deepseek4, so deliberately not enabled.
+      - '--moe-cache'
+      - '${MOE_CACHE:-auto}'
+      - '--fit'
+      - 'off'
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 40
+      start_period: 900s

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq3xxs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq3xxs/moecache.yml
@@ -267,8 +267,16 @@ services:
           export LLAMA_ARG_THREADS="$${THREADS}"
           echo "[threads] -t $${LLAMA_ARG_THREADS} (THREADS set explicitly)" >&2
         else
-          export LLAMA_ARG_THREADS=28
-          echo "[threads] -t 28 (slug default; validated for GLM bring-up)" >&2
+          # PORTABLE DEFAULT = nproc/2, matching the launcher's resolve_offload_threads
+          # so both paths agree. ⚠️ nproc/2 is a FLOOR, not the optimum: on our 32c/
+          # 8-channel reference host `-t 28` measured ~20% faster than nproc/2=16. That
+          # 28 belongs in the OPERATOR's .env, NOT in the shipped default -- pinning it
+          # here handed a 32-core-tuned value to every user and oversubscribed smaller
+          # boxes. Set THREADS=<n> to tune; the useful zone is an ABSOLUTE ~24-32.
+          _np=$$(nproc 2>/dev/null || echo 8)
+          _half=$$(( _np / 2 )); [ "$$_half" -lt 1 ] && _half=1
+          export LLAMA_ARG_THREADS="$$_half"
+          echo "[threads] -t $${LLAMA_ARG_THREADS} (auto = nproc/2, nproc=$$_np; set THREADS to tune)" >&2
         fi
 
         # ── vision projector guard ──────────────────────────────────────────

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/moecache.yml
@@ -227,8 +227,16 @@ services:
           export LLAMA_ARG_THREADS="$${THREADS}"
           echo "[threads] -t $${LLAMA_ARG_THREADS} (THREADS set explicitly)" >&2
         else
-          export LLAMA_ARG_THREADS=28
-          echo "[threads] -t 28 (slug default; validated for GLM bring-up)" >&2
+          # PORTABLE DEFAULT = nproc/2, matching the launcher's resolve_offload_threads
+          # so both paths agree. ⚠️ nproc/2 is a FLOOR, not the optimum: on our 32c/
+          # 8-channel reference host `-t 28` measured ~20% faster than nproc/2=16. That
+          # 28 belongs in the OPERATOR's .env, NOT in the shipped default -- pinning it
+          # here handed a 32-core-tuned value to every user and oversubscribed smaller
+          # boxes. Set THREADS=<n> to tune; the useful zone is an ABSOLUTE ~24-32.
+          _np=$$(nproc 2>/dev/null || echo 8)
+          _half=$$(( _np / 2 )); [ "$$_half" -lt 1 ] && _half=1
+          export LLAMA_ARG_THREADS="$$_half"
+          echo "[threads] -t $${LLAMA_ARG_THREADS} (auto = nproc/2, nproc=$$_np; set THREADS to tune)" >&2
         fi
 
         # ── vision projector guard ──────────────────────────────────────────

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/unsloth-ud-iq3xxs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/unsloth-ud-iq3xxs/moecache.yml
@@ -335,8 +335,16 @@ services:
           export LLAMA_ARG_THREADS="$${THREADS}"
           echo "[threads] -t $${LLAMA_ARG_THREADS} (THREADS set explicitly)" >&2
         else
-          export LLAMA_ARG_THREADS=28
-          echo "[threads] -t 28 (slug default; validated for GLM bring-up)" >&2
+          # PORTABLE DEFAULT = nproc/2, matching the launcher's resolve_offload_threads
+          # so both paths agree. ⚠️ nproc/2 is a FLOOR, not the optimum: on our 32c/
+          # 8-channel reference host `-t 28` measured ~20% faster than nproc/2=16. That
+          # 28 belongs in the OPERATOR's .env, NOT in the shipped default -- pinning it
+          # here handed a 32-core-tuned value to every user and oversubscribed smaller
+          # boxes. Set THREADS=<n> to tune; the useful zone is an ABSOLUTE ~24-32.
+          _np=$$(nproc 2>/dev/null || echo 8)
+          _half=$$(( _np / 2 )); [ "$$_half" -lt 1 ] && _half=1
+          export LLAMA_ARG_THREADS="$$_half"
+          echo "[threads] -t $${LLAMA_ARG_THREADS} (auto = nproc/2, nproc=$$_np; set THREADS to tune)" >&2
         fi
 
         # ── vision projector guard ──────────────────────────────────────────

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/unsloth-ud-iq4xs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/unsloth-ud-iq4xs/moecache.yml
@@ -299,8 +299,16 @@ services:
           export LLAMA_ARG_THREADS="$${THREADS}"
           echo "[threads] -t $${LLAMA_ARG_THREADS} (THREADS set explicitly)" >&2
         else
-          export LLAMA_ARG_THREADS=28
-          echo "[threads] -t 28 (slug default; validated for GLM bring-up)" >&2
+          # PORTABLE DEFAULT = nproc/2, matching the launcher's resolve_offload_threads
+          # so both paths agree. ⚠️ nproc/2 is a FLOOR, not the optimum: on our 32c/
+          # 8-channel reference host `-t 28` measured ~20% faster than nproc/2=16. That
+          # 28 belongs in the OPERATOR's .env, NOT in the shipped default -- pinning it
+          # here handed a 32-core-tuned value to every user and oversubscribed smaller
+          # boxes. Set THREADS=<n> to tune; the useful zone is an ABSOLUTE ~24-32.
+          _np=$$(nproc 2>/dev/null || echo 8)
+          _half=$$(( _np / 2 )); [ "$$_half" -lt 1 ] && _half=1
+          export LLAMA_ARG_THREADS="$$_half"
+          echo "[threads] -t $${LLAMA_ARG_THREADS} (auto = nproc/2, nproc=$$_np; set THREADS to tune)" >&2
         fi
 
         # ── vision projector guard ──────────────────────────────────────────

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/unsloth-ud-iq3xxs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/unsloth-ud-iq3xxs/moecache.yml
@@ -335,8 +335,16 @@ services:
           export LLAMA_ARG_THREADS="$${THREADS}"
           echo "[threads] -t $${LLAMA_ARG_THREADS} (THREADS set explicitly)" >&2
         else
-          export LLAMA_ARG_THREADS=28
-          echo "[threads] -t 28 (slug default; validated for GLM bring-up)" >&2
+          # PORTABLE DEFAULT = nproc/2, matching the launcher's resolve_offload_threads
+          # so both paths agree. ⚠️ nproc/2 is a FLOOR, not the optimum: on our 32c/
+          # 8-channel reference host `-t 28` measured ~20% faster than nproc/2=16. That
+          # 28 belongs in the OPERATOR's .env, NOT in the shipped default -- pinning it
+          # here handed a 32-core-tuned value to every user and oversubscribed smaller
+          # boxes. Set THREADS=<n> to tune; the useful zone is an ABSOLUTE ~24-32.
+          _np=$$(nproc 2>/dev/null || echo 8)
+          _half=$$(( _np / 2 )); [ "$$_half" -lt 1 ] && _half=1
+          export LLAMA_ARG_THREADS="$$_half"
+          echo "[threads] -t $${LLAMA_ARG_THREADS} (auto = nproc/2, nproc=$$_np; set THREADS to tune)" >&2
         fi
 
         # ── vision projector guard ──────────────────────────────────────────

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/unsloth-ud-iq4xs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/unsloth-ud-iq4xs/moecache.yml
@@ -299,8 +299,16 @@ services:
           export LLAMA_ARG_THREADS="$${THREADS}"
           echo "[threads] -t $${LLAMA_ARG_THREADS} (THREADS set explicitly)" >&2
         else
-          export LLAMA_ARG_THREADS=28
-          echo "[threads] -t 28 (slug default; validated for GLM bring-up)" >&2
+          # PORTABLE DEFAULT = nproc/2, matching the launcher's resolve_offload_threads
+          # so both paths agree. ⚠️ nproc/2 is a FLOOR, not the optimum: on our 32c/
+          # 8-channel reference host `-t 28` measured ~20% faster than nproc/2=16. That
+          # 28 belongs in the OPERATOR's .env, NOT in the shipped default -- pinning it
+          # here handed a 32-core-tuned value to every user and oversubscribed smaller
+          # boxes. Set THREADS=<n> to tune; the useful zone is an ABSOLUTE ~24-32.
+          _np=$$(nproc 2>/dev/null || echo 8)
+          _half=$$(( _np / 2 )); [ "$$_half" -lt 1 ] && _half=1
+          export LLAMA_ARG_THREADS="$$_half"
+          echo "[threads] -t $${LLAMA_ARG_THREADS} (auto = nproc/2, nproc=$$_np; set THREADS to tune)" >&2
         fi
 
         # ── vision projector guard ──────────────────────────────────────────

--- a/models/inkling-small/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/moecache.yml
+++ b/models/inkling-small/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/moecache.yml
@@ -165,6 +165,10 @@ services:
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     environment:
+      # Bare passthrough — docker forwards ONLY what is declared here, so without
+      # this line the entrypoint's THREADS branch can never fire and the knob is
+      # inert. Never write `- THREADS=${THREADS:-}`: that sets it EMPTY.
+      - THREADS
       # Expert-cache tuning — inherited from the 2×24 GB DeepSeek derivation.
       - GGML_CUDA_MOE_CACHE_ADMIT_AFTER=${MOE_ADMIT_AFTER:-64}
       - GGML_CUDA_MOE_CACHE_RESERVE_MB=${MOE_RESERVE_MB:-1536}
@@ -225,6 +229,23 @@ services:
       - /bin/bash
       - -c
       - |
+        # -- Threads -------------------------------------------------------------
+        # Resolved HERE, not as a `-t` CLI arg: CLI beats env, so a command-line -t
+        # silently overrides anything set below. PORTABLE DEFAULT = nproc/2, matching
+        # the launcher's resolve_offload_threads so both paths agree. The old `-t 8`
+        # was far below optimum on any capable host; nproc/2 is the safe choice when
+        # the operator's core count is unknown. ⚠️ Still a FLOOR, not the optimum --
+        # the useful zone is an ABSOLUTE ~24-32 threads. Set THREADS=<n> to tune.
+        if [ -n "$${THREADS:-}" ]; then
+          export LLAMA_ARG_THREADS="$${THREADS}"
+          echo "[threads] -t $${LLAMA_ARG_THREADS} (THREADS set explicitly)" >&2
+        else
+          _np=$$(nproc 2>/dev/null || echo 8)
+          _half=$$(( _np / 2 )); [ "$$_half" -lt 1 ] && _half=1
+          export LLAMA_ARG_THREADS="$$_half"
+          echo "[threads] -t $${LLAMA_ARG_THREADS} (auto = nproc/2, nproc=$$_np)" >&2
+        fi
+
         exec /app/llama-server "$$@"
       - --
     command:
@@ -286,8 +307,6 @@ services:
       # ⚠️ The bare-compose default is deliberately conservative. Under the
       # launchers THREADS is injected; llama.cpp's own default collapses
       # CPU-offload decode by ~31%, so never leave this to the engine.
-      - '-t'
-      - '${THREADS:-8}'
       - '-ub'
       - '${UBATCH:-2048}'
       - '-b'

--- a/models/inkling-small/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/residency.yml
+++ b/models/inkling-small/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/residency.yml
@@ -238,6 +238,10 @@ services:
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     environment:
+      # Bare passthrough — docker forwards ONLY what is declared here, so without
+      # this line the entrypoint's THREADS branch can never fire and the knob is
+      # inert. Never write `- THREADS=${THREADS:-}`: that sets it EMPTY.
+      - THREADS
       # Expert-cache tuning — inherited from the 2×24 GB DeepSeek derivation.
       # ⚠️ On THIS compose the cache is a REMAINDER consumer, not the primary
       # mechanism: residency is allocated first (at model load) and the pools are
@@ -302,6 +306,23 @@ services:
       - /bin/bash
       - -c
       - |
+        # -- Threads -------------------------------------------------------------
+        # Resolved HERE, not as a `-t` CLI arg: CLI beats env, so a command-line -t
+        # silently overrides anything set below. PORTABLE DEFAULT = nproc/2, matching
+        # the launcher's resolve_offload_threads so both paths agree. The old `-t 8`
+        # was far below optimum on any capable host; nproc/2 is the safe choice when
+        # the operator's core count is unknown. ⚠️ Still a FLOOR, not the optimum --
+        # the useful zone is an ABSOLUTE ~24-32 threads. Set THREADS=<n> to tune.
+        if [ -n "$${THREADS:-}" ]; then
+          export LLAMA_ARG_THREADS="$${THREADS}"
+          echo "[threads] -t $${LLAMA_ARG_THREADS} (THREADS set explicitly)" >&2
+        else
+          _np=$$(nproc 2>/dev/null || echo 8)
+          _half=$$(( _np / 2 )); [ "$$_half" -lt 1 ] && _half=1
+          export LLAMA_ARG_THREADS="$$_half"
+          echo "[threads] -t $${LLAMA_ARG_THREADS} (auto = nproc/2, nproc=$$_np)" >&2
+        fi
+
         exec /app/llama-server "$$@"
       - --
     command:
@@ -364,8 +385,6 @@ services:
       # ⚠️ The bare-compose default is deliberately conservative. Under the
       # launchers THREADS is injected; llama.cpp's own default collapses
       # CPU-offload decode by ~31%, so never leave this to the engine.
-      - '-t'
-      - '${THREADS:-8}'
       - '-ub'
       - '${UBATCH:-2048}'
       - '-b'

--- a/models/inkling-small/llamacpp-club3090/compose/multi4/unsloth-ud-iq4xs/moecache.yml
+++ b/models/inkling-small/llamacpp-club3090/compose/multi4/unsloth-ud-iq4xs/moecache.yml
@@ -170,6 +170,10 @@ services:
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
     environment:
+      # Bare passthrough — docker forwards ONLY what is declared here, so without
+      # this line the entrypoint's THREADS branch can never fire and the knob is
+      # inert. Never write `- THREADS=${THREADS:-}`: that sets it EMPTY.
+      - THREADS
       # Expert-cache tuning — inherited from the 2×24 GB DeepSeek derivation.
       - GGML_CUDA_MOE_CACHE_ADMIT_AFTER=${MOE_ADMIT_AFTER:-64}
       - GGML_CUDA_MOE_CACHE_RESERVE_MB=${MOE_RESERVE_MB:-1536}
@@ -230,6 +234,23 @@ services:
       - /bin/bash
       - -c
       - |
+        # -- Threads -------------------------------------------------------------
+        # Resolved HERE, not as a `-t` CLI arg: CLI beats env, so a command-line -t
+        # silently overrides anything set below. PORTABLE DEFAULT = nproc/2, matching
+        # the launcher's resolve_offload_threads so both paths agree. The old `-t 8`
+        # was far below optimum on any capable host; nproc/2 is the safe choice when
+        # the operator's core count is unknown. ⚠️ Still a FLOOR, not the optimum --
+        # the useful zone is an ABSOLUTE ~24-32 threads. Set THREADS=<n> to tune.
+        if [ -n "$${THREADS:-}" ]; then
+          export LLAMA_ARG_THREADS="$${THREADS}"
+          echo "[threads] -t $${LLAMA_ARG_THREADS} (THREADS set explicitly)" >&2
+        else
+          _np=$$(nproc 2>/dev/null || echo 8)
+          _half=$$(( _np / 2 )); [ "$$_half" -lt 1 ] && _half=1
+          export LLAMA_ARG_THREADS="$$_half"
+          echo "[threads] -t $${LLAMA_ARG_THREADS} (auto = nproc/2, nproc=$$_np)" >&2
+        fi
+
         exec /app/llama-server "$$@"
       - --
     command:
@@ -291,8 +312,6 @@ services:
       # ⚠️ The bare-compose default is deliberately conservative. Under the
       # launchers THREADS is injected; llama.cpp's own default collapses
       # CPU-offload decode by ~31%, so never leave this to the engine.
-      - '-t'
-      - '${THREADS:-8}'
       - '-ub'
       - '${UBATCH:-2048}'
       - '-b'

--- a/models/qwen3.8-27b/llama-cpp/compose/dual/unsloth-q8kxl/q8kv.yml
+++ b/models/qwen3.8-27b/llama-cpp/compose/dual/unsloth-q8kxl/q8kv.yml
@@ -14,7 +14,7 @@
 #   Max ctx:   262144 — the ARCHITECTURAL ceiling (config.json
 #              max_position_embeddings); COMPUTED to fit, never measured
 #   Genesis:   N/A — llama.cpp engine; Genesis is vLLM/Qwen3-Next-specific
-#   Status:    🐣 Incubating
+#   Status:    🧪 Experimental
 #   Caveats:   NOTHING HAS BOOTED. Authored 2026-08-14 while the weights were still
 #              downloading; zero runtime evidence exists for any claim below.
 #              Specifically unvalidated:

--- a/models/qwen3.8-27b/llama-cpp/compose/single/unsloth-iq4xs/q4kv-vision.yml
+++ b/models/qwen3.8-27b/llama-cpp/compose/single/unsloth-iq4xs/q4kv-vision.yml
@@ -12,7 +12,7 @@
 #              ⚠️ The q4@262K + projector COMBINATION is boot-verified for fit on
 #              this rig (see MEASURED below); NOT depth-validated (no NIAH/soak/8pk).
 #   Genesis:   N/A — llama.cpp engine; Genesis is vLLM/Qwen3-Next-specific
-#   Status:    🐣 Incubating
+#   Status:    🧪 Experimental
 #   Caveats:   THREE, all disclosed:
 #              (1) ⚠️ q4_0 KV is BELOW the stack serving floor. Stack policy is a
 #                  q8_0-grade KV for anything that serves; q4_0 KLD is ~5.75x worse

--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
@@ -33,7 +33,7 @@
 #   Max ctx:   262144 — the architectural ceiling. COMPUTED + inherited, never
 #              measured on this model at ANY topology.
 #   Genesis:   none — intentionally Genesis-free
-#   Status:    🐣 Incubating
+#   Status:    🧪 Experimental
 # ⚠️ #1096 (accumulated-ctx decode cliff): in long multi-turn agentic, decode collapses to
 #    single-block emission — ~12k accumulated ctx for DFlash2 (SPEC_N depth does NOT move it,
 #    n=3≡n=7) / ~17-21k for MTP; SEVERE on Ampere (~4 tok/s), milder on Blackwell. Drafter TYPE,

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
@@ -35,7 +35,7 @@
 #   Max ctx:   262144 — the architectural ceiling. COMPUTED + inherited, never
 #              measured on this model at ANY topology.
 #   Genesis:   none — intentionally Genesis-free
-#   Status:    🐣 Incubating
+#   Status:    🧪 Experimental
 # ⚠️ #1096 (accumulated-ctx decode cliff): in long multi-turn agentic, decode collapses to
 #    single-block emission — ~12k accumulated ctx for DFlash2 (SPEC_N depth does NOT move it,
 #    n=3≡n=7) / ~17-21k for MTP; SEVERE on Ampere (~4 tok/s), milder on Blackwell. Drafter TYPE,

--- a/models/qwen3.8-flash-next/llamacpp-club3090/compose/dual/unsloth-ud-q4kxl/moecache.yml
+++ b/models/qwen3.8-flash-next/llamacpp-club3090/compose/dual/unsloth-ud-q4kxl/moecache.yml
@@ -226,8 +226,16 @@ services:
           # — but leaving it as the FALLBACK hands that penalty to every
           # direct-compose user who never sets THREADS. The good zone is an
           # ABSOLUTE ~24-32, so pin the measured value; THREADS still overrides.
-          export LLAMA_ARG_THREADS="28"
-          echo "[threads] -t $${LLAMA_ARG_THREADS} (pinned default; set THREADS to override)" >&2
+          # PORTABLE DEFAULT = nproc/2, matching the launcher's resolve_offload_threads
+          # so both paths agree. ⚠️ nproc/2 is a FLOOR, not the optimum: on our 32c/
+          # 8-channel reference host `-t 28` measured ~20% faster than nproc/2=16. That
+          # 28 belongs in the OPERATOR's .env, NOT in the shipped default -- pinning it
+          # here handed a 32-core-tuned value to every user and oversubscribed smaller
+          # boxes. Set THREADS=<n> to tune; the useful zone is an ABSOLUTE ~24-32.
+          _np=$$(nproc 2>/dev/null || echo 8)
+          _half=$$(( _np / 2 )); [ "$$_half" -lt 1 ] && _half=1
+          export LLAMA_ARG_THREADS="$$_half"
+          echo "[threads] -t $${LLAMA_ARG_THREADS} (auto = nproc/2, nproc=$$_np; set THREADS to tune)" >&2
         fi
 
         # ⚠️ DEFAULT 0: THIS MODEL HAS NO DRAFTER. The GGUF carries no MTP head

--- a/models/qwen3.8-flash-next/llamacpp-club3090/compose/multi4/unsloth-ud-q4kxl/moecache.yml
+++ b/models/qwen3.8-flash-next/llamacpp-club3090/compose/multi4/unsloth-ud-q4kxl/moecache.yml
@@ -241,8 +241,16 @@ services:
           # — but leaving it as the FALLBACK hands that penalty to every
           # direct-compose user who never sets THREADS. The good zone is an
           # ABSOLUTE ~24-32, so pin the measured value; THREADS still overrides.
-          export LLAMA_ARG_THREADS="28"
-          echo "[threads] -t $${LLAMA_ARG_THREADS} (pinned default; set THREADS to override)" >&2
+          # PORTABLE DEFAULT = nproc/2, matching the launcher's resolve_offload_threads
+          # so both paths agree. ⚠️ nproc/2 is a FLOOR, not the optimum: on our 32c/
+          # 8-channel reference host `-t 28` measured ~20% faster than nproc/2=16. That
+          # 28 belongs in the OPERATOR's .env, NOT in the shipped default -- pinning it
+          # here handed a 32-core-tuned value to every user and oversubscribed smaller
+          # boxes. Set THREADS=<n> to tune; the useful zone is an ABSOLUTE ~24-32.
+          _np=$$(nproc 2>/dev/null || echo 8)
+          _half=$$(( _np / 2 )); [ "$$_half" -lt 1 ] && _half=1
+          export LLAMA_ARG_THREADS="$$_half"
+          echo "[threads] -t $${LLAMA_ARG_THREADS} (auto = nproc/2, nproc=$$_np; set THREADS to tune)" >&2
         fi
 
         # ⚠️ DEFAULT 0: THIS MODEL HAS NO DRAFTER. The GGUF carries no MTP head

--- a/models/qwen3.8-flash-next/llamacpp-club3090/compose/multi8/unsloth-ud-q4kxl/moecache.yml
+++ b/models/qwen3.8-flash-next/llamacpp-club3090/compose/multi8/unsloth-ud-q4kxl/moecache.yml
@@ -241,8 +241,16 @@ services:
           # — but leaving it as the FALLBACK hands that penalty to every
           # direct-compose user who never sets THREADS. The good zone is an
           # ABSOLUTE ~24-32, so pin the measured value; THREADS still overrides.
-          export LLAMA_ARG_THREADS="28"
-          echo "[threads] -t $${LLAMA_ARG_THREADS} (pinned default; set THREADS to override)" >&2
+          # PORTABLE DEFAULT = nproc/2, matching the launcher's resolve_offload_threads
+          # so both paths agree. ⚠️ nproc/2 is a FLOOR, not the optimum: on our 32c/
+          # 8-channel reference host `-t 28` measured ~20% faster than nproc/2=16. That
+          # 28 belongs in the OPERATOR's .env, NOT in the shipped default -- pinning it
+          # here handed a 32-core-tuned value to every user and oversubscribed smaller
+          # boxes. Set THREADS=<n> to tune; the useful zone is an ABSOLUTE ~24-32.
+          _np=$$(nproc 2>/dev/null || echo 8)
+          _half=$$(( _np / 2 )); [ "$$_half" -lt 1 ] && _half=1
+          export LLAMA_ARG_THREADS="$$_half"
+          echo "[threads] -t $${LLAMA_ARG_THREADS} (auto = nproc/2, nproc=$$_np; set THREADS to tune)" >&2
         fi
 
         # ⚠️ DEFAULT 0: THIS MODEL HAS NO DRAFTER. The GGUF carries no MTP head

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -1556,6 +1556,14 @@ if (( CAP_ENABLED )); then
     fi
     while IFS= read -r _l; do [[ -n "$_l" ]] && echo "  ${_l} MiB (post-run)"; done \
       < <(cap_vram_per_device 2>/dev/null || true)
+    # Component split — added 2026-08-31. The triplet above says HOW MUCH VRAM is
+    # held; this says WHAT holds it, and the `unaccounted` term is the point: on a
+    # CPU-offload MoE with a drafter, ~7.5 GiB across two cards was DRAFT CONTEXT
+    # even with `-devd none` (drafter weights on the host). Nothing else surfaced it.
+    if _vsplit="$(cap_vram_breakdown "${CAP_LOG:-}" 2>/dev/null)" && [[ -n "$_vsplit" ]]; then
+      echo "  component split (MiB):"
+      printf '%s\n' "$_vsplit"
+    fi
   else
     cap_note_unavailable "VRAM triplet" "nvidia-smi not available"
   fi

--- a/scripts/lib/capture.sh
+++ b/scripts/lib/capture.sh
@@ -334,6 +334,31 @@ cap_moe_cache_config() {
 }
 
 # ---------------------------------------------------------------------------
+# VRAM breakdown — where the card's memory actually went
+# ---------------------------------------------------------------------------
+# Added 2026-08-31 after a DeepSeek-V4-Flash-Vision-Exp run where nvidia-smi read
+# 22,612 MiB/card and NOTHING in the bench output said what held it. Two facts
+# that only a breakdown surfaces:
+#   • `-devd none` (drafter on the HOST) still costs ~7.5 GiB of VRAM across two
+#     cards for the DRAFT CONTEXT. "On the host" is not "free".
+#   • The moe-cache pool GROWS after boot (5,814 -> 9,248 MiB on CUDA0 over three
+#     generations) until it hits the free-minus-reserve floor. A pool figure read
+#     at boot is a LOWER BOUND — quoting it understated the warmed pool by 42%.
+# One line per device. Components are llama.cpp-family; on other engines those
+# lines are absent and only the nvidia-smi total is reported.
+cap_vram_breakdown() {                 # $1=log
+  local log="${1:-}"
+  [[ -r "$log" ]] || return 1
+  command -v python3 >/dev/null 2>&1 || return 1
+  local _d
+  # resolve from BASH_SOURCE, never cwd: a wrong dir here would make the
+  # breakdown silently vanish from every run instead of failing loudly
+  _d="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || return 1
+  [[ -r "${_d}/vram_breakdown.py" ]] || return 1
+  PYTHONUTF8="${PYTHONUTF8:-1}" python3 "${_d}/vram_breakdown.py" "$log"
+}
+
+# ---------------------------------------------------------------------------
 # moe-cache log parsing — one python entry point, several modes
 # ---------------------------------------------------------------------------
 # Line shapes handled (both the fork's current census format and the older one):

--- a/scripts/lib/profiles/models/deepseek-v4-flash-vision-exp.yml
+++ b/scripts/lib/profiles/models/deepseek-v4-flash-vision-exp.yml
@@ -1,0 +1,123 @@
+schema_version: 1
+id: deepseek-v4-flash-vision-exp
+display_name: DeepSeek-V4-Flash-Vision-Exp (deepseek4 MoE)
+description: DeepSeek4 MoE (43 layers, 256 routed experts top-6 + 1 shared, MLA single-KV-head, DSA indexer) on two 3090s via CPU expert offload. Expert bundle verified byte-identical to DeepSeek-V4-Flash-0731 from this GGUF's tensor table. NO vision despite the name -- no projector is published and the GGUF carries no vision tensors.
+family: deepseek4-moe
+# Arch: `deepseek4`. 43 layers, ALL of them MoE (no dense prefix) — 256 routed
+# experts top-6 plus 1 shared expert per layer. MLA + compressors + DSA indexer.
+# 1M native context; we ship 200K (see max_ctx notes on the weights entries).
+# All arch values below read from the GGUF via `print_info` on a live b10236 boot,
+# not from a model card.
+hidden_size: 4096              # n_embd
+num_hidden_layers: 43          # n_layer — ALL MoE, no dense prefix
+num_attn_heads: 64             # n_head
+num_kv_heads: 1                # n_head_kv — MLA compresses to a single KV head
+head_dim_attn: 512             # n_embd_head_k == n_embd_head_v
+attention_k_eq_v: true         # 512 == 512, K and V head dims match
+num_experts: 256               # n_expert
+num_experts_per_tok: 6         # n_expert_used
+num_shared_experts: 1
+max_ctx_supported: 1048576     # n_ctx_train — we SHIP 200K, see the weights notes
+vision_capable: false            # "Vision" IS IN THE NAME, NOT IN THE WEIGHTS. Gated
+                                 # 2026-08-31 BEFORE download: no mmproj in the repo, no
+                                 # clip/vision KV keys, and all 1,328 tensors across shards
+                                 # 2-5 are blk/output/token_embd -- zero vision tensors.
+default_weight_variant: unsloth-ud-q8kxl
+valid_tp: [2, 4]
+compatible_drafters: []          # EMPTY PENDING MEASUREMENT, not by evidence: 0731's DSpark has an
+                                 # IDENTICAL tokenizer (gpt2, vocab 129,280, bos 0 / eos 1) and is
+                                 # the same base model + vision training, so it is a plausible
+                                 # drafter. ACCEPTANCE against this checkpoint is unmeasured --
+                                 # add `dspark` here once it is.
+# The KV calculator has no model for MLA + a SWA window + DSA indexing, so every
+# slug sets kvcalc_key="SKIP". Flagged here too so nobody wires it up by reflex.
+kv_calc_supported: false
+
+# ---------------------------------------------------------------------------
+# CPU-offload residency constants (measured 2026-08-06 from the GGUFs directly,
+# via tensor-data offset deltas — see docs/deepseek-vram-ladder/).
+#
+# `preflight_cpu_offload_ram()` sizes host RAM from these:
+#     host_need ≈ Σ(bundle bytes of layers NOT resident) + overhead
+#
+# ⚠️ ROUTED-EXPERTS-ONLY. The `-ot` regex matches `ffn_(gate|up|down)_exps.weight`;
+# the SHARED expert is `_shexp` — a different tensor name, so it stays on GPU by
+# design (offloading it costs ~+2.2 GB/token of RAM traffic). Measured separately
+# below so nobody re-derives these from total FFN bytes and over-counts.
+# ---------------------------------------------------------------------------
+moe_layers: 43
+
+offload_residency:
+  unsloth-ud-q8kxl:
+    # UNIFORM across all 43 layers — a scalar is safe for this quant.
+    expert_bundle_mib: 3264
+    expert_bundle_uniform: true
+    routed_total_gib: 137.1
+    shared_expert_mib_per_layer: 48        # stays on GPU, NOT part of the bundle
+    dense_gpu_gib: 11.7                    # dense/attn/embed, always GPU-resident
+
+# ---------------------------------------------------------------------------
+# VRAM sizing (measured 2026-08-06, docs/deepseek-vram-ladder/RESULTS.md).
+#
+# ⚠️ The context term is NOT the dominant one and is NOT what OOMs this model.
+# Compute buffers are RESERVED AT BOOT (`sched_reserve`) and are driven by -ub,
+# not by context: 3948 + 3697 MiB at -ub 4096, plus ~6.8 GB more when the DSpark
+# drafter is attached. Context contributes only ~11.5 MiB per 1K, quant-independent.
+# A guard that models context alone will pass a config that dies on first prefill.
+# ---------------------------------------------------------------------------
+vram_sizing:
+  ctx_mib_per_1k: 11.5                     # total across cards (~5.8/card)
+  first_decode_topup_mib: 66               # flat; everything else lands at boot
+  compute_reserve_mib:
+    ub2048: { total: 1600 }                # ladder config, no drafter
+    ub4096: { cuda0: 3948, cuda1: 3697 }   # measured with -lv 4
+  # drafter_dspark_mib intentionally ABSENT: this model ships no drafter.
+
+weights:
+  # ⚠️⚠️ THIS REPO HOLDS 13 QUANTS — 1,537 GB. `files:` is what scopes the fetch.
+  # With no `files:`, setup.sh runs `hf download <repo> --local-dir <subdir>` and
+  # pulls the WHOLE repo (every quant) — verified against the HF API 2026-08-07.
+  #
+  # ⚠️ And `--local-dir` PRESERVES repo folder structure (verified empirically,
+  # not assumed): a file at `UD-Q8_K_XL/x.gguf` lands at `<local_dir>/UD-Q8_K_XL/
+  # x.gguf`. So `local_subdir` must be the BUCKET and `files:` must carry the
+  # quant-folder prefix — pointing local_subdir at the quant dir would nest it
+  # twice (`…/UD-Q8_K_XL/UD-Q8_K_XL/`), which no compose points at.
+  # `path:` stays the QUANT dir: it is the physical weights location and keeps
+  # key-resolution precise (weights.py `_resolve_key`), while `local_subdir` is
+  # the download target. They are deliberately different here — don't "fix" it.
+  unsloth-ud-q8kxl:
+    path: deepseek-v4-flash-vision-exp-gguf/unsloth-ud-q8kxl/UD-Q8_K_XL
+    local_subdir: deepseek-v4-flash-vision-exp-gguf/unsloth-ud-q8kxl
+    size_gb: 151
+    format: gguf
+    status: incubating
+    hf_repo: unsloth/DeepSeek-V4-Flash-Vision-Exp-GGUF
+    shards: 5
+    files:
+      - UD-Q8_K_XL/DeepSeek-V4-Flash-Vision-Exp-UD-Q8_K_XL-00001-of-00005.gguf
+      - UD-Q8_K_XL/DeepSeek-V4-Flash-Vision-Exp-UD-Q8_K_XL-00002-of-00005.gguf
+      - UD-Q8_K_XL/DeepSeek-V4-Flash-Vision-Exp-UD-Q8_K_XL-00003-of-00005.gguf
+      - UD-Q8_K_XL/DeepSeek-V4-Flash-Vision-Exp-UD-Q8_K_XL-00004-of-00005.gguf
+      - UD-Q8_K_XL/DeepSeek-V4-Flash-Vision-Exp-UD-Q8_K_XL-00005-of-00005.gguf
+    # ⚠️ REQUIRED on every GGUF entry — `verify_glob` defaults to `*.safetensors`,
+    # which matches NOTHING here. Omitting it made c3 report the weights absent
+    # while they sat on disk, and made setup.sh exit 1 after a successful 151 GB
+    # download with "download may have failed" (weights.py:132, setup.sh:114).
+    # Globbed relative to `local_subdir`, so it carries the quant prefix too —
+    # which also makes each match a valid REPO path for the hash check.
+    verify_glob: "UD-Q8_K_XL/*.gguf"
+    # MXFP4 experts (~91% of the file) + BF16 attention. ⚠️ The quant NAME does not
+    # give you the byte size — 3264 MiB/layer is a MEASUREMENT, not a calculation
+    # from "Q8". Every new quant needs measuring, not deriving.
+    manual_note: "Quality tier. NO published perf/quality numbers — incubating. Ships 200K, NOT 262K: at 262K with the drafter attached it boots READY at 97.4% VRAM, survives a trivial decode, then dies on a ~15.7K-token prefill with CUDA OOM in cuMemCreate (reproduced 2026-08-06)."
+
+# `setup:` — dispatch policy for scripts/setup.sh (contract C1); see
+# qwen3.6-27b.yml for the field reference. Only the non-default keys appear.
+setup:
+  # Only ONE tier is catalogued here (Q8). The repo also publishes UD-Q4_K_XL,
+  # deliberately NOT catalogued: its experts are the SAME MXFP4 as Q8 (verified
+  # from the tensor table), so it changes only the non-expert path and buys no
+  # expert residency -- the thing that actually governs speed on this rig.
+  primary: unsloth-ud-q8kxl
+  # No always_draft: no drafter exists for this variant.

--- a/scripts/lib/profiles/registry.yaml
+++ b/scripts/lib/profiles/registry.yaml
@@ -2251,6 +2251,68 @@ entries:
     serve_aliases: []
     required_sm: 8.6
     category: frontier
+  llamacpp-club3090/deepseek-flash-vision-dual-q8-moecache:
+    model: deepseek-v4-flash-vision-exp
+    weights_variant: unsloth-ud-q8kxl
+    workload: long-ctx-single
+    engine: llamacpp-club3090-v1.6
+    drafter: null
+    spec_method: null
+    kv_format: fp16
+    act_format: 16bit
+    act8_capable: false
+    offload: tensor-override
+    moe_cache: true
+    host_ram_gb: 156
+    chat_template: native
+    tp: 2
+    max_ctx: 204800
+    max_num_seqs: 1
+    mem_util: null
+    compose_path: models/deepseek-v4-flash-vision-exp/llamacpp-club3090/compose/dual/unsloth-ud-q8kxl/moecache.yml
+    requires_nvlink: false
+    requires_homogeneous_arch: false
+    required_engine_features: []
+    default_port: 8128
+    kvcalc_key: SKIP
+    status: experimental
+    status_note: "VALIDATED 2026-08-31 -- first boot PASSED. verify-full 10/10 (tool-calling, streaming tool-calls, thinking, 2K output quality). Booted in 100 s. Bench (3 warm + 5 measured, canonical sampler) at the SHIPPED default THREADS unset -> -t 16, DRAFTER-FREE: decode 22.94 narrative (CV 1.5%) / 21.29 code (CV 0.5%); prefill 407.3 @10K (CV 1.0%) and 343.9 @90K; decode-at-depth 20.82 @10K and 19.69 @90K -- only -14% shallow-to-90K, the v1.6 indexer key-cache showing on a second architecture; TTFT 157-173 ms short; moe-cache hit rate 63.1% / 60.2% per card; pool 5,360 slots of 11,008 experts (48.7%), single allocation. Expert bundle 3264 MiB/layer uniform, MXFP4, verified from the GGUF tensor table BEFORE download and confirmed live at boot. FLOOR NOT CEILING: 16 threads is ~20% below this rig's measured optimum of 28, and no drafter is mounted -- code decode is where that shows (0731 with DSpark records 27.01). NO VISION despite the model name: no mmproj published, no clip/vision metadata, zero vision tensors across all 1,328. Serves TEXT-ONLY. DRAFTER: none wired, but 0731's DSpark has an IDENTICAL tokenizer (gpt2, vocab 129,280, bos 0 / eos 1) -- acceptance against this checkpoint is UNMEASURED, so it is deliberately not mounted. QUALITY UNTESTED: no 8-pack, no soak. ATTRIBUTION: the expert cache is leloch's work (RFC ggml-org#24528), unmerged in mainline."
+    weights_companions: []
+    gateway: false
+    serve_aliases: []
+    required_sm: 8.6
+    category: frontier
+  llamacpp-club3090/deepseek-flash-vision-multi4-q8-moecache:
+    model: deepseek-v4-flash-vision-exp
+    weights_variant: unsloth-ud-q8kxl
+    workload: long-ctx-single
+    engine: llamacpp-club3090-v1.6
+    drafter: null
+    spec_method: null
+    kv_format: fp16
+    act_format: 16bit
+    act8_capable: false
+    offload: tensor-override
+    moe_cache: true
+    host_ram_gb: 156
+    chat_template: native
+    tp: 4
+    max_ctx: 204800
+    max_num_seqs: 1
+    mem_util: null
+    compose_path: models/deepseek-v4-flash-vision-exp/llamacpp-club3090/compose/multi4/unsloth-ud-q8kxl/moecache.yml
+    requires_nvlink: false
+    requires_homogeneous_arch: false
+    required_engine_features: []
+    default_port: 8129
+    kvcalc_key: SKIP
+    status: experimental
+    status_note: "NEVER BOOTED, permanently: this rig has exactly two GPUs, so 4-card topologies are COMMUNITY-VALIDATED BY DESIGN, not a pending TODO. The DUAL sibling passed verify-full 10/10 on 2026-08-31 (22.94 narrative / 21.29 code / 407.3 prefill@10K at -t 16, drafter-free), which validates the model+engine path but says NOTHING about 4-card VRAM, pool sizing or the -ot split -- all of that is inherited from the dual and must be re-derived. NO VISION despite the model name: no mmproj published, no clip/vision metadata, zero vision tensors across all 1,328. Serves TEXT-ONLY. DRAFTER: none wired; 0731's DSpark is tokenizer-identical (gpt2, 129,280) but its acceptance here is UNMEASURED. QUALITY UNTESTED. ATTRIBUTION: the expert cache is leloch's work (RFC ggml-org#24528), unmerged in mainline."
+    weights_companions: []
+    gateway: false
+    serve_aliases: []
+    required_sm: 8.6
+    category: frontier
   llamacpp-club3090/deepseek-flash-dual-q8-moecache:
     model: deepseek-v4-flash-0731
     weights_variant: unsloth-q8-kxl
@@ -2701,7 +2763,7 @@ entries:
     required_engine_features: []
     default_port: 8090
     kvcalc_key: SKIP
-    status: incubating
+    status: experimental
     status_note: "Qwen3.8-27B UD-IQ4_XS GGUF + F16 mmproj on a single 3090 (llama-cpp-local, b10236). q4_0/q4_0 KV @262144 + VISION, built-in MTP n=2 (--spec-type draft-mtp). ⭐ MAX-EVERYTHING single-card config (maintainer decision 2026-08-20): the q4_0 KV (BELOW the stack q8 serving floor) is the mechanism that fits full 262K ctx AND the F16 projector on one 24 GB card. For serving-grade q8_0 KV (131K) override KV_TYPE=q8_0 CTX_SIZE=131072 on this compose (q8@131K + vision, decode-free). ✅ VALIDATED 2026-08-20 (single 3090, GPU0, this exact compose): boots + fits 22,290 MiB load / 22,332 MiB peak under image-encode (~2.2 GiB headroom); verify-full PASS (all functional checks; the 2 skips are vLLM-only); image recognition CORRECT (blue-circle + red-7 probe); n_ctx_slot=262144, 'multimodal model' loaded; text decode projector-free (bench parity w/ the q8 text config, 61.7 narr / 72.7 code). CAVEATS: (1) q4_0 KV KLD ~5.75x worse than q8_0, NEVER depth-validated on this DeltaNet hybrid family — a max-ctx/vision exhibit, not serving-grade; (2) vision untested beyond one image probe — a large/high-res image at 262K encodes into far more tokens and could OOM the thin ~2.2 GiB margin (set IMAGE_MIN_TOKENS with budget in mind); (3) 262K NIAH-clean to 240,635 tok (91%) 2026-08-20 (addressability via verify-stress FAST; full-fidelity retrieval NIAH + fine ladder past 240K still unrun). Precedent: qwen3.6-27b's mtp-vision also ran q4_0 KV. Launch --force (incubating; hidden from switch.sh --list). Promote to 🧪/⚠️ only after a q4-config bench + verify-stress NIAH + soak; q4 KV keeps it off ✅ permanently (floor policy)."
     weights_companions:
       - gguf_mmproj_f16
@@ -2746,7 +2808,7 @@ entries:
     required_engine_features: []
     default_port: 8087
     kvcalc_key: SKIP
-    status: incubating
+    status: experimental
     status_note: "Qwen3.8-27B (Unsloth Dynamic UD-Q8_K_XL GGUF, 31.5 GB) on dual 3090 layer-split (-sm layer -ts 1,1 — PCIe-only, no NVLink, no cross-GPU all-reduce), mainline llama.cpp (llama-cpp-local pin, server-cuda-b10236). q8_0/q8_0 KV @262144 (the model's architectural max_position_embeddings, i.e. genuinely max context), -b 4096 -ub 512, built-in MTP n=2 (--spec-type draft-mtp), text-only. Dual is mandatory, not a preference: 31.5 GB of weights does not fit a 24 GB card. ⚠️ NOTHING HAS BOOTED — authored 2026-08-14 before the weights landed; the weights are now down and sha256-verified, but this slug has still never been launched. Unvalidated: never launched, verify-full 0/8 (not run), no verify-stress / NIAH / soak / bench / 8-pack, and NO TPS number is claimed. The 262144 ceiling is COMPUTED, not measured: 16 growing layers x 4 KV heads x 256 head_dim x 2 tensors = 32,768 elements/token, at q8_0 = 34,816 B/token = 8.50 GiB at 262K; against 47.40 GiB usable across both cards that is 31.50 (weights — the HF page figure, taken while the file was STILL DOWNLOADING and unconfirmed on this rig; almost certainly decimal GB, so the real GiB footprint is likely ~29.3 and the true headroom LARGER, since the IQ4_NL sibling's page '16.3 GB' landed as 15.22 GiB) + 8.50 (KV) + ~2.50 (buffers) = 42.50 GiB, ~4.90 GiB headroom (~21.25 of ~23.40 GiB per card under an even 32/32 layer split, which puts 8 of the 16 full-attention layers on each — evenness ASSUMED, not read off a boot). Allocating 262144 is NOT filling it: the Tess-4-27B dual, which has identical growing-attention geometry, allocates 262144 and NIAH-fills to ~240K (~91%) — expect a comparable or worse gap here until a ladder proves otherwise. ALSO UNPROVEN: that this GGUF loads on the b10236 pin at all — the pin predates the model. q8_0 KV is free here (q4_0 would save 4.25 GiB but buys no context, since 262144 is already the architectural ceiling) and pairing near-lossless UD-Q8_K_XL weights with a lossy KV would be an odd trade. Vision is OFF because the mmproj projectors in the same HF repo were not downloaded. Promote to 🧪 on a clean boot + verify-full; to ⚠️/✅ only after the full gate."
     weights_companions: []
     gateway: false
@@ -2834,7 +2896,7 @@ entries:
     required_engine_features: []
     default_port: 8092
     kvcalc_key: SKIP
-    status: incubating
+    status: experimental
     status_note: "Qwen3.8-27B 'max accuracy' tier, 4-card (TP=4): official Qwen/Qwen3.8-27B-FP8 weights + bf16 KV + MTP n=3 @262144. Identical to vllm/qwen38-27b-dual-max apart from --tensor-parallel-size, the required gpu-count, and --kv-cache-dtype; keep the first two in lockstep. ⚠️ KV DELIBERATELY DIVERGES from the dual (2026-08-15): this runs bf16 (--kv-cache-dtype auto over the pinned --dtype bfloat16) where the dual runs fp8 e4m3, because only TP>=4 has the per-card headroom — weights fall to ~7.2 GiB/card here vs ~14.4 on the dual, so a 16.00 GiB bf16 pool fits (~4.00 GiB/card) where it would not on 2 cards. Do not 'restore lockstep' by reverting it, and do not propagate it to the dual. TWO independent reasons this is incubating, and only the first is closable. (1) NOTHING HAS BOOTED on any card count — authored 2026-08-14; the weights have since landed and verified (30.87 GB / 28.75 GiB, all 66 safetensors CRC32-clean) but no engine has ever loaded them; no verify-full (0/8), no verify-stress / NIAH / soak / bench / 8-pack, NO TPS number claimed, no `Quality:` field, and the 262144 ceiling is arithmetic plus a qwen3.6-27b analogy rather than a measured fill depth. Engine compatibility is likewise inferred: the v0.25.1 pin predates this model. (2) ⛔ 4-CARD IS COMMUNITY-VALIDATED BY DESIGN and that is PERMANENT, not a TODO: the maintainer rig has exactly two 3090s, so TP=4 can never boot here and should never be filed as pending work. The on-rig proxy is vllm/qwen38-27b-dual-max, which is the same serving config at TP=2 EXCEPT for KV (it runs fp8 e4m3, this runs bf16) — so its numbers transfer on topology but NOT on pool size, concurrency, or any KV-sensitive quality result — and everything TP=4-specific (NCCL across 4 PCIe cards, the 4-way shard, the larger KV pool) is validated by whoever first runs it on 4 cards; that first community boot IS the validation. num_kv_heads=4 divides evenly by 4, so the shard is valid on paper. What TP=4 buys is headroom, not context: 262144 is already the architectural ceiling and the dual is projected to reach it, so the 4 cards convert ~14.4 GiB/card of weights into ~7.2, leaving far more room for KV pool and concurrency — on the qwen3.6-27b equivalent, single-stream decode was ~flat from 2 to 4 cards and the pool is what grew. Expect that shape, expect nothing quantitative. PCIe-only with no NVLink means more ranks = more all-reduce on a slow bus; custom all-reduce stays disabled in the entrypoint. Everything else (dense-not-MoE confirmation, the 16-growing-layer KV math — but DOUBLED for bf16: 65,536 B/token = 16.00 GiB @262K, ~4.00 GiB/card at TP=4, where the dual's note states the fp8 figure of 32,768 B/token, the 30.9 GB decimal / 28.8 GiB unit trap, why fp8_e5m2 is rejected, why the chat template is NATIVE and not froggeric, the MODEL-CARD sampler — Instruct row, temp 0.7 / top_p 0.80 / presence_penalty 1.5, because thinking ships off — and the built-in-MTP caveat) matches the dual sibling's note verbatim. ⚠️ MTP drafter exposed to OPEN vllm#50021 (GDN spec-decode wild write, live in this pin; v0.26.0 predates the fix) — structural exposure inherited from the hybrid-GDN family, never observed here because nothing has run. Mitigate with SPEC=off. Detail + re-test trigger: docs/UPSTREAM.md. Launch requires --force (incubating); hidden from switch.sh --list. Promote to 🧪 only after a clean boot + verify-full on a real 4-card host."
     weights_companions: []
     gateway: false
@@ -2878,7 +2940,7 @@ entries:
     required_engine_features: []
     default_port: 8093
     kvcalc_key: SKIP
-    status: incubating
+    status: experimental
     status_note: "Qwen3.8-27B 'max accuracy' tier, 8-card (TP=8): same serving config as vllm/qwen38-27b-multi4-max with three lines changed — --tensor-parallel-size, the Requires-min-gpu-count header, and the port. ⚠️⚠️ TP=8 IS NOT THE SAME SHARD SHAPE AS TP=2/TP=4 AND DOES NOT SCALE THE SAME WAY: this model has num_kv_heads=4, which divides cleanly by 2 and by 4 but NOT by 8. At TP=8 vLLM REPLICATES KV heads across rank pairs rather than splitting them, so per-card KV stays at roughly the TP=4 figure (~4.00 GiB @262K at this compose's bf16 KV), NOT half of it. Only the WEIGHTS take the full 8-way split (~3.6 GiB/card vs ~7.2 at TP=4). So the 8-card gain over 4 is weight headroom only, bought with more all-reduce traffic on a PCIe bus with no NVLink — and on the qwen3.6-27b equivalent single-stream decode was ALREADY ~flat from 2 cards to 4. Expect flat-or-worse decode; expect nothing quantitative until measured. (1) NOTHING HAS BOOTED on any card count — the weights are on disk and CRC32-verified (66 safetensors, 30.87 GB decimal / 28.75 GiB, revision 017b9c7a) but no engine has loaded them; no verify-full, no bench, no 8-pack, no Quality: field, and 262144 is arithmetic plus a sibling analogy rather than a measured fill. (2) ⛔ 8-CARD IS COMMUNITY-VALIDATED BY DESIGN and that is PERMANENT, not a TODO: the maintainer rig has exactly two 3090s, so TP=8 can never boot here and must never be filed as pending work. The on-rig proxy is vllm/qwen38-27b-dual-max (TP=2, which HAS booted and passed verify-full on the reference 2x3090 2026-08-17, with a canonical bench (67.39 narr / 85.75 code tok/s, MTP accept 2.62) — see BENCHMARKS.md) — but it runs fp8 e4m3 KV where this runs bf16 (--kv-cache-dtype auto), a deliberate 2026-08-15 divergence on headroom grounds, so its pool/concurrency numbers do NOT transfer. Everything TP=8-specific — NCCL across 8 PCIe cards, the 8-way weight shard, KV-head replication — is validated by whoever first runs it on 8 cards; that first community boot IS the validation. Report via numbers-from-your-rig. P2P is NOT hardcoded: scripts/detect_nvlink.sh (NVLINK_MODE=auto) probes the interconnect and, when it finds a fast one, exports NCCL_P2P_LEVEL and UNSETS the compose's NCCL_P2P_DISABLE default — so an 8-card host with working P2P picks it up automatically. ⚠️ A 'topo -p2p OK' line reports a grant, not a working transfer; prove it with a real transfer check. ⚠️ MTP drafter exposed to OPEN vllm#50021 (GDN spec-decode wild write, live in this pin); mitigate with SPEC=off. Detail: docs/UPSTREAM.md. Launch requires --force (incubating); hidden from switch.sh --list. Promote to 🧪 only after a clean boot + verify-full on a real 8-card host. Everything else (dense-not-MoE, the 16-growing-layer KV math, the decimal/GiB unit trap, why fp8_e5m2 is rejected, the NATIVE chat template, the MODEL-CARD sampler) matches the multi4 sibling verbatim."
     weights_companions: []
     gateway: false

--- a/scripts/lib/vram_breakdown.py
+++ b/scripts/lib/vram_breakdown.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Break a GPU's VRAM down into the buffers that actually hold it.
+
+Called by capture.sh::cap_vram_breakdown from bench.sh. Reads the engine's own
+boot log for named buffers, then reconciles against nvidia-smi so the gap
+between "what the engine told us" and "what the card reports" is visible rather
+than silent -- that gap is where a draft context hides.
+
+Two traps this encodes, both paid for on 2026-08-31:
+  * moe-cache pool: take the LAST report per (device, pool index). A drafter load
+    triggers a SECOND allocation and both are logged; summing all matches
+    double-counts (measured 13,947 against a live 6,820 -- 2.05x).
+  * A pool figure read at boot is a LOWER BOUND. The pool grows into free VRAM
+    as traffic admits experts, until it hits the free-minus-reserve floor.
+
+Scope: the BYTE split only. Pool slot counts, hit rates and cache health belong to
+CAPTURE: EXPERT CACHE and are deliberately not duplicated here -- one owner per
+number, so the two sections can never disagree.
+"""
+import re
+import subprocess
+import sys
+
+
+def _per_dev(text, pat, agg=False):
+    out = {}
+    for m in re.finditer(pat, text):
+        dev, val = m.group(1), float(m.group(2))
+        out[dev] = out.get(dev, 0.0) + val if agg else val
+    return out
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        return 1
+    try:
+        text = open(sys.argv[1], encoding="utf-8", errors="replace").read()
+    except OSError:
+        return 1
+
+    model = _per_dev(text, r"load_tensors:\s+(CUDA\d) model buffer size =\s+([\d.]+) MiB")
+    compute = _per_dev(text, r"sched_reserve:\s+(CUDA\d) compute buffer size =\s+([\d.]+) MiB")
+    kv = _per_dev(text, r"llama_kv_cache:\s+(CUDA\d) KV buffer size =\s+([\d.]+) MiB", agg=True)
+    state = _per_dev(text, r"_comp_state:\s+(CUDA\d) \S+ \S+ state buffer size =\s+([\d.]+) MiB", agg=True)
+
+    # LAST report per (device, pool) -- never sum every match, see module docstring
+    last = {}
+    for m in re.finditer(
+        r"\[moe-cache\] (CUDA\d) pool\[(\d)\]:.*?slots=(\d+).*?total=(\d+) MiB", text
+    ):
+        last[(m.group(1), m.group(2))] = (int(m.group(3)), int(m.group(4)))
+    pool, slots, allocs = {}, {}, {}
+    for (dev, idx), (sl, mib) in last.items():
+        pool[dev] = pool.get(dev, 0) + mib
+        slots[dev] = slots.get(dev, 0) + sl
+    for m in re.finditer(r"\[moe-cache\] (CUDA\d) pool\[(\d)\]:", text):
+        k = (m.group(1), m.group(2))
+        allocs[k] = allocs.get(k, 0) + 1
+
+    smi = {}
+    try:
+        out = subprocess.run(
+            ["nvidia-smi", "--query-gpu=index,memory.used,memory.total",
+             "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, encoding="utf-8", timeout=10,
+        ).stdout
+        for line in out.strip().splitlines():
+            i, used, tot = [x.strip() for x in line.split(",")]
+            smi["CUDA" + i] = (float(used), float(tot))
+    except Exception:
+        pass
+
+    devs = sorted(set(model) | set(smi) | set(pool))
+    if not devs:
+        return 1
+
+    for dev in devs:
+        parts, acc = [], 0.0
+        for label, src in (("model", model), ("kv", kv), ("state", state),
+                           ("compute", compute), ("pool", pool)):
+            if dev in src:
+                parts.append("%s=%.0f" % (label, src[dev]))
+                acc += src[dev]
+        if dev in smi:
+            used, tot = smi[dev]
+            parts.append("total=%.0f/%.0fMiB(%.0f%%)" % (used, tot, 100 * used / tot))
+            if acc:
+                # everything the card reports that the engine did not name:
+                # draft context, CUDA runtime, fragmentation
+                parts.append("unaccounted=%.0f" % (used - acc))
+        print("  %s: %s" % (dev, "  ".join(parts)))
+
+    n = max(allocs.values()) if allocs else 0
+    if n > 1:
+        print("  WARNING: %d moe-cache allocations logged per pool — figures above take the "
+              "LAST (summing them double-counts)" % n)
+    if pool:
+        print("  pool slots + hit rate: see CAPTURE: EXPERT CACHE below (this line is the "
+              "BYTE split only)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test-compose-registry-disk.sh
+++ b/scripts/tests/test-compose-registry-disk.sh
@@ -35,8 +35,8 @@ def check(cond, msg):
         print(f"FAIL: {msg}")
         failures.append(msg)
 
-check(len(COMPOSE_REGISTRY) == 109, f"registry expects 109 entries (got {len(COMPOSE_REGISTRY)})")
-check(len(disk_paths) == 110, f"disk expects 110 compose files (got {len(disk_paths)})")
+check(len(COMPOSE_REGISTRY) == 111, f"registry expects 111 entries (got {len(COMPOSE_REGISTRY)})")
+check(len(disk_paths) == 112, f"disk expects 112 compose files (got {len(disk_paths)})")
 check(registry_paths <= disk_paths, "all registry compose_path values exist on disk")
 parked_disk_only = disk_paths - registry_paths
 # Disk-only (non-registry) composes allowed: parked SGLang archives, plus the experimental

--- a/scripts/tests/test-preflight-cpu-offload.sh
+++ b/scripts/tests/test-preflight-cpu-offload.sh
@@ -463,9 +463,20 @@ declare -F resolve_offload_threads >/dev/null 2>&1 && ok "resolve_offload_thread
 # the bare-compose fallback must be LOW, not the reference rig's number: over-subscribing
 # measured -69% vs under-subscribing -9.6%, so err low when the core count is unknown.
 for f in "$Q8" "$IQ2" "$M4" "$FORK_Q8" "$FORK_M4" "$INK_CACHE" "$INK_M4" "$INK_RES"; do
-  fb="$(command grep -oE 'THREADS:-[0-9]+' "$f" | command grep -oE '[0-9]+' | head -1)"
-  [[ -n "$fb" && "$fb" -le 8 ]] && ok "$(basename "$(dirname "$f")")/$(basename "$f"): safe THREADS fallback ($fb)" \
-    || bad "$(basename "$(dirname "$f")")/$(basename "$f"): THREADS fallback '$fb' is too high for an unknown rig"
+  # Two acceptable shapes, both safe on an unknown rig:
+  #   (a) entrypoint resolution to nproc/2  — the CURRENT convention (adapts to the host)
+  #   (b) a literal `THREADS:-N` with N <= 8 — the older bare-compose fallback
+  # A hardcoded high number (e.g. the reference rig's 28) is what this rejects:
+  # it over-subscribes a smaller box. CLI `-t` is separately forbidden because it
+  # beats the entrypoint env.
+  _lbl="$(basename "$(dirname "$f")")/$(basename "$f")"
+  if command grep -qE '_np / 2|nproc/2' "$f"; then
+    ok "$_lbl: resolves THREADS to nproc/2 in the entrypoint (portable)"
+  else
+    fb="$(command grep -oE 'THREADS:-[0-9]+' "$f" | command grep -oE '[0-9]+' | head -1)"
+    [[ -n "$fb" && "$fb" -le 8 ]] && ok "$_lbl: safe THREADS fallback ($fb)" \
+      || bad "$_lbl: THREADS fallback '$fb' is neither nproc/2 nor <=8 — unsafe on an unknown rig"
+  fi
 done
 
 # ---- wiring ----

--- a/scripts/tests/test-profiles-compat.sh
+++ b/scripts/tests/test-profiles-compat.sh
@@ -33,7 +33,7 @@ run_test "load_profiles parses all profile groups" <<'PY'
 from scripts.lib.profiles.compat import load_profiles
 p = load_profiles()
 assert len(p.hardware) == 11  # +dgx-spark (#576 follow-up), +rtx-a6000 (#948 thread)
-assert len(p.models) == 20   # +inkling-small, +qwen3.8-27b, +glm-5.3-flash, +qwen3.8-flash-next
+assert len(p.models) == 21   # +inkling-small, +qwen3.8-27b, +glm-5.3-flash, +qwen3.8-flash-next, +deepseek-v4-flash-vision-exp
 assert len(p.workloads) == 5
 assert len(p.engines) == 17   # +llamacpp-club3090-v1.1, -v1.5, -v1.6
 assert len(p.drafters) == 18  # +syvai-qwen38-dflash2, +anbeeld-glm53-dflash2
@@ -510,7 +510,7 @@ PY
 run_test "strict keys: every shipped profile group loads under validation" <<'PY'
 from scripts.lib.profiles.compat import load_profiles
 p = load_profiles()  # raises UnknownProfileKeyError on any unknown key
-assert len(p.models) == 20
+assert len(p.models) == 21
 PY
 
 run_test "strict keys: typo'd top-level model key fails naming file + closest key" <<'PY'


### PR DESCRIPTION
Two commits on top of the merged #1116 (`2aa4a34c` landed with that PR).

## `6f4958a8` — new model + portable threads + status promotions

**DeepSeek-V4-Flash-Vision-Exp**, 2 slugs (dual :8128, multi4 :8129) on moe-cache
v1.6, built by copying the validated 0731 sibling. **First boot passed: verify-full
10/10 in 100 s.**

Two findings gated from the GGUF tensor table *before* the 162 GB download:
- ⛔ **No vision despite the name** — no mmproj published, no clip/vision metadata,
  zero vision tensors across all 1,328. Serves text-only. Disclosed in the compose
  header, registry note and model profile; the slug name does not disclose it
  (kept by maintainer decision).
- ⚠️ **Both unsloth UD tiers share one expert type (MXFP4)** — the Q4/Q8 names
  describe the non-expert path only, which is why they are 4% apart in size. Tier
  choice does not change expert residency on a moe-cache rig.

**Threads:** `-t` now resolves to `nproc/2` in the entrypoint on **all 19**
llama.cpp-family composes; none ships a CLI `-t` (CLI beats env and would silently
override). Replaces a hardcoded 28 (the reference rig's value, over-subscribing
smaller boxes) and a hardcoded 8 (below optimum anywhere). 28 moves to the
operator's `.env`. `THREADS` is declared in `environment:` everywhere — without
that docker never forwards it and the knob is inert.

**Status:** four Qwen3.8-27B slugs promoted incubating → experimental.

## `2d784720` — VRAM component split in `CAPTURE: VRAM`

`nvidia-smi` reporting 22,612 MiB/card said nothing about what held it. The split
names the buffers and computes `unaccounted`, which turned out to be **~7.5 GiB of
draft context across two cards even with `-devd none`**. Byte split only — slots
and hit rates stay with `CAPTURE: EXPERT CACHE`, one owner per number.

## Validation

Full suite **126/126** at `6f4958a8`; bench guards **5/5** at `2d784720`. The new
model's compose was booted for real and passed verify-full 10/10.

## Not validated

- ⚠️ **Throughput numbers in the BENCHMARKS row are swap-confounded.** `bench.sh`
  flagged `swap check: FAIL` on the run; the host defaults to `vm.swappiness=60`,
  which evicts the serving process's own pages to cache the model file it is
  streaming. Correcting these is tracked separately — the structural facts (boots,
  verify-full 10/10, pool sizes, VRAM split) are unaffected.
- No 8-pack quality, no soak, no verify-stress on any of it.
- `multi4` has never booted — two GPUs here, permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
