### PR TITLE
fix(setup): skip non-numeric WEIGHT_SIZE_GB in the disk gate instead of crashing

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -587,6 +587,16 @@ _disk_need_gb() {
       compgen -G "${MODEL_DIR}/${dir}/${glob}" >/dev/null 2>&1 && present=1
     fi
     [[ "$present" == "1" ]] && continue
+    # Some profiles declare a non-numeric size (qwen3.6-27b gguf emits the
+    # literal `WEIGHT_SIZE_GB=variable`, #1131).  Bash arithmetic would read
+    # that string as an unset variable name under `set -u` and kill the
+    # preflight.  Skip it with a note -- the download reports the real size
+    # when it runs -- instead of crashing.  (The note goes to stderr: stdout
+    # of this function is command-substituted into PREFLIGHT_DISK_GB.)
+    if [[ ! "$size" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+      echo "[preflight] WARN:  $key: non-numeric size '$size' -- excluded from the disk estimate; set PREFLIGHT_DISK_GB=<N> to override." >&2
+      continue
+    fi
     total=$(( total + ${size%%.*} ))
   done
   # Headroom for partial-download temp files, plus a floor so a fully-present


### PR DESCRIPTION
# RESULT-1131 — setup.sh: `WEIGHT_SIZE_GB=variable` no longer kills the disk gate

## Branch

`fix/1131-disk-need-gb` (off `origin/master`)

```
 scripts/setup.sh | 10 ++++++++++
 1 file changed, 10 insertions(+)
```

## What changed and why

`_disk_need_gb` fed the literal string `WEIGHT_SIZE_GB=variable` (emitted by
the qwen3.6-27b gguf profile) into bash arithmetic
(`total=$(( total + ${size%%.*} ))`). Under `set -u` the string resolved as an
unset variable name and killed setup.sh mid-preflight
(`line 590: variable: unbound variable`), before any gate could run.

The gate now skips a non-numeric `size` with a stderr note. The issue listed
two acceptable fixes ("skipped in the disk gate with a note" or "rejected at
catalog-read time"); the gate-local skip was chosen because it is the issue's
first-listed preference and keeps the fix to the function that crashes —
catalog-read rejection would also change what `weights.py entry` emits for
every other consumer. The note goes to **stderr** deliberately: the function's
stdout is command-substituted into `PREFLIGHT_DISK_GB`, so a stdout note would
corrupt the derived number. The download itself reports the real size when it
runs.

## Acceptance evidence

**Before** (empty `MODEL_DIR`, so nothing counts as present and the arithmetic
path is taken):

```
[model]   qwen3.6-27b:unsloth-q4km -> unsloth/Qwen3.6-27B-MTP-GGUF Qwen3.6-27B-Q4_K_M.gguf -> qwen3.6-27b-gguf/unsloth-mtp-q4km
scripts/setup.sh: line 590: variable: unbound variable
```

**After** (same command, fix applied):

```
[preflight] WARN:  qwen3.6-27b:unsloth-q4km: non-numeric size 'variable' -- excluded from the disk estimate; set PREFLIGHT_DISK_GB=<N> to override.
[preflight] checking environment...
[preflight] docker:  29.7.2 (compose v2 ok)
[preflight] gpu:     2× detected
[preflight] disk:    385 GB free at /tmp/tmp.5YsNQ1YPlU (need ~5 GB)
```

Numeric path unchanged, via a direct `_disk_need_gb` harness (function
extracted, `MODEL_DIR` empty so nothing counts as present):

```
numeric (agents-a1:fp8-dynamic, 36.0, absent): need=46  [expect 46]
variable (qwen3.6-27b:unsloth-q4km):          need=5  [expect 5, WARN on stderr]
```

## Guard suite

`PASS=131 FAIL=0` (all `scripts/tests/*.sh` on this branch).

## Deliberately left alone

- **Catalog-read rejection** (the issue's alternative): stricter, but changes
  `weights.py`'s contract for every consumer and would hide the profile from
  setup entirely; the gate-local skip matches the issue's first preference.
- `PREFLIGHT_DISK_GB` escape hatch and its header docs — already correct, and
  the new note points at it.


Closes #1131.
