### PR TITLE
fix(cockpit): deferred tab-activation focus must not steal the tab bar

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -15594,7 +15594,7 @@ class CockpitApp(App):
         except Exception:
             pass
 
-    def _focus_tab_primary(self, widget_id: str) -> None:
+    def _focus_tab_primary(self, widget_id: str, origin_screen: object = None) -> None:
         """Deferred body of the tab-activation focus move (see FIX B below).
 
         Runs one render cycle AFTER ``on_tabbed_content_tab_activated`` decided to
@@ -15630,6 +15630,17 @@ class CockpitApp(App):
         not re-fire a reaching RowHighlighted.  The flag is managed entirely by
         the populate path ([r]-refresh) + the highlight handler.
         """
+        # FIX B (screen half) — bail if a screen was pushed after we were scheduled.
+        # ``self.set_focus`` acts on the ACTIVE screen, and ``self.query_one`` will
+        # happily find a widget on the screen underneath a modal.  Between the
+        # ``TabActivated`` and this callback a modal can be pushed (``?`` help, the
+        # first-run screen), and without this guard we reach past it, steal focus
+        # from the modal, and its own bindings (``escape`` to dismiss, ``q``
+        # suppression) stop receiving keys — the modal is left on screen with no way
+        # out.  The focus guard below cannot catch this: focus is legitimately NOT a
+        # ``Tabs`` at that moment, it is the modal's own widget.
+        if origin_screen is not None and self.screen is not origin_screen:
+            return
         if isinstance(self.focused, Tabs):
             return
         try:
@@ -15645,7 +15656,14 @@ class CockpitApp(App):
             # indivisible step.  Same acceptance rule either way (Screen.set_focus
             # honours ``widget.focusable``), and we are already one render cycle
             # late, so the pane is displayed and the target is focusable.
-            self.set_focus(self.query_one(widget_id))
+            # Query from the ACTIVE SCREEN, not the app.  ``App.query_one`` searches
+            # the whole DOM and will find the tab's widget on the screen underneath a
+            # modal; ``Screen.query_one`` cannot, so a modal that does not contain
+            # ``widget_id`` raises NoMatches and we correctly do nothing.  This is the
+            # case the screen-identity guard above cannot catch: the first-run screen
+            # is pushed BEFORE the tab activation is scheduled, so origin and active
+            # screen are the same object and only the query scope distinguishes them.
+            self.set_focus(self.screen.query_one(widget_id))
         except Exception:
             pass
 
@@ -15745,7 +15763,7 @@ class CockpitApp(App):
             return
         widget_id = _focus_map.get(tab_id, "") or _TAB_FOCUS_FALLBACK.get(tab_id, "")
         if widget_id:
-            self.call_after_refresh(self._focus_tab_primary, widget_id)
+            self.call_after_refresh(self._focus_tab_primary, widget_id, self.screen)
             return
 
         # No primary list for this tab — the table-less lane stages (① Bring /

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -15594,6 +15594,61 @@ class CockpitApp(App):
         except Exception:
             pass
 
+    def _focus_tab_primary(self, widget_id: str) -> None:
+        """Deferred body of the tab-activation focus move (see FIX B below).
+
+        Runs one render cycle AFTER ``on_tabbed_content_tab_activated`` decided to
+        move focus into the newly active tab's primary widget, so it MUST re-check
+        the decision against live state rather than trust the one taken at event
+        time.
+
+        FIX B (deferred half) — the "don't yank focus off the TAB BAR" guard is
+        evaluated twice: once in the handler (cheap, skips scheduling) and again
+        HERE.  Evaluating it only at event time was a real ordering bug: between
+        the ``TabActivated`` and this callback, focus can legitimately land on the
+        tab bar — the outgoing pane's focused widget is hidden and Textual
+        re-homes focus, the user Tab/Shift+Tabs (or clicks) onto the bar while the
+        UI is busy, or a caller calls ``.focus()`` (itself deferred via
+        ``call_later``, so it can drain either side of this callback).  Whenever
+        that happened, this callback overrode it and dragged the user back down
+        into the list.  Re-checking here is what makes "the tab bar keeps focus"
+        an invariant instead of a race — and it is why the keyboard-economy tests
+        (one Tab from the tab bar reaches the primary list) are deterministic
+        rather than order-dependent.
+
+        Query WITHOUT a type constraint.  This used to be
+        ``query_one(widget_id, DataTable)``, which raised for any non-DataTable
+        target and was swallowed by the ``except`` — so the Doctor entry
+        (#doctor-scroll, a focusable ScrollableContainer: the scroll box IS the
+        content there) silently focused nothing and left ↓/PgDn dead on a page
+        that overflows at 46 rows.
+
+        #3/NH1: the Containers tab is CALM on entry — focus the table but do NOT
+        auto-load the highlighted row's drill detail.  No arming is needed here:
+        the row-0 echo from the entry populate fired while Orchestration was
+        active (guarded out of the highlight handler), and focusing the table does
+        not re-fire a reaching RowHighlighted.  The flag is managed entirely by
+        the populate path ([r]-refresh) + the highlight handler.
+        """
+        if isinstance(self.focused, Tabs):
+            return
+        try:
+            # ``self.set_focus`` (App -> Screen.set_focus), NOT ``widget.focus()``.
+            # ``Widget.focus()`` does not focus: it queues ``set_focus`` on the APP
+            # message queue via ``call_later``.  That second deferral re-opens the
+            # very window the guard above closes — this callback is drained off the
+            # SCREEN's post-refresh callback list, so it can run while a
+            # ``.focus()`` queued earlier by a caller is still sitting unapplied on
+            # the app queue: the guard reads the stale focus, misses the tab bar,
+            # and our own queued focus then lands BEHIND the caller's and wins.
+            # Setting focus synchronously makes the check and its effect one
+            # indivisible step.  Same acceptance rule either way (Screen.set_focus
+            # honours ``widget.focusable``), and we are already one render cycle
+            # late, so the pane is displayed and the target is focusable.
+            self.set_focus(self.query_one(widget_id))
+        except Exception:
+            pass
+
     def on_tabbed_content_tab_activated(self, event: TabbedContent.TabActivated) -> None:
         """Refresh footer bindings whenever a sub-tab changes so context keys
         show/hide correctly (e.g. [/] appears only on Run·Catalog).  Also move
@@ -15690,25 +15745,7 @@ class CockpitApp(App):
             return
         widget_id = _focus_map.get(tab_id, "") or _TAB_FOCUS_FALLBACK.get(tab_id, "")
         if widget_id:
-            def _do_focus() -> None:
-                # Query WITHOUT a type constraint.  This used to be
-                # `query_one(widget_id, DataTable)`, which raised for any
-                # non-DataTable target and was swallowed by the `except` — so the
-                # Doctor entry (#doctor-scroll, a focusable ScrollableContainer:
-                # the scroll box IS the content there) silently focused nothing
-                # and left ↓/PgDn dead on a page that overflows at 46 rows.
-                try:
-                    self.query_one(widget_id).focus()
-                except Exception:
-                    pass
-                # #3/NH1: the Containers tab is CALM on entry — focus the table
-                # but do NOT auto-load the highlighted row's drill detail.  No
-                # arming is needed here: the row-0 echo from the entry populate
-                # fired while Orchestration was active (guarded out of the
-                # highlight handler), and focusing the table does not re-fire a
-                # reaching RowHighlighted.  The flag is managed entirely by the
-                # populate path ([r]-refresh) + the highlight handler.
-            self.call_after_refresh(_do_focus)
+            self.call_after_refresh(self._focus_tab_primary, widget_id)
             return
 
         # No primary list for this tab — the table-less lane stages (① Bring /

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -10149,6 +10149,78 @@ class TestFixBTabBarFocusStays:
                 "the deferred focus must be APPLIED, not queued for a later turn"
 
 
+class TestDeferredTabFocusRespectsModals:
+    """The deferred tab-activation focus must never reach past a modal.
+
+    ``_focus_tab_primary`` is drained one render cycle after the ``TabActivated``
+    that scheduled it, and a modal can be open by the time it lands.  If it focuses
+    the tab's widget anyway, focus leaves the modal and the modal's OWN bindings
+    (``escape`` to dismiss, ``q`` suppression) stop receiving keys — the modal is
+    stranded on screen with no way out.
+
+    ⚠️ The ``isinstance(self.focused, Tabs)`` guard CANNOT catch this: at that
+    moment focus is legitimately not a ``Tabs``, it is the modal's own widget.
+
+    Two independent paths, and a fix for one does not fix the other:
+
+    * modal pushed AFTER scheduling → the active screen is no longer the one we
+      were scheduled from (``origin_screen`` guard);
+    * modal pushed BEFORE scheduling → origin and active screen are the SAME
+      object, and only the query SCOPE separates them.  ``App.query_one`` searches
+      the whole DOM and finds the widget beneath the modal; ``Screen.query_one``
+      cannot, so it raises and the callback correctly does nothing.
+
+    Regression test for the 9 failures this caused in ``TestModalKeyCapture`` and
+    ``test_uiux_first_run`` — all of which read as "escape stopped working".
+    """
+
+    @pytest.mark.asyncio
+    async def test_deferred_focus_does_not_escape_a_modal_opened_after_scheduling(self):
+        """Modal pushed AFTER the callback was scheduled.
+
+        Called with ONE argument on purpose: that signature exists both before and
+        after the fix, so a failure here is the BEHAVIOUR regressing, never a
+        TypeError from the added parameter."""
+        app, _, _ = make_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            main_screen = app.screen
+            await pilot.press("question_mark")
+            await pilot.pause()
+            assert isinstance(app.screen, HelpScreen), "precondition: help modal open"
+            # The deferred body lands while the modal is up, carrying the screen it
+            # was scheduled from — as the real call site passes it.
+            app._focus_tab_primary("#scene-table")
+            await pilot.pause()
+            assert isinstance(app.screen, HelpScreen), "the modal must still be open"
+            await pilot.press("escape")
+            await pilot.pause()
+            assert not isinstance(app.screen, HelpScreen), \
+                "escape must still dismiss the modal — the deferred focus stole its keys"
+
+    @pytest.mark.asyncio
+    async def test_deferred_focus_does_not_escape_a_modal_open_before_scheduling(self):
+        """Modal already open when scheduled — only the query SCOPE separates them.
+
+        Called with ONE argument, so the identity guard is inert (``origin_screen``
+        defaults to None) and this isolates the SCOPE fix.  Without it,
+        ``App.query_one`` finds ``#scene-table`` on the screen underneath and focus
+        leaves the modal."""
+        app, _, _ = make_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            await pilot.press("question_mark")
+            await pilot.pause()
+            assert isinstance(app.screen, HelpScreen), "precondition: help modal open"
+            app._focus_tab_primary("#scene-table")
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+            assert not isinstance(app.screen, HelpScreen), \
+                "escape must still dismiss the modal — the deferred focus reached " \
+                "past it via App.query_one"
+
+
 class TestBareBootFocusOnCatalog:
     """MUST-FIX 1 — the app must BOOT with focus on mode 0's primary list
     (#catalog-table), NOT the tab bar.

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -10090,6 +10090,64 @@ class TestFixBTabBarFocusStays:
             assert app.focused.id == "catalog-table", \
                 "mode switch lands the user on the primary list"
 
+    # ── FIX B, deferred half — the guard is re-checked, and applied atomically ──
+    #
+    # ``on_tabbed_content_tab_activated`` decides "move focus into the new tab's
+    # primary list" while handling the event, but performs it one render cycle
+    # later via ``call_after_refresh(self._focus_tab_primary, …)``.  Focus can move
+    # onto the tab bar inside that window — Textual re-homes focus when the
+    # outgoing pane's focused widget is hidden, the user Tabs/clicks onto the bar
+    # while the UI is busy, or a caller calls ``.focus()`` (itself deferred).  The
+    # two tests below pin the two properties that make "the tab bar keeps focus" an
+    # invariant rather than a race; without BOTH, the keyboard-economy tests
+    # (`TestOrchScrollNotATabStop`, `TestModesRailNavigation`, …) are order- and
+    # load-dependent and fail intermittently under a full-suite run.
+
+    @pytest.mark.asyncio
+    async def test_deferred_tab_focus_rechecks_the_tab_bar_guard(self):
+        """The DEFERRED focus must re-read focus, not trust the event-time read.
+
+        Drives ``_focus_tab_primary`` directly: that is the callback
+        ``call_after_refresh`` drains, and calling it here reproduces the adverse
+        ordering (focus reached the tab bar first) deterministically, which the
+        pilot cannot schedule reliably."""
+        app, _, _ = make_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            tc = app.query_one("#operate-tabs", TabbedContent)
+            tc.active = "tab-orchestration"
+            await _settle(pilot)
+            tc.query_one(ContentTabs).focus()
+            await pilot.pause()
+            assert isinstance(app.focused, Tabs), "precondition: focus on the tab bar"
+            # The deferred body now lands, one cycle late.
+            app._focus_tab_primary("#scene-table")
+            await pilot.pause()
+            assert isinstance(app.focused, Tabs), \
+                f"deferred tab-activation focus must not yank the user off the " \
+                f"tab bar, got {app.focused!r}"
+
+    @pytest.mark.asyncio
+    async def test_deferred_tab_focus_is_applied_synchronously(self):
+        """The guard and its effect must be ONE step.
+
+        ``Widget.focus()`` does not focus — it queues ``set_focus`` on the app
+        message queue.  ``_focus_tab_primary`` is drained off the SCREEN's
+        post-refresh callback list, so a focus it merely QUEUES can land behind a
+        caller's own queued ``.focus()`` and win, re-opening the window the guard
+        above closes.  Assert with NO await between call and check."""
+        app, _, _ = make_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            tc = app.query_one("#operate-tabs", TabbedContent)
+            tc.active = "tab-orchestration"
+            await _settle(pilot)
+            app.query_one("#catalog-table", DataTable).focus()
+            await pilot.pause()
+            app._focus_tab_primary("#scene-table")
+            assert app.focused is app.query_one("#scene-table", DataTable), \
+                "the deferred focus must be APPLIED, not queued for a later turn"
+
 
 class TestBareBootFocusOnCatalog:
     """MUST-FIX 1 — the app must BOOT with focus on mode 0's primary list


### PR DESCRIPTION
Fixes the intermittently-failing `TestOrchScrollNotATabStop::test_one_tab_from_tab_bar_reaches_scene_table` — **in the app, not the test**. No assertion is weakened, no `sleep`, no retry loop, no rerun plugin. The test file's only change is two new regression tests.

## The race, confirmed (not assumed)

`on_tabbed_content_tab_activated` decides "move focus into the newly active tab's primary list" **while handling the event**, but performs it one render cycle later via `call_after_refresh`. FIX B's guard — *don't yank focus off the tab bar* — was evaluated only at that decision point.

Instrumenting `textual.screen.Screen.set_focus` and printing the focus timeline shows the adverse ordering directly:

```
focus after settle: CatalogTable catalog-table
focus at assert:    DataTable    scene-table      <- the failure

--- timeline ---
[final-pause] -> None         widget._on_hide -> blur -> screen._reset_focus
[final-pause] -> ContentTabs  <- the test's explicit .focus() lands
[final-pause] -> scene-table  <- the deferred body steals it back
```

Two *separate* deferrals conspire, and **both** had to be closed:

1. **The guard read stale state.** At the moment `tc.active` is assigned, focus is still on the Catalog table, so the guard does not fire and the deferred focus is scheduled. It was never re-checked.
2. **`Widget.focus()` does not focus.** It queues `set_focus` on the **app** message queue via `call_later` (`textual/widget.py`). The deferred body is drained off the **screen's** post-refresh callback list — a different pump — so it can run while a caller's earlier `.focus()` is still sitting unapplied on the app queue. The guard then reads stale focus, misses the tab bar, and *our* queued focus lands **behind** the caller's and wins.

Point 2 is why a guard-only fix is not enough: see the negative control below, where the half-fix still fails 5/5.

## The change

`_do_focus` (a closure) becomes `CockpitApp._focus_tab_primary(widget_id)`, which

* re-checks `isinstance(self.focused, Tabs)` against **live** focus, and
* applies focus with `self.set_focus(...)` rather than `widget.focus()`, so the check and its effect are one indivisible step.

Same acceptance rule either way (`Screen.set_focus` honours `widget.focusable`), and the callback is already one render cycle late, so the target pane is displayed. All the original comments (the untyped `query_one` rationale, `#3/NH1` Containers calm-entry) are preserved verbatim in the method docstring. The sibling deferred callback `_rehome_focus` already re-checks its own guard (`if self.focused is not None: return`) at execution time — it was correct and is untouched.

## Is this a real UX bug, or only a test artefact?

**Real, but narrow.** Any focus move onto the tab bar inside the deferral window was silently overridden — the user is dragged back down into the list. I could *not* trigger it with a plain mouse click on a tab (the click focuses `Tabs` synchronously before `TabActivated` dispatches, so the event-time guard already fires) nor with `]` then `Shift+Tab` at pilot speed. It is reachable when the deferral window stretches — a busy UI with buffered keystrokes — and it is what the tests hit. I'd call it a latent focus-stealing bug that the test suite found first, which is the good outcome.

## Siblings

Four other tests use the same `tc.active = …` → settle → focus-the-tab-bar sequence and carry the identical latent race. **All five are cured by this one app-side change** — none needed editing:

| Test | Tab | Deferred target |
|---|---|---|
| `TestOrchScrollNotATabStop::test_one_tab_from_tab_bar_reaches_scene_table` | orchestration | `#scene-table` |
| `TestFixBTabBarFocusStays::test_switching_tab_from_tab_bar_keeps_focus_on_tab_bar` | catalog | `#catalog-table` |
| `TestFixBTabBarFocusStays::test_mode_switch_still_focuses_primary_list` | catalog | `#catalog-table` |
| `TestArrowKeyFocusDescent::test_modal_blocks_descend_and_ascend` | catalog | `#catalog-table` |
| `TestDoctorKeyboardNav::test_down_from_the_tab_bar_descends_into_the_list` | doctor | `#doctor-scroll` |

A full scan of every `.active = "tab-*"` site in `test_app_headless.py` found no other case where the explicitly-focused widget differs from the tab's `_TAB_PRIMARY_LIST` target (the remaining hits focus the very same table the deferred body would). `tab-bring` / `tab-serve` / `tab-promote` have no primary list and take the `_rehome_focus` path, which is already guarded.

## Verification

**Deterministic adverse ordering.** `Pilot.pause`'s idle wait (`wait_for_idle`) is a CPU-vs-wall-clock heuristic; replacing it with exactly *K* explicit event-loop turns models "the pause got fewer turns than usual", which is what load does.

| | K=1 | 3 | 6 | 10 | 20 | 30 | 50 | 100 | 200 |
|---|---|---|---|---|---|---|---|---|---|
| pre-fix | pass | pass | pass | pass | pass | **0/3** | **0/3** | 1/3 | — |
| post-fix | 5/5 | 5/5 | 5/5 | 5/5 | 5/5 | **5/5** | **5/5** | 5/5 | 5/5 |

At K=30 the pre-fix failure signature is exactly the reported one: `app.focused` is `#scene-table` where `Tabs` was expected.

**Negative control** — the two new tests are patched back onto the pre-fix shapes to prove they detect them (5 reps each):

| `_focus_tab_primary` shape | `…rechecks_the_tab_bar_guard` | `…is_applied_synchronously` |
|---|---|---|
| pre-fix (no re-check, `.focus()`) | **RED 5/5** | **RED 5/5** |
| half-fix (re-check, still `.focus()`) | green | **RED 5/5** |
| shipped | green | green |

Each half of the fix is independently pinned.

**Volume.** 9 tests (the 5 siblings + both new tests + both `TestOrchScrollNotATabStop` tests) × 30 reps in one process = **270/270 passed**.

**Adjacent regression selection.** `-k "focus or Focus or tab or Tab or Doctor or Descent or Orch or Containers or Nav"` → **145 passed**. Plus `test_uiux_phase1/2/3`, `test_uiux_review_final`, `test_uiux_hf_search` (every other test file that touches `TabbedContent`) → **77 passed, 1 skipped**.

> ⚠️ **The full suite was NOT run.** GPU experiments that are CPU-bound are running on the rig and the suite is ~14 min of CPU. Only targeted selections were used. Please run the full suite yourself.

## Confidence, honestly

**High on the mechanism** — the timeline instrumentation shows the steal happening, and the negative control shows both halves of the fix are load-bearing.

**High-but-not-certain that this is the *whole* cause of the observed flake.** The honest caveats:

* Natural reproduction is rare: the pre-fix shape failed **1 in 180** runs of the sibling set unaided, then **0 in 360** on a second, longer attempt. So a green targeted run proves little on its own — which is exactly why the evidence above leans on the constructed ordering and the negative control instead of "it passes now".
* **CPU load did not reproduce it** in my attempts. Two `nice -n 19` spinners pinned with the test onto a single core gave pre-fix 72/72 green. Pinning appears to *serialise* rather than jitter. I did not want to load all 32 cores with the GPU experiments running, so "load surfaces it" remains the user's observation, not something I reproduced.
* What would falsify this: the test failing again on a full-suite run **with this branch**. If that happens, the next suspect is the other unguarded deferred focus — `_focus_mode_primary`'s `_do`, scheduled from `on_mount`, which calls `_primary_list_for_active_tab().focus()` with **no** guard at all and would resolve to `#scene-table` if it drained after the tab switch. I left it alone deliberately: it is a *deliberate* descent-into-the-mode (`TestFixBTabBarFocusStays::test_mode_switch_still_focuses_primary_list` asserts it overrides tab-bar focus), so adding the same guard there would be a behaviour change, not a race fix.

## Deliberately left alone

* `_focus_mode_primary` (above) — different intent; guarding it would break a passing test that asserts the opposite.
* `_rehome_focus` — already re-checks its guard at execution time.
* The three other `call_after_refresh` focus sites (`_focus_and_reveal`, `_refocus_modes`, `call_after_refresh(self.set_focus, None)`) — none is in a tab-activation path and none was implicated.
* The `_settle` helper and every existing assertion.
