### PR TITLE
fix(vram-breakdown): count drafter weights and GLM recurrent state

### DIFF
--- a/scripts/lib/vram_breakdown.py
+++ b/scripts/lib/vram_breakdown.py
@@ -38,10 +38,17 @@ def main() -> int:
     except OSError:
         return 1
 
-    model = _per_dev(text, r"load_tensors:\s+(CUDA\d) model buffer size =\s+([\d.]+) MiB")
+    # A GPU-pinned drafter emits the same `model buffer size` line as the
+    # target model -- the two weights are additive, so last-wins would report
+    # the drafter's and drop the target's into unaccounted.
+    model = _per_dev(text, r"load_tensors:\s+(CUDA\d) model buffer size =\s+([\d.]+) MiB", agg=True)
     compute = _per_dev(text, r"sched_reserve:\s+(CUDA\d) compute buffer size =\s+([\d.]+) MiB")
     kv = _per_dev(text, r"llama_kv_cache:\s+(CUDA\d) KV buffer size =\s+([\d.]+) MiB", agg=True)
     state = _per_dev(text, r"_comp_state:\s+(CUDA\d) \S+ \S+ state buffer size =\s+([\d.]+) MiB", agg=True)
+    # GLM names this buffer `llama_memory_recurrent ... RS` -- same kind of
+    # state as DeepSeek's `_comp_state`, so it folds into the `state` column.
+    for d, v in _per_dev(text, r"llama_memory_recurrent:\s+(CUDA\d) RS buffer size =\s+([\d.]+) MiB", agg=True).items():
+        state[d] = state.get(d, 0.0) + v
 
     # LAST report per (device, pool) -- never sum every match, see module docstring
     last = {}

--- a/scripts/tests/test-vram-breakdown.sh
+++ b/scripts/tests/test-vram-breakdown.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs --
+# repo sources carry unicode and a non-UTF-8 locale breaks the parser paths
+# (#779).  Enforced by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+# test-vram-breakdown.sh — regression for club-3090 #1171.
+#
+# The VRAM breakdown parser (`scripts/lib/vram_breakdown.py`) reported the
+# DRAFTER's weights as `model=` on any slug with a GPU-pinned drafter
+# (`_per_dev` last-wins vs. two additive `load_tensors` lines), and never
+# matched GLM's `llama_memory_recurrent ... RS` state line (only DeepSeek's
+# `_comp_state`).  Fix: `model` aggregates, and the RS line folds into the
+# `state` column.
+#
+# Fixture-driven (deterministic log text, no Docker/GPU/network): asserts the
+# per-device `model=`/`state=` tokens, which do not depend on nvidia-smi being
+# present.  The `total=`/`unaccounted=` figures DO depend on a live nvidia-smi
+# and are deliberately not asserted here; the real GLM+DFlash2 boot acceptance
+# (model=3969, CUDA1 unaccounted 6080 -> 2561) is recorded in the PR.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+python3 - <<'PY'
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+PARSER = ["python3", "scripts/lib/vram_breakdown.py"]
+failures: list[str] = []
+
+
+def check(cond: bool, msg: str) -> None:
+    if cond:
+        print(f"PASS: {msg}")
+    else:
+        print(f"FAIL: {msg}", file=sys.stderr)
+        failures.append(msg)
+
+
+def run(log_text: str) -> str:
+    with tempfile.NamedTemporaryFile("w", suffix=".log", delete=False) as f:
+        f.write(log_text)
+        path = f.name
+    r = subprocess.run(PARSER + [path], capture_output=True, text=True)
+    Path(path).unlink()
+    if r.returncode != 0:
+        failures.append(f"parser exited {r.returncode}: {r.stderr[:200]}")
+    return r.stdout
+
+
+# --- #1171: two-model boot (GLM-5.3-Flash target + DFlash2 drafter on CUDA1)
+glm = """\
+0.12.593.897 I load_tensors:        CUDA0 model buffer size =  3524.46 MiB
+0.12.593.898 I load_tensors:        CUDA1 model buffer size =  3313.42 MiB
+1.00.332.286 I llama_kv_cache:      CUDA0 KV buffer size =   337.50 MiB
+1.00.358.673 I llama_memory_recurrent:      CUDA0 RS buffer size =   231.19 MiB
+1.00.361.303 I llama_memory_recurrent:      CUDA1 RS buffer size =   205.50 MiB
+1.02.627.213 I sched_reserve:      CUDA0 compute buffer size =  5329.04 MiB
+1.02.627.225 I sched_reserve:      CUDA1 compute buffer size =  5208.35 MiB
+1.03.247.930 I load_tensors:        CUDA1 model buffer size =   655.73 MiB
+1.03.561.019 I llama_kv_cache:      CUDA1 KV buffer size =    80.00 MiB
+"""
+out = run(glm)
+check("model=3969" in out,
+      "drafter no longer overwrites model=: CUDA1 model= 3313.42+655.73=3969")
+check("state=231" in out and "state=206" in out,
+      "GLM recurrent RS lines are counted in state= per device")
+check("model=3524" in out, "CUDA0 target model is unchanged")
+
+# --- DeepSeek `_comp_state` must still parse into state= (no regression)
+ds = """\
+0.10.000.000 I load_tensors:        CUDA0 model buffer size =  1000.00 MiB
+0.11.000.000 I llama_per_fixed_state:      _comp_state: CUDA0 q4_0 1 state buffer size =  128.00 MiB
+"""
+out = run(ds)
+check("model=1000" in out, "single-model boot: model= is the one line, untouched")
+check("state=128" in out, "DeepSeek _comp_state still parses into state=")
+
+# --- no-drafter boot: single load_tensors line per device stays correct
+single = """\
+0.12.000.000 I load_tensors:        CUDA0 model buffer size =  2048.00 MiB
+0.12.000.001 I load_tensors:        CUDA1 model buffer size =  1024.00 MiB
+"""
+out = run(single)
+check("model=2048" in out and "model=1024" in out,
+      "no-drafter boot: one line per device, values unchanged")
+
+if failures:
+    print(f"\n{len(failures)} assertion(s) failed.", file=sys.stderr)
+    sys.exit(1)
+print("\nAll vram_breakdown #1171 assertions passed.")
+PY
+
+echo "test-vram-breakdown.sh OK"


### PR DESCRIPTION
# RESULT-1171 — vram_breakdown: drafter weights additive + GLM recurrent state counted

## Branch

`fix/1171-vram-attribution` (off `origin/master`)

```
 scripts/lib/vram_breakdown.py        |  9 +++-
 scripts/tests/test-vram-breakdown.sh | 98 ++++++++++++++++++++++++++++++++++++
 2 files changed, 106 insertions(+), 1 deletion(-)
```

## What changed and why

1. **`model` is now additive** (`agg=True`): a slug with a GPU-pinned drafter
   emits the same `load_tensors: CUDA<n> model buffer size` line as the target
   model, and the two weights are additive — last-wins reported the drafter's
   656 MiB and dropped the target's 3,313 MiB into `unaccounted`.
2. **GLM recurrent state is matched**: `llama_memory_recurrent: CUDA<n> RS
   buffer size` (GLM) folds into the existing `state` column alongside
   DeepSeek's `_comp_state` — same kind of buffer, different line shape.
   Folding (rather than a new column) keeps the output line width unchanged.

**Defect 3 (drafter compute) is deliberately NOT fixed** — see below.

## Acceptance evidence

Live reference boot (`docker logs llama-cpp-glm53-flash-iq3xxs-moecache` — the
exact GLM-5.3-Flash + DFlash2 boot from the issue):

**Before:**
```
CUDA0: model=3524  kv=1238  compute=5329  pool=11714  total=22936/24576MiB(93%)  unaccounted=1131
CUDA1: model=656  kv=1111  compute=5240  pool=9903  total=22990/24576MiB(94%)  unaccounted=6080
```

**After:**
```
CUDA0: model=3524  kv=1238  state=231  compute=5329  pool=11714  total=22936/24576MiB(93%)  unaccounted=900
CUDA1: model=3969  kv=1111  state=206  compute=5240  pool=9903  total=22990/24576MiB(94%)  unaccounted=2561
```

- CUDA1 `model=3969` = 3313.42 + 655.73 — target + drafter, exactly per the
  acceptance line.
- CUDA1 `unaccounted` 6080 → **2561** (issue projected ~2,563; the 2 MiB delta
  is `.42/.73/.50` rounding in the issue's per-defect arithmetic).
- CUDA0 also gains its own 231 MiB RS into `state` (it was silently
  unaccounted before).
- No-drafter and DeepSeek `_comp_state` boots: covered by the fixture test
  below — both still parse (single `model=` unchanged; `_comp_state` →
  `state=128`).

## Guard-suite regression test

New `scripts/tests/test-vram-breakdown.sh` (fixture log text, no
Docker/GPU/network; asserts only the deterministic `model=`/`state=` tokens —
`total=`/`unaccounted=` depend on a live nvidia-smi):

```
PASS: drafter no longer overwrites model=: CUDA1 model= 3313.42+655.73=3969
PASS: GLM recurrent RS lines are counted in state= per device
PASS: CUDA0 target model is unchanged
PASS: single-model boot: model= is the one line, untouched
PASS: DeepSeek _comp_state still parses into state=
PASS: no-drafter boot: one line per device, values unchanged
```

**Negative control:** reverting `vram_breakdown.py` → `2 assertions failed`
(the two-model and RS assertions; exactly the defects). Restored → all pass.
Also exports `PYTHONUTF8=1` per #779, as enforced by `test-locale-utf8.sh`
(the first sweep caught its absence; fixed and re-swept).

## Guard suite

`PASS=132 FAIL=0` (131 pre-existing + this branch's new
`test-vram-breakdown.sh`). One first-sweep failure (`test-locale-utf8.sh`,
missing `PYTHONUTF8` export in the new test) was fixed and the suite re-run —
not a flake, a real convention miss in the new test file.

## Deliberately left alone

- **Defect 3 — the drafter's compute buffer.** Not mechanical: the CUDA1
  reservations are 5208.35 (target), 1606.48 (drafter), then 5240.16 (the
  target re-reserving *after* the drafter loaded). First and third are the
  same buffer re-reserved (must not sum); the second is additive; and
  `sched_reserve` lines do not label their context, so a positional rule gives
  the wrong answer. Left for the engine-side fix the issue suggests (label the
  reservation in the log, or track re-reservations per device). **Remains
  open on #1171** — ~956 MiB of CUDA1 `unaccounted` stays attributed to
  "other" until then.


Closes #1171.
