### PR TITLE
feat(c3): Doctor's checks are a keyboard list — ↑/↓ pick, ⏎ runs

### DIFF
--- a/tools/serve-cockpit/README.md
+++ b/tools/serve-cockpit/README.md
@@ -16,7 +16,7 @@ Two modes, shown as a tab bar; the producer mode is hidden in the lean view.
   - **Catalog** — the full registry of model variants; filter, inspect, and **serve** one (`⏎`).
   - **Orchestration** — live GPU cards, the `gpu-mode` scenes (incl. `ai-studio`), and supporting services; switch scene / stop.
   - **Containers** — running/stopped services with engine + port; drill into **Logs / Top / Config**, start a stopped one.
-  - **Doctor** — "is it serving correctly?" — `health.sh` live + `verify` / `verify-full` reads, basic/full reports, and the power-cap sweep.
+  - **Doctor** — "is it serving correctly?" — six checks you can arrow through and run with `⏎` (or by hotkey): `health.sh` live, `verify` / `verify-full`, basic / full reports, and the power-cap sweep.
 - **`2` Bring & Validate** *(producer lane — hidden in lean view)*
   - The add-a-model pipeline: **① Bring** (fit-check an HF repo) → **② Serve** (generate a compose + serve untested) → … → **⑤ Promote**.
 
@@ -59,7 +59,8 @@ own location; override with **`C3_REPO_ROOT=/path/to/club-3090`** if you install
 |-----|--------|
 | `1` / `2` | Run & Operate · Bring & Validate |
 | `↑ ↓ ← →` | move within / between the tab bar and content |
-| `⏎` | primary action for the focused row (serve / start / download / confirm) |
+| `⏎` | primary action for the focused row (serve / start / download / confirm / run the selected Doctor check) |
+| `↑ ↓` on **Doctor** | pick one of the six checks; `⏎` runs it. The per-check hotkeys (`y` `v` `V` `R` `F` `w`) still jump straight to one. |
 | `k` | stop a service / cancel a download |
 | `f` | force-start (experimental — skips the fit gate) |
 | `f` | Containers — log follow: arm/pause the live log tail for the selected container (Containers tab only; inside the staged-write modal `f` = force-start, which shadows app keys) |

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -954,7 +954,7 @@ class HelpScreen(ModalScreen):
   ③ Gate:    [cyan]⏎[/cyan] launch validation step (gated)   [cyan]F[/cyan] full battery report.sh --full (~43-min · confirm · uses serving model)   [cyan]K[/cyan] boot-log KV back-solve vs kv-calc (read)
   ④ Measure: [cyan]⏎[/cyan] open report   [cyan]m[/cyan] vs catalog bar (read)   [cyan]s[/cyan] submit to localmaxxing (gated · never auto)
   ⑤ Promote:  [cyan]P[/cyan] scaffold the registry entry — slug + port are yours to edit; ⏎ writes the LOCAL layer (confirm-gated)
-  [cyan]v[/cyan] ▸ Evaluate via c3t [yellow](preview / mock this phase)[/yellow]
+  [cyan]v[/cyan] ▸ Evaluate via c3t [yellow](confirm-gated · RUNS against the serving model)[/yellow]
   [cyan]Ctrl+n[/cyan] New bring — clear ①/② state and start over
   Happy path: [cyan]2[/cyan] → paste repo → Inspect → Fit-check → [cyan]D[/cyan]? → [cyan]s[/cyan] → ⏎ Serve → ③ Gate → ④ Measure → [cyan]P[/cyan]
 """
@@ -4949,6 +4949,50 @@ class ValidateRunPane(Container):
         body.update("\n".join(lines))
 
 
+class DoctorScroll(ScrollableContainer):
+    """Doctor's scroll box, which is also its check LIST.
+
+    Arrows are handled in this widget's OWN ``on_key`` — the same scoping the
+    ModeSwitcher uses, and for the same reason: a focused widget sees key events
+    first, so ↑/↓ move the selection ONLY while Doctor's list holds focus and
+    reach the app's arrow model unchanged everywhere else.  Stopping the event
+    also suppresses ScrollableContainer's inherited ↑/↓ = scroll-a-line, which
+    this replaces: moving the selection scrolls it into view, so a line-scroll
+    that could strand the selection off-screen is not wanted.  PgUp/PgDn/Home/End
+    keep their inherited scrolling.
+
+    ⏎ is deliberately NOT handled here — it bubbles to the app's `primary_action`,
+    which dispatches per tab, so Doctor's ⏎ is declared the same way as Catalog's
+    and shows in the footer through the same path.
+    """
+
+    def on_key(self, event) -> None:
+        if event.key not in ("up", "down"):
+            return
+        pane = None
+        try:
+            pane = self.query_ancestor(DoctorPane)
+        except Exception:
+            return
+        if pane is None:
+            return
+        event.stop()
+        event.prevent_default()
+        # ↑ at the first check ascends to the tab bar, matching what a primary
+        # DataTable at cursor row 0 does (action_ascend_to_tabbar) — Doctor is not
+        # a DataTable, so that priority binding is gated off here and the same
+        # affordance has to be provided explicitly.
+        if event.key == "up" and pane.selected_index == 0:
+            try:
+                bar = self.app._active_tab_bar()   # type: ignore[attr-defined]
+            except Exception:
+                bar = None
+            if bar is not None:
+                bar.focus()
+            return
+        pane.move_selection(-1 if event.key == "up" else 1)
+
+
 class DoctorPane(Container):
     """Operate / Doctor tab: "is the running model serving correctly?".
 
@@ -4992,6 +5036,14 @@ class DoctorPane(Container):
         margin-bottom: 1;
         height: auto;
     }
+    /* The ↑/↓ selection. Doctor is a list of runnable checks, so the selected
+       one must be unmistakable — same accent-ring language as Button:focus. */
+    DoctorPane .doctor-card.-selected {
+        border: tall $accent;
+    }
+    DoctorPane .doctor-card.-selected .doctor-card-title {
+        text-style: bold reverse;
+    }
     DoctorPane .doctor-card-title {
         text-style: bold;
         color: $accent;
@@ -5002,6 +5054,58 @@ class DoctorPane(Container):
     }
     """
 
+    # ── Check selection (↑/↓ navigate · ⏎ runs) ──────────────────────────────
+    # Doctor is a list of six runnable checks. Before this it was reachable only
+    # by hotkey: the arrows scrolled and ⏎ did nothing, so a user who did not
+    # already know v/V/R/F/w/y could read the cards and not run any of them.
+    selected_index: int = 0
+
+    def on_mount(self) -> None:
+        self.paint_selection()
+
+    def move_selection(self, delta: int) -> None:
+        """Move the selection by ``delta``, CLAMPED (no wrap).
+
+        Clamped, not wrapping: the last two cards are `report --full` (~43 min,
+        uses the serving GPUs) and the power-cap sweep (mutates the GPU cap).
+        Wrapping past the end would land the cursor on those by holding ↓, which
+        is the wrong thing to make effortless.
+        """
+        target = max(0, min(self.selected_index + delta, len(_DOCTOR_CHECKS) - 1))
+        if target == self.selected_index:
+            return
+        self.selected_index = target
+        self.paint_selection()
+
+    def paint_selection(self) -> None:
+        """Apply the -selected class and scroll the selected card into view."""
+        for idx, (card_id, _action, _label) in enumerate(_DOCTOR_CHECKS):
+            try:
+                card = self.query_one(f"#{card_id}")
+            except Exception:
+                continue
+            card.set_class(idx == self.selected_index, "-selected")
+            if idx == self.selected_index:
+                try:
+                    card.scroll_visible(animate=False)
+                except Exception:
+                    pass
+        # The footer's ⏎ label names the SELECTED check, so it has to resync.
+        # Both halves are required and the pairing is the one the tab-activation
+        # handler uses: _sync_footer_labels mutates the binding description, and
+        # refresh_bindings fires the `bindings_changed` signal that lets the
+        # footer decide to recompose. Without the second call nothing re-renders
+        # and the label silently keeps the previous check's name.
+        try:
+            self.app._sync_footer_labels()   # type: ignore[attr-defined]
+            self.app.refresh_bindings()
+        except Exception:
+            pass
+
+    def selected_check(self) -> tuple[str, str, str]:
+        idx = max(0, min(self.selected_index, len(_DOCTOR_CHECKS) - 1))
+        return _DOCTOR_CHECKS[idx]
+
     def compose(self) -> ComposeResult:
         # #1153: a ScrollableContainer defaults to can_focus=True, so it sits in
         # the Tab chain as a DEAD STOP — one extra Tab before every real control.
@@ -5011,7 +5115,7 @@ class DoctorPane(Container):
         # has no table or list to Tab to — the scroll box IS the content, and
         # without focus ↓/PgDn do nothing on a page that overflows at 46 rows.
         # The lane panes keep can_focus=False because they have real controls.
-        with ScrollableContainer(id="doctor-scroll"):
+        with DoctorScroll(id="doctor-scroll"):
             yield Label(
                 "Doctor  [dim]— is the running model serving correctly?[/dim]",
                 id="doctor-heading",
@@ -5059,7 +5163,7 @@ class DoctorPane(Container):
                     "[dim]press [cyan]F[/cyan] — report.sh --full "
                     "([yellow]~43 min · uses the serving GPUs · confirm-gated[/yellow]): "
                     "streams into the ③ Gate; the artifact lands in results/ "
-                    "(viewable in Validate · Evidence)[/dim]",
+                    "(viewable in Bring & Validate · ④ Measure)[/dim]",
                     id="doctor-fullreport-body",
                 )
             with Container(classes="doctor-card", id="doctor-card-sweep"):
@@ -5074,9 +5178,11 @@ class DoctorPane(Container):
                     id="doctor-sweep-body",
                 )
             yield Label(
-                "[dim][cyan]y[/cyan] re-run health   ·   [cyan]v[/cyan] verify   ·   "
-                "[cyan]V[/cyan] verify-full   ·   [cyan]R[/cyan] report   ·   "
-                "[cyan]F[/cyan] report --full   ·   [cyan]w[/cyan] power-cap sweep[/dim]",
+                "[dim][cyan]↑↓[/cyan] pick a check   ·   [cyan]⏎[/cyan] run it   "
+                "[dim]— or jump straight to one:[/dim]   [cyan]y[/cyan] health   ·   "
+                "[cyan]v[/cyan] verify   ·   [cyan]V[/cyan] verify-full   ·   "
+                "[cyan]R[/cyan] report   ·   [cyan]F[/cyan] report --full   ·   "
+                "[cyan]w[/cyan] cap sweep[/dim]",
                 id="doctor-hint",
             )
 
@@ -5101,7 +5207,7 @@ class DoctorPane(Container):
             # here — a navigation pointer to the gated serve path.
             body.update(
                 "[red]✗[/red]  API not reachable\n"
-                "   [dim]→ fix: serve a model — Run · Catalog ([cyan]1[/cyan]), pick a "
+                "   [dim]→ fix: serve a model — Run & Operate · Catalog ([cyan]1[/cyan]), pick a "
                 "variant, [cyan]⏎[/cyan] (reconcile-gated)[/dim]"
             )
             return
@@ -5110,7 +5216,7 @@ class DoctorPane(Container):
         if not dr.serving:
             # Reachable endpoint but nothing served — point at the serve path.
             line += (
-                "\n   [dim]→ fix: serve a model — Run · Catalog ([cyan]1[/cyan]) "
+                "\n   [dim]→ fix: serve a model — Run & Operate · Catalog ([cyan]1[/cyan]) "
                 "[cyan]⏎[/cyan][/dim]"
             )
         body.update(line)
@@ -5132,7 +5238,7 @@ class DoctorPane(Container):
         if vs.error:
             body.update(
                 f"[red]✗[/red]  {vs.error}\n"
-                "   [dim]→ fix: serve a model — Run · Catalog ([cyan]1[/cyan]) "
+                "   [dim]→ fix: serve a model — Run & Operate · Catalog ([cyan]1[/cyan]) "
                 "[cyan]⏎[/cyan] (reconcile-gated)[/dim]"
             )
             return
@@ -5147,7 +5253,7 @@ class DoctorPane(Container):
                 lines.append(f"        [dim]→ {c.hint}[/dim]")
         if not vs.reachable:
             lines.append(
-                "   [dim]→ fix: serve a model — Run · Catalog ([cyan]1[/cyan]) "
+                "   [dim]→ fix: serve a model — Run & Operate · Catalog ([cyan]1[/cyan]) "
                 "[cyan]⏎[/cyan][/dim]"
             )
         body.update("\n".join(lines))
@@ -8554,8 +8660,13 @@ class FocusableFooter(Footer):
             active = self.screen.active_bindings
         except Exception:
             return ()
+        # `description` is part of the signature: the footer RENDERS it, so a
+        # recompose-suppression that ignored it made every `_relabel_binding`
+        # invisible whenever the visible key set was unchanged (③ Gate kept
+        # showing "⏎ Serve" from ② Serve indefinitely, and Doctor's ⏎ label could
+        # not follow the ↑/↓ selection at all).
         return tuple(
-            (binding.key, binding.action, enabled)
+            (binding.key, binding.action, enabled, binding.description)
             for (_node, binding, enabled, _tooltip) in active.values()
             if binding.show
         )
@@ -8634,7 +8745,7 @@ _PALETTE_COMMANDS: tuple[tuple[str, str, str], ...] = (
     # Producer lane (Bring & Validate) — filtered out on the lean surface.
     ("serve_untested", "Serve untested (② Serve)", "Producer lane — generate a compose + serve it untested"),
     ("measure_vs_bar", "Compare vs catalog bar (④ Measure)", "Producer lane — read · flags protocol"),
-    ("evaluate_target", "Evaluate running target (preview)", "Producer lane — c3t evaluate (mock this phase)"),
+    ("evaluate_target", "Evaluate running target", "Producer lane — c3t evaluate (confirm-gated · runs against the serving model)"),
     ("promote_catalog", "Promote this model (⑤)", "Producer lane — scaffold the registry entry; the write is confirm-gated"),
     ("search_hf", "Search Hugging Face repos (① Bring)", "Producer lane — search HF and fill the repo field (\\[f])"),
 )
@@ -8665,6 +8776,21 @@ _TAB_PRIMARY_LIST: dict[str, str] = {
 # DATATABLES and is shared with the ↓ descend / ↑ ascend gates, which need a list.
 # Doctor's scroll container is focused on tab activation instead (see
 # on_tabbed_content_tab_activated) so ↓/PgDn work on its overflowing page.
+# Operate · Doctor — the six check cards, in the order `compose` yields them.
+# ONE source of truth for three things that must never drift apart: the ↑/↓
+# navigation order, the ⏎ dispatch target, and the footer label.  A card added to
+# `DoctorPane.compose` without a row here is unreachable by keyboard; a row here
+# without a card raises on selection.  `test_doctor_registry_matches_compose_order`
+# asserts both directions against the rendered DOM.
+_DOCTOR_CHECKS: tuple[tuple[str, str, str], ...] = (
+    ("doctor-card-health",     "doctor_rerun",      "Re-run health"),
+    ("doctor-card-verify",     "doctor_verify",     "Verify serving"),
+    ("doctor-card-verifyfull", "doctor_verify_full", "Verify-full"),
+    ("doctor-card-report",     "rig_report",        "Rig report"),
+    ("doctor-card-fullreport", "full_report",       "Full report"),
+    ("doctor-card-sweep",      "power_cap_sweep",   "Cap sweep"),
+)
+
 _TAB_FOCUS_FALLBACK: dict[str, str] = {
     "tab-doctor": "#doctor-scroll",
 }
@@ -8828,10 +8954,10 @@ class CockpitApp(App):
         # Operate · Containers / Validate — context-sensitive read keys.
         Binding("t", "context_t", "Top / Sort", show=False),
         # Phase 5 — the three v2 hooks:
-        #   [v] Evaluate via c3t (mock this phase — label says so)
+        #   [v] Evaluate via c3t (confirm-gated; the launch is REAL)
         #   [P] Promotion scaffold preview (no live catalog write this phase)
         #   [O] Optimize for my card (kv-calc brain; apply = gated stage)
-        Binding("v", "evaluate_target", "Evaluate (preview)", show=False),
+        Binding("v", "evaluate_target", "Evaluate via c3t", show=False),
         Binding("P", "promote_catalog", "Scaffold preview", show=False),
         # R3b-1 — producer lane ② Serve: generate a compose + serve it untested
         # (also reachable via ⏎ on the ② Serve stage).
@@ -9206,7 +9332,7 @@ class CockpitApp(App):
                 bar = self._active_tab_bar()
                 if bar is None or focused is not bar:
                     return False
-                return self._primary_list_for_active_tab() is not None
+                return self._descend_target_for_active_tab() is not None
             # ascend_to_tabbar: [up] ascends in EXACTLY ONE case (priority binding):
             #   focus is the active tab's PRIMARY DataTable at cursor row 0 →
             #   ascend to the tab bar (above row 0 / off a primary list → the
@@ -9338,7 +9464,12 @@ class CockpitApp(App):
     # Doctor / Containers (mode 0) have NO ⏎ primary, so ⏎ is hidden there.
     def _primary_action_enabled(self) -> bool:
         if self._active_mode == 0:
-            return self._current_subtab() in ("tab-catalog", "tab-orchestration")
+            # tab-doctor joined this set when Doctor's cards became ↑/↓ selectable
+            # and ⏎-runnable. It was excluded while Doctor was read-only — and the
+            # Modes rail said "⏎ Select" there anyway, which was simply untrue.
+            return self._current_subtab() in (
+                "tab-catalog", "tab-orchestration", "tab-doctor",
+            )
         if self._active_mode == 1:
             return True
         return False
@@ -9371,6 +9502,16 @@ class CockpitApp(App):
                 enter_label = "Serve"
             elif tab == "tab-orchestration":
                 enter_label = "Switch scene"
+            elif tab == "tab-doctor":
+                # Name the SELECTED check, so ⏎ says what it will actually run
+                # rather than a generic verb — the whole point of a list you
+                # arrow through is that the commit key tracks the cursor.
+                try:
+                    enter_label = self.query_one(
+                        "#doctor-pane", DoctorPane
+                    ).selected_check()[2]
+                except Exception:
+                    enter_label = "Run check"
         elif self._active_mode == 1:
             tab = self._active_validate_tab()
             enter_label = {
@@ -12344,15 +12485,36 @@ class CockpitApp(App):
         except Exception:
             return None
 
+    def _descend_target_for_active_tab(self):
+        """What [down] on the tab bar descends INTO for the active tab.
+
+        The primary DataTable when the tab has one, else the tab's
+        _TAB_FOCUS_FALLBACK widget — Doctor has no table, but its scroll box IS
+        its check list, so [down] must reach it or the list is keyboard-reachable
+        only by Tab.  Kept separate from `_primary_list_for_active_tab`, which is
+        typed to DataTable and shared with the ↑-ascend gate.
+        """
+        table = self._primary_list_for_active_tab()
+        if table is not None:
+            return table
+        tab_id = self._current_subtab() or ""
+        selector = _TAB_FOCUS_FALLBACK.get(tab_id, "")
+        if not selector:
+            return None
+        try:
+            return self.query_one(selector)
+        except Exception:
+            return None
+
     def action_descend_to_content(self) -> None:
         """[down] on the tab bar → move focus INTO the active tab's primary list.
 
         Does NOT reset the list's cursor — the preserved row stays selected.  A
         no-op when there is no primary list (check_action also gates this away)."""
-        table = self._primary_list_for_active_tab()
-        if table is not None:
+        target = self._descend_target_for_active_tab()
+        if target is not None:
             try:
-                table.focus()
+                target.focus()
             except Exception:
                 pass
 
@@ -12429,8 +12591,35 @@ class CockpitApp(App):
                 self._run_primary()
             elif tab == "tab-orchestration":
                 self._operate_primary()
+            elif tab == "tab-doctor":
+                self._doctor_primary()
         elif self._active_mode == 1:
             self._validate_primary()
+
+    def _doctor_primary(self) -> None:
+        """⏎ on Operate · Doctor — run the SELECTED check.
+
+        Dispatches to the very same action the check's hotkey fires, so the
+        confirm gates come along for free: `full_report` and `power_cap_sweep`
+        are confirm-gated at their action, and pressing ⏎ on those cards gets the
+        same dialog `F`/`w` would.  Nothing is special-cased here — a check that
+        gains a gate later gains it on both paths at once.
+        """
+        try:
+            _card_id, action, _label = self.query_one(
+                "#doctor-pane", DoctorPane
+            ).selected_check()
+        except Exception:
+            return
+        # check_action gates the hotkeys (e.g. producer-only verbs); honour the
+        # same verdict for ⏎ so the two paths can never disagree about whether a
+        # check is currently allowed.
+        if self.check_action(action, ()) is False:
+            return
+        handler = getattr(self, f"action_{action}", None)
+        if handler is None:
+            return
+        handler()
 
     def _validate_primary(self) -> None:
         """⏎ in the Bring & Validate lane — context-specific per stage (R3b-1):
@@ -13767,11 +13956,13 @@ class CockpitApp(App):
         hook lives here); the live target is captured by the Operate estate poll
         and remains available via ``_target_obj``.
 
-        Confirm-gated, MOCK-ONLY launch — c3t runs the post-boot evaluator
-        against the live serving model (heavy).  The hand-off carries the SAME
-        ``ServingTarget`` object the Estate poll detected (design §4/§6.6); the
-        launch streams via ``launch_evaluate`` (write runner, NEVER live this
-        phase — conftest blocks the spawn, tests fake it)."""
+        Confirm-gated and REAL: the commit spawns ``scripts/c3t`` through the
+        production write runner and evaluates the live serving model (heavy).
+        This used to be labelled "mock this phase" in four places; the only thing
+        that made it a mock was ``conftest`` blocking the spawn in TESTS, which
+        does nothing in a real run.  The hand-off carries the SAME
+        ``ServingTarget`` object the Estate poll detected (design §4/§6.6) and
+        streams via ``launch_evaluate``."""
         if self._active_mode != 1:
             return
         handoff = self._data.evaluate_handoff(self._target_obj)
@@ -13793,18 +13984,19 @@ class CockpitApp(App):
 
     @work(exclusive=True, group="evaluate")
     async def launch_c3t_evaluate(self) -> None:
-        """Launch c3t scoped to the SHARED ServingTarget, streamed (MOCK-ONLY).
+        """Launch c3t scoped to the SHARED ServingTarget, streamed.
 
-        ⚠️  WIRED-BUT-MOCK-ONLY.  c3t runs tests against the live serving model;
-        the write runner is NEVER executed live this phase (conftest blocks the
-        spawn; tests inject a FakeWriteRunner).  The SAME ``ServingTarget`` the
-        Estate poll captured is passed by identity so c3t evaluates exactly what
-        is running."""
+        ⚠️  THIS RUNS FOR REAL — c3t runs tests against the live serving model
+        through the production write runner.  The former "NEVER executed live
+        this phase (conftest blocks the spawn)" note described the TEST
+        environment only; conftest does not run in a real session.  The SAME
+        ``ServingTarget`` the Estate poll captured is passed by identity so c3t
+        evaluates exactly what is running."""
         live = self._serve_live_pane()
         if live is not None:
             tgt = self._target_obj
             label = getattr(tgt, "model", "") or getattr(tgt, "url", "") or "target"
-            live.append_line(f"[green]▶ c3t evaluate[/green] {label} (mock-only this phase)")
+            live.append_line(f"[green]▶ c3t evaluate[/green] {label}")
 
         def _on_line(text: str) -> None:
             if live is not None:

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -4933,11 +4933,14 @@ class CockpitData:
         on_event: Optional[Callable[[Any], None]] = None,
         on_line: Optional[Callable[[str], None]] = None,
     ) -> Any:
-        """Launch c3t scoped to the SHARED ServingTarget, streamed (MOCK-ONLY).
+        """Launch c3t scoped to the SHARED ServingTarget, streamed.
 
-        ⚠️  WIRED-BUT-MOCK-ONLY.  c3t runs the post-boot evaluator against the
-        live serving model — heavy.  The write runner is NEVER executed live this
-        phase; conftest blocks the real spawn and tests inject a FakeWriteRunner.
+        ⚠️  THIS RUNS FOR REAL.  c3t is spawned through ``self._write_runner`` —
+        the production runner in a real session — and evaluates the live serving
+        model (heavy).  The previous "WIRED-BUT-MOCK-ONLY / never executed live"
+        note described only the TEST environment: conftest blocks the spawn and
+        tests inject a FakeWriteRunner, neither of which applies in production.
+        Callers must keep this behind the confirm gate.
 
         Scopes c3t to ``target`` by passing the endpoint/model/container through
         the child env (``C3T_REPO_ROOT`` + ``C3T_TARGET_*``) so the test-console

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -9589,7 +9589,7 @@ class TestDoctorRerunAndRemediation:
             pane._render_health(DoctorRead(reachable=False))
             body = str(app.query_one("#doctor-health-body", Static).render())
             assert "not reachable" in body
-            assert "fix:" in body and "Run · Catalog" in body
+            assert "fix:" in body and "Run & Operate · Catalog" in body
 
 
 class TestA9GateLadderOutcome:
@@ -10132,16 +10132,23 @@ class TestArrowKeyFocusDescent:
     # ── No-op surfaces — Doctor (no primary list) ────────────────────────────────
 
     @pytest.mark.asyncio
-    async def test_doctor_tab_bar_down_is_a_noop(self):
-        """Doctor has no primary list → descend is a no-op (focus stays on the bar)."""
+    async def test_doctor_tab_bar_down_descends_into_the_check_list(self):
+        """[down] on Doctor's tab bar descends into its check list.
+
+        Was `test_doctor_tab_bar_down_is_a_noop`: Doctor had no primary DataTable,
+        so descend was gated off and focus stayed on the bar. Doctor's cards are
+        now ↑/↓-selectable and ⏎-runnable, so it has a list to descend INTO — it
+        resolves through _TAB_FOCUS_FALLBACK rather than _TAB_PRIMARY_LIST, which
+        stays DataTable-only for the ↑-ascend gate."""
         app, _, _ = make_app()
         async with app.run_test(size=(120, 40)) as pilot:
             await _settle(pilot)
             await self._focus_tab_bar(pilot, "#operate-tabs", "tab-doctor")
             await pilot.press("down")
             await pilot.pause()
-            assert isinstance(app.focused, Tabs), \
-                f"down on Doctor's tab bar (no list) must stay on the bar, got {app.focused!r}"
+            await _settle(pilot)
+            assert app.focused is not None and app.focused.id == "doctor-scroll", \
+                f"down on Doctor's tab bar must reach its check list, got {app.focused!r}"
 
     # ── Modal invariant — arrows never steal focus to/from the tab bar ───────────
 
@@ -10250,6 +10257,159 @@ class TestArrowKeyFocusDescent:
             await _settle(pilot)   # the focus call is deferred one refresh cycle
             focused = app.focused
             assert focused is not None and focused.id == "doctor-scroll"
+
+
+class TestDoctorKeyboardNav:
+    """Doctor is a LIST of runnable checks: ↑/↓ select, ⏎ runs the selection.
+
+    Before this, Doctor was reachable only by hotkey — arrows scrolled and ⏎ did
+    nothing — so a user who did not already know v/V/R/F/w/y could read all six
+    cards and run none of them."""
+
+    @pytest.mark.asyncio
+    async def test_registry_matches_compose_order_both_ways(self):
+        """_DOCTOR_CHECKS must mirror the rendered card order exactly.
+
+        The registry drives navigation order, ⏎ dispatch AND the footer label, so
+        drift against `compose` would silently run the wrong check. Asserted in
+        both directions: no rendered card missing from the registry, no registry
+        row without a card, same sequence."""
+        from club3090_cockpit.app import _DOCTOR_CHECKS, DoctorPane
+
+        app, _, _ = make_app()
+        async with app.run_test(size=(120, 44)) as pilot:
+            await _settle(pilot)
+            pane = app.query_one("#doctor-pane", DoctorPane)
+            rendered = [c.id for c in pane.query(".doctor-card")]
+            assert rendered == [row[0] for row in _DOCTOR_CHECKS]
+            # every action names a real handler on the app
+            for _cid, action, label in _DOCTOR_CHECKS:
+                assert hasattr(app, f"action_{action}"), action
+                assert label
+
+    async def _enter_doctor(self, app, pilot):
+        app.query_one("#catalog-table").focus()
+        await _settle(pilot)
+        app.query_one("#operate-tabs", TabbedContent).active = "tab-doctor"
+        await _settle(pilot)
+        await _settle(pilot)   # the focus call is deferred one refresh cycle
+
+    @pytest.mark.asyncio
+    async def test_arrows_move_the_selection_and_enter_runs_it(self):
+        from club3090_cockpit.app import _DOCTOR_CHECKS, DoctorPane
+
+        fired = []
+        app, _, _ = make_app(surface="producer")
+        for _cid, action, _lbl in _DOCTOR_CHECKS:
+            setattr(app, f"action_{action}", (lambda a=action: fired.append(a)))
+        async with app.run_test(size=(120, 44)) as pilot:
+            await _settle(pilot)
+            await self._enter_doctor(app, pilot)
+            assert app.focused is not None and app.focused.id == "doctor-scroll"
+            pane = app.query_one("#doctor-pane", DoctorPane)
+            assert pane.selected_index == 0
+            await pilot.press("down")
+            await _settle(pilot)
+            assert pane.selected_index == 1
+            # ⏎ runs the SELECTED check, not a fixed one.
+            await pilot.press("enter")
+            await _settle(pilot)
+            assert fired == [_DOCTOR_CHECKS[1][1]]
+
+    @pytest.mark.asyncio
+    async def test_selection_is_clamped_not_wrapped(self):
+        """Holding ↓ must not land on `report --full` (~43 min, uses the serving
+        GPUs) or the power-cap sweep by wrapping around from the top."""
+        from club3090_cockpit.app import _DOCTOR_CHECKS, DoctorPane
+
+        app, _, _ = make_app(surface="producer")
+        async with app.run_test(size=(120, 44)) as pilot:
+            await _settle(pilot)
+            await self._enter_doctor(app, pilot)
+            pane = app.query_one("#doctor-pane", DoctorPane)
+            for _ in range(len(_DOCTOR_CHECKS) + 4):
+                await pilot.press("down")
+            await _settle(pilot)
+            assert pane.selected_index == len(_DOCTOR_CHECKS) - 1
+            await pilot.press("down")
+            await _settle(pilot)
+            assert pane.selected_index == len(_DOCTOR_CHECKS) - 1
+
+    @pytest.mark.asyncio
+    async def test_up_at_first_check_ascends_to_the_tab_bar(self):
+        """Mirrors what a primary DataTable at cursor row 0 does. Doctor is not a
+        DataTable, so the priority ascend binding is gated off and this widget has
+        to offer the affordance itself."""
+        from club3090_cockpit.app import DoctorPane
+
+        app, _, _ = make_app(surface="producer")
+        async with app.run_test(size=(120, 44)) as pilot:
+            await _settle(pilot)
+            await self._enter_doctor(app, pilot)
+            assert app.query_one("#doctor-pane", DoctorPane).selected_index == 0
+            await pilot.press("up")
+            await _settle(pilot)
+            assert isinstance(app.focused, Tabs)
+
+    @pytest.mark.asyncio
+    async def test_down_from_the_tab_bar_descends_into_the_list(self):
+        """[down] on the tab bar reaches Doctor's list. It resolves through
+        _TAB_FOCUS_FALLBACK because Doctor has no primary DataTable."""
+        app, _, _ = make_app(surface="producer")
+        async with app.run_test(size=(120, 44)) as pilot:
+            await _settle(pilot)
+            tc = app.query_one("#operate-tabs", TabbedContent)
+            tc.active = "tab-doctor"
+            await _settle(pilot)
+            bar = app._active_tab_bar()
+            assert bar is not None
+            bar.focus()
+            await _settle(pilot)
+            await pilot.press("down")
+            await _settle(pilot)
+            await _settle(pilot)
+            assert app.focused is not None and app.focused.id == "doctor-scroll"
+
+    @pytest.mark.asyncio
+    async def test_footer_enter_label_follows_the_selection(self):
+        """The ⏎ label names the selected check — which only repaints because the
+        footer's recompose signature now includes `description`."""
+        from club3090_cockpit.app import _DOCTOR_CHECKS
+
+        app, _, _ = make_app(surface="producer")
+        async with app.run_test(size=(120, 44)) as pilot:
+            await _settle(pilot)
+            await self._enter_doctor(app, pilot)
+
+            # Read the RENDERED footer, not the binding objects: _relabel_binding
+            # mutates those either way, so asserting on them passes even with the
+            # recompose fix reverted (confirmed by negative control). The claim is
+            # about what the user SEES, so query the FooterKey widgets.
+            ff = app.query_one(FocusableFooter)
+
+            def enter_label():
+                for k in ff.query(FooterKey):
+                    if k.key == "enter":
+                        return k.description
+                return ""
+
+            assert enter_label() == _DOCTOR_CHECKS[0][2]
+            await pilot.press("down")
+            await _settle(pilot)
+            assert enter_label() == _DOCTOR_CHECKS[1][2]
+
+    @pytest.mark.asyncio
+    async def test_hotkeys_still_work_alongside_the_list(self):
+        """The list is ADDITIVE — the documented hotkeys keep firing."""
+        app, _, _ = make_app(surface="producer")
+        fired = []
+        app.action_doctor_verify_full = lambda: fired.append("V")  # type: ignore
+        async with app.run_test(size=(120, 44)) as pilot:
+            await _settle(pilot)
+            await self._enter_doctor(app, pilot)
+            await pilot.press("V")      # verify-full's hotkey, selection on card 0
+            await _settle(pilot)
+            assert fired == ["V"]
 
 
 class TestSubtabCycleScopedToDirectPanes:
@@ -11377,16 +11537,25 @@ class TestTier1PrimaryActionAndSKeyHonesty:
             assert app.check_action("primary_action", ()) is True
 
     @pytest.mark.asyncio
-    async def test_enter_not_advertised_on_doctor(self):
-        """⏎ no-ops on Doctor → check_action falsey so the footer never shows
-        the misleading 'Enter Select' there."""
+    async def test_enter_on_doctor_is_advertised_and_names_the_check(self):
+        """⏎ on Doctor runs the SELECTED check, so it is advertised — and labelled.
+
+        Was `test_enter_not_advertised_on_doctor`, which was right for a read-only
+        Doctor: ⏎ did nothing, so advertising it would have been the misleading
+        "Enter Select" the Modes rail was showing. Doctor's cards are now a
+        keyboard-navigable list whose ⏎ dispatches the selected check, so the
+        honest state is the opposite — the key IS shown, and its label names the
+        check rather than a generic verb."""
+        from club3090_cockpit.app import _DOCTOR_CHECKS
+
         app, _, _ = make_app()
         async with app.run_test(size=(120, 40)) as pilot:
             await _enter_operate(pilot, tab="tab-doctor")
-            assert app.check_action("primary_action", ()) is False
-            # And the footer genuinely omits the enter key on Doctor.
+            assert app.check_action("primary_action", ()) is True
             footer_keys = {k.key for k in app.query(FooterKey)}
-            assert "enter" not in footer_keys
+            assert "enter" in footer_keys
+            labels = {k.description for k in app.query(FooterKey) if k.key == "enter"}
+            assert labels == {_DOCTOR_CHECKS[0][2]}
 
     @pytest.mark.asyncio
     async def test_enter_not_advertised_on_containers(self):


### PR DESCRIPTION
Doctor renders six runnable checks but was reachable **only by hotkey**: the arrows scrolled the box and `⏎` did nothing. A user who didn't already know `y`/`v`/`V`/`R`/`F`/`w` could read all six cards and run none of them.

Now `↑`/`↓` move a selection and `⏎` runs it.

## The details that matter

- **`⏎` dispatches the same action the hotkey fires**, so the confirm gates come along for free — `⏎` on `report --full` or the cap sweep gets the same dialog `F`/`w` would, and a check that gains a gate later gains it on both paths at once. `check_action` is consulted first, so the two paths can't disagree about whether a check is allowed.
- **Selection is clamped, not wrapping.** The last two cards are `report --full` (~43 min, uses the serving GPUs) and the power-cap sweep (mutates the GPU cap). Wrapping from the top would land the cursor on those by holding `↓`, which is the wrong thing to make effortless.
- `↑` at the first check ascends to the tab bar, mirroring what a primary `DataTable` at cursor row 0 does. `↓` on the tab bar now descends *into* the list, resolved through `_TAB_FOCUS_FALLBACK` — `_TAB_PRIMARY_LIST` stays DataTable-only because the `↑`-ascend gate requires that type.
- `_DOCTOR_CHECKS` is one source of truth for nav order, `⏎` dispatch and the footer label, drift-guarded against the rendered DOM in both directions.
- The footer's `⏎` label names the selected check, so it says what it will run.
- **Hotkeys are untouched.**

## Two bugs this exposed — both prerequisites

The footer's recompose-suppression signature was `(key, action, enabled)`. It excluded the **description the footer renders**, so every `_relabel_binding` was invisible whenever the visible key set was unchanged. Independently of Doctor, that means **③ Gate kept showing "⏎ Serve" carried over from ② Serve, indefinitely**.

And `_relabel_binding` alone doesn't repaint — it has to be paired with `refresh_bindings()` to fire the `bindings_changed` signal, the way the tab-activation handler already does.

## Also from the review pass

**`[v]` Evaluate was labelled "preview" / "mock this phase" in four places and ran for real.** `launch_evaluate` spawns `scripts/c3t` through the production write runner against the live serving model. The only thing making it a mock was `conftest` blocking the spawn in *tests*, which does nothing in a real session. It also wrote `(mock-only this phase)` into the live pane while c3t was genuinely running. The copy now says what it does.

Stale user-facing tab names: `Validate · Evidence` → `Bring & Validate · ④ Measure`, and 4× `Run · Catalog` → `Run & Operate · Catalog`.

## Verification

`1051 passed, 1 skipped, 0 failed`.

Three tests asserted the read-only Doctor contract and were rebased onto the new one rather than deleted (a fourth was pinning a stale tab name). Both new guards were negative-controlled.

Worth noting one of those controls caught a bad test of mine: the first footer-label test **passed with the fix reverted**, because it read the binding objects — which `_relabel_binding` mutates either way — instead of the rendered `FooterKey` widgets. It now asserts what the user sees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
