### PR TITLE
fix(qwen3.8-27b): map reasoning_effort high -> xhigh, not medium

### DIFF
--- a/models/qwen3.8-27b/vllm/patches/qwen38-reasoning-effort-template/PROVENANCE.md
+++ b/models/qwen3.8-27b/vllm/patches/qwen38-reasoning-effort-template/PROVENANCE.md
@@ -1,7 +1,7 @@
 # qwen38-reasoning-effort-template
 
 Vendored copy of Qwen3.8-27B's own `chat_template.jinja` with a **single semantic
-change**: `reasoning_effort: "high"` is mapped onto `medium` instead of raising.
+change**: `reasoning_effort: "high"` is mapped onto `xhigh` instead of raising.
 
 ## The defect
 
@@ -58,18 +58,37 @@ So one vendored file is correct for every slug, and the quantiser is irrelevant.
 
 ## The change
 
-Seven lines inserted before the validation. `high` maps to **`medium`**, the
-un-nudged baseline — the rung with no template branch and no injected preamble.
+A short mapping inserted before the validation. `high` maps to **`xhigh`**,
+Qwen3.8's real top rung.
 
-`xhigh` was the other candidate, and it is the wrong one here. It is Qwen3.8's
-top rung, so it looks like the intent-preserving choice for a caller asking for
-the standard top rung — but it injects a "think carefully, validate assumptions,
-consider alternatives" system preamble that is slow and timeout-prone, and a
-Claude-API client sends `high` on **every** request. Mapping to the top rung
-would therefore put all agent traffic into the slowest reasoning mode by
-default, on slugs that ship `max_num_seqs=1`. medium keeps the request served
-and un-nudged; a caller who genuinely wants the deep mode can still ask for
-`xhigh` by name.
+### Why `xhigh` and not `medium`
+
+The original submission mapped `high` onto `medium`, reasoning that `medium` is
+the un-nudged baseline while `xhigh` injects a "think carefully, validate
+assumptions, consider alternatives" preamble that is slow and timeout-prone — and
+that a Claude-API client sends `high` on *every* request, so mapping to the top
+rung would push all agent traffic into the slowest mode on slugs shipping
+`max_num_seqs=1`. That cost is real and documented in the compose headers.
+
+It was changed to `xhigh` on merge, for three reasons:
+
+1. **Bijection.** `low`/`medium`/`high` maps onto `low`/`medium`/`xhigh` with the
+   ordering intact. Under the `medium` mapping, two distinct client values collapse
+   onto one server behaviour and the top rung becomes **unreachable through
+   standard OpenAI/Anthropic vocabulary at all**.
+2. **These are not a scale with a middle.** `medium` has no template branch and
+   injects nothing. So mapping the top rung there does not hand the caller "one
+   rung down" — it hands them *no reasoning instruction whatsoever*, which is the
+   opposite of what they asked for.
+3. **The cost belongs in the default, not the vocabulary.** Traffic that sends no
+   `reasoning_effort` is governed by the server default (`low`, set via
+   `--default-chat-template-kwargs`) and is unaffected by this mapping. A caller
+   that explicitly sends `high` has opted in. If `xhigh` is too slow for a given
+   agent, the agent should send `medium` — the server should not silently
+   reinterpret the word.
+
+⚠️ The trade this accepts: clients that hardcode `high` land on the slow path.
+That is deliberate, per-request, and reversible by the caller.
 
 Everything else is byte-identical to upstream.
 

--- a/models/qwen3.8-27b/vllm/patches/qwen38-reasoning-effort-template/chat_template.jinja
+++ b/models/qwen3.8-27b/vllm/patches/qwen38-reasoning-effort-template/chat_template.jinja
@@ -45,12 +45,20 @@
 {%- set reasoning_instructions = '' %}
 {%- if enable_thinking is undefined or enable_thinking is true %}
     {%- set resolved_reasoning_effort = reasoning_effort|default('xhigh') %}
-    {#- club-3090 PATCH: Qwen3.8's ladder is low/medium/xhigh with no `high`, so
-        the stock template hard-raises on the value generic OpenAI/Anthropic
-        clients send. Map it onto `medium` -- the un-nudged baseline -- rather
-        than xhigh, whose preamble is slow and timeout-prone. Otherwise upstream. -#}
+    {#- club-3090 PATCH: Qwen3.8's ladder is low/medium/xhigh with no `high`, which
+        OpenAI- and Anthropic-shaped clients send as their TOP rung. Map it onto
+        `xhigh` -- the real top rung -- so the three standard values map bijectively
+        onto the three real ones and the caller's ordinal intent survives.
+        NOT `medium`: these are not a scale with a middle. `medium` has NO branch
+        and injects NOTHING, so mapping the top rung there hands a caller asking
+        for maximum reasoning the un-nudged baseline, and leaves `xhigh`
+        unreachable through standard vocabulary entirely.
+        xhigh's preamble is slower -- that is the caller's trade to make, and it is
+        opt-in per request. Callers that send nothing are unaffected: the server
+        default (`low`, via --default-chat-template-kwargs) still governs them.
+        Otherwise upstream. -#}
     {%- if resolved_reasoning_effort == 'high' %}
-        {%- set resolved_reasoning_effort = 'medium' %}
+        {%- set resolved_reasoning_effort = 'xhigh' %}
     {%- endif %}
     {%- if resolved_reasoning_effort not in ('xhigh', 'medium', 'low') %}
         {{- raise_exception('Unexpected reasoning effort ' ~ reasoning_effort ~ '. Supported types are xhigh (default), medium, and low.') }}


### PR DESCRIPTION
Follow-up to #1094 (merged). The fix is unchanged; only the mapping target moves.

`medium` has no template branch and injects **nothing**. So mapping the top rung
there does not give a caller one rung down — it gives them no reasoning
instruction at all, and leaves `xhigh` unreachable through standard
OpenAI/Anthropic vocabulary entirely. `high` → `xhigh` makes low/medium/high map
bijectively onto low/medium/xhigh with ordering intact.

The submission's cost argument (xhigh is slow; Claude-API clients send `high` on
every request) is real, but belongs in the **default**, not the vocabulary:
traffic sending no `reasoning_effort` is governed by the server default (`low`)
and is untouched here. An explicit `high` is opt-in, and a caller for whom xhigh
is too slow can send `medium`.

Rendered stock vs vendored across the ladder:

| effort | stock | vendored |
|---|---|---|
| low / medium / xhigh / unset | — | byte-identical (same sha256) |
| **high** | **RAISED** | renders identically to `xhigh` (`0a7393b3`) |
| bogus | RAISED | RAISED |

Guards green. PROVENANCE.md records both the original reasoning and why it changed.