### PR TITLE
fix(qwen3.8-27b): drop the retracted #1096 decode-cliff claim from 20 composes

### DIFF
--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2-fp8.yml
@@ -12,11 +12,19 @@
 #              ultrafast/bf16 tier this fits the full 262K).
 #   Genesis:   none
 #   Status:    🧪 Experimental
-# ⚠️ #1096 (accumulated-ctx decode cliff): in long multi-turn agentic, decode collapses to
-#    single-block emission — ~12k accumulated ctx for DFlash2 (SPEC_N depth does NOT move it,
-#    n=3≡n=7) / ~17-21k for MTP; SEVERE on Ampere (~4 tok/s), milder on Blackwell. Drafter TYPE,
-#    not depth, sets the floor. Interim: MTP tier (higher cliff) or SPEC_N=0 for sustained >~20k.
-#    Real fix pending upstream ReplaySSM (vllm#49887 GDN-spec / vllm#50172). NOT immune to this.
+# ⛔⛔ #1096 RETRACTED 2026-09-08 — THERE IS NO ACCUMULATED-CTX DECODE CLIFF. The collapse
+#    figures came from OUR harness, not the engine: bench-agentic set TTFT on the first
+#    `content` delta, so a thinking model's entire reasoning phase was charged to prefill and
+#    the decode window fell under its 5%-of-wall "degenerate" rule. Fixed in #1218. That rule
+#    flags whatever has slow prefill relative to decode, which is also why the pattern looked
+#    hardware-dependent (Blackwell prefills fast -> "clean"; Ampere -> "collapsed").
+#    Re-test, both arms, same v0.27.1 pin, cross-checked against vLLM's OWN histograms:
+#    MTP n=3 -> 110.2 tok/s @ 21,443 ctx; DFlash2 n=7 -> 159.4 @ 12,275. Decode FLAT across
+#    1.2K->35.3K, zero degenerate turns, zero preemptions. ⛔ Do NOT set SPEC_N=0 or prefer the
+#    MTP tier for long contexts on this basis — that advice was wrong and costs you the drafter.
+# ⚠️ What DOES survive: vllm#35387 — a real spec tax that scales with drafter DEPTH, not
+#    context (29K: no-spec 57.0 -> n=1 40.6 / n=2 36.0 / n=3 32.7 tok/s), profiled to the
+#    cudagraph downgrade FULL_AND_PIECEWISE -> PIECEWISE. A steady tax, not a cliff.
 #   Best for:  DFlash2 on the FAST envelope — full 262K + concurrency. (Immune to the #52873 acceptance-collapse, NOT the #1096 ctx cliff — see below.)
 # ---------------------------------------------------------------------------
 # SUPERFAST = the FAST tier (int4, fp8 KV, 262K) with MTP → DFlash2. vs fast/MTP:

--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2.yml
@@ -19,11 +19,19 @@
 #              bf16 KV can't fit 262K here (needs ~10.93 GiB vs ~9.1 available).
 #   Genesis:   none
 #   Status:    🧪 Experimental
-# ⚠️ #1096 (accumulated-ctx decode cliff): in long multi-turn agentic, decode collapses to
-#    single-block emission — ~12k accumulated ctx for DFlash2 (SPEC_N depth does NOT move it,
-#    n=3≡n=7) / ~17-21k for MTP; SEVERE on Ampere (~4 tok/s), milder on Blackwell. Drafter TYPE,
-#    not depth, sets the floor. Interim: MTP tier (higher cliff) or SPEC_N=0 for sustained >~20k.
-#    Real fix pending upstream ReplaySSM (vllm#49887 GDN-spec / vllm#50172). NOT immune to this.
+# ⛔⛔ #1096 RETRACTED 2026-09-08 — THERE IS NO ACCUMULATED-CTX DECODE CLIFF. The collapse
+#    figures came from OUR harness, not the engine: bench-agentic set TTFT on the first
+#    `content` delta, so a thinking model's entire reasoning phase was charged to prefill and
+#    the decode window fell under its 5%-of-wall "degenerate" rule. Fixed in #1218. That rule
+#    flags whatever has slow prefill relative to decode, which is also why the pattern looked
+#    hardware-dependent (Blackwell prefills fast -> "clean"; Ampere -> "collapsed").
+#    Re-test, both arms, same v0.27.1 pin, cross-checked against vLLM's OWN histograms:
+#    MTP n=3 -> 110.2 tok/s @ 21,443 ctx; DFlash2 n=7 -> 159.4 @ 12,275. Decode FLAT across
+#    1.2K->35.3K, zero degenerate turns, zero preemptions. ⛔ Do NOT set SPEC_N=0 or prefer the
+#    MTP tier for long contexts on this basis — that advice was wrong and costs you the drafter.
+# ⚠️ What DOES survive: vllm#35387 — a real spec tax that scales with drafter DEPTH, not
+#    context (29K: no-spec 57.0 -> n=1 40.6 / n=2 36.0 / n=3 32.7 tok/s), profiled to the
+#    cudagraph downgrade FULL_AND_PIECEWISE -> PIECEWISE. A steady tax, not a cliff.
 #   Best for:  ⭐ ULTRAFAST decode — the throughput tier (~227 code / ~132 narr TPS).
 # ---------------------------------------------------------------------------
 # THE "ULTRAFAST" TIER — DFlash2 external drafter on the INT4 target.

--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
@@ -36,11 +36,19 @@
 #   Max ctx:   262144 — architectural ceiling, NOT measured on this checkpoint
 #   Genesis:   none
 #   Status:    🧪 Experimental
-# ⚠️ #1096 (accumulated-ctx decode cliff): in long multi-turn agentic, decode collapses to
-#    single-block emission — ~12k accumulated ctx for DFlash2 (SPEC_N depth does NOT move it,
-#    n=3≡n=7) / ~17-21k for MTP; SEVERE on Ampere (~4 tok/s), milder on Blackwell. Drafter TYPE,
-#    not depth, sets the floor. Interim: MTP tier (higher cliff) or SPEC_N=0 for sustained >~20k.
-#    Real fix pending upstream ReplaySSM (vllm#49887 GDN-spec / vllm#50172). NOT immune to this.
+# ⛔⛔ #1096 RETRACTED 2026-09-08 — THERE IS NO ACCUMULATED-CTX DECODE CLIFF. The collapse
+#    figures came from OUR harness, not the engine: bench-agentic set TTFT on the first
+#    `content` delta, so a thinking model's entire reasoning phase was charged to prefill and
+#    the decode window fell under its 5%-of-wall "degenerate" rule. Fixed in #1218. That rule
+#    flags whatever has slow prefill relative to decode, which is also why the pattern looked
+#    hardware-dependent (Blackwell prefills fast -> "clean"; Ampere -> "collapsed").
+#    Re-test, both arms, same v0.27.1 pin, cross-checked against vLLM's OWN histograms:
+#    MTP n=3 -> 110.2 tok/s @ 21,443 ctx; DFlash2 n=7 -> 159.4 @ 12,275. Decode FLAT across
+#    1.2K->35.3K, zero degenerate turns, zero preemptions. ⛔ Do NOT set SPEC_N=0 or prefer the
+#    MTP tier for long contexts on this basis — that advice was wrong and costs you the drafter.
+# ⚠️ What DOES survive: vllm#35387 — a real spec tax that scales with drafter DEPTH, not
+#    context (29K: no-spec 57.0 -> n=1 40.6 / n=2 36.0 / n=3 32.7 tok/s), profiled to the
+#    cudagraph downgrade FULL_AND_PIECEWISE -> PIECEWISE. A steady tax, not a cliff.
 #   Best for:  single-stream INT4 serving with the drafter — the throughput tier
 # ---------------------------------------------------------------------------
 # THE "FAST" TIER — the INT4 counterpart to the official-FP8 "max" tier.

--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/dflash2-fp8.yml
@@ -16,11 +16,19 @@
 #   Max ctx:   262144 (fp8 KV fits the full arch max).
 #   Genesis:   none
 #   Status:    🧪 Experimental
-# ⚠️ #1096 (accumulated-ctx decode cliff): in long multi-turn agentic, decode collapses to
-#    single-block emission — ~12k accumulated ctx for DFlash2 (SPEC_N depth does NOT move it,
-#    n=3≡n=7) / ~17-21k for MTP; SEVERE on Ampere (~4 tok/s), milder on Blackwell. Drafter TYPE,
-#    not depth, sets the floor. Interim: MTP tier (higher cliff) or SPEC_N=0 for sustained >~20k.
-#    Real fix pending upstream ReplaySSM (vllm#49887 GDN-spec / vllm#50172). NOT immune to this.
+# ⛔⛔ #1096 RETRACTED 2026-09-08 — THERE IS NO ACCUMULATED-CTX DECODE CLIFF. The collapse
+#    figures came from OUR harness, not the engine: bench-agentic set TTFT on the first
+#    `content` delta, so a thinking model's entire reasoning phase was charged to prefill and
+#    the decode window fell under its 5%-of-wall "degenerate" rule. Fixed in #1218. That rule
+#    flags whatever has slow prefill relative to decode, which is also why the pattern looked
+#    hardware-dependent (Blackwell prefills fast -> "clean"; Ampere -> "collapsed").
+#    Re-test, both arms, same v0.27.1 pin, cross-checked against vLLM's OWN histograms:
+#    MTP n=3 -> 110.2 tok/s @ 21,443 ctx; DFlash2 n=7 -> 159.4 @ 12,275. Decode FLAT across
+#    1.2K->35.3K, zero degenerate turns, zero preemptions. ⛔ Do NOT set SPEC_N=0 or prefer the
+#    MTP tier for long contexts on this basis — that advice was wrong and costs you the drafter.
+# ⚠️ What DOES survive: vllm#35387 — a real spec tax that scales with drafter DEPTH, not
+#    context (29K: no-spec 57.0 -> n=1 40.6 / n=2 36.0 / n=3 32.7 tok/s), profiled to the
+#    cudagraph downgrade FULL_AND_PIECEWISE -> PIECEWISE. A steady tax, not a cliff.
 #   Best for:  DFlash2 on the MAX/fidelity envelope — full 262K + concurrency.
 # ---------------------------------------------------------------------------
 # SUPERMAX = the MAX tier (official FP8, fp8 KV, 262K) with MTP → DFlash2. Immune to the #52873

--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/dflash2.yml
@@ -15,11 +15,19 @@
 #              KV fits LESS than the int4 ultrafast's ~200K. Set from the KV pool.)
 #   Genesis:   none
 #   Status:    🧪 Experimental
-# ⚠️ #1096 (accumulated-ctx decode cliff): in long multi-turn agentic, decode collapses to
-#    single-block emission — ~12k accumulated ctx for DFlash2 (SPEC_N depth does NOT move it,
-#    n=3≡n=7) / ~17-21k for MTP; SEVERE on Ampere (~4 tok/s), milder on Blackwell. Drafter TYPE,
-#    not depth, sets the floor. Interim: MTP tier (higher cliff) or SPEC_N=0 for sustained >~20k.
-#    Real fix pending upstream ReplaySSM (vllm#49887 GDN-spec / vllm#50172). NOT immune to this.
+# ⛔⛔ #1096 RETRACTED 2026-09-08 — THERE IS NO ACCUMULATED-CTX DECODE CLIFF. The collapse
+#    figures came from OUR harness, not the engine: bench-agentic set TTFT on the first
+#    `content` delta, so a thinking model's entire reasoning phase was charged to prefill and
+#    the decode window fell under its 5%-of-wall "degenerate" rule. Fixed in #1218. That rule
+#    flags whatever has slow prefill relative to decode, which is also why the pattern looked
+#    hardware-dependent (Blackwell prefills fast -> "clean"; Ampere -> "collapsed").
+#    Re-test, both arms, same v0.27.1 pin, cross-checked against vLLM's OWN histograms:
+#    MTP n=3 -> 110.2 tok/s @ 21,443 ctx; DFlash2 n=7 -> 159.4 @ 12,275. Decode FLAT across
+#    1.2K->35.3K, zero degenerate turns, zero preemptions. ⛔ Do NOT set SPEC_N=0 or prefer the
+#    MTP tier for long contexts on this basis — that advice was wrong and costs you the drafter.
+# ⚠️ What DOES survive: vllm#35387 — a real spec tax that scales with drafter DEPTH, not
+#    context (29K: no-spec 57.0 -> n=1 40.6 / n=2 36.0 / n=3 32.7 tok/s), profiled to the
+#    cudagraph downgrade FULL_AND_PIECEWISE -> PIECEWISE. A steady tax, not a cliff.
 #   Best for:  MAX decode on the fidelity weights — FA2 fast path (sacrifices ctx).
 # ---------------------------------------------------------------------------
 # ULTRAMAX = the MAX tier (official FP8) with DFlash2 on the bf16/FLASH_ATTN fast

--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
@@ -37,11 +37,19 @@
 #              qwen3.6-27b FP8 tier. NEVER MEASURED HERE. See "Context budget".
 #   Genesis:   none — intentionally Genesis-free
 #   Status:    🧪 Experimental
-# ⚠️ #1096 (accumulated-ctx decode cliff): in long multi-turn agentic, decode collapses to
-#    single-block emission — ~12k accumulated ctx for DFlash2 (SPEC_N depth does NOT move it,
-#    n=3≡n=7) / ~17-21k for MTP; SEVERE on Ampere (~4 tok/s), milder on Blackwell. Drafter TYPE,
-#    not depth, sets the floor. Interim: MTP tier (higher cliff) or SPEC_N=0 for sustained >~20k.
-#    Real fix pending upstream ReplaySSM (vllm#49887 GDN-spec / vllm#50172). NOT immune to this.
+# ⛔⛔ #1096 RETRACTED 2026-09-08 — THERE IS NO ACCUMULATED-CTX DECODE CLIFF. The collapse
+#    figures came from OUR harness, not the engine: bench-agentic set TTFT on the first
+#    `content` delta, so a thinking model's entire reasoning phase was charged to prefill and
+#    the decode window fell under its 5%-of-wall "degenerate" rule. Fixed in #1218. That rule
+#    flags whatever has slow prefill relative to decode, which is also why the pattern looked
+#    hardware-dependent (Blackwell prefills fast -> "clean"; Ampere -> "collapsed").
+#    Re-test, both arms, same v0.27.1 pin, cross-checked against vLLM's OWN histograms:
+#    MTP n=3 -> 110.2 tok/s @ 21,443 ctx; DFlash2 n=7 -> 159.4 @ 12,275. Decode FLAT across
+#    1.2K->35.3K, zero degenerate turns, zero preemptions. ⛔ Do NOT set SPEC_N=0 or prefer the
+#    MTP tier for long contexts on this basis — that advice was wrong and costs you the drafter.
+# ⚠️ What DOES survive: vllm#35387 — a real spec tax that scales with drafter DEPTH, not
+#    context (29K: no-spec 57.0 -> n=1 40.6 / n=2 36.0 / n=3 32.7 tok/s), profiled to the
+#    cudagraph downgrade FULL_AND_PIECEWISE -> PIECEWISE. A steady tax, not a cliff.
 #   Caveats:   ✅ BOOTED + verify-full PASS on the reference rig (2× 3090) 2026-08-17.
 #              Promoted 🐣 → 🧪 per this compose's own gate ("clean boot + verify-full").
 #              MEASURED 2026-08-17, stock vllm/vllm-openai:v0.27.1, 3 warm + 5 measured:

--- a/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
@@ -29,11 +29,19 @@
 #   Max ctx:   262144
 #   Genesis:   none
 #   Status:    🧪 Experimental
-# ⚠️ #1096 (accumulated-ctx decode cliff): in long multi-turn agentic, decode collapses to
-#    single-block emission — ~12k accumulated ctx for DFlash2 (SPEC_N depth does NOT move it,
-#    n=3≡n=7) / ~17-21k for MTP; SEVERE on Ampere (~4 tok/s), milder on Blackwell. Drafter TYPE,
-#    not depth, sets the floor. Interim: MTP tier (higher cliff) or SPEC_N=0 for sustained >~20k.
-#    Real fix pending upstream ReplaySSM (vllm#49887 GDN-spec / vllm#50172). NOT immune to this.
+# ⛔⛔ #1096 RETRACTED 2026-09-08 — THERE IS NO ACCUMULATED-CTX DECODE CLIFF. The collapse
+#    figures came from OUR harness, not the engine: bench-agentic set TTFT on the first
+#    `content` delta, so a thinking model's entire reasoning phase was charged to prefill and
+#    the decode window fell under its 5%-of-wall "degenerate" rule. Fixed in #1218. That rule
+#    flags whatever has slow prefill relative to decode, which is also why the pattern looked
+#    hardware-dependent (Blackwell prefills fast -> "clean"; Ampere -> "collapsed").
+#    Re-test, both arms, same v0.27.1 pin, cross-checked against vLLM's OWN histograms:
+#    MTP n=3 -> 110.2 tok/s @ 21,443 ctx; DFlash2 n=7 -> 159.4 @ 12,275. Decode FLAT across
+#    1.2K->35.3K, zero degenerate turns, zero preemptions. ⛔ Do NOT set SPEC_N=0 or prefer the
+#    MTP tier for long contexts on this basis — that advice was wrong and costs you the drafter.
+# ⚠️ What DOES survive: vllm#35387 — a real spec tax that scales with drafter DEPTH, not
+#    context (29K: no-spec 57.0 -> n=1 40.6 / n=2 36.0 / n=3 32.7 tok/s), profiled to the
+#    cudagraph downgrade FULL_AND_PIECEWISE -> PIECEWISE. A steady tax, not a cliff.
 #   Caveats:   FALLBACK-ONLY VALIDATION. Boots + serves on 2x sm_86, but through
 #              the Marlin W4A16 fallback — the FP4 path this quant exists for is
 #              UNEXERCISED. No Blackwell boot yet. See the arch note below.

--- a/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/dflash2-fp8.yml
@@ -14,11 +14,19 @@
 #              ultrafast/bf16 tier this fits the full 262K).
 #   Genesis:   none
 #   Status:    🧪 Experimental
-# ⚠️ #1096 (accumulated-ctx decode cliff): in long multi-turn agentic, decode collapses to
-#    single-block emission — ~12k accumulated ctx for DFlash2 (SPEC_N depth does NOT move it,
-#    n=3≡n=7) / ~17-21k for MTP; SEVERE on Ampere (~4 tok/s), milder on Blackwell. Drafter TYPE,
-#    not depth, sets the floor. Interim: MTP tier (higher cliff) or SPEC_N=0 for sustained >~20k.
-#    Real fix pending upstream ReplaySSM (vllm#49887 GDN-spec / vllm#50172). NOT immune to this.
+# ⛔⛔ #1096 RETRACTED 2026-09-08 — THERE IS NO ACCUMULATED-CTX DECODE CLIFF. The collapse
+#    figures came from OUR harness, not the engine: bench-agentic set TTFT on the first
+#    `content` delta, so a thinking model's entire reasoning phase was charged to prefill and
+#    the decode window fell under its 5%-of-wall "degenerate" rule. Fixed in #1218. That rule
+#    flags whatever has slow prefill relative to decode, which is also why the pattern looked
+#    hardware-dependent (Blackwell prefills fast -> "clean"; Ampere -> "collapsed").
+#    Re-test, both arms, same v0.27.1 pin, cross-checked against vLLM's OWN histograms:
+#    MTP n=3 -> 110.2 tok/s @ 21,443 ctx; DFlash2 n=7 -> 159.4 @ 12,275. Decode FLAT across
+#    1.2K->35.3K, zero degenerate turns, zero preemptions. ⛔ Do NOT set SPEC_N=0 or prefer the
+#    MTP tier for long contexts on this basis — that advice was wrong and costs you the drafter.
+# ⚠️ What DOES survive: vllm#35387 — a real spec tax that scales with drafter DEPTH, not
+#    context (29K: no-spec 57.0 -> n=1 40.6 / n=2 36.0 / n=3 32.7 tok/s), profiled to the
+#    cudagraph downgrade FULL_AND_PIECEWISE -> PIECEWISE. A steady tax, not a cliff.
 #   Best for:  DFlash2 on the FAST envelope — full 262K + concurrency. (Immune to the #52873 acceptance-collapse, NOT the #1096 ctx cliff — see below.)
 # ---------------------------------------------------------------------------
 # SUPERFAST = the FAST tier (int4, fp8 KV, 262K) with MTP → DFlash2. vs fast/MTP:

--- a/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/dflash2.yml
@@ -20,11 +20,19 @@
 #              not the tier's). UNMEASURED here (community-validated).
 #   Genesis:   none
 #   Status:    🧪 Experimental
-# ⚠️ #1096 (accumulated-ctx decode cliff): in long multi-turn agentic, decode collapses to
-#    single-block emission — ~12k accumulated ctx for DFlash2 (SPEC_N depth does NOT move it,
-#    n=3≡n=7) / ~17-21k for MTP; SEVERE on Ampere (~4 tok/s), milder on Blackwell. Drafter TYPE,
-#    not depth, sets the floor. Interim: MTP tier (higher cliff) or SPEC_N=0 for sustained >~20k.
-#    Real fix pending upstream ReplaySSM (vllm#49887 GDN-spec / vllm#50172). NOT immune to this.
+# ⛔⛔ #1096 RETRACTED 2026-09-08 — THERE IS NO ACCUMULATED-CTX DECODE CLIFF. The collapse
+#    figures came from OUR harness, not the engine: bench-agentic set TTFT on the first
+#    `content` delta, so a thinking model's entire reasoning phase was charged to prefill and
+#    the decode window fell under its 5%-of-wall "degenerate" rule. Fixed in #1218. That rule
+#    flags whatever has slow prefill relative to decode, which is also why the pattern looked
+#    hardware-dependent (Blackwell prefills fast -> "clean"; Ampere -> "collapsed").
+#    Re-test, both arms, same v0.27.1 pin, cross-checked against vLLM's OWN histograms:
+#    MTP n=3 -> 110.2 tok/s @ 21,443 ctx; DFlash2 n=7 -> 159.4 @ 12,275. Decode FLAT across
+#    1.2K->35.3K, zero degenerate turns, zero preemptions. ⛔ Do NOT set SPEC_N=0 or prefer the
+#    MTP tier for long contexts on this basis — that advice was wrong and costs you the drafter.
+# ⚠️ What DOES survive: vllm#35387 — a real spec tax that scales with drafter DEPTH, not
+#    context (29K: no-spec 57.0 -> n=1 40.6 / n=2 36.0 / n=3 32.7 tok/s), profiled to the
+#    cudagraph downgrade FULL_AND_PIECEWISE -> PIECEWISE. A steady tax, not a cliff.
 #   Best for:  ⭐ ULTRAFAST decode at TP=4 (community-validated).
 # ---------------------------------------------------------------------------
 # ULTRAFAST tier — DFlash2 external drafter, 4-card. See dual-ultrafast

--- a/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
@@ -38,11 +38,19 @@
 #   Max ctx:   262144 — architectural ceiling, NOT measured on this checkpoint
 #   Genesis:   none
 #   Status:    🧪 Experimental
-# ⚠️ #1096 (accumulated-ctx decode cliff): in long multi-turn agentic, decode collapses to
-#    single-block emission — ~12k accumulated ctx for DFlash2 (SPEC_N depth does NOT move it,
-#    n=3≡n=7) / ~17-21k for MTP; SEVERE on Ampere (~4 tok/s), milder on Blackwell. Drafter TYPE,
-#    not depth, sets the floor. Interim: MTP tier (higher cliff) or SPEC_N=0 for sustained >~20k.
-#    Real fix pending upstream ReplaySSM (vllm#49887 GDN-spec / vllm#50172). NOT immune to this.
+# ⛔⛔ #1096 RETRACTED 2026-09-08 — THERE IS NO ACCUMULATED-CTX DECODE CLIFF. The collapse
+#    figures came from OUR harness, not the engine: bench-agentic set TTFT on the first
+#    `content` delta, so a thinking model's entire reasoning phase was charged to prefill and
+#    the decode window fell under its 5%-of-wall "degenerate" rule. Fixed in #1218. That rule
+#    flags whatever has slow prefill relative to decode, which is also why the pattern looked
+#    hardware-dependent (Blackwell prefills fast -> "clean"; Ampere -> "collapsed").
+#    Re-test, both arms, same v0.27.1 pin, cross-checked against vLLM's OWN histograms:
+#    MTP n=3 -> 110.2 tok/s @ 21,443 ctx; DFlash2 n=7 -> 159.4 @ 12,275. Decode FLAT across
+#    1.2K->35.3K, zero degenerate turns, zero preemptions. ⛔ Do NOT set SPEC_N=0 or prefer the
+#    MTP tier for long contexts on this basis — that advice was wrong and costs you the drafter.
+# ⚠️ What DOES survive: vllm#35387 — a real spec tax that scales with drafter DEPTH, not
+#    context (29K: no-spec 57.0 -> n=1 40.6 / n=2 36.0 / n=3 32.7 tok/s), profiled to the
+#    cudagraph downgrade FULL_AND_PIECEWISE -> PIECEWISE. A steady tax, not a cliff.
 #   Best for:  4-card INT4 — KV pool and concurrency headroom, not single-stream speed
 # ---------------------------------------------------------------------------
 # THE "FAST" TIER — the INT4 counterpart to the official-FP8 "max" tier.

--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/dflash2-fp8.yml
@@ -18,11 +18,19 @@
 #   Max ctx:   262144 (fp8 KV fits the full arch max).
 #   Genesis:   none
 #   Status:    🧪 Experimental
-# ⚠️ #1096 (accumulated-ctx decode cliff): in long multi-turn agentic, decode collapses to
-#    single-block emission — ~12k accumulated ctx for DFlash2 (SPEC_N depth does NOT move it,
-#    n=3≡n=7) / ~17-21k for MTP; SEVERE on Ampere (~4 tok/s), milder on Blackwell. Drafter TYPE,
-#    not depth, sets the floor. Interim: MTP tier (higher cliff) or SPEC_N=0 for sustained >~20k.
-#    Real fix pending upstream ReplaySSM (vllm#49887 GDN-spec / vllm#50172). NOT immune to this.
+# ⛔⛔ #1096 RETRACTED 2026-09-08 — THERE IS NO ACCUMULATED-CTX DECODE CLIFF. The collapse
+#    figures came from OUR harness, not the engine: bench-agentic set TTFT on the first
+#    `content` delta, so a thinking model's entire reasoning phase was charged to prefill and
+#    the decode window fell under its 5%-of-wall "degenerate" rule. Fixed in #1218. That rule
+#    flags whatever has slow prefill relative to decode, which is also why the pattern looked
+#    hardware-dependent (Blackwell prefills fast -> "clean"; Ampere -> "collapsed").
+#    Re-test, both arms, same v0.27.1 pin, cross-checked against vLLM's OWN histograms:
+#    MTP n=3 -> 110.2 tok/s @ 21,443 ctx; DFlash2 n=7 -> 159.4 @ 12,275. Decode FLAT across
+#    1.2K->35.3K, zero degenerate turns, zero preemptions. ⛔ Do NOT set SPEC_N=0 or prefer the
+#    MTP tier for long contexts on this basis — that advice was wrong and costs you the drafter.
+# ⚠️ What DOES survive: vllm#35387 — a real spec tax that scales with drafter DEPTH, not
+#    context (29K: no-spec 57.0 -> n=1 40.6 / n=2 36.0 / n=3 32.7 tok/s), profiled to the
+#    cudagraph downgrade FULL_AND_PIECEWISE -> PIECEWISE. A steady tax, not a cliff.
 #   Best for:  DFlash2 on the MAX/fidelity envelope — full 262K + concurrency.
 # ---------------------------------------------------------------------------
 # SUPERMAX = the MAX tier (official FP8, fp8 KV, 262K) with MTP → DFlash2. Immune to the #52873

--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/dflash2.yml
@@ -16,11 +16,19 @@
 #   Max ctx:   131072 → higher at TP≥4 as weights split (MEASURED; community-validated).
 #   Genesis:   none
 #   Status:    🧪 Experimental
-# ⚠️ #1096 (accumulated-ctx decode cliff): in long multi-turn agentic, decode collapses to
-#    single-block emission — ~12k accumulated ctx for DFlash2 (SPEC_N depth does NOT move it,
-#    n=3≡n=7) / ~17-21k for MTP; SEVERE on Ampere (~4 tok/s), milder on Blackwell. Drafter TYPE,
-#    not depth, sets the floor. Interim: MTP tier (higher cliff) or SPEC_N=0 for sustained >~20k.
-#    Real fix pending upstream ReplaySSM (vllm#49887 GDN-spec / vllm#50172). NOT immune to this.
+# ⛔⛔ #1096 RETRACTED 2026-09-08 — THERE IS NO ACCUMULATED-CTX DECODE CLIFF. The collapse
+#    figures came from OUR harness, not the engine: bench-agentic set TTFT on the first
+#    `content` delta, so a thinking model's entire reasoning phase was charged to prefill and
+#    the decode window fell under its 5%-of-wall "degenerate" rule. Fixed in #1218. That rule
+#    flags whatever has slow prefill relative to decode, which is also why the pattern looked
+#    hardware-dependent (Blackwell prefills fast -> "clean"; Ampere -> "collapsed").
+#    Re-test, both arms, same v0.27.1 pin, cross-checked against vLLM's OWN histograms:
+#    MTP n=3 -> 110.2 tok/s @ 21,443 ctx; DFlash2 n=7 -> 159.4 @ 12,275. Decode FLAT across
+#    1.2K->35.3K, zero degenerate turns, zero preemptions. ⛔ Do NOT set SPEC_N=0 or prefer the
+#    MTP tier for long contexts on this basis — that advice was wrong and costs you the drafter.
+# ⚠️ What DOES survive: vllm#35387 — a real spec tax that scales with drafter DEPTH, not
+#    context (29K: no-spec 57.0 -> n=1 40.6 / n=2 36.0 / n=3 32.7 tok/s), profiled to the
+#    cudagraph downgrade FULL_AND_PIECEWISE -> PIECEWISE. A steady tax, not a cliff.
 #   Best for:  MAX decode on the fidelity weights — FA2 fast path (sacrifices ctx).
 # ---------------------------------------------------------------------------
 # ULTRAMAX = the MAX tier (official FP8) with DFlash2 on the bf16/FLASH_ATTN fast

--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
@@ -45,11 +45,19 @@
 #              measured on this model at ANY topology.
 #   Genesis:   none — intentionally Genesis-free
 #   Status:    🧪 Experimental
-# ⚠️ #1096 (accumulated-ctx decode cliff): in long multi-turn agentic, decode collapses to
-#    single-block emission — ~12k accumulated ctx for DFlash2 (SPEC_N depth does NOT move it,
-#    n=3≡n=7) / ~17-21k for MTP; SEVERE on Ampere (~4 tok/s), milder on Blackwell. Drafter TYPE,
-#    not depth, sets the floor. Interim: MTP tier (higher cliff) or SPEC_N=0 for sustained >~20k.
-#    Real fix pending upstream ReplaySSM (vllm#49887 GDN-spec / vllm#50172). NOT immune to this.
+# ⛔⛔ #1096 RETRACTED 2026-09-08 — THERE IS NO ACCUMULATED-CTX DECODE CLIFF. The collapse
+#    figures came from OUR harness, not the engine: bench-agentic set TTFT on the first
+#    `content` delta, so a thinking model's entire reasoning phase was charged to prefill and
+#    the decode window fell under its 5%-of-wall "degenerate" rule. Fixed in #1218. That rule
+#    flags whatever has slow prefill relative to decode, which is also why the pattern looked
+#    hardware-dependent (Blackwell prefills fast -> "clean"; Ampere -> "collapsed").
+#    Re-test, both arms, same v0.27.1 pin, cross-checked against vLLM's OWN histograms:
+#    MTP n=3 -> 110.2 tok/s @ 21,443 ctx; DFlash2 n=7 -> 159.4 @ 12,275. Decode FLAT across
+#    1.2K->35.3K, zero degenerate turns, zero preemptions. ⛔ Do NOT set SPEC_N=0 or prefer the
+#    MTP tier for long contexts on this basis — that advice was wrong and costs you the drafter.
+# ⚠️ What DOES survive: vllm#35387 — a real spec tax that scales with drafter DEPTH, not
+#    context (29K: no-spec 57.0 -> n=1 40.6 / n=2 36.0 / n=3 32.7 tok/s), profiled to the
+#    cudagraph downgrade FULL_AND_PIECEWISE -> PIECEWISE. A steady tax, not a cliff.
 #   Caveats:   TWO independent reasons, and neither is a TODO that this rig can close.
 #              (1) NOTHING HAS BOOTED, on any card count. Authored 2026-08-14; the
 #                  weights have since landed and verified (30.87 GB / 28.75 GiB,

--- a/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/dflash2-fp8.yml
@@ -14,11 +14,19 @@
 #              ultrafast/bf16 tier this fits the full 262K).
 #   Genesis:   none
 #   Status:    🧪 Experimental
-# ⚠️ #1096 (accumulated-ctx decode cliff): in long multi-turn agentic, decode collapses to
-#    single-block emission — ~12k accumulated ctx for DFlash2 (SPEC_N depth does NOT move it,
-#    n=3≡n=7) / ~17-21k for MTP; SEVERE on Ampere (~4 tok/s), milder on Blackwell. Drafter TYPE,
-#    not depth, sets the floor. Interim: MTP tier (higher cliff) or SPEC_N=0 for sustained >~20k.
-#    Real fix pending upstream ReplaySSM (vllm#49887 GDN-spec / vllm#50172). NOT immune to this.
+# ⛔⛔ #1096 RETRACTED 2026-09-08 — THERE IS NO ACCUMULATED-CTX DECODE CLIFF. The collapse
+#    figures came from OUR harness, not the engine: bench-agentic set TTFT on the first
+#    `content` delta, so a thinking model's entire reasoning phase was charged to prefill and
+#    the decode window fell under its 5%-of-wall "degenerate" rule. Fixed in #1218. That rule
+#    flags whatever has slow prefill relative to decode, which is also why the pattern looked
+#    hardware-dependent (Blackwell prefills fast -> "clean"; Ampere -> "collapsed").
+#    Re-test, both arms, same v0.27.1 pin, cross-checked against vLLM's OWN histograms:
+#    MTP n=3 -> 110.2 tok/s @ 21,443 ctx; DFlash2 n=7 -> 159.4 @ 12,275. Decode FLAT across
+#    1.2K->35.3K, zero degenerate turns, zero preemptions. ⛔ Do NOT set SPEC_N=0 or prefer the
+#    MTP tier for long contexts on this basis — that advice was wrong and costs you the drafter.
+# ⚠️ What DOES survive: vllm#35387 — a real spec tax that scales with drafter DEPTH, not
+#    context (29K: no-spec 57.0 -> n=1 40.6 / n=2 36.0 / n=3 32.7 tok/s), profiled to the
+#    cudagraph downgrade FULL_AND_PIECEWISE -> PIECEWISE. A steady tax, not a cliff.
 #   Best for:  DFlash2 on the FAST envelope — full 262K + concurrency. (Immune to the #52873 acceptance-collapse, NOT the #1096 ctx cliff — see below.)
 # ---------------------------------------------------------------------------
 # SUPERFAST = the FAST tier (int4, fp8 KV, 262K) with MTP → DFlash2. vs fast/MTP:

--- a/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/dflash2.yml
@@ -21,11 +21,19 @@
 #              not the tier's). UNMEASURED here (community-validated).
 #   Genesis:   none
 #   Status:    🧪 Experimental
-# ⚠️ #1096 (accumulated-ctx decode cliff): in long multi-turn agentic, decode collapses to
-#    single-block emission — ~12k accumulated ctx for DFlash2 (SPEC_N depth does NOT move it,
-#    n=3≡n=7) / ~17-21k for MTP; SEVERE on Ampere (~4 tok/s), milder on Blackwell. Drafter TYPE,
-#    not depth, sets the floor. Interim: MTP tier (higher cliff) or SPEC_N=0 for sustained >~20k.
-#    Real fix pending upstream ReplaySSM (vllm#49887 GDN-spec / vllm#50172). NOT immune to this.
+# ⛔⛔ #1096 RETRACTED 2026-09-08 — THERE IS NO ACCUMULATED-CTX DECODE CLIFF. The collapse
+#    figures came from OUR harness, not the engine: bench-agentic set TTFT on the first
+#    `content` delta, so a thinking model's entire reasoning phase was charged to prefill and
+#    the decode window fell under its 5%-of-wall "degenerate" rule. Fixed in #1218. That rule
+#    flags whatever has slow prefill relative to decode, which is also why the pattern looked
+#    hardware-dependent (Blackwell prefills fast -> "clean"; Ampere -> "collapsed").
+#    Re-test, both arms, same v0.27.1 pin, cross-checked against vLLM's OWN histograms:
+#    MTP n=3 -> 110.2 tok/s @ 21,443 ctx; DFlash2 n=7 -> 159.4 @ 12,275. Decode FLAT across
+#    1.2K->35.3K, zero degenerate turns, zero preemptions. ⛔ Do NOT set SPEC_N=0 or prefer the
+#    MTP tier for long contexts on this basis — that advice was wrong and costs you the drafter.
+# ⚠️ What DOES survive: vllm#35387 — a real spec tax that scales with drafter DEPTH, not
+#    context (29K: no-spec 57.0 -> n=1 40.6 / n=2 36.0 / n=3 32.7 tok/s), profiled to the
+#    cudagraph downgrade FULL_AND_PIECEWISE -> PIECEWISE. A steady tax, not a cliff.
 #   Best for:  ⭐ ULTRAFAST decode at TP=8 (community-validated).
 # ---------------------------------------------------------------------------
 # ULTRAFAST tier — DFlash2 external drafter, 8-card. See dual-ultrafast

--- a/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
@@ -38,11 +38,19 @@
 #   Max ctx:   262144 — architectural ceiling, NOT measured on this checkpoint
 #   Genesis:   none
 #   Status:    🧪 Experimental
-# ⚠️ #1096 (accumulated-ctx decode cliff): in long multi-turn agentic, decode collapses to
-#    single-block emission — ~12k accumulated ctx for DFlash2 (SPEC_N depth does NOT move it,
-#    n=3≡n=7) / ~17-21k for MTP; SEVERE on Ampere (~4 tok/s), milder on Blackwell. Drafter TYPE,
-#    not depth, sets the floor. Interim: MTP tier (higher cliff) or SPEC_N=0 for sustained >~20k.
-#    Real fix pending upstream ReplaySSM (vllm#49887 GDN-spec / vllm#50172). NOT immune to this.
+# ⛔⛔ #1096 RETRACTED 2026-09-08 — THERE IS NO ACCUMULATED-CTX DECODE CLIFF. The collapse
+#    figures came from OUR harness, not the engine: bench-agentic set TTFT on the first
+#    `content` delta, so a thinking model's entire reasoning phase was charged to prefill and
+#    the decode window fell under its 5%-of-wall "degenerate" rule. Fixed in #1218. That rule
+#    flags whatever has slow prefill relative to decode, which is also why the pattern looked
+#    hardware-dependent (Blackwell prefills fast -> "clean"; Ampere -> "collapsed").
+#    Re-test, both arms, same v0.27.1 pin, cross-checked against vLLM's OWN histograms:
+#    MTP n=3 -> 110.2 tok/s @ 21,443 ctx; DFlash2 n=7 -> 159.4 @ 12,275. Decode FLAT across
+#    1.2K->35.3K, zero degenerate turns, zero preemptions. ⛔ Do NOT set SPEC_N=0 or prefer the
+#    MTP tier for long contexts on this basis — that advice was wrong and costs you the drafter.
+# ⚠️ What DOES survive: vllm#35387 — a real spec tax that scales with drafter DEPTH, not
+#    context (29K: no-spec 57.0 -> n=1 40.6 / n=2 36.0 / n=3 32.7 tok/s), profiled to the
+#    cudagraph downgrade FULL_AND_PIECEWISE -> PIECEWISE. A steady tax, not a cliff.
 #   Best for:  8-card INT4 — maximum weight headroom; expect flat decode vs TP=4
 # ---------------------------------------------------------------------------
 # THE "FAST" TIER — the INT4 counterpart to the official-FP8 "max" tier.

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/dflash2-fp8.yml
@@ -18,11 +18,19 @@
 #   Max ctx:   262144 (fp8 KV fits the full arch max).
 #   Genesis:   none
 #   Status:    🧪 Experimental
-# ⚠️ #1096 (accumulated-ctx decode cliff): in long multi-turn agentic, decode collapses to
-#    single-block emission — ~12k accumulated ctx for DFlash2 (SPEC_N depth does NOT move it,
-#    n=3≡n=7) / ~17-21k for MTP; SEVERE on Ampere (~4 tok/s), milder on Blackwell. Drafter TYPE,
-#    not depth, sets the floor. Interim: MTP tier (higher cliff) or SPEC_N=0 for sustained >~20k.
-#    Real fix pending upstream ReplaySSM (vllm#49887 GDN-spec / vllm#50172). NOT immune to this.
+# ⛔⛔ #1096 RETRACTED 2026-09-08 — THERE IS NO ACCUMULATED-CTX DECODE CLIFF. The collapse
+#    figures came from OUR harness, not the engine: bench-agentic set TTFT on the first
+#    `content` delta, so a thinking model's entire reasoning phase was charged to prefill and
+#    the decode window fell under its 5%-of-wall "degenerate" rule. Fixed in #1218. That rule
+#    flags whatever has slow prefill relative to decode, which is also why the pattern looked
+#    hardware-dependent (Blackwell prefills fast -> "clean"; Ampere -> "collapsed").
+#    Re-test, both arms, same v0.27.1 pin, cross-checked against vLLM's OWN histograms:
+#    MTP n=3 -> 110.2 tok/s @ 21,443 ctx; DFlash2 n=7 -> 159.4 @ 12,275. Decode FLAT across
+#    1.2K->35.3K, zero degenerate turns, zero preemptions. ⛔ Do NOT set SPEC_N=0 or prefer the
+#    MTP tier for long contexts on this basis — that advice was wrong and costs you the drafter.
+# ⚠️ What DOES survive: vllm#35387 — a real spec tax that scales with drafter DEPTH, not
+#    context (29K: no-spec 57.0 -> n=1 40.6 / n=2 36.0 / n=3 32.7 tok/s), profiled to the
+#    cudagraph downgrade FULL_AND_PIECEWISE -> PIECEWISE. A steady tax, not a cliff.
 #   Best for:  DFlash2 on the MAX/fidelity envelope — full 262K + concurrency.
 # ---------------------------------------------------------------------------
 # SUPERMAX = the MAX tier (official FP8, fp8 KV, 262K) with MTP → DFlash2. Immune to the #52873

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/dflash2.yml
@@ -16,11 +16,19 @@
 #   Max ctx:   131072 → higher at TP≥4 as weights split (MEASURED; community-validated).
 #   Genesis:   none
 #   Status:    🧪 Experimental
-# ⚠️ #1096 (accumulated-ctx decode cliff): in long multi-turn agentic, decode collapses to
-#    single-block emission — ~12k accumulated ctx for DFlash2 (SPEC_N depth does NOT move it,
-#    n=3≡n=7) / ~17-21k for MTP; SEVERE on Ampere (~4 tok/s), milder on Blackwell. Drafter TYPE,
-#    not depth, sets the floor. Interim: MTP tier (higher cliff) or SPEC_N=0 for sustained >~20k.
-#    Real fix pending upstream ReplaySSM (vllm#49887 GDN-spec / vllm#50172). NOT immune to this.
+# ⛔⛔ #1096 RETRACTED 2026-09-08 — THERE IS NO ACCUMULATED-CTX DECODE CLIFF. The collapse
+#    figures came from OUR harness, not the engine: bench-agentic set TTFT on the first
+#    `content` delta, so a thinking model's entire reasoning phase was charged to prefill and
+#    the decode window fell under its 5%-of-wall "degenerate" rule. Fixed in #1218. That rule
+#    flags whatever has slow prefill relative to decode, which is also why the pattern looked
+#    hardware-dependent (Blackwell prefills fast -> "clean"; Ampere -> "collapsed").
+#    Re-test, both arms, same v0.27.1 pin, cross-checked against vLLM's OWN histograms:
+#    MTP n=3 -> 110.2 tok/s @ 21,443 ctx; DFlash2 n=7 -> 159.4 @ 12,275. Decode FLAT across
+#    1.2K->35.3K, zero degenerate turns, zero preemptions. ⛔ Do NOT set SPEC_N=0 or prefer the
+#    MTP tier for long contexts on this basis — that advice was wrong and costs you the drafter.
+# ⚠️ What DOES survive: vllm#35387 — a real spec tax that scales with drafter DEPTH, not
+#    context (29K: no-spec 57.0 -> n=1 40.6 / n=2 36.0 / n=3 32.7 tok/s), profiled to the
+#    cudagraph downgrade FULL_AND_PIECEWISE -> PIECEWISE. A steady tax, not a cliff.
 #   Best for:  MAX decode on the fidelity weights — FA2 fast path (sacrifices ctx).
 # ---------------------------------------------------------------------------
 # ULTRAMAX = the MAX tier (official FP8) with DFlash2 on the bf16/FLASH_ATTN fast

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
@@ -47,11 +47,19 @@
 #              measured on this model at ANY topology.
 #   Genesis:   none — intentionally Genesis-free
 #   Status:    🧪 Experimental
-# ⚠️ #1096 (accumulated-ctx decode cliff): in long multi-turn agentic, decode collapses to
-#    single-block emission — ~12k accumulated ctx for DFlash2 (SPEC_N depth does NOT move it,
-#    n=3≡n=7) / ~17-21k for MTP; SEVERE on Ampere (~4 tok/s), milder on Blackwell. Drafter TYPE,
-#    not depth, sets the floor. Interim: MTP tier (higher cliff) or SPEC_N=0 for sustained >~20k.
-#    Real fix pending upstream ReplaySSM (vllm#49887 GDN-spec / vllm#50172). NOT immune to this.
+# ⛔⛔ #1096 RETRACTED 2026-09-08 — THERE IS NO ACCUMULATED-CTX DECODE CLIFF. The collapse
+#    figures came from OUR harness, not the engine: bench-agentic set TTFT on the first
+#    `content` delta, so a thinking model's entire reasoning phase was charged to prefill and
+#    the decode window fell under its 5%-of-wall "degenerate" rule. Fixed in #1218. That rule
+#    flags whatever has slow prefill relative to decode, which is also why the pattern looked
+#    hardware-dependent (Blackwell prefills fast -> "clean"; Ampere -> "collapsed").
+#    Re-test, both arms, same v0.27.1 pin, cross-checked against vLLM's OWN histograms:
+#    MTP n=3 -> 110.2 tok/s @ 21,443 ctx; DFlash2 n=7 -> 159.4 @ 12,275. Decode FLAT across
+#    1.2K->35.3K, zero degenerate turns, zero preemptions. ⛔ Do NOT set SPEC_N=0 or prefer the
+#    MTP tier for long contexts on this basis — that advice was wrong and costs you the drafter.
+# ⚠️ What DOES survive: vllm#35387 — a real spec tax that scales with drafter DEPTH, not
+#    context (29K: no-spec 57.0 -> n=1 40.6 / n=2 36.0 / n=3 32.7 tok/s), profiled to the
+#    cudagraph downgrade FULL_AND_PIECEWISE -> PIECEWISE. A steady tax, not a cliff.
 #   Caveats:   TWO independent reasons, and neither is a TODO that this rig can close.
 #              (1) NOTHING HAS BOOTED, on any card count. Authored 2026-08-14; the
 #                  weights have since landed and verified (30.87 GB / 28.75 GiB,

--- a/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
@@ -31,11 +31,19 @@
 #   Max ctx:   65536 — NOT the architectural ceiling; see the VRAM note
 #   Genesis:   none
 #   Status:    🧪 Experimental
-# ⚠️ #1096 (accumulated-ctx decode cliff): in long multi-turn agentic, decode collapses to
-#    single-block emission — ~12k accumulated ctx for DFlash2 (SPEC_N depth does NOT move it,
-#    n=3≡n=7) / ~17-21k for MTP; SEVERE on Ampere (~4 tok/s), milder on Blackwell. Drafter TYPE,
-#    not depth, sets the floor. Interim: MTP tier (higher cliff) or SPEC_N=0 for sustained >~20k.
-#    Real fix pending upstream ReplaySSM (vllm#49887 GDN-spec / vllm#50172). NOT immune to this.
+# ⛔⛔ #1096 RETRACTED 2026-09-08 — THERE IS NO ACCUMULATED-CTX DECODE CLIFF. The collapse
+#    figures came from OUR harness, not the engine: bench-agentic set TTFT on the first
+#    `content` delta, so a thinking model's entire reasoning phase was charged to prefill and
+#    the decode window fell under its 5%-of-wall "degenerate" rule. Fixed in #1218. That rule
+#    flags whatever has slow prefill relative to decode, which is also why the pattern looked
+#    hardware-dependent (Blackwell prefills fast -> "clean"; Ampere -> "collapsed").
+#    Re-test, both arms, same v0.27.1 pin, cross-checked against vLLM's OWN histograms:
+#    MTP n=3 -> 110.2 tok/s @ 21,443 ctx; DFlash2 n=7 -> 159.4 @ 12,275. Decode FLAT across
+#    1.2K->35.3K, zero degenerate turns, zero preemptions. ⛔ Do NOT set SPEC_N=0 or prefer the
+#    MTP tier for long contexts on this basis — that advice was wrong and costs you the drafter.
+# ⚠️ What DOES survive: vllm#35387 — a real spec tax that scales with drafter DEPTH, not
+#    context (29K: no-spec 57.0 -> n=1 40.6 / n=2 36.0 / n=3 32.7 tok/s), profiled to the
+#    cudagraph downgrade FULL_AND_PIECEWISE -> PIECEWISE. A steady tax, not a cliff.
 #   Caveats:   NEVER BOOTED — and NOT bootable on the reference rig (24 GB < the
 #              32 GB floor below). The sibling dual-nvfp4 slug boots and passes
 #              verify-full 9/9, which validates everything the two SHARE (weight


### PR DESCRIPTION
The header block asserting an **"accumulated-ctx decode cliff"** was retracted on 2026-09-08 — but only in `learnings/`. It survived verbatim in **all 20** qwen3.8-27b vLLM composes, which is where operators actually read it.

## There was never a cliff

`bench-agentic` set TTFT on the first **`content`** delta. Every model in that matrix is a *thinking* model, so the server streams `reasoning_content` deltas first — the entire reasoning phase was charged to prefill, the decode window collapsed below the harness's own 5%-of-wall "degenerate" threshold, and it printed `single-block emission … wall 2.0 tok/s`. Fixed in #1218.

Measured live at ~21K ctx while the old harness was calling it collapsed:

| | |
|---|---|
| first **reasoning** delta | 28.64 s — 278 deltas, streaming normally |
| first **content** delta | 34.69 s |
| last delta | 35.95 s |
| old TTFT / window | 34.69 s / **1.25 s = 3.5% of wall → FLAGGED** |
| true window | **7.31 s = 20% → fine** |

That rule flags whatever has *slow prefill relative to decode*, which also explains the "hardware severity split" the block reported: Blackwell prefills fast → large ratio → "clean"; Ampere + CPU offload → prefill-dominated wall → "collapsed". A denominator effect, not a hardware property.

## Corrected re-test

Both arms, same v0.27.1 pin, cross-checked against vLLM's **own** histograms (`vllm:request_generation_tokens_sum` / `vllm:request_decode_time_seconds_sum` — recorded in-engine, immune to parser cost or SSE coalescing):

| slug | recorded threshold | client | engine |
|---|---|---|---|
| `qwen38-27b-dual-max` (MTP n=3) | collapse ~21k → 1.5–6 tok/s | **110.2 @ 21,443** | 109.2 |
| `qwen38-27b-dual-supermax` (DFlash2 n=7) | collapse ~12k → 4–6 tok/s | **159.4 @ 12,275** | 154.1 |

Decode **flat** across 1.2K → 35.3K on both arms, zero degenerate turns, zero preemptions, two instruments agreeing within 1–2%.

## Why this is more than tidying

The block told operators:

> Interim: MTP tier (higher cliff) or **SPEC_N=0** for sustained >~20k

That is advice to **throw away the drafter** to dodge a problem that does not exist — on the tier whose entire purpose is the drafter.

## What survives is kept, not deleted

vllm#35387 is a **real** spec tax that scales with drafter **depth**, not context (29K: no-spec 57.0 → n=1 40.6 / n=2 36.0 / n=3 32.7 tok/s), profiled to the cudagraph downgrade `FULL_AND_PIECEWISE → PIECEWISE`. The replacement text carries it, framed as a steady tax rather than a cliff.

Full guard suite green: **150 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
