### PR TITLE
fix(concurrency-probe): a -1 MB VRAM delta must not FAIL the fit verdict

### DIFF
--- a/scripts/concurrency-probe.sh
+++ b/scripts/concurrency-probe.sh
@@ -524,10 +524,17 @@ PY
     fail=0
     clean="$(sed -n 's/.* clean=\([0-9]*\).*/\1/p' <<<"$line")"
     running="$(sed -n 's/.* running=\([^ ]*\).*/\1/p' <<<"$line")"
+    running_max="$(sed -n 's/.* running_max=\([^ ]*\).*/\1/p' <<<"$line")"
+    waiting_max="$(sed -n 's/.* waiting_max=\([^ ]*\).*/\1/p' <<<"$line")"
     [[ "$rc" != "0" || "$clean" != "1" ]] && fail=1
-    if [[ "$running" =~ ^[0-9]+$ && "$running" -lt "$n" ]]; then
+    # Key off the PEAK, not the racy last sample. A rung where every request
+    # completed but whose final metrics sample happened to land after they
+    # finished reads running=0 and used to fail the rung AND early-stop the
+    # ladder — silently truncating the very measurement the sweep exists to
+    # produce. (From @voiceagentscc's #1212.)
+    if [[ "$running_max" =~ ^[0-9]+$ && "$running_max" -lt "$n" ]]; then
       fail=1
-      echo "[sweep] admitted ${running}/${n} — treating as fail for early-stop"
+      echo "[sweep] admitted peak ${running_max}/${n} (waiting ${waiting_max:-?}) — treating as fail for early-stop"
     fi
     if [[ "$fail" == "1" && "$EARLY_STOP" == "1" ]]; then
       ROW_DEAD[$ctx]="$n"

--- a/scripts/lib/concurrency_probe.py
+++ b/scripts/lib/concurrency_probe.py
@@ -310,8 +310,14 @@ def engine_stats(container):
     # below max_num_seqs when --max-num-batched-tokens caps the per-step budget:
     # a sweep rung labelled N=64 may only ever run ~10 wide. Reporting the label
     # without this reads as a concurrency measurement when it is a queue-depth one.
+    #
+    # Returns (run, wait, run_max, wait_max, hit). ``run``/``wait`` are the LAST
+    # sample in the window; ``run_max``/``wait_max`` are the PEAK across it. The
+    # last sample is racy — taken at an arbitrary moment relative to request
+    # lifetimes, so a request that finished first reads ``running < N`` though it
+    # was admitted and ran. (Peak tracking from @voiceagentscc's #1212.)
     if not container:
-        return (None, None, None)
+        return (None, None, None, None, None)
     try:
         out = subprocess.run(
             ["docker", "logs", "--tail", "400", container],
@@ -323,15 +329,18 @@ def engine_stats(container):
         )
         txt = (out.stdout or "") + (out.stderr or "")
     except Exception:
-        return (None, None, None)
-    run = wait = hit = None
+        return (None, None, None, None, None)
+    run = wait = run_max = wait_max = hit = None
     for m in re.finditer(
         r"Running:\s*(\d+)\s*reqs?,\s*Waiting:\s*(\d+)\s*reqs?", txt
     ):
-        run, wait = int(m.group(1)), int(m.group(2))
+        r, w = int(m.group(1)), int(m.group(2))
+        run, wait = r, w
+        run_max = r if run_max is None else max(run_max, r)
+        wait_max = w if wait_max is None else max(wait_max, w)
     for m in re.finditer(r"[Pp]refix cache hit rate:\s*([0-9.]+)", txt):
         hit = float(m.group(1))
-    return (run, wait, hit)
+    return (run, wait, run_max, wait_max, hit)
 
 
 def vram_used_mb():
@@ -410,6 +419,40 @@ def format_result(fields):
         if k not in seen:
             parts.append(f"{k}={v}")
     return "RESULT " + " ".join(parts)
+
+
+def admission_ok(run_peaks, n):
+    """Were all ``n`` streams actually admitted?
+
+    ``run_peaks`` is the PER-ROUND PEAK ``Running:`` value — NOT the last sample.
+    A request that finishes before the sample is taken reads ``running < n`` even
+    though it ran, so the last sample cannot prove under-admission. A peak that
+    reached ``n`` proves ``n`` were admitted; a later dip is just completion.
+
+    Fails CLOSED when peaks exist and never reached ``n``. True when there is no
+    engine data — absence of evidence is not evidence of under-admission.
+    """
+    peaks = [r for r in run_peaks if r is not None]
+    if not peaks:
+        return True
+    return max(peaks) >= n
+
+
+def vram_ok(leak, growth):
+    """Is the post-warm VRAM delta acceptable?
+
+    ⚠️ The band is SYMMETRIC. The old rule was ``0 <= leak <= growth`` — ``growth``
+    MB of headroom upward and **zero** downward — so VRAM ticking down by a single
+    megabyte between the warm baseline and the final round failed the run. That is
+    the actual cause of #1211: the reporter's N=2 trace was
+    ``cold 44302 -> warm 44303 -> final 44302``, a **-1 MB** delta, and it failed
+    with every request completed, no errors and nothing queued. Re-running flipped
+    the verdict because the jitter flipped sign.
+
+    A negative delta is not a leak. It stays bounded below so a container that
+    collapses mid-probe (VRAM falling by the size of the model) still fails.
+    """
+    return -growth <= leak <= growth
 
 
 def run_probe():
@@ -578,6 +621,8 @@ def run_probe():
     tps_p05_by_round = []
     run_by_round = []
     wait_by_round = []
+    runmax_by_round = []
+    waitmax_by_round = []
     hit_by_round = []
     for rnd in range(1, ROUNDS + 1):
         t0 = time.time()
@@ -611,9 +656,11 @@ def run_probe():
         tps_p05 = pct(tps_ok, 0.05)
         ttft_p95_by_round.append(ttft_p95)
         tps_p05_by_round.append(tps_p05)
-        run, wait, hit = engine_stats(CONTAINER)
+        run, wait, run_max, wait_max, hit = engine_stats(CONTAINER)
         run_by_round.append(run)
         wait_by_round.append(wait)
+        runmax_by_round.append(run_max)
+        waitmax_by_round.append(wait_max)
         hit_by_round.append(hit)
         print(
             f"{rnd:>5} {done:>4}/{N:<2} {silent:>7} {errs:>7} {v:>8} "
@@ -652,7 +699,20 @@ def run_probe():
     else:
         retention = 1.0  # too few post-warmup rounds to judge
 
-    clean_fit = (bad == 0) and (0 <= leak <= GROWTH)
+    # ⚠️ These MUST come from the per-round PEAK lists. Taking them from
+    # run_by_round/wait_by_round (each round's LAST sample) reintroduces the same
+    # race one level up: at N=1 every round's last sample is taken after the single
+    # request completed, so every entry reads 0 and their max is 0.
+    run_peak = max([r for r in runmax_by_round if r is not None], default=None)
+    wait_peak = max([w for w in waitmax_by_round if w is not None], default=None)
+    admitted_ok = admission_ok(runmax_by_round, N)
+
+    # ⚠️ Admission is deliberately NOT a term here. It never was, and adding it
+    # would put a metrics-sampling race into the fit verdict — a run where every
+    # request completed cleanly must not fail because of when we happened to look.
+    # Genuine under-admission still shows as done < N (which feeds `bad`), as
+    # requests WAITING, and in the peak reported below.
+    clean_fit = (bad == 0) and vram_ok(leak, GROWTH)
     floor_ok = (report_tps >= TPS_FLOOR) if TPS_FLOOR > 0 else True
     retention_ok = (retention >= RETENTION_MIN) if ROUNDS >= 3 else True
     PASS = clean_fit and floor_ok and (retention_ok if VALIDATE else True)
@@ -691,13 +751,21 @@ def run_probe():
         f"· slowest-decile stream {s_p05:.1f} tok/s (vs median {report_tps:.1f})"
     )
     if s_run is not None:
+        # This warning prints directly above the verdict line, so a spurious fire
+        # reads as the CAUSE of a FAIL it had nothing to do with — which is exactly
+        # how #1211 was diagnosed, by its reporter and by #1212. Gate it on the peak.
+        peak_note = (
+            f"  (peak {run_peak} across {ROUNDS} rounds)"
+            if run_peak is not None and run_peak != s_run
+            else ""
+        )
         admitted = (
             ""
-            if s_run >= N
-            else f"  ** engine admitted {s_run} of {N} requested — the rest QUEUED **"
+            if admitted_ok
+            else f"  ** engine admitted {run_peak} of {N} requested — the rest QUEUED **"
         )
         print(
-            f"  engine: running {s_run} · waiting {s_wait}"
+            f"  engine: running {s_run} · waiting {s_wait}{peak_note}"
             + (f" · prefix-cache hit {s_hit:.1f}%" if s_hit is not None else "")
             + admitted
         )
@@ -735,6 +803,8 @@ def run_probe():
         "tps_p05": _fmt_num(s_p05, 2),
         "running": "-" if s_run is None else s_run,
         "waiting": "-" if s_wait is None else s_wait,
+        "running_max": "-" if run_peak is None else run_peak,
+        "waiting_max": "-" if wait_peak is None else wait_peak,
         "prefix_hit": "-" if s_hit is None else f"{s_hit:.1f}",
         "cache": CACHE,
         "cached_toks": f"{steady_cached:.0f}",

--- a/scripts/tests/test-concurrency-probe-verdict.sh
+++ b/scripts/tests/test-concurrency-probe-verdict.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# test-concurrency-probe-verdict — guards the two verdict rules in
+# scripts/lib/concurrency_probe.py that produced the false `FAIL — fit` in #1211.
+#
+# ⚠️ It imports and calls the REAL functions, and statically asserts the REAL
+# wiring. A guard that re-implements the rule inline and tests the copy proves
+# nothing: PR #1212's version of this test passed unchanged with the admission
+# logic gutted to `run_peak = None`, because it never touched run_probe. Every
+# assertion here fails if the corresponding production line is reverted — that
+# was verified by reverting each one.
+#
+# The two rules:
+#   vram_ok(leak, growth)         — SYMMETRIC band. The old `0 <= leak` failed a
+#                                   -1 MB delta, which is what #1211 actually hit.
+#   admission_ok(run_peaks, n)    — judged on the PER-ROUND PEAK, never the racy
+#                                   last sample (#1212's insight).
+set -euo pipefail
+
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PROBE="$ROOT_DIR/scripts/concurrency-probe.sh"
+LIB="$ROOT_DIR/scripts/lib/concurrency_probe.py"
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+bash -n "$PROBE" || fail "bash -n: syntax error"
+python3 -m py_compile "$LIB" || fail "py_compile concurrency_probe.py"
+echo "  ✓ syntax"
+
+# --- the REAL functions, imported ------------------------------------------------
+PYTHONPATH="$ROOT_DIR/scripts/lib" python3 - "$LIB" <<'PY' || fail "verdict rules"
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("cp", sys.argv[1])
+m = importlib.util.module_from_spec(spec); sys.modules["cp"] = m
+spec.loader.exec_module(m)
+
+bad = []
+def ck(cond, msg):
+    if not cond: bad.append(msg)
+
+# --- vram_ok: the #1211 case -----------------------------------------------------
+# The reporter's own N=2 trace: cold 44302 -> warm 44303 -> final 44302.
+leak_1211 = 44302 - 44303
+ck(leak_1211 == -1, "fixture drift: the #1211 delta is -1 MB")
+ck(m.vram_ok(leak_1211, 200) is True,
+   "#1211: a -1 MB post-warm delta must PASS (it failed under `0 <= leak`)")
+ck(m.vram_ok(0, 200) is True,     "a 0 MB delta must pass")
+ck(m.vram_ok(199, 200) is True,   "growth inside the band must pass")
+ck(m.vram_ok(201, 200) is False,  "a real leak above the band must FAIL")
+# Bounded below: a container collapsing mid-probe must still fail, not read clean.
+ck(m.vram_ok(-20924, 200) is False,
+   "VRAM falling by the size of the model must FAIL (collapsed container)")
+ck(m.vram_ok(-201, 200) is False, "below the band must FAIL")
+
+# --- admission_ok: judged on the peak -------------------------------------------
+ck(m.admission_ok([1, 1, 1, 1, 1], 1) is True,  "N=1 peak=1 is admitted")
+ck(m.admission_ok([2, 2], 2) is True,           "N=2 peak=2 is admitted")
+ck(m.admission_ok([0, 2, 0], 2) is True,        "a dip after the peak is completion")
+ck(m.admission_ok([1, 1], 2) is False,          "peak<N fails closed")
+ck(m.admission_ok([], 2) is True,               "no engine data must not fail admission")
+ck(m.admission_ok([None, None], 2) is True,     "all-None must not fail admission")
+
+if bad:
+    for b in bad: print("  ⛔", b)
+    sys.exit(1)
+print("  ✓ vram_ok symmetric band (#1211) · admission_ok on the peak (#1212)")
+PY
+
+# --- the WIRING (a correct rule called with the wrong list is still the bug) -----
+command grep -q 'clean_fit = (bad == 0) and vram_ok(leak, GROWTH)' "$LIB" \
+  || fail "clean_fit must use vram_ok() — a literal '0 <= leak' reintroduces #1211"
+command grep -qE 'admitted_ok = admission_ok\(\s*runmax_by_round' "$LIB" \
+  || fail "admission_ok must be called with runmax_by_round (the PEAK list); \
+run_by_round is each round's LAST sample and reintroduces the race one level up"
+command grep -qE 'run_peak = max\(\[r for r in runmax_by_round' "$LIB" \
+  || fail "run_peak must come from the peak list"
+command grep -q 'runmax_by_round.append' "$LIB" \
+  || fail "the per-round peak must actually be collected"
+# Admission must NOT be folded into the fit verdict: that puts a sampling race
+# into a verdict that a clean run has already earned.
+command grep -qE 'clean_fit = .*admitted_ok' "$LIB" \
+  && fail "admission must NOT be a term in clean_fit — a run where every request \
+completed must not fail on when the metrics sample landed"
+echo "  ✓ wiring: peak list, vram_ok, and admission kept out of clean_fit"
+
+# --- the sweep early-stop keys off the peak --------------------------------------
+command grep -qE 'running_max.*-lt.*"\$n"' "$PROBE" \
+  || fail "sweep early-stop must compare the PEAK running against n"
+command grep -q 'running_max=' "$PROBE" \
+  || fail "sweep must parse running_max from the RESULT line"
+echo "  ✓ sweep early-stop keys off the peak running"
+
+echo "test-concurrency-probe-verdict: ok"


### PR DESCRIPTION
Closes #1211. Supersedes #1212 — see **Relationship to #1212** below; the peak-admission
insight and two of the three code changes here are @voiceagentscc's.

## What actually caused #1211

Not the admission sample. The reporter's own N=2 trace gives it away:

```
VRAM: cold 44302 -> warm 44303 -> final 44302 MB
post-warm growth: -1 MB
```

The verdict was `clean_fit = (bad == 0) and (0 <= leak <= GROWTH)`, with
`leak = final - warm`. That band is **asymmetric**: `VRAM_GROWTH_MB` (default 200) of
headroom upward and **zero** downward. A −1 MB delta — one megabyte of measurement
jitter — fails the run, with every request completed, no errors and nothing queued. That
is also why re-running the identical workload flipped the verdict: the jitter flipped sign.

The `** engine admitted 0 of 1 requested — the rest QUEUED **` line is a **red herring**.
On `master` it feeds only a warning string, never `clean_fit`:

```python
admitted = "" if s_run >= N else "  ** engine admitted … QUEUED **"
```

It prints on the line immediately above `FAIL — fit`, which is why it reads as the cause —
to the reporter, and to #1212.

## Changes

1. **`vram_ok(leak, growth)`** — the band is symmetric: `-growth <= leak <= growth`. A
   negative delta is not a leak. It stays bounded *below* so a container collapsing
   mid-probe (VRAM falling by the size of the model) still fails rather than reading clean;
   that is not hypothetical — a probe run during this work read `leak=-20924` when its
   server was killed mid-run.
2. **`admission_ok(run_peaks, n)`** — admission judged on the **per-round peak**, never the
   racy last sample (#1212's insight). Used to gate the QUEUED warning, so it stops firing
   on a clean completion and stops implicating itself in unrelated failures.
3. **Sweep early-stop keys off the peak** (#1212's fix). This is where the racy sample
   genuinely caused a failure: a rung where every request completed could fail *and*
   early-stop the ladder, silently truncating the measurement the sweep exists to produce.

Both rules are module-level functions so they can be tested for real, and
`engine_stats()` now returns `(run, wait, run_max, wait_max, hit)`.

⚠️ **Admission is deliberately NOT folded into `clean_fit`.** It never was, and adding it
puts a metrics-sampling race into a verdict a clean run has already earned. Genuine
under-admission still surfaces as `done < N` (which feeds `bad`), as requests WAITING, and
in the reported peak.

## Relationship to #1212

@voiceagentscc identified the last-sample/peak race correctly, and the sweep early-stop fix
and the `engine_stats` peak tracking are taken from that PR. Three things differ:

- **#1212 does not fix #1211.** Both reported runs fail on the VRAM band, which #1212
  leaves untouched. Its live "PASS after the change" does not discriminate — a run with
  `leak >= 0` passes on `master` too.
- **The peak was collected but never read.** `runmax_by_round` / `waitmax_by_round` were
  appended to and never used; `run_peak` came from `run_by_round`, each round's *last*
  sample. That reintroduces the same race one level up — at N=1 every round's last sample
  is taken after the single request completed, so all entries read 0 and their max is 0.
- **It folds `admitted_ok` into `clean_fit`**, adding a failure vector to single-N mode
  that did not exist, and (given the above) a racy one.

## Verification

`scripts/tests/test-concurrency-probe-verdict.sh` imports and calls the **real** functions
and asserts the **real** wiring, including that admission stays out of `clean_fit`. Every
assertion was checked by reverting the corresponding production line:

| reverted to | guard |
|---|---|
| `0 <= leak <= GROWTH` (the #1211 bug) | **fails** ✅ |
| `admission_ok(run_by_round, N)` (#1212 as submitted) | **fails** ✅ |
| `clean_fit … and admitted_ok` (the #1212 regression) | **fails** ✅ |
| sweep early-stop on the racy last sample | **fails** ✅ |

⚠️ This matters because #1212's guard was **vacuous**: it re-implemented the rule in an
inline snippet and tested the copy, then grepped the source for strings. Hardcoding
`run_peak = None` — disabling admission checking entirely — left it green.

Also green: `test-concurrency-probe`, `test-spec-sweep`.

Live N=1 run (qwen3.6-27b AutoRound INT4, vLLM v0.27.1, 16K prompts, 5 rounds):

```
round    done  silent  errors  vram_MB   per-strm   run/wait
    1..5  1/1        0       0    20927      45.5      1/0
VRAM: cold 20567 -> warm 20927 -> final 20927 (post-warm growth 0 MB / 200)
engine: running 1 · waiting 0
concurrency 1 @ ~16000 tok: PASS — sustained clean
RESULT ... clean=1 pass=1 leak=0 running=1 waiting=0 running_max=1 waiting_max=0
```

⚠️ Read that for what it is: `leak=0`, so this run would have passed on `master` too. It
confirms **no regression**, that `running_max`/`waiting_max` reach the RESULT line for the
sweep driver, and that the QUEUED warning stays silent on a clean completion. It does
**not** exercise the −1 MB case — that is covered by the unit test, using the reporter's
exact VRAM trace, with the old band as its negative control.
