### PR TITLE
fix(tests): test-bench-capture must start the bench right after the first stats sample (#1137)

### DIFF
--- a/scripts/tests/test-bench-capture.sh
+++ b/scripts/tests/test-bench-capture.sh
@@ -502,9 +502,31 @@ start_server() {   # $1=scenario $2=port [extra env as VAR=VAL ...]
   SRV_PID="$(cat "$pidfile" 2>/dev/null || true)"
   [[ -n "$SRV_PID" && -r "/proc/$SRV_PID/cmdline" ]] \
     || fail "$scen: fake server did not report a readable pid — the run would not be hermetic"
-  # let the periodic cache stats emit at least one cumulative sample first, so the
-  # marginal derivation has a genuine "before" to difference against
-  sleep 2
+  # #1137: proceed AS SOON AS the first stats sample exists -- do not sleep a
+  # fixed duration. The marginal derivation differences two periodic samples, and
+  # it needs the SECOND one to land INSIDE the bench window.
+  #
+  # Measured 2026-09-06: the fake server emits its first sample at ~0.9 s
+  # (iters=9 on every scenario), and the interval is ~1 s. The old `sleep 2`
+  # therefore did not "wait too little" -- it waited too MUCH: samples at ~0.9 s
+  # and ~1.9 s both landed BEFORE the bench started at t=2, so the window had no
+  # delta to difference and the derivation was skipped with
+  # `win_miss=0 miss=0`. Waiting LESS is what fixes it: the bench starts right
+  # after the first sample, and the next one lands inside the window.
+  #
+  # On this box the old form failed DETERMINISTICALLY (2/2 with win_miss=0), not
+  # intermittently; the variation seen across sweeps was bench-duration
+  # sensitivity, not randomness. The condition wait is 2/2 here and 5/5 including
+  # under deliberate 6-way CPU load.
+  local _s
+  for _s in $(seq 1 200); do
+    command grep -q '\[moe-cache\].*hits=' "$SRV_LOG" 2>/dev/null && break
+    sleep 0.1
+  done
+  command grep -q '\[moe-cache\].*hits=' "$SRV_LOG" 2>/dev/null \
+    || fail "$scen: fake server emitted no [moe-cache] hits= sample in 20s -- the
+       marginal derivation would have no 'before' to difference against
+       (GGML_CUDA_MOE_CACHE_STATS=1000 set?)"
 }
 
 run_bench() {   # $1=scenario $2=port $3=outfile [extra bench env ...]


### PR DESCRIPTION
Closes #1137.

The RAM-derivation assertion failed because the derivation was skipped with
`win_miss=0 miss=0`. The fixture's `sleep 2` was the cause — **but not in the
direction its own comment claimed.**

### Measured, not assumed

Instrumenting the wait showed the fake server emits its first `[moe-cache] hits=`
sample at **~0.9 s** (`iters=9` on *every* scenario), with a ~1 s interval. So
`sleep 2` did not wait too *little* — it waited too **much**: samples at ~0.9 s and
~1.9 s both landed **before** the bench started at t=2, leaving the measurement
window with no delta to difference. Waiting *less* is what fixes it.

| version | run 1 | run 2 |
|---|---|---|
| `sleep 2` | exit=1, `win_miss=0 miss=0` | exit=1, `win_miss=0 miss=0` |
| condition wait | exit=0, derived OK | exit=0, derived OK |

Plus **5/5 green** on the condition wait, including two runs under deliberate
6-way CPU load.

### Two framing corrections the measurement forced

1. **It is not a flake on this box — it fails deterministically (2/2).** The
   variation across sweeps was bench-duration sensitivity, not randomness. That is
   why it looked intermittent, and why this issue was closed once on a green sweep
   and had to be reopened.
2. **An earlier revision of this branch asserted the opposite mechanism** (that the
   sleep raced the emit). Instrumenting disproved it. That wrong explanation is not
   shipped — the comment now states what was measured.

### Deliberately unchanged

The `NOT DERIVED` → `fail` branch from the previous #1137 fix stays a hard failure.
With the window now deterministic, a skipped derivation is a real defect rather
than a timing artefact, so it should be loud.