### PR TITLE
fix(concurrency-probe): judge admission by peak running, not the racy last sample

### DIFF
--- a/scripts/concurrency-probe.sh
+++ b/scripts/concurrency-probe.sh
@@ -524,10 +524,16 @@ PY
     fail=0
     clean="$(sed -n 's/.* clean=\([0-9]*\).*/\1/p' <<<"$line")"
     running="$(sed -n 's/.* running=\([^ ]*\).*/\1/p' <<<"$line")"
+    running_max="$(sed -n 's/.* running_max=\([^ ]*\).*/\1/p' <<<"$line")"
+    waiting_max="$(sed -n 's/.* waiting_max=\([^ ]*\).*/\1/p' <<<"$line")"
     [[ "$rc" != "0" || "$clean" != "1" ]] && fail=1
-    if [[ "$running" =~ ^[0-9]+$ && "$running" -lt "$n" ]]; then
+    # A late sample reading running < n after a request finished is normal
+    # completion, not under-admission — so fail (and early-stop) only when the
+    # PEAK running stayed below n. (clean already encodes this; the explicit
+    # check keeps the early-stop reason self-documenting in the log.)
+    if [[ "$running_max" =~ ^[0-9]+$ && "$running_max" -lt "$n" ]]; then
       fail=1
-      echo "[sweep] admitted ${running}/${n} — treating as fail for early-stop"
+      echo "[sweep] admitted ${running_max}/${n} (waiting ${waiting_max:-?}) — treating as fail for early-stop"
     fi
     if [[ "$fail" == "1" && "$EARLY_STOP" == "1" ]]; then
       ROW_DEAD[$ctx]="$n"

--- a/scripts/lib/concurrency_probe.py
+++ b/scripts/lib/concurrency_probe.py
@@ -310,8 +310,14 @@ def engine_stats(container):
     # below max_num_seqs when --max-num-batched-tokens caps the per-step budget:
     # a sweep rung labelled N=64 may only ever run ~10 wide. Reporting the label
     # without this reads as a concurrency measurement when it is a queue-depth one.
+    #
+    # Returns (run, wait, run_max, wait_max, hit). The bare run/wait are the LAST
+    # "Running:" line in the tail; run_max/wait_max are the PEAK across every line.
+    # The last sample is racy: a request that finishes before the sample is taken
+    # reads running < N even though it was admitted and ran, so the peak is the
+    # honest admission signal and the last sample is only a snapshot.
     if not container:
-        return (None, None, None)
+        return (None, None, None, None, None)
     try:
         out = subprocess.run(
             ["docker", "logs", "--tail", "400", container],
@@ -323,15 +329,18 @@ def engine_stats(container):
         )
         txt = (out.stdout or "") + (out.stderr or "")
     except Exception:
-        return (None, None, None)
-    run = wait = hit = None
+        return (None, None, None, None, None)
+    run = wait = run_max = wait_max = hit = None
     for m in re.finditer(
         r"Running:\s*(\d+)\s*reqs?,\s*Waiting:\s*(\d+)\s*reqs?", txt
     ):
-        run, wait = int(m.group(1)), int(m.group(2))
+        r, w = int(m.group(1)), int(m.group(2))
+        run, wait = r, w
+        run_max = r if run_max is None else max(run_max, r)
+        wait_max = w if wait_max is None else max(wait_max, w)
     for m in re.finditer(r"[Pp]refix cache hit rate:\s*([0-9.]+)", txt):
         hit = float(m.group(1))
-    return (run, wait, hit)
+    return (run, wait, run_max, wait_max, hit)
 
 
 def vram_used_mb():
@@ -578,6 +587,8 @@ def run_probe():
     tps_p05_by_round = []
     run_by_round = []
     wait_by_round = []
+    runmax_by_round = []
+    waitmax_by_round = []
     hit_by_round = []
     for rnd in range(1, ROUNDS + 1):
         t0 = time.time()
@@ -611,9 +622,11 @@ def run_probe():
         tps_p05 = pct(tps_ok, 0.05)
         ttft_p95_by_round.append(ttft_p95)
         tps_p05_by_round.append(tps_p05)
-        run, wait, hit = engine_stats(CONTAINER)
+        run, wait, run_max, wait_max, hit = engine_stats(CONTAINER)
         run_by_round.append(run)
         wait_by_round.append(wait)
+        runmax_by_round.append(run_max)
+        waitmax_by_round.append(wait_max)
         hit_by_round.append(hit)
         print(
             f"{rnd:>5} {done:>4}/{N:<2} {silent:>7} {errs:>7} {v:>8} "
@@ -652,7 +665,19 @@ def run_probe():
     else:
         retention = 1.0  # too few post-warmup rounds to judge
 
-    clean_fit = (bad == 0) and (0 <= leak <= GROWTH)
+    # Admission: did the engine actually run N wide at some point? The peak
+    # across samples is the honest signal — a request that finishes before a
+    # sample is taken reads running < N on that (last) sample alone, so the
+    # last sample (s_run) is racy and must not by itself fail fit. If the peak
+    # reached N, N were admitted; a later sample dipping below N is just a
+    # request completing. If the peak never reached N we cannot prove N were
+    # admitted, so fail closed — a genuinely under-admitted server shows this
+    # as running < N (usually with requests WAITING, but the peak alone is the
+    # conservative, race-free test).
+    run_peak = max([r for r in run_by_round if r is not None], default=None)
+    wait_peak = max([w for w in wait_by_round if w is not None], default=None)
+    admitted_ok = (run_peak is None) or (run_peak >= N)
+    clean_fit = (bad == 0) and (0 <= leak <= GROWTH) and admitted_ok
     floor_ok = (report_tps >= TPS_FLOOR) if TPS_FLOOR > 0 else True
     retention_ok = (retention >= RETENTION_MIN) if ROUNDS >= 3 else True
     PASS = clean_fit and floor_ok and (retention_ok if VALIDATE else True)
@@ -691,13 +716,19 @@ def run_probe():
         f"· slowest-decile stream {s_p05:.1f} tok/s (vs median {report_tps:.1f})"
     )
     if s_run is not None:
+        # Only flag under-admission when the PEAK never reached N. A late sample
+        # reading running < N after a request finished is normal completion, not
+        # queuing — so a run whose peak reached N must not print the QUEUED warning.
+        peak_note = ""
+        if run_peak is not None and run_peak < N:
+            peak_note = f"  (peak {run_peak} across {ROUNDS} samples)"
         admitted = (
             ""
-            if s_run >= N
+            if admitted_ok
             else f"  ** engine admitted {s_run} of {N} requested — the rest QUEUED **"
         )
         print(
-            f"  engine: running {s_run} · waiting {s_wait}"
+            f"  engine: running {s_run} · waiting {s_wait}{peak_note}"
             + (f" · prefix-cache hit {s_hit:.1f}%" if s_hit is not None else "")
             + admitted
         )
@@ -735,6 +766,8 @@ def run_probe():
         "tps_p05": _fmt_num(s_p05, 2),
         "running": "-" if s_run is None else s_run,
         "waiting": "-" if s_wait is None else s_wait,
+        "running_max": "-" if run_peak is None else run_peak,
+        "waiting_max": "-" if wait_peak is None else wait_peak,
         "prefix_hit": "-" if s_hit is None else f"{s_hit:.1f}",
         "cache": CACHE,
         "cached_toks": f"{steady_cached:.0f}",

--- a/scripts/tests/test-concurrency-probe-admission.sh
+++ b/scripts/tests/test-concurrency-probe-admission.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# test-concurrency-probe-admission — regression guard for the concurrency-probe
+# admission race: a late `running < N` metrics sample (a request that finished
+# before the sample was taken) must NOT be misread as the engine failing to
+# admit all N streams. The honest admission signal is the PEAK running observed
+# across the round's samples, and a genuine under-admission is only present
+# when a request is actually observed WAITING while running < N.
+#
+# Fully offline: no server, no docker, no run_probe. It (a) unit-checks the
+# admission rule the same way run_probe computes it, and (b) statically asserts
+# the two call sites (the python verdict + the shell sweep early-stop) key off
+# the peak + waiting, not the racy last sample.
+set -euo pipefail
+
+# Force Python UTF-8 mode (PEP 540) before the first python3 call (#779).
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PROBE="$ROOT_DIR/scripts/concurrency-probe.sh"
+LIB="$ROOT_DIR/scripts/lib/concurrency_probe.py"
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# 1. syntax
+bash -n "$PROBE" || fail "bash -n: syntax error"
+python3 -m py_compile "$LIB" || fail "py_compile concurrency_probe.py"
+echo "  ✓ syntax"
+
+# 2. the admission rule, exercised exactly as run_probe computes it:
+#    admitted_ok = (run_peak is None) or (run_peak >= N)
+#    (true -> the fit gate passes on admission; false -> FAIL — fit)
+admitted_ok() {  # $1=N  $2=run_peak  -> echoes 1/0
+  python3 -c '
+import sys
+N, rp = int(sys.argv[1]), sys.argv[2]
+run_peak = None if rp == "-" else int(rp)
+ok = (run_peak is None) or (run_peak >= N)
+print(1 if ok else 0)
+' "$1" "$2"
+}
+# N=1, request completes before the final metrics sample (last sample running=0):
+# the peak was 1 (>= N), so it was admitted -> PASS.
+[[ "$(admitted_ok 1 1)" == "1" ]] || fail "N=1 complete-before-sample must be admitted (PASS)"
+# N=2, both admitted; one finishes before an intermediate sample (peak=2).
+[[ "$(admitted_ok 2 2)" == "1" ]] || fail "N=2 one-finishes-before-sample must be admitted (PASS)"
+# N=2, server genuinely only runs 1 (peak<N) whether or not the other queued:
+# we cannot prove 2 were admitted -> FAIL.
+[[ "$(admitted_ok 2 1)" == "0" ]] || fail "N=2 peak<2 (genuinely under-admitted) must FAIL"
+# No engine stats at all (no container / no Running: lines): cannot prove
+# under-admission, so it must not fail admission.
+[[ "$(admitted_ok 2 -)" == "1" ]] || fail "missing engine stats must not fail admission"
+echo "  ✓ admission rule: peak>=N admits; peak<N fails closed; late running<N is completion"
+
+# 3. the python verdict + RESULT line key off the PEAK, not the last sample.
+command grep -q 'run_peak is None' "$LIB" \
+  || fail "run_probe must gate admission on the peak running (run_peak is None …)"
+command grep -q 'run_peak >= N' "$LIB" \
+  || fail "run_probe must treat run_peak >= N as admitted"
+command grep -q 'admitted_ok' "$LIB" \
+  || fail "run_probe must fold admitted_ok into the fit verdict"
+command grep -q 'running_max' "$LIB" \
+  || fail "RESULT line must carry running_max for the sweep driver"
+command grep -q 'waiting_max' "$LIB" \
+  || fail "RESULT line must carry waiting_max for the sweep driver"
+echo "  ✓ python verdict + RESULT line use the peak, not the last sample"
+
+# 4. the shell sweep early-stop keys off the PEAK running (running_max), not
+#    the racy last-sample running= that produced the false FAIL — fit.
+command grep -q 'running_max' "$PROBE" \
+  || fail "sweep path must read running_max from the RESULT line"
+command grep -qE 'running_max.*-lt.*"\$n"' "$PROBE" \
+  || fail "sweep early-stop must compare the PEAK running against n"
+echo "  ✓ sweep early-stop keys off the peak running, not the last sample"
+
+echo "test-concurrency-probe-admission: ok"


### PR DESCRIPTION
## Summary

`concurrency-probe` reported `FAIL — fit` even when every requested stream completed successfully (0 errors, 0 silent, 0 waiting, stable VRAM) — and the same workload passed on re-run. The verdict flipped on sample timing: the probe read a single instantaneous `Running: N reqs, Waiting: M reqs` sample taken *after* the round's N requests had all completed, and treated a value below N as proof the engine failed to admit them. A request that finished before the sample was taken reads `running < N` (even 0) — so N=1 against a 2-slot server failed one run and passed the next.

The fix judges admission by the **peak** simultaneously-observed `running` across the round's samples, not the last one. A request that ran and then finished still registers in an earlier sample, so `peak >= N` proves N were admitted; a late `running < N` is just completion. If the peak never reached N we cannot prove N were admitted, so we fail closed.

- `scripts/lib/concurrency_probe.py`
  - `engine_stats()` now returns `(run, wait, run_max, wait_max, hit)` — the last sample *and* the peak across the `docker logs --tail 400` window.
  - `run_probe()`: `admitted_ok = (run_peak is None) or (run_peak >= N)`, folded into `clean_fit`. The `** admitted … QUEUED **` warning is gated on `admitted_ok` (no longer fired by a clean completion), and the `engine:` line shows the peak when it dipped below N.
  - RESULT line gains `running_max=` / `waiting_max=` (the existing `running=` / `waiting=` last-sample fields are unchanged).
- `scripts/concurrency-probe.sh` (sweep path)
  - The early-stop fail now keys off `running_max < n` instead of the racy last-sample `running < n`, so a rung where every request completed no longer trips a false fail / early-stop.
- `scripts/tests/test-concurrency-probe-admission.sh` (new)
  - Fully offline (no server, no docker, no `run_probe`), so it runs on any rig: unit-checks the admission rule (N=1 complete-before-sample → PASS; N=2 one-finishes-before-sample → PASS; N=2 peak<N → FAIL; no engine stats → PASS) and statically asserts both call sites key off the peak, not the last sample.

Genuine failure detection is untouched: request errors, silent responses, incomplete rounds (`done < N`), VRAM growth, and a server that truly runs fewer than N wide (peak < N, with requests waiting) all still FAIL. The "streams beyond the slot count QUEUE, not batch" warning is unchanged.

## Type of change

- [ ] New compose variant (`models/<model>/<engine>/compose/docker-compose.<name>.yml`)
- [ ] New patch / sidecar (`models/<model>/<engine>/patches/`)
- [x] New script or tool (`scripts/`, `tools/`)
- [ ] New model (`models/<new-model>/`)
- [ ] Doc-only / typo
- [ ] Other (describe)

## Verification

- [x] **Full rig + validation report attached** — see "N/A justifications" below; the change is to the probe's own verdict logic, not a compose, so the relevant evidence is the probe's own runs below.
- [ ] **Profile header complete** (new/changed compose)
- [ ] **BENCHMARKS row added**
- [ ] **CHANGELOG entry added** in `models/<model>/CHANGELOG.md`

Ran on the reporter's rig (dual 3090, vLLM v0.27.1, Qwen3.8-27B int4, `--max-num-seqs 2`, `:8104` — the instance from the issue, no restart):

- `bash scripts/tests/test-concurrency-probe-admission.sh` → ok (ran twice, stable)
- `bash scripts/tests/test-concurrency-probe.sh` → ok
- `bash scripts/tests/test-default-url-gateway.sh` → ok
- Full `scripts/tests/*.sh` sweep: **135 pass / 10 fail — all 10 fail identically on the clean tree** (missing `nvidia-smi`/`yaml` in this container, live-container tests); no new failures from this change.
- Live, against the running dual instance:
  - `CONCURRENCY=1` → `PASS — sustained clean` (previously the false `FAIL — fit`)
  - auto-detected N=2 → `PASS — sustained clean`

### N/A justifications (if any boxes above are unchecked)

- **Profile header / BENCHMARKS / CHANGELOG:** N/A — no compose, model, or benchmark data touched; the change is to the probe's verdict logic and its tests.
- **Full rig report:** N/A — no compose/patch/variant changed, so `report.sh --full` would re-measure an unchanged stack. The load-bearing evidence is the probe's own before/after on the issue's exact repro (above) plus the offline test suite.

## Cross-links

- Closes #1211
- Related upstream: none (vLLM's `Running:`/`Waiting:` log lines are the data source; no upstream change)