### PR TITLE
docs(qwen3.8-27b): correct the multi4/multi8-max wild-write caveat — same two-fault split as the dual

### DIFF
--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
@@ -61,28 +61,46 @@
 #                  larger KV pool) is validated by whoever first runs it on 4 cards
 #                  — that first community boot IS the validation, not a confirmation
 #                  of ours. Report numbers via the `numbers-from-your-rig` template.
-#              • ⚠️ MTP × hybrid-GDN wild write — vllm#50021, OPEN and LIVE IN THIS PIN.
+#              • ⚠️ MTP × hybrid-GDN wild write — TWO faults share this signature: one is
+#                PATCHED here, one (vllm#50021) is STILL LIVE IN THIS PIN.
 #                Inherited exposure: Qwen3.8-27B is the same Qwen3-Next/DeltaNet
-#                hybrid-GDN family as qwen3.6-27b and Tess-4-27B, and the fault is an
-#                UNBOUNDED index in the shared GDN spec-decode path — quant-,
-#                topology- and depth-independent. See "Upstream-risk" below.
+#                hybrid-GDN family as qwen3.6-27b and Tess-4-27B, and the unpatched
+#                fault is an UNBOUNDED index in the shared GDN spec-decode path —
+#                quant-, topology- and depth-independent. See "Upstream-risk" below.
 #              Promote to 🧪 only after a clean boot + verify-full on a real 4-card
 #              host; to ⚠️/✅ only after the full gate there.
-#   Upstream-risk:  • ⚠️ MTP × hybrid-GDN wild write — vllm#50021, OPEN and LIVE IN THIS PIN.
-#                The GDN spec-decode path builds a state-block index from an UNBOUNDED
-#                accepted-token count; a zero/stale count dereferences a wild address →
-#                `CUDA error: unspecified launch failure` + Xid 13/31 and a dead worker,
-#                typically after minutes of agent-shaped traffic rather than at boot.
-#                Not quant-, topology- or depth-specific: hit on Ampere+Ada and on
-#                2× 5090 across NVFP4 AND W4A8 alike. The vendored pr48375 fixes
-#                vllm#43559 (corruption) and does NOT cover this fault.
-#                ⚠️ This model has never run, so it has never been OBSERVED to crash —
-#                absence of evidence, not evidence of absence. The exposure is
-#                structural (same hybrid-GDN kernel, MTP on) and carries over.
-#                MITIGATION: run the drafter off — SPEC=off. Lower n cuts frequency,
+#   Upstream-risk:  • ⚠️ MTP × hybrid-GDN wild write — TWO faults share this signature:
+#                one is PATCHED here, one (vllm#50021) is STILL LIVE IN THIS PIN.
+#                Symptom: `CUDA error: unspecified launch failure` + Xid 13/31 and a dead
+#                worker, after minutes of agent-shaped traffic rather than at boot. Not
+#                quant-, topology- or depth-specific: hit on Ampere+Ada and on 2× 5090
+#                across NVFP4 AND W4A8 alike. The vendored pr48375 fixes vllm#43559
+#                (corruption) and does NOT cover this fault.
+#                ⚠️ DO NOT TREAT THE TWO AS ONE:
+#                (a) a CROSS-STREAM RACE in `synchronize_input_prep` (the next step's
+#                    `_update_states` block-table mutation raced the still-in-flight
+#                    spec-decode postprocess → stale state-block index → wild write).
+#                    ✅ PATCHED HERE by `vllm-gdn-mtp-async-spec-order` (OURS, not
+#                    upstream), installed by the entrypoint before serve; anchor drift
+#                    makes the container REFUSE TO BOOT rather than serve unpatched.
+#                (b) vllm#50021's UNBOUNDED `num_accepted`-derived index (Site 1,
+#                    re-verified byte-identical on v0.27.1). 🔴 STILL LIVE — open
+#                    upstream, NOT vendored. The patch above does NOT bound it.
+#                ⚠️ CORRECTION (this block previously said otherwise): a #50021 merge +
+#                pin bump clears (b) ONLY. It never covered (a) — its in-kernel bounds
+#                were built and crashed 2/2.
+#                ⚠️ NEITHER the exposure NOR the fix has been observed on THIS topology:
+#                the model has never run here. Both carry over the same way — by shared
+#                kernel, not by measurement. The patch's evidence (3/3 boots to 33–36k
+#                generated tokens where 5/5 unpatched arms died at 6–13k) is from the
+#                reference 2× 3090; it is OURS, not community-blessed, and says nothing
+#                about a 4-/8-card NCCL topology.
+#                MITIGATION here: run the drafter off — SPEC=off. Lower n cuts frequency,
 #                NOT exposure (n=3 was called stable on one rig and crashed AT n=3 on
-#                another). Clears when #50021 merges and a pin bump inherits it;
-#                v0.26.0 PREDATES the fix. Detail + re-test trigger: docs/UPSTREAM.md.
+#                another). ⚠️ The `ASYNC_SCHED=off` fallback wired on the dual sibling
+#                (#1139) is NOT plumbed on this compose — do not copy that advice across.
+#                Neither addresses the separate acceptance-collapse bug (vllm#52873).
+#                Detail + re-test trigger: docs/UPSTREAM.md.
 #   Best for:  max-weight-fidelity Qwen3.8-27B on 4 cards — the topology buys KV pool
 #              and concurrency, not single-stream decode. NOT yet recommendable for
 #              anything; see Caveats.

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
@@ -63,28 +63,46 @@
 #                  larger KV pool) is validated by whoever first runs it on 8 cards
 #                  — that first community boot IS the validation, not a confirmation
 #                  of ours. Report numbers via the `numbers-from-your-rig` template.
-#              • ⚠️ MTP × hybrid-GDN wild write — vllm#50021, OPEN and LIVE IN THIS PIN.
+#              • ⚠️ MTP × hybrid-GDN wild write — TWO faults share this signature: one is
+#                PATCHED here, one (vllm#50021) is STILL LIVE IN THIS PIN.
 #                Inherited exposure: Qwen3.8-27B is the same Qwen3-Next/DeltaNet
-#                hybrid-GDN family as qwen3.6-27b and Tess-4-27B, and the fault is an
-#                UNBOUNDED index in the shared GDN spec-decode path — quant-,
-#                topology- and depth-independent. See "Upstream-risk" below.
+#                hybrid-GDN family as qwen3.6-27b and Tess-4-27B, and the unpatched
+#                fault is an UNBOUNDED index in the shared GDN spec-decode path —
+#                quant-, topology- and depth-independent. See "Upstream-risk" below.
 #              Promote to 🧪 only after a clean boot + verify-full on a real 8-card
 #              host; to ⚠️/✅ only after the full gate there.
-#   Upstream-risk:  • ⚠️ MTP × hybrid-GDN wild write — vllm#50021, OPEN and LIVE IN THIS PIN.
-#                The GDN spec-decode path builds a state-block index from an UNBOUNDED
-#                accepted-token count; a zero/stale count dereferences a wild address →
-#                `CUDA error: unspecified launch failure` + Xid 13/31 and a dead worker,
-#                typically after minutes of agent-shaped traffic rather than at boot.
-#                Not quant-, topology- or depth-specific: hit on Ampere+Ada and on
-#                2× 5090 across NVFP4 AND W4A8 alike. The vendored pr48375 fixes
-#                vllm#43559 (corruption) and does NOT cover this fault.
-#                ⚠️ This model has never run, so it has never been OBSERVED to crash —
-#                absence of evidence, not evidence of absence. The exposure is
-#                structural (same hybrid-GDN kernel, MTP on) and carries over.
-#                MITIGATION: run the drafter off — SPEC=off. Lower n cuts frequency,
+#   Upstream-risk:  • ⚠️ MTP × hybrid-GDN wild write — TWO faults share this signature:
+#                one is PATCHED here, one (vllm#50021) is STILL LIVE IN THIS PIN.
+#                Symptom: `CUDA error: unspecified launch failure` + Xid 13/31 and a dead
+#                worker, after minutes of agent-shaped traffic rather than at boot. Not
+#                quant-, topology- or depth-specific: hit on Ampere+Ada and on 2× 5090
+#                across NVFP4 AND W4A8 alike. The vendored pr48375 fixes vllm#43559
+#                (corruption) and does NOT cover this fault.
+#                ⚠️ DO NOT TREAT THE TWO AS ONE:
+#                (a) a CROSS-STREAM RACE in `synchronize_input_prep` (the next step's
+#                    `_update_states` block-table mutation raced the still-in-flight
+#                    spec-decode postprocess → stale state-block index → wild write).
+#                    ✅ PATCHED HERE by `vllm-gdn-mtp-async-spec-order` (OURS, not
+#                    upstream), installed by the entrypoint before serve; anchor drift
+#                    makes the container REFUSE TO BOOT rather than serve unpatched.
+#                (b) vllm#50021's UNBOUNDED `num_accepted`-derived index (Site 1,
+#                    re-verified byte-identical on v0.27.1). 🔴 STILL LIVE — open
+#                    upstream, NOT vendored. The patch above does NOT bound it.
+#                ⚠️ CORRECTION (this block previously said otherwise): a #50021 merge +
+#                pin bump clears (b) ONLY. It never covered (a) — its in-kernel bounds
+#                were built and crashed 2/2.
+#                ⚠️ NEITHER the exposure NOR the fix has been observed on THIS topology:
+#                the model has never run here. Both carry over the same way — by shared
+#                kernel, not by measurement. The patch's evidence (3/3 boots to 33–36k
+#                generated tokens where 5/5 unpatched arms died at 6–13k) is from the
+#                reference 2× 3090; it is OURS, not community-blessed, and says nothing
+#                about a 4-/8-card NCCL topology.
+#                MITIGATION here: run the drafter off — SPEC=off. Lower n cuts frequency,
 #                NOT exposure (n=3 was called stable on one rig and crashed AT n=3 on
-#                another). Clears when #50021 merges and a pin bump inherits it;
-#                v0.26.0 PREDATES the fix. Detail + re-test trigger: docs/UPSTREAM.md.
+#                another). ⚠️ The `ASYNC_SCHED=off` fallback wired on the dual sibling
+#                (#1139) is NOT plumbed on this compose — do not copy that advice across.
+#                Neither addresses the separate acceptance-collapse bug (vllm#52873).
+#                Detail + re-test trigger: docs/UPSTREAM.md.
 #   Best for:  max-weight-fidelity Qwen3.8-27B on 8 cards — the topology buys KV pool
 #              and concurrency, not single-stream decode. NOT yet recommendable for
 #              anything; see Caveats.


### PR DESCRIPTION
Closes the "immediate action" in #1147. Comment-only, both `multi4` and `multi8` `fp8/mtp.yml`.

## What was wrong

Both siblings carried the **identical** stale claim #1146 removed from the dual — *"Clears when
#50021 merges and a pin bump inherits it"* — while both mount `vllm-gdn-mtp-async-spec-order`.
Their risk blocks contain no card-count wording, so the two files' blocks were byte-identical and
took the same correction.

**Two faults share the Xid 13/31 signature and the block conflated them:**

| | fault | state |
|---|---|---|
| **(a)** | cross-stream race in `synchronize_input_prep` | ✅ patched here by `vllm-gdn-mtp-async-spec-order` (ours); anchor drift boot-refuses |
| **(b)** | vllm#50021's unbounded `num_accepted` index | 🔴 still live, not vendored |

A #50021 merge clears **(b) only** — it never covered (a), whose in-kernel bounds were built and
crashed 2/2.

## Two things the dual's block does not need

These composes have **never run**, which changes what can honestly be claimed:

**Neither the exposure nor the fix has been observed on this topology.** The original block was
careful that the *exposure* carries over structurally rather than by measurement — the fix carries
over exactly the same way, and the block now says so. The patch's evidence (3/3 boots to 33–36k
generated tokens where 5/5 unpatched arms died at 6–13k) is reference 2× 3090, **ours**, not
community-blessed, and says nothing about a 4-/8-card NCCL topology.

**`ASYNC_SCHED=off` is NOT plumbed here.** The dual sibling got it in #1139; these did not. Called
out explicitly so nobody carries that advice across a topology boundary and finds it inert — which
is precisely the defect #1139 fixed, and the reason it went unnoticed for ten days.

## Scope + verification

Comment-only — no flags, mounts, env or status changed.

- both composes: `docker compose config -q` parses
- 8 compose guards green: `status-drift`, `registry-disk`, `mounts-resolve`,
  `entrypoint-env-declared`, `spec-toggle-contract`, `sampler-profiles`, `no-repeated-args`,
  `homogeneous-arch-drift`

## Deliberately not done here

**Wiring `ASYNC_SCHED` on these two.** It would be a behaviour change to composes nobody can boot,
on hardware we do not have, and #1139's value came with on-rig measurement behind it. Documenting
the asymmetry is honest; silently propagating an unmeasured knob is not. Happy to do it as its own
PR if you'd rather have parity.

The remaining six composes flagged in #1147 (`tess-4-27b`, `thinkingcap-27b`, four `qwen3.6-27b`)
are **candidates, not confirmed defects** — mounting patch X while awaiting PR #N for a different
bug is legitimate. They need reading one at a time, which is what the proposed guard is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
