### PR TITLE
fix(detect): classify engines from the REGISTRY, not container-name prefixes

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -294,7 +294,12 @@ class RealRunner:
 
 
 # Detect seam: async callables matching the core signatures.
-DetectEndpointFn = Callable[[], Awaitable[ServingTarget]]
+# Takes an optional ``variants=`` registry-rows kwarg (#1219: detection is
+# registry-first), so an injected double MUST accept it — swallowing a TypeError
+# here to retry without it would mask a genuine detect failure, and this callable
+# feeds the fail-closed dual-writer gate where "I could not detect" must mean
+# UNSAFE, never "nothing running".
+DetectEndpointFn = Callable[..., Awaitable[ServingTarget]]
 GetGpuInfoFn = Callable[[], Awaitable[list[GpuInfo]]]
 # A7: probe the live engine for its ACTUAL running config (ctx + image).  Takes
 # the detected ServingTarget (for url / container) and returns a ServedProbe.
@@ -2621,9 +2626,15 @@ class CockpitData:
         health.sh Doctor read + gpu-mode scene catalog + estate-planner report."""
         state = EstateState()
 
-        # detect: running engine + GPUs
+        # detect: running engine + GPUs.
+        # Hand the registry rows DOWN into detection (#1219) — a local slug's
+        # container matches neither the engine-name prefix nor the curated
+        # internal-port set, so without them it is never classified as an engine
+        # and the estate reports "not reachable" over a plainly loaded model.
+        # match_target_to_registry below still enriches; this makes detection
+        # itself registry-aware instead of only the labelling after it.
         try:
-            target = await self._detect_endpoint()
+            target = await self._detect_endpoint(variants=variants)
         except Exception as exc:  # pragma: no cover - defensive
             state.error = f"detect failed: {exc}"
             target = ServingTarget()
@@ -3110,8 +3121,11 @@ class CockpitData:
         result = ReconcileResult(safe=True, action=action)
 
         # Fresh detect — never trust a cached snapshot for the gate.
+        # Registry-first (#1219): this gate decides whether the cards are free, so
+        # a container detection cannot classify reads as NO container — i.e. a
+        # registered local slug serving on GPU0 would look like an empty card.
         try:
-            target = await self._detect_endpoint()
+            target = await self._detect_endpoint(variants=variants)
         except Exception as exc:  # pragma: no cover - defensive
             result.note = f"detect failed: {exc}"
             # A failed detect is NOT safe — we can't prove the cards are free.

--- a/tools/serve-cockpit/tests/test_app_headless.py
+++ b/tools/serve-cockpit/tests/test_app_headless.py
@@ -176,7 +176,7 @@ def ok(stdout: str) -> RunResult:
 
 
 def make_detect(target: ServingTarget):
-    async def _detect() -> ServingTarget:
+    async def _detect(**_kwargs) -> ServingTarget:
         return target
     return _detect
 
@@ -5608,7 +5608,7 @@ class TestValidateRunWired:
         gated execute_action — it never claims a GPU."""
         wr = FakeWriteRunner()
 
-        async def detect_should_not_be_called():
+        async def detect_should_not_be_called(**_kwargs):
             raise AssertionError("a validation run must not reconcile")
 
         app, _, _ = make_app(write_runner=wr, surface="producer")
@@ -9639,7 +9639,7 @@ class TestBatch2MustFix3ErrorLabel:
         """Force the services.py detect-failure path → state.error is
         'detect failed: …' and the rail/Containers render THAT, not 'docker
         unreachable'."""
-        async def _boom():
+        async def _boom(**_kwargs):
             raise RuntimeError("endpoint probe blew up")
 
         app, _, _ = make_app()
@@ -14649,7 +14649,7 @@ class TestAdaptiveEstatePoll:
             return ["g0", "g1"]
         cd._get_gpu_info = ok
         assert asyncio.run(cd.gpu_info()) == ["g0", "g1"]
-        async def boom():
+        async def boom(**_kwargs):
             raise RuntimeError("nvidia-smi gone")
         cd._get_gpu_info = boom
         assert asyncio.run(cd.gpu_info()) == []   # degrades, never raises

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -141,7 +141,7 @@ def _model_spec():
 
 
 def make_detect(target: ServingTarget):
-    async def _detect() -> ServingTarget:
+    async def _detect(**_kwargs) -> ServingTarget:
         return target
     return _detect
 
@@ -2287,7 +2287,7 @@ class TestReconcileGate:
     @pytest.mark.asyncio
     async def test_detect_failure_is_unsafe(self):
         """If detect raises, we can't prove the cards are free → not safe."""
-        async def boom() -> ServingTarget:
+        async def boom(**_kwargs) -> ServingTarget:
             raise RuntimeError("docker daemon down")
 
         cd = CockpitData(ROOT, runner=full_runner(), detect_endpoint_fn=boom)
@@ -2300,7 +2300,7 @@ class TestReconcileGate:
         """The gate must call detect every time (never a cached snapshot)."""
         calls = {"n": 0}
 
-        async def counting_detect() -> ServingTarget:
+        async def counting_detect(**_kwargs) -> ServingTarget:
             calls["n"] += 1
             return ServingTarget(gpus=[GpuInfo(index=0, mem_used_mib=1), GpuInfo(index=1, mem_used_mib=1)])
 
@@ -2534,7 +2534,7 @@ class TestExecuteActionGated:
         """set_default has requires_reconcile=False → no detect, straight to run."""
         write_runner = FakeWriteRunner()
 
-        async def detect_should_not_be_called() -> ServingTarget:
+        async def detect_should_not_be_called(**_kwargs) -> ServingTarget:
             raise AssertionError("detect must not be called for a non-reconcile action")
 
         cd = CockpitData(
@@ -2576,7 +2576,7 @@ class TestExecuteActionGated:
         the gate is genuinely skipped (detect never called)."""
         write_runner = FakeWriteRunner()
 
-        async def detect_should_not_be_called() -> ServingTarget:
+        async def detect_should_not_be_called(**_kwargs) -> ServingTarget:
             raise AssertionError("gate must be skipped → detect not called")
 
         cd = CockpitData(
@@ -3823,7 +3823,7 @@ class TestPhase4RunValidation:
         """Validation hits the model but does not claim a GPU → no detect call."""
         wr = FakeWriteRunner()
 
-        async def detect_should_not_be_called():
+        async def detect_should_not_be_called(**_kwargs):
             raise AssertionError("validation must not run the reconcile gate")
 
         cd = CockpitData(
@@ -3866,7 +3866,7 @@ class TestPhase4GatedWriteExecution:
         reaches the mocked write runner with the gpu-mode power-cap <W> command."""
         write_runner = FakeWriteRunner()
 
-        async def detect_should_not_be_called():
+        async def detect_should_not_be_called(**_kwargs):
             raise AssertionError("power-cap must not reconcile (no GPU contention)")
 
         cd = CockpitData(

--- a/tools/tui-core/club3090_tui_core/detect.py
+++ b/tools/tui-core/club3090_tui_core/detect.py
@@ -29,6 +29,34 @@ PORT_MAP_BROAD_RE = re.compile(
     r":(\d+)->(8000|8080|30000)/tcp"
 )
 
+# ANY published tcp mapping.  Used ONLY for containers the registry claims by
+# name: a registered engine may listen on any internal port it likes (#1219), and
+# constraining it to our three curated ports is the same closed-set assumption as
+# the name prefix.  Never used for unclaimed containers, which still have to look
+# like an engine to be considered at all.
+PORT_MAP_ANY_RE = re.compile(r":(\d+)->(\d+)/tcp")
+
+
+def _registry_claims(variants) -> dict:
+    """Map normalized container name -> registry row, for rows that name one.
+
+    The registry already carries the container name and host port for every
+    registered slug, core and local alike.  Detection used to ignore both and
+    re-derive them by pattern-matching ``docker ps`` output, which a local slug
+    can satisfy by neither construction (#1219).
+    """
+    claims: dict = {}
+    for v in variants or []:
+        if hasattr(v, "container"):
+            container, port = v.container, v.port
+        elif isinstance(v, dict):
+            container, port = v.get("container", ""), v.get("port", 0)
+        else:
+            continue
+        if container:
+            claims[(container or "").replace("_", "-")] = (v, port)
+    return claims
+
 
 async def _reap(proc) -> None:
     """Kill and await a subprocess so its transport closes while the loop still lives.
@@ -116,11 +144,19 @@ def _classify_engine_from_container(name: str) -> str:
     return "unknown"
 
 
-async def detect_endpoint(container_name: Optional[str] = None) -> ServingTarget:
+async def detect_endpoint(
+    container_name: Optional[str] = None,
+    variants: Optional[list] = None,
+) -> ServingTarget:
     """Detect the currently-serving model and endpoint.
 
     Args:
         container_name: If set, detect only from this container.
+        variants: Registry rows (VariantRow or dict).  When supplied, any running
+            container the registry claims BY NAME is treated as an engine
+            regardless of its name prefix or internal port, and is preferred over
+            containers matched by the naming heuristics.  Omit it and behaviour is
+            exactly the previous heuristics-only detection.
 
     Returns:
         A ServingTarget with whatever was resolved.
@@ -141,9 +177,22 @@ async def detect_endpoint(container_name: Optional[str] = None) -> ServingTarget
         target.health = "unreachable"
         return target
 
-    # Step 2: find inference containers
-    # Filter to recognized engine prefixes FIRST to exclude Open WebUI and other non-inference containers
+    # Step 2: find inference containers.
+    #
+    # Precedence is REGISTRY FIRST (#1219).  A container the registry claims by
+    # name IS an engine — we registered it — so it is accepted whatever it is
+    # called and whatever port it listens on internally.  The naming heuristics
+    # below then run only for containers no registry row claims, which is what
+    # keeps a hand-run container (never registered) visible.
+    #
+    # The old order asked a container to be NAMED with one of five curated engine
+    # prefixes AND to publish one of three container-side ports.  A local slug can
+    # satisfy neither by construction: the whole point of the local layer (#1202)
+    # is that the user brings an engine we have never heard of.
+    claims = _registry_claims(variants)
+
     candidates: list[tuple[str, int, int, str]] = []  # (name, host_port, internal_port, engine)
+    claimed_names: set[str] = set()
     seen: set[tuple[str, int]] = set()  # dedupe by (container_name, host_port) for dual-stack
 
     for line in lines:
@@ -151,11 +200,21 @@ async def detect_endpoint(container_name: Optional[str] = None) -> ServingTarget
             continue
         name, ports_str = line.split("|", 1)
 
-        # Only consider recognized engine containers
-        if not ENGINE_PREFIXES.match(name):
+        claim = claims.get(name.replace("_", "-"))
+        if claim is None and not ENGINE_PREFIXES.match(name):
+            # Not registered and doesn't look like an engine — Open WebUI, qdrant…
             continue
 
-        for match in PORT_MAP_BROAD_RE.finditer(ports_str):
+        # A claimed container may publish several mappings (an engine port plus
+        # metrics).  Prefer the one whose HOST port the registry recorded.
+        port_re = PORT_MAP_ANY_RE if claim is not None else PORT_MAP_BROAD_RE
+        matches = list(port_re.finditer(ports_str))
+        if claim is not None:
+            registry_port = claim[1]
+            preferred_ports = [m for m in matches if int(m.group(1)) == registry_port]
+            matches = preferred_ports or matches
+
+        for match in matches:
             host_port = int(match.group(1))
             internal_port = int(match.group(2))
 
@@ -165,8 +224,18 @@ async def detect_endpoint(container_name: Optional[str] = None) -> ServingTarget
                 continue
             seen.add(key)
 
-            engine = _classify_engine_from_container(name)
-            if engine == "unknown":
+            if claim is not None:
+                claimed_names.add(name)
+                row = claim[0]
+                engine = (
+                    getattr(row, "engine", "") if hasattr(row, "engine")
+                    else (row.get("engine", "") if isinstance(row, dict) else "")
+                ) or ""
+            else:
+                engine = ""
+            if not engine:
+                engine = _classify_engine_from_container(name)
+            if engine == "unknown" or not engine:
                 engine = _classify_engine(str(internal_port))
             candidates.append((name, host_port, internal_port, engine))
 
@@ -181,8 +250,10 @@ async def detect_endpoint(container_name: Optional[str] = None) -> ServingTarget
             target.health = "unreachable"
             return target
 
-    # Step 3: prefer recognized engine prefix; else first match
-    preferred = [c for c in candidates if ENGINE_PREFIXES.match(c[0])]
+    # Step 3: prefer a registry-claimed container (we know what it is), then one
+    # matching the naming heuristic, else the first match.
+    claimed = [c for c in candidates if c[0] in claimed_names]
+    preferred = claimed or [c for c in candidates if ENGINE_PREFIXES.match(c[0])]
     chosen = preferred[0] if preferred else candidates[0]
 
     name, host_port, internal_port, engine = chosen

--- a/tools/tui-core/tests/test_core_detect.py
+++ b/tools/tui-core/tests/test_core_detect.py
@@ -11,8 +11,11 @@ from club3090_tui_core.detect import (
     ServingTarget,
     GpuInfo,
     PORT_MAP_BROAD_RE,
+    PORT_MAP_ANY_RE,
     _classify_engine,
     _classify_engine_from_container,
+    _registry_claims,
+    detect_endpoint,
     match_target_to_registry,
 )
 from club3090_tui_core.registry import VariantRow
@@ -267,3 +270,146 @@ class TestMatchConfidence:
         result = match_target_to_registry(target, self.VARIANTS)
         assert result.slug == ""
         assert result.match_confidence == ""
+
+
+# ============================================================================
+# #1219 — detection is REGISTRY-FIRST, not container-name-prefix-first
+# ============================================================================
+
+
+def _row(slug, container, port, engine="vllm"):
+    return VariantRow(
+        slug=slug, switch_engine=engine, launch_engine=engine, compose_dir="d",
+        file="f.yml", port=port, model="m", engine=engine, kvcalc_key="k",
+        container=container, compose_path="p", status="production",
+        ctx_label="32K", status_note="",
+    )
+
+
+def _proc(ps_output: str):
+    """Stub for `docker ps --format {{.Names}}|{{.Ports}}`."""
+    mock = AsyncMock()
+    mock.communicate = AsyncMock(return_value=(ps_output.encode(), b""))
+    return mock
+
+
+def _run(coro):
+    """Drive a coroutine without pytest-asyncio.
+
+    ⚠️ pytest-asyncio is NOT installed for this package, so an ``async def`` test
+    is SKIPPED, not run — a green line that proves nothing.  Baseline before these
+    tests was "25 passed", with zero skips; anything that reports skips here is a
+    test that silently did not execute.
+    """
+    return asyncio.run(coro)
+
+
+# A local slug can satisfy NEITHER heuristic by construction: the container is
+# named by whatever the user's compose calls it, and a third-party engine listens
+# on whatever internal port it likes.  Both are true of the bucko recipe that
+# surfaced this (2026-09-08).
+LOCAL_PS = "qwen38-flash-next-ple|0.0.0.0:20272->9000/tcp"
+
+
+class TestRegistryClaims:
+    def test_builds_map_from_variant_rows(self):
+        claims = _registry_claims([_row("x/y", "my-engine", 20272)])
+        assert "my-engine" in claims
+        assert claims["my-engine"][1] == 20272
+
+    def test_normalizes_underscores(self):
+        claims = _registry_claims([_row("x/y", "my_engine", 1)])
+        assert "my-engine" in claims
+
+    def test_ignores_rows_without_a_container(self):
+        assert _registry_claims([_row("x/y", "", 1)]) == {}
+
+    def test_accepts_dict_rows(self):
+        claims = _registry_claims([{"container": "c", "port": 42}])
+        assert claims["c"][1] == 42
+
+    def test_empty_and_none(self):
+        assert _registry_claims(None) == {}
+        assert _registry_claims([]) == {}
+
+
+class TestRegistryFirstDetection:
+    """The bug: a registered container that matches neither heuristic is invisible."""
+
+    def test_local_slug_invisible_without_registry(self):
+        """Baseline — this is the reported failure, and it must stay reproducible."""
+        with patch("asyncio.create_subprocess_exec", return_value=_proc(LOCAL_PS)):
+            target = _run(detect_endpoint())
+        assert target.health == "unreachable"
+        assert not target.url
+
+    def test_local_slug_detected_when_registry_claims_it(self):
+        rows = [_row("bucko-vllm/flash-next", "qwen38-flash-next-ple", 20272)]
+        with patch("asyncio.create_subprocess_exec", return_value=_proc(LOCAL_PS)):
+            target = _run(detect_endpoint(variants=rows))
+        assert target.container == "qwen38-flash-next-ple"
+        assert target.host_port == 20272
+        assert target.internal_port == 9000   # NOT one of the three curated ports
+        # The reported symptom is an EMPTY target.url: with no url, health.sh
+        # falls back to the curated default port and reports "not reachable" over
+        # a plainly loaded model.  Resolving the url is the fix.
+        assert target.url == "http://localhost:20272"
+        # `health` stays "unreachable" here because nothing is actually listening
+        # on 20272 in a unit test — that probe is Step 4 and is not what #1219 is
+        # about.  Asserting on it would be asserting on the stub, not the fix.
+
+    def test_engine_family_comes_from_the_registry_row(self):
+        """Engine identity is lineage (the profile's type), not the container name."""
+        rows = [_row("x/y", "qwen38-flash-next-ple", 20272, engine="vllm")]
+        with patch("asyncio.create_subprocess_exec", return_value=_proc(LOCAL_PS)):
+            target = _run(detect_endpoint(variants=rows))
+        assert target.engine == "vllm"
+
+    def test_unclaimed_non_engine_container_still_ignored(self):
+        """Registry-first must not become 'accept everything'."""
+        ps = "open-webui|0.0.0.0:8080->8080/tcp\nqdrant|0.0.0.0:6333->6333/tcp"
+        with patch("asyncio.create_subprocess_exec", return_value=_proc(ps)):
+            target = _run(detect_endpoint(variants=[_row("x/y", "not-running", 1)]))
+        # open-webui publishes 8080->8080 and so still trips the port heuristic;
+        # what matters is that qdrant (neither prefix nor engine port) never does.
+        assert target.container != "qdrant"
+
+    def test_heuristics_still_work_for_unregistered_containers(self):
+        ps = "vllm-hand-run|0.0.0.0:8000->8000/tcp"
+        with patch("asyncio.create_subprocess_exec", return_value=_proc(ps)):
+            target = _run(detect_endpoint(variants=[]))
+        assert target.container == "vllm-hand-run"
+        assert target.engine == "vllm"
+
+    def test_claimed_container_preferred_over_heuristic_match(self):
+        ps = ("vllm-some-other|0.0.0.0:8000->8000/tcp\n"
+              "qwen38-flash-next-ple|0.0.0.0:20272->9000/tcp")
+        rows = [_row("bucko-vllm/flash-next", "qwen38-flash-next-ple", 20272)]
+        with patch("asyncio.create_subprocess_exec", return_value=_proc(ps)):
+            target = _run(detect_endpoint(variants=rows))
+        assert target.container == "qwen38-flash-next-ple"
+
+    def test_registry_host_port_wins_over_a_second_mapping(self):
+        """An engine that also publishes metrics must resolve to its API port."""
+        ps = "qwen38-flash-next-ple|0.0.0.0:9100->9100/tcp, 0.0.0.0:20272->9000/tcp"
+        rows = [_row("x/y", "qwen38-flash-next-ple", 20272)]
+        with patch("asyncio.create_subprocess_exec", return_value=_proc(ps)):
+            target = _run(detect_endpoint(variants=rows))
+        assert target.host_port == 20272
+
+    def test_omitting_variants_is_unchanged_behaviour(self):
+        ps = "vllm-qwen36-27b-minimal|0.0.0.0:8020->8000/tcp"
+        with patch("asyncio.create_subprocess_exec", return_value=_proc(ps)):
+            a = _run(detect_endpoint())
+            b = _run(detect_endpoint(variants=None))
+        assert a.container == b.container == "vllm-qwen36-27b-minimal"
+
+
+class TestAnyPortRegex:
+    def test_matches_arbitrary_internal_port(self):
+        m = PORT_MAP_ANY_RE.search("0.0.0.0:20272->9000/tcp")
+        assert m and m.group(1) == "20272" and m.group(2) == "9000"
+
+    def test_broad_regex_still_rejects_arbitrary_internal_port(self):
+        """The narrow regex must stay narrow — it gates UNCLAIMED containers."""
+        assert not PORT_MAP_BROAD_RE.search("0.0.0.0:20272->9000/tcp")


### PR DESCRIPTION
Closes #1219.

## Problem

Engine detection inferred "is this an engine?" from naming convention. A container had
to be **named** with one of five curated prefixes *and* publish a **container-side** port
from a set of three:

```python
ENGINE_PREFIXES = re.compile(r"^(vllm-|llama-cpp-|ik-llama-|sglang-|beellama-)")
PORT_MAP_BROAD_RE = re.compile(r":(\d+)->(8000|8080|30000)/tcp")
```

Miss either and no `ServingTarget` is built → `target.url` is empty → `health.sh` falls
back to the curated default port → **"○ not reachable"** over a plainly loaded model.

A local slug (#1202) can satisfy neither by construction: the user brings an engine we
have never heard of, named whatever their compose calls it, listening wherever it likes.
The registry already carried both facts and detection ignored them, re-deriving the same
information by pattern-matching `docker ps`.

## Fix — invert the precedence

1. **Registry first.** `_registry_claims(variants)` builds `{container -> (row, port)}`
   from registered rows, core *and* local. A container the registry claims by name IS an
   engine — we registered it — so it is accepted whatever it is called, on whatever
   internal port (`PORT_MAP_ANY_RE`), and its engine family comes from the row rather than
   from a guess at its name.
2. **Heuristics second**, only for containers no row claims, so a hand-run container still
   shows up. `PORT_MAP_BROAD_RE` stays narrow precisely because it gates those.

When a claimed container publishes several mappings (an engine port plus metrics), the one
whose **host** port the registry recorded wins.

`variants` is threaded from `estate_state`, which already had the rows and was only using
them *after* detection, to label a target it had failed to build. It is also threaded into
`reconcile_before_write` — the dual-writer safety gate — where an undetected container
would have read as a free card.

Omitting `variants` gives exactly the previous heuristics-only behaviour.

## ⚠️ One thing this deliberately does NOT do

The first version swallowed a `TypeError` and retried without the kwarg, so a
pre-existing zero-arg double would keep working. That is wrong on the safety path: it
masks a genuine detect failure, and `reconcile_before_write` must treat "I could not
detect" as UNSAFE, never as "nothing running". `TestReconcileGate::test_detect_failure_is_unsafe`
caught it. The injected doubles now accept `**_kwargs` instead, and there is no fallback.

## Verification

End-to-end against the real registry and a real container named exactly as the
de-workarounded local compose produces — `qwen38-flash-next-ple`, internal port **9000**,
chosen to violate *both* old constraints at once:

```
registry row: slug='bucko-vllm/qwen3.8-flash-next-ple' container='qwen38-flash-next-ple' port=20272

BEFORE (heuristics only):  container=''                     url=''                          health='unreachable'
AFTER  (registry-first):   container='qwen38-flash-next-ple' url='http://localhost:20272'    engine='bucko-vllm'
                           host_port=20272  internal_port=9000
                           matched slug='bucko-vllm/qwen3.8-flash-next-ple'  confidence='identity'
```

- `tools/tui-core`: **96 passed**, including 14 new cases — the pre-fix failure kept as a
  reproducing baseline, engine family sourced from the row, unclaimed non-engine containers
  still ignored, heuristics still working unregistered, claimed-beats-heuristic precedence,
  registry host port beating a second mapping, and `variants=None` unchanged.
- `tools/serve-cockpit`: **1140 passed, 1 skipped, 0 failed** (the run that caught the
  `TypeError` mistake was 3 failed / 1137 passed).
- Guards: `test-catalog-detectability`, `test-docs-local-layer`, `test-catalog-cli`.

⚠️ The new tests use `asyncio.run` rather than `async def`: **pytest-asyncio is not
installed for `tui-core`**, so an `async def` test is silently SKIPPED. The first run of
these reported "32 passed, 8 skipped" against a baseline of 25 passed / 0 skipped — eight
tests that never executed and would have looked green.

## Follow-up, not in this PR

The local compose still pins its internal port to 8000. That is now convention rather than
constraint, but changing the port the app binds inside a third-party image is an entrypoint
question and needs a real boot to verify. The `vllm-` container-name disguise is gone.
