### PR TITLE
feat(profiles): make catalog provenance a first-class `origin` field; core wins (#1202 P2)

### DIFF
--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -55,6 +55,12 @@ COMPOSE_STATUS_EMOJI = {
 
 def _entry(
     *,
+    # Catalog provenance (#1202). FIRST-CLASS FIELD, never derived from the slug
+    # string: publishing a local recipe upstream later must flip this value and
+    # leave the slug alone. Encoding provenance in the NAME would make publish a
+    # rename, breaking every reference a user holds (their scripts, notes,
+    # compose pins). Core rows default; the local loader injects "local".
+    origin="core",
     model,
     weights_variant,
     workload,
@@ -196,6 +202,7 @@ def _entry(
             f"{compose_path}: status={status!r} not in {STATUS_VALUES}"
         )
     entry = {
+        "origin": origin,
         "model": model,
         "weights_variant": weights_variant,
         "workload": workload,
@@ -841,8 +848,15 @@ def load_local_registry(root=None):
                 f"{path}: local slug {slug!r} must live under the "
                 f"{LOCAL_SLUG_PREFIX!r} namespace"
             )
-        if slug in core_slugs or slug in local:
-            raise LocalRegistryError(f"{path}: local slug collides: {slug!r}")
+        if slug in local:
+            raise LocalRegistryError(f"{path}: duplicate local slug: {slug!r}")
+        # ⚠️ A collision with CORE is NOT an error (#1202). Refusing at load would
+        # let a routine stack update — us shipping a curated slug whose name a user
+        # already registered — break their working setup with no warning, and take
+        # the whole local layer down with it. Core wins the lookup; the local row
+        # stays loaded and MARKED so `--list` can show what happened and the user
+        # can rename it. Silent shadowing in either direction is the bad outcome.
+        shadowed = slug in core_slugs
         model = kwargs.get("model")
         if model in core_models:
             raise LocalRegistryError(
@@ -850,14 +864,20 @@ def load_local_registry(root=None):
             )
         if model in local_models:
             raise LocalRegistryError(f"{path}: duplicate local model id {model!r}")
+        if "origin" in kwargs:
+            raise LocalRegistryError(
+                f"{path}: local entry {slug!r} may not set 'origin' — it is "
+                f"stamped by the loader, not self-declared"
+            )
         try:
-            entry = _entry(**kwargs)
+            entry = _entry(origin="local", **kwargs)
         except TypeError as exc:
             raise LocalRegistryError(
                 f"{path}: local entry {slug!r} has bad _entry kwargs: {exc}"
             ) from exc
         except ValueError as exc:
             raise LocalRegistryError(f"{path}: local entry {slug!r}: {exc}") from exc
+        entry["shadowed_by_core"] = shadowed
         local[slug] = entry
         local_models.add(model)
     return local
@@ -874,8 +894,17 @@ def get_registry(root=None):
     local = load_local_registry(root)
     if not local:
         return COMPOSE_REGISTRY
+    # CORE WINS (#1202). `merged.update(local)` would let a local row shadow a
+    # shipped slug silently. That is unreachable while local slugs live under a
+    # separate namespace, but P3 gives them the same `<engine>/<name>` shape as
+    # curated rows, at which point the collision is real. Decide it here, once:
+    # core owns the lookup, and the shadowed local row is still returned by
+    # load_local_registry (flagged `shadowed_by_core`) so listings can show it.
     merged = dict(COMPOSE_REGISTRY)
-    merged.update(local)
+    for slug, entry in local.items():
+        if slug in merged:
+            continue
+        merged[slug] = entry
     return merged
 
 

--- a/scripts/tests/test-registry-origin-field.sh
+++ b/scripts/tests/test-registry-origin-field.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Guard: catalog provenance is a FIELD (`origin`), stamped by the loader, and
+# core wins a slug collision (#1202 P2).
+#
+# Why a field and not the slug prefix: publishing a local recipe upstream later
+# must flip a value and leave the slug alone. Encoding provenance in the NAME
+# makes publish a RENAME, breaking every reference a user holds. export_pr.py
+# already does that rename today (`core_slug = f"{ns}/{slug[len('local/'):]}"`).
+#
+# Three properties, each of which has failed or could fail silently:
+#   1. every row carries `origin`; core rows say "core"
+#   2. a local row cannot DECLARE its own origin (spoofing core would hide it)
+#   3. core wins the merged view. This one is a real inversion: the merge was
+#      `merged.update(local)`, i.e. LOCAL silently won. Unreachable while local
+#      slugs sit in their own namespace, live the moment P3 lands.
+set -uo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+rc=0
+
+out="$(python3 - <<'PY' 2>&1
+import inspect, json, sys, tempfile, shutil
+from pathlib import Path
+sys.path.insert(0, ".")
+from scripts.lib.profiles import compose_registry as cr
+
+fail = []
+
+# 1. core rows stamp origin=core
+core_slug = next(iter(cr.COMPOSE_REGISTRY))
+if cr.COMPOSE_REGISTRY[core_slug].get("origin") != "core":
+    fail.append(f"core row {core_slug!r} origin={cr.COMPOSE_REGISTRY[core_slug].get('origin')!r}, want 'core'")
+missing = [s for s, e in cr.COMPOSE_REGISTRY.items() if "origin" not in e]
+if missing:
+    fail.append(f"{len(missing)} core rows carry no origin field, e.g. {missing[0]!r}")
+
+sig = inspect.signature(cr._entry)
+required = [n for n, p in sig.parameters.items()
+            if p.default is inspect._empty and p.kind is p.KEYWORD_ONLY]
+tmpl = dict(cr.COMPOSE_REGISTRY[core_slug])
+kw = {n: (tmpl[n] if n in tmpl else "composes/x/base.yml") for n in required}
+
+root = Path(tempfile.mkdtemp())
+try:
+    (root / "scripts/lib/profiles-local").mkdir(parents=True)
+    reg = root / "scripts/lib/profiles-local/registry.local.json"
+
+    # 2. a valid local row is stamped local, not self-declared
+    mine = dict(kw); mine["model"] = "guard-local-model"; mine["status"] = "experimental"
+    reg.write_text(json.dumps({"local/guard": mine}))
+    e = cr.load_local_registry(root)["local/guard"]
+    if e.get("origin") != "local":
+        fail.append(f"local row origin={e.get('origin')!r}, want 'local'")
+
+    # 3. spoofing origin must be refused
+    spoof = dict(mine); spoof["origin"] = "core"
+    reg.write_text(json.dumps({"local/spoof": spoof}))
+    try:
+        cr.load_local_registry(root)
+        fail.append("a local row was allowed to declare origin='core' (spoofable)")
+    except cr.LocalRegistryError:
+        pass
+
+    # 4. core wins the merge
+    real = cr.load_local_registry
+    cr.load_local_registry = lambda r=None: {
+        core_slug: {**tmpl, "origin": "local", "shadowed_by_core": True}
+    }
+    try:
+        if cr.get_registry()[core_slug].get("origin") != "core":
+            fail.append("a local row shadowed a CORE slug in the merged view")
+    finally:
+        cr.load_local_registry = real
+finally:
+    shutil.rmtree(root)
+
+print("FAIL:" + "; ".join(fail) if fail else "OK")
+PY
+)"
+
+case "$out" in
+  OK) echo "  ok   origin stamped, unspoofable, core wins" ;;
+  FAIL:*) echo "  FAIL ${out#FAIL:}"; rc=1 ;;
+  *) echo "  FAIL guard could not run: $out"; rc=1 ;;
+esac
+
+# Source-level: the merge must not be a plain update(), which lets local win.
+if command grep -qE "^\s*merged\.update\(local\)" scripts/lib/profiles/compose_registry.py; then
+  echo "  FAIL get_registry uses merged.update(local) — local silently shadows core"; rc=1
+else
+  echo "  ok   merge is not a blind update(local)"
+fi
+
+[[ "$rc" == "0" ]] && echo "PASS: provenance is a field and core wins" || echo "FAIL: origin/precedence regression"
+exit "$rc"


### PR DESCRIPTION
**#1202 P2** — provenance moves off the slug string and onto the entry.

## What changed

`_entry(origin="core")` — every row carries `origin`. The local loader stamps `origin="local"` itself and **refuses a row that declares its own**: a local row claiming `"core"` would hide itself from exactly the listings meant to mark it.

## Why a field, not a prefix — confirmed by existing code

Publishing later must flip a value and leave the slug alone. That isn't speculative: **`export_pr.py` already renames on publish today**:

```python
core_slug = f"{ns}/{str(entry['slug'])[len(_LOCAL_SLUG_PREFIX):]}"
```

It strips `local/` and prefixes the engine namespace derived from the compose path — producing exactly the `<engine>/<name>` shape P3 gives local slugs. **After the hard-cut that arithmetic collapses to identity and publish stops being a rename**, so a user's scripts, notes and compose pins survive it. (It's also a fourth prefix-dependent consumer for P3, alongside `promote.py`, `demote.py` and the cockpit.)

## ⚠️ The merge was inverted

`get_registry` did `merged.update(local)` — **a local row silently shadowed a shipped slug.** Unreachable while local slugs live in their own namespace; live the moment P3 gives them the same shape. Core now wins the lookup.

A core collision at load also no longer raises. Refusing would let a routine stack update — us shipping a curated slug whose name a user already registered — break their working setup with no warning, and take the whole local layer down with it. The row stays loaded and flagged `shadowed_by_core` so listings can show what happened and the user can rename it. Local-vs-local collisions still raise: that's one file the user controls.

**The shadow path is unreachable until P3** (the namespace check refuses a non-`local/` slug before the collision test runs), so its test lands there. The merge precedence is testable now and is pinned.

## Guard

`test-registry-origin-field.sh` pins: core rows stamp `core`, every row carries the field, a local row is stamped rather than self-declared, spoofing is refused, and core wins the merged view — plus a source-level check that the merge isn't a blind `update(local)`. Negative-controlled: restoring `merged.update(local)` fails both the behavioural and the source check.

Removing the *explicit* anti-spoof check does **not** fail the guard, and that's correct — a duplicate `origin` kwarg raises `TypeError` inside `_entry`, which the loader already converts to `LocalRegistryError`. The property is double-defended; the explicit check only improves the message. The guard tests the property, not the implementation.

## Correction to the plan

There is **no existing `local` marker in `--list` to repoint.** Nothing in `switch.sh`, `registry-emit.sh` or `registry-lookup.sh` renders one — the `(NA: …, local)` line in #1153 is illustrative. Local rows are indistinguishable in listings *today*, and after P3 they'll be shape-identical to curated rows as well. So **P5 must add the marker off `origin`**, not move one.

## Testing

37 registry/catalog guards green after the schema change.
