### PR TITLE
feat(c3): view the compose behind a slug — [c] opens it, read-only

### DIFF
--- a/tools/serve-cockpit/README.md
+++ b/tools/serve-cockpit/README.md
@@ -67,6 +67,7 @@ own location; override with **`C3_REPO_ROOT=/path/to/club-3090`** if you install
 | `r` | refresh the catalog (re-reads the registry) |
 | `S` | settings — set Model Dir + HF token (`Ctrl+S` saves) |
 | `N` | new pod — Operate · Orchestration: compose a model + GPU set (fit-checked, gated) |
+| `c` | **view the compose** behind the focused row — Catalog (what the slug will run), Containers, or a lane stage. Read-only; shows the profile header, the file's actual image/port/ctx/KV, and the raw YAML. *(On Orchestration `c` is power-cap.)* |
 | `Y` | copy the focused context to the clipboard |
 | `.` | toggle the left rail (full-width content) |
 | `C` | toggle lean view (hide / restore the Bring & Validate mode) |

--- a/tools/serve-cockpit/README.md
+++ b/tools/serve-cockpit/README.md
@@ -16,7 +16,7 @@ Two modes, shown as a tab bar; the producer mode is hidden in the lean view.
   - **Catalog** — the full registry of model variants; filter, inspect, and **serve** one (`⏎`).
   - **Orchestration** — live GPU cards, the `gpu-mode` scenes (incl. `ai-studio`), and supporting services; switch scene / stop.
   - **Containers** — running/stopped services with engine + port; drill into **Logs / Top / Config**, start a stopped one.
-  - **Doctor** — "is it serving correctly?" — `health.sh` live + `verify` / `verify-full` reads, basic/full reports, and the power-cap sweep.
+  - **Doctor** — "is it serving correctly?" — six checks you can arrow through and run with `⏎` (or by hotkey): `health.sh` live, `verify` / `verify-full`, basic / full reports, and the power-cap sweep.
 - **`2` Bring & Validate** *(producer lane — hidden in lean view)*
   - The add-a-model pipeline: **① Bring** (fit-check an HF repo) → **② Serve** (generate a compose + serve untested) → … → **⑤ Promote**.
 
@@ -59,7 +59,8 @@ own location; override with **`C3_REPO_ROOT=/path/to/club-3090`** if you install
 |-----|--------|
 | `1` / `2` | Run & Operate · Bring & Validate |
 | `↑ ↓ ← →` | move within / between the tab bar and content |
-| `⏎` | primary action for the focused row (serve / start / download / confirm) |
+| `⏎` | primary action for the focused row (serve / start / download / confirm / run the selected Doctor check) |
+| `↑ ↓` on **Doctor** | pick one of the six checks; `⏎` runs it. The per-check hotkeys (`y` `v` `V` `R` `F` `w`) still jump straight to one. |
 | `k` | stop a service / cancel a download |
 | `f` | force-start (experimental — skips the fit gate) |
 | `f` | Containers — log follow: arm/pause the live log tail for the selected container (Containers tab only; inside the staged-write modal `f` = force-start, which shadows app keys) |

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -954,7 +954,7 @@ class HelpScreen(ModalScreen):
   ③ Gate:    [cyan]⏎[/cyan] launch validation step (gated)   [cyan]F[/cyan] full battery report.sh --full (~43-min · confirm · uses serving model)   [cyan]K[/cyan] boot-log KV back-solve vs kv-calc (read)
   ④ Measure: [cyan]⏎[/cyan] open report   [cyan]m[/cyan] vs catalog bar (read)   [cyan]s[/cyan] submit to localmaxxing (gated · never auto)
   ⑤ Promote:  [cyan]P[/cyan] scaffold the registry entry — slug + port are yours to edit; ⏎ writes the LOCAL layer (confirm-gated)
-  [cyan]v[/cyan] ▸ Evaluate via c3t [yellow](preview / mock this phase)[/yellow]
+  [cyan]v[/cyan] ▸ Evaluate via c3t [yellow](confirm-gated · RUNS against the serving model)[/yellow]
   [cyan]Ctrl+n[/cyan] New bring — clear ①/② state and start over
   Happy path: [cyan]2[/cyan] → paste repo → Inspect → Fit-check → [cyan]D[/cyan]? → [cyan]s[/cyan] → ⏎ Serve → ③ Gate → ④ Measure → [cyan]P[/cyan]
 """
@@ -4949,6 +4949,50 @@ class ValidateRunPane(Container):
         body.update("\n".join(lines))
 
 
+class DoctorScroll(ScrollableContainer):
+    """Doctor's scroll box, which is also its check LIST.
+
+    Arrows are handled in this widget's OWN ``on_key`` — the same scoping the
+    ModeSwitcher uses, and for the same reason: a focused widget sees key events
+    first, so ↑/↓ move the selection ONLY while Doctor's list holds focus and
+    reach the app's arrow model unchanged everywhere else.  Stopping the event
+    also suppresses ScrollableContainer's inherited ↑/↓ = scroll-a-line, which
+    this replaces: moving the selection scrolls it into view, so a line-scroll
+    that could strand the selection off-screen is not wanted.  PgUp/PgDn/Home/End
+    keep their inherited scrolling.
+
+    ⏎ is deliberately NOT handled here — it bubbles to the app's `primary_action`,
+    which dispatches per tab, so Doctor's ⏎ is declared the same way as Catalog's
+    and shows in the footer through the same path.
+    """
+
+    def on_key(self, event) -> None:
+        if event.key not in ("up", "down"):
+            return
+        pane = None
+        try:
+            pane = self.query_ancestor(DoctorPane)
+        except Exception:
+            return
+        if pane is None:
+            return
+        event.stop()
+        event.prevent_default()
+        # ↑ at the first check ascends to the tab bar, matching what a primary
+        # DataTable at cursor row 0 does (action_ascend_to_tabbar) — Doctor is not
+        # a DataTable, so that priority binding is gated off here and the same
+        # affordance has to be provided explicitly.
+        if event.key == "up" and pane.selected_index == 0:
+            try:
+                bar = self.app._active_tab_bar()   # type: ignore[attr-defined]
+            except Exception:
+                bar = None
+            if bar is not None:
+                bar.focus()
+            return
+        pane.move_selection(-1 if event.key == "up" else 1)
+
+
 class DoctorPane(Container):
     """Operate / Doctor tab: "is the running model serving correctly?".
 
@@ -4992,6 +5036,14 @@ class DoctorPane(Container):
         margin-bottom: 1;
         height: auto;
     }
+    /* The ↑/↓ selection. Doctor is a list of runnable checks, so the selected
+       one must be unmistakable — same accent-ring language as Button:focus. */
+    DoctorPane .doctor-card.-selected {
+        border: tall $accent;
+    }
+    DoctorPane .doctor-card.-selected .doctor-card-title {
+        text-style: bold reverse;
+    }
     DoctorPane .doctor-card-title {
         text-style: bold;
         color: $accent;
@@ -5002,6 +5054,58 @@ class DoctorPane(Container):
     }
     """
 
+    # ── Check selection (↑/↓ navigate · ⏎ runs) ──────────────────────────────
+    # Doctor is a list of six runnable checks. Before this it was reachable only
+    # by hotkey: the arrows scrolled and ⏎ did nothing, so a user who did not
+    # already know v/V/R/F/w/y could read the cards and not run any of them.
+    selected_index: int = 0
+
+    def on_mount(self) -> None:
+        self.paint_selection()
+
+    def move_selection(self, delta: int) -> None:
+        """Move the selection by ``delta``, CLAMPED (no wrap).
+
+        Clamped, not wrapping: the last two cards are `report --full` (~43 min,
+        uses the serving GPUs) and the power-cap sweep (mutates the GPU cap).
+        Wrapping past the end would land the cursor on those by holding ↓, which
+        is the wrong thing to make effortless.
+        """
+        target = max(0, min(self.selected_index + delta, len(_DOCTOR_CHECKS) - 1))
+        if target == self.selected_index:
+            return
+        self.selected_index = target
+        self.paint_selection()
+
+    def paint_selection(self) -> None:
+        """Apply the -selected class and scroll the selected card into view."""
+        for idx, (card_id, _action, _label) in enumerate(_DOCTOR_CHECKS):
+            try:
+                card = self.query_one(f"#{card_id}")
+            except Exception:
+                continue
+            card.set_class(idx == self.selected_index, "-selected")
+            if idx == self.selected_index:
+                try:
+                    card.scroll_visible(animate=False)
+                except Exception:
+                    pass
+        # The footer's ⏎ label names the SELECTED check, so it has to resync.
+        # Both halves are required and the pairing is the one the tab-activation
+        # handler uses: _sync_footer_labels mutates the binding description, and
+        # refresh_bindings fires the `bindings_changed` signal that lets the
+        # footer decide to recompose. Without the second call nothing re-renders
+        # and the label silently keeps the previous check's name.
+        try:
+            self.app._sync_footer_labels()   # type: ignore[attr-defined]
+            self.app.refresh_bindings()
+        except Exception:
+            pass
+
+    def selected_check(self) -> tuple[str, str, str]:
+        idx = max(0, min(self.selected_index, len(_DOCTOR_CHECKS) - 1))
+        return _DOCTOR_CHECKS[idx]
+
     def compose(self) -> ComposeResult:
         # #1153: a ScrollableContainer defaults to can_focus=True, so it sits in
         # the Tab chain as a DEAD STOP — one extra Tab before every real control.
@@ -5011,7 +5115,7 @@ class DoctorPane(Container):
         # has no table or list to Tab to — the scroll box IS the content, and
         # without focus ↓/PgDn do nothing on a page that overflows at 46 rows.
         # The lane panes keep can_focus=False because they have real controls.
-        with ScrollableContainer(id="doctor-scroll"):
+        with DoctorScroll(id="doctor-scroll"):
             yield Label(
                 "Doctor  [dim]— is the running model serving correctly?[/dim]",
                 id="doctor-heading",
@@ -5059,7 +5163,7 @@ class DoctorPane(Container):
                     "[dim]press [cyan]F[/cyan] — report.sh --full "
                     "([yellow]~43 min · uses the serving GPUs · confirm-gated[/yellow]): "
                     "streams into the ③ Gate; the artifact lands in results/ "
-                    "(viewable in Validate · Evidence)[/dim]",
+                    "(viewable in Bring & Validate · ④ Measure)[/dim]",
                     id="doctor-fullreport-body",
                 )
             with Container(classes="doctor-card", id="doctor-card-sweep"):
@@ -5074,9 +5178,11 @@ class DoctorPane(Container):
                     id="doctor-sweep-body",
                 )
             yield Label(
-                "[dim][cyan]y[/cyan] re-run health   ·   [cyan]v[/cyan] verify   ·   "
-                "[cyan]V[/cyan] verify-full   ·   [cyan]R[/cyan] report   ·   "
-                "[cyan]F[/cyan] report --full   ·   [cyan]w[/cyan] power-cap sweep[/dim]",
+                "[dim][cyan]↑↓[/cyan] pick a check   ·   [cyan]⏎[/cyan] run it   "
+                "[dim]— or jump straight to one:[/dim]   [cyan]y[/cyan] health   ·   "
+                "[cyan]v[/cyan] verify   ·   [cyan]V[/cyan] verify-full   ·   "
+                "[cyan]R[/cyan] report   ·   [cyan]F[/cyan] report --full   ·   "
+                "[cyan]w[/cyan] cap sweep[/dim]",
                 id="doctor-hint",
             )
 
@@ -5101,7 +5207,7 @@ class DoctorPane(Container):
             # here — a navigation pointer to the gated serve path.
             body.update(
                 "[red]✗[/red]  API not reachable\n"
-                "   [dim]→ fix: serve a model — Run · Catalog ([cyan]1[/cyan]), pick a "
+                "   [dim]→ fix: serve a model — Run & Operate · Catalog ([cyan]1[/cyan]), pick a "
                 "variant, [cyan]⏎[/cyan] (reconcile-gated)[/dim]"
             )
             return
@@ -5110,7 +5216,7 @@ class DoctorPane(Container):
         if not dr.serving:
             # Reachable endpoint but nothing served — point at the serve path.
             line += (
-                "\n   [dim]→ fix: serve a model — Run · Catalog ([cyan]1[/cyan]) "
+                "\n   [dim]→ fix: serve a model — Run & Operate · Catalog ([cyan]1[/cyan]) "
                 "[cyan]⏎[/cyan][/dim]"
             )
         body.update(line)
@@ -5132,7 +5238,7 @@ class DoctorPane(Container):
         if vs.error:
             body.update(
                 f"[red]✗[/red]  {vs.error}\n"
-                "   [dim]→ fix: serve a model — Run · Catalog ([cyan]1[/cyan]) "
+                "   [dim]→ fix: serve a model — Run & Operate · Catalog ([cyan]1[/cyan]) "
                 "[cyan]⏎[/cyan] (reconcile-gated)[/dim]"
             )
             return
@@ -5147,7 +5253,7 @@ class DoctorPane(Container):
                 lines.append(f"        [dim]→ {c.hint}[/dim]")
         if not vs.reachable:
             lines.append(
-                "   [dim]→ fix: serve a model — Run · Catalog ([cyan]1[/cyan]) "
+                "   [dim]→ fix: serve a model — Run & Operate · Catalog ([cyan]1[/cyan]) "
                 "[cyan]⏎[/cyan][/dim]"
             )
         body.update("\n".join(lines))
@@ -8554,8 +8660,13 @@ class FocusableFooter(Footer):
             active = self.screen.active_bindings
         except Exception:
             return ()
+        # `description` is part of the signature: the footer RENDERS it, so a
+        # recompose-suppression that ignored it made every `_relabel_binding`
+        # invisible whenever the visible key set was unchanged (③ Gate kept
+        # showing "⏎ Serve" from ② Serve indefinitely, and Doctor's ⏎ label could
+        # not follow the ↑/↓ selection at all).
         return tuple(
-            (binding.key, binding.action, enabled)
+            (binding.key, binding.action, enabled, binding.description)
             for (_node, binding, enabled, _tooltip) in active.values()
             if binding.show
         )
@@ -8634,7 +8745,7 @@ _PALETTE_COMMANDS: tuple[tuple[str, str, str], ...] = (
     # Producer lane (Bring & Validate) — filtered out on the lean surface.
     ("serve_untested", "Serve untested (② Serve)", "Producer lane — generate a compose + serve it untested"),
     ("measure_vs_bar", "Compare vs catalog bar (④ Measure)", "Producer lane — read · flags protocol"),
-    ("evaluate_target", "Evaluate running target (preview)", "Producer lane — c3t evaluate (mock this phase)"),
+    ("evaluate_target", "Evaluate running target", "Producer lane — c3t evaluate (confirm-gated · runs against the serving model)"),
     ("promote_catalog", "Promote this model (⑤)", "Producer lane — scaffold the registry entry; the write is confirm-gated"),
     ("search_hf", "Search Hugging Face repos (① Bring)", "Producer lane — search HF and fill the repo field (\\[f])"),
 )
@@ -8665,6 +8776,21 @@ _TAB_PRIMARY_LIST: dict[str, str] = {
 # DATATABLES and is shared with the ↓ descend / ↑ ascend gates, which need a list.
 # Doctor's scroll container is focused on tab activation instead (see
 # on_tabbed_content_tab_activated) so ↓/PgDn work on its overflowing page.
+# Operate · Doctor — the six check cards, in the order `compose` yields them.
+# ONE source of truth for three things that must never drift apart: the ↑/↓
+# navigation order, the ⏎ dispatch target, and the footer label.  A card added to
+# `DoctorPane.compose` without a row here is unreachable by keyboard; a row here
+# without a card raises on selection.  `test_doctor_registry_matches_compose_order`
+# asserts both directions against the rendered DOM.
+_DOCTOR_CHECKS: tuple[tuple[str, str, str], ...] = (
+    ("doctor-card-health",     "doctor_rerun",      "Re-run health"),
+    ("doctor-card-verify",     "doctor_verify",     "Verify serving"),
+    ("doctor-card-verifyfull", "doctor_verify_full", "Verify-full"),
+    ("doctor-card-report",     "rig_report",        "Rig report"),
+    ("doctor-card-fullreport", "full_report",       "Full report"),
+    ("doctor-card-sweep",      "power_cap_sweep",   "Cap sweep"),
+)
+
 _TAB_FOCUS_FALLBACK: dict[str, str] = {
     "tab-doctor": "#doctor-scroll",
 }
@@ -8828,10 +8954,10 @@ class CockpitApp(App):
         # Operate · Containers / Validate — context-sensitive read keys.
         Binding("t", "context_t", "Top / Sort", show=False),
         # Phase 5 — the three v2 hooks:
-        #   [v] Evaluate via c3t (mock this phase — label says so)
+        #   [v] Evaluate via c3t (confirm-gated; the launch is REAL)
         #   [P] Promotion scaffold preview (no live catalog write this phase)
         #   [O] Optimize for my card (kv-calc brain; apply = gated stage)
-        Binding("v", "evaluate_target", "Evaluate (preview)", show=False),
+        Binding("v", "evaluate_target", "Evaluate via c3t", show=False),
         Binding("P", "promote_catalog", "Scaffold preview", show=False),
         # R3b-1 — producer lane ② Serve: generate a compose + serve it untested
         # (also reachable via ⏎ on the ② Serve stage).
@@ -9206,7 +9332,7 @@ class CockpitApp(App):
                 bar = self._active_tab_bar()
                 if bar is None or focused is not bar:
                     return False
-                return self._primary_list_for_active_tab() is not None
+                return self._descend_target_for_active_tab() is not None
             # ascend_to_tabbar: [up] ascends in EXACTLY ONE case (priority binding):
             #   focus is the active tab's PRIMARY DataTable at cursor row 0 →
             #   ascend to the tab bar (above row 0 / off a primary list → the
@@ -9338,7 +9464,12 @@ class CockpitApp(App):
     # Doctor / Containers (mode 0) have NO ⏎ primary, so ⏎ is hidden there.
     def _primary_action_enabled(self) -> bool:
         if self._active_mode == 0:
-            return self._current_subtab() in ("tab-catalog", "tab-orchestration")
+            # tab-doctor joined this set when Doctor's cards became ↑/↓ selectable
+            # and ⏎-runnable. It was excluded while Doctor was read-only — and the
+            # Modes rail said "⏎ Select" there anyway, which was simply untrue.
+            return self._current_subtab() in (
+                "tab-catalog", "tab-orchestration", "tab-doctor",
+            )
         if self._active_mode == 1:
             return True
         return False
@@ -9371,6 +9502,16 @@ class CockpitApp(App):
                 enter_label = "Serve"
             elif tab == "tab-orchestration":
                 enter_label = "Switch scene"
+            elif tab == "tab-doctor":
+                # Name the SELECTED check, so ⏎ says what it will actually run
+                # rather than a generic verb — the whole point of a list you
+                # arrow through is that the commit key tracks the cursor.
+                try:
+                    enter_label = self.query_one(
+                        "#doctor-pane", DoctorPane
+                    ).selected_check()[2]
+                except Exception:
+                    enter_label = "Run check"
         elif self._active_mode == 1:
             tab = self._active_validate_tab()
             enter_label = {
@@ -12344,15 +12485,36 @@ class CockpitApp(App):
         except Exception:
             return None
 
+    def _descend_target_for_active_tab(self):
+        """What [down] on the tab bar descends INTO for the active tab.
+
+        The primary DataTable when the tab has one, else the tab's
+        _TAB_FOCUS_FALLBACK widget — Doctor has no table, but its scroll box IS
+        its check list, so [down] must reach it or the list is keyboard-reachable
+        only by Tab.  Kept separate from `_primary_list_for_active_tab`, which is
+        typed to DataTable and shared with the ↑-ascend gate.
+        """
+        table = self._primary_list_for_active_tab()
+        if table is not None:
+            return table
+        tab_id = self._current_subtab() or ""
+        selector = _TAB_FOCUS_FALLBACK.get(tab_id, "")
+        if not selector:
+            return None
+        try:
+            return self.query_one(selector)
+        except Exception:
+            return None
+
     def action_descend_to_content(self) -> None:
         """[down] on the tab bar → move focus INTO the active tab's primary list.
 
         Does NOT reset the list's cursor — the preserved row stays selected.  A
         no-op when there is no primary list (check_action also gates this away)."""
-        table = self._primary_list_for_active_tab()
-        if table is not None:
+        target = self._descend_target_for_active_tab()
+        if target is not None:
             try:
-                table.focus()
+                target.focus()
             except Exception:
                 pass
 
@@ -12429,8 +12591,35 @@ class CockpitApp(App):
                 self._run_primary()
             elif tab == "tab-orchestration":
                 self._operate_primary()
+            elif tab == "tab-doctor":
+                self._doctor_primary()
         elif self._active_mode == 1:
             self._validate_primary()
+
+    def _doctor_primary(self) -> None:
+        """⏎ on Operate · Doctor — run the SELECTED check.
+
+        Dispatches to the very same action the check's hotkey fires, so the
+        confirm gates come along for free: `full_report` and `power_cap_sweep`
+        are confirm-gated at their action, and pressing ⏎ on those cards gets the
+        same dialog `F`/`w` would.  Nothing is special-cased here — a check that
+        gains a gate later gains it on both paths at once.
+        """
+        try:
+            _card_id, action, _label = self.query_one(
+                "#doctor-pane", DoctorPane
+            ).selected_check()
+        except Exception:
+            return
+        # check_action gates the hotkeys (e.g. producer-only verbs); honour the
+        # same verdict for ⏎ so the two paths can never disagree about whether a
+        # check is currently allowed.
+        if self.check_action(action, ()) is False:
+            return
+        handler = getattr(self, f"action_{action}", None)
+        if handler is None:
+            return
+        handler()
 
     def _validate_primary(self) -> None:
         """⏎ in the Bring & Validate lane — context-specific per stage (R3b-1):
@@ -13767,11 +13956,13 @@ class CockpitApp(App):
         hook lives here); the live target is captured by the Operate estate poll
         and remains available via ``_target_obj``.
 
-        Confirm-gated, MOCK-ONLY launch — c3t runs the post-boot evaluator
-        against the live serving model (heavy).  The hand-off carries the SAME
-        ``ServingTarget`` object the Estate poll detected (design §4/§6.6); the
-        launch streams via ``launch_evaluate`` (write runner, NEVER live this
-        phase — conftest blocks the spawn, tests fake it)."""
+        Confirm-gated and REAL: the commit spawns ``scripts/c3t`` through the
+        production write runner and evaluates the live serving model (heavy).
+        This used to be labelled "mock this phase" in four places; the only thing
+        that made it a mock was ``conftest`` blocking the spawn in TESTS, which
+        does nothing in a real run.  The hand-off carries the SAME
+        ``ServingTarget`` object the Estate poll detected (design §4/§6.6) and
+        streams via ``launch_evaluate``."""
         if self._active_mode != 1:
             return
         handoff = self._data.evaluate_handoff(self._target_obj)
@@ -13793,18 +13984,19 @@ class CockpitApp(App):
 
     @work(exclusive=True, group="evaluate")
     async def launch_c3t_evaluate(self) -> None:
-        """Launch c3t scoped to the SHARED ServingTarget, streamed (MOCK-ONLY).
+        """Launch c3t scoped to the SHARED ServingTarget, streamed.
 
-        ⚠️  WIRED-BUT-MOCK-ONLY.  c3t runs tests against the live serving model;
-        the write runner is NEVER executed live this phase (conftest blocks the
-        spawn; tests inject a FakeWriteRunner).  The SAME ``ServingTarget`` the
-        Estate poll captured is passed by identity so c3t evaluates exactly what
-        is running."""
+        ⚠️  THIS RUNS FOR REAL — c3t runs tests against the live serving model
+        through the production write runner.  The former "NEVER executed live
+        this phase (conftest blocks the spawn)" note described the TEST
+        environment only; conftest does not run in a real session.  The SAME
+        ``ServingTarget`` the Estate poll captured is passed by identity so c3t
+        evaluates exactly what is running."""
         live = self._serve_live_pane()
         if live is not None:
             tgt = self._target_obj
             label = getattr(tgt, "model", "") or getattr(tgt, "url", "") or "target"
-            live.append_line(f"[green]▶ c3t evaluate[/green] {label} (mock-only this phase)")
+            live.append_line(f"[green]▶ c3t evaluate[/green] {label}")
 
         def _on_line(text: str) -> None:
             if live is not None:

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -2020,6 +2020,273 @@ class _CopyableModal:
         return self._copy_payload or ""
 
 
+# ── Compose viewer (READ) ────────────────────────────────────────────────────
+
+
+class ComposeViewScreen(_CopyableModal, ModalScreen):
+    """The compose behind whatever the user is looking at — READ-ONLY.
+
+    Catalog rows, container drills and lane stages all name a config the user has
+    only ever seen summarised. The serve confirm shows the CATALOG'S CLAIMS (ctx,
+    measured TPS, fit) — not the file — and a Route-K / generated serve shows the
+    docker command and nothing else, so the user commits a compose they have not
+    read and cannot reopen. This is that missing last look.
+
+    Two layers, in this order:
+      1. the `Profile (at-a-glance)` header + the mechanical facts derived from
+         the file (image / port / ctx / KV / TP), because the header is 15-40
+         lines of prose and `command:` sits ~100 lines down;
+      2. the raw YAML, pygments-highlighted via rich.syntax (present already —
+         no new dependency), wrapped so the page never scrolls sideways.
+
+    READ-ONLY BY DESIGN in this increment: no edit verb exists yet on any
+    provenance. The provenance line still states editability, because that is the
+    fact a reader needs before they go and change the file in their own editor —
+    and for a CURATED file the honest answer is "don't, it is git-tracked and
+    shared; a change here diverges your checkout from upstream".
+    """
+
+    DEFAULT_CSS = """
+    ComposeViewScreen {
+        align: center middle;
+    }
+    ComposeViewScreen > Vertical {
+        width: 92%;
+        max-width: 120;
+        height: 96%;
+        border: thick $accent;
+        background: $surface;
+        padding: 1 2;
+    }
+    ComposeViewScreen .compose-title {
+        text-style: bold;
+        color: $accent;
+    }
+    ComposeViewScreen #compose-path {
+        color: $text-muted;
+    }
+    ComposeViewScreen #compose-provenance {
+        margin-bottom: 1;
+    }
+    ComposeViewScreen #compose-facts {
+        height: auto;
+        max-height: 12;
+        overflow-y: auto;
+        margin-bottom: 1;
+    }
+    ComposeViewScreen #compose-rule {
+        color: $text-muted;
+    }
+    ComposeViewScreen #compose-scroll {
+        height: 1fr;
+        border: solid $primary;
+    }
+    """
+
+    BINDINGS = [
+        Binding("escape", "dismiss", "Close"),
+        Binding("c", "dismiss", "Close"),
+        Binding("h", "toggle_header", "Header", show=True),
+        Binding("Y", "app.copy_context", "Copy", show=True),
+    ]
+
+    # Provenance kind → the accent colour of its banner.
+    _KIND_STYLE = {
+        "curated":   "yellow",
+        "local":     "green",
+        "generated": "cyan",
+        "external":  "green",
+        "missing":   "red",
+    }
+
+    def __init__(self, path: str, *, title: str = "", **kwargs):
+        super().__init__(**kwargs)
+        self._path = path
+        self._title = title or "Compose"
+        self._show_header = True
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Label(f"Compose · {self._title}", classes="compose-title")
+            yield Static("", id="compose-path")
+            yield Static("", id="compose-provenance")
+            yield Static("", id="compose-facts")
+            yield Static("", id="compose-rule")
+            with ScrollableContainer(id="compose-scroll"):
+                yield Static("", id="compose-body")
+            yield Footer()
+
+    def on_mount(self) -> None:
+        # Size the facts strip to the TERMINAL, not a fixed 12 rows. On an 80x24
+        # the modal is ~21 rows, and a fixed strip plus the header lines pushed
+        # the YAML — the thing the viewer exists to show — entirely below the
+        # fold, reachable only by pressing [h]. A third of the height keeps both
+        # visible; the strip scrolls when the header is long.
+        try:
+            avail = int(self.app.size.height)
+            self.query_one("#compose-facts", Static).styles.max_height = max(
+                4, min(12, avail // 4)
+            )
+        except Exception:
+            pass
+        self._load()
+
+    def action_toggle_header(self) -> None:
+        """[h] hides the facts strip — more rows of YAML on a short terminal."""
+        self._show_header = not self._show_header
+        for wid in ("#compose-facts", "#compose-provenance", "#compose-path"):
+            try:
+                self.query_one(wid).display = self._show_header
+            except Exception:
+                pass
+
+    def _load(self) -> None:
+        from pathlib import Path
+
+        from club3090_cockpit.data import (
+            classify_compose_provenance,
+            derive_compose_facts,
+            parse_profile_header,
+        )
+
+        root = getattr(self.app, "_repo_root", None) or Path(".")
+        prov = classify_compose_provenance(self._path, root)
+        colour = self._KIND_STYLE.get(prov.kind, "white")
+        try:
+            self.query_one("#compose-path", Static).update(prov.rel or prov.path)
+            self.query_one("#compose-provenance", Static).update(
+                f"[{colour}]┃ {prov.reason}[/{colour}]"
+            )
+        except Exception:
+            pass
+
+        if prov.kind == "missing":
+            try:
+                self.query_one("#compose-body", Static).update(
+                    "[red]file not found[/red]"
+                )
+                self.query_one("#compose-facts", Static).update("")
+            except Exception:
+                pass
+            return
+
+        try:
+            text = Path(prov.path).read_text(encoding="utf-8", errors="replace")
+        except Exception as exc:
+            try:
+                self.query_one("#compose-body", Static).update(
+                    f"[red]could not read:[/red] {exc}"
+                )
+            except Exception:
+                pass
+            return
+
+        self._copy_payload = text   # [Y] copies the RAW file, not the rendering
+        facts = derive_compose_facts(text, prov.path)
+        header = parse_profile_header(text)
+        try:
+            self.query_one("#compose-facts", Static).update(
+                self._facts_markup(header, facts)
+            )
+            self.query_one("#compose-rule", Static).update(
+                f"── yaml · {len(text.splitlines())} lines · "
+                f"[dim]h header · Y copy · Esc close[/dim] ──"
+            )
+        except Exception:
+            pass
+
+        # rich.syntax gives pygments highlighting with no new dependency, and
+        # word_wrap keeps a long `volumes:` line inside the modal instead of
+        # forcing a horizontal scroll.
+        try:
+            from rich.syntax import Syntax
+
+            body = Syntax(
+                text, "yaml", line_numbers=True, word_wrap=True, theme="ansi_dark"
+            )
+        except Exception:
+            body = text
+        try:
+            self.query_one("#compose-body", Static).update(body)
+        except Exception:
+            pass
+
+    def _facts_markup(self, header, facts) -> str:
+        """The header fields first, then what the file mechanically states.
+
+        Status is rendered with the catalog's own glyph so one status means one
+        symbol app-wide, and a REQUIRED-but-missing Caveats line is called out —
+        that combination reds `test-compose-status-drift` on the user's checkout,
+        so it is worth seeing here rather than at commit time.
+        """
+        from rich.markup import escape
+
+        from club3090_cockpit.data import COMPOSE_STATUS_EMOJI
+
+        rows: list[str] = []
+        if header.present:
+            status = header.status_word
+            glyph = _STATUS_GLYPH.get(status, "") if status else ""
+            shown = header.fields.get("Status", "")
+            # We render the catalog's own glyph, so drop the header's leading
+            # emoji rather than printing two symbols for one status.
+            if glyph:
+                for emoji in COMPOSE_STATUS_EMOJI:
+                    if shown.startswith(emoji):
+                        shown = shown[len(emoji):].strip()
+                        break
+            rows.append(f"[bold]Status[/bold]    {glyph} {escape(shown)}".rstrip())
+            if header.caveats_missing:
+                rows.append(
+                    "[yellow]Caveats   ⚠ REQUIRED for this status — missing[/yellow]"
+                )
+
+        # The mechanical facts go HIGH — above the prose fields. "What will this
+        # actually run" is the question the viewer exists to answer, and a long
+        # multi-line Caveats (675 chars is real, and 84 of 112 composes carry one)
+        # would otherwise push port/ctx/image below the fold of the facts box.
+        def shown(value: str) -> str:
+            """`${MAX_MODEL_LEN:-262144}` reads as `262144 ($MAX_MODEL_LEN)`.
+
+            The token is faithful to the file, but a strip of raw `${VAR:-x}` is
+            unreadable at a glance — and the effective value IS the default
+            unless the user overrides it, which is exactly what the reader is
+            here to learn. The variable name is kept, dimmed, because it is how
+            they would override it."""
+            m = re.fullmatch(r"\$\{([A-Za-z_][A-Za-z0-9_]*):-(.*)\}", value.strip())
+            if not m:
+                return f"[bold]{escape(value)}[/bold]"
+            var, default = m.group(1), m.group(2)
+            if not default:
+                return f"[dim]unset (${var})[/dim]"
+            return f"[bold]{escape(default)}[/bold] [dim](${var})[/dim]"
+
+        mech = []
+        for label, val in (
+            ("image", facts.image), ("port", facts.port), ("ctx", facts.max_ctx),
+            ("kv", facts.kv_dtype), ("tp", facts.tp), ("served-as", facts.served_name),
+        ):
+            if val:
+                mech.append(f"{label} {shown(str(val))}")
+        if mech:
+            rows.append("[dim]" + "  ·  ".join(mech) + "[/dim]")
+
+        if header.present:
+            # Caveats LAST: it is by far the longest field, so leading with it
+            # would bury everything else behind a scroll.
+            for key in ("Model", "Topology", "Drafter", "KV", "Vision",
+                        "Max ctx", "Genesis", "Best for", "Caveats"):
+                val = header.fields.get(key, "").strip()
+                if val:
+                    rows.append(f"[bold]{key}[/bold]{' ' * max(1, 10 - len(key))}{escape(val)}")
+        else:
+            rows.append("[dim]no `Profile (at-a-glance)` header in this file[/dim]")
+        return "\n".join(rows)
+
+    def action_dismiss(self) -> None:
+        self.app.pop_screen()
+
+
 # ── Explain detail modal ────────────────────────────────────────────────────────
 
 
@@ -8949,6 +9216,11 @@ class CockpitApp(App):
         Binding("N", "new_pod", "New pod", show=False),
         # Operate · Orchestration — power-cap menu (default / clear / custom W).
         Binding("c", "power_cap", "Power cap", show=False),
+        # [c] view the compose behind the focused thing. A SECOND `c`, gated to a
+        # disjoint (mode, tab) set from power_cap above — the same dual-binding
+        # idiom v/k/f/D/w already use. Orchestration keeps power-cap; everywhere
+        # a compose is identifiable, `c` opens it.
+        Binding("c", "view_compose", "View compose", show=False),
         # Operate · Doctor — power-cap sweep (heavy A/B bench; gated rig write).
         Binding("w", "power_cap_sweep", "Cap sweep", show=False),
         # Operate · Containers / Validate — context-sensitive read keys.
@@ -9193,6 +9465,10 @@ class CockpitApp(App):
         "estate_off":       ({0}, {"tab-orchestration"}),
         "new_pod":      ({0}, {"tab-orchestration"}),
         "power_cap":        ({0}, {"tab-orchestration"}),
+        # Disjoint from power_cap by construction: every tab here is one where a
+        # compose path is resolvable, and none of them is tab-orchestration.
+        "view_compose":     ({0, 1}, {"tab-catalog", "tab-containers",
+                                      "tab-bring", "tab-serve", "tab-promote"}),
         # power-cap sweep lives on Doctor now (a tuning/diagnostic bench, not a
         # live-estate control) — prune was removed from the cockpit entirely.
         "power_cap_sweep":  ({0}, {"tab-doctor"}),
@@ -12595,6 +12871,62 @@ class CockpitApp(App):
                 self._doctor_primary()
         elif self._active_mode == 1:
             self._validate_primary()
+
+    def action_view_compose(self) -> None:
+        """[c] — open the compose behind whatever is focused, READ-ONLY.
+
+        Resolves per surface rather than from one global: Catalog and Containers
+        name a catalog slug whose registry row carries `compose_path`; the lane
+        stages name the file the user brought or staged. When nothing here
+        resolves a path, say which surface has one instead of opening an empty
+        modal."""
+        path, title = self._compose_target_for_focus()
+        if not path:
+            self.notify(
+                "No compose to show here — open one from Catalog (a slug), "
+                "Containers (a running service), or a lane stage after ① Bring.",
+                title="Compose", severity="warning", timeout=5,
+            )
+            return
+        self.push_screen(ComposeViewScreen(path, title=title))
+
+    def _compose_target_for_focus(self) -> tuple[str, str]:
+        """(compose path, human title) for the focused surface — ("","") if none."""
+        from pathlib import Path as _P
+
+        mode = self._active_mode
+        tab = self._current_subtab() if mode == 0 else self._active_validate_tab()
+
+        if mode == 0 and tab == "tab-catalog":
+            try:
+                entry = self.query_one("#catalog-pane", CatalogPane).selected_entry()
+            except Exception:
+                entry = None
+            if entry is not None:
+                row = getattr(entry, "row", None)
+                path = getattr(row, "compose_path", "") or ""
+                if path:
+                    return path, getattr(entry, "slug", "") or _P(path).name
+            return "", ""
+
+        if mode == 0 and tab == "tab-containers":
+            con = self._selected_container()
+            slug = getattr(con, "slug", "") if con is not None else ""
+            if slug:
+                row = next(
+                    (v for v in self._variants if getattr(v, "slug", "") == slug), None
+                )
+                path = getattr(row, "compose_path", "") if row is not None else ""
+                if path:
+                    return path, slug
+            return "", ""
+
+        # Lane: the compose in hand (Route-K) or the one staged for ⑤.
+        if mode == 1:
+            brought = getattr(self, "_bring_swap_compose", "") or ""
+            if brought:
+                return brought, _P(brought).name
+        return "", ""
 
     def _doctor_primary(self) -> None:
         """⏎ on Operate · Doctor — run the SELECTED check.

--- a/tools/serve-cockpit/club3090_cockpit/data.py
+++ b/tools/serve-cockpit/club3090_cockpit/data.py
@@ -2413,6 +2413,171 @@ _ENGINE_BY_IMAGE = (
 )
 
 
+# Compose `Status:` header emoji → registry status word.  DUPLICATED from
+# scripts/lib/profiles/compose_registry.COMPOSE_STATUS_EMOJI on purpose: data.py
+# is stdlib-only and importable on the launcher's no-PyYAML path, so it must not
+# import the profiles package.  `test_status_emoji_map_parity` asserts the two
+# stay identical.
+COMPOSE_STATUS_EMOJI = {
+    "✅": "production",
+    "⚠️": "caveats",
+    "🧪": "experimental",
+    "🐣": "incubating",
+    "👁️": "preview",
+    "⏸️": "upstream-gated",
+    "🗑️": "deprecated",
+}
+
+# Statuses whose profile header MUST carry a Caveats: line (AGENTS.md Status enum).
+_CAVEATS_REQUIRED = frozenset({"caveats", "incubating", "preview", "upstream-gated", "deprecated"})
+
+# Canonical field order of the `# Profile (at-a-glance):` block.
+_HEADER_FIELDS = (
+    "Model", "Topology", "Drafter", "KV", "Vision", "Max ctx", "Genesis",
+    "Status", "Caveats", "Quality", "Best for",
+)
+
+
+@dataclass
+class ProfileHeader:
+    """The `# Profile (at-a-glance):` block, parsed.
+
+    Block-SCOPED, matching compose_registry.compose_header_status: fields are read
+    only between `# Profile (at-a-glance):` and the `# ---` separator, so a
+    free-form `# Status: ...` line further down cannot be mistaken for the schema.
+    ComposeFacts.status_header uses a looser any-line regex, which is fine for its
+    job (a quick Route-K sniff) but too loose to render as "the header".
+
+    Continuation-aware: an indented comment line inside the block that has no
+    `Key:` prefix appends to the previous field — 84 of 112 live composes carry a
+    multi-line `Caveats:` and dropping the continuations would show a truncated
+    caveat, which is worse than showing none.
+    """
+
+    present: bool = False
+    fields: dict = field(default_factory=dict)   # ordered, as encountered
+    status_word: str = ""                        # STATUS_VALUES word, or ""
+    line_of: dict = field(default_factory=dict)  # field -> 1-based line number
+
+    @property
+    def caveats_required(self) -> bool:
+        return self.status_word in _CAVEATS_REQUIRED
+
+    @property
+    def caveats_missing(self) -> bool:
+        return self.caveats_required and not self.fields.get("Caveats", "").strip()
+
+
+def parse_profile_header(text: str) -> ProfileHeader:
+    """Parse the profile-schema block. Never raises."""
+    hdr = ProfileHeader()
+    try:
+        lines = text.splitlines()
+    except Exception:
+        return hdr
+    in_block = False
+    last_key = ""
+    for idx, raw in enumerate(lines, start=1):
+        stripped = raw.strip()
+        if not in_block:
+            if stripped.startswith("# Profile (at-a-glance):"):
+                in_block = True
+                hdr.present = True
+            continue
+        if stripped.startswith("# --") or stripped.startswith("#--"):
+            break
+        if not stripped.startswith("#"):
+            # The block is a comment run; a non-comment line ends it.
+            break
+        body = stripped.lstrip("#").strip()
+        if not body:
+            continue
+        key = ""
+        for cand in _HEADER_FIELDS:
+            if body.startswith(cand + ":"):
+                key = cand
+                break
+        if key:
+            hdr.fields[key] = body[len(key) + 1:].strip()
+            hdr.line_of[key] = idx
+            last_key = key
+        elif last_key:
+            # Continuation of the previous field (the multi-line Caveats shape).
+            hdr.fields[last_key] = (hdr.fields[last_key] + " " + body).strip()
+    value = hdr.fields.get("Status", "")
+    for emoji, word in COMPOSE_STATUS_EMOJI.items():
+        if value.startswith(emoji):
+            hdr.status_word = word
+            break
+    return hdr
+
+
+@dataclass
+class ComposeProvenance:
+    """WHERE a compose came from — which decides whether c3 may edit it.
+
+    The asymmetry this exists to make legible: a CURATED compose is git-tracked
+    and shared, governed by the profile-schema gates, and changed through a PR.
+    Editing one in place silently diverges the user's checkout from upstream —
+    the failure is not a bad edit, it is a checkout that quietly serves something
+    the catalog misdescribes. A LOCAL-layer or EXTERNAL (Route-K) compose is the
+    user's own and freely editable.
+    """
+
+    kind: str = "missing"     # curated | local | generated | external | missing
+    path: str = ""            # absolute
+    rel: str = ""             # repo-relative when inside the root, else ""
+    editable: bool = False
+    reason: str = ""          # one user-facing line
+
+
+def classify_compose_provenance(path: str, repo_root) -> ComposeProvenance:
+    """Classify a compose path. Pure: no git, no I/O beyond exists()."""
+    from pathlib import Path
+
+    try:
+        root = Path(repo_root).resolve()
+        target = Path(path).expanduser()
+        target = (root / target) if not target.is_absolute() else target
+        target = target.resolve()
+    except Exception:
+        return ComposeProvenance(kind="missing", path=str(path), reason=f"MISSING · {path}")
+
+    prov = ComposeProvenance(path=str(target))
+    try:
+        prov.rel = str(target.relative_to(root))
+    except Exception:
+        prov.rel = ""
+
+    if not target.is_file():
+        prov.kind = "missing"
+        prov.reason = f"MISSING · {prov.rel or target}"
+        return prov
+
+    name = target.name
+    if name.startswith("c3-genc-") or name.startswith("_brought-"):
+        prov.kind = "generated"
+        prov.editable = True
+        prov.reason = "GENERATED · ephemeral — regenerated by ② Serve"
+        return prov
+    if prov.rel:
+        parts = Path(prov.rel).parts
+        if parts[:1] == ("models",):
+            prov.kind = "curated"
+            prov.editable = False
+            prov.reason = "CURATED · git-tracked · read-only here"
+            return prov
+        if parts[:3] == ("scripts", "lib", "profiles-local"):
+            prov.kind = "local"
+            prov.editable = True
+            prov.reason = "LOCAL LAYER · yours"
+            return prov
+    prov.kind = "external"
+    prov.editable = True
+    prov.reason = "YOUR FILE · outside the curated catalog"
+    return prov
+
+
 def derive_compose_facts(text: str, path: str = "") -> ComposeFacts:
     """Read a user-supplied compose (#1153 Route-K). Never raises.
 
@@ -2463,10 +2628,26 @@ def derive_compose_facts(text: str, path: str = "") -> ComposeFacts:
             continue
         toks.extend(t.strip('"').strip("'") for t in ln.split() if t.strip('"').strip("'"))
 
+    # YAML block-scalar introducers. A flag whose "value" is one of these did not
+    # get a value at all — the next line starts a literal block.
+    _BLOCK_SCALARS = {"|", ">", "|-", ">-", "|+", ">+"}
+    # A short flag directly after a shell is the SHELL's flag, not the engine's:
+    # `entrypoint: [bash, -c, |...]` is the standard vLLM compose shape, and its
+    # bash -c was being read as llama.cpp's -c (ctx-size), so max_ctx came back
+    # as "|" for every such compose.
+    _SHELLS = {"bash", "sh", "zsh", "/bin/bash", "/bin/sh"}
+
     def flag(*names: str) -> str:
-        for i, t in enumerate(toks):
-            base = t.split("=", 1)[0]
-            if base in names:
+        # Alias PRIORITY, not token order: callers list the canonical name first
+        # (e.g. "--max-model-len" before "-c"), so an unrelated short flag
+        # appearing earlier in the file must not win over the real one.
+        for name in names:
+            for i, t in enumerate(toks):
+                base = t.split("=", 1)[0]
+                if base != name:
+                    continue
+                if i > 0 and toks[i - 1] in _SHELLS and not name.startswith("--"):
+                    continue
                 if "=" in t:                      # --flag=value
                     v = t.split("=", 1)[1]
                 elif i + 1 < len(toks):           # --flag value
@@ -2474,7 +2655,7 @@ def derive_compose_facts(text: str, path: str = "") -> ComposeFacts:
                 else:
                     continue
                 v = v.strip().strip('"').strip("'")
-                if v and not v.startswith("-"):
+                if v and not v.startswith("-") and v not in _BLOCK_SCALARS:
                     return v
         return ""
 

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -4933,11 +4933,14 @@ class CockpitData:
         on_event: Optional[Callable[[Any], None]] = None,
         on_line: Optional[Callable[[str], None]] = None,
     ) -> Any:
-        """Launch c3t scoped to the SHARED ServingTarget, streamed (MOCK-ONLY).
+        """Launch c3t scoped to the SHARED ServingTarget, streamed.
 
-        ⚠️  WIRED-BUT-MOCK-ONLY.  c3t runs the post-boot evaluator against the
-        live serving model — heavy.  The write runner is NEVER executed live this
-        phase; conftest blocks the real spawn and tests inject a FakeWriteRunner.
+        ⚠️  THIS RUNS FOR REAL.  c3t is spawned through ``self._write_runner`` —
+        the production runner in a real session — and evaluates the live serving
+        model (heavy).  The previous "WIRED-BUT-MOCK-ONLY / never executed live"
+        note described only the TEST environment: conftest blocks the spawn and
+        tests inject a FakeWriteRunner, neither of which applies in production.
+        Callers must keep this behind the confirm gate.
 
         Scopes c3t to ``target`` by passing the endpoint/model/container through
         the child env (``C3T_REPO_ROOT`` + ``C3T_TARGET_*``) so the test-console

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -9589,7 +9589,7 @@ class TestDoctorRerunAndRemediation:
             pane._render_health(DoctorRead(reachable=False))
             body = str(app.query_one("#doctor-health-body", Static).render())
             assert "not reachable" in body
-            assert "fix:" in body and "Run · Catalog" in body
+            assert "fix:" in body and "Run & Operate · Catalog" in body
 
 
 class TestA9GateLadderOutcome:
@@ -10132,16 +10132,23 @@ class TestArrowKeyFocusDescent:
     # ── No-op surfaces — Doctor (no primary list) ────────────────────────────────
 
     @pytest.mark.asyncio
-    async def test_doctor_tab_bar_down_is_a_noop(self):
-        """Doctor has no primary list → descend is a no-op (focus stays on the bar)."""
+    async def test_doctor_tab_bar_down_descends_into_the_check_list(self):
+        """[down] on Doctor's tab bar descends into its check list.
+
+        Was `test_doctor_tab_bar_down_is_a_noop`: Doctor had no primary DataTable,
+        so descend was gated off and focus stayed on the bar. Doctor's cards are
+        now ↑/↓-selectable and ⏎-runnable, so it has a list to descend INTO — it
+        resolves through _TAB_FOCUS_FALLBACK rather than _TAB_PRIMARY_LIST, which
+        stays DataTable-only for the ↑-ascend gate."""
         app, _, _ = make_app()
         async with app.run_test(size=(120, 40)) as pilot:
             await _settle(pilot)
             await self._focus_tab_bar(pilot, "#operate-tabs", "tab-doctor")
             await pilot.press("down")
             await pilot.pause()
-            assert isinstance(app.focused, Tabs), \
-                f"down on Doctor's tab bar (no list) must stay on the bar, got {app.focused!r}"
+            await _settle(pilot)
+            assert app.focused is not None and app.focused.id == "doctor-scroll", \
+                f"down on Doctor's tab bar must reach its check list, got {app.focused!r}"
 
     # ── Modal invariant — arrows never steal focus to/from the tab bar ───────────
 
@@ -10250,6 +10257,159 @@ class TestArrowKeyFocusDescent:
             await _settle(pilot)   # the focus call is deferred one refresh cycle
             focused = app.focused
             assert focused is not None and focused.id == "doctor-scroll"
+
+
+class TestDoctorKeyboardNav:
+    """Doctor is a LIST of runnable checks: ↑/↓ select, ⏎ runs the selection.
+
+    Before this, Doctor was reachable only by hotkey — arrows scrolled and ⏎ did
+    nothing — so a user who did not already know v/V/R/F/w/y could read all six
+    cards and run none of them."""
+
+    @pytest.mark.asyncio
+    async def test_registry_matches_compose_order_both_ways(self):
+        """_DOCTOR_CHECKS must mirror the rendered card order exactly.
+
+        The registry drives navigation order, ⏎ dispatch AND the footer label, so
+        drift against `compose` would silently run the wrong check. Asserted in
+        both directions: no rendered card missing from the registry, no registry
+        row without a card, same sequence."""
+        from club3090_cockpit.app import _DOCTOR_CHECKS, DoctorPane
+
+        app, _, _ = make_app()
+        async with app.run_test(size=(120, 44)) as pilot:
+            await _settle(pilot)
+            pane = app.query_one("#doctor-pane", DoctorPane)
+            rendered = [c.id for c in pane.query(".doctor-card")]
+            assert rendered == [row[0] for row in _DOCTOR_CHECKS]
+            # every action names a real handler on the app
+            for _cid, action, label in _DOCTOR_CHECKS:
+                assert hasattr(app, f"action_{action}"), action
+                assert label
+
+    async def _enter_doctor(self, app, pilot):
+        app.query_one("#catalog-table").focus()
+        await _settle(pilot)
+        app.query_one("#operate-tabs", TabbedContent).active = "tab-doctor"
+        await _settle(pilot)
+        await _settle(pilot)   # the focus call is deferred one refresh cycle
+
+    @pytest.mark.asyncio
+    async def test_arrows_move_the_selection_and_enter_runs_it(self):
+        from club3090_cockpit.app import _DOCTOR_CHECKS, DoctorPane
+
+        fired = []
+        app, _, _ = make_app(surface="producer")
+        for _cid, action, _lbl in _DOCTOR_CHECKS:
+            setattr(app, f"action_{action}", (lambda a=action: fired.append(a)))
+        async with app.run_test(size=(120, 44)) as pilot:
+            await _settle(pilot)
+            await self._enter_doctor(app, pilot)
+            assert app.focused is not None and app.focused.id == "doctor-scroll"
+            pane = app.query_one("#doctor-pane", DoctorPane)
+            assert pane.selected_index == 0
+            await pilot.press("down")
+            await _settle(pilot)
+            assert pane.selected_index == 1
+            # ⏎ runs the SELECTED check, not a fixed one.
+            await pilot.press("enter")
+            await _settle(pilot)
+            assert fired == [_DOCTOR_CHECKS[1][1]]
+
+    @pytest.mark.asyncio
+    async def test_selection_is_clamped_not_wrapped(self):
+        """Holding ↓ must not land on `report --full` (~43 min, uses the serving
+        GPUs) or the power-cap sweep by wrapping around from the top."""
+        from club3090_cockpit.app import _DOCTOR_CHECKS, DoctorPane
+
+        app, _, _ = make_app(surface="producer")
+        async with app.run_test(size=(120, 44)) as pilot:
+            await _settle(pilot)
+            await self._enter_doctor(app, pilot)
+            pane = app.query_one("#doctor-pane", DoctorPane)
+            for _ in range(len(_DOCTOR_CHECKS) + 4):
+                await pilot.press("down")
+            await _settle(pilot)
+            assert pane.selected_index == len(_DOCTOR_CHECKS) - 1
+            await pilot.press("down")
+            await _settle(pilot)
+            assert pane.selected_index == len(_DOCTOR_CHECKS) - 1
+
+    @pytest.mark.asyncio
+    async def test_up_at_first_check_ascends_to_the_tab_bar(self):
+        """Mirrors what a primary DataTable at cursor row 0 does. Doctor is not a
+        DataTable, so the priority ascend binding is gated off and this widget has
+        to offer the affordance itself."""
+        from club3090_cockpit.app import DoctorPane
+
+        app, _, _ = make_app(surface="producer")
+        async with app.run_test(size=(120, 44)) as pilot:
+            await _settle(pilot)
+            await self._enter_doctor(app, pilot)
+            assert app.query_one("#doctor-pane", DoctorPane).selected_index == 0
+            await pilot.press("up")
+            await _settle(pilot)
+            assert isinstance(app.focused, Tabs)
+
+    @pytest.mark.asyncio
+    async def test_down_from_the_tab_bar_descends_into_the_list(self):
+        """[down] on the tab bar reaches Doctor's list. It resolves through
+        _TAB_FOCUS_FALLBACK because Doctor has no primary DataTable."""
+        app, _, _ = make_app(surface="producer")
+        async with app.run_test(size=(120, 44)) as pilot:
+            await _settle(pilot)
+            tc = app.query_one("#operate-tabs", TabbedContent)
+            tc.active = "tab-doctor"
+            await _settle(pilot)
+            bar = app._active_tab_bar()
+            assert bar is not None
+            bar.focus()
+            await _settle(pilot)
+            await pilot.press("down")
+            await _settle(pilot)
+            await _settle(pilot)
+            assert app.focused is not None and app.focused.id == "doctor-scroll"
+
+    @pytest.mark.asyncio
+    async def test_footer_enter_label_follows_the_selection(self):
+        """The ⏎ label names the selected check — which only repaints because the
+        footer's recompose signature now includes `description`."""
+        from club3090_cockpit.app import _DOCTOR_CHECKS
+
+        app, _, _ = make_app(surface="producer")
+        async with app.run_test(size=(120, 44)) as pilot:
+            await _settle(pilot)
+            await self._enter_doctor(app, pilot)
+
+            # Read the RENDERED footer, not the binding objects: _relabel_binding
+            # mutates those either way, so asserting on them passes even with the
+            # recompose fix reverted (confirmed by negative control). The claim is
+            # about what the user SEES, so query the FooterKey widgets.
+            ff = app.query_one(FocusableFooter)
+
+            def enter_label():
+                for k in ff.query(FooterKey):
+                    if k.key == "enter":
+                        return k.description
+                return ""
+
+            assert enter_label() == _DOCTOR_CHECKS[0][2]
+            await pilot.press("down")
+            await _settle(pilot)
+            assert enter_label() == _DOCTOR_CHECKS[1][2]
+
+    @pytest.mark.asyncio
+    async def test_hotkeys_still_work_alongside_the_list(self):
+        """The list is ADDITIVE — the documented hotkeys keep firing."""
+        app, _, _ = make_app(surface="producer")
+        fired = []
+        app.action_doctor_verify_full = lambda: fired.append("V")  # type: ignore
+        async with app.run_test(size=(120, 44)) as pilot:
+            await _settle(pilot)
+            await self._enter_doctor(app, pilot)
+            await pilot.press("V")      # verify-full's hotkey, selection on card 0
+            await _settle(pilot)
+            assert fired == ["V"]
 
 
 class TestSubtabCycleScopedToDirectPanes:
@@ -11377,16 +11537,25 @@ class TestTier1PrimaryActionAndSKeyHonesty:
             assert app.check_action("primary_action", ()) is True
 
     @pytest.mark.asyncio
-    async def test_enter_not_advertised_on_doctor(self):
-        """⏎ no-ops on Doctor → check_action falsey so the footer never shows
-        the misleading 'Enter Select' there."""
+    async def test_enter_on_doctor_is_advertised_and_names_the_check(self):
+        """⏎ on Doctor runs the SELECTED check, so it is advertised — and labelled.
+
+        Was `test_enter_not_advertised_on_doctor`, which was right for a read-only
+        Doctor: ⏎ did nothing, so advertising it would have been the misleading
+        "Enter Select" the Modes rail was showing. Doctor's cards are now a
+        keyboard-navigable list whose ⏎ dispatches the selected check, so the
+        honest state is the opposite — the key IS shown, and its label names the
+        check rather than a generic verb."""
+        from club3090_cockpit.app import _DOCTOR_CHECKS
+
         app, _, _ = make_app()
         async with app.run_test(size=(120, 40)) as pilot:
             await _enter_operate(pilot, tab="tab-doctor")
-            assert app.check_action("primary_action", ()) is False
-            # And the footer genuinely omits the enter key on Doctor.
+            assert app.check_action("primary_action", ()) is True
             footer_keys = {k.key for k in app.query(FooterKey)}
-            assert "enter" not in footer_keys
+            assert "enter" in footer_keys
+            labels = {k.description for k in app.query(FooterKey) if k.key == "enter"}
+            assert labels == {_DOCTOR_CHECKS[0][2]}
 
     @pytest.mark.asyncio
     async def test_enter_not_advertised_on_containers(self):

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -710,22 +710,37 @@ def make_app(
     root = repo_root or FAKE_REPO_ROOT
     # The Optimize brain reads engine/hardware KV-legality lists off the repo
     # tree (stdlib yml scan) — seed the two tiny profile files it needs so the
-    # option table renders in tests.  (Idempotent; nothing else reads these.)
+    # option table renders in tests.
+    #
+    # ⚠️ NEVER OVERWRITE AN EXISTING FILE.  This block used to write
+    # unconditionally, and its "(Idempotent; nothing else reads these.)" claim was
+    # false on both counts: the real repo ships 77-line versions of both files
+    # that `engine_drafters` and the profile-compat layer read.  Any test passing
+    # `repo_root=<the real repo>` therefore TRUNCATED two tracked files to a
+    # 6-line stub — silently, since the writes are wrapped in `except OSError`.
+    # That is how test_services / test_route_g started failing: not from their
+    # own code, but because an unrelated test had clobbered the profile tree.
+    # Seeding a fake root still works (nothing is there yet); a real tree is left
+    # exactly as found.
     try:
         eng = root / "scripts" / "lib" / "profiles" / "engines"
         eng.mkdir(parents=True, exist_ok=True)
-        (eng / "vllm-stable.yml").write_text(
-            "supported_kv_formats:\n"
-            "  - bf16\n  - fp16\n  - fp8_e4m3\n  - fp8_e5m2\n"
-            "  - int8_per_token_head\n", encoding="utf-8")
+        stub = eng / "vllm-stable.yml"
+        if not stub.exists():
+            stub.write_text(
+                "supported_kv_formats:\n"
+                "  - bf16\n  - fp16\n  - fp8_e4m3\n  - fp8_e5m2\n"
+                "  - int8_per_token_head\n", encoding="utf-8")
         hw = root / "scripts" / "lib" / "profiles" / "hardware"
         hw.mkdir(parents=True, exist_ok=True)
         # Ampere card: fp8_e4m3 NOT hardware-legal → dropped from the options.
-        (hw / "rtx-3090.yml").write_text(
-            "sm: 8.6\nvram_gb: 24\n"
-            "supported_kv_formats:\n"
-            "  - bf16\n  - fp16\n  - fp8_e5m2\n  - int8_per_token_head\n",
-            encoding="utf-8")
+        hw_stub = hw / "rtx-3090.yml"
+        if not hw_stub.exists():
+            hw_stub.write_text(
+                "sm: 8.6\nvram_gb: 24\n"
+                "supported_kv_formats:\n"
+                "  - bf16\n  - fp16\n  - fp8_e5m2\n  - int8_per_token_head\n",
+                encoding="utf-8")
     except OSError:
         pass
     runner = runner or FakeRunner(responses or fake_responses())
@@ -10257,6 +10272,41 @@ class TestArrowKeyFocusDescent:
             await _settle(pilot)   # the focus call is deferred one refresh cycle
             focused = app.focused
             assert focused is not None and focused.id == "doctor-scroll"
+
+
+class TestMakeAppDoesNotClobberRealFiles:
+    """`make_app` seeds two profile stubs under its repo_root — it must NEVER
+    overwrite a file that already exists.
+
+    It used to write unconditionally, so any test handed `repo_root=<the real
+    checkout>` truncated `scripts/lib/profiles/engines/vllm-stable.yml` (77 lines)
+    and `hardware/rtx-3090.yml` to a 6-line stub. Tracked files, silently, with
+    the writes swallowed by `except OSError`. The visible symptom was unrelated
+    tests failing (`engine_drafters` returning []), which points the reader at
+    the wrong code entirely."""
+
+    def test_existing_profile_files_are_left_alone(self, tmp_path):
+        eng = tmp_path / "scripts" / "lib" / "profiles" / "engines"
+        hw = tmp_path / "scripts" / "lib" / "profiles" / "hardware"
+        eng.mkdir(parents=True)
+        hw.mkdir(parents=True)
+        real_eng = "id: vllm-stable\nsupported_drafters:\n  - mtp\n"
+        real_hw = "sm: 8.6\nvram_gb: 24\nreal: yes\n"
+        (eng / "vllm-stable.yml").write_text(real_eng, encoding="utf-8")
+        (hw / "rtx-3090.yml").write_text(real_hw, encoding="utf-8")
+
+        make_app(repo_root=tmp_path)
+
+        assert (eng / "vllm-stable.yml").read_text(encoding="utf-8") == real_eng
+        assert (hw / "rtx-3090.yml").read_text(encoding="utf-8") == real_hw
+
+    def test_absent_profile_files_are_still_seeded(self, tmp_path):
+        """The seeding itself must keep working on a bare fake root."""
+        make_app(repo_root=tmp_path)
+        eng = tmp_path / "scripts" / "lib" / "profiles" / "engines" / "vllm-stable.yml"
+        hw = tmp_path / "scripts" / "lib" / "profiles" / "hardware" / "rtx-3090.yml"
+        assert "supported_kv_formats" in eng.read_text(encoding="utf-8")
+        assert "sm: 8.6" in hw.read_text(encoding="utf-8")
 
 
 class TestDoctorKeyboardNav:

--- a/tools/serve-cockpit/tests/test_compose_viewer.py
+++ b/tools/serve-cockpit/tests/test_compose_viewer.py
@@ -1,0 +1,277 @@
+"""Compose viewer (Stage 1, READ-ONLY) — the data layer and the [c] surface.
+
+The gap this closes: Catalog rows, container drills and lane stages all name a
+config the user has only ever seen summarised. The serve confirm shows the
+CATALOG'S CLAIMS (ctx, measured TPS, fit) rather than the file, and a Route-K or
+generated serve shows only the docker command — so a user commits a compose they
+have not read and cannot reopen.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from textual.widgets import Static, TabbedContent
+
+from club3090_cockpit.app import ComposeViewScreen
+from club3090_cockpit.data import (
+    COMPOSE_STATUS_EMOJI,
+    classify_compose_provenance,
+    derive_compose_facts,
+    parse_profile_header,
+)
+
+from .test_app_headless import _settle, make_app
+
+REPO = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A THROWAWAY repo root holding one real curated compose.
+
+    App-level tests must never be handed the real checkout: `make_app` seeds two
+    profile stubs under `<root>/scripts/lib/profiles/`, so pointing it at the
+    real tree truncated two tracked files. The data-layer tests below still read
+    the real composes directly — that is a pure read and is the point of them."""
+    src = (
+        REPO / "models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml"
+    )
+    if not src.is_file():
+        pytest.skip("needs the repo tree")
+    dst = tmp_path / "models/qwen3.6-27b/vllm/compose/dual/autoround-int4/fp8-mtp.yml"
+    dst.parent.mkdir(parents=True)
+    dst.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+    return tmp_path
+
+
+# ── Header parser ────────────────────────────────────────────────────────────
+
+
+class TestProfileHeaderParser:
+    def test_block_scoped_ignores_prose_status_further_down(self):
+        """A `# Status:` outside the schema block must NOT be read as the header.
+
+        This is the whole reason for a block-scoped parser rather than
+        ComposeFacts.status_header's any-line regex: the gate
+        (compose_registry.compose_header_status) stops at the `# ---` separator,
+        and the viewer must agree with the gate or it shows a status the drift
+        check disagrees with."""
+        text = (
+            "# ===========================\n"
+            "# Profile (at-a-glance):\n"
+            "#   Model:     Test\n"
+            "#   Status:    🐣 Incubating\n"
+            "#   Caveats:   not validated\n"
+            "# ---------------------------\n"
+            "#   Status:    ✅ Production   <- prose, must be ignored\n"
+            "services:\n"
+            "  x:\n"
+            "    image: busybox\n"
+        )
+        h = parse_profile_header(text)
+        assert h.present
+        assert h.status_word == "incubating"
+        assert h.fields["Model"] == "Test"
+        assert not h.caveats_missing
+
+    def test_continuation_lines_append_to_the_previous_field(self):
+        """84 of 112 live composes carry a multi-line Caveats; dropping the
+        continuations would render a truncated caveat, which is worse than none."""
+        text = (
+            "# Profile (at-a-glance):\n"
+            "#   Status:    ⚠️ Production w/ caveats\n"
+            "#   Caveats:   first clause;\n"
+            "#              second clause;\n"
+            "#              third clause\n"
+            "# ---\n"
+        )
+        h = parse_profile_header(text)
+        assert h.status_word == "caveats"
+        assert "first clause" in h.fields["Caveats"]
+        assert "second clause" in h.fields["Caveats"]
+        assert "third clause" in h.fields["Caveats"]
+
+    def test_missing_required_caveats_is_flagged(self):
+        """A status in the caveats-required set with no Caveats line reds
+        test-compose-status-drift on the user's own checkout — worth seeing in
+        the viewer rather than at commit time."""
+        text = "# Profile (at-a-glance):\n#   Status:    🐣 Incubating\n# ---\n"
+        h = parse_profile_header(text)
+        assert h.caveats_required and h.caveats_missing
+
+    def test_no_header_is_not_an_error(self):
+        h = parse_profile_header("services:\n  x:\n    image: busybox\n")
+        assert not h.present and h.status_word == ""
+
+    def test_status_emoji_map_parity_with_the_gate(self):
+        """data.py DUPLICATES the map (it is stdlib-only and must not import the
+        profiles package). Parity is asserted rather than assumed."""
+        import sys
+
+        sys.path.insert(0, str(REPO / "scripts" / "lib" / "profiles"))
+        from compose_registry import COMPOSE_STATUS_EMOJI as GATE
+
+        assert COMPOSE_STATUS_EMOJI == GATE
+
+    @pytest.mark.skipif(not (REPO / "models").is_dir(), reason="needs the repo tree")
+    def test_agrees_with_the_gate_on_every_shipped_compose(self):
+        import sys
+
+        sys.path.insert(0, str(REPO / "scripts" / "lib" / "profiles"))
+        from compose_registry import compose_header_status
+
+        files = sorted((REPO / "models").glob("*/*/compose/**/*.yml"))
+        assert files, "no composes found"
+        for f in files:
+            text = f.read_text(encoding="utf-8")
+            assert parse_profile_header(text).status_word == (
+                compose_header_status(text) or ""
+            ), f
+
+
+# ── Provenance ───────────────────────────────────────────────────────────────
+
+
+class TestComposeProvenance:
+    def test_curated_is_not_editable(self, tmp_path):
+        """The asymmetry the whole design turns on: a git-tracked curated compose
+        edited in place silently diverges the checkout from upstream."""
+        p = tmp_path / "models" / "m" / "vllm" / "compose" / "dual" / "q" / "base.yml"
+        p.parent.mkdir(parents=True)
+        p.write_text("image: x\n", encoding="utf-8")
+        prov = classify_compose_provenance(str(p), tmp_path)
+        assert prov.kind == "curated" and prov.editable is False
+        assert "read-only" in prov.reason
+
+    def test_local_layer_is_editable(self, tmp_path):
+        p = tmp_path / "scripts" / "lib" / "profiles-local" / "composes" / "x" / "base.yml"
+        p.parent.mkdir(parents=True)
+        p.write_text("image: x\n", encoding="utf-8")
+        prov = classify_compose_provenance(str(p), tmp_path)
+        assert prov.kind == "local" and prov.editable is True
+
+    def test_generated_is_flagged_ephemeral(self, tmp_path):
+        p = tmp_path / "c3-genc-abc.yml"
+        p.write_text("image: x\n", encoding="utf-8")
+        prov = classify_compose_provenance(str(p), tmp_path)
+        assert prov.kind == "generated" and "ephemeral" in prov.reason
+
+    def test_external_file_outside_the_repo(self, tmp_path):
+        outside = tmp_path / "elsewhere"
+        outside.mkdir()
+        p = outside / "mine.yml"
+        p.write_text("image: x\n", encoding="utf-8")
+        prov = classify_compose_provenance(str(p), tmp_path / "repo")
+        assert prov.kind == "external" and prov.editable is True
+
+    def test_missing_path(self, tmp_path):
+        prov = classify_compose_provenance(str(tmp_path / "nope.yml"), tmp_path)
+        assert prov.kind == "missing" and prov.editable is False
+
+
+# ── The flag resolver regression ─────────────────────────────────────────────
+
+
+class TestFlagResolverShellCollision:
+    def test_bash_dash_c_does_not_hijack_max_ctx(self):
+        """`entrypoint: [bash, -c, |...]` is the standard vLLM compose shape.
+
+        flag() matched the FIRST token equal to ANY alias, so bash's -c beat
+        --max-model-len and max_ctx came back as the YAML block scalar "|".
+        125 of 133 shipped composes reported the wrong context this way, and
+        derive_compose_facts is what ① Bring's Route-K ingestion reads."""
+        text = (
+            "services:\n"
+            "  vllm:\n"
+            "    image: vllm/vllm-openai:v0.27.1\n"
+            "    entrypoint:\n"
+            "      - bash\n"
+            "      - -c\n"
+            "      - |\n"
+            "        exec vllm serve \\\n"
+            "    command:\n"
+            "      - --max-model-len\n"
+            '      - "${MAX_MODEL_LEN:-262144}"\n'
+        )
+        facts = derive_compose_facts(text)
+        assert facts.max_ctx == "${MAX_MODEL_LEN:-262144}"
+
+    def test_llama_cpp_short_ctx_flag_still_read(self):
+        """The -c alias must keep working when it is genuinely the engine's."""
+        text = (
+            "services:\n"
+            "  llama:\n"
+            "    image: llama.cpp:latest\n"
+            "    command:\n"
+            "      - -c\n"
+            "      - 65536\n"
+        )
+        assert derive_compose_facts(text).max_ctx == "65536"
+
+    @pytest.mark.skipif(not (REPO / "models").is_dir(), reason="needs the repo tree")
+    def test_no_shipped_compose_reports_a_block_scalar_ctx(self):
+        for f in sorted((REPO / "models").glob("*/*/compose/**/*.yml")):
+            ctx = derive_compose_facts(f.read_text(encoding="utf-8")).max_ctx
+            assert ctx not in ("|", ">", "|-", ">-", "|+", ">+"), f
+
+
+# ── The [c] surface ──────────────────────────────────────────────────────────
+
+
+class TestViewComposeKey:
+    @pytest.mark.asyncio
+    async def test_c_on_catalog_opens_the_slugs_compose(self, repo):
+        """The anchor placement: [c] on a Catalog row opens the file that slug
+        will actually run."""
+        app, _, _ = make_app(repo_root=repo, surface="producer")
+        async with app.run_test(size=(120, 44)) as pilot:
+            await _settle(pilot)
+            path, title = app._compose_target_for_focus()
+            assert path.endswith(".yml") and title
+            await pilot.press("c")
+            await _settle(pilot)
+            assert isinstance(app.screen, ComposeViewScreen)
+            prov = str(app.screen.query_one("#compose-provenance", Static).render())
+            assert "CURATED" in prov and "read-only" in prov
+
+    @pytest.mark.asyncio
+    async def test_viewer_shows_facts_and_yaml_and_copies_raw(self, repo):
+        app, _, _ = make_app(repo_root=repo, surface="producer")
+        async with app.run_test(size=(120, 44)) as pilot:
+            await _settle(pilot)
+            path, _ = app._compose_target_for_focus()
+            await pilot.press("c")
+            await _settle(pilot)
+            facts = str(app.screen.query_one("#compose-facts", Static).render())
+            assert "Status" in facts
+            # ${VAR:-default} is unwrapped for display, not shown raw.
+            assert "${MAX_MODEL_LEN" not in facts
+            # [Y] copies the RAW file, not the rendering.
+            raw = (repo / path).read_text(encoding="utf-8")
+            assert app.screen.copyable_text() == raw
+
+    @pytest.mark.asyncio
+    async def test_c_is_inert_on_orchestration_where_it_is_power_cap(self, repo):
+        """The two `c` bindings must have DISJOINT gates — Orchestration keeps
+        power-cap, so the viewer must not fire there."""
+        app, _, _ = make_app(repo_root=repo, surface="producer")
+        async with app.run_test(size=(120, 44)) as pilot:
+            await _settle(pilot)
+            app.query_one("#operate-tabs", TabbedContent).active = "tab-orchestration"
+            await _settle(pilot)
+            assert app.check_action("view_compose", ()) is False
+            assert app.check_action("power_cap", ()) is not False
+
+    @pytest.mark.asyncio
+    async def test_esc_and_c_both_close(self, repo):
+        app, _, _ = make_app(repo_root=repo, surface="producer")
+        async with app.run_test(size=(120, 44)) as pilot:
+            await _settle(pilot)
+            await pilot.press("c")
+            await _settle(pilot)
+            assert isinstance(app.screen, ComposeViewScreen)
+            await pilot.press("c")
+            await _settle(pilot)
+            assert not isinstance(app.screen, ComposeViewScreen)


### PR DESCRIPTION
Stage 1 of the compose viewer/editor design: **the viewer, read-only**.

Catalog rows, container drills and lane stages all name a config the user has only ever seen summarised. The serve confirm shows the *catalog's claims* — ctx, measured TPS, fit — not the file. A Route-K or generated serve shows only the docker command. So a user commits a compose they have never read and can't reopen. Two independent reviews landed on this same gap.

## What `c` does

Opens the compose behind the focused thing. Two layers: the `Profile (at-a-glance)` header plus the facts the file *mechanically* states (image / port / ctx / KV / TP), then the raw YAML with pygments highlighting through `rich.syntax` — already a dependency, so no new package.

`${MAX_MODEL_LEN:-262144}` renders as `262144 ($MAX_MODEL_LEN)`. The effective value is what the reader came for; the variable name is how they'd override it.

Wired on **Catalog** (the anchor — what this slug will actually run), **Containers**, and the **lane** stages. `c` is a *second* binding on the key with gates disjoint from `power_cap`, the same dual-binding idiom `v`/`k`/`f`/`D`/`w` already use — Orchestration keeps power-cap.

## Why read-only

No edit verb exists yet on any provenance. The provenance line still states editability, because that's what a reader needs before changing the file in their own editor — and for a **curated** compose the honest answer is *don't*: it's git-tracked and shared, so an in-place edit silently diverges the checkout from upstream, and the catalog starts misdescribing what you serve. `classify_compose_provenance` makes that mechanical (curated / local / generated / external / missing) instead of relying on the user noticing which directory they're in.

## Two bugs found on the way

**`derive_compose_facts` reported the wrong `max_ctx` for 125 of 133 shipped composes.** `flag()` returned the first token matching *any* alias in token order, so the `-c` in `entrypoint: [bash, -c, |...]` — the standard vLLM compose shape — beat `--max-model-len`, and `max_ctx` came back as the YAML block scalar `"|"`. This is the function **① Bring's Route-K ingestion reads**, so every Route-K user has been seeing a garbage context value. Fixed with alias *priority* (callers list the canonical name first), a shell-flag guard, and block scalars rejected as values.

**`make_app()` was destroying tracked files.** It seeded two profile stubs by writing them *unconditionally* into whatever `repo_root` it was handed, commented `(Idempotent; nothing else reads these.)` — false on both counts. The real repo ships 77-line versions that `engine_drafters` and the profile-compat layer read. Any test passing the real checkout truncated two tracked files to a 6-line stub — silently, since the writes sit inside `except OSError`.

My own new tests tripped it. The symptom was three *unrelated* tests failing (`engine_drafters` returning `[]`), which points a reader at entirely the wrong code — I nearly spent the diagnosis there. It now never overwrites an existing file, and a guard test asserts both halves (existing files untouched, bare roots still seeded).

## Verification

`1071 passed, 1 skipped, 0 failed`.

18 new tests, including two that check this code against the repo's own authority rather than against itself: the duplicated status-emoji map is asserted equal to `compose_registry.COMPOSE_STATUS_EMOJI`, and the header parser is asserted to agree with the **drift gate's** parse on every shipped compose (133/133). Negative-controlled: the flag fix, the disjointness of the two `c` gates, and the clobber guard.

## Next

Stages 2–4 of the design (Containers "running vs on-disk" truth, the editor for the user's own files, and fork-to-local) are not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
