### PR TITLE
fix(residency): charge a single-card drafter to that card only (#1233)

### DIFF
--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q2k/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q2k/offload.yml
@@ -218,6 +218,12 @@
 #   per-card terms (compute ~5300, unacc ~900) held constant.
 #   ⚠️ DERIVED, NOT MEASURED, for multi4/multi8 -- this rig has 2 GPUs.
 # CPU-Offload-Draft-Reserve-MiB: 2342
+# CPU-Offload-Draft-Card: 1
+#   The drafter is pinned to CUDA1 by `-devd CUDA1`, so ONLY card 1 pays the
+#   2,342 MiB above. Without this, the resolver charged it to EVERY card and
+#   card 0 came back a bundle short -- ~4.9 GiB of host RAM left on the floor
+#   on a 2-card rig (club-3090#1233). Unset = charge every card (the old
+#   behaviour, still the default for every compose that omits it).
 #   MEASURED on CUDA1 2026-09-06: 655.73 weights + 80.00 KV + 1606.48 compute.
 #   Its own term because the drafter loads AFTER the resolver reads FREE VRAM.
 #   ⤷ ALL-on-CPU worst case. Grounded: this quant is 106.5 GiB of weights (102.62 GiB

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q3km/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q3km/offload.yml
@@ -216,6 +216,12 @@
 #   per-card terms (compute ~5300, unacc ~900) held constant.
 #   ⚠️ DERIVED, NOT MEASURED, for multi4/multi8 -- this rig has 2 GPUs.
 # CPU-Offload-Draft-Reserve-MiB: 2342
+# CPU-Offload-Draft-Card: 1
+#   The drafter is pinned to CUDA1 by `-devd CUDA1`, so ONLY card 1 pays the
+#   2,342 MiB above. Without this, the resolver charged it to EVERY card and
+#   card 0 came back a bundle short -- ~4.9 GiB of host RAM left on the floor
+#   on a 2-card rig (club-3090#1233). Unset = charge every card (the old
+#   behaviour, still the default for every compose that omits it).
 #   MEASURED on CUDA1 2026-09-06: 655.73 weights + 80.00 KV + 1606.48 compute.
 #   Its own term because the drafter loads AFTER the resolver reads FREE VRAM.
 #   ⤷ ALL-on-CPU worst case. Grounded: this quant is 139.2 GiB of weights (134.37 GiB

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q2k/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q2k/offload.yml
@@ -221,6 +221,12 @@
 #   per-card terms (compute ~5300, unacc ~900) held constant.
 #   ⚠️ DERIVED, NOT MEASURED, for multi4/multi8 -- this rig has 2 GPUs.
 # CPU-Offload-Draft-Reserve-MiB: 2342
+# CPU-Offload-Draft-Card: 1
+#   The drafter is pinned to CUDA1 by `-devd CUDA1`, so ONLY card 1 pays the
+#   2,342 MiB above. Without this, the resolver charged it to EVERY card and
+#   card 0 came back a bundle short -- ~4.9 GiB of host RAM left on the floor
+#   on a 2-card rig (club-3090#1233). Unset = charge every card (the old
+#   behaviour, still the default for every compose that omits it).
 #   MEASURED on CUDA1 2026-09-06: 655.73 weights + 80.00 KV + 1606.48 compute.
 #   Its own term because the drafter loads AFTER the resolver reads FREE VRAM.
 #   ⤷ ALL-on-CPU worst case. Grounded: this quant is 106.5 GiB of weights (102.62 GiB

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q3km/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q3km/offload.yml
@@ -217,6 +217,12 @@
 #   per-card terms (compute ~5300, unacc ~900) held constant.
 #   ⚠️ DERIVED, NOT MEASURED, for multi4/multi8 -- this rig has 2 GPUs.
 # CPU-Offload-Draft-Reserve-MiB: 2342
+# CPU-Offload-Draft-Card: 1
+#   The drafter is pinned to CUDA1 by `-devd CUDA1`, so ONLY card 1 pays the
+#   2,342 MiB above. Without this, the resolver charged it to EVERY card and
+#   card 0 came back a bundle short -- ~4.9 GiB of host RAM left on the floor
+#   on a 2-card rig (club-3090#1233). Unset = charge every card (the old
+#   behaviour, still the default for every compose that omits it).
 #   MEASURED on CUDA1 2026-09-06: 655.73 weights + 80.00 KV + 1606.48 compute.
 #   Its own term because the drafter loads AFTER the resolver reads FREE VRAM.
 #   ⤷ ALL-on-CPU worst case. Grounded: this quant is 139.2 GiB of weights (134.37 GiB

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q2k/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q2k/offload.yml
@@ -221,6 +221,12 @@
 #   per-card terms (compute ~5300, unacc ~900) held constant.
 #   ⚠️ DERIVED, NOT MEASURED, for multi4/multi8 -- this rig has 2 GPUs.
 # CPU-Offload-Draft-Reserve-MiB: 2342
+# CPU-Offload-Draft-Card: 1
+#   The drafter is pinned to CUDA1 by `-devd CUDA1`, so ONLY card 1 pays the
+#   2,342 MiB above. Without this, the resolver charged it to EVERY card and
+#   card 0 came back a bundle short -- ~4.9 GiB of host RAM left on the floor
+#   on a 2-card rig (club-3090#1233). Unset = charge every card (the old
+#   behaviour, still the default for every compose that omits it).
 #   MEASURED on CUDA1 2026-09-06: 655.73 weights + 80.00 KV + 1606.48 compute.
 #   Its own term because the drafter loads AFTER the resolver reads FREE VRAM.
 #   ⤷ ALL-on-CPU worst case. Grounded: this quant is 106.5 GiB of weights (102.62 GiB

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q3km/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q3km/offload.yml
@@ -217,6 +217,12 @@
 #   per-card terms (compute ~5300, unacc ~900) held constant.
 #   ⚠️ DERIVED, NOT MEASURED, for multi4/multi8 -- this rig has 2 GPUs.
 # CPU-Offload-Draft-Reserve-MiB: 2342
+# CPU-Offload-Draft-Card: 1
+#   The drafter is pinned to CUDA1 by `-devd CUDA1`, so ONLY card 1 pays the
+#   2,342 MiB above. Without this, the resolver charged it to EVERY card and
+#   card 0 came back a bundle short -- ~4.9 GiB of host RAM left on the floor
+#   on a 2-card rig (club-3090#1233). Unset = charge every card (the old
+#   behaviour, still the default for every compose that omits it).
 #   MEASURED on CUDA1 2026-09-06: 655.73 weights + 80.00 KV + 1606.48 compute.
 #   Its own term because the drafter loads AFTER the resolver reads FREE VRAM.
 #   ⤷ ALL-on-CPU worst case. Grounded: this quant is 139.2 GiB of weights (134.37 GiB

--- a/scripts/lib/compose-meta.sh
+++ b/scripts/lib/compose-meta.sh
@@ -531,6 +531,14 @@ resolve_offload_residency() {
   # compose that does not declare it. Overridable for A/B via RESIDENCY_DRAFT_MB.
   local draft; draft="$(compose_meta_get "$compose_file" cpu-offload-draft-reserve-mib || true)"
   [[ "$draft" =~ ^[0-9]+$ ]] || draft=0
+  # WHICH card actually pays it (#1233). A drafter pinned with `-devd CUDA<n>` costs
+  # VRAM on THAT card only, but `draft` used to be charged to every card -- so card 0
+  # was reserved for a cost it never incurred and came back a bundle short. Unset =>
+  # -1 => charge EVERY card, i.e. byte-for-byte today's behaviour for every compose
+  # that does not declare it (the #931 calibration points are untouched).
+  local draft_card; draft_card="$(compose_meta_get "$compose_file" cpu-offload-draft-card || true)"
+  [[ "$draft_card" =~ ^[0-9]+$ ]] || draft_card=-1
+  if [[ "${RESIDENCY_DRAFT_CARD:-}" =~ ^-?[0-9]+$ ]]; then draft_card="$RESIDENCY_DRAFT_CARD"; fi
   # ⚠️ plain `if`, NOT `[[ ]] && assign`: the latter returns non-zero when the
   # condition is false, and every caller runs under `set -e` — that aborts the
   # launcher mid-resolve. Same trap documented in preflight.sh.
@@ -545,7 +553,7 @@ resolve_offload_residency() {
   local per_card=$(( layers / n ))
   local i fit rule var applied="" res_i
   for (( i=0; i<n; i++ )); do
-    res_i=$(( reserve + draft + (i == 0 ? extra : 0) ))
+    res_i=$(( reserve + ( (draft_card < 0 || i == draft_card) ? draft : 0 ) + (i == 0 ? extra : 0) ))
     # An explicit OT_G<i> from the user/env ALWAYS WINS and is never clobbered —
     # same contract as THREADS (resolve_offload_threads). This is the supported
     # way to pin more residency than the sizer grants (the grant is deliberately
@@ -625,6 +633,14 @@ offload_residency_grant_mib() {
   # compose that does not declare it. Overridable for A/B via RESIDENCY_DRAFT_MB.
   local draft; draft="$(compose_meta_get "$compose_file" cpu-offload-draft-reserve-mib || true)"
   [[ "$draft" =~ ^[0-9]+$ ]] || draft=0
+  # WHICH card actually pays it (#1233). A drafter pinned with `-devd CUDA<n>` costs
+  # VRAM on THAT card only, but `draft` used to be charged to every card -- so card 0
+  # was reserved for a cost it never incurred and came back a bundle short. Unset =>
+  # -1 => charge EVERY card, i.e. byte-for-byte today's behaviour for every compose
+  # that does not declare it (the #931 calibration points are untouched).
+  local draft_card; draft_card="$(compose_meta_get "$compose_file" cpu-offload-draft-card || true)"
+  [[ "$draft_card" =~ ^[0-9]+$ ]] || draft_card=-1
+  if [[ "${RESIDENCY_DRAFT_CARD:-}" =~ ^-?[0-9]+$ ]]; then draft_card="$RESIDENCY_DRAFT_CARD"; fi
   # ⚠️ plain `if`, NOT `[[ ]] && assign`: the latter returns non-zero when the
   # condition is false, and every caller runs under `set -e` — that aborts the
   # launcher mid-resolve. Same trap documented in preflight.sh.
@@ -641,7 +657,7 @@ offload_residency_grant_mib() {
   local i fit rule total_mib=0 var ucount res_i
   local -a lays
   for (( i=0; i<n; i++ )); do
-    res_i=$(( reserve + draft + (i == 0 ? extra : 0) ))
+    res_i=$(( reserve + ( (draft_card < 0 || i == draft_card) ? draft : 0 ) + (i == 0 ? extra : 0) ))
     # A user-set OT_G<i> is what will ACTUALLY be pinned (the injector never
     # clobbers it) — price ITS layer count, not the auto fit, so the gate and
     # the boot describe the same config. First hit in the wild: a 123 GB box


### PR DESCRIPTION
Closes #1233.

## The bug

`resolve_offload_residency()` charged the drafter's VRAM to **every** card, but a compose that pins its drafter with `-devd CUDA<n>` only pays it on **one**. `compose-meta.sh` computed:

```bash
res_i=$(( reserve + draft + (i == 0 ? extra : 0) ))
```

`draft` → every card. `extra` → card 0 only. So the single per-card asymmetry the model could express was applied to card 0, while a `-devd CUDA1` compose needs it on card 1 — leaving card 0 reserved for a cost it never incurs *and* separately charged the `first_card_extra` premised on it carrying "the larger drafter half".

Measured on GLM-5.3-Flash static-offload, dual 2×3090, drafter on CUDA1 (`Draft-Reserve-MiB: 2342`):

| | card0 | card1 | host RSS |
|---|---|---|---|
| before | 17,064 MiB used — **7,512 FREE** | 22,448 / 2,128 | **90.7 GiB** |
| hand-tuned `OT_G0` | 22,048 / 2,528 | 22,412 / 2,164 | **85.9 GiB** |

**~4.9 GiB of host RAM on the floor**, on a tier whose entire purpose is lowering the host-RAM floor.

## The fix

A `CPU-Offload-Draft-Card: <n>` header. Unset resolves to `-1` = charge every card, so **every compose that omits it is byte-for-byte unchanged**:

```bash
res_i=$(( reserve + ( (draft_card < 0 || i == draft_card) ? draft : 0 ) + (i == 0 ? extra : 0) ))
```

Applied to **both** consumers — `resolve_offload_residency()` (which grants) and `offload_resident_mib()` (which the RAM gate uses to subtract resident bytes). They must agree or the gate mis-subtracts; the patch changes them identically. Overridable for A/B via `RESIDENCY_DRAFT_CARD`, mirroring the existing `RESIDENCY_DRAFT_MB`.

The six GLM static composes declare `Draft-Card: 1`.

## Verification

**No-op for everything that doesn't declare it** — patched resolver vs master's, same composes, on this rig:

```
MASTER   q8-kxl : card0: none (0 fit) · card1: auto 1 bundles (blk 42)
PATCHED  q8-kxl : card0: none (0 fit) · card1: auto 1 bundles (blk 42)
MASTER   iq2-xxs: card0: auto 3 bundles (blk 0|1|2) · card1: auto 3 bundles (blk 42|41|40)
PATCHED  iq2-xxs: card0: auto 3 bundles (blk 0|1|2) · card1: auto 3 bundles (blk 42|41|40)
```

Byte-identical, including the `IQ2-dual 3/card on 2×24 GB` figure the resolver's own doc lists as a calibration point that must keep reproducing.

**Effect where it is declared** — GLM q2k dual:

```
before: card0: auto 3 bundles (blk 3|4|5)   · card1: auto 4 bundles (blk 44|43|42|41)
after:  card0: auto 4 bundles (blk 3|4|5|6) · card1: auto 4 bundles (blk 44|43|42|41)
```

+1 bundle = +2,502 MiB resident = **~2.44 GiB of host RAM recovered**, with no hand-tuning.

⚠️ **This recovers one of the two bundles the `OT_G` override finds.** The model's fit is floor-conservative and grants card0 4; measurement showed 5 fits (card0 at 22,048 MiB used, 2,528 free). The override still buys the last bundle and the composes still document it — the fix means you no longer lose a *whole* bundle by default.

⚠️ **Scope:** only affects composes pinning a drafter to a specific card. The DeepSeek static tier uses `-devd none` (host drafter), where the per-card charge is symmetric and the old model was already correct — which is why those grants are unchanged above.

Full guard suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
