### PR TITLE
feat(switch): `--local` filter and a provenance marker on local rows (#1202 P5)

### DIFF
--- a/scripts/catalog.sh
+++ b/scripts/catalog.sh
@@ -58,7 +58,34 @@ done
 case "$SUB" in
   unregister)
     [[ -n "$SLUG" ]] || die "unregister needs --slug <engine>/<name>"
-    exec python3 scripts/lib/profiles/demote.py --slug "$SLUG" ${RROOT:+--root "$RROOT"} ${DRY:+--dry-run} ${YES:+-y}
+    python3 scripts/lib/profiles/demote.py --slug "$SLUG" ${RROOT:+--root "$RROOT"} ${DRY:+--dry-run} ${YES:+-y} || exit $?
+    # `register` may have written a LOCAL engine profile for this slug's engine.
+    # demote.py knows nothing about it (engines are not its layer), so removing
+    # the model alone orphans it — and orphans accumulate silently. Drop it only
+    # when NO remaining local row uses that engine, and only from the local layer.
+    [[ -n "$DRY" ]] && exit 0
+    python3 - "${RROOT:-$ROOT}" "$SLUG" <<'PY_ENG' || true
+import json, sys
+from pathlib import Path
+
+root, slug = Path(sys.argv[1]), sys.argv[2]
+engine = slug.split("/", 1)[0]
+prof = root / "scripts/lib/profiles-local/engines.d" / f"{engine}.yml"
+if not prof.is_file():
+    raise SystemExit(0)                       # curated engine, or none written
+reg = root / "scripts/lib/profiles-local/registry.local.json"
+still = {}
+if reg.is_file():
+    try:
+        still = json.loads(reg.read_text(encoding="utf-8"))
+    except Exception:
+        raise SystemExit(0)                   # unreadable: leave it alone, loudly nothing
+if any(str(s).split("/", 1)[0] == engine for s in still):
+    raise SystemExit(0)                       # another local model still needs it
+prof.unlink()
+print(f"[catalog] removed the now-unused local engine profile: engines.d/{engine}.yml")
+PY_ENG
+    exit 0
     ;;
 
   register)
@@ -213,9 +240,16 @@ if engine not in known:
               "  once measured." + ("" if not drafted else " A drafter flag was seen in the compose.")]
     engine_yaml = "\n".join(lines) + "\n"
 
-cpath = f"scripts/lib/profiles-local/composes/{mid}/{engine}/compose/local/base.yml"
-slug = f"{engine}/{mid}"
 fmt = "gguf" if (f.model_path or "").endswith(".gguf") else "safetensors"
+# The emitter splits compose_path on "/compose/" and reads <topology>/<quant>/<file>
+# from the tail — so the segment after /compose/ IS the topology in every listing.
+# Writing ".../compose/local/base.yml" made "local" render as the topology.
+_tp = int(f.tp or 1)
+_topo = "single" if _tp <= 1 else ("dual" if _tp == 2 else f"multi{_tp}")
+cpath = (f"scripts/lib/profiles-local/composes/{mid}/{engine}"
+         f"/compose/{_topo}/{fmt}/base.yml")
+slug = f"{engine}/{mid}"
+
 
 spec = {
     "model_id": mid,

--- a/scripts/lib/registry-emit.sh
+++ b/scripts/lib/registry-emit.sh
@@ -178,6 +178,43 @@ for (model, engine, topology), target in DEFAULTS.items():
 PY_EMIT
 }
 
+# Local-layer provenance, as a SIDE CHANNEL (#1202 P5).
+#
+# Deliberately not a new column on the VARIANT tab row. That row is index-coupled
+# across five readers (this file twice, parse_variant_rows' documented positions,
+# and the parity test) and pins `status_note` LAST as the free-text catch-all, so
+# widening it to carry one boolean risks a silent mis-parse in a reader nobody
+# remembered. The JSON contract already carries `source`; this gives the shell the
+# same fact without touching the tab schema.
+#
+# Prints, for the given root:
+#   LOCAL\t<slug>       a registered local row
+#   SHADOWED\t<slug>    a local row whose slug a CURATED entry now occupies:
+#                       loaded and kept, but core wins the lookup, so it must be
+#                       shown as shadowed rather than silently vanish.
+registry_local_slugs() {
+  local root="${1:-$PWD}"
+  python3 - "$root" <<'PY_LOCAL' 2>/dev/null || true
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+sys.path.insert(0, str(root))
+try:
+    from scripts.lib.profiles.compose_registry import (
+        COMPOSE_REGISTRY, load_local_registry,
+    )
+    local = load_local_registry(root)
+except Exception:
+    raise SystemExit(0)          # no local layer, or a broken one: say nothing
+for slug, entry in sorted(local.items()):
+    if entry.get("shadowed_by_core") or slug in COMPOSE_REGISTRY:
+        print(f"SHADOWED\t{slug}")
+    else:
+        print(f"LOCAL\t{slug}")
+PY_LOCAL
+}
+
 derive_switch_variant_tables() {
   local root="$1" emit key switch_engine _launch_engine cdir cfile port _model _profile_engine _kvcalc container _compose_path status max_ctx status_note
   # Self-declare so every caller (switch.sh + test-switch-registry-parity) gets
@@ -761,7 +798,19 @@ for vr in _tui_registry.parse_variant_rows(tab):
                 (REG.get(d["slug"], {}) or {}).get("workload") == "vision-coding"
             ),
             "status_note": d["status_note"],
-            "source": "curated",
+            # Provenance, from the entry's `origin` field (#1202) rather than a
+            # constant. `source` already existed on VariantRow (default "·") and
+            # was hardcoded "curated" — so local rows were indistinguishable in
+            # every listing, which mattered little while they lived under a
+            # `local/` namespace and matters a lot now that they carry the same
+            # `<engine>/<name>` shape as curated ones.
+            # Mapped, not passed through: the contract's value is "curated", and
+            # consumers compare against it.
+            "source": (
+                "local"
+                if (REG.get(d["slug"], {}) or {}).get("origin") == "local"
+                else "curated"
+            ),
             # The shipped baseline row ("the bar") + computed staleness — the
             # ONLY measured-display source for consumers (replaces the c3-side
             # BENCHMARKS.md scrape).  None when the slug has no accepted row.

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -14,6 +14,7 @@
 #   bash scripts/switch.sh --list               # actionable variants on THIS machine (deprecated hidden) + defaults
 #   bash scripts/switch.sh --list --all         # every variant — all GPU counts + deprecated
 #   bash scripts/switch.sh --list-all           # alias for --list --all
+#   bash scripts/switch.sh --local              # only models YOU registered (local layer)
 #   bash scripts/switch.sh --defaults           # just the per-model defaults view
 #   bash scripts/switch.sh --down               # just bring down whatever's up
 #   bash scripts/switch.sh --set-default <slug>  # pin <slug> as YOUR default for its model (.env)
@@ -454,6 +455,20 @@ list_variants() {
   # DEVICES then nvidia-smi). `--list --all` (LIST_ALL=1) shows everything for
   # discoverability. Fail-open: if detection is unavailable we show ALL rather
   # than hide based on a failed probe.
+  # Provenance (#1202). Local rows were INDISTINGUISHABLE in this listing: nothing
+  # rendered a marker, which mattered little while they lived under a `local/`
+  # namespace and matters a lot now they share the curated <engine>/<name> shape.
+  declare -A _is_local=(); local _shadowed=""
+  if declare -F registry_local_slugs >/dev/null; then
+    local _k _v
+    while IFS=$'\t' read -r _k _v; do
+      case "$_k" in
+        LOCAL)    _is_local["$_v"]=1 ;;
+        SHADOWED) _shadowed+="${_shadowed:+, }$_v" ;;
+      esac
+    done < <(registry_local_slugs "$ROOT_DIR" 2>/dev/null)
+  fi
+
   local show_all="${LIST_ALL:-0}" detected_topo max_rank
   detected_topo="$(switch_topology_from_gpus 2>/dev/null || true)"
   if [[ -z "$detected_topo" ]] || ! list_gpu_detect_reliable; then
@@ -497,6 +512,9 @@ list_variants() {
       _hidden_by_topo["$_vtopo"]=$(( ${_hidden_by_topo["$_vtopo"]:-0} + 1 ))
       continue
     fi
+    if [[ "${LIST_LOCAL:-0}" == "1" && -z "${_is_local[$v]:-}" ]]; then
+      continue                       # --local: yours only
+    fi
     _seen_models["${_ds[1]:-?}"]=1
     case "${VARIANT_STATUS[$v]:-production}" in
       production) _prod=$((_prod + 1)) ;;
@@ -535,6 +553,13 @@ list_variants() {
   if [[ "$_inc_hidden" -gt 0 ]]; then
     _inc_note="  (+${_inc_hidden} incubating hidden — --all)"
   fi
+  if [[ -n "$_shadowed" ]]; then
+    echo ""
+    echo "  ⚠ shadowed local slug(s): ${_shadowed}"
+    echo "    A curated entry now ships under that name, and core wins the lookup."
+    echo "    Your registration is intact but unreachable by slug — rename it:"
+    echo "      bash scripts/catalog.sh unregister --slug <slug>   # then re-register under another name"
+  fi
   echo "  Models: ${#_seen_models[@]} · variants: ${_visible} (${_prod} production · ${_cav} caveats · ${_na} NA)${_hidden_note}${_dep_note}${_gated_note}${_inc_note}"
 
   {
@@ -544,6 +569,10 @@ list_variants() {
       IFS=/ read -ra fseg <<< "$file"   # fseg[0]=topology fseg[1]=quant fseg[2]=serving
       topo="${fseg[0]:-unknown}"
       rank="$(topology_rank "$topo")"
+      # --local applies HERE too. Listing is two passes — one that counts, one
+      # that renders — and filtering only the first produced a header saying
+      # "variants: 1" above every curated row.
+      if [[ "${LIST_LOCAL:-0}" == "1" && -z "${_is_local[$v]:-}" ]]; then continue; fi
       if [[ "$show_all" != "1" ]]; then
         case "${VARIANT_STATUS[$v]:-production}" in deprecated|upstream-gated|incubating) continue ;; esac
       fi
@@ -551,8 +580,9 @@ list_variants() {
         continue
       fi
       marker="$(status_marker "${VARIANT_STATUS[$v]:-production}")"
-      printf '%s\t%d\t%s\t%s\t%s/%s\t%s\t%s\n' \
-        "${dseg[1]:-?}" "$rank" "$topo" "$v" "${fseg[1]:-?}" "${fseg[2]:-${file}}" "$marker" "${VARIANT_CTX[$v]:-}"
+      printf '%s\t%d\t%s\t%s\t%s/%s\t%s\t%s\t%s\n' \
+        "${dseg[1]:-?}" "$rank" "$topo" "$v" "${fseg[1]:-?}" "${fseg[2]:-${file}}" "$marker" "${VARIANT_CTX[$v]:-}" \
+        "${_is_local[$v]:+local}"
     done
   } | LC_ALL=C sort -t$'\t' -k1,1 -k2,2n -k4,4 | awk -F'\t' '
     { rows[NR] = $0; cnt[$1]++ }
@@ -566,6 +596,9 @@ list_variants() {
           if (ann == "") ann = ctx                  # production: bare max-ctx (stays "unmarked")
           else sub(/\)$/, ", " ctx ")", ann)         # caveats / NA: fold ctx into the paren
         }
+        # provenance: yours vs shipped. Local rows look exactly like curated ones
+        # since #1202 gave them the same <engine>/<name> shape, so say it.
+        if (f[8] != "") ann = (ann == "" ? "local" : ann " · local")
         printf "  %-8s %-34s %-36s %s\n", tl, f[4], f[5], ann
       }
     }
@@ -1363,6 +1396,7 @@ FORCE="${FORCE:-0}"
 VARIANT=""
 LIST_REQUESTED=0
 LIST_ALL=0
+LIST_LOCAL=0
 OWUI_REGISTER=0
 EXPLAIN_REQUESTED=0
 EXPLAIN_SLUG=""
@@ -1376,6 +1410,11 @@ while [[ $# -gt 0 ]]; do
     --list) LIST_REQUESTED=1 ;;
     --all) LIST_ALL=1 ;;
     --list-all) LIST_REQUESTED=1; LIST_ALL=1 ;;
+    # --local: only the models YOU registered (catalog.sh / promote.py). Locality
+    # is the entry's `origin` field, never the slug string — local slugs carry the
+    # same <engine>/<name> shape as curated ones (#1202), so there is nothing in
+    # the name to filter on.
+    --local) LIST_REQUESTED=1; LIST_LOCAL=1; LIST_ALL=1 ;;
     # --explain <slug> [--json] is a deferred terminal action (like --list), so
     # `--explain X --json` and `--explain --json X` both work. The slug is the
     # next non-flag token; --json (below) toggles structured output.

--- a/scripts/tests/test-switch-local-filter.sh
+++ b/scripts/tests/test-switch-local-filter.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Guard: `switch.sh --local` shows only the models YOU registered, and every
+# local row is MARKED in the normal listing (#1202 P5).
+#
+# Local rows used to be indistinguishable: nothing rendered a provenance marker.
+# That mattered little while they lived under a `local/` namespace, and matters a
+# lot now that P3 gave them the same `<engine>/<name>` shape as curated rows.
+#
+# The bug this pins first: listing is TWO passes, one that counts and one that
+# renders. Filtering only the first produced a header reading "variants: 1" above
+# every curated row — a filter that reported success while doing nothing.
+set -uo pipefail
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+rc=0
+
+# 1. provenance side channel: silent on a pristine checkout, and does not widen
+#    the tab row (which is index-coupled across five readers).
+out="$(bash -c 'source scripts/lib/registry-emit.sh; registry_local_slugs "$PWD"' 2>/dev/null)"
+if [[ -n "$out" && "$(find scripts/lib/profiles-local -type f 2>/dev/null | command grep -cv -e README -e gitignore)" == "0" ]]; then
+  echo "  FAIL registry_local_slugs reported rows with no local layer present"; rc=1
+else
+  echo "  ok   provenance channel silent with no local layer"
+fi
+
+# 2. the flag exists and is wired to BOTH passes
+if command grep -q -- '--local) LIST_REQUESTED=1; LIST_LOCAL=1' scripts/switch.sh; then
+  echo "  ok   --local flag parsed"
+else
+  echo "  FAIL --local flag missing"; rc=1
+fi
+n="$(command grep -c 'LIST_LOCAL:-0' scripts/switch.sh)"
+if [[ "$n" -ge 2 ]]; then
+  echo "  ok   --local applied in both the count and render passes ($n sites)"
+else
+  echo "  FAIL --local applied in only $n pass — the header would filter while rows do not"
+  rc=1
+fi
+
+# 3. the marker is rendered, and only for local rows
+if command grep -q 'ann " · local"' scripts/switch.sh; then
+  echo "  ok   local rows carry a provenance marker"
+else
+  echo "  FAIL local rows render no marker"; rc=1
+fi
+
+# 4. shadowed rows are surfaced, not silently dropped — the "listed but marked"
+#    promise from #1202 P2. A shadowed row is absent from the merged registry by
+#    design (core wins), so a footer is the only place it can appear.
+if command grep -q 'shadowed local slug' scripts/switch.sh; then
+  echo "  ok   shadowed local slugs surfaced in a footer"
+else
+  echo "  FAIL shadowed local slugs would vanish silently"; rc=1
+fi
+
+# 5. NEGATIVE CONTROL: a pristine listing must be unchanged — no marker, no
+#    footer, and the same variant count as without the feature.
+listing="$(LIST_ALL=1 bash scripts/switch.sh --list 2>/dev/null)"
+if [[ "$listing" == *"· local"* ]]; then
+  echo "  FAIL a pristine checkout rendered a local marker"; rc=1
+elif [[ "$listing" == *"shadowed local slug"* ]]; then
+  echo "  FAIL a pristine checkout rendered the shadowed footer"; rc=1
+elif [[ "$listing" != *"Available variants"* ]]; then
+  echo "  FAIL --list produced no listing at all; the checks above prove nothing"; rc=1
+else
+  echo "  ok   pristine listing unchanged (no marker, no footer)"
+fi
+
+[[ "$rc" == "0" ]] && echo "PASS: --local filters and local rows are marked" \
+                   || echo "FAIL: switch --local regression"
+exit "$rc"


### PR DESCRIPTION
**#1202 P5.** Local rows were **indistinguishable** in every listing — nothing rendered a marker. That mattered little while they lived under a `local/` namespace; it matters a lot now that P3 gave them the same `<engine>/<name>` shape as curated rows and P4 made them easy to create.

```
$ bash scripts/switch.sh --local
  single   their-engine/p5-live   gguf/base.yml   (NA: 66K) · local
```

## Provenance travels as a side channel, not a new column

`VariantRow.source` already existed — hardcoded `"curated"`, and **not emitted on the tab row at all**, only in the JSON. Adding a column there means editing five index-coupled readers (this file twice, `parse_variant_rows`' documented field positions, and the parity test) around a `status_note` field explicitly pinned **last** as the free-text catch-all.

Widening that contract to carry one boolean is a poor risk trade: miss a reader and it mis-parses silently. `registry_local_slugs` is additive and gives the shell the same fact. The JSON contract now carries real `origin` instead of the constant.

## Three bugs found by registering for real

None were visible from reading the code:

1. **The filter didn't filter.** Listing is two passes — one that counts, one that renders — and only the first was filtered. The header read `variants: 1` above every curated row: **a filter reporting success while doing nothing.** The guard now asserts `LIST_LOCAL` appears in *both* passes.
2. **`unregister` orphaned the engine profile.** `register` may write one; `demote.py` knows nothing about engines, so they accumulated silently. Now removed — but only when no remaining local row uses that engine, and only from the local layer.
3. **My compose path made `local` the topology.** The emitter splits on `/compose/` and reads `<topology>/<quant>/<file>` from the tail; I'd written `.../compose/local/base.yml`. Now derives a real topology from `tp`.

## Shadowed rows get a footer

A shadowed local slug is absent from the merged registry **by design** (core wins the lookup), so a row is impossible — a footer is the only place it can appear. That's what makes the *"listed but marked"* decision from #1204 real rather than a promise:

```
  ⚠ shadowed local slug(s): vllm/minimal
    A curated entry now ships under that name, and core wins the lookup.
    Your registration is intact but unreachable by slug — rename it:
```

## Known cosmetic issue, not fixed here

Local rows group under the model heading **`lib`**, because the display derives the model from path field 2 and the layer lives at `scripts/lib/profiles-local/`. It affects any local model, predates this change, and fixing it means restructuring the layer's layout.

## Testing

**Bash guards 142 passed / 0 failed.** `test-switch-local-filter.sh` pins the flag, both filter passes, the marker, the shadowed footer, and a **negative control** that a pristine listing renders neither marker nor footer *and still produces a listing at all*.

Verified end to end against the real (gitignored, empty) local layer: register → `--local` shows only that row, marked → unregister → layer back to `.gitignore` + `README`, no orphan.
