### PR TITLE
feat(qwen3.8-27b): ship thinking by default across all 22 composes

### DIFF
--- a/models/qwen3.8-27b/llama-cpp/compose/dual/unsloth-q8kxl/q8kv.yml
+++ b/models/qwen3.8-27b/llama-cpp/compose/dual/unsloth-q8kxl/q8kv.yml
@@ -173,10 +173,13 @@
 #                    PCIe-only 3090s; row-split leans on cross-GPU traffic this
 #                    rig has no fast path for)
 #   SERVED_NAME      --alias value       (default: qwen3.8-27b)
-#   REASONING        thinking gate       (default: off — stack-wide policy)
+#   REASONING        thinking gate       (default: ON — 2026-09-01 flip; INSTRUCT=1 opts out)
 #   REASONING_FORMAT reasoning routing   (default: deepseek — hygiene)
-#   TEMP/TOP_P/TOP_K/MIN_P               (defaults: 0.6 / 0.95 / 20 / 0.0 — the stack's
-#                    Qwen sampler. NOT verified against this model's card.)
+#   TEMP/TOP_P/TOP_K/MIN_P               (defaults: 1.0 / 0.95 / 20 / 0.0 — the card's
+#                    THINKING row. The 0.6/0.95 stated here before 2026-09-01 was stale;
+#                    the command block never used those values.)
+#   INSTRUCT         one-knob opt-out    (unset by default; INSTRUCT=1 restores the card's
+#                    INSTRUCT row AND --reasoning off, together)
 #   REPEAT_PENALTY   anti-loop           (default: 1.0)
 #   PORT             host port           (default: 8087)
 #   CUDA_VISIBLE_DEVICES  which GPUs     (default: 0,1 — both cards)
@@ -203,8 +206,9 @@ services:
       - SPEC_N=${SPEC_N:-}
       - SPEC=${SPEC:-}
       # ⭐ Default reasoning effort = low when thinking is on (2026-08-16),
-      # matching the vLLM composes. INERT under the shipped `--reasoning off`:
-      # the template only reads reasoning_effort inside
+      # matching the vLLM composes. NOW ACTIVE on every request: thinking became
+      # the default 2026-09-01. It goes INERT only under INSTRUCT=1, because the
+      # template reads reasoning_effort inside
       # `if enable_thinking is undefined or true`, and --reasoning off passes
       # enable_thinking:false.
       # ⚠️ low is an ACTIVE instruction: 'Keep your thinking brief and focused,
@@ -244,21 +248,29 @@ services:
     # ⚠️ Comments CANNOT live inside the `command: >-` folded scalar below — every line there is
     #   part of one command string, and a `#` line becomes literal argv text
     #   ('invalid command line string' at compose parse). Keep notes above this key.
-    # SAMPLER — from the Qwen3.8-27B model card. THIS COMPOSE SHIPS INSTRUCT (NON-THINKING).
+    # SAMPLER — from the Qwen3.8-27B model card. THIS COMPOSE SHIPS THINKING (flipped 2026-09-01).
     #   Qwen publishes two sets and they differ in every value that matters:
-    #     Instruct / non-thinking (SHIPPED HERE) : temp 0.7, top_p 0.80, top_k 20, min_p 0.0,
-    #                                             presence_penalty 1.5, repetition_penalty 1.0
-    #     Thinking                               : temp 1.0, top_p 0.95, top_k 20, min_p 0.0,
+    #     Thinking (SHIPPED HERE)                : temp 1.0, top_p 0.95, top_k 20, min_p 0.0,
     #                                             presence_penalty 0.0, repetition_penalty 1.0
-    #   `--reasoning off` and the instruct sampler are set TOGETHER below. Compose cannot branch,
-    #   so if you flip REASONING=on you MUST also set TEMP=1.0 TOP_P=0.95 PRESENCE_PENALTY=0.0
-    #   — the sampler does NOT follow the reasoning flag, and mismatching them is silent.
+    #     Instruct / non-thinking (INSTRUCT=1)   : temp 0.7, top_p 0.80, top_k 20, min_p 0.0,
+    #                                             presence_penalty 1.5, repetition_penalty 1.0
+    #   `--reasoning on` and the thinking sampler are set TOGETHER below, and INSTRUCT=1 flips
+    #   BOTH back together. The sampler does NOT follow the reasoning flag on its own, so a bare
+    #   REASONING=off leaves the THINKING sampler in place — mismatching them is silent.
+    #   ⭐ WHY THINKING IS THE DEFAULT — a community request, backed by our own 8-pack (issue
+    #   #1027, dual 3090 fp8): instruct scored 120/150 pass@1, the WORST of the four modes
+    #   measured, against 135 (effort=low), 137 (xhigh), 129 (medium). The cost is latency,
+    #   2-6x per turn (cli-40 1.76s -> 8.27s; instructfollow-15 0.48s -> 3.09s) — though
+    #   reasonmath-15 got FASTER (5.26s -> 3.64s). Set INSTRUCT=1 when turn latency outweighs
+    #   accuracy. Those numbers are from the vLLM fp8 dual; this llama.cpp compose is UNMEASURED
+    #   on the 8-pack — the mode choice transfers, the scores do not.
     #   ⚠️ presence_penalty=1.5 is prescribed by the card for THIS mode specifically, to curb
     #   endless repetition; under thinking it must be 0.0 instead, or the reasoning trace's
     #   natural repetition gets penalised. The two values move in OPPOSITE directions between
     #   modes — never carry one across. (The first authoring pass omitted it entirely; llama.cpp
     #   defaults it to 0.0.) Qwen notes 0-2 is the usable band and >2 degrades quality.
-    #   ⚠️ Thinking-off is the stack default for Qwen and is a deliberate policy, not an oversight.
+    #   ⚠️ Thinking-ON is this model's default as of 2026-09-01, superseding the earlier
+    #   thinking-off policy announced in discussion #1024. Both were deliberate.
     #   ⚠️ These are SERVING defaults only. scripts/bench.sh sends its own fixed canonical sampler
     #   (temp 0.6 / top_p 0.95 / top_k 20 / min_p 0.0) on every request so BENCHMARKS.md rows stay
     #   comparable across models and engines — a bench number is NOT evidence about these values.
@@ -267,36 +279,42 @@ services:
     #   * Client sends sampler fields   -> the REQUEST wins (two temperature:0 calls returned
     #                                      byte-identical text while the server default was 0.6).
     #   * Client sends
-    #       "chat_template_kwargs": {"enable_thinking": true}
-    #                                   -> thinking is enabled FOR THAT REQUEST even though the
-    #                                      server runs --reasoning off; the trace lands in
-    #                                      message.reasoning_content and the answer in
+    #       "chat_template_kwargs": {"enable_thinking": false}
+    #                                   -> thinking is disabled FOR THAT REQUEST even though the
+    #                                      server runs --reasoning on. ⚠️ The direction verified
+    #                                      live on b10236 (2026-08-14) was the MIRROR of this one
+    #                                      (enable_thinking:true against a --reasoning off server);
+    #                                      same chat-template kwarg, but this direction is
+    #                                      UNVERIFIED on this build. With thinking on, the trace
+    #                                      lands in message.reasoning_content and the answer in
     #                                      message.content (--reasoning-format deepseek).
     #
-    #   ⚠️ THE TWO KNOBS ARE INDEPENDENT — this is the trap. Enabling thinking per-request does
-    #   NOT change the sampler: the request inherits the INSTRUCT values above, including
-    #   presence_penalty 1.5, which the card prescribes only for non-thinking and which actively
-    #   penalises a reasoning trace's natural repetition. An agent that wants thinking must send
-    #   the thinking sampler in the SAME request:
+    #   ⚠️ THE TWO KNOBS ARE INDEPENDENT — this is the trap, and the 2026-09-01 flip INVERTED
+    #   its direction. Disabling thinking per-request does NOT change the sampler: the request
+    #   inherits the THINKING values above, including presence_penalty 0.0, where the card
+    #   prescribes 1.5 for non-thinking to curb endless repetition. A client that wants instruct
+    #   must send the instruct sampler in the SAME request:
     #
     #     {"messages": [...],
-    #      "chat_template_kwargs": {"enable_thinking": true},
-    #      "temperature": 1.0, "top_p": 0.95, "top_k": 20,
-    #      "min_p": 0.0, "presence_penalty": 0.0}
+    #      "chat_template_kwargs": {"enable_thinking": false},
+    #      "temperature": 0.7, "top_p": 0.80, "top_k": 20,
+    #      "min_p": 0.0, "presence_penalty": 1.5}
     #
-    #   ⇒ No separate thinking slug is needed, and no reboot: a caller opts in per request. That
-    #   is why this compose ships one mode rather than a sibling `thinking.yml`.
-    # ⭐ ONE-KNOB THINKING MODE:  THINKING=1  flips reasoning AND the whole sampler together.
-    #   Without it you get the card's INSTRUCT row (the flags above). With it, the trailing
-    #   ${THINKING:+...} line appends the card's THINKING row, and llama.cpp takes the LAST value
-    #   of a repeated flag — so `THINKING=1` alone is sufficient and correct. top_k/min_p/
+    #   ⇒ No separate instruct slug is needed, and no reboot: a caller opts out per request. That
+    #   is why this compose ships one mode rather than a sibling `instruct.yml`.
+    # ⭐ ONE-KNOB INSTRUCT MODE:  INSTRUCT=1  flips reasoning AND the whole sampler back together.
+    #   Without it you get the card's THINKING row (the flags above). With it, the trailing
+    #   ${INSTRUCT:+...} line appends the card's INSTRUCT row, and llama.cpp takes the LAST value
+    #   of a repeated flag — so `INSTRUCT=1` alone is sufficient and correct. top_k/min_p/
     #   repeat-penalty are identical across both modes, so they are not repeated.
+    #   THINKING=1 is kept as a back-compat NO-OP — it re-asserts what is now already default.
+    #   ⚠️ Do not set both: INSTRUCT is appended last, so INSTRUCT=1 wins over THINKING=1.
     #
-    #   Precedence is preserved: an explicit TEMP/TOP_P/PRESENCE_PENALTY survives THINKING,
-    #   because the appended values are themselves ${VAR:-default}. Verified 2026-08-14:
-    #     (unset)              -> --temp 0.7
-    #     THINKING=1           -> --temp 0.7 ... --temp 1.0        (thinking wins)
-    #     THINKING=1 TEMP=0.42 -> --temp 0.42 ... --temp 0.42      (user wins)
+    #   Precedence is preserved: an explicit TEMP/TOP_P/PRESENCE_PENALTY survives INSTRUCT,
+    #   because the appended values are themselves ${VAR:-default}. Verified 2026-09-01:
+    #     (unset)              -> --temp 1.0
+    #     INSTRUCT=1           -> --temp 1.0 ... --temp 0.7       (instruct wins)
+    #     INSTRUCT=1 TEMP=0.42 -> --temp 0.42 ... --temp 0.42     (user wins)
     #
     #   ⚠️⚠️ RE-TEST TRIGGER — THIS RESTS ON DEPRECATED UPSTREAM BEHAVIOUR.
     #   b10236 warns: "DEPRECATED: argument '--temp' specified multiple times, use
@@ -366,15 +384,16 @@ services:
       --spec-type draft-mtp
       --spec-draft-n-max ${SPEC_N:-${MTP_DRAFT_N_MAX:-2}}
       --jinja
-      --reasoning ${REASONING:-off}
+      --reasoning ${REASONING:-on}
       --reasoning-format ${REASONING_FORMAT:-deepseek}
-      --temp ${TEMP:-${TEMPERATURE:-0.7}}
-      --top-p ${TOP_P:-0.80}
+      --temp ${TEMP:-${TEMPERATURE:-1.0}}
+      --top-p ${TOP_P:-0.95}
       --top-k ${TOP_K:-20}
       --min-p ${MIN_P:-0.0}
-      --presence-penalty ${PRESENCE_PENALTY:-1.5}
+      --presence-penalty ${PRESENCE_PENALTY:-0.0}
       --repeat-penalty ${REPEAT_PENALTY:-1.0}
       ${THINKING:+--reasoning ${REASONING:-on} --temp ${TEMP:-${TEMPERATURE:-1.0}} --top-p ${TOP_P:-0.95} --presence-penalty ${PRESENCE_PENALTY:-0.0}}
+      ${INSTRUCT:+--reasoning ${REASONING:-off} --temp ${TEMP:-${TEMPERATURE:-0.7}} --top-p ${TOP_P:-0.80} --presence-penalty ${PRESENCE_PENALTY:-1.5}}
     deploy:
       resources:
         reservations:

--- a/models/qwen3.8-27b/llama-cpp/compose/single/unsloth-iq4xs/q4kv-vision.yml
+++ b/models/qwen3.8-27b/llama-cpp/compose/single/unsloth-iq4xs/q4kv-vision.yml
@@ -115,8 +115,10 @@
 #   IMAGE_MIN_TOKENS min image tokens    (unset by default; set 1024 for grounding)
 #   NP               parallel slots      (default: 1)
 #   SERVED_NAME      --alias value       (default: qwen3.8-27b)
-#   REASONING        thinking gate       (default: off — stack-wide policy)
-#   TEMP/TOP_P/TOP_K/MIN_P               (defaults: card INSTRUCT row — 0.7 / 0.80 / 20 / 0.0)
+#   REASONING        thinking gate       (default: ON — 2026-09-01 flip; INSTRUCT=1 opts out)
+#   INSTRUCT         one-knob opt-out    (unset by default; INSTRUCT=1 restores the card's
+#                                        INSTRUCT row AND --reasoning off, together)
+#   TEMP/TOP_P/TOP_K/MIN_P               (defaults: card THINKING row — 1.0 / 0.95 / 20 / 0.0)
 #   PORT             host port           (default: 8090)
 #   CUDA_VISIBLE_DEVICES  which GPU      (default: 0 — leaves GPU 1 free)
 #   LLAMACPP_IMAGE   engine image        (default: the llama-cpp-local pin)
@@ -140,18 +142,21 @@ services:
       # Drafter toggle - docker forwards only what is declared here.
       - SPEC_N=${SPEC_N:-}
       - SPEC=${SPEC:-}
-      # Default reasoning effort = low when thinking is on; INERT under --reasoning off.
+      # Default reasoning effort = low; ACTIVE on every request since the 2026-09-01
+      # thinking flip. INERT only under INSTRUCT=1 (which passes enable_thinking:false).
       # (See the q8_0 sibling header for the full `high`->xhigh template trap on this engine.)
       - LLAMA_ARG_CHAT_TEMPLATE_KWARGS=${LLAMA_ARG_CHAT_TEMPLATE_KWARGS:-{"reasoning_effort":"${REASONING_EFFORT:-low}"}}
       - CUDA_VISIBLE_DEVICES=${ESTATE_GPUS:-${CUDA_VISIBLE_DEVICES:-0}}
     # ⚠ -np 1 is intentional on a single 24 GB card — extra slots divide throughput
     #   and each takes its own KV slice. The projector + 262K KV leave no room anyway.
     # ⚠️ BUILT-IN MTP — head EMBEDDED in this GGUF (blk.64.nextn.*). No drafter file mounted.
-    # ⚠️ SAMPLER ships the card's INSTRUCT (non-thinking) row: temp 0.7 / top_p 0.80 /
-    #   top_k 20 / min_p 0.0 / presence_penalty 1.5. THINKING=1 flips reasoning AND the
-    #   whole sampler together (last-wins on repeated flags — see the q8_0 sibling header
-    #   for the deprecated-behaviour re-test trigger on pin bumps). bench.sh sends its own
-    #   fixed canonical sampler regardless.
+    # ⚠️ SAMPLER ships the card's THINKING row: temp 1.0 / top_p 0.95 / top_k 20 /
+    #   min_p 0.0 / presence_penalty 0.0 (flipped 2026-09-01 — community request backed by
+    #   issue #1027, where instruct scored 120/150 pass@1, worst of four modes tested).
+    #   INSTRUCT=1 flips reasoning AND the whole sampler back together (last-wins on
+    #   repeated flags — see the q8_0 sibling header for the full rationale and the
+    #   deprecated-behaviour re-test trigger on pin bumps). THINKING=1 is now a back-compat
+    #   no-op. bench.sh sends its own fixed canonical sampler regardless.
     # ⚠️ Comments CANNOT live inside the `command: >-` folded scalar — keep notes above this key.
     # The image ENTRYPOINT is ["/app/llama-server"]; this wrapper adds the drafter toggle.
     entrypoint:
@@ -200,16 +205,17 @@ services:
       --spec-type draft-mtp
       --spec-draft-n-max ${SPEC_N:-${MTP_DRAFT_N_MAX:-2}}
       --jinja
-      --reasoning ${REASONING:-off}
+      --reasoning ${REASONING:-on}
       --reasoning-format ${REASONING_FORMAT:-deepseek}
-      --temp ${TEMP:-${TEMPERATURE:-0.7}}
-      --top-p ${TOP_P:-0.80}
+      --temp ${TEMP:-${TEMPERATURE:-1.0}}
+      --top-p ${TOP_P:-0.95}
       --top-k ${TOP_K:-20}
       --min-p ${MIN_P:-0.0}
-      --presence-penalty ${PRESENCE_PENALTY:-1.5}
+      --presence-penalty ${PRESENCE_PENALTY:-0.0}
       --repeat-penalty ${REPEAT_PENALTY:-1.0}
       ${IMAGE_MIN_TOKENS:+--image-min-tokens ${IMAGE_MIN_TOKENS}}
       ${THINKING:+--reasoning ${REASONING:-on} --temp ${TEMP:-${TEMPERATURE:-1.0}} --top-p ${TOP_P:-0.95} --presence-penalty ${PRESENCE_PENALTY:-0.0}}
+      ${INSTRUCT:+--reasoning ${REASONING:-off} --temp ${TEMP:-${TEMPERATURE:-0.7}} --top-p ${TOP_P:-0.80} --presence-penalty ${PRESENCE_PENALTY:-1.5}}
     deploy:
       resources:
         reservations:

--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2-fp8.yml
@@ -77,7 +77,7 @@ services:
       # from the model-card row matching ENABLE_THINKING, so these must reach the
       # container. Absent -> empty -> the entrypoint's `:=` row default applies;
       # an explicit value crosses unchanged and still wins over both rows.
-      - ENABLE_THINKING=${ENABLE_THINKING:-false}
+      - ENABLE_THINKING=${ENABLE_THINKING:-true}
       - TEMP=${TEMP:-}
       - TOP_P=${TOP_P:-}
       - TOP_K=${TOP_K:-}
@@ -162,7 +162,7 @@ services:
         # from .env or shell STILL WINS in both branches. top_k / min_p are
         # identical across the rows and stay mode-independent.
         _temp="$${TEMP:-}"
-        if [ "$${ENABLE_THINKING:-false}" = "true" ]; then
+        if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         else
@@ -216,9 +216,9 @@ services:
       # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
-      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
-      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
-      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ ACTIVE on every request since the 2026-09-01 thinking flip. The template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`,
+      # so it goes INERT only under ENABLE_THINKING=false.
       # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
       # "Keep your thinking brief and focused, moving directly to the conclusion
       # without unnecessary elaboration." The three levels are NOT a scale with a
@@ -228,10 +228,11 @@ services:
       # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching
-      # ENABLE_THINKING (instruct by default; thinking when true); explicit
+      # ENABLE_THINKING (THINKING by default since 2026-09-01; instruct when
+      # false); explicit
       # TEMP/TOP_P/PRESENCE_PENALTY still win. Both rows: "SAMPLER" header above.
       - --host
       - 0.0.0.0

--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2.yml
@@ -112,7 +112,7 @@ services:
       # from the model-card row matching ENABLE_THINKING, so these must reach the
       # container. Absent -> empty -> the entrypoint's `:=` row default applies;
       # an explicit value crosses unchanged and still wins over both rows.
-      - ENABLE_THINKING=${ENABLE_THINKING:-false}
+      - ENABLE_THINKING=${ENABLE_THINKING:-true}
       - TEMP=${TEMP:-}
       - TOP_P=${TOP_P:-}
       - TOP_K=${TOP_K:-}
@@ -197,7 +197,7 @@ services:
         # from .env or shell STILL WINS in both branches. top_k / min_p are
         # identical across the rows and stay mode-independent.
         _temp="$${TEMP:-}"
-        if [ "$${ENABLE_THINKING:-false}" = "true" ]; then
+        if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         else
@@ -253,9 +253,9 @@ services:
       # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
-      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
-      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
-      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ ACTIVE on every request since the 2026-09-01 thinking flip. The template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`,
+      # so it goes INERT only under ENABLE_THINKING=false.
       # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
       # "Keep your thinking brief and focused, moving directly to the conclusion
       # without unnecessary elaboration." The three levels are NOT a scale with a
@@ -265,10 +265,11 @@ services:
       # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching
-      # ENABLE_THINKING (instruct by default; thinking when true); explicit
+      # ENABLE_THINKING (THINKING by default since 2026-09-01; instruct when
+      # false); explicit
       # TEMP/TOP_P/PRESENCE_PENALTY still win. Both rows: "SAMPLER" header above.
       - --host
       - 0.0.0.0

--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
@@ -185,7 +185,7 @@ services:
       # from the model-card row matching ENABLE_THINKING, so these must reach the
       # container. Absent -> empty -> the entrypoint's `:=` row default applies;
       # an explicit value crosses unchanged and still wins over both rows.
-      - ENABLE_THINKING=${ENABLE_THINKING:-false}
+      - ENABLE_THINKING=${ENABLE_THINKING:-true}
       - TEMP=${TEMP:-}
       - TOP_P=${TOP_P:-}
       - TOP_K=${TOP_K:-}
@@ -268,7 +268,7 @@ services:
         # from .env or shell STILL WINS in both branches. top_k / min_p are
         # identical across the rows and stay mode-independent.
         _temp="$${TEMP:-}"
-        if [ "$${ENABLE_THINKING:-false}" = "true" ]; then
+        if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         else
@@ -332,9 +332,9 @@ services:
       # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
-      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
-      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
-      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ ACTIVE on every request since the 2026-09-01 thinking flip. The template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`,
+      # so it goes INERT only under ENABLE_THINKING=false.
       # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
       # "Keep your thinking brief and focused, moving directly to the conclusion
       # without unnecessary elaboration." The three levels are NOT a scale with a
@@ -344,10 +344,11 @@ services:
       # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching
-      # ENABLE_THINKING (instruct by default; thinking when true); explicit
+      # ENABLE_THINKING (THINKING by default since 2026-09-01; instruct when
+      # false); explicit
       # TEMP/TOP_P/PRESENCE_PENALTY still win. Both rows: "SAMPLER" header above.
       - --host
       - 0.0.0.0

--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/dflash2-fp8.yml
@@ -72,7 +72,7 @@ services:
       # from the model-card row matching ENABLE_THINKING, so these must reach the
       # container. Absent -> empty -> the entrypoint's `:=` row default applies;
       # an explicit value crosses unchanged and still wins over both rows.
-      - ENABLE_THINKING=${ENABLE_THINKING:-false}
+      - ENABLE_THINKING=${ENABLE_THINKING:-true}
       - TEMP=${TEMP:-}
       - TEMPERATURE=${TEMPERATURE:-}
       - TOP_P=${TOP_P:-}
@@ -181,7 +181,7 @@ services:
         # branches. top_k / min_p / repetition_penalty are identical across the
         # rows and stay mode-independent.
         _temp="$${TEMP:-$${TEMPERATURE:-}}"
-        if [ "$${ENABLE_THINKING:-false}" = "true" ]; then
+        if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         else
@@ -245,9 +245,9 @@ services:
       # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
-      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
-      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
-      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ ACTIVE on every request since the 2026-09-01 thinking flip. The template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`,
+      # so it goes INERT only under ENABLE_THINKING=false.
       # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
       # "Keep your thinking brief and focused, moving directly to the conclusion
       # without unnecessary elaboration." The three levels are NOT a scale with a
@@ -257,7 +257,7 @@ services:
       # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       - --enable-auto-tool-choice
       # The 3.8 template emits the same <tool_call><function=…><parameter=…> XML
       # as 3.6 (verified by reading the template), so this parser applies.
@@ -273,7 +273,8 @@ services:
       - --enable-chunked-prefill
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching
-      # ENABLE_THINKING (instruct by default; thinking when true); explicit
+      # ENABLE_THINKING (THINKING by default since 2026-09-01; instruct when
+      # false); explicit
       # TEMP/TOP_P/PRESENCE_PENALTY still win. Both rows: "SAMPLER" header above.
       - --host
       - 0.0.0.0

--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/dflash2.yml
@@ -72,7 +72,7 @@ services:
       # from the model-card row matching ENABLE_THINKING, so these must reach the
       # container. Absent -> empty -> the entrypoint's `:=` row default applies;
       # an explicit value crosses unchanged and still wins over both rows.
-      - ENABLE_THINKING=${ENABLE_THINKING:-false}
+      - ENABLE_THINKING=${ENABLE_THINKING:-true}
       - TEMP=${TEMP:-}
       - TEMPERATURE=${TEMPERATURE:-}
       - TOP_P=${TOP_P:-}
@@ -181,7 +181,7 @@ services:
         # branches. top_k / min_p / repetition_penalty are identical across the
         # rows and stay mode-independent.
         _temp="$${TEMP:-$${TEMPERATURE:-}}"
-        if [ "$${ENABLE_THINKING:-false}" = "true" ]; then
+        if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         else
@@ -247,9 +247,9 @@ services:
       # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
-      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
-      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
-      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ ACTIVE on every request since the 2026-09-01 thinking flip. The template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`,
+      # so it goes INERT only under ENABLE_THINKING=false.
       # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
       # "Keep your thinking brief and focused, moving directly to the conclusion
       # without unnecessary elaboration." The three levels are NOT a scale with a
@@ -259,7 +259,7 @@ services:
       # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       - --enable-auto-tool-choice
       # The 3.8 template emits the same <tool_call><function=…><parameter=…> XML
       # as 3.6 (verified by reading the template), so this parser applies.
@@ -275,7 +275,8 @@ services:
       - --enable-chunked-prefill
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching
-      # ENABLE_THINKING (instruct by default; thinking when true); explicit
+      # ENABLE_THINKING (THINKING by default since 2026-09-01; instruct when
+      # false); explicit
       # TEMP/TOP_P/PRESENCE_PENALTY still win. Both rows: "SAMPLER" header above.
       - --host
       - 0.0.0.0

--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
@@ -207,7 +207,7 @@
 #   </thinking> hallucination, unclosed think before a tool call, no-user-query
 #   crash, developer role, …). If those symptoms show up, that audit — not a
 #   blind froggeric mount — is the next step.
-#   Note the stack-wide `enable_thinking: false` default below ALSO suppresses
+#   Note the stack-wide `enable_thinking: true` default below ALSO suppresses
 #   the xhigh reasoning-effort preamble, since the template gates it on thinking.
 #
 # Dependencies:
@@ -324,7 +324,7 @@ services:
       # from the model-card row matching ENABLE_THINKING, so these must reach the
       # container. Absent -> empty -> the entrypoint's `:=` row default applies;
       # an explicit value crosses unchanged and still wins over both rows.
-      - ENABLE_THINKING=${ENABLE_THINKING:-false}
+      - ENABLE_THINKING=${ENABLE_THINKING:-true}
       - TEMP=${TEMP:-}
       - TEMPERATURE=${TEMPERATURE:-}
       - TOP_P=${TOP_P:-}
@@ -431,7 +431,7 @@ services:
         # branches. top_k / min_p / repetition_penalty are identical across the
         # rows and stay mode-independent.
         _temp="$${TEMP:-$${TEMPERATURE:-}}"
-        if [ "$${ENABLE_THINKING:-false}" = "true" ]; then
+        if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         else
@@ -495,9 +495,9 @@ services:
       # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
-      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
-      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
-      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ ACTIVE on every request since the 2026-09-01 thinking flip. The template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`,
+      # so it goes INERT only under ENABLE_THINKING=false.
       # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
       # "Keep your thinking brief and focused, moving directly to the conclusion
       # without unnecessary elaboration." The three levels are NOT a scale with a
@@ -507,7 +507,7 @@ services:
       # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       - --enable-auto-tool-choice
       # The 3.8 template emits the same <tool_call><function=…><parameter=…> XML
       # as 3.6 (verified by reading the template), so this parser applies.
@@ -533,7 +533,8 @@ services:
       - "${PREFIX_MATCH_UNIT:-16}"
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching
-      # ENABLE_THINKING (instruct by default; thinking when true); explicit
+      # ENABLE_THINKING (THINKING by default since 2026-09-01; instruct when
+      # false); explicit
       # TEMP/TOP_P/PRESENCE_PENALTY still win. Both rows: "SAMPLER" header above.
       - --host
       - 0.0.0.0

--- a/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
@@ -112,7 +112,7 @@ services:
       # from the model-card row matching ENABLE_THINKING, so these must reach the
       # container. Absent -> empty -> the entrypoint's `:=` row default applies;
       # an explicit value crosses unchanged and still wins over both rows.
-      - ENABLE_THINKING=${ENABLE_THINKING:-false}
+      - ENABLE_THINKING=${ENABLE_THINKING:-true}
       - TEMP=${TEMP:-}
       - TOP_P=${TOP_P:-}
       - TOP_K=${TOP_K:-}
@@ -179,7 +179,7 @@ services:
         # from .env or shell STILL WINS in both branches. top_k / min_p are
         # identical across the rows and stay mode-independent.
         _temp="$${TEMP:-}"
-        if [ "$${ENABLE_THINKING:-false}" = "true" ]; then
+        if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         else
@@ -242,9 +242,9 @@ services:
       # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
-      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
-      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
-      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ ACTIVE on every request since the 2026-09-01 thinking flip. The template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`,
+      # so it goes INERT only under ENABLE_THINKING=false.
       # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
       # "Keep your thinking brief and focused, moving directly to the conclusion
       # without unnecessary elaboration." The three levels are NOT a scale with a
@@ -254,10 +254,11 @@ services:
       # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching
-      # ENABLE_THINKING (instruct by default; thinking when true); explicit
+      # ENABLE_THINKING (THINKING by default since 2026-09-01; instruct when
+      # false); explicit
       # TEMP/TOP_P/PRESENCE_PENALTY still win. Both rows: "SAMPLER" header above.
       - --host
       - 0.0.0.0

--- a/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/dflash2-fp8.yml
@@ -79,7 +79,7 @@ services:
       # from the model-card row matching ENABLE_THINKING, so these must reach the
       # container. Absent -> empty -> the entrypoint's `:=` row default applies;
       # an explicit value crosses unchanged and still wins over both rows.
-      - ENABLE_THINKING=${ENABLE_THINKING:-false}
+      - ENABLE_THINKING=${ENABLE_THINKING:-true}
       - TEMP=${TEMP:-}
       - TOP_P=${TOP_P:-}
       - TOP_K=${TOP_K:-}
@@ -164,7 +164,7 @@ services:
         # from .env or shell STILL WINS in both branches. top_k / min_p are
         # identical across the rows and stay mode-independent.
         _temp="$${TEMP:-}"
-        if [ "$${ENABLE_THINKING:-false}" = "true" ]; then
+        if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         else
@@ -217,9 +217,9 @@ services:
       # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
-      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
-      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
-      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ ACTIVE on every request since the 2026-09-01 thinking flip. The template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`,
+      # so it goes INERT only under ENABLE_THINKING=false.
       # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
       # "Keep your thinking brief and focused, moving directly to the conclusion
       # without unnecessary elaboration." The three levels are NOT a scale with a
@@ -229,10 +229,11 @@ services:
       # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching
-      # ENABLE_THINKING (instruct by default; thinking when true); explicit
+      # ENABLE_THINKING (THINKING by default since 2026-09-01; instruct when
+      # false); explicit
       # TEMP/TOP_P/PRESENCE_PENALTY still win. Both rows: "SAMPLER" header above.
       - --host
       - 0.0.0.0

--- a/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/dflash2.yml
@@ -90,7 +90,7 @@ services:
       # from the model-card row matching ENABLE_THINKING, so these must reach the
       # container. Absent -> empty -> the entrypoint's `:=` row default applies;
       # an explicit value crosses unchanged and still wins over both rows.
-      - ENABLE_THINKING=${ENABLE_THINKING:-false}
+      - ENABLE_THINKING=${ENABLE_THINKING:-true}
       - TEMP=${TEMP:-}
       - TOP_P=${TOP_P:-}
       - TOP_K=${TOP_K:-}
@@ -175,7 +175,7 @@ services:
         # from .env or shell STILL WINS in both branches. top_k / min_p are
         # identical across the rows and stay mode-independent.
         _temp="$${TEMP:-}"
-        if [ "$${ENABLE_THINKING:-false}" = "true" ]; then
+        if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         else
@@ -230,9 +230,9 @@ services:
       # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
-      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
-      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
-      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ ACTIVE on every request since the 2026-09-01 thinking flip. The template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`,
+      # so it goes INERT only under ENABLE_THINKING=false.
       # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
       # "Keep your thinking brief and focused, moving directly to the conclusion
       # without unnecessary elaboration." The three levels are NOT a scale with a
@@ -242,10 +242,11 @@ services:
       # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching
-      # ENABLE_THINKING (instruct by default; thinking when true); explicit
+      # ENABLE_THINKING (THINKING by default since 2026-09-01; instruct when
+      # false); explicit
       # TEMP/TOP_P/PRESENCE_PENALTY still win. Both rows: "SAMPLER" header above.
       - --host
       - 0.0.0.0

--- a/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
@@ -160,7 +160,7 @@ services:
       # from the model-card row matching ENABLE_THINKING, so these must reach the
       # container. Absent -> empty -> the entrypoint's `:=` row default applies;
       # an explicit value crosses unchanged and still wins over both rows.
-      - ENABLE_THINKING=${ENABLE_THINKING:-false}
+      - ENABLE_THINKING=${ENABLE_THINKING:-true}
       - TEMP=${TEMP:-}
       - TOP_P=${TOP_P:-}
       - TOP_K=${TOP_K:-}
@@ -240,7 +240,7 @@ services:
         # from .env or shell STILL WINS in both branches. top_k / min_p are
         # identical across the rows and stay mode-independent.
         _temp="$${TEMP:-}"
-        if [ "$${ENABLE_THINKING:-false}" = "true" ]; then
+        if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         else
@@ -301,9 +301,9 @@ services:
       # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
-      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
-      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
-      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ ACTIVE on every request since the 2026-09-01 thinking flip. The template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`,
+      # so it goes INERT only under ENABLE_THINKING=false.
       # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
       # "Keep your thinking brief and focused, moving directly to the conclusion
       # without unnecessary elaboration." The three levels are NOT a scale with a
@@ -313,10 +313,11 @@ services:
       # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching
-      # ENABLE_THINKING (instruct by default; thinking when true); explicit
+      # ENABLE_THINKING (THINKING by default since 2026-09-01; instruct when
+      # false); explicit
       # TEMP/TOP_P/PRESENCE_PENALTY still win. Both rows: "SAMPLER" header above.
       - --host
       - 0.0.0.0

--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/dflash2-fp8.yml
@@ -72,7 +72,7 @@ services:
       # from the model-card row matching ENABLE_THINKING, so these must reach the
       # container. Absent -> empty -> the entrypoint's `:=` row default applies;
       # an explicit value crosses unchanged and still wins over both rows.
-      - ENABLE_THINKING=${ENABLE_THINKING:-false}
+      - ENABLE_THINKING=${ENABLE_THINKING:-true}
       - TEMP=${TEMP:-}
       - TEMPERATURE=${TEMPERATURE:-}
       - TOP_P=${TOP_P:-}
@@ -181,7 +181,7 @@ services:
         # branches. top_k / min_p / repetition_penalty are identical across the
         # rows and stay mode-independent.
         _temp="$${TEMP:-$${TEMPERATURE:-}}"
-        if [ "$${ENABLE_THINKING:-false}" = "true" ]; then
+        if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         else
@@ -249,9 +249,9 @@ services:
       # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
-      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
-      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
-      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ ACTIVE on every request since the 2026-09-01 thinking flip. The template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`,
+      # so it goes INERT only under ENABLE_THINKING=false.
       # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
       # "Keep your thinking brief and focused, moving directly to the conclusion
       # without unnecessary elaboration." The three levels are NOT a scale with a
@@ -261,7 +261,7 @@ services:
       # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       - --enable-auto-tool-choice
       - --tool-call-parser
       - qwen3_coder
@@ -274,7 +274,8 @@ services:
       - --enable-chunked-prefill
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching
-      # ENABLE_THINKING (instruct by default; thinking when true); explicit
+      # ENABLE_THINKING (THINKING by default since 2026-09-01; instruct when
+      # false); explicit
       # TEMP/TOP_P/PRESENCE_PENALTY still win. Both rows: "SAMPLER" header above.
       - --host
       - 0.0.0.0

--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/dflash2.yml
@@ -71,7 +71,7 @@ services:
       # from the model-card row matching ENABLE_THINKING, so these must reach the
       # container. Absent -> empty -> the entrypoint's `:=` row default applies;
       # an explicit value crosses unchanged and still wins over both rows.
-      - ENABLE_THINKING=${ENABLE_THINKING:-false}
+      - ENABLE_THINKING=${ENABLE_THINKING:-true}
       - TEMP=${TEMP:-}
       - TEMPERATURE=${TEMPERATURE:-}
       - TOP_P=${TOP_P:-}
@@ -180,7 +180,7 @@ services:
         # branches. top_k / min_p / repetition_penalty are identical across the
         # rows and stay mode-independent.
         _temp="$${TEMP:-$${TEMPERATURE:-}}"
-        if [ "$${ENABLE_THINKING:-false}" = "true" ]; then
+        if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         else
@@ -250,9 +250,9 @@ services:
       # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
-      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
-      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
-      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ ACTIVE on every request since the 2026-09-01 thinking flip. The template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`,
+      # so it goes INERT only under ENABLE_THINKING=false.
       # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
       # "Keep your thinking brief and focused, moving directly to the conclusion
       # without unnecessary elaboration." The three levels are NOT a scale with a
@@ -262,7 +262,7 @@ services:
       # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       - --enable-auto-tool-choice
       - --tool-call-parser
       - qwen3_coder
@@ -275,7 +275,8 @@ services:
       - --enable-chunked-prefill
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching
-      # ENABLE_THINKING (instruct by default; thinking when true); explicit
+      # ENABLE_THINKING (THINKING by default since 2026-09-01; instruct when
+      # false); explicit
       # TEMP/TOP_P/PRESENCE_PENALTY still win. Both rows: "SAMPLER" header above.
       - --host
       - 0.0.0.0

--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
@@ -225,7 +225,7 @@ services:
       # from the model-card row matching ENABLE_THINKING, so these must reach the
       # container. Absent -> empty -> the entrypoint's `:=` row default applies;
       # an explicit value crosses unchanged and still wins over both rows.
-      - ENABLE_THINKING=${ENABLE_THINKING:-false}
+      - ENABLE_THINKING=${ENABLE_THINKING:-true}
       - TEMP=${TEMP:-}
       - TEMPERATURE=${TEMPERATURE:-}
       - TOP_P=${TOP_P:-}
@@ -332,7 +332,7 @@ services:
         # branches. top_k / min_p / repetition_penalty are identical across the
         # rows and stay mode-independent.
         _temp="$${TEMP:-$${TEMPERATURE:-}}"
-        if [ "$${ENABLE_THINKING:-false}" = "true" ]; then
+        if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         else
@@ -400,9 +400,9 @@ services:
       # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
-      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
-      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
-      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ ACTIVE on every request since the 2026-09-01 thinking flip. The template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`,
+      # so it goes INERT only under ENABLE_THINKING=false.
       # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
       # "Keep your thinking brief and focused, moving directly to the conclusion
       # without unnecessary elaboration." The three levels are NOT a scale with a
@@ -412,7 +412,7 @@ services:
       # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       - --enable-auto-tool-choice
       - --tool-call-parser
       - qwen3_coder
@@ -435,7 +435,8 @@ services:
       - "${PREFIX_MATCH_UNIT:-16}"
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching
-      # ENABLE_THINKING (instruct by default; thinking when true); explicit
+      # ENABLE_THINKING (THINKING by default since 2026-09-01; instruct when
+      # false); explicit
       # TEMP/TOP_P/PRESENCE_PENALTY still win. Both rows: "SAMPLER" header above.
       - --host
       - 0.0.0.0

--- a/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/dflash2-fp8.yml
@@ -79,7 +79,7 @@ services:
       # from the model-card row matching ENABLE_THINKING, so these must reach the
       # container. Absent -> empty -> the entrypoint's `:=` row default applies;
       # an explicit value crosses unchanged and still wins over both rows.
-      - ENABLE_THINKING=${ENABLE_THINKING:-false}
+      - ENABLE_THINKING=${ENABLE_THINKING:-true}
       - TEMP=${TEMP:-}
       - TOP_P=${TOP_P:-}
       - TOP_K=${TOP_K:-}
@@ -164,7 +164,7 @@ services:
         # from .env or shell STILL WINS in both branches. top_k / min_p are
         # identical across the rows and stay mode-independent.
         _temp="$${TEMP:-}"
-        if [ "$${ENABLE_THINKING:-false}" = "true" ]; then
+        if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         else
@@ -217,9 +217,9 @@ services:
       # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
-      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
-      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
-      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ ACTIVE on every request since the 2026-09-01 thinking flip. The template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`,
+      # so it goes INERT only under ENABLE_THINKING=false.
       # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
       # "Keep your thinking brief and focused, moving directly to the conclusion
       # without unnecessary elaboration." The three levels are NOT a scale with a
@@ -229,10 +229,11 @@ services:
       # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching
-      # ENABLE_THINKING (instruct by default; thinking when true); explicit
+      # ENABLE_THINKING (THINKING by default since 2026-09-01; instruct when
+      # false); explicit
       # TEMP/TOP_P/PRESENCE_PENALTY still win. Both rows: "SAMPLER" header above.
       - --host
       - 0.0.0.0

--- a/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/dflash2.yml
@@ -91,7 +91,7 @@ services:
       # from the model-card row matching ENABLE_THINKING, so these must reach the
       # container. Absent -> empty -> the entrypoint's `:=` row default applies;
       # an explicit value crosses unchanged and still wins over both rows.
-      - ENABLE_THINKING=${ENABLE_THINKING:-false}
+      - ENABLE_THINKING=${ENABLE_THINKING:-true}
       - TEMP=${TEMP:-}
       - TOP_P=${TOP_P:-}
       - TOP_K=${TOP_K:-}
@@ -176,7 +176,7 @@ services:
         # from .env or shell STILL WINS in both branches. top_k / min_p are
         # identical across the rows and stay mode-independent.
         _temp="$${TEMP:-}"
-        if [ "$${ENABLE_THINKING:-false}" = "true" ]; then
+        if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         else
@@ -231,9 +231,9 @@ services:
       # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
-      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
-      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
-      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ ACTIVE on every request since the 2026-09-01 thinking flip. The template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`,
+      # so it goes INERT only under ENABLE_THINKING=false.
       # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
       # "Keep your thinking brief and focused, moving directly to the conclusion
       # without unnecessary elaboration." The three levels are NOT a scale with a
@@ -243,10 +243,11 @@ services:
       # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching
-      # ENABLE_THINKING (instruct by default; thinking when true); explicit
+      # ENABLE_THINKING (THINKING by default since 2026-09-01; instruct when
+      # false); explicit
       # TEMP/TOP_P/PRESENCE_PENALTY still win. Both rows: "SAMPLER" header above.
       - --host
       - 0.0.0.0

--- a/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
@@ -160,7 +160,7 @@ services:
       # from the model-card row matching ENABLE_THINKING, so these must reach the
       # container. Absent -> empty -> the entrypoint's `:=` row default applies;
       # an explicit value crosses unchanged and still wins over both rows.
-      - ENABLE_THINKING=${ENABLE_THINKING:-false}
+      - ENABLE_THINKING=${ENABLE_THINKING:-true}
       - TEMP=${TEMP:-}
       - TOP_P=${TOP_P:-}
       - TOP_K=${TOP_K:-}
@@ -240,7 +240,7 @@ services:
         # from .env or shell STILL WINS in both branches. top_k / min_p are
         # identical across the rows and stay mode-independent.
         _temp="$${TEMP:-}"
-        if [ "$${ENABLE_THINKING:-false}" = "true" ]; then
+        if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         else
@@ -301,9 +301,9 @@ services:
       # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
-      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
-      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
-      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ ACTIVE on every request since the 2026-09-01 thinking flip. The template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`,
+      # so it goes INERT only under ENABLE_THINKING=false.
       # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
       # "Keep your thinking brief and focused, moving directly to the conclusion
       # without unnecessary elaboration." The three levels are NOT a scale with a
@@ -313,10 +313,11 @@ services:
       # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching
-      # ENABLE_THINKING (instruct by default; thinking when true); explicit
+      # ENABLE_THINKING (THINKING by default since 2026-09-01; instruct when
+      # false); explicit
       # TEMP/TOP_P/PRESENCE_PENALTY still win. Both rows: "SAMPLER" header above.
       - --host
       - 0.0.0.0

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/dflash2-fp8.yml
@@ -72,7 +72,7 @@ services:
       # from the model-card row matching ENABLE_THINKING, so these must reach the
       # container. Absent -> empty -> the entrypoint's `:=` row default applies;
       # an explicit value crosses unchanged and still wins over both rows.
-      - ENABLE_THINKING=${ENABLE_THINKING:-false}
+      - ENABLE_THINKING=${ENABLE_THINKING:-true}
       - TEMP=${TEMP:-}
       - TEMPERATURE=${TEMPERATURE:-}
       - TOP_P=${TOP_P:-}
@@ -181,7 +181,7 @@ services:
         # branches. top_k / min_p / repetition_penalty are identical across the
         # rows and stay mode-independent.
         _temp="$${TEMP:-$${TEMPERATURE:-}}"
-        if [ "$${ENABLE_THINKING:-false}" = "true" ]; then
+        if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         else
@@ -263,9 +263,9 @@ services:
       # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
-      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
-      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
-      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ ACTIVE on every request since the 2026-09-01 thinking flip. The template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`,
+      # so it goes INERT only under ENABLE_THINKING=false.
       # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
       # "Keep your thinking brief and focused, moving directly to the conclusion
       # without unnecessary elaboration." The three levels are NOT a scale with a
@@ -275,7 +275,7 @@ services:
       # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       - --enable-auto-tool-choice
       - --tool-call-parser
       - qwen3_coder
@@ -288,7 +288,8 @@ services:
       - --enable-chunked-prefill
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching
-      # ENABLE_THINKING (instruct by default; thinking when true); explicit
+      # ENABLE_THINKING (THINKING by default since 2026-09-01; instruct when
+      # false); explicit
       # TEMP/TOP_P/PRESENCE_PENALTY still win. Both rows: "SAMPLER" header above.
       - --host
       - 0.0.0.0

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/dflash2.yml
@@ -71,7 +71,7 @@ services:
       # from the model-card row matching ENABLE_THINKING, so these must reach the
       # container. Absent -> empty -> the entrypoint's `:=` row default applies;
       # an explicit value crosses unchanged and still wins over both rows.
-      - ENABLE_THINKING=${ENABLE_THINKING:-false}
+      - ENABLE_THINKING=${ENABLE_THINKING:-true}
       - TEMP=${TEMP:-}
       - TEMPERATURE=${TEMPERATURE:-}
       - TOP_P=${TOP_P:-}
@@ -180,7 +180,7 @@ services:
         # branches. top_k / min_p / repetition_penalty are identical across the
         # rows and stay mode-independent.
         _temp="$${TEMP:-$${TEMPERATURE:-}}"
-        if [ "$${ENABLE_THINKING:-false}" = "true" ]; then
+        if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         else
@@ -264,9 +264,9 @@ services:
       # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
-      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
-      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
-      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ ACTIVE on every request since the 2026-09-01 thinking flip. The template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`,
+      # so it goes INERT only under ENABLE_THINKING=false.
       # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
       # "Keep your thinking brief and focused, moving directly to the conclusion
       # without unnecessary elaboration." The three levels are NOT a scale with a
@@ -276,7 +276,7 @@ services:
       # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       - --enable-auto-tool-choice
       - --tool-call-parser
       - qwen3_coder
@@ -289,7 +289,8 @@ services:
       - --enable-chunked-prefill
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching
-      # ENABLE_THINKING (instruct by default; thinking when true); explicit
+      # ENABLE_THINKING (THINKING by default since 2026-09-01; instruct when
+      # false); explicit
       # TEMP/TOP_P/PRESENCE_PENALTY still win. Both rows: "SAMPLER" header above.
       - --host
       - 0.0.0.0

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
@@ -229,7 +229,7 @@ services:
       # from the model-card row matching ENABLE_THINKING, so these must reach the
       # container. Absent -> empty -> the entrypoint's `:=` row default applies;
       # an explicit value crosses unchanged and still wins over both rows.
-      - ENABLE_THINKING=${ENABLE_THINKING:-false}
+      - ENABLE_THINKING=${ENABLE_THINKING:-true}
       - TEMP=${TEMP:-}
       - TEMPERATURE=${TEMPERATURE:-}
       - TOP_P=${TOP_P:-}
@@ -336,7 +336,7 @@ services:
         # branches. top_k / min_p / repetition_penalty are identical across the
         # rows and stay mode-independent.
         _temp="$${TEMP:-$${TEMPERATURE:-}}"
-        if [ "$${ENABLE_THINKING:-false}" = "true" ]; then
+        if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         else
@@ -418,9 +418,9 @@ services:
       # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
-      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
-      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
-      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ ACTIVE on every request since the 2026-09-01 thinking flip. The template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`,
+      # so it goes INERT only under ENABLE_THINKING=false.
       # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
       # "Keep your thinking brief and focused, moving directly to the conclusion
       # without unnecessary elaboration." The three levels are NOT a scale with a
@@ -430,7 +430,7 @@ services:
       # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       - --enable-auto-tool-choice
       - --tool-call-parser
       - qwen3_coder
@@ -453,7 +453,8 @@ services:
       - "${PREFIX_MATCH_UNIT:-16}"
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching
-      # ENABLE_THINKING (instruct by default; thinking when true); explicit
+      # ENABLE_THINKING (THINKING by default since 2026-09-01; instruct when
+      # false); explicit
       # TEMP/TOP_P/PRESENCE_PENALTY still win. Both rows: "SAMPLER" header above.
       - --host
       - 0.0.0.0

--- a/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
@@ -133,7 +133,7 @@ services:
       # from the model-card row matching ENABLE_THINKING, so these must reach the
       # container. Absent -> empty -> the entrypoint's `:=` row default applies;
       # an explicit value crosses unchanged and still wins over both rows.
-      - ENABLE_THINKING=${ENABLE_THINKING:-false}
+      - ENABLE_THINKING=${ENABLE_THINKING:-true}
       - TEMP=${TEMP:-}
       - TOP_P=${TOP_P:-}
       - TOP_K=${TOP_K:-}
@@ -200,7 +200,7 @@ services:
         # from .env or shell STILL WINS in both branches. top_k / min_p are
         # identical across the rows and stay mode-independent.
         _temp="$${TEMP:-}"
-        if [ "$${ENABLE_THINKING:-false}" = "true" ]; then
+        if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         else
@@ -263,9 +263,9 @@ services:
       # ⭐ reasoning_effort default = low (2026-08-16). It is a PER-REQUEST OpenAI
       # control, so this is only the fallback for callers that send nothing — any
       # agent still picks its own level per request.
-      # ⚠️ INERT while enable_thinking is false (the shipped default): the template
-      # only reads reasoning_effort inside `if enable_thinking is undefined or true`.
-      # It takes effect the moment ENABLE_THINKING=true.
+      # ⚠️ ACTIVE on every request since the 2026-09-01 thinking flip. The template
+      # only reads reasoning_effort inside `if enable_thinking is undefined or true`,
+      # so it goes INERT only under ENABLE_THINKING=false.
       # ⚠️ low is an ACTIVE instruction, not "less of medium" — it injects
       # "Keep your thinking brief and focused, moving directly to the conclusion
       # without unnecessary elaboration." The three levels are NOT a scale with a
@@ -275,10 +275,11 @@ services:
       # you want the model un-nudged rather than pushed toward brevity.
       # ⚠️ Valid values are xhigh | medium | low. Anything else RAISES at template
       # render (`high` included — it does NOT silently remap).
-      - '{"enable_thinking": ${ENABLE_THINKING:-false}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
+      - '{"enable_thinking": ${ENABLE_THINKING:-true}, "reasoning_effort": "${REASONING_EFFORT:-low}"}'
       # SAMPLER moved INTO the entrypoint (#984/#1014): at boot it derives
       # --override-generation-config from the model-card row matching
-      # ENABLE_THINKING (instruct by default; thinking when true); explicit
+      # ENABLE_THINKING (THINKING by default since 2026-09-01; instruct when
+      # false); explicit
       # TEMP/TOP_P/PRESENCE_PENALTY still win. Both rows: "SAMPLER" header above.
       - --host
       - 0.0.0.0

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -168,12 +168,22 @@ def _entry(
     # {...}} with temperature/top_p/top_k/min_p/presence_penalty/
     # repetition_penalty. None (the default) = single-row model, the compose's
     # static sampler is the only truth. When set, the compose entrypoint derives
-    # its shipped default from the INSTRUCT row and flips to THINKING on
-    # ENABLE_THINKING=true; test-compose-sampler-profiles.sh asserts the compose
-    # can never drift from this data. Adding a key here is the allowlist gate:
+    # its shipped default from `sampler_default_mode` (below) and flips to the
+    # OTHER row on the opt-in knob; test-compose-sampler-profiles.sh asserts the
+    # compose can never drift from this data. Adding a key here is the
+    # allowlist gate:
     # local-layer rows go through _entry(**kwargs) too, so an unknown sampler
     # kwarg fails loudly (LocalRegistryError), never silently.
     sampler_profiles=None,
+    # Which sampler_profiles row the compose ships when the user sets NO env:
+    # "instruct" (the default when omitted) or "thinking". This is POLICY, not a
+    # restatement of the compose — the gate renders the compose and asserts the
+    # resolved sampler equals THIS row, so an accidental flip of a compose
+    # default fails loudly rather than passing because expectation and evidence
+    # were read from the same file. qwen3.8-27b moved to "thinking" 2026-09-01
+    # (community request + issue #1027, where instruct scored worst of the four
+    # modes measured); qwen3.8-flash-next still ships "instruct".
+    sampler_default_mode=None,
     # Speculation that needs NO drafter GGUF (the ngram-* runtime spec-types).
     # Those slugs keep `drafter=None` by design, so consumers deriving a label
     # from `drafter` alone would report 'no speculation' while it is running.
@@ -255,6 +265,17 @@ def _entry(
         entry["sampler_profiles"] = {
             mode: dict(row) for mode, row in sampler_profiles.items()
         }
+        # Normalised here so every consumer sees an explicit mode and none has
+        # to re-implement the "absent means instruct" default.
+        _mode = sampler_default_mode or "instruct"
+        if _mode not in ("instruct", "thinking"):
+            raise ValueError(
+                "sampler_default_mode must be 'instruct' or 'thinking', "
+                f"got {sampler_default_mode!r}"
+            )
+        entry["sampler_default_mode"] = _mode
+    elif sampler_default_mode is not None:
+        raise ValueError("sampler_default_mode set without sampler_profiles")
     return entry
 
 

--- a/scripts/lib/profiles/registry.yaml
+++ b/scripts/lib/profiles/registry.yaml
@@ -2125,6 +2125,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: instruct
   llamacpp-club3090/qwen38-flash-next-multi4-q4kxl-moecache:
     model: qwen3.8-flash-next
     weights_variant: unsloth-ud-q4kxl
@@ -2172,6 +2173,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: instruct
   llamacpp-club3090/qwen38-flash-next-multi8-q4kxl-moecache:
     model: qwen3.8-flash-next
     weights_variant: unsloth-ud-q4kxl
@@ -2219,6 +2221,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: instruct
   llamacpp-club3090/deepseek-flash-multi4-q8-moecache:
     model: deepseek-v4-flash-0731
     weights_variant: unsloth-q8-kxl
@@ -2784,6 +2787,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: thinking
   llamacpp/qwen38-27b-dual-q8kxl:
     model: qwen3.8-27b
     weights_variant: unsloth-q8kxl
@@ -2828,6 +2832,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: thinking
   vllm/qwen38-27b-dual-max:
     model: qwen3.8-27b
     weights_variant: fp8
@@ -2872,6 +2877,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: thinking
   vllm/qwen38-27b-multi4-max:
     model: qwen3.8-27b
     weights_variant: fp8
@@ -2916,6 +2922,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: thinking
   vllm/qwen38-27b-multi8-max:
     model: qwen3.8-27b
     weights_variant: fp8
@@ -2960,6 +2967,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: thinking
   vllm/qwen38-27b-dual-supermax:
     model: qwen3.8-27b
     weights_variant: fp8
@@ -3004,6 +3012,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: thinking
   vllm/qwen38-27b-multi4-supermax:
     model: qwen3.8-27b
     weights_variant: fp8
@@ -3048,6 +3057,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: thinking
   vllm/qwen38-27b-multi8-supermax:
     model: qwen3.8-27b
     weights_variant: fp8
@@ -3092,6 +3102,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: thinking
   vllm/qwen38-27b-dual-ultramax:
     model: qwen3.8-27b
     weights_variant: fp8
@@ -3136,6 +3147,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: thinking
   vllm/qwen38-27b-multi4-ultramax:
     model: qwen3.8-27b
     weights_variant: fp8
@@ -3180,6 +3192,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: thinking
   vllm/qwen38-27b-multi8-ultramax:
     model: qwen3.8-27b
     weights_variant: fp8
@@ -3224,6 +3237,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: thinking
   vllm/qwen38-27b-dual-fast:
     model: qwen3.8-27b
     weights_variant: autoround-int4
@@ -3268,6 +3282,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: thinking
   vllm/qwen38-27b-multi4-fast:
     model: qwen3.8-27b
     weights_variant: autoround-int4
@@ -3312,6 +3327,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: thinking
   vllm/qwen38-27b-multi8-fast:
     model: qwen3.8-27b
     weights_variant: autoround-int4
@@ -3356,6 +3372,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: thinking
   vllm/qwen38-27b-dual-superfast:
     model: qwen3.8-27b
     weights_variant: autoround-int4
@@ -3400,6 +3417,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: thinking
   vllm/qwen38-27b-multi4-superfast:
     model: qwen3.8-27b
     weights_variant: autoround-int4
@@ -3444,6 +3462,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: thinking
   vllm/qwen38-27b-multi8-superfast:
     model: qwen3.8-27b
     weights_variant: autoround-int4
@@ -3488,6 +3507,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: thinking
   vllm/qwen38-27b-dual-ultrafast:
     model: qwen3.8-27b
     weights_variant: autoround-int4
@@ -3532,6 +3552,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: thinking
   vllm/qwen38-27b-multi4-ultrafast:
     model: qwen3.8-27b
     weights_variant: autoround-int4
@@ -3576,6 +3597,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: thinking
   vllm/qwen38-27b-multi8-ultrafast:
     model: qwen3.8-27b
     weights_variant: autoround-int4
@@ -3620,6 +3642,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: thinking
   vllm/qwen38-27b-single-nvfp4:
     model: qwen3.8-27b
     weights_variant: nvfp4
@@ -3664,6 +3687,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: thinking
   vllm/qwen38-27b-dual-nvfp4:
     model: qwen3.8-27b
     weights_variant: nvfp4
@@ -3708,6 +3732,7 @@ entries:
         min_p: 0.0
         presence_penalty: 0.0
         repetition_penalty: 1.0
+    sampler_default_mode: thinking
 
 defaults:
   qwen3.6-27b:

--- a/scripts/tests/test-compose-sampler-profiles.sh
+++ b/scripts/tests/test-compose-sampler-profiles.sh
@@ -19,9 +19,12 @@
 # Checks, for every registry entry WITH sampler_profiles:
 #   (a) shape: exactly instruct+thinking rows, numeric sampler fields,
 #       instruct != thinking (a per-mode registry that isn't per-mode is noise);
-#   (b) the compose RENDERED with no env ships the card's INSTRUCT row;
-#   (c) the compose RENDERED with ENABLE_THINKING=true (vLLM) / THINKING=1
-#       (llama.cpp) ships the THINKING row;
+#   (b) the compose RENDERED with no env ships the row named by the registry's
+#       `sampler_default_mode` (absent = "instruct"; qwen3.8-27b = "thinking"
+#       since 2026-09-01);
+#   (c) the compose RENDERED with the OPT-IN knob for the other mode ships that
+#       other row — ENABLE_THINKING=true/false (vLLM), THINKING=1 / INSTRUCT=1
+#       (llama.cpp);
 #   (d) explicit TEMP/TOP_P/PRESENCE_PENALTY beat both rows (`:=` contract,
 #       and last-flag-wins on the llama.cpp tail).
 # Rendering runs each compose's real entrypoint under bash with the engine
@@ -240,6 +243,7 @@ def argv_under(text, env):
                           .replace("/app/llama-server", str(stub)))
         e = {k: v for k, v in os.environ.items()
              if not k.startswith(("SPEC", "NUM_SPEC", "ENABLE_THINKING", "THINKING",
+                             "INSTRUCT",
                                   "TEMP", "TEMPERATURE", "TOP_P", "TOP_K", "MIN_P",
                                   "PRESENCE_PENALTY", "REPEAT_PENALTY"))}
         e.update(container_env(text, env))
@@ -343,18 +347,41 @@ for slug, entry in sorted(with_profiles.items()):
     # routed those composes through the vLLM extractor, which looks for
     # --override-generation-config and returned None for every check.
     llama = str(entry.get("engine") or "").startswith(("llama-cpp", "llamacpp"))
-    mode_env = {"THINKING": "1"} if llama else {"ENABLE_THINKING": "true"}
-    mode_label = "THINKING=1" if llama else "ENABLE_THINKING=true"
+
+    # WHICH row the compose ships by default is registry POLICY, not something
+    # read back out of the compose — deriving the expectation from the same file
+    # that supplies the evidence would make an accidental flip self-approving.
+    # Absent key = "instruct" (the pre-2026-09-01 stack-wide default).
+    default_mode = entry.get("sampler_default_mode") or "instruct"
+    check(default_mode in ("instruct", "thinking"),
+          f"{slug}: sampler_default_mode is instruct|thinking (got {default_mode!r})")
+    if default_mode not in ("instruct", "thinking"):
+        continue
+    other_mode = "thinking" if default_mode == "instruct" else "instruct"
+
+    # The opt-IN knob is whichever one selects the NON-default row, so it flips
+    # with the policy: llama.cpp composes carry both ${THINKING:+...} and
+    # ${INSTRUCT:+...} argv tails, vLLM composes derive their row from
+    # ENABLE_THINKING at boot.
+    if llama:
+        mode_env = {"THINKING": "1"} if other_mode == "thinking" else {"INSTRUCT": "1"}
+        mode_label = "THINKING=1" if other_mode == "thinking" else "INSTRUCT=1"
+    else:
+        want = "true" if other_mode == "thinking" else "false"
+        mode_env = {"ENABLE_THINKING": want}
+        mode_label = f"ENABLE_THINKING={want}"
 
     d_args, d_err = argv_under(text, {})
     d_row = sampler_payload(d_args, llama=llama)
-    check(rows_agree(d_row, profiles["instruct"]),
-          f"{slug}: default render ships the INSTRUCT row (got {d_row}; {d_err})")
+    check(rows_agree(d_row, profiles[default_mode]),
+          f"{slug}: default render ships the {default_mode.upper()} row "
+          f"(got {d_row}; {d_err})")
 
     t_args, t_err = argv_under(text, mode_env)
     t_row = sampler_payload(t_args, llama=llama)
-    check(rows_agree(t_row, profiles["thinking"]),
-          f"{slug}: {mode_label} ships the THINKING row (got {t_row}; {t_err})")
+    check(rows_agree(t_row, profiles[other_mode]),
+          f"{slug}: {mode_label} ships the {other_mode.upper()} row "
+          f"(got {t_row}; {t_err})")
 
     x_args, x_err = argv_under(text, {
         **mode_env, "TEMP": "0.42", "TOP_P": "0.5", "PRESENCE_PENALTY": "0.1",


### PR DESCRIPTION
Ships `enable_thinking` on by default across the 22 coupled qwen3.8-27b composes.

## Why

A community request, and our own 8-pack backs it: on the dual-3090 fp8 arm in #1027 the
instruct row scored **120/150 pass@1 — the worst of the four modes measured** — against
135 (effort=low), 137 (xhigh), 129 (medium). The cost is latency, 2–6× per turn
(cli-40 1.76s → 8.27s; instructfollow-15 0.48s → 3.09s), though reasonmath-15 got
*faster* (5.26s → 3.64s).

Opt out with `ENABLE_THINKING=false`.

## What changed

**vLLM (20 composes)** is one variable: since #1014 the entrypoint derives the sampler row
from `ENABLE_THINKING` at boot, so `:-false` → `:-true` carries the sampler with it.

**llama.cpp (2 composes)** needed four flags moved together. Their base argv *was* the
instruct row, so flipping `--reasoning` alone would have served reasoning at
`presence_penalty 1.5` — the mismatch the model card warns causes language mixing. A new
`${INSTRUCT:+...}` tail restores the instruct row **and** `--reasoning` off together
(llama.cpp honours the last occurrence of a repeated flag); `THINKING=1` is kept as a
back-compat no-op. Note a bare `REASONING=off` still leaves the thinking sampler in place —
inherent to last-wins, now documented in both headers.

**The gate.** `test-compose-sampler-profiles` hardcoded `default == INSTRUCT` and failed
22/22, correctly. Rather than relax it, `sampler_default_mode` now declares the policy in
the registry, so the expectation lives **outside** the compose the gate renders — an
accidental flip of a compose default still fails instead of being self-approving. Absent
key means "instruct", so the three qwen3.8-flash-next slugs are unaffected.

Also corrects three claims the flip falsified in the vLLM composes: "instruct by default",
"INERT while enable_thinking is false", and "takes effect the moment `ENABLE_THINKING=true`"
(`reasoning_effort` is now active on every request, inert only under `ENABLE_THINKING=false`).

## Verification

Rendered all 25 coupled composes in **both** modes and compared to the model card rather
than to the registry (which would be circular): **25/25 correct in both modes**, across both
engine dialects.

Guard sweep on this branch: **125/126**. The one failure is `test-bench-capture.sh`
("the derived RAM figure must carry its 'not a counter' caveat"), which **fails identically
on clean `origin/master`** — verified as a null control. It is pre-existing and unrelated:
this commit touches no bench files. The original commit message claimed 126/126, which was
true on its older base; `master` has since moved five commits and picked up that failure.

No boot and no bench — this is a config change checked by render only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
