### PR TITLE
feat(c3): Route-K — ① accepts a compose you already wrote

### DIFF
--- a/scripts/tests/test-docs-local-layer.sh
+++ b/scripts/tests/test-docs-local-layer.sh
@@ -61,11 +61,27 @@ done
 
 # promote.py must keep defaulting to the safe layer, and keep the core gate.
 python3 - <<'PY' || fail=1
-import re, sys
+import re, subprocess, sys
 src = open("scripts/lib/profiles/promote.py", encoding="utf-8").read()
 ok = True
-if not re.search(r'"--layer".*?default="local"', src, re.S):
-    print("  FAIL promote.py --layer no longer defaults to 'local'"); ok = False
+
+# BEHAVIOUR, not the literal. This check used to assert `default="local"` in the
+# argparse call — and went red when #1155 changed it to `default=None` + a
+# `args.layer or "local"` resolution, which preserves the behaviour exactly. A
+# guard that tests a spelling instead of an outcome fails on a correct change and
+# teaches people to edit the guard. Ask the tool what it does instead.
+help_out = subprocess.run(
+    [sys.executable, "scripts/lib/profiles/promote.py", "--help"],
+    capture_output=True, text=True,
+).stdout
+if "local (default" not in help_out:
+    print("  FAIL promote.py --help no longer states that LOCAL is the default")
+    ok = False
+if not re.search(r'choices=\("local",\s*"core"\)', src):
+    print("  FAIL promote.py --layer no longer offers exactly local|core"); ok = False
+# a defaulted (None) layer must still resolve to local, never to core
+if not re.search(r'args\.layer\s*=\s*args\.layer\s*or\s*"local"', src):
+    print("  FAIL a defaulted --layer no longer resolves to 'local'"); ok = False
 if '_CORE_GATE_ENV = "C3_ALLOW_CORE_PROMOTE"' not in src:
     print("  FAIL promote.py core gate env renamed/removed"); ok = False
 sys.exit(0 if ok else 1)

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -946,6 +946,7 @@ class HelpScreen(ModalScreen):
     _LANE_SECTION = """\
 [bold]Bring & Validate[/bold] (producer lane — the ① → ⑤ pipeline)
   ① Bring:   [cyan]f[/cyan] search HF (fills the repo field)   fit-check an HF model   [cyan]s[/cyan] Continue → ② Serve (weights on disk)   [cyan]D[/cyan] download weights
+  ①ᴋ Bring:  paste a COMPOSE PATH (*.yml) instead of a repo → Route-K: serves YOUR file, ⑤ registers it (no download, no HF call)
   ② Serve:   [cyan]⏎[/cyan]/[cyan]g[/cyan] serve untested (Route-C = your weights · else catalog reproduction)
   ③ Gate:    [cyan]⏎[/cyan] launch validation step (gated)   [cyan]F[/cyan] full battery report.sh --full (~43-min · confirm · uses serving model)   [cyan]K[/cyan] boot-log KV back-solve vs kv-calc (read)
   ④ Measure: [cyan]⏎[/cyan] open report   [cyan]m[/cyan] vs catalog bar (read)   [cyan]s[/cyan] submit to localmaxxing (gated · never auto)
@@ -12159,7 +12160,13 @@ class CockpitApp(App):
         servable = bool(
             byo is not None
             and not getattr(byo, "error", "")
-            and (getattr(byo, "sibling_slug", "") or getattr(byo, "profile_like", ""))
+            and (
+                getattr(byo, "sibling_slug", "")
+                or getattr(byo, "profile_like", "")
+                # #1153 Route-K is servable BY ITSELF — the compose in hand is the
+                # thing served, so it needs no catalog sibling to reproduce.
+                or getattr(byo, "route", "") == "K"
+            )
         )
         if not servable:
             self.notify(
@@ -12167,7 +12174,14 @@ class CockpitApp(App):
                 title="② Serve", severity="warning", timeout=3,
             )
             return
-        if not self._data.bring_weights_present(getattr(byo, "repo", "")):
+        # #1153: Route-K brought its OWN compose, which points at its own weights.
+        # bring_weights_present only probes c3's pull dir (<HF_HOME>/club3090/pulls),
+        # so weights living anywhere else — /mnt/models/huggingface, the rig
+        # convention — read as "not on disk" and offer a re-download the user does
+        # not need. The probe is meaningless for a compose in hand; skip it.
+        if getattr(byo, "route", "") != "K" and not self._data.bring_weights_present(
+            getattr(byo, "repo", "")
+        ):
             self.notify(
                 "Weights not on disk yet — press [D] to download first.",
                 title="② Serve", severity="warning", timeout=4,
@@ -13489,9 +13503,90 @@ class CockpitApp(App):
             return
         profile = self._selected_profile_like("#lane-bring-profile-input")
         if not repo:
-            self.notify("Enter an HF repo (org/Model).", title="① Bring", severity="warning", timeout=3)
+            self.notify(
+                "Enter an HF repo (org/Model) — or the path to a compose you "
+                "already have.",
+                title="① Bring", severity="warning", timeout=4,
+            )
+            return
+        # #1153 Route-K: the most common BYOM position is "weights on disk +
+        # a working compose", and the funnel had no door for it. A value that
+        # looks like a compose FILE takes the K route; anything else is an HF
+        # repo exactly as before.
+        if self._looks_like_compose_path(repo):
+            self._bring_compose_in_hand(repo)
             return
         self.run_byo_check(repo, profile)
+
+    @staticmethod
+    def _looks_like_compose_path(value: str) -> bool:
+        """A compose path, not an HF repo (#1153). Deliberately narrow: it must
+        END in .yml/.yaml AND exist on disk. `org/Model` never matches, and a
+        typo'd path falls through to the HF check, whose error names the repo —
+        better than a confident 'file not found' about something that was never
+        meant to be a file."""
+        from pathlib import Path as _Path
+
+        v = (value or "").strip().strip('"').strip("'")
+        if not v.lower().endswith((".yml", ".yaml")):
+            return False
+        try:
+            return _Path(v).expanduser().is_file()
+        except OSError:
+            return False
+
+    def _bring_compose_in_hand(self, path: str) -> None:
+        """① Route-K — ingest a compose the user already wrote (#1153).
+
+        Reads what the compose mechanically states (engine/model/ctx/KV/tp/port)
+        and arms ② with it. No download, no HF call, no catalog reproduction: the
+        compose IS the thing that will be served, and later the thing ⑤ registers."""
+        from pathlib import Path as _Path
+
+        from club3090_cockpit.data import ByoResult, derive_compose_facts
+
+        p = _Path(path.strip().strip('"').strip("'")).expanduser()
+        try:
+            text = p.read_text(encoding="utf-8")
+        except OSError as exc:
+            self.notify(f"Cannot read {p}: {exc}", title="① Bring",
+                        severity="error", timeout=6)
+            return
+        facts = derive_compose_facts(text, path=str(p))
+        if not facts.ok:
+            self.notify(
+                f"Not usable as a compose: {facts.error}",
+                title="① Bring", severity="error", timeout=6,
+            )
+            return
+        self._bring_swap_compose = str(p)
+        self._bring_compose_facts = facts
+        res = ByoResult(
+            repo=facts.served_name or p.stem,
+            profile_like="",
+            route="K",
+            arch=facts.engine,
+            eligible=True,
+            fit_verdict="compose in hand",
+            note=(
+                f"Route-K — your compose: {p.name} · engine {facts.engine or '?'}"
+                + (f" · ctx {facts.max_ctx}" if facts.max_ctx else "")
+                + (f" · KV {facts.kv_dtype}" if facts.kv_dtype else "")
+                + (f" · TP {facts.tp}" if facts.tp else "")
+                + (f" · port {facts.port}" if facts.port else "")
+                + ". ② Serve runs THIS file; ⑤ registers it."
+            ),
+        )
+        self._last_byo = res
+        try:
+            self.query_one("#lane-bring-pane", LaneBringPane).populate(res)
+        except Exception:
+            pass
+        self.notify(
+            f"Route-K: {p.name} read — ② Serve will run this compose.",
+            title="① Bring", timeout=5,
+        )
+        self._advance_to_serve()
 
     def action_serve_untested(self) -> None:
         """[g] / ⏎ in the Bring & Validate lane ② Serve: serve an untested
@@ -13532,8 +13627,11 @@ class CockpitApp(App):
         # the sibling compose (--model at the BROUGHT weights + MTP per the head),
         # serve THAT directly — not a reproduction of the sibling's own catalog
         # compose. This is the bring-your-own weight-swap, now wired.
+        # #1153 Route-K rides the branch Route-C already has: ② serves a compose
+        # path verbatim via `docker compose -f <path> up -d`. Nothing else in
+        # ②③④ changes — the gate and measure stages are endpoint-driven.
         swap_compose = getattr(self, "_bring_swap_compose", "")
-        if swap_compose and getattr(self._last_byo, "route", "") == "C":
+        if swap_compose and getattr(self._last_byo, "route", "") in ("C", "K"):
             self._serve_generated_compose(swap_compose)
             return
         # Route-C with the weights ALREADY on disk but no swap compose emitted yet

--- a/tools/serve-cockpit/club3090_cockpit/data.py
+++ b/tools/serve-cockpit/club3090_cockpit/data.py
@@ -2374,6 +2374,136 @@ def _quant_slug_for_arch(byo: Optional["ByoResult"]) -> str:
     return "autoround-int4"
 
 
+@dataclass
+class ComposeFacts:
+    """What a compose file mechanically tells us (#1153 Route-K).
+
+    A user who already has a working compose is the most common BYOM position,
+    and until now the funnel had no door for them: ① takes an HF repo, and the
+    only compose that could enter was one c3 itself emitted. This is the read
+    half — everything a compose CAN state about itself. Arch dims are absent by
+    construction (a compose does not carry hidden_size); those come from the
+    weights, or stay as required inline edits in ⑤.
+
+    Regex over text, stdlib only — matching serve_override_defaults, which must
+    stay importable on the launcher's no-PyYAML path."""
+
+    path: str = ""
+    ok: bool = False
+    error: str = ""
+    image: str = ""
+    engine: str = ""          # vllm | llama-cpp | ik-llama | unknown
+    model_path: str = ""      # --model / -m / GGUF_FILE
+    served_name: str = ""     # --served-model-name / -a
+    port: str = ""            # ${PORT:-N} or a ports: mapping
+    max_ctx: str = ""         # --max-model-len / -c
+    kv_dtype: str = ""        # --kv-cache-dtype / -ctk
+    tp: str = ""              # --tensor-parallel-size / -ts / device count
+    status_header: str = ""   # the profile-header Status: line, when present
+    service: str = ""
+
+
+_ENGINE_BY_IMAGE = (
+    ("vllm", "vllm"),
+    ("llamacpp-club3090", "llama-cpp"),
+    ("llama.cpp", "llama-cpp"),
+    ("llama-cpp", "llama-cpp"),
+    ("ik-llama", "ik-llama"),
+    ("ik_llama", "ik-llama"),
+)
+
+
+def derive_compose_facts(text: str, path: str = "") -> ComposeFacts:
+    """Read a user-supplied compose (#1153 Route-K). Never raises.
+
+    Flags are read from a TOKEN stream, not by regex-guessing around each name:
+    a compose states its command either as a YAML list (``- --model`` / ``- val``
+    on separate lines) or as one folded string (``>- -m x -c 65536``), and a
+    per-flag regex gets the list form wrong — it captures the next line's ``-``.
+    Flatten first, then walk pairs."""
+    import re as _re
+
+    f = ComposeFacts(path=path)
+    if not (text or "").strip():
+        f.error = "empty compose"
+        return f
+
+    f.image = ""
+    m = _re.search(r"^\s*image:\s*(\S+)", text, _re.M)
+    if m:
+        f.image = m.group(1).strip().strip('"').strip("'")
+    low = f.image.lower()
+    for needle, eng in _ENGINE_BY_IMAGE:
+        if needle in low:
+            f.engine = eng
+            break
+    else:
+        f.engine = "unknown" if f.image else ""
+
+    m = _re.search(r"^services:\s*\n\s{2,}([A-Za-z0-9_.-]+):", text, _re.M)
+    if m:
+        f.service = m.group(1)
+
+    # ── token stream ────────────────────────────────────────────────────────
+    toks: list[str] = []
+    for raw in text.splitlines():
+        ln = raw.strip()
+        if not ln or ln.startswith("#"):
+            continue
+        if ln.startswith("- "):
+            ln = ln[2:].strip()
+        elif ln == "-":
+            continue
+        # exec form: command: ["--model=/w/x", "--max-model-len=32768"]
+        if ln.startswith(("command:", "entrypoint:")) and "[" in ln:
+            ln = ln[ln.index("[") + 1:]
+        ln = ln.replace("[", " ").replace("]", " ").replace(",", " ")
+        ln = ln.strip('"').strip("'")
+        if not ln or ln.endswith(":"):
+            continue
+        toks.extend(t.strip('"').strip("'") for t in ln.split() if t.strip('"').strip("'"))
+
+    def flag(*names: str) -> str:
+        for i, t in enumerate(toks):
+            base = t.split("=", 1)[0]
+            if base in names:
+                if "=" in t:                      # --flag=value
+                    v = t.split("=", 1)[1]
+                elif i + 1 < len(toks):           # --flag value
+                    v = toks[i + 1]
+                else:
+                    continue
+                v = v.strip().strip('"').strip("'")
+                if v and not v.startswith("-"):
+                    return v
+        return ""
+
+    f.model_path  = flag("--model", "-m", "GGUF_FILE")
+    f.served_name = flag("--served-model-name", "-a", "--alias")
+    f.max_ctx     = flag("--max-model-len", "-c", "--ctx-size")
+    f.kv_dtype    = flag("--kv-cache-dtype", "-ctk", "--cache-type-k")
+    f.tp          = flag("--tensor-parallel-size", "-tp", "-ts")
+    if not f.tp:
+        m = _re.search(r"CUDA_VISIBLE_DEVICES[=:\s]+\"?([0-9,]+)", text)
+        if m:
+            f.tp = str(len([x for x in m.group(1).split(",") if x.strip()]))
+
+    m = (_re.search(r"\$\{PORT:-([0-9]+)\}", text)
+         or _re.search(r"^\s*-\s*\"?([0-9]{2,5}):[0-9]+", text, _re.M))
+    if m:
+        f.port = m.group(1)
+
+    m = _re.search(r"^#\s*Status:\s*(.+)$", text, _re.M)
+    if m:
+        f.status_header = m.group(1).strip()
+
+    if not f.image:
+        f.error = "no image: found — is this a compose file?"
+        return f
+    f.ok = True
+    return f
+
+
 def compute_promote_scaffold(
     *,
     byo: Optional["ByoResult"],

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -5496,6 +5496,67 @@ class TestPromoteHookWired:
             assert "scripts/tests/*.sh" in body   # authoritative-before-commit note
 
     @pytest.mark.asyncio
+    async def test_route_k_ingests_a_user_compose_and_arms_serve(self):
+        """#1153 Route-K: a compose path at ① is read, armed for ②, and reaches ⑤.
+
+        This is the BYOM position the funnel had no door for — weights already on
+        disk, compose already written. No HF call, no download, no catalog
+        reproduction: the user's file IS what gets served and registered."""
+        import tempfile as _tf
+        from pathlib import Path as _P
+
+        wr = FakeWriteRunner()
+        app, _, _ = make_app(write_runner=wr, surface="producer")
+        with _tf.TemporaryDirectory() as td:
+            cpath = _P(td) / "my-model.yml"
+            cpath.write_text(
+                "services:\n  vllm:\n    image: vllm/vllm-openai:v0.27.1\n"
+                '    ports:\n      - "${PORT:-20242}:8000"\n'
+                "    command:\n      - --model\n      - /mnt/models/huggingface/mine\n"
+                "      - --max-model-len\n      - \"131072\"\n",
+                encoding="utf-8",
+            )
+            async with app.run_test(size=(120, 40)) as pilot:
+                await _settle(pilot)
+                await pilot.press("2")
+                await _settle(pilot)
+                app.query_one("#lane-bring-url-input", Input).value = str(cpath)
+                app._trigger_lane_bring()
+                await _settle(pilot)
+
+                byo = app._last_byo
+                assert byo is not None and byo.route == "K", f"route={byo and byo.route}"
+                assert byo.error == ""
+                assert app._bring_swap_compose == str(cpath)
+                # what the compose stated, read back
+                facts = app._bring_compose_facts
+                assert facts.engine == "vllm"
+                assert facts.model_path == "/mnt/models/huggingface/mine"
+                assert facts.port == "20242"
+
+                # ① [s] must NOT demand a download: the weights probe only knows
+                # c3's own pull dir, and Route-K's compose points at its own weights
+                app._bring_advance_to_serve()
+                await _settle(pilot)
+
+                # and ⑤ carries the user's compose, not an empty string (#1156)
+                text, src = app._promote_compose_text()
+                assert "vllm/vllm-openai" in text
+                assert src == str(cpath)
+            assert wr.started == []      # nothing executed
+
+    async def test_route_k_only_triggers_on_a_real_compose_file(self):
+        """An HF repo must never be mistaken for a path, and a bogus path must not
+        claim to be one — it falls through to the HF check, whose error names the
+        repo."""
+        app, _, _ = make_app(surface="producer")
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            assert app._looks_like_compose_path("org/Model-Name") is False
+            assert app._looks_like_compose_path("unsloth/Qwen3-27B") is False
+            assert app._looks_like_compose_path("/nope/missing.yml") is False
+            assert app._looks_like_compose_path("") is False
+
     async def test_promote_spec_is_accepted_by_the_real_promote_executor(self):
         """#1156: validate the plan with the tool that will RUN it.
 

--- a/tools/serve-cockpit/tests/test_compose_facts.py
+++ b/tools/serve-cockpit/tests/test_compose_facts.py
@@ -1,0 +1,112 @@
+"""#1153 Route-K — `derive_compose_facts` reads a user-supplied compose.
+
+The BYOM user most likely to exist has weights on disk and a working compose, and
+until Route-K the funnel had no door for them: ① takes an HF repo, and the only
+compose that could enter was one c3 itself emitted.
+
+This is the pure read half, tested here without a TUI (the same seam
+test_family_scaffold.py uses for the promote scaffold). It must handle the three
+shapes a compose actually takes in the wild — YAML list, folded string, and JSON
+exec form — because a per-flag regex gets the list form wrong: it captures the
+next line's `-` instead of the value.
+"""
+
+from __future__ import annotations
+
+from club3090_cockpit.data import derive_compose_facts
+
+
+VLLM_LIST = """# Profile (at-a-glance):
+#   Status: 🧪 Experimental
+services:
+  vllm:
+    image: vllm/vllm-openai:v0.27.1
+    environment:
+      - CUDA_VISIBLE_DEVICES=0,1
+    ports:
+      - "${PORT:-8101}:8000"
+    command:
+      - --model
+      - /models/my-model
+      - --served-model-name
+      - my-model
+      - --max-model-len
+      - "131072"
+      - --kv-cache-dtype
+      - fp8_e4m3
+      - --tensor-parallel-size
+      - "2"
+"""
+
+LLAMA_FOLDED = """services:
+  llama:
+    image: ghcr.io/ggerganov/llama.cpp:server
+    ports:
+      - "9001:8080"
+    command: >-
+      -m /models/mine.gguf -c 65536 -ctk q8_0 -a mine -ts 2
+"""
+
+EXEC_FORM = """services:
+  vllm:
+    image: vllm/vllm-openai:v0.27.1
+    command: ["--model=/w/x", "--max-model-len=32768", "--tensor-parallel-size=2"]
+"""
+
+
+class TestDeriveComposeFacts:
+    def test_vllm_yaml_list_form(self):
+        f = derive_compose_facts(VLLM_LIST, path="/tmp/x.yml")
+        assert f.ok and not f.error
+        assert f.engine == "vllm"
+        assert f.model_path == "/models/my-model"
+        assert f.served_name == "my-model"
+        assert f.max_ctx == "131072"
+        assert f.kv_dtype == "fp8_e4m3"
+        assert f.tp == "2"
+        assert f.port == "8101"          # ${PORT:-8101}, not the container 8000
+        assert "Experimental" in f.status_header
+        assert f.path == "/tmp/x.yml"
+
+    def test_llama_folded_string_form(self):
+        f = derive_compose_facts(LLAMA_FOLDED)
+        assert f.ok
+        assert f.engine == "llama-cpp"
+        assert f.model_path == "/models/mine.gguf"
+        assert f.max_ctx == "65536"
+        assert f.kv_dtype == "q8_0"
+        assert f.served_name == "mine"
+        assert f.tp == "2"
+        assert f.port == "9001"          # from the ports: mapping
+
+    def test_json_exec_form(self):
+        f = derive_compose_facts(EXEC_FORM)
+        assert f.ok
+        assert f.model_path == "/w/x"    # --flag=value
+        assert f.max_ctx == "32768"
+        assert f.tp == "2"
+
+    def test_a_flag_never_captures_the_next_flag_as_its_value(self):
+        """The bug a per-flag regex makes: `- --model` followed by `- --foo`."""
+        f = derive_compose_facts(
+            "services:\n  v:\n    image: vllm/vllm-openai:v0.27.1\n"
+            "    command:\n      - --model\n      - --trust-remote-code\n"
+        )
+        assert f.model_path == "", f"captured a flag as a value: {f.model_path!r}"
+
+    def test_tp_falls_back_to_the_device_count(self):
+        f = derive_compose_facts(
+            "services:\n  v:\n    image: vllm/vllm-openai:v0.27.1\n"
+            "    environment:\n      - CUDA_VISIBLE_DEVICES=0,1,2,3\n"
+        )
+        assert f.tp == "4"
+
+    def test_empty_and_non_compose_are_refused_not_guessed(self):
+        assert derive_compose_facts("").error == "empty compose"
+        assert derive_compose_facts("   \n").ok is False
+        f = derive_compose_facts("services:\n  x:\n    build: .\n")
+        assert f.ok is False and "no image" in f.error
+
+    def test_never_raises_on_junk(self):
+        for junk in ("\x00\x01", "]]]{{{", "image:\n" * 500, "- " * 1000):
+            derive_compose_facts(junk)   # must not raise


### PR DESCRIPTION
Builds **Route-K** from #1153 — the entry point for the BYOM position the funnel had no door for.

## What it does

Paste a **compose path** at ① instead of an HF repo. c3 reads it, arms ②, serves **that file**, and
⑤ registers it. No download, no HF call, no catalog reproduction.

That is the user in #1153: *weights already on disk, compose already written and working*. Until now
their only route was `promote.py --spec-file` with a hand-written spec carrying arch facts and ~15
registry kwargs.

## The pure core, tested without a TUI

`derive_compose_facts()` in `data.py` — the same seam `test_family_scaffold.py` uses. Reads engine
(from `image:`), model path, served name, port, ctx, KV dtype, TP (falling back to a
`CUDA_VISIBLE_DEVICES` count), and the `Status:` header. Regex + tokens, **stdlib only** —
`serve_override_defaults` must stay importable on the launcher's no-PyYAML path.

⚠️ **Flags are read from a token stream, not per-flag regexes.** The regex version silently captures
**the next flag** as a value in YAML-list form:

```yaml
command:
  - --model
  - --trust-remote-code     # → model_path == "--trust-remote-code"
```

It parses, it looks plausible, and it is wrong. Three shapes are covered — YAML list, folded string,
JSON exec form — and there is a test named for exactly that failure.

## Wiring — three narrow changes

| where | change |
|---|---|
| ① | detects a compose path: must **end** `.yml`/`.yaml` **and** exist. `org/Model` can never match; a typo falls through to the HF check, whose error names the repo — better than a confident *"file not found"* about something never meant to be a file |
| ② | rides the branch Route-C already had — guard widens `route == "C"` → `("C", "K")`. Nothing else in ②③④ changes; those stages are endpoint-driven |
| ① `[s]` | the **F2 blocker is lifted for K**. `bring_weights_present` only probes c3's own pull dir, so weights at `/mnt/models/huggingface` — the rig convention — read as *"not on disk"* and offer a re-download nobody needs. The probe is meaningless for a compose in hand |

## A guard regression this PR also fixes

`test-docs-local-layer.sh` asserted the **literal** `default="local"` in `promote.py`'s argparse, and
went red when #1155 changed it to `default=None` + `args.layer or "local"` — behaviour identical,
spelling different.

**That was my regression, merged in #1155 without running the guard that covers it**; the sweep
caught it. Fixed by making the guard run `promote.py --help` and assert the **outcome**, plus that a
defaulted layer still resolves to `local` and never `core`. Negative-controlled: injecting
`or "core"` fails it.

A guard that tests a spelling fails on a correct change and teaches people to edit the guard.

## Verification

- cockpit suite **1041 passed, 1 skipped** (was 1032 — 7 deriver + 2 headless)
- Route-K headless test drives ① → armed ② → ⑤ carrying the user's compose text
- a second test asserts `org/Model`, a missing path and `""` are **never** taken as composes

## Deliberately not here

Gap 2 (local-layer list / inspect / edit / remove) and F3–F7 from the review. Bundling them would
make one unreviewable PR out of three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
