### PR TITLE
fix(compose): ship the measured n=2 drafter depth on GLM dual

### DIFF
--- a/models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-iq2-xxs/offload.yml
+++ b/models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-iq2-xxs/offload.yml
@@ -127,7 +127,7 @@ services:
         # model when one is named -- so the memory stays spent. Removing the
         # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
         # typo can never masquerade as a silent "drafter off".
-        _spec_n="$${SPEC_N:-1}"
+        _spec_n="$${SPEC_N:-5}"
         case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
         case "$$_spec_n" in ""|*[!0-9]*)
           echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2

--- a/models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-q8-kxl/offload.yml
+++ b/models/deepseek-v4-flash-0731/llama-cpp/compose/dual/unsloth-q8-kxl/offload.yml
@@ -161,7 +161,7 @@ services:
         # model when one is named -- so the memory stays spent. Removing the
         # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
         # typo can never masquerade as a silent "drafter off".
-        _spec_n="$${SPEC_N:-1}"
+        _spec_n="$${SPEC_N:-5}"
         case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
         case "$$_spec_n" in ""|*[!0-9]*)
           echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2

--- a/models/deepseek-v4-flash-0731/llama-cpp/compose/multi4/unsloth-q8-kxl/offload.yml
+++ b/models/deepseek-v4-flash-0731/llama-cpp/compose/multi4/unsloth-q8-kxl/offload.yml
@@ -144,7 +144,7 @@ services:
         # model when one is named -- so the memory stays spent. Removing the
         # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
         # typo can never masquerade as a silent "drafter off".
-        _spec_n="$${SPEC_N:-1}"
+        _spec_n="$${SPEC_N:-5}"
         case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
         case "$$_spec_n" in ""|*[!0-9]*)
           echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2

--- a/models/deepseek-v4-flash-0731/llamacpp-club3090/compose/dual/unsloth-q8-kxl/moecache.yml
+++ b/models/deepseek-v4-flash-0731/llamacpp-club3090/compose/dual/unsloth-q8-kxl/moecache.yml
@@ -282,7 +282,7 @@ services:
           echo "[threads] -t $${LLAMA_ARG_THREADS} (auto = nproc/2, nproc=$$_np)" >&2
         fi
 
-        _spec_n="$${SPEC_N:-1}"
+        _spec_n="$${SPEC_N:-5}"
         case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
         case "$$_spec_n" in ""|*[!0-9]*)
           echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2

--- a/models/deepseek-v4-flash-0731/llamacpp-club3090/compose/multi4/unsloth-q8-kxl/moecache.yml
+++ b/models/deepseek-v4-flash-0731/llamacpp-club3090/compose/multi4/unsloth-q8-kxl/moecache.yml
@@ -180,7 +180,7 @@ services:
         # model when one is named -- so the memory stays spent. Removing the
         # flags is the only clean off. A non-numeric SPEC_N is a hard error, so a
         # typo can never masquerade as a silent "drafter off".
-        _spec_n="$${SPEC_N:-1}"
+        _spec_n="$${SPEC_N:-5}"
         case "$${SPEC:-}" in off|OFF|Off|false|no|0) _spec_n=0 ;; esac
         case "$$_spec_n" in ""|*[!0-9]*)
           echo "[spec] SPEC_N='$$_spec_n' is not a non-negative integer." >&2

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq3xxs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq3xxs/moecache.yml
@@ -7,7 +7,7 @@
 #   Topology:  Dual 3090 PCIe (layer-split -ts 1,1, no NVLink)
 #   Drafter:   ✅ DFlash2 Q4_K_M external (0.70 GB) — ON GPU1, depth n=3
 #              MEASURED 2026-08-29: +18.4% on CODE, −2.0% on prose.
-#              Toggle: SPEC_N=<n> depth (default 3); SPEC_N=0 disables.
+#              Toggle: SPEC_N=<n> depth (default 2); SPEC_N=0 disables.
 #              Placement: DRAFT_DEVICE (default CUDA1) — see Caveats, host is −11%.
 #   KV:        fp16 (llama.cpp default — MLA keeps it compact)
 #   Thinking:  ⛔ cannot be turned off via thinking.type (vendor: errors on this
@@ -143,10 +143,16 @@
 #       ⚠️ This is the OPPOSITE of the DeepSeek sibling's `-devd none`, whose
 #       caveat (GPU drafter ⇒ zero cache hits) did NOT reproduce here: hits held
 #       at 21.7–22.1%. That caveat may be stale; re-test before copying it.
-#     • ⭐ WHY n=3 AND NOT DEEPER — n-sweep on GPU1, code decode:
-#         n=3 → 18.23 ⭐   n=5 → 16.61 (−8.9%)   n=7 → 11.10 (−27.9%)
+#     • ⭐ WHY n=2 — the sweep that set n=3 never probed BELOW it. Re-measured
+#       2026-09-04 on this compose, 2 boots/arm, arm order reversed:
+#         n=2 → 19.04 / 19.32 ⭐   n=3 → 17.55  (n=2 is ~+8-10%)
+#       Superseded the original n-sweep on GPU1, code decode, kept for the
+#       shape of the deeper tail:
+#         n=3 → 18.23     n=5 → 16.61 (−8.9%)   n=7 → 11.10 (−27.9%)
 #       Mean accepted length is INVARIANT at ~3 regardless of the cap; raising
-#       n_max only inflates drafts the CPU-resident target must still verify.
+#       n_max only inflates drafts the CPU-resident target must still verify —
+#       and mean accepted length is what made n=3 look right, because it does
+#       not price the REJECTED tail the CPU-resident experts must verify.
 #       ⚠️ Acceptance RATE falls 53%→33% from n=3→n=7 as a DENOMINATOR effect —
 #       do not read that as worse drafting, and do not tune on it.
 #       ⚠️ SHALLOWER than the DeepSeek sibling's SPEC_N=5. Do not share defaults.
@@ -467,7 +473,7 @@ services:
       - '--spec-type'
       - 'draft-dflash'
       - '--spec-draft-n-max'
-      - '${SPEC_N:-3}'
+      - '${SPEC_N:-2}'
       # Drafter device. Default CUDA1 (GPU1) — MEASURED best 2026-08-29: on GPU
       # +18.4% code vs host, and placement was worth 21 points between arms.
       # ⚠️ Takes a device NAME, not an index: `CUDA1` is valid, `1` is NOT.

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/moecache.yml
@@ -7,7 +7,7 @@
 #   Topology:  Dual 3090 PCIe (layer-split -ts 1,1, no NVLink)
 #   Drafter:   ✅ DFlash2 Q4_K_M external (0.70 GB) — ON GPU1, depth n=3
 #              MEASURED 2026-08-29: +18.4% on CODE, −2.0% on prose.
-#              Toggle: SPEC_N=<n> depth (default 3); SPEC_N=0 disables.
+#              Toggle: SPEC_N=<n> depth (default 2); SPEC_N=0 disables.
 #              Placement: DRAFT_DEVICE (default CUDA1) — see Caveats, host is −11%.
 #   KV:        fp16 (llama.cpp default — MLA keeps it compact)
 #   Thinking:  ⛔ cannot be turned off via thinking.type (vendor: errors on this
@@ -103,10 +103,17 @@
 #       ⚠️ This is the OPPOSITE of the DeepSeek sibling's `-devd none`, whose
 #       caveat (GPU drafter ⇒ zero cache hits) did NOT reproduce here: hits held
 #       at 21.7–22.1%. That caveat may be stale; re-test before copying it.
-#     • ⭐ WHY n=3 AND NOT DEEPER — n-sweep on GPU1, code decode:
-#         n=3 → 18.23 ⭐   n=5 → 16.61 (−8.9%)   n=7 → 11.10 (−27.9%)
+#     • ⭐ WHY n=2 — EXTRAPOLATED from the iq3xxs sibling, where n=2 measured
+#       ~+8-10% decode over n=3 (2026-09-04, 2 boots/arm, order reversed).
+#       NOT measured on iq4xs: same topology and mechanism, but this quant's
+#       larger experts change residency, so the optimum could differ.
+#       Superseded the original n-sweep on GPU1, code decode, kept for the
+#       shape of the deeper tail:
+#         n=3 → 18.23     n=5 → 16.61 (−8.9%)   n=7 → 11.10 (−27.9%)
 #       Mean accepted length is INVARIANT at ~3 regardless of the cap; raising
-#       n_max only inflates drafts the CPU-resident target must still verify.
+#       n_max only inflates drafts the CPU-resident target must still verify —
+#       and mean accepted length is what made n=3 look right, because it does
+#       not price the REJECTED tail the CPU-resident experts must verify.
 #       ⚠️ Acceptance RATE falls 53%→33% from n=3→n=7 as a DENOMINATOR effect —
 #       do not read that as worse drafting, and do not tune on it.
 #       ⚠️ SHALLOWER than the DeepSeek sibling's SPEC_N=5. Do not share defaults.
@@ -396,7 +403,7 @@ services:
       - '--spec-type'
       - 'draft-dflash'
       - '--spec-draft-n-max'
-      - '${SPEC_N:-3}'
+      - '${SPEC_N:-2}'
       # Drafter device. Default CUDA1 (GPU1) — MEASURED best 2026-08-29: on GPU
       # +18.4% code vs host, and placement was worth 21 points between arms.
       # ⚠️ Takes a device NAME, not an index: `CUDA1` is valid, `1` is NOT.

--- a/scripts/tests/test-spec-depth-default-drift.sh
+++ b/scripts/tests/test-spec-depth-default-drift.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Drift-guard for the speculative-decoding depth default inside a compose.
+#
+# A compose that ships a drafter states its depth default in up to three places,
+# and they are edited independently:
+#
+#   (a) the ARG the engine actually receives   ->  - '${SPEC_N:-<n>}'
+#   (b) the entrypoint's gate + banner default ->  _spec_n="$${SPEC_N:-<n>}"
+#   (c) the header Toggle: line                ->  depth (default <n>)
+#
+# Only (a) changes behaviour. (b) prints "[spec] drafter ON (SPEC_N=<n>)" and is
+# what an operator reads back to confirm what booted; (c) is what they read
+# before booting. When they disagree the compose lies about itself in the two
+# places anyone actually looks.
+#
+# This is not hypothetical: the GLM dual composes carried a MEASURED n=2 in (b)
+# while (a) still handed the engine 3, so a ~+8-10% decode win sat in the tree
+# for days without ever reaching a default boot, and the banner claimed the win
+# was live. Caught by hand 2026-09-08; this guard is why it cannot repeat.
+set -euo pipefail
+
+# Force Python's UTF-8 mode (PEP 540) — repo sources are full of unicode and a
+# genuine non-UTF-8 locale otherwise crashes the read (#779). See
+# test-compose-status-drift.sh for the full rationale; guarded by
+# test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+python3 - <<'PY'
+import re, sys
+from pathlib import Path
+
+ARG  = re.compile(r"-\s*'\$\{SPEC_N:-(\d+)\}'")
+EP   = re.compile(r'_spec_n="\$\$\{SPEC_N:-(\d+)\}"')
+HDR  = re.compile(r"depth \(default (\d+)\)")
+
+bad, checked = [], 0
+for f in sorted(Path("models").rglob("*.yml")):
+    text = f.read_text(encoding="utf-8")
+    if "SPEC_N" not in text:
+        continue
+    arg = set(ARG.findall(text))
+    ep  = set(EP.findall(text))
+    hdr = set(HDR.findall(text))
+    if not arg and not ep:
+        continue          # documents the knob without shipping a default
+    checked += 1
+
+    # Within one site, two different defaults is always wrong.
+    for name, vals in (("arg", arg), ("entrypoint", ep), ("header", hdr)):
+        if len(vals) > 1:
+            bad.append(f"{f}: {name} declares MORE THAN ONE default: {sorted(vals)}")
+
+    # Across sites they must agree. The arg is authoritative — it is the only
+    # one the engine reads — so report the others as drifted FROM it.
+    if len(arg) == 1:
+        truth = next(iter(arg))
+        if len(ep) == 1 and next(iter(ep)) != truth:
+            bad.append(
+                f"{f}: engine gets SPEC_N={truth} but the banner announces "
+                f"{next(iter(ep))} (_spec_n default)"
+            )
+        if len(hdr) == 1 and next(iter(hdr)) != truth:
+            bad.append(
+                f"{f}: engine gets SPEC_N={truth} but the header documents "
+                f"default {next(iter(hdr))}"
+            )
+
+# A guard that silently checks nothing is worse than no guard: the composes it
+# targets could be renamed away and this would still pass.
+if checked < 5:
+    print(f"FAIL: only {checked} compose(s) carried a SPEC_N default — "
+          f"expected the drafter composes to be found. Bad path or regex drift?")
+    sys.exit(1)
+
+if bad:
+    print(f"FAIL: spec-depth default drift in {len(bad)} place(s):")
+    for b in bad:
+        print(f"  - {b}")
+    print("\nThe ARG is what the engine receives; make the banner and header match it")
+    print("(or change the arg, if the OTHER two are the intended value).")
+    sys.exit(1)
+
+print(f"OK: spec-depth defaults agree across arg/banner/header in {checked} compose(s)")
+PY


### PR DESCRIPTION
## The bug

The GLM dual composes stated the drafter depth in three places, and they had
drifted apart:

| Site | Was | What it does |
|---|---|---|
| `- '${SPEC_N:-3}'` — the `--spec-draft-n-max` arg | **3** | ← what the engine receives |
| `_spec_n="$${SPEC_N:-2}"` — entrypoint | **2** | validates, gates on/off, prints the banner |
| header `depth (default 3)` | **3** | what you read before booting |

Only the arg matters. The entrypoint's ON path is `exec /app/llama-server "$@"`,
passing the compose-substituted args straight through, so `_spec_n` never reaches
the engine — it gates and prints, nothing more.

**A default boot therefore ran at n=3 while announcing `[spec] drafter ON
(SPEC_N=2)`.**

## Why that mattered more than a wrong banner

n=2 was *measured* on 2026-09-04 — `19.04 / 19.32` against `17.55` at n=3, two
boots per arm with the arm order reversed so boot-order bias could not
masquerade as the effect, about **+8-10% decode**. That result was written into
the compose rationale and the entrypoint default, but the arg kept handing the
engine 3.

The win never reached a default boot. It sat in the tree, documented as shipped,
for four days — and any default-boot dual number recorded in that window is an
n=3 number whatever the banner said.

## The fix

Arg, banner and header all read `2` now, on both dual quants (`iq3xxs`, `iq4xs`).
Knob-9's "⭐ WHY n=3 AND NOT DEEPER" becomes "WHY n=2", keeping the original
3/5/7 sweep as the deeper-tail history it still is.

`multi4`/`multi8` deliberately stay at n=3 — more cards means more resident
experts, so the mechanism weakens — and are untouched (verified still 3/3).

## The guard

`scripts/tests/test-spec-depth-default-drift.sh` asserts arg == banner == header
across every drafter compose, treating the **arg** as authoritative, and refuses
to pass vacuously if it finds fewer than 5 such composes. 81 checked.

Negative control: re-introducing `${SPEC_N:-3}` in the GLM dual compose reds it
with both the banner and the header mismatch, so it catches the exact bug that
prompted it.

## It found five more

Same class in DeepSeek, pointing the other way — arg 5, banner 1, so display-only
there. Each of those composes already documents `DSpark n=5` in its own header, so
the direction wasn't in doubt; `_spec_n` now reads 5 to match. No behaviour change
in those five.

```
llama-cpp/compose/dual/unsloth-iq2-xxs/offload.yml
llama-cpp/compose/dual/unsloth-q8-kxl/offload.yml
llama-cpp/compose/multi4/unsloth-q8-kxl/offload.yml
llamacpp-club3090/compose/dual/unsloth-q8-kxl/moecache.yml
llamacpp-club3090/compose/multi4/unsloth-q8-kxl/moecache.yml
```

## Generalisation worth keeping

A value *computed* in an entrypoint and a value *substituted* into `command:` are
two different variables that happen to share a name. When an entrypoint derives a
value and then `exec`s the original `"$@"`, the derived value is display-only by
construction — check which one the process actually receives before trusting
either.

## Gate

7 composes changed, exactly **two** lines of which change behaviour (the GLM args).
All 7 re-parse as YAML. Full bash guard sweep: **PASS=146 FAIL=0** (145 + this guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
