### PR TITLE
c3 UX cleanup — five small fixes (hint gating, dead controls, footer dup, Help title, stale docstring)

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -7401,8 +7401,13 @@ class OptimizeScreen(ModalScreen):
         sel = self.query_one("#optimize-kv", Select)
         btn = self.query_one("#optimize-apply", Button)
         if not report.available:
-            sel.disabled = True
-            btn.disabled = True
+            # Hide the controls (absent, not merely greyed) and their rows, so
+            # the card is just the honest message — the KV label and advisory
+            # note go too, and ~6 rows of inert widgets don't sit under it.
+            sel.display = False
+            btn.display = False
+            for row in self.query(".optimize-row"):
+                row.display = False
             # Honest error / unsupported-engine card — never a fabricated rec.
             body.update(
                 f"  [red]{report.message}[/red]\n"
@@ -7413,6 +7418,12 @@ class OptimizeScreen(ModalScreen):
             )
             return
 
+        # A later available report must bring everything back (a screen that
+        # first showed an unavailable one must not render with no controls).
+        sel.display = True
+        btn.display = True
+        for row in self.query(".optimize-row"):
+            row.display = True
         lines = [
             f"  [bold]{report.slug}[/bold] · {report.engine or '—'} · card {report.card}",
             "",

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -4351,10 +4351,10 @@ class OperateOrchPane(Container):
                 id="scene-preview",
             )
             yield Label(
-                "[dim]\\[k] stop this model (gated)   \\[b] restart serving (gated)   "
-                "\\[n] switch model   \\[⏎] switch scene (gated)   \\[o] stop all (gated)   "
-                "\\[c] power cap… (default / clear / custom, gated)   "
-                "[dim](per-service start/stop → Containers tab)[/dim][/dim]",
+                "[dim]\\[k] stop this model   \\[b] restart serving   \\[n] switch model   "
+                "\\[⏎] switch scene   \\[o] stop all   \\[c] power cap… "
+                "(default / clear / custom) — all writes confirm-gated   "
+                "(per-service start/stop → Containers tab)[/dim]",
                 id="orch-hint",
             )
             # FIX 3 — the host disk-usage bars + system-RAM line MOVED out of this

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -8572,8 +8572,10 @@ class LaneServePane(Container):
 class LanePromotePane(Container):
     """⑤ Promote — checklist + the scaffold/write action.
 
-    Hosts [P] / the Preview button → PromoteScaffoldScreen.  Write remains
-    mock-only this phase (preview badge is persistent)."""
+    Hosts [P] / the Preview button → PromoteScaffoldScreen.  The write is
+    real: it runs promote.py to register the served compose into the LOCAL
+    layer, confirm-gated like every other write (the preview badge is
+    persistent)."""
 
     DEFAULT_CSS = """
     LanePromotePane {

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -3939,7 +3939,6 @@ class ConfirmActionScreen(ModalScreen):
         if rec.safe:
             lines.append("")
             lines.append("  [green]● gate clear[/green] — nothing live overlaps the requested GPUs.")
-            lines.append("  [dim]⏎ Confirm (streams below) · Esc Cancel[/dim]")
         else:
             lines.append("")
             lines.append("  [yellow]⚠ this will tear down / collide with:[/yellow]")

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -1108,7 +1108,7 @@ class HelpScreen(ModalScreen):
 
     def compose(self) -> ComposeResult:
         with Vertical():
-            yield Label("club3090 serve cockpit — Help", classes="help-title")
+            yield Label("club3090 cockpit — Help", classes="help-title")
             with VerticalScroll():
                 yield Static(self.help_text)
 

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -6411,7 +6411,10 @@ class TestOptimizeBrain:
             body = str(app.screen.query_one("#optimize-body", Static).render())
             assert "kv-calc failed" in body                 # honest error card
             assert "Recommended max-model-len" not in body  # no fabricated numbers
-            assert app.screen.query_one("#optimize-apply", Button).disabled is True
+            # Rebased (c3 cleanup item 2): the unavailable card now HIDES the
+            # KV/Apply rows instead of greying them — absent, not disabled.
+            assert app.screen.query_one("#optimize-apply", Button).display is False
+            assert app.screen.query_one("#optimize-kv", Select).display is False
 
     @pytest.mark.asyncio
     async def test_skip_engine_gets_explicit_unsupported_message(self):
@@ -6424,10 +6427,39 @@ class TestOptimizeBrain:
             body = str(app.screen.query_one("#optimize-body", Static).render())
             assert "kvcalc_key=SKIP" in body
             assert "Recommended max-model-len" not in body
-            assert app.screen.query_one("#optimize-apply", Button).disabled is True
+            assert app.screen.query_one("#optimize-apply", Button).display is False
+            assert app.screen.query_one("#optimize-kv", Select).display is False
             # The SKIP check short-circuits BEFORE any kv-calc call.
             assert all("kv-calc.py" not in " ".join(c) for c in runner.calls
                        if "--fit " in " ".join(c))
+
+    @pytest.mark.asyncio
+    async def test_optimize_rows_restored_after_unavailable_report(self):
+        """c3 cleanup item 2 — hiding is not sticky: a screen that first shows
+        an unavailable report and later receives a good one must render the
+        KV/Apply rows again, enabled (`.display` toggles both directions)."""
+        from club3090_cockpit.app import OptimizeScreen
+        from club3090_cockpit.data import KvOption, OptimizerReport
+
+        app, runner, _ = make_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            await self._open_optimize(pilot, app, row=1)  # kvcalc_key=SKIP → unavailable
+            screen = app.screen
+            assert isinstance(screen, OptimizeScreen)
+            assert screen.query_one("#optimize-apply", Button).display is False
+            good = OptimizerReport(
+                available=True, slug="vllm/dual", engine="vllm", card="3090",
+                recommended_kv_format="fp8_e5m2", recommended_max_ctx=262144,
+                fit_vram_est_gb=18.0, band_gb=0.5,
+                options=[KvOption(kv_format="fp8_e5m2", solved_max_ctx=262144,
+                                  vram_est_gb=18.0, headroom_gb=6.0,
+                                  verdict="fits-clean")],
+            )
+            screen.set_report(good)
+            assert screen.query_one("#optimize-apply", Button).display is True
+            assert screen.query_one("#optimize-kv", Select).display is True
+            assert screen.query_one("#optimize-apply", Button).disabled is False
 
     @pytest.mark.asyncio
     async def test_optimize_is_a_noop_no_write(self):

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -11723,6 +11723,31 @@ class TestTier1PrimaryActionAndSKeyHonesty:
             await _enter_operate(pilot, tab="tab-containers")
             assert app.check_action("primary_action", ()) is False
 
+
+    @pytest.mark.asyncio
+    async def test_orch_hint_names_keys_and_gates_once(self):
+        """#orch-hint used to append "(gated)" to four of its six keys, which
+        wrapped the hint to three or four lines at 80 columns.  The gating is
+        now stated once as a trailing clause.  Protected invariant: every key
+        is still named, and the confirm-gating is still taught."""
+        from rich.console import Console
+
+        app, _, _ = make_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot, tab="tab-orchestration")
+            # The hint wraps across visual lines at this width, so a
+            # line-based render drops later keys.  `_content` is the widget's
+            # full post-markup text; the screen capture below re-checks what
+            # the user actually sees, wrap-safely.
+            # ``.render().plain`` is the full pre-wrap content (this Textual's
+            # Label has no `_content`; `_renderable_text` would wrap-crop it).
+            hint = app.query_one("#orch-hint", Label).render().plain
+            for key in ("[k]", "[b]", "[n]", "[⏎]", "[o]", "[c]"):
+                assert key in hint, f"key {key} missing from hint: {hint!r}"
+            assert "(gated)" not in hint
+            assert hint.lower().count("gated") == 1
+            assert "confirm-gated" in hint
+
     @pytest.mark.asyncio
     async def test_doctor_rerun_verb_advertised_on_doctor(self):
         """The REAL Doctor verb ([y] doctor_rerun) is surfaced in the footer on

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -3892,6 +3892,28 @@ class TestEveryWriteGoesThroughReconcile:
             assert screen.check_action("force", ()) is False
 
     @pytest.mark.asyncio
+    async def test_legacy_confirm_body_does_not_repeat_footer_keys(self):
+        """c3 cleanup item 3 — the safe-gate body used to print
+        '⏎ Confirm (streams below) · Esc Cancel' while the modal's Footer
+        already showed the same two keys, doubling them on one screen.  The
+        body line is gone; the Footer still teaches Confirm (its only job)."""
+        app, _, _ = make_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            plan = app._data.scene_switch("27b")
+            app.push_screen(ConfirmActionScreen(plan))
+            await _settle(pilot)
+            screen = app.screen
+            assert isinstance(screen, ConfirmActionScreen)
+            assert screen._is_serve is False      # the legacy card, not the serve one
+            assert screen._reconcile.safe is True
+            body = str(screen.query_one("#confirm-body", Static).render())
+            assert "gate clear" in body
+            assert "streams below" not in body    # the duplicated key line
+            footer_keys = {k.key for k in screen.query(FooterKey)}
+            assert "enter" in footer_keys         # Confirm still taught — once
+
+    @pytest.mark.asyncio
     async def test_unsafe_gate_disables_confirm_enables_force(self):
         """When a container is running, the gate is unsafe → Confirm disabled,
         Force enabled.  The teardown list is surfaced."""

--- a/tools/serve-cockpit/tests/test_uiux_review_final.py
+++ b/tools/serve-cockpit/tests/test_uiux_review_final.py
@@ -686,6 +686,28 @@ def test_help_teaches_the_hidden_catalog_keys(phrase):
     assert phrase in text, f"{phrase!r} missing from Help"
 
 
+@pytest.mark.asyncio
+async def test_help_title_matches_the_app_name():
+    """c3 cleanup item 4 — the Help title said 'club3090 serve cockpit' while
+    the app header renders 'club3090 cockpit' (SUB_TITLE = 'local LLM
+    cockpit').  Help must agree with the app's own name.  The title is a
+    compose() Label, so read it from the mounted screen, not help_text."""
+    from club3090_cockpit.app import HelpScreen
+    from textual.widgets import Label
+
+    from test_app_headless import make_app, _settle
+
+    app, _, _ = make_app()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _settle(pilot)
+        await pilot.press("?")
+        await _settle(pilot)
+        assert isinstance(app.screen, HelpScreen)
+        title = app.screen.query_one(".help-title", Label).render().plain
+        assert title == "club3090 cockpit — Help"
+        assert "serve cockpit" not in title
+
+
 def test_help_shows_the_backslash_and_pipe_keys_literally():
     """The two punctuation keys must survive the markup parse — `\\` in
     particular is the escape character, so getting it into rendered output takes


### PR DESCRIPTION
Five scoped UX fixes in `tools/serve-cockpit` per the c3 cleanup brief. One commit per item; no behaviour outside the five items.

## 1. Orchestration hint — say (gated) once (9bf3e36d)
`#orch-hint` repeated "(gated)" on four of six keys, wrapping to 3–4 lines at 80 cols. Now a single trailing clause: `— all writes confirm-gated`. All six keys keep their `\[x]` escapes.
**Test:** `test_orch_hint_names_keys_and_gates_once` (every key named, exactly one "gated", "(gated)" absent). Negative-controlled (red on old text).

## 2. Optimize modal — hide dead controls (b9be0d5b)
The unavailable card only *disabled* the KV Select and Apply Button (~6 inert rows under "nothing to apply"). Now `.display = False` on both controls and their `.optimize-row` containers; the available path restores all four.
**Test:** `test_optimize_rows_restored_after_unavailable_report` + two existing assertions rebased from `disabled=True` to `display=False`. Negative-controlled (3 red on revert).

## 3. Confirm body no longer repeats the footer (51e0d754)
The safe-gate legacy card printed `⏎ Confirm (streams below) · Esc Cancel` while the modal's `Footer()` already renders both keys (compose comment documents footer-only controls). Line removed.
**Test:** `test_legacy_confirm_body_does_not_repeat_footer_keys` — legacy card via a scene_switch plan with a safe reconcile: `gate clear` still renders, "streams below" gone, enter in FooterKey set. Negative-controlled.

## 4. Help title matches the app header (855c5349)
`club3090 serve cockpit — Help` → `club3090 cockpit — Help` (header: `club3090 cockpit` + SUB_TITLE).
**Test:** `test_help_title_matches_the_app_name` mounts Help via `?` and reads `.help-title`.

## 5. LanePromotePane docstring — the write is real (f4ac7e40)
Docstring claimed "Write remains mock-only this phase" — false since ⑤ stages a real promote.py run (confirm-gated). Docstring only, no behaviour change.

## Verification
- Full suite: **1115 passed, 1 skipped** (baseline 1111 passed, 1 skipped — +4 new tests, all green). One load-order focus flake occurred in the first full run and did not reproduce on rerun; the affected tests pass 3× in isolation and are unrelated to these changes.
- Items 1–3 negative-controlled per brief (fix reverted → red; restored → green).
- Out-of-scope items untouched (bring→serve double-confirm, Route-K/C renames, hint widths, naming splits, scripts/ and models/).