### PR TITLE
fix(quality-test): survive pipx two-token shebangs under set -e

### DIFF
--- a/scripts/quality-test.sh
+++ b/scripts/quality-test.sh
@@ -766,14 +766,16 @@ if { [[ -z "$PACK" ]] && { [[ "$MODE" == "--full" && "$NO_SANDBOX" != "1" ]] || 
     # WITHOUT rewriting the console script, so the script mtime under-reports
     # "CLI last updated". Take max(script mtime, checkout last-commit time).
     if [[ -n "$_bl_bin" ]]; then
-      _bl_py="$(head -1 "$_bl_bin" 2>/dev/null | sed 's/^#!//')"
+      # Take only the interpreter path: pipx writes a two-token shebang
+      # (`#!/.../python -E`), and keeping the flag makes the -x test below fail.
+      _bl_py="$(head -1 "$_bl_bin" 2>/dev/null | sed 's/^#!//' | awk '{print $1}')"
       _bl_src_dir="$([[ -x "$_bl_py" ]] && "$_bl_py" -c 'import importlib.metadata as m, json
 try:
     d = json.loads(m.distribution("benchlocal-cli").read_text("direct_url.json") or "{}")
     u = d.get("url", "")
     print(u[7:] if (d.get("dir_info") or {}).get("editable") and u.startswith("file://") else "")
 except Exception:
-    pass' 2>/dev/null)"
+    pass' 2>/dev/null || true)"
       if [[ -n "$_bl_src_dir" && -d "$_bl_src_dir" ]]; then
         _bl_commit_ts="$(git -C "$_bl_src_dir" log -1 --format=%ct 2>/dev/null || echo 0)"
         [[ "$_bl_commit_ts" -gt "$_bl_mtime" ]] && _bl_mtime="$_bl_commit_ts"


### PR DESCRIPTION
`scripts/quality-test.sh` aborts silently on a pipx-installed `benchlocal-cli`, before any pack runs, with no error message.

The provenance block reads the console script shebang to locate its interpreter:

```bash
_bl_py="$(head -1 "$_bl_bin" 2>/dev/null | sed 's/^#!//')"
_bl_src_dir="$([[ -x "$_bl_py" ]] && "$_bl_py" -c '...' 2>/dev/null)"
```

pipx writes a two-token shebang and `sed` strips only the `#!`:

```
#!/home/ai/.local/share/pipx/venvs/benchlocal-cli/bin/python -E
```

so `_bl_py` becomes `/…/python -E`, `[[ -x ]]` is false, the command substitution inherits status 1, and `set -e` kills the script. Reproduced on this rig with master's exact snippet:

```
$ bash /tmp/repro.sh; echo "exit=$?"
exit=1          # the echo after the assignment never runs
```

It reads as "the run just did nothing", which cost me a while to track down while getting the sandboxed packs going on a 4x 3090 box.

This takes the first shebang token so the interpreter actually resolves, and adds `|| true` so an unusual install layout degrades to "no editable checkout detected" instead of ending the run. Verified on the same rig: `bash -n` clean, the snippet now reaches the following line, and `quality-test.sh` runs to completion.

Both halves are wanted. The `awk` alone fixes pipx; the `|| true` keeps any other odd layout from being fatal, since this block is provenance metadata rather than something a run depends on.
