### PR TITLE
feat(byom): keep local models out of the curated port band; document what destroys the layer

### DIFF
--- a/docs/BRING_YOUR_OWN.md
+++ b/docs/BRING_YOUR_OWN.md
@@ -268,6 +268,26 @@ and `registry.local.json`, with slugs namespaced under `local/`. The directory i
 - a local entry can never become a *curated* default, and a broken local layer
   fails loudly rather than silently shrinking the catalog.
 
+> **Ports: your models live in the 202xx band.** The curated catalog occupies
+> **8010–8199**, and it grows — so a local model parked in that range can collide
+> with a slug that arrives in a later `git pull`, and it turns the repo's own
+> `test-compose-port-conflicts` guard red on your checkout. `promote.py` refuses a
+> local port that is already curated and tells you the deterministic replacement
+> (`20200 + crc32(model_id) % 100`) — the same value c3's Promote scaffold assigns.
+> Set your compose's `${PORT:-NNNN}` to match.
+
+> ⚠️ **One command destroys this layer: `git clean -xdf`.** Your models here are
+> *gitignored*, which is what makes them survive `git pull`, a branch switch, and even
+> `git reset --hard` (all measured). But `-x` tells `git clean` to remove **ignored**
+> files too, so the reflex "really clean the repo" command deletes every model you
+> registered — silently, with no recovery. `git clean -fd` (no `-x`) is safe; so is
+> `git stash -u`, though `git stash --all` is not.
+>
+> ⚠️ **It is not a backup either.** The layer lives inside this checkout and is resolved
+> from the repo root it was imported from, so a second clone has its own empty layer and
+> re-cloning loses everything. `export_pr.py --out <dir>` (§5) writes a complete portable
+> bundle — the easiest way to keep a copy outside the tree.
+
 > **Guided equivalent:** c3's Bring & Validate lane, stage **⑤ Promote** — the
 > scaffold pre-fills every arch fact the deriver knows and you fill in
 > `display_name` + `family`. Its key line names all three destinations:

--- a/scripts/lib/profiles-local/README.md
+++ b/scripts/lib/profiles-local/README.md
@@ -90,6 +90,43 @@ Delete the file(s): `rm scripts/lib/profiles-local/models.d/<id>.yml`, the
 compose dir, and the JSON entry. There is nothing else to revert — no core file
 was ever touched.
 
+## Ports — the 202xx band
+
+The curated catalog occupies **8010–8199** and grows over time, so a local model
+parked there can collide with a slug that lands in a later `git pull` — and it turns
+the repo's own `test-compose-port-conflicts` guard red on *your* checkout, whose fix
+text invites editing a curated entry you should never touch.
+
+Local models use **202xx**: `20200 + crc32(model_id) % 100`, deterministic per model
+id. c3's Promote scaffold assigns it automatically; `promote.py` refuses a local port
+that is already curated and names the replacement. Keep the compose's
+`${PORT:-NNNN}` in step with the registry entry's `default_port`.
+
+## ⚠️ What can and cannot destroy this directory
+
+Everything here is **gitignored**, which makes it survive the operations that would
+otherwise clobber it. Measured on a real clone with a model registered here:
+
+| operation | your models |
+|---|---|
+| `git pull` | ✅ survive |
+| `git fetch` + **`git reset --hard`** | ✅ survive |
+| branch switch / `git checkout` | ✅ survive |
+| `git clean -fd` | ✅ survive |
+| `git stash -u` | ✅ survive |
+| **`git clean -xdf`** | ❌ **DELETED — no warning, no recovery** |
+
+**`git clean -xdf` is the one that bites.** It is the reflex command for "really clean
+this repo", and its `-x` removes *ignored* files — which is exactly what this directory
+is. `git clean -fd` (without `-x`) is safe; `-xdf` wipes every model you registered here.
+The same applies to `git stash --all`, which stashes ignored files too.
+
+**This directory is also not a backup.** It lives inside the checkout, and the layer is
+resolved from the repo root it was imported from — so a second clone has its own empty
+layer, and deleting or re-cloning this one loses everything in it. If a local model
+matters to you, keep a copy outside the tree; `export_pr.py --out <dir>` (below) writes a
+complete, portable bundle and is the easiest way to do that.
+
 ## Contributing a local model back to the club catalog
 
 The local layer is a **staging ground for a contribution, not a dead end.** Once

--- a/scripts/lib/profiles/promote.py
+++ b/scripts/lib/profiles/promote.py
@@ -65,6 +65,7 @@ import json
 import os
 import re
 import subprocess
+import zlib
 import sys
 from pathlib import Path
 from typing import Any, Optional
@@ -461,6 +462,31 @@ def validate_spec(spec: Any, root: Path, layer: str) -> dict:
             raise Refusal(f"registry kwargs are not valid _entry kwargs: {exc}")
         except ValueError as exc:
             raise Refusal(f"registry kwargs rejected by _entry: {exc}")
+        # ── LOCAL: keep BYOM ports out of the curated band (#1142 follow-up) ──
+        # The curated catalog occupies 8010-8199. A local slug landing on one of
+        # those ports turns the repo's OWN test-compose-port-conflicts guard red
+        # on the user's checkout, and its remediation text invites reassigning
+        # "one side" — i.e. editing a curated entry they must never touch.
+        # Refuse the collision here and hand them the deterministic 202xx
+        # LOCAL-band port the c3 Promote scaffold already assigns, so the CLI and
+        # the cockpit agree on one convention.
+        want = kwargs.get("default_port")
+        if want is not None:
+            core_ports = {
+                e.get("default_port")
+                for e in _import_compose_registry(root, merged=False).values()
+            }
+            if want in core_ports:
+                suggested = 20200 + (zlib.crc32(mid.encode("utf-8")) % 100)
+                raise Refusal(
+                    f"default_port {want} is already used by the curated catalog. "
+                    f"LOCAL models live in the 202xx band so a `git pull` of new "
+                    f"curated slugs can never collide with yours — use {suggested} "
+                    f"(deterministic for model id {mid!r}; the same value c3's "
+                    f"Promote scaffold assigns) and set the compose's "
+                    f"${{PORT:-NNNN}} to match"
+                )
+
         return spec
 
     # ── layer == "core": maintainer-gated curated-catalog write ──────────────

--- a/scripts/tests/test_promote.py
+++ b/scripts/tests/test_promote.py
@@ -250,6 +250,29 @@ class TestCoreGate:
             root / "scripts/lib/profiles/registry.yaml"
         ).read_text()
 
+    # ── BYOM ports must not land in the curated band ────────────────────────
+    #
+    # A local slug on a curated port turns the repo's OWN
+    # test-compose-port-conflicts guard red on the user's checkout, and its
+    # remediation text invites reassigning "one side" — i.e. editing a curated
+    # entry they must never touch. Refuse at promote time instead.
+
+    def test_local_port_in_curated_band_is_refused(self, root):
+        spec = _spec()
+        spec["registry_entry"]["kwargs"]["default_port"] = 8101  # dual-ultrafast
+        res = _run_cli(root, spec)
+        assert res.returncode == promote.EXIT_COLLISION, res.stdout + res.stderr
+        assert "already used by the curated catalog" in res.stderr
+        assert "202xx" in res.stderr
+        # it must NAME the deterministic replacement, not just complain
+        import zlib
+        assert str(20200 + (zlib.crc32(b"my-model") % 100)) in res.stderr
+        assert not (root / "scripts/lib/profiles-local/registry.local.json").exists()
+
+    def test_local_port_outside_the_curated_band_is_fine(self, root):
+        res = _run_cli(root, _spec())          # the fixture already uses 20242
+        assert res.returncode == 0, res.stderr + res.stdout
+
     # ── #1142: the repo-root .env must reach the gate ───────────────────────
     #
     # Before the fix these tools read only the real environment, so a maintainer


### PR DESCRIPTION
Three BYOM gaps, all found by **testing** rather than reading. Follow-up to #1142.

## 1. Port band — local models were free to collide with the catalog

The curated catalog occupies **8010–8199** and grows. A local slug parked there collides with
whatever arrives in a later `git pull` — and, measured, it turns the repo's **own**
`test-compose-port-conflicts` guard red on the user's checkout:

```
PORT 8101:
  local/my-local-model-dual-q4km  [my-local-model]
  vllm/qwen38-27b-dual-ultrafast  [qwen3.8-27b]
Fix: reassign one side to a free default_port …
```

…whose fix text invites reassigning *"one side"* — i.e. editing a curated entry they must never
touch.

A **202xx LOCAL band already existed**, but only inside c3's Promote scaffold
(`20200 + crc32(model_id) % 100`, deterministic per model id), documented nowhere a user reads and
unenforced on the CLI path. `promote.py --layer local` now refuses a port already used by a core
entry and **names that deterministic replacement**, so the CLI and the cockpit agree on one
convention.

## 2. What actually destroys the local layer

Measured on a real clone with a model registered in it:

| operation | outcome |
|---|---|
| `git pull` · `fetch` + **`reset --hard`** · branch switch · `git clean -fd` · `git stash -u` | ✅ survives |
| **`git clean -xdf`** | ❌ **silently deleted** |

`-x` removes *ignored* files, which is exactly what the layer is — and `clean -xdf` is the reflex
"really clean this repo" command. Nor is the layer a backup: it lives inside the checkout and is
resolved from the repo root it was imported from, so a second clone has its own empty one and
re-cloning loses everything. Both documented, pointing at `export_pr.py --out` for a portable copy.

## 3. Registering an already-downloaded model works — verified, no change needed

A user with weights on disk and a working compose can register with **no `hf_repo` field at all**
(`hf_repos` is variant-scoped and optional). End-to-end on a clean clone: exit 0, files written to
the gitignored layer, `get_registry()` **111 core → 112 merged**, the `local/` slug resolving and
invisible to git.

## ⚠️ The port guard's first two drafts were silently dead

Worth recording, because `ast.parse` endorsed both:

1. it sat **after** the local branch's `return spec` — unreachable;
2. relocated, its comment block at 8 spaces was **skipped by the tokenizer**, so the body at 12
   spaces *continued the preceding `except ValueError` handler* — it ran only when `_entry()`
   raised.

Only the end-to-end run caught either. Tests now cover **both directions**: a curated port is
refused *and names the deterministic replacement*; a 202xx port is accepted.

## Verification

- 17 `test_promote.py` tests pass in a clean `git worktree` (the fixture cannot run in a checkout
  that has served a model — see #1142)
- `test-docs-local-layer`, `test-compose-port-conflicts`, `test-script-permissions`,
  `test-caveat-patch-ambiguity` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
