### PR TITLE
fix(preflight): gpu-fit failure gives Linux-only advice that is a dead end on WSL (#1134)

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -697,6 +697,20 @@ preflight_compose_gpu_fit() {
   echo "[preflight]        Fix: free that VRAM, or lower the ceiling —" >&2
   echo "[preflight]             GPU_MEMORY_UTILIZATION=0.90 bash scripts/switch.sh <variant>" >&2
   echo "[preflight]        — then retry.  (Bypass this check with --force.)" >&2
+    # club-3090#1134: on WSL the advice above is a dead end. nvidia-smi INSIDE the
+    # VM reports "No running processes found" while the card is nearly full,
+    # because the VRAM is held by WINDOWS-side processes it cannot see -- and
+    # `docker ps` will not show them either. A user following the Linux advice
+    # finds nothing and concludes the gate is wrong, then reaches for --force.
+    if grep -qiE 'microsoft|wsl' /proc/version 2>/dev/null; then
+      echo "[preflight]        WSL DETECTED -- the advice above needs adjusting:" >&2
+      echo "[preflight]          nvidia-smi in WSL says 'No running processes found' even when the card" >&2
+      echo "[preflight]          is full. The VRAM is held on the WINDOWS side and is invisible here;" >&2
+      echo "[preflight]          'docker ps' will not show it. Check Windows Task Manager > Performance" >&2
+      echo "[preflight]          > GPU instead, and close browsers (hardware acceleration), games and" >&2
+      echo "[preflight]          launchers, and anything driving the display." >&2
+      echo "[preflight]          --force does NOT free memory: vLLM will still abort after loading." >&2
+    fi
   if [[ "$force" == "1" ]]; then
     echo "[preflight] WARN:  --force set — launching anyway; vLLM may still abort at the free-memory check." >&2
     return 0


### PR DESCRIPTION
The free-VRAM gate already **catches** the #1134 case correctly. What fails is the
**diagnosis it offers**.

Its remediation says *"something else is holding VRAM … check `docker ps`"*. On WSL
that leads nowhere:

- `nvidia-smi` **inside** WSL reports `No running processes found` while the card is
  nearly full — the VRAM is held by **Windows-side** processes it cannot see;
- `docker ps` will not show them either.

So the user follows the advice, finds nothing holding the memory, reasonably
concludes the gate is wrong, and reaches for `--force` — which warns, launches
anyway, and lets vLLM abort after the load.

That is exactly #1134's path: 2×3090 under WSL2, **17,461 and 20,079 MiB already
consumed at idle** with `No running processes found`, launched with `--force`,
container crashes after the model loads. Against `gpu_memory_utilization=0.90` the
compose needs ~21.7 GiB/card and had ~7.1 and ~4.5 free.

Adds a WSL-gated hint on that failure path: point at **Windows Task Manager >
Performance > GPU** rather than `docker ps`, and say plainly that **`--force` does
not free memory**.

No behaviour change — same gate, same exit codes, extra lines only when
`/proc/version` reports microsoft/wsl. Verified silent on this rig (a QEMU VM) and
verified to render under a simulated WSL `/proc/version`.