### PR TITLE
docs(qwen3.8-27b): correct the dual-max wild-write caveat — two faults, one patched, one still live

### DIFF
--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
@@ -76,24 +76,49 @@
 #                "Upstream-risk" below and the docs/UPSTREAM.md row.
 #              Promote to 🧪 only after a clean boot + verify-full; to ⚠️/✅ only
 #              after the full gate (verify-stress + bench + soak + quality).
-#   Upstream-risk:  • ⚠️ MTP × hybrid-GDN wild write — vllm#50021, OPEN and LIVE IN THIS PIN.
-#                The GDN spec-decode path builds a state-block index from an UNBOUNDED
-#                accepted-token count; a zero/stale count dereferences a wild address →
-#                `CUDA error: unspecified launch failure` + Xid 13/31 and a dead worker,
-#                typically after minutes of agent-shaped traffic rather than at boot.
-#                Not quant-, topology- or depth-specific: hit on Ampere+Ada and on
-#                2× 5090 across NVFP4 AND W4A8 alike. The vendored pr48375 fixes
-#                vllm#43559 (corruption) and does NOT cover this fault.
-#                ⚠️ CONFIRMED IN PRODUCTION 2026-08-19 (@alexpolo1 #1059): crashed once
-#                on THIS slug (2× 3090, MTP n=3, 44 h uptime, from a HEALTHY state) —
-#                Xid 31 VIRT_WRITE both cards. Async scheduling is AUTO-ON for MTP here
-#                ('mtp' ∈ EagleModelTypes → the disable-guard doesn't fire, no warning),
-#                so the shipped default is MTP + prefix-cache + async — the #1052 combo.
-#                MITIGATIONS (two): (1) ASYNC_SCHED=off (--no-async-scheduling) —
-#                eliminates the crash at ~0% cost and KEEPS the drafter; (2) SPEC=off —
-#                drops the drafter. Lower n cuts frequency NOT exposure (crashed AT n=3).
-#                Clears when #50021 merges and a pin bump inherits it;
-#                v0.26.0 PREDATES the fix, so the queued bump inherits nothing here.
+#   Upstream-risk:  • ⚠️ MTP × hybrid-GDN wild write — TWO faults share this signature:
+#                one is PATCHED here, one (vllm#50021) is STILL LIVE IN THIS PIN.
+#                Symptom: `CUDA error: unspecified launch failure` / Xid 13/31 and a dead
+#                worker, after minutes of agent-shaped traffic rather than at boot. Not
+#                quant-, topology- or depth-specific: hit on Ampere+Ada and on 2× 5090
+#                across NVFP4 AND W4A8 alike. The vendored pr48375 fixes vllm#43559
+#                (corruption) and does NOT cover this fault.
+#                ⚠️ CONFIRMED IN PRODUCTION 2026-08-19 (@alexpolo1 #1059): crashed once on
+#                THIS slug (2× 3090, MTP n=3, 44 h uptime, from a HEALTHY state) — Xid 31
+#                VIRT_WRITE both cards. ⚠️ That boot was UNPATCHED: the fix below landed
+#                2026-08-23 (#1091), two days after the field report.
+#                Async scheduling is AUTO-ON for MTP here ('mtp' ∈ EagleModelTypes → the
+#                disable-guard doesn't fire, no warning), so the shipped combo is
+#                MTP + prefix-cache + async — the #1052 combo.
+#                ⚠️ TWO DISTINCT FAULTS share this signature — do not treat them as one:
+#                (a) a CROSS-STREAM RACE in `synchronize_input_prep`: the next step's
+#                    `_update_states` block-table mutation raced the still-in-flight
+#                    spec-decode postprocess → stale state-block index → wild write.
+#                    ✅ PATCHED HERE by `vllm-gdn-mtp-async-spec-order` (OURS, not
+#                    upstream), mounted + installed by the entrypoint before serve;
+#                    anchor drift makes the container REFUSE TO BOOT rather than serve
+#                    unpatched. Evidence: async-ON survived 3/3 boots to 33–36k generated
+#                    tokens (crossing ctx 32k + a compaction) where 5/5 unpatched arms
+#                    died at 6–13k; TPS neutral.
+#                (b) vllm#50021's UNBOUNDED `num_accepted`-derived index (Site 1,
+#                    `…/flash_linear_attention/ops/fused_sigmoid_gating.py:106`, re-verified
+#                    byte-identical on v0.27.1 2026-08-16). 🔴 STILL LIVE — open upstream,
+#                    NOT vendored. Our patch does NOT bound this index.
+#                ⚠️ CORRECTION (this block previously said otherwise): #50021 does NOT fix
+#                (a) — its in-kernel bounds were built and crashed 2/2. So a #50021 merge +
+#                pin bump clears (b) only, and never cleared (a). Conversely the shipped
+#                patch closes (a) and leaves (b) exposed. #1059's signature is consistent
+#                with EITHER; its attribution between them is NOT established.
+#                RESIDUAL — why this stays a caveat: (b) is unfixed; the fix for (a) is
+#                OURS, validated on the reference 2× 3090 only and NOT community-blessed;
+#                33–36k generated tokens is not the 44 h of production traffic that
+#                surfaced #1059; and neither addresses the separate acceptance-collapse
+#                bug (vllm#52873 / Bug A).
+#                FALLBACKS if it recurs: (1) ASYNC_SCHED=off (--no-async-scheduling) — keeps
+#                the drafter, wired 2026-09-02 (#1139, thanks @metaoutfitter; it was header
+#                prose only before that). Note it avoids (a) AND removes the async trigger
+#                path, but does not bound (b). (2) SPEC=off — drops the drafter, avoiding
+#                both. Lower n cuts frequency NOT exposure (crashed AT n=3).
 #                Full detail, evidence stack + re-test trigger: docs/UPSTREAM.md.
 #   Best for:  max-weight-fidelity Qwen3.8-27B on 2 cards, and the on-rig proxy for
 #              the 4-card vllm/qwen38-27b-multi4-max. NOT yet recommendable for


### PR DESCRIPTION
Follow-up to #1139. Comment-only change to `dual/fp8/mtp.yml`'s `Upstream-risk` block.

## Why

The block was written **2026-08-21** — two days *before* the fix landed (**#1091**, 08-23) — and was
never revisited. As shipped it:

- told users the crash **"clears when #50021 merges and a pin bump inherits it"**
- listed **"MITIGATIONS (two)"**, both of which cost throughput
- **never mentioned** that this compose already mounts *and installs*
  `vllm-gdn-mtp-async-spec-order`

So we were steering people to workarounds for a fault the shipped compose partly closes, while
promising a resolution that will not arrive.

## The substantive correction

**Two distinct faults share the Xid 13/31 wild-write signature, and the block conflated them:**

| | fault | state |
|---|---|---|
| **(a)** | cross-stream race in `synchronize_input_prep` — the next step's `_update_states` block-table mutation raced the still-in-flight spec-decode postprocess → stale state-block index → wild write | ✅ **patched here** by `vllm-gdn-mtp-async-spec-order` (ours, not upstream); anchor drift boot-refuses. async-ON survived **3/3 boots to 33–36k** generated tokens where **5/5 unpatched arms died at 6–13k**; TPS neutral |
| **(b)** | vllm#50021's unbounded `num_accepted`-derived index (Site 1, re-verified **byte-identical on v0.27.1**) | 🔴 **still live** — open upstream, not vendored. Our patch does not bound it |

Therefore **a #50021 merge clears (b) only, and never covered (a)** — its in-kernel bounds were
built and **crashed 2/2**. The old line was wrong in both directions. #1059's signature is
consistent with either fault; **the attribution is not established**, and the block now says so
rather than implying it.

## Also recorded

- **#1059's boot was UNPATCHED** — the field report predates the fix by two days. Worth stating,
  because "confirmed in production" reads as "the current config crashes" otherwise.
- Mitigation (1) `ASYNC_SCHED=off` is now **actually wired** (#1139, @metaoutfitter) rather than
  header prose — with the caveat that it avoids (a) and removes the async trigger path, but **does
  not bound (b)**.
- Residual risk stated plainly: (b) is unfixed; the fix for (a) is **ours**, reference-rig-only and
  not community-blessed; **33–36k generated tokens is not the 44 h of production traffic** that
  surfaced #1059; and neither touches the acceptance-collapse bug (vllm#52873 / Bug A).

## Scope + verification

Comment-only — no flags, mounts, env or status changed. Status stays `🧪 Experimental`.

- `docker compose config -q` parses
- 8 compose guards green: `status-drift`, `entrypoint-env-declared`, `spec-toggle-contract`,
  `no-repeated-args`, `mounts-resolve`, `registry-disk`, `sampler-profiles`, `image-drift`

**Not changed, flagged instead:** the `multi4`/`multi8` `fp8/mtp.yml` siblings mount the same patch
but carry no risk block at all. That is absence rather than staleness, and they are
community-validated-by-design, so I did not invent one for hardware we cannot boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
