### PR TITLE
chore(registry): moe-cache slugs incubating -> experimental, engine label v1.5 -> v1.6

### DIFF
--- a/models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-iq2-xxs/offload.yml
+++ b/models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-iq2-xxs/offload.yml
@@ -11,7 +11,7 @@
 #   Vision:    no
 #   Max ctx:   204800
 #   Genesis:   N/A — llama.cpp engine
-#   Status:    🐣 Incubating
+#   Status:    🧪 Experimental
 #   Caveats:   • Canonical bench PUBLISHED 2026-08-09 (BENCHMARKS.md row 3, reference
 #                2×3090): decode 15.4 narrative / 24.3 code (canonical sampling),
 #                prefill 436 @10K / 311 @90K, TTFT ~165 ms. The 8-pack is still

--- a/models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-q8-kxl/offload.yml
+++ b/models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-q8-kxl/offload.yml
@@ -12,7 +12,7 @@
 #   Vision:    no
 #   Max ctx:   204800  (⚠️ NOT 262144 — see Caveats)
 #   Genesis:   N/A — llama.cpp engine
-#   Status:    🐣 Incubating
+#   Status:    🧪 Experimental
 #   Caveats:   • Canonical bench PUBLISHED 2026-08-09 (BENCHMARKS.md row 2, reference
 #                2×3090, 3-boot medians): decode 17.1 narrative / 26.9 code
 #                (canonical sampling), prefill 369 @10K / 287 @90K, TTFT 169 ms.

--- a/models/deepseek-v4-flash-0731/llama-cpp/compose/multi4/unsloth-q8-kxl/offload.yml
+++ b/models/deepseek-v4-flash-0731/llama-cpp/compose/multi4/unsloth-q8-kxl/offload.yml
@@ -10,7 +10,7 @@
 #   Vision:    no
 #   Max ctx:   204800
 #   Genesis:   N/A — llama.cpp engine
-#   Status:    🐣 Incubating
+#   Status:    🧪 Experimental
 #   Caveats:   • NO performance or quality numbers are published for this slug —
 #                it is INCUBATING. A canonical bench and the 8-pack are both owed;
 #                only operational validation (boot + prefill probe + verify-full) exists.

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq3xxs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq3xxs/moecache.yml
@@ -80,7 +80,7 @@
 #      (-mmdev none), which is what keeps this survivable. Watch it.
 #      ⚠️ Quality at IQ3 is STILL UNTESTED — coherent on a one-word probe is
 #      not a quality result. No verify-full, no bench, no 8-pack.
-#   Status:    🐣 Incubating
+#   Status:    🧪 Experimental
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/moecache.yml
@@ -40,7 +40,7 @@
 #   ⤷ ALL-on-CPU worst case. Grounded: UD-IQ4_XS is 146.1 GiB of weights and the
 #     measured serving RSS with experts offloaded was 141.5 GiB (bench 2026-08-29).
 #     Registry `host_ram_gb: 142` is the NOMINAL figure and must stay <= this.
-#   Status:    🐣 Incubating
+#   Status:    🧪 Experimental
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
@@ -270,6 +270,13 @@ services:
           done
           set -- "$${ARGS[@]}"
         fi
+        # ⚠️ n=2, NOT n=3. EXTRAPOLATED from the iq3xxs sibling, where it measured
+        # ~+8-10% decode (2026-09-04, 2 boots/arm, order reversed). Same topology
+        # and the same CPU-offload mechanism — a rejected draft is verified
+        # against CPU-resident experts — but this quant's larger experts change
+        # residency, so the optimum could differ. NOT measured on iq4xs.
+        # multi4/multi8 deliberately stay at n=3: more cards means more resident
+        # experts, so the mechanism weakens, and we cannot test them on 2 GPUs.
         _spec_n="$${SPEC_N:-3}"
         case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
         case "$$_spec_n" in

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/unsloth-ud-iq3xxs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/unsloth-ud-iq3xxs/moecache.yml
@@ -125,7 +125,7 @@
 #      not a quality result. No verify-full, no bench, no 8-pack.
 #      ⚠️ The numbers above are the DUAL measurement, inherited here.
 #      Pools are sized per device (free-minus-reserve) — re-measure.
-#   Status:    🐣 Incubating
+#   Status:    🧪 Experimental
 #   Caveats:   • ⚠️⚠️ THE TUNING BELOW IS INHERITED FROM THE DUAL SLUG, NOT DERIVED
 #                FOR 4 CARDS — the single most important caveat on this file.
 #                `RESERVE_MB=1536`, `-ub/-b 4096`, `SPEC_N=3` and `DRAFT_DEVICE=CUDA1`

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/unsloth-ud-iq4xs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/unsloth-ud-iq4xs/moecache.yml
@@ -89,7 +89,7 @@
 #   ⚠️ Measure ONE knob at a time against wall-clock, ≥3 runs per arm. On 2×24 GB
 #   between-boot spread at identical config is ~0.5%, so a double-digit gap is a
 #   config difference, not noise.
-#   Status:    🐣 Incubating
+#   Status:    🧪 Experimental
 #   Caveats:   • ⚠️⚠️ THE TUNING BELOW IS INHERITED FROM THE DUAL SLUG, NOT DERIVED
 #                FOR 4 CARDS — the single most important caveat on this file.
 #                `RESERVE_MB=1536`, `-ub/-b 4096`, `SPEC_N=3` and `DRAFT_DEVICE=CUDA1`

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/unsloth-ud-iq3xxs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/unsloth-ud-iq3xxs/moecache.yml
@@ -125,7 +125,7 @@
 #      not a quality result. No verify-full, no bench, no 8-pack.
 #      ⚠️ The numbers above are the DUAL measurement, inherited here.
 #      Pools are sized per device (free-minus-reserve) — re-measure.
-#   Status:    🐣 Incubating
+#   Status:    🧪 Experimental
 #   Caveats:   • ⚠️⚠️ THE TUNING BELOW IS INHERITED FROM THE DUAL SLUG, NOT DERIVED
 #                FOR 8 CARDS — the single most important caveat on this file.
 #                `RESERVE_MB=1536`, `-ub/-b 4096`, `SPEC_N=3` and `DRAFT_DEVICE=CUDA1`

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/unsloth-ud-iq4xs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/unsloth-ud-iq4xs/moecache.yml
@@ -89,7 +89,7 @@
 #   ⚠️ Measure ONE knob at a time against wall-clock, ≥3 runs per arm. On 2×24 GB
 #   between-boot spread at identical config is ~0.5%, so a double-digit gap is a
 #   config difference, not noise.
-#   Status:    🐣 Incubating
+#   Status:    🧪 Experimental
 #   Caveats:   • ⚠️⚠️ THE TUNING BELOW IS INHERITED FROM THE DUAL SLUG, NOT DERIVED
 #                FOR 8 CARDS — the single most important caveat on this file.
 #                `RESERVE_MB=1536`, `-ub/-b 4096`, `SPEC_N=3` and `DRAFT_DEVICE=CUDA1`

--- a/models/qwen3.8-flash-next/llamacpp-club3090/compose/dual/unsloth-ud-q4kxl/moecache.yml
+++ b/models/qwen3.8-flash-next/llamacpp-club3090/compose/dual/unsloth-ud-q4kxl/moecache.yml
@@ -36,7 +36,7 @@
 #   Max ctx:   204800 shipped. 262144 is the model's NATIVE figure and boots,
 #              but 204800 is what was benched and what the pool was sized for.
 #   Genesis:   N/A — llama.cpp engine
-#   Status:    🐣 Incubating
+#   Status:    🧪 Experimental
 # CPU-Offload-Host-RAM-GB: 110
 #   ⤷ ALL-on-CPU worst case, from the 105 GB of weights + headroom. Registry
 #     `host_ram_gb` is the NOMINAL figure and must stay <= this.

--- a/models/qwen3.8-flash-next/llamacpp-club3090/compose/multi4/unsloth-ud-q4kxl/moecache.yml
+++ b/models/qwen3.8-flash-next/llamacpp-club3090/compose/multi4/unsloth-ud-q4kxl/moecache.yml
@@ -36,7 +36,7 @@
 #   Max ctx:   204800 shipped. 262144 is the model's NATIVE figure and boots,
 #              but 204800 is what was benched and what the pool was sized for.
 #   Genesis:   N/A — llama.cpp engine
-#   Status:    🐣 Incubating — ⚠️ NEVER BOOTED (this rig has 2 GPUs)
+#   Status:    🧪 Experimental
 # CPU-Offload-Host-RAM-GB: 110
 #   ⤷ ALL-on-CPU worst case, from the 105 GB of weights + headroom. Registry
 #     `host_ram_gb` is the NOMINAL figure and must stay <= this.

--- a/models/qwen3.8-flash-next/llamacpp-club3090/compose/multi8/unsloth-ud-q4kxl/moecache.yml
+++ b/models/qwen3.8-flash-next/llamacpp-club3090/compose/multi8/unsloth-ud-q4kxl/moecache.yml
@@ -36,7 +36,7 @@
 #   Max ctx:   204800 shipped. 262144 is the model's NATIVE figure and boots,
 #              but 204800 is what was benched and what the pool was sized for.
 #   Genesis:   N/A — llama.cpp engine
-#   Status:    🐣 Incubating — ⚠️ NEVER BOOTED (this rig has 2 GPUs)
+#   Status:    🧪 Experimental
 # CPU-Offload-Host-RAM-GB: 110
 #   ⤷ ALL-on-CPU worst case, from the 105 GB of weights + headroom. Registry
 #     `host_ram_gb` is the NOMINAL figure and must stay <= this.

--- a/scripts/lib/profiles/registry.yaml
+++ b/scripts/lib/profiles/registry.yaml
@@ -1884,7 +1884,7 @@ entries:
     model: glm-5.3-flash
     weights_variant: unsloth-ud-iq4xs
     workload: long-ctx-single
-    engine: llamacpp-club3090-v1.5
+    engine: llamacpp-club3090-v1.6
     drafter: anbeeld-glm53-dflash2
     spec_method: null
     kv_format: fp16
@@ -1904,7 +1904,7 @@ entries:
     required_engine_features: []
     default_port: 8119
     kvcalc_key: SKIP
-    status: incubating
+    status: experimental
     status_note: "🧪 Validated 2026-08-29 on llamacpp-club3090-v1.5 (rc0): verify-full 8/9 -- the one failure is [8] output-quality under reasoning_effort=max, a HARNESS budget artefact (2000 tokens spent reasoning), fixed in verify-full by scaling MT_QUALITY with the thinking allowance; the same check PASSES at reasoning_effort=low with 9,875 chars. bench.sh canonical: decode 13.95 narrative (CV 2.8%) / 17.71 code (CV 4.5%), prefill 386.7@10K (CV 0.7%) / 279.8@90K (CV 2.3%). ⚠️ TTFT@93K is ~338 s -- the practical ceiling for deep-context agent work, and the number to optimise against rather than decode. Vision 4/4 on ground truth (mmproj-F16, clip projector glm5next). DFlash2 drafter on CUDA1 n=3: acceptance 0.533, mean accepted length 2.60, per-position (0.760, 0.512, 0.331) -- placement measured +18.4% code vs host, and depth past 3 is DESTRUCTIVE (n=5 -8.9%, n=7 -27.9%). ⚠️ Decode TPS is THINKING-INCLUSIVE and length-sensitive: the same config reads 13.95 over 1,000 tokens and 17.71 over 800. Compare only equal completion lengths. Shipped z.ai vendor serving config (temperature 1 / top_p 0.95 / reasoning_effort max / clear_thinking false / max_tokens 65536) + vision. ⚠️⚠️ THINKING CANNOT BE DISABLED: z.ai docs state GLM-5.3-FLASH uses forced thinking and thinking.type=disabled RETURNS AN ERROR; the working control is reasoning_effort (max|high|low, `low` is 5.3/5.3-Flash-only) and `none` is NOT valid -- silently ignored. Measured: low -> 0 ch reasoning, max -> ~1,170 ch. NOT a graded dial -- `high` lands beside `low`, not between. Per-request overrides BEAT this server default (verified both via chat_template_kwargs and the top-level OpenAI field), which is the intended split: serving ships vendor, agents dial per request. ⚠️ Expert pool 2,143 slots (CUDA0 iq3_s 763 + iq4_xs 395; CUDA1 iq3_s 921 + iq4_xs 64) at RESERVE_MB=1536 -- read at LLAMA_ARG_LOG_VERBOSITY=4 and SUMMED per device; a single pool's used=N/N counter under-reports ~4x. ⚠️ QUALITY UNTESTED at any quant -- no 8-pack has been run on this model."
     weights_companions:
       - dflash2-q4km
@@ -1917,7 +1917,7 @@ entries:
     model: glm-5.3-flash
     weights_variant: unsloth-ud-iq4xs
     workload: long-ctx-single
-    engine: llamacpp-club3090-v1.5
+    engine: llamacpp-club3090-v1.6
     drafter: anbeeld-glm53-dflash2
     spec_method: null
     kv_format: fp16
@@ -1937,7 +1937,7 @@ entries:
     required_engine_features: []
     default_port: 8120
     kvcalc_key: SKIP
-    status: incubating
+    status: experimental
     status_note: "🐣 NEVER BOOTED -- this rig has 2 GPUs, so 4-card topologies are COMMUNITY-VALIDATED BY DESIGN; 'never booted here' is a permanent property, not a TODO. ⚠️⚠️ ALL TUNING IS INHERITED FROM THE DUAL SLUG, NOT DERIVED FOR 4 CARDS: RESERVE_MB=1536, -ub/-b 4096, SPEC_N=3, DRAFT_DEVICE=CUDA1 and MMPROJ_DEVICE=CUDA0 were every one measured on 2x24 GB. Re-derive before trusting them. ⚠️ `-ot` force-disables pipeline parallelism (silently), so prefill is GPU-asymmetric -- measured GPU0 67.6% SM vs GPU1 26.6% on 2 cards -- and the waste scales WITH card count. Do NOT size a 4-card deployment by extrapolating single-card prefill throughput. See docs/ADDING_MODELS.md M1-M10 and learnings/moe-cache-engine.md section 11. Shipped z.ai vendor serving config (temperature 1 / top_p 0.95 / reasoning_effort max / clear_thinking false / max_tokens 65536) + vision. ⚠️⚠️ THINKING CANNOT BE DISABLED: z.ai docs state GLM-5.3-FLASH uses forced thinking and thinking.type=disabled RETURNS AN ERROR; the working control is reasoning_effort (max|high|low, `low` is 5.3/5.3-Flash-only) and `none` is NOT valid -- silently ignored. Measured: low -> 0 ch reasoning, max -> ~1,170 ch. NOT a graded dial -- `high` lands beside `low`, not between. Per-request overrides BEAT this server default (verified both via chat_template_kwargs and the top-level OpenAI field), which is the intended split: serving ships vendor, agents dial per request. ⚠️ Expert pool 2,143 slots (CUDA0 iq3_s 763 + iq4_xs 395; CUDA1 iq3_s 921 + iq4_xs 64) at RESERVE_MB=1536 -- read at LLAMA_ARG_LOG_VERBOSITY=4 and SUMMED per device; a single pool's used=N/N counter under-reports ~4x. ⚠️ QUALITY UNTESTED at any quant -- no 8-pack has been run on this model."
     weights_companions:
       - dflash2-q4km
@@ -1950,7 +1950,7 @@ entries:
     model: glm-5.3-flash
     weights_variant: unsloth-ud-iq4xs
     workload: long-ctx-single
-    engine: llamacpp-club3090-v1.5
+    engine: llamacpp-club3090-v1.6
     drafter: anbeeld-glm53-dflash2
     spec_method: null
     kv_format: fp16
@@ -1970,7 +1970,7 @@ entries:
     required_engine_features: []
     default_port: 8121
     kvcalc_key: SKIP
-    status: incubating
+    status: experimental
     status_note: "🐣 NEVER BOOTED -- this rig has 2 GPUs, so 8-card topologies are COMMUNITY-VALIDATED BY DESIGN; 'never booted here' is a permanent property, not a TODO. ⚠️⚠️ ALL TUNING IS INHERITED FROM THE DUAL SLUG, NOT DERIVED FOR 8 CARDS: RESERVE_MB=1536, -ub/-b 4096, SPEC_N=3, DRAFT_DEVICE=CUDA1 and MMPROJ_DEVICE=CUDA0 were every one measured on 2x24 GB. Re-derive before trusting them. ⚠️ `-ot` force-disables pipeline parallelism (silently), so prefill is GPU-asymmetric -- measured GPU0 67.6% SM vs GPU1 26.6% on 2 cards -- and the waste scales WITH card count. Do NOT size a 8-card deployment by extrapolating single-card prefill throughput. See docs/ADDING_MODELS.md M1-M10 and learnings/moe-cache-engine.md section 11. Shipped z.ai vendor serving config (temperature 1 / top_p 0.95 / reasoning_effort max / clear_thinking false / max_tokens 65536) + vision. ⚠️⚠️ THINKING CANNOT BE DISABLED: z.ai docs state GLM-5.3-FLASH uses forced thinking and thinking.type=disabled RETURNS AN ERROR; the working control is reasoning_effort (max|high|low, `low` is 5.3/5.3-Flash-only) and `none` is NOT valid -- silently ignored. Measured: low -> 0 ch reasoning, max -> ~1,170 ch. NOT a graded dial -- `high` lands beside `low`, not between. Per-request overrides BEAT this server default (verified both via chat_template_kwargs and the top-level OpenAI field), which is the intended split: serving ships vendor, agents dial per request. ⚠️ Expert pool 2,143 slots (CUDA0 iq3_s 763 + iq4_xs 395; CUDA1 iq3_s 921 + iq4_xs 64) at RESERVE_MB=1536 -- read at LLAMA_ARG_LOG_VERBOSITY=4 and SUMMED per device; a single pool's used=N/N counter under-reports ~4x. ⚠️ QUALITY UNTESTED at any quant -- no 8-pack has been run on this model."
     weights_companions:
       - dflash2-q4km
@@ -1983,7 +1983,7 @@ entries:
     model: glm-5.3-flash
     weights_variant: unsloth-ud-iq3xxs
     workload: long-ctx-single
-    engine: llamacpp-club3090-v1.5
+    engine: llamacpp-club3090-v1.6
     drafter: anbeeld-glm53-dflash2
     spec_method: null
     kv_format: fp16
@@ -2003,7 +2003,7 @@ entries:
     required_engine_features: []
     default_port: 8125
     kvcalc_key: SKIP
-    status: incubating
+    status: experimental
     status_note: "🧪 EXPERIMENTAL — NEVER BOOTED. Copied from the VALIDATED unsloth-ud-iq4xs sibling 2026-08-29; the non-comment delta is 4 lines (service key, container_name, port, weights path + shard count 5->4). ⭐ The POINT is residency: expert byte-size is the master variable, and this quant's experts are 24% smaller — MEASURED from the GGUF tensor table per-expert-matrix over expert_count=288: iq2_s 2,624 KiB x82 (63.6%, dominant), iq3_s 3,520 x41, iq4_xs 4,352 x3, q2_K 2,688 x2, q3_K 3,520 x1; weighted average 2,957 vs IQ4_XS's 3,867. ⭐ MEASURED on first boot 2026-08-29 (dual, slots SUMMED per device): CUDA0 1,975 + CUDA1 1,506 = 3,481 slots vs IQ4_XS's 2,143 = +62.4%, in a SMALLER pool (9,714 vs 10,874 MiB) — the whole gain is expert byte-size, and it beat the ~31% predicted from the 24% average shrink because the realised pools are more iq2_s-dominated than the model-wide average. Coherent on a one-word probe. ⚠️ CARDS IMBALANCED: 22,604 / 23,850 MiB leaves ~726 MiB CUDA1 headroom. ⚠️ host_ram_gb 110 is nominal against the compose's 114 worst case (113 GiB of weights); the IQ4_XS serving-RSS measurement does NOT transfer. ⚠️ QUALITY AT IQ3 IS UNTESTED — no verify-full, no bench, no 8-pack on this quant."
     weights_companions:
       - dflash2-q4km
@@ -2016,7 +2016,7 @@ entries:
     model: glm-5.3-flash
     weights_variant: unsloth-ud-iq3xxs
     workload: long-ctx-single
-    engine: llamacpp-club3090-v1.5
+    engine: llamacpp-club3090-v1.6
     drafter: anbeeld-glm53-dflash2
     spec_method: null
     kv_format: fp16
@@ -2036,7 +2036,7 @@ entries:
     required_engine_features: []
     default_port: 8126
     kvcalc_key: SKIP
-    status: incubating
+    status: experimental
     status_note: "🧪 EXPERIMENTAL — NEVER BOOTED. Copied from the VALIDATED unsloth-ud-iq4xs sibling 2026-08-29; the non-comment delta is 4 lines (service key, container_name, port, weights path + shard count 5->4). ⭐ The POINT is residency: expert byte-size is the master variable, and this quant's experts are 24% smaller — MEASURED from the GGUF tensor table per-expert-matrix over expert_count=288: iq2_s 2,624 KiB x82 (63.6%, dominant), iq3_s 3,520 x41, iq4_xs 4,352 x3, q2_K 2,688 x2, q3_K 3,520 x1; weighted average 2,957 vs IQ4_XS's 3,867. ⭐ MEASURED on first boot 2026-08-29 (dual, slots SUMMED per device): CUDA0 1,975 + CUDA1 1,506 = 3,481 slots vs IQ4_XS's 2,143 = +62.4%, in a SMALLER pool (9,714 vs 10,874 MiB) — the whole gain is expert byte-size, and it beat the ~31% predicted from the 24% average shrink because the realised pools are more iq2_s-dominated than the model-wide average. Coherent on a one-word probe. ⚠️ CARDS IMBALANCED: 22,604 / 23,850 MiB leaves ~726 MiB CUDA1 headroom. ⚠️ host_ram_gb 110 is nominal against the compose's 114 worst case (113 GiB of weights); the IQ4_XS serving-RSS measurement does NOT transfer. ⚠️ QUALITY AT IQ3 IS UNTESTED — no verify-full, no bench, no 8-pack on this quant."
     weights_companions:
       - dflash2-q4km
@@ -2049,7 +2049,7 @@ entries:
     model: glm-5.3-flash
     weights_variant: unsloth-ud-iq3xxs
     workload: long-ctx-single
-    engine: llamacpp-club3090-v1.5
+    engine: llamacpp-club3090-v1.6
     drafter: anbeeld-glm53-dflash2
     spec_method: null
     kv_format: fp16
@@ -2069,7 +2069,7 @@ entries:
     required_engine_features: []
     default_port: 8127
     kvcalc_key: SKIP
-    status: incubating
+    status: experimental
     status_note: "🧪 EXPERIMENTAL — NEVER BOOTED. Copied from the VALIDATED unsloth-ud-iq4xs sibling 2026-08-29; the non-comment delta is 4 lines (service key, container_name, port, weights path + shard count 5->4). ⭐ The POINT is residency: expert byte-size is the master variable, and this quant's experts are 24% smaller — MEASURED from the GGUF tensor table per-expert-matrix over expert_count=288: iq2_s 2,624 KiB x82 (63.6%, dominant), iq3_s 3,520 x41, iq4_xs 4,352 x3, q2_K 2,688 x2, q3_K 3,520 x1; weighted average 2,957 vs IQ4_XS's 3,867. ⭐ MEASURED on first boot 2026-08-29 (dual, slots SUMMED per device): CUDA0 1,975 + CUDA1 1,506 = 3,481 slots vs IQ4_XS's 2,143 = +62.4%, in a SMALLER pool (9,714 vs 10,874 MiB) — the whole gain is expert byte-size, and it beat the ~31% predicted from the 24% average shrink because the realised pools are more iq2_s-dominated than the model-wide average. Coherent on a one-word probe. ⚠️ CARDS IMBALANCED: 22,604 / 23,850 MiB leaves ~726 MiB CUDA1 headroom. ⚠️ host_ram_gb 110 is nominal against the compose's 114 worst case (113 GiB of weights); the IQ4_XS serving-RSS measurement does NOT transfer. ⚠️ QUALITY AT IQ3 IS UNTESTED — no verify-full, no bench, no 8-pack on this quant."
     weights_companions:
       - dflash2-q4km
@@ -2082,7 +2082,7 @@ entries:
     model: qwen3.8-flash-next
     weights_variant: unsloth-ud-q4kxl
     workload: long-ctx-single
-    engine: llamacpp-club3090-v1.5
+    engine: llamacpp-club3090-v1.6
     drafter: null
     spec_method: ngram-mod
     kv_format: q8_0
@@ -2102,7 +2102,7 @@ entries:
     required_engine_features: []
     default_port: 8122
     kvcalc_key: SKIP
-    status: incubating
+    status: experimental
     status_note: "🧪 Validated 2026-08-29 on llamacpp-club3090-v1.5 (rc0): verify-full 10/10 (the MTP check skips -- it is vLLM-log-format-specific), bench-agentic 2x12 turns to 35,254 prompt tok with TTFT growing 8.0x against 25.1x context (SUB-LINEAR) and decode 27.7-44 TPS with no cliff in the 21-26K band, vision 4/4 on ground truth. bench.sh canonical: decode 39.28 narrative (CV 0.8%) / 38.57 code (CV 1.8%), prefill 749.09@10K (CV 0.2%), TTFT ~415 ms -- the FASTEST model on this stack as of this date, and the reason is expert BYTE-SIZE (1,638,400 weights per ffn_up vs GLM's 8,388,608), not the quant. Expert pool 9,435 slots (CUDA0 q4_K 3,044 + q5_1 1,490 + q8_0 128; CUDA1 q4_K 2,955 + q5_1 1,329 + q8_0 305 + q5_K 184) at MOE_RESERVE_MB=1536 -- read at LLAMA_ARG_LOG_VERBOSITY=4 and SUMMED per device; this quant makes 3-4 pools PER CARD and one pool's used=N/N under-reports badly. ⭐ Projector ships on the HOST (-mmdev none, default since 2026-08-29): on CUDA0 it cost 1,114 MiB and is allocated AFTER the pool is sized, leaving only 830 MiB headroom with a drafter active -- a latent OOM on the first image request. Host placement costs ZERO cache slots (9,435 either way) and GPU1 was byte-identical across the A/B. ⛔ NO DRAFTER EXISTS: no MTP head in the GGUF (nextn_predict_layers ABSENT, verified) and no external drafter for qwen4exp; engine support is an OPEN DRAFT PR (ggml-org/llama.cpp#27836). n-gram drafting needs no drafter file and IS available: ngram-mod at n_max=8 measured +64% on REPEATED context but -1.3% (noise) on held-out prompts -- the gain is cache-residency dependent, not acceptance dependent, so it is NOT enabled by default. ⛔ Its DEFAULTS are harmful (n_max=64 measured -7.6%) and --spec-draft-n-max binds NONE of the ngram types. ⚠️ Ships 204800, NOT the declared 262144 -- that boots but collapses the pool to 802/1,026 MiB. ⚠️ QUALITY UNTESTED -- no 8-pack has been run on this model."
     weights_companions:
       - mmproj-f16
@@ -2130,7 +2130,7 @@ entries:
     model: qwen3.8-flash-next
     weights_variant: unsloth-ud-q4kxl
     workload: long-ctx-single
-    engine: llamacpp-club3090-v1.5
+    engine: llamacpp-club3090-v1.6
     drafter: null
     spec_method: ngram-mod
     kv_format: q8_0
@@ -2150,7 +2150,7 @@ entries:
     required_engine_features: []
     default_port: 8123
     kvcalc_key: SKIP
-    status: incubating
+    status: experimental
     status_note: "🐣 NEVER BOOTED -- this rig has 2 GPUs, so 4-card topologies are COMMUNITY-VALIDATED BY DESIGN; 'never booted here' is a permanent property, NOT a TODO. Derived mechanically from the VALIDATED dual sibling by a 5-line delta (service key, container_name, port, device_ids, -ts); everything else is byte-identical, verified by diff. ⛔ CONSTANTS ARE INHERITED, NOT MEASURED: MOE_RESERVE_MB (1536), -ub/-b and CTX (204800) were derived against 2x24 GB, and moe-cache `granted` is computed per device as free-minus-reserve, so per-card pools WILL differ at 4 cards -- re-derive before quoting any number. ⭐ The thing to measure first on real hardware: `-ot ...=CPU` DISABLES pipeline parallelism (learnings/moe-cache-engine.md section 11), and that costs more the more cards you add. ✅ Unlike GLM's multi4, the projector is on the HOST (-mmdev none) so this does NOT inherit the card-0 pinning hazard where the projector lands on the card carrying pool + KV."
     weights_companions:
       - mmproj-f16
@@ -2178,7 +2178,7 @@ entries:
     model: qwen3.8-flash-next
     weights_variant: unsloth-ud-q4kxl
     workload: long-ctx-single
-    engine: llamacpp-club3090-v1.5
+    engine: llamacpp-club3090-v1.6
     drafter: null
     spec_method: ngram-mod
     kv_format: q8_0
@@ -2198,7 +2198,7 @@ entries:
     required_engine_features: []
     default_port: 8124
     kvcalc_key: SKIP
-    status: incubating
+    status: experimental
     status_note: "🐣 NEVER BOOTED -- this rig has 2 GPUs, so 8-card topologies are COMMUNITY-VALIDATED BY DESIGN; 'never booted here' is a permanent property, NOT a TODO. Derived mechanically from the VALIDATED dual sibling by a 5-line delta (service key, container_name, port, device_ids, -ts); everything else is byte-identical, verified by diff. ⛔ CONSTANTS ARE INHERITED, NOT MEASURED: MOE_RESERVE_MB (1536), -ub/-b and CTX (204800) were derived against 2x24 GB, and moe-cache `granted` is computed per device as free-minus-reserve, so per-card pools WILL differ at 8 cards -- re-derive before quoting any number. ⭐ The thing to measure first on real hardware: `-ot ...=CPU` DISABLES pipeline parallelism (learnings/moe-cache-engine.md section 11), and that costs more the more cards you add. ✅ Unlike GLM's multi8, the projector is on the HOST (-mmdev none) so this does NOT inherit the card-0 pinning hazard where the projector lands on the card carrying pool + KV."
     weights_companions:
       - mmproj-f16
@@ -2372,7 +2372,7 @@ entries:
     required_engine_features: []
     default_port: 8030
     kvcalc_key: SKIP
-    status: incubating
+    status: experimental
     status_note: "A 284B MoE on 2x24 GB. QUALITY TIER of the two DeepSeek-Flash offload slugs. Stock upstream b10236, zero patches. Three levers compose: CPU expert offload (137 GiB of routed experts in host RAM) + partial residency (bundles pinned back onto the GPUs, sized by the launcher from DETECTED free VRAM) + the DSpark drafter. HARD GATE: ~146 GB host RAM worst case -- preflight REFUSES below it. Ships 200K, NOT 262K: at 262K with the drafter it boots READY at 97.4% VRAM, passes a trivial decode, then dies on a ~15.7K-token prefill (CUDA OOM in cuMemCreate, reproduced 2026-08-06). CANONICAL BENCH PUBLISHED 2026-08-09 (BENCHMARKS.md row 2, reference 2x3090, 3-boot medians): decode 17.1 narrative / 26.9 code at canonical sampling, prefill 369 @10K / 287 @90K, TTFT 169 ms; greedy-replay 35.2. The 8-pack is still owed -- stays incubating until quality lands."
     weights_companions:
       - dspark
@@ -2404,7 +2404,7 @@ entries:
     required_engine_features: []
     default_port: 8031
     kvcalc_key: SKIP
-    status: incubating
+    status: experimental
     status_note: "REACH TIER of the two DeepSeek-Flash offload slugs: ~86 GB host RAM worst case vs the Q8 tier's ~146 GB, which is what makes a 284B model fit a constrained box. Stock upstream b10236, zero patches; same three levers (offload + launcher-sized residency + DSpark). ~2.6-bit experts. Scoped to dual 24 GB by design. CANONICAL BENCH PUBLISHED 2026-08-09 (BENCHMARKS.md row 3, reference 2x3090): decode 15.4 narrative / 24.3 code at canonical sampling, prefill 436 @10K / 311 @90K -- decode ~10% SLOWER than Q8 (lower draft acceptance on 2.6-bit experts); this tier's case is the RAM gate and prefill, not decode. The 8-pack is still owed, and quality is the open question on a quant this low -- stays incubating. FIRST COMMUNITY VALIDATION: 2x5090 + 123 GB (#931) -- asymmetric 7+8 residency, prefill-90K x3 clean, NIAH ladder to 188K, soak-stable VRAM; that pair of runs is the calibration source for the additive auto-sizer."
     weights_companions:
       - dspark
@@ -2436,7 +2436,7 @@ entries:
     required_engine_features: []
     default_port: 8116
     kvcalc_key: SKIP
-    status: incubating
+    status: experimental
     status_note: "4-card QUALITY tier. NEVER BOOTED BY US. 2026-08-07: a 4x3090 + 128 GB owner (@milano, Discord) BOOTED it after correcting two constants this compose had COPIED from the dual file and never re-derived for four cards -- reserve 18000 (a 2-way dense split) granted 1 bundle/card where 2 fit, and the 146 GB gate then REFUSED the 128 GB box this slug exists to serve. Reserve now 14500 (additive #931 recalibration; the interim x0.55-era value was 12000); host_ram_gb=120 HERE is the nominal 4x24 figure (what the catalog displays -- @milano measured it), while the COMPOSE HEADER carries the 146 all-experts-on-CPU worst case and preflight computes the rig-specific need by subtracting detected residency (~121 at 4x24; 4x16 GB fits zero bundles and correctly gates at ~146). The mismatch is deliberate -- do not 'fix' either number to match the other. STILL UNVALIDATED BEYOND BOOT: no real prefill probe yet, and on this model boot is NOT sufficient -- the 262K config booted, passed a trivial decode, then died on the first ~15.7K prefill. Prefill probe requested. The argument is NOT throughput: every layer pinned to a GPU is a layer NOT in host RAM, so host RAM FALLS with card count -- **120 GB MEASURED** at 4x24 GB (was ~113 est.) vs ~146 at 2x24 -- first 4-card boot by @milano 2026-08-07. 128 GB is a very common host config, which the 2-card Q8 slug EXCLUDES and this one FITS, so multi4 is what puts the quality tier inside a mainstream RAM budget. Residency should also be at its best here (~23% of expert traffic on GPU vs 4.7% on two cards). No IQ2 multi slug: on four cards Q8 itself drops into a 128 GB budget, so a low-bit tier is not needed to fit."
     weights_companions:
       - dspark

--- a/scripts/tests/test-engine-label-matches-compose.sh
+++ b/scripts/tests/test-engine-label-matches-compose.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Drift-guard: a registry entry's `engine` label must name the engine the
+# compose ACTUALLY runs.
+#
+# Why this exists. When the moe-cache engine went v1.5 -> v1.6, the GLM and
+# Qwen-flash composes were repointed to the new image digest but their registry
+# `engine:` labels were not. Nine live slugs then advertised
+# `llamacpp-club3090-v1.5` while running the v1.6 image — c3's catalogue showed
+# v1.5, and any benchmark read back from the registry had the wrong provenance.
+# Their deepseek-vision siblings got both halves of the same change, so this was
+# a propagation gap, not a decision. Nothing caught it, which is why it sat.
+#
+# The rule, and why each clause is here rather than a simple equality test:
+#
+#   (1) SKIP deprecated entries. Retired engines legitimately keep stale pins as
+#       history (7 beellama slugs + 1 deprecated vLLM one drift this way today);
+#       failing on them would make the gate permanently red for no benefit.
+#   (2) SKIP engines whose profile declares NO `install.spec`. That is by design
+#       for ik-llama and llama-cpp-local — registry-emit.sh: "no docker-image
+#       install.spec (ik / llama.cpp pin per-compose or roll by policy)". There
+#       is nothing to compare against, and treating absence as a mismatch would
+#       red every one of those entries.
+#   (3) Otherwise the compose's first `image:` default must EQUAL the profile
+#       spec.
+#
+# The two failure modes are NOT the same and the message says which:
+#   - llama.cpp family: the compose is the pin truth (the launchers inject only
+#     VLLM_IMAGE / BEELLAMA_IMAGE), so a mismatch means the LABEL IS FALSE about
+#     what runs.
+#   - vLLM: the launcher injects the profile's image and OVERRIDES the compose
+#     default, so a mismatch means the compose's own default is misleading to a
+#     human reading it — real, but a different bug.
+set -euo pipefail
+
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale decodes reads, stdout AND argv with the locale codec, which
+# crashes the launcher/emit paths (#779). Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+export PYTHONPATH="$ROOT_DIR${PYTHONPATH:+:$PYTHONPATH}"
+
+python3 - <<'PY'
+import re
+from pathlib import Path
+
+import yaml
+
+from scripts.lib.profiles.compose_registry import get_registry
+
+ROOT = Path(".")
+ENGINES = ROOT / "scripts" / "lib" / "profiles" / "engines"
+
+# Matches a bare literal AND the ${ENGINE_IMAGE:-literal} env-fallback form —
+# the same shape registry-emit.sh's _compose_image_default reads.
+IMG = re.compile(r"^\s*image:\s*[\"']?(?:\$\{[A-Z_0-9]+:-)?([^\s}\"']+)\}?", re.M)
+
+# Statuses that are historical rather than live. A retired engine keeping a
+# stale pin is a record, not a defect.
+SKIP_STATUS = {"deprecated"}
+
+failures = []
+checked = skipped_status = skipped_nospec = 0
+
+
+def check(cond, msg):
+    if cond:
+        print(f"PASS: {msg}")
+    else:
+        print(f"FAIL: {msg}")
+        failures.append(msg)
+
+
+_spec_cache = {}
+
+
+def engine_spec(engine):
+    """The engine profile's declared image, or None when it declares none."""
+    if engine not in _spec_cache:
+        p = ENGINES / f"{engine}.yml"
+        spec = None
+        if p.is_file():
+            data = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+            spec = (data.get("install") or {}).get("spec")
+        _spec_cache[engine] = spec
+    return _spec_cache[engine]
+
+
+for slug, entry in sorted(get_registry().items()):
+    engine = entry.get("engine")
+    compose_path = entry.get("compose_path")
+    if not engine or not compose_path:
+        continue
+    if entry.get("status") in SKIP_STATUS:
+        skipped_status += 1
+        continue
+
+    spec = engine_spec(engine)
+    if not spec:
+        # (2) by design for ik / llama.cpp — nothing declared to compare against.
+        skipped_nospec += 1
+        continue
+
+    f = ROOT / compose_path
+    if not f.is_file():
+        continue
+    m = IMG.search(f.read_text(encoding="utf-8"))
+    if not m:
+        continue
+
+    compose_img = m.group(1)
+    checked += 1
+    if compose_img == spec:
+        continue
+
+    if engine.startswith("vllm"):
+        why = (
+            "the launcher INJECTS the profile image, so the compose default is a "
+            "misleading fallback (a human reading the compose sees the wrong tag)"
+        )
+    else:
+        why = (
+            "this engine pins PER-COMPOSE, so the compose wins and the registry "
+            "label is FALSE about what actually runs"
+        )
+    check(
+        False,
+        f"{slug}: engine label {engine!r} declares {spec!r} but the compose pins "
+        f"{compose_img!r} — {why}",
+    )
+
+print(
+    f"\nchecked {checked} entries "
+    f"({skipped_status} skipped: deprecated, {skipped_nospec} skipped: engine declares no spec)"
+)
+if failures:
+    print(f"\n{len(failures)} engine-label mismatch(es)")
+    raise SystemExit(1)
+print("engine labels match the images their composes pin")
+PY


### PR DESCRIPTION
## What

Twelve slugs move `incubating` → `experimental`, and their engine label is
corrected from `llamacpp-club3090-v1.5` to `llamacpp-club3090-v1.6`.

- 9 moe-cache slugs (glm-5.3-flash ×6, qwen3.8-flash-next ×3)
- 3 llama-cpp deepseek-v4-flash slugs

**Why the status:** these have been booted and benched on this rig, so
`incubating` understates them. `experimental` is the honest label.

**Why the engine label:** it read `v1.5` while the composes pin the **v1.6**
image. The label is what c3's catalogue renders, so the estate panel was naming
an engine that is not the one serving. This was found by reading the catalogue,
not by any test — nothing asserted the two agreed.

## The gate

Adds `scripts/tests/test-engine-label-matches-compose.sh`: a registry entry's
engine label must equal the image its compose pins. Three clauses —

1. skip `deprecated` entries (a dead slug's label is not load-bearing),
2. skip engines whose profile declares no `install.spec` (nothing to compare),
3. otherwise require an exact match.

Negative-controlled in both directions: it reds on a deliberately mismatched
label and stays green when the mismatch is reverted.

```
checked 64 entries (36 skipped: deprecated, 11 skipped: engine declares no spec)
engine labels match the images their composes pin
```

## Note

⚠️ `test-bench-capture.sh` currently fails on **master** (see #1137, reopened) —
a legitimate skip calls `fail` when the synthetic bench yields zero cache misses.
It is unrelated to this change, which touches no bench code.

First of a three-PR stack: this → #SPECN → #KVTYPE.
