### PR TITLE
feat(qwen3.8-27b): wire ASYNC_SCHED=off on dual-max — vllm#50021 mitigation (1), drafter kept

### DIFF
--- a/models/qwen3.8-27b/CHANGELOG.md
+++ b/models/qwen3.8-27b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 Dated history for Qwen3.8-27B configs in this repo. Append-only — add a new entry, don't rewrite past ones.
 
+## 2026-09-02 — dual-max: `ASYNC_SCHED=off` wired — vllm#50021 mitigation (1), drafter kept at ~0% cost
+
+The `dual/fp8/mtp.yml` header has documented two mitigations for the [vllm#50021](https://github.com/vllm-project/vllm/pull/50021) MTP × hybrid-GDN wild write since the 2026-08-19 production crash (#1059): (1) `ASYNC_SCHED=off` → `--no-async-scheduling`, which keeps the drafter, and (2) `SPEC=off`, which drops it. Only (2) was actually plumbed — `ASYNC_SCHED` was header prose with no env passthrough and no entrypoint branch, so anyone following the header got the drafter-off path by default and paid for it in decode. This wires (1) the same way `SPEC` is wired: env passthrough + entrypoint `case`, off by default, appended to both `exec vllm serve` branches.
+
+**Measured on-rig (2026-09-02, ref 2×3090 PCIe, v0.27.1, canonical 3 warm + 5 measured, same boot family):**
+
+| Config | narr / **code** decode | prefill @10K / @90K | TTFT | MTP AL |
+|---|--:|--:|--:|--:|
+| `SPEC=off` (mitigation 2) | 44.2 / **45.1** | 1353 / 1097 | 77–84 ms | — |
+| `ASYNC_SCHED=off`, MTP n=3 (mitigation 1) | **67.8 / 88.1** | 1316 / 1058 | 98–113 ms | 3.0–3.3 |
+| BENCHMARKS row 2026-08-17 (async ON, MTP n=3) | 67.4 / 85.8 | 1166 / 942 | 152 ms | 2.62 |
+
+Mitigation (1) restores **+53% prose / +95% code** decode over the drafter-off path and is at parity or better with the async-ON catalog row on every column — the header's ~0% cost claim holds. Decode CV 2.1% / 3.3%; VRAM 22.3 GB/card, 0 MiB leak; no Xid / CUDA-error signatures across bench + 8-pack + verify-full on the new config. ⚠️ This bounds the crash *mechanism* the maintainer identified (MTP + prefix-cache + async), not #50021 itself, which is still open — a 10-minute bench is not 44 h of agent traffic. If Xid 31 recurs, `SPEC=off` remains the fallback.
+
 ## 2026-08-23 — dual-fast: FlashInfer decode-buffer unpin merged (#1051) — MTP concurrency unlocked to C=32
 
 Merged **[#1051](https://github.com/noonghunna/club-3090/pull/1051)** (thanks **@A1RM4X** — reproduced independently on-rig before promoting). New patch [`vllm-flashinfer-decode-pin`](vllm/patches/vllm-flashinfer-decode-pin/README.md) flips `pin_memory=True→False` on the `flashinfer/decode.py` workspace-buffer allocs, forcing a synchronous plan copy per step and closing the stale-plan async-copy race ([vllm#40756](https://github.com/vllm-project/vllm/issues/40756)) that crashed `vllm/qwen38-27b-dual-fast` (W4A8 + MTP n=4 + fp8 KV) with an Xid 31 VIRT_READ under concurrency. Idempotent, marker-gated, no-ops without FlashInfer, hard-fails on drift (boot-refused). Wired on `mtp.yml` alongside `vllm-gdn-mtp-async-spec-order` (the two fix **distinct** bugs: async wild-write vs decode-plan race).

--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
@@ -232,7 +232,9 @@
 #   MODEL_DIR / PORT / TP / PP / MAX_MODEL_LEN / GPU_MEMORY_UTILIZATION /
 #   MAX_NUM_BATCHED_TOKENS / KV_CACHE_DTYPE / PREFIX_CACHE_ARG /
 #   TEMP TOP_P TOP_K MIN_P PRESENCE_PENALTY REPEAT_PENALTY
-#   SPEC=off                    -> drop the MTP drafter (the vllm#50021 mitigation)
+#   SPEC=off                    -> drop the MTP drafter (vllm#50021 mitigation 2)
+#   ASYNC_SCHED=off             -> --no-async-scheduling: vllm#50021 mitigation 1,
+#                                  keeps the drafter (measured 2026-09-02: ~0% cost)
 #   VLLM_USE_FLASHINFER_SAMPLER -> default 0 here; see the env block note
 #
 # SAMPLER — follows the Qwen3.8-27B MODEL CARD, not the stack's Qwen3.6 defaults.
@@ -319,6 +321,7 @@ services:
       # lives in the entrypoint, not in these lines, so it cannot drift.
       - SPEC_N=${SPEC_N:-}
       - SPEC=${SPEC:-}
+      - ASYNC_SCHED=${ASYNC_SCHED:-}
       # Sampler env passthrough (#984/#1014): the ENTRYPOINT — not compose
       # interpolation, which has no if/else — derives --override-generation-config
       # from the model-card row matching ENABLE_THINKING, so these must reach the
@@ -423,6 +426,14 @@ services:
         else
           echo "[spec] drafter OFF (SPEC_N=0 / SPEC=off) - no speculative decoding" >&2
         fi
+        # -- Async-scheduling toggle: vllm#50021 mitigation (1) from the header --
+        #   ASYNC_SCHED=off -> --no-async-scheduling. Keeps the drafter; closes the
+        #   MTP + prefix-cache + async combo that produced the 2026-08-19 Xid 31.
+        ASYNC_ARGS=()
+        case "$${ASYNC_SCHED:-}" in off|OFF|Off|false|no|0)
+          ASYNC_ARGS=(--no-async-scheduling)
+          echo "[async] async scheduling OFF (ASYNC_SCHED=off) - vllm#50021 mitigation, drafter kept" >&2 ;;
+        esac
         # -- Sampler follows the reasoning mode ----------------------------------
         # The card publishes TWO sampler rows (see "SAMPLER" in the header);
         # ENABLE_THINKING now selects the row — one variable instead of the
@@ -440,9 +451,9 @@ services:
         fi
         SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY},\"repetition_penalty\":$${REPEAT_PENALTY:-1.0}}")
         if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@" "$${SPEC_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@" "$${SPEC_ARGS[@]}" "$${ASYNC_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
         else
-          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@" "$${SPEC_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@" "$${SPEC_ARGS[@]}" "$${ASYNC_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
         fi
       - --
     command:


### PR DESCRIPTION
## Summary

`models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml` (`vllm/qwen38-27b-dual-max`) has documented **two** mitigations for the vllm#50021 MTP × hybrid-GDN wild write since the 2026-08-19 production crash (#1059): **(1)** `ASYNC_SCHED=off` → `--no-async-scheduling`, which *keeps the drafter*, and **(2)** `SPEC=off`, which drops it. Only (2) is actually plumbed — `ASYNC_SCHED` exists in the header prose only, with no env passthrough and no entrypoint branch, and there's no extra-args passthrough either. So anyone following the header lands on the drafter-off path and pays for it in decode.

This wires (1) exactly the way `SPEC` is wired: env passthrough + entrypoint `case`, **off by default**, appended to both `exec vllm serve` branches. Plus the knob in the "Override defaults" list and a dated entry in `models/qwen3.8-27b/CHANGELOG.md`. No behaviour change unless `ASYNC_SCHED=off` is set.

**Measured impact** (ref 2×3090 PCIe, `vllm/vllm-openai:v0.27.1`, canonical `bench.sh` 3 warm + 5 measured, same boot family, same day):

| Config | narr / **code** decode tok/s | CV | prefill @10K / @90K | TTFT (short) | MTP AL |
|---|--:|--:|--:|--:|--:|
| `SPEC=off` (mitigation 2) | 44.2 / **45.1** | 2.3% / 0.1% | 1353 / 1097 | 77–84 ms | — |
| **`ASYNC_SCHED=off`, MTP n=3 (mitigation 1)** | **67.8 / 88.1** | 2.1% / 3.3% | 1316 / 1058 | 98–113 ms | 3.0–3.3 |
| BENCHMARKS row 2026-08-17 (async ON, MTP n=3) | 67.4 / 85.8 | 1.5% / 3.5% | 1166 / 942 | 152 ms | 2.62 |

Mitigation (1) is **+53% prose / +95% code** over the drafter-off path and at parity or better than the async-ON catalog row on every column — the header's "~0% cost" claim holds. VRAM 22.3 GB/card, 0 MiB leak. Decode @10K depth 85.4, @90K 75.8.

**Trade-off / what this does not claim:** it bounds the crash *combo* the header identifies (MTP + prefix-cache + async scheduling), not #50021 itself, which is still open in this pin. The original crash took 44 h of agent traffic to surface; a bench + 8-pack + verify-full session is not that. `SPEC=off` stays the fallback and is unchanged.

## Type of change

- [ ] New compose variant
- [ ] New patch / sidecar
- [ ] New script or tool
- [ ] New model
- [ ] Doc-only / typo
- [x] Other: env-gated flag toggle on an existing compose (off by default) + CHANGELOG entry

## Verification

- [x] `bash scripts/verify-full.sh` on the new config — **10/10 PASS** (serving, tool_calls, streamed tool_calls with no `<tool_call>` leak, reasoning split, long-output variety, **MTP acceptance length 2.78**, vision 4/4)
- [x] `bash scripts/bench.sh` — canonical 3 warm + 5 measured, both shapes + both prefill depths; run-by-run output in the first comment
- [x] `bash scripts/report.sh` — redacted rig report in the first comment
- [x] Gate tests pass against the modified compose: `test-compose-entrypoint-env-declared` (105 composes, every env var read is declared), `test-spec-toggle-contract` (85 drafter composes), `test-compose-sampler-profiles`, `test-compose-no-repeated-args`, `test-compose-status-drift`, `test-compose-image-drift`, `test-compose-mounts-resolve`
- [x] **Profile header** — unchanged (`🧪 Experimental`); no status change claimed
- [ ] **BENCHMARKS row** — N/A: not a new variant. Numbers are in this description and the CHANGELOG entry; happy to add a dated sub-row under the existing dual-max entry if you'd rather have it there.
- [x] **CHANGELOG entry** — `models/qwen3.8-27b/CHANGELOG.md`, 2026-09-02
- [ ] `verify-stress.sh` / soak-continuous — N/A for a scheduler flag on an existing multi-card compose (no context-ceiling or KV change); the 262K ceiling and NIAH fill depth are unchanged from the slug's existing gate state. Will run on request.

### Also observed while validating (not changed here, FYI)

- vLLM's `--override-generation-config` drops `presence_penalty` (only `temperature/top_p/top_k/min_p/repetition_penalty` survive — visible in the boot-log "overridden by generation_config" line and confirmed empirically: an omitted `presence_penalty` behaves as `0`, not the instruct row's `1.5`). So the compose's "instruct row presence=1.5" is inert on vLLM; clients must send it themselves. Separate concern, separate PR if you want one.
- 8-pack on this slug, thinking OFF vs ON (`reasoning_effort=low`), n=1: **123 → 133/150**, cli-40 27 → 32, dataextract 10 → 14 — consistent with #1027. Details available if useful for the slug's promotion gate.

## Cross-links

- Related: #1059 (the production crash this mitigates), #1052 (MTP + prefix-cache + async combo), discussion #993 / #1024 (Qwen3.8 rollout), #1027 (8-pack by reasoning effort)
- Related upstream: vllm-project/vllm#50021 (open — the structural exposure this does *not* close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
