### PR TITLE
feat(catalog): rename + update for local entries — the shadowing remedy we owed (#1202 P7)

### DIFF
--- a/docs/BRING_YOUR_OWN.md
+++ b/docs/BRING_YOUR_OWN.md
@@ -339,8 +339,27 @@ listing tells you so instead of quietly swallowing it:
 ```
 
 Core wins on purpose: a stack update must never silently change what one of our
-slugs points at. Your files are untouched — unregister and re-register under
-another name to get it back. (Renaming in place is not yet possible; see #1202.)
+slugs points at. Your files are untouched — rename it and it is reachable again:
+
+```bash
+bash scripts/catalog.sh rename --slug vllm/minimal --to my-llamacpp/minimal --dry-run
+bash scripts/catalog.sh rename --slug vllm/minimal --to my-llamacpp/minimal
+```
+
+The slug's namespace **is** the engine, so renaming across engines moves the compose
+tree and rewrites the entry's `engine` field with it — and is refused outright if the
+target engine has no profile, rather than leaving you with a slug that claims an
+engine which does not exist.
+
+You can also edit an entry in place without re-registering:
+
+```bash
+bash scripts/catalog.sh update --slug my-llamacpp/my-model --set workload=fast-chat --set max_ctx=32768
+```
+
+`origin` is not editable — it is stamped by the loader, and a local row able to call
+itself `core` would hide from the very listings meant to mark it. `model` is not
+editable either: it names the files on disk, so changing it is a move, not an edit.
 
 The directory is
 **gitignored** (everything except its README and `.gitignore`), so:

--- a/scripts/catalog.sh
+++ b/scripts/catalog.sh
@@ -12,6 +12,8 @@
 #                         [--engine-type T] [--min-sm N] [--dry-run] [-y]
 #   catalog.sh register   --spec-file <path> [--dry-run] [-y]
 #   catalog.sh unregister --slug <engine>/<name> [--dry-run] [-y]
+#   catalog.sh rename     --slug <old> --to <new>  [--dry-run]
+#   catalog.sh update     --slug <slug> --set K=V  [--dry-run]   (repeatable)
 #
 #   --root <dir>  operate on a throwaway tree instead of this checkout (tests).
 #
@@ -34,7 +36,7 @@ usage() {
 [[ $# -gt 0 ]] || usage 2
 SUB="$1"; shift
 
-COMPOSE="" SPEC_FILE="" ENGINE="" MODEL="" WORKLOAD="" PORT="" SLUG="" DRY="" YES="" RROOT="" WEIGHTS="" ETYPE="" MINSM=""
+COMPOSE="" SPEC_FILE="" ENGINE="" MODEL="" WORKLOAD="" PORT="" SLUG="" DRY="" YES="" RROOT="" WEIGHTS="" ETYPE="" MINSM="" TO=""; declare -a SETS=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --compose)   COMPOSE="${2:-}"; shift 2 ;;
@@ -47,6 +49,8 @@ while [[ $# -gt 0 ]]; do
     --engine-type) ETYPE="${2:-}"; shift 2 ;;
     --min-sm)    MINSM="${2:-}"; shift 2 ;;
     --slug)      SLUG="${2:-}"; shift 2 ;;
+    --to)        TO="${2:-}"; shift 2 ;;
+    --set)       SETS+=("${2:-}"); shift 2 ;;
     --root)      RROOT="${2:-}"; shift 2 ;;
     --dry-run)   DRY="--dry-run"; shift ;;
     -y|--yes)    YES="--yes"; shift ;;
@@ -86,6 +90,23 @@ prof.unlink()
 print(f"[catalog] removed the now-unused local engine profile: engines.d/{engine}.yml")
 PY_ENG
     exit 0
+    ;;
+
+  rename)
+    # The remedy #1202 promised for a SHADOWED slug and never shipped: a curated
+    # entry appearing under your name leaves your row loaded but unreachable, and
+    # "rename it" was the advice with no way to do it.
+    [[ -n "$SLUG" && -n "$TO" ]] || die "rename needs --slug <old> --to <new>"
+    exec python3 scripts/lib/profiles/amend.py --slug "$SLUG" --to "$TO" \
+         ${RROOT:+--root "$RROOT"} ${DRY:+--dry-run} ${YES:+-y}
+    ;;
+
+  update)
+    [[ -n "$SLUG" ]] || die "update needs --slug <slug>"
+    [[ ${#SETS[@]} -gt 0 ]] || die "update needs at least one --set KEY=VALUE"
+    _args=(); for _kv in "${SETS[@]}"; do _args+=(--set "$_kv"); done
+    exec python3 scripts/lib/profiles/amend.py --slug "$SLUG" "${_args[@]}" \
+         ${RROOT:+--root "$RROOT"} ${DRY:+--dry-run} ${YES:+-y}
     ;;
 
   register)
@@ -306,5 +327,5 @@ PY
     ;;
 
   -h|--help) usage 0 ;;
-  *) die "unknown subcommand: $SUB (expected register | unregister)" ;;
+  *) die "unknown subcommand: $SUB (expected register | unregister | rename | update)" ;;
 esac

--- a/scripts/lib/profiles/amend.py
+++ b/scripts/lib/profiles/amend.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Local-layer AMENDMENT — rename a slug, or edit an entry's fields in place.
+
+The local layer was create-and-delete only: ``promote.py`` refuses every "already
+exists" case and ``demote.py`` only removes, so changing one field meant demoting
+and re-promoting.
+
+That is not merely inconvenient. #1202 decided a local slug colliding with a
+newly-shipped curated one is **shadowed** — core wins the lookup, and the local
+row is kept and MARKED "so the user can rename it". No rename existed, so the
+remedy we advertised was unreachable. ``rename`` is that remedy; ``update`` is
+the convenience half.
+
+    RENAME_OK <old> -> <new>
+    UPDATE_OK <slug>
+
+⛔ CORE IS NEVER TOUCHED. Same guard as demote.py, and grounded the same way: a
+slug is resolved in ``registry.local.json`` FIRST, and anything absent is refused
+before a byte is read or written. That is stronger than a name test — a curated
+slug can never appear in a file this layer is the sole writer of — and it fails
+closed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+_DEFAULT_ROOT = Path(__file__).resolve().parents[3]
+_LOCAL_REGISTRY_REL = "scripts/lib/profiles-local/registry.local.json"
+_LOCAL_COMPOSES_REL = "scripts/lib/profiles-local/composes"
+_LOCAL_ENGINES_REL = "scripts/lib/profiles-local/engines.d"
+
+EXIT_REFUSED = 3
+
+# Fields a user may edit. `origin` is deliberately ABSENT: a local row that could
+# set itself to "core" would hide from the very listings meant to mark it — the
+# same anti-spoof reasoning as registration. `model` is absent too: it names the
+# files on disk, so changing it is a move, not an edit.
+_EDITABLE = ("workload", "max_ctx", "max_num_seqs", "mem_util", "default_port",
+             "kv_format", "tp", "drafter", "status")
+
+
+class Refusal(Exception):
+    """Refused before anything was read or written."""
+
+
+def _load(root: Path) -> dict[str, Any]:
+    path = root / _LOCAL_REGISTRY_REL
+    if not path.is_file():
+        raise Refusal(
+            f"no local layer at {_LOCAL_REGISTRY_REL} — nothing registered on this rig"
+        )
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise Refusal(f"{path} is unreadable — fix or remove it first: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise Refusal(f"{path} is not a JSON object")
+    return raw
+
+
+def _require_local(root: Path, slug: str) -> dict[str, Any]:
+    """Resolve `slug` in the LOCAL layer, or refuse. The core-safety guard."""
+    raw = _load(root)
+    if slug in raw:
+        return raw
+    try:
+        sys.path.insert(0, str(root))
+        from scripts.lib.profiles.compose_registry import COMPOSE_REGISTRY
+
+        is_core = slug in COMPOSE_REGISTRY
+    except Exception:
+        is_core = False
+    if is_core:
+        raise Refusal(
+            f"{slug!r} is a CURATED catalog entry, not a local one. This tool only "
+            f"amends the local layer; a curated entry is git-tracked and a PR is how "
+            f"it changes."
+        )
+    known = ", ".join(sorted(raw)) or "(none registered)"
+    raise Refusal(f"{slug} is not in {_LOCAL_REGISTRY_REL}. Registered: {known}")
+
+
+def _check_new_slug(root: Path, raw: dict[str, Any], new: str) -> None:
+    if new.count("/") != 1 or new.startswith("/") or new.endswith("/"):
+        raise Refusal(f"{new!r} must be '<engine>/<name>'")
+    if new in raw:
+        raise Refusal(f"{new!r} is already registered locally")
+    # A rename must re-run the SAME collision test registration does, or it is a
+    # way to smuggle a shadowed slug back in through the side door.
+    try:
+        sys.path.insert(0, str(root))
+        from scripts.lib.profiles.compose_registry import COMPOSE_REGISTRY
+
+        if new in COMPOSE_REGISTRY:
+            raise Refusal(
+                f"{new!r} is a curated slug — renaming onto it would be shadowed "
+                f"immediately (core wins the lookup). Pick another name."
+            )
+    except Refusal:
+        raise
+    except Exception:
+        pass  # registry unreadable: the local-side checks above still applied
+
+
+def _engine_exists(root: Path, engine: str) -> bool:
+    """Is `engine` a known engine — curated, or in the local engines.d layer?"""
+    if (root / _LOCAL_ENGINES_REL / f"{engine}.yml").is_file():
+        return True
+    try:
+        sys.path.insert(0, str(root))
+        from scripts.lib.profiles.compat import load_profiles
+
+        return engine in load_profiles().engines
+    except Exception:
+        return False
+
+
+def plan_rename(root: Path, old: str, new: str) -> dict[str, Any]:
+    raw = _require_local(root, old)
+    _check_new_slug(root, raw, new)
+    entry = raw[old] if isinstance(raw.get(old), dict) else {}
+    old_engine, new_engine = old.split("/", 1)[0], new.split("/", 1)[0]
+    mid = str(entry.get("model") or "")
+    moves = []
+    if old_engine != new_engine:
+        # The slug's namespace IS the engine (#1202) — so changing it changes
+        # which engine the entry claims, and the `engine` KWARG must follow.
+        # Leaving them to disagree looked harmless (nothing validates this path)
+        # and would have quietly broken the one convention the design rests on.
+        if not _engine_exists(root, new_engine):
+            raise Refusal(
+                f"no engine profile for {new_engine!r}. The slug's namespace is the "
+                f"engine, so renaming into it would claim an engine that does not "
+                f"exist. Register a model on it first (catalog.sh register --engine "
+                f"{new_engine} --engine-type …), or rename within an existing engine."
+            )
+    if old_engine != new_engine and mid:
+        # the engine segment is part of the compose path, so it has to follow
+        src = root / _LOCAL_COMPOSES_REL / mid / old_engine
+        dst = root / _LOCAL_COMPOSES_REL / mid / new_engine
+        if src.is_dir():
+            moves.append((src, dst))
+    return {"old": old, "new": new, "entry": entry, "moves": moves,
+            "old_engine": old_engine, "new_engine": new_engine, "raw": raw}
+
+
+def do_rename(root: Path, old: str, new: str, *, dry_run: bool = False) -> dict[str, Any]:
+    plan = plan_rename(root, old, new)
+    if dry_run:
+        return plan
+    raw, entry = plan["raw"], dict(plan["entry"])
+    for src, dst in plan["moves"]:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        src.rename(dst)
+        print(f"[amend] moved {src.relative_to(root)} -> {dst.relative_to(root)}")
+    if plan["old_engine"] != plan["new_engine"]:
+        entry["engine"] = plan["new_engine"]
+        print(f"[amend] engine: {plan['old_engine']} -> {plan['new_engine']}")
+    if plan["moves"]:
+        cp = str(entry.get("compose_path") or "")
+        marker = f"/{plan['old_engine']}/"
+        if marker in cp:
+            entry["compose_path"] = cp.replace(marker, f"/{plan['new_engine']}/", 1)
+    raw[new] = entry
+    del raw[old]
+    (root / _LOCAL_REGISTRY_REL).write_text(
+        json.dumps(raw, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(f"[amend] registry.local.json: {old} -> {new}")
+    return plan
+
+
+def do_update(root: Path, slug: str, edits: dict[str, Any], *,
+              dry_run: bool = False) -> dict[str, Any]:
+    raw = _require_local(root, slug)
+    entry = dict(raw[slug] if isinstance(raw.get(slug), dict) else {})
+    if not edits:
+        raise Refusal(f"nothing to change — pass at least one of: {', '.join(_EDITABLE)}")
+    bad = [k for k in edits if k not in _EDITABLE]
+    if bad:
+        raise Refusal(
+            f"not editable: {', '.join(sorted(bad))}. Editable: {', '.join(_EDITABLE)}. "
+            f"('origin' is stamped by the loader; 'model' names the files on disk, so "
+            f"changing it is a move, not an edit.)"
+        )
+    before = {k: entry.get(k) for k in edits}
+    entry.update(edits)
+    if dry_run:
+        return {"slug": slug, "before": before, "after": edits}
+    raw[slug] = entry
+    (root / _LOCAL_REGISTRY_REL).write_text(
+        json.dumps(raw, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    for k in sorted(edits):
+        print(f"[amend] {slug}: {k}: {before[k]!r} -> {edits[k]!r}")
+    return {"slug": slug, "before": before, "after": edits}
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Rename or edit a LOCAL catalog entry (never the curated one)."
+    )
+    ap.add_argument("--slug", required=True, help="the local <engine>/<name> slug")
+    ap.add_argument("--to", help="rename: the new <engine>/<name> slug")
+    ap.add_argument("--set", action="append", default=[], metavar="KEY=VALUE",
+                    help=f"update a field ({', '.join(_EDITABLE)}); repeatable")
+    ap.add_argument("--root", default=str(_DEFAULT_ROOT), help="repo root")
+    ap.add_argument("--dry-run", action="store_true", help="print the plan, change nothing")
+    ap.add_argument("-y", "--yes", action="store_true", help="skip the confirmation")
+    args = ap.parse_args(argv)
+
+    if bool(args.to) == bool(args.set):
+        print("[amend] pass exactly one of --to (rename) or --set (update)", file=sys.stderr)
+        return 2
+
+    root = Path(args.root).resolve()
+    try:
+        if args.to:
+            plan = do_rename(root, args.slug, args.to, dry_run=args.dry_run)
+            if args.dry_run:
+                print(f"[amend] dry-run: {plan['old']} -> {plan['new']}")
+                for src, dst in plan["moves"]:
+                    print(f"[amend]   would move {src.relative_to(root)}")
+                print("[amend] nothing written.")
+                return 0
+            print(f"RENAME_OK {args.slug} -> {args.to}")
+            return 0
+
+        edits: dict[str, Any] = {}
+        for kv in args.set:
+            if "=" not in kv:
+                print(f"[amend] --set expects KEY=VALUE, got {kv!r}", file=sys.stderr)
+                return 2
+            k, v = kv.split("=", 1)
+            if v.isdigit():
+                edits[k] = int(v)
+            elif v.replace(".", "", 1).isdigit():
+                edits[k] = float(v)
+            elif v.lower() in ("none", "null"):
+                edits[k] = None
+            else:
+                edits[k] = v
+        res = do_update(root, args.slug, edits, dry_run=args.dry_run)
+        if args.dry_run:
+            for k in sorted(res["after"]):
+                print(f"[amend] dry-run {res['slug']}: {k}: "
+                      f"{res['before'][k]!r} -> {res['after'][k]!r}")
+            print("[amend] nothing written.")
+            return 0
+        print(f"UPDATE_OK {args.slug}")
+        return 0
+    except Refusal as exc:
+        print(f"[amend] refused: {exc}", file=sys.stderr)
+        return EXIT_REFUSED
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test-catalog-amend.sh
+++ b/scripts/tests/test-catalog-amend.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Guard: `catalog.sh rename` / `update` amend the LOCAL layer only (#1202 P7).
+#
+# `rename` is not a convenience. #1202 decided a local slug colliding with a
+# newly-shipped curated one is SHADOWED — kept and marked "so the user can rename
+# it" — and then shipped no rename, so the advertised remedy was unreachable.
+set -uo pipefail
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+rc=0
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/scripts" "$TMP/tools"
+cp -r scripts/lib "$TMP/scripts/"; cp -r tools/tui-core "$TMP/tools/"
+
+printf '{"hidden_size":64,"num_hidden_layers":2,"num_attention_heads":4,"num_key_value_heads":2,"max_position_embeddings":65536}\n' > "$TMP/cfg.json"
+cat > "$TMP/c.yml" <<'YML'
+services:
+  mine:
+    image: ghcr.io/someone/their-own-engine:v1
+    ports: ["${PORT:-8199}:8199"]
+    command: >
+      /app/llama-server -m /models/m.gguf -a amend-probe -c 65536 -ctk q8_0 -ts 1,1
+YML
+scripts/catalog.sh register --compose "$TMP/c.yml" --engine their-engine --engine-type llama.cpp \
+  --weights "$TMP/cfg.json" --root "$TMP" -y >/dev/null 2>&1 \
+  || { echo "  FAIL fixture register failed; nothing below proves anything"; exit 1; }
+CORE="$(python3 -c "
+import sys; sys.path.insert(0,'.')
+from scripts.lib.profiles.compose_registry import COMPOSE_REGISTRY
+print(next(iter(COMPOSE_REGISTRY)))")"
+REG="$TMP/scripts/lib/profiles-local/registry.local.json"
+before_core="$(find scripts/lib/profiles -type f | sort | xargs -r md5sum | md5sum)"
+
+chk() { # name, expect-refusal(0/1), cmd...
+  local name="$1" want="$2"; shift 2
+  "$@" >/dev/null 2>&1; local code=$?
+  if [[ "$want" == "1" && "$code" -eq 0 ]]; then echo "  FAIL $name was ACCEPTED"; rc=1
+  elif [[ "$want" == "0" && "$code" -ne 0 ]]; then echo "  FAIL $name failed (exit $code)"; rc=1
+  else echo "  ok   $name"; fi
+}
+
+chk "curated slug rename refused"      1 scripts/catalog.sh rename --slug "$CORE" --to mine/x --root "$TMP"
+chk "curated slug update refused"      1 scripts/catalog.sh update --slug "$CORE" --set workload=fast-chat --root "$TMP"
+chk "rename ONTO a curated slug refused" 1 scripts/catalog.sh rename --slug their-engine/amend-probe --to "$CORE" --root "$TMP"
+chk "origin is not editable"           1 scripts/catalog.sh update --slug their-engine/amend-probe --set origin=core --root "$TMP"
+chk "rename into an unknown engine refused" 1 scripts/catalog.sh rename --slug their-engine/amend-probe --to nope/amend-probe --root "$TMP"
+chk "--dry-run rename"                 0 scripts/catalog.sh rename --slug their-engine/amend-probe --to their-engine/x --root "$TMP" --dry-run
+
+if command grep -q "their-engine/amend-probe" "$REG"; then
+  echo "  ok   --dry-run changed nothing"
+else
+  echo "  FAIL --dry-run mutated the registry"; rc=1
+fi
+
+chk "real rename"                      0 scripts/catalog.sh rename --slug their-engine/amend-probe --to their-engine/renamed --root "$TMP"
+chk "real update"                      0 scripts/catalog.sh update --slug their-engine/renamed --set workload=fast-chat --root "$TMP"
+
+# The slug's namespace IS the engine, so the two must never drift apart.
+if python3 - "$REG" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+raise SystemExit(0 if all(k.split("/", 1)[0] == v.get("engine") for k, v in d.items()) else 1)
+PY
+then echo "  ok   slug namespace and entry.engine agree"
+else echo "  FAIL slug namespace and entry.engine disagree after amend"; rc=1; fi
+
+# The amended layer must still load, or the edit produced a broken catalog.
+if (cd "$TMP" && python3 -c "
+import sys; sys.path.insert(0,'.')
+from scripts.lib.profiles.compose_registry import load_local_registry
+r = load_local_registry('.')
+raise SystemExit(0 if r and next(iter(r.values())).get('origin') == 'local' else 1)") 2>/dev/null
+then echo "  ok   amended layer still loads, origin preserved"
+else echo "  FAIL amended layer does not load"; rc=1; fi
+
+[[ "$before_core" == "$(find scripts/lib/profiles -type f | sort | xargs -r md5sum | md5sum)" ]] \
+  || { echo "  FAIL the curated catalog changed"; rc=1; }
+
+[[ "$rc" == "0" ]] && echo "PASS: rename/update amend only the local layer" \
+                   || echo "FAIL: catalog amend regression"
+exit "$rc"


### PR DESCRIPTION
**#1202 P7** — the remedy this issue promised and never shipped.

```
catalog.sh rename --slug <old> --to <new>     # --dry-run first
catalog.sh update --slug <s>  --set K=V       # repeatable
```

## Why `rename` is not a convenience

The local layer was **create-and-delete only**: `promote.py` refuses every "already exists" case, `demote.py` only removes. Changing one field meant demoting and re-promoting.

That mattered more than ergonomics. #1204 decided a local slug colliding with a newly-shipped curated one is **shadowed** — kept and *marked* "so the user can rename it" — and no rename existed. **We advertised a remedy that could not be reached.**

## ⛔ A bug I introduced, found by checking rather than assuming

My first rename changed the slug but **not** the entry's `engine` kwarg, leaving `slug=other-engine/x` with `engine=their-engine`.

Nothing validates that path — `load_profiles` cross-checks `COMPOSE_REGISTRY`, which is core-only, and the emit path passed clean. So it would have shipped **silently**, while breaking the one convention this whole change rests on: *the slug's namespace **is** the engine.*

A cross-engine rename now moves the compose tree, rewrites `engine` with it, and is **refused** when the target engine has no profile — rather than leaving a slug that claims an engine which does not exist. The guard pins that the two never drift apart.

## Four refusals

All grounded the same way as `demote.py` — resolve in `registry.local.json` first, fail closed, before a byte is read or written:

| refused | why |
|---|---|
| renaming/updating a **curated** slug | those are git-tracked; a PR is how they change |
| renaming **onto** a curated slug | it would be shadowed instantly — core wins the lookup |
| `--set origin=…` | a local row able to call itself `core` would hide from the very listings meant to mark it |
| `--set model=…` | it names the files on disk, so changing it is a move, not an edit |

## Doc correction

P6 (#1208) shipped *"renaming in place is not yet possible"*, which this makes false. Removed and replaced with the real commands. A stale claim that outlives the constraint that produced it is worse than no claim.

## Testing

`test-catalog-amend.sh` pins **11 properties**, including that `--dry-run` mutates nothing, the amended layer still loads with `origin` preserved, slug namespace and `entry.engine` agree, and the curated catalog is **byte-identical** afterwards. It refuses a vacuous run if the fixture registration fails.

**Bash guards 144 passed / 0 failed.**
