### PR TITLE
fix(c3): ⑤ Promote never passed the compose, so every LOCAL write was refused

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -6531,6 +6531,20 @@ class PromoteScaffoldScreen(_CopyableModal, ModalScreen):
             )
             return
         spec = self._edited_spec()
+        # #1156: refuse BEFORE pop_screen, next to the maintainer gate above and
+        # for the same reason — promote.py rejects an empty spec.compose.content
+        # (exit 3), and that refusal reached only the RunLog, so a doomed write
+        # read as "dispatched". Refusing here keeps the user's filled-in
+        # display_name/family instead of dropping them with the screen.
+        if not ((spec.get("compose") or {}).get("content") or "").strip():
+            self.notify(
+                "Nothing to register: ⑤ writes the compose that was actually "
+                "served — serve the model at ② first, then promote.",
+                title="Promote",
+                severity="error",
+                timeout=7,
+            )
+            return
         self.app.pop_screen()
         if self._on_stage_write is not None:
             self._on_stage_write(layer, spec)
@@ -13894,7 +13908,15 @@ class CockpitApp(App):
             )
             return
         meas = self._measurement_for_promote()
-        scaffold = self._data.promote_scaffold(byo=self._last_byo, measurement=meas)
+        # #1156: the scaffold's spec.compose.content was NEVER filled — the app
+        # called promote_scaffold() without compose_text, data.py defaulted it to
+        # "", and promote.py refuses an empty content (exit 3). Every "Write LOCAL
+        # layer" from this screen was refused, and the refusal only reached the
+        # RunLog, so it read as a success. Pass the compose ②③④ actually served.
+        compose_text, _compose_src = self._promote_compose_text()
+        scaffold = self._data.promote_scaffold(
+            byo=self._last_byo, measurement=meas, compose_text=compose_text,
+        )
         if not scaffold.computed:
             self.notify(
                 f"Cannot scaffold: {scaffold.error or 'incomplete BYO facts'}",
@@ -13908,10 +13930,8 @@ class CockpitApp(App):
         self.push_screen(
             PromoteScaffoldScreen(
                 scaffold,
-                on_stage_write=lambda layer, spec: self.push_screen(
-                    ConfirmActionScreen(
-                        self._data.promote_write_plan(scaffold, layer=layer, spec=spec)
-                    )
+                on_stage_write=lambda layer, spec: self._stage_promote_write(
+                    scaffold, layer, spec
                 ),
                 on_export_pr=lambda spec: self.push_screen(
                     ConfirmActionScreen(
@@ -13921,6 +13941,49 @@ class CockpitApp(App):
                 ),
             )
         )
+
+    def _stage_promote_write(self, scaffold, layer: str, spec: dict) -> None:
+        """Gate the ⑤ write on having a compose to register (#1156).
+
+        The PREVIEW is allowed without one — ⑤ is advertised as a preview and [P]
+        must still open after a bare fit-check. The WRITE is not: promote.py
+        refuses an empty ``spec.compose.content`` (exit 3), and that refusal used
+        to reach only the RunLog, so a doomed write reported as "dispatched".
+        Say it here, where the user is looking."""
+        if not ((spec.get("compose") or {}).get("content") or "").strip():
+            self.notify(
+                "Nothing to register: ⑤ writes the compose that was actually "
+                "served — serve the model at ② first, then promote.",
+                title="⑤ Promote",
+                severity="warning",
+                timeout=7,
+            )
+            return
+        self.push_screen(
+            ConfirmActionScreen(
+                self._data.promote_write_plan(scaffold, layer=layer, spec=spec)
+            )
+        )
+
+    def _promote_compose_text(self) -> tuple[str, str]:
+        """The compose ⑤ should register — the one ②③④ actually served (#1156).
+
+        Returns (text, source-path). ("", "") when nothing has been served, which
+        the caller turns into a visible refusal rather than a doomed write plan.
+
+        NOTE: only the CONTENT travels. `sibling_compose_path` is deliberately NOT
+        passed — it overrides the DESTINATION path, and promote.py requires a local
+        write to land under scripts/lib/profiles-local/composes/ (it refuses
+        anything outside the layer)."""
+        from pathlib import Path as _Path   # module-scope Path is not imported here
+
+        path = getattr(self, "_bring_swap_compose", "") or ""
+        if not path:
+            return "", ""
+        try:
+            return _Path(path).read_text(encoding="utf-8"), path
+        except OSError:
+            return "", path
 
     def _measurement_for_promote(self) -> Optional[Measurement]:
         """Best-effort Evidence measurement for the Promote scaffold: the matched

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -93,6 +93,19 @@ FAKE_REPO_ROOT = Path("/tmp/fake-club-3090-test-root")
 # ---------------------------------------------------------------------------
 
 
+# #1156: a minimal but REAL compose — ⑤ must register the one that was served.
+_FAKE_COMPOSE = (
+    "# Profile (at-a-glance):\n"
+    "#   Status: 🐣 Incubating\n"
+    "# ---\n"
+    "services:\n"
+    "  llm:\n"
+    "    image: vllm/vllm-openai:v0.27.1\n"
+    "    ports:\n"
+    '      - "${PORT:-20242}:8000"\n'
+)
+
+
 class FakeRunner:
     """Canned-output read runner keyed on a substring of the command.
 
@@ -5483,6 +5496,86 @@ class TestPromoteHookWired:
             assert "scripts/tests/*.sh" in body   # authoritative-before-commit note
 
     @pytest.mark.asyncio
+    async def test_promote_spec_is_accepted_by_the_real_promote_executor(self):
+        """#1156: validate the plan with the tool that will RUN it.
+
+        The mock-only test asserts the plan's SHAPE and stops — a FakeWriteRunner
+        cannot disagree with you. That is exactly how a spec carrying an empty
+        `compose.content`, which promote.py refuses with exit 3 on every single
+        invocation, sat under a green suite. Feed the built spec to the real
+        executor in --dry-run (validates fully, writes nothing)."""
+        import os as _os
+        import subprocess as _sp
+        import sys as _sys
+        from pathlib import Path as _Path
+
+        _repo = _Path(__file__).resolve().parents[3]   # <repo>/tools/serve-cockpit/tests
+
+        wr = FakeWriteRunner()
+        app, _, _ = make_app(write_runner=wr, surface="producer")
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            app.run_byo_check("unsloth/Qwen3-27B-abliterated", "vllm/dual")
+            await _settle(pilot)
+            await pilot.press("2")
+            await _settle(pilot)
+            await pilot.press("P")
+            await pilot.pause()
+            app.screen.query_one("#promote-display-input", Input).value = "Qwen3 27B Abliterated"
+            app.screen.on_input_changed(None)
+            app.screen.query_one("#promote-family-input", Input).value = "qwen3-dense"
+            app.screen.on_input_changed(None)
+            # #1156: ⑤ registers the compose ②③④ served; the write is refused
+            # without one. These tests exercise the GATE, not the compose source.
+            app.screen._scaffold.spec["compose"]["content"] = _FAKE_COMPOSE
+            app.screen.query_one("#promote-stage-btn", Button).press()
+            await pilot.pause()
+            assert isinstance(app.screen, ConfirmActionScreen)
+            spec_json = app.screen._plan.env["C3_PROMOTE_SPEC"]
+
+        env = dict(_os.environ)
+        env["C3_PROMOTE_SPEC"] = spec_json
+        env.pop("C3_ALLOW_CORE_PROMOTE", None)
+        res = _sp.run(
+            [_sys.executable, str(_repo / "scripts/lib/profiles/promote.py"),
+             "--spec-env", "C3_PROMOTE_SPEC", "--layer", "local",
+             "--root", str(_repo), "--dry-run"],
+            capture_output=True, text=True, env=env, cwd=str(_repo),
+        )
+        assert res.returncode == 0, (
+            "the real promote.py REFUSED the spec this screen builds:\n"
+            f"{res.stderr}{res.stdout}"
+        )
+        assert "REFUSED" not in res.stderr
+
+    async def test_promote_write_refused_without_a_served_compose(self):
+        """#1156: ⑤ registers the compose ②③④ served. With none in hand the write
+        must be refused ON SCREEN — not built into a plan promote.py will reject
+        with exit 3 while the RunLog swallows the reason."""
+        wr = FakeWriteRunner()
+        app, _, _ = make_app(write_runner=wr, surface="producer")
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            app.run_byo_check("unsloth/Qwen3-27B-abliterated", "vllm/dual")
+            await _settle(pilot)
+            await pilot.press("2")
+            await _settle(pilot)
+            await pilot.press("P")
+            await pilot.pause()
+            # the PREVIEW still opens — ⑤ is advertised as a preview
+            assert isinstance(app.screen, PromoteScaffoldScreen)
+            app.screen.query_one("#promote-display-input", Input).value = "Q"
+            app.screen.on_input_changed(None)
+            app.screen.query_one("#promote-family-input", Input).value = "qwen3-dense"
+            app.screen.on_input_changed(None)
+            app.screen.query_one("#promote-stage-btn", Button).press()
+            await pilot.pause()
+            # ...but the WRITE is refused: no confirm screen, nothing dispatched
+            assert isinstance(app.screen, PromoteScaffoldScreen), (
+                "a write with no compose in hand must not reach the confirm gate"
+            )
+            assert wr.started == []
+
     async def test_promote_stage_write_is_gated_mock_only(self):
         """Staging the write opens the standard confirm gate; the plan is
         mock-only and writes nothing into scripts/ (no auto-fire)."""
@@ -5506,6 +5599,9 @@ class TestPromoteHookWired:
             assert app.screen.query_one("#promote-stage-btn", Button).disabled is True
             app.screen.query_one("#promote-family-input", Input).value = "qwen3-dense"
             app.screen.on_input_changed(None)
+            # #1156: ⑤ registers the compose ②③④ served; the write is refused
+            # without one. These tests exercise the GATE, not the compose source.
+            app.screen._scaffold.spec["compose"]["content"] = _FAKE_COMPOSE
             assert app.screen.query_one("#promote-stage-btn", Button).disabled is False
             # Stage the gated write — routes through ConfirmActionScreen.
             app.screen.query_one("#promote-stage-btn", Button).press()
@@ -5520,6 +5616,9 @@ class TestPromoteHookWired:
             assert _spec["display_name"] == "Qwen3 27B Abliterated"
             assert _spec["family"] == "qwen3-dense"
             assert _spec["registry_entry"]["slug"].startswith("local/")
+            # #1156: THIS assertion was missing, and its absence let a plan that
+            # promote.py always refuses (empty compose.content) pass as green.
+            assert _spec["compose"]["content"].strip(), "spec.compose.content is empty"
             # Nothing executed yet — the write is mock-only and never auto-fired.
             assert wr.started == []
 
@@ -5563,6 +5662,9 @@ class TestPromoteHookWired:
             app.screen.query_one("#promote-display-input", Input).value = "Qwen3 27B Abliterated"
             app.screen.query_one("#promote-family-input", Input).value = "qwen3-dense"
             app.screen.on_input_changed(None)
+            # #1156: ⑤ registers the compose ②③④ served; the write is refused
+            # without one. These tests exercise the GATE, not the compose source.
+            app.screen._scaffold.spec["compose"]["content"] = _FAKE_COMPOSE
             # WITHOUT the flag: refused in-screen, nothing staged.
             app.screen._stage_write(layer="core")
             await pilot.pause()
@@ -11235,6 +11337,9 @@ class TestTier1PreviewModalEnterBindings:
             app.screen.query_one("#promote-display-input", Input).value = "Qwen3 27B Abliterated"
             app.screen.query_one("#promote-family-input", Input).value = "qwen3-dense"
             app.screen.on_input_changed(None)
+            # #1156: ⑤ registers the compose ②③④ served; the write is refused
+            # without one. These tests exercise the GATE, not the compose source.
+            app.screen._scaffold.spec["compose"]["content"] = _FAKE_COMPOSE
             await pilot.press("enter")
             await pilot.pause()
             assert isinstance(app.screen, ConfirmActionScreen)


### PR DESCRIPTION
Fixes #1156.

## The bug

c3's headline BYOM action could not succeed. `app.py` called `promote_scaffold()` **without**
`compose_text`; `data.py` defaulted it to `""`; that landed in `spec.compose.content`; `promote.py`
refuses an empty content with **exit 3**. Every *"Write LOCAL layer"* was refused — and the refusal
reached only the RunLog, so the user saw `promote … dispatched` and believed it worked.

## The fix

**Pass the compose ②③④ actually served** (`_bring_swap_compose`) as `compose_text`.

Only the **content** travels. `sibling_compose_path` is deliberately *not* passed — it overrides the
**destination**, and `promote.py` requires a local write to land under `profiles-local/composes/`,
so passing it would trade one refusal for another.

**Refuse in `PromoteScaffoldScreen._stage_write`, before `pop_screen()`** — beside the existing
maintainer-gate refusal, which uses exactly that shape. Two earlier placements were wrong and are
worth recording:

| placement | why it was wrong |
|---|---|
| refuse at `[P]` | broke the **preview** the lane advertises (*"⑤ Promotion Preview … preview only"*) |
| refuse in the app-level callback | fired **after** `pop_screen()`, discarding the user's `display_name`/`family` |

The app-level guard stays as defense-in-depth — this file's own idiom for the core gate.

## The tests, which are the point

The mock-only test now asserts `spec["compose"]["content"]` is non-empty — **the assertion whose
absence hid this**.

**Four existing tests staged writes that could never have succeeded, and nothing noticed.** That
dependency *was* the bug; they now put a compose in hand first.

Two new tests:
- a write with no compose is **refused and never reaches the confirm gate**
- the spec the screen builds is fed to the **real `promote.py --dry-run`**

That last one is structural. A `FakeWriteRunner` cannot disagree with you — which is precisely how a
spec that fails on *every* invocation sat under **1030 green tests**.

## Controlled, not assumed

My first control was weak: removing the compose merely tripped the new UI guard, proving the guard
rather than the test. The real control injects a **curated port (8101)** — which the UI cannot
detect and only `promote.py` knows about:

```
E  AssertionError: the real promote.py REFUSED the spec this screen builds:
E    [promote] REFUSED: default_port 8101 is already used by the curated catalog.
```

The verdict comes from the tool that will actually run.

## Verification

`TestPromoteHookWired` 9/9. Full cockpit suite result appended below before merge.

Found by an independent review of this lane, not by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
