### PR TITLE
refactor(profiles): lift derive_compose_facts out of the cockpit into shared profiles (#1202 P1)

### DIFF
--- a/scripts/lib/profiles/compose_facts.py
+++ b/scripts/lib/profiles/compose_facts.py
@@ -1,0 +1,162 @@
+"""Compose-file facts — what a compose mechanically states about itself.
+
+Lifted out of the cockpit (#1202 P1). It used to live in
+``club3090_cockpit.data``, which made it unreachable from the CLI: the local
+model layer was write-only from the UI *because the UI owned the only
+implementation* of compose->spec derivation (#1153).
+
+Regex over text, stdlib only — matching ``serve_override_defaults``, which must
+stay importable on the launcher's no-PyYAML path. No repo imports, so both the
+cockpit and ``scripts/`` can consume it.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass
+class ComposeFacts:
+    """What a compose file mechanically tells us (#1153 Route-K).
+
+    A user who already has a working compose is the most common BYOM position,
+    and until now the funnel had no door for them: ① takes an HF repo, and the
+    only compose that could enter was one c3 itself emitted. This is the read
+    half — everything a compose CAN state about itself. Arch dims are absent by
+    construction (a compose does not carry hidden_size); those come from the
+    weights, or stay as required inline edits in ⑤.
+
+    Regex over text, stdlib only — matching serve_override_defaults, which must
+    stay importable on the launcher's no-PyYAML path."""
+
+    path: str = ""
+    ok: bool = False
+    error: str = ""
+    image: str = ""
+    engine: str = ""          # vllm | llama-cpp | ik-llama | unknown
+    model_path: str = ""      # --model / -m / GGUF_FILE
+    served_name: str = ""     # --served-model-name / -a
+    port: str = ""            # ${PORT:-N} or a ports: mapping
+    max_ctx: str = ""         # --max-model-len / -c
+    kv_dtype: str = ""        # --kv-cache-dtype / -ctk
+    tp: str = ""              # --tensor-parallel-size / -ts / device count
+    status_header: str = ""   # the profile-header Status: line, when present
+    service: str = ""
+
+
+_ENGINE_BY_IMAGE = (
+    ("vllm", "vllm"),
+    ("llamacpp-club3090", "llama-cpp"),
+    ("llama.cpp", "llama-cpp"),
+    ("llama-cpp", "llama-cpp"),
+    ("ik-llama", "ik-llama"),
+    ("ik_llama", "ik-llama"),
+)
+
+
+def derive_compose_facts(text: str, path: str = "") -> ComposeFacts:
+    """Read a user-supplied compose (#1153 Route-K). Never raises.
+
+    Flags are read from a TOKEN stream, not by regex-guessing around each name:
+    a compose states its command either as a YAML list (``- --model`` / ``- val``
+    on separate lines) or as one folded string (``>- -m x -c 65536``), and a
+    per-flag regex gets the list form wrong — it captures the next line's ``-``.
+    Flatten first, then walk pairs."""
+    import re as _re
+
+    f = ComposeFacts(path=path)
+    if not (text or "").strip():
+        f.error = "empty compose"
+        return f
+
+    f.image = ""
+    m = _re.search(r"^\s*image:\s*(\S+)", text, _re.M)
+    if m:
+        f.image = m.group(1).strip().strip('"').strip("'")
+    low = f.image.lower()
+    for needle, eng in _ENGINE_BY_IMAGE:
+        if needle in low:
+            f.engine = eng
+            break
+    else:
+        f.engine = "unknown" if f.image else ""
+
+    m = _re.search(r"^services:\s*\n\s{2,}([A-Za-z0-9_.-]+):", text, _re.M)
+    if m:
+        f.service = m.group(1)
+
+    # ── token stream ────────────────────────────────────────────────────────
+    toks: list[str] = []
+    for raw in text.splitlines():
+        ln = raw.strip()
+        if not ln or ln.startswith("#"):
+            continue
+        if ln.startswith("- "):
+            ln = ln[2:].strip()
+        elif ln == "-":
+            continue
+        # exec form: command: ["--model=/w/x", "--max-model-len=32768"]
+        if ln.startswith(("command:", "entrypoint:")) and "[" in ln:
+            ln = ln[ln.index("[") + 1:]
+        ln = ln.replace("[", " ").replace("]", " ").replace(",", " ")
+        ln = ln.strip('"').strip("'")
+        if not ln or ln.endswith(":"):
+            continue
+        toks.extend(t.strip('"').strip("'") for t in ln.split() if t.strip('"').strip("'"))
+
+    # YAML block-scalar introducers. A flag whose "value" is one of these did not
+    # get a value at all — the next line starts a literal block.
+    _BLOCK_SCALARS = {"|", ">", "|-", ">-", "|+", ">+"}
+    # A short flag directly after a shell is the SHELL's flag, not the engine's:
+    # `entrypoint: [bash, -c, |...]` is the standard vLLM compose shape, and its
+    # bash -c was being read as llama.cpp's -c (ctx-size), so max_ctx came back
+    # as "|" for every such compose.
+    _SHELLS = {"bash", "sh", "zsh", "/bin/bash", "/bin/sh"}
+
+    def flag(*names: str) -> str:
+        # Alias PRIORITY, not token order: callers list the canonical name first
+        # (e.g. "--max-model-len" before "-c"), so an unrelated short flag
+        # appearing earlier in the file must not win over the real one.
+        for name in names:
+            for i, t in enumerate(toks):
+                base = t.split("=", 1)[0]
+                if base != name:
+                    continue
+                if i > 0 and toks[i - 1] in _SHELLS and not name.startswith("--"):
+                    continue
+                if "=" in t:                      # --flag=value
+                    v = t.split("=", 1)[1]
+                elif i + 1 < len(toks):           # --flag value
+                    v = toks[i + 1]
+                else:
+                    continue
+                v = v.strip().strip('"').strip("'")
+                if v and not v.startswith("-") and v not in _BLOCK_SCALARS:
+                    return v
+        return ""
+
+    f.model_path  = flag("--model", "-m", "GGUF_FILE")
+    f.served_name = flag("--served-model-name", "-a", "--alias")
+    f.max_ctx     = flag("--max-model-len", "-c", "--ctx-size")
+    f.kv_dtype    = flag("--kv-cache-dtype", "-ctk", "--cache-type-k")
+    f.tp          = flag("--tensor-parallel-size", "-tp", "-ts")
+    if not f.tp:
+        m = _re.search(r"CUDA_VISIBLE_DEVICES[=:\s]+\"?([0-9,]+)", text)
+        if m:
+            f.tp = str(len([x for x in m.group(1).split(",") if x.strip()]))
+
+    m = (_re.search(r"\$\{PORT:-([0-9]+)\}", text)
+         or _re.search(r"^\s*-\s*\"?([0-9]{2,5}):[0-9]+", text, _re.M))
+    if m:
+        f.port = m.group(1)
+
+    m = _re.search(r"^#\s*Status:\s*(.+)$", text, _re.M)
+    if m:
+        f.status_header = m.group(1).strip()
+
+    if not f.image:
+        f.error = "no image: found — is this a compose file?"
+        return f
+    f.ok = True
+    return f

--- a/scripts/tests/test-compose-facts-shared.sh
+++ b/scripts/tests/test-compose-facts-shared.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Guard: compose-fact derivation has exactly ONE implementation, reachable from
+# BOTH the CLI (scripts/) and the cockpit (tools/serve-cockpit/).
+#
+# Why this exists (#1202 P1): derive_compose_facts used to live inside
+# club3090_cockpit.data. Nothing outside the cockpit could import it, which is
+# *why* the local model layer was write-only from the UI (#1153) -- the UI owned
+# the only implementation of compose->spec derivation. It now lives in
+# scripts/lib/profiles/compose_facts.py and the cockpit delegates.
+#
+# The failure this pins is a silent re-fork: someone "fixes" a parsing bug in one
+# consumer and the two drift. The test derives the SAME compose through BOTH
+# import paths and requires byte-identical results.
+set -uo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+ROOT="$PWD"
+rc=0
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+cat > "$TMP/c.yml" <<'YML'
+# Status: 🧪 Experimental
+services:
+  my-local-thing:
+    image: ghcr.io/someuser/my-llamacpp:v9.9-custom
+    ports:
+      - "${PORT:-8199}:8199"
+    command: >
+      /app/llama-server -m /models/m.gguf -a my-local-model
+      -c 65536 -ctk q8_0 -ts 1,1 --port 8199
+YML
+
+FIELDS="ok engine image model_path served_name port max_ctx kv_dtype tp service status_header"
+EXTRACT="
+import json, sys
+f = derive_compose_facts(open(sys.argv[1], encoding='utf-8').read(), sys.argv[1])
+print(json.dumps({k: getattr(f, k) for k in '$FIELDS'.split()}, sort_keys=True))
+"
+
+# A) the CLI path -- plain python from the repo root, no venv
+cli="$(cd "$ROOT" && python3 -c "
+import sys; sys.path.insert(0, '.')
+from scripts.lib.profiles.compose_facts import derive_compose_facts
+$EXTRACT" "$TMP/c.yml" 2>&1)" || { echo "  FAIL CLI path could not derive: $cli"; exit 1; }
+
+# B) the cockpit path -- through data.py, in the cockpit venv if present.
+VENV="$ROOT/tools/serve-cockpit/.venv/bin/python"
+if [[ -x "$VENV" ]]; then
+  cockpit="$(cd "$ROOT/tools/serve-cockpit" && "$VENV" -c "
+from club3090_cockpit.data import derive_compose_facts
+$EXTRACT" "$TMP/c.yml" 2>&1)" || { echo "  FAIL cockpit path could not derive: $cockpit"; exit 1; }
+  if [[ "$cli" == "$cockpit" ]]; then
+    echo "  ok   both import paths agree"
+  else
+    echo "  FAIL the two consumers DIVERGED"
+    echo "    cli:     $cli"
+    echo "    cockpit: $cockpit"
+    rc=1
+  fi
+  # ⛔ IDENTITY, not just equal output. Output parity cannot tell "cockpit
+  # delegates to the shared module" from "the old implementation is still inline
+  # and the shared module is a COPY of it" -- both produce identical facts. That
+  # is not hypothetical: during this change a stray `git checkout --` reverted
+  # data.py to its inline version and the output-parity check still passed, so
+  # the duplication would have shipped. Same class object, or it is a re-fork.
+  if "$VENV" -c "
+import sys
+from pathlib import Path
+from club3090_cockpit.data import ComposeFacts as FromCockpit
+sys.path.insert(0, str(Path('$ROOT').resolve()))
+from scripts.lib.profiles.compose_facts import ComposeFacts as FromShared
+raise SystemExit(0 if FromCockpit is FromShared else 1)
+" 2>/dev/null; then
+    echo "  ok   cockpit ComposeFacts IS the shared class (delegating, not duplicated)"
+  else
+    echo "  FAIL cockpit ComposeFacts is a DIFFERENT class object — the implementation"
+    echo "       has been re-inlined or copied; the move has been undone"
+    rc=1
+  fi
+
+  # The delegation must not have orphaned the type.
+  if "$VENV" -c "from club3090_cockpit.data import ComposeFacts" 2>/dev/null; then
+    echo "  ok   ComposeFacts still importable from club3090_cockpit.data"
+  else
+    echo "  FAIL ComposeFacts no longer importable from club3090_cockpit.data"; rc=1
+  fi
+else
+  echo "  skip cockpit venv absent — CLI path only"
+fi
+
+# The shared module must stay stdlib-only: it is imported on the launcher's
+# no-PyYAML path, and a repo import would re-create the coupling this removed.
+if command grep -qE "^(import|from) (yaml|club3090)" scripts/lib/profiles/compose_facts.py; then
+  echo "  FAIL compose_facts.py grew a yaml/cockpit import — it must stay stdlib-only"; rc=1
+else
+  echo "  ok   compose_facts.py is stdlib-only"
+fi
+
+# Source-level duplication check, independent of imports.
+if command grep -qE "^class ComposeFacts" tools/serve-cockpit/club3090_cockpit/data.py; then
+  echo "  FAIL data.py defines its own ComposeFacts again — implementation re-inlined"; rc=1
+else
+  echo "  ok   data.py carries no inline ComposeFacts"
+fi
+
+# Refuse a vacuous pass: the extraction must actually have produced fields.
+case "$cli" in
+  *'"served_name": "my-local-model"'*) echo "  ok   derivation produced real fields" ;;
+  *) echo "  FAIL derivation returned nothing usable: $cli"; rc=1 ;;
+esac
+
+[[ "$rc" == "0" ]] && echo "PASS: one implementation, both consumers agree" || echo "FAIL: compose-facts sharing regression"
+exit "$rc"

--- a/tools/serve-cockpit/club3090_cockpit/data.py
+++ b/tools/serve-cockpit/club3090_cockpit/data.py
@@ -2374,45 +2374,6 @@ def _quant_slug_for_arch(byo: Optional["ByoResult"]) -> str:
     return "autoround-int4"
 
 
-@dataclass
-class ComposeFacts:
-    """What a compose file mechanically tells us (#1153 Route-K).
-
-    A user who already has a working compose is the most common BYOM position,
-    and until now the funnel had no door for them: ① takes an HF repo, and the
-    only compose that could enter was one c3 itself emitted. This is the read
-    half — everything a compose CAN state about itself. Arch dims are absent by
-    construction (a compose does not carry hidden_size); those come from the
-    weights, or stay as required inline edits in ⑤.
-
-    Regex over text, stdlib only — matching serve_override_defaults, which must
-    stay importable on the launcher's no-PyYAML path."""
-
-    path: str = ""
-    ok: bool = False
-    error: str = ""
-    image: str = ""
-    engine: str = ""          # vllm | llama-cpp | ik-llama | unknown
-    model_path: str = ""      # --model / -m / GGUF_FILE
-    served_name: str = ""     # --served-model-name / -a
-    port: str = ""            # ${PORT:-N} or a ports: mapping
-    max_ctx: str = ""         # --max-model-len / -c
-    kv_dtype: str = ""        # --kv-cache-dtype / -ctk
-    tp: str = ""              # --tensor-parallel-size / -ts / device count
-    status_header: str = ""   # the profile-header Status: line, when present
-    service: str = ""
-
-
-_ENGINE_BY_IMAGE = (
-    ("vllm", "vllm"),
-    ("llamacpp-club3090", "llama-cpp"),
-    ("llama.cpp", "llama-cpp"),
-    ("llama-cpp", "llama-cpp"),
-    ("ik-llama", "ik-llama"),
-    ("ik_llama", "ik-llama"),
-)
-
-
 # Compose `Status:` header emoji → registry status word.  DUPLICATED from
 # scripts/lib/profiles/compose_registry.COMPOSE_STATUS_EMOJI on purpose: data.py
 # is stdlib-only and importable on the launcher's no-PyYAML path, so it must not
@@ -2578,20 +2539,37 @@ def classify_compose_provenance(path: str, repo_root) -> ComposeProvenance:
     return prov
 
 
-def derive_compose_facts(text: str, path: str = "") -> ComposeFacts:
-    """Read a user-supplied compose (#1153 Route-K). Never raises.
+def _compose_facts_mod():
+    """Shared compose-facts implementation (#1202 P1).
 
-    Flags are read from a TOKEN stream, not by regex-guessing around each name:
-    a compose states its command either as a YAML list (``- --model`` / ``- val``
-    on separate lines) or as one folded string (``>- -m x -c 65536``), and a
-    per-flag regex gets the list form wrong — it captures the next line's ``-``.
-    Flatten first, then walk pairs."""
-    import re as _re
+    It used to live here, which made it unreachable from the CLI — the local
+    layer was write-only from the UI *because the UI owned the only
+    implementation* (#1153). It now lives in scripts/lib/profiles/.
 
-    f = ComposeFacts(path=path)
-    if not (text or "").strip():
-        f.error = "empty compose"
-        return f
+    The cockpit venv does NOT carry the repo root on sys.path (services.py
+    inserts it at runtime for exactly this reason), so resolve it from this
+    file's own location — cwd- and caller-independent."""
+    import sys as _sys
+    from pathlib import Path as _Path
+
+    root = str(_Path(__file__).resolve().parents[3])
+    if root not in _sys.path:
+        _sys.path.insert(0, root)
+    from scripts.lib.profiles import compose_facts as _cf
+
+    return _cf
+
+
+def derive_compose_facts(text: str, path: str = ""):
+    """See scripts/lib/profiles/compose_facts.derive_compose_facts."""
+    return _compose_facts_mod().derive_compose_facts(text, path)
+
+
+def __getattr__(name):
+    """Keep ComposeFacts importable from this module after the P1 move."""
+    if name == "ComposeFacts":
+        return _compose_facts_mod().ComposeFacts
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
     f.image = ""
     m = _re.search(r"^\s*image:\s*(\S+)", text, _re.M)


### PR DESCRIPTION
**#1202 P1** — the pure relocation, done alone and first so existing tests pin the behaviour through the move.

## Why this one first

`derive_compose_facts` lived inside `club3090_cockpit.data`, and nothing outside the cockpit could import it. That is *why* the local model layer was write-only from the UI (#1153): **the UI owned the only implementation** of compose→spec derivation, so a user with an existing working compose had a door in c3 and no door at all from the CLI. Everything else in #1202 depends on this being shared.

`ComposeFacts`, `_ENGINE_BY_IMAGE` and `derive_compose_facts` move to `scripts/lib/profiles/compose_facts.py` (stdlib-only, matching `serve_override_defaults`, which must stay importable on the launcher's no-PyYAML path). `club3090_cockpit.data` delegates and re-exports `ComposeFacts` via module `__getattr__`, so **every existing caller and test is unchanged** — the 25 pinning tests in `test_compose_facts.py` / `test_compose_viewer.py` passed without edits.

Pure relocation. No behaviour change.

## ⚠️ Constraint worth knowing before sharing anything else

The **cockpit venv does not carry the repo root on `sys.path`** — `scripts.lib.profiles` is not importable from it. A module-level import here would have broken the cockpit outright. `services.py` already works around this by inserting `self.repo_root` at runtime (*"cwd-independent import"*); this wrapper instead resolves the root from `data.py`'s own `__file__`, so it needs no caller context and works in the venv, in tests, and at runtime.

## The guard, and why it checks identity

`test-compose-facts-shared.sh` derives one compose through **both** import paths and requires byte-identical output — plus three things output parity cannot give you:

- the cockpit's `ComposeFacts` **is** the shared class object (delegating, not duplicated)
- `data.py` contains no inline `class ComposeFacts`
- `compose_facts.py` grows no `yaml`/cockpit import

The identity check is not defensive padding. While developing this, a stray `git checkout --` reverted `data.py` to its inline version, leaving `compose_facts.py` as a mere **copy** — and the output-parity check still passed, because identical code produces identical output. Duplication would have shipped under a green test. Both new checks are negative-controlled against exactly that state.

## End-to-end

Validated against a hand-written compose on an engine we don't ship (`ghcr.io/someuser/my-llamacpp:v9.9-custom`). Every field extracts — model path, served name, port, ctx, kv dtype, tp, service, status header — **except**:

```
"engine": "unknown"
```

`_ENGINE_BY_IMAGE` matches substrings of images we ship, so a genuinely new engine cannot be inferred. That confirms **`catalog.sh register --engine <id>` (P4) must be an explicit input, not derived** — deriving it would stamp `unknown` on precisely the users #1202 exists to serve.

## Testing

Full cockpit suite **1124 passed / 1 skipped**. Bash guards green: `compose-facts-shared`, `docs-local-layer`, `catalog-baseline`, `registry-lookup`, `default-resolver`, `model-default-resolver`, `thinking-probe-optin`.
