### PR TITLE
fix(verify): detect thinking-only models instead of assuming a dial means OFF

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1716,6 +1716,18 @@ preflight_detect_thinking_control() {
       # (scenario 3's no-regression promise holds). Only a demonstrably-IGNORED
       # switch is downgraded to `none` — which is what makes the caller widen its
       # token budgets instead of blaming the model.
+      # ⚠️ The scan proves a template NAMES a key. Its SILENCE proves nothing:
+      # in endpoint-first mode (--url, no container) there is no template to scan
+      # at all, and a reasoning_effort-only model is then declared switch-less.
+      # That is how a GLM-5.3-Flash run reported `thinking-control=none off={}
+      # on={}` while the dial worked perfectly -- and the resulting TOK_SCALE=64
+      # then masked it on the short checks while [8] still failed. When the scan
+      # comes back empty, ask the SERVER before believing it.
+      if [[ "$THINK_CONTROL" == "none" ]] && [[ "${THINK_PROBE:-0}" == "1" ]] \
+         && [[ -n "$model" ]] && curl -sf -m 5 "${url%/}/v1/models" >/dev/null 2>&1 \
+         && [[ "$(_preflight_probe_thinking_key "$url" "$model" '{"reasoning_effort": "low"}')" != "0" ]]; then
+        THINK_CONTROL="reasoning_effort"
+      fi
       if [[ "$THINK_CONTROL" != "none" ]] && [[ "${THINK_PROBE:-0}" == "1" ]] \
          && [[ -n "$model" ]] && curl -sf -m 5 "${url%/}/v1/models" >/dev/null 2>&1; then
         local _off_probe_kw=""
@@ -1752,6 +1764,21 @@ preflight_detect_thinking_control() {
                 THINK_EFFORT_OFF_VALUE="$_lvl"; break
               fi
             done
+            # ⚠️ A DIAL IS NOT AN OFF SWITCH — three states, not two.
+            # GLM-5.3-Flash accepts only low|high (everything else, `none` included,
+            # coerces to MAX) and has NO zero-reasoning level: even the minimum still
+            # spends tokens thinking. Consumers size token budgets on "can this be
+            # turned off", so a model with a working dial but no off position got the
+            # un-widened budget — ~30 tokens against ~30 tokens of unavoidable
+            # reasoning — which reads downstream as empty content and gets blamed on
+            # the model (#1128, #1129). Measure it and say so.
+            if [[ -n "${THINK_EFFORT_OFF_VALUE:-}" ]]; then
+              local _off_rlen
+              _off_rlen="$(_preflight_probe_thinking_reasoning "$url" "$model" "{\"reasoning_effort\": \"${THINK_EFFORT_OFF_VALUE}\"}")"
+              if [[ "$_off_rlen" =~ ^[0-9]+$ ]] && (( _off_rlen > 0 )); then
+                THINK_ALWAYS_ON=1
+              fi
+            fi
             if [[ -z "${THINK_EFFORT_OFF_VALUE:-}" ]]; then
               THINK_CONTROL="none"
             else
@@ -1829,6 +1856,8 @@ preflight_detect_thinking_control() {
   # it directly instead of parsing the fragment above.
   THINK_OFF_STD=''
   THINK_ON_STD=''
+  # 1 = model always reasons, even at its lowest level (dial, but no OFF).
+  THINK_ALWAYS_ON="${THINK_ALWAYS_ON:-0}"
   THINK_EFFORT_OFF_VALUE="${THINK_EFFORT_OFF_VALUE:-}"
   THINK_EFFORT_ON_VALUE="${THINK_EFFORT_ON_VALUE:-}"
   THINK_OFF_EFFORT=''

--- a/scripts/tests/test-thinking-probe-optin.sh
+++ b/scripts/tests/test-thinking-probe-optin.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Guard: every FUNCTIONAL check that grades response CONTENT must opt into the
+# thinking effort-ladder probe (THINK_PROBE=1) before calling the detector.
+#
+# Without it the detector stops at the template SCAN, which proves only that a key
+# is NAMED. For the GLM-5.3 family the scan's off-value `reasoning_effort: "none"`
+# is not a valid level -- the template accepts only low|high and coerces anything
+# else to MAX -- so "thinking off" becomes the strongest possible thinking request.
+# The model then spends its whole budget reasoning and returns empty content, and
+# every content-grading check reads that as a model failure. verify-stress.sh
+# shipped without the opt-in and failed two community 4x3090 reports that way
+# (#1128, #1129), scoring a healthy rig as broken.
+#
+# MEASUREMENT scripts (bench*, soak, concurrency) are deliberately NOT listed:
+# the probe fires real requests and they must not perturb their own numbers.
+set -uo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+rc=0
+for f in scripts/verify-full.sh scripts/verify.sh scripts/verify-stress.sh; do
+  [[ -f "$f" ]] || { echo "  FAIL $f missing"; rc=1; continue; }
+  if ! command grep -q 'preflight_detect_thinking_control' "$f"; then
+    echo "  skip $f (does not use the detector)"; continue
+  fi
+  # THINK_PROBE=1 must appear BEFORE the detector call, not merely somewhere.
+  probe_ln=$(command grep -n '^\s*THINK_PROBE=1' "$f" | head -1 | cut -d: -f1)
+  call_ln=$(command grep -n '^\s*preflight_detect_thinking_control' "$f" | head -1 | cut -d: -f1)
+  if [[ -z "$probe_ln" ]]; then
+    echo "  FAIL $f calls the detector without THINK_PROBE=1 -> ladder skipped, invalid off-value used"
+    rc=1
+  elif [[ -z "$call_ln" || "$probe_ln" -ge "$call_ln" ]]; then
+    echo "  FAIL $f sets THINK_PROBE=1 at line $probe_ln, at/after the call on $call_ln"
+    rc=1
+  else
+    echo "  ok   $f (THINK_PROBE=1 on $probe_ln, detector on $call_ln)"
+  fi
+done
+[[ "$rc" == "0" ]] && echo "PASS: content-grading checks opt into the effort ladder" || echo "FAIL: thinking-probe opt-in regression"
+exit "$rc"

--- a/scripts/verify-full.sh
+++ b/scripts/verify-full.sh
@@ -184,7 +184,14 @@ fi
 # would then fire instead. Scale both together. Every model with a detected
 # switch is unaffected: the multiplier is 1 and the timeouts are unchanged.
 TOK_SCALE=1
-[[ "$THINK_CONTROL" == none* ]] && TOK_SCALE="${VERIFY_TOK_SCALE:-64}"
+# Widen for BOTH "no switch at all" and "switch exists but has no OFF position".
+# The second case is a thinking-only model (GLM-5.3-Flash: the dial accepts only
+# low|high and every level still reasons). It used to fall through to TOK_SCALE=1
+# and got a 30-token budget against ~30 tokens of unavoidable reasoning, which
+# surfaces as "empty completion" and reads as a model fault rather than a budget.
+if [[ "$THINK_CONTROL" == none* || "${THINK_ALWAYS_ON:-0}" == "1" ]]; then
+  TOK_SCALE="${VERIFY_TOK_SCALE:-64}"
+fi
 MT_BASIC=$(( 30 * TOK_SCALE ))
 MT_STREAM=$(( 120 * TOK_SCALE ))
 if (( TOK_SCALE > 1 )); then

--- a/scripts/verify-stress.sh
+++ b/scripts/verify-stress.sh
@@ -174,7 +174,11 @@ content = (
 req = {
     "model": model,
     "messages": [{"role": "user", "content": content}],
-    "max_tokens": 30,
+    # A thinking-only model spends part of every budget reasoning before it can
+    # answer (GLM-5.3-Flash: ~30 tokens even at its lowest level), so a flat 30
+    # leaves nothing for the phrase and the needle reads as a recall miss.
+    # preflight sets NEEDLE_MAX_TOKENS from THINK_ALWAYS_ON.
+    "max_tokens": int(os.environ.get("NEEDLE_MAX_TOKENS") or 30),
     "temperature": 0.0,
     **json.loads(os.environ.get("THINK_FRAG_OFF") or '{"chat_template_kwargs": {"enable_thinking": false}}'),
     }
@@ -365,11 +369,27 @@ MODEL="${MODEL:-qwen3.6-27b}"
 # failures. See preflight.sh::preflight_detect_thinking_control. THINK_FRAG_*
 # is the complete request fragment, splatted by the python blocks below.
 if declare -F preflight_detect_thinking_control >/dev/null; then
+  # Opt in to the effort-ladder probe. Without it the detector stops at the
+  # template SCAN, which only proves a key is NAMED — and for the GLM-5.3 family
+  # the scan's default off-value `reasoning_effort: "none"` is not a valid level.
+  # The template accepts only low|high and coerces everything else to MAX, so the
+  # "thinking off" request was the strongest possible thinking request: the model
+  # spent the whole budget reasoning, returned empty content, and every needle in
+  # the ladder above read as a recall failure (#1128, #1129). The ladder probe
+  # walks minimal|low|medium and finds a level that actually yields content.
+  # Same reasoning as verify-full.sh: this is a functional check, and one extra
+  # request is cheap next to a ladder that can run for 400s per rung.
+  THINK_PROBE=1
   preflight_detect_thinking_control
 else
   THINK_FRAG_OFF='{"chat_template_kwargs": {"enable_thinking": false}}'
   THINK_FRAG_ON='{"chat_template_kwargs": {"enable_thinking": true}}'
 fi
+# Needle replies are a short phrase, so 30 tokens is right for a model that can
+# actually stop thinking. One that cannot needs room for the reasoning first.
+NEEDLE_MAX_TOKENS=30
+[[ "${THINK_ALWAYS_ON:-0}" == "1" ]] && NEEDLE_MAX_TOKENS="${VERIFY_NEEDLE_MAX_TOKENS:-512}"
+export NEEDLE_MAX_TOKENS
 export THINK_FRAG_OFF THINK_FRAG_ON
 if [[ -z "${CONTAINER:-}" && -f "${ROOT_DIR}/scripts/lib/registry-lookup.sh" ]]; then
   # The old literal default 'vllm-qwen36-27b' matches NO registry container, so


### PR DESCRIPTION
Follows #1194. That PR stopped the harness reporting a crash when a model returned no content; this one fixes **why** the content was missing.

## The third state

The detector modelled two states — *has a switch* / *has none* — and sized token budgets on that binary. There is a third: **a working effort dial with no OFF position.** GLM-5.3-Flash is one, and its template is explicit:

```jinja
{%- set effective_reasoning_effort = reasoning_effort if reasoning_effort is defined
    and reasoning_effort in ['low', 'high'] else 'max' -%}
```

Only `low` and `high` are accepted. Everything else — `none` included — coerces to **`max`**. So the "thinking off" request we were sending was the *strongest possible* thinking request. Measured on a live dual IQ3_XXS:

| `reasoning_effort` | finish | content | reasoning | answer |
|---|---|---|---|---|
| `none` → **max** | length | **0 ch** | 1367 ch | `''` |
| `low` | stop | 18 ch | 96 ch | ✅ correct |
| `high` | stop | 18 ch | 266 ch | ✅ correct |

This also retires an earlier stack note claiming no per-request thinking switch works on GLM. It works — we were sending a value the template rejects.

## Three gaps

**1. A dial was treated as an OFF switch.** `verify-full` widened budgets only for `THINK_CONTROL==none`, so a thinking-only model got 30 tokens against ~30 tokens of unavoidable reasoning and returned empty content — read downstream as a model fault. preflight now measures reasoning at the chosen minimum level, exports `THINK_ALWAYS_ON`, and both consumers honour it (`verify-stress`'s flat `max_tokens: 30` for needles now scales too).

**2. The ladder was gated behind the template scan.** In endpoint-first mode (`--url`, no container) there is no template to scan, so a `reasoning_effort`-only model was declared switch-less. A GLM rebench reported `thinking-control=none off={} on={}` while the dial worked perfectly — and the resulting `TOK_SCALE=64` masked it on short checks while the 2K-token quality check still failed. The scan's *silence* is no longer taken as an answer.

**3. The fallback probe only tried `enable_thinking`**, never `reasoning_effort`, so that path could not see this family at all.

`verify-stress` also now opts into the probe, as `verify-full` and `verify.sh` already did. The comment directly above that call already described this exact failure — *"full effort through the whole longctx ladder, blowing the tight token budgets ... for reasons that look like recall failures"* — so the intent was there and only the opt-in was missing.

## Why it matters beyond one model

An inert or mis-valued thinking switch does not fail loudly. It fails as **somebody else's bad score** — every content-grading check reads the model as degraded. That is how two community 4×3090 reports (#1128, #1129) failed a healthy rig, and it means GLM quality numbers taken under the old path were measured at max reasoning with empty content.

## Testing

Guard suite green: `thinking-control`, `verify-stress-ceiling`, `verify-stress-salt`, `ladder-verdict`, and the new `test-thinking-probe-optin.sh` (which asserts `THINK_PROBE=1` is set *before* the detector call; measurement scripts deliberately excluded since the probe fires real requests). The ladder was verified selecting `off={"reasoning_effort": "low"}` against a live GLM endpoint.

⚠️ **End-to-end `verify-stress` on GLM is still pending** — a rebench is in flight and I did not want probe traffic perturbing its numbers. I'll post the ladder result here before this is merged.
