### PR TITLE
feat(qwen3.8-27b): port the MAMBA_BLOCK_SIZE knob to the other seven vLLM composes (+ args-array scope gate)

### DIFF
--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
@@ -394,6 +394,8 @@ services:
       # been benched on 3.8 — re-run the A/B before treating 0 as tuned.
       - VLLM_USE_FLASHINFER_SAMPLER=${VLLM_USE_FLASHINFER_SAMPLER:-0}
       - OMP_NUM_THREADS=1
+      - MAMBA_BLOCK_SIZE=${MAMBA_BLOCK_SIZE:-}
+      - MAMBA_CACHE_DTYPE=${MAMBA_CACHE_DTYPE:-}
       # DeepGEMM (vLLM's fp8-GEMM path) is built for Hopper (sm_90) + datacenter
       # Blackwell. Consumer Blackwell (5090 / PRO 6000 / GB10, sm_120/121) has no
       # recipe and hard-fails "recipe not found" at boot (disc #571).
@@ -475,10 +477,28 @@ services:
           echo "[sampler] instruct row (default): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         fi
         SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY},\"repetition_penalty\":$${REPEAT_PENALTY:-1.0}}")
+        # -- Mamba/GDN cache knobs (hybrid-model KV headroom) --
+        #   MAMBA_BLOCK_SIZE=<tokens>  checkpoint SSM state every N tokens (align mode; multiple of 8)
+        #   MAMBA_CACHE_DTYPE=bfloat16 store conv+ssm state in bf16 instead of fp32
+        # Ported from dual/autoround-int4 (#1170). In align mode the GDN/SSM state is
+        # checkpointed at EVERY attention block and those pages come out of the same pool
+        # as attention KV WITHOUT appearing in vLLM's "GPU KV cache size" figure, so the
+        # nominal token count overstates usable capacity. A larger block means fewer
+        # state pages per sequence.
+        # MUST be defined BEFORE the NVLink if/else below: BOTH exec branches reference
+        # MAMBA_ARGS, so defining it inside the then-branch would leave the else-branch
+        # (the no-NVLink path, i.e. most rigs) expanding an unset array -- the knob would
+        # be silently dead exactly where it is most likely to be used.
+        # UNMEASURED ON THIS SLUG: #1170 measured ~20% recovery on dual/autoround-int4
+        # only. The block size align pads to is per-slug, so neither the gap nor the right
+        # value transfers -- probe with live kv_cache_usage_perc first. Off by default.
+        MAMBA_ARGS=()
+        if [ -n "$${MAMBA_BLOCK_SIZE:-}" ]; then MAMBA_ARGS+=(--mamba-block-size "$${MAMBA_BLOCK_SIZE}"); echo "[mamba] block size $${MAMBA_BLOCK_SIZE}" >&2; fi
+        if [ -n "$${MAMBA_CACHE_DTYPE:-}" ]; then MAMBA_ARGS+=(--mamba-cache-dtype "$${MAMBA_CACHE_DTYPE}"); echo "[mamba] cache dtype $${MAMBA_CACHE_DTYPE}" >&2; fi
         if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@" "$${SPEC_ARGS[@]}" "$${ASYNC_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@" "$${SPEC_ARGS[@]}" "$${ASYNC_ARGS[@]}" "$${MAMBA_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
         else
-          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@" "$${SPEC_ARGS[@]}" "$${ASYNC_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@" "$${SPEC_ARGS[@]}" "$${ASYNC_ARGS[@]}" "$${MAMBA_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
         fi
       - --
     command:

--- a/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
@@ -131,6 +131,8 @@ services:
       - VLLM_NO_USAGE_STATS=1
       - VLLM_USE_FLASHINFER_SAMPLER=${VLLM_USE_FLASHINFER_SAMPLER:-0}
       - OMP_NUM_THREADS=1
+      - MAMBA_BLOCK_SIZE=${MAMBA_BLOCK_SIZE:-}
+      - MAMBA_CACHE_DTYPE=${MAMBA_CACHE_DTYPE:-}
       # DeepGEMM: no recipe on consumer Blackwell (5090 / PRO 6000 / GB10,
       # sm_120/121) — the launchers auto-inject VLLM_USE_DEEP_GEMM=0 there
       # (disc #571/#580, NVFP4 follow-up #613). THIS BARE PASS-THROUGH LINE IS
@@ -187,7 +189,22 @@ services:
           echo "[sampler] instruct row (default): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         fi
         SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY}}")
-        exec vllm serve $$AR "$$@" "$${SPEC_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
+        # -- Mamba/GDN cache knobs (hybrid-model KV headroom) --
+        #   MAMBA_BLOCK_SIZE=<tokens>  checkpoint SSM state every N tokens (align mode; multiple of 8)
+        #   MAMBA_CACHE_DTYPE=bfloat16 store conv+ssm state in bf16 instead of fp32
+        # Ported from dual/autoround-int4 (#1170). In align mode the GDN/SSM state is
+        # checkpointed at EVERY attention block and those pages come out of the same
+        # pool as attention KV WITHOUT appearing in vLLM's "GPU KV cache size" figure,
+        # so the nominal token count overstates usable capacity. Raising the block size
+        # cuts the number of state pages per sequence.
+        # UNMEASURED ON THIS SLUG: #1170 measured ~20%% recovery on dual/autoround-int4
+        # only. The block size that align pads to is per-slug, so neither the gap nor
+        # the right value transfers -- probe with live kv_cache_usage_perc before
+        # trusting a number here. Off by default: upstream behaviour is unchanged.
+        MAMBA_ARGS=()
+        if [ -n "$${MAMBA_BLOCK_SIZE:-}" ]; then MAMBA_ARGS+=(--mamba-block-size "$${MAMBA_BLOCK_SIZE}"); echo "[mamba] block size $${MAMBA_BLOCK_SIZE}" >&2; fi
+        if [ -n "$${MAMBA_CACHE_DTYPE:-}" ]; then MAMBA_ARGS+=(--mamba-cache-dtype "$${MAMBA_CACHE_DTYPE}"); echo "[mamba] cache dtype $${MAMBA_CACHE_DTYPE}" >&2; fi
+        exec vllm serve $$AR "$$@" "$${SPEC_ARGS[@]}" "$${MAMBA_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
       - --
     command:
       - --model

--- a/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
@@ -179,6 +179,8 @@ services:
       - VLLM_NO_USAGE_STATS=1
       - VLLM_USE_FLASHINFER_SAMPLER=${VLLM_USE_FLASHINFER_SAMPLER:-0}
       - OMP_NUM_THREADS=1
+      - MAMBA_BLOCK_SIZE=${MAMBA_BLOCK_SIZE:-}
+      - MAMBA_CACHE_DTYPE=${MAMBA_CACHE_DTYPE:-}
       - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
       # ⭐ W4A8 (int8 activations) SHIPS ON — set W4A8=0 for the W4A16 path.
       - W4A8=${W4A8:-1}
@@ -248,7 +250,22 @@ services:
           echo "[sampler] instruct row (default): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         fi
         SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY}}")
-        exec vllm serve $$AR "$$@" "$${SPEC_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
+        # -- Mamba/GDN cache knobs (hybrid-model KV headroom) --
+        #   MAMBA_BLOCK_SIZE=<tokens>  checkpoint SSM state every N tokens (align mode; multiple of 8)
+        #   MAMBA_CACHE_DTYPE=bfloat16 store conv+ssm state in bf16 instead of fp32
+        # Ported from dual/autoround-int4 (#1170). In align mode the GDN/SSM state is
+        # checkpointed at EVERY attention block and those pages come out of the same
+        # pool as attention KV WITHOUT appearing in vLLM's "GPU KV cache size" figure,
+        # so the nominal token count overstates usable capacity. Raising the block size
+        # cuts the number of state pages per sequence.
+        # UNMEASURED ON THIS SLUG: #1170 measured ~20%% recovery on dual/autoround-int4
+        # only. The block size that align pads to is per-slug, so neither the gap nor
+        # the right value transfers -- probe with live kv_cache_usage_perc before
+        # trusting a number here. Off by default: upstream behaviour is unchanged.
+        MAMBA_ARGS=()
+        if [ -n "$${MAMBA_BLOCK_SIZE:-}" ]; then MAMBA_ARGS+=(--mamba-block-size "$${MAMBA_BLOCK_SIZE}"); echo "[mamba] block size $${MAMBA_BLOCK_SIZE}" >&2; fi
+        if [ -n "$${MAMBA_CACHE_DTYPE:-}" ]; then MAMBA_ARGS+=(--mamba-cache-dtype "$${MAMBA_CACHE_DTYPE}"); echo "[mamba] cache dtype $${MAMBA_CACHE_DTYPE}" >&2; fi
+        exec vllm serve $$AR "$$@" "$${SPEC_ARGS[@]}" "$${MAMBA_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
       - --
     command:
       - --model

--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
@@ -285,6 +285,8 @@ services:
       # ⚠️ The supporting A/B is a QWEN3.6 measurement. Nothing is benched on 3.8.
       - VLLM_USE_FLASHINFER_SAMPLER=${VLLM_USE_FLASHINFER_SAMPLER:-0}
       - OMP_NUM_THREADS=1
+      - MAMBA_BLOCK_SIZE=${MAMBA_BLOCK_SIZE:-}
+      - MAMBA_CACHE_DTYPE=${MAMBA_CACHE_DTYPE:-}
       # DeepGEMM (vLLM's fp8-GEMM path) is built for Hopper (sm_90) + datacenter
       # Blackwell. Consumer Blackwell (sm_120/121) has no recipe and hard-fails
       # "recipe not found" at boot (disc #571). switch.sh/launch.sh auto-inject
@@ -358,10 +360,28 @@ services:
           echo "[sampler] instruct row (default): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         fi
         SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY},\"repetition_penalty\":$${REPEAT_PENALTY:-1.0}}")
+        # -- Mamba/GDN cache knobs (hybrid-model KV headroom) --
+        #   MAMBA_BLOCK_SIZE=<tokens>  checkpoint SSM state every N tokens (align mode; multiple of 8)
+        #   MAMBA_CACHE_DTYPE=bfloat16 store conv+ssm state in bf16 instead of fp32
+        # Ported from dual/autoround-int4 (#1170). In align mode the GDN/SSM state is
+        # checkpointed at EVERY attention block and those pages come out of the same pool
+        # as attention KV WITHOUT appearing in vLLM's "GPU KV cache size" figure, so the
+        # nominal token count overstates usable capacity. A larger block means fewer
+        # state pages per sequence.
+        # MUST be defined BEFORE the NVLink if/else below: BOTH exec branches reference
+        # MAMBA_ARGS, so defining it inside the then-branch would leave the else-branch
+        # (the no-NVLink path, i.e. most rigs) expanding an unset array -- the knob would
+        # be silently dead exactly where it is most likely to be used.
+        # UNMEASURED ON THIS SLUG: #1170 measured ~20% recovery on dual/autoround-int4
+        # only. The block size align pads to is per-slug, so neither the gap nor the right
+        # value transfers -- probe with live kv_cache_usage_perc first. Off by default.
+        MAMBA_ARGS=()
+        if [ -n "$${MAMBA_BLOCK_SIZE:-}" ]; then MAMBA_ARGS+=(--mamba-block-size "$${MAMBA_BLOCK_SIZE}"); echo "[mamba] block size $${MAMBA_BLOCK_SIZE}" >&2; fi
+        if [ -n "$${MAMBA_CACHE_DTYPE:-}" ]; then MAMBA_ARGS+=(--mamba-cache-dtype "$${MAMBA_CACHE_DTYPE}"); echo "[mamba] cache dtype $${MAMBA_CACHE_DTYPE}" >&2; fi
         if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@" "$${SPEC_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@" "$${SPEC_ARGS[@]}" "$${MAMBA_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
         else
-          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@" "$${SPEC_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@" "$${SPEC_ARGS[@]}" "$${MAMBA_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
         fi
       - --
     command:

--- a/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
@@ -179,6 +179,8 @@ services:
       - VLLM_NO_USAGE_STATS=1
       - VLLM_USE_FLASHINFER_SAMPLER=${VLLM_USE_FLASHINFER_SAMPLER:-0}
       - OMP_NUM_THREADS=1
+      - MAMBA_BLOCK_SIZE=${MAMBA_BLOCK_SIZE:-}
+      - MAMBA_CACHE_DTYPE=${MAMBA_CACHE_DTYPE:-}
       - PYTORCH_CUDA_ALLOC_CONF=${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}
       # ⭐ W4A8 (int8 activations) SHIPS ON — set W4A8=0 for the W4A16 path.
       - W4A8=${W4A8:-1}
@@ -248,7 +250,22 @@ services:
           echo "[sampler] instruct row (default): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         fi
         SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY}}")
-        exec vllm serve $$AR "$$@" "$${SPEC_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
+        # -- Mamba/GDN cache knobs (hybrid-model KV headroom) --
+        #   MAMBA_BLOCK_SIZE=<tokens>  checkpoint SSM state every N tokens (align mode; multiple of 8)
+        #   MAMBA_CACHE_DTYPE=bfloat16 store conv+ssm state in bf16 instead of fp32
+        # Ported from dual/autoround-int4 (#1170). In align mode the GDN/SSM state is
+        # checkpointed at EVERY attention block and those pages come out of the same
+        # pool as attention KV WITHOUT appearing in vLLM's "GPU KV cache size" figure,
+        # so the nominal token count overstates usable capacity. Raising the block size
+        # cuts the number of state pages per sequence.
+        # UNMEASURED ON THIS SLUG: #1170 measured ~20%% recovery on dual/autoround-int4
+        # only. The block size that align pads to is per-slug, so neither the gap nor
+        # the right value transfers -- probe with live kv_cache_usage_perc before
+        # trusting a number here. Off by default: upstream behaviour is unchanged.
+        MAMBA_ARGS=()
+        if [ -n "$${MAMBA_BLOCK_SIZE:-}" ]; then MAMBA_ARGS+=(--mamba-block-size "$${MAMBA_BLOCK_SIZE}"); echo "[mamba] block size $${MAMBA_BLOCK_SIZE}" >&2; fi
+        if [ -n "$${MAMBA_CACHE_DTYPE:-}" ]; then MAMBA_ARGS+=(--mamba-cache-dtype "$${MAMBA_CACHE_DTYPE}"); echo "[mamba] cache dtype $${MAMBA_CACHE_DTYPE}" >&2; fi
+        exec vllm serve $$AR "$$@" "$${SPEC_ARGS[@]}" "$${MAMBA_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
       - --
     command:
       - --model

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
@@ -289,6 +289,8 @@ services:
       # ⚠️ The supporting A/B is a QWEN3.6 measurement. Nothing is benched on 3.8.
       - VLLM_USE_FLASHINFER_SAMPLER=${VLLM_USE_FLASHINFER_SAMPLER:-0}
       - OMP_NUM_THREADS=1
+      - MAMBA_BLOCK_SIZE=${MAMBA_BLOCK_SIZE:-}
+      - MAMBA_CACHE_DTYPE=${MAMBA_CACHE_DTYPE:-}
       # DeepGEMM (vLLM's fp8-GEMM path) is built for Hopper (sm_90) + datacenter
       # Blackwell. Consumer Blackwell (sm_120/121) has no recipe and hard-fails
       # "recipe not found" at boot (disc #571). switch.sh/launch.sh auto-inject
@@ -362,10 +364,28 @@ services:
           echo "[sampler] instruct row (default): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         fi
         SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY},\"repetition_penalty\":$${REPEAT_PENALTY:-1.0}}")
+        # -- Mamba/GDN cache knobs (hybrid-model KV headroom) --
+        #   MAMBA_BLOCK_SIZE=<tokens>  checkpoint SSM state every N tokens (align mode; multiple of 8)
+        #   MAMBA_CACHE_DTYPE=bfloat16 store conv+ssm state in bf16 instead of fp32
+        # Ported from dual/autoround-int4 (#1170). In align mode the GDN/SSM state is
+        # checkpointed at EVERY attention block and those pages come out of the same pool
+        # as attention KV WITHOUT appearing in vLLM's "GPU KV cache size" figure, so the
+        # nominal token count overstates usable capacity. A larger block means fewer
+        # state pages per sequence.
+        # MUST be defined BEFORE the NVLink if/else below: BOTH exec branches reference
+        # MAMBA_ARGS, so defining it inside the then-branch would leave the else-branch
+        # (the no-NVLink path, i.e. most rigs) expanding an unset array -- the knob would
+        # be silently dead exactly where it is most likely to be used.
+        # UNMEASURED ON THIS SLUG: #1170 measured ~20% recovery on dual/autoround-int4
+        # only. The block size align pads to is per-slug, so neither the gap nor the right
+        # value transfers -- probe with live kv_cache_usage_perc first. Off by default.
+        MAMBA_ARGS=()
+        if [ -n "$${MAMBA_BLOCK_SIZE:-}" ]; then MAMBA_ARGS+=(--mamba-block-size "$${MAMBA_BLOCK_SIZE}"); echo "[mamba] block size $${MAMBA_BLOCK_SIZE}" >&2; fi
+        if [ -n "$${MAMBA_CACHE_DTYPE:-}" ]; then MAMBA_ARGS+=(--mamba-cache-dtype "$${MAMBA_CACHE_DTYPE}"); echo "[mamba] cache dtype $${MAMBA_CACHE_DTYPE}" >&2; fi
         if [ "$${_NVLINK_ENABLED:-0}" = "1" ]; then
-          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@" "$${SPEC_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} "$$@" "$${SPEC_ARGS[@]}" "$${MAMBA_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
         else
-          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@" "$${SPEC_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
+          exec vllm serve $${VLLM_ENFORCE_EAGER:+--enforce-eager} --disable-custom-all-reduce "$$@" "$${SPEC_ARGS[@]}" "$${MAMBA_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
         fi
       - --
     command:

--- a/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
@@ -152,6 +152,8 @@ services:
       - VLLM_NO_USAGE_STATS=1
       - VLLM_USE_FLASHINFER_SAMPLER=${VLLM_USE_FLASHINFER_SAMPLER:-0}
       - OMP_NUM_THREADS=1
+      - MAMBA_BLOCK_SIZE=${MAMBA_BLOCK_SIZE:-}
+      - MAMBA_CACHE_DTYPE=${MAMBA_CACHE_DTYPE:-}
       # DeepGEMM: no recipe on consumer Blackwell (5090 / PRO 6000 / GB10,
       # sm_120/121) — the launchers auto-inject VLLM_USE_DEEP_GEMM=0 there
       # (disc #571/#580, NVFP4 follow-up #613). THIS BARE PASS-THROUGH LINE IS
@@ -208,7 +210,22 @@ services:
           echo "[sampler] instruct row (default): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         fi
         SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY}}")
-        exec vllm serve $$AR "$$@" "$${SPEC_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
+        # -- Mamba/GDN cache knobs (hybrid-model KV headroom) --
+        #   MAMBA_BLOCK_SIZE=<tokens>  checkpoint SSM state every N tokens (align mode; multiple of 8)
+        #   MAMBA_CACHE_DTYPE=bfloat16 store conv+ssm state in bf16 instead of fp32
+        # Ported from dual/autoround-int4 (#1170). In align mode the GDN/SSM state is
+        # checkpointed at EVERY attention block and those pages come out of the same
+        # pool as attention KV WITHOUT appearing in vLLM's "GPU KV cache size" figure,
+        # so the nominal token count overstates usable capacity. Raising the block size
+        # cuts the number of state pages per sequence.
+        # UNMEASURED ON THIS SLUG: #1170 measured ~20%% recovery on dual/autoround-int4
+        # only. The block size that align pads to is per-slug, so neither the gap nor
+        # the right value transfers -- probe with live kv_cache_usage_perc before
+        # trusting a number here. Off by default: upstream behaviour is unchanged.
+        MAMBA_ARGS=()
+        if [ -n "$${MAMBA_BLOCK_SIZE:-}" ]; then MAMBA_ARGS+=(--mamba-block-size "$${MAMBA_BLOCK_SIZE}"); echo "[mamba] block size $${MAMBA_BLOCK_SIZE}" >&2; fi
+        if [ -n "$${MAMBA_CACHE_DTYPE:-}" ]; then MAMBA_ARGS+=(--mamba-cache-dtype "$${MAMBA_CACHE_DTYPE}"); echo "[mamba] cache dtype $${MAMBA_CACHE_DTYPE}" >&2; fi
+        exec vllm serve $$AR "$$@" "$${SPEC_ARGS[@]}" "$${MAMBA_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
       - --
     command:
       - --model

--- a/scripts/tests/test-compose-args-array-scope.sh
+++ b/scripts/tests/test-compose-args-array-scope.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Every "${X_ARGS[@]}" used on an `exec` line must be ASSIGNED at a block depth no
+# deeper than that exec -- i.e. not inside a branch the exec's own path may skip.
+#
+# WHY: a compose entrypoint that ends in `if ...; then exec A; else exec B; fi` will
+# happily accept an array assigned inside ONE branch. The other branch expands an
+# unset array to nothing and the feature is SILENTLY DEAD on that path, while
+# `docker compose config`, `bash -n` and every other gate stay green -- the script
+# is perfectly valid bash.
+#
+# Caught for real: porting #1170's MAMBA_BLOCK_SIZE knob to the fp8 composes put
+# MAMBA_ARGS=() inside the `_NVLINK_ENABLED=1` then-branch. The else-branch is the
+# no-NVLink path -- most rigs, including this one -- so the knob would have shipped
+# dead exactly where it was most likely to be used.
+#
+# ⚠️ Indentation is NOT a sufficient proxy: in these composes the branch execs sit
+# at the same column as a block nudged inside the branch. Depth is tracked from the
+# shell keywords instead.
+set -uo pipefail
+cd "$(dirname "$0")/../.." || exit 1
+
+python3 - <<'PY' || exit 1
+import re, sys, yaml, pathlib
+
+def script_of(path):
+    try: d = yaml.safe_load(open(path))
+    except Exception: return None
+    for svc in (d.get("services") or {}).values():
+        ep = svc.get("entrypoint")
+        if isinstance(ep, list):
+            # NOT ep[-1]: these composes end with a literal "--", and picking it
+            # yields a 2-char string that passes every check vacuously.
+            cand = [e for e in ep if isinstance(e, str) and "exec " in e]
+            if cand: return max(cand, key=len)
+    return None
+
+OPEN  = re.compile(r'^\s*(if|for|while|until|case)\b')
+CLOSE = re.compile(r'^\s*(fi|done|esac)\b')
+ALT   = re.compile(r'^\s*(else|elif)\b')
+ONELINE = re.compile(r'\b(fi|done|esac)\s*;?\s*$')
+
+def scope_paths(lines):
+    """Path of enclosing BRANCH ids per line.  `else`/`elif` starts a NEW id at the
+    same depth, so an assignment in the then-branch does not dominate the
+    else-branch -- which plain depth counting cannot express."""
+    paths, stack, nxt = [], [], [0]
+    def fresh():
+        nxt[0] += 1
+        return nxt[0]
+    for ln in lines:
+        if CLOSE.match(ln) and stack: stack.pop()
+        elif ALT.match(ln) and stack: stack[-1] = fresh()
+        paths.append(tuple(stack))
+        if OPEN.match(ln) and not ONELINE.search(ln): stack.append(fresh())
+    return paths
+
+checked = refs = 0
+problems = []
+
+for p in sorted(pathlib.Path("models").rglob("*.yml")):
+    if "compose" not in str(p): continue
+    s = script_of(p)
+    if not s: continue
+    checked += 1
+    lines = s.splitlines()
+    paths = scope_paths(lines)
+    for i, ln in enumerate(lines):
+        if not re.match(r'^\s*exec\b', ln): continue
+        for arr in set(re.findall(r'\$\{?([A-Z_]+_ARGS)\[@\]', ln)):
+            refs += 1
+            asg = [j for j, l in enumerate(lines) if re.match(rf'^\s*{arr}=\(', l)]
+            if not asg:
+                problems.append(f"{p}: exec uses ${{{arr}[@]}} but it is never assigned"); continue
+            # an assignment dominates the exec iff it comes first AND its branch
+            # path is a prefix of the exec's (same scope, or an enclosing one)
+            ok = any(j < i and paths[i][:len(paths[j])] == paths[j] for j in asg)
+            if not ok:
+                problems.append(
+                    f"{p}: {arr} is assigned only inside a branch that the exec on line "
+                    f"{i+1} does not share -- that path expands an unset array, silently "
+                    f"dropping the feature")
+
+if checked == 0 or refs == 0:
+    print(f"FAIL: vacuous run (checked={checked}, refs={refs}) -- extraction is broken", file=sys.stderr); sys.exit(1)
+for m in problems: print("FAIL: " + m, file=sys.stderr)
+if problems: sys.exit(1)
+print(f"  checked {checked} entrypoints, {refs} array reference(s) -- each assigned before, and no deeper than, every exec that uses it")
+PY
+echo "test-compose-args-array-scope.sh OK"


### PR DESCRIPTION
Follow-up to #1170, which the author flagged as likely applying to every Qwen3.x
hybrid-GDN slug on `align`. It does: all eight `qwen3.8-27b` vLLM composes ship
`${MAMBA_CACHE_MODE:-align}`, so all eight carry the same accounting gap — the
GDN/SSM state is checkpointed at every attention block and those pages come out
of the same pool as attention KV **without appearing in vLLM's "GPU KV cache
size" figure**.

Ports `MAMBA_BLOCK_SIZE` / `MAMBA_CACHE_DTYPE` to the remaining seven:

`dual/fp8` · `dual/nvfp4` · `multi4/autoround-int4` · `multi4/fp8` ·
`multi8/autoround-int4` · `multi8/fp8` · `single/nvfp4`

**Off by default everywhere** — upstream behaviour is byte-identical unless set.

⚠️ Each is commented **UNMEASURED ON THIS SLUG**. #1170's ~20% recovery was
measured on `dual/autoround-int4` on the contributor's reference rig; the block
size `align` pads to is per-slug, so neither the gap nor the `8192` value
transfers. Probe with a live `kv_cache_usage_perc` first. `ASYNC_SCHED` is left
alone — it has its own history via #1139.

## The gate, and why it took three tries

Three of these composes end in `if _NVLINK_ENABLED; then exec A; else exec B; fi`
— **two** exec lines. My first version of this port assigned `MAMBA_ARGS` inside
the then-branch, so the else-branch — the **no-NVLink path, which is what most
rigs including ours actually take** — expanded an unset array. The knob would have
shipped silently dead precisely where it was most likely to be used, and
`docker compose config`, `bash -n` and every existing gate stayed green, because
the script is valid bash either way.

`test-compose-args-array-scope.sh` catches that class across all 123 compose
entrypoints. Getting it right needed three attempts, each of which is a reason the
naive version fails:

1. **Indentation is not branch membership** — the misplaced block sat at the same
   column as the branch execs.
2. **Block depth is not either** — both execs are at the *same* depth, in
   different branches.
3. It now tracks **branch scope**, where `else`/`elif` starts a new scope id, and
   requires an assignment's scope path to be a prefix of the exec's.

It also refuses to pass vacuously: an earlier revision extracted `entrypoint[-1]`,
which in these composes is the literal `"--"`, and cheerfully reported OK having
checked **0 entrypoints**. The gate now fails if it finds nothing to check.

Negative-controlled: re-introducing the defect fails with the branch and line
named; reverting passes.

## Verification

- `test-compose-entrypoint-env-declared`, `test-compose-no-repeated-args`,
  `test-spec-toggle-contract`, `test-compose-status-drift`,
  `test-compose-args-array-scope` — all green
- all 7 composes parse under `docker compose config`
- `MAMBA_ARGS` confirmed assigned before, and in a scope dominating, every exec in
  all 8 composes

No boot test: these are opt-in knobs on `🧪 Experimental` slugs, five of which are
multi-GPU topologies this rig cannot run.
