### PR TITLE
fix(cockpit): re-read the catalog after a registry write

### DIFF
--- a/docs/BRING_YOUR_OWN.md
+++ b/docs/BRING_YOUR_OWN.md
@@ -329,6 +329,22 @@ bash scripts/switch.sh --list --all     # everything; yours are tagged “· loc
   single   my-llamacpp/my-model    gguf/base.yml    (NA: 66K) · local
 ```
 
+Or from the cockpit, which manages the layer without dropping to the CLI:
+
+| Key | Where | Does |
+|---|---|---|
+| `ctrl+l` | anywhere in c3 | opens the local layer — every slug you registered, `shadowed` included |
+| `r` | on a row | unregister it |
+| `n` | on a row | rename it (moves the compose tree when the engine changes) |
+| `e` | on a row | edit one field, `KEY=VALUE` |
+| `esc` | | close |
+
+`ctrl+l` is advertised in the footer only while the layer has something in it.
+Every one of those actions is a repo write, so it goes through the same confirm
+gate as a serve — you see the `catalog.sh` command before anything is touched,
+and `Enter` commits it. The catalog re-reads itself afterwards; you do not need
+to refresh. A curated slug is unreachable from this view by construction.
+
 If a later `git pull` ships a curated slug under a name you already used, the
 listing tells you so instead of quietly swallowing it:
 

--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -12524,6 +12524,24 @@ class CockpitApp(App):
         }
         if plan.kind in _SYNC_REPOLL_KINDS:
             self.load_estate()
+        # A registry WRITE changes what the CATALOG lists, and nothing re-read
+        # it — so after ⑤ Promote registered a slug, or the local-layer view
+        # removed/renamed one, the table kept showing the OLD registry until the
+        # user pressed [r] themselves (reported on the first real use of the
+        # #1153 remove).  The estate re-poll above is the wrong instrument: the
+        # rig didn't change, the registry did.  Re-read it on the same
+        # successful-write path (a REFUSED write returned above and never
+        # reaches here).  load_catalog is @work(exclusive, group="catalog"), so
+        # this coalesces with any in-flight load rather than racing it, and it
+        # no-ops safely when the pane isn't mounted.
+        _REGISTRY_REPOLL_KINDS = {
+            "promote_catalog",   # ⑤ registers a NEW local entry
+            "local_remove",      # #1153 local-layer management
+            "local_rename",
+            "local_update",
+        }
+        if plan.kind in _REGISTRY_REPOLL_KINDS:
+            self.load_catalog()
         if plan.kind == "serve":
             if live is not None:
                 # Reveal the transient Run boot pane (Fold 2).  Do NOT print the

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -8890,6 +8890,98 @@ def _count_load_estate(monkeypatch):
     return calls
 
 
+def _count_load_catalog(monkeypatch):
+    """Wrap CockpitApp.load_catalog so a test can count how many times it fired.
+    Returns the counter dict (``{"n": int}``)."""
+    import club3090_cockpit.app as appmod
+
+    calls = {"n": 0}
+    orig = appmod.CockpitApp.load_catalog
+
+    def counting(self):
+        calls["n"] += 1
+        return orig(self)
+
+    monkeypatch.setattr(appmod.CockpitApp, "load_catalog", counting)
+    return calls
+
+
+class TestRegistryWriteRereadsCatalog:
+    """A registry-mutating write re-reads the CATALOG (not just the estate).
+
+    Regression: removing a slug from the local-layer view left it on screen
+    until the user pressed [r] by hand — the write path re-polled the estate
+    (the rig) but never the registry (what actually changed)."""
+
+    @pytest.mark.asyncio
+    async def test_local_remove_rereads_catalog(self, monkeypatch):
+        wr = FakeWriteRunner()
+        app, _, _ = make_app(write_runner=wr)
+        calls = _count_load_catalog(monkeypatch)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _settle(pilot)
+            before = calls["n"]
+            plan = app._data.local_amend_plan("remove", "my-engine/my-model")
+            assert plan.kind == "local_remove"
+            app.dispatch_action(plan)
+            await _settle(pilot)
+            assert calls["n"] > before      # the removal re-read the registry
+            assert len(wr.started) == 1     # gate intact — the write went through
+
+    @pytest.mark.asyncio
+    async def test_local_rename_and_update_reread_catalog(self, monkeypatch):
+        for kind, kw in (("rename", {"to": "my-engine/renamed"}),
+                         ("update", {"sets": ["workload=fast-chat"]})):
+            wr = FakeWriteRunner()
+            app, _, _ = make_app(write_runner=wr)
+            calls = _count_load_catalog(monkeypatch)
+            async with app.run_test(size=(120, 40)) as pilot:
+                await _settle(pilot)
+                before = calls["n"]
+                plan = app._data.local_amend_plan(kind, "my-engine/my-model", **kw)
+                assert plan.kind == f"local_{kind}"
+                app.dispatch_action(plan)
+                await _settle(pilot)
+                assert calls["n"] > before, kind
+                assert len(wr.started) == 1, kind
+
+    @pytest.mark.asyncio
+    async def test_non_registry_write_does_not_reread_catalog(self, monkeypatch):
+        """NEGATIVE CONTROL — a write that doesn't touch the registry (container
+        rm) must NOT re-read the catalog, or the assertion above would pass for
+        every plan kind and prove nothing."""
+        wr = FakeWriteRunner()
+        app, _, _ = make_app(write_runner=wr)
+        calls = _count_load_catalog(monkeypatch)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot)
+            before = calls["n"]
+            plan = app._data.container_rm("vllm-qwen36-27b-dual")
+            app.dispatch_action(plan)
+            await _settle(pilot)
+            assert len(wr.started) == 1     # it DID write
+            assert calls["n"] == before     # but the registry didn't change
+
+    @pytest.mark.asyncio
+    async def test_refused_write_does_not_reread_catalog(self, monkeypatch):
+        """NEGATIVE CONTROL — a write REFUSED at the gate never mutated the
+        registry, so it must not re-read it either."""
+        wr = FakeWriteRunner()
+        responses = fake_responses(**{"docker ps": ok(DOCKER_PS_ENGINE)})
+        gpus = [GpuInfo(index=0, mem_used_mib=22000), GpuInfo(index=1, mem_used_mib=1)]
+        app, _, _ = make_app(
+            responses=responses, gpus=gpus, target=ServingTarget(gpus=gpus), write_runner=wr
+        )
+        calls = _count_load_catalog(monkeypatch)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot)
+            before = calls["n"]
+            app.dispatch_action(app._data.serve("vllm/dual"))   # not forced → refused
+            await _settle(pilot)
+            assert wr.started == []
+            assert calls["n"] == before
+
+
 class TestBatch2A1RepollAfterEveryWrite:
     """A1 — every SUCCESSFUL GPU-mutating write re-polls the estate; a REFUSED
     write does not."""


### PR DESCRIPTION
Found by using the shipped #1153 feature: removing a slug from the local-layer
view left it on screen until you pressed `[r]` yourself.

## The bug

`dispatch_action` re-polls the **estate** after every successful write
(`_SYNC_REPOLL_KINDS` — power cap, scene switch, container rm). A local amend
doesn't change the rig, though; it changes the **registry**, and nothing re-read
that. The estate re-poll was the wrong instrument, so the catalog kept painting
rows from before the write.

`⑤ Promote` had the same gap pointing the other way: it registers a new local
entry, and the catalog kept listing the state from before it.

## The fix

On the same successful-write path (a gate-refused write returns before it):

```python
_REGISTRY_REPOLL_KINDS = {
    "promote_catalog",   # ⑤ registers a NEW local entry
    "local_remove",      # #1153 local-layer management
    "local_rename",
    "local_update",
}
if plan.kind in _REGISTRY_REPOLL_KINDS:
    self.load_catalog()
```

`load_catalog` is `@work(exclusive=True, group="catalog")`, so it coalesces with
an in-flight load rather than racing it, and returns early when the pane isn't
mounted.

**Checked the reload actually re-reads** rather than repainting a cached copy:
`load_local_registry` does a fresh `read_text` of `registry.local.json` per call,
and catalog rows come from a `registry-emit.sh` **subprocess**. There is no
in-process copy to invalidate — otherwise this fix would have gone green in tests
that only count calls, and still done nothing live.

## Tests

4 new, and verified non-vacuous: with the fix reverted the two positives fail
(`assert 1 > 1`) and the two negative controls keep passing.

| Test | Asserts |
|---|---|
| `test_local_remove_rereads_catalog` | a remove re-reads the registry |
| `test_local_rename_and_update_reread_catalog` | rename + update do too |
| `test_non_registry_write_does_not_reread_catalog` | **control** — `container_rm` does not |
| `test_refused_write_does_not_reread_catalog` | **control** — a refused write does not |

The controls are what stop the positive assertion from being true for every plan
kind and therefore proving nothing.

## Docs

`BRING_YOUR_OWN.md` documented `catalog.sh` but never mentioned the cockpit route
to the same actions — the discoverability half of the same report (`ctrl+l` was
reachable but unadvertised, fixed in #1213). Added the key table to *Seeing what
you registered*, noting the binding shows only while the layer is non-empty and
that the catalog now re-reads itself.

## Gate

- bash guard sweep: **PASS=145 FAIL=0**
- cockpit suite: **1128 passed, 1 skipped** (1124 + the 4 above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
