### PR TITLE
feat(engines): register sglang-stable + define the sglang patch contract

### DIFF
--- a/models/glm-5.3-flash/sglang/patches/README.md
+++ b/models/glm-5.3-flash/sglang/patches/README.md
@@ -1,0 +1,78 @@
+# Patches for GLM-5.3-Flash on SGLang
+
+**Nothing is vendored here yet, and that is deliberate.** This file defines the patch
+contract for the `sglang` engine type so the first real patch has somewhere to land, and
+records the one attempt already made so it is not repeated.
+
+## The contract (mirrors the vLLM one, not the old sglang one)
+
+Two patch styles exist in this repo. Use the first.
+
+| style | where | delivery |
+|---|---|---|
+| ✅ **install_script** | `models/<model>/vllm/patches/<patch-id>/` | `install.sh` mounted into the container and invoked before the server starts |
+| 🗑️ bare `.py` overlay | `models/qwen3.6-27b/sglang/patches/patch_*.py` | undefined — deprecated 2026-06-05 (#254), no functional compose uses them |
+
+A new sglang patch is a directory `models/<model>/sglang/patches/<patch-id>/` containing an
+idempotent `install.sh`, plus a `patches.yml` entry:
+
+```yaml
+- id: <model>-sglang-<what>
+  model: [<model>]
+  files: [models/<model>/sglang/patches/<patch-id>]
+  delivery: {dockerfile_bake: false, entrypoint_invoke: true, genesis: false}
+  delivery_mechanism: install_script
+  delivery_spec:
+    script: models/<model>/sglang/patches/<patch-id>/install.sh
+    mounted_at: /etc/club3090/<patch-id>.sh
+    invoke: bash /etc/club3090/<patch-id>.sh
+    invoked_before: sglang-launch
+    wired_at: [volumes, entrypoint]
+  drift_guard: {kind: behavioral, check: "<observable that fails if the patch silently no-ops>", on_fail: capability-degraded}
+  upstream: {ref: sgl-project/sglang#NNNNN, status: <open|merged|ours>, drop_when: "<condition>"}
+```
+
+⚠️ `test-patch-attribution` enforces both directions: every `files:` path must exist, and
+every `.py`/`.sh` under a `patches/` tree must be claimed by an entry. A `.md` is not an
+artifact, which is why this README needs no entry. Adding code here without the entry
+reds the guard.
+
+⚠️ `install.sh` must be **anchor-based and refuse on drift** (grep for the exact upstream
+line it patches; `exit 1` if absent) rather than applying blind. An overlay that silently
+no-ops against a bumped image is the failure mode the `drift_guard` field exists for.
+
+## Recorded dead end: `glm5-next-sideload` (2026-09-09)
+
+Do not retry this shape.
+
+Someone attempted to side-load `glm5_next` support onto the **v0.5.19 release image** by
+copying individual files from sglang main: `srt/models/glm5_next.py`,
+`srt/models/glm5_next_nextn.py`, `srt/configs/glm5_next.py`, a newer
+`kernels/ops/layernorm/mhc.py` (v0.5.19's lacks the `hc_contract`/`hc_pre`/`hc_post` that
+glm5_next needs), plus appending `AutoConfig.register('glm5_next'/'glm5_next_text', …)` to
+`configs/__init__.py`.
+
+It got further than expected and still failed:
+
+1. ✅ config registration worked — `model_type=glm5_next` resolved, flashinfer backend announced;
+2. ⛔ the model import then died on `is_dsa_prefill_cp_interleave` missing from
+   `layers/attention/dsa/utils.py`.
+
+**sglang#36507 touches ~50 files.** Per-file backporting onto a release image is a dead
+end, not an unfinished job — each fixed import reveals the next. The supported route is a
+main-built image (`lmsysorg/sglang:dev-cu12`) carrying the whole change natively, declared
+as its own engine profile.
+
+The sideload files are NOT vendored here on purpose: they are copies of upstream sources
+that can never work on the pinned image, and keeping them would oblige `patches.yml` to
+carry an entry for code with no path to working. This record is the useful part.
+
+⚠️ Even with a main-built image, the Ampere question is open: sparse-MLA/DSA backends are
+SM90-gated (see `LEARNINGS.md` 2026-09-09), and SGLang's Triton DSA path is the only
+plausible route on sm_86 — **unvalidated**.
+
+## Likely first real patch
+
+Not glm5_next. Discussion #1178 (@jb-seo) reports Qwen3.8-27B running on this engine with
+**3 in-container patches** on v0.5.18. Those are the first concrete candidates for this
+contract, and reproducing them is what would let `sglang-stable` carry a validated compose.

--- a/scripts/gpu-mode.sh
+++ b/scripts/gpu-mode.sh
@@ -451,15 +451,25 @@ show_status() {
         m=$(curl -sf -m 2 http://localhost:8013/v1/models | python3 -c "import sys,json;d=json.load(sys.stdin);print(', '.join(x['id'] for x in d.get('data',[])))" 2>/dev/null)
         echo -e "  ${GREEN}▶${NC} 27b-dual-max @ :8013 → ${m:-unknown} (max-tier dual + fp8 + 262K)"
     fi
-    # :8020 = llama.cpp single-card. llamacpp/default + llamacpp/mtp share the
-    # base container llama-cpp-qwen36-27b (same compose, collapsed 2026-05-22);
-    # llamacpp/mtp-vision now defaults to llama-cpp-qwen36-27b-vision (#169).
-    # All still match the llama-cpp-* prefix used for detection below.
+    # :8020 is a multi-slug port (vllm/minimal today; the deprecated
+    # llama.cpp / ik-llama single-card slugs also landed here) and every one of
+    # those slugs serves the same model ids, so :8030's served-name
+    # disambiguation cannot tell them apart. Classify from the REGISTRY instead
+    # — match the container that actually publishes the port against each
+    # variant row's registered container name — never from a name prefix.
     if curl -sf -m 2 "http://localhost:${p_llamacpp}/v1/models" >/dev/null 2>&1; then
         _endpoint_up=1
-        local m
+        local m c8020 fam8020
         m=$(curl -sf -m 2 "http://localhost:${p_llamacpp}/v1/models" | python3 -c "import sys,json;d=json.load(sys.stdin);print(', '.join(x['id'] for x in d.get('data',[])))" 2>/dev/null)
-        echo -e "  ${GREEN}▶${NC} llamacpp/single @ :${p_llamacpp} → ${m:-unknown} (llama.cpp single-card)"
+        fam8020="llamacpp"   # legacy fallback when docker/registry lookups fail
+        c8020=$(sudo docker ps --filter "publish=${p_llamacpp}" --format '{{.Names}}' 2>/dev/null | sed -n '1p')
+        if [[ -n "${c8020}" ]] && declare -F registry_lookup_cache_path >/dev/null 2>&1 && registry_lookup_cache_path; then
+            local hit
+            hit=$(REGISTRY_LOOKUP_CACHE="${_registry_lookup_cache}" REGISTRY_LOOKUP_CONTAINER="${c8020}" \
+                  python3 -c "import json,os;rows=json.load(open(os.environ['REGISTRY_LOOKUP_CACHE'],encoding='utf-8')).get('variants',[]);h=[r for r in rows if r.get('container')==os.environ['REGISTRY_LOOKUP_CONTAINER']];print(h[0]['slug'].split('/',1)[0] if h else '')" 2>/dev/null)
+            [[ -n "${hit}" ]] && fam8020="${hit}"
+        fi
+        echo -e "  ${GREEN}▶${NC} ${fam8020}/single @ :${p_llamacpp} → ${m:-unknown} (single-card)"
     fi
     if curl -sf -m 2 http://localhost:8030/v1/models >/dev/null 2>&1; then
         _endpoint_up=1

--- a/scripts/lib/profiles/engines/sglang-stable.yml
+++ b/scripts/lib/profiles/engines/sglang-stable.yml
@@ -1,0 +1,51 @@
+schema_version: 1
+id: sglang-stable
+display_name: SGLang stable v0.5.19
+type: sglang
+stability: stable
+install:
+  method: docker_image
+  spec: lmsysorg/sglang:v0.5.19
+min_sm: 8.0
+supported_model_families:
+  - qwen3-next-hybrid   # 🌐 COMMUNITY-EVIDENCED, not rig-validated: club-3090 discussion
+                        # #1178 (@jb-seo) — Qwen3.8-27B TP=2 AutoRound INT4 + native MTP
+                        # head (n=4), flashinfer attention, 97-121 decode TPS on dual
+                        # 3090s; 640K fp8 KV at 0.96 mem-fraction also measured (89-94
+                        # TPS). ⚠️ Measured on v0.5.18 WITH 3 in-container patches, not
+                        # on stock v0.5.19. Nobody has booted this engine on THIS rig.
+                        # Treat as a lead, not a guarantee, until a compose is validated.
+#
+# ⛔ glm5-next is NOT a supported family on this pin. An earlier draft of this file
+#    listed it as "experimental via sideload patch"; that is DISPROVEN. The glm5_next
+#    model/config/MTP support landed in sglang MAIN only (sglang#36507, 2026-09-06) and
+#    is absent from v0.5.18, v0.5.19 and `latest` — their bundled transformers rejects
+#    model_type=glm5_next outright. Per-file sideloading onto a release image was tried
+#    on-rig and FAILED: config registration succeeded, then the model import died on
+#    `is_dsa_prefill_cp_interleave` missing from layers/attention/dsa/utils.py. #36507
+#    touches ~50 files, so per-file backporting is a dead end, not an unfinished job.
+#    A glm5_next-capable SGLang engine needs a MAIN-built image (lmsysorg/sglang:dev-cu12)
+#    declared as its OWN engine profile — and even then the Ampere question is open: see
+#    LEARNINGS.md 2026-09-09 (sparse-MLA/DSA is SM90-gated; SGLang's Triton DSA path is
+#    the only Ampere-plausible route and is UNVALIDATED on sm_86).
+features:
+  native_mtp: true               # Qwen3.8 native MTP head (#1178: n=4). Community-evidenced.
+  flashinfer_attention: true     # #1178 used flashinfer for full attention on Ampere.
+  hybrid_linear_attention: true  # KDA/GDN linear layers via FLA Triton kernels — same
+                                 # class as qwen3-next on this engine.
+supported_kv_formats:
+  - bf16
+  - fp8_e4m3            # #1178: KV fp8_e4m3 on Qwen3.8-27B dual-3090.
+  - fp8_e5m2
+required_overlays: []
+vendored_overlays: []
+required_genesis: false
+notes: >-
+  SGLang stable, REGISTERED BUT NOT YET WIRED: no compose targets this engine and it has
+  never been booted on this rig. It is deliberately absent from arch_patches.yml, so
+  generate_compose/pull-gate will REFUSE an sglang pin ("engine pin has no loads:true
+  match") until a compose is live-validated — that refusal is correct, not a gap to
+  paper over. Add the arch/pin row in the same change as the first working compose.
+  Patch delivery for this engine follows models/<model>/sglang/patches/ (see the README
+  there); it mirrors the vLLM install_script contract rather than the older bare-.py
+  sglang patches under models/qwen3.6-27b/sglang/patches/, which are deprecated (#254).

--- a/scripts/tests/test-profiles-compat.sh
+++ b/scripts/tests/test-profiles-compat.sh
@@ -39,7 +39,7 @@ assert len(p.models) - _nloc("scripts/lib/profiles-local/models.d") == 21   # +i
 assert len(p.workloads) == 5
 _p = __import__("pathlib").Path
 _nloc = lambda d: len(list(_p(d).glob("*.yml"))) if _p(d).is_dir() else 0
-assert len(p.engines) - _nloc("scripts/lib/profiles-local/engines.d") == 17   # +llamacpp-club3090-v1.1, -v1.5, -v1.6
+assert len(p.engines) - _nloc("scripts/lib/profiles-local/engines.d") == 18   # +llamacpp-club3090-v1.1, -v1.5, -v1.6, +sglang-stable
 assert len(p.drafters) == 18  # +syvai-qwen38-dflash2, +anbeeld-glm53-dflash2
 assert len(p.calibration) == 6
 PY

--- a/services/spark-dashboard/docker-compose.yml
+++ b/services/spark-dashboard/docker-compose.yml
@@ -16,7 +16,7 @@
 # (repo policy: never `latest` for services we depend on operationally).
 #
 # Override via .env or shell:
-#   SPARK_DASHBOARD_IMAGE   image (default: pinned v0.13.0 — multi-GPU selector UI landed in v0.12.0)
+#   SPARK_DASHBOARD_IMAGE   image (default: pinned v0.14.0 — multi-GPU selector UI landed in v0.12.0)
 #   SPARK_DASHBOARD_PORT    UI/API port on the host (default 3010; host network)
 #   DOCKER_GID              host docker group GID (default 999 = Debian/Ubuntu common, but GIDs vary
 #                           per install — 984/988/999 all seen in the wild, so SET YOURS explicitly:
@@ -24,7 +24,7 @@
 #                           silently disables container-based engine discovery)
 services:
   spark-dashboard:
-    image: ${SPARK_DASHBOARD_IMAGE:-ghcr.io/niklasfrick/spark-dashboard:v0.13.0}
+    image: ${SPARK_DASHBOARD_IMAGE:-ghcr.io/niklasfrick/spark-dashboard:v0.14.0}
     container_name: spark-dashboard
     restart: unless-stopped
 


### PR DESCRIPTION
Registers the `sglang-stable` engine profile and defines the patch-delivery contract for
the `sglang` engine type. Groundwork for the GLM-5.3-Flash engine investigation; **no
behaviour changes for any existing slug.**

## Registered but NOT wired — on purpose

No compose targets this engine, and it has never been booted on this rig. It is
deliberately **absent from `arch_patches.yml`**, so `generate_compose` / the pull-gate will
refuse an sglang pin (`engine pin has no loads:true match`) until a compose is
live-validated.

That refusal is correct behaviour, not a gap. The profile's `notes:` says so explicitly, so
the next person doesn't "fix" it by adding an unvalidated `loads: true` row and handing the
resolver a config nobody has booted.

## What I corrected in the draft

This started from an untracked draft left in the main checkout. Two claims in it don't hold:

**`glm5-next` was listed as an experimental supported family "via the sideload patch".**
Disproven by the same investigation that produced the draft:

- `glm5_next` landed in sglang **main** only (sglang#36507, 2026-09-06). v0.5.18, v0.5.19
  and `latest` don't have it — their bundled transformers rejects `model_type=glm5_next`.
- Per-file sideloading onto a release image was tried on-rig. Config registration
  succeeded; the model import then died on `is_dsa_prefill_cp_interleave` missing from
  `layers/attention/dsa/utils.py`.
- #36507 touches ~50 files, so that shape is a **dead end, not an unfinished job** — each
  fixed import reveals the next.

Shipping the family would have handed the next reader a config that cannot work. It's
removed, with the failure chain recorded in the profile and the patches README.

**`qwen3-next-hybrid` was listed as flatly supported.** It's now marked
🌐 **community-evidenced**: discussion #1178 (@jb-seo) measured 97–121 decode TPS on dual
3090s — but on **v0.5.18 with 3 in-container patches**, not stock v0.5.19, and not on this
rig. A lead, not a guarantee.

## The patch contract

`models/glm-5.3-flash/sglang/patches/README.md` defines it: a patch is a directory with an
idempotent, **anchor-based `install.sh` that REFUSES on drift**, plus a `patches.yml` entry
using the vLLM `install_script` shape (`script` / `mounted_at` / `invoke` /
`invoked_before` / `wired_at`) with `drift_guard` and `upstream`. It steers away from the
older bare-`.py` sglang patches under `models/qwen3.6-27b/sglang/patches/` (deprecated
2026-06-05, #254).

⚠️ **The sideload files are not vendored, deliberately.** `test-patch-attribution` enforces
both directions — every `files:` path must exist, and every `.py`/`.sh` under a `patches/`
tree must be claimed by an entry. Vendoring copies of upstream sources that cannot work on
the pinned image would oblige `patches.yml` to carry an entry for code with no path to
working. The recorded failure chain is the part with value; a `.md` is not an artifact, so
the contract documents itself without that obligation.

## Verification

Full guard sweep: **PASS=150 FAIL=0**, run under a hermetic `docker` shim that blocks
`compose up` **and** every teardown verb, so the suite could not boot or destroy real estate
while a model was serving (that has happened twice this week; see the tracker). The shim
recorded `blocked-up=0 blocked-teardown=0` — the suite never attempted either, which
independently confirms the #1222 dry-run fix is holding.

Also measured while preparing this: `lmsysorg/sglang:v0.5.19` against the config-only
GLM-5.3-Flash snapshot with `--load-format dummy` on GPU1 fails at
`KeyError: 'glm5_next'` / "Transformers does not recognize this architecture" — i.e. at
config resolution, before any model code or kernel. That is the evidence behind dropping
`glm5-next` from this profile, and it doubles as the negative control for the pending
`dev-cu12` probe: a packaging failure and a kernel failure are distinguishable.

`test-profiles-compat` hard-asserts the engine count, so its fixture moves 17 → 18.
