### PR TITLE
c3 UX review: key-hint markup, footer honesty, focus traps, narrow terminals

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -6070,10 +6070,22 @@ class SettingsScreen(ModalScreen):
     }
     SettingsScreen > Vertical {
         width: 84;
+        /* An 80-col terminal is narrower than the card: without max-width the
+           right edge (and the Select's ▼) rendered off-screen. */
+        max-width: 100%;
         height: auto;
+        /* ~27 rows of fields on a 24-row terminal pushed BOTH the hint line and
+           the `^s Save / esc Cancel` Footer off the bottom of the screen — a
+           first-run user on a small terminal had no visible way to save.  Cap
+           the card at the viewport and let the fields scroll INSIDE it, so the
+           Footer stays pinned and reachable at every size. */
+        max-height: 100%;
         border: thick $accent;
         background: $surface;
         padding: 1 2;
+    }
+    SettingsScreen #settings-scroll {
+        height: auto;
     }
     SettingsScreen .settings-title {
         text-style: bold;
@@ -6115,40 +6127,50 @@ class SettingsScreen(ModalScreen):
     def compose(self) -> ComposeResult:
         with Vertical():
             yield Label("Settings", classes="settings-title")
-            yield Label("Model dir  [dim](weights live under <dir>/huggingface/)[/dim]",
-                        classes="settings-field")
-            yield Input(value=self._model_dir, placeholder="/mnt/models/huggingface", id="set-model-dir")
-            tok_ph = ("hf_…  (leave blank to keep the current token)"
-                      if self._hf_token_set else "hf_…  (for gated / private repos)")
-            yield Label("HuggingFace token", classes="settings-field")
-            yield Input(value="", password=True, placeholder=tok_ph, id="set-hf-token")
-            yield Label("Director placement  [dim](ai-studio prompt-crafter · :8090)[/dim]",
-                        classes="settings-field")
-            yield Select(
-                [("GPU 0 — fast craft, ~4.6 GB (default)", "gpu0"),
-                 ("GPU 1 — only when free, not during video", "gpu1"),
-                 ("CPU — frees GPU0 for long video, slow craft", "cpu")],
-                value=self._director_device, allow_blank=False, id="set-director-device",
-            )
-            yield Label(
-                "Master logging  [dim](app + non-download commands · downloads always log)[/dim]",
-                classes="settings-field",
-            )
-            log_switch = Switch(value=self._log_enabled, id="set-c3-log")
-            log_switch.disabled = self._log_env_override
-            yield log_switch
-            if self._log_path:
-                yield Label(f"[dim]Active log: {self._log_path}[/dim]", classes="settings-field")
-            elif self._log_env_override:
+            # The fields scroll; the title and the Footer do not.  See the
+            # max-height note in DEFAULT_CSS.
+            with VerticalScroll(id="settings-scroll"):
+                yield Label("Model dir  [dim](weights live under <dir>/huggingface/)[/dim]",
+                            classes="settings-field")
+                yield Input(value=self._model_dir, placeholder="/mnt/models/huggingface",
+                            id="set-model-dir")
+                tok_ph = ("hf_…  (leave blank to keep the current token)"
+                          if self._hf_token_set else "hf_…  (for gated / private repos)")
+                yield Label("HuggingFace token", classes="settings-field")
+                yield Input(value="", password=True, placeholder=tok_ph, id="set-hf-token")
+                yield Label("Director placement  [dim](ai-studio prompt-crafter · :8090)[/dim]",
+                            classes="settings-field")
+                yield Select(
+                    [("GPU 0 — fast craft, ~4.6 GB (default)", "gpu0"),
+                     ("GPU 1 — only when free, not during video", "gpu1"),
+                     ("CPU — frees GPU0 for long video, slow craft", "cpu")],
+                    value=self._director_device, allow_blank=False, id="set-director-device",
+                )
                 yield Label(
-                    "[dim]C3_LOG controls this launch; change the shell override to alter it.[/dim]",
+                    "Master logging  [dim](app + non-download commands · downloads always log)[/dim]",
                     classes="settings-field",
                 )
-            yield Label(
-                "[dim]Ctrl+S save · Esc cancel · HF_HOME auto-derived under the model dir · "
-                "director change applies on next ai-studio start[/dim]",
-                classes="settings-field",
-            )
+                log_switch = Switch(value=self._log_enabled, id="set-c3-log")
+                log_switch.disabled = self._log_env_override
+                yield log_switch
+                if self._log_path:
+                    yield Label(f"[dim]Active log: {self._log_path}[/dim]",
+                                classes="settings-field")
+                elif self._log_env_override:
+                    yield Label(
+                        "[dim]C3_LOG controls this launch; change the shell override to "
+                        "alter it.[/dim]",
+                        classes="settings-field",
+                    )
+                # The "Ctrl+S save · Esc cancel" half of this line was a duplicate
+                # of the Footer directly below it, and duplicating it is what
+                # pushed the Footer off a 24-row screen.  Keep only what the
+                # Footer cannot say.
+                yield Label(
+                    "[dim]HF_HOME auto-derived under the model dir · "
+                    "director change applies on next ai-studio start[/dim]",
+                    classes="settings-field",
+                )
             yield Footer()
 
     def action_save(self) -> None:

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -1048,7 +1048,7 @@ class HelpScreen(ModalScreen):
             "",
             "  click row = select + preview   double-click row = model info (\\[i])",
             "  click column header = column picker ([|])",
-            "  [Y] copies the context-relevant text (OSC52 — needs an OSC52 terminal;",
+            "  \\[Y] copies the context-relevant text (OSC52 — needs an OSC52 terminal;",
             "  works over SSH). To drag-select raw text, hold SHIFT while dragging —",
             "  the terminal bypasses the app's mouse capture and selects natively.",
          ])
@@ -3401,12 +3401,12 @@ class ConfirmActionScreen(ModalScreen):
         if self._thinking == "inherit":
             lines.append(
                 "  [bold]thinking[/bold] [dim]inherit[/dim] — no env injected "
-                "(entrypoint default: off → instruct row) · [t] force-on"
+                "(entrypoint default: off → instruct row) · \\[t] force-on"
             )
         elif self._thinking == "on":
             lines.append(
                 "  [bold]thinking[/bold] [green]FORCE-ON[/green] "
-                "([green]ENABLE_THINKING=true[/green]) · [t] cycle"
+                "([green]ENABLE_THINKING=true[/green]) · \\[t] cycle"
             )
             lines.append(
                 f"  [bold]sampler[/bold] thinking row: temp "
@@ -3420,26 +3420,26 @@ class ConfirmActionScreen(ModalScreen):
                 lines.append(
                     "  [bold]sampler[/bold] card defaults apply"
                     + (" — inherited overrides cleared" if self._sampler_reset else "")
-                    + " · [r] reset to card defaults"
+                    + " · \\[r] reset to card defaults"
                 )
             else:
                 shown = ", ".join(f"{k}={v}" for k, v in sorted(ovr.items()))
                 lines.append(
                     "  [yellow]⚠ shell overrides beat the card row:[/yellow] "
-                    f"{shown} · [r] reset to card defaults"
+                    f"{shown} · \\[r] reset to card defaults"
                 )
         else:
             lines.append(
                 "  [bold]thinking[/bold] FORCE-OFF "
                 "([yellow]ENABLE_THINKING=false[/yellow] — pins the instruct row even "
-                "if the shell exports true) · [t] cycle"
+                "if the shell exports true) · \\[t] cycle"
             )
         # Persisted default (#1014 follow-up) — what switch.sh will resolve on
         # later launches. inherit has nothing to save ([T] is gated off there).
         persisted = self._thinking_persisted()
         disp = persisted if persisted else "none"
         suffix = (
-            f" · [T] save '{self._thinking}' as default"
+            f" · \\[T] save '{self._thinking}' as default"
             if self._thinking != "inherit"
             else ""
         )
@@ -3682,25 +3682,25 @@ class ConfirmActionScreen(ModalScreen):
                     lines.append(
                         "  [bold]int8 acts[/bold] [green]ON[/green] "
                         "([green]VLLM_MARLIN_INPUT_DTYPE=int8[/green] — W4A8 prefill "
-                        f"win, quality-tied ⚑{learn}) · [a] toggle"
+                        f"win, quality-tied ⚑{learn}) · \\[a] toggle"
                     )
                 else:
                     lines.append(
                         "  [bold]int8 acts[/bold] [dim]off[/dim] "
-                        f"(W4A8 int8 activations ⚑ experimental{learn}) · [a] enable"
+                        f"(W4A8 int8 activations ⚑ experimental{learn}) · \\[a] enable"
                     )
             elif mode == "inverted":
                 if self._act8_on:
                     lines.append(
                         "  [bold]int8 acts[/bold] [green]ON[/green] "
                         "(shipped default — W4A8 int8 activations, quality-tied ⚑"
-                        f"{learn}) · [a] disable"
+                        f"{learn}) · \\[a] disable"
                     )
                 else:
                     lines.append(
                         "  [bold]int8 acts[/bold] [dim]off[/dim] "
                         "(W4A16 via [green]W4A8=0[/green] — gives up the int8 prefill "
-                        f"win{learn}) · [a] enable"
+                        f"win{learn}) · \\[a] enable"
                     )
             elif mode == "fixed":
                 lines.append(
@@ -4819,7 +4819,7 @@ class OperateContainersPane(Container):
                     placeholder="Select a running container — its docker logs stream here.",
                 )
             with TabPane("Top", id="drill-tab-stats"):
-                yield Static("[dim]highlight a container (move cursor) or press [t] — docker top loads[/dim]", id="drill-stats")
+                yield Static("[dim]highlight a container (move cursor) or press \\[t] — docker top loads[/dim]", id="drill-stats")
             with TabPane("Config", id="drill-tab-config"):
                 yield Static("[dim]highlight a container (move cursor) to load its config[/dim]", id="drill-config")
         yield Label(
@@ -6650,8 +6650,8 @@ class FirstRunScreen(ModalScreen):
         lines += [
             "",
             " [cyan]1 · Pick[/cyan]     keys [1-3] choose the model above.",
-            " [cyan]2 · Download[/cyan] [d] — fetch its weights (resumable; the normal [D] action).",
-            " [cyan]3 · Launch[/cyan]   [l] — the usual reconcile-gated serve confirm.",
+            " [cyan]2 · Download[/cyan] \\[d] — fetch its weights (resumable; the normal \\[D] action).",
+            " [cyan]3 · Launch[/cyan]   \\[l] — the usual reconcile-gated serve confirm.",
         ]
         return "\n".join(lines)
 
@@ -7133,7 +7133,7 @@ class ExportPrBundleScreen(_CopyableModal, ModalScreen):
             )
             yield Static(self._body_text(), id="export-body")
             yield Label(
-                "[dim][Y] copy bundle paths · Esc Close[/dim]",
+                "[dim]\\[Y] copy bundle paths · Esc Close[/dim]",
             )
 
     def _body_text(self) -> str:
@@ -9031,7 +9031,7 @@ _PALETTE_COMMANDS: tuple[tuple[str, str, str], ...] = (
     ("power_cap", "Power cap…", "Orchestration — power-cap menu: default 230W / clear / custom W (gated)"),
     ("power_cap_sweep", "Power cap sweep", "Doctor — sweep power caps + bench at each (gated)"),
     ("container_logs", "Container logs", "Containers — stream the selected container's logs"),
-    ("container_follow", "Container log follow", "Containers — [f] arm/pause the live log tail for the selected container"),
+    ("container_follow", "Container log follow", "Containers — \\[f] arm/pause the live log tail for the selected container"),
     ("doctor_rerun", "Re-run Doctor health", "Doctor — re-run the live health read (read-only)"),
     ("doctor_verify", "Verify serving", "Doctor — send a test query to the model (verify.sh · read)"),
     ("doctor_verify_full", "Verify-full battery", "Doctor — functional battery (verify-full.sh · ~1-2 min · read)"),
@@ -10361,7 +10361,7 @@ class CockpitApp(App):
         # trusted otherwise) — a banner on the catalog status line ([S] to set).
         from pathlib import Path as _Path
         mdir = self._data.weights_model_dir()
-        note = "" if _Path(mdir).is_dir() else f"⚠ model dir not found ({mdir}) — press [S] to set it"
+        note = "" if _Path(mdir).is_dir() else f"⚠ model dir not found ({mdir}) — press \\[S] to set it"
         pane.set_model_dir_note(note)
         # First-run guide (fresh-rig onboarding): AFTER the weights join, an
         # all-absent catalog + no local measurements → the ONE-TIME dismissable
@@ -11436,7 +11436,7 @@ class CockpitApp(App):
         # second 20+ GB fetch of the same repo (#617).  [k] cancels.
         if repo in self._active_bring_download():
             self.notify(
-                f"Already downloading {repo} — press [k] to cancel.",
+                f"Already downloading {repo} — press \\[k] to cancel.",
                 title="Download", timeout=4,
             )
             return
@@ -11447,7 +11447,7 @@ class CockpitApp(App):
         if _disk is not None:
             self.notify(
                 f"Already downloading {repo} (pid {_disk.get('pid')}) — "
-                "press [k] to cancel.",
+                "press \\[k] to cancel.",
                 title="Download", timeout=4,
             )
             return
@@ -11482,7 +11482,7 @@ class CockpitApp(App):
         if size_gb and size_gb > 0 and not fits:
             self.notify(
                 f"Disk may be tight ({free_gb:.0f} GB free / ~{need_gb:.0f} needed) "
-                "— starting anyway; free space or change Model Dir [S] if it fails.",
+                "— starting anyway; free space or change Model Dir \\[S] if it fails.",
                 title="Download", severity="warning", timeout=8,
             )
         # One download at a time (shared runner + exclusive worker): starting a
@@ -13074,7 +13074,7 @@ class CockpitApp(App):
             getattr(byo, "repo", "")
         ):
             self.notify(
-                "Weights not on disk yet — press [D] to download first.",
+                "Weights not on disk yet — press \\[D] to download first.",
                 title="② Serve", severity="warning", timeout=4,
             )
             return
@@ -13445,7 +13445,7 @@ class CockpitApp(App):
         self.stream_container_logs(con.name)  # snapshot — rebases the anchor (Task 4)
         self._log_follow_timer = self.set_interval(_LOG_FOLLOW_PERIOD, self._log_follow_tick)
         self._set_log_follow_title()
-        self.notify("Log follow armed — [f] to pause", title="Logs", timeout=3)
+        self.notify("Log follow armed — \\[f] to pause", title="Logs", timeout=3)
 
     def _log_follow_pause(self) -> None:
         """following → paused: stop the timer (anchor/name kept)."""
@@ -14720,7 +14720,7 @@ class CockpitApp(App):
         if not swap_compose:
             self.notify(
                 "② Serve: apply-swap --emit-only produced no compose — see the log. "
-                "You can still press [D] to download + emit.",
+                "You can still press \\[D] to download + emit.",
                 title="② Serve", severity="warning", timeout=6,
             )
             return
@@ -14852,7 +14852,7 @@ class CockpitApp(App):
             weights_file = ""
         if not weights_file:
             self.notify(
-                "No .gguf on disk yet — press [D] to download the selected quant.",
+                "No .gguf on disk yet — press \\[D] to download the selected quant.",
                 title="② Serve", severity="warning", timeout=5,
             )
             return

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -7911,6 +7911,12 @@ class LaneBringPane(Container):
                  downloading: bool = False) -> None:
         card = self.query_one("#lane-bring-result-card", Static)
         card.update(_byo_result_text(res, weights_present, downloading))
+        # At 80x24 the verdict lands below the fold — the answer to the question
+        # the user just asked would be off-screen with nothing saying so.
+        try:
+            card.scroll_visible(animate=False)
+        except Exception:
+            pass
         # Stateful next-hint: failure → repair; success → single valid next key.
         can_continue = False
         if getattr(res, "error", ""):
@@ -11119,6 +11125,20 @@ class CockpitApp(App):
         except Exception:
             pass
 
+    def _scroll_bring_result_into_view(self) -> None:
+        """Bring ① Bring's verdict card on screen.
+
+        At 80x24 the result card sits below the fold after both Inspect and
+        Fit-check — the pane answers the user's question off-screen and nothing
+        indicates there is more to read.  Best-effort: a silent no-op when the
+        pane is not mounted."""
+        try:
+            self.query_one("#lane-bring-result-card", Static).scroll_visible(
+                animate=False
+            )
+        except Exception:
+            pass
+
     def _reveal_funnel_slugs(
         self, artifact_format: str, artifact_gb: Optional[float]
     ) -> None:
@@ -11147,13 +11167,22 @@ class CockpitApp(App):
             # Dogfood r2 — the pre-selected recommendation's details show
             # immediately (updates ride on_select_changed thereafter).
             pane.show_slug_details(self._funnel_slug_details(rec) if rec else "")
-            # Focus what was just revealed. Without this the user Tabs past the
-            # three action buttons to reach the config Select they were just told
-            # to pick from — four keys to reach the one control the pane is
-            # asking about. Deferred: the widget is not visible this cycle.
-            self.call_after_refresh(
-                lambda: self._focus_if_present("#lane-bring-profile-input")
-            )
+            # Focus what was just revealed, and focus the thing ⏎ actually does.
+            #
+            # This used to focus #lane-bring-profile-input (the config Select).
+            # That put the user in a keyboard trap: the footer and the Modes rail
+            # both say "⏎ Fit-check", but ⏎ on a focused Select opens its
+            # dropdown, so the advertised primary action was unreachable from the
+            # focus the app itself had just set.  The Fit-check button is the
+            # correct target — the Select is one Shift+Tab away and is already
+            # pre-set to the ⭐ recommendation, so the common path (accept the
+            # recommendation, fit-check it) is now zero keys instead of a trap.
+            # Deferred: the widgets are not visible this cycle.
+            def _focus_and_reveal() -> None:
+                self._focus_if_present("#lane-bring-fit-btn")
+                self._scroll_bring_result_into_view()
+
+            self.call_after_refresh(_focus_and_reveal)
             # Bug A (2026-07-09): the §2b size floor can hide EVERY slug — a 54G
             # bf16 repo on a 48G rig — leaving only the ✎ sentinel with NO
             # explanation.  Surface an honest verdict, distinguishing "too big for

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -6996,6 +6996,13 @@ class PromoteScaffoldScreen(_CopyableModal, ModalScreen):
             return
         stage.disabled = not self._can_stage()
         core.disabled = not self._can_stage()
+        # Enabling the buttons is only HALF the state change: ``check_action``
+        # gates ⏎ / C on the same ``_can_stage()``, and the Footer caches that
+        # verdict.  Without this the footer keeps showing only "esc Close"
+        # after the required edits are filled, so the ⏎ that just became valid
+        # is invisible.  Mutating state never repaints the footer on its own —
+        # ``refresh_bindings()`` is the other half.
+        self.refresh_bindings()
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "promote-stage-btn":

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -9235,7 +9235,24 @@ class CockpitApp(App):
         Binding("2", "mode_validate", "Bring & Validate", show=False),
         # Footer description is rewritten live by `_sync_footer_labels` (Fit-check /
         # Serve / Launch step / …) — "Select" is only the class default.
-        Binding("enter", "primary_action", "Select", show=True),
+        #
+        # show=False DELIBERATELY.  A focused DataTable declares its own
+        # `enter → select_cursor (show=False)`, and the deepest focused node
+        # wins the footer — so ⏎ silently vanished from the footer on every
+        # table-focused pane, which is the BOOT state of Catalog, Orchestration
+        # and ③ Gate.  The key itself always worked (RowSelected routes to
+        # `action_primary_action`); only the advertisement was inconsistent,
+        # present in some panes and absent in others for the same key.
+        #
+        # Rather than fight DataTable for the slot in the four primary tables,
+        # ⏎ is advertised in ONE consistent place instead: `#mode-action-hint`
+        # in the Modes rail, which `_sync_footer_labels` already writes with the
+        # SAME computed label ("⏎ Serve", "⏎ Fit-check", "⏎ Re-run health"), plus
+        # each pane's own hint line.  That is honest in every pane and frees
+        # ~14 columns of footer at 80 wide, where the footer is the scarcest
+        # space on screen.  `_relabel_binding` is still useful: it keeps the
+        # command-palette/tooltip text truthful.
+        Binding("enter", "primary_action", "Select", show=False),
         # Catalog (Run) — default pin management (.env write, gated=no GPU).
         Binding("d", "set_default", "Set default", show=False),
         Binding("D", "clear_default", "Clear default", show=False),

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -1041,6 +1041,15 @@ class HelpScreen(ModalScreen):
             "  [cyan]e[/cyan] explain   [cyan]i[/cyan] model info (metadata popup for the selected slug)",
             "  [cyan]d[/cyan] set-default   [cyan]D[/cyan] clear-default",
             "  [cyan]O[/cyan] ▸ Optimize for my card (kv-calc recs, advisory)",
+            # These six are show=False bindings whose ONLY other teaching surface
+            # is the pane's own hint line — which is itself clipped on a narrow
+            # terminal.  Help is where they have to be findable.
+            "  [cyan]\\ [/cyan]model scope (dropdown)   [cyan]/[/cyan] filter   "
+            "[cyan]s[/cyan] sort — group-by-model → TPS ↓ → GB ↑ → ctx ↓",
+            "  [cyan]h[/cyan] reveal 🗑️ deprecated + hardware-incompatible slugs   "
+            "[cyan]w[/cyan] downloaded-only",
+            "  [cyan]|[/cyan] columns picker (show/hide + reorder; persisted)   "
+            "[cyan]u[/cyan] copy the serving API URL",
             "",
             "[bold]Run & Operate · Orchestration[/bold]",
             "  [cyan]⏎[/cyan] switch scene   [cyan]k[/cyan] stop THIS model   [cyan]b[/cyan] restart serving   [cyan]n[/cyan] switch model (→ Catalog tab)   (writes gated)",
@@ -9142,6 +9151,8 @@ _PALETTE_COMMANDS: tuple[tuple[str, str, str], ...] = (
     ("explain", "Explain selected slug", "Catalog — detail + cross-rig benchmarks"),
     ("model_info", "Model info", "Catalog — metadata popup for the selected slug (\\[i])"),
     ("filter_catalog", "Filter catalog", "Catalog — filter by slug / engine / status"),
+    ("toggle_catalog_model", "Model scope (Catalog)", "Catalog — narrow to one model (\\[\\] dropdown)"),
+    ("catalog_columns", "Catalog columns…", "Catalog — show/hide + reorder columns (\\[|] · persisted)"),
     ("toggle_catalog_deprecated", "Show/hide deprecated", "Catalog — reveal 🗑️ deprecated slugs (hidden by default)"),
     ("toggle_catalog_downloaded", "Show only downloaded", "Catalog — narrow to slugs whose weights are already on disk"),
     ("copy_endpoint", "Copy the serving API URL", "Run & Operate — copy http://<lan>:<port>/v1 for your agent/client (no auth by default)"),
@@ -15678,6 +15689,32 @@ class CockpitApp(App):
                 # reaching RowHighlighted.  The flag is managed entirely by the
                 # populate path ([r]-refresh) + the highlight handler.
             self.call_after_refresh(_do_focus)
+            return
+
+        # No primary list for this tab — the table-less lane stages (① Bring /
+        # ② Serve / ⑤ Promote) and mode-0 Doctor.  The comment above says focus
+        # should simply STAY on the tab bar here, and that is right whenever the
+        # focused widget survives the switch.  It does NOT when the OUTGOING tab
+        # owned it: a user typing in ① Bring's repo field who presses [s] to
+        # advance to ② Serve has their focused Input hidden, `app.focused` goes
+        # None, and the next Tab lands on the ModeSwitcher at the very top of the
+        # DOM instead of anywhere in the stage they just opened.  Re-home to the
+        # lane tab bar — the same target `_focus_mode_primary` uses for mode 1,
+        # and a ContentTabs rather than an Input so 1/2 and [ ] keep routing.
+        #
+        # Guarded on `focused is None` so this can only ever FILL a hole; it must
+        # never yank focus off a widget that is still live.
+        def _rehome_focus() -> None:
+            if self.focused is not None:
+                return
+            try:
+                bar = self._active_tab_bar()
+                if bar is not None:
+                    bar.focus()
+            except Exception:
+                pass
+
+        self.call_after_refresh(_rehome_focus)
 
     # ── Widget event handlers ─────────────────────────────────────────────────────────
 

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -10020,7 +10020,7 @@ class CockpitApp(App):
             pass
         return changed
 
-    def _apply_footer_width_policy(self) -> None:
+    def _apply_footer_width_policy(self, width: Optional[int] = None) -> None:
         """Width-gate the two redundant global keys so the CONTEXT key survives.
 
         The footer renders bindings in declaration order and the six globals are
@@ -10035,7 +10035,13 @@ class CockpitApp(App):
         The KEYS keep working at every width; only the footer advertisement is
         gated.  Above the threshold everything is shown as before."""
         try:
-            wide = self.size.width >= _FOOTER_WIDE_COLS
+            # `width` comes from the Resize EVENT.  `self.size` is not updated
+            # yet while the event is being handled, so reading it here gated on
+            # the PREVIOUS width — the footer lagged one resize behind (verified:
+            # 140 → 80 still showed r/S, 80 → 140 then hid them).
+            if width is None:
+                width = self.size.width
+            wide = width >= _FOOTER_WIDE_COLS
         except Exception:
             return
         changed = False
@@ -10048,7 +10054,9 @@ class CockpitApp(App):
             self.refresh_bindings()
 
     def on_resize(self, event) -> None:
-        self._apply_footer_width_policy()
+        self._apply_footer_width_policy(
+            getattr(getattr(event, "size", None), "width", None)
+        )
 
     def _sync_footer_labels(self) -> None:
         """Phase 1.3 — mirror the live meaning of context keys in the footer.

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -2334,12 +2334,17 @@ class ExplainScreen(_CopyableModal, ModalScreen):
         Binding("Y", "app.copy_context", "Copy", show=True),
     ]
 
-    def __init__(self, slug: str, *, model: str = "", engine: str = "", **kwargs):
+    def __init__(self, slug: str, *, model: str = "", engine: str = "",
+                 status: str = "", **kwargs):
         super().__init__(**kwargs)
         self._slug = slug
-        # (model, engine) drive the cross-rig benchmark fold (Fold 3).
+        # (model, engine) drive the cross-rig benchmark fold (Fold 3).  They —
+        # and `status` — are ALSO the fallback for the identity rows: see
+        # `_rerender`.  The caller already holds these on the CatalogEntry, so
+        # the modal never has to show "—" for a fact the row behind it displays.
         self._model = model
         self._engine = engine
+        self._status = status
         # Cached detail (our-rig story) so the cross-rig benchmark rows folded in
         # from the retired Benchmarks tab can be appended once they arrive.
         self._detail: Optional[dict] = None
@@ -2379,15 +2384,38 @@ class ExplainScreen(_CopyableModal, ModalScreen):
         body = self.query_one("#explain-body", Static)
         detail, error = self._detail, self._detail_error
         if error or detail is None:
-            body.update(f"[red]explain failed:[/red] {error or 'no data'}")
+            # Even a hard failure should not hide what the caller already knows —
+            # the catalog row behind this modal is displaying these three fields.
+            known = [
+                f"  [bold]{label}[/bold]  {value}"
+                for label, value in (
+                    ("Model ", self._model),
+                    ("Engine", self._engine),
+                    ("Status", self._status),
+                )
+                if value
+            ]
+            head = f"[red]explain failed:[/red] {error or 'no data'}"
+            body.update("\n".join([head, "", *known]) if known else head)
             return
         reg = detail.get("registry", {}) or {}
         fit = detail.get("fit", {}) or {}
         benches = detail.get("benchmarks", []) or []
+        # `switch.sh --explain` can answer without a `registry` block (or with an
+        # empty one).  Reading it with a "—" default then rendered "Model — /
+        # Engine — / Status —" directly on top of a catalog row that was showing
+        # the real values — the modal contradicting the screen behind it.  The
+        # CatalogEntry's fields are the SAME registry facts, already in hand, so
+        # use them whenever explain doesn't carry its own.
+        model = reg.get("model") or self._model or "—"
+        engine = reg.get("engine") or self._engine or "—"
+        status = str(reg.get("status") or self._status or "")
         lines: list[str] = []
-        lines.append(f"  [bold]Model[/bold]   {reg.get('model', '—')}")
-        lines.append(f"  [bold]Engine[/bold]  {reg.get('engine', '—')}")
-        lines.append(f"  [bold]Status[/bold]  {_status_glyph(str(reg.get('status', '')))} {reg.get('status', '—')}")
+        lines.append(f"  [bold]Model[/bold]   {model}")
+        lines.append(f"  [bold]Engine[/bold]  {engine}")
+        lines.append(
+            f"  [bold]Status[/bold]  {_status_glyph(status)} {status or '—'}"
+        )
         if reg.get("status_note"):
             lines.append(f"  [bold]Caveat[/bold]  [yellow]{reg.get('status_note')}[/yellow]")
         lines.append(f"  [bold]Card[/bold]    {detail.get('card', '—')}")
@@ -12955,7 +12983,14 @@ class CockpitApp(App):
             return
         # The screen loads its own detail + cross-rig on mount (so the body query
         # resolves against a fully-mounted modal — Fold 3 cross-rig fold included).
-        self.push_screen(ExplainScreen(entry.slug, model=entry.model, engine=entry.engine))
+        self.push_screen(
+            ExplainScreen(
+                entry.slug,
+                model=entry.model,
+                engine=entry.engine,
+                status=entry.status,
+            )
+        )
 
     def action_model_info(self) -> None:
         """[i] — the local-data model-info popup for the selected catalog row

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -389,6 +389,28 @@ _CATALOG_COLUMNS: "list[tuple[str, str]]" = [
 ]
 _CATALOG_HEADERS = dict(_CATALOG_COLUMNS)
 _CATALOG_PINNED = {"slug"}  # identity — never hideable
+
+# #22 — narrow-terminal column default.  With all 16 columns on, an 80-col
+# terminal shows `model · slug · provider · we…` and nothing else: the table
+# needs 151 columns and gets 46, so the columns you actually PICK on (status,
+# ctx, TPS) sit ~100 columns off-screen right, reachable only by horizontal
+# scroll that nothing advertises.  Below _CATALOG_NARROW_COLS the config and
+# topology facets fold away by default, leaving identity + the decision columns.
+# This is a DEFAULT, not a lock: it applies only when the user has no persisted
+# [|] picker preference, and picking columns overrides it permanently.
+# Two tiers, because 80 and 120 are very different budgets.  Measured against
+# the rendered table width, not guessed:
+#   < 120 : fold the config + topology facets  → model · slug · ctx · TPS · status
+#   < 100 : also fold `model`  → slug · ctx · TPS · status  (the model is still
+#           named by the \\[\\] model-scope dropdown, the preview strip under the
+#           table, and the default group-by-model sort)
+_CATALOG_NARROW_COLS = 120
+_CATALOG_VERY_NARROW_COLS = 100
+_CATALOG_NARROW_HIDDEN = {
+    "provider", "weights", "gb", "kv", "act", "offload", "host_ram", "spec",
+    "8pk", "topo", "engine",
+}
+_CATALOG_VERY_NARROW_HIDDEN = _CATALOG_NARROW_HIDDEN | {"model"}
 _CATALOG_SORTS: "list[tuple[str, str]]" = [
     # The [s] catalog sort cycle, in order.  "model" is the DEFAULT — the
     # stable group-by-model registry view (switch.sh --list look); the other
@@ -410,18 +432,38 @@ def _sanitize_catalog_sort(saved: Any) -> str:
     return key if key in _CATALOG_SORT_KEYS else "model"
 
 
-def _sanitize_catalog_columns(saved: Any) -> tuple[list[str], set[str]]:
+def _sanitize_catalog_columns(
+    saved: Any, *, width: Optional[int] = None
+) -> tuple[list[str], set[str]]:
     """Normalise a persisted ``{"order": [...], "hidden": [...]}`` into a safe
     ``(order, hidden)`` pair: unknown keys dropped, canonical keys missing from
     a saved order inserted next to their canonical neighbour (a NEWLY-shipped
     column appears, visible, without wiping the user's layout), pinned keys
-    forced visible.  Tolerant of any malformed shape → canonical defaults."""
+    forced visible.  Tolerant of any malformed shape → canonical defaults.
+
+    ``width`` is the terminal width and applies ONLY when there is no persisted
+    preference: below ``_CATALOG_NARROW_COLS`` the default hidden set becomes
+    ``_CATALOG_NARROW_HIDDEN`` so the pick-decision columns are on screen
+    instead of scrolled off the right edge.  A user who has touched the [|]
+    picker keeps exactly what they chose, at every width."""
     default_order = [k for k, _ in _CATALOG_COLUMNS]
+
+    def _default_hidden() -> set[str]:
+        if width is None:
+            return set()
+        if width < _CATALOG_VERY_NARROW_COLS:
+            return set(_CATALOG_VERY_NARROW_HIDDEN) - _CATALOG_PINNED
+        if width < _CATALOG_NARROW_COLS:
+            return set(_CATALOG_NARROW_HIDDEN) - _CATALOG_PINNED
+        return set()
+
+    if not saved:
+        return list(default_order), _default_hidden()
     try:
         raw_order = [str(k) for k in (saved or {}).get("order", [])]
         raw_hidden = [str(k) for k in (saved or {}).get("hidden", [])]
     except (AttributeError, TypeError):
-        return list(default_order), set()
+        return list(default_order), _default_hidden()
     order = [k for k in raw_order if k in _CATALOG_HEADERS]
     # de-dup, first occurrence wins
     seen: set[str] = set()
@@ -1005,7 +1047,8 @@ class HelpScreen(ModalScreen):
             "  [cyan]o[/cyan] stop ALL (tears down the whole estate)   [cyan]c[/cyan] power cap… (default 230W / clear / custom W)   (all gated)",
             "  [cyan]N[/cyan] new pod (run several models on GPU subsets — name · slug · GPU set, fit-checked + gated)",
             "[bold]Run & Operate · Containers[/bold]",
-            "  [cyan]l[/cyan] logs   [cyan]t[/cyan] top (read)   [cyan]s[/cyan] restart   [cyan]x[/cyan] stop   [cyan]X[/cyan] rm   (writes gated)",
+            "  [cyan]l[/cyan] logs   [cyan]t[/cyan] top   [cyan]c[/cyan] compose   [cyan]f[/cyan] follow (arm/pause the live tail)   (all read)",
+            "  [cyan]s[/cyan] restart · start if stopped   [cyan]x[/cyan] stop   [cyan]X[/cyan] rm   (writes gated)",
             "[bold]Run & Operate · Doctor[/bold]  — is it serving correctly?",
             "  [cyan]y[/cyan] health (read)   [cyan]v[/cyan] verify   [cyan]V[/cyan] verify-full   [cyan]R[/cyan] report   [cyan]F[/cyan] report --full   [cyan]w[/cyan] power-cap sweep (gated)",
         ]
@@ -1160,7 +1203,12 @@ class CatalogPane(Container):
         height: 1fr;
     }
     CatalogPane #catalog-status {
-        height: 1;
+        /* `width: auto` computed a 112-col region against a 46-col viewport, so
+           the line was truncated horizontally at every realistic width — the
+           "run bench.sh / quality-test.sh" nudge never finished rendering below
+           ~170 cols.  1fr + auto height makes it wrap instead of vanish. */
+        width: 1fr;
+        height: auto;
         color: $text-muted;
         padding: 0 1;
     }
@@ -1183,6 +1231,13 @@ class CatalogPane(Container):
     }
     CatalogPane DataTable {
         height: 1fr;
+        /* The table is the pane.  With `height: 1fr` alone it lost every row to
+           its auto-height siblings (status / preview / hint) plus the 12-row
+           #serve-live that appears after a Start: at 80x24 it collapsed to
+           height 1 — not even the header — so starting a model made the list
+           you started it from vanish.  Floor it; the preview strip already has
+           `overflow-y: auto` and is the right thing to squeeze. */
+        min-height: 6;
     }
     CatalogPane #catalog-preview {
         height: auto;
@@ -1198,7 +1253,12 @@ class CatalogPane(Container):
         color: $text;
     }
     CatalogPane #catalog-hint {
-        height: 1;
+        /* This one IS in the app-level `width: 1fr` list, so it wraps — but
+           `height: 1` then clipped every wrapped row but the first.  At 80 cols
+           that cut the line at "[c]", so `[s] sort` and `[|] columns` never
+           rendered at ANY width below ~159.  Those two keys have no other
+           teaching surface, which is why they read as nonexistent. */
+        height: auto;
         color: $text-muted;
         padding: 0 1;
     }
@@ -1265,8 +1325,11 @@ class CatalogPane(Container):
         # the user's picker state ([|]), applied at launch from the persisted
         # "catalog_columns" settings key via apply_persisted_settings (an app
         # constructed directly — tests — starts canonical).
+        # `width` folds the config/topology facets away on a narrow terminal —
+        # but ONLY when there is no persisted [|] preference (see #22 above).
         self._col_order, self._col_hidden = _sanitize_catalog_columns(
-            getattr(self.app, "catalog_columns_pref", None)
+            getattr(self.app, "catalog_columns_pref", None),
+            width=getattr(getattr(self.app, "size", None), "width", None),
         )
         self._apply_columns_to_table(table)
         # Full enriched catalog, and the current filter substring.
@@ -4850,11 +4913,14 @@ class OperateContainersPane(Container):
                 yield Static("[dim]highlight a container (move cursor) or press \\[t] — docker top loads[/dim]", id="drill-stats")
             with TabPane("Config", id="drill-tab-config"):
                 yield Static("[dim]highlight a container (move cursor) to load its config[/dim]", id="drill-config")
+        # Two deliberate lines, not one long wrap.  At 80x24 this pane gets 46
+        # columns, and the old single run-on hint wrapped to FOUR of the 24 rows
+        # — which is what squeezed the Logs RichLog down to two lines.  Reads /
+        # writes are split so the gating fact is stated once, and the full
+        # per-key detail lives in ? (Help), which carries all seven keys.
         yield Label(
-            "[dim]move cursor or \\[l]/\\[t] to load detail · \\[l] logs   \\[t] top   "
-            "\\[c] compose   "
-            "\\[f] follow   \\[s] restart · start if stopped (gated)   \\[x] stop (gated)   "
-            "\\[X] rm (reconcile-gated)[/dim]",
+            "[dim]\\[l] logs  \\[t] top  \\[c] compose  \\[f] follow\n"
+            "\\[s] restart  \\[x] stop  \\[X] rm  · gated[/dim]",
             id="containers-hint",
         )
 
@@ -7626,19 +7692,16 @@ class LaneBringPane(Container):
         height: auto;
         margin-top: 1;
     }
-    LaneBringPane #lane-bring-inspect-btn {
-        /* was width:14 with NO margin — below Button's min width, and it sat
-           flush against its neighbour so the two read as one control. */
-        width: 16;
-        margin-left: 2;
-    }
-    LaneBringPane #lane-bring-validate-compose-btn {
-        width: 20;
-        margin-left: 2;
-    }
-    LaneBringPane #lane-bring-search-btn {
-        width: auto;
-        margin-left: 2;
+    /* The three buttons were fixed at 16 / 20 / auto with `margin-left: 2` each
+       — 58 columns of demand in the 42 the pane gets at 80 wide.  The third
+       button overflowed the screen edge and "Validate compose" rendered as
+       "Va": still clickable, unreadable, and invisible as a control.  Share the
+       row instead (1fr each) with a floor that keeps every label legible, and
+       halve the gutters. */
+    LaneBringPane #lane-bring-actions Button {
+        width: 1fr;
+        min-width: 12;
+        margin-left: 1;
     }
     LaneBringPane #lane-bring-gguf-select {
         width: 36;
@@ -9207,6 +9270,13 @@ class CockpitCommands(Provider):
 
 # ── Main application ──────────────────────────────────────────────────────────────
 
+# Footer width policy (#16): at/above this many columns the footer shows the
+# redundant global keys (r Refresh · S Settings); below it they are hidden so the
+# pane's own context key is not the one that gets clipped.  120 is the width at
+# which the WORST case — Doctor, the only pane with two context keys ("v Verify
+# serving" + "y Re-run health") — still fits alongside them; at 100 it did not.
+_FOOTER_WIDE_COLS = 120
+
 # Containers log-follow (\\[f]) — docker-logs poll cadence while armed.  2s is
 # imperceptible for a log tail and keeps the read-runner calls cheap.
 _LOG_FOLLOW_PERIOD = 2.0
@@ -9232,6 +9302,8 @@ class CockpitApp(App):
     BINDINGS = [
         Binding("q", "quit", "Quit", show=True),
         Binding("question_mark", "help", "Help", show=True),
+        # r / S are width-gated in the footer by _apply_footer_width_policy:
+        # shown at >= _FOOTER_WIDE_COLS, hidden below it.  See that method.
         Binding("r", "refresh", "Refresh", show=True),
         # Sub-tab cycle — shown when the mode has sub-tabs (check_action gates).
         # Both brackets show=True so [ and ] are symmetric in the footer (the
@@ -9441,6 +9513,14 @@ class CockpitApp(App):
     #evidence-hint, #lane-bring-hint, #lane-serve-hint, #lane-promote-hint {
         width: 1fr;
     }
+    /* Pane HEADINGS have exactly the same problem and were never added here:
+       being `width: auto` Labels they were TRUNCATED (not wrapped) at 80 cols —
+       "① Bring — inspect an HF model, or bring a co", "Doctor — is the running
+       model serving cor", "Gate (⏎ launches the selected step — confirm-".
+       Each loses the clause that says what the pane is for. */
+    #doctor-heading, #lane-bring-heading, #lane-serve-heading, #run-heading {
+        width: 1fr;
+    }
     #main-layout {
         height: 1fr;
     }
@@ -9497,8 +9577,19 @@ class CockpitApp(App):
     }
     #panel-run > #serve-live.serving {
         display: block;
-        height: 12;
+        /* Was a fixed `height: 12`.  On a 24-row terminal that 13-row sibling
+           squeezed #operate-tabs until the catalog DataTable collapsed to
+           height 1 — not even its header row survived, so starting a model made
+           the list you started it from disappear.  Take the space only when
+           there is space: `1fr` up to the old 12, with a min-height on the tabs
+           so the table always keeps a usable number of rows. */
+        height: 1fr;
+        max-height: 12;
+        min-height: 5;
         margin: 0 1 1 1;
+    }
+    #panel-run > #operate-tabs {
+        min-height: 12;
     }
     /* FIX 1 — while a ModalScreen is topmost, suppress the BASE FocusableFooter
        (the main screen's footer renders UNDER/around the modal otherwise, showing
@@ -9897,6 +9988,56 @@ class CockpitApp(App):
                         return
         except Exception:
             pass
+
+    def _set_binding_show(self, action: str, show: bool) -> bool:
+        """Flip a BINDING's footer visibility in place; True if it changed.
+
+        Per-instance copy, same pattern as `_relabel_binding`.  Note this is the
+        only way to hide a key WITHOUT disabling it: returning False from
+        `check_action` would also stop the key firing, and None would grey it
+        out — neither of which is wanted for keys that must keep working."""
+        import dataclasses
+
+        changed = False
+        try:
+            for bindings in self._bindings.key_to_bindings.values():
+                for i, b in enumerate(bindings):
+                    if b.action == action and b.show != show:
+                        bindings[i] = dataclasses.replace(b, show=show)
+                        changed = True
+        except Exception:
+            pass
+        return changed
+
+    def _apply_footer_width_policy(self) -> None:
+        """Width-gate the two redundant global keys so the CONTEXT key survives.
+
+        The footer renders bindings in declaration order and the six globals are
+        declared first, so at 80 columns the key that is actually about the pane
+        you are looking at is the one that gets cut — measured: "s Sort" → "s
+        So", "s Restart" → "s Re", "v Verify serving" → "v Ve", and on ④ Measure
+        "s Submit" lost its description entirely.  That is exactly backwards.
+
+        `r` (Refresh) and `S` (Settings) are the two globals with a full fallback
+        elsewhere — both are in the ? Help overlay AND in the ^p command palette —
+        so they are the right ~23 columns to reclaim below _FOOTER_WIDE_COLS.
+        The KEYS keep working at every width; only the footer advertisement is
+        gated.  Above the threshold everything is shown as before."""
+        try:
+            wide = self.size.width >= _FOOTER_WIDE_COLS
+        except Exception:
+            return
+        changed = False
+        for action in ("refresh", "settings"):
+            if self._set_binding_show(action, wide):
+                changed = True
+        if changed:
+            # Flipping `show` is only half of it — the Footer caches the
+            # displayed-binding signature and will not repaint on its own.
+            self.refresh_bindings()
+
+    def on_resize(self, event) -> None:
+        self._apply_footer_width_policy()
 
     def _sync_footer_labels(self) -> None:
         """Phase 1.3 — mirror the live meaning of context keys in the footer.

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -1232,13 +1232,22 @@ class TestNavNodesExist:
         """#1014 L3: while the resolved mode is thinking, the card shows the
         registry 'thinking' row (temp/top_p/presence) near the toggle; inherit
         shows no sampler row; force-off pins the instruct row explicitly."""
+        # Assert on the MARKUP-PARSED line, not the raw source string: the key
+        # hints are written `\\[t]` / `\\[r]`, and a raw-substring assertion for
+        # "[t]" passes whether or not the escape is present — so it never
+        # protected the thing it looks like it protects (Textual deletes an
+        # unescaped `[t]`).  Parsing first makes the assertion real.
+        def _seen(lines):
+            from textual.content import Content
+            return "\n".join(Content.from_markup(ln).plain for ln in lines)
+
         m = self._thinking_modal(tmp_path=tmp_path)
         inherit_lines = m._thinking_card_lines()
-        assert any("inherit" in ln and "[t]" in ln for ln in inherit_lines)
+        assert "[t]" in _seen(inherit_lines) and "inherit" in _seen(inherit_lines)
         assert not any("temp" in ln for ln in inherit_lines)
 
         m.action_cycle_thinking()   # → on
-        on_lines = "\n".join(m._thinking_card_lines())
+        on_lines = _seen(m._thinking_card_lines())
         assert "FORCE-ON" in on_lines and "ENABLE_THINKING=true" in on_lines
         assert "temp 1 · top_p 0.95 · presence 0" in on_lines, on_lines
         assert "model card" in on_lines and "[r] reset to card defaults" in on_lines
@@ -13772,10 +13781,14 @@ class TestSettings:
         async with app.run_test(size=(120, 40)) as pilot:
             await _settle(pilot)
             pane = app.query_one("#catalog-pane", CatalogPane)
-            pane.set_model_dir_note("⚠ model dir not found — press [S] to set it")
+            # Mirror the production note verbatim (app.py escapes the key hint):
+            # the banner is interpolated into a markup Static, so an unescaped
+            # "[S]" is deleted before the user sees it.
+            pane.set_model_dir_note("⚠ model dir not found — press \\[S] to set it")
             await pilot.pause()
-            status = str(app.query_one("#catalog-status", Label).render())
+            status = _renderable_text(app.query_one("#catalog-status", Label))
             assert "model dir not found" in status
+            assert "[S]" in status, status
 
     @pytest.mark.asyncio
     async def test_env_model_dir_picked_up(self, monkeypatch):

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -9939,19 +9939,28 @@ class TestFooterOutOfTabChain:
         # un-gating [2].  The mode keys [1]/[2] are now show=False permanently
         # (they cost scarce footer width on a 100-col terminal while the Modes
         # rail already teaches them), so a surface flip changes NO displayed
-        # binding and could no longer exercise this.  A mode flip can: entering
-        # the lane un-gates [⏎], which the footer does display.  It is also the
-        # change a user actually makes.
+        # binding and could no longer exercise this.
+        #
+        # It then used the mode flip un-gating [⏎].  That no longer works either:
+        # ⏎ is show=False on the app binding now (a focused DataTable's own
+        # `select_cursor` binding won the footer slot on Catalog / Orchestration /
+        # ③ Gate, so ⏎ appeared in some panes and not others for the same key;
+        # it is advertised in the Modes rail instead).  The invariant under test
+        # is unchanged — a REAL displayed-binding change must flip the signature
+        # and recompose — so it now rides on the same mode flip's DESCRIPTION
+        # change, which is exactly what `description`-in-the-signature exists for:
+        # `]` is relabelled "Next tab" → "Next stage".
         app, _, _ = make_app(surface="producer")
         async with app.run_test(size=(120, 40)) as pilot:
             await _settle(pilot)
             ff = app.query_one(FocusableFooter)
             sig_before = ff._last_binding_sig
-            # Sanity: [⏎] is NOT displayed in mode 0 (no ⏎ primary on entry).
-            assert "enter" not in {k.key for k in ff.query(FooterKey)}
-            await pilot.press("2")   # → Bring & Validate, where ⏎ = fit-check
+            labels_before = {k.key: k.description for k in ff.query(FooterKey)}
+            assert labels_before.get("right_square_bracket") == "Next tab", labels_before
+            await pilot.press("2")   # → Bring & Validate, where ] = "Next stage"
             await _settle(pilot)
-            assert "enter" in {k.key for k in ff.query(FooterKey)}
+            labels_after = {k.key: k.description for k in ff.query(FooterKey)}
+            assert labels_after.get("right_square_bracket") == "Next stage", labels_after
             assert ff._last_binding_sig != sig_before
 
 
@@ -10503,9 +10512,24 @@ class TestDoctorKeyboardNav:
             assert app.focused is not None and app.focused.id == "doctor-scroll"
 
     @pytest.mark.asyncio
-    async def test_footer_enter_label_follows_the_selection(self):
-        """The ⏎ label names the selected check — which only repaints because the
-        footer's recompose signature now includes `description`."""
+    async def test_enter_label_follows_the_selection(self):
+        """The ⏎ label names the SELECTED check and tracks ↑/↓.
+
+        Renamed from `test_footer_enter_label_follows_the_selection`: ⏎ is no
+        longer advertised in the footer at all (the app binding is show=False —
+        a focused DataTable's own `select_cursor` binding used to win that slot
+        on Catalog / Orchestration / ③ Gate, so ⏎ showed in some panes and not
+        others).  It is advertised in the Modes rail's `#mode-action-hint`, which
+        the same `_sync_footer_labels` line writes.  The invariant — the label
+        follows the cursor instead of naming a fixed check — is unchanged.
+
+        (The footer's recompose-signature-includes-`description` invariant that
+        this test used to double as a probe for is covered on its own by
+        `test_footer_recomposes_on_a_real_binding_change`.)
+
+        Read the RENDERED label, not the binding objects: `_relabel_binding`
+        mutates those either way, so asserting on them would pass even with the
+        repaint reverted."""
         from club3090_cockpit.app import _DOCTOR_CHECKS
 
         app, _, _ = make_app(surface="producer")
@@ -10513,22 +10537,15 @@ class TestDoctorKeyboardNav:
             await _settle(pilot)
             await self._enter_doctor(app, pilot)
 
-            # Read the RENDERED footer, not the binding objects: _relabel_binding
-            # mutates those either way, so asserting on them passes even with the
-            # recompose fix reverted (confirmed by negative control). The claim is
-            # about what the user SEES, so query the FooterKey widgets.
-            ff = app.query_one(FocusableFooter)
-
             def enter_label():
-                for k in ff.query(FooterKey):
-                    if k.key == "enter":
-                        return k.description
-                return ""
+                return _renderable_text(
+                    app.query_one("#mode-action-hint", Label)
+                ).strip()
 
-            assert enter_label() == _DOCTOR_CHECKS[0][2]
+            assert enter_label() == f"⏎ {_DOCTOR_CHECKS[0][2]}"
             await pilot.press("down")
             await _settle(pilot)
-            assert enter_label() == _DOCTOR_CHECKS[1][2]
+            assert enter_label() == f"⏎ {_DOCTOR_CHECKS[1][2]}"
 
     @pytest.mark.asyncio
     async def test_hotkeys_still_work_alongside_the_list(self):
@@ -11677,17 +11694,27 @@ class TestTier1PrimaryActionAndSKeyHonesty:
         "Enter Select" the Modes rail was showing. Doctor's cards are now a
         keyboard-navigable list whose ⏎ dispatches the selected check, so the
         honest state is the opposite — the key IS shown, and its label names the
-        check rather than a generic verb."""
+        check rather than a generic verb.
+
+        The ADVERTISEMENT moved: it used to read the Footer, but the app's ⏎
+        binding is show=False now — a focused DataTable's own `select_cursor`
+        binding won the footer slot, so ⏎ showed in some panes and vanished in
+        others (Catalog / Orchestration / ③ Gate all boot table-focused) for a key
+        that worked everywhere.  ⏎ is advertised in ONE place instead:
+        `#mode-action-hint` in the Modes rail, written by the same
+        `_sync_footer_labels` line that used to relabel the footer.  The invariant
+        this test protects — "⏎ is advertised on Doctor and names the SELECTED
+        check, not a generic verb" — is unchanged; only where it is read from."""
         from club3090_cockpit.app import _DOCTOR_CHECKS
 
         app, _, _ = make_app()
         async with app.run_test(size=(120, 40)) as pilot:
             await _enter_operate(pilot, tab="tab-doctor")
             assert app.check_action("primary_action", ()) is True
-            footer_keys = {k.key for k in app.query(FooterKey)}
-            assert "enter" in footer_keys
-            labels = {k.description for k in app.query(FooterKey) if k.key == "enter"}
-            assert labels == {_DOCTOR_CHECKS[0][2]}
+            hint = _renderable_text(app.query_one("#mode-action-hint", Label)).strip()
+            assert hint == f"⏎ {_DOCTOR_CHECKS[0][2]}", hint
+            # ...and it is NOT duplicated in the footer under a second label.
+            assert "enter" not in {k.key for k in app.query(FooterKey)}
 
     @pytest.mark.asyncio
     async def test_enter_not_advertised_on_containers(self):

--- a/tools/serve-cockpit/tests/test_uiux_review_final.py
+++ b/tools/serve-cockpit/tests/test_uiux_review_final.py
@@ -195,3 +195,57 @@ async def test_promote_footer_gains_enter_when_required_edits_fill():
 
         assert screen.query_one("#promote-stage-btn", Button).disabled is False
         assert "Write LOCAL layer" in _footer_keys(screen), _footer_keys(screen)
+
+
+# ── #2 · ⏎ is advertised consistently, in one place ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_enter_advertised_consistently_across_table_and_non_table_panes():
+    """⏎ used to appear in the footer on non-table panes and VANISH on
+    table-focused ones (Catalog, Orchestration and ③ Gate all boot with a
+    DataTable focused, and DataTable's own `enter → select_cursor` binding is
+    show=False and wins over the app's).  The key worked in all of them — only
+    the advertisement was inconsistent.
+
+    ⏎ is now advertised in exactly one place, the Modes rail's
+    `#mode-action-hint`, in EVERY pane and with the pane's real verb."""
+    from textual.widgets import Label
+    from textual.widgets._footer import FooterKey
+
+    app, _, _ = make_app(surface="producer")
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _settle(pilot)
+        await _settle(pilot)
+
+        # Catalog: a DataTable owns focus (the case that used to lose ⏎).
+        assert isinstance(app.focused, DataTable), type(app.focused).__name__
+        hint = _renderable_text(app.query_one("#mode-action-hint", Label)).strip()
+        assert hint == "⏎ Serve", hint
+        assert "enter" not in {k.key for k in app.query(FooterKey)}
+
+        # Bring & Validate: focus is NOT a DataTable — used to be the pane where
+        # the footer DID show ⏎, i.e. the source of the inconsistency.
+        await pilot.press("2")
+        await _settle(pilot)
+        await _settle(pilot)
+        hint = _renderable_text(app.query_one("#mode-action-hint", Label)).strip()
+        assert hint == "⏎ Fit-check", hint
+        assert "enter" not in {k.key for k in app.query(FooterKey)}
+
+
+@pytest.mark.asyncio
+async def test_enter_still_works_on_a_table_focused_pane():
+    """Dropping show=True is a DISPLAY change only — ⏎ on a catalog row must
+    still reach the primary action (via DataTable.RowSelected)."""
+    app, _, _ = make_app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _settle(pilot)
+        await _settle(pilot)
+        fired = []
+        app.action_primary_action = lambda *a, **k: fired.append(True)  # type: ignore[method-assign]
+        app.query_one("#catalog-table", DataTable).focus()
+        await _settle(pilot)
+        await pilot.press("enter")
+        await _settle(pilot)
+        assert fired, "⏎ no longer routes to the primary action"

--- a/tools/serve-cockpit/tests/test_uiux_review_final.py
+++ b/tools/serve-cockpit/tests/test_uiux_review_final.py
@@ -249,3 +249,76 @@ async def test_enter_still_works_on_a_table_focused_pane():
         await pilot.press("enter")
         await _settle(pilot)
         assert fired, "⏎ no longer routes to the primary action"
+
+
+# ── #4 · no keyboard trap after Inspect ─────────────────────────────────────
+
+
+async def _reveal_bring_stage2(app, pilot, monkeypatch=None):
+    """Drive ① Bring to the post-Inspect stage-2 reveal (no HF call)."""
+    await pilot.press("2")
+    await _settle(pilot)
+    entries, _err = await app._data.load_catalog_rows()
+    app._variants = [e.row for e in entries]
+    app._known_gpu_vram_gb = lambda: 24.0        # type: ignore[method-assign]
+    app._known_gpu_count = lambda: 2             # type: ignore[method-assign]
+    app._reveal_funnel_slugs("safetensors", 15.0)
+    await _settle(pilot)
+    await _settle(pilot)
+
+
+@pytest.mark.asyncio
+async def test_inspect_focuses_the_fit_check_button_not_the_select():
+    """After the stage-2 reveal the app focused the config Select while the
+    footer and Modes rail both advertise "⏎ Fit-check".  ⏎ on a focused Select
+    opens its dropdown, so the advertised primary action was unreachable from
+    the focus the app had just set — a keyboard trap.
+
+    The Fit-check button is the right target: the Select is one Shift+Tab away
+    and already defaults to the ⭐ recommendation."""
+    from textual.widgets import Label
+
+    app, _, _ = make_app(surface="producer")
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _settle(pilot)
+        await _reveal_bring_stage2(app, pilot)
+
+        assert app.focused is not None
+        assert app.focused.id == "lane-bring-fit-btn", (
+            f"focus landed on {app.focused.id!r}, so ⏎ does not do what the rail "
+            f"advertises"
+        )
+        # ...and the advertisement it has to match is still Fit-check.
+        hint = _renderable_text(app.query_one("#mode-action-hint", Label)).strip()
+        assert hint == "⏎ Fit-check", hint
+
+
+@pytest.mark.asyncio
+async def test_enter_after_inspect_runs_fit_check():
+    """The end-to-end claim behind the focus change: pressing the advertised ⏎
+    from the focus the app sets must actually fit-check."""
+    app, _, _ = make_app(surface="producer")
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _settle(pilot)
+        await _reveal_bring_stage2(app, pilot)
+        fired = []
+        app._trigger_lane_bring = lambda *a, **k: fired.append(True)  # type: ignore
+        await pilot.press("enter")
+        await _settle(pilot)
+        assert fired, "⏎ from the post-Inspect focus did not run the fit-check"
+
+
+@pytest.mark.asyncio
+async def test_bring_result_card_is_on_screen_at_80x24():
+    """At 80x24 the verdict card sat below the fold after Inspect, so the pane
+    answered the user's question off-screen with nothing saying so."""
+    app, _, _ = make_app(surface="producer")
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _settle(pilot)
+        await _reveal_bring_stage2(app, pilot)
+        card = app.query_one("#lane-bring-result-card", Static)
+        assert card.display
+        bottom = card.region.y + card.region.height
+        assert card.region.y >= 0 and bottom <= 24, (
+            f"result card {card.region} is off-screen at 80x24"
+        )

--- a/tools/serve-cockpit/tests/test_uiux_review_final.py
+++ b/tools/serve-cockpit/tests/test_uiux_review_final.py
@@ -322,3 +322,49 @@ async def test_bring_result_card_is_on_screen_at_80x24():
         assert card.region.y >= 0 and bottom <= 24, (
             f"result card {card.region} is off-screen at 80x24"
         )
+
+
+# ── #7 · Settings must be saveable at 80x24 ─────────────────────────────────
+
+
+@pytest.mark.parametrize("size", [(80, 24), (100, 30), (120, 40)])
+@pytest.mark.asyncio
+async def test_settings_save_affordance_is_on_screen(size):
+    """SettingsScreen was `height: auto` with ~27 rows of content and no
+    max-height, so on a 24-row terminal BOTH the hint line and the
+    `^s Save / esc Cancel` Footer rendered below the bottom of the screen — a
+    first-run user on a small terminal had no visible way to save.  The card was
+    also `width: 84` on an 80-col screen.
+
+    Geometry alone is not enough here (an in-bounds region can still be clipped),
+    so this asserts the footer's rendered TEXT is present too."""
+    from club3090_cockpit.app import SettingsScreen
+    from textual.widgets import Footer
+
+    width, height = size
+    app, _, _ = make_app(surface="producer")
+    async with app.run_test(size=size) as pilot:
+        await _settle(pilot)
+        await app.push_screen(SettingsScreen("/mnt/models/huggingface", False))
+        await _settle(pilot)
+        await _settle(pilot)
+
+        card = app.screen.query_one("Vertical")
+        assert card.region.y + card.region.height <= height, (
+            f"settings card {card.region} overflows a {width}x{height} screen"
+        )
+        assert card.region.x + card.region.width <= width, (
+            f"settings card {card.region} is wider than {width} cols"
+        )
+
+        footer = app.screen.query_one(Footer)
+        assert footer.region.y + footer.region.height <= height, (
+            f"the Save/Cancel footer is off-screen at {width}x{height}: {footer.region}"
+        )
+
+        console = Console(width=width, no_color=True, legacy_windows=False)
+        with console.capture() as cap:
+            console.print(app.screen._compositor)
+        rendered = cap.get()
+        assert "Save" in rendered, f"no visible way to save at {width}x{height}"
+        assert "Cancel" in rendered

--- a/tools/serve-cockpit/tests/test_uiux_review_final.py
+++ b/tools/serve-cockpit/tests/test_uiux_review_final.py
@@ -59,9 +59,12 @@ _KNOWN_SAFE = {
 
 
 def _string_nodes(tree: ast.AST):
-    """Yield (lineno, text) for every non-docstring string literal, with
+    """Yield (lineno, text) for every markup-RENDERED string literal, with
     f-string expression slots collapsed to \\x00 so a tag split across an
-    f-string boundary is still seen as one tag."""
+    f-string boundary is still seen as one tag.
+
+    Skips docstrings and `DEFAULT_CSS` / `CSS` blocks: neither is ever parsed as
+    markup, and both legitimately contain bracketed key names in comments."""
     docs = set()
     for n in ast.walk(tree):
         if isinstance(n, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
@@ -73,6 +76,11 @@ def _string_nodes(tree: ast.AST):
                 and isinstance(body[0].value.value, str)
             ):
                 docs.add(id(body[0].value))
+        # CSS blocks: `DEFAULT_CSS = """…"""` / `CSS = """…"""`
+        if isinstance(n, ast.Assign):
+            names = {t.id for t in n.targets if isinstance(t, ast.Name)}
+            if names & {"DEFAULT_CSS", "CSS"}:
+                docs.add(id(n.value))
     seen = set()
     for node in ast.walk(tree):
         if id(node) in docs:
@@ -426,3 +434,172 @@ async def test_explain_error_still_reports_what_the_caller_knows():
         assert "explain failed" in body
         assert entry.model in body, body
         assert entry.engine in body, body
+
+
+# ── #16–#22 · narrow terminals (80x24 and 100x30 are real users) ────────────
+
+
+def _screen_text(app, width: int) -> str:
+    """The compositor as the user sees it.  NEVER collapse whitespace here — it
+    breaks matches across box-drawing characters and has twice reported a
+    working feature as broken."""
+    console = Console(width=width, no_color=True, legacy_windows=False)
+    with console.capture() as cap:
+        console.print(app.screen._compositor)
+    return cap.get()
+
+
+@pytest.mark.asyncio
+async def test_pane_headings_wrap_instead_of_truncating_at_80():
+    """#17 — the four pane headings are `width: auto` Labels, so at 80 cols they
+    were CUT, not wrapped: "① Bring — inspect an HF model, or bring a co".  Each
+    lost the clause that says what the pane is for.  They are now in the same
+    `width: 1fr` rule the hint lines already used."""
+    app, _, _ = make_app(surface="producer")
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.press("2")
+        await _settle(pilot)
+        await _settle(pilot)
+        heading = app.query_one("#lane-bring-heading")
+        assert heading.region.x + heading.region.width <= 80, heading.region
+        assert heading.region.height > 1, "heading did not wrap — still truncating"
+        assert "compose you already have" in _screen_text(app, 80)
+
+
+@pytest.mark.asyncio
+async def test_catalog_hint_shows_the_sort_and_columns_keys_at_80():
+    """#18 — `#catalog-hint` wraps (it is in the `width: 1fr` list) but was
+    `height: 1`, which clipped every wrapped row but the first.  At 80 cols the
+    line stopped at "[c]", so `[s] sort` and `[|] columns` never rendered at any
+    width below ~159 — and neither key had another teaching surface."""
+    app, _, _ = make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _settle(pilot)
+        await _settle(pilot)
+        rendered = _screen_text(app, 80)
+        assert "[s] sort" in rendered, rendered
+        assert "[|] columns" in rendered, rendered
+
+
+@pytest.mark.asyncio
+async def test_bring_action_buttons_fit_at_80():
+    """#19 — the three action buttons were fixed at 16/20/auto with 2-col
+    gutters: 58 columns of demand in the 42 the pane gets at 80 wide, so
+    "Validate compose" rendered as "Va"."""
+    app, _, _ = make_app(surface="producer")
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.press("2")
+        await _settle(pilot)
+        await _settle(pilot)
+        row = app.query_one("#lane-bring-actions")
+        for button in row.query("Button"):
+            right = button.region.x + button.region.width
+            assert right <= 80, f"{button.id} overflows to col {right}"
+        assert "Validate" in _screen_text(app, 80)
+
+
+@pytest.mark.asyncio
+async def test_catalog_table_survives_a_start_at_80x24():
+    """#21 — `#serve-live` was a fixed 13-row sibling; on a 24-row terminal it
+    squeezed the catalog DataTable to height 1, so not even its header row
+    survived.  Starting a model made the list you started it from vanish."""
+    app, _, _ = make_app()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _settle(pilot)
+        await _settle(pilot)
+        app.query_one("#serve-live").add_class("serving")   # what _serving_live_pane does
+        await _settle(pilot)
+        await _settle(pilot)
+        table = app.query_one("#catalog-table", DataTable)
+        assert table.region.height >= 4, (
+            f"catalog table collapsed to {table.region.height} rows after a Start"
+        )
+        assert "slug" in _screen_text(app, 80)
+
+
+@pytest.mark.asyncio
+async def test_containers_hint_is_two_rows_and_the_log_pane_keeps_lines():
+    """#20 — the run-on Containers hint wrapped to FOUR of the 24 rows at 80x24,
+    which is what squeezed the Logs RichLog down to two lines."""
+    from textual.widgets import RichLog
+    from test_app_headless import _enter_operate
+
+    app, _, _ = make_app(surface="producer")
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _enter_operate(pilot, tab="tab-containers")
+        await _settle(pilot)
+        hint = app.query_one("#containers-hint")
+        assert hint.region.height <= 2, f"hint takes {hint.region.height} rows"
+        log = app.query_one("#drill-logs").query_one(RichLog)
+        assert log.region.height >= 4, f"log pane is {log.region.height} rows"
+
+
+@pytest.mark.parametrize(
+    "width,must_show",
+    [(80, ("Sort",)), (100, ("Sort",)), (120, ("Sort", "Refresh", "Settings"))],
+)
+@pytest.mark.asyncio
+async def test_footer_keeps_the_context_key_at_every_width(width, must_show):
+    """#16 — the footer renders bindings in declaration order and the six
+    globals are declared first, so the key that is actually about the pane you
+    are looking at was the one that got cut: "s Sort" → "s So", "s Submit" → "s
+    ".  `r`/`S` are width-gated now (both are in Help AND the command palette),
+    and the keys keep working at every width — only the advertisement is gated."""
+    app, _, _ = make_app()
+    async with app.run_test(size=(width, 30)) as pilot:
+        await _settle(pilot)
+        await _settle(pilot)
+        footer_line = _screen_text(app, width).splitlines()[-1]
+        for label in must_show:
+            assert label in footer_line, f"{label!r} clipped at {width}: {footer_line!r}"
+        if width < 120:
+            assert "Refresh" not in footer_line
+        # the gated keys still WORK — hidden is not disabled
+        assert app.check_action("refresh", ()) is not False
+        assert app.check_action("settings", ()) is not False
+
+
+@pytest.mark.parametrize(
+    "width,expected",
+    [
+        (80, ["slug", "ctx", "tps", "status"]),
+        (100, ["model", "slug", "ctx", "tps", "status"]),
+        (120, [k for k, _ in __import__("club3090_cockpit.app", fromlist=["x"])._CATALOG_COLUMNS]),
+    ],
+)
+@pytest.mark.asyncio
+async def test_catalog_narrow_column_default(width, expected):
+    """#22 — with all 16 columns on, the table needs 151 cols and gets 46 at 80
+    wide, so status/ctx/TPS (the columns you PICK on) sat ~100 columns
+    off-screen right behind an unadvertised horizontal scroll.  Narrow widths
+    now default to the decision columns; 120+ is unchanged."""
+    from club3090_cockpit.app import CatalogPane
+
+    app, _, _ = make_app()
+    async with app.run_test(size=(width, 30)) as pilot:
+        await _settle(pilot)
+        await _settle(pilot)
+        pane = app.query_one("#catalog-pane", CatalogPane)
+        assert pane._visible_columns() == expected
+
+
+@pytest.mark.asyncio
+async def test_catalog_narrow_default_never_overrides_a_saved_picker_choice():
+    """The narrow default is a DEFAULT.  A user who has used the [|] picker
+    keeps exactly what they chose, at every width."""
+    from club3090_cockpit.app import CatalogPane
+
+    app, _, _ = make_app()
+    app.catalog_columns_pref = {
+        "order": [k for k, _ in __import__(
+            "club3090_cockpit.app", fromlist=["x"]
+        )._CATALOG_COLUMNS],
+        "hidden": ["ctx"],
+    }
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _settle(pilot)
+        await _settle(pilot)
+        pane = app.query_one("#catalog-pane", CatalogPane)
+        visible = pane._visible_columns()
+        assert "ctx" not in visible          # their choice honoured
+        assert "provider" in visible         # narrow default NOT applied on top

--- a/tools/serve-cockpit/tests/test_uiux_review_final.py
+++ b/tools/serve-cockpit/tests/test_uiux_review_final.py
@@ -697,3 +697,37 @@ def test_help_shows_the_backslash_and_pipe_keys_literally():
     text = Content.from_markup(HelpScreen(surface="producer").help_text).plain
     assert "\\ model scope" in text, text[:0] or "backslash key not rendered"
     assert "| columns picker" in text
+
+
+@pytest.mark.asyncio
+async def test_footer_width_gate_follows_a_live_resize():
+    """The gate must read the RESIZE EVENT's width, not `self.size`.
+
+    `self.size` is not updated yet while a Resize event is being handled, so
+    reading it there gated on the PREVIOUS width and the footer lagged one
+    resize behind: 140 → 80 still showed `r`/`S`, and 80 → 140 then hid them —
+    exactly inverted."""
+    from textual.widgets._footer import FooterKey
+
+    app, _, _ = make_app()
+    async with app.run_test(size=(140, 40)) as pilot:
+        await _settle(pilot)
+        await _settle(pilot)
+
+        def keys():
+            return {k.key_display for k in app.screen.query(FooterKey)}
+
+        assert {"r", "S"} <= keys()
+
+        await pilot.resize_terminal(80, 24)
+        await _settle(pilot)
+        await _settle(pilot)
+        assert not ({"r", "S"} & keys()), keys()
+
+        await pilot.resize_terminal(140, 40)
+        await _settle(pilot)
+        await _settle(pilot)
+        assert {"r", "S"} <= keys(), keys()
+
+        # hidden is never disabled
+        assert app.check_action("refresh", ()) is not False

--- a/tools/serve-cockpit/tests/test_uiux_review_final.py
+++ b/tools/serve-cockpit/tests/test_uiux_review_final.py
@@ -368,3 +368,61 @@ async def test_settings_save_affordance_is_on_screen(size):
         rendered = cap.get()
         assert "Save" in rendered, f"no visible way to save at {width}x{height}"
         assert "Cancel" in rendered
+
+
+# ── #15 · Explain must not show dashes for facts the row behind it displays ──
+
+
+@pytest.mark.asyncio
+async def test_explain_falls_back_to_the_catalog_row_when_explain_has_no_registry():
+    """`switch.sh --explain` can answer without a `registry` block.  Reading it
+    with a "—" default rendered "Model — / Engine — / Status —" directly on top
+    of a catalog row that was showing the real values.  The CatalogEntry carries
+    the same registry facts, so the modal falls back to them."""
+    from club3090_cockpit.app import CatalogPane
+
+    app, _, _ = make_app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _settle(pilot)
+        await _settle(pilot)
+        entry = app.query_one("#catalog-pane", CatalogPane).selected_entry()
+        assert entry.model and entry.engine and entry.status  # not a vacuous test
+
+        app.action_explain()
+        await _settle(pilot)
+        await _settle(pilot)
+        screen = app.screen
+        # explain answered, but with nothing structured in it
+        screen.set_detail({"registry": {}}, None)
+        await _settle(pilot)
+
+        body = _renderable_text(screen.query_one("#explain-body", Static))
+        assert entry.model in body, body
+        assert entry.engine in body, body
+        assert entry.status in body, body
+        for field in ("Model", "Engine", "Status"):
+            assert f"{field}   —" not in body and f"{field}  —" not in body, body
+
+
+@pytest.mark.asyncio
+async def test_explain_error_still_reports_what_the_caller_knows():
+    """A hard explain failure used to render only "explain failed: …", hiding
+    the three identity fields the catalog row behind it was displaying."""
+    from club3090_cockpit.app import CatalogPane
+
+    app, _, _ = make_app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _settle(pilot)
+        await _settle(pilot)
+        entry = app.query_one("#catalog-pane", CatalogPane).selected_entry()
+        app.action_explain()
+        await _settle(pilot)
+        await _settle(pilot)
+        screen = app.screen
+        screen.set_detail(None, "switch.sh exited 1")
+        await _settle(pilot)
+
+        body = _renderable_text(screen.query_one("#explain-body", Static))
+        assert "explain failed" in body
+        assert entry.model in body, body
+        assert entry.engine in body, body

--- a/tools/serve-cockpit/tests/test_uiux_review_final.py
+++ b/tools/serve-cockpit/tests/test_uiux_review_final.py
@@ -603,3 +603,97 @@ async def test_catalog_narrow_default_never_overrides_a_saved_picker_choice():
         visible = pane._visible_columns()
         assert "ctx" not in visible          # their choice honoured
         assert "provider" in visible         # narrow default NOT applied on top
+
+
+# ── keyboard economy ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_lane_stage_switch_never_leaves_focus_nowhere():
+    """A table-less lane stage (① Bring / ② Serve / ⑤ Promote) has no primary
+    list to focus.  When the OUTGOING tab owned the focused widget — a user
+    typing in ① Bring's repo field who presses [s] — hiding that pane left
+    `app.focused` None, and the next Tab landed on the ModeSwitcher at the top
+    of the DOM rather than anywhere in the stage they had just opened.
+
+    Focus is re-homed to the lane tab bar, the same target `_focus_mode_primary`
+    uses for mode 1."""
+    from textual.widgets import Input
+    from textual.widgets._tabs import Tabs
+
+    app, _, _ = make_app(surface="producer")
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.press("2")
+        await _settle(pilot)
+        await _settle(pilot)
+
+        for target in ("tab-serve", "tab-promote"):
+            app.query_one("#validate-tabs").active = "tab-bring"
+            await _settle(pilot)
+            app.query_one("#lane-bring-url-input", Input).focus()
+            await _settle(pilot)
+            await _settle(pilot)
+            assert isinstance(app.focused, Input)   # not a vacuous setup
+
+            app.query_one("#validate-tabs").active = target
+            await _settle(pilot)
+            await _settle(pilot)
+            assert app.focused is not None, f"focus black hole entering {target}"
+            assert isinstance(app.focused, Tabs), (
+                f"{target} re-homed focus to {app.focused!r}, not the lane tab bar"
+            )
+
+
+@pytest.mark.asyncio
+async def test_advance_to_serve_leaves_focus_somewhere_useful():
+    """The `[s]` Continue → ② Serve path specifically (the review's report)."""
+    from textual.widgets import Input
+    from textual.widgets._tabs import Tabs
+
+    app, _, _ = make_app(surface="producer")
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.press("2")
+        await _settle(pilot)
+        app.query_one("#lane-bring-url-input", Input).focus()
+        await _settle(pilot)
+        await _settle(pilot)
+        app._advance_to_serve()
+        await _settle(pilot)
+        await _settle(pilot)
+        assert app.focused is not None
+        assert isinstance(app.focused, Tabs)
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "model scope",
+        "sort — group-by-model",
+        "deprecated + hardware-incompatible",
+        "downloaded-only",
+        "columns picker",
+        "copy the serving API URL",
+    ],
+)
+def test_help_teaches_the_hidden_catalog_keys(phrase):
+    """Six Catalog keys are `show=False` bindings whose only other teaching
+    surface is the pane hint line — which is itself clipped on a narrow
+    terminal.  Help must carry them.
+
+    Asserts on the MARKUP-PARSED help text, so a hint eaten by the markup parser
+    (see the key-hint sweep above) still fails."""
+    from club3090_cockpit.app import HelpScreen
+
+    text = Content.from_markup(HelpScreen(surface="producer").help_text).plain
+    assert phrase in text, f"{phrase!r} missing from Help"
+
+
+def test_help_shows_the_backslash_and_pipe_keys_literally():
+    """The two punctuation keys must survive the markup parse — `\\` in
+    particular is the escape character, so getting it into rendered output takes
+    care."""
+    from club3090_cockpit.app import HelpScreen
+
+    text = Content.from_markup(HelpScreen(surface="producer").help_text).plain
+    assert "\\ model scope" in text, text[:0] or "backslash key not rendered"
+    assert "| columns picker" in text

--- a/tools/serve-cockpit/tests/test_uiux_review_final.py
+++ b/tools/serve-cockpit/tests/test_uiux_review_final.py
@@ -564,7 +564,7 @@ async def test_footer_keeps_the_context_key_at_every_width(width, must_show):
     [
         (80, ["slug", "ctx", "tps", "status"]),
         (100, ["model", "slug", "ctx", "tps", "status"]),
-        (120, [k for k, _ in __import__("club3090_cockpit.app", fromlist=["x"])._CATALOG_COLUMNS]),
+        (120, [k for k, _ in app_mod._CATALOG_COLUMNS]),
     ],
 )
 @pytest.mark.asyncio
@@ -591,9 +591,7 @@ async def test_catalog_narrow_default_never_overrides_a_saved_picker_choice():
 
     app, _, _ = make_app()
     app.catalog_columns_pref = {
-        "order": [k for k, _ in __import__(
-            "club3090_cockpit.app", fromlist=["x"]
-        )._CATALOG_COLUMNS],
+        "order": [k for k, _ in app_mod._CATALOG_COLUMNS],
         "hidden": ["ctx"],
     }
     async with app.run_test(size=(80, 24)) as pilot:
@@ -695,7 +693,7 @@ def test_help_shows_the_backslash_and_pipe_keys_literally():
     from club3090_cockpit.app import HelpScreen
 
     text = Content.from_markup(HelpScreen(surface="producer").help_text).plain
-    assert "\\ model scope" in text, text[:0] or "backslash key not rendered"
+    assert "\\ model scope" in text, "the backslash key did not survive the markup parse"
     assert "| columns picker" in text
 
 

--- a/tools/serve-cockpit/tests/test_uiux_review_final.py
+++ b/tools/serve-cockpit/tests/test_uiux_review_final.py
@@ -139,3 +139,59 @@ async def test_first_run_guide_shows_the_keys_it_teaches():
         body = _renderable_text(app.screen.query_one("#first-run-body", Static))
         for key in ("[d]", "[D]", "[l]"):
             assert key in body, f"{key} missing from the rendered first-run guide:\n{body}"
+
+
+# ── #6 · ⑤ Promote's footer must follow the stage gate ──────────────────────
+
+
+def _footer_keys(screen) -> str:
+    """The footer as the user reads it — 'key description' per rendered key.
+
+    Footer.render() is a Blank (it paints through child FooterKey widgets), so
+    a str(render()) assertion would test nothing."""
+    from textual.widgets._footer import FooterKey
+
+    return " | ".join(f"{k.key_display} {k.description}" for k in screen.query(FooterKey))
+
+
+def _scaffold():
+    from club3090_cockpit.app import PromoteScaffold
+
+    return PromoteScaffold(
+        model_id="foo",
+        repo="org/foo",
+        profile_path="models/foo.yml",
+        profile_yaml="id: foo\n",
+        registry_entry="entry",
+        error="",
+    )
+
+
+@pytest.mark.asyncio
+async def test_promote_footer_gains_enter_when_required_edits_fill():
+    """`on_input_changed` enabled the stage buttons but never called
+    `refresh_bindings()`, so the footer stayed 'esc Close' after ⏎ had become
+    valid — the action that just unlocked was invisible.
+
+    Enablement and `refresh_bindings()` are two halves of one state change."""
+    from club3090_cockpit.app import PromoteScaffoldScreen
+    from textual.widgets import Button, Input
+
+    app, _, _ = make_app(surface="producer")
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _settle(pilot)
+        await app.push_screen(PromoteScaffoldScreen(_scaffold()))
+        await _settle(pilot)
+        await _settle(pilot)
+        screen = app.screen
+
+        assert screen.query_one("#promote-stage-btn", Button).disabled is True
+        assert "Write LOCAL layer" not in _footer_keys(screen)
+
+        screen.query_one("#promote-display-input", Input).value = "Foo Model"
+        screen.query_one("#promote-family-input", Input).value = "qwen"
+        await _settle(pilot)
+        await _settle(pilot)
+
+        assert screen.query_one("#promote-stage-btn", Button).disabled is False
+        assert "Write LOCAL layer" in _footer_keys(screen), _footer_keys(screen)

--- a/tools/serve-cockpit/tests/test_uiux_review_final.py
+++ b/tools/serve-cockpit/tests/test_uiux_review_final.py
@@ -1,0 +1,141 @@
+"""Final UX-review batch — key-hint markup, footer refresh, focus, narrow terminals.
+
+Each test here pins a behaviour that was observably wrong in the shipped app.
+Where a test is a *class* guard (rather than one site), it sweeps the source so
+a future edit that reintroduces the bug anywhere reds the suite.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+import pytest
+from rich.console import Console
+from textual.content import Content
+from textual.widgets import DataTable, Static
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from test_app_headless import _renderable_text, _settle, make_app  # noqa: E402
+
+import club3090_cockpit.app as app_mod  # noqa: E402
+
+
+# ── #5 · key hints must survive Textual markup ──────────────────────────────
+
+# Style tags this codebase genuinely uses, plus regex character classes and
+# type names that happen to live inside brackets in a string literal.  Anything
+# NOT in here that a markup parse deletes is a key hint being eaten.
+_LEGIT_TAGS = {
+    "bold", "cyan", "dim", "green", "red", "yellow", "italic", "underline",
+    "orange1", "b",
+    "/bold", "/cyan", "/dim", "/green", "/red", "/yellow", "/italic",
+    "/underline", "/orange1", "/b",
+    "\x00", "/\x00", "bold \x00", "/bold \x00",
+    "A-Za-z0-9_", "A-Za-z_", "a-z0-9_", "0-9a-f", "Kk", "KM", "/-", "A-Za-z",
+    "ByoResult", "GpuInfo",
+}
+
+# Verified NOT markup-rendered, so their brackets survive as typed:
+#   app.py  — the Header sub_title is plain text (Textual does not parse markup
+#             there); proved by rendering a Header with a "[k]" sub_title.
+#   services.py — these strings land in a RichLog(markup=True), which uses
+#             *rich* markup.  Rich's tag regex requires a leading lowercase
+#             letter / # / / / @, so "[S]" survives there (Textual's parser,
+#             which the Static/Label/Toast paths use, would eat it).
+#             "[log]" / "[apply-swap]" ARE eaten in that pane, but they are
+#             log-line prefixes teed to the on-disk log as well — escaping them
+#             would write a literal backslash into the log file.  Left alone
+#             deliberately; tracked in the PR description, not here.
+_KNOWN_SAFE = {
+    ("club3090_cockpit/app.py", "k"),
+    ("club3090_cockpit/services.py", "S"),
+    ("club3090_cockpit/services.py", "log"),
+    ("club3090_cockpit/services.py", "apply-swap"),
+}
+
+
+def _string_nodes(tree: ast.AST):
+    """Yield (lineno, text) for every non-docstring string literal, with
+    f-string expression slots collapsed to \\x00 so a tag split across an
+    f-string boundary is still seen as one tag."""
+    docs = set()
+    for n in ast.walk(tree):
+        if isinstance(n, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            body = n.body
+            if (
+                body
+                and isinstance(body[0], ast.Expr)
+                and isinstance(body[0].value, ast.Constant)
+                and isinstance(body[0].value.value, str)
+            ):
+                docs.add(id(body[0].value))
+    seen = set()
+    for node in ast.walk(tree):
+        if id(node) in docs:
+            continue
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            text = node.value
+        elif isinstance(node, ast.JoinedStr):
+            text = "".join(
+                v.value if isinstance(v, ast.Constant) and isinstance(v.value, str) else "\x00"
+                for v in node.values
+            )
+        else:
+            continue
+        key = (node.lineno, text)
+        if key in seen:
+            continue
+        seen.add(key)
+        yield node.lineno, text
+
+
+@pytest.mark.parametrize(
+    "rel", ["club3090_cockpit/app.py", "club3090_cockpit/data.py", "club3090_cockpit/services.py"]
+)
+def test_key_hints_are_escaped_from_textual_markup(rel):
+    """Textual markup deletes `[d]`, `[l]`, `[t]`, `[Y]`, `[esc]`… — i.e. exactly
+    the key hints the UI text exists to teach.  The fix is the `\\[x]` escape the
+    codebase already uses; this sweeps for any site that forgot it."""
+    path = Path(__file__).resolve().parents[1] / rel
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    offenders = []
+    for lineno, text in _string_nodes(tree):
+        if "[" not in text:
+            continue
+        try:
+            plain = Content.from_markup(text).plain
+        except Exception:
+            plain = None
+        for m in re.finditer(r"(?<!\\)\[([^\[\]]{1,10})\]", text):
+            tag = m.group(1)
+            if plain is not None and m.group(0) in plain:
+                continue  # survived the parse — not a tag
+            if tag in _LEGIT_TAGS or (rel, tag) in _KNOWN_SAFE:
+                continue
+            offenders.append(f"{rel}:{lineno}  [{tag}]  in {text.strip()[:70]!r}")
+    assert not offenders, "unescaped key hints (use \\[x]):\n" + "\n".join(offenders)
+
+
+@pytest.mark.asyncio
+async def test_first_run_guide_shows_the_keys_it_teaches():
+    """FirstRunScreen's numbered guide rendered as '2 · Download  — fetch its
+    weights' — the `[d]` / `[D]` / `[l]` it exists to teach were deleted by the
+    markup parser.  Asserts on the RENDERED card, not the source string."""
+    from club3090_cockpit.app import FirstRunScreen, ProfileOption
+
+    opts = [
+        ProfileOption("Model A · single", "model-a/single", "single"),
+        ProfileOption("Model B · dual", "model-b/dual", "dual"),
+    ]
+    app, _, _ = make_app(surface="producer")
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _settle(pilot)
+        await app.push_screen(FirstRunScreen(opts, recommended="model-a/single", gpu_count=2))
+        await _settle(pilot)
+        body = _renderable_text(app.screen.query_one("#first-run-body", Static))
+        for key in ("[d]", "[D]", "[l]"):
+            assert key in body, f"{key} missing from the rendered first-run guide:\n{body}"


### PR DESCRIPTION
UX-review batch: the items left after the earlier merged batches. Nine commits,
one item (or one coherent group) each, every behaviour change tested and every
important test negative-controlled — reverted the fix, confirmed the test goes
red, restored.

**Please review and merge yourself — I have deliberately not merged this.**

## Fixed

**#5 — key hints were being deleted by Textual's markup parser.** `[d]`, `[l]`,
`[t]`, `[a]`, `[r]`, `[Y]`, `[T]`, `[S]`, `[D]`, `[k]`, `[f]` all parse as style
tags and get dropped, so `FirstRunScreen`'s onboarding guide rendered as
*"2 · Download — fetch its weights"* — the guide taught nothing. Swept the whole
class rather than the reported sites: **24 strings** across FirstRunScreen,
`_thinking_card_lines`, the act8 lines, `OperateContainersPane`,
`ExportPrBundleScreen`, `HelpScreen`, the command-palette table, the catalog
status banner, and **seven `self.notify` toasts** (Textual renders toast
messages as markup too). A source-level sweep guard now makes the class
unreproducible.

**#6 — ⑤ Promote's footer never updated.** `on_input_changed` enabled both stage
buttons but never called `refresh_bindings()`, so the footer stayed `esc Close`
after `⏎ Write LOCAL layer` had become valid. Reproduced headlessly before/after.

**#2 — `⏎` vanished from the footer on table-focused panes.** Took the *drop
`show=True`* option. Reason: `_sync_footer_labels` computes the label once and
already writes it to `#mode-action-hint` in the Modes rail — verified reading
"⏎ Serve" on Catalog and "⏎ Re-run health" on Doctor. So nothing is lost, ⏎ is
now advertised identically in every pane, and it frees ~14 columns of the
scarcest space on screen. Redeclaring on the four tables would have shown a
stock "Select" — a second, conflicting label for the same key.

**#4 — keyboard trap after Inspect.** Focus landed on the config Select while
both the footer and rail said "⏎ Fit-check", so ⏎ opened a dropdown. Focus the
Fit-check button instead, and `scroll_visible()` the verdict card (measured: it
sat at y=15 height 11 on a 24-row screen).

**#7 — Settings was unsaveable at 80×24.** The card measured 28 rows *and 84
columns* on an 80×24 screen, putting the Save/Cancel footer at y=25. Added
`max-height`/`max-width` + a scroll container, and deleted the hint half that
duplicated the Footer.

**#15 — Explain showed dashes for values the row behind it displayed.** Falls
back to the `CatalogEntry`; `status` is now passed too. Also fixed the harder
case in the same function — a hard failure showed *only* the error.

**#16–#22 — narrow terminals.** Headings wrap instead of truncating; the catalog
hint's `[s] sort` / `[|] columns` render at 80 (they previously needed ~159
columns); `#catalog-status` had the *opposite* cause and needed a different fix;
the ① Bring buttons fit; the Containers hint went 4 rows → 2 and the log pane 2
→ 4; the catalog table survives a Start (height 1 → 6); the footer keeps the
*context* key by width-gating `r`/`S`; and narrow widths default to the
pick-decision columns (table width 151 → 47 at 80).

**Keyboard economy — focus + Help.** Filled the lane focus black holes (fixed in
the shared tab-activation handler, since the hole is the same on ⑤ entry), and
added the six undiscoverable Catalog keys to Help plus two palette entries.

## Found already-correct / premise didn't hold

- **`_sync_jobs_chip`'s `"[k] cancels"`** — the Header `sub_title` is *not*
  markup-parsed (proved by rendering one). Left alone.
- **`services.py`'s `"[S] Settings"`** — that string lands in a
  `RichLog(markup=True)`, and *rich*'s tag regex requires a lowercase leading
  char, so `[S]` survives there. Textual's parser would have eaten it; rich's
  does not.
- **`c` / `e` / `y` missing from ⑤ Promote's footer** — not a second instance of
  #6. The screen auto-focuses an Input and Textual deliberately suppresses
  single-printable bindings while one has focus, so the footer is honest.

## Deliberately left

- **The bring→serve double-confirm.** Collapsing it would be a **safety
  regression**, not just a refactor: `ConfirmActionScreen` re-runs a *fresh*
  reconcile immediately before executing, which is the entire point of the gate.
  Running it inside the preview means the verdict is computed while the user is
  still reading YAML and can be arbitrarily stale by the time they commit. It
  would also create a second write path outside the uniform gate. Worth doing
  only with a deliberate design decision about gate freshness — your call, not a
  drive-by.
- **`[log]` / `[apply-swap]` prefixes** eaten in the LivePane. Same markup class,
  but those lines are teed to the on-disk log as well, so escaping them writes
  literal backslashes into the log file. Needs an escape-at-the-render-boundary
  change in `tui-core`, not a string edit.
- **Doctor's second context key** still clips at 80 (two context keys plus
  globals do not fit). Better than before — it used to vanish entirely — and
  fixing it means shortening a label.

## Testing

`1111 passed, 1 skipped` (was 1074 + 1 before this branch) — 37 new test cases in
`tests/test_uiux_review_final.py`.

Three existing tests asserted behaviour this PR deliberately changes. Rather
than delete them I rebased each onto the invariant it was actually protecting,
and each docstring says what changed and why. Two more asserted `"[r] …"`
against the *raw* markup string — a substring of the escaped form too, so they
passed either way; they now parse the markup first.

## One thing to know about the branch

While this work was in flight another session in the shared checkout created
`fix/reserve-ab-correction` **off this branch's tip** and committed unrelated
moe-cache work there. Two consequences:

- That branch carries all of these c3 commits as ancestors. Its own PR diff will
  look larger than its one real commit until it is rebased onto `master`.
- One commit of mine (the resize-lag fix) landed on *their* branch before I
  noticed, so it exists on both. I cherry-picked it here and deliberately did
  **not** rewrite their branch to remove the duplicate — they may be mid-work.
  The patches are identical, so whichever merges first makes the other a no-op,
  but you may prefer to drop it from theirs.

This branch itself is clean: nine commits, all c3, none of theirs.
