### PR TITLE
fix(c3): VRAM breakdown must read the FULL boot log, both streams

### DIFF
--- a/RESULT-1118.md
+++ b/RESULT-1118.md
@@ -137,3 +137,32 @@ rig's default `ESTATE_GPUS=0,1`), and the aggregate view is always correct.
   number). The panel surfaces the parser's moe-cache *warning* only.
 - **`test-bench-capture.sh` failure on master** (#1137, reopened): pre-existing,
   reproduced on `origin/master`; not touched.
+
+
+---
+
+## Follow-up (post-merge fix, `fix/1118-full-bootlog`)
+
+The merged panel rendered `other 0G ⚠` with **no component rows** on the live
+glm53-flash-dual container. Root cause (both mine, in the service seam):
+
+1. `vram_breakdown` read `docker logs --tail 4000` — the component lines
+   (`load_tensors`/`sched_reserve`) live at the HEAD of the log, and the
+   container's log had grown to **578,740 lines** (boot in the first ~70):
+   the tail window contained **zero** component lines.
+2. `container_logs` only surfaces stderr when stdout is empty, and
+   llama.cpp announces the buffers on **stderr** — stdout traffic alone
+   dropped them even inside the window.
+
+Fix: `vram_breakdown` reads the **full log, both streams** through the same
+runner seam (no `--tail`; the caller already caches it on the 600 s stride).
+`container_logs` itself is untouched for its Containers-tab consumers.
+
+**Evidence:** `docker logs --tail 4000 <glm container> | grep -c load_tensors`
+→ **0**; full log → **67**. Guard regression in
+`test-pull-download-ladder.sh`'s sibling — a streams-aware runner in
+`TestEstateVramSplit.test_worker_populates_split_and_G_cycles` (component
+lines on stderr, later traffic on stdout) asserts: no `--tail` in the
+docker-logs command, the parser's temp log saw `load_tensors` (both streams
+merged), and the rail renders the split. Cockpit suite re-run:
+**1124 passed, 1 skipped.**

--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -2452,27 +2452,37 @@ class CockpitData:
 
     # ── READ: container logs ──────────────────────────────────────────────────────
 
-    async def vram_breakdown(self, container: str, *, tail: int = 4000) -> dict[str, Any]:
+    async def vram_breakdown(self, container: str) -> dict[str, Any]:
         """Per-GPU VRAM component split for the serving container (#1118, READ).
 
-        Same seam as bootlog_solve: ``docker logs --tail <N> <container>``
-        through the injected read runner, then
-        ``scripts/lib/vram_breakdown.py <log> --json`` (the parser bench.sh
-        uses; the packaged TUI never imports repo internals).
+        Same seam as bootlog_solve: ``docker logs <container>`` through the
+        injected read runner, then ``scripts/lib/vram_breakdown.py <log>
+        --json`` (the parser bench.sh uses; the packaged TUI never imports
+        repo internals).
 
-        Returns ``{"ok": bool, "container", "devices": [...], "warnings":
-        [...], "error"}``.  Honest failures (no container, docker logs
-        unavailable, parser garbage) return ``ok=False`` with the reason;
-        the caller renders last-known + a staleness cue instead of guessing."""
+        Reads the FULL log, both streams, and is cached by the caller (600 s
+        stride): the component lines live at the HEAD of the log (boot-time
+        load_tensors / sched_reserve), and a tail window on a long-running
+        container drops them entirely -- measured 578k lines with the boot in
+        the first ~70 on glm53-flash-dual.  Boot lines are on STDERR, and
+        ``container_logs`` only surfaces stderr when stdout is empty, so this
+        method reads the runner directly and merges both streams."""
         if not container:
             return {"ok": False, "container": container, "devices": [],
                     "warnings": [], "error": "no serving container resolved"}
-        res = await self.container_logs(container, tail=tail)
-        if res.get("error"):
+        res = await self._runner.run(
+            ["docker", "logs", container],
+            cwd=str(self.repo_root), timeout=60.0,
+        )
+        if res.timed_out:
             return {"ok": False, "container": container, "devices": [],
                     "warnings": [],
-                    "error": f"docker logs unavailable: {res['error']}"}
-        lines = res.get("lines") or []
+                    "error": f"timed out reading logs for {container}"}
+        # docker logs splits app output across stdout/stderr; llama.cpp
+        # announces the buffers on stderr while later traffic lands on
+        # stdout -- both are needed, so merge unconditionally.
+        text = f"{res.stdout or ''}\n{res.stderr or ''}"
+        lines = text.splitlines()
         import tempfile
 
         fd, path = tempfile.mkstemp(prefix="c3-vram-", suffix=".log")

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -3201,18 +3201,45 @@ class TestEstateVramSplit:
 
     @pytest.mark.asyncio
     async def test_worker_populates_split_and_G_cycles(self):
-        payload = json.dumps({
-            "devices": self.PAYLOAD["devices"],
-            "warnings": self.PAYLOAD["warnings"],
-        })
-        glm_log = (
-            "0.12.593.897 I load_tensors:        CUDA0 model buffer size =  3524.46 MiB\n"
-            "1.03.561.019 I llama_kv_cache:      CUDA1 KV buffer size =    80.00 MiB\n")
-        runner = FakeRunner(responses={
-            "docker logs": RunResult(returncode=0, stdout=glm_log, stderr=""),
-            "vram_breakdown.py": RunResult(returncode=0, stdout=payload,
-                                           stderr=""),
-        })
+        # Regression (#1118 follow-up): the boot component lines live on
+        # STDERR of a long log whose head any --tail window drops.  The read
+        # must take the FULL log and merge BOTH streams.
+
+        class _StreamsRunner(FakeRunner):
+            """docker-logs served with BOTH streams; for the parser call,
+            reads the handed temp log so the test can see what it got."""
+
+            def __init__(self, stdout, stderr):
+                super().__init__({})
+                self._out, self._err = stdout, stderr
+                self.parser_saw_load_tensors = False
+
+            async def run(self, cmd, *, cwd, timeout=30.0):
+                self.calls.append(list(cmd))
+                joined = " ".join(cmd)
+                if "vram_breakdown.py" in joined:
+                    log_file = cmd[cmd.index("--json") - 1]
+                    content = Path(log_file).read_text()
+                    self.parser_saw_load_tensors = "load_tensors" in content
+                    payload = json.dumps({
+                        "devices": (
+                            [{"device": "CUDA0", "model": 3524, "kv": 1238,
+                              "state": 231, "compute": 5329, "pool": 11714,
+                              "used": 22938, "total": 24576,
+                              "unaccounted": 902}]
+                            if self.parser_saw_load_tensors else []),
+                        "warnings": [],
+                    })
+                    return RunResult(returncode=0, stdout=payload, stderr="")
+                if "docker" in joined and "logs" in joined:
+                    return RunResult(returncode=0, stdout=self._out,
+                                     stderr=self._err)
+                return RunResult(returncode=0, stdout="", stderr="")
+        runner = _StreamsRunner(
+            stdout="later traffic line (stdout)\n",
+            stderr=("0.12.593.897 I load_tensors:        CUDA0 model buffer "
+                    "size =  3524.46 MiB\n"),
+        )
         app, _, _ = make_app(runner=runner)
         app._active_mode = 1                  # keep the mode-0 estate poll out
         app._periodic_estate_refresh = lambda: None   # freeze the poll for assertions
@@ -3237,6 +3264,15 @@ class TestEstateVramSplit:
             await app.workers.wait_for_complete()
             await pilot.pause()
             assert app._vram_split and app._vram_split["ok"]
+            # #1118 follow-up regressions: the docker-logs read carries NO
+            # --tail (the boot lines live at the head of a long log), and the
+            # parser's temp log merged BOTH streams (stderr, where llama.cpp
+            # announces the buffers).
+            docker_logs_cmds = [c for c in runner.calls
+                                if c[:2] == ["docker", "logs"]]
+            assert docker_logs_cmds
+            assert all("--tail" not in c for c in docker_logs_cmds)
+            assert runner.parser_saw_load_tensors is True
             rail = app.query_one("#rail-status", RailStatus)
             assert "VRAM split · estate" in rail.render().plain
             app.action_estate_vram_cycle()           # estate -> CUDA0


### PR DESCRIPTION
Follow-up to #1180: on the live glm53-flash-dual container the estate card rendered `other 0G ⚠` with no component rows.

Root cause (both in the vram_breakdown service seam):
- it read `docker logs --tail 4000`; the component lines (`load_tensors`, `sched_reserve`, moe-cache) live at the HEAD of the log, and the container's log is now 578,740 lines with the boot in the first ~70 — the tail window contained zero component lines (verified: `docker logs --tail 4000 <c> | grep -c load_tensors` → 0; full log → 67).
- it surfaced stderr only when stdout was empty, and llama.cpp announces the buffers on stderr.

Fix: vram_breakdown reads the FULL log, both streams, through the same runner seam (no --tail — the caller already caches it on the 600 s stride). container_logs is untouched for its Containers-tab consumers. RESULT-1118.md documents the regression and evidence.

Test: streams-aware fake runner (component lines on stderr, later traffic on stdout) asserts no --tail in the docker-logs command, that the parser's temp log saw load_tensors (both streams merged), and the rail renders the split. Full cockpit suite on this branch: 1124 passed, 1 skipped.