### PR TITLE
fix(tests): repair the generate-compose fixtures #1188 broke

### DIFF
--- a/scripts/tests/test-generate-compose.sh
+++ b/scripts/tests/test-generate-compose.sh
@@ -183,12 +183,29 @@ for prof in GOLDEN:
     finally:
         os.unlink(gen_file)
 
-# At least one golden carries a real delivery-gap (the correction-#4 case).
+# The `wired` classification must be exercised by real data, not just structurally
+# present. Do NOT re-pin this to a specific dead patch: it was previously asserted
+# on qwen-vllm-pr35936-required-fallback, which club-3090#1188 correctly removed
+# from consideration (the overlay had been inert for two engine pins), and this
+# check went red as collateral. Assert against a patch that is genuinely wired.
 _, m_min = gc.generate(root, "vllm/minimal")
-check("qwen-qwen3coder-tool-parser-deferred-commit" in m_min["undelivered"],
-      "vllm/minimal must surface the qwen3coder delivery-gap as undelivered")
-check("qwen-vllm-pr35936-required-fallback" in m_min["wired"],
-      "vllm/minimal must wire the pr35936 fallback")
+check("qwen-froggeric-chat-template" in m_min["wired"],
+      f"vllm/minimal must wire the froggeric chat template (got {m_min['wired']})")
+
+# ⚠️ COVERAGE GAP, deliberately visible rather than silently dropped.
+# `undelivered` (the correction-#4 delivery-gap path) has NO live example any
+# more: qwen-qwen3coder-tool-parser-deferred-commit was the only patch that
+# produced one, and #1188 removed it after club-3090#1012 showed it patches a file
+# that no longer exists on any supported pin. Every golden now returns [].
+# So this asserts only the SHAPE. If a patch with a real delivery gap reappears,
+# restore a value assertion here -- a structural check cannot catch a classifier
+# that silently stops populating the list.
+check(isinstance(m_min["undelivered"], list),
+      "generate() must always return an `undelivered` list")
+check(m_min["undelivered"] == [],
+      f"no patch currently has a delivery gap; if this fires, a real fixture is "
+      f"available again and the value assertion above should be restored "
+      f"(got {m_min['undelivered']})")
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
#1188 cleared `load_bearing_when` on the two dormant patches — correct, they had
been inert for two engine pins (#1012). But `test-generate-compose.sh` used those
two patches as its **fixtures** for the `wired` and `undelivered` classifications,
so removing them from consideration took the test red.

| | `test-generate-compose.sh` |
|---|---|
| `6dc74115` (before #1188) | **exit=0** |
| current master | **exit=1** |

**`wired`** → re-pointed at `qwen-froggeric-chat-template`, which `vllm/minimal`
genuinely wires.

**`undelivered`** → has **no live example any more**; every golden returns `[]`.
Rather than delete the check and quietly lose the coverage, it asserts the shape
*and* asserts the list is empty, with a comment saying to restore a value
assertion if a real delivery-gap fixture reappears. A structural check cannot
catch a classifier that silently stops populating the list — that limitation is
now visible in the test instead of waiting to be discovered.

My regression. Two process notes, because both mattered:

- I ran `test-patch-attribution`, `test-compose-mounts-resolve` and
  `test-locale-utf8` for #1188 but **not** `test-generate-compose` — the other
  consumer of `load_bearing_when`. A `patches.yml` edit should run everything that
  reads it.
- I then cited a `PASS=134 FAIL=0` sweep as evidence master was green. **That sweep
  started before #1188 merged.** A green sweep is evidence only about the commit it
  ran on.

Negative-controlled: breaking the wired assertion fails the test; restoring passes.