### PR TITLE
fix(promote): honour repo-root .env so the core gate stops being a silent no-op

### DIFF
--- a/scripts/lib/profiles/export_pr.py
+++ b/scripts/lib/profiles/export_pr.py
@@ -437,6 +437,13 @@ def main(argv: Optional[list[str]] = None) -> int:
     args = ap.parse_args(argv)
 
     root = Path(args.root).resolve()
+    # #1142: same as promote.py — no shell wrapper sources .env for this tool, so
+    # honour it here too (real environment wins). Matters for --spec-env.
+    try:  # package context
+        from scripts.lib.profiles.repo_dotenv import apply_dotenv
+    except ImportError:  # direct-script context
+        from repo_dotenv import apply_dotenv
+    apply_dotenv(root)
     out = Path(args.out).resolve()
     try:
         if args.spec_env:

--- a/scripts/lib/profiles/promote.py
+++ b/scripts/lib/profiles/promote.py
@@ -91,6 +91,15 @@ _LOCAL_FORCED_STATUS = "incubating"
 # core must be present, or the core catalog is untouchable.
 _CORE_GATE_ENV = "C3_ALLOW_CORE_PROMOTE"
 
+# #1142: repo-root .env support. Kept as a dual import so this file works both as
+# a script (`python3 scripts/lib/profiles/promote.py` — own dir on sys.path) and
+# as a package module (`from scripts.lib.profiles import promote`, as the tests do).
+try:  # package context
+    from scripts.lib.profiles.repo_dotenv import apply_dotenv
+except ImportError:  # direct-script context
+    from repo_dotenv import apply_dotenv
+
+
 _MODEL_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
 _SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9.-]*/[a-z0-9][a-z0-9._-]*$")
 
@@ -458,8 +467,9 @@ def validate_spec(spec: Any, root: Path, layer: str) -> dict:
     if os.environ.get(_CORE_GATE_ENV) != "1":
         raise Refusal(
             f"core-catalog writes are maintainer-gated: re-run with --layer core "
-            f"AND {_CORE_GATE_ENV}=1 in the environment (community users: use the "
-            f"default --layer local)"
+            f"AND {_CORE_GATE_ENV}=1 — exported in the shell OR set in the "
+            f"repo-root .env (both are read; the environment wins). Community "
+            f"users: use the default --layer local"
         )
     if slug.startswith(_LOCAL_SLUG_PREFIX):
         raise Refusal(
@@ -620,6 +630,14 @@ def main(argv: Optional[list[str]] = None) -> int:
     args = ap.parse_args(argv)
 
     root = Path(args.root).resolve()
+    # #1142: the shell launchers source <root>/.env, but these tools are invoked
+    # directly (no wrapper in scripts/ runs them), so a gate parked there used to
+    # be a SILENT no-op — no error, no effect. Fill UNSET keys from it, and say so
+    # when the maintainer gate is one of them: .env stops being silent BOTH ways.
+    _from_dotenv = apply_dotenv(root)
+    if _CORE_GATE_ENV in _from_dotenv:
+        print(f"[promote] {_CORE_GATE_ENV} read from {root}/.env "
+              f"(export it in the shell to override)", file=sys.stderr)
     try:
         if args.spec_env:
             raw_spec = os.environ.get(args.spec_env)

--- a/scripts/lib/profiles/repo_dotenv.py
+++ b/scripts/lib/profiles/repo_dotenv.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Repo-root ``.env`` loading for the python profile tools (#1142).
+
+WHY THIS EXISTS. The shell launchers source ``<root>/.env`` (``set -a`` in
+``launch.sh`` / ``setup.sh``), so users reasonably expect a value parked there to
+reach the tooling. ``promote.py`` and ``export_pr.py`` are invoked DIRECTLY —
+there is no shell wrapper anywhere in ``scripts/`` that runs them — so they read
+only the real environment. A maintainer putting ``C3_ALLOW_CORE_PROMOTE=1`` in
+``.env`` therefore got a **silent no-op**: no error, no effect, and a core
+promote that kept refusing for no visible reason.
+
+PRECEDENCE is the same as the shell path and as ``estate_cli.load_dotenv``: the
+**real environment wins**; ``.env`` only fills keys that are unset. So exporting
+a var still overrides the file, and nothing already set is ever clobbered.
+
+Parsing is the union of the two hand-rolled readers already in the tree —
+``estate_cli.load_dotenv`` (whole file, but no ``export`` prefix, no CR) and
+``deriver._model_dir_from_env_or_dotenv`` (``export`` prefix + CR + the #599
+non-UTF-8-locale ``errors="replace"`` read, but one key only). Those two callers
+are deliberately left alone here; they can adopt this later.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def parse_dotenv(root) -> dict[str, str]:
+    """``<root>/.env`` → ``{KEY: VALUE}``. ``{}`` when absent or unreadable.
+
+    Tolerates ``export KEY=v``, CRLF, ``#`` comments, blank lines and quoted
+    values. Never raises: a malformed ``.env`` must not take down a promote."""
+    out: dict[str, str] = {}
+    try:
+        text = (Path(root) / ".env").read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return out
+    for raw in text.splitlines():
+        line = raw.strip().rstrip("\r")
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        if line.startswith("export "):
+            line = line[len("export "):]
+        key, _, value = line.partition("=")
+        key = key.strip()
+        if not key:
+            continue
+        out[key] = value.strip().strip('"').strip("'")
+    return out
+
+
+def apply_dotenv(root) -> list[str]:
+    """Fill UNSET ``os.environ`` keys from ``<root>/.env``.
+
+    Returns the keys actually injected (sorted) so a caller can SAY where a
+    value came from — the point of the fix is that ``.env`` stops being silent,
+    in both directions."""
+    injected = []
+    for key, value in parse_dotenv(root).items():
+        if key not in os.environ:
+            os.environ[key] = value
+            injected.append(key)
+    return sorted(injected)

--- a/scripts/tests/test_promote.py
+++ b/scripts/tests/test_promote.py
@@ -250,6 +250,48 @@ class TestCoreGate:
             root / "scripts/lib/profiles/registry.yaml"
         ).read_text()
 
+    # ── #1142: the repo-root .env must reach the gate ───────────────────────
+    #
+    # Before the fix these tools read only the real environment, so a maintainer
+    # putting C3_ALLOW_CORE_PROMOTE=1 in .env got a SILENT no-op: no error, no
+    # effect, and a core promote that kept refusing for no visible reason.
+
+    def test_core_gate_honoured_from_dotenv(self, root):
+        """.env alone satisfies the gate — and the tool SAYS where it came from."""
+        (root / ".env").write_text(
+            "# maintainer rig\nexport C3_ALLOW_CORE_PROMOTE=1\n", encoding="utf-8"
+        )
+        res = _run_cli(root, _spec(layer_local=False), "--layer", "core")
+        assert res.returncode == 0, res.stderr + res.stdout
+        assert "PROMOTE_OK" in res.stdout
+        assert "read from" in res.stderr and "C3_ALLOW_CORE_PROMOTE" in res.stderr
+
+    def test_dotenv_does_not_override_the_real_environment(self, root):
+        """Environment WINS over .env — the shell-launcher precedence."""
+        (root / ".env").write_text("C3_ALLOW_CORE_PROMOTE=1\n", encoding="utf-8")
+        res = _run_cli(
+            root, _spec(layer_local=False), "--layer", "core",
+            env_extra={"C3_ALLOW_CORE_PROMOTE": "0"},
+        )
+        assert res.returncode == promote.EXIT_COLLISION
+        assert "maintainer-gated" in res.stderr
+
+    def test_dotenv_absent_or_malformed_still_refuses_cleanly(self, root):
+        """A junk .env must neither crash the tool nor open the gate."""
+        (root / ".env").write_text(
+            "not-a-pair\n\n#c\nC3_ALLOW_CORE_PROMOTE=0\n", encoding="utf-8"
+        )
+        res = _run_cli(root, _spec(layer_local=False), "--layer", "core")
+        assert res.returncode == promote.EXIT_COLLISION
+        assert "maintainer-gated" in res.stderr
+        assert "Traceback" not in res.stderr
+
+    def test_local_layer_needs_no_dotenv_and_stays_the_default(self, root):
+        """The safe path is unaffected by any of this."""
+        res = _run_cli(root, _spec())
+        assert res.returncode == 0, res.stderr + res.stdout
+        assert "C3_ALLOW_CORE_PROMOTE" not in res.stderr
+
     def test_core_with_flag_writes_curated_catalog(self, root):
         res = _run_cli(
             root,


### PR DESCRIPTION
Fixes the `.env` no-op reported in #1142. Independent of #1143 (docs) — cut from `master`, no overlap.

## The bug

The shell launchers source `<root>/.env` (`set -a` in `launch.sh` / `setup.sh`), so a
value parked there is reasonably expected to reach the tooling. But `promote.py` and
`export_pr.py` are invoked **directly** — no wrapper anywhere in `scripts/` runs them —
so they read only the real environment.

A maintainer putting `C3_ALLOW_CORE_PROMOTE=1` in `.env` therefore got a **silent
no-op**: no error, no effect, and a core promote that kept refusing for no visible
reason. A config that quietly does nothing is the trap class this repo normally guards
against.

## The fix

| file | change |
|---|---|
| `repo_dotenv.py` *(new)* | shared reader. Parsing is the **union** of the two hand-rolled readers already in the tree — `estate_cli.load_dotenv` (whole file, but no `export` prefix, no CR) and `deriver._model_dir_from_env_or_dotenv` (`export` + CR + the #599 non-UTF-8-locale `errors="replace"` read, but one key only). Never raises: a malformed `.env` must not take down a promote. |
| `promote.py` | fills **unset** env keys from `<root>/.env`, and **prints** when the maintainer gate came from the file. Refusal message now names both sources. |
| `export_pr.py` | same load; matters for `--spec-env`. |

**Precedence matches the shell path: the real environment wins**, `.env` only fills what
is unset.

**The gate is not weakened.** `--layer` still defaults to `local`, so `.env` grants the
**capability** to write core, never the **intent** — that still requires an explicit
`--layer core` every time. Capability ambient, intent explicit.

`.env` also stops being silent in the *other* direction: when the gate is satisfied from
the file, the tool says so on stderr, so a core write is never mysterious.

## Tests

Four added to `test_promote.py`: the gate honoured from `.env` (and announced), the
environment overriding `.env`, a malformed `.env` neither crashing nor opening the gate,
and the local default path untouched.

```
test_promote.py                        15 passed
test_export_pr.py + test_local_registry.py + test_model_spec.py   93 passed
```

## Note for maintainers — a pre-existing test-harness papercut

These suites **cannot run in a checkout that has served a model.** `test_promote.py`'s
`root` fixture `copytree`s `models/`, which by then contains **root-owned**
`torch_compile` caches written by containers, and the copy dies on `Permission denied` —
taking existing tests down with it, not just new ones. Only 1 file under those paths is
tracked, so the caches are pure build artifact.

I verified this branch in a `git worktree` (tracked files only), where all 15 + 93 pass.
Worth a follow-up: have the fixture `ignore_patterns(..., "cache")` so the suite survives
on any rig that has actually run something. Left out of this PR as unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
