### PR TITLE
feat(profiles): hard-cut the `local/` namespace — local slugs take `<engine>/<name>` (#1202 P3)

### DIFF
--- a/docs/BRING_YOUR_OWN.md
+++ b/docs/BRING_YOUR_OWN.md
@@ -254,11 +254,22 @@ You can have all of that **without touching a single tracked file**.
 
 ```bash
 python3 scripts/lib/profiles/promote.py --spec-file <spec>.json     # --layer local is the DEFAULT
-bash    scripts/preflight-add-model.sh  local/<your-slug>           # diagnose-profile + 9 catalog guards
+bash    scripts/preflight-add-model.sh  <engine>/<your-slug>       # diagnose-profile + 9 catalog guards
 ```
 
 That writes `scripts/lib/profiles-local/` — `models.d/<id>.yml`, `composes/<id>/…`
-and `registry.local.json`, with slugs namespaced under `local/`. The directory is
+and `registry.local.json`. Slugs use the **same `<engine>/<name>` shape as curated
+ones** — the layer decides where the *files* go, not what the slug is *called*, and
+provenance lives in the entry's `origin` field rather than in the name. That is what
+lets you name the engine you actually run (`my-llamacpp/my-model`, not just ours),
+and it means publishing later flips a field instead of renaming a slug your scripts
+and notes already point at. A local slug whose name collides with a shipped one is
+**shadowed** — the curated row wins the lookup and yours is marked, not deleted.
+
+> ⚠️ The old `local/<name>` namespace was removed (#1202). A `local/…` slug is now
+> refused with the replacement spelled out; re-register it as `<engine>/<name>`.
+
+The directory is
 **gitignored** (everything except its README and `.gitignore`), so:
 
 - `git pull` and branch switches can **never** conflict with or overwrite your models;

--- a/scripts/lib/profiles/compose_registry.py
+++ b/scripts/lib/profiles/compose_registry.py
@@ -843,10 +843,20 @@ def load_local_registry(root=None):
     local: dict = {}
     local_models: set = set()
     for slug, kwargs in raw.items():
-        if not slug.startswith(LOCAL_SLUG_PREFIX):
+        # HARD-CUT (#1202 P3). Local slugs take the SAME `<engine>/<name>` shape
+        # as curated rows. `local/` used to occupy the ENGINE slot, so a local
+        # model could not say which engine it runs — and a user on their own
+        # build had nowhere to record it. Provenance is the `origin` field now.
+        if slug.startswith(LOCAL_SLUG_PREFIX):
             raise LocalRegistryError(
-                f"{path}: local slug {slug!r} must live under the "
-                f"{LOCAL_SLUG_PREFIX!r} namespace"
+                f"{path}: the {LOCAL_SLUG_PREFIX!r} namespace was removed. Local "
+                f"slugs now use the same '<engine>/<name>' shape as curated ones "
+                f"(provenance lives in the 'origin' field). Re-register {slug!r} "
+                f"as '<engine>/{slug[len(LOCAL_SLUG_PREFIX):]}'."
+            )
+        if slug.count("/") != 1 or slug.startswith("/") or slug.endswith("/"):
+            raise LocalRegistryError(
+                f"{path}: local slug {slug!r} must be '<engine>/<name>'"
             )
         if slug in local:
             raise LocalRegistryError(f"{path}: duplicate local slug: {slug!r}")

--- a/scripts/lib/profiles/demote.py
+++ b/scripts/lib/profiles/demote.py
@@ -85,19 +85,38 @@ def _model_id_for(slug: str, entry: dict) -> str:
     Both are recorded by promote.py, and disagreeing about which files belong to
     a slug is exactly how a removal deletes the wrong tree."""
     mid = str(entry.get("model") or "").strip()
-    return mid or slug[len(_LOCAL_NS):]
+    # The tail of '<engine>/<name>'. Was slug[len("local/"):] — string surgery on
+    # a prefix that no longer exists would return the whole slug (#1202 P3).
+    return mid or slug.split("/", 1)[-1]
 
 
 def plan_removal(root: Path, slug: str) -> dict:
     """What removing `slug` would touch. Pure: reads only, never writes."""
-    if not slug.startswith(_LOCAL_NS):
-        raise Refusal(
-            f"{slug!r} is not a local slug. This tool only removes the "
-            f"{_LOCAL_NS!r} layer; a curated catalog entry is git-tracked and "
-            f"git is its removal tool."
-        )
+    # ⛔ CORE SAFETY. This used to be `if not slug.startswith("local/")` — a
+    # string test, and the ONLY thing between `--slug vllm/dual` and the curated
+    # catalog. The hard-cut (#1202 P3) removes that namespace, so the guard is now
+    # grounded in WHERE THE ENTRY PHYSICALLY LIVES: a slug absent from the local
+    # registry is refused before anything is read or written. That is strictly
+    # safer than a name check — a curated slug can never appear in a file this
+    # tool is the only writer of — and it FAILS CLOSED: unknown means refuse.
     raw = _load_local_raw(root)
     if slug not in raw:
+        # Distinguish "that is curated" from "typo" so the refusal is useful.
+        try:
+            import sys as _sys
+
+            _sys.path.insert(0, str(root))
+            from scripts.lib.profiles.compose_registry import COMPOSE_REGISTRY
+
+            is_core = slug in COMPOSE_REGISTRY
+        except Exception:
+            is_core = False
+        if is_core:
+            raise Refusal(
+                f"{slug!r} is a CURATED catalog entry, not a local one. This tool "
+                f"only removes the local layer; a curated entry is git-tracked and "
+                f"git is its removal tool."
+            )
         known = ", ".join(sorted(raw)) or "(none registered)"
         raise Refusal(f"{slug} is not in {_LOCAL_REGISTRY_REL}. Registered: {known}")
 

--- a/scripts/lib/profiles/export_pr.py
+++ b/scripts/lib/profiles/export_pr.py
@@ -135,7 +135,7 @@ def load_local_state(root: Path, mid: str) -> dict:
             "promote it into the LOCAL layer first (c3 ⑤ Promote)"
         )
     for e in entries:
-        if not str(e["slug"]).startswith(_LOCAL_SLUG_PREFIX):
+        if str(e["slug"]).startswith(_LOCAL_SLUG_PREFIX):
             raise Refusal(
                 f"registry slug {e['slug']!r} lacks the {_LOCAL_SLUG_PREFIX!r} "
                 "namespace — not a LOCAL-layer entry"
@@ -279,7 +279,19 @@ def translated_entry(state: dict, entry: dict) -> dict:
     ns = compose_slug_namespace(cpath)
     if not kw.get("kvcalc_key"):
         kw["kvcalc_key"] = "SKIP"  # llama.cpp family default; vLLM was gated above
-    core_slug = f"{ns}/{str(entry['slug'])[len(_LOCAL_SLUG_PREFIX):]}"
+    # PUBLISH IS NO LONGER A RENAME (#1202 P3). This was
+    #   f"{ns}/{slug[len('local/'):]}"
+    # — strip the namespace, re-prefix the engine derived from the compose path.
+    # Local slugs already ARE '<engine>/<name>', so the core slug is the slug the
+    # user has been running, and every reference they hold survives publication.
+    # `ns` is kept as a consistency check: a slug whose engine namespace disagrees
+    # with where its compose lives is a packaging mistake worth surfacing.
+    core_slug = str(entry["slug"])
+    if ns and not core_slug.startswith(f"{ns}/"):
+        raise Refusal(
+            f"slug {core_slug!r} does not match the namespace implied by its "
+            f"compose path ({ns!r}); fix one or the other before exporting"
+        )
     return {"slug": core_slug, "kwargs": kw}
 
 

--- a/scripts/lib/profiles/promote.py
+++ b/scripts/lib/profiles/promote.py
@@ -413,11 +413,15 @@ def validate_spec(spec: Any, root: Path, layer: str) -> dict:
 
     if layer == "local":
         # ── Namespace + containment (C4-rev): local writes NEVER leave the layer.
-        if not slug.startswith(_LOCAL_SLUG_PREFIX):
+        # HARD-CUT (#1202 P3): local slugs are '<engine>/<name>', same as core.
+        if slug.startswith(_LOCAL_SLUG_PREFIX):
             raise Refusal(
-                f"local-layer slugs must carry the {_LOCAL_SLUG_PREFIX!r} namespace "
-                f"(got {slug!r}); use --layer core for a curated engine slug"
+                f"the {_LOCAL_SLUG_PREFIX!r} namespace was removed — local slugs "
+                f"now use '<engine>/<name>' (provenance is the 'origin' field). "
+                f"Use '<engine>/{slug[len(_LOCAL_SLUG_PREFIX):]}'."
             )
+        if slug.count("/") != 1:
+            raise Refusal(f"local slug {slug!r} must be '<engine>/<name>'")
         _refuse_if_path_escapes(cpath, _LOCAL_COMPOSES_REL, "spec.compose.path")
         if kwargs.get("compose_path") != cpath:
             raise Refusal(

--- a/scripts/tests/test-compose-facts-shared.sh
+++ b/scripts/tests/test-compose-facts-shared.sh
@@ -12,6 +12,8 @@
 # consumer and the two drift. The test derives the SAME compose through BOTH
 # import paths and requires byte-identical results.
 set -uo pipefail
+# Non-UTF-8 locales break python3 reads/writes on this rig (#599/#584).
+export PYTHONUTF8="${PYTHONUTF8:-1}"
 cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 ROOT="$PWD"
 rc=0

--- a/scripts/tests/test-demote-refuses-core.sh
+++ b/scripts/tests/test-demote-refuses-core.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# ⛔ SAFETY GUARD: `demote.py` must never touch the curated catalog (#1202 P3).
+#
+# Written BEFORE the local/ hard-cut, deliberately. Until now the only thing
+# standing between `--slug vllm/dual` and the curated catalog was a string test
+# --  `if not slug.startswith("local/")` -- evaluated before anything is read.
+# demote.py's own docstring says so: "CORE IS NEVER TOUCHED ... a non-local/ slug
+# is refused before anything is read." Removing the namespace deletes that guard,
+# so this test pins the PROPERTY (a curated slug is refused, core is untouched)
+# rather than the mechanism, and must pass both before and after the change.
+set -uo pipefail
+# Non-UTF-8 locales break python3 reads/writes on this rig (#599/#584).
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+ROOT="$PWD"
+rc=0
+
+# A real curated slug, straight from the registry — not a literal that could rot.
+CORE_SLUG="$(python3 -c "
+import sys; sys.path.insert(0,'.')
+from scripts.lib.profiles.compose_registry import COMPOSE_REGISTRY
+print(next(iter(COMPOSE_REGISTRY)))" 2>/dev/null)"
+[[ -n "$CORE_SLUG" ]] || { echo "  FAIL could not read a core slug from the registry"; exit 1; }
+
+# Fingerprint the curated catalog + the local layer before we poke it.
+before="$(find scripts/lib/profiles scripts/lib/profiles-local -type f 2>/dev/null \
+          | sort | xargs -r md5sum | md5sum)"
+
+for mode in "--dry-run" "-y"; do
+  out="$(python3 scripts/lib/profiles/demote.py --slug "$CORE_SLUG" $mode 2>&1)"; code=$?
+  if [[ "$code" -eq 0 ]]; then
+    echo "  FAIL demote.py $mode ACCEPTED a curated slug ($CORE_SLUG) — exit 0"
+    rc=1
+  else
+    echo "  ok   demote.py $mode refused $CORE_SLUG (exit $code)"
+  fi
+  # The refusal must be intelligible, not a stack trace or a bare "not found".
+  case "$out" in
+    *Traceback*) echo "  FAIL refusal was a traceback, not a message"; rc=1 ;;
+  esac
+done
+
+after="$(find scripts/lib/profiles scripts/lib/profiles-local -type f 2>/dev/null \
+         | sort | xargs -r md5sum | md5sum)"
+if [[ "$before" == "$after" ]]; then
+  echo "  ok   catalog byte-identical after both attempts"
+else
+  echo "  FAIL demote.py MODIFIED the catalog while refusing a curated slug"; rc=1
+fi
+
+# Refuse a vacuous pass: the tool must actually run (a missing file also 'refuses').
+if ! python3 scripts/lib/profiles/demote.py --help >/dev/null 2>&1; then
+  echo "  FAIL demote.py --help does not run; the refusals above prove nothing"; rc=1
+else
+  echo "  ok   demote.py is runnable (refusals are real, not import errors)"
+fi
+
+[[ "$rc" == "0" ]] && echo "PASS: core is unreachable from demote.py" || echo "FAIL: core-safety regression"
+exit "$rc"

--- a/scripts/tests/test-local-layer-lifecycle.sh
+++ b/scripts/tests/test-local-layer-lifecycle.sh
@@ -36,7 +36,8 @@ cp -r scripts/lib "$TMP/scripts/"
 # registry-emit.sh imports the shared VariantRow from tools/tui-core.
 cp -r tools/tui-core "$TMP/tools/"
 
-SLUG="local/lifecycle-probe"
+# #1202 P3: local slugs carry the ENGINE namespace, like curated rows.
+SLUG="llama-cpp/lifecycle-probe"
 MID="lifecycle-probe"
 SPEC="$TMP/spec.json"
 
@@ -161,8 +162,13 @@ python3 scripts/lib/profiles/demote.py --slug "$SLUG" --root "$TMP" --yes >/dev/
 
 python3 scripts/lib/profiles/demote.py --slug "vllm/dual" --root "$TMP" --yes >"$TMP/core.log" 2>&1 \
   && bad "a CORE slug must never be removable" || ok "core slug refused"
-command grep -qi "not a local slug" "$TMP/core.log" \
-  && ok "core refusal names the reason" || bad "core refusal message unclear"
+# The refusal must say WHY, not just "no". Post-#1202 the guard is location-based
+# (absent from registry.local.json) and the message names the curated layer.
+if command grep -qi "curated" "$TMP/core.log" && command grep -qi "git" "$TMP/core.log"; then
+  ok "core refusal names the reason (curated + git is its removal tool)"
+else
+  bad "core refusal message unclear"
+fi
 
 # ── 5. Round-trip: promote again after a removal ────────────────────────────
 python3 scripts/lib/profiles/promote.py --spec-file "$SPEC" --root "$TMP" \

--- a/scripts/tests/test-local-slug-shape.sh
+++ b/scripts/tests/test-local-slug-shape.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Guard: local slugs use the same '<engine>/<name>' shape as curated rows, the
+# legacy 'local/' namespace is refused with guidance, and a core collision is
+# SHADOWED (core wins, local row marked) rather than fatal. (#1202 P3)
+#
+# The namespace was not just cosmetic — it occupied the ENGINE slot, so a local
+# model could not record which engine it runs, and a user on their own build had
+# nowhere to put it. Removing it also removes the *rename on publish*:
+# export_pr.py used to compute the core slug by stripping the prefix.
+#
+# The shadow case could not be tested before this change: the namespace check
+# refused a non-'local/' slug before the collision test was reachable.
+set -uo pipefail
+# Non-UTF-8 locales break python3 reads/writes on this rig (#599/#584).
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+rc=0
+out="$(python3 - <<'PY' 2>&1
+import inspect, json, sys, tempfile, shutil
+from pathlib import Path
+sys.path.insert(0, ".")
+from scripts.lib.profiles import compose_registry as cr
+
+fail = []
+sig = inspect.signature(cr._entry)
+req = [n for n, p in sig.parameters.items()
+       if p.default is inspect._empty and p.kind is p.KEYWORD_ONLY]
+core_slug = next(iter(cr.COMPOSE_REGISTRY))
+tmpl = dict(cr.COMPOSE_REGISTRY[core_slug])
+kw = {n: (tmpl[n] if n in tmpl else "composes/x/base.yml") for n in req}
+
+root = Path(tempfile.mkdtemp())
+try:
+    (root / "scripts/lib/profiles-local").mkdir(parents=True)
+    reg = root / "scripts/lib/profiles-local/registry.local.json"
+
+    def load(d):
+        reg.write_text(json.dumps(d))
+        try:
+            return cr.load_local_registry(root), None
+        except cr.LocalRegistryError as e:
+            return None, str(e)
+
+    row = lambda mid: dict(kw, model=mid, status="experimental")
+
+    _, err = load({"local/mine": row("m1")})
+    if not err:
+        fail.append("legacy 'local/' slug was accepted")
+    elif "engine" not in err:
+        fail.append("legacy refusal does not tell the user the new shape")
+
+    got, err = load({"my-llamacpp/mine": row("m2")})
+    if err:
+        fail.append(f"'<engine>/<name>' refused: {err[:60]}")
+    elif got["my-llamacpp/mine"].get("origin") != "local":
+        fail.append("accepted local row not stamped origin=local")
+
+    _, err = load({"noslash": row("m3")})
+    if not err:
+        fail.append("a slug with no '/' was accepted")
+
+    # The shadow path — core wins, local row loaded AND marked.
+    got, err = load({core_slug: row("m4")})
+    if err:
+        fail.append(f"core collision still raises instead of shadowing: {err[:50]}")
+    else:
+        if not got[core_slug].get("shadowed_by_core"):
+            fail.append("shadowed local row is not marked shadowed_by_core")
+        if cr.get_registry(root)[core_slug].get("origin") != "core":
+            fail.append("local row shadowed a CORE slug in the merged view")
+finally:
+    shutil.rmtree(root)
+
+print("FAIL:" + "; ".join(fail) if fail else "OK")
+PY
+)"
+case "$out" in
+  OK) echo "  ok   shape enforced, legacy refused, core collision shadowed" ;;
+  FAIL:*) echo "  FAIL ${out#FAIL:}"; rc=1 ;;
+  *) echo "  FAIL guard could not run: $out"; rc=1 ;;
+esac
+
+# No file may still DERIVE locality by stripping the prefix (demote.py:88 and
+# export_pr.py:282 both did; that arithmetic silently returns the wrong value).
+# Only DERIVATION counts — an assignment or a return. Using the stripped tail
+# inside a refusal message ("Use '<engine>/<name>' instead") is fine: those sit
+# in branches that have just proven the prefix is present, and they compute
+# nothing the code relies on.
+_deriv='(^|[^#])[[:space:]]*(return|[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=)[^#]*\[len\((_LOCAL_SLUG_PREFIX|_LOCAL_NS)\):\]'
+if command grep -rnE "$_deriv" scripts/lib/profiles/*.py >/dev/null 2>&1; then
+  echo "  FAIL a file still DERIVES a value by stripping the local prefix:"
+  command grep -rnE "$_deriv" scripts/lib/profiles/*.py | sed 's/^/       /'
+  rc=1
+else
+  echo "  ok   no prefix-stripping arithmetic remains"
+fi
+
+[[ "$rc" == "0" ]] && echo "PASS: local slugs share the curated shape" || echo "FAIL: hard-cut regression"
+exit "$rc"

--- a/scripts/tests/test-registry-origin-field.sh
+++ b/scripts/tests/test-registry-origin-field.sh
@@ -14,6 +14,8 @@
 #      `merged.update(local)`, i.e. LOCAL silently won. Unreachable while local
 #      slugs sit in their own namespace, live the moment P3 lands.
 set -uo pipefail
+# Non-UTF-8 locales break python3 reads/writes on this rig (#599/#584).
+export PYTHONUTF8="${PYTHONUTF8:-1}"
 cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 rc=0
 
@@ -46,14 +48,14 @@ try:
 
     # 2. a valid local row is stamped local, not self-declared
     mine = dict(kw); mine["model"] = "guard-local-model"; mine["status"] = "experimental"
-    reg.write_text(json.dumps({"local/guard": mine}))
-    e = cr.load_local_registry(root)["local/guard"]
+    reg.write_text(json.dumps({"my-engine/guard": mine}))
+    e = cr.load_local_registry(root)["my-engine/guard"]
     if e.get("origin") != "local":
         fail.append(f"local row origin={e.get('origin')!r}, want 'local'")
 
     # 3. spoofing origin must be refused
     spoof = dict(mine); spoof["origin"] = "core"
-    reg.write_text(json.dumps({"local/spoof": spoof}))
+    reg.write_text(json.dumps({"my-engine/spoof": spoof}))
     try:
         cr.load_local_registry(root)
         fail.append("a local row was allowed to declare origin='core' (spoofable)")

--- a/tools/serve-cockpit/club3090_cockpit/data.py
+++ b/tools/serve-cockpit/club3090_cockpit/data.py
@@ -2759,15 +2759,20 @@ def compute_promote_scaffold(
     _moe = getattr(mspec, "moe", None)  # rendered into the preview below
     vision_hint = _vis.value if _vis is not None else None
     short = mid.replace("qwen3.6-", "qwen-").replace("gemma-4-", "gemma-")
+    # HARD-CUT (#1202 P3): a local slug carries the ENGINE namespace, exactly like
+    # a curated one — `local/` used to squat in that slot. Provenance is the
+    # `origin` field now, stamped by the loader, so the layer still decides where
+    # the FILES go; it no longer decides what the slug is CALLED. A user model
+    # whose name happens to match a shipped slug is shadowed (core wins) and
+    # marked, not refused.
+    registry_slug = f"vllm/{short}-dual-{quant}"
     if layer == "local":
-        registry_slug = f"local/{short}-dual-{quant}"
         profile_path = f"scripts/lib/profiles-local/models.d/{mid}.yml"
         compose_path = (
             sibling_compose_path
             or f"scripts/lib/profiles-local/composes/{mid}/vllm/compose/dual/{quant}/base.yml"
         )
     else:
-        registry_slug = f"vllm/{short}-dual-{quant}"
         profile_path = f"scripts/lib/profiles/models/{mid}.yml"
         compose_path = (
             sibling_compose_path

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -6035,7 +6035,11 @@ class TestPromoteHookWired:
             _spec = json.loads(app.screen._plan.env["C3_PROMOTE_SPEC"])
             assert _spec["display_name"] == "Qwen3 27B Abliterated"
             assert _spec["family"] == "qwen3-dense"
-            assert _spec["registry_entry"]["slug"].startswith("local/")
+            # #1202 P3: engine namespace, not `local/`. `--layer local` above is
+            # what keeps the write inside the gitignored layer.
+            _slug = _spec["registry_entry"]["slug"]
+            assert not _slug.startswith("local/")
+            assert _slug.count("/") == 1, _slug
             # #1156: THIS assertion was missing, and its absence let a plan that
             # promote.py always refuses (empty compose.content) pass as green.
             assert _spec["compose"]["content"].strip(), "spec.compose.content is empty"

--- a/tools/serve-cockpit/tests/test_route_g_e2e.py
+++ b/tools/serve-cockpit/tests/test_route_g_e2e.py
@@ -232,7 +232,9 @@ def test_route_g_all_legs_end_to_end(tmp_path: Path, monkeypatch):
     assert weight_meta["hf_repo"] == REPO
 
     slug = spec["registry_entry"]["slug"]
-    assert slug.startswith("local/")
+    # #1202 P3: engine namespace, not `local/` (layer asserted above).
+    assert not slug.startswith("local/")
+    assert slug.count("/") == 1, slug
     assert spec["registry_entry"]["kwargs"]["model"] == MID
     assert spec["registry_entry"]["kwargs"]["max_ctx"] == 131072
     assert spec["registry_entry"]["kwargs"]["status"] == "incubating"

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -3989,7 +3989,12 @@ class TestPromoteScaffold:
         # C4-rev: LOCAL layer by default — gitignored paths + local/ namespace.
         assert sc.layer == "local"
         assert sc.profile_path.startswith("scripts/lib/profiles-local/models.d/")
-        assert sc.registry_slug.startswith("local/")
+        # #1202 P3: the slug carries the ENGINE namespace, like a curated row —
+        # `local/` used to squat in that slot. The LAYER (asserted above) still
+        # decides where the files go; it no longer decides what the slug is called.
+        assert not sc.registry_slug.startswith("local/")
+        assert sc.registry_slug.count("/") == 1, sc.registry_slug
+        assert sc.registry_slug.split("/", 1)[0] == "vllm", sc.registry_slug
         assert sc.spec["compose"]["path"].startswith(
             "scripts/lib/profiles-local/composes/"
         )


### PR DESCRIPTION
**#1202 P3** — the hard-cut. `local/` occupied the **engine** slot.

Every curated slug is `<engine>/<name>` (`vllm/dual`, `llamacpp-club3090/glm53-…`), so a local model could not say which engine it runs — and `promote.py` had no `engine` key at all. A user on their own build had nowhere to record it. Provenance moved to `origin` in #1204; the namespace goes here.

## ⛔ The safety guard, and why its test was written first

`local/` was the **only** thing between `--slug vllm/dual` and the curated catalog — a `startswith` test run before anything is read, exactly as `demote.py`'s docstring advertised. So `test-demote-refuses-core.sh` was written **before** the change and pins the *property* (a curated slug is refused, catalog byte-identical afterwards) rather than the mechanism. It was green before the cut and stayed green after.

The replacement is **location-based**: a slug absent from `registry.local.json` is refused before anything is read or written. That's *stronger* than a name test — a curated slug can never appear in a file `demote.py` is the sole writer of — and it fails closed. The message improved as a side effect:

```
'vllm/minimal' is a CURATED catalog entry, not a local one. This tool only removes
the local layer; a curated entry is git-tracked and git is its removal tool.
```

## Five files, not four

`compose_registry.py`, `promote.py`, `demote.py`, `export_pr.py` — **and the cockpit**. `data.py:2763` *mints* slugs (`f"local/{short}-dual-{quant}"`), so c3 would have generated slugs the loader now refuses. `preflight-add-model.sh` was checked and has no prefix dependency.

## Publish stops being a rename

Prefix-stripping arithmetic removed in two places, both of which would silently return a wrong value once the prefix is gone: `demote.py:88` (model id) and `export_pr.py:282` (core slug). The second is the interesting one — publishing used to compute `f"{ns}/{slug[len('local/'):]}"`, i.e. **rename**. Local slugs already *are* `<engine>/<name>`, so the core slug is now the slug the user has been running: their scripts, notes and compose pins survive publication. `ns` is retained as a consistency check.

## The shadow path works

Reachable for the first time — the namespace check used to refuse a non-`local/` slug before the collision test could run. A core-colliding local row **loads**, is marked `shadowed_by_core=True`, and the merged view resolves to **core**: the listed-but-marked decision from #1204, finally exercised.

## Tests

Four updated. Each pinned the old slug contract **while its LAYER assertions kept passing** — that's what distinguishes updating a test from papering over a break. They now assert more than before: no `local/` prefix **and** `<engine>/<name>` shape **and** the engine slot, where they previously checked only a prefix.

`test-local-layer-lifecycle` runs **19/19** on the new namespace: promote → merged-view visibility → dry-run → demote → **re-promote succeeds**, which is the real proof removal is complete.

Also fixed: my four new/edited guards didn't `export PYTHONUTF8`, which `test-locale-utf8` correctly caught — the non-UTF-8 locale trap (#599/#584) would have bitten a user with a `de_DE.iso88591` shell, not us.

Docs updated here rather than deferred to P6, since the hard-cut is user-facing: `BRING_YOUR_OWN.md` now states the shape, the shadowing behaviour, and carries a migration note.

**Cockpit suite 1124 passed / 1 skipped · bash guards 140 passed / 0 failed.**
