### PR TITLE
feat(glm-5.3-flash): wire KV_TYPE on the dual moecache compose (default f16)

### DIFF
--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq3xxs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq3xxs/moecache.yml
@@ -406,6 +406,21 @@ services:
       - '1,1'
       - '-fa'
       - 'on'
+      # KV cache type. ⚠️ DEFAULT IS f16 — NOT q8_0, unlike the Qwen sibling.
+      # GLM is MLA on its 12 full-attention blocks (34 of 46 are SSM/recurrent), so
+      # V is DERIVED, not stored: a boot logs `K (f16): 1650.00 MiB, V (f16): 0.00`.
+      # KV is therefore already small and q8 buys ~825 MiB, not the ~3 GB it buys on
+      # the GQA sibling. Set KV_TYPE=q8_0 to try it. Requires -fa on (above).
+      # ⚠️ UNVALIDATED on glm5next as of 2026-09-04: the V-transpose gate that blocks
+      # quantised KV on the inkling sibling is AMBIGUOUS on a hybrid — it would apply,
+      # if at all, only to the 12 MLA blocks, not the 34 recurrent ones. Boot before
+      # trusting. Do NOT flip this default until that boot is on record.
+      # q8_0 is the SERVING-GRADE FLOOR on this stack — never go below it for a
+      # serving slug (sub-q8 is a speed exhibit only).
+      - '--cache-type-k'
+      - '${KV_TYPE:-f16}'
+      - '--cache-type-v'
+      - '${KV_TYPE:-f16}'
       # ⚠️ SINGLE -ot with comma-separated rules. Current mainline DEPRECATES
       # repeated -ot and honours ONLY THE LAST occurrence.
       # ✅ Stock regex is CORRECT for glm5next — verified 2026-08-27 against the


### PR DESCRIPTION
> **Stacked on #1176 (which is stacked on #1175)** — merge in order. Against
> #1176 this is 1 file, +15/-0.

## What

Wires `KV_TYPE` on the GLM dual moecache compose. **Default stays `f16`, so
shipped behaviour is unchanged.** This adds the knob and records the findings —
it does not change a default.

## Why

The GLM composes had **no KV-type mechanism at all** — no flag, no env path — so
they fell through to `f16` while the Qwen sibling parameterises
`${KV_TYPE:-q8_0}`. The result read backwards: the model **with** MLA used more
KV (1,650 MiB) than the model without it (956 MiB), purely because one was
quantised and the other was not.

## Findings from booting it

**It boots.** The V-transpose gate that blocks quantised KV on the inkling
sibling does **not** apply to this hybrid. `q8_0` and `q4_0` both serve; smoke
checks clean.

**The engine refuses to quantise the indexer, by design:**

```
create_memory: indexer key cache stays f16 rather than q8_0:
               it also holds the compressor gates
```

| region | f16 | q8_0 | q4_0 |
|---|---:|---:|---:|
| main attention K | 2,200 | 1,169 | **619** |
| **indexer KV (DSA)** | 1,650 | 1,650 | 1,650 ← never moves |
| recurrent state (f32) | 437 | 437 | 437 |

The indexer alone exceeds the entire quantised main cache, so the lever caps at
**−24% of KV at q8_0** and −37% at q4_0 — it can never reach the −47% a GQA model
sees. Freed VRAM also converts **sub-linearly**: 1,581 MiB bought +4.1% pool
slots (7,127 → 7,418), about half the arithmetic prediction.

## What is NOT claimed

Throughput is **not established**, and no default changes on its strength:

- the depth legs ran at unequal prompt lengths (86,785 vs 93,331 tokens, both
  labelled "90k"), so that comparison is uncontrolled;
- 90k was **n=1** per arm (`CV 0.0%` there is one draw, not precision);
- a source trace of the FA path argues quantised K should be **slower** at depth
  on this model (`D=512` excludes the vector kernel and forces MMA-f16, which
  dequantises the K view on every call).

Confirmation with identical tokenized prefixes and alternating boots is queued.

⚠️ `q4_0` is a **speed exhibit only** — `q8_0` is the serving-grade floor on this
stack, and this PR does not make either one a default.
