### PR TITLE
fix(preflight): judge thinking levels by reasoning length, not "did it answer"

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1635,13 +1635,21 @@ except Exception:
 # python3 — callers keep working defaults. Overridden by VERIFY_THINK_OFF /
 # VERIFY_THINK_ON (plain JSON objects).
 _preflight_probe_thinking_key() {
+  # ⚠️ THE PROBE'S OWN BUDGET MUST CLEAR THE MINIMUM REASONING, or a
+  # thinking-only model is undetectable BY CONSTRUCTION. At 24 tokens
+  # GLM-5.3-Flash at its lowest level returns finish=length with 98 chars of
+  # reasoning and EMPTY content -- so every level scores 0, the ladder finds no
+  # working level, and the model is declared switch-less. Measured at
+  # reasoning_effort=low: 24 tok -> content='' (length); 256 tok -> content='OK.'
+  # (stop). 256 still discriminates, because a high-effort level burns straight
+  # through it (max: 1367 chars of reasoning, no content, at 300 tok).
   # Echo the content length a trivial question returns under the given kwargs.
   # A working off-switch answers in a few tokens; an ignored one burns the whole
   # budget reasoning and returns empty content.
   local url="$1" model="$2" kwargs="$3"
   curl -sf -m 90 "${url%/}/v1/chat/completions" \
     -H "Content-Type: application/json" \
-    -d "{\"model\": \"${model}\", \"messages\": [{\"role\": \"user\", \"content\": \"Say OK.\"}], \"max_tokens\": 24, \"temperature\": 0.0, \"chat_template_kwargs\": ${kwargs}}" 2>/dev/null \
+    -d "{\"model\": \"${model}\", \"messages\": [{\"role\": \"user\", \"content\": \"Say OK.\"}], \"max_tokens\": 256, \"temperature\": 0.0, \"chat_template_kwargs\": ${kwargs}}" 2>/dev/null \
     | python3 -c "import sys,json; print(len((json.load(sys.stdin)['choices'][0]['message'].get('content') or '').strip()))" 2>/dev/null \
     || echo 0
 }

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1666,6 +1666,32 @@ _preflight_probe_thinking_reasoning_both() {
     || echo 0
 }
 
+_preflight_probe_thinking_pair() {
+  # Echo "<content_len>:<reasoning_len>" from ONE request.
+  #
+  # ⚠️ CONTENT PRESENCE DOES NOT DISCRIMINATE EFFORT LEVELS. The sibling probe
+  # asks "Say OK." and checks whether any content came back, and the OFF ladder
+  # used that to decide whether a level turns thinking off. On a trivial prompt
+  # with a workable budget EVERY level answers -- including max -- so the test is
+  # blind exactly where it matters. It also flipped behaviour when the budget was
+  # raised from 24 to 256: at 24 no level answered (ladder ran, found nothing,
+  # model declared switch-less); at 256 the scan's own value answered (gate went
+  # false and the ladder was skipped entirely). Same symptom, different cause.
+  #
+  # "Did thinking stop?" is a question about REASONING length, so ask that.
+  local url="$1" model="$2" kwargs="$3"
+  curl -sf -m 90 "${url%/}/v1/chat/completions" \
+    -H "Content-Type: application/json" \
+    -d "{\"model\": \"${model}\", \"messages\": [{\"role\": \"user\", \"content\": \"Say OK.\"}], \"max_tokens\": 256, \"temperature\": 0.0, \"chat_template_kwargs\": ${kwargs}}" 2>/dev/null \
+    | python3 -c "
+import sys, json
+d = json.load(sys.stdin)['choices'][0]['message']
+c = (d.get('content') or '').strip()
+r = (d.get('reasoning_content') or d.get('reasoning') or '').strip()
+print(f'{len(c)}:{len(r)}')" 2>/dev/null \
+    || echo "0:0"
+}
+
 _preflight_probe_thinking_reasoning() {
   # Echo the REASONING length a trivial question returns under the given kwargs.
   # The sibling probe measures CONTENT — right for proving a value turns thinking
@@ -1743,8 +1769,28 @@ preflight_detect_thinking_control() {
           enable_thinking)  _off_probe_kw='{"enable_thinking": false}'   ;;
           reasoning_effort) _off_probe_kw='{"reasoning_effort": "none"}' ;;
         esac
-        if [[ -n "$_off_probe_kw" ]] \
-           && [[ "$(_preflight_probe_thinking_key "$url" "$model" "$_off_probe_kw")" == "0" ]]; then
+        # Ask whether the scan's off-value actually STOPS the reasoning. If it
+        # leaves reasoning behind it is not an off-switch, whatever it is named,
+        # and we must walk the ladder. Asymmetric on purpose, as before: a value
+        # that genuinely silences thinking (rlen 0) keeps the scan's answer and
+        # every model passing today keeps its exact request shape.
+        local _off_pair="" _off_rlen0=0
+        if [[ -n "$_off_probe_kw" ]]; then
+          _off_pair="$(_preflight_probe_thinking_pair "$url" "$model" "$_off_probe_kw")"
+          _off_rlen0="${_off_pair##*:}"
+          [[ "$_off_rlen0" =~ ^[0-9]+$ ]] || _off_rlen0=0
+        fi
+        local _off_clen0="${_off_pair%%:*}"
+        [[ "$_off_clen0" =~ ^[0-9]+$ ]] || _off_clen0=0
+        # Enter the ladder when EITHER signal says the value is not an off-switch:
+        #   rlen > 0  -> it left reasoning behind (the GLM case)
+        #   clen == 0 -> it produced no answer at all (the original "named but
+        #                ignored" case, and the only signal available on engines
+        #                that never expose reasoning_content -- vLLM inlines
+        #                thinking in content, so rlen is always 0 there and a
+        #                reasoning-only test would be blind).
+        # A genuine off-switch (rlen 0 AND clen > 0) still keeps the scan's answer.
+        if [[ -n "$_off_probe_kw" ]] && { (( _off_rlen0 > 0 )) || (( _off_clen0 == 0 )); }; then
           # ⚠️ "this VALUE did not work" is NOT "this KEY does not exist" — the
           # distinction caused a real misdiagnosis. `reasoning_effort: none` is
           # INVALID on the GLM-5.3 family (vendor lists max|high|low only) and is
@@ -1767,26 +1813,28 @@ preflight_detect_thinking_control() {
           # A model whose first candidate works is unaffected — the ladder stops there.
           if [[ "$THINK_CONTROL" == "reasoning_effort" ]]; then
             local _lvl
+            # ⚠️ PICK BY REASONING, NOT BY "IT ANSWERED". Taking the first level
+            # that returns content picks whichever is tried first, because on a
+            # trivial prompt every level answers. Probe all candidates and keep the
+            # one that reasons LEAST while still producing an answer -- that is the
+            # closest thing to "off" the model actually offers. For GLM-5.3-Flash
+            # only low|high are valid and everything else coerces to max, so
+            # `minimal` and `medium` reason heavily and `low` wins on merit rather
+            # than on loop order.
+            local _lvl _pair _clen _rlen _best_rlen=-1
             for _lvl in minimal low medium; do
-              if [[ "$(_preflight_probe_thinking_key "$url" "$model" "{\"reasoning_effort\": \"${_lvl}\"}")" != "0" ]]; then
-                THINK_EFFORT_OFF_VALUE="$_lvl"; break
+              _pair="$(_preflight_probe_thinking_pair "$url" "$model" "{\"reasoning_effort\": \"${_lvl}\"}")"
+              _clen="${_pair%%:*}"; _rlen="${_pair##*:}"
+              [[ "$_clen" =~ ^[0-9]+$ ]] || continue
+              [[ "$_rlen" =~ ^[0-9]+$ ]] || continue
+              (( _clen > 0 )) || continue          # produced no answer -- unusable
+              if (( _best_rlen < 0 || _rlen < _best_rlen )); then
+                _best_rlen="$_rlen"; THINK_EFFORT_OFF_VALUE="$_lvl"
               fi
+              (( _rlen == 0 )) && break            # a true off-switch; stop looking
             done
-            # ⚠️ A DIAL IS NOT AN OFF SWITCH — three states, not two.
-            # GLM-5.3-Flash accepts only low|high (everything else, `none` included,
-            # coerces to MAX) and has NO zero-reasoning level: even the minimum still
-            # spends tokens thinking. Consumers size token budgets on "can this be
-            # turned off", so a model with a working dial but no off position got the
-            # un-widened budget — ~30 tokens against ~30 tokens of unavoidable
-            # reasoning — which reads downstream as empty content and gets blamed on
-            # the model (#1128, #1129). Measure it and say so.
-            if [[ -n "${THINK_EFFORT_OFF_VALUE:-}" ]]; then
-              local _off_rlen
-              _off_rlen="$(_preflight_probe_thinking_reasoning "$url" "$model" "{\"reasoning_effort\": \"${THINK_EFFORT_OFF_VALUE}\"}")"
-              if [[ "$_off_rlen" =~ ^[0-9]+$ ]] && (( _off_rlen > 0 )); then
-                THINK_ALWAYS_ON=1
-              fi
-            fi
+            # Reuse the winning measurement rather than spending another request.
+            (( _best_rlen > 0 )) && THINK_ALWAYS_ON=1
             if [[ -z "${THINK_EFFORT_OFF_VALUE:-}" ]]; then
               THINK_CONTROL="none"
             else


### PR DESCRIPTION
Completes the detection work opened in #1196. **Validated against a live endpoint this time**, which is how #1196 shipped without working.

## The bug

The OFF ladder decided whether an effort level turns thinking off by asking `"Say OK."` and checking whether any content came back. On a trivial prompt with a workable budget **every level answers — including `max`** — so the test was blind exactly where it mattered.

It also flipped behaviour when #1197 raised the probe budget, which is why the symptom looked stable while the cause moved underneath it:

| probe budget | what happens | result |
|---|---|---|
| 24 (pre-#1197) | no level answers | gate true → ladder runs → finds nothing → **model declared switch-less** |
| 256 (post-#1197) | the scan's own value answers | gate **false** → ladder skipped entirely → **keeps the invalid `none`** |

Both land on `off={"reasoning_effort": "none"}` — which GLM's template coerces to `max`, the opposite of the intent.

## The fix

"Did thinking stop?" is a question about **reasoning length**, so ask that.

- **`_preflight_probe_thinking_pair`** returns `content_len:reasoning_len` from one request, so a level is judged on the right signal without doubling request count.
- **The gate** enters the ladder when *either* `rlen > 0` (reasoning left behind) **or** `clen == 0` (no answer at all).
- **The ladder** keeps the level that reasons *least* while still answering, instead of the first that answers — which otherwise just picks whichever is tried first. For GLM only `low|high` are valid and everything else coerces to `max`, so `low` now wins on merit rather than loop order.
- `THINK_ALWAYS_ON` comes from that winning measurement, letting the extra probe from #1196 be deleted.

A genuine off-switch (`rlen == 0` **and** `clen > 0`) still keeps the scan's answer, so every model passing today keeps its exact request shape.

### The second disjunct is load-bearing

`clen == 0` isn't belt-and-braces. Engines that inline thinking in `content` never emit `reasoning_content`, so `rlen` is always 0 there and a reasoning-only test would be **blind** — the ladder would silently stop firing for them. My first version tested reasoning only, and `test-thinking-control` case 10 caught precisely that regression before it left the branch.

## Validation

```
CONTROL=reasoning_effort   ALWAYS_ON=1   OFF_VALUE=low   ON_VALUE=high
[autodetect] thinking-control='reasoning_effort' off={"reasoning_effort": "low"}
```

21 s of real probing against the ~5 s short-circuit before. **This is the first end-to-end success** — #1196 and #1197 each removed one blocker without reaching it.

Guard suite green: `thinking-control`, `thinking-probe-optin`, `verify-stress-ladder-verdict`, `verify-stress-ceiling`, `verify-stress-salt`, `report-exit-code`.

## What this unblocks

With autodetection working, `verify-stress` no longer needs the manual `VERIFY_THINK_OFF` override on GLM. Under that override the full ladder passes cleanly — **all 5 ceiling rungs, fillable to 188,019 tok (91% of `n_ctx`), zero VRAM drift** — the same shape as the qwen38 TP4 control in #1127. The rungs that were scored as a quality ceiling in #1128/#1129 recall correctly.
