### PR TITLE
docs(qwen3.8-27b): vision headers from measurement — all three dual tiers see (#1181)

### DIFF
--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
@@ -13,30 +13,24 @@
 #   Drafter:   MTP n=4 built-in (SPEC_N override; SPEC_N=0 disables)
 #              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8 -> e4m3 (KV_CACHE_DTYPE override)
-#   Vision:    ⚠️ NOT SERVED on this tier — the vision tower is present (bf16) but
-#              has never been served. The ✅ WORKING claim here was measured
-#              2026-08-16 on the **Avuja** AutoRound export; the fast tier swapped to
-#              **Frozenlock** on 2026-08-20 (#1052 / PR #1070) and vision was never
-#              re-verified across that swap. The profile has said "VISION tower
-#              present (bf16), never served" for this variant all along
-#              (profiles/models/qwen3.8-27b.yml), and `switch.sh --explain` reports
-#              `vision no`. club-3090#1181 reports this tier answering identically
-#              for two DIFFERENT images on a 2x3090.
-#              ⚠️ Do NOT diagnose vision from prompt_tokens: a 256x256 image adds
-#              exactly 66 tokens ((256/16/2)^2 + 2 markers) whether or not an encoder
-#              runs, because the template expands the vision placeholders textually.
+#   Vision:    ✅ MEASURED WORKING on 2 x RTX 3090, 2026-09-06 — image INPUT.
+#              Probe: three solid-colour 256x256 PNGs (red/blue/green), temp=0,
+#              thinking off, "answer with one word: what colour is this image?".
+#              All three tiers answered 3/3 DISTINCT and 3/3 CORRECT:
+#                  dual-fast (Frozenlock INT4)  Red / Blue / Green
+#                  dual-max  (official FP8)     Red / Blue / Green
+#                  dual-nvfp4                   Red / Blue / Green
+#              ⚠️ club-3090#1181 reported dual-fast BLIND (identical '🙂' for every
+#              image) on a different 2x3090. NOT REPRODUCED here; cause unknown, so
+#              treat vision as rig-dependent and re-probe rather than assuming.
+#              ⚠️ VIDEO is NOT covered by this probe, and the INT4 export ships no
+#              video_preprocessor_config.json (FP8/NVFP4 do) — assume video untested.
+#              ⚠️ Do NOT diagnose from prompt_tokens: every request above read
+#              EXACTLY 90 regardless of tier, because the template expands the vision
+#              placeholders textually whether or not an encoder runs.
 #              ⚠️ Nor from the registry.py:117 "no registered multimodal processor"
-#              warning: tiers that DO see log it too. The only sound test is whether
-#              two different images produce different output.
-#              INPUT ONLY: it consumes media and emits TEXT. No image/video
-#              generation — the arch has no VAE/UNet/diffusion head.
-#              Image: colour+layout described correctly at temp 0 (red/blue/green
-#              discriminated, ~66-70 prompt tokens). Video: 3.25s clip, correct
-#              temporal order + the blended transition frame. Smoke test only —
-#              no vision quality gate, no resolution/duration limits explored.
-#              Video cost ~72.7 tok/s @256x256 (36 tok/frame at default fps=2),
-#              scaling with pixel count: 23 @128px, 263 @512px, 583 @768px.
-#              So ~61 min of 256x256 video fits the 262144 window; ~17 min @512px.
+#              warning — all three tiers log it, and all three see. The only sound
+#              test is whether DIFFERENT images produce DIFFERENT output.
 #   Template:  native + club-3090 alias — the model's own chat_template.jinja
 #              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #   Max ctx:   262144 — architectural ceiling, NOT measured on this checkpoint

--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
@@ -10,24 +10,24 @@
 #              is weight-only, no k_scale/v_scale tensors, and vLLM disables
 #              calculate_kv_scales on this hybrid family). NOT fp8_e5m2 — that is
 #              hard-rejected against an fp8 checkpoint. See "KV choice" below.
-#   Vision:    ⚠️ UNVERIFIED HERE — the checkpoint is vision-capable (the FP8 quant
-#              skips every visual.blocks.* module, and preprocessor_config.json +
-#              video_preprocessor_config.json ship in-repo, so no separate projector
-#              is needed), but the profile records it as NEVER EXERCISED on this
-#              stack. club-3090#1181 reports it answering correctly for two different
-#              images on a 2x3090; that has not been reproduced here.
-#              ⚠️ prompt_tokens rising is NOT evidence of working vision (the vision
-#              placeholders tokenize identically whether or not an encoder runs), and
-#              the registry.py:117 multimodal warning is logged by seeing tiers too.
-#              INPUT ONLY: it consumes media and emits TEXT. No image/video
-#              generation — the arch has no VAE/UNet/diffusion head.
-#              Image: colour+layout described correctly at temp 0 (red/blue/green
-#              discriminated, ~66-70 prompt tokens). Video: 3.25s clip, correct
-#              temporal order + the blended transition frame. Smoke test only —
-#              no vision quality gate, no resolution/duration limits explored.
-#              Video cost ~72.7 tok/s @256x256 (36 tok/frame at default fps=2),
-#              scaling with pixel count: 23 @128px, 263 @512px, 583 @768px.
-#              So ~61 min of 256x256 video fits the 262144 window; ~17 min @512px.
+#   Vision:    ✅ MEASURED WORKING on 2 x RTX 3090, 2026-09-06 — image INPUT.
+#              Probe: three solid-colour 256x256 PNGs (red/blue/green), temp=0,
+#              thinking off, "answer with one word: what colour is this image?".
+#              All three tiers answered 3/3 DISTINCT and 3/3 CORRECT:
+#                  dual-fast (Frozenlock INT4)  Red / Blue / Green
+#                  dual-max  (official FP8)     Red / Blue / Green
+#                  dual-nvfp4                   Red / Blue / Green
+#              ⚠️ club-3090#1181 reported dual-fast BLIND (identical '🙂' for every
+#              image) on a different 2x3090. NOT REPRODUCED here; cause unknown, so
+#              treat vision as rig-dependent and re-probe rather than assuming.
+#              ⚠️ VIDEO is NOT covered by this probe, and the INT4 export ships no
+#              video_preprocessor_config.json (FP8/NVFP4 do) — assume video untested.
+#              ⚠️ Do NOT diagnose from prompt_tokens: every request above read
+#              EXACTLY 90 regardless of tier, because the template expands the vision
+#              placeholders textually whether or not an encoder runs.
+#              ⚠️ Nor from the registry.py:117 "no registered multimodal processor"
+#              warning — all three tiers log it, and all three see. The only sound
+#              test is whether DIFFERENT images produce DIFFERENT output.
 #   Template:  native + club-3090 alias — the model's own chat_template.jinja
 #              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #              ⚠️ This is a deliberate break from the qwen3.6-27b composes; see

--- a/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
@@ -6,21 +6,24 @@
 #   Drafter:   MTP n=3 built-in (SPEC_N override; SPEC_N=0 disables)
 #              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8 -> e4m3 (KV_CACHE_DTYPE override)
-#   Vision:    ⚠️ UNVERIFIED — no vision measurement exists for this variant, and the
-#              profile carries no vision note for it at all. The previous
-#              ✅ WORKING line was inherited from the 2026-08-16 FP8/Avuja
-#              measurement and never applied to this export. Treat as unknown until
-#              probed with two DIFFERENT images (see #1181 for the method and for
-#              why prompt_tokens and the registry.py:117 warning both mislead).
-#              INPUT ONLY: it consumes media and emits TEXT. No image/video
-#              generation — the arch has no VAE/UNet/diffusion head.
-#              Image: colour+layout described correctly at temp 0 (red/blue/green
-#              discriminated, ~66-70 prompt tokens). Video: 3.25s clip, correct
-#              temporal order + the blended transition frame. Smoke test only —
-#              no vision quality gate, no resolution/duration limits explored.
-#              Video cost ~72.7 tok/s @256x256 (36 tok/frame at default fps=2),
-#              scaling with pixel count: 23 @128px, 263 @512px, 583 @768px.
-#              So ~61 min of 256x256 video fits the 262144 window; ~17 min @512px.
+#   Vision:    ✅ MEASURED WORKING on 2 x RTX 3090, 2026-09-06 — image INPUT.
+#              Probe: three solid-colour 256x256 PNGs (red/blue/green), temp=0,
+#              thinking off, "answer with one word: what colour is this image?".
+#              All three tiers answered 3/3 DISTINCT and 3/3 CORRECT:
+#                  dual-fast (Frozenlock INT4)  Red / Blue / Green
+#                  dual-max  (official FP8)     Red / Blue / Green
+#                  dual-nvfp4                   Red / Blue / Green
+#              ⚠️ club-3090#1181 reported dual-fast BLIND (identical '🙂' for every
+#              image) on a different 2x3090. NOT REPRODUCED here; cause unknown, so
+#              treat vision as rig-dependent and re-probe rather than assuming.
+#              ⚠️ VIDEO is NOT covered by this probe, and the INT4 export ships no
+#              video_preprocessor_config.json (FP8/NVFP4 do) — assume video untested.
+#              ⚠️ Do NOT diagnose from prompt_tokens: every request above read
+#              EXACTLY 90 regardless of tier, because the template expands the vision
+#              placeholders textually whether or not an encoder runs.
+#              ⚠️ Nor from the registry.py:117 "no registered multimodal processor"
+#              warning — all three tiers log it, and all three see. The only sound
+#              test is whether DIFFERENT images produce DIFFERENT output.
 #   Template:  native + club-3090 alias — the model's own chat_template.jinja
 #              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #   Max ctx:   262144

--- a/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
@@ -13,30 +13,26 @@
 #   Drafter:   MTP n=4 built-in (SPEC_N override; SPEC_N=0 disables)
 #              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8 -> e4m3 (KV_CACHE_DTYPE override)
-#   Vision:    ⚠️ NOT SERVED on this tier — the vision tower is present (bf16) but
-#              has never been served. The ✅ WORKING claim here was measured
-#              2026-08-16 on the **Avuja** AutoRound export; the fast tier swapped to
-#              **Frozenlock** on 2026-08-20 (#1052 / PR #1070) and vision was never
-#              re-verified across that swap. The profile has said "VISION tower
-#              present (bf16), never served" for this variant all along
-#              (profiles/models/qwen3.8-27b.yml), and `switch.sh --explain` reports
-#              `vision no`. club-3090#1181 reports this tier answering identically
-#              for two DIFFERENT images on a 2x3090.
-#              ⚠️ Do NOT diagnose vision from prompt_tokens: a 256x256 image adds
-#              exactly 66 tokens ((256/16/2)^2 + 2 markers) whether or not an encoder
-#              runs, because the template expands the vision placeholders textually.
+#   Vision:    ⚠️ UNPROBED ON THIS TOPOLOGY — the 2-card slug of this same weight
+#              variant measured working 2026-09-06; this multi-GPU topology cannot
+#              be booted on a 2-GPU rig, so it is inference, not measurement.
+#              Probe: three solid-colour 256x256 PNGs (red/blue/green), temp=0,
+#              thinking off, "answer with one word: what colour is this image?".
+#              All three tiers answered 3/3 DISTINCT and 3/3 CORRECT:
+#                  dual-fast (Frozenlock INT4)  Red / Blue / Green
+#                  dual-max  (official FP8)     Red / Blue / Green
+#                  dual-nvfp4                   Red / Blue / Green
+#              ⚠️ club-3090#1181 reported dual-fast BLIND (identical '🙂' for every
+#              image) on a different 2x3090. NOT REPRODUCED here; cause unknown, so
+#              treat vision as rig-dependent and re-probe rather than assuming.
+#              ⚠️ VIDEO is NOT covered by this probe, and the INT4 export ships no
+#              video_preprocessor_config.json (FP8/NVFP4 do) — assume video untested.
+#              ⚠️ Do NOT diagnose from prompt_tokens: every request above read
+#              EXACTLY 90 regardless of tier, because the template expands the vision
+#              placeholders textually whether or not an encoder runs.
 #              ⚠️ Nor from the registry.py:117 "no registered multimodal processor"
-#              warning: tiers that DO see log it too. The only sound test is whether
-#              two different images produce different output.
-#              INPUT ONLY: it consumes media and emits TEXT. No image/video
-#              generation — the arch has no VAE/UNet/diffusion head.
-#              Image: colour+layout described correctly at temp 0 (red/blue/green
-#              discriminated, ~66-70 prompt tokens). Video: 3.25s clip, correct
-#              temporal order + the blended transition frame. Smoke test only —
-#              no vision quality gate, no resolution/duration limits explored.
-#              Video cost ~72.7 tok/s @256x256 (36 tok/frame at default fps=2),
-#              scaling with pixel count: 23 @128px, 263 @512px, 583 @768px.
-#              So ~61 min of 256x256 video fits the 262144 window; ~17 min @512px.
+#              warning — all three tiers log it, and all three see. The only sound
+#              test is whether DIFFERENT images produce DIFFERENT output.
 #   Template:  native + club-3090 alias — the model's own chat_template.jinja
 #              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #   Max ctx:   262144 — architectural ceiling, NOT measured on this checkpoint

--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
@@ -18,24 +18,26 @@
 #              (vLLM has no literal `fp16` value for --kv-cache-dtype; `auto`
 #              following a bf16 model dtype IS the 16-bit KV path, and matches
 #              `kv_format="bf16"` in the registry.)
-#   Vision:    ⚠️ UNVERIFIED HERE — the checkpoint is vision-capable (the FP8 quant
-#              skips every visual.blocks.* module, and preprocessor_config.json +
-#              video_preprocessor_config.json ship in-repo, so no separate projector
-#              is needed), but the profile records it as NEVER EXERCISED on this
-#              stack. club-3090#1181 reports it answering correctly for two different
-#              images on a 2x3090; that has not been reproduced here.
-#              ⚠️ prompt_tokens rising is NOT evidence of working vision (the vision
-#              placeholders tokenize identically whether or not an encoder runs), and
-#              the registry.py:117 multimodal warning is logged by seeing tiers too.
-#              INPUT ONLY: it consumes media and emits TEXT. No image/video
-#              generation — the arch has no VAE/UNet/diffusion head.
-#              Image: colour+layout described correctly at temp 0 (red/blue/green
-#              discriminated, ~66-70 prompt tokens). Video: 3.25s clip, correct
-#              temporal order + the blended transition frame. Smoke test only —
-#              no vision quality gate, no resolution/duration limits explored.
-#              Video cost ~72.7 tok/s @256x256 (36 tok/frame at default fps=2),
-#              scaling with pixel count: 23 @128px, 263 @512px, 583 @768px.
-#              So ~61 min of 256x256 video fits the 262144 window; ~17 min @512px.
+#   Vision:    ⚠️ UNPROBED ON THIS TOPOLOGY — the 2-card slug of this same weight
+#              variant measured working 2026-09-06; this multi-GPU topology cannot
+#              be booted on a 2-GPU rig, so it is inference, not measurement.
+#              Probe: three solid-colour 256x256 PNGs (red/blue/green), temp=0,
+#              thinking off, "answer with one word: what colour is this image?".
+#              All three tiers answered 3/3 DISTINCT and 3/3 CORRECT:
+#                  dual-fast (Frozenlock INT4)  Red / Blue / Green
+#                  dual-max  (official FP8)     Red / Blue / Green
+#                  dual-nvfp4                   Red / Blue / Green
+#              ⚠️ club-3090#1181 reported dual-fast BLIND (identical '🙂' for every
+#              image) on a different 2x3090. NOT REPRODUCED here; cause unknown, so
+#              treat vision as rig-dependent and re-probe rather than assuming.
+#              ⚠️ VIDEO is NOT covered by this probe, and the INT4 export ships no
+#              video_preprocessor_config.json (FP8/NVFP4 do) — assume video untested.
+#              ⚠️ Do NOT diagnose from prompt_tokens: every request above read
+#              EXACTLY 90 regardless of tier, because the template expands the vision
+#              placeholders textually whether or not an encoder runs.
+#              ⚠️ Nor from the registry.py:117 "no registered multimodal processor"
+#              warning — all three tiers log it, and all three see. The only sound
+#              test is whether DIFFERENT images produce DIFFERENT output.
 #   Template:  native + club-3090 alias — the model's own chat_template.jinja
 #              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #              See the dual sibling's "Chat template" section for the full diff.

--- a/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
@@ -13,30 +13,26 @@
 #   Drafter:   MTP n=4 built-in (SPEC_N override; SPEC_N=0 disables)
 #              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8 -> e4m3 (KV_CACHE_DTYPE override)
-#   Vision:    ⚠️ NOT SERVED on this tier — the vision tower is present (bf16) but
-#              has never been served. The ✅ WORKING claim here was measured
-#              2026-08-16 on the **Avuja** AutoRound export; the fast tier swapped to
-#              **Frozenlock** on 2026-08-20 (#1052 / PR #1070) and vision was never
-#              re-verified across that swap. The profile has said "VISION tower
-#              present (bf16), never served" for this variant all along
-#              (profiles/models/qwen3.8-27b.yml), and `switch.sh --explain` reports
-#              `vision no`. club-3090#1181 reports this tier answering identically
-#              for two DIFFERENT images on a 2x3090.
-#              ⚠️ Do NOT diagnose vision from prompt_tokens: a 256x256 image adds
-#              exactly 66 tokens ((256/16/2)^2 + 2 markers) whether or not an encoder
-#              runs, because the template expands the vision placeholders textually.
+#   Vision:    ⚠️ UNPROBED ON THIS TOPOLOGY — the 2-card slug of this same weight
+#              variant measured working 2026-09-06; this multi-GPU topology cannot
+#              be booted on a 2-GPU rig, so it is inference, not measurement.
+#              Probe: three solid-colour 256x256 PNGs (red/blue/green), temp=0,
+#              thinking off, "answer with one word: what colour is this image?".
+#              All three tiers answered 3/3 DISTINCT and 3/3 CORRECT:
+#                  dual-fast (Frozenlock INT4)  Red / Blue / Green
+#                  dual-max  (official FP8)     Red / Blue / Green
+#                  dual-nvfp4                   Red / Blue / Green
+#              ⚠️ club-3090#1181 reported dual-fast BLIND (identical '🙂' for every
+#              image) on a different 2x3090. NOT REPRODUCED here; cause unknown, so
+#              treat vision as rig-dependent and re-probe rather than assuming.
+#              ⚠️ VIDEO is NOT covered by this probe, and the INT4 export ships no
+#              video_preprocessor_config.json (FP8/NVFP4 do) — assume video untested.
+#              ⚠️ Do NOT diagnose from prompt_tokens: every request above read
+#              EXACTLY 90 regardless of tier, because the template expands the vision
+#              placeholders textually whether or not an encoder runs.
 #              ⚠️ Nor from the registry.py:117 "no registered multimodal processor"
-#              warning: tiers that DO see log it too. The only sound test is whether
-#              two different images produce different output.
-#              INPUT ONLY: it consumes media and emits TEXT. No image/video
-#              generation — the arch has no VAE/UNet/diffusion head.
-#              Image: colour+layout described correctly at temp 0 (red/blue/green
-#              discriminated, ~66-70 prompt tokens). Video: 3.25s clip, correct
-#              temporal order + the blended transition frame. Smoke test only —
-#              no vision quality gate, no resolution/duration limits explored.
-#              Video cost ~72.7 tok/s @256x256 (36 tok/frame at default fps=2),
-#              scaling with pixel count: 23 @128px, 263 @512px, 583 @768px.
-#              So ~61 min of 256x256 video fits the 262144 window; ~17 min @512px.
+#              warning — all three tiers log it, and all three see. The only sound
+#              test is whether DIFFERENT images produce DIFFERENT output.
 #   Template:  native + club-3090 alias — the model's own chat_template.jinja
 #              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #   Max ctx:   262144 — architectural ceiling, NOT measured on this checkpoint

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
@@ -20,24 +20,26 @@
 #              (vLLM has no literal `fp16` value for --kv-cache-dtype; `auto`
 #              following a bf16 model dtype IS the 16-bit KV path, and matches
 #              `kv_format="bf16"` in the registry.)
-#   Vision:    ⚠️ UNVERIFIED HERE — the checkpoint is vision-capable (the FP8 quant
-#              skips every visual.blocks.* module, and preprocessor_config.json +
-#              video_preprocessor_config.json ship in-repo, so no separate projector
-#              is needed), but the profile records it as NEVER EXERCISED on this
-#              stack. club-3090#1181 reports it answering correctly for two different
-#              images on a 2x3090; that has not been reproduced here.
-#              ⚠️ prompt_tokens rising is NOT evidence of working vision (the vision
-#              placeholders tokenize identically whether or not an encoder runs), and
-#              the registry.py:117 multimodal warning is logged by seeing tiers too.
-#              INPUT ONLY: it consumes media and emits TEXT. No image/video
-#              generation — the arch has no VAE/UNet/diffusion head.
-#              Image: colour+layout described correctly at temp 0 (red/blue/green
-#              discriminated, ~66-70 prompt tokens). Video: 3.25s clip, correct
-#              temporal order + the blended transition frame. Smoke test only —
-#              no vision quality gate, no resolution/duration limits explored.
-#              Video cost ~72.7 tok/s @256x256 (36 tok/frame at default fps=2),
-#              scaling with pixel count: 23 @128px, 263 @512px, 583 @768px.
-#              So ~61 min of 256x256 video fits the 262144 window; ~17 min @512px.
+#   Vision:    ⚠️ UNPROBED ON THIS TOPOLOGY — the 2-card slug of this same weight
+#              variant measured working 2026-09-06; this multi-GPU topology cannot
+#              be booted on a 2-GPU rig, so it is inference, not measurement.
+#              Probe: three solid-colour 256x256 PNGs (red/blue/green), temp=0,
+#              thinking off, "answer with one word: what colour is this image?".
+#              All three tiers answered 3/3 DISTINCT and 3/3 CORRECT:
+#                  dual-fast (Frozenlock INT4)  Red / Blue / Green
+#                  dual-max  (official FP8)     Red / Blue / Green
+#                  dual-nvfp4                   Red / Blue / Green
+#              ⚠️ club-3090#1181 reported dual-fast BLIND (identical '🙂' for every
+#              image) on a different 2x3090. NOT REPRODUCED here; cause unknown, so
+#              treat vision as rig-dependent and re-probe rather than assuming.
+#              ⚠️ VIDEO is NOT covered by this probe, and the INT4 export ships no
+#              video_preprocessor_config.json (FP8/NVFP4 do) — assume video untested.
+#              ⚠️ Do NOT diagnose from prompt_tokens: every request above read
+#              EXACTLY 90 regardless of tier, because the template expands the vision
+#              placeholders textually whether or not an encoder runs.
+#              ⚠️ Nor from the registry.py:117 "no registered multimodal processor"
+#              warning — all three tiers log it, and all three see. The only sound
+#              test is whether DIFFERENT images produce DIFFERENT output.
 #   Template:  native + club-3090 alias — the model's own chat_template.jinja
 #              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #              See the dual sibling's "Chat template" section for the full diff.

--- a/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
@@ -6,21 +6,26 @@
 #   Drafter:   MTP n=3 built-in (SPEC_N override; SPEC_N=0 disables)
 #              Toggle: SPEC_N=<n> sets depth; SPEC_N=0 (or SPEC=off) disables
 #   KV:        fp8 -> e4m3 (KV_CACHE_DTYPE override)
-#   Vision:    ⚠️ UNVERIFIED — no vision measurement exists for this variant, and the
-#              profile carries no vision note for it at all. The previous
-#              ✅ WORKING line was inherited from the 2026-08-16 FP8/Avuja
-#              measurement and never applied to this export. Treat as unknown until
-#              probed with two DIFFERENT images (see #1181 for the method and for
-#              why prompt_tokens and the registry.py:117 warning both mislead).
-#              INPUT ONLY: it consumes media and emits TEXT. No image/video
-#              generation — the arch has no VAE/UNet/diffusion head.
-#              Image: colour+layout described correctly at temp 0 (red/blue/green
-#              discriminated, ~66-70 prompt tokens). Video: 3.25s clip, correct
-#              temporal order + the blended transition frame. Smoke test only —
-#              no vision quality gate, no resolution/duration limits explored.
-#              Video cost ~72.7 tok/s @256x256 (36 tok/frame at default fps=2),
-#              scaling with pixel count: 23 @128px, 263 @512px, 583 @768px.
-#              So ~61 min of 256x256 video fits the 262144 window; ~17 min @512px.
+#   Vision:    ⚠️ UNPROBED ON THIS TOPOLOGY — the DUAL slug of this same NVFP4
+#              variant measured working 2026-09-06; this SINGLE-card topology was
+#              not booted, so it is inference, not measurement.
+#              Probe: three solid-colour 256x256 PNGs (red/blue/green), temp=0,
+#              thinking off, "answer with one word: what colour is this image?".
+#              All three tiers answered 3/3 DISTINCT and 3/3 CORRECT:
+#                  dual-fast (Frozenlock INT4)  Red / Blue / Green
+#                  dual-max  (official FP8)     Red / Blue / Green
+#                  dual-nvfp4                   Red / Blue / Green
+#              ⚠️ club-3090#1181 reported dual-fast BLIND (identical '🙂' for every
+#              image) on a different 2x3090. NOT REPRODUCED here; cause unknown, so
+#              treat vision as rig-dependent and re-probe rather than assuming.
+#              ⚠️ VIDEO is NOT covered by this probe, and the INT4 export ships no
+#              video_preprocessor_config.json (FP8/NVFP4 do) — assume video untested.
+#              ⚠️ Do NOT diagnose from prompt_tokens: every request above read
+#              EXACTLY 90 regardless of tier, because the template expands the vision
+#              placeholders textually whether or not an encoder runs.
+#              ⚠️ Nor from the registry.py:117 "no registered multimodal processor"
+#              warning — all three tiers log it, and all three see. The only sound
+#              test is whether DIFFERENT images produce DIFFERENT output.
 #   Template:  native + club-3090 alias — the model's own chat_template.jinja
 #              with `high` remapped to `medium` (patches/qwen38-reasoning-effort-template)
 #   Max ctx:   65536 — NOT the architectural ceiling; see the VRAM note


### PR DESCRIPTION
Follow-up to #1185. That PR removed a stale `✅ WORKING (measured 2026-08-16)`
claim and replaced it with per-tier "not served" / "unverified" text taken from
the profile notes. **Those replacements were too pessimistic.** Probed on this rig:

Three solid-colour 256×256 PNGs, `temp=0`, thinking off, *"answer with one word:
what colour is this image?"*

| slug | red | blue | green | verdict |
|---|---|---|---|---|
| `dual-fast` (Frozenlock INT4) | Red | Blue | Green | **SEES** 3/3 |
| `dual-max` (official FP8) | Red | Blue | Green | **SEES** 3/3 |
| `dual-nvfp4` | Red | Blue | Green | **SEES** 3/3 |

#1185's *"VISION tower present, never served"* for the INT4 tier was my misreading:
the profile meant never **exercised**, not **incapable**. It has now been exercised.

⚠️ **#1181's finding is not reproduced.** They measured `dual-fast` blind
(identical `'🙂'` for every image) on a different 2×3090 at `8abac569`. Cause
unknown, so the headers say vision is rig-dependent and to re-probe rather than assume.

### Scope kept honest

- `multi4`/`multi8` → **UNPROBED ON THIS TOPOLOGY**. Same weights, but a 2-GPU rig
  cannot boot them — inference, not measurement.
- `single/nvfp4` → **also unprobed**: the *dual* nvfp4 slug was probed, not the
  single-card one. (Caught in review; it was briefly marked measured on the
  strength of a different topology.)
- **Video not covered** — and the INT4 export ships no
  `video_preprocessor_config.json` while FP8/NVFP4 do.

### Both #1181 traps held here, and are recorded inline

- `prompt_tokens` read **exactly 90** on every request across all three tiers,
  seeing or not. Not a signal.
- The `registry.py:117` multimodal warning is logged by all three tiers, all of
  which see.

Structural note: **the checkpoints cannot tell you.** All three carry the complete
333-tensor vision tower, all BF16, unquantized, identical `vision_config`. Vision
here is a *runtime* property.

8/8 parse; status-drift, no-repeated-args, locale-utf8 green.