### PR TITLE
fix(concurrency-probe): SWEEP_DRY must not boot the slug

### DIFF
--- a/scripts/concurrency-probe.sh
+++ b/scripts/concurrency-probe.sh
@@ -607,7 +607,19 @@ if [[ -n "$SWEEP" ]]; then
   # (experimental/incubating) — switch.sh refuses it without --force, AFTER tearing
   # the old container down. Restore-on-exit trap returns the slug to its default
   # config if a probe dies mid-sweep. (Same fix as spec-sweep, 2026-08-20.)
-  trap 'rm -f "${cells_jsonl:-}"; bash "$ROOT_DIR/scripts/switch.sh" --force "$SLUG" >/dev/null 2>&1 || true' EXIT
+  #
+  # ⚠️ The restore trap MUST NOT be installed on a dry run. It fires at process
+  # exit — i.e. AFTER the last [sweep:dry] line is printed — so a stdout assertion
+  # of "no boot happened" passes while the trap boots the slug for real. That is
+  # exactly how SWEEP_DRY=1 left a live vllm/minimal behind on this rig
+  # (2026-09-08): the guard suite ran the dry case, went green, and booted a 20 GB
+  # model. A dry run must touch nothing. spec-sweep.sh avoids this by exiting
+  # before its traps; this branch handles dry inside the loop, so it guards here.
+  if [[ "$SWEEP_DRY" == "1" ]]; then
+    trap 'rm -f "${cells_jsonl:-}"' EXIT
+  else
+    trap 'rm -f "${cells_jsonl:-}"; bash "$ROOT_DIR/scripts/switch.sh" --force "$SLUG" >/dev/null 2>&1 || true' EXIT
+  fi
   for N in $SWEEP; do
     if [[ "$SWEEP_DRY" == "1" ]]; then
       echo "[sweep:dry] would: MAX_NUM_SEQS=$N switch.sh $SLUG  ->  wait ready  ->  probe N=$N"
@@ -657,8 +669,15 @@ if [[ -n "$SWEEP" ]]; then
   else
     echo "  no N met the bar — lower the sweep range or the target_ctx, or check the floor."
   fi
-  echo "[sweep] restoring $SLUG default boot config…"
-  bash "$ROOT_DIR/scripts/switch.sh" --force "$SLUG" >/dev/null 2>&1 || true
+  # ⚠️ Restore only if we actually changed anything. On SWEEP_DRY the loop above
+  # `continue`s without booting, so there is nothing to restore — and calling
+  # switch.sh here would boot the slug for real at the end of a run whose entire
+  # contract is "print the plan, touch nothing". This is the line that left a live
+  # vllm/minimal on the rig (2026-09-08); the exit trap above was the second one.
+  if [[ "$SWEEP_DRY" != "1" ]]; then
+    echo "[sweep] restoring $SLUG default boot config…"
+    bash "$ROOT_DIR/scripts/switch.sh" --force "$SLUG" >/dev/null 2>&1 || true
+  fi
   trap - EXIT
   _cp_emit "$knee" "$knee_tps" "$knee_agg"
   exit 0

--- a/scripts/tests/test-concurrency-probe.sh
+++ b/scripts/tests/test-concurrency-probe.sh
@@ -13,6 +13,43 @@ PROBE="$ROOT_DIR/scripts/concurrency-probe.sh"
 LIB="$ROOT_DIR/scripts/lib/concurrency_probe.py"
 fail() { echo "FAIL: $1" >&2; exit 1; }
 
+# --- hermetic docker layer -----------------------------------------------------
+# Several cases below run the probe for real, and the probe's SWEEP path installs
+# a restore-on-exit trap that calls `switch.sh --force "$SLUG"`. That trap fires at
+# process exit — AFTER the last line of output — so a stdout-only assertion of
+# "no boot happened" goes green while a real `docker compose up` runs behind it.
+#
+# That is not hypothetical: on 2026-09-08 this test booted vllm/minimal (20 GB of
+# VRAM) on the rig and the guard sweep still reported PASS. It also means the
+# suite could tear down whatever was serving at the time.
+#
+# Stubbing `docker` on PATH for the whole file fixes both: the probe and switch.sh
+# run for real, but cannot touch the estate, and any boot attempt is RECORDED so
+# the dry-run case can assert on the side effect instead of on stdout.
+SHIMDIR="$(mktemp -d)"
+trap 'rm -rf "$SHIMDIR"' EXIT
+COMPOSE_UP_LOG="$SHIMDIR/compose-up.log"
+: > "$COMPOSE_UP_LOG"
+cat > "$SHIMDIR/docker" <<SHIM
+#!/usr/bin/env bash
+# Records any \`compose ... up\`; answers everything else with a benign success.
+_c=0
+for a in "\$@"; do
+  [ "\$a" = "compose" ] && _c=1
+  if [ "\$_c" = 1 ] && [ "\$a" = "up" ]; then echo "\$*" >> "$COMPOSE_UP_LOG"; exit 0; fi
+done
+exit 0
+SHIM
+chmod +x "$SHIMDIR/docker"
+export PATH="$SHIMDIR:$PATH"
+
+# Negative control: the stub must actually record a boot, or every assertion that
+# reads COMPOSE_UP_LOG below is vacuous and would pass over a live regression.
+docker compose -f /dev/null up -d >/dev/null 2>&1 || true
+[[ -s "$COMPOSE_UP_LOG" ]] || fail "docker stub does not record 'compose up' — the boot assertions would be vacuous"
+: > "$COMPOSE_UP_LOG"
+echo "  ✓ docker stubbed (estate-safe) + stub self-test"
+
 # 1. syntax
 bash -n "$PROBE" || fail "bash -n: syntax error"
 python3 -m py_compile "$LIB" || fail "py_compile concurrency_probe.py"
@@ -34,7 +71,10 @@ out="$(SWEEP="4 8 12" SLUG=vllm/minimal SWEEP_DRY=1 bash "$PROBE" 2>&1)"
 [[ "$(command grep -c '\[sweep:dry\]' <<<"$out")" == "3" ]] || fail "SWEEP_DRY should print one plan line per N (3)"
 command grep -q '\[sweep\] boot' <<<"$out" && fail "SWEEP_DRY must not boot the server"
 command grep -q "sweep knee" <<<"$out" || fail "SWEEP should always print a knee summary"
-echo "  ✓ SWEEP_DRY plans 3 reboots without booting"
+if [[ -s "$COMPOSE_UP_LOG" ]]; then
+  fail "SWEEP_DRY ran 'docker compose up' — the restore-on-exit trap booted the slug: $(tr '\n' ';' < "$COMPOSE_UP_LOG")"
+fi
+echo "  ✓ SWEEP_DRY plans 3 reboots without booting (asserted at the docker layer)"
 
 # 4. --sweep --dry does NOT need SLUG and must not plan switch.sh reboots.
 out="$(bash "$PROBE" --sweep --dry --n 1,2,4,8 --ctx 1k,4k,16k 2>&1)"

--- a/scripts/tests/test-spec-sweep.sh
+++ b/scripts/tests/test-spec-sweep.sh
@@ -9,6 +9,39 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SWEEP="$ROOT_DIR/scripts/spec-sweep.sh"
 fail() { echo "FAIL: $1" >&2; exit 1; }
 
+# --- hermetic docker layer -----------------------------------------------------
+# Cases 4 and 5 run spec-sweep.sh for real in SWEEP_DRY mode and assert on stdout.
+# A stdout assertion cannot see a boot that happens in an exit trap or after the
+# last printed line — which is exactly how the sibling tool (concurrency-probe.sh)
+# booted a 20 GB model under a GREEN guard sweep on 2026-09-08. spec-sweep.sh is
+# currently safe (its dry path `exit 0`s before the traps are installed), but
+# nothing proved that, and nothing stopped a future edit from regressing it.
+#
+# Stub `docker` on PATH: the tool and switch.sh still run for real, but cannot
+# touch the estate, and any boot attempt is RECORDED so we assert on the side
+# effect rather than the output.
+SHIMDIR="$(mktemp -d)"
+trap 'rm -rf "$SHIMDIR"' EXIT
+COMPOSE_UP_LOG="$SHIMDIR/compose-up.log"
+: > "$COMPOSE_UP_LOG"
+cat > "$SHIMDIR/docker" <<SHIM
+#!/usr/bin/env bash
+_c=0
+for a in "\$@"; do
+  [ "\$a" = "compose" ] && _c=1
+  if [ "\$_c" = 1 ] && [ "\$a" = "up" ]; then echo "\$*" >> "$COMPOSE_UP_LOG"; exit 0; fi
+done
+exit 0
+SHIM
+chmod +x "$SHIMDIR/docker"
+export PATH="$SHIMDIR:$PATH"
+
+# Negative control: without this, a clean COMPOSE_UP_LOG proves nothing.
+docker compose -f /dev/null up -d >/dev/null 2>&1 || true
+[[ -s "$COMPOSE_UP_LOG" ]] || fail "docker stub does not record 'compose up' — the boot assertion would be vacuous"
+: > "$COMPOSE_UP_LOG"
+echo "  ✓ docker stubbed (estate-safe) + stub self-test"
+
 # 1. syntax
 bash -n "$SWEEP" || fail "bash -n: syntax error"
 echo "  ✓ syntax"
@@ -47,7 +80,11 @@ out="$(SWEEP_N="0 3" SLUG=vllm/dual SWEEP_DRY=1 bash "$SWEEP" 2>&1)"
 grep -q "engine=vllm" <<<"$out" || fail "vllm/dual should resolve engine=vllm"
 grep -q "SPEC_N=0 switch.sh vllm/dual" <<<"$out" || fail "n=0 arm should plan SPEC_N=0"
 grep -q "SPEC_N=3 switch.sh vllm/dual" <<<"$out" || fail "n=3 arm should plan SPEC_N=3"
+if [[ -s "$COMPOSE_UP_LOG" ]]; then
+  fail "SWEEP_DRY ran 'docker compose up' — a dry run must boot nothing: $(tr '\n' ';' < "$COMPOSE_UP_LOG")"
+fi
 echo "  ✓ vLLM SWEEP_DRY plans reboot-per-arm (one knob, SPEC_N=0 baseline)"
+echo "  ✓ SWEEP_DRY booted nothing at the docker layer (both slugs)"
 
 # 6. vLLM without SLUG refused (exit 2) — can't reboot without a target.
 #    (Engine defaults to llamacpp without a slug, so force via a vllm slug


### PR DESCRIPTION
## Problem

`SWEEP_DRY=1` on `concurrency-probe.sh` — a mode whose entire contract is "print
the plan, touch nothing" — **booted the target slug for real**, twice over:

1. the restore-on-exit `trap` (`switch.sh --force "$SLUG"`) was installed *before*
   the dry check, so it fired at process exit;
2. the post-loop `[sweep] restoring …` call ran unconditionally — the dry loop
   `continue`s straight into it. **This was the primary one.**

Anyone previewing a sweep plan was rebooting their serving slug.

## Why the guard suite never caught it

`test-concurrency-probe.sh` asserted the property on **stdout** — "no `[sweep] boot`
line". Both boots happen *after* the last line is printed, so the assertion is
structurally incapable of seeing them. The suite reported PASS while a 20 GB model
loaded behind it. Found by running all 156 guards under a `docker` shim that logs
every `compose … up` with its process ancestry.

## Fix

- **`scripts/concurrency-probe.sh`** — both call sites now guard on `SWEEP_DRY`.
- **`scripts/tests/test-concurrency-probe.sh`** — stubs `docker` on PATH for the
  whole file and asserts on the *side effect* (a recording log) instead of the
  narration. This also makes the test hermetic: it can no longer boot or tear down
  real estate, closing one vector of the "guard sweep can destroy a serving model"
  problem.
- **`scripts/tests/test-spec-sweep.sh`** — same hermetic stub + assertion for the
  sibling tool. `spec-sweep.sh` is *not* affected by the bug (its dry path `exit 0`s
  before the traps), but nothing proved that and nothing stopped a regression.

Every stub carries a self-test that it actually records, so a silently-broken stub
cannot make the assertions vacuous.

## Verification

Negative control, run in all three directions:

| probe state | new test |
|---|---|
| both call sites unfixed | **FAILS**, printing the recorded `compose … up` argv |
| trap fixed, post-loop restore unfixed | **FAILS** |
| both fixed | passes |

Full guard suite green under the shim: **PASS=149 FAIL=0**, with exactly one
recorded boot attempt — `test-concurrency-probe.sh`, which ran early in that sweep
against the unfixed tree. Both affected tests then verified individually against
the fix.

⚠️ A clean post-fix re-run of the whole suite was **not** performed.
