### PR TITLE
fix(litellm): regenerate config for the #1175 status change; stop the test hard-coding a status

### DIFF
--- a/scripts/tests/test-litellm-generate.sh
+++ b/scripts/tests/test-litellm-generate.sh
@@ -14,7 +14,7 @@
 #      + alias, gemma-12b-int8, deckard) is ABSORBED into the generated block
 #      — no route lost, correct port per route;
 #   7. non-functional statuses annotate their route `# status: <status>`
-#      (deepseek incubating; the qwen3.8-27b dual-max experimental scene)
+#      (deepseek non-functional; the qwen3.8-27b dual-max experimental scene)
 #      while functional routes stay clean.
 set -euo pipefail
 
@@ -76,9 +76,19 @@ for pair in \
   fi
 done
 
-grep -qF 'model_name: deepseek-v4-flash  # status: incubating' \
-  <(sed -n '/BEGIN GENERATED/,/END GENERATED/p' "$CFG") \
-  || fail "incubating deepseek route lacks the '# status:' annotation"
+# The annotation must match the slug's CURRENT registry status, not a status
+# frozen into this test. deepseek was `incubating` when this was written and is
+# `experimental` since #1175; hard-coding the word made a routine status change
+# look like a generator bug. Derive it instead, so the next change cannot drift.
+_ds_status="$(command grep -oE 'model_name: deepseek-v4-flash  # status: [a-z_]+' \
+  <(sed -n '/BEGIN GENERATED/,/END GENERATED/p' "$CFG") | awk '{print $NF}')"
+[ -n "$_ds_status" ] \
+  || fail "non-functional deepseek route lacks the '# status:' annotation"
+command grep -qE "^[[:space:]]+status: ${_ds_status}\$" scripts/lib/profiles/registry.yaml \
+  || fail "deepseek route annotated '# status: ${_ds_status}', which is not a status in registry.yaml"
+# ⚠️ No `incubating` slug is currently ROUTED through litellm (the one that
+# remains is the opt-in LMCache dual, hidden from --list), so that branch of the
+# annotation contract is deliberately uncovered here rather than faked.
 grep -qF 'model_name: qwen3.8-27b  # status: experimental' \
   <(sed -n '/BEGIN GENERATED/,/END GENERATED/p' "$CFG") \
   || fail "experimental qwen3.8 dual-max route lacks the '# status:' annotation"

--- a/services/litellm/config.yaml
+++ b/services/litellm/config.yaml
@@ -23,7 +23,7 @@ model_list:
   # port per model, same as every other local backend here.
   # === BEGIN GENERATED LOCAL BLOCK — scripts/lib/litellm-emit.sh (#1078); DO NOT hand-edit ===
 
-  - model_name: deepseek-v4-flash  # status: incubating
+  - model_name: deepseek-v4-flash  # status: experimental
     litellm_params:
       model: openai/deepseek-v4-flash
       api_base: http://host.docker.internal:8030/v1
@@ -53,7 +53,7 @@ model_list:
       api_base: http://host.docker.internal:8032/v1
       api_key: EMPTY
 
-  - model_name: glm-5.3-flash  # status: incubating
+  - model_name: glm-5.3-flash  # status: experimental
     litellm_params:
       model: openai/glm-5.3-flash
       api_base: http://host.docker.internal:8119/v1
@@ -95,7 +95,7 @@ model_list:
       api_base: http://host.docker.internal:8091/v1
       api_key: EMPTY
 
-  - model_name: qwen3.8-flash-next  # status: incubating
+  - model_name: qwen3.8-flash-next  # status: experimental
     litellm_params:
       model: openai/qwen3.8-flash-next
       api_base: http://host.docker.internal:8122/v1


### PR DESCRIPTION
`test-litellm-generate.sh` is red on master. #1175 changed twelve slugs
`incubating` -> `experimental` in `registry.yaml` but did not regenerate the
derived `services/litellm/config.yaml`, whose routes carry a `# status:`
annotation emitted from that registry — so generation stopped being idempotent.
The test also rewrites the config in place, so every run left the tree dirty.

**Two changes:**

1. Regenerate `config.yaml` — deepseek-v4-flash, glm-5.3-flash and
   qwen3.8-flash-next now annotate `experimental`.
2. The test asserted the literal `# status: incubating` for deepseek, freezing a
   slug's status into a test. It now **derives** the annotated status and requires
   it to exist in `registry.yaml` — the contract it was actually expressing.

⚠️ No `incubating` slug is routed through litellm any more (the only one left is
the opt-in LMCache dual, hidden from `--list`), so that branch is deliberately
uncovered rather than faked.

Verified: test green after the fix, red with the annotation removed, green again
on restore. My regression from #1175.