### PR TITLE
fix(tests): args-array-scope gate must export PYTHONUTF8 (#779)

### DIFF
--- a/scripts/tests/test-compose-args-array-scope.sh
+++ b/scripts/tests/test-compose-args-array-scope.sh
@@ -17,6 +17,9 @@
 # at the same column as a block nudged inside the branch. Depth is tracked from the
 # shell keywords instead.
 set -uo pipefail
+# #779: this gate parses compose YAML through python3; without PYTHONUTF8 a
+# non-UTF8 locale mangles the entrypoint text and the scan silently misreads.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
 cd "$(dirname "$0")/../.." || exit 1
 
 python3 - <<'PY' || exit 1


### PR DESCRIPTION
`test-compose-args-array-scope.sh` (added in #1182) calls python3 without
exporting `PYTHONUTF8`, which `test-locale-utf8.sh` enforces per #779. Master is
133/1 on it.

Not cosmetic here: the gate reads entrypoint scripts out of YAML and scans them
line by line. Under a non-UTF8 locale the text decodes wrong, the scan misreads,
and it reports a clean pass over composes it never correctly parsed — which is
precisely the vacuous-green failure the gate exists to prevent, and which an
earlier revision of it already committed once by extracting `entrypoint[-1]`.

My regression from #1182. Verified: `test-locale-utf8.sh` exit=0, and the gate
still reports 123 entrypoints / 106 array references.