### PR TITLE
feat(catalog): scripts/catalog.sh + a local ENGINE layer, so a user's own build can register (#1202 P4)

### DIFF
--- a/docs/BRING_YOUR_OWN.md
+++ b/docs/BRING_YOUR_OWN.md
@@ -252,10 +252,56 @@ Serving by hand (§1) gets you a running model but not a *first-class* one: no
 `launch.sh` / `switch.sh --list` discovery, no VRAM projection, no guard coverage.
 You can have all of that **without touching a single tracked file**.
 
+**If you already have a working compose, that is all you need:**
+
+```bash
+bash scripts/catalog.sh register --compose ./my-compose.yml \
+     --engine my-llamacpp --engine-type llama.cpp \
+     --weights /path/to/model.gguf            # or an HF config.json
+bash scripts/preflight-add-model.sh  my-llamacpp/<your-model>   # diagnose-profile + 9 catalog guards
+```
+
+`register` reads your compose and fills in what it can — engine, context, KV format,
+tensor split, port, model id, weights path — then **prints every value it resolved,
+marked `(given)` or `(derived)`, before writing anything**. `--dry-run` shows the whole
+plan and writes nothing. A compose is read mechanically: it cannot know whether your
+`-ts 1,1` means a layer split or tensor parallelism in the catalog's sense, so check the
+list rather than trusting it.
+
+Three things it will **refuse** rather than guess, because guessing wrong is silent:
+
+| refusal | why |
+|---|---|
+| `--engine` | your image matches nothing we ship. Recording `engine: unknown` is worse than stopping. |
+| `--weights` | a compose cannot state `hidden_size`; the dims come from your GGUF header or an HF `config.json`. Refused **before** writing, so a half-written layer never happens. |
+| `--engine-type` | what your engine *behaves like* (`llama.cpp`, `vllm`, …). It drives drafter and feature logic, and a wrong value fails silently. |
+
+**Running your own engine build is expected, not exceptional.** If `--engine` names an
+engine the catalog does not know, a profile is written for it under
+`profiles-local/engines.d/` from evidence only: your image, the KV format your compose
+actually uses, and the compute capability of the card it demonstrably runs on. Capability
+blocks it cannot verify are left **empty** — the stack makes no promises on your behalf.
+Widen them once you have measured. This is exactly how our own fork is registered:
+`llamacpp-club3090` is a distinct `id` with `type: llama.cpp`.
+
+To remove one again:
+
+```bash
+bash scripts/catalog.sh unregister --slug my-llamacpp/<your-model>   # --dry-run first if you like
+```
+
+It refuses any slug that is not in your local layer, so a curated entry is unreachable
+from it — those are git-tracked and git is their removal tool.
+
+<details><summary>Hand-authoring the spec instead</summary>
+
+Still supported, and what `register` builds for you underneath:
+
 ```bash
 python3 scripts/lib/profiles/promote.py --spec-file <spec>.json     # --layer local is the DEFAULT
-bash    scripts/preflight-add-model.sh  <engine>/<your-slug>       # diagnose-profile + 9 catalog guards
 ```
+
+</details>
 
 That writes `scripts/lib/profiles-local/` — `models.d/<id>.yml`, `composes/<id>/…`
 and `registry.local.json`. Slugs use the **same `<engine>/<name>` shape as curated

--- a/scripts/catalog.sh
+++ b/scripts/catalog.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# catalog.sh — register / unregister models in YOUR local catalog layer (#1202 P4).
+#
+# The local layer had an executor (promote.py / demote.py) but no front door:
+# both live under scripts/lib/, which reads as internal, and registering meant
+# hand-authoring a spec JSON. Meanwhile the compose->spec derivation lived only
+# inside the cockpit, so the layer was write-only from the UI (#1153). This is
+# the CLI half; c3 and this script now share one derivation.
+#
+#   catalog.sh register   --compose <path> [--engine ID] [--model ID]
+#                         [--workload W] [--port N] [--weights PATH]
+#                         [--engine-type T] [--min-sm N] [--dry-run] [-y]
+#   catalog.sh register   --spec-file <path> [--dry-run] [-y]
+#   catalog.sh unregister --slug <engine>/<name> [--dry-run] [-y]
+#
+#   --root <dir>  operate on a throwaway tree instead of this checkout (tests).
+#
+# NOTHING here can touch the curated catalog: promote.py defaults to the local
+# layer (core needs C3_ALLOW_CORE_PROMOTE=1) and demote.py refuses any slug that
+# is not in registry.local.json.
+set -uo pipefail
+# Non-UTF-8 locales break python3 reads/writes on this rig (#599/#584).
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+ROOT="$PWD"
+
+die() { printf '[catalog] %s\n' "$*" >&2; exit 2; }
+
+usage() {
+  sed -n '2,18p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+[[ $# -gt 0 ]] || usage 2
+SUB="$1"; shift
+
+COMPOSE="" SPEC_FILE="" ENGINE="" MODEL="" WORKLOAD="" PORT="" SLUG="" DRY="" YES="" RROOT="" WEIGHTS="" ETYPE="" MINSM=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --compose)   COMPOSE="${2:-}"; shift 2 ;;
+    --spec-file) SPEC_FILE="${2:-}"; shift 2 ;;
+    --engine)    ENGINE="${2:-}"; shift 2 ;;
+    --model)     MODEL="${2:-}"; shift 2 ;;
+    --workload)  WORKLOAD="${2:-}"; shift 2 ;;
+    --port)      PORT="${2:-}"; shift 2 ;;
+    --weights)   WEIGHTS="${2:-}"; shift 2 ;;
+    --engine-type) ETYPE="${2:-}"; shift 2 ;;
+    --min-sm)    MINSM="${2:-}"; shift 2 ;;
+    --slug)      SLUG="${2:-}"; shift 2 ;;
+    --root)      RROOT="${2:-}"; shift 2 ;;
+    --dry-run)   DRY="--dry-run"; shift ;;
+    -y|--yes)    YES="--yes"; shift ;;
+    -h|--help)   usage 0 ;;
+    *) die "unknown option: $1" ;;
+  esac
+done
+
+case "$SUB" in
+  unregister)
+    [[ -n "$SLUG" ]] || die "unregister needs --slug <engine>/<name>"
+    exec python3 scripts/lib/profiles/demote.py --slug "$SLUG" ${RROOT:+--root "$RROOT"} ${DRY:+--dry-run} ${YES:+-y}
+    ;;
+
+  register)
+    if [[ -n "$SPEC_FILE" ]]; then
+      # Escape hatch, retained: BRING_YOUR_OWN.md documents this and removing it
+      # would break anyone following those docs today.
+      [[ -f "$SPEC_FILE" ]] || die "no such spec file: $SPEC_FILE"
+      exec python3 scripts/lib/profiles/promote.py --spec-file "$SPEC_FILE" \
+           --layer local ${RROOT:+--root "$RROOT"} ${DRY:+--dry-run} ${YES:+--yes}
+    fi
+    [[ -n "$COMPOSE" ]] || die "register needs --compose <path> (or --spec-file)"
+    [[ -f "$COMPOSE" ]] || die "no such compose: $COMPOSE"
+
+    # min_sm is a capability CLAIM. The honest value is the card the engine is
+    # demonstrably running on, not a low number that claims old hardware works.
+    if [[ -z "$MINSM" ]]; then
+      MINSM="$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d ' ')"
+    fi
+    SPEC="$(mktemp)"; trap 'rm -f "$SPEC"' EXIT
+    # Derivation + spec assembly. Everything derived is PRINTED before the write:
+    # a compose is read mechanically and cannot know whether `-ts 1,1` means a
+    # layer split or tensor parallelism in the catalog's sense, so a wrong value
+    # nobody saw is worse than a prompt.
+    python3 - "$COMPOSE" "$SPEC" "$ENGINE" "$MODEL" "$WORKLOAD" "$PORT" "$WEIGHTS" \
+             "${RROOT:-$ROOT}" "$ETYPE" "$MINSM" <<'PY' || exit $?
+import json, sys, zlib
+from pathlib import Path
+
+sys.path.insert(0, ".")
+from scripts.lib.profiles.compose_facts import derive_compose_facts
+
+src, out, engine_in, model_in, workload_in, port_in, weights_in, wroot, etype_in, minsm_in = sys.argv[1:11]
+text = Path(src).read_text(encoding="utf-8")
+f = derive_compose_facts(text, src)
+if not f.ok:
+    print(f"[catalog] cannot read {src}: {f.error or 'unparseable'}", file=sys.stderr)
+    raise SystemExit(2)
+
+# ENGINE — the one field that cannot be inferred for an image we do not ship.
+# Writing engine="unknown" into the catalog would be worse than refusing, and
+# this is exactly the user the local layer exists for (their own build).
+engine = engine_in or (f.engine if f.engine and f.engine != "unknown" else "")
+if not engine:
+    print(f"[catalog] the engine could not be inferred from image "
+          f"{f.image or '(none)'!r}. Pass --engine <id> (e.g. --engine my-llamacpp).",
+          file=sys.stderr)
+    raise SystemExit(2)
+
+mid = model_in or f.served_name
+if not mid:
+    print("[catalog] no model id: the compose has no --served-model-name/-a. "
+          "Pass --model <id>.", file=sys.stderr)
+    raise SystemExit(2)
+
+max_ctx = int(f.max_ctx or 0) or 4096
+# workload is pure taxonomy — nothing in a compose states it. Propose from ctx.
+workload = workload_in or ("long-ctx-single" if max_ctx >= 65536 else "fast-chat")
+
+# LOCAL models live in the 202xx band so a `git pull` of new curated slugs cannot
+# collide with them. promote.py suggests exactly this value on refusal; compute it
+# up front so registration succeeds the first time instead of failing with advice.
+port = int(port_in) if port_in else 20200 + (zlib.crc32(mid.encode("utf-8")) % 100)
+
+# ⛔ ARCH IS REQUIRED, AND MUST BE CHECKED BEFORE THE WRITE.
+# promote.py reads spec["arch"] with .get, so a missing arch passes its own
+# validation — and then the post-write re-check dies with KeyError: 'hidden_size'
+# in compat.py, leaving the layer WRITTEN AND BROKEN ("NO ROLLBACK"). A compose
+# cannot carry arch dims by construction, so read them from the weights.
+arch = {}
+if weights_in:
+    from scripts.lib.profiles.deriver import gguf_facts_from_file
+    facts = gguf_facts_from_file(weights_in) if weights_in.endswith(".gguf") else None
+    if facts is None and weights_in.endswith(".json"):
+        cfg = json.loads(Path(weights_in).read_text(encoding="utf-8"))
+        facts = {"hidden_size": cfg.get("hidden_size"),
+                 "num_hidden_layers": cfg.get("num_hidden_layers"),
+                 "num_attn_heads": cfg.get("num_attention_heads"),
+                 "num_kv_heads": cfg.get("num_key_value_heads"),
+                 "max_ctx_supported": cfg.get("max_position_embeddings"),
+                 # A KV-math hint. The GGUF path derives it; an HF config does not
+                 # state it, and False is the ordinary case (K and V differ). Said
+                 # out loud because it is the one value here that is assumed.
+                 "attention_k_eq_v": False}
+    for k in ("hidden_size", "num_hidden_layers", "num_attn_heads", "num_kv_heads",
+              "head_dim_attn", "max_ctx_supported", "attention_k_eq_v"):
+        if facts and facts.get(k) is not None:
+            arch[k] = facts[k]
+
+# The profile factory bracket-accesses SIX arch fields; a missing one is a
+# KeyError in compat.py AFTER promote has written the layer. Enumerated from the
+# factory rather than guessed — twice now a shorter list let a broken write through.
+_ARCH_REQUIRED = ("hidden_size", "num_hidden_layers", "num_attn_heads",
+                  "num_kv_heads", "max_ctx_supported", "attention_k_eq_v")
+if "max_ctx_supported" not in arch and max_ctx:
+    arch["max_ctx_supported"] = max_ctx      # the compose proves at least this much
+need = [k for k in _ARCH_REQUIRED if arch.get(k) is None]
+if need:
+    print(f"[catalog] the model profile needs arch dims a compose cannot state: "
+          f"{', '.join(need)}.", file=sys.stderr)
+    print(f"[catalog] pass --weights <path-to.gguf> (header read only) or "
+          f"<config.json>. Refusing BEFORE writing — promote would otherwise write "
+          f"the layer and then fail its own re-check, leaving it broken.",
+          file=sys.stderr)
+    raise SystemExit(2)
+
+# ── the engine profile ────────────────────────────────────────────────────────
+# cross-reference validation requires `engine` to resolve, and engines used to be
+# core-only — so a user on their OWN build could not register at all. Write a
+# minimal profile for an engine the catalog does not know, from EVIDENCE only:
+# what the compose states, and what the rig demonstrably runs. Nothing is assumed
+# on the user's behalf; unverified capability blocks are left empty so the stack
+# makes no promises it cannot keep.
+sys.path.insert(0, wroot)
+from scripts.lib.profiles.compat import load_profiles  # noqa: E402
+try:
+    known = set(load_profiles().engines)
+except Exception:
+    known = set()
+
+# ⚠️ TWO VOCABULARIES. compose_facts yields `llama-cpp` (hyphen); engine profiles
+# use `llama.cpp` (dot), and `type` has no enum validation — so passing the
+# derived value through would write something that matches nothing, silently
+# costing the fork its drafter compatibility. Map, never pass through.
+_TYPE_BY_FACT = {"llama-cpp": "llama.cpp", "vllm": "vllm", "ik-llama": "ik-llama"}
+engine_yaml = ""
+if engine not in known:
+    etype = etype_in or _TYPE_BY_FACT.get(f.engine, "")
+    if not etype:
+        print(f"[catalog] {engine!r} is not a known engine and its lineage cannot be "
+              f"inferred from image {f.image or '(none)'!r}. Pass --engine-type "
+              f"(llama.cpp | vllm | …) so drafter/feature logic knows what it "
+              f"behaves like.", file=sys.stderr)
+        raise SystemExit(2)
+    kvs = [f.kv_dtype] if f.kv_dtype else []
+    drafted = ("--model-draft" in text) or (" -md " in text)
+    lines = [
+        "schema_version: 1",
+        f"id: {engine}",
+        f"display_name: {engine} (local, registered from a compose)",
+        f"type: {etype}",
+        "stability: experimental",
+        f"min_sm: {minsm_in or '7.5'}",
+    ]
+    if f.image:
+        lines += ["install:", "  method: docker", f'  spec: "{f.image}"']
+    if kvs:
+        lines += ["supported_kv_formats:"] + [f"  - {k}" for k in kvs]
+    lines += ["notes: >",
+              f"  Registered by catalog.sh from {Path(src).name}. Capabilities are",
+              "  EVIDENCED, not assumed: only what the compose demonstrably uses is",
+              "  declared. Widen supported_kv_formats / supported_drafters / features",
+              "  once measured." + ("" if not drafted else " A drafter flag was seen in the compose.")]
+    engine_yaml = "\n".join(lines) + "\n"
+
+cpath = f"scripts/lib/profiles-local/composes/{mid}/{engine}/compose/local/base.yml"
+slug = f"{engine}/{mid}"
+fmt = "gguf" if (f.model_path or "").endswith(".gguf") else "safetensors"
+
+spec = {
+    "model_id": mid,
+    "display_name": mid,
+    "family": "dense",
+    "weights": {"local": {"path": f.model_path, "local_subdir": mid, "size_gb": 1.0,
+                          "format": fmt, "status": "incubating", "hf_repo": "",
+                          "engine": engine, "kind": "main",
+                          "verify_glob": "*.gguf" if fmt == "gguf" else "*.safetensors"}},
+    "arch": arch,
+    "default_weight_variant": "local",
+    "vision_capable": False,
+    "compose": {"path": cpath, "content": text},
+    "registry_entry": {"slug": slug, "kwargs": {
+        "model": mid, "weights_variant": "local", "workload": workload,
+        "engine": engine, "drafter": None,
+        "kv_format": f.kv_dtype or "f16", "tp": int(f.tp or 1),
+        "max_ctx": max_ctx, "max_num_seqs": 1, "mem_util": 0.9,
+        "compose_path": cpath, "default_port": port, "kvcalc_key": "SKIP"}},
+}
+Path(out).write_text(json.dumps(spec, indent=1), encoding="utf-8")
+if engine_yaml:
+    d = Path(wroot) / "scripts/lib/profiles-local/engines.d"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{engine}.yml").write_text(engine_yaml, encoding="utf-8")
+    print(f"[catalog] wrote a local ENGINE profile: profiles-local/engines.d/{engine}.yml "
+          f"(type={etype}, capabilities evidenced from the compose)")
+
+def mark(v, given):  # show the user which values THEY chose vs which we guessed
+    return "given" if given else "derived"
+
+print("[catalog] resolved from the compose — check these before it writes:")
+for label, val, given in (
+    ("slug",      slug,              bool(engine_in and model_in)),
+    ("model",     mid,               bool(model_in)),
+    ("engine",    engine,            bool(engine_in)),
+    ("workload",  workload,          bool(workload_in)),
+    ("max_ctx",   max_ctx,           False),
+    ("kv_format", f.kv_dtype or "f16", False),
+    ("tp",        f.tp or 1,         False),
+    ("port",      port,              bool(port_in)),
+    ("weights",   f.model_path,      False),
+    ("arch",      f"hidden={arch['hidden_size']} layers={arch['num_hidden_layers']} "
+                  f"heads={arch['num_attn_heads']}/{arch['num_kv_heads']}", True),
+):
+    print(f"[catalog]   {label:10s} {str(val):46s} ({mark(val, given)})")
+if f.port and str(port) != str(f.port):
+    print(f"[catalog]   note: the compose serves on {f.port}; the catalog entry uses "
+          f"{port} (LOCAL 202xx band). Your compose is unchanged.")
+PY
+
+    exec python3 scripts/lib/profiles/promote.py --spec-file "$SPEC" \
+         --layer local ${RROOT:+--root "$RROOT"} ${DRY:+--dry-run} ${YES:+--yes}
+    ;;
+
+  -h|--help) usage 0 ;;
+  *) die "unknown subcommand: $SUB (expected register | unregister)" ;;
+esac

--- a/scripts/lib/profiles/compat.py
+++ b/scripts/lib/profiles/compat.py
@@ -825,7 +825,9 @@ def load_profiles(root: Path = PROFILE_ROOT) -> Profiles:
             **_load_local_models(root),
         },
         workloads=_load_dir(root, "workloads", _workload),
-        engines=_load_dir(root, "engines", _engine),
+        # Local first, core second: core wins a collision (same precedence as
+        # the registry — a user cannot redefine a shipped engine out from under us).
+        engines={**_load_local_engines(root), **_load_dir(root, "engines", _engine)},
         drafters=_load_dir(root, "drafters", _drafter),
         calibration=_load_dir(root, "calibration", _calibration),
     )
@@ -861,6 +863,25 @@ def _load_local_models(root: Path) -> dict[str, Any]:
     if not local_dir.is_dir():
         return {}
     return _load_dir(local_dir, ".", _model)
+
+
+def _load_local_engines(root: Path) -> dict[str, Any]:
+    """The LOCAL layer's engine profiles (scripts/lib/profiles-local/engines.d/).
+
+    #1202: a user running their OWN engine build — a fork of something we ship,
+    or something we have never seen — could register a model whose `engine`
+    referenced nothing, and cross-reference validation refused it *after* the
+    write. Engines were core-only while models beside them already merged a local
+    layer; this closes that asymmetry.
+
+    Same schema/factory as core engines, so a broken local engine profile fails
+    as loudly as a broken core one. Absent layer → {} (pristine checkout
+    unchanged). Core wins a collision, matching the registry's precedence: a user
+    cannot silently redefine a shipped engine."""
+    local_dir = Path(root).parent / "profiles-local" / "engines.d"
+    if not local_dir.is_dir():
+        return {}
+    return _load_dir(local_dir, ".", _engine)
 
 
 def _cudagraph_mode(hardware: list[HardwareProfile]) -> Optional[str]:

--- a/scripts/tests/test-catalog-cli.sh
+++ b/scripts/tests/test-catalog-cli.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Guard: scripts/catalog.sh is the front door to the LOCAL layer (#1202 P4).
+#
+# Pins the four properties that make it safe to hand a stranger:
+#   1. an engine that cannot be inferred REFUSES and names the fix, rather than
+#      writing engine="unknown" into the catalog — that user (their own engine
+#      build) is precisely who the local layer exists for;
+#   2. everything auto-filled is PRINTED before the write. A compose is read
+#      mechanically and cannot know whether `-ts 1,1` is a layer split or tensor
+#      parallelism in the catalog's sense, so a wrong value nobody saw is worse
+#      than a prompt;
+#   3. register -> unregister is a clean round trip in a throwaway root;
+#   4. `unregister` cannot reach the curated catalog.
+set -uo pipefail
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+ROOT="$PWD"
+rc=0
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/scripts" "$TMP/tools"
+cp -r scripts/lib "$TMP/scripts/"
+cp -r tools/tui-core "$TMP/tools/"
+
+# Arch dims come from the weights. A fabricated config.json exercises that path
+# without depending on a multi-GB GGUF existing on a contributor's machine.
+cat > "$TMP/config.json" <<'JSON'
+{"hidden_size": 64, "num_hidden_layers": 2, "num_attention_heads": 4, "num_key_value_heads": 2}
+JSON
+W="$TMP/config.json"
+
+C="$TMP/byo.yml"
+cat > "$C" <<'YML'
+services:
+  mine:
+    image: ghcr.io/someone/their-own-engine:v1
+    ports:
+      - "${PORT:-8199}:8199"
+    command: >
+      /app/llama-server -m /models/m.gguf -a byo-probe -c 65536 -ctk q8_0 -ts 1,1
+YML
+
+# 1. unknown engine -> refuse, and say what to do
+out="$(scripts/catalog.sh register --compose "$C" --root "$TMP" --dry-run -y 2>&1)"; code=$?
+if [[ "$code" -eq 0 ]]; then
+  echo "  FAIL an uninferable engine was accepted (would write engine=unknown)"; rc=1
+elif [[ "$out" != *"--engine"* ]]; then
+  echo "  FAIL refusal does not name the fix (--engine)"; rc=1
+else
+  echo "  ok   uninferable engine refused, fix named"
+fi
+
+# 2. derived values are shown
+out="$(scripts/catalog.sh register --compose "$C" --engine their-engine --engine-type llama.cpp --weights "$W" --root "$TMP" --dry-run -y 2>&1)"
+missing=""
+for k in slug model engine workload max_ctx kv_format tp port; do
+  [[ "$out" == *"$k"* ]] || missing="$missing $k"
+done
+if [[ -n "$missing" ]]; then
+  echo "  FAIL derived values not shown before write:$missing"; rc=1
+else
+  echo "  ok   derived values printed for confirmation"
+fi
+[[ "$out" == *"dry-run"* ]] || { echo "  FAIL --dry-run did not reach the executor"; rc=1; }
+
+# 2b. arch is REQUIRED and must be refused BEFORE the write — promote reads it
+# with .get, so a missing arch passes its validation and then dies in the
+# post-write re-check, leaving the layer written and broken ("NO ROLLBACK").
+out="$(scripts/catalog.sh register --compose "$C" --engine their-engine --engine-type llama.cpp --root "$TMP" --dry-run -y 2>&1)"; code=$?
+if [[ "$code" -eq 0 ]]; then
+  echo "  FAIL registered with no arch dims (post-write re-check would break the layer)"; rc=1
+elif [[ "$out" != *"--weights"* ]]; then
+  echo "  FAIL arch refusal does not name the fix (--weights)"; rc=1
+else
+  echo "  ok   missing arch refused BEFORE writing, fix named"
+fi
+
+# 2c. an unknown engine needs a declared lineage, never a guess: `type` has no
+# enum validation, so a wrong value silently costs the fork drafter compat.
+out="$(scripts/catalog.sh register --compose "$C" --engine their-engine --weights "$W" --root "$TMP" --dry-run -y 2>&1)"
+if [[ "$out" == *"--engine-type"* ]]; then
+  echo "  ok   unknown lineage refused, --engine-type named"
+else
+  echo "  FAIL unknown engine lineage was guessed rather than refused"; rc=1
+fi
+
+# 3. round trip
+if scripts/catalog.sh register --compose "$C" --engine their-engine --engine-type llama.cpp --weights "$W" --root "$TMP" -y >/dev/null 2>&1; then
+  REG="$TMP/scripts/lib/profiles-local/registry.local.json"
+  if command grep -q "their-engine/byo-probe" "$REG" 2>/dev/null; then
+    echo "  ok   register wrote their-engine/byo-probe"
+  else
+    echo "  FAIL slug missing from registry.local.json"; rc=1
+  fi
+  # the engine profile must exist, and carry EVIDENCE not assumptions
+  EP="$TMP/scripts/lib/profiles-local/engines.d/their-engine.yml"
+  if [[ -f "$EP" ]]; then
+    if command grep -q "type: llama.cpp" "$EP" && command grep -q "q8_0" "$EP"; then
+      echo "  ok   engine profile written with evidenced type + kv format"
+    else
+      echo "  FAIL engine profile missing declared lineage or the compose's kv format"; rc=1
+    fi
+    if command grep -qE "^(supported_drafters|features|supported_model_families):" "$EP"; then
+      echo "  FAIL engine profile claims capabilities the compose does not evidence"; rc=1
+    else
+      echo "  ok   engine profile claims nothing unverified"
+    fi
+  else
+    echo "  FAIL no local engine profile written for an unknown engine"; rc=1
+  fi
+
+  if scripts/catalog.sh unregister --slug their-engine/byo-probe --root "$TMP" -y >/dev/null 2>&1; then
+    if [[ -f "$REG" ]] && command grep -q "their-engine/byo-probe" "$REG" 2>/dev/null; then
+      echo "  FAIL unregister left the slug behind"; rc=1
+    else
+      echo "  ok   unregister removed it (clean round trip)"
+    fi
+  else
+    echo "  FAIL unregister failed"; rc=1
+  fi
+else
+  echo "  FAIL register failed in a throwaway root"; rc=1
+fi
+
+# 4. the curated catalog is unreachable from the front door too
+CORE="$(python3 -c "
+import sys; sys.path.insert(0,'.')
+from scripts.lib.profiles.compose_registry import COMPOSE_REGISTRY
+print(next(iter(COMPOSE_REGISTRY)))")"
+before="$(find scripts/lib/profiles -type f | sort | xargs -r md5sum | md5sum)"
+if scripts/catalog.sh unregister --slug "$CORE" -y >/dev/null 2>&1; then
+  echo "  FAIL catalog.sh unregister ACCEPTED the curated slug $CORE"; rc=1
+else
+  echo "  ok   curated slug refused through the front door"
+fi
+[[ "$before" == "$(find scripts/lib/profiles -type f | sort | xargs -r md5sum | md5sum)" ]] \
+  || { echo "  FAIL the curated catalog changed"; rc=1; }
+
+[[ "$rc" == "0" ]] && echo "PASS: catalog.sh registers, unregisters, and cannot reach core" \
+                   || echo "FAIL: catalog.sh regression"
+exit "$rc"


### PR DESCRIPTION
**#1202 P4 (+P4a).** The front door — and the thing that turned out to block it.

```
catalog.sh register   --compose <path> [--engine ID] [--engine-type T] [--weights PATH]
                      [--model ID] [--workload W] [--port N] [--min-sm N] [--dry-run] [-y]
catalog.sh register   --spec-file <path>          # retained; BRING_YOUR_OWN.md documents it
catalog.sh unregister --slug <engine>/<name>      # wraps demote.py
```

## ⛔ P4a was a blocker, not future work

The plan said a local engine-profile layer could wait. **It could not.** Cross-reference validation requires `engine` to resolve, and engines were **core-only** — `compat.py` did `engines=_load_dir(root,"engines",_engine)` with no local merge, while models *right beside it* already did `{**core, **_load_local_models(root)}`.

So the headline case for this entire issue — **a user running their own engine build** — could not register at all. It surfaced the only way it could: by running a real registration end to end, where `promote` wrote the layer and then died on `engine references unknown 'my-llamacpp'`.

`compat.py` now merges `profiles-local/engines.d/`, **core last so core wins** — a user cannot redefine a shipped engine. Pristine checkout unchanged: 17 engines.

## Evidenced, not assumed

A generated engine profile fills only what can be *shown*:

| field | evidence |
|---|---|
| `install.spec` | the compose's own `image:` — exact |
| `min_sm` | compute capability of the card it **demonstrably runs on**, not a low number claiming old hardware |
| `supported_kv_formats` | the `-ctk` the compose actually uses |
| `stability` | `experimental` — honest for something we have never run |
| `features`, `supported_drafters` | **empty**, with a note to widen once measured |

Reading a compose tells us what an engine is *asked* to do, never what it *can* do. (Fingerprinting a running engine is the natural follow-up and deliberately out of scope; these profiles are shaped narrow and annotated so it can widen them later rather than undo assumptions.)

## Three refusals, because each wrong guess is silent

- **`--engine`** — the image matches nothing we ship. Writing `engine: unknown` into the catalog is worse than refusing, and that user is precisely who this is for.
- **`--weights`** — arch dims missing (below).
- **`--engine-type`** — lineage uninferable. `type` has **no enum validation**, so a wrong value silently costs the fork its drafter compatibility. Note the two vocabularies disagree: compose facts yield `llama-cpp` (hyphen), profiles use `llama.cpp` (dot) — so the CLI **maps** rather than passes through.

## ⚠️ Arch is enforced in the wrong place (pre-existing)

`promote.py` reads `spec["arch"]` with `.get`, so a missing arch passes *its* validation and then dies in `compat.py` **after** the write — layer written, broken, `NO ROLLBACK`. `catalog.sh` derives the dims via the repo's existing `deriver.gguf_facts_from_file` (header read — verified on a real 4-shard GLM GGUF: hidden=4096, layers=46, heads=64/64) or an HF `config.json`, and **refuses before writing**.

I guessed the required list at four fields; the test caught a fifth (`max_ctx_supported`). It is now **enumerated from the factory: six**.

## `default_port` is allocated, not derived

Local models live in the **202xx band** so a `git pull` of new curated slugs cannot collide. `promote.py` already computes `20200 + crc32(model_id) % 100` and suggests it on refusal; `catalog.sh` computes it up front so registration succeeds first time, leaves the user's compose untouched, and prints the difference.

## Show, don't assume

Everything auto-filled prints with `(given)`/`(derived)` marking before the write, and `--dry-run` resolves without writing. A compose is read mechanically — it cannot know whether `-ts 1,1` is a layer split or tensor parallelism in the catalog's sense.

## Verification

```
PROMOTE_OK my-llamacpp/my-local-model [layer=local]     exit 0, post-write re-check green
```

`test-catalog-cli.sh` pins nine properties, including that the curated catalog is unreachable through the front door and that a generated engine profile claims nothing unverified. Its fixture uses a fabricated `config.json` rather than a real GGUF, so it does not depend on `/mnt/models` existing on a contributor's machine.

**Bash guards: 141 passed / 0 failed.**
