### PR TITLE
fix(preflight): give the thinking probe enough budget to see a thinking-only model

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1635,13 +1635,21 @@ except Exception:
 # python3 — callers keep working defaults. Overridden by VERIFY_THINK_OFF /
 # VERIFY_THINK_ON (plain JSON objects).
 _preflight_probe_thinking_key() {
+  # ⚠️ THE PROBE'S OWN BUDGET MUST CLEAR THE MINIMUM REASONING, or a
+  # thinking-only model is undetectable BY CONSTRUCTION. At 24 tokens
+  # GLM-5.3-Flash at its lowest level returns finish=length with 98 chars of
+  # reasoning and EMPTY content -- so every level scores 0, the ladder finds no
+  # working level, and the model is declared switch-less. Measured at
+  # reasoning_effort=low: 24 tok -> content='' (length); 256 tok -> content='OK.'
+  # (stop). 256 still discriminates, because a high-effort level burns straight
+  # through it (max: 1367 chars of reasoning, no content, at 300 tok).
   # Echo the content length a trivial question returns under the given kwargs.
   # A working off-switch answers in a few tokens; an ignored one burns the whole
   # budget reasoning and returns empty content.
   local url="$1" model="$2" kwargs="$3"
   curl -sf -m 90 "${url%/}/v1/chat/completions" \
     -H "Content-Type: application/json" \
-    -d "{\"model\": \"${model}\", \"messages\": [{\"role\": \"user\", \"content\": \"Say OK.\"}], \"max_tokens\": 24, \"temperature\": 0.0, \"chat_template_kwargs\": ${kwargs}}" 2>/dev/null \
+    -d "{\"model\": \"${model}\", \"messages\": [{\"role\": \"user\", \"content\": \"Say OK.\"}], \"max_tokens\": 256, \"temperature\": 0.0, \"chat_template_kwargs\": ${kwargs}}" 2>/dev/null \
     | python3 -c "import sys,json; print(len((json.load(sys.stdin)['choices'][0]['message'].get('content') or '').strip()))" 2>/dev/null \
     || echo 0
 }


### PR DESCRIPTION
Follow-up to #1196, and a correction to it.

## The bug

The probe that decides whether an effort level "works" asks a trivial question with `max_tokens: 24` and checks whether any content came back. A model that cannot stop reasoning spends that budget before reaching content, so **every** level scores 0, the ladder finds no working level, and the model is declared switch-less. A thinking-only model is undetectable by construction.

Measured on GLM-5.3-Flash IQ3_XXS at `reasoning_effort: low`, using the probe's own `"Say OK."` prompt:

| `max_tokens` | finish | content | reasoning |
|---|---|---|---|
| **24** (shipped) | `length` | `''` | 98 chars |
| 256 | `stop` | `'OK.'` | 129 chars |

256 still discriminates rather than blessing every level — a high-effort level burns straight through it (`reasoning_effort: max` gave 1367 chars of reasoning and no content at 300 tokens), so the OFF ladder still rejects it.

This is #1196's own bug one level down: a token budget sized for a model that can be told to stop thinking.

## ⚠️ This does not finish the job

With it applied, the detector **still** returns `off={"reasoning_effort": "none"}`, `OFF_VALUE` unset, in ~5 seconds against a live GLM endpoint. The ladder is still not being reached — something earlier in `preflight_detect_thinking_control` short-circuits before it, and I have not found what.

So **#1196's end-to-end goal is not met.** I merged that PR describing it as fixing thinking-only detection; on the model it was written for, it does not yet. This removes one blocker of at least two. Please don't treat the detection work as closed on the strength of this PR.

## Verification

Verified against a live endpoint rather than only the guard suite — which is what I should have done before merging #1196. Supplying the effort value by hand:

```
VERIFY_THINK_OFF='{"reasoning_effort": "low"}' bash scripts/verify-stress.sh
```

```
thinking-control='reasoning_effort (off overridden)'  off={"reasoning_effort": "low"}
✓  9,540 tokens: recalled 'silver otter 15'    prefill=302.9 t/s
✓ 28,439 tokens: recalled 'amber capybara 10'  prefill=331.8 t/s
```

Those are the rungs that returned `' '` and were scored `recall MISS — quality ceiling reached` in #1128/#1129. There was no attention ceiling at 9.5K; it was a spent budget. That override is the workaround until autodetection is fixed.
