### PR TITLE
docs(qwen3.8-27b): correct the stale "Vision: ✅ WORKING" header on all 8 vLLM composes (#1181)

### DIFF
--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
@@ -13,7 +13,21 @@
 #   Drafter:   MTP n=4 built-in (SPEC_N override; SPEC_N=0 disables)
 #              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8 -> e4m3 (KV_CACHE_DTYPE override)
-#   Vision:    ✅ WORKING — image + video INPUT, no extra flags (measured 2026-08-16).
+#   Vision:    ⚠️ NOT SERVED on this tier — the vision tower is present (bf16) but
+#              has never been served. The ✅ WORKING claim here was measured
+#              2026-08-16 on the **Avuja** AutoRound export; the fast tier swapped to
+#              **Frozenlock** on 2026-08-20 (#1052 / PR #1070) and vision was never
+#              re-verified across that swap. The profile has said "VISION tower
+#              present (bf16), never served" for this variant all along
+#              (profiles/models/qwen3.8-27b.yml), and `switch.sh --explain` reports
+#              `vision no`. club-3090#1181 reports this tier answering identically
+#              for two DIFFERENT images on a 2x3090.
+#              ⚠️ Do NOT diagnose vision from prompt_tokens: a 256x256 image adds
+#              exactly 66 tokens ((256/16/2)^2 + 2 markers) whether or not an encoder
+#              runs, because the template expands the vision placeholders textually.
+#              ⚠️ Nor from the registry.py:117 "no registered multimodal processor"
+#              warning: tiers that DO see log it too. The only sound test is whether
+#              two different images produce different output.
 #              INPUT ONLY: it consumes media and emits TEXT. No image/video
 #              generation — the arch has no VAE/UNet/diffusion head.
 #              Image: colour+layout described correctly at temp 0 (red/blue/green

--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
@@ -10,7 +10,15 @@
 #              is weight-only, no k_scale/v_scale tensors, and vLLM disables
 #              calculate_kv_scales on this hybrid family). NOT fp8_e5m2 — that is
 #              hard-rejected against an fp8 checkpoint. See "KV choice" below.
-#   Vision:    ✅ WORKING — image + video INPUT, no extra flags (measured 2026-08-16).
+#   Vision:    ⚠️ UNVERIFIED HERE — the checkpoint is vision-capable (the FP8 quant
+#              skips every visual.blocks.* module, and preprocessor_config.json +
+#              video_preprocessor_config.json ship in-repo, so no separate projector
+#              is needed), but the profile records it as NEVER EXERCISED on this
+#              stack. club-3090#1181 reports it answering correctly for two different
+#              images on a 2x3090; that has not been reproduced here.
+#              ⚠️ prompt_tokens rising is NOT evidence of working vision (the vision
+#              placeholders tokenize identically whether or not an encoder runs), and
+#              the registry.py:117 multimodal warning is logged by seeing tiers too.
 #              INPUT ONLY: it consumes media and emits TEXT. No image/video
 #              generation — the arch has no VAE/UNet/diffusion head.
 #              Image: colour+layout described correctly at temp 0 (red/blue/green

--- a/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
@@ -6,7 +6,12 @@
 #   Drafter:   MTP n=3 built-in (SPEC_N override; SPEC_N=0 disables)
 #              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8 -> e4m3 (KV_CACHE_DTYPE override)
-#   Vision:    ✅ WORKING — image + video INPUT, no extra flags (measured 2026-08-16).
+#   Vision:    ⚠️ UNVERIFIED — no vision measurement exists for this variant, and the
+#              profile carries no vision note for it at all. The previous
+#              ✅ WORKING line was inherited from the 2026-08-16 FP8/Avuja
+#              measurement and never applied to this export. Treat as unknown until
+#              probed with two DIFFERENT images (see #1181 for the method and for
+#              why prompt_tokens and the registry.py:117 warning both mislead).
 #              INPUT ONLY: it consumes media and emits TEXT. No image/video
 #              generation — the arch has no VAE/UNet/diffusion head.
 #              Image: colour+layout described correctly at temp 0 (red/blue/green

--- a/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
@@ -13,7 +13,21 @@
 #   Drafter:   MTP n=4 built-in (SPEC_N override; SPEC_N=0 disables)
 #              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8 -> e4m3 (KV_CACHE_DTYPE override)
-#   Vision:    ✅ WORKING — image + video INPUT, no extra flags (measured 2026-08-16).
+#   Vision:    ⚠️ NOT SERVED on this tier — the vision tower is present (bf16) but
+#              has never been served. The ✅ WORKING claim here was measured
+#              2026-08-16 on the **Avuja** AutoRound export; the fast tier swapped to
+#              **Frozenlock** on 2026-08-20 (#1052 / PR #1070) and vision was never
+#              re-verified across that swap. The profile has said "VISION tower
+#              present (bf16), never served" for this variant all along
+#              (profiles/models/qwen3.8-27b.yml), and `switch.sh --explain` reports
+#              `vision no`. club-3090#1181 reports this tier answering identically
+#              for two DIFFERENT images on a 2x3090.
+#              ⚠️ Do NOT diagnose vision from prompt_tokens: a 256x256 image adds
+#              exactly 66 tokens ((256/16/2)^2 + 2 markers) whether or not an encoder
+#              runs, because the template expands the vision placeholders textually.
+#              ⚠️ Nor from the registry.py:117 "no registered multimodal processor"
+#              warning: tiers that DO see log it too. The only sound test is whether
+#              two different images produce different output.
 #              INPUT ONLY: it consumes media and emits TEXT. No image/video
 #              generation — the arch has no VAE/UNet/diffusion head.
 #              Image: colour+layout described correctly at temp 0 (red/blue/green

--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
@@ -18,7 +18,15 @@
 #              (vLLM has no literal `fp16` value for --kv-cache-dtype; `auto`
 #              following a bf16 model dtype IS the 16-bit KV path, and matches
 #              `kv_format="bf16"` in the registry.)
-#   Vision:    ✅ WORKING — image + video INPUT, no extra flags (measured 2026-08-16).
+#   Vision:    ⚠️ UNVERIFIED HERE — the checkpoint is vision-capable (the FP8 quant
+#              skips every visual.blocks.* module, and preprocessor_config.json +
+#              video_preprocessor_config.json ship in-repo, so no separate projector
+#              is needed), but the profile records it as NEVER EXERCISED on this
+#              stack. club-3090#1181 reports it answering correctly for two different
+#              images on a 2x3090; that has not been reproduced here.
+#              ⚠️ prompt_tokens rising is NOT evidence of working vision (the vision
+#              placeholders tokenize identically whether or not an encoder runs), and
+#              the registry.py:117 multimodal warning is logged by seeing tiers too.
 #              INPUT ONLY: it consumes media and emits TEXT. No image/video
 #              generation — the arch has no VAE/UNet/diffusion head.
 #              Image: colour+layout described correctly at temp 0 (red/blue/green

--- a/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
@@ -13,7 +13,21 @@
 #   Drafter:   MTP n=4 built-in (SPEC_N override; SPEC_N=0 disables)
 #              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8 -> e4m3 (KV_CACHE_DTYPE override)
-#   Vision:    ✅ WORKING — image + video INPUT, no extra flags (measured 2026-08-16).
+#   Vision:    ⚠️ NOT SERVED on this tier — the vision tower is present (bf16) but
+#              has never been served. The ✅ WORKING claim here was measured
+#              2026-08-16 on the **Avuja** AutoRound export; the fast tier swapped to
+#              **Frozenlock** on 2026-08-20 (#1052 / PR #1070) and vision was never
+#              re-verified across that swap. The profile has said "VISION tower
+#              present (bf16), never served" for this variant all along
+#              (profiles/models/qwen3.8-27b.yml), and `switch.sh --explain` reports
+#              `vision no`. club-3090#1181 reports this tier answering identically
+#              for two DIFFERENT images on a 2x3090.
+#              ⚠️ Do NOT diagnose vision from prompt_tokens: a 256x256 image adds
+#              exactly 66 tokens ((256/16/2)^2 + 2 markers) whether or not an encoder
+#              runs, because the template expands the vision placeholders textually.
+#              ⚠️ Nor from the registry.py:117 "no registered multimodal processor"
+#              warning: tiers that DO see log it too. The only sound test is whether
+#              two different images produce different output.
 #              INPUT ONLY: it consumes media and emits TEXT. No image/video
 #              generation — the arch has no VAE/UNet/diffusion head.
 #              Image: colour+layout described correctly at temp 0 (red/blue/green

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
@@ -20,7 +20,15 @@
 #              (vLLM has no literal `fp16` value for --kv-cache-dtype; `auto`
 #              following a bf16 model dtype IS the 16-bit KV path, and matches
 #              `kv_format="bf16"` in the registry.)
-#   Vision:    ✅ WORKING — image + video INPUT, no extra flags (measured 2026-08-16).
+#   Vision:    ⚠️ UNVERIFIED HERE — the checkpoint is vision-capable (the FP8 quant
+#              skips every visual.blocks.* module, and preprocessor_config.json +
+#              video_preprocessor_config.json ship in-repo, so no separate projector
+#              is needed), but the profile records it as NEVER EXERCISED on this
+#              stack. club-3090#1181 reports it answering correctly for two different
+#              images on a 2x3090; that has not been reproduced here.
+#              ⚠️ prompt_tokens rising is NOT evidence of working vision (the vision
+#              placeholders tokenize identically whether or not an encoder runs), and
+#              the registry.py:117 multimodal warning is logged by seeing tiers too.
 #              INPUT ONLY: it consumes media and emits TEXT. No image/video
 #              generation — the arch has no VAE/UNet/diffusion head.
 #              Image: colour+layout described correctly at temp 0 (red/blue/green

--- a/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
@@ -6,7 +6,12 @@
 #   Drafter:   MTP n=3 built-in (SPEC_N override; SPEC_N=0 disables)
 #              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8 -> e4m3 (KV_CACHE_DTYPE override)
-#   Vision:    ✅ WORKING — image + video INPUT, no extra flags (measured 2026-08-16).
+#   Vision:    ⚠️ UNVERIFIED — no vision measurement exists for this variant, and the
+#              profile carries no vision note for it at all. The previous
+#              ✅ WORKING line was inherited from the 2026-08-16 FP8/Avuja
+#              measurement and never applied to this export. Treat as unknown until
+#              probed with two DIFFERENT images (see #1181 for the method and for
+#              why prompt_tokens and the registry.py:117 warning both mislead).
 #              INPUT ONLY: it consumes media and emits TEXT. No image/video
 #              generation — the arch has no VAE/UNet/diffusion head.
 #              Image: colour+layout described correctly at temp 0 (red/blue/green


### PR DESCRIPTION
Fixes #1181. All eight vLLM composes carried one line:

```
Vision:    ✅ WORKING — image + video INPUT, no extra flags (measured 2026-08-16).
```

It was wrong on **all three tiers**, in three different ways — and the repo already
contradicted it in each case:

| tier | header claimed | repo actually said |
|---|---|---|
| **autoround-int4** (fast) | ✅ WORKING | *"VISION tower present (bf16), **never served**"* |
| **fp8** (max) | ✅ WORKING, measured | *"vision-capable … ⚠️ **NEVER EXERCISED**"* |
| **nvfp4** | ✅ WORKING | **no vision note at all** |

The INT4 case is the reporter's: the 2026-08-16 measurement was taken on the
**Avuja** export, the tier swapped to **Frozenlock** on 2026-08-20 (#1052 / PR
#1070), and the claim rode across the swap unverified. `switch.sh --explain`
already reports `vision no` for it.

Headers now state what is known per tier, and carry the two traps #1181
documents — both of which make a blind tier look healthy:

- **`prompt_tokens` rising proves nothing.** A 256×256 image adds exactly 66
  tokens (`(256/16/2)² + 2` markers) on a *blind* tier, because the template
  expands the vision placeholders textually whether or not an encoder runs.
- **The `registry.py:117` multimodal warning is a red herring** — tiers that *do*
  see log it too.

Docs only: no `command:`, flag, mount or env change. 8/8 parse; status-drift,
no-repeated-args, locale-utf8 and args-array-scope all green.

A red/blue probe of the three **dual** tiers on this rig follows separately —
this PR removes an unsupported claim rather than substituting our own.