### PR TITLE
feat(qwen3.8-27b): bare passthroughs for VLLM_CACHE_ROOT and VLLM_LOG_STATS_INTERVAL

### DIFF
--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2-fp8.yml
@@ -111,6 +111,17 @@ services:
       # var is exported at all, and this stays a BARE pass-through so an explicit
       # host value still wins.
       - VLLM_MARLIN_INPUT_DTYPE
+      # ⚠️⚠️ BARE pass-throughs — NEVER give these a `${VAR:-}` default. Compose would
+      # then set them to the EMPTY STRING, and vLLM crashes on both:
+      #   VLLM_LOG_STATS_INTERVAL="" -> float("") -> ValueError at startup (envs.py:836-838)
+      #   VLLM_CACHE_ROOT=""         -> compile cache resolves relative to CWD
+      # Bare form means docker forwards them ONLY when the host has them set, so
+      # these lines are inert for every normal boot.
+      # Probe use (fa2-fp8kv Session 1): VLLM_CACHE_ROOT=/tmp/vllm-cache-<arm>
+      # isolates each arm's torch.compile graph (the cache CANNOT key on W4A8);
+      # VLLM_LOG_STATS_INTERVAL=2.0 tightens the `Avg generation throughput` window.
+      - VLLM_CACHE_ROOT
+      - VLLM_LOG_STATS_INTERVAL
     entrypoint:
       - bash
       - -c

--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2.yml
@@ -146,6 +146,17 @@ services:
       # var is exported at all, and this stays a BARE pass-through so an explicit
       # host value still wins.
       - VLLM_MARLIN_INPUT_DTYPE
+      # ⚠️⚠️ BARE pass-throughs — NEVER give these a `${VAR:-}` default. Compose would
+      # then set them to the EMPTY STRING, and vLLM crashes on both:
+      #   VLLM_LOG_STATS_INTERVAL="" -> float("") -> ValueError at startup (envs.py:836-838)
+      #   VLLM_CACHE_ROOT=""         -> compile cache resolves relative to CWD
+      # Bare form means docker forwards them ONLY when the host has them set, so
+      # these lines are inert for every normal boot.
+      # Probe use (fa2-fp8kv Session 1): VLLM_CACHE_ROOT=/tmp/vllm-cache-<arm>
+      # isolates each arm's torch.compile graph (the cache CANNOT key on W4A8);
+      # VLLM_LOG_STATS_INTERVAL=2.0 tightens the `Avg generation throughput` window.
+      - VLLM_CACHE_ROOT
+      - VLLM_LOG_STATS_INTERVAL
     entrypoint:
       - bash
       - -c


### PR DESCRIPTION
Adds two bare env passthroughs to the dual `autoround-int4` composes. **Inert unless the
host sets them** — no argv change, no default change, no behaviour change to any existing boot.

## Why

Both are needed for A/B or probe work on these tiers and neither could be forwarded, because
docker only passes what `environment:` declares.

**`VLLM_CACHE_ROOT`** — the composes mount one shared host compile-cache dir
(`../../../cache/torch_compile`) across every arm, and vLLM's torch.compile/AOT cache key
does **not** include `VLLM_MARLIN_INPUT_DTYPE`. So a `W4A8=0` arm and a `W4A8=1` arm can
silently serve the *same compiled graph* while both logs look correct. Redirecting the cache
root per arm gives real isolation — no host-dir juggling, and no `sudo` (the shared dir is
root-owned).

**`VLLM_LOG_STATS_INTERVAL`** — sets the `Avg generation throughput` window. The 10 s default
is too coarse to resolve a decode floor: at ~100 tok/s one window is ~1000 tokens, so a
400–1000 token completion is one or two samples. At 2.0 s you get ~200-token windows at
health and ~10-token windows inside a collapse.

## ⚠️ Both MUST stay bare — do not "fix" them into `${VAR:-}`

Giving either an empty-string default would set it to `""` in every container, and vLLM
fails on both:

```
VLLM_LOG_STATS_INTERVAL=""  ->  float("")  ->  ValueError at startup   (envs.py:836-838)
VLLM_CACHE_ROOT=""          ->  compile cache resolves relative to CWD
```

That would crash-loop **every** boot of both tiers, for every user. The bare form means
docker forwards them only when the host has them set — which is exactly why the existing
`VLLM_MARLIN_INPUT_DTYPE` passthrough two lines above is written the same way. A comment
block records this so the reasoning survives.

## Verification

| check | result |
|---|---|
| render with both **unset** | both emit `null` — i.e. not forwarded, identical to the existing `VLLM_MARLIN_INPUT_DTYPE` passthrough |
| render with both **set** | `VLLM_CACHE_ROOT: /tmp/x`, `VLLM_LOG_STATS_INTERVAL: "2.0"` |
| `docker compose config -q` | clean on both files |
| guard sweep | **125/126** |

The one failure is `test-bench-capture.sh`, which has been red on `master` since #1121 and is
tracked in #1137. This branch is cut from current `master`, so it is the documented
pre-existing failure and not a bisect artifact.

No boot required: this adds no argv and changes no default. (Both vars were exercised live
during the fa2-fp8kv probe work — per-arm cache isolation and 2 s stats windows — which is
where the empty-string failure modes above were found.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
