### PR TITLE
fix(catalog): derive what a real third-party recipe actually states

### DIFF
--- a/scripts/catalog.sh
+++ b/scripts/catalog.sh
@@ -9,7 +9,8 @@
 #
 #   catalog.sh register   --compose <path> [--engine ID] [--model ID]
 #                         [--workload W] [--port N] [--weights PATH]
-#                         [--engine-type T] [--min-sm N] [--dry-run] [-y]
+#                         [--engine-type T] [--min-sm N] [--hf-repo ID]
+#                         [--dry-run] [-y]
 #   catalog.sh register   --spec-file <path> [--dry-run] [-y]
 #   catalog.sh unregister --slug <engine>/<name> [--dry-run] [-y]
 #   catalog.sh rename     --slug <old> --to <new>  [--dry-run]
@@ -36,7 +37,7 @@ usage() {
 [[ $# -gt 0 ]] || usage 2
 SUB="$1"; shift
 
-COMPOSE="" SPEC_FILE="" ENGINE="" MODEL="" WORKLOAD="" PORT="" SLUG="" DRY="" YES="" RROOT="" WEIGHTS="" ETYPE="" MINSM="" TO=""; declare -a SETS=()
+COMPOSE="" SPEC_FILE="" ENGINE="" MODEL="" WORKLOAD="" PORT="" SLUG="" DRY="" YES="" RROOT="" WEIGHTS="" HFREPO="" ETYPE="" MINSM="" TO=""; declare -a SETS=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --compose)   COMPOSE="${2:-}"; shift 2 ;;
@@ -46,6 +47,7 @@ while [[ $# -gt 0 ]]; do
     --workload)  WORKLOAD="${2:-}"; shift 2 ;;
     --port)      PORT="${2:-}"; shift 2 ;;
     --weights)   WEIGHTS="${2:-}"; shift 2 ;;
+    --hf-repo)   HFREPO="${2:-}"; shift 2 ;;
     --engine-type) ETYPE="${2:-}"; shift 2 ;;
     --min-sm)    MINSM="${2:-}"; shift 2 ;;
     --slug)      SLUG="${2:-}"; shift 2 ;;
@@ -131,14 +133,15 @@ PY_ENG
     # layer split or tensor parallelism in the catalog's sense, so a wrong value
     # nobody saw is worse than a prompt.
     python3 - "$COMPOSE" "$SPEC" "$ENGINE" "$MODEL" "$WORKLOAD" "$PORT" "$WEIGHTS" \
-             "${RROOT:-$ROOT}" "$ETYPE" "$MINSM" <<'PY' || exit $?
+             "${RROOT:-$ROOT}" "$ETYPE" "$MINSM" "$HFREPO" <<'PY' || exit $?
 import json, sys, zlib
 from pathlib import Path
 
 sys.path.insert(0, ".")
 from scripts.lib.profiles.compose_facts import derive_compose_facts
 
-src, out, engine_in, model_in, workload_in, port_in, weights_in, wroot, etype_in, minsm_in = sys.argv[1:11]
+(src, out, engine_in, model_in, workload_in, port_in, weights_in, wroot,
+ etype_in, minsm_in, hf_repo_in) = sys.argv[1:12]
 text = Path(src).read_text(encoding="utf-8")
 f = derive_compose_facts(text, src)
 if not f.ok:
@@ -176,16 +179,68 @@ port = int(port_in) if port_in else 20200 + (zlib.crc32(mid.encode("utf-8")) % 1
 # in compat.py, leaving the layer WRITTEN AND BROKEN ("NO ROLLBACK"). A compose
 # cannot carry arch dims by construction, so read them from the weights.
 arch = {}
+cfg_extra = {}          # provenance/shape facts read off the checkpoint, not defaulted
 if weights_in:
     from scripts.lib.profiles.deriver import gguf_facts_from_file
+    # A DIRECTORY is what anyone naturally passes (it is what they downloaded),
+    # so resolve it to the file we actually read instead of refusing with advice
+    # that looks like it was already followed.
+    wpath = Path(weights_in)
+    if wpath.is_dir():
+        if (wpath / "config.json").is_file():
+            weights_in = str(wpath / "config.json")
+        else:
+            ggufs = sorted(g for g in wpath.glob("*.gguf")
+                           if "mmproj" not in g.name.lower())
+            if len(ggufs) == 1:
+                weights_in = str(ggufs[0])
+            elif ggufs:
+                print(f"[catalog] {wpath} holds {len(ggufs)} .gguf files — "
+                      f"name the one to read with --weights <file>.", file=sys.stderr)
+                raise SystemExit(2)
+            else:
+                print(f"[catalog] {wpath} has no config.json and no .gguf — "
+                      f"arch dims cannot be read from it.", file=sys.stderr)
+                raise SystemExit(2)
     facts = gguf_facts_from_file(weights_in) if weights_in.endswith(".gguf") else None
     if facts is None and weights_in.endswith(".json"):
         cfg = json.loads(Path(weights_in).read_text(encoding="utf-8"))
-        facts = {"hidden_size": cfg.get("hidden_size"),
-                 "num_hidden_layers": cfg.get("num_hidden_layers"),
-                 "num_attn_heads": cfg.get("num_attention_heads"),
-                 "num_kv_heads": cfg.get("num_key_value_heads"),
-                 "max_ctx_supported": cfg.get("max_position_embeddings"),
+        # A MULTIMODAL wrapper config (…ForConditionalGeneration) states the text
+        # dims in a NESTED section and leaves the top level holding only the
+        # wrapper's own fields, so a top-level-only read sees None for every dim
+        # and refuses a model that is perfectly describable. Prefer the top level
+        # when it has the dims; otherwise take the first nested section that does.
+        # Per-key fallback to the top level, because some configs split
+        # max_position_embeddings out of the text section.
+        _NESTED = ("text_config", "language_model_config", "thinker_config",
+                   "llm_config")
+        sect = cfg if cfg.get("hidden_size") is not None else next(
+            (cfg[k] for k in _NESTED
+             if isinstance(cfg.get(k), dict)
+             and cfg[k].get("hidden_size") is not None),
+            cfg,
+        )
+        def _cfg(key):
+            v = sect.get(key)
+            return cfg.get(key) if v is None else v
+        # Provenance + shape the model profile needs, taken from the SAME config
+        # rather than defaulted. `family` was hardcoded "dense", which is not even
+        # in this field's vocabulary (it names the model FAMILY — qwen/gemma/glm),
+        # and vision_capable was hardcoded False for checkpoints that ship a
+        # vision_config.
+        _mt = str(cfg.get("model_type") or sect.get("model_type") or "")
+        for _fam in ("qwen", "gemma", "glm", "deepseek", "llama", "mistral",
+                     "phi", "nemotron"):
+            if _mt.startswith(_fam):
+                cfg_extra["family"] = _fam
+                break
+        if isinstance(cfg.get("vision_config"), dict):
+            cfg_extra["vision_capable"] = True
+        facts = {"hidden_size": _cfg("hidden_size"),
+                 "num_hidden_layers": _cfg("num_hidden_layers"),
+                 "num_attn_heads": _cfg("num_attention_heads"),
+                 "num_kv_heads": _cfg("num_key_value_heads"),
+                 "max_ctx_supported": _cfg("max_position_embeddings"),
                  # A KV-math hint. The GGUF path derives it; an HF config does not
                  # state it, and False is the ordinary case (K and V differ). Said
                  # out loud because it is the one value here that is assumed.
@@ -205,6 +260,22 @@ if weights_in:
 # --weights <gguf> registration, because gguf_facts_from_file does not return it
 # — so the GGUF path, the likelier one for this rig, was broken while the
 # config.json path (which sets it explicitly) passed the test.
+# ⛔ THE WORKLOAD MUST EXIST, AND MUST ALSO BE CHECKED BEFORE THE WRITE.
+# compat's cross-reference validation runs AFTER promote has written all three
+# artifacts, and a dangling workload ref fails it — which does not just break the
+# new entry, it takes the WHOLE profile system down: every launcher calls
+# load_profiles(), so one typo in one local registration makes every CORE slug
+# unloadable until the user hand-edits a gitignored JSON. `--workload max-context`
+# (a plausible-sounding name that does not exist) did exactly that here.
+_known_wl = sorted(x.stem for x in Path("scripts/lib/profiles/workloads").glob("*.yml"))
+if workload and _known_wl and workload not in _known_wl:
+    print(f"[catalog] unknown workload {workload!r}. Known: {', '.join(_known_wl)}.",
+          file=sys.stderr)
+    print(f"[catalog] Refusing BEFORE writing — a dangling workload reference fails "
+          f"compat's cross-reference check AFTER the write, and that failure takes "
+          f"the ENTIRE profile system down, core slugs included.", file=sys.stderr)
+    raise SystemExit(2)
+
 _ARCH_REQUIRED = ("hidden_size", "num_hidden_layers", "num_attn_heads",
                   "num_kv_heads", "max_ctx_supported")
 if "max_ctx_supported" not in arch and max_ctx:
@@ -279,21 +350,58 @@ cpath = (f"scripts/lib/profiles-local/composes/{mid}/{engine}"
 slug = f"{engine}/{mid}"
 
 
+# Weights FACTS, not placeholders. size_gb was hardcoded 1.0 and hf_repo "",
+# so the catalog reported a 120 GiB checkpoint as 1 GB from an unnamed provider
+# — the c3 "provider" column is blank for exactly this reason.
+_wdir = None
+if weights_in:
+    _wp = Path(weights_in)
+    _wdir = _wp if _wp.is_dir() else _wp.parent
+_size_gb = 1.0
+if _wdir and _wdir.is_dir():
+    try:
+        _b = sum(x.stat().st_size for x in _wdir.rglob("*")
+                 if x.is_file() and ".cache" not in x.parts)
+        if _b:
+            _size_gb = round(_b / 2**30, 1)
+    except OSError:
+        pass
+_hf_repo = hf_repo_in or ""
+spec_family = cfg_extra.get("family", "dense")
+
+# OFFLOAD. The vocabulary is a closed set whose values mean different mechanisms
+# ("uva" = vLLM demand-paged experts, "prefetch" = bulk layer prefetch,
+# "residency"/"tensor-override" = llama.cpp -ot). A wrong value here has already
+# caused a real misdiagnosis, so name it only when the compose NAMES it; when the
+# compose only proves offload is ON, say so and let the user state which.
+_offload = None
+_ob = (f.offload_backend or "").strip().lower()
+if _ob in ("uva", "prefetch", "residency", "tensor-override"):
+    _offload = _ob
+elif f.cpu_offload_gb and int(f.cpu_offload_gb) > 0:
+    print(f"[catalog] note: the compose offloads to host RAM "
+          f"(cpu-offload-gb={f.cpu_offload_gb}) but does not name the BACKEND, and "
+          f"the value decides the mechanism. Left unset; state it with: "
+          f"catalog.sh update --slug <slug> --set offload=uva", file=sys.stderr)
+
 spec = {
     "model_id": mid,
     "display_name": mid,
-    "family": "dense",
-    "weights": {"local": {"path": f.model_path, "local_subdir": mid, "size_gb": 1.0,
-                          "format": fmt, "status": "incubating", "hf_repo": "",
+    "family": spec_family,
+    "weights": {"local": {"path": str(_wdir) if _wdir else f.model_path,
+                          "local_subdir": mid, "size_gb": _size_gb,
+                          "format": fmt, "status": "incubating", "hf_repo": _hf_repo,
                           "engine": engine, "kind": "main",
                           "verify_glob": "*.gguf" if fmt == "gguf" else "*.safetensors"}},
     "arch": arch,
     "default_weight_variant": "local",
-    "vision_capable": False,
+    "vision_capable": bool(cfg_extra.get("vision_capable", False)),
     "compose": {"path": cpath, "content": text},
     "registry_entry": {"slug": slug, "kwargs": {
         "model": mid, "weights_variant": "local", "workload": workload,
         "engine": engine, "drafter": None,
+        "spec_method": f.spec_method or None,
+        "offload": _offload,
         "kv_format": f.kv_dtype or "f16", "tp": int(f.tp or 1),
         "max_ctx": max_ctx, "max_num_seqs": 1, "mem_util": 0.9,
         "compose_path": cpath, "default_port": port, "kvcalc_key": "SKIP"}},
@@ -320,6 +428,17 @@ for label, val, given in (
     ("tp",        f.tp or 1,         False),
     ("port",      port,              bool(port_in)),
     ("weights",   f.model_path,      False),
+    # These four decide c3 catalog COLUMNS (Spec Dec · Offload · provider ·
+    # size). They were hardcoded to None/""/1.0 and so rendered as blanks, which
+    # reads as "this recipe does not do that" rather than "nobody looked".
+    ("spec",      (f"{f.spec_method} n={f.spec_depth}" if f.spec_method and f.spec_depth
+                   else (f.spec_method or "(none found)")), False),
+    ("offload",   _offload or (f"on, backend unnamed (cpu-offload-gb={f.cpu_offload_gb})"
+                               if f.cpu_offload_gb else "(none found)"), False),
+    ("provider",  _hf_repo or "(none — pass --hf-repo)", bool(hf_repo_in)),
+    ("size_gb",   _size_gb,          False),
+    ("family",    spec_family,       False),
+    ("vision",    bool(cfg_extra.get("vision_capable", False)), False),
     ("arch",      f"hidden={arch['hidden_size']} layers={arch['num_hidden_layers']} "
                   f"heads={arch['num_attn_heads']}/{arch['num_kv_heads']}", True),
 ):

--- a/scripts/lib/profiles/amend.py
+++ b/scripts/lib/profiles/amend.py
@@ -40,8 +40,13 @@ EXIT_REFUSED = 3
 # set itself to "core" would hide from the very listings meant to mark it — the
 # same anti-spoof reasoning as registration. `model` is absent too: it names the
 # files on disk, so changing it is a move, not an edit.
+# `offload` and `spec_method` are editable because a compose often CANNOT prove
+# them: when the image's own entrypoint builds the command line, the backend name
+# and the speculative config live inside the image, not the compose. The
+# derivation says so rather than guessing (a wrong `offload` value has caused a
+# real misdiagnosis before), which leaves stating it as the user's job.
 _EDITABLE = ("workload", "max_ctx", "max_num_seqs", "mem_util", "default_port",
-             "kv_format", "tp", "drafter", "status")
+             "kv_format", "tp", "drafter", "status", "offload", "spec_method")
 
 
 class Refusal(Exception):

--- a/scripts/lib/profiles/compose_facts.py
+++ b/scripts/lib/profiles/compose_facts.py
@@ -43,6 +43,15 @@ class ComposeFacts:
     tp: str = ""              # --tensor-parallel-size / -ts / device count
     status_header: str = ""   # the profile-header Status: line, when present
     service: str = ""
+    # ── evidence a compose carries about HOW it serves ────────────────
+    # These decide three c3 catalog columns (Offload · Spec Dec · and the
+    # residency axis). They were never read, so a recipe whose whole point is
+    # CPU-offloaded experts with an MTP drafter registered as a plain resident
+    # model with no speculation — every column blank, nothing wrong on screen.
+    cpu_offload_gb: str = ""  # --cpu-offload-gb / CPU_OFFLOAD_GB
+    offload_backend: str = "" # --offload-backend (uva / …)
+    spec_method: str = ""     # --speculative-config "method" / MTP_DEPTH / -md
+    spec_depth: str = ""      # num_speculative_tokens / MTP_DEPTH / SPEC_N
 
 
 _ENGINE_BY_IMAGE = (
@@ -53,6 +62,32 @@ _ENGINE_BY_IMAGE = (
     ("ik-llama", "ik-llama"),
     ("ik_llama", "ik-llama"),
 )
+
+
+def _numeric(tok: str) -> str:
+    """A flag's value as a plain number, or "" when it is not one.
+
+    Compose flags are usually written `--max-model-len ${MAX_MODEL_LEN:-262144}`,
+    so the raw token is a shell expansion, not a number. Callers int() these, and
+    an unexpanded token is an unhandled ValueError rather than a clean refusal —
+    which is what registering most of this repo's own composes used to do. Take
+    the DEFAULT out of a ${VAR:-N} expansion, since that is the value that runs
+    when the variable is unset; anything still non-numeric returns "" so the
+    caller's own fallback (and its "derived" labelling) takes over honestly.
+    """
+    tok = (tok or "").strip().strip("\"'")
+    if not tok:
+        return ""
+    if tok.isdigit():
+        return tok
+    if tok.startswith("${") and tok.endswith("}"):
+        # Defaults CHAIN: `${MAX_MODEL_LEN:-${CTX:-262144}}` falls through to the
+        # INNERMOST default when nothing is set, so that is the value a plain
+        # `up -d` runs with. Take the last one rather than the first.
+        nums = re.findall(r":-\s*([0-9]+)\s*\}", tok)
+        if nums:
+            return nums[-1]
+    return ""
 
 
 def derive_compose_facts(text: str, path: str = "") -> ComposeFacts:
@@ -138,13 +173,68 @@ def derive_compose_facts(text: str, path: str = "") -> ComposeFacts:
 
     f.model_path  = flag("--model", "-m", "GGUF_FILE")
     f.served_name = flag("--served-model-name", "-a", "--alias")
-    f.max_ctx     = flag("--max-model-len", "-c", "--ctx-size")
+    f.max_ctx     = _numeric(flag("--max-model-len", "-c", "--ctx-size"))
     f.kv_dtype    = flag("--kv-cache-dtype", "-ctk", "--cache-type-k")
-    f.tp          = flag("--tensor-parallel-size", "-tp", "-ts")
+    f.tp          = _numeric(flag("--tensor-parallel-size", "-tp", "-ts"))
+
+    # ENV-DRIVEN COMPOSES. A compose that drives its engine through `environment:`
+    # states the context there, not as a flag — either because the image's own
+    # entrypoint builds the command line (every third-party runtime does this) or
+    # because the engine reads LLAMA_ARG_*. 75 composes in THIS repo do it, so a
+    # flag-only read is not an edge case: it silently returns nothing and the
+    # caller falls back to a small default, advertising a 262K model as 4K.
+    # Accepts `KEY: "${KEY:-N}"`, `KEY: N`, and list-form `- KEY=N`, taking the
+    # DEFAULT out of a ${VAR:-N} expansion since that is what runs unset.
+    if not f.max_ctx:
+        for var in ("MAX_MODEL_LEN", "LLAMA_ARG_CTX_SIZE", "MAX_CTX", "CTX_SIZE"):
+            # ⚠️ ANCHORED. Unanchored, `MAX_MODEL_LEN` matches inside
+            # `VLLM_ALLOW_LONG_MAX_MODEL_LEN=1` and derives a 1-token context for
+            # seven of this repo's own composes.
+            m = _re.search(
+                rf"(?:^|[\s\-\"']){var}\s*[:=]\s*[\"']?"
+                rf"(?:\$\{{{var}:-)?([0-9]+)", text, _re.M)
+            if m:
+                f.max_ctx = m.group(1)
+                break
     if not f.tp:
         m = _re.search(r"CUDA_VISIBLE_DEVICES[=:\s]+\"?([0-9,]+)", text)
         if m:
             f.tp = str(len([x for x in m.group(1).split(",") if x.strip()]))
+
+    # ── offload + speculation evidence ────────────────────────────────
+    # Flag first (authoritative), then the env spelling, because a compose whose
+    # IMAGE builds the command line can only state these in `environment:`.
+    f.cpu_offload_gb = _numeric(flag("--cpu-offload-gb"))
+    if not f.cpu_offload_gb:
+        m = _re.search(r"(?:^|[\s\-\"'])CPU_OFFLOAD_GB\s*[:=]\s*[\"']?"
+                       r"(?:\$\{CPU_OFFLOAD_GB:-)?([0-9]+)", text, _re.M)
+        if m:
+            f.cpu_offload_gb = m.group(1)
+    f.offload_backend = (flag("--offload-backend") or "").strip("\"'")
+
+    # Speculation. `--speculative-config '{"method":"mtp",...}'` is the vLLM
+    # spelling; MTP_DEPTH/SPEC_N is how an env-driven compose says the same
+    # thing. A drafter MODEL flag proves speculation without naming a method.
+    m = _re.search(r'"method"\s*:\s*\\?"([a-z0-9_-]+)', text)
+    if m:
+        f.spec_method = m.group(1)
+    m = _re.search(r'"num_speculative_tokens"\s*:\s*\\?"?'
+                   r'(?:\$\{[A-Za-z_][A-Za-z0-9_]*:-)?([0-9]+)', text)
+    if m:
+        f.spec_depth = m.group(1)
+    if not f.spec_depth:
+        for var, meth in (("MTP_DEPTH", "mtp"), ("SPEC_N", "")):
+            m = _re.search(rf"(?:^|[\s\-\"']){var}\s*[:=]\s*[\"']?"
+                           rf"(?:\$\{{{var}:-)?([0-9]+)", text, _re.M)
+            if m:
+                f.spec_depth = m.group(1)
+                f.spec_method = f.spec_method or meth
+                break
+    if not f.spec_method and flag("--speculative-model", "-md", "--model-draft"):
+        f.spec_method = "draft-model"
+    # An explicit zero disables it; do not report speculation that is off.
+    if f.spec_depth == "0":
+        f.spec_method, f.spec_depth = "", ""
 
     m = (_re.search(r"\$\{PORT:-([0-9]+)\}", text)
          or _re.search(r"^\s*-\s*\"?([0-9]{2,5}):[0-9]+", text, _re.M))

--- a/scripts/lib/profiles/weights.py
+++ b/scripts/lib/profiles/weights.py
@@ -78,13 +78,32 @@ def _require_yaml() -> None:
 
 
 def _load_models() -> dict[str, dict[str, Any]]:
+    """Every model profile: the curated set, plus the LOCAL layer.
+
+    The local layer was invisible here, and this module feeds `enrich_weights`,
+    which is what fills c3's provider and GB columns — so a model a user
+    registered showed a blank provider and no size no matter what its profile
+    said. Curated wins a collision, matching compose_registry's core-wins rule
+    (a local id colliding with core is refused at load anyway, so this is
+    belt-and-braces rather than a live case). A broken/absent local layer is not
+    an error: this must never take the curated listing down.
+    """
     _require_yaml()
     out: dict[str, dict[str, Any]] = {}
-    for path in sorted((PROFILE_ROOT / "models").glob("*.yml")):
-        with path.open("r", encoding="utf-8") as fh:
-            data = yaml.safe_load(fh) or {}
-        model_id = str(data.get("id") or path.stem)
-        out[model_id] = data
+    local_dir = PROFILE_ROOT.parent / "profiles-local" / "models.d"
+    for root in (local_dir, PROFILE_ROOT / "models"):   # core LAST → core wins
+        try:
+            paths = sorted(root.glob("*.yml")) if root.is_dir() else []
+        except OSError:
+            continue
+        for path in paths:
+            try:
+                with path.open("r", encoding="utf-8") as fh:
+                    data = yaml.safe_load(fh) or {}
+            except (OSError, yaml.YAMLError):
+                continue
+            model_id = str(data.get("id") or path.stem)
+            out[model_id] = data
     return out
 
 

--- a/scripts/tests/test-catalog-derivation-robustness.sh
+++ b/scripts/tests/test-catalog-derivation-robustness.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Guard: what `catalog.sh register` can actually READ off a real-world compose
+# and checkpoint, and what it must REFUSE before writing anything.
+#
+# Every case here is a failure a real third-party recipe produced on first
+# contact (DominikBucko/qwen38-flash-next-2x3090, 2026-09-08). They share one
+# shape: the derivation silently returned a wrong-but-plausible value, or died
+# on an input the whole ecosystem uses.
+#
+#   1. NESTED CONFIG. A multimodal checkpoint (…ForConditionalGeneration) states
+#      the text dims under `text_config`, so a top-level-only read sees None for
+#      every dim and refuses a model it could describe perfectly well.
+#   2. A DIRECTORY is what people pass to --weights, because it is what they
+#      downloaded. Refusing it with advice they appear to have followed is a
+#      dead end.
+#   3. SHELL EXPANSIONS. `--max-model-len ${MAX_MODEL_LEN:-262144}` is the
+#      commonest idiom in this repo's own composes; the raw token reached an
+#      int() and raised an unhandled ValueError instead of refusing.
+#   4. ENV-DRIVEN COMPOSES. A compose whose image builds its own command line
+#      states the context in `environment:`. 75 composes here do it. Reading
+#      only flags silently yielded a 4096 default for a 262K model.
+#   5. UNKNOWN WORKLOAD must refuse BEFORE the write. compat validates
+#      cross-references AFTER promote writes all three artifacts, and a dangling
+#      workload ref does not just break the new row — load_profiles() then fails
+#      for EVERY caller, so one typo makes the whole catalog, core included,
+#      unloadable until a gitignored JSON is hand-edited.
+set -uo pipefail
+
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+rc=0
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/scripts" "$TMP/tools" "$TMP/weights"
+cp -r scripts/lib "$TMP/scripts/"
+cp -r tools/tui-core "$TMP/tools/"
+
+# ── 1 + 2: nested config, reached through a DIRECTORY ────────────────
+cat > "$TMP/weights/config.json" <<'JSON'
+{"architectures": ["Qwen4ExpForConditionalGeneration"],
+ "model_type": "qwen4_exp",
+ "text_config": {"hidden_size": 2560, "num_hidden_layers": 48,
+                 "num_attention_heads": 24, "num_key_value_heads": 2,
+                 "max_position_embeddings": 262144},
+ "vision_config": {"hidden_size": 1152}}
+JSON
+
+C="$TMP/envdriven.yml"
+cat > "$C" <<'YML'
+services:
+  theirs:
+    image: ghcr.io/someone/their-runtime:locked
+    environment:
+      PORT: "${PORT:-20299}"
+      CUDA_VISIBLE_DEVICES: "0,1"
+      MAX_MODEL_LEN: "${MAX_MODEL_LEN:-262144}"
+      CPU_OFFLOAD_GB: "${CPU_OFFLOAD_GB:-30}"
+      MTP_DEPTH: "${MTP_DEPTH:-3}"
+    command: ["/model"]
+YML
+
+out="$(scripts/catalog.sh register --compose "$C" --engine their-vllm --engine-type vllm \
+        --model nested-probe --weights "$TMP/weights" --workload long-ctx-single \
+        --root "$TMP" --dry-run -y 2>&1)"; code=$?
+if [[ "$code" -ne 0 ]]; then
+  echo "  FAIL a DIRECTORY + nested text_config was refused (exit $code)"; rc=1
+  printf '%s\n' "$out" | sed 's/^/       /' | tail -4
+else
+  echo "  ok   --weights <dir> resolved to config.json"
+  command grep -q "hidden=2560 layers=48 heads=24/2" <<<"$out" \
+    || { echo "  FAIL nested text_config dims not read: $(command grep -o 'arch .*' <<<"$out")"; rc=1; }
+  command grep -q "hidden=2560" <<<"$out" && echo "  ok   nested text_config dims read"
+  # 4: the context came from environment:, not a flag, and is NOT the 4096 default
+  if command grep -qE "max_ctx +262144" <<<"$out"; then
+    echo "  ok   env-driven MAX_MODEL_LEN read (not the 4096 fallback)"
+  else
+    echo "  FAIL env-driven context not read: $(command grep -o 'max_ctx.*' <<<"$out")"; rc=1
+  fi
+fi
+
+# ── 3: a shell expansion in a FLAG must not reach int() ──────────────
+C2="$TMP/expansion.yml"
+cat > "$C2" <<'YML'
+services:
+  theirs:
+    image: ghcr.io/someone/vllm-ish:v1
+    ports:
+      - "${PORT:-20298}:20298"
+    command: >
+      vllm serve /model --max-model-len ${MAX_MODEL_LEN:-${CTX:-131072}}
+      --tensor-parallel-size ${TP:-2}
+YML
+out2="$(scripts/catalog.sh register --compose "$C2" --engine their-vllm --engine-type vllm \
+         --model expansion-probe --weights "$TMP/weights" --workload long-ctx-single \
+         --root "$TMP" --dry-run -y 2>&1)"; code2=$?
+if [[ "$code2" -ne 0 ]]; then
+  echo "  FAIL a \${VAR:-N} flag value crashed the derivation (exit $code2)"; rc=1
+  printf '%s\n' "$out2" | sed 's/^/       /' | tail -3
+elif command grep -qE "max_ctx +131072" <<<"$out2" && command grep -qE "tp +2" <<<"$out2"; then
+  echo "  ok   \${VAR:-\${VAR2:-N}} resolved to its innermost default"
+else
+  echo "  FAIL expansion not resolved: $(command grep -oE 'max_ctx.*|tp +[0-9]+' <<<"$out2" | tr '\n' ' ')"; rc=1
+fi
+
+# ── 5: unknown workload refuses BEFORE writing ───────────────────────
+snap() { find "$TMP/scripts/lib/profiles-local" -type f 2>/dev/null | sort | xargs -r md5sum | md5sum; }
+before="$(snap)"
+out3="$(scripts/catalog.sh register --compose "$C" --engine wl-engine --engine-type vllm \
+         --model wl-probe --weights "$TMP/weights" --workload not-a-real-workload \
+         --root "$TMP" -y 2>&1)"; code3=$?
+if [[ "$code3" -eq 0 ]]; then
+  echo "  FAIL an unknown workload was ACCEPTED — compat will fail for every caller"; rc=1
+elif ! command grep -qi "unknown workload" <<<"$out3"; then
+  echo "  FAIL refused, but not for the workload: $(tail -1 <<<"$out3")"; rc=1
+else
+  echo "  ok   unknown workload refused, and it named the known ones"
+fi
+if [[ "$before" != "$(snap)" ]]; then
+  echo "  FAIL the refusal still WROTE to the local layer (the whole point is it must not)"; rc=1
+else
+  echo "  ok   nothing written on the refusal"
+fi
+
+# ── 6: the facts behind the c3 COLUMNS ───────────────────────────────
+# spec / offload / provider / size / family / vision were hardcoded to
+# None/""/1.0/"dense"/False, so a CPU-offloaded MoE with an MTP drafter
+# registered as a plain resident dense model with no speculation. Every column
+# blank reads as "this recipe does not do that", not as "nobody looked".
+out4="$(scripts/catalog.sh register --compose "$C" --engine col-engine --engine-type vllm \
+         --model col-probe --weights "$TMP/weights" --workload long-ctx-single \
+         --hf-repo someorg/Some-Model-W4A16 --root "$TMP" --dry-run -y 2>&1)"
+check() {  # check <label> <regex>
+  if command grep -qE "$2" <<<"$out4"; then echo "  ok   $1"; else
+    echo "  FAIL $1 — not in the pre-write table"; rc=1; fi
+}
+check "MTP depth read from an env-driven compose"  "spec +mtp n=3"
+check "provider recorded from --hf-repo"           "provider +someorg/Some-Model-W4A16"
+check "family read from the checkpoint, not 'dense'" "family +qwen"
+check "vision_config seen"                          "vision +True"
+if command grep -qE "size_gb +1\.0( |$)" <<<"$out4"; then
+  echo "  FAIL size_gb is still the 1.0 placeholder"; rc=1
+else
+  echo "  ok   size_gb measured, not the 1.0 placeholder"
+fi
+# offload: PRESENT but backend unnamed -> must NOT be guessed
+if command grep -qE "offload +on, backend unnamed" <<<"$out4"; then
+  echo "  ok   offload evidence surfaced without guessing the backend"
+else
+  echo "  FAIL offload evidence not surfaced: $(command grep -oE 'offload .*' <<<"$out4")"; rc=1
+fi
+# and a NAMED backend is taken verbatim
+C3="$TMP/named-backend.yml"
+sed 's|CPU_OFFLOAD_GB: "${CPU_OFFLOAD_GB:-30}"|CPU_OFFLOAD_GB: "30"|' "$C" > "$C3" 2>/dev/null || cp "$C" "$C3"
+printf '    command: ["--offload-backend", "uva"]\n' >> "$C3"
+out5="$(scripts/catalog.sh register --compose "$C3" --engine col-engine --engine-type vllm \
+         --model col-probe2 --weights "$TMP/weights" --workload long-ctx-single \
+         --root "$TMP" --dry-run -y 2>&1)"
+command grep -qE "offload +uva" <<<"$out5" \
+  && echo "  ok   a NAMED offload backend is taken verbatim" \
+  || { echo "  FAIL named backend not read: $(command grep -oE 'offload .*' <<<"$out5")"; rc=1; }
+
+# ── 7: the local layer is visible to the WEIGHTS enrichment ──────────
+# weights.py feeds c3's provider + GB columns and globbed only the curated
+# models/ dir, so a local model's provider was blank whatever its profile said.
+if python3 - <<'PYEOF'
+import subprocess, sys, json, pathlib
+src = pathlib.Path("scripts/lib/profiles/weights.py").read_text(encoding="utf-8")
+sys.exit(0 if "profiles-local" in src else 1)
+PYEOF
+then echo "  ok   weights.py reads the local layer"
+else echo "  FAIL weights.py still ignores profiles-local (provider/GB stay blank)"; rc=1; fi
+
+[[ "$rc" == "0" ]] && echo "PASS: catalog.sh derivation is robust to real-world composes and checkpoints" \
+                   || echo "FAIL: catalog.sh derivation regression"
+exit "$rc"

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -12774,7 +12774,32 @@ class TestProfileTemplateDerivation:
         # representative (vllm/qwen38-27b-multi8-*). Same shape as the #905 note
         # above: an entirely incubating group still gets a representative, which is
         # rule (d) working as designed, not a regression.
-        assert len(opts) == 10, f"expected 10 reps, got {len(opts)}: {[o.slug for o in opts]}"
+        # LOCAL-AWARE. This reads the REAL registry, so a model the user has
+        # registered on this rig legitimately adds groups: a local slug on its own
+        # engine creates a new (engine, topology) pair and a representative for it.
+        # Counting those would make the guard fail for anyone who has used the
+        # local layer — the #1213 lesson, where hardcoded core counts went red the
+        # moment a local model existed. Count the CURATED reps and let local ones
+        # ride along.
+        import subprocess as _sp, sys as _sys
+        _local = set()
+        try:
+            _out = _sp.run(
+                [_sys.executable, "-c",
+                 "import sys;sys.path.insert(0,'.');"
+                 "from scripts.lib.profiles.compose_registry import local_entries;"
+                 "print('\\n'.join(e['slug'] for e in local_entries()))"],
+                capture_output=True, text=True, timeout=60, cwd=str(repo_root),
+            )
+            if _out.returncode == 0:
+                _local = {l.strip() for l in _out.stdout.splitlines() if l.strip()}
+        except (OSError, _sp.TimeoutExpired):
+            pass
+        core_opts = [o for o in opts if o.slug not in _local]
+        assert len(core_opts) == 10, (
+            f"expected 10 curated reps, got {len(core_opts)}: "
+            f"{[o.slug for o in core_opts]} (local: {sorted(_local)})"
+        )
 
         # The 1-card rig default must be FUNCTIONAL + non-incubating — ideally the
         # registry's curated single default (vllm/minimal).

--- a/tools/serve-cockpit/tests/test_compose_viewer.py
+++ b/tools/serve-cockpit/tests/test_compose_viewer.py
@@ -196,7 +196,12 @@ class TestFlagResolverShellCollision:
             '      - "${MAX_MODEL_LEN:-262144}"\n'
         )
         facts = derive_compose_facts(text)
-        assert facts.max_ctx == "${MAX_MODEL_LEN:-262144}"
+        # The value is now RESOLVED to the expansion's default (callers int() it,
+        # and the raw token used to reach that int() as an unhandled ValueError).
+        # What this test guards is unchanged: bash's -c must not win over
+        # --max-model-len, so the one answer that means the bug is back is "|".
+        assert facts.max_ctx == "262144"
+        assert facts.max_ctx != "|"
 
     def test_llama_cpp_short_ctx_flag_still_read(self):
         """The -c alias must keep working when it is genuinely the engine's."""


### PR DESCRIPTION
Setting up a real community recipe on this rig — a pinned vLLM fork serving
Qwen3.8-Flash-Next on 2×3090 — broke local-layer registration seven ways before
it got as far as a catalog row.

They share one root cause. Everything true about a recipe like that lives in the
**image's entrypoint and `environment:`**, and the derivation read only compose
CLI flags. So it did not fail loudly; it produced a plausible, wrong row.

## Refusals that were wrong

| | |
|---|---|
| Arch dims read only at the **top level** of `config.json` | Every multimodal wrapper (`…ForConditionalGeneration`, dims under `text_config`) was unregisterable |
| `--weights <dir>` unhandled | Refused the input people naturally pass — the directory they downloaded — with advice they appeared to have already followed |

## Values that were wrong but plausible

- **`--max-model-len ${MAX_MODEL_LEN:-262144}` reached an `int()` as a raw token** —
  an unhandled `ValueError` traceback, not a refusal. That is the commonest idiom
  in this repo: **75 composes** drive context through env, and defaults nest as
  `${A:-${B:-N}}`.
- **Env-driven composes** yielded the `4096` fallback for a 262K model.
- **`spec` / `offload` / `provider` / `size_gb` / `family` / `vision`** were
  hardcoded to `None` / `""` / `1.0` / `"dense"` / `False`. A CPU-offloaded MoE
  with an MTP drafter registered as a plain resident dense model with no
  speculation. Blank columns read as *"this recipe does not do that"*, not
  *"nobody looked"*. (`"dense"` is not even in that field's vocabulary — it names
  the model family: qwen/gemma/glm.)
- **`weights.py` globbed only curated `models/`**, so the local layer was invisible
  to the enrichment that fills the provider and GB columns — the provider stayed
  blank no matter what the local profile said.

## And one that was dangerous

An unknown `--workload` was validated **after** promote wrote all three artifacts.
`compat` then failed for *every* caller, so one typo made the whole catalog —
**core slugs included** — unloadable until a gitignored JSON was hand-edited.
Hit live with `--workload max-context`: plausible, and not a real workload.

Now refused before the write, naming the five that exist.

## What is deliberately NOT derived

`offload` is a closed vocabulary whose values mean different mechanisms (`uva` =
demand-paged experts, `prefetch` = bulk layer prefetch, `residency` /
`tensor-override` = llama.cpp `-ot`). `CPU_OFFLOAD_GB` alone cannot distinguish
them, and that field's own comment records a wrong value causing a real
misdiagnosis. So when a compose proves offload is on but does not name the
backend, the tool **says so and names the fix** rather than guessing.

`offload` and `spec_method` join `_EDITABLE` so the user can state what a compose
cannot prove.

## Pre-write table

The "check these before it writes" table is the safety contract, and these facts
were absent from it. It now prints spec, offload, provider, size, family and
vision alongside the rest.

## Gate

`test-catalog-derivation-robustness.sh` — 14 checks, **10 of which fail against
the pre-fix code**. Every case is a failure the real recipe actually produced.

- bash guard sweep: **PASS=147 FAIL=0**
- cockpit suite: **1128 passed, 1 skipped**, run with a local model registered

Two cockpit tests needed updating, both pinning assumptions this work invalidates:
`test_bash_dash_c_does_not_hijack_max_ctx` pinned the *raw* expansion as its
expected value (incidental to its real point — it now asserts the resolved number
and still asserts the bug signature `"|"`), and `test_real_registry_reps_are_status_aware`
hardcoded `== 10` representatives against the **real** registry, so any local slug
on its own engine made it 11. That one is the #1213 lesson resurfacing: guards
that read the real registry must stay green when a local model exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
