### PR TITLE
fix(verify): stop reporting a crash when the model returns no content

### DIFF
--- a/scripts/tests/test-verify-stress-ladder-verdict.sh
+++ b/scripts/tests/test-verify-stress-ladder-verdict.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Guard: the ceiling-ladder verdict chain in verify-stress.sh must classify every
+# combination of ladder outcomes, and must NOT fall through to the "engine may
+# have crashed early" catch-all for cases the ladder body deliberately produces.
+#
+# Why this exists: the chain shipped without a branch for "recall missed, nothing
+# failed, nothing passed" — the exact state the ladder body creates when it breaks
+# on a first-rung recall miss ("break out of the ladder, and pass the probe"). Two
+# community 4x3090 GLM reports (#1128/#1129) were scored as hard FAILs telling the
+# reporter to go looking for an engine crash that never happened, on a rig whose
+# every other check passed. A ladder verdict that can say "crashed" when nothing
+# crashed is worse than no verdict, so each state is pinned here.
+set -uo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+SRC="scripts/verify-stress.sh"
+[[ -f "$SRC" ]] || { echo "FAIL: $SRC not found"; exit 1; }
+
+START='if [[ "$any_fail" == "0" && "$any_pass" == "1" ]]; then'
+END='fail "ceiling ladder: no rung succeeded and none were skipped"'
+s=$(command grep -n -F "$START" "$SRC" | head -1 | cut -d: -f1)
+e=$(command grep -n -F "$END"   "$SRC" | head -1 | cut -d: -f1)
+[[ -n "$s" && -n "$e" && "$e" -gt "$s" ]] || { echo "FAIL: could not locate the verdict chain (anchors moved?)"; exit 1; }
+CHAIN=$(mktemp); trap 'rm -f "$CHAIN"' EXIT
+sed -n "${s},$((e+2))p" "$SRC" > "$CHAIN"
+
+# Refuse a vacuous run: the extract must actually be the chain.
+lines=$(wc -l < "$CHAIN")
+[[ "$lines" -ge 20 ]] || { echo "FAIL: extracted only $lines lines — not the verdict chain"; exit 1; }
+for needle in 'any_sizing_error' 'any_skipped' 'ceiling ladder'; do
+  command grep -q -- "$needle" "$CHAIN" || { echo "FAIL: extract missing '$needle' — wrong region"; exit 1; }
+done
+
+rc=0
+check() {
+  local name="$1" expect="$2" setup="$3"
+  local out verdict
+  out=$( set +e
+    pass() { echo "PASS|$1"; return 0; }
+    fail() { echo "FAIL|$1"; return 1; }
+    skip() { echo "SKIP|$1"; return 0; }
+    any_pass=0 any_fail=0 any_skipped=0 any_recall_miss=0 any_recall_empty=0 any_sizing_error=0
+    first_fail_tokens=0 first_recall_miss_tokens=94000 first_recall_miss_pct=46
+    last_pass_tokens=0 last_pass_pct=0 rung_count=5 ceiling_start=95000 n_ctx=204800
+    vram_after_all=0 vram_before_all=0 vram_margin_mb=800 tok_per_scale_unit=63
+    LOG_CMD="docker logs X"
+    eval "$setup"
+    source "$CHAIN" 2>&1 | head -1 )
+  verdict="${out%%|*}"
+  if [[ "$verdict" == "$expect" ]]; then
+    echo "  ok   $name -> $verdict"
+  else
+    echo "  FAIL $name -> got '$verdict', want '$expect'"; rc=1
+  fi
+}
+
+echo "verify-stress ceiling-ladder verdict states:"
+# The reported regression: model returned no content, system filled the rung.
+check "empty content, system OK   " SKIP 'any_recall_miss=1; any_recall_empty=1'
+# Genuine wrong answer on the first rung — the ladder body's documented intent.
+check "recall miss, system OK     " PASS 'any_recall_miss=1'
+# NEGATIVE CONTROLS — these must keep failing.
+check "true crash (nothing ran)   " FAIL 'true'
+check "OOM wall after passes      " FAIL 'any_pass=1; any_fail=1'
+check "recall miss then OOM       " FAIL 'any_recall_miss=1; any_fail=1'
+check "all rungs rejected (400)   " FAIL 'any_skipped=1'
+check "filler sizing error        " FAIL 'any_sizing_error=1'
+check "clean sweep, all rungs pass" PASS 'any_pass=1'
+
+[[ "$rc" == "0" ]] && echo "PASS: all ladder verdict states classified" || echo "FAIL: ladder verdict regression"
+exit "$rc"

--- a/scripts/verify-full.sh
+++ b/scripts/verify-full.sh
@@ -553,7 +553,12 @@ check_output_quality() {
 import sys, json, re
 try:
     d = json.load(sys.stdin)
-    c = d['choices'][0]['message'].get('content') or ''
+    msg = d['choices'][0]['message']
+    c = msg.get('content') or ''
+    # Thinking models put the reasoning elsewhere; an empty content with a
+    # non-empty reasoning trace is a spent budget, not a dead generator.
+    r = msg.get('reasoning_content') or msg.get('reasoning') or ''
+    rlen = len(r)
     finish = d['choices'][0].get('finish_reason') or 'n/a'
     clen = len(c)
     cascade = 'tool_call_cascade' if '<tool_call>' in c else 'none'
@@ -570,14 +575,20 @@ try:
     words = re.findall(r\"[A-Za-z']+\", c.lower())
     sample = words[:200]
     variety = (len(set(sample)) / len(sample)) if sample else 0.0
-    print(f'{clen}|{cascade}|{max_repeat}|{variety:.3f}|{finish}')
+    print(f'{clen}|{cascade}|{max_repeat}|{variety:.3f}|{finish}|{rlen}')
 except Exception as e:
-    print(f'err|{e}|0|0|n/a')
+    print(f'err|{e}|0|0|n/a|0')
 " 2>/dev/null)"
 
-  IFS='|' read -r clen cascade max_repeat variety finish <<< "$analysis"
+  IFS='|' read -r clen cascade max_repeat variety finish rlen <<< "$analysis"
   if [[ "$clen" == "err" ]]; then
     fail "couldn't parse response: $cascade" "$(echo "$resp" | head -c 200)"
+  elif [[ "${clen:-0}" == "0" && "$finish" == "length" ]]; then
+    # finish=length means tokens WERE generated — they just never reached content.
+    # On a thinking model whose thinking switch is inert, the reasoning trace eats
+    # the whole budget. That is not a silent generation failure and must not be
+    # scored as one (see GLM-5.3-Flash: no per-request thinking switch takes effect).
+    skip "coherence INCONCLUSIVE — no content but ${rlen:-0} reasoning chars, finish=length (budget spent on reasoning; raise max_tokens or disable thinking)"
   elif [[ "${clen:-0}" == "0" ]]; then
     fail "empty completion (finish=${finish})" "Likely silent generation failure"
   elif [[ "$cascade" == "tool_call_cascade" ]]; then

--- a/scripts/verify-stress.sh
+++ b/scripts/verify-stress.sh
@@ -1544,6 +1544,10 @@ with open('${cal_req}', 'w') as f:
 
   # Step 3: run each rung
   local any_pass=0 any_fail=0 any_skipped=0 any_recall_miss=0 any_sizing_error=0
+  # A recall miss with EMPTY content is not a quality result — the model returned
+  # nothing to score (thinking models can spend the whole budget on reasoning).
+  # Tracked separately so it is never reported as an attention-quality ceiling.
+  local any_recall_empty=0
   local last_pass_tokens=0 last_pass_pct=0
   local first_fail_tokens=0 first_recall_miss_tokens=0 first_recall_miss_pct=0
   local vram_before_all vram_after_all
@@ -1628,8 +1632,17 @@ with open('${cal_req}', 'w') as f:
         done
         local pct=0
         [[ "$prompt_tok" -gt 0 && "$n_ctx" -gt 0 ]] && pct=$(( prompt_tok * 100 / n_ctx ))
-        local outcome="recalled"
-        [[ "$all_match" == "1" ]] || outcome="recall_miss"
+        local outcome="recalled" recall_empty=0 miss_label="quality ceiling reached"
+        if [[ "$all_match" != "1" ]]; then
+          outcome="recall_miss"
+          # Whitespace-only content = the model produced no answer at all. That is
+          # NOT an attention-quality ceiling (it shows up even at trivial depth) —
+          # classify it INCONCLUSIVE and say so.
+          if [[ -z "$(printf '%s' "$content_raw" | tr -d '[:space:]')" ]]; then
+            outcome="recall_empty"; recall_empty=1
+            miss_label="no content returned — INCONCLUSIVE, recall not scorable"
+          fi
+        fi
         record_rung "ceiling_ladder" "${rung_idx}" "${target_tokens}" "200" "$outcome" \
           "$prompt_tok" "$prefill_tps" "$prefill_ms" "$hit_delta" "$cache_dirty"
         if [[ "$all_match" == "1" ]]; then
@@ -1644,10 +1657,11 @@ with open('${cal_req}', 'w') as f:
           # Log it, break out of the ladder, and pass the probe so the
           # pipeline moves to the next stage without wasting time on
           # unreliable depths.
-          printf "    \033[33m△\033[0m rung %d/%d: target=%dK  actual=%dK tok (%d%%)  recall MISS (got: '%s') — quality ceiling reached%s%s\n" \
+          printf "    \033[33m△\033[0m rung %d/%d: target=%dK  actual=%dK tok (%d%%)  recall MISS (got: '%s') — %s%s%s\n" \
             "$rung_idx" "$rung_count" "$((target_tokens / 1000))" "$((prompt_tok / 1000))" "$pct" \
-            "$(echo "$content_raw" | head -c 60 | tr '\n' ' ')" "$prefill_str" "$vram_str"
+            "$(echo "$content_raw" | head -c 60 | tr '\n' ' ')" "$miss_label" "$prefill_str" "$vram_str"
           any_recall_miss=1
+          [[ "$recall_empty" == "1" ]] && any_recall_empty=1
           if [[ "$first_recall_miss_tokens" -eq 0 ]]; then
             first_recall_miss_tokens="$prompt_tok"
             first_recall_miss_pct="$pct"
@@ -1763,6 +1777,19 @@ with open('${cal_req}', 'w') as f:
   elif [[ "$any_fail" == "1" ]]; then
     fail "ceiling ladder: first rung at ${ceiling_start} tok already failed — ceiling may be below probe 7 range" \
          "Check whether the engine survived probe 7's 90K rung. If not, the ceiling is <90K. Check: ${LOG_CMD}"
+  elif [[ "$any_recall_empty" == "1" && "$any_fail" == "0" ]]; then
+    # The ladder ran, the system filled the rung, but the model returned no content
+    # so recall could not be scored. Not a system failure, and NOT a quality ceiling
+    # (it shows up at trivial depth too). INCONCLUSIVE — counts in neither bucket.
+    skip "ceiling ladder INCONCLUSIVE — system filled ${first_recall_miss_tokens} tok, model returned no content (recall not scorable)"
+    printf "    \033[33m→\033[0m %s\n" "On thinking models this is the reasoning budget consuming the whole completion."
+    printf "      %s\n" "Disable thinking for this model or raise max_tokens. The engine did NOT crash."
+  elif [[ "$any_recall_miss" == "1" && "$any_fail" == "0" ]]; then
+    # Recall missed on the first rung and the loop broke there by design (see the
+    # ladder body: "break out of the ladder, and pass the probe"). Without this
+    # branch that intent was lost and the run fell through to the catch-all below,
+    # reporting a crash that never happened.
+    pass "ceiling ladder: quality ceiling at or below the first rung (${first_recall_miss_tokens} tok, ${first_recall_miss_pct:-?}% of n_ctx=${n_ctx}) — system filled it, recall missed"
   elif [[ "$any_pass" == "0" && "$any_skipped" == "1" ]]; then
     # All rungs got legitimate HTTP 400 (target > n_ctx) — ladder measured nothing.
     # This is NOT a pass. A ladder that tested nothing must warn.


### PR DESCRIPTION
Closes #1128. Closes #1129.

Two community 4×3090 GLM-5.3-Flash reports came back as hard **FAIL** on rigs where everything else passed. Neither rig was at fault, and — importantly — **the multi4 composes are not either.**

The control is in the same reporter's own submissions: **#1127**, qwen3.8-flash-next on the *same four cards*, recalled all five ceiling rungs up to 188K tokens (91% of `n_ctx`) and passed every stage. #1126 (TP2) likewise. So the topology is fine; the difference is the model, and both failures were ours.

## What went wrong

**Ceiling ladder verdict (`verify-stress.sh`)**

The ladder body breaks on a first-rung recall miss, and its own comment states the intent — *"break out of the ladder, and pass the probe"*. The verdict chain had no branch for the state that produces: recall missed, nothing failed, nothing passed. It fell through to the catch-all:

```
✗ ceiling ladder: no rung succeeded and none were skipped
  → Engine may have crashed early.
```

Nothing crashed. The engine filled a 94K-token rung at 234 t/s and reported free VRAM. The reporter was sent to hunt a crash that never happened.

Two branches added, both for `any_fail == 0`:
- genuine recall miss → **passes** as a quality ceiling at or below the first rung, matching how probes 1 and 7 already score the identical outcome (*"system OK, quality ceiling reached"*)
- whitespace-only content → **INCONCLUSIVE**, reported as *recall not scorable*

That second distinction matters. Empty content is not an attention-quality ceiling — in #1129 it appears at **9,538 tokens**, far below any plausible ceiling. Calling it a quality ceiling put a quality claim on a model that had simply returned nothing.

**Coherence check (`verify-full.sh`)**

`empty completion (finish=length)` was scored as a silent generation failure. But `finish=length` means tokens *were* generated and never reached `content` — on a thinking model whose per-request thinking switch is inert, that is the reasoning trace consuming the whole budget. Now INCONCLUSIVE, with the reasoning length reported. An empty completion with any other finish reason still fails.

## Guard

`test-verify-stress-ladder-verdict.sh` pins all eight ladder verdict states against the real chain, extracted by anchor and refusing a vacuous run. Run against the **pre-fix** script it fails on exactly the two states these reports hit:

```
FAIL empty content, system OK    -> got 'FAIL', want 'SKIP'
FAIL recall miss, system OK      -> got 'FAIL', want 'PASS'
ok   true crash (nothing ran)    -> FAIL
ok   OOM wall after passes       -> FAIL
ok   recall miss then OOM        -> FAIL
ok   all rungs rejected (400)    -> FAIL
ok   filler sizing error         -> FAIL
```

Every negative control still fails as it should, so the branches did not simply widen into a pass.

## Not fixed here

#1129 also shows 2/25 soak turns returning `500 Failed to parse tool call arguments as JSON: parse error at line 1, column 74`. That is a real engine/parser issue on GLM tool calls, unrelated to the harness, and wants its own issue.

Reported-by: @shaxs
