### PR TITLE
perf(glm-5.3-flash): dual moecache drafter depth SPEC_N 3 -> 2 (+8-10% decode)

### DIFF
--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq3xxs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq3xxs/moecache.yml
@@ -321,7 +321,19 @@ services:
           done
           set -- "$${ARGS[@]}"
         fi
-        _spec_n="$${SPEC_N:-3}"
+        # ⚠️ n=2, NOT n=3. MEASURED on this compose 2026-09-04, two boots per arm
+        # with the arm ORDER REVERSED between runs so boot-order bias could not
+        # masquerade as the effect:
+        #     SPEC_N=3  decode median 17.55
+        #     SPEC_N=2  decode median 19.04 / 19.32   -> ~+8-10%
+        # Our original n-sweep tested no-spec / 3 / 5 / 7 and called n=3 the peak
+        # because everything DEEPER collapsed — it never probed below it. The
+        # mechanism: a rejected draft token is verified against CPU-RESIDENT
+        # experts, and on this rig that verification outweighs the extra
+        # acceptance the third token buys. Mean accepted length (3.27-3.75) is
+        # what made n=3 look right; it does not price the rejected tail.
+        # Details: learnings/moe-cache-engine.md + learnings/glm-5.3-flash.md.
+        _spec_n="$${SPEC_N:-2}"
         case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
         case "$$_spec_n" in
           ""|*[!0-9]*)

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/moecache.yml
@@ -277,7 +277,7 @@ services:
         # residency, so the optimum could differ. NOT measured on iq4xs.
         # multi4/multi8 deliberately stay at n=3: more cards means more resident
         # experts, so the mechanism weakens, and we cannot test them on 2 GPUs.
-        _spec_n="$${SPEC_N:-3}"
+        _spec_n="$${SPEC_N:-2}"
         case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
         case "$$_spec_n" in
           ""|*[!0-9]*)


### PR DESCRIPTION
> **Stacked on #1175** — review/merge that first. This PR's diff against master
> includes it; against #1175 it is 2 files, +14/-2.

## What

GLM-5.3-Flash **dual** moecache composes: drafter depth `SPEC_N` 3 → 2.
multi4/multi8 deliberately stay at 3.

## Measurement

Two boots per arm, **arm order reversed between runs**, so boot-order bias could
not masquerade as the effect:

| depth | boot 1 | boot 2 | median |
|---|---:|---:|---:|
| `n=3` (shipped) | 17.55 *(ran 1st)* | 17.77 *(ran 2nd)* | 17.66 |
| **`n=2`** | 19.04 *(ran 2nd)* | 19.32 *(ran 1st)* | **19.18** |

**+8.6%.** Within-arm spread 1.2% and 1.5%, against a ~2.8% boot-to-boot floor on
this rig — and each arm scored slightly higher in whichever run it went *second*,
so order contributes a fraction of a percent and cannot explain the gap.

Prefill unchanged (335.9 vs 337.8), as expected: the drafter does not touch it.

## Why we had it wrong

Our original n-sweep tested no-spec / 3 / 5 / 7 and called 3 the peak because
everything **deeper** collapsed — it never probed below. Mechanism: a rejected
draft token is verified against **CPU-resident** experts, and on this rig that
verification outweighs the acceptance the third token buys. Mean accepted length
(3.27–3.75) is what made n=3 look right; it prices the *accepted* tokens and says
nothing about the cost of the rejected tail.

multi4/multi8 stay at 3: more cards means more resident experts, so the mechanism
weakens — and they cannot be tested on a 2-GPU rig.
