### PR TITLE
fix(bench): make the RAM-derivation refusal loud, and split its two failure causes

### DIFF
--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -1780,16 +1780,34 @@ print(f"{sum(xs)/len(xs):.2f}" if xs else "")
         fi
         unset CAP_LINE_LIMIT
 
-        _ram=""; _ram_scope=""; _ram_arith=""; _ram_caveat=""
+        _ram=""; _ram_scope=""; _ram_arith=""; _ram_caveat=""; _ram_why=""
+        # #1137: `|| true` used to turn an un-derivable figure into an EMPTY string
+        # and then into a silently ABSENT report block — the caveat line vanished
+        # and the only downstream symptom was a test complaining the caveat TEXT
+        # was missing, pointing at formatting rather than at the empty input.
+        # Capture the reason instead, and print it below.
         if [[ -n "$_exp" ]] && (( _win_ok )) && (( _win_secs > 0 )) && (( _win_miss > 0 )); then
-          _ram="$(cap_ram_rd_mbps "$_win_miss" "$_exp" "$_win_secs" || true)"
+          _ram_errf="$(mktemp)"
+          _ram="$(cap_ram_rd_mbps "$_win_miss" "$_exp" "$_win_secs" 2>"$_ram_errf")" \
+            || _ram_why="$(cat "$_ram_errf" 2>/dev/null)"
+          rm -f "$_ram_errf"
           _ram_scope="(DECODE WINDOW)"
           _ram_arith="= ${_win_miss} misses x ${_exp} KiB / ${_win_secs}s of decode"
         elif [[ -n "$_exp" && -n "$_miss" && "${_miss:-0}" -gt 0 ]]; then
-          _ram="$(cap_ram_rd_mbps "$_miss" "$_exp" "$CAP_ELAPSED" || true)"
+          _ram_errf="$(mktemp)"
+          _ram="$(cap_ram_rd_mbps "$_miss" "$_exp" "$CAP_ELAPSED" 2>"$_ram_errf")" \
+            || _ram_why="$(cat "$_ram_errf" 2>/dev/null)"
+          rm -f "$_ram_errf"
           _ram_scope="(WHOLE RUN — diluted)"
           _ram_arith="= ${_miss} misses x ${_exp} KiB / ${CAP_ELAPSED}s"
           _ram_caveat="dilution"
+        else
+          _ram_why="inputs unavailable — expert_kib=${_exp:-<none>} win_miss=${_win_miss:-<none>} miss=${_miss:-<none>}"
+        fi
+        if [[ -z "$_ram" && -n "$_ram_why" ]]; then
+          # SAY SO. An absent derivation is a fact about the run, not a reason to
+          # print nothing — silence here is what made #1137 unreadable.
+          echo "  derived host-RAM read demand: NOT DERIVED — ${_ram_why}"
         fi
         if [[ -n "$_ram" ]]; then
           CAP_RAM_DEMAND="$_ram"

--- a/scripts/lib/capture.sh
+++ b/scripts/lib/capture.sh
@@ -946,11 +946,27 @@ cap_swap_verdict() {
 # It is a LOWER BOUND on the miss path only (it ignores KV traffic, activations
 # and prefetch). Never present it as a measured bandwidth.
 cap_ram_rd_mbps() {
+  # Refusing to derive is CORRECT when an input cannot support it — but say WHICH
+  # input, on stderr, and use a distinct exit code (#1137). Callers used to write
+  # `|| true`, which turned "un-derivable" into an empty string and then into a
+  # silently ABSENT report block: the only downstream symptom was a test
+  # complaining the caveat TEXT was missing, which points at formatting instead
+  # of at the empty input that actually caused it.
+  #
+  #   exit 2  deliberate refusal — an input is zero/negative/non-numeric
+  #   exit 1  awk itself failed (missing, or an arithmetic fault)
   local misses="${1:-0}" expert_kib="${2:-0}" elapsed="${3:-0}"
+  local bad=()
+  [[ "$misses"     =~ ^[0-9]+(\.[0-9]+)?$ ]] && awk -v v="$misses"     'BEGIN{exit !(v>0)}' || bad+=("misses=${misses:-<empty>}")
+  [[ "$expert_kib" =~ ^[0-9]+(\.[0-9]+)?$ ]] && awk -v v="$expert_kib" 'BEGIN{exit !(v>0)}' || bad+=("expert_kib=${expert_kib:-<empty>}")
+  [[ "$elapsed"    =~ ^[0-9]+(\.[0-9]+)?$ ]] && awk -v v="$elapsed"    'BEGIN{exit !(v>0)}' || bad+=("elapsed=${elapsed:-<empty>}")
+  if (( ${#bad[@]} )); then
+    printf 'cap_ram_rd_mbps: cannot derive host-RAM read demand — %s\n' "${bad[*]}" >&2
+    return 2
+  fi
   awk -v m="$misses" -v k="$expert_kib" -v e="$elapsed" 'BEGIN{
-    if (m <= 0 || k <= 0 || e <= 0) exit 1
     printf "%.0f\n", m * k / 1024 / e
-  }'
+  }' || return 1
 }
 
 # cap_stream_triad_gbps [seconds] — item 9b. A ~3 s STREAM-triad ceiling on the

--- a/scripts/tests/test-bench-capture.sh
+++ b/scripts/tests/test-bench-capture.sh
@@ -544,6 +544,13 @@ command grep -q 'status: OK' "$H" || fail "healthy run should classify OK: $(com
 command grep -q 'CUDA0 marginal=' "$H" || fail "per-device marginal rate missing from output"
 command grep -q 'CUDA1 marginal=' "$H" || fail "the CUDA0/CUDA1 split was averaged away — item 3d"
 command grep -q 'CUDA0 pools=' "$H" || fail "per-device pool census missing from output"
+# #1137: these are TWO different failures and used to produce one message. If the
+# derivation was skipped, say which input was empty — do not report it as missing
+# caveat TEXT, which points at formatting and hides the real cause.
+if command grep -q 'derived host-RAM read demand: NOT DERIVED' "$H"; then
+  fail "the RAM derivation was SKIPPED, so its caveat is legitimately absent: $(
+        command grep -m1 'NOT DERIVED' "$H")"
+fi
 command grep -q 'DERIVED, NOT A PERF COUNTER' "$H" \
   || fail "the derived RAM figure must carry its 'not a counter' caveat"
 command grep -q 'MARGINAL' "$H" || fail "the marginal-vs-cumulative caveat is missing"


### PR DESCRIPTION
Addresses the re-scoped #1137: **the RAM-caveat assertion is host-sensitive and fails opaquely.**

## The defect

#1137 reported a failure on *"the derived RAM figure must carry its 'not a counter' caveat"*. That
message points at **formatting**. The mechanism underneath was an **empty input**, and nothing said so.

`bench.sh` derived the figure with `cap_ram_rd_mbps … || true`, so a refusal became an empty string,
the entire report block was omitted, and the only downstream symptom was the caveat *text* appearing
to be missing. The next person is sent after a formatting regression that never happened.

## Three changes, all about telling two things apart

| file | change |
|---|---|
| `capture.sh` | `cap_ram_rd_mbps` names the offending input on stderr — `cannot derive host-RAM read demand — misses=0` — and uses a distinct exit code: **2** = deliberate refusal (input zero/negative/non-numeric), **1** = awk itself failed. Refusing was always correct and stays tested; what was missing was *which* input. |
| `bench.sh` | no `\|\| true`. The reason is captured (`mktemp`, not a fixed `/tmp` name) and **printed into the report**: `derived host-RAM read demand: NOT DERIVED — misses=0`. An absent derivation is a fact about the run, not a reason to print nothing. |
| the test | checks the `NOT DERIVED` line **first** and fails with *"the RAM derivation was SKIPPED, so its caveat is legitimately absent: `<reason>`"*. Two causes, two messages. |

## Verified by negative control — at the right layer

Forcing `_exp` empty in `bench.sh` (a host where the expert size is unavailable — the shape that
would empty `_ram`) produces:

```
FAIL: the RAM derivation was SKIPPED, so its caveat is legitimately absent:
  derived host-RAM read demand: NOT DERIVED — inputs unavailable —
  expert_kib=<none> win_miss=0 …
```

⚠️ **A first control attempt was INCONCLUSIVE and looked like a pass.** Injecting into
`cap_ram_rd_mbps` itself broke that function's own unit assertion (line 421), so the run died
*before* reaching the path under test — it exited 1 for the wrong reason. Recorded because reading
that as confirmation would have shipped a diagnostic I had never actually exercised.

Unit-level, all four hold: arithmetic unchanged (`94001 4352 60 == 6658`), still refuses zero
misses, refusal names the culprit, exit code 2.

## What this does NOT do

**It does not explain why #1137 failed on the reporter's rig and passes here.** Three quiescent runs
pass, and **zero commits** have touched the test or its subject since filing. This change only
guarantees that the next time it goes red, the message names the empty input.

The reporter's original repro is still the missing input — if it still fails there, the new line
should now say which value was unavailable.

Full test green before and after the control (exit 0, ~120s); tree restored from backup, injection
removed (0 occurrences).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
