### PR TITLE
fix(catalog): unbreak --weights <gguf>, surface the local-layer view, keep the suite green once a model is registered

### DIFF
--- a/scripts/catalog.sh
+++ b/scripts/catalog.sh
@@ -198,8 +198,15 @@ if weights_in:
 # The profile factory bracket-accesses SIX arch fields; a missing one is a
 # KeyError in compat.py AFTER promote has written the layer. Enumerated from the
 # factory rather than guessed — twice now a shorter list let a broken write through.
+# NOT attention_k_eq_v: promote.py fills it with a documented conservative
+# default ("compat.ModelProfile REQUIRES attention_k_eq_v — emit the conservative
+# default when the spec doesn't carry the fact"), and the post-write diagnose +
+# kv-calc gates flag it for correction. Requiring it here refused every
+# --weights <gguf> registration, because gguf_facts_from_file does not return it
+# — so the GGUF path, the likelier one for this rig, was broken while the
+# config.json path (which sets it explicitly) passed the test.
 _ARCH_REQUIRED = ("hidden_size", "num_hidden_layers", "num_attn_heads",
-                  "num_kv_heads", "max_ctx_supported", "attention_k_eq_v")
+                  "num_kv_heads", "max_ctx_supported")
 if "max_ctx_supported" not in arch and max_ctx:
     arch["max_ctx_supported"] = max_ctx      # the compose proves at least this much
 need = [k for k in _ARCH_REQUIRED if arch.get(k) is None]

--- a/scripts/tests/test-catalog-cli.sh
+++ b/scripts/tests/test-catalog-cli.sh
@@ -154,6 +154,49 @@ else
   echo "  FAIL register failed in a throwaway root"; rc=1
 fi
 
+# 3b. THE OTHER ARCH SOURCE. Arch dims come from a GGUF header or an HF
+# config.json, and the two are NOT interchangeable: gguf_facts_from_file does not
+# return `attention_k_eq_v` while a config.json path can set it. Testing only the
+# config.json leg passed while `--weights <model.gguf>` — the likelier path on a
+# GGUF rig — refused every registration. Cover both, and SKIP LOUDLY rather than
+# silently passing when this machine has no .gguf to read.
+# Pick a MODEL gguf, not just any .gguf. The first hit on this rig was
+# `mmproj-F16.gguf` — a multimodal projector with no arch dims — so the leg
+# failed on a bad fixture while the code was correct. Done in ONE python call:
+# the bash loop that did this was fragile under the test's quoting and silently
+# selected nothing, which read as "no gguf on this machine".
+GG="$(python3 - <<'PY_PICK' 2>/dev/null
+import glob, sys
+sys.path.insert(0, ".")
+from scripts.lib.profiles.deriver import gguf_facts_from_file
+
+need = ("hidden_size", "num_hidden_layers", "num_attn_heads", "num_kv_heads")
+for cand in sorted(glob.glob("/mnt/models/huggingface/**/*.gguf", recursive=True))[:40]:
+    try:
+        f = gguf_facts_from_file(cand) or {}
+    except Exception:
+        continue
+    if all(f.get(k) is not None for k in need):
+        print(cand)
+        break
+PY_PICK
+)"
+if [[ -z "$GG" ]]; then
+  echo "  skip GGUF arch leg — no .gguf on this machine (config.json leg still ran)"
+else
+  if scripts/catalog.sh register --compose "$C" --engine gguf-engine --engine-type llama.cpp \
+       --weights "$GG" --root "$TMP" -y >/dev/null 2>&1; then
+    if command grep -q "gguf-engine/byo-probe" "$REG" 2>/dev/null; then
+      echo "  ok   arch derived from a real GGUF header"
+    else
+      echo "  FAIL GGUF register reported success but wrote no entry"; rc=1
+    fi
+    scripts/catalog.sh unregister --slug gguf-engine/byo-probe --root "$TMP" -y >/dev/null 2>&1
+  else
+    echo "  FAIL --weights <gguf> refused; only the config.json path works"; rc=1
+  fi
+fi
+
 # 4. the curated catalog is unreachable from the front door too
 CORE="$(python3 -c "
 import sys; sys.path.insert(0,'.')

--- a/scripts/tests/test-compose-status-drift.sh
+++ b/scripts/tests/test-compose-status-drift.sh
@@ -47,7 +47,13 @@ enum = set(STATUS_VALUES)
 
 # C4-rev: merged view — a LOCAL layer entry's compose header is drift-checked
 # exactly like a core one.
+# LOCAL rows are skipped. This gate asserts that a compose WE ship carries a
+# Status header matching its registry status. A user's own compose is theirs:
+# demanding our header convention in it makes the whole suite red the moment
+# anyone registers a model (#1202/#1153), which is exactly what happened.
 for key, entry in sorted(get_registry().items()):
+    if (entry or {}).get("origin") == "local":
+        continue
     status = entry.get("status")
     # (a) registry status in the enum.
     check(status in enum, f"{key}: registry status {status!r} in enum")

--- a/scripts/tests/test-profiles-compat.sh
+++ b/scripts/tests/test-profiles-compat.sh
@@ -33,9 +33,13 @@ run_test "load_profiles parses all profile groups" <<'PY'
 from scripts.lib.profiles.compat import load_profiles
 p = load_profiles()
 assert len(p.hardware) == 11  # +dgx-spark (#576 follow-up), +rtx-a6000 (#948 thread)
-assert len(p.models) == 21   # +inkling-small, +qwen3.8-27b, +glm-5.3-flash, +qwen3.8-flash-next, +deepseek-v4-flash-vision-exp
+_p = __import__("pathlib").Path
+_nloc = lambda d: len(list(_p(d).glob("*.yml"))) if _p(d).is_dir() else 0
+assert len(p.models) - _nloc("scripts/lib/profiles-local/models.d") == 21   # +inkling-small, +qwen3.8-27b, +glm-5.3-flash, +qwen3.8-flash-next, +deepseek-v4-flash-vision-exp
 assert len(p.workloads) == 5
-assert len(p.engines) == 17   # +llamacpp-club3090-v1.1, -v1.5, -v1.6
+_p = __import__("pathlib").Path
+_nloc = lambda d: len(list(_p(d).glob("*.yml"))) if _p(d).is_dir() else 0
+assert len(p.engines) - _nloc("scripts/lib/profiles-local/engines.d") == 17   # +llamacpp-club3090-v1.1, -v1.5, -v1.6
 assert len(p.drafters) == 18  # +syvai-qwen38-dflash2, +anbeeld-glm53-dflash2
 assert len(p.calibration) == 6
 PY
@@ -510,7 +514,9 @@ PY
 run_test "strict keys: every shipped profile group loads under validation" <<'PY'
 from scripts.lib.profiles.compat import load_profiles
 p = load_profiles()  # raises UnknownProfileKeyError on any unknown key
-assert len(p.models) == 21
+_p = __import__("pathlib").Path
+_nloc = lambda d: len(list(_p(d).glob("*.yml"))) if _p(d).is_dir() else 0
+assert len(p.models) - _nloc("scripts/lib/profiles-local/models.d") == 21
 PY
 
 run_test "strict keys: typo'd top-level model key fails naming file + closest key" <<'PY'

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -9701,7 +9701,7 @@ class CockpitApp(App):
         # bisection: "L" hangs test_force_button_reissues_forced_plan, "Z" and
         # "ctrl+l" pass. Only `a` and `j` are free in both cases app-wide, and
         # neither reads as "local layer".
-        Binding("ctrl+l", "local_layer", "Local layer", show=False),
+        Binding("ctrl+l", "local_layer", "Local layer", show=True),
         # R3b-1 — producer lane ② Serve: generate a compose + serve it untested
         # (also reachable via ⏎ on the ② Serve stage).
         Binding("g", "serve_untested", "Serve untested", show=False),
@@ -10042,6 +10042,12 @@ class CockpitApp(App):
         4. Sub-tab cycle keys — True only in modes that have sub-tabs.
         5. Everything else — True (pass-through; modals handle their own capture).
         """
+        # [ctrl+l] is advertised only when the local layer has something in it —
+        # a footer entry that opens an empty table is noise on every rig that has
+        # never registered a model.
+        if action == "local_layer":
+            return self._has_local_entries()
+
         from textual.widgets import Input as _Input
 
         # Surface gate (R3a): producer-only actions are hidden on the consumer
@@ -15745,6 +15751,21 @@ class CockpitApp(App):
                 ),
             )
         )
+
+    def _has_local_entries(self) -> bool:
+        """Is there anything in the local layer to manage?
+
+        Drives whether [ctrl+l] is advertised in the footer. A user who has
+        registered a model looks for the remove action ON THE ROW and does not
+        find it — the affordance existed but only behind a hidden key, which is
+        barely shipping it. Showing the binding exactly when it does something is
+        the cheap half of that fix."""
+        try:
+            from scripts.lib.profiles.compose_registry import local_entries
+
+            return bool(local_entries())
+        except Exception:
+            return False
 
     def action_local_layer(self) -> None:
         """[L] — list the LOCAL layer and act on it (#1153)."""


### PR DESCRIPTION
Three defects found by **actually using** the feature shipped in #1202/#1153. None were visible to the suite, because every sweep ran against an **empty local layer**.

## 1. `--weights <model.gguf>` refused every registration

The required-arch list included `attention_k_eq_v`, which `gguf_facts_from_file` doesn't return — while `promote.py` **already fills it** with a documented conservative default. The test only exercised the `config.json` path, which sets the field explicitly, so the *likelier* path on a GGUF rig was broken while the test stayed green.

Dropped from the list. The test now covers **both** arch sources, and **skips loudly** when the machine has no `.gguf` rather than passing silently.

The GGUF leg also needed a real fixture: the first `.gguf` on this rig is `mmproj-F16.gguf`, a multimodal projector with no arch dims — so the leg failed on a bad fixture while the code was correct. Discovery now verifies a candidate actually yields the dims.

## 2. The management view was unreachable in practice

`[ctrl+l]` shipped with `show=False`, so nothing in the UI pointed at it and Enter on a row ran the normal serve flow. A user who registers a model looks for remove **on the row** and finds nothing. A feature nobody can find is barely shipped.

Now advertised in the footer, gated on the layer having entries — a footer item that opens an empty table is noise on a rig that never registered anything.

## 3. ⛔ The guard suite went red the moment anyone used the feature

`test-profiles-compat` asserts `len(p.models) == 21` and `len(p.engines) == 17`. But `load_profiles()` **merges the local layer**, so those totals were really asserting *"this user has registered nothing"*.

`test-compose-status-drift` demanded a `Status:` header matching the registry status — right for a compose **we** ship, wrong for a user's own file, which isn't ours to police.

Counts now subtract the local layer; drift skips local rows.

**This is the one that matters most.** #1202/#1153 shipped a feature whose first real use turns the suite red, and every sweep passed because the layer was empty every time.

⚠️ My first attempt at this replaced `from scripts.lib.profiles.compat import load_profiles` — a **prefix** of longer `import load_profiles, fits, …` lines — splitting them across **46 sites** and breaking `fits`. Restored the file and redid it touching only the two assertion lines.

## Testing

Both states, which is the whole point:

- **with a local model + engine registered:** bash guards **145/0**, cockpit **1124 passed / 1 skipped**
- **pristine layer:** both affected guards re-verified
