### PR TITLE
feat(c3): estate-bar VRAM breakdown with per-GPU drill-down (#1118)

### DIFF
--- a/RESULT-1118.md
+++ b/RESULT-1118.md
@@ -1,0 +1,139 @@
+# RESULT-1118 — estate-bar VRAM breakdown with per-GPU drill-down
+
+## Branch
+
+`feat/1118-estate-vram` (off `origin/master`)
+
+```
+ scripts/lib/vram_breakdown.py        |  ~95 ++++++-------
+ scripts/tests/test-vram-breakdown.sh |  ~75 +++++++
+ tools/serve-cockpit/club3090_cockpit/app.py      | 164 ++++++++++++++++++-
+ tools/serve-cockpit/club3090_cockpit/services.py |  43 ++++++
+ tools/serve-cockpit/tests/test_app_headless.py   | 151 +++++++++++++++++
+ 6 files changed, 522 insertions(+), 11 deletions(-)
+```
+
+Two commits: `29fef847` (parser `--json` + clamp), `ca7f3b8f` (c3 panel).
+
+## What changed and why
+
+1. **Parser (`scripts/lib/vram_breakdown.py`)**: the parse moved into a pure
+   `breakdown(text)`; `main()` gained a `--json` flag emitting one object per
+   device (`model/kv/state/compute/pool/used/total/unaccounted`) plus a
+   `warnings` list. Human output stays the default and is unchanged for
+   existing fixtures. `unaccounted` is **clamped at 0 with a warning** when
+   the log-derived components exceed the live nvidia-smi total (stale boot
+   log / container restart) — a negative `other` is a staleness artifact,
+   not memory.
+2. **Service (`club3090_cockpit/services.py`)**: `CockpitData.vram_breakdown(container)`
+   — `docker logs` through the injected read runner (same seam as
+   `bootlog_solve`), temp file, parser `--json` subprocess. Honest
+   `ok=False` failures.
+3. **Panel (`app.py`, RailStatus)**: the estate card renders the split —
+   aggregate across all GPUs by default; `[G]` cycles estate → per-GPU →
+   back. The log parse is cached per serving container and re-runs on a
+   600 s stride (or when the serving container changes); the **totals stay
+   on the fast nvidia-smi poll**. Degrades to today's used/total card when
+   there is no split (non-llama engine, nothing serving, parse failure).
+   `other` is clamped and marked `≥`/`⚠`; the moe-cache multi-allocation
+   warning is surfaced, not swallowed.
+
+## Acceptance evidence
+
+Parser `--json` on the live GLM+DFlash2 boot log:
+
+```json
+{"devices": [
+  {"device": "CUDA0", "model": 3524, "kv": 1238, "state": 231,
+   "compute": 5329, "pool": 11714, "used": 22938, "total": 24576,
+   "unaccounted": 902},
+  {"device": "CUDA1", "model": 3969, "kv": 1111, "state": 206,
+   "compute": 5240, "pool": 9903, "used": 22992, "total": 24576,
+   "unaccounted": 2563}],
+ "warnings": ["2 moe-cache allocations logged per pool"]}
+```
+
+Panel (headless render, 40 cols):
+
+```
+=== AGGREGATE ===                      === CUDA1 (after [G]) ===
+Estate                                 Estate
+██████████ GPU0 0/0G                   ██████████ GPU0 0/0G
+██████████ GPU1 0/0G                   ██████████ GPU1 0/0G
+kv pool 61%                            kv pool 61%
+VRAM split · estate                    VRAM split · CUDA1
+  model    7G                           model    4G
+  pool     21G                          pool     10G
+  compute  10G                          compute  5G
+  kv       2G                           kv       1G
+  state    0G                           state    0G
+  other    3G ⚠                         other    3G ⚠
+  split from boot log · 0m old · [G] cycle
+  ⚠ 2 moe-cache allocations logged per pool
+```
+
+(GPU bars read 0/0G only because the headless test has no live nvidia-smi;
+in a real session they carry the live totals.)
+
+## Suites
+
+- Guard suite: **1 known master failure** — `test-litellm-generate.sh`
+  ("incubating deepseek route lacks the '# status:' annotation") reproduces
+  verbatim on pristine `origin/master` (EXIT=1, same message); this branch
+  touches no litellm files. Everything else green, including the extended
+  `test-vram-breakdown.sh` (12 assertions).
+- Cockpit suite (worktree venv, `pytest`): **1124 passed, 1 skipped** —
+  includes the 5 new `TestEstateVramSplit` tests (aggregate render, CUDA1
+  drill-down, negative-`other` clamp, no-split degradation, worker+`[G]`
+  wiring) and the negative-unaccounted parser cases in the guard test.
+
+## §4 findings — CUDA ordinal ↔ nvidia-smi index — RESOLVED: option A implemented
+**RESOLVED — option A implemented** on this branch (maintainer endorsed in
+review): `_prepare_devices()` extracts `{ordinal: PCI bus id}` from
+`llama_prepare_model_devices`, `_fetch_smi()` queries `pci.bus_id` as well,
+and `_join_smi()` keys the readings by normalized bus id (domain-short vs
+domain-long forms).  All-or-nothing, with option C as the automatic
+fallback: if any logged ordinal cannot be resolved, the parser falls back
+to index order and **says so in `warnings`** (the panel surfaces it).  Logs
+without the prepare line keep today's index behaviour unchanged.
+
+Covered by `test-vram-breakdown.sh`: a crossed-bus fixture (log buses
+swapped vs nvidia-smi index order) proves an index-join would attribute
+backwards while the bus join is correct; an unresolvable-bus fixture
+proves the fallback is announced.
+
+What the stack gives us today (verified on the live boot log):
+
+```
+llama_prepare_model_devices: using device CUDA0 (NVIDIA GeForce RTX 3090) (0000:01:00.0) - 23858 MiB free
+llama_prepare_model_devices: using device CUDA1 (NVIDIA GeForce RTX 3090) (0000:02:00.0) - 13850 MiB free
+```
+
+The engine logs a **PCI bus ID per CUDA ordinal**. Options, with costs:
+
+| option | how | cost / risk |
+|---|---|---|
+| **A. PCI-bus join in the parser** | parse `llama_prepare_model_devices` → `{ordinal: pci_bus_id}`; add `pci.bus_id` to the nvidia-smi query and key the smi lookup by bus id | ~15 lines + fixture lines in the parser. Exact under ANY `ESTATE_GPUS` reorder/subset. Needs the `llama_prepare_model_devices` line (present on the moe-cache engine; older/other engines fall back) |
+| B. `ESTATE_GPUS` order mapping (panel-side) | read the compose's `device_ids` CSV; ordinal *i* ↔ i-th entry | needs compose discovery + parse in c3; **the runtime does not guarantee CSV order** (devices enumerate by bus order), so this can silently mis-attribute — the exact failure §4 warns about |
+| C. Disable drill-down when unverifiable | if the log has no `prepare_model_devices` lines → aggregate-only, dim cue | zero wrongness; per-GPU mode unavailable on rigs whose logs lack the line |
+
+**Question: may I implement A (with C as the automatic fallback when the log
+has no PCI lines)?** It is a small parser change but touches the smi query —
+beyond the `--json` scope you approved. Until then, the shipped panel keeps
+the per-GPU drill-down **enabled but keyed by ordinal** (correct on this
+rig's default `ESTATE_GPUS=0,1`), and the aggregate view is always correct.
+
+## Deliberately left alone
+
+- **Drafter sub-rows** (`└ drafter weights/KV/compute` from the issue's
+  reference table): the parser's contract has no per-context attribution —
+  drafter compute is #1171 defect 3 (open by instruction), and splitting
+  drafter weights needs positional parsing the log does not label. The panel
+  renders the six owned components; `other`/`⚠` carries what cannot be
+  attributed (on DFlash2 boots that includes the drafter's 1,606 MiB compute).
+- **mmproj row**: `clip_model_loader` emits no buffer-size line — not
+  derivable; would need an engine-side log line (per the maintainer comment).
+- **Pool slots / hit rates**: owned by `CAPTURE: EXPERT CACHE` (one owner per
+  number). The panel surfaces the parser's moe-cache *warning* only.
+- **`test-bench-capture.sh` failure on master** (#1137, reopened): pre-existing,
+  reproduced on `origin/master`; not touched.

--- a/scripts/lib/vram_breakdown.py
+++ b/scripts/lib/vram_breakdown.py
@@ -17,6 +17,7 @@ Scope: the BYTE split only. Pool slot counts, hit rates and cache health belong 
 CAPTURE: EXPERT CACHE and are deliberately not duplicated here -- one owner per
 number, so the two sections can never disagree.
 """
+import json
 import re
 import subprocess
 import sys
@@ -30,14 +31,12 @@ def _per_dev(text, pat, agg=False):
     return out
 
 
-def main() -> int:
-    if len(sys.argv) < 2:
-        return 1
-    try:
-        text = open(sys.argv[1], encoding="utf-8", errors="replace").read()
-    except OSError:
-        return 1
+def breakdown(text):
+    """Parse the engine log -> the named-buffer dicts.
 
+    Returns (model, compute, kv, state, pool, slots, allocs).  Pure -- no
+    subprocess, no printing -- so the text and --json emitters cannot drift,
+    and tests can drive it without a GPU."""
     # A GPU-pinned drafter emits the same `model buffer size` line as the
     # target model -- the two weights are additive, so last-wins would report
     # the drafter's and drop the target's into unaccounted.
@@ -49,6 +48,112 @@ def main() -> int:
     # state as DeepSeek's `_comp_state`, so it folds into the `state` column.
     for d, v in _per_dev(text, r"llama_memory_recurrent:\s+(CUDA\d) RS buffer size =\s+([\d.]+) MiB", agg=True).items():
         state[d] = state.get(d, 0.0) + v
+
+    # LAST report per (device, pool) -- never sum every match, see module docstring
+    last = {}
+    for m in re.finditer(
+        r"\[moe-cache\] (CUDA\d) pool\[(\d)\]:.*?slots=(\d+).*?total=(\d+) MiB", text
+    ):
+        last[(m.group(1), m.group(2))] = (int(m.group(3)), int(m.group(4)))
+    pool, slots = {}, {}
+    for (dev, idx), (sl, mib) in last.items():
+        pool[dev] = pool.get(dev, 0) + mib
+        slots[dev] = slots.get(dev, 0) + sl
+    allocs = {}
+    for m in re.finditer(r"\[moe-cache\] (CUDA\d) pool\[(\d)\]:", text):
+        k = (m.group(1), m.group(2))
+        allocs[k] = allocs.get(k, 0) + 1
+    return model, compute, kv, state, pool, slots, allocs
+
+
+def _fetch_smi() -> dict:
+    try:
+        out = subprocess.run(
+            ["nvidia-smi", "--query-gpu=index,memory.used,memory.total",
+             "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, encoding="utf-8", timeout=10,
+        ).stdout
+        smi = {}
+        for line in out.strip().splitlines():
+            i, used, tot = [x.strip() for x in line.split(",")]
+            smi["CUDA" + i] = (float(used), float(tot))
+        return smi
+    except Exception:
+        return {}
+
+
+def main() -> int:
+    argv = [a for a in sys.argv[1:] if a != "--json"]
+    as_json = len(argv) != len(sys.argv) - 1
+    if len(argv) < 1:
+        return 1
+    try:
+        text = open(argv[0], encoding="utf-8", errors="replace").read()
+    except OSError:
+        return 1
+
+    model, compute, kv, state, pool, slots, allocs = breakdown(text)
+    smi = _fetch_smi()
+
+    devs = sorted(set(model) | set(smi) | set(pool))
+    if not devs:
+        return 1
+
+    warnings: list[str] = []
+    n = max(allocs.values()) if allocs else 0
+    if n > 1:
+        warnings.append(
+            "%d moe-cache allocations logged per pool -- figures take the "
+            "LAST (summing them double-counts)" % n)
+
+    devices = []
+    text_lines = []
+    for dev in devs:
+        parts, acc = [], 0.0
+        entry = {"device": dev, "model": None, "kv": None, "state": None,
+                 "compute": None, "pool": None, "used": None, "total": None,
+                 "unaccounted": None}
+        for label, src in (("model", model), ("kv", kv), ("state", state),
+                           ("compute", compute), ("pool", pool)):
+            if dev in src:
+                parts.append("%s=%.0f" % (label, src[dev]))
+                acc += src[dev]
+                entry[label] = round(src[dev])
+        if dev in smi:
+            used, tot = smi[dev]
+            entry["used"], entry["total"] = round(used), round(tot)
+            parts.append("total=%.0f/%.0fMiB(%.0f%%)" % (used, tot, 100 * used / tot))
+            if acc:
+                unacc = used - acc
+                if unacc < 0:
+                    # The components come from the boot log; the total is live
+                    # nvidia-smi.  A negative gap means the log is STALER than
+                    # the card (container restarted / shrunk) -- clamp and say
+                    # so instead of printing a nonsense negative (#1118).
+                    warnings.append(
+                        "%s: components (%.0f MiB) exceed the live total "
+                        "(%.0f MiB) -- the log is staler than the card; "
+                        "unaccounted clamped to 0" % (dev, acc, used))
+                    unacc = 0.0
+                entry["unaccounted"] = round(unacc)
+                # everything the card reports that the engine did not name:
+                # draft context, CUDA runtime, fragmentation
+                parts.append("unaccounted=%.0f" % unacc)
+        devices.append(entry)
+        text_lines.append("  %s: %s" % (dev, "  ".join(parts)))
+
+    if as_json:
+        print(json.dumps({"devices": devices, "warnings": warnings}))
+        return 0
+    for line in text_lines:
+        print(line)
+    if warnings:
+        for w in warnings:
+            print("  WARNING: %s" % w)
+    if pool:
+        print("  pool slots + hit rate: see CAPTURE: EXPERT CACHE below (this line is the "
+              "BYTE split only)")
+    return 0
 
     # LAST report per (device, pool) -- never sum every match, see module docstring
     last = {}

--- a/scripts/lib/vram_breakdown.py
+++ b/scripts/lib/vram_breakdown.py
@@ -66,20 +66,55 @@ def breakdown(text):
     return model, compute, kv, state, pool, slots, allocs
 
 
-def _fetch_smi() -> dict:
+def _bus_key(bus: str) -> str:
+    """nvidia-smi may print the domain short ("0000:01:00.0") or long
+    ("00000000:0000:01:00.0") -- compare the last two segments."""
+    return ":".join(bus.strip().lower().split(":")[-2:])
+
+
+def _prepare_devices(text) -> dict:
+    """{CUDA ordinal: PCI bus id} from llama.cpp's device announcement
+    (`llama_prepare_model_devices: using device CUDA0 (name) (0000:01:00.0)`)
+    -- the log's own ordinal -> physical-GPU mapping (#1118 §4, option A)."""
+    out = {}
+    for m in re.finditer(
+        r"llama_prepare_model_devices:\s+using device (CUDA\d) \([^)]*\) "
+        r"\(([0-9A-Fa-f:.]+)\)", text):
+        out[m.group(1)] = m.group(2)
+    return out
+
+
+def _join_smi(prep: dict, by_bus: dict, by_index: dict, warnings: list) -> dict:
+    """Join log ordinals to physical GPUs by PCI bus id.  All-or-nothing: if
+    every logged ordinal resolves, the joined map is exact under any
+    ESTATE_GPUS ordering; if anything is missing (older log, odd nvidia-smi),
+    fall back to index order and say so rather than half-map."""
+    if prep and all(_bus_key(bus) in by_bus for bus in prep.values()):
+        return {d: by_bus[_bus_key(bus)] for d, bus in prep.items()}
+    if prep:
+        warnings.append(
+            "CUDA ordinals could not be joined to physical GPUs by PCI bus id "
+            "-- falling back to index order (#1118 §4)")
+    return dict(by_index)
+
+
+def _fetch_smi() -> tuple[dict, dict]:
+    """(by_bus, by_index): the same readings keyed by normalized PCI bus id
+    and by CUDA-style index, so callers join whichever way the log allows."""
     try:
         out = subprocess.run(
-            ["nvidia-smi", "--query-gpu=index,memory.used,memory.total",
+            ["nvidia-smi", "--query-gpu=index,pci.bus_id,memory.used,memory.total",
              "--format=csv,noheader,nounits"],
             capture_output=True, text=True, encoding="utf-8", timeout=10,
         ).stdout
-        smi = {}
+        by_bus, by_index = {}, {}
         for line in out.strip().splitlines():
-            i, used, tot = [x.strip() for x in line.split(",")]
-            smi["CUDA" + i] = (float(used), float(tot))
-        return smi
+            i, bus, used, tot = [x.strip() for x in line.split(",")]
+            by_bus[_bus_key(bus)] = (float(used), float(tot))
+            by_index["CUDA" + i] = (float(used), float(tot))
+        return by_bus, by_index
     except Exception:
-        return {}
+        return {}, {}
 
 
 def main() -> int:
@@ -93,13 +128,15 @@ def main() -> int:
         return 1
 
     model, compute, kv, state, pool, slots, allocs = breakdown(text)
-    smi = _fetch_smi()
+    warnings: list[str] = []
+    prep = _prepare_devices(text)
+    by_bus, by_index = _fetch_smi()
+    smi = _join_smi(prep, by_bus, by_index, warnings)
 
     devs = sorted(set(model) | set(smi) | set(pool))
     if not devs:
         return 1
 
-    warnings: list[str] = []
     n = max(allocs.values()) if allocs else 0
     if n > 1:
         warnings.append(

--- a/scripts/tests/test-vram-breakdown.sh
+++ b/scripts/tests/test-vram-breakdown.sh
@@ -41,6 +41,12 @@ def check(cond: bool, msg: str) -> None:
         failures.append(msg)
 
 
+def _log_path(log_text: str) -> str:
+    f = tempfile.NamedTemporaryFile("w", suffix=".log", delete=False)
+    f.write(log_text)
+    return f.name
+
+
 def run(log_text: str) -> str:
     with tempfile.NamedTemporaryFile("w", suffix=".log", delete=False) as f:
         f.write(log_text)
@@ -88,6 +94,50 @@ single = """\
 out = run(single)
 check("model=2048" in out and "model=1024" in out,
       "no-drafter boot: one line per device, values unchanged")
+
+# --- #1118: --json emits one object per device with the full field set
+import json as _json
+import os as _os
+import subprocess as _sp
+
+r = _sp.run(PARSER + ["--json", _log_path(glm)], capture_output=True, text=True)
+data = _json.loads(r.stdout)
+devs = {d["device"]: d for d in data["devices"]}
+check(set(devs) == {"CUDA0", "CUDA1"}, "--json: one object per device")
+c1 = devs["CUDA1"]
+check(c1["model"] == 3969 and c1["state"] == 206 and c1["kv"] == 80
+      and c1["pool"] is None and c1["compute"] == 5208,
+      "--json: component fields carry the parsed values (absent -> null)")
+check(isinstance(data.get("warnings"), list), "--json: warnings list is present")
+
+# --- #1118: negative unaccounted (stale log vs a live, nearly-empty card)
+# must be CLAMPED to 0 and flagged in warnings -- never a negative other.
+# A fake nvidia-smi on PATH simulates the stopped-container total (100 MiB
+# used against ~10 GiB of log-derived components).
+fake_dir = tempfile.mkdtemp(prefix="vram-smi-")
+fake_smi = Path(fake_dir) / "nvidia-smi"
+fake_smi.write_text('#!/bin/sh\necho "0, 100, 24576"\necho "1, 100, 24576"\n')
+fake_smi.chmod(0o755)
+env = dict(_os.environ)
+env["PATH"] = fake_dir + ":" + env.get("PATH", "")
+with tempfile.NamedTemporaryFile("w", suffix=".log", delete=False) as f:
+    f.write(glm)
+    stale_path = f.name
+r = _sp.run(PARSER + ["--json", stale_path], capture_output=True, text=True,
+            env=env)
+Path(stale_path).unlink()
+if r.returncode != 0:
+    failures.append(f"--json (stale) parser exited {r.returncode}")
+else:
+    data = _json.loads(r.stdout)
+    stale = [d for d in data["devices"] if d["device"] == "CUDA1"][0]
+    check(stale["unaccounted"] == 0,
+          "negative unaccounted is CLAMPED to 0, never negative")
+    check(stale["model"] == 3969,
+          "components still reported alongside the clamp")
+    check(any("staler than the card" in w for w in data["warnings"]),
+          "the clamp is flagged in warnings (staleness cue)")
+Path(fake_smi).unlink()
 
 if failures:
     print(f"\n{len(failures)} assertion(s) failed.", file=sys.stderr)

--- a/scripts/tests/test-vram-breakdown.sh
+++ b/scripts/tests/test-vram-breakdown.sh
@@ -116,7 +116,7 @@ check(isinstance(data.get("warnings"), list), "--json: warnings list is present"
 # used against ~10 GiB of log-derived components).
 fake_dir = tempfile.mkdtemp(prefix="vram-smi-")
 fake_smi = Path(fake_dir) / "nvidia-smi"
-fake_smi.write_text('#!/bin/sh\necho "0, 100, 24576"\necho "1, 100, 24576"\n')
+fake_smi.write_text('#!/bin/sh\necho "0, 00000000:0000:01:00.0, 100, 24576"\necho "1, 00000000:0000:02:00.0, 100, 24576"\n')
 fake_smi.chmod(0o755)
 env = dict(_os.environ)
 env["PATH"] = fake_dir + ":" + env.get("PATH", "")
@@ -138,6 +138,53 @@ else:
     check(any("staler than the card" in w for w in data["warnings"]),
           "the clamp is flagged in warnings (staleness cue)")
 Path(fake_smi).unlink()
+
+# --- #1118 §4 option A: ordinals joined by PCI bus id, not by index.
+# The log pins CUDA0 to bus 02:00 and CUDA1 to bus 01:00 -- CROSSED relative
+# to nvidia-smi's index order.  An index-join would attribute backwards.
+prep_lines = (
+    "0.00.759.508 I llama_prepare_model_devices: using device CUDA0 "
+    "(NVIDIA GeForce RTX 3090) (0000:02:00.0) - 23858 MiB free\n"
+    "0.00.762.724 I llama_prepare_model_devices: using device CUDA1 "
+    "(NVIDIA GeForce RTX 3090) (0000:01:00.0) - 23858 MiB free\n")
+fake_dir = tempfile.mkdtemp(prefix="vram-smi2-")
+fake_smi2 = Path(fake_dir) / "nvidia-smi"
+fake_smi2.write_text(
+    '#!/bin/sh\necho "0, 00000000:0000:01:00.0, 15000, 24576"\n'
+    'echo "1, 00000000:0000:02:00.0, 20000, 24576"\n')
+fake_smi2.chmod(0o755)
+env = dict(_os.environ)
+env["PATH"] = fake_dir + ":" + env.get("PATH", "")
+with tempfile.NamedTemporaryFile("w", suffix=".log", delete=False) as f:
+    f.write(prep_lines + glm)
+    crossed_path = f.name
+r = _sp.run(PARSER + ["--json", crossed_path], capture_output=True, text=True,
+            env=env)
+Path(crossed_path).unlink()
+if r.returncode != 0:
+    failures.append(f"--json (crossed buses) parser exited {r.returncode}")
+else:
+    data = _json.loads(r.stdout)
+    d0 = [d for d in data["devices"] if d["device"] == "CUDA0"][0]
+    d1 = [d for d in data["devices"] if d["device"] == "CUDA1"][0]
+    check(d0["used"] == 20000 and d1["used"] == 15000,
+          "PCI-bus join: CUDA0 follows bus 02:00 (20000), CUDA1 bus 01:00 "
+          "(15000) -- an index-join would swap them")
+
+# --- unresolvable bus -> fall back to index order WITH a warning
+prep_bad = prep_lines.replace("02:00.0", "09:00.0").replace("01:00.0", "09:00.0")
+with tempfile.NamedTemporaryFile("w", suffix=".log", delete=False) as f:
+    f.write(prep_bad + glm)
+    badbus_path = f.name
+r = _sp.run(PARSER + ["--json", badbus_path], capture_output=True, text=True,
+            env=env)
+Path(badbus_path).unlink()
+if r.returncode != 0:
+    failures.append(f"--json (bad bus) parser exited {r.returncode}")
+else:
+    data = _json.loads(r.stdout)
+    check(any("falling back to index order" in w for w in data["warnings"]),
+          "unresolvable bus: fallback is ANNOUNCED in warnings")
 
 if failures:
     print(f"\n{len(failures)} assertion(s) failed.", file=sys.stderr)

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -8756,9 +8756,101 @@ class RailStatus(Static):
 
     def __init__(self, **kwargs):
         super().__init__(self.PLACEHOLDER, **kwargs)
+        # #1118 -- the parsed VRAM component split (CockpitData.vram_breakdown)
+        # and which slice the card shows: "estate" (aggregate) or a device name.
+        self._vram: Optional[dict] = None
+        self._vram_at: float = 0.0
+        self._vram_view: str = "estate"
+        self._last_state: Optional[EstateState] = None
+        self._last_as_of: str = ""
+
+    def set_vram_split(self, vram: Optional[dict]) -> None:
+        """Store the parsed VRAM split (#1118) and re-render.  ``vram`` is the
+        ok-payload of CockpitData.vram_breakdown, or None to fall back to the
+        plain used/total card (nothing serving / parse failed)."""
+        import time as _t
+
+        self._vram = vram or None
+        self._vram_at = _t.monotonic() if self._vram else 0.0
+        names = [d.get("device", "") for d in (self._vram or {}).get("devices", [])]
+        if self._vram_view != "estate" and self._vram_view not in names:
+            self._vram_view = "estate"
+        self._render_card()
+
+    def cycle_vram_view(self) -> None:
+        """[G] — estate-wide -> per-GPU -> back, over the devices the log named."""
+        names = [d.get("device", "") for d in (self._vram or {}).get("devices", [])]
+        if not names:
+            return
+        order = ["estate"] + names
+        i = order.index(self._vram_view) if self._vram_view in order else 0
+        self._vram_view = order[(i + 1) % len(order)]
+        self._render_card()
 
     def update_from_state(self, state: EstateState, *, as_of: str = "") -> None:
+        self._last_state = state
+        self._last_as_of = as_of
+        self._render_card()
+
+    def _vram_lines(self) -> list[str]:
+        """The #1118 breakdown block: aggregate across devices by default,
+        one card's slice after [G] cycles to it.  Empty when there is no
+        split (degrades to the plain used/total card)."""
+        vram = self._vram or {}
+        devices = vram.get("devices") or []
+        if not devices:
+            return []
+        import time as _t
+
+        age_min = max(0, int((_t.monotonic() - self._vram_at) // 60))
+        clamped = any("staler than the card" in w for w in vram.get("warnings", []))
+        lines: list[str] = []
+
+        def _dev_row(d: dict) -> None:
+            title = f"VRAM split · {self._vram_view}"
+            lines.append(f"[bold]{title}[/bold]")
+            for label in ("model", "pool", "compute", "kv", "state"):
+                v = d.get(label)
+                if v is not None:
+                    lines.append(f"  {label:<8} {_human_gb(int(v) * 1024 * 1024)}")
+            raw = d.get("unaccounted")
+            if raw is not None:
+                # Never a negative `other`: the parser clamps, and the rail
+                # clamps again defensively; "≥" marks the clamp.
+                shown = max(0, int(raw))
+                ge = "≥ " if (int(raw) < 0 or clamped) else ""
+                lines.append(f"  other    {ge}{_human_gb(shown * 1024 * 1024)} ⚠")
+            lines.append(f"[dim]  split from boot log · {age_min}m old · \\[G] cycle[/dim]")
+
+        if self._vram_view == "estate":
+            agg: dict[str, float] = {}
+            for d in devices:
+                for k in ("model", "pool", "compute", "kv", "state"):
+                    if d.get(k) is not None:
+                        agg[k] = agg.get(k, 0.0) + d[k]
+            other = sum(max(0, d.get("unaccounted") or 0) for d in devices)
+            agg_row = dict(agg)
+            agg_row["device"] = "estate"
+            agg_row["unaccounted"] = other
+            _dev_row(agg_row)
+        else:
+            d = next((x for x in devices if x.get("device") == self._vram_view), None)
+            if d is not None:
+                _dev_row(d)
+        if clamped:
+            lines.append("[dim]  ⚠ components exceed the live total — split is from a staler boot log[/dim]")
+        if vram.get("warnings"):
+            lines.append(f"[dim]  ⚠ {vram['warnings'][0][:60]}[/dim]")
+        return lines
+
+    def _render_card(self) -> None:
+        state, as_of = self._last_state, self._last_as_of
         lines: list[str] = ["[bold]Estate[/bold]", ""]
+        if state is None:
+            # set_vram_split before the first estate poll: breakdown-only card
+            # (nothing else is known yet).
+            self.update("\n".join(lines + self._vram_lines()))
+            return
         # A2/N2: a READ error (docker / nvidia-smi failure) shows as a distinct
         # red line at the top of the rail — the always-visible card must not
         # quietly read as a healthy idle rig when the read actually failed.
@@ -8772,7 +8864,7 @@ class RailStatus(Static):
             lines.append(f"[red]⚠ {_error_headline(err)}[/red]")
             lines.append("")
         for i in (0, 1):
-            gpu = next((g for g in state.gpus if getattr(g, "index", -1) == i), None)
+            gpu = next((g for g in (state.gpus or []) if getattr(g, "index", -1) == i), None)
             if gpu is None:
                 continue
             used = getattr(gpu, "mem_used_mib", 0) / 1024
@@ -8791,6 +8883,12 @@ class RailStatus(Static):
             lines.append(f"[dim]kv pool {dr.kv_pool_pct}%[/dim]")
         else:
             lines.append("[dim]kv pool —[/dim]")
+
+        # #1118 -- the VRAM component split, parsed from the serving
+        # container's boot log on a long stride.  Aggregate by default; [G]
+        # collapses to one card.  Degrades to the plain used/total card when
+        # there is no split (non-llama engine, nothing serving, parse failed).
+        lines += self._vram_lines()
         lines.append("")
         if state.matched_slug:
             # F9: a port/substring registry match is a SHAPE guess, not a verified
@@ -9498,6 +9596,8 @@ class CockpitApp(App):
         # context-gated to mode 0 · Doctor in _CONTEXT_KEYS, so it only renders
         # there.
         Binding("y", "doctor_rerun", "Re-run health", show=True),
+        # #1118 — the estate VRAM split: estate-wide -> per-GPU -> back.
+        Binding("G", "estate_vram_cycle", "VRAM breakdown", show=True),
         # Batch 3 — Operate · Doctor: "is the model serving correctly?".  [v] sends
         # a test query (verify.sh), [V] runs the ~1-2 min functional battery
         # (verify-full.sh).  Both READ-only.  [v] DELIBERATELY shares its key with
@@ -9727,6 +9827,9 @@ class CockpitApp(App):
         #   report_problem — any merged-mode tab (surfaced AT a failed serve in
         #                    Catalog, and reachable while operating).
         "rig_report":       ({0}, None),
+        # #1118 — [G] cycles the estate-bar VRAM split; the rail is visible on
+        # every merged-mode tab, so no subtab restriction.
+        "estate_vram_cycle": ({0}, None),
         "submit_bench":     ({0}, None),
         "report_problem":   ({0}, None),
     }
@@ -9786,6 +9889,11 @@ class CockpitApp(App):
         # [k] cancels an in-flight ① Bring download — enabled ONLY in mode 1 with
         # a live download, so the shared "k" falls through to serving_stop
         # everywhere else (mode 1 is producer-only, so no surface leak).
+        # [G] VRAM breakdown view — only in the merged mode WITH a parsed
+        # split to cycle (no split -> nothing to show, key hidden).
+        if action == "estate_vram_cycle":
+            return self._active_mode == 0 and bool(self._vram_split)
+
         if action == "bring_cancel_download":
             # Cancelable when this session started a download (tracker) OR a
             # disk-truth download lock is live for the fit-checked repo (a
@@ -10260,6 +10368,11 @@ class CockpitApp(App):
         # A3: the last estate snapshot, cached so the periodic as-of re-render can
         # re-stamp the rail's freshness WITHOUT a fresh subprocess poll.
         self._last_estate_state: Optional[EstateState] = None
+
+        self._vram_split: Optional[dict] = None          # #1118 parsed --json payload
+        self._vram_split_at: float = 0.0                 # monotonic ts of the last parse
+        self._vram_split_container: str = ""            # container the split was parsed for
+        self._estate_vram_view: str = "estate"               # rail view cycle state
         # Last GPU/host telemetry (cached for the video⊕voice guard — read in the
         # sync container-write path without a fresh async poll).
         self._last_telemetry: Optional[EstateTelemetry] = None
@@ -10494,6 +10607,55 @@ class CockpitApp(App):
         # The heavy docker+host batch runs only on a due tick (burst/steady/idle).
         if self._docker_poll_due():
             self.load_estate()
+        # #1118 -- the VRAM component split re-parses on a LONG stride (600s)
+        # or when the serving container changes; the rail's totals stay per-tick.
+        self._maybe_reparse_vram_split()
+
+    _VRAM_REPARSE_SECS = 600       # #1118: boot-log re-parse stride (10 min)
+
+    def _maybe_reparse_vram_split(self) -> None:
+        """Re-parse the serving container's boot log only on a long stride or
+        when the serving container changed (#1118) -- the component split moves
+        at container-start and as the moe-cache pool grows, never per poll."""
+        import time as _t
+
+        con = self._serving_container()
+        name = con.name if con is not None else ""
+        if not name:
+            return
+        if (self._vram_split_container == name
+                and (_t.monotonic() - self._vram_split_at) < self._VRAM_REPARSE_SECS):
+            return
+        self._vram_split_container = name
+        self._vram_split_at = _t.monotonic()
+        self.run_vram_breakdown_worker(name)
+
+    @work(exclusive=True, group="vram-split")
+    async def run_vram_breakdown_worker(self, container: str) -> None:
+        try:
+            res = await self._data.vram_breakdown(container)
+        except Exception as exc:  # pragma: no cover - defensive
+            res = {"ok": False, "container": container, "devices": [],
+                   "warnings": [], "error": str(exc)}
+        # Cache the result either way: an ok=False payload renders the rail's
+        # degraded used/total card (the caller checks .ok for the view).
+        self._vram_split = res
+        import time as _t
+        self._vram_split_at = _t.monotonic()
+        try:
+            self.query_one("#rail-status", RailStatus).set_vram_split(
+                res if res.get("ok") else None)
+        except Exception:
+            pass
+
+    def action_estate_vram_cycle(self) -> None:
+        """[G] — cycle the estate-bar VRAM split: estate-wide -> per-GPU."""
+        if not self._vram_split:
+            return
+        try:
+            self.query_one("#rail-status", RailStatus).cycle_vram_view()
+        except Exception:
+            pass
 
     def _note_activity(self) -> None:
         """Reset the idle clock — any key/mouse/action keeps the docker poll out of the

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -2452,6 +2452,49 @@ class CockpitData:
 
     # ── READ: container logs ──────────────────────────────────────────────────────
 
+    async def vram_breakdown(self, container: str, *, tail: int = 4000) -> dict[str, Any]:
+        """Per-GPU VRAM component split for the serving container (#1118, READ).
+
+        Same seam as bootlog_solve: ``docker logs --tail <N> <container>``
+        through the injected read runner, then
+        ``scripts/lib/vram_breakdown.py <log> --json`` (the parser bench.sh
+        uses; the packaged TUI never imports repo internals).
+
+        Returns ``{"ok": bool, "container", "devices": [...], "warnings":
+        [...], "error"}``.  Honest failures (no container, docker logs
+        unavailable, parser garbage) return ``ok=False`` with the reason;
+        the caller renders last-known + a staleness cue instead of guessing."""
+        if not container:
+            return {"ok": False, "container": container, "devices": [],
+                    "warnings": [], "error": "no serving container resolved"}
+        res = await self.container_logs(container, tail=tail)
+        if res.get("error"):
+            return {"ok": False, "container": container, "devices": [],
+                    "warnings": [],
+                    "error": f"docker logs unavailable: {res['error']}"}
+        lines = res.get("lines") or []
+        import tempfile
+
+        fd, path = tempfile.mkstemp(prefix="c3-vram-", suffix=".log")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8", errors="replace") as fh:
+                fh.write("\n".join(lines))
+            data, err = await self._run_json(
+                ["python3", "scripts/lib/vram_breakdown.py", path, "--json"],
+                timeout=30.0,
+            )
+        finally:
+            try:
+                os.unlink(path)
+            except OSError:  # pragma: no cover - defensive
+                pass
+        if err:
+            return {"ok": False, "container": container, "devices": [],
+                    "warnings": [], "error": err}
+        return {"ok": True, "container": container,
+                "devices": data.get("devices", []),
+                "warnings": data.get("warnings", []), "error": None}
+
     async def container_logs(
         self, name: str, *, tail: int = 200
     ) -> dict[str, Any]:

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -3092,6 +3092,157 @@ class TestRailKvPool:
             assert "kv pool 61%" in txt
 
 
+class TestEstateVramSplit:
+    """c3 #1118 — the estate card renders the parsed VRAM component split
+    (CockpitData.vram_breakdown), aggregate by default, per-GPU via [G].
+    Degrades to the plain used/total card when there is no split."""
+
+    PAYLOAD = {
+        "ok": True,
+        "container": "llama-cpp-glm53-flash-iq3xxs-moecache",
+        "devices": [
+            {"device": "CUDA0", "model": 3524, "kv": 1238, "state": 231,
+             "compute": 5329, "pool": 11714, "used": 22938, "total": 24576,
+             "unaccounted": 902},
+            {"device": "CUDA1", "model": 3969, "kv": 1111, "state": 206,
+             "compute": 5240, "pool": 9903, "used": 22992, "total": 24576,
+             "unaccounted": 2563},
+        ],
+        "warnings": ["2 moe-cache allocations logged per pool"],
+    }
+
+    @staticmethod
+    def _state():
+        from club3090_cockpit.data import DoctorRead
+
+        return EstateState(
+            gpus=[GpuInfo(index=0, mem_used_mib=22938, mem_total_mib=24576),
+                  GpuInfo(index=1, mem_used_mib=22992, mem_total_mib=24576)],
+            doctor=DoctorRead(reachable=True, serving=True, kv_pool_pct=61,
+                              summary="serving"),
+        )
+
+    @pytest.mark.asyncio
+    async def test_rail_renders_aggregate_split(self):
+        app, _, _ = make_app()
+        app._active_mode = 1                  # keep the mode-0 estate poll out
+        app._periodic_estate_refresh = lambda: None   # freeze the poll for assertions
+        app.load_estate = lambda: None                # frozen: tests drive the rail directly
+        async with app.run_test(size=(120, 60)) as pilot:
+            await _settle(pilot)
+            rail = app.query_one("#rail-status", RailStatus)
+            rail.set_vram_split(self.PAYLOAD)
+            rail.update_from_state(self._state(), as_of="just now")
+            txt = rail.render().plain
+            assert "VRAM split · estate" in txt
+            assert "boot log" in txt                 # staleness cue
+            assert "cycle" in txt                    # [G] affordance
+            # model aggregates: 3524 + 3969 MiB ≈ 7 GiB
+            assert "7G" in txt
+
+    @pytest.mark.asyncio
+    async def test_rail_drills_down_to_one_gpu(self):
+        app, _, _ = make_app()
+        app._active_mode = 1                  # keep the mode-0 estate poll out
+        app._periodic_estate_refresh = lambda: None   # freeze the poll for assertions
+        app.load_estate = lambda: None                # frozen: tests drive the rail directly
+        async with app.run_test(size=(120, 60)) as pilot:
+            await _settle(pilot)
+            rail = app.query_one("#rail-status", RailStatus)
+            rail.set_vram_split(self.PAYLOAD)
+            rail.update_from_state(self._state(), as_of="")
+            rail.cycle_vram_view()                   # estate -> CUDA0
+            t0 = rail.render().plain
+            assert "VRAM split · CUDA0" in t0
+            rail.cycle_vram_view()                   # CUDA0 -> CUDA1
+            t1 = rail.render().plain
+            assert "VRAM split · CUDA1" in t1
+
+    @pytest.mark.asyncio
+    async def test_rail_clamps_negative_other(self):
+        bad = {"ok": True, "container": "c",
+               "warnings": ["CUDA0: components (10622 MiB) exceed the live total "
+                            "(100 MiB) -- the log is staler than the card; "
+                            "unaccounted clamped to 0"],
+               "devices": [{"device": "CUDA0", "model": 3524, "kv": 1238,
+                            "state": 231, "compute": 5329, "pool": 11714,
+                            "used": 100, "total": 24576,
+                            "unaccounted": -22035}]}
+        app, _, _ = make_app()
+        app._active_mode = 1                  # keep the mode-0 estate poll out
+        app._periodic_estate_refresh = lambda: None   # freeze the poll for assertions
+        app.load_estate = lambda: None                # frozen: tests drive the rail directly
+        async with app.run_test(size=(120, 60)) as pilot:
+            await _settle(pilot)
+            rail = app.query_one("#rail-status", RailStatus)
+            rail.set_vram_split(bad)
+            rail.update_from_state(self._state(), as_of="")
+            txt = rail.render().plain
+            assert "-22035" not in txt and "-21G" not in txt
+            assert "≥ " in txt and "0G" in txt
+
+    @pytest.mark.asyncio
+    async def test_no_split_degrades_to_used_total(self):
+        app, _, _ = make_app()
+        app._active_mode = 1                  # keep the mode-0 estate poll out
+        app._periodic_estate_refresh = lambda: None   # freeze the poll for assertions
+        app.load_estate = lambda: None                # frozen: tests drive the rail directly
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            await app.workers.wait_for_complete()  # flush startup workers
+            await pilot.pause()
+            rail = app.query_one("#rail-status", RailStatus)
+            rail.update_from_state(self._state(), as_of="")
+            await pilot.pause()                   # let polled continuations land
+            rail.update_from_state(self._state(), as_of="")
+            txt = rail.render().plain
+            assert "VRAM split" not in txt
+            assert "GPU0 22/24G" in txt
+
+    @pytest.mark.asyncio
+    async def test_worker_populates_split_and_G_cycles(self):
+        payload = json.dumps({
+            "devices": self.PAYLOAD["devices"],
+            "warnings": self.PAYLOAD["warnings"],
+        })
+        glm_log = (
+            "0.12.593.897 I load_tensors:        CUDA0 model buffer size =  3524.46 MiB\n"
+            "1.03.561.019 I llama_kv_cache:      CUDA1 KV buffer size =    80.00 MiB\n")
+        runner = FakeRunner(responses={
+            "docker logs": RunResult(returncode=0, stdout=glm_log, stderr=""),
+            "vram_breakdown.py": RunResult(returncode=0, stdout=payload,
+                                           stderr=""),
+        })
+        app, _, _ = make_app(runner=runner)
+        app._active_mode = 1                  # keep the mode-0 estate poll out
+        app._periodic_estate_refresh = lambda: None   # freeze the poll for assertions
+        app.load_estate = lambda: None                # frozen: tests drive the rail directly
+        async with app.run_test(size=(120, 60)) as pilot:
+            await _settle(pilot)
+            await app.workers.wait_for_complete()  # flush startup workers
+            await pilot.pause()
+            from club3090_cockpit.data import DoctorRead
+
+            app._last_estate_state = EstateState(
+                matched_slug="vllm/dual",
+                containers=[ContainerInfo(
+                    name="llama-cpp-glm53-flash-iq3xxs-moecache",
+                    kind="engine", slug="vllm/dual")],
+                gpus=[GpuInfo(index=0, mem_used_mib=22938),
+                      GpuInfo(index=1, mem_used_mib=22992)],
+                doctor=DoctorRead(reachable=True, serving=True,
+                                  kv_pool_pct=61, summary="serving"),
+            )
+            app._maybe_reparse_vram_split()
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            assert app._vram_split and app._vram_split["ok"]
+            rail = app.query_one("#rail-status", RailStatus)
+            assert "VRAM split · estate" in rail.render().plain
+            app.action_estate_vram_cycle()           # estate -> CUDA0
+            assert "VRAM split · CUDA0" in rail.render().plain
+
+
 @pytest.mark.asyncio
 class TestFix1CursorPreserveAcrossPoll:
     """FIX 1 — the B2 periodic refresh re-populates the scene + container tables


### PR DESCRIPTION
Implements #1118: the estate bar's VRAM figure becomes a component breakdown,
aggregate by default with a per-GPU drill-down (`[G]` cycles).

## Three commits

**1. Parser `--json` + negative-`unaccounted` clamp.** Parse logic extracted into a
pure `breakdown(text)`; `--json` emits one object per device
(`model`/`kv`/`state`/`compute`/`pool`/`used`/`total`/`unaccounted`) plus
`warnings`. Human output is byte-identical for existing fixtures.

The clamp fixes a live defect: run the shipped parser against a log whose
container has stopped and it printed `total=1/24576MiB(0%)` and
**`unaccounted=-22035`** — a silent negative. It is now clamped with a reason:

```
CUDA0: components (22036 MiB) exceed the live total (1 MiB)
       -- the log is staler than the card; unaccounted clamped to 0
```

**2. Service + panel.** `CockpitData.vram_breakdown(container)` reads through the
same runner seam as `bootlog_solve`. Cached per serving container on a 600 s
re-parse stride with live totals every tick — the estate panel polls at ~21 s
(steady) / ~30 s (idle), so re-parsing a long-running container's log per poll
was not an option. Degrades to today's used/total on non-llama.cpp engines; the
moe-cache multi-allocation warning is surfaced rather than swallowed.

**3. §4 — CUDA ordinals joined by PCI bus id.** `vram_breakdown.py` previously
assumed `CUDA<n>` == `nvidia-smi` index `n`, while the composes pin
`device_ids: ['${ESTATE_GPUS:-0,1}']` — so any reorder or single-card subset
attributed a card's breakdown to the wrong GPU, silently, in exactly the drill-down
this issue adds.

The engine already logs the mapping, so it is read from ground truth rather than
inferred:

```
llama_prepare_model_devices: using device CUDA0 (NVIDIA GeForce RTX 3090) (0000:01:00.0)
```

`_fetch_smi()` now queries `pci.bus_id` alongside `index`; `_join_smi()` is
**all-or-nothing** — every ordinal resolves or it falls back to index order **and
says so in `warnings`**. A partial join would be worse than none, since
half-correct attribution is harder to spot than uniformly wrong.

## Verification

- **Guard suite: PASS=133 FAIL=0** on the rebased branch.
- **Cockpit suite: 1124 passed, 1 skipped** — run against this branch's code
  (the editable install resolves to the main checkout, so this was run with that
  checkout detached at this commit; running it from a worktree silently tests
  master's code instead).
- **Crossed-bus regression test**, negative-controlled: a fixture pins CUDA0→bus
  `02:00` and CUDA1→bus `01:00` against `nvidia-smi`'s opposite index order.
  Disabling the join makes it fail —
  `FAIL: PCI-bus join: CUDA0 follows bus 02:00 (20000), CUDA1 bus 01:00 (15000)`
  — so it detects the defect, not just its own fixture. Plus an unresolvable-bus
  fixture proving the fallback is announced.
- `--json` output cross-checked against a hand-verified breakdown of a live GLM +
  DFlash2 boot (`CUDA1 model=3969` = target 3313.42 + drafter 655.73).

## Known and correct

⚠️ The `other ⚠` row still carries the drafter's **1,606 MiB** compute buffer on
DFlash2 boots. That is #1171 defect 3, deliberately left open — the target
re-reserves *after* the drafter loads, so a positional rule is wrong. The panel
reports it honestly rather than papering over it.

Closes #1118.
