### PR TITLE
fix(tests): allow --spec-file in the quality-test doc drift guard (regression from #1143)

### DIFF
--- a/scripts/tests/test-quality-passthrough.sh
+++ b/scripts/tests/test-quality-passthrough.sh
@@ -273,6 +273,7 @@ OTHER_TOOL_OK = {
     "--in-place",                        # benchlocal-cli rescore
     "--dry-run",                         # quality-baseline.sh / report.sh
     "--clear-default", "--set-default", "--profile-like",       # switch.sh
+    "--spec-file",                       # promote.py / export_pr.py (#1143)
 }
 allowed = known | PASS_THROUGH_OK | OTHER_TOOL_OK
 


### PR DESCRIPTION
**My regression from #1143, currently red on `master`.**

#1143 added `promote.py` / `export_pr.py` invocations to `AGENTS.md`. `test-quality-passthrough.sh`'s drift guard scans that file for any hyphenated `--flag` and asserts it is executable by `quality-test.sh`, so `--spec-file` read as documented-but-unexecutable:

```
AGENTS.md:231 documents unexecutable flag --spec-file
AGENTS.md:232 documents unexecutable flag --spec-file
```

The guard already has the correct escape — `OTHER_TOOL_OK`, *"flags belonging to OTHER commands the docs mention alongside quality-test.sh"*, the set that already carries `switch.sh`'s `--set-default` and `rebench-full`'s `--with-8pack-thinking`. `--spec-file` is added there, attributed to its owning tools.

Only `--spec-file` trips it: the scanner's `flag_re` requires an internal hyphen, so `--out`, `--layer`, `--check` and `--root` never matched, and `--dry-run` was already allowlisted.

**Verified the fix does not blunt the guard.** Injecting a bogus `quality-test.sh --totally-made-up-flag` into AGENTS.md still fails it with the right message (exit 1); removing it restores PASS. I did not want to silence a guard to green my own change.

**How this was missed:** I merged #1149 without waiting for the full sweep, on the reasoning that an additive test file could not affect others. That reasoning was correct about #1149 — the breakage came from #1143, merged earlier, and only a full sweep would have surfaced it. Sweep now reads **PASS=126 FAIL=1**, the remainder being `test-bench-capture.sh` (known, #1137).

🤖 Generated with [Claude Code](https://claude.com/claude-code)