### PR TITLE
fix(cockpit): render one GPU card per card, and default to multi4/multi8

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/app.py
+++ b/tools/serve-cockpit/club3090_cockpit/app.py
@@ -843,18 +843,53 @@ def profile_templates(
     return out
 
 
+# Card counts that have REAL composes, smallest first.  Scanned from the registry
+# 2026-09-08: single 34 · dual 52 · multi4 17 · multi8 9 — and NO multi3, even
+# though `_TOPO_ORDER` still lists one (that entry is vestigial: `_variant_topology`
+# would accept a multi3 path, but no compose has ever used it).  Deriving the ladder
+# from card counts rather than from `_TOPO_ORDER` keeps a topology nobody ships out
+# of the default path.
+_TOPO_BY_CARDS: tuple[tuple[int, str], ...] = (
+    (1, "single"), (2, "dual"), (4, "multi4"), (8, "multi8"),
+)
+
+
+def _topology_ladder(num_gpus: int) -> list[str]:
+    """Topologies to try for a rig with ``num_gpus`` cards, BEST FIT FIRST.
+
+    The rule is *the largest topology that fits, then degrade*.  A topology needing
+    MORE cards than the rig has cannot run at all; one needing fewer always can.  So
+    4 cards → multi4, dual, single; 8 → multi8, multi4, dual, single; 1 → single.
+
+    Counts with no exact topology take the largest that fits rather than inventing a
+    slug: **3 → dual** (there are no multi3 composes) and **5-7 → multi4**.
+
+    The DEGRADING half matters as much as the exact fit.  Before this, a ≥2-card rig
+    asked only for "dual" and, when no dual option existed, fell through to "the first
+    option" — which sorts by ``_TOPO_ORDER``, i.e. a SINGLE-card slug.  A 4-card rig
+    with no multi4 default now lands on dual, which is both launchable and closer to
+    the hardware, instead of a one-card slug chosen by sort order.
+    """
+    n = max(1, int(num_gpus or 1))
+    fits = [topo for cards, topo in _TOPO_BY_CARDS if cards <= n]
+    return list(reversed(fits)) or ["single"]
+
+
 def default_profile_template(
     options: list["ProfileOption"], num_gpus: int
 ) -> Optional[str]:
     """A12 — pick the dropdown's default value for the rig's own topology.
 
     Rule (deterministic, meaningful): prefer the registry's CANONICAL slug for
-    the rig topology — a slug literally named ``<engine>/<topo>`` (``vllm/dual``
-    for ≥2 cards, ``vllm/single`` for 1 card), preferring a ``vllm/``-prefixed
-    slug; then any literal ``<engine>/<topo>`` slug; then any slug whose
-    topology matches; finally the first option.  NEVER an arbitrary alphabetical
-    (e.g. Gemma/beellama) slug.  Topology comes from the carried-through
-    ``ProfileOption.topology`` — never re-derived from the label.
+    the rig topology — a slug literally named ``<engine>/<topo>`` (``vllm/multi4``
+    on 4 cards, ``vllm/dual`` on 2, ``vllm/single`` on 1), preferring a
+    ``vllm/``-prefixed slug; then any literal ``<engine>/<topo>`` slug; then any
+    slug whose topology matches; finally the first option.  NEVER an arbitrary
+    alphabetical (e.g. Gemma/beellama) slug.  Topology comes from the
+    carried-through ``ProfileOption.topology`` — never re-derived from the label.
+
+    The rig topology is the largest that FITS the card count, degrading when it has
+    no option — see ``_topology_ladder``.
 
     **FIX 2 status floor — a Select default MUST be launchable.** The earlier
     rule returned the FIRST vllm-single option for a 1-card rig, which (since the
@@ -868,11 +903,15 @@ def default_profile_template(
     default to an absent value)."""
     if not options:
         return None
-    want = "single" if num_gpus <= 1 else "dual"
+    # ≥4-card rigs (#David412, 2026-09-08): this asked only for "single" or "dual",
+    # so a 4- or 8-GPU rig was offered DUAL templates and the multi4/multi8 slugs it
+    # actually wanted were reachable only through the custom escape hatch.  The
+    # ladder is best-fit-first with degradation — see _topology_ladder.
+    ladder = _topology_ladder(num_gpus)
 
-    def _pick(pool: list["ProfileOption"]) -> Optional[str]:
+    def _pick(pool: list["ProfileOption"], want: str) -> Optional[str]:
         """The original topology-preference order, applied to a pre-filtered
-        option pool (functional-only, then the full set)."""
+        option pool (functional-only, then the full set) for ONE topology."""
         same_topo = [o for o in pool if o.topology == want]
         # 1. the canonical vllm slug literally named "vllm/<topo>".
         canonical_vllm = f"vllm/{want}"
@@ -896,10 +935,19 @@ def default_profile_template(
 
     # Status floor: a functional default first.  Fall back to the full set, then
     # to the first option, so the return is always a real (selectable) value.
+    #
+    # ORDER MATTERS: the whole ladder is walked over the FUNCTIONAL pool before any
+    # of it is walked over the full set.  A launchable dual slug beats an
+    # incubating multi4 one on a 4-card rig — that is the FIX 2 status floor
+    # (a Select default MUST be launchable), and degrading topology is the cheaper
+    # concession of the two.
     functional = [o for o in options if _status_is_functional(o.status)]
-    return _pick(functional) or _pick(options) or (
-        functional[0].slug if functional else options[0].slug
-    )
+    for pool in (functional, options):
+        for want in ladder:
+            hit = _pick(pool, want)
+            if hit:
+                return hit
+    return functional[0].slug if functional else options[0].slug
 
 
 def _set_select_options(
@@ -4638,6 +4686,68 @@ class OperateOrchPane(Container):
         except Exception:
             pass
 
+    @staticmethod
+    def _gpu_slot_count(gpus) -> int:
+        """How many card widgets a GPU snapshot needs.
+
+        Driven by the HIGHEST index present, not by ``len(gpus)``: with a gap in the
+        indices (card 1 fell off the bus, 0 and 2 remain) the slot count must still
+        cover index 2, so the surviving cards keep their real GPU numbers instead of
+        sliding down a slot.  Floors at 1 so an EMPTY read still has a card 0 for the
+        "nvidia-smi returned nothing" message to live on.
+        """
+        idxs = [
+            int(getattr(g, "index", -1)) for g in (gpus or [])
+            if isinstance(getattr(g, "index", None), int)
+        ]
+        return max(1, (max(idxs) + 1) if idxs else 0, len(gpus or []))
+
+    def _sync_gpu_cards(self, want: int) -> None:
+        """Mount/remove GPU cards so exactly ``want`` slots exist.
+
+        The panel used to compose exactly two cards, so a 4-GPU rig read all four and
+        rendered two — reported from the field as "c3 only detects 2 GPU of 4 while
+        nvtop detects everyone" (2026-09-08).  Detection was never the problem; these
+        widgets were.
+
+        Idempotent, and converges in BOTH directions so a count that changes between
+        polls (a card dropping off the bus, or appearing) does not leave stale cards.
+        Newly mounted cards carry the same "querying nvidia-smi…" placeholder they
+        would have had at startup and are filled by the caller on this same pass when
+        Textual has already processed the mount, otherwise on the next poll tick —
+        never left blank.
+        """
+        try:
+            scroll = self.query_one("#orch-scroll")
+        except Exception:
+            return
+        have = len(self.query(".gpu-card"))
+        want = max(1, int(want))
+        if want == have:
+            return
+        if want > have:
+            cards = [
+                Container(
+                    Label(f"GPU{i}", classes="gpu-card-title"),
+                    Static("[dim]querying nvidia-smi…[/dim]", id=f"gpu{i}-bar"),
+                    classes="gpu-card",
+                    id=f"gpu{i}-card",
+                )
+                for i in range(have, want)
+            ]
+            try:
+                # Anchored BEFORE #serving-line: the cards belong at the top of the
+                # pane, and a bare mount() would append them under the scene table.
+                scroll.mount_all(cards, before=scroll.query_one("#serving-line"))
+            except Exception:
+                pass
+            return
+        for i in range(want, have):
+            try:
+                self.query_one(f"#gpu{i}-card").remove()
+            except Exception:
+                pass
+
     def _populate_gpus(self, state: EstateState) -> None:
         # N2: when nvidia-smi returned NOTHING at all (no cards in the snapshot),
         # say so honestly on the first card rather than a calm "not present" per
@@ -4645,8 +4755,17 @@ class OperateOrchPane(Container):
         # GPU-less rig.  A per-index gap (one card present, the other not) still
         # uses the calm "not present".
         no_gpus_at_all = not state.gpus
-        for i, bar_id, title_id in ((0, "#gpu0-bar", "#gpu0-card"), (1, "#gpu1-bar", "#gpu1-card")):
-            bar = self.query_one(bar_id, Static)
+        slots = self._gpu_slot_count(state.gpus)
+        self._sync_gpu_cards(slots)
+        for i in range(slots):
+            bar_id = f"#gpu{i}-bar"
+            # A card mounted THIS pass may not be in the DOM yet (mount is async);
+            # it keeps its startup placeholder and fills on the next tick rather
+            # than raising and aborting the cards that ARE present.
+            try:
+                bar = self.query_one(bar_id, Static)
+            except Exception:
+                continue
             gpu = next((g for g in state.gpus if getattr(g, "index", -1) == i), None)
             if gpu is None:
                 if no_gpus_at_all and i == 0:

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -3043,6 +3043,129 @@ async def test_scene_preview_shows_all_services_no_clip():
         assert "max-height" not in preview_rule
 
 
+class TestGpuCardsScaleToCardCount:
+    """The GPU panel renders ONE card per detected GPU, at any count.
+
+    Reported from the field 2026-09-08: "c3 cockpit only detects 2 GPU of 4 while
+    nvtop detects everyone".  Detection was never the problem — get_gpu_info()
+    parses every nvidia-smi line — but compose() defined exactly two card widgets
+    and _populate_gpus iterated a hardcoded (0, 1) pair, so cards 2+ were read and
+    dropped at render time.
+
+    This rig has TWO GPUs, so every count here is otherwise unreachable and would
+    ship on assumption.  That is the point of these fixtures.
+    """
+
+    @staticmethod
+    def _cards(n):
+        return [
+            GpuInfo(index=i, mem_used_mib=(i + 1) * 1024, mem_total_mib=24 * 1024,
+                    utilization=10 * i)
+            for i in range(n)
+        ]
+
+    async def _settled(self, app, pilot):
+        """Enter Operate and run a SECOND poll, so cards mounted on the first pass
+        (mount is async — they carry the startup placeholder until the DOM catches
+        up) are filled before anything is asserted."""
+        await _enter_operate(pilot)
+        app._periodic_estate_refresh()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+    @pytest.mark.asyncio
+    async def test_four_gpu_rig_renders_four_cards(self):
+        gpus = self._cards(4)
+        app, _, _ = make_app(gpus=gpus, target=ServingTarget(gpus=gpus))
+        async with app.run_test(size=(120, 60)) as pilot:
+            await self._settled(app, pilot)
+            assert len(app.query(".gpu-card")) == 4
+            for i in range(4):
+                bar = str(app.query_one(f"#gpu{i}-bar", Static).render())
+                assert f"{(i + 1)}.0 / 24.0 GiB" in bar, f"card {i}: {bar!r}"
+
+    @pytest.mark.asyncio
+    async def test_eight_gpu_rig_renders_eight_cards(self):
+        gpus = self._cards(8)
+        app, _, _ = make_app(gpus=gpus, target=ServingTarget(gpus=gpus))
+        async with app.run_test(size=(120, 80)) as pilot:
+            await self._settled(app, pilot)
+            assert len(app.query(".gpu-card")) == 8
+            bar7 = str(app.query_one("#gpu7-bar", Static).render())
+            assert "8.0 / 24.0 GiB" in bar7
+
+    @pytest.mark.asyncio
+    async def test_single_gpu_rig_drops_the_second_static_card(self):
+        """compose() lays down two cards; a 1-card rig must converge DOWN, not keep
+        an empty "not present" slot forever."""
+        gpus = self._cards(1)
+        app, _, _ = make_app(gpus=gpus, target=ServingTarget(gpus=gpus))
+        async with app.run_test(size=(120, 40)) as pilot:
+            await self._settled(app, pilot)
+            assert len(app.query(".gpu-card")) == 1
+            assert not app.query("#gpu1-card")
+
+    @pytest.mark.asyncio
+    async def test_card_count_change_between_polls_converges_both_ways(self):
+        """A card appearing or falling off the bus mid-session must not leave stale
+        widgets behind in either direction."""
+        gpus = self._cards(2)
+        app, _, _ = make_app(gpus=gpus, target=ServingTarget(gpus=gpus))
+        async with app.run_test(size=(120, 80)) as pilot:
+            await self._settled(app, pilot)
+            assert len(app.query(".gpu-card")) == 2
+            pane = app.query_one("#operate-orch-pane", OperateOrchPane)
+            st = pane._last_state
+            # 2 -> 4
+            st.gpus = self._cards(4)
+            pane._populate_gpus(st)
+            await pilot.pause()
+            pane._populate_gpus(st)
+            await pilot.pause()
+            assert len(app.query(".gpu-card")) == 4
+            # 4 -> 2 (two cards vanish)
+            st.gpus = self._cards(2)
+            pane._populate_gpus(st)
+            await pilot.pause()
+            assert len(app.query(".gpu-card")) == 2
+            assert not app.query("#gpu3-card")
+
+    @pytest.mark.asyncio
+    async def test_index_gap_keeps_real_gpu_numbers(self):
+        """Cards 0 and 2 present, 1 missing: slot 2 must still BE GPU2 (a
+        len()-driven count would slide it down to slot 1 and mislabel it), and the
+        gap keeps the calm "not present" — not the alarming empty-read message."""
+        gpus = [
+            GpuInfo(index=0, mem_used_mib=1024, mem_total_mib=24 * 1024),
+            GpuInfo(index=2, mem_used_mib=3 * 1024, mem_total_mib=24 * 1024),
+        ]
+        app, _, _ = make_app(gpus=gpus, target=ServingTarget(gpus=gpus))
+        async with app.run_test(size=(120, 60)) as pilot:
+            await self._settled(app, pilot)
+            assert len(app.query(".gpu-card")) == 3
+            assert "3.0 / 24.0 GiB" in str(app.query_one("#gpu2-bar", Static).render())
+            gap = str(app.query_one("#gpu1-bar", Static).render())
+            assert "not present" in gap
+            assert "nvidia-smi returned nothing" not in gap
+
+    @pytest.mark.asyncio
+    async def test_empty_read_keeps_one_card_and_the_honest_message(self):
+        """N2 degradation is unchanged: an empty read is nvidia-smi failing, not a
+        GPU-less rig, and it still says so on card 0."""
+        app, _, _ = make_app(gpus=[], target=ServingTarget(gpus=[]))
+        async with app.run_test(size=(120, 40)) as pilot:
+            await _enter_operate(pilot)
+            pane = app.query_one("#operate-orch-pane", OperateOrchPane)
+            st = pane._last_state
+            if st is not None:
+                st.gpus = []
+                pane._populate_gpus(st)
+                await pilot.pause()
+                assert len(app.query(".gpu-card")) == 1
+                bar0 = str(app.query_one("#gpu0-bar", Static).render())
+                assert "nvidia-smi returned nothing" in bar0
+
+
 class TestRailKvPool:
     """c3 — the estate rail card shows the serving target's KV pool from the
     SAME poll (doctor.kv_pool_pct, parsed by health.sh), honestly '—' when the
@@ -12829,6 +12952,95 @@ class TestProfileTemplateDerivation:
                     f"rep {o.slug!r} is {o.status!r} but its ({fam},{o.topology}) "
                     f"group has a functional sibling"
                 )
+
+
+class TestRigTopologyLadder:
+    """The rig default understands rigs bigger than this one.
+
+    The picker asked only for "single" (1 card) or "dual" (anything more), so a 4-
+    or 8-GPU rig was offered DUAL templates while the multi4/multi8 slugs it wanted
+    were reachable only through the custom escape hatch.  This rig has TWO cards, so
+    every count below is otherwise untestable.
+    """
+
+    def _mk(self, slug, engine, path, status="production"):
+        return VariantRow(
+            slug=slug, switch_engine=engine, launch_engine=engine,
+            compose_dir=path.rsplit("/", 1)[0], file=path.rsplit("/", 1)[1],
+            port=8000, model="q", engine=engine, kvcalc_key="k", container="c",
+            compose_path=path, status=status, ctx_label="262K", status_note="",
+        )
+
+    def _full_ladder_rows(self):
+        return [
+            self._mk("vllm/single", "vllm-stable", "models/q/vllm/compose/single/aq/base.yml"),
+            self._mk("vllm/dual", "vllm-stable", "models/q/vllm/compose/dual/aq/fp8.yml"),
+            self._mk("vllm/multi4", "vllm-stable", "models/q/vllm/compose/multi4/aq/fp8.yml"),
+            self._mk("vllm/multi8", "vllm-stable", "models/q/vllm/compose/multi8/aq/fp8.yml"),
+        ]
+
+    def test_exact_topology_per_card_count(self):
+        opts = profile_templates(self._full_ladder_rows())
+        assert default_profile_template(opts, 1) == "vllm/single"
+        assert default_profile_template(opts, 2) == "vllm/dual"
+        assert default_profile_template(opts, 4) == "vllm/multi4"
+        assert default_profile_template(opts, 8) == "vllm/multi8"
+
+    def test_counts_without_a_topology_take_the_largest_that_fits(self):
+        """3 -> dual (no multi3 composes exist), 5-7 -> multi4, >8 -> multi8.  The
+        alternative — inventing multi3/multi5 — names slugs the registry does not
+        have."""
+        opts = profile_templates(self._full_ladder_rows())
+        assert default_profile_template(opts, 3) == "vllm/dual"
+        for n in (5, 6, 7):
+            assert default_profile_template(opts, n) == "vllm/multi4", f"{n} cards"
+        assert default_profile_template(opts, 16) == "vllm/multi8"
+
+    def test_degrades_when_the_rig_topology_has_no_option(self):
+        """A 4-card rig on a registry with no multi4 slug lands on dual — the
+        largest that fits and exists — not on a single-card slug picked by sort
+        order, which is what "first option" used to hand it."""
+        rows = [
+            self._mk("vllm/single", "vllm-stable", "models/q/vllm/compose/single/aq/base.yml"),
+            self._mk("vllm/dual", "vllm-stable", "models/q/vllm/compose/dual/aq/fp8.yml"),
+        ]
+        opts = profile_templates(rows)
+        assert default_profile_template(opts, 4) == "vllm/dual"
+        assert default_profile_template(opts, 8) == "vllm/dual"
+
+    def test_status_floor_outranks_topology_fit(self):
+        """FIX 2's floor is preserved: a launchable DUAL beats an incubating multi4
+        on a 4-card rig.  A Select default must be launchable; degrading topology is
+        the cheaper concession."""
+        rows = [
+            self._mk("vllm/dual", "vllm-stable", "models/q/vllm/compose/dual/aq/fp8.yml"),
+            self._mk("vllm/multi4", "vllm-stable",
+                     "models/q/vllm/compose/multi4/aq/fp8.yml", status="incubating"),
+        ]
+        opts = profile_templates(rows)
+        assert default_profile_template(opts, 4) == "vllm/dual"
+
+    def test_non_functional_only_still_returns_a_real_option(self):
+        """The invariant that outlives every rule here: a Select cannot default to a
+        value absent from its options."""
+        rows = [
+            self._mk("vllm/multi4", "vllm-stable",
+                     "models/q/vllm/compose/multi4/aq/fp8.yml", status="incubating"),
+        ]
+        opts = profile_templates(rows)
+        slugs = {o.slug for o in opts}
+        for n in (1, 2, 4, 8):
+            assert default_profile_template(opts, n) in slugs, f"{n} cards"
+
+    def test_ladder_shape(self):
+        from club3090_cockpit.app import _topology_ladder
+
+        assert _topology_ladder(1) == ["single"]
+        assert _topology_ladder(2) == ["dual", "single"]
+        assert _topology_ladder(4) == ["multi4", "dual", "single"]
+        assert _topology_ladder(8) == ["multi8", "multi4", "dual", "single"]
+        # Degenerate inputs must not produce an empty ladder.
+        assert _topology_ladder(0) == ["single"]
 
 
 class TestCatalogPreview:


### PR DESCRIPTION
Closes #1220.

Reported by **@David412** on Discord: *"i use the c3 cookpit and its only detect 2 gpu of 4
while nvtop detect everyone"*.

## Detection was never the problem

`get_gpu_info()` parses every line `nvidia-smi` returns, no cap. All four cards were read.
Anything driven by the real GPU list — fit checks, VRAM accounting, container attribution —
was already using all four.

## The render loop was capped

`compose()` defined exactly two card widgets (`gpu0-card`, `gpu1-card`) and `_populate_gpus`
iterated a fixed pair, so GPUs 2+ were read and dropped at draw time. Written on a 2-GPU rig,
never exercised on more.

Cards are now mounted/removed to match the detected count. Preserved exactly: the "no GPUs —
nvidia-smi returned nothing" message for a wholly empty read, the calm "not present" for a
per-index gap, and the fast-repaint path with its no-op-before-first-poll guard. Slot count is
driven by max index + 1, not `len(gpus)`, so a gap does not slide survivors down a slot and
mislabel them.

## Second limitation, found while in there

The default picker was `single` if ≤1 GPU else `dual` — no multi branch, so a 4-GPU rig was
offered dual templates. It now walks a ladder: **1→single, 2/3→dual, 4-7→multi4, 8+→multi8**,
largest that fits then degrade.

A registry scan drove that shape rather than `_TOPO_ORDER`: **single 34, dual 52, multi4 17,
multi8 9, and zero multi3** — despite `_TOPO_ORDER` still listing multi3. Inventing multi3/multi5
would name slugs that do not exist.

The degrading half mattered more than expected: the old fallback returned "the first option",
which sorts by `_TOPO_ORDER` and is therefore a **single-card** slug. A 4-card rig with no multi4
now lands on dual. The status floor still outranks topology fit — the whole ladder is walked over
the *functional* pool before the full set, so a launchable dual beats an incubating multi4.

## Testing

12 tests: 4-GPU and 8-GPU fixtures, 1-GPU (converges *down* — the second static card is
removed), a count that changes between polls (2→4→2), an index gap (0 and 2 present → 3 slots,
card 2 keeps its number), an empty read, plus the ladder's exact fits, fallbacks, degradation,
status floor and always-returns-a-real-option invariant.

**9 of the 12 fail against the pre-change code** — every panel failure literally `assert 2 == N`,
the two hardcoded slots. The other 3 pass either way and are regression guards rather than
differentiators; flagging that rather than claiming 12/12.

## Gate

- cockpit suite: **1140 passed, 1 skipped** (baseline 1128 + 12)
- bash guard sweep: **149/0**

⚠️ Still unexercised on real 4-GPU hardware — we have two cards, so the fixtures are a model of
the hardware, not the hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
