### PR TITLE
fix(hf-fetch): missing hf binary escalates to rung 3; CLI announces failure

### DIFF
--- a/scripts/lib/profiles/hf_fetch.py
+++ b/scripts/lib/profiles/hf_fetch.py
@@ -144,6 +144,14 @@ def is_xet_refusal(blob: str) -> bool:
     return all(m in low for m in _XET_REFUSAL_MARKERS)
 
 
+def _is_tool_unavailable(rc: int, blob: str) -> bool:
+    """True iff rung 1 failed because the `hf` CLI is not installed at all
+    (rc=127, or the which() probe's message) — a fallback-ELIGIBLE cause:
+    rung 3 needs only curl, so a missing binary must not kill the ladder
+    (#1132).  Distinct from the 50 GB refusal, which is a policy wall."""
+    return rc == 127 or "is on PATH" in blob
+
+
 def hf_xet_importable(python: Optional[str] = None) -> bool:
     """Is `hf_xet` ALREADY importable in the environment the `hf` CLI runs under?
 
@@ -813,8 +821,11 @@ def escalate(repo_id: str, local_dir: Path, includes: list[str], *,
              curl_runner: Optional[Callable] = None,
              xet_available: Optional[Callable[[], bool]] = None,
              tree_fn: Optional[Callable] = None,
-             stall_timeout: int = 300) -> LadderResult:
-    """Rungs 2 and 3, entered ONLY after rung 1 hit the too-large refusal.
+             stall_timeout: int = 300,
+             entry_note: str = "") -> LadderResult:
+    """Rungs 2 and 3, entered after rung 1 failed in a fallback-ELIGIBLE way:
+    the too-large refusal, or the `hf` CLI missing entirely (#1132 — rung 3
+    needs only curl).
 
     Each rung announces why the previous one could not deliver, so a log shows
     the whole decision chain rather than a bare "downloading (again)"."""
@@ -822,9 +833,12 @@ def escalate(repo_id: str, local_dir: Path, includes: list[str], *,
     allow = allow_xet_enabled() if allow_xet is None else allow_xet
     notes: list[str] = []
 
-    log("[hf-fetch] rung 1 (classic LFS) REFUSED this repo: huggingface_hub "
-        "client-side blocks the plain HTTP path for files over 50 GB. This is "
-        "a hard policy wall, not flakiness — retrying it cannot succeed.")
+    if entry_note:
+        log(f"[hf-fetch] rung 1 (classic LFS) never stood a chance: {entry_note}")
+    else:
+        log("[hf-fetch] rung 1 (classic LFS) REFUSED this repo: huggingface_hub "
+            "client-side blocks the plain HTTP path for files over 50 GB. This is "
+            "a hard policy wall, not flakiness — retrying it cannot succeed.")
     if classic_error:
         log(f"[hf-fetch]   hub said: {classic_error.strip()[:300]}")
 
@@ -976,14 +990,21 @@ def fetch(repo_id: str, local_dir: Path, includes: list[str], *,
             f"`hf download` hashes as it writes, so no separate gate is run "
             f"on this rung.")
         return LadderResult(ok=True, rung="classic", files=list(names))
-    if not is_xet_refusal(blob):
+    # #1132: the too-large refusal escalates, and so does a missing `hf`
+    # binary -- rung 3 needs only curl, so a bare exit would waste the one
+    # rung that could have served the pull.  Anything else (network, auth)
+    # stays a hard failure.
+    tool_missing = _is_tool_unavailable(rc, blob)
+    if not (is_xet_refusal(blob) or tool_missing):
         return LadderResult(ok=False, failure="fallback-failed",
                             detail=f"rung 1 failed (rc={rc}): "
                                    f"{blob.strip()[-400:]}")
     try:
         return escalate(repo_id, local_dir, todo, classic_error=blob,
                         meta=metas, revision=revision, allow_xet=allow,
-                        token=token, log=log)
+                        token=token, log=log,
+                        entry_note=("`hf`/`huggingface-cli` is not on PATH"
+                                    if tool_missing else ""))
     except LadderError as exc:
         log(f"[hf-fetch] FAILED: {exc.detail or exc.token}")
         return LadderResult(ok=False, failure=exc.token, detail=exc.detail)
@@ -1031,6 +1052,12 @@ def _main(argv: list[str]) -> int:
     res = fetch(args.repo, Path(args.local_dir), includes,
                 revision=args.revision, allow_xet=args.allow_xet or None,
                 do_verify_in_place=args.verify_in_place or None)
+    if not res.ok:
+        # #1132 -- a bare `exit 1` discarded the failure token + detail,
+        # contradicting the #804/#812 auditability contract exactly when the
+        # pull failed.  Announce, then exit.
+        default_log(f"[hf-fetch] FAILED: {res.failure}"
+                    + (f" — {res.detail.strip()[-400:]}" if res.detail else ""))
     return 0 if res.ok else 1
 
 

--- a/scripts/tests/test-pull-download-ladder.sh
+++ b/scripts/tests/test-pull-download-ladder.sh
@@ -491,6 +491,75 @@ with tempfile.TemporaryDirectory() as td:
 check(callable(getattr(HF, "_main", None)) and callable(getattr(HF, "fetch", None)),
       "hf_fetch exposes a standalone fetch() + a CLI entry point")
 
+# ---------------------------------------------------------------------------
+# #1132 -- a missing `hf` binary must ESCALATE to rung 3 instead of dying with
+# a bare exit 1, and _main must announce the failure token + detail on stderr.
+# ---------------------------------------------------------------------------
+import subprocess as _sp
+
+_orig_tree, _orig_which, _orig_run, _orig_raw = (
+    HF.repo_tree, HF.shutil.which, HF.subprocess.run, HF.raw_resolve_fetch)
+try:
+    HF.repo_tree = lambda *a, **k: TREE
+
+    # (a) tool unavailable -> rung 3 serves the pull; entry names the cause.
+    # null BOTH probe names: a rig with `huggingface-cli` installed would
+    # otherwise run the real downloader here.
+    HF.shutil.which = lambda n: None if n in ("hf", "huggingface-cli") else _orig_which(n)
+    def _fake_raw(repo, name, local_dir, **kw):
+        dest = Path(local_dir) / name
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(BODY)
+        return dest
+    HF.raw_resolve_fetch = _fake_raw
+    log127 = Log()
+    with tempfile.TemporaryDirectory() as td:
+        def _runner_127(repo, local_dir, includes, xet):
+            return 127, "neither `hf` nor `huggingface-cli` is on PATH"
+        res = HF.fetch("org/Repo", Path(td), [BIG], allow_xet=False,
+                       log=log127)
+    check(res.ok and res.rung == "raw-resolve",
+          f"#1132 missing hf binary: rung 3 serves the pull "
+          f"(rung={res.rung!r} ok={res.ok})")
+    check(res.verified == [BIG], "#1132 missing hf: sha256 gate still runs")
+    check("never stood a chance" in log127.text()
+          and "not on PATH" in log127.text(),
+          "#1132 missing hf: entry announcement names the real cause")
+    check("rung 3" in log127.text(), "#1132 missing hf: escalation reached rung 3")
+
+    # (b) a NON-tool failure (network/auth) stays a hard failure -- no escalation.
+    HF.shutil.which = lambda n: "/usr/bin/hf" if n == "hf" else None
+    HF.subprocess.run = lambda argv, **kw: SimpleNamespace(
+        returncode=1, stdout="", stderr="connection reset by peer")
+    lognet = Log()
+    with tempfile.TemporaryDirectory() as td:
+        def _runner_netfail(repo, local_dir, includes, xet):
+            return 1, "connection reset by peer"
+        res = HF.fetch("org/Repo", Path(td), [BIG], allow_xet=False,
+                       log=lognet)
+    check(not res.ok and res.failure == "fallback-failed",
+          "#1132 non-tool rung-1 failure stays a hard failure")
+    check("rung 3" not in lognet.text(),
+          "#1132 non-tool failure does NOT escalate")
+
+    # (c) _main announces the failure token + detail on stderr, then exits 1.
+    HF.subprocess.run = _orig_run
+    probe = (
+        "import sys; sys.path.insert(0, %r); "
+        "from scripts.lib.profiles import hf_fetch as HF;"
+        "HF.fetch = lambda *a, **k: HF.LadderResult("
+        "ok=False, failure='fallback-failed', "
+        "detail='rung 1 failed (rc=1): boom');"
+        "sys.exit(HF._main(['some/repo', '--local-dir', 'x']))" % str(root)
+    )
+    proc = _sp.run([sys.executable, "-c", probe], capture_output=True, text=True)
+    check(proc.returncode == 1, "#1132 _main still exits 1 on failure")
+    check("FAILED: fallback-failed" in proc.stderr and "boom" in proc.stderr,
+          "#1132 _main announces the failure token + detail on stderr")
+finally:
+    HF.repo_tree, HF.shutil.which, HF.subprocess.run, HF.raw_resolve_fetch = (
+        _orig_tree, _orig_which, _orig_run, _orig_raw)
+
 if failures:
     print(f"\n{len(failures)} assertion(s) failed.", file=sys.stderr)
     sys.exit(1)


### PR DESCRIPTION
# RESULT-1132 — hf_fetch.py: rung-1 failure detail + missing-binary escalation

## Branch

`fix/1132-hf-fetch-detail` (off `origin/master`)

```
 scripts/lib/profiles/hf_fetch.py           | 41 +++++++++++++---
 scripts/tests/test-pull-download-ladder.sh | 69 ++++++++++++++++++++++++++++++
 2 files changed, 103 insertions(+), 7 deletions(-)
```

Path note: the file is `scripts/lib/profiles/hf_fetch.py` (the brief's
`scripts/lib/hf_fetch.py` was a guess; the issue repro had it right).

## What changed and why

1. **`_main()` no longer swallows the failure.** It printed nothing on the
   non-ok path and returned a bare `1`, contradicting the module's own
   #804/#812 contract ("every rung announces which rung ran", "logs are
   auditable"). It now announces `FAILED: <failure token> — <detail>` on
   stderr before exiting 1.
2. **A missing `hf` binary is fallback-eligible.** `_hf_download` returns
   `rc=127` ("neither `hf` nor `huggingface-cli` is on PATH") when the CLI is
   absent, but `fetch()` only escalated on the 50 GB Xet refusal — so the
   ladder died even though rung 3 (raw resolve + curl + sha256 gate) has no
   `hf` dependency. New `_is_tool_unavailable(rc, blob)` treats that case as
   escalation-eligible; `escalate()` takes `entry_note` so its announcement
   names the real cause instead of the 50 GB narrative. Non-tool failures
   (network/auth) remain hard failures and do **not** escalate — their
   retries cannot succeed either, and escalating them would mask a real
   error behind a slow curl.

## Acceptance evidence

CLI on a PATH-stripped env (no `hf`/`huggingface-cli` visible — the issue's
exact scenario), real repo, real 20 GB target file (killed by timeout once
rung 3 was proven streaming):

```
[hf-fetch] starting: unsloth/Qwen3.6-27B-MTP-GGUF -> /tmp/tmp.xMlafg2yQb (1 file(s) to fetch)
[hf-fetch] rung 1 (classic LFS) never stood a chance: `hf`/`huggingface-cli` is not on PATH
[hf-fetch]   hub said: neither `hf` nor `huggingface-cli` is on PATH
[hf-fetch] escalating for 1 file(s): Qwen3.6-27B-Q4_K_M.gguf
[hf-fetch] rung 2 (Xet) SKIPPED — operator opt-in required (ALLOW_XET=1 or pull.sh --allow-xet). ...
[hf-fetch] rung 3 (raw resolve + curl) — single-stream, resumable, re-resolved per retry. ...
```

In-process (network-free, module-patched) assertions in
`scripts/tests/test-pull-download-ladder.sh`:

```
PASS: #1132 missing hf binary: rung 3 serves the pull (rung='raw-resolve' ok=True)
PASS: #1132 missing hf: sha256 gate still runs
PASS: #1132 missing hf: entry announcement names the real cause
PASS: #1132 missing hf: escalation reached rung 3
PASS: #1132 non-tool rung-1 failure stays a hard failure
PASS: #1132 non-tool failure does NOT escalate
PASS: #1132 _main still exits 1 on failure
PASS: #1132 _main announces the failure token + detail on stderr
```

**Negative control:** reverting `hf_fetch.py` to HEAD~ turns 5 assertions red;
restored, the full ladder file ends `All #804 download-ladder assertions
passed.`

## Guard suite

`PASS=131 FAIL=0` (all `scripts/tests/*.sh` on this branch; the branch adds no
new test *file* — the #1132 checks extend `test-pull-download-ladder.sh`, and
the 132nd file, `test-vram-breakdown.sh`, lives on `fix/1171-vram-attribution`).

## Deliberately left alone

- **Defect 3 of #1171** (interleaved `sched_reserve`) — different issue, not
  touched here.
- **Rung 2 when the binary is missing:** if an operator opts into Xet on a
  hf-less host, rung 2 fails rc=127 and the ladder falls through to rung 3 —
  already the correct behaviour, so no special-casing was added.
- The failure token for a generic rung-1 failure stays `fallback-failed`
  (unchanged vocabulary; #1132 is about visibility, not new tokens).


Closes #1132.
