### PR TITLE
fix(bench-agentic): measure decode correctly on reasoning models

### DIFF
--- a/scripts/bench-agentic.sh
+++ b/scripts/bench-agentic.sh
@@ -166,6 +166,44 @@ import json, os, sys, time, urllib.request, statistics as s, pathlib
 # works is model-specific and an unrecognised one is silently ignored. Returns
 # the payload fragment: the kwargs object plus, when the model uses an effort
 # dial, the OpenAI-standard top-level parameter alongside it.
+def _scrape_engine_metrics(base_url):
+    """vLLM's own counters — the ONLY decode figure immune to the frontend.
+
+    Client-side timing is hostage to the API-server event loop: the Qwen3 tool
+    parser re-scans the whole accumulated argument on every delta, and while it
+    runs, engine outputs queue and get MERGED into a few large SSE chunks. The
+    stream then looks slow when decode was fine. These histograms are recorded
+    inside the engine, before any of that.
+
+      decode TPS = Δrequest_generation_tokens_sum / Δrequest_decode_time_seconds_sum
+      Δnum_preemptions > 0 marks a REAL stall (recompute), not a display artifact.
+
+    Returns {} when /metrics is unavailable — the run degrades to client-side
+    numbers rather than failing.
+    """
+    import urllib.request
+    want = ("vllm:request_generation_tokens_sum",
+            "vllm:request_decode_time_seconds_sum",
+            "vllm:request_prefill_time_seconds_sum",
+            "vllm:num_preemptions_total", "vllm:num_preemptions")
+    out = {}
+    try:
+        with urllib.request.urlopen(base_url.rstrip("/") + "/metrics", timeout=5) as r:
+            for line in r.read().decode("utf-8", "replace").splitlines():
+                if line.startswith("#") or " " not in line:
+                    continue
+                name, _, val = line.partition(" ")
+                base = name.split("{", 1)[0]
+                if base in want:
+                    try:
+                        out[base] = out.get(base, 0.0) + float(val)
+                    except ValueError:
+                        pass
+    except Exception:
+        return {}
+    return out
+
+
 def _think(on=False):
     import os as _o, json as _j
     raw = _o.environ.get("THINK_ON_KW" if on else "THINK_OFF_KW")
@@ -268,7 +306,15 @@ def run_turn(messages, fixture_turn, session_id, turn_idx):
         # turn (HTTP 500 on replay). 600 lets the call complete; the _safe_args
         # guard below backstops any residual clip.
         "max_tokens": 600,
-        "temperature": 0.3,
+        # ⚠️ GREEDY + FIXED SEED. At temperature 0.3 each run generated DIFFERENT
+        # text, so per-turn numbers were not comparable ACROSS runs — a turn read
+        # 56.2 TPS in one run and "unmeasurable" in the next purely because the
+        # model happened to emit a long tool argument the second time. Every
+        # cross-run turn-by-turn comparison made on that basis was invalid
+        # (2026-09-08). Boot-to-boot noise remains; generation noise does not.
+        # Override with BENCH_TEMPERATURE / BENCH_SEED to sample deliberately.
+        "temperature": float(os.environ.get("BENCH_TEMPERATURE", "0")),
+        "seed": int(os.environ.get("BENCH_SEED", "1096")),
         "stream": True,
         "stream_options": {"include_usage": True},
         **_think(),
@@ -280,6 +326,7 @@ def run_turn(messages, fixture_turn, session_id, turn_idx):
     t_send = time.time()
     ttft = None
     completion_tokens = 0
+    sse_chunks = 0            # chunks carrying `choices` — see chunks_per_token below
     prompt_tokens = 0
     content_parts = []
     tool_calls_acc = {}
@@ -298,8 +345,23 @@ def run_turn(messages, fixture_turn, session_id, turn_idx):
                 continue
             choices = chunk.get("choices") or []
             if choices:
+                sse_chunks += 1
                 delta = choices[0].get("delta", {})
-                if ttft is None and (delta.get("content") or delta.get("tool_calls")):
+                # ⚠️ TTFT = FIRST CHUNK CARRYING `choices`, whatever the delta
+                # type. This is exactly what `vllm bench serve` does
+                # (benchmarks/lib/endpoint_request_func.py) and it is the only
+                # rule that cannot be broken by a new delta kind.
+                #
+                # It was "first CONTENT delta", which on a thinking model charged
+                # the ENTIRE reasoning phase to prefill and left a decode window
+                # of a few percent — reported as "single-block emission ... wall
+                # 2.0 tok/s", i.e. a decode COLLAPSE that never happened.
+                # Measured 2026-09-08 on qwen3.8-flash-next-ple @ ~21K ctx:
+                # first reasoning delta 28.64s, first content delta 34.69s;
+                # 278 reasoning deltas had streamed normally throughout.
+                # Narrowing this to content+tool_calls+reasoning would still miss
+                # the next delta kind; taking the chunk is the durable fix.
+                if ttft is None:
                     ttft = time.time() - t_send
                 if delta.get("content"):
                     content_parts.append(delta["content"])
@@ -394,7 +456,31 @@ def run_turn(messages, fixture_turn, session_id, turn_idx):
     # so 5% sits ~20x away from any autoregressive turn and cannot fire on one.
     # None means UNMEASURABLE — not slow, not zero.
     decode_s = wall - ttft
-    degenerate = wall <= 0 or decode_s <= 0 or decode_s < DEGEN_WINDOW_FRAC * wall
+    # ⛔ THE WINDOW/WALL RATIO IS RETIRED AS A HEALTH SIGNAL (2026-09-08).
+    # window/wall == decode/(prefill+decode), so it encodes ANSWER LENGTH and
+    # CONTEXT SIZE, not throughput: at 21K prompt (~28s prefill) a perfectly
+    # healthy 60-token tool call decodes in 1.2s = 4% of wall and trips a 5%
+    # threshold. No threshold value fixes that — the metric is measuring the
+    # wrong thing. It is kept ONLY to guard the genuinely zero-width case
+    # (decode_s <= 0), which is arithmetic, not a heuristic.
+    #
+    # What actually produces few-chunk turns here is FRONTEND coalescing: the
+    # Qwen3 tool parser re-scans the whole accumulated argument text on every
+    # delta (3 passes, no structural-char gate), ~3.2 ms/delta at 20K chars
+    # ≈ 8s of API-server CPU for one long tool argument. That runs on the same
+    # event loop as the engine's output handler, so outputs queue and
+    # RequestOutputCollector MERGES them into a few large SSE chunks. That is a
+    # frontend cost, NOT a decode collapse, and it must not be reported as one.
+    #
+    # Healthy streaming is ~1 chunk per engine step (1 token/step without
+    # speculation, 1..n+1 with it). Far fewer chunks than tokens ⇒ the client
+    # saw coalesced output — its OWN category, never "decode collapse".
+    # A single chunk means there is NO OBSERVABLE decode window — you cannot time
+    # an interval from one sample. That is the dLLM/canvas case (#809), and it is
+    # a statement about what was observed, not a threshold on how fast it was.
+    degenerate = wall <= 0 or decode_s <= 0 or sse_chunks <= 1
+    chunks_per_token = (sse_chunks / completion_tokens) if completion_tokens > 0 else 0.0
+    frontend_bound = bool(completion_tokens >= 50 and chunks_per_token < 0.10)
     if completion_tokens <= 0:
         # The genuine silent-empty turn. It has always reported 0 and that
         # discriminator must not regress into an "unmeasurable" n/a.
@@ -410,6 +496,10 @@ def run_turn(messages, fixture_turn, session_id, turn_idx):
         "decode_tps": decode_tps,
         "wall_tps": (completion_tokens / wall) if wall > 0 else 0.0,
         "decode_degenerate": bool(degenerate and completion_tokens > 0),
+        "completion_tokens": completion_tokens,
+        "sse_chunks": sse_chunks,
+        "chunks_per_token": chunks_per_token,
+        "frontend_bound": frontend_bound,
         "completion_tokens": completion_tokens,
         "prompt_tokens": prompt_tokens,
         "tool_calls": len(tool_calls_response),
@@ -436,7 +526,23 @@ for session in range(1, SESSIONS + 1):
     for turn_idx in range(TURNS):
         fixture_turn = FIXTURE[turn_idx]
         try:
+            # Bracket the turn with the engine's OWN counters. Client timing can
+            # be distorted by frontend coalescing; these cannot.
+            _em0 = _scrape_engine_metrics(URL)
             m = run_turn(messages, fixture_turn, session, turn_idx)
+            _em1 = _scrape_engine_metrics(URL)
+            if _em0 and _em1:
+                d_tok = _em1.get("vllm:request_generation_tokens_sum", 0.0) - \
+                        _em0.get("vllm:request_generation_tokens_sum", 0.0)
+                d_dec = _em1.get("vllm:request_decode_time_seconds_sum", 0.0) - \
+                        _em0.get("vllm:request_decode_time_seconds_sum", 0.0)
+                d_pre = (_em1.get("vllm:num_preemptions_total",
+                                  _em1.get("vllm:num_preemptions", 0.0)) -
+                         _em0.get("vllm:num_preemptions_total",
+                                  _em0.get("vllm:num_preemptions", 0.0)))
+                m["engine_decode_tps"] = (d_tok / d_dec) if d_dec > 0 else None
+                m["engine_gen_tokens"] = d_tok
+                m["preemptions"] = d_pre
             per_turn_metrics[turn_idx].append(m)
             if m.get("tool_call_missed"):
                 tool_call_misses += 1
@@ -446,10 +552,25 @@ for session in range(1, SESSIONS + 1):
                 # defect (#809). wall_TPS is the honest figure for such a turn.
                 if m["decode_tps"] is None:
                     dcol = f"{'n/a':>11}"
-                    miss = (f"  (decode window 0 — single-block emission; "
-                            f"wall {m['wall_tps']:.1f} tok/s){miss}")
+                    miss = (f"  (zero-width decode window; wall "
+                            f"{m['wall_tps']:.1f} tok/s){miss}")
                 else:
                     dcol = f"{m['decode_tps']:>11.1f}"
+                # FRONTEND-BOUND is its own category and NEVER implies slow
+                # decode: the decode number stands, the client just received it
+                # coalesced into few chunks (parser cost on the API-server loop).
+                # The engine's own decode rate, when /metrics is reachable. This
+                # is the citable number: it is measured inside the engine and is
+                # unaffected by parser cost or SSE coalescing.
+                if m.get("engine_decode_tps"):
+                    miss = (f"  [engine {m['engine_decode_tps']:.1f} tok/s"
+                            + (f", {int(m['preemptions'])} preemption(s)"
+                               if m.get("preemptions") else "") + f"]{miss}")
+                if m.get("frontend_bound"):
+                    miss = (f"  ⚠ frontend-bound: {m['sse_chunks']} chunks for "
+                            f"{m['completion_tokens']} tok "
+                            f"({m['chunks_per_token']:.3f} chunks/tok) — client-side "
+                            f"coalescing, decode itself is unaffected{miss}")
                 print(f"  {turn_idx+1:<5} {m['prompt_tokens']:>10,} {m['ttft_ms']:>9.0f} "
                       f"{dcol} {m['result_chars']:>13,}{miss}", flush=True)
         except Exception as e:
@@ -541,9 +662,13 @@ for turn_idx in contiguous:
 # take a `n/a` column for a broken run or a low figure for a slow model.
 if degen_total:
     print(f"\n  decode-window  unmeasurable on {degen_total}/{turns_total} turn(s) "
-          f"(decode window < {DEGEN_WINDOW_FRAC:.0%} of wall).")
+          f"(zero-width window: the last chunk arrived at TTFT).")
     print("                 Those turns are EXCLUDED from every decode_TPS above; their honest")
     print("                 throughput figure is wall TPS, which INCLUDES prefill.")
+    print("                 NOTE: this is now arithmetic (decode_s <= 0), not a ratio. The old")
+    print("                 'window < 5% of wall' rule was RETIRED — it encoded answer length")
+    print("                 and context size, so a healthy short answer after a long prefill")
+    print("                 tripped it and read as a decode collapse.")
 if gran == "canvas":
     print(f"\n  ⚠ CANVAS GRANULARITY ({gran_why})")
     print("    dLLM: block emission, decode window undefined. decode_TPS is NOT a decode rate")

--- a/scripts/catalog.sh
+++ b/scripts/catalog.sh
@@ -134,7 +134,7 @@ PY_ENG
     # nobody saw is worse than a prompt.
     python3 - "$COMPOSE" "$SPEC" "$ENGINE" "$MODEL" "$WORKLOAD" "$PORT" "$WEIGHTS" \
              "${RROOT:-$ROOT}" "$ETYPE" "$MINSM" "$HFREPO" <<'PY' || exit $?
-import json, sys, zlib
+import json, os, sys, zlib
 from pathlib import Path
 
 sys.path.insert(0, ".")
@@ -366,6 +366,25 @@ if _wdir and _wdir.is_dir():
             _size_gb = round(_b / 2**30, 1)
     except OSError:
         pass
+# ⚠️ RELATIVE TO MODEL_DIR, never absolute. The launcher's preflight joins
+# MODEL_DIR onto `path`, so an absolute value yields
+# "/mnt/models/huggingface//mnt/models/huggingface/<dir>" and the boot refuses on a
+# path that plainly exists. Core profiles are relative
+# ("glm-5.3-flash-gguf/UD-IQ4_XS"), with local_subdir the FIRST segment. And the
+# subdir is the real DIRECTORY name — it was the model id, which is only the same
+# string by coincidence.
+_md = os.environ.get("MODEL_DIR") or "/mnt/models/huggingface"
+_rel_path = ""
+if _wdir:
+    try:
+        _rel_path = str(_wdir.resolve().relative_to(Path(_md).resolve()))
+    except ValueError:
+        _rel_path = _wdir.name
+        print(f"[catalog] note: {_wdir} is not under MODEL_DIR ({_md}); recording "
+              f"{_rel_path!r} as the subdir. Launch with MODEL_DIR pointing at its "
+              f"parent, or the preflight will not find it.", file=sys.stderr)
+_rel_subdir = _rel_path.split("/")[0] if _rel_path else mid
+
 _hf_repo = hf_repo_in or ""
 spec_family = cfg_extra.get("family", "dense")
 
@@ -384,12 +403,51 @@ elif f.cpu_offload_gb and int(f.cpu_offload_gb) > 0:
           f"the value decides the mechanism. Left unset; state it with: "
           f"catalog.sh update --slug <slug> --set offload=uva", file=sys.stderr)
 
+# ⚠️ DETECTABILITY. A compose can be perfectly valid and still be INVISIBLE to
+# c3: club3090_tui_core.detect classifies engine containers by NAME PREFIX and by
+# the CONTAINER-SIDE port. Miss either and no ServingTarget is built, health.sh
+# falls back to the curated default port, and the estate reads "not reachable"
+# while the GPU bars plainly show the model loaded. That is a heuristic we own,
+# and it predates the local layer — a user's own engine cannot be expected to
+# satisfy it. WARN, never refuse: the registration is correct, our detector is
+# the narrow part. Tracked in club-3090-todo.md (registry-first detection).
+#
+# ⚠️ These two constants MIRROR club3090_tui_core.detect. They are duplicated
+# because catalog.sh must run on the launcher's no-extra-deps path;
+# test-catalog-detectability.sh asserts they still match, so a change there
+# cannot silently strand this warning.
+_DETECT_PREFIXES = ("vllm-", "llama-cpp-", "ik-llama-", "sglang-", "beellama-")
+_DETECT_PORTS = ("8000", "8080", "30000")
+_undetectable = []
+if f.container_name and not f.container_name.startswith(_DETECT_PREFIXES):
+    _undetectable.append(
+        f"container_name {f.container_name!r} starts with none of "
+        f"{', '.join(_DETECT_PREFIXES)}"
+    )
+if f.internal_port and f.internal_port not in _DETECT_PORTS:
+    _undetectable.append(
+        f"container-side port {f.internal_port} is not one of "
+        f"{', '.join(_DETECT_PORTS)}"
+    )
+if _undetectable:
+    print("[catalog] ⚠️  REGISTERED, BUT c3 WILL NOT SEE IT SERVING:", file=sys.stderr)
+    for _u in _undetectable:
+        print(f"[catalog]     - {_u}", file=sys.stderr)
+    print("[catalog]   The slug, weights and compose are fine — this is our estate "
+          "detector,", file=sys.stderr)
+    print("[catalog]   which infers engines from naming conventions that predate the "
+          "local layer.", file=sys.stderr)
+    print("[catalog]   Until that is registry-driven, rename the container to a "
+          "listed prefix", file=sys.stderr)
+    print("[catalog]   and publish on a listed container-side port to be detected.",
+          file=sys.stderr)
+
 spec = {
     "model_id": mid,
     "display_name": mid,
     "family": spec_family,
-    "weights": {"local": {"path": str(_wdir) if _wdir else f.model_path,
-                          "local_subdir": mid, "size_gb": _size_gb,
+    "weights": {"local": {"path": _rel_path, "local_subdir": _rel_subdir,
+                          "size_gb": _size_gb,
                           "format": fmt, "status": "incubating", "hf_repo": _hf_repo,
                           "engine": engine, "kind": "main",
                           "verify_glob": "*.gguf" if fmt == "gguf" else "*.safetensors"}},

--- a/scripts/lib/profiles/compose_facts.py
+++ b/scripts/lib/profiles/compose_facts.py
@@ -48,6 +48,12 @@ class ComposeFacts:
     # residency axis). They were never read, so a recipe whose whole point is
     # CPU-offloaded experts with an MTP drafter registered as a plain resident
     # model with no speculation — every column blank, nothing wrong on screen.
+    # Detectability: what the ESTATE layer needs to recognise this container.
+    # club3090_tui_core.detect classifies by container NAME prefix and by the
+    # CONTAINER-SIDE port, so a compose can be perfectly valid and still be
+    # invisible to c3. Surfaced here so registration can say so up front.
+    container_name: str = ""  # services.<svc>.container_name
+    internal_port: str = ""   # the CONTAINER side of a ports: mapping
     cpu_offload_gb: str = ""  # --cpu-offload-gb / CPU_OFFLOAD_GB
     offload_backend: str = "" # --offload-backend (uva / …)
     spec_method: str = ""     # --speculative-config "method" / MTP_DEPTH / -md
@@ -62,6 +68,18 @@ _ENGINE_BY_IMAGE = (
     ("ik-llama", "ik-llama"),
     ("ik_llama", "ik-llama"),
 )
+
+
+def _expand_default_token(tok: str) -> str:
+    """`${VAR:-value}` -> `value`; anything else unchanged.
+
+    container_name is routinely written as an override-able expansion
+    (`${ESTATE_CONTAINER:-llama-cpp-foo}`), and the DEFAULT is the name that
+    actually runs when nothing overrides it — which is what detection sees.
+    """
+    tok = (tok or "").strip().strip("\"'")
+    m = re.fullmatch(r"\$\{[A-Za-z_][A-Za-z0-9_]*:-([^}]*)\}", tok)
+    return m.group(1) if m else tok
 
 
 def _numeric(tok: str) -> str:
@@ -200,6 +218,23 @@ def derive_compose_facts(text: str, path: str = "") -> ComposeFacts:
         m = _re.search(r"CUDA_VISIBLE_DEVICES[=:\s]+\"?([0-9,]+)", text)
         if m:
             f.tp = str(len([x for x in m.group(1).split(",") if x.strip()]))
+
+    # container_name + the CONTAINER side of the port mapping (detectability).
+    m = _re.search(r"^\s*container_name:\s*[\"']?([^\"'\s]+)", text, _re.M)
+    if m:
+        f.container_name = _expand_default_token(m.group(1))
+    # The CONTAINER side is the TRAILING number of a mapping inside the ports:
+    # block. Scoped to that block, and taken as the last ":<digits>" on the line,
+    # because the host side is routinely a nested expansion full of colons
+    # (`${ESTATE_PORT:-${PORT:-8119}}`) that a naive segment split gets wrong.
+    _pm = _re.search(r"^(\s*)ports:\s*$(.*?)(?=^\1\S|\Z)", text, _re.M | _re.S)
+    if _pm:
+        for _line in _pm.group(2).splitlines():
+            _lm = _re.match(r"\s*-\s*[\"']?.*?:([0-9]+)(?:/(?:tcp|udp))?[\"']?\s*$",
+                            _line)
+            if _lm:
+                f.internal_port = _lm.group(1)
+                break
 
     # ── offload + speculation evidence ────────────────────────────────
     # Flag first (authoritative), then the env spelling, because a compose whose

--- a/scripts/tests/test-bench-agentic-ramp.sh
+++ b/scripts/tests/test-bench-agentic-ramp.sh
@@ -77,6 +77,21 @@ class H(BaseHTTPRequestHandler):
             if EMIT_TC:
                 delta["tool_calls"] = TC
             ev({"choices": [{"delta": delta}], "usage": USAGE})
+        elif MODE == "reasoning":
+            # THINKING MODEL SHAPE. The server streams `reasoning` deltas for a
+            # long time, THEN a short content tail. If TTFT is taken at the first
+            # CONTENT delta, the whole reasoning phase is charged to prefill and
+            # the decode window collapses below the degenerate threshold — the
+            # turn reports "single-block emission, wall ~2 tok/s", which reads as
+            # a decode COLLAPSE that never happened (2026-09-08; it mimics #1096
+            # closely enough to be mistaken for it).
+            for _ in range(6):
+                ev({"choices": [{"delta": {"reasoning": "thinking... "}}]})
+                time.sleep(0.05)
+            ev({"choices": [{"delta": {"content": "Done."}}]})
+            if EMIT_TC:
+                ev({"choices": [{"delta": {"tool_calls": TC}}]})
+            ev({"choices": [{"delta": {}}], "usage": USAGE})
         else:
             ev({"choices": [{"delta": {"content": "Looking into it."}}]})
             # A real decode window. Without this the mock's own burst-write makes
@@ -154,7 +169,11 @@ echo "── canvas granularity: zero-width decode window must print n/a, never 
 out="$(run_bench 1 canvas QUIET=0)"
 assert_no_absurd_decode "$out" "canvas ramp"
 assert_contains "$out" "n/a"                       # the per-turn column
-assert_contains "$out" "single-block emission"     # ...and WHY it is n/a
+assert_contains "$out" "zero-width decode window"  # ...and WHY it is n/a
+# ⛔ The label was "single-block emission" and the trigger was a
+# window/wall RATIO. Both retired 2026-09-08: the ratio encoded answer
+# length + context size, so a healthy short answer after a long prefill
+# tripped it. The trigger is now "one chunk ⇒ nothing to time".
 assert_contains "$out" "decode-window  unmeasurable"
 assert_contains "$out" "⚠ CANVAS GRANULARITY"
 assert_contains "$out" "HEADLINE number is wall TPS"
@@ -165,7 +184,7 @@ assert_contains "$out" "TTFT growth by accumulated context"
 echo "  ✓ canvas: n/a per turn with a reason, exclusion stated, ramp + TTFT curve intact"
 
 echo "── additivity: an AR run carries none of the canvas machinery ──"
-for unwanted in "CANVAS GRANULARITY" "single-block emission" "decode-window  unmeasurable"; do
+for unwanted in "CANVAS GRANULARITY" "zero-width decode window" "decode-window  unmeasurable"; do
   assert_absent "$ar_out" "$unwanted"
 done
 assert_no_absurd_decode "$ar_out" "AR ramp"
@@ -177,5 +196,22 @@ assert_absent   "$out" "⚠ CANVAS GRANULARITY"
 assert_contains "$out" "n/a"                       # the per-turn guard is NOT overridable
 assert_no_absurd_decode "$out" "canvas ramp, granularity forced to token"
 echo "  ✓ the label is declarable; the zero-width guard is not overridable"
+
+echo "── thinking model: reasoning deltas count as first token ──"
+# A reasoning-parser model streams `reasoning` deltas long before the first
+# `content` delta. Taking TTFT at the content delta charges the ENTIRE reasoning
+# phase to prefill, and the turn reports as a zero-width decode window — i.e. a
+# COLLAPSE that did not happen. Measured 2026-09-08 on a live thinking model at
+# ~21K ctx: first reasoning delta 28.64s, first content delta 34.69s, window
+# 1.25s = 3.5% of wall = flagged. 278 reasoning deltas had streamed normally.
+out="$(run_bench 1 reasoning QUIET=0)"
+assert_absent "$out" "zero-width decode window"
+assert_absent "$out" "decode-window  unmeasurable"
+# and it must still produce a real per-turn decode number, not n/a
+if grep -qE "^\s*[0-9]+\s+[0-9,]+\s+[0-9]+\s+n/a" <<<"$out"; then
+  echo "ASSERT FAIL: a thinking-model turn still reported n/a decode"; echo "$out"; exit 1
+fi
+assert_no_absurd_decode "$out" "reasoning ramp"
+echo "  ✓ reasoning deltas start the decode window — a thinking model is measurable"
 
 echo "test-bench-agentic-ramp: ok"

--- a/scripts/tests/test-catalog-detectability.sh
+++ b/scripts/tests/test-catalog-detectability.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Guard: registering a slug c3 cannot SEE must say so at registration time.
+#
+# The estate layer classifies engine containers by NAME PREFIX and by the
+# CONTAINER-SIDE port (club3090_tui_core.detect). Those are heuristics we own,
+# and they predate the local layer: a user's own engine cannot be expected to
+# satisfy them. When it does not, everything looks fine — the slug registers, the
+# weights resolve, the model serves — and c3 reports "○ not reachable" while the
+# GPU bars show the model plainly loaded. That happened for real on 2026-09-08.
+#
+# So registration WARNS (never refuses — the registration is correct; our
+# detector is the narrow part), and this guard pins three things:
+#   1. an undetectable container NAME warns;
+#   2. an undetectable container-side PORT warns;
+#   3. a conforming compose does NOT warn (the negative control — without it the
+#      warning could fire always and still "pass");
+# plus an ANTI-DRIFT check: catalog.sh duplicates detect.py's prefixes/ports
+# because it must run on the launcher's no-extra-deps path, so if detect.py ever
+# changes, this guard fails rather than leaving the warning quietly wrong.
+set -uo pipefail
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+rc=0
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/scripts" "$TMP/tools" "$TMP/w"
+cp -r scripts/lib "$TMP/scripts/"; cp -r tools/tui-core "$TMP/tools/"
+cat > "$TMP/w/config.json" <<'JSON'
+{"model_type":"qwen","hidden_size":64,"num_hidden_layers":2,
+ "num_attention_heads":4,"num_key_value_heads":2,"max_position_embeddings":4096}
+JSON
+
+mk() {  # mk <file> <container_name> <internal_port>
+  cat > "$1" <<YML
+services:
+  probe:
+    image: ghcr.io/someone/their-runtime:locked
+    container_name: $2
+    ports:
+      - "\${BIND_HOST:-0.0.0.0}:\${ESTATE_PORT:-\${PORT:-20272}}:$3"
+    environment:
+      MAX_MODEL_LEN: "\${MAX_MODEL_LEN:-32768}"
+    command: ["/model"]
+YML
+}
+
+reg() {  # reg <compose> <model> -> stdout+stderr
+  scripts/catalog.sh register --compose "$1" --engine their-vllm --engine-type vllm \
+    --model "$2" --weights "$TMP/w" --workload fast-chat --root "$TMP" --dry-run -y 2>&1
+}
+
+mk "$TMP/bad-name.yml" "qwen38-flash-next-ple" 8000
+out="$(reg "$TMP/bad-name.yml" p-badname)"
+command grep -q "WILL NOT SEE IT SERVING" <<<"$out" && command grep -q "container_name" <<<"$out" \
+  && echo "  ok   an unprefixed container name warns" \
+  || { echo "  FAIL an unprefixed container name did NOT warn"; rc=1; }
+
+mk "$TMP/bad-port.yml" "vllm-probe" 20272
+out="$(reg "$TMP/bad-port.yml" p-badport)"
+command grep -q "container-side port" <<<"$out" \
+  && echo "  ok   an undetectable container-side port warns" \
+  || { echo "  FAIL an undetectable container-side port did NOT warn"; rc=1; }
+
+# NEGATIVE CONTROL — a conforming compose must stay silent, or the checks above
+# would pass for every input and prove nothing.
+mk "$TMP/good.yml" "vllm-probe" 8000
+out="$(reg "$TMP/good.yml" p-good)"
+if command grep -q "WILL NOT SEE IT SERVING" <<<"$out"; then
+  echo "  FAIL a CONFORMING compose warned — the check fires unconditionally"; rc=1
+else
+  echo "  ok   a conforming compose does not warn"
+fi
+
+# ANTI-DRIFT — catalog.sh's copy must still match detect.py.
+python3 - <<'PY' || rc=1
+import re, sys, pathlib
+det = pathlib.Path("tools/tui-core/club3090_tui_core/detect.py").read_text(encoding="utf-8")
+cat = pathlib.Path("scripts/catalog.sh").read_text(encoding="utf-8")
+m = re.search(r"ENGINE_PREFIXES\s*=\s*re\.compile\(r\"\^\(([^)]*)\)\"\)", det)
+n = re.search(r'_DETECT_PREFIXES\s*=\s*\(([^)]*)\)', cat)
+if not m or not n:
+    print("  FAIL could not read the prefix lists from both files"); sys.exit(1)
+det_p = set(x for x in m.group(1).split("|") if x)
+cat_p = set(re.findall(r'"([^"]+)"', n.group(1)))
+if det_p != cat_p:
+    print(f"  FAIL prefix DRIFT — detect.py={sorted(det_p)} catalog.sh={sorted(cat_p)}")
+    sys.exit(1)
+mp = re.search(r"PORT_MAP_RE\s*=\s*re\.compile\(\s*\n?\s*r\"[^\"]*\((\d+(?:\|\d+)*)\)", det)
+np_ = re.search(r'_DETECT_PORTS\s*=\s*\(([^)]*)\)', cat)
+if not mp or not np_:
+    print("  FAIL could not read the port lists from both files"); sys.exit(1)
+det_ports = set(mp.group(1).split("|"))
+cat_ports = set(re.findall(r'"(\d+)"', np_.group(1)))
+if det_ports != cat_ports:
+    print(f"  FAIL port DRIFT — detect.py={sorted(det_ports)} catalog.sh={sorted(cat_ports)}")
+    sys.exit(1)
+print("  ok   catalog.sh's copy still matches detect.py (no drift)")
+PY
+
+[[ "$rc" == "0" ]] && echo "PASS: registration warns when c3 could not see the slug" \
+                   || echo "FAIL: detectability warning regression"
+exit "$rc"


### PR DESCRIPTION
Two independent fixes found while registering a community recipe. The first
invalidates published numbers, including the evidence in #1096.

## 1. `bench-agentic` measured decode wrong on every reasoning model

TTFT was taken at the first **`content`** delta. A reasoning model streams
`reasoning`/`reasoning_content` deltas *first*, so the whole reasoning phase was
charged to prefill, the decode window fell under the 5%-of-wall threshold, and the
turn printed:

```
single-block emission ... wall 2.0 tok/s
```

A decode **collapse that never happened**. Measured live at ~21 K ctx:

| | |
|---|---|
| first **reasoning** delta | 28.64 s — 278 deltas, streaming normally |
| first **content** delta | 34.69 s |
| old TTFT / window | 34.69 s / **1.25 s = 3.5% of wall → flagged** |
| correct TTFT / window | 28.64 s / 7.31 s = 20% → fine |

Compounding it: `usage.completion_tokens` **includes** reasoning tokens, so
`decode_tps` divided reasoning-inclusive tokens by a reasoning-exclusive window,
inflating the turns that *were* reported.

### Why the old rule reproduced a convincing pathology

`window/wall` is `decode/(prefill+decode)`, so it flags whatever has **slow prefill
relative to decode** — nothing to do with health. At 21 K prompt (~28 s prefill) a
perfectly healthy 60-token tool call decodes in 1.2 s = 4% and trips a 5% threshold.

### Changes

1. **TTFT = first chunk carrying `choices`**, any delta type — what `vllm bench serve`
   does. Listing delta names would just miss the next one.
2. **The window/wall ratio is retired.** What remains is arithmetic: zero-width, or a
   single chunk (you cannot time an interval from one sample — the dLLM/canvas case).
3. **`frontend-bound` is its own category** and states decode is unaffected. Few-chunk
   turns come from the tool parser re-scanning the whole accumulated argument on every
   delta (~3.2 ms/delta at 20 K chars) on the API-server event loop, so outputs queue
   and `RequestOutputCollector` merges them. A frontend cost must never read as a
   decode collapse.
4. **Greedy + fixed seed.** At temperature 0.3 each run generated different text, so
   per-turn numbers were not comparable across runs — a turn read 56.2 TPS in one run
   and "unmeasurable" in the next.
5. **Engine-side metrics per turn** —
   `vllm:request_generation_tokens_sum / vllm:request_decode_time_seconds_sum` plus
   `Δvllm:num_preemptions`. Recorded inside the engine, immune to parser cost and SSE
   coalescing. Verified live: client and engine agree within 1-2% per turn.

### Re-test with the corrected harness — 96 turns, 4 arms, zero collapses

2 sessions × 12 turns each, greedy, engine-corroborated, vLLM v0.27.1:

| arm | decode range | flagged | at the threshold #1096 records |
|---|---|---|---|
| `vllm/qwen38-27b-dual-max` (MTP n=3) | 92-113 | 0/12 | **110.2 @ 21,443** (recorded 1.5-6) |
| `vllm/qwen38-27b-dual-supermax` (DFlash2 n=7) | 130-164 | 0/12 | **159.4 @ 12,275** (recorded 4-6) |
| flash-next MTP | 72-108 | 0/12 | — |
| flash-next spec-off | 44-50 | 0/12 | — |

⚠️ **Any bench-agentic figure recorded for a reasoning model before this is suspect in
both directions** — `n/a` turns that were healthy, and decode TPS that was inflated.
Correction filed in `learnings/qwen3.8-27b.md`; #1096 gets a comment.

Guard: `MOCK_MODE=reasoning` in the offline mock asserts a thinking-model turn is
measurable. Fails against the old code with
`ASSERT FAIL: unexpected 'single-block emission'`.

## 2. `catalog.sh` warns when a registered slug will be invisible to c3

A local registration can be entirely correct and still never show as serving: the
estate layer classifies engine containers by **name prefix** and **container-side
port**.

```
ENGINE_PREFIXES = ^(vllm-|llama-cpp-|ik-llama-|sglang-|beellama-)
PORT_MAP_RE     = :(\d+)->(8000|8080|30000)/tcp
```

Miss either → no `ServingTarget` → `health.sh` falls back to the curated default port →
c3 reports "not reachable" while the GPU bars plainly show the model loaded. Hit for
real with a container named `qwen38-flash-next-ple` on `20272:20272`.

Those heuristics **predate the local layer**, and a user's own engine cannot be
expected to satisfy naming conventions for engines we sanctioned. So this **warns and
never refuses** — the registration is correct; our detector is the narrow part. The
real fix is registry-first detection (the registry already emits `container` and `port`
correctly); tracked in the stack todo.

⚠️ `catalog.sh` duplicates `detect.py`'s lists because it runs on the launcher's
no-extra-deps path. `test-catalog-detectability.sh` parses **both files** and fails on
divergence — verified by drifting one character.

## Gate

- bash guard sweep: **PASS=148 FAIL=0**
- cockpit suite: **1128 passed, 1 skipped**
- both guards negative-controlled against the pre-fix code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
