### PR TITLE
feat(qwen3.8): SGLang metrics + concurrency headroom, and an honest sampler contract across all three engines

### DIFF
--- a/models/qwen3.8-27b/llama-cpp/compose/dual/unsloth-q8kxl/q8kv.yml
+++ b/models/qwen3.8-27b/llama-cpp/compose/dual/unsloth-q8kxl/q8kv.yml
@@ -245,6 +245,29 @@ services:
     #   made exactly that inference and shipped `Drafter: none`. Only the tensor table is evidence.
     #   n=2 matches the qwen3.6-27b and deckard llama.cpp composes; UNMEASURED for this model.
     #   MTP_DRAFT_N_MAX=0 disables it; sweep it once there is a bench.
+    # ⭐ THIS IS THE ONLY ENGINE OF THE THREE THAT DELIVERS THE WHOLE CARD ROW.
+    # llama-server seeds every request from the CLI sampler params — server-task.cpp
+    # params_from_json_cmpl(): `defaults.sampling = params_base.sampling`, then each
+    # field is `json_value(data, "<key>", defaults.sampling.<field>)`, e.g.
+    # `json_value(data, "presence_penalty", defaults.sampling.penalty_present)`. No
+    # allowlist, no hard-coded request-side default — so presence_penalty 0.0/1.5 DOES
+    # land here. vLLM and SGLang both drop it: their get_diff_sampling_param() /
+    # get_default_sampling_params() allowlists carry no penalties, and both chat adapters
+    # declare presence_penalty with a hard 0.0 default that always wins, making it a
+    # client-side parameter there. (Read at llama.cpp 0d227ec; the pin is newer, b10236,
+    # but this path is longstanding.)
+    #
+    # ⚠️ THE INSTRUCT=1 / THINKING=1 FLIP RIDES ON A DEPRECATED SPELLING. It appends a
+    # second copy of the flags and lets the last one win. b10236 warns on exactly that:
+    #     DEPRECATED: argument '--temp' specified multiple times, use comma-separated
+    #     values instead (only last value will be used)
+    # Last-wins is CONFIRMED on the pin (the warning says so), so the flip is correct
+    # today, and a DEFAULT boot is clean — every sampler flag below appears exactly once
+    # (verified by rendering: default 1x each; INSTRUCT=1 duplicates 4; THINKING=1
+    # duplicates 4 with identical values). But "comma-separated" is multi-VALUE syntax:
+    # if repeats ever come to mean "append" instead of "replace", INSTRUCT=1 breaks
+    # silently. The fix is to resolve the row once in the entrypoint shell, the way this
+    # model's vLLM and SGLang composes do — that needs a boot to land safely.
     # ⚠️ Comments CANNOT live inside the `command: >-` folded scalar below — every line there is
     #   part of one command string, and a `#` line becomes literal argv text
     #   ('invalid command line string' at compose parse). Keep notes above this key.

--- a/models/qwen3.8-27b/llama-cpp/compose/single/unsloth-iq4xs/q4kv-vision.yml
+++ b/models/qwen3.8-27b/llama-cpp/compose/single/unsloth-iq4xs/q4kv-vision.yml
@@ -157,6 +157,29 @@ services:
     #   repeated flags — see the q8_0 sibling header for the full rationale and the
     #   deprecated-behaviour re-test trigger on pin bumps). THINKING=1 is now a back-compat
     #   no-op. bench.sh sends its own fixed canonical sampler regardless.
+    # ⭐ THIS IS THE ONLY ENGINE OF THE THREE THAT DELIVERS THE WHOLE CARD ROW.
+    # llama-server seeds every request from the CLI sampler params — server-task.cpp
+    # params_from_json_cmpl(): `defaults.sampling = params_base.sampling`, then each
+    # field is `json_value(data, "<key>", defaults.sampling.<field>)`, e.g.
+    # `json_value(data, "presence_penalty", defaults.sampling.penalty_present)`. No
+    # allowlist, no hard-coded request-side default — so presence_penalty 0.0/1.5 DOES
+    # land here. vLLM and SGLang both drop it: their get_diff_sampling_param() /
+    # get_default_sampling_params() allowlists carry no penalties, and both chat adapters
+    # declare presence_penalty with a hard 0.0 default that always wins, making it a
+    # client-side parameter there. (Read at llama.cpp 0d227ec; the pin is newer, b10236,
+    # but this path is longstanding.)
+    #
+    # ⚠️ THE INSTRUCT=1 / THINKING=1 FLIP RIDES ON A DEPRECATED SPELLING. It appends a
+    # second copy of the flags and lets the last one win. b10236 warns on exactly that:
+    #     DEPRECATED: argument '--temp' specified multiple times, use comma-separated
+    #     values instead (only last value will be used)
+    # Last-wins is CONFIRMED on the pin (the warning says so), so the flip is correct
+    # today, and a DEFAULT boot is clean — every sampler flag below appears exactly once
+    # (verified by rendering: default 1x each; INSTRUCT=1 duplicates 4; THINKING=1
+    # duplicates 4 with identical values). But "comma-separated" is multi-VALUE syntax:
+    # if repeats ever come to mean "append" instead of "replace", INSTRUCT=1 breaks
+    # silently. The fix is to resolve the row once in the entrypoint shell, the way this
+    # model's vLLM and SGLang composes do — that needs a boot to land safely.
     # ⚠️ Comments CANNOT live inside the `command: >-` folded scalar — keep notes above this key.
     # The image ENTRYPOINT is ["/app/llama-server"]; this wrapper adds the drafter toggle.
     entrypoint:

--- a/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2-bf16.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2-bf16.yml
@@ -185,6 +185,14 @@ services:
       - MAX_RUNNING_REQUESTS
       - MAMBA_SSM_DTYPE
       - W4A8
+      - ENABLE_THINKING
+      - TEMP
+      - TOP_P
+      - TOP_K
+      - MIN_P
+      - PRESENCE_PENALTY
+      - REPEAT_PENALTY
+      - REASONING_EFFORT
       - CHUNKED_PREFILL_SIZE
       - DRAFTER_DIR
       - DRAFT_QUANT
@@ -249,6 +257,75 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
+        # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
+        # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked
+        # on every provider we serve: the official FP8 and unsloth GGUF cards restate
+        # both rows verbatim; Frozenlock / RadixArk / syvai / z-lab add no sampling
+        # guidance of their own, so the base card governs for those checkpoints too.
+        #
+        # ⚠️⚠️ ONLY THE THINKING ROW ACTUALLY LANDS HERE — AND NOT BECAUSE OF THE
+        # --preferred-sampling-params FLAG BELOW. Three mechanisms, two of which bite:
+        #   1. --default-chat-template-kwargs IS enforced (applied to every request
+        #      unless the request overrides it) -> the thinking MODE is real, and so
+        #      is reasoning_effort.
+        #   2. --sampling-defaults model (pinned below) makes the engine read the
+        #      checkpoint's generation_config.json, which ships temperature 1.0 /
+        #      top_k 20 / top_p 0.95 — EXACTLY the card's thinking row. THAT is what
+        #      serves the thinking row: Qwen's file, not our flag. The file is
+        #      byte-identical across our int4 and fp8 checkpoints, and there is no
+        #      instruct row anywhere in any of them.
+        #   3. --preferred-sampling-params is INERT on /v1/chat/completions. It IS
+        #      merged (tokenizer_manager.py:1353, `{**preferred, **request}`), but the
+        #      chat adapter's to_sampling_params resolves EVERY key eagerly through
+        #      get_param() — user -> generation_config.json -> OpenAI default — so the
+        #      request dict is always fully populated and always wins the merge. The
+        #      merged result is byte-identical to the unmerged one. It bites only on
+        #      the native /generate endpoint. (SGLang's own Responses-API path,
+        #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
+        #      this flag; the chat path does not — filed upstream.)
+        # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
+        #   ON THE THINKING ROW. A client wanting the instruct row must send
+        #   temperature/top_p/presence_penalty itself — which is exactly what the
+        #   model card's own non-thinking example does, and what bench.sh does.
+        # ⇒ presence_penalty cannot be pinned server-side on EITHER engine: vLLM's
+        #   get_diff_sampling_param() and SGLang's get_default_sampling_params() share
+        #   the same allowlist (repetition_penalty, temperature, top_k, top_p, min_p),
+        #   and both chat adapters declare presence_penalty with a hard 0.0 default, so
+        #   it is always present in the request and always wins. The card anticipates
+        #   this: "support for sampling parameters varies according to inference
+        #   frameworks." It is a client-side parameter, full stop.
+        # We keep the flag because /get_model_info then advertises the correct row to
+        # clients that introspect it — the one thing it genuinely does.
+        _think="${ENABLE_THINKING:-true}"
+        _temp="${TEMP:-}"
+        if [ "$$_think" = "true" ]; then
+          : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
+          echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   temp/top_p/top_k served via generation_config.json (--sampling-defaults model)" >&2
+        else
+          : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
+          echo "[sampler] instruct row (ENABLE_THINKING=false): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   ⚠️ thinking is OFF but the SAMPLER IS NOT: the engine still serves the" >&2
+          echo "[sampler]   ⚠️ thinking row from generation_config.json. Send temperature/top_p/" >&2
+          echo "[sampler]   ⚠️ presence_penalty per-request to get the instruct row." >&2
+        fi
+        echo "[sampler] ⚠️ presence_penalty is CLIENT-SIDE on both engines (engine allowlists drop it)" >&2
+        # ⚠️⚠️ reasoning_effort MUST travel with enable_thinking. This checkpoint's
+        # BUILT-IN template does `reasoning_effort|default('xhigh')` — the SLOWEST,
+        # longest rung — so leaving it unset serves xhigh on EVERY request. The
+        # vLLM tiers for this same model pin `low` (2026-08-16), so an unset value
+        # here would make the two engines serve DIFFERENT reasoning depth by
+        # default and stop being comparable at all.
+        # ⚠️ Ladder is low / medium / xhigh — there is NO `high` rung. The vLLM
+        # tiers mount a patched template that maps high -> xhigh; we use the
+        # checkpoint's built-in template, which has no such mapping.
+        _reff="${REASONING_EFFORT:-low}"
+        case "$$_reff" in low|medium|xhigh) : ;; *) echo "[sampler] REASONING_EFFORT='$$_reff' must be low|medium|xhigh" >&2; exit 1 ;; esac
+        echo "[sampler] reasoning_effort=$$_reff (template default would be xhigh)" >&2
+        SAMPLER=(--default-chat-template-kwargs "{\"enable_thinking\": $$_think, \"reasoning_effort\": \"$$_reff\"}"
+                 --sampling-defaults model
+                 --preferred-sampling-params "{\"temperature\": $$_temp, \"top_p\": $${TOP_P}, \"top_k\": $${TOP_K:-20}, \"min_p\": $${MIN_P:-0.0}, \"presence_penalty\": $${PRESENCE_PENALTY}, \"repetition_penalty\": $${REPEAT_PENALTY:-1.0}}")
         exec python3 -m sglang.launch_server \
           --model-path "$$M" \
           --tp-size 2 \
@@ -262,6 +339,8 @@ services:
           --mem-fraction-static "${MEM_FRACTION:-0.82}" \
           --max-running-requests "${MAX_RUNNING_REQUESTS:-1}" \
           --trust-remote-code \
+          --enable-metrics \
+          "$${SAMPLER[@]}" \
           --reasoning-parser "${REASONING_PARSER:-qwen3}" \
           --tool-call-parser "${TOOL_CALL_PARSER:-qwen3_coder}" \
           --host 0.0.0.0 --port 30000 \

--- a/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2-bf16.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2-bf16.yml
@@ -283,7 +283,7 @@ services:
         #      merged result is byte-identical to the unmerged one. It bites only on
         #      the native /generate endpoint. (SGLang's own Responses-API path,
         #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
-        #      this flag; the chat path does not — filed upstream.)
+        #      this flag; the chat path does not — sglang#39096.)
         # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
         #   ON THE THINKING ROW. A client wanting the instruct row must send
         #   temperature/top_p/presence_penalty itself — which is exactly what the

--- a/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2.yml
@@ -317,7 +317,7 @@ services:
         #      merged result is byte-identical to the unmerged one. It bites only on
         #      the native /generate endpoint. (SGLang's own Responses-API path,
         #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
-        #      this flag; the chat path does not — filed upstream.)
+        #      this flag; the chat path does not — sglang#39096.)
         # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
         #   ON THE THINKING ROW. A client wanting the instruct row must send
         #   temperature/top_p/presence_penalty itself — which is exactly what the

--- a/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2.yml
@@ -219,6 +219,14 @@ services:
       - MAX_RUNNING_REQUESTS
       - MAMBA_SSM_DTYPE
       - W4A8
+      - ENABLE_THINKING
+      - TEMP
+      - TOP_P
+      - TOP_K
+      - MIN_P
+      - PRESENCE_PENALTY
+      - REPEAT_PENALTY
+      - REASONING_EFFORT
       - CHUNKED_PREFILL_SIZE
       - DRAFTER_DIR
       - DRAFT_QUANT
@@ -283,6 +291,75 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
+        # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
+        # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked
+        # on every provider we serve: the official FP8 and unsloth GGUF cards restate
+        # both rows verbatim; Frozenlock / RadixArk / syvai / z-lab add no sampling
+        # guidance of their own, so the base card governs for those checkpoints too.
+        #
+        # ⚠️⚠️ ONLY THE THINKING ROW ACTUALLY LANDS HERE — AND NOT BECAUSE OF THE
+        # --preferred-sampling-params FLAG BELOW. Three mechanisms, two of which bite:
+        #   1. --default-chat-template-kwargs IS enforced (applied to every request
+        #      unless the request overrides it) -> the thinking MODE is real, and so
+        #      is reasoning_effort.
+        #   2. --sampling-defaults model (pinned below) makes the engine read the
+        #      checkpoint's generation_config.json, which ships temperature 1.0 /
+        #      top_k 20 / top_p 0.95 — EXACTLY the card's thinking row. THAT is what
+        #      serves the thinking row: Qwen's file, not our flag. The file is
+        #      byte-identical across our int4 and fp8 checkpoints, and there is no
+        #      instruct row anywhere in any of them.
+        #   3. --preferred-sampling-params is INERT on /v1/chat/completions. It IS
+        #      merged (tokenizer_manager.py:1353, `{**preferred, **request}`), but the
+        #      chat adapter's to_sampling_params resolves EVERY key eagerly through
+        #      get_param() — user -> generation_config.json -> OpenAI default — so the
+        #      request dict is always fully populated and always wins the merge. The
+        #      merged result is byte-identical to the unmerged one. It bites only on
+        #      the native /generate endpoint. (SGLang's own Responses-API path,
+        #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
+        #      this flag; the chat path does not — filed upstream.)
+        # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
+        #   ON THE THINKING ROW. A client wanting the instruct row must send
+        #   temperature/top_p/presence_penalty itself — which is exactly what the
+        #   model card's own non-thinking example does, and what bench.sh does.
+        # ⇒ presence_penalty cannot be pinned server-side on EITHER engine: vLLM's
+        #   get_diff_sampling_param() and SGLang's get_default_sampling_params() share
+        #   the same allowlist (repetition_penalty, temperature, top_k, top_p, min_p),
+        #   and both chat adapters declare presence_penalty with a hard 0.0 default, so
+        #   it is always present in the request and always wins. The card anticipates
+        #   this: "support for sampling parameters varies according to inference
+        #   frameworks." It is a client-side parameter, full stop.
+        # We keep the flag because /get_model_info then advertises the correct row to
+        # clients that introspect it — the one thing it genuinely does.
+        _think="${ENABLE_THINKING:-true}"
+        _temp="${TEMP:-}"
+        if [ "$$_think" = "true" ]; then
+          : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
+          echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   temp/top_p/top_k served via generation_config.json (--sampling-defaults model)" >&2
+        else
+          : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
+          echo "[sampler] instruct row (ENABLE_THINKING=false): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   ⚠️ thinking is OFF but the SAMPLER IS NOT: the engine still serves the" >&2
+          echo "[sampler]   ⚠️ thinking row from generation_config.json. Send temperature/top_p/" >&2
+          echo "[sampler]   ⚠️ presence_penalty per-request to get the instruct row." >&2
+        fi
+        echo "[sampler] ⚠️ presence_penalty is CLIENT-SIDE on both engines (engine allowlists drop it)" >&2
+        # ⚠️⚠️ reasoning_effort MUST travel with enable_thinking. This checkpoint's
+        # BUILT-IN template does `reasoning_effort|default('xhigh')` — the SLOWEST,
+        # longest rung — so leaving it unset serves xhigh on EVERY request. The
+        # vLLM tiers for this same model pin `low` (2026-08-16), so an unset value
+        # here would make the two engines serve DIFFERENT reasoning depth by
+        # default and stop being comparable at all.
+        # ⚠️ Ladder is low / medium / xhigh — there is NO `high` rung. The vLLM
+        # tiers mount a patched template that maps high -> xhigh; we use the
+        # checkpoint's built-in template, which has no such mapping.
+        _reff="${REASONING_EFFORT:-low}"
+        case "$$_reff" in low|medium|xhigh) : ;; *) echo "[sampler] REASONING_EFFORT='$$_reff' must be low|medium|xhigh" >&2; exit 1 ;; esac
+        echo "[sampler] reasoning_effort=$$_reff (template default would be xhigh)" >&2
+        SAMPLER=(--default-chat-template-kwargs "{\"enable_thinking\": $$_think, \"reasoning_effort\": \"$$_reff\"}"
+                 --sampling-defaults model
+                 --preferred-sampling-params "{\"temperature\": $$_temp, \"top_p\": $${TOP_P}, \"top_k\": $${TOP_K:-20}, \"min_p\": $${MIN_P:-0.0}, \"presence_penalty\": $${PRESENCE_PENALTY}, \"repetition_penalty\": $${REPEAT_PENALTY:-1.0}}")
         exec python3 -m sglang.launch_server \
           --model-path "$$M" \
           --tp-size 2 \
@@ -296,6 +373,8 @@ services:
           --mem-fraction-static "${MEM_FRACTION:-0.82}" \
           --max-running-requests "${MAX_RUNNING_REQUESTS:-1}" \
           --trust-remote-code \
+          --enable-metrics \
+          "$${SAMPLER[@]}" \
           --reasoning-parser "${REASONING_PARSER:-qwen3}" \
           --tool-call-parser "${TOOL_CALL_PARSER:-qwen3_coder}" \
           --host 0.0.0.0 --port 30000 \

--- a/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/mtp.yml
@@ -329,7 +329,7 @@ services:
         #      merged result is byte-identical to the unmerged one. It bites only on
         #      the native /generate endpoint. (SGLang's own Responses-API path,
         #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
-        #      this flag; the chat path does not — filed upstream.)
+        #      this flag; the chat path does not — sglang#39096.)
         # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
         #   ON THE THINKING ROW. A client wanting the instruct row must send
         #   temperature/top_p/presence_penalty itself — which is exactly what the

--- a/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/mtp.yml
@@ -245,6 +245,14 @@ services:
       - MAX_RUNNING_REQUESTS
       - MAMBA_SSM_DTYPE
       - W4A8
+      - ENABLE_THINKING
+      - TEMP
+      - TOP_P
+      - TOP_K
+      - MIN_P
+      - PRESENCE_PENALTY
+      - REPEAT_PENALTY
+      - REASONING_EFFORT
       - CHUNKED_PREFILL_SIZE
     deploy:
       resources:
@@ -295,6 +303,75 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
+        # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
+        # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked
+        # on every provider we serve: the official FP8 and unsloth GGUF cards restate
+        # both rows verbatim; Frozenlock / RadixArk / syvai / z-lab add no sampling
+        # guidance of their own, so the base card governs for those checkpoints too.
+        #
+        # ⚠️⚠️ ONLY THE THINKING ROW ACTUALLY LANDS HERE — AND NOT BECAUSE OF THE
+        # --preferred-sampling-params FLAG BELOW. Three mechanisms, two of which bite:
+        #   1. --default-chat-template-kwargs IS enforced (applied to every request
+        #      unless the request overrides it) -> the thinking MODE is real, and so
+        #      is reasoning_effort.
+        #   2. --sampling-defaults model (pinned below) makes the engine read the
+        #      checkpoint's generation_config.json, which ships temperature 1.0 /
+        #      top_k 20 / top_p 0.95 — EXACTLY the card's thinking row. THAT is what
+        #      serves the thinking row: Qwen's file, not our flag. The file is
+        #      byte-identical across our int4 and fp8 checkpoints, and there is no
+        #      instruct row anywhere in any of them.
+        #   3. --preferred-sampling-params is INERT on /v1/chat/completions. It IS
+        #      merged (tokenizer_manager.py:1353, `{**preferred, **request}`), but the
+        #      chat adapter's to_sampling_params resolves EVERY key eagerly through
+        #      get_param() — user -> generation_config.json -> OpenAI default — so the
+        #      request dict is always fully populated and always wins the merge. The
+        #      merged result is byte-identical to the unmerged one. It bites only on
+        #      the native /generate endpoint. (SGLang's own Responses-API path,
+        #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
+        #      this flag; the chat path does not — filed upstream.)
+        # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
+        #   ON THE THINKING ROW. A client wanting the instruct row must send
+        #   temperature/top_p/presence_penalty itself — which is exactly what the
+        #   model card's own non-thinking example does, and what bench.sh does.
+        # ⇒ presence_penalty cannot be pinned server-side on EITHER engine: vLLM's
+        #   get_diff_sampling_param() and SGLang's get_default_sampling_params() share
+        #   the same allowlist (repetition_penalty, temperature, top_k, top_p, min_p),
+        #   and both chat adapters declare presence_penalty with a hard 0.0 default, so
+        #   it is always present in the request and always wins. The card anticipates
+        #   this: "support for sampling parameters varies according to inference
+        #   frameworks." It is a client-side parameter, full stop.
+        # We keep the flag because /get_model_info then advertises the correct row to
+        # clients that introspect it — the one thing it genuinely does.
+        _think="${ENABLE_THINKING:-true}"
+        _temp="${TEMP:-}"
+        if [ "$$_think" = "true" ]; then
+          : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
+          echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   temp/top_p/top_k served via generation_config.json (--sampling-defaults model)" >&2
+        else
+          : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
+          echo "[sampler] instruct row (ENABLE_THINKING=false): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   ⚠️ thinking is OFF but the SAMPLER IS NOT: the engine still serves the" >&2
+          echo "[sampler]   ⚠️ thinking row from generation_config.json. Send temperature/top_p/" >&2
+          echo "[sampler]   ⚠️ presence_penalty per-request to get the instruct row." >&2
+        fi
+        echo "[sampler] ⚠️ presence_penalty is CLIENT-SIDE on both engines (engine allowlists drop it)" >&2
+        # ⚠️⚠️ reasoning_effort MUST travel with enable_thinking. This checkpoint's
+        # BUILT-IN template does `reasoning_effort|default('xhigh')` — the SLOWEST,
+        # longest rung — so leaving it unset serves xhigh on EVERY request. The
+        # vLLM tiers for this same model pin `low` (2026-08-16), so an unset value
+        # here would make the two engines serve DIFFERENT reasoning depth by
+        # default and stop being comparable at all.
+        # ⚠️ Ladder is low / medium / xhigh — there is NO `high` rung. The vLLM
+        # tiers mount a patched template that maps high -> xhigh; we use the
+        # checkpoint's built-in template, which has no such mapping.
+        _reff="${REASONING_EFFORT:-low}"
+        case "$$_reff" in low|medium|xhigh) : ;; *) echo "[sampler] REASONING_EFFORT='$$_reff' must be low|medium|xhigh" >&2; exit 1 ;; esac
+        echo "[sampler] reasoning_effort=$$_reff (template default would be xhigh)" >&2
+        SAMPLER=(--default-chat-template-kwargs "{\"enable_thinking\": $$_think, \"reasoning_effort\": \"$$_reff\"}"
+                 --sampling-defaults model
+                 --preferred-sampling-params "{\"temperature\": $$_temp, \"top_p\": $${TOP_P}, \"top_k\": $${TOP_K:-20}, \"min_p\": $${MIN_P:-0.0}, \"presence_penalty\": $${PRESENCE_PENALTY}, \"repetition_penalty\": $${REPEAT_PENALTY:-1.0}}")
         exec python3 -m sglang.launch_server \
           --model-path "$$M" \
           --tp-size 2 \
@@ -308,6 +385,8 @@ services:
           --mem-fraction-static "${MEM_FRACTION:-0.90}" \
           --max-running-requests "${MAX_RUNNING_REQUESTS:-1}" \
           --trust-remote-code \
+          --enable-metrics \
+          "$${SAMPLER[@]}" \
           --reasoning-parser "${REASONING_PARSER:-qwen3}" \
           --tool-call-parser "${TOOL_CALL_PARSER:-qwen3_coder}" \
           --host 0.0.0.0 --port 30000 \

--- a/models/qwen3.8-27b/sglang/compose/dual/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/fp8/dflash2.yml
@@ -350,7 +350,7 @@ services:
         #      merged result is byte-identical to the unmerged one. It bites only on
         #      the native /generate endpoint. (SGLang's own Responses-API path,
         #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
-        #      this flag; the chat path does not — filed upstream.)
+        #      this flag; the chat path does not — sglang#39096.)
         # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
         #   ON THE THINKING ROW. A client wanting the instruct row must send
         #   temperature/top_p/presence_penalty itself — which is exactly what the

--- a/models/qwen3.8-27b/sglang/compose/dual/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/fp8/dflash2.yml
@@ -251,6 +251,14 @@ services:
       - MAX_RUNNING_REQUESTS
       - MAMBA_SSM_DTYPE
       - W4A8
+      - ENABLE_THINKING
+      - TEMP
+      - TOP_P
+      - TOP_K
+      - MIN_P
+      - PRESENCE_PENALTY
+      - REPEAT_PENALTY
+      - REASONING_EFFORT
       - CHUNKED_PREFILL_SIZE
       - QUANTIZATION
       - DRAFTER_DIR
@@ -316,6 +324,75 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
+        # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
+        # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked
+        # on every provider we serve: the official FP8 and unsloth GGUF cards restate
+        # both rows verbatim; Frozenlock / RadixArk / syvai / z-lab add no sampling
+        # guidance of their own, so the base card governs for those checkpoints too.
+        #
+        # ⚠️⚠️ ONLY THE THINKING ROW ACTUALLY LANDS HERE — AND NOT BECAUSE OF THE
+        # --preferred-sampling-params FLAG BELOW. Three mechanisms, two of which bite:
+        #   1. --default-chat-template-kwargs IS enforced (applied to every request
+        #      unless the request overrides it) -> the thinking MODE is real, and so
+        #      is reasoning_effort.
+        #   2. --sampling-defaults model (pinned below) makes the engine read the
+        #      checkpoint's generation_config.json, which ships temperature 1.0 /
+        #      top_k 20 / top_p 0.95 — EXACTLY the card's thinking row. THAT is what
+        #      serves the thinking row: Qwen's file, not our flag. The file is
+        #      byte-identical across our int4 and fp8 checkpoints, and there is no
+        #      instruct row anywhere in any of them.
+        #   3. --preferred-sampling-params is INERT on /v1/chat/completions. It IS
+        #      merged (tokenizer_manager.py:1353, `{**preferred, **request}`), but the
+        #      chat adapter's to_sampling_params resolves EVERY key eagerly through
+        #      get_param() — user -> generation_config.json -> OpenAI default — so the
+        #      request dict is always fully populated and always wins the merge. The
+        #      merged result is byte-identical to the unmerged one. It bites only on
+        #      the native /generate endpoint. (SGLang's own Responses-API path,
+        #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
+        #      this flag; the chat path does not — filed upstream.)
+        # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
+        #   ON THE THINKING ROW. A client wanting the instruct row must send
+        #   temperature/top_p/presence_penalty itself — which is exactly what the
+        #   model card's own non-thinking example does, and what bench.sh does.
+        # ⇒ presence_penalty cannot be pinned server-side on EITHER engine: vLLM's
+        #   get_diff_sampling_param() and SGLang's get_default_sampling_params() share
+        #   the same allowlist (repetition_penalty, temperature, top_k, top_p, min_p),
+        #   and both chat adapters declare presence_penalty with a hard 0.0 default, so
+        #   it is always present in the request and always wins. The card anticipates
+        #   this: "support for sampling parameters varies according to inference
+        #   frameworks." It is a client-side parameter, full stop.
+        # We keep the flag because /get_model_info then advertises the correct row to
+        # clients that introspect it — the one thing it genuinely does.
+        _think="${ENABLE_THINKING:-true}"
+        _temp="${TEMP:-}"
+        if [ "$$_think" = "true" ]; then
+          : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
+          echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   temp/top_p/top_k served via generation_config.json (--sampling-defaults model)" >&2
+        else
+          : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
+          echo "[sampler] instruct row (ENABLE_THINKING=false): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   ⚠️ thinking is OFF but the SAMPLER IS NOT: the engine still serves the" >&2
+          echo "[sampler]   ⚠️ thinking row from generation_config.json. Send temperature/top_p/" >&2
+          echo "[sampler]   ⚠️ presence_penalty per-request to get the instruct row." >&2
+        fi
+        echo "[sampler] ⚠️ presence_penalty is CLIENT-SIDE on both engines (engine allowlists drop it)" >&2
+        # ⚠️⚠️ reasoning_effort MUST travel with enable_thinking. This checkpoint's
+        # BUILT-IN template does `reasoning_effort|default('xhigh')` — the SLOWEST,
+        # longest rung — so leaving it unset serves xhigh on EVERY request. The
+        # vLLM tiers for this same model pin `low` (2026-08-16), so an unset value
+        # here would make the two engines serve DIFFERENT reasoning depth by
+        # default and stop being comparable at all.
+        # ⚠️ Ladder is low / medium / xhigh — there is NO `high` rung. The vLLM
+        # tiers mount a patched template that maps high -> xhigh; we use the
+        # checkpoint's built-in template, which has no such mapping.
+        _reff="${REASONING_EFFORT:-low}"
+        case "$$_reff" in low|medium|xhigh) : ;; *) echo "[sampler] REASONING_EFFORT='$$_reff' must be low|medium|xhigh" >&2; exit 1 ;; esac
+        echo "[sampler] reasoning_effort=$$_reff (template default would be xhigh)" >&2
+        SAMPLER=(--default-chat-template-kwargs "{\"enable_thinking\": $$_think, \"reasoning_effort\": \"$$_reff\"}"
+                 --sampling-defaults model
+                 --preferred-sampling-params "{\"temperature\": $$_temp, \"top_p\": $${TOP_P}, \"top_k\": $${TOP_K:-20}, \"min_p\": $${MIN_P:-0.0}, \"presence_penalty\": $${PRESENCE_PENALTY}, \"repetition_penalty\": $${REPEAT_PENALTY:-1.0}}")
         exec python3 -m sglang.launch_server \
           --model-path "$$M" \
           --tp-size 2 \
@@ -329,6 +406,8 @@ services:
           --mem-fraction-static "${MEM_FRACTION:-0.84}" \
           --max-running-requests "${MAX_RUNNING_REQUESTS:-1}" \
           --trust-remote-code \
+          --enable-metrics \
+          "$${SAMPLER[@]}" \
           --reasoning-parser "${REASONING_PARSER:-qwen3}" \
           --tool-call-parser "${TOOL_CALL_PARSER:-qwen3_coder}" \
           --host 0.0.0.0 --port 30000 \

--- a/models/qwen3.8-27b/sglang/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/fp8/mtp.yml
@@ -299,6 +299,14 @@ services:
       - MAX_RUNNING_REQUESTS
       - MAMBA_SSM_DTYPE
       - W4A8
+      - ENABLE_THINKING
+      - TEMP
+      - TOP_P
+      - TOP_K
+      - MIN_P
+      - PRESENCE_PENALTY
+      - REPEAT_PENALTY
+      - REASONING_EFFORT
       - QUANTIZATION
       - CHUNKED_PREFILL_SIZE
     deploy:
@@ -350,6 +358,75 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
+        # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
+        # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked
+        # on every provider we serve: the official FP8 and unsloth GGUF cards restate
+        # both rows verbatim; Frozenlock / RadixArk / syvai / z-lab add no sampling
+        # guidance of their own, so the base card governs for those checkpoints too.
+        #
+        # ⚠️⚠️ ONLY THE THINKING ROW ACTUALLY LANDS HERE — AND NOT BECAUSE OF THE
+        # --preferred-sampling-params FLAG BELOW. Three mechanisms, two of which bite:
+        #   1. --default-chat-template-kwargs IS enforced (applied to every request
+        #      unless the request overrides it) -> the thinking MODE is real, and so
+        #      is reasoning_effort.
+        #   2. --sampling-defaults model (pinned below) makes the engine read the
+        #      checkpoint's generation_config.json, which ships temperature 1.0 /
+        #      top_k 20 / top_p 0.95 — EXACTLY the card's thinking row. THAT is what
+        #      serves the thinking row: Qwen's file, not our flag. The file is
+        #      byte-identical across our int4 and fp8 checkpoints, and there is no
+        #      instruct row anywhere in any of them.
+        #   3. --preferred-sampling-params is INERT on /v1/chat/completions. It IS
+        #      merged (tokenizer_manager.py:1353, `{**preferred, **request}`), but the
+        #      chat adapter's to_sampling_params resolves EVERY key eagerly through
+        #      get_param() — user -> generation_config.json -> OpenAI default — so the
+        #      request dict is always fully populated and always wins the merge. The
+        #      merged result is byte-identical to the unmerged one. It bites only on
+        #      the native /generate endpoint. (SGLang's own Responses-API path,
+        #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
+        #      this flag; the chat path does not — filed upstream.)
+        # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
+        #   ON THE THINKING ROW. A client wanting the instruct row must send
+        #   temperature/top_p/presence_penalty itself — which is exactly what the
+        #   model card's own non-thinking example does, and what bench.sh does.
+        # ⇒ presence_penalty cannot be pinned server-side on EITHER engine: vLLM's
+        #   get_diff_sampling_param() and SGLang's get_default_sampling_params() share
+        #   the same allowlist (repetition_penalty, temperature, top_k, top_p, min_p),
+        #   and both chat adapters declare presence_penalty with a hard 0.0 default, so
+        #   it is always present in the request and always wins. The card anticipates
+        #   this: "support for sampling parameters varies according to inference
+        #   frameworks." It is a client-side parameter, full stop.
+        # We keep the flag because /get_model_info then advertises the correct row to
+        # clients that introspect it — the one thing it genuinely does.
+        _think="${ENABLE_THINKING:-true}"
+        _temp="${TEMP:-}"
+        if [ "$$_think" = "true" ]; then
+          : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
+          echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   temp/top_p/top_k served via generation_config.json (--sampling-defaults model)" >&2
+        else
+          : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
+          echo "[sampler] instruct row (ENABLE_THINKING=false): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   ⚠️ thinking is OFF but the SAMPLER IS NOT: the engine still serves the" >&2
+          echo "[sampler]   ⚠️ thinking row from generation_config.json. Send temperature/top_p/" >&2
+          echo "[sampler]   ⚠️ presence_penalty per-request to get the instruct row." >&2
+        fi
+        echo "[sampler] ⚠️ presence_penalty is CLIENT-SIDE on both engines (engine allowlists drop it)" >&2
+        # ⚠️⚠️ reasoning_effort MUST travel with enable_thinking. This checkpoint's
+        # BUILT-IN template does `reasoning_effort|default('xhigh')` — the SLOWEST,
+        # longest rung — so leaving it unset serves xhigh on EVERY request. The
+        # vLLM tiers for this same model pin `low` (2026-08-16), so an unset value
+        # here would make the two engines serve DIFFERENT reasoning depth by
+        # default and stop being comparable at all.
+        # ⚠️ Ladder is low / medium / xhigh — there is NO `high` rung. The vLLM
+        # tiers mount a patched template that maps high -> xhigh; we use the
+        # checkpoint's built-in template, which has no such mapping.
+        _reff="${REASONING_EFFORT:-low}"
+        case "$$_reff" in low|medium|xhigh) : ;; *) echo "[sampler] REASONING_EFFORT='$$_reff' must be low|medium|xhigh" >&2; exit 1 ;; esac
+        echo "[sampler] reasoning_effort=$$_reff (template default would be xhigh)" >&2
+        SAMPLER=(--default-chat-template-kwargs "{\"enable_thinking\": $$_think, \"reasoning_effort\": \"$$_reff\"}"
+                 --sampling-defaults model
+                 --preferred-sampling-params "{\"temperature\": $$_temp, \"top_p\": $${TOP_P}, \"top_k\": $${TOP_K:-20}, \"min_p\": $${MIN_P:-0.0}, \"presence_penalty\": $${PRESENCE_PENALTY}, \"repetition_penalty\": $${REPEAT_PENALTY:-1.0}}")
         exec python3 -m sglang.launch_server \
           --model-path "$$M" \
           --tp-size 2 \
@@ -363,6 +440,8 @@ services:
           --mem-fraction-static "${MEM_FRACTION:-0.92}" \
           --max-running-requests "${MAX_RUNNING_REQUESTS:-1}" \
           --trust-remote-code \
+          --enable-metrics \
+          "$${SAMPLER[@]}" \
           --reasoning-parser "${REASONING_PARSER:-qwen3}" \
           --tool-call-parser "${TOOL_CALL_PARSER:-qwen3_coder}" \
           --host 0.0.0.0 --port 30000 \

--- a/models/qwen3.8-27b/sglang/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/fp8/mtp.yml
@@ -384,7 +384,7 @@ services:
         #      merged result is byte-identical to the unmerged one. It bites only on
         #      the native /generate endpoint. (SGLang's own Responses-API path,
         #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
-        #      this flag; the chat path does not — filed upstream.)
+        #      this flag; the chat path does not — sglang#39096.)
         # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
         #   ON THE THINKING ROW. A client wanting the instruct row must send
         #   temperature/top_p/presence_penalty itself — which is exactly what the

--- a/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/dflash2.yml
@@ -254,6 +254,14 @@ services:
       - MAX_RUNNING_REQUESTS
       - MAMBA_SSM_DTYPE
       - W4A8
+      - ENABLE_THINKING
+      - TEMP
+      - TOP_P
+      - TOP_K
+      - MIN_P
+      - PRESENCE_PENALTY
+      - REPEAT_PENALTY
+      - REASONING_EFFORT
       - CHUNKED_PREFILL_SIZE
       - DRAFTER_DIR
       - DRAFT_QUANT
@@ -318,6 +326,75 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
+        # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
+        # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked
+        # on every provider we serve: the official FP8 and unsloth GGUF cards restate
+        # both rows verbatim; Frozenlock / RadixArk / syvai / z-lab add no sampling
+        # guidance of their own, so the base card governs for those checkpoints too.
+        #
+        # ⚠️⚠️ ONLY THE THINKING ROW ACTUALLY LANDS HERE — AND NOT BECAUSE OF THE
+        # --preferred-sampling-params FLAG BELOW. Three mechanisms, two of which bite:
+        #   1. --default-chat-template-kwargs IS enforced (applied to every request
+        #      unless the request overrides it) -> the thinking MODE is real, and so
+        #      is reasoning_effort.
+        #   2. --sampling-defaults model (pinned below) makes the engine read the
+        #      checkpoint's generation_config.json, which ships temperature 1.0 /
+        #      top_k 20 / top_p 0.95 — EXACTLY the card's thinking row. THAT is what
+        #      serves the thinking row: Qwen's file, not our flag. The file is
+        #      byte-identical across our int4 and fp8 checkpoints, and there is no
+        #      instruct row anywhere in any of them.
+        #   3. --preferred-sampling-params is INERT on /v1/chat/completions. It IS
+        #      merged (tokenizer_manager.py:1353, `{**preferred, **request}`), but the
+        #      chat adapter's to_sampling_params resolves EVERY key eagerly through
+        #      get_param() — user -> generation_config.json -> OpenAI default — so the
+        #      request dict is always fully populated and always wins the merge. The
+        #      merged result is byte-identical to the unmerged one. It bites only on
+        #      the native /generate endpoint. (SGLang's own Responses-API path,
+        #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
+        #      this flag; the chat path does not — filed upstream.)
+        # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
+        #   ON THE THINKING ROW. A client wanting the instruct row must send
+        #   temperature/top_p/presence_penalty itself — which is exactly what the
+        #   model card's own non-thinking example does, and what bench.sh does.
+        # ⇒ presence_penalty cannot be pinned server-side on EITHER engine: vLLM's
+        #   get_diff_sampling_param() and SGLang's get_default_sampling_params() share
+        #   the same allowlist (repetition_penalty, temperature, top_k, top_p, min_p),
+        #   and both chat adapters declare presence_penalty with a hard 0.0 default, so
+        #   it is always present in the request and always wins. The card anticipates
+        #   this: "support for sampling parameters varies according to inference
+        #   frameworks." It is a client-side parameter, full stop.
+        # We keep the flag because /get_model_info then advertises the correct row to
+        # clients that introspect it — the one thing it genuinely does.
+        _think="${ENABLE_THINKING:-true}"
+        _temp="${TEMP:-}"
+        if [ "$$_think" = "true" ]; then
+          : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
+          echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   temp/top_p/top_k served via generation_config.json (--sampling-defaults model)" >&2
+        else
+          : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
+          echo "[sampler] instruct row (ENABLE_THINKING=false): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   ⚠️ thinking is OFF but the SAMPLER IS NOT: the engine still serves the" >&2
+          echo "[sampler]   ⚠️ thinking row from generation_config.json. Send temperature/top_p/" >&2
+          echo "[sampler]   ⚠️ presence_penalty per-request to get the instruct row." >&2
+        fi
+        echo "[sampler] ⚠️ presence_penalty is CLIENT-SIDE on both engines (engine allowlists drop it)" >&2
+        # ⚠️⚠️ reasoning_effort MUST travel with enable_thinking. This checkpoint's
+        # BUILT-IN template does `reasoning_effort|default('xhigh')` — the SLOWEST,
+        # longest rung — so leaving it unset serves xhigh on EVERY request. The
+        # vLLM tiers for this same model pin `low` (2026-08-16), so an unset value
+        # here would make the two engines serve DIFFERENT reasoning depth by
+        # default and stop being comparable at all.
+        # ⚠️ Ladder is low / medium / xhigh — there is NO `high` rung. The vLLM
+        # tiers mount a patched template that maps high -> xhigh; we use the
+        # checkpoint's built-in template, which has no such mapping.
+        _reff="${REASONING_EFFORT:-low}"
+        case "$$_reff" in low|medium|xhigh) : ;; *) echo "[sampler] REASONING_EFFORT='$$_reff' must be low|medium|xhigh" >&2; exit 1 ;; esac
+        echo "[sampler] reasoning_effort=$$_reff (template default would be xhigh)" >&2
+        SAMPLER=(--default-chat-template-kwargs "{\"enable_thinking\": $$_think, \"reasoning_effort\": \"$$_reff\"}"
+                 --sampling-defaults model
+                 --preferred-sampling-params "{\"temperature\": $$_temp, \"top_p\": $${TOP_P}, \"top_k\": $${TOP_K:-20}, \"min_p\": $${MIN_P:-0.0}, \"presence_penalty\": $${PRESENCE_PENALTY}, \"repetition_penalty\": $${REPEAT_PENALTY:-1.0}}")
         exec python3 -m sglang.launch_server \
           --model-path "$$M" \
           --tp-size 4 \
@@ -329,8 +406,10 @@ services:
           --attention-backend "${ATTENTION_BACKEND:-flashinfer}" \
           --context-length "${CONTEXT_LENGTH:-262144}" \
           --mem-fraction-static "${MEM_FRACTION:-0.82}" \
-          --max-running-requests "${MAX_RUNNING_REQUESTS:-1}" \
+          --max-running-requests "${MAX_RUNNING_REQUESTS:-2}" \
           --trust-remote-code \
+          --enable-metrics \
+          "$${SAMPLER[@]}" \
           --reasoning-parser "${REASONING_PARSER:-qwen3}" \
           --tool-call-parser "${TOOL_CALL_PARSER:-qwen3_coder}" \
           --host 0.0.0.0 --port 30000 \

--- a/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/dflash2.yml
@@ -352,7 +352,7 @@ services:
         #      merged result is byte-identical to the unmerged one. It bites only on
         #      the native /generate endpoint. (SGLang's own Responses-API path,
         #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
-        #      this flag; the chat path does not — filed upstream.)
+        #      this flag; the chat path does not — sglang#39096.)
         # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
         #   ON THE THINKING ROW. A client wanting the instruct row must send
         #   temperature/top_p/presence_penalty itself — which is exactly what the

--- a/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/mtp.yml
@@ -372,7 +372,7 @@ services:
         #      merged result is byte-identical to the unmerged one. It bites only on
         #      the native /generate endpoint. (SGLang's own Responses-API path,
         #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
-        #      this flag; the chat path does not — filed upstream.)
+        #      this flag; the chat path does not — sglang#39096.)
         # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
         #   ON THE THINKING ROW. A client wanting the instruct row must send
         #   temperature/top_p/presence_penalty itself — which is exactly what the

--- a/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/mtp.yml
@@ -288,6 +288,14 @@ services:
       - MAX_RUNNING_REQUESTS
       - MAMBA_SSM_DTYPE
       - W4A8
+      - ENABLE_THINKING
+      - TEMP
+      - TOP_P
+      - TOP_K
+      - MIN_P
+      - PRESENCE_PENALTY
+      - REPEAT_PENALTY
+      - REASONING_EFFORT
       - CHUNKED_PREFILL_SIZE
     deploy:
       resources:
@@ -338,6 +346,75 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
+        # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
+        # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked
+        # on every provider we serve: the official FP8 and unsloth GGUF cards restate
+        # both rows verbatim; Frozenlock / RadixArk / syvai / z-lab add no sampling
+        # guidance of their own, so the base card governs for those checkpoints too.
+        #
+        # ⚠️⚠️ ONLY THE THINKING ROW ACTUALLY LANDS HERE — AND NOT BECAUSE OF THE
+        # --preferred-sampling-params FLAG BELOW. Three mechanisms, two of which bite:
+        #   1. --default-chat-template-kwargs IS enforced (applied to every request
+        #      unless the request overrides it) -> the thinking MODE is real, and so
+        #      is reasoning_effort.
+        #   2. --sampling-defaults model (pinned below) makes the engine read the
+        #      checkpoint's generation_config.json, which ships temperature 1.0 /
+        #      top_k 20 / top_p 0.95 — EXACTLY the card's thinking row. THAT is what
+        #      serves the thinking row: Qwen's file, not our flag. The file is
+        #      byte-identical across our int4 and fp8 checkpoints, and there is no
+        #      instruct row anywhere in any of them.
+        #   3. --preferred-sampling-params is INERT on /v1/chat/completions. It IS
+        #      merged (tokenizer_manager.py:1353, `{**preferred, **request}`), but the
+        #      chat adapter's to_sampling_params resolves EVERY key eagerly through
+        #      get_param() — user -> generation_config.json -> OpenAI default — so the
+        #      request dict is always fully populated and always wins the merge. The
+        #      merged result is byte-identical to the unmerged one. It bites only on
+        #      the native /generate endpoint. (SGLang's own Responses-API path,
+        #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
+        #      this flag; the chat path does not — filed upstream.)
+        # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
+        #   ON THE THINKING ROW. A client wanting the instruct row must send
+        #   temperature/top_p/presence_penalty itself — which is exactly what the
+        #   model card's own non-thinking example does, and what bench.sh does.
+        # ⇒ presence_penalty cannot be pinned server-side on EITHER engine: vLLM's
+        #   get_diff_sampling_param() and SGLang's get_default_sampling_params() share
+        #   the same allowlist (repetition_penalty, temperature, top_k, top_p, min_p),
+        #   and both chat adapters declare presence_penalty with a hard 0.0 default, so
+        #   it is always present in the request and always wins. The card anticipates
+        #   this: "support for sampling parameters varies according to inference
+        #   frameworks." It is a client-side parameter, full stop.
+        # We keep the flag because /get_model_info then advertises the correct row to
+        # clients that introspect it — the one thing it genuinely does.
+        _think="${ENABLE_THINKING:-true}"
+        _temp="${TEMP:-}"
+        if [ "$$_think" = "true" ]; then
+          : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
+          echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   temp/top_p/top_k served via generation_config.json (--sampling-defaults model)" >&2
+        else
+          : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
+          echo "[sampler] instruct row (ENABLE_THINKING=false): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   ⚠️ thinking is OFF but the SAMPLER IS NOT: the engine still serves the" >&2
+          echo "[sampler]   ⚠️ thinking row from generation_config.json. Send temperature/top_p/" >&2
+          echo "[sampler]   ⚠️ presence_penalty per-request to get the instruct row." >&2
+        fi
+        echo "[sampler] ⚠️ presence_penalty is CLIENT-SIDE on both engines (engine allowlists drop it)" >&2
+        # ⚠️⚠️ reasoning_effort MUST travel with enable_thinking. This checkpoint's
+        # BUILT-IN template does `reasoning_effort|default('xhigh')` — the SLOWEST,
+        # longest rung — so leaving it unset serves xhigh on EVERY request. The
+        # vLLM tiers for this same model pin `low` (2026-08-16), so an unset value
+        # here would make the two engines serve DIFFERENT reasoning depth by
+        # default and stop being comparable at all.
+        # ⚠️ Ladder is low / medium / xhigh — there is NO `high` rung. The vLLM
+        # tiers mount a patched template that maps high -> xhigh; we use the
+        # checkpoint's built-in template, which has no such mapping.
+        _reff="${REASONING_EFFORT:-low}"
+        case "$$_reff" in low|medium|xhigh) : ;; *) echo "[sampler] REASONING_EFFORT='$$_reff' must be low|medium|xhigh" >&2; exit 1 ;; esac
+        echo "[sampler] reasoning_effort=$$_reff (template default would be xhigh)" >&2
+        SAMPLER=(--default-chat-template-kwargs "{\"enable_thinking\": $$_think, \"reasoning_effort\": \"$$_reff\"}"
+                 --sampling-defaults model
+                 --preferred-sampling-params "{\"temperature\": $$_temp, \"top_p\": $${TOP_P}, \"top_k\": $${TOP_K:-20}, \"min_p\": $${MIN_P:-0.0}, \"presence_penalty\": $${PRESENCE_PENALTY}, \"repetition_penalty\": $${REPEAT_PENALTY:-1.0}}")
         exec python3 -m sglang.launch_server \
           --model-path "$$M" \
           --tp-size 4 \
@@ -349,8 +426,10 @@ services:
           --attention-backend "${ATTENTION_BACKEND:-flashinfer}" \
           --context-length "${CONTEXT_LENGTH:-262144}" \
           --mem-fraction-static "${MEM_FRACTION:-0.90}" \
-          --max-running-requests "${MAX_RUNNING_REQUESTS:-1}" \
+          --max-running-requests "${MAX_RUNNING_REQUESTS:-2}" \
           --trust-remote-code \
+          --enable-metrics \
+          "$${SAMPLER[@]}" \
           --reasoning-parser "${REASONING_PARSER:-qwen3}" \
           --tool-call-parser "${TOOL_CALL_PARSER:-qwen3_coder}" \
           --host 0.0.0.0 --port 30000 \

--- a/models/qwen3.8-27b/sglang/compose/multi4/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/fp8/dflash2.yml
@@ -383,7 +383,7 @@ services:
         #      merged result is byte-identical to the unmerged one. It bites only on
         #      the native /generate endpoint. (SGLang's own Responses-API path,
         #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
-        #      this flag; the chat path does not — filed upstream.)
+        #      this flag; the chat path does not — sglang#39096.)
         # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
         #   ON THE THINKING ROW. A client wanting the instruct row must send
         #   temperature/top_p/presence_penalty itself — which is exactly what the

--- a/models/qwen3.8-27b/sglang/compose/multi4/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/fp8/dflash2.yml
@@ -284,6 +284,14 @@ services:
       - MAX_RUNNING_REQUESTS
       - MAMBA_SSM_DTYPE
       - W4A8
+      - ENABLE_THINKING
+      - TEMP
+      - TOP_P
+      - TOP_K
+      - MIN_P
+      - PRESENCE_PENALTY
+      - REPEAT_PENALTY
+      - REASONING_EFFORT
       - CHUNKED_PREFILL_SIZE
       - QUANTIZATION
       - DRAFTER_DIR
@@ -349,6 +357,75 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
+        # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
+        # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked
+        # on every provider we serve: the official FP8 and unsloth GGUF cards restate
+        # both rows verbatim; Frozenlock / RadixArk / syvai / z-lab add no sampling
+        # guidance of their own, so the base card governs for those checkpoints too.
+        #
+        # ⚠️⚠️ ONLY THE THINKING ROW ACTUALLY LANDS HERE — AND NOT BECAUSE OF THE
+        # --preferred-sampling-params FLAG BELOW. Three mechanisms, two of which bite:
+        #   1. --default-chat-template-kwargs IS enforced (applied to every request
+        #      unless the request overrides it) -> the thinking MODE is real, and so
+        #      is reasoning_effort.
+        #   2. --sampling-defaults model (pinned below) makes the engine read the
+        #      checkpoint's generation_config.json, which ships temperature 1.0 /
+        #      top_k 20 / top_p 0.95 — EXACTLY the card's thinking row. THAT is what
+        #      serves the thinking row: Qwen's file, not our flag. The file is
+        #      byte-identical across our int4 and fp8 checkpoints, and there is no
+        #      instruct row anywhere in any of them.
+        #   3. --preferred-sampling-params is INERT on /v1/chat/completions. It IS
+        #      merged (tokenizer_manager.py:1353, `{**preferred, **request}`), but the
+        #      chat adapter's to_sampling_params resolves EVERY key eagerly through
+        #      get_param() — user -> generation_config.json -> OpenAI default — so the
+        #      request dict is always fully populated and always wins the merge. The
+        #      merged result is byte-identical to the unmerged one. It bites only on
+        #      the native /generate endpoint. (SGLang's own Responses-API path,
+        #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
+        #      this flag; the chat path does not — filed upstream.)
+        # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
+        #   ON THE THINKING ROW. A client wanting the instruct row must send
+        #   temperature/top_p/presence_penalty itself — which is exactly what the
+        #   model card's own non-thinking example does, and what bench.sh does.
+        # ⇒ presence_penalty cannot be pinned server-side on EITHER engine: vLLM's
+        #   get_diff_sampling_param() and SGLang's get_default_sampling_params() share
+        #   the same allowlist (repetition_penalty, temperature, top_k, top_p, min_p),
+        #   and both chat adapters declare presence_penalty with a hard 0.0 default, so
+        #   it is always present in the request and always wins. The card anticipates
+        #   this: "support for sampling parameters varies according to inference
+        #   frameworks." It is a client-side parameter, full stop.
+        # We keep the flag because /get_model_info then advertises the correct row to
+        # clients that introspect it — the one thing it genuinely does.
+        _think="${ENABLE_THINKING:-true}"
+        _temp="${TEMP:-}"
+        if [ "$$_think" = "true" ]; then
+          : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
+          echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   temp/top_p/top_k served via generation_config.json (--sampling-defaults model)" >&2
+        else
+          : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
+          echo "[sampler] instruct row (ENABLE_THINKING=false): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   ⚠️ thinking is OFF but the SAMPLER IS NOT: the engine still serves the" >&2
+          echo "[sampler]   ⚠️ thinking row from generation_config.json. Send temperature/top_p/" >&2
+          echo "[sampler]   ⚠️ presence_penalty per-request to get the instruct row." >&2
+        fi
+        echo "[sampler] ⚠️ presence_penalty is CLIENT-SIDE on both engines (engine allowlists drop it)" >&2
+        # ⚠️⚠️ reasoning_effort MUST travel with enable_thinking. This checkpoint's
+        # BUILT-IN template does `reasoning_effort|default('xhigh')` — the SLOWEST,
+        # longest rung — so leaving it unset serves xhigh on EVERY request. The
+        # vLLM tiers for this same model pin `low` (2026-08-16), so an unset value
+        # here would make the two engines serve DIFFERENT reasoning depth by
+        # default and stop being comparable at all.
+        # ⚠️ Ladder is low / medium / xhigh — there is NO `high` rung. The vLLM
+        # tiers mount a patched template that maps high -> xhigh; we use the
+        # checkpoint's built-in template, which has no such mapping.
+        _reff="${REASONING_EFFORT:-low}"
+        case "$$_reff" in low|medium|xhigh) : ;; *) echo "[sampler] REASONING_EFFORT='$$_reff' must be low|medium|xhigh" >&2; exit 1 ;; esac
+        echo "[sampler] reasoning_effort=$$_reff (template default would be xhigh)" >&2
+        SAMPLER=(--default-chat-template-kwargs "{\"enable_thinking\": $$_think, \"reasoning_effort\": \"$$_reff\"}"
+                 --sampling-defaults model
+                 --preferred-sampling-params "{\"temperature\": $$_temp, \"top_p\": $${TOP_P}, \"top_k\": $${TOP_K:-20}, \"min_p\": $${MIN_P:-0.0}, \"presence_penalty\": $${PRESENCE_PENALTY}, \"repetition_penalty\": $${REPEAT_PENALTY:-1.0}}")
         exec python3 -m sglang.launch_server \
           --model-path "$$M" \
           --tp-size 4 \
@@ -360,8 +437,10 @@ services:
           --attention-backend "${ATTENTION_BACKEND:-flashinfer}" \
           --context-length "${CONTEXT_LENGTH:-262144}" \
           --mem-fraction-static "${MEM_FRACTION:-0.84}" \
-          --max-running-requests "${MAX_RUNNING_REQUESTS:-1}" \
+          --max-running-requests "${MAX_RUNNING_REQUESTS:-2}" \
           --trust-remote-code \
+          --enable-metrics \
+          "$${SAMPLER[@]}" \
           --reasoning-parser "${REASONING_PARSER:-qwen3}" \
           --tool-call-parser "${TOOL_CALL_PARSER:-qwen3_coder}" \
           --host 0.0.0.0 --port 30000 \

--- a/models/qwen3.8-27b/sglang/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/fp8/mtp.yml
@@ -397,7 +397,7 @@ services:
         #      merged result is byte-identical to the unmerged one. It bites only on
         #      the native /generate endpoint. (SGLang's own Responses-API path,
         #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
-        #      this flag; the chat path does not — filed upstream.)
+        #      this flag; the chat path does not — sglang#39096.)
         # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
         #   ON THE THINKING ROW. A client wanting the instruct row must send
         #   temperature/top_p/presence_penalty itself — which is exactly what the

--- a/models/qwen3.8-27b/sglang/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/fp8/mtp.yml
@@ -312,6 +312,14 @@ services:
       - MAX_RUNNING_REQUESTS
       - MAMBA_SSM_DTYPE
       - W4A8
+      - ENABLE_THINKING
+      - TEMP
+      - TOP_P
+      - TOP_K
+      - MIN_P
+      - PRESENCE_PENALTY
+      - REPEAT_PENALTY
+      - REASONING_EFFORT
       - QUANTIZATION
       - CHUNKED_PREFILL_SIZE
     deploy:
@@ -363,6 +371,75 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
+        # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
+        # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked
+        # on every provider we serve: the official FP8 and unsloth GGUF cards restate
+        # both rows verbatim; Frozenlock / RadixArk / syvai / z-lab add no sampling
+        # guidance of their own, so the base card governs for those checkpoints too.
+        #
+        # ⚠️⚠️ ONLY THE THINKING ROW ACTUALLY LANDS HERE — AND NOT BECAUSE OF THE
+        # --preferred-sampling-params FLAG BELOW. Three mechanisms, two of which bite:
+        #   1. --default-chat-template-kwargs IS enforced (applied to every request
+        #      unless the request overrides it) -> the thinking MODE is real, and so
+        #      is reasoning_effort.
+        #   2. --sampling-defaults model (pinned below) makes the engine read the
+        #      checkpoint's generation_config.json, which ships temperature 1.0 /
+        #      top_k 20 / top_p 0.95 — EXACTLY the card's thinking row. THAT is what
+        #      serves the thinking row: Qwen's file, not our flag. The file is
+        #      byte-identical across our int4 and fp8 checkpoints, and there is no
+        #      instruct row anywhere in any of them.
+        #   3. --preferred-sampling-params is INERT on /v1/chat/completions. It IS
+        #      merged (tokenizer_manager.py:1353, `{**preferred, **request}`), but the
+        #      chat adapter's to_sampling_params resolves EVERY key eagerly through
+        #      get_param() — user -> generation_config.json -> OpenAI default — so the
+        #      request dict is always fully populated and always wins the merge. The
+        #      merged result is byte-identical to the unmerged one. It bites only on
+        #      the native /generate endpoint. (SGLang's own Responses-API path,
+        #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
+        #      this flag; the chat path does not — filed upstream.)
+        # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
+        #   ON THE THINKING ROW. A client wanting the instruct row must send
+        #   temperature/top_p/presence_penalty itself — which is exactly what the
+        #   model card's own non-thinking example does, and what bench.sh does.
+        # ⇒ presence_penalty cannot be pinned server-side on EITHER engine: vLLM's
+        #   get_diff_sampling_param() and SGLang's get_default_sampling_params() share
+        #   the same allowlist (repetition_penalty, temperature, top_k, top_p, min_p),
+        #   and both chat adapters declare presence_penalty with a hard 0.0 default, so
+        #   it is always present in the request and always wins. The card anticipates
+        #   this: "support for sampling parameters varies according to inference
+        #   frameworks." It is a client-side parameter, full stop.
+        # We keep the flag because /get_model_info then advertises the correct row to
+        # clients that introspect it — the one thing it genuinely does.
+        _think="${ENABLE_THINKING:-true}"
+        _temp="${TEMP:-}"
+        if [ "$$_think" = "true" ]; then
+          : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
+          echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   temp/top_p/top_k served via generation_config.json (--sampling-defaults model)" >&2
+        else
+          : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
+          echo "[sampler] instruct row (ENABLE_THINKING=false): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   ⚠️ thinking is OFF but the SAMPLER IS NOT: the engine still serves the" >&2
+          echo "[sampler]   ⚠️ thinking row from generation_config.json. Send temperature/top_p/" >&2
+          echo "[sampler]   ⚠️ presence_penalty per-request to get the instruct row." >&2
+        fi
+        echo "[sampler] ⚠️ presence_penalty is CLIENT-SIDE on both engines (engine allowlists drop it)" >&2
+        # ⚠️⚠️ reasoning_effort MUST travel with enable_thinking. This checkpoint's
+        # BUILT-IN template does `reasoning_effort|default('xhigh')` — the SLOWEST,
+        # longest rung — so leaving it unset serves xhigh on EVERY request. The
+        # vLLM tiers for this same model pin `low` (2026-08-16), so an unset value
+        # here would make the two engines serve DIFFERENT reasoning depth by
+        # default and stop being comparable at all.
+        # ⚠️ Ladder is low / medium / xhigh — there is NO `high` rung. The vLLM
+        # tiers mount a patched template that maps high -> xhigh; we use the
+        # checkpoint's built-in template, which has no such mapping.
+        _reff="${REASONING_EFFORT:-low}"
+        case "$$_reff" in low|medium|xhigh) : ;; *) echo "[sampler] REASONING_EFFORT='$$_reff' must be low|medium|xhigh" >&2; exit 1 ;; esac
+        echo "[sampler] reasoning_effort=$$_reff (template default would be xhigh)" >&2
+        SAMPLER=(--default-chat-template-kwargs "{\"enable_thinking\": $$_think, \"reasoning_effort\": \"$$_reff\"}"
+                 --sampling-defaults model
+                 --preferred-sampling-params "{\"temperature\": $$_temp, \"top_p\": $${TOP_P}, \"top_k\": $${TOP_K:-20}, \"min_p\": $${MIN_P:-0.0}, \"presence_penalty\": $${PRESENCE_PENALTY}, \"repetition_penalty\": $${REPEAT_PENALTY:-1.0}}")
         exec python3 -m sglang.launch_server \
           --model-path "$$M" \
           --tp-size 4 \
@@ -374,8 +451,10 @@ services:
           --attention-backend "${ATTENTION_BACKEND:-flashinfer}" \
           --context-length "${CONTEXT_LENGTH:-262144}" \
           --mem-fraction-static "${MEM_FRACTION:-0.86}" \
-          --max-running-requests "${MAX_RUNNING_REQUESTS:-1}" \
+          --max-running-requests "${MAX_RUNNING_REQUESTS:-2}" \
           --trust-remote-code \
+          --enable-metrics \
+          "$${SAMPLER[@]}" \
           --reasoning-parser "${REASONING_PARSER:-qwen3}" \
           --tool-call-parser "${TOOL_CALL_PARSER:-qwen3_coder}" \
           --host 0.0.0.0 --port 30000 \

--- a/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/dflash2.yml
@@ -259,6 +259,14 @@ services:
       - MAX_RUNNING_REQUESTS
       - MAMBA_SSM_DTYPE
       - W4A8
+      - ENABLE_THINKING
+      - TEMP
+      - TOP_P
+      - TOP_K
+      - MIN_P
+      - PRESENCE_PENALTY
+      - REPEAT_PENALTY
+      - REASONING_EFFORT
       - CHUNKED_PREFILL_SIZE
       - DRAFTER_DIR
       - DRAFT_QUANT
@@ -323,6 +331,75 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
+        # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
+        # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked
+        # on every provider we serve: the official FP8 and unsloth GGUF cards restate
+        # both rows verbatim; Frozenlock / RadixArk / syvai / z-lab add no sampling
+        # guidance of their own, so the base card governs for those checkpoints too.
+        #
+        # ⚠️⚠️ ONLY THE THINKING ROW ACTUALLY LANDS HERE — AND NOT BECAUSE OF THE
+        # --preferred-sampling-params FLAG BELOW. Three mechanisms, two of which bite:
+        #   1. --default-chat-template-kwargs IS enforced (applied to every request
+        #      unless the request overrides it) -> the thinking MODE is real, and so
+        #      is reasoning_effort.
+        #   2. --sampling-defaults model (pinned below) makes the engine read the
+        #      checkpoint's generation_config.json, which ships temperature 1.0 /
+        #      top_k 20 / top_p 0.95 — EXACTLY the card's thinking row. THAT is what
+        #      serves the thinking row: Qwen's file, not our flag. The file is
+        #      byte-identical across our int4 and fp8 checkpoints, and there is no
+        #      instruct row anywhere in any of them.
+        #   3. --preferred-sampling-params is INERT on /v1/chat/completions. It IS
+        #      merged (tokenizer_manager.py:1353, `{**preferred, **request}`), but the
+        #      chat adapter's to_sampling_params resolves EVERY key eagerly through
+        #      get_param() — user -> generation_config.json -> OpenAI default — so the
+        #      request dict is always fully populated and always wins the merge. The
+        #      merged result is byte-identical to the unmerged one. It bites only on
+        #      the native /generate endpoint. (SGLang's own Responses-API path,
+        #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
+        #      this flag; the chat path does not — filed upstream.)
+        # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
+        #   ON THE THINKING ROW. A client wanting the instruct row must send
+        #   temperature/top_p/presence_penalty itself — which is exactly what the
+        #   model card's own non-thinking example does, and what bench.sh does.
+        # ⇒ presence_penalty cannot be pinned server-side on EITHER engine: vLLM's
+        #   get_diff_sampling_param() and SGLang's get_default_sampling_params() share
+        #   the same allowlist (repetition_penalty, temperature, top_k, top_p, min_p),
+        #   and both chat adapters declare presence_penalty with a hard 0.0 default, so
+        #   it is always present in the request and always wins. The card anticipates
+        #   this: "support for sampling parameters varies according to inference
+        #   frameworks." It is a client-side parameter, full stop.
+        # We keep the flag because /get_model_info then advertises the correct row to
+        # clients that introspect it — the one thing it genuinely does.
+        _think="${ENABLE_THINKING:-true}"
+        _temp="${TEMP:-}"
+        if [ "$$_think" = "true" ]; then
+          : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
+          echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   temp/top_p/top_k served via generation_config.json (--sampling-defaults model)" >&2
+        else
+          : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
+          echo "[sampler] instruct row (ENABLE_THINKING=false): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   ⚠️ thinking is OFF but the SAMPLER IS NOT: the engine still serves the" >&2
+          echo "[sampler]   ⚠️ thinking row from generation_config.json. Send temperature/top_p/" >&2
+          echo "[sampler]   ⚠️ presence_penalty per-request to get the instruct row." >&2
+        fi
+        echo "[sampler] ⚠️ presence_penalty is CLIENT-SIDE on both engines (engine allowlists drop it)" >&2
+        # ⚠️⚠️ reasoning_effort MUST travel with enable_thinking. This checkpoint's
+        # BUILT-IN template does `reasoning_effort|default('xhigh')` — the SLOWEST,
+        # longest rung — so leaving it unset serves xhigh on EVERY request. The
+        # vLLM tiers for this same model pin `low` (2026-08-16), so an unset value
+        # here would make the two engines serve DIFFERENT reasoning depth by
+        # default and stop being comparable at all.
+        # ⚠️ Ladder is low / medium / xhigh — there is NO `high` rung. The vLLM
+        # tiers mount a patched template that maps high -> xhigh; we use the
+        # checkpoint's built-in template, which has no such mapping.
+        _reff="${REASONING_EFFORT:-low}"
+        case "$$_reff" in low|medium|xhigh) : ;; *) echo "[sampler] REASONING_EFFORT='$$_reff' must be low|medium|xhigh" >&2; exit 1 ;; esac
+        echo "[sampler] reasoning_effort=$$_reff (template default would be xhigh)" >&2
+        SAMPLER=(--default-chat-template-kwargs "{\"enable_thinking\": $$_think, \"reasoning_effort\": \"$$_reff\"}"
+                 --sampling-defaults model
+                 --preferred-sampling-params "{\"temperature\": $$_temp, \"top_p\": $${TOP_P}, \"top_k\": $${TOP_K:-20}, \"min_p\": $${MIN_P:-0.0}, \"presence_penalty\": $${PRESENCE_PENALTY}, \"repetition_penalty\": $${REPEAT_PENALTY:-1.0}}")
         exec python3 -m sglang.launch_server \
           --model-path "$$M" \
           --tp-size 8 \
@@ -334,8 +411,10 @@ services:
           --attention-backend "${ATTENTION_BACKEND:-flashinfer}" \
           --context-length "${CONTEXT_LENGTH:-262144}" \
           --mem-fraction-static "${MEM_FRACTION:-0.82}" \
-          --max-running-requests "${MAX_RUNNING_REQUESTS:-1}" \
+          --max-running-requests "${MAX_RUNNING_REQUESTS:-2}" \
           --trust-remote-code \
+          --enable-metrics \
+          "$${SAMPLER[@]}" \
           --reasoning-parser "${REASONING_PARSER:-qwen3}" \
           --tool-call-parser "${TOOL_CALL_PARSER:-qwen3_coder}" \
           --host 0.0.0.0 --port 30000 \

--- a/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/dflash2.yml
@@ -357,7 +357,7 @@ services:
         #      merged result is byte-identical to the unmerged one. It bites only on
         #      the native /generate endpoint. (SGLang's own Responses-API path,
         #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
-        #      this flag; the chat path does not — filed upstream.)
+        #      this flag; the chat path does not — sglang#39096.)
         # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
         #   ON THE THINKING ROW. A client wanting the instruct row must send
         #   temperature/top_p/presence_penalty itself — which is exactly what the

--- a/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/mtp.yml
@@ -377,7 +377,7 @@ services:
         #      merged result is byte-identical to the unmerged one. It bites only on
         #      the native /generate endpoint. (SGLang's own Responses-API path,
         #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
-        #      this flag; the chat path does not — filed upstream.)
+        #      this flag; the chat path does not — sglang#39096.)
         # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
         #   ON THE THINKING ROW. A client wanting the instruct row must send
         #   temperature/top_p/presence_penalty itself — which is exactly what the

--- a/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/mtp.yml
@@ -293,6 +293,14 @@ services:
       - MAX_RUNNING_REQUESTS
       - MAMBA_SSM_DTYPE
       - W4A8
+      - ENABLE_THINKING
+      - TEMP
+      - TOP_P
+      - TOP_K
+      - MIN_P
+      - PRESENCE_PENALTY
+      - REPEAT_PENALTY
+      - REASONING_EFFORT
       - CHUNKED_PREFILL_SIZE
     deploy:
       resources:
@@ -343,6 +351,75 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
+        # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
+        # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked
+        # on every provider we serve: the official FP8 and unsloth GGUF cards restate
+        # both rows verbatim; Frozenlock / RadixArk / syvai / z-lab add no sampling
+        # guidance of their own, so the base card governs for those checkpoints too.
+        #
+        # ⚠️⚠️ ONLY THE THINKING ROW ACTUALLY LANDS HERE — AND NOT BECAUSE OF THE
+        # --preferred-sampling-params FLAG BELOW. Three mechanisms, two of which bite:
+        #   1. --default-chat-template-kwargs IS enforced (applied to every request
+        #      unless the request overrides it) -> the thinking MODE is real, and so
+        #      is reasoning_effort.
+        #   2. --sampling-defaults model (pinned below) makes the engine read the
+        #      checkpoint's generation_config.json, which ships temperature 1.0 /
+        #      top_k 20 / top_p 0.95 — EXACTLY the card's thinking row. THAT is what
+        #      serves the thinking row: Qwen's file, not our flag. The file is
+        #      byte-identical across our int4 and fp8 checkpoints, and there is no
+        #      instruct row anywhere in any of them.
+        #   3. --preferred-sampling-params is INERT on /v1/chat/completions. It IS
+        #      merged (tokenizer_manager.py:1353, `{**preferred, **request}`), but the
+        #      chat adapter's to_sampling_params resolves EVERY key eagerly through
+        #      get_param() — user -> generation_config.json -> OpenAI default — so the
+        #      request dict is always fully populated and always wins the merge. The
+        #      merged result is byte-identical to the unmerged one. It bites only on
+        #      the native /generate endpoint. (SGLang's own Responses-API path,
+        #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
+        #      this flag; the chat path does not — filed upstream.)
+        # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
+        #   ON THE THINKING ROW. A client wanting the instruct row must send
+        #   temperature/top_p/presence_penalty itself — which is exactly what the
+        #   model card's own non-thinking example does, and what bench.sh does.
+        # ⇒ presence_penalty cannot be pinned server-side on EITHER engine: vLLM's
+        #   get_diff_sampling_param() and SGLang's get_default_sampling_params() share
+        #   the same allowlist (repetition_penalty, temperature, top_k, top_p, min_p),
+        #   and both chat adapters declare presence_penalty with a hard 0.0 default, so
+        #   it is always present in the request and always wins. The card anticipates
+        #   this: "support for sampling parameters varies according to inference
+        #   frameworks." It is a client-side parameter, full stop.
+        # We keep the flag because /get_model_info then advertises the correct row to
+        # clients that introspect it — the one thing it genuinely does.
+        _think="${ENABLE_THINKING:-true}"
+        _temp="${TEMP:-}"
+        if [ "$$_think" = "true" ]; then
+          : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
+          echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   temp/top_p/top_k served via generation_config.json (--sampling-defaults model)" >&2
+        else
+          : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
+          echo "[sampler] instruct row (ENABLE_THINKING=false): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   ⚠️ thinking is OFF but the SAMPLER IS NOT: the engine still serves the" >&2
+          echo "[sampler]   ⚠️ thinking row from generation_config.json. Send temperature/top_p/" >&2
+          echo "[sampler]   ⚠️ presence_penalty per-request to get the instruct row." >&2
+        fi
+        echo "[sampler] ⚠️ presence_penalty is CLIENT-SIDE on both engines (engine allowlists drop it)" >&2
+        # ⚠️⚠️ reasoning_effort MUST travel with enable_thinking. This checkpoint's
+        # BUILT-IN template does `reasoning_effort|default('xhigh')` — the SLOWEST,
+        # longest rung — so leaving it unset serves xhigh on EVERY request. The
+        # vLLM tiers for this same model pin `low` (2026-08-16), so an unset value
+        # here would make the two engines serve DIFFERENT reasoning depth by
+        # default and stop being comparable at all.
+        # ⚠️ Ladder is low / medium / xhigh — there is NO `high` rung. The vLLM
+        # tiers mount a patched template that maps high -> xhigh; we use the
+        # checkpoint's built-in template, which has no such mapping.
+        _reff="${REASONING_EFFORT:-low}"
+        case "$$_reff" in low|medium|xhigh) : ;; *) echo "[sampler] REASONING_EFFORT='$$_reff' must be low|medium|xhigh" >&2; exit 1 ;; esac
+        echo "[sampler] reasoning_effort=$$_reff (template default would be xhigh)" >&2
+        SAMPLER=(--default-chat-template-kwargs "{\"enable_thinking\": $$_think, \"reasoning_effort\": \"$$_reff\"}"
+                 --sampling-defaults model
+                 --preferred-sampling-params "{\"temperature\": $$_temp, \"top_p\": $${TOP_P}, \"top_k\": $${TOP_K:-20}, \"min_p\": $${MIN_P:-0.0}, \"presence_penalty\": $${PRESENCE_PENALTY}, \"repetition_penalty\": $${REPEAT_PENALTY:-1.0}}")
         exec python3 -m sglang.launch_server \
           --model-path "$$M" \
           --tp-size 8 \
@@ -354,8 +431,10 @@ services:
           --attention-backend "${ATTENTION_BACKEND:-flashinfer}" \
           --context-length "${CONTEXT_LENGTH:-262144}" \
           --mem-fraction-static "${MEM_FRACTION:-0.90}" \
-          --max-running-requests "${MAX_RUNNING_REQUESTS:-1}" \
+          --max-running-requests "${MAX_RUNNING_REQUESTS:-2}" \
           --trust-remote-code \
+          --enable-metrics \
+          "$${SAMPLER[@]}" \
           --reasoning-parser "${REASONING_PARSER:-qwen3}" \
           --tool-call-parser "${TOOL_CALL_PARSER:-qwen3_coder}" \
           --host 0.0.0.0 --port 30000 \

--- a/models/qwen3.8-27b/sglang/compose/multi8/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/fp8/dflash2.yml
@@ -291,6 +291,14 @@ services:
       - MAX_RUNNING_REQUESTS
       - MAMBA_SSM_DTYPE
       - W4A8
+      - ENABLE_THINKING
+      - TEMP
+      - TOP_P
+      - TOP_K
+      - MIN_P
+      - PRESENCE_PENALTY
+      - REPEAT_PENALTY
+      - REASONING_EFFORT
       - CHUNKED_PREFILL_SIZE
       - QUANTIZATION
       - DRAFTER_DIR
@@ -356,6 +364,75 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
+        # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
+        # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked
+        # on every provider we serve: the official FP8 and unsloth GGUF cards restate
+        # both rows verbatim; Frozenlock / RadixArk / syvai / z-lab add no sampling
+        # guidance of their own, so the base card governs for those checkpoints too.
+        #
+        # ⚠️⚠️ ONLY THE THINKING ROW ACTUALLY LANDS HERE — AND NOT BECAUSE OF THE
+        # --preferred-sampling-params FLAG BELOW. Three mechanisms, two of which bite:
+        #   1. --default-chat-template-kwargs IS enforced (applied to every request
+        #      unless the request overrides it) -> the thinking MODE is real, and so
+        #      is reasoning_effort.
+        #   2. --sampling-defaults model (pinned below) makes the engine read the
+        #      checkpoint's generation_config.json, which ships temperature 1.0 /
+        #      top_k 20 / top_p 0.95 — EXACTLY the card's thinking row. THAT is what
+        #      serves the thinking row: Qwen's file, not our flag. The file is
+        #      byte-identical across our int4 and fp8 checkpoints, and there is no
+        #      instruct row anywhere in any of them.
+        #   3. --preferred-sampling-params is INERT on /v1/chat/completions. It IS
+        #      merged (tokenizer_manager.py:1353, `{**preferred, **request}`), but the
+        #      chat adapter's to_sampling_params resolves EVERY key eagerly through
+        #      get_param() — user -> generation_config.json -> OpenAI default — so the
+        #      request dict is always fully populated and always wins the merge. The
+        #      merged result is byte-identical to the unmerged one. It bites only on
+        #      the native /generate endpoint. (SGLang's own Responses-API path,
+        #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
+        #      this flag; the chat path does not — filed upstream.)
+        # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
+        #   ON THE THINKING ROW. A client wanting the instruct row must send
+        #   temperature/top_p/presence_penalty itself — which is exactly what the
+        #   model card's own non-thinking example does, and what bench.sh does.
+        # ⇒ presence_penalty cannot be pinned server-side on EITHER engine: vLLM's
+        #   get_diff_sampling_param() and SGLang's get_default_sampling_params() share
+        #   the same allowlist (repetition_penalty, temperature, top_k, top_p, min_p),
+        #   and both chat adapters declare presence_penalty with a hard 0.0 default, so
+        #   it is always present in the request and always wins. The card anticipates
+        #   this: "support for sampling parameters varies according to inference
+        #   frameworks." It is a client-side parameter, full stop.
+        # We keep the flag because /get_model_info then advertises the correct row to
+        # clients that introspect it — the one thing it genuinely does.
+        _think="${ENABLE_THINKING:-true}"
+        _temp="${TEMP:-}"
+        if [ "$$_think" = "true" ]; then
+          : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
+          echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   temp/top_p/top_k served via generation_config.json (--sampling-defaults model)" >&2
+        else
+          : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
+          echo "[sampler] instruct row (ENABLE_THINKING=false): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   ⚠️ thinking is OFF but the SAMPLER IS NOT: the engine still serves the" >&2
+          echo "[sampler]   ⚠️ thinking row from generation_config.json. Send temperature/top_p/" >&2
+          echo "[sampler]   ⚠️ presence_penalty per-request to get the instruct row." >&2
+        fi
+        echo "[sampler] ⚠️ presence_penalty is CLIENT-SIDE on both engines (engine allowlists drop it)" >&2
+        # ⚠️⚠️ reasoning_effort MUST travel with enable_thinking. This checkpoint's
+        # BUILT-IN template does `reasoning_effort|default('xhigh')` — the SLOWEST,
+        # longest rung — so leaving it unset serves xhigh on EVERY request. The
+        # vLLM tiers for this same model pin `low` (2026-08-16), so an unset value
+        # here would make the two engines serve DIFFERENT reasoning depth by
+        # default and stop being comparable at all.
+        # ⚠️ Ladder is low / medium / xhigh — there is NO `high` rung. The vLLM
+        # tiers mount a patched template that maps high -> xhigh; we use the
+        # checkpoint's built-in template, which has no such mapping.
+        _reff="${REASONING_EFFORT:-low}"
+        case "$$_reff" in low|medium|xhigh) : ;; *) echo "[sampler] REASONING_EFFORT='$$_reff' must be low|medium|xhigh" >&2; exit 1 ;; esac
+        echo "[sampler] reasoning_effort=$$_reff (template default would be xhigh)" >&2
+        SAMPLER=(--default-chat-template-kwargs "{\"enable_thinking\": $$_think, \"reasoning_effort\": \"$$_reff\"}"
+                 --sampling-defaults model
+                 --preferred-sampling-params "{\"temperature\": $$_temp, \"top_p\": $${TOP_P}, \"top_k\": $${TOP_K:-20}, \"min_p\": $${MIN_P:-0.0}, \"presence_penalty\": $${PRESENCE_PENALTY}, \"repetition_penalty\": $${REPEAT_PENALTY:-1.0}}")
         exec python3 -m sglang.launch_server \
           --model-path "$$M" \
           --tp-size 8 \
@@ -367,8 +444,10 @@ services:
           --attention-backend "${ATTENTION_BACKEND:-flashinfer}" \
           --context-length "${CONTEXT_LENGTH:-262144}" \
           --mem-fraction-static "${MEM_FRACTION:-0.84}" \
-          --max-running-requests "${MAX_RUNNING_REQUESTS:-1}" \
+          --max-running-requests "${MAX_RUNNING_REQUESTS:-2}" \
           --trust-remote-code \
+          --enable-metrics \
+          "$${SAMPLER[@]}" \
           --reasoning-parser "${REASONING_PARSER:-qwen3}" \
           --tool-call-parser "${TOOL_CALL_PARSER:-qwen3_coder}" \
           --host 0.0.0.0 --port 30000 \

--- a/models/qwen3.8-27b/sglang/compose/multi8/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/fp8/dflash2.yml
@@ -390,7 +390,7 @@ services:
         #      merged result is byte-identical to the unmerged one. It bites only on
         #      the native /generate endpoint. (SGLang's own Responses-API path,
         #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
-        #      this flag; the chat path does not — filed upstream.)
+        #      this flag; the chat path does not — sglang#39096.)
         # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
         #   ON THE THINKING ROW. A client wanting the instruct row must send
         #   temperature/top_p/presence_penalty itself — which is exactly what the

--- a/models/qwen3.8-27b/sglang/compose/multi8/fp8/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/fp8/mtp.yml
@@ -404,7 +404,7 @@ services:
         #      merged result is byte-identical to the unmerged one. It bites only on
         #      the native /generate endpoint. (SGLang's own Responses-API path,
         #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
-        #      this flag; the chat path does not — filed upstream.)
+        #      this flag; the chat path does not — sglang#39096.)
         # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
         #   ON THE THINKING ROW. A client wanting the instruct row must send
         #   temperature/top_p/presence_penalty itself — which is exactly what the

--- a/models/qwen3.8-27b/sglang/compose/multi8/fp8/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/fp8/mtp.yml
@@ -319,6 +319,14 @@ services:
       - MAX_RUNNING_REQUESTS
       - MAMBA_SSM_DTYPE
       - W4A8
+      - ENABLE_THINKING
+      - TEMP
+      - TOP_P
+      - TOP_K
+      - MIN_P
+      - PRESENCE_PENALTY
+      - REPEAT_PENALTY
+      - REASONING_EFFORT
       - QUANTIZATION
       - CHUNKED_PREFILL_SIZE
     deploy:
@@ -370,6 +378,75 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
+        # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
+        # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked
+        # on every provider we serve: the official FP8 and unsloth GGUF cards restate
+        # both rows verbatim; Frozenlock / RadixArk / syvai / z-lab add no sampling
+        # guidance of their own, so the base card governs for those checkpoints too.
+        #
+        # ⚠️⚠️ ONLY THE THINKING ROW ACTUALLY LANDS HERE — AND NOT BECAUSE OF THE
+        # --preferred-sampling-params FLAG BELOW. Three mechanisms, two of which bite:
+        #   1. --default-chat-template-kwargs IS enforced (applied to every request
+        #      unless the request overrides it) -> the thinking MODE is real, and so
+        #      is reasoning_effort.
+        #   2. --sampling-defaults model (pinned below) makes the engine read the
+        #      checkpoint's generation_config.json, which ships temperature 1.0 /
+        #      top_k 20 / top_p 0.95 — EXACTLY the card's thinking row. THAT is what
+        #      serves the thinking row: Qwen's file, not our flag. The file is
+        #      byte-identical across our int4 and fp8 checkpoints, and there is no
+        #      instruct row anywhere in any of them.
+        #   3. --preferred-sampling-params is INERT on /v1/chat/completions. It IS
+        #      merged (tokenizer_manager.py:1353, `{**preferred, **request}`), but the
+        #      chat adapter's to_sampling_params resolves EVERY key eagerly through
+        #      get_param() — user -> generation_config.json -> OpenAI default — so the
+        #      request dict is always fully populated and always wins the merge. The
+        #      merged result is byte-identical to the unmerged one. It bites only on
+        #      the native /generate endpoint. (SGLang's own Responses-API path,
+        #      protocol.py:1793, omits unset keys SPECIFICALLY so they fall through to
+        #      this flag; the chat path does not — filed upstream.)
+        # ⇒ ENABLE_THINKING=false genuinely turns thinking OFF, but the SAMPLER STAYS
+        #   ON THE THINKING ROW. A client wanting the instruct row must send
+        #   temperature/top_p/presence_penalty itself — which is exactly what the
+        #   model card's own non-thinking example does, and what bench.sh does.
+        # ⇒ presence_penalty cannot be pinned server-side on EITHER engine: vLLM's
+        #   get_diff_sampling_param() and SGLang's get_default_sampling_params() share
+        #   the same allowlist (repetition_penalty, temperature, top_k, top_p, min_p),
+        #   and both chat adapters declare presence_penalty with a hard 0.0 default, so
+        #   it is always present in the request and always wins. The card anticipates
+        #   this: "support for sampling parameters varies according to inference
+        #   frameworks." It is a client-side parameter, full stop.
+        # We keep the flag because /get_model_info then advertises the correct row to
+        # clients that introspect it — the one thing it genuinely does.
+        _think="${ENABLE_THINKING:-true}"
+        _temp="${TEMP:-}"
+        if [ "$$_think" = "true" ]; then
+          : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
+          echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   temp/top_p/top_k served via generation_config.json (--sampling-defaults model)" >&2
+        else
+          : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
+          echo "[sampler] instruct row (ENABLE_THINKING=false): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
+          echo "[sampler]   ⚠️ thinking is OFF but the SAMPLER IS NOT: the engine still serves the" >&2
+          echo "[sampler]   ⚠️ thinking row from generation_config.json. Send temperature/top_p/" >&2
+          echo "[sampler]   ⚠️ presence_penalty per-request to get the instruct row." >&2
+        fi
+        echo "[sampler] ⚠️ presence_penalty is CLIENT-SIDE on both engines (engine allowlists drop it)" >&2
+        # ⚠️⚠️ reasoning_effort MUST travel with enable_thinking. This checkpoint's
+        # BUILT-IN template does `reasoning_effort|default('xhigh')` — the SLOWEST,
+        # longest rung — so leaving it unset serves xhigh on EVERY request. The
+        # vLLM tiers for this same model pin `low` (2026-08-16), so an unset value
+        # here would make the two engines serve DIFFERENT reasoning depth by
+        # default and stop being comparable at all.
+        # ⚠️ Ladder is low / medium / xhigh — there is NO `high` rung. The vLLM
+        # tiers mount a patched template that maps high -> xhigh; we use the
+        # checkpoint's built-in template, which has no such mapping.
+        _reff="${REASONING_EFFORT:-low}"
+        case "$$_reff" in low|medium|xhigh) : ;; *) echo "[sampler] REASONING_EFFORT='$$_reff' must be low|medium|xhigh" >&2; exit 1 ;; esac
+        echo "[sampler] reasoning_effort=$$_reff (template default would be xhigh)" >&2
+        SAMPLER=(--default-chat-template-kwargs "{\"enable_thinking\": $$_think, \"reasoning_effort\": \"$$_reff\"}"
+                 --sampling-defaults model
+                 --preferred-sampling-params "{\"temperature\": $$_temp, \"top_p\": $${TOP_P}, \"top_k\": $${TOP_K:-20}, \"min_p\": $${MIN_P:-0.0}, \"presence_penalty\": $${PRESENCE_PENALTY}, \"repetition_penalty\": $${REPEAT_PENALTY:-1.0}}")
         exec python3 -m sglang.launch_server \
           --model-path "$$M" \
           --tp-size 8 \
@@ -381,8 +458,10 @@ services:
           --attention-backend "${ATTENTION_BACKEND:-flashinfer}" \
           --context-length "${CONTEXT_LENGTH:-262144}" \
           --mem-fraction-static "${MEM_FRACTION:-0.86}" \
-          --max-running-requests "${MAX_RUNNING_REQUESTS:-1}" \
+          --max-running-requests "${MAX_RUNNING_REQUESTS:-2}" \
           --trust-remote-code \
+          --enable-metrics \
+          "$${SAMPLER[@]}" \
           --reasoning-parser "${REASONING_PARSER:-qwen3}" \
           --tool-call-parser "${TOOL_CALL_PARSER:-qwen3_coder}" \
           --host 0.0.0.0 --port 30000 \

--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2-fp8.yml
@@ -108,6 +108,7 @@ services:
       - TOP_K=${TOP_K:-}
       - MIN_P=${MIN_P:-}
       - PRESENCE_PENALTY=${PRESENCE_PENALTY:-}
+      - REPEAT_PENALTY=${REPEAT_PENALTY:-}
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
       - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
@@ -198,6 +199,20 @@ services:
         # from .env or shell STILL WINS in both branches. top_k / min_p are
         # identical across the rows and stay mode-independent.
         _temp="$${TEMP:-}"
+        # ⚠️ presence_penalty IS SILENTLY DROPPED — it is in the JSON below for
+        # intent, but vLLM never applies it. get_diff_sampling_param()
+        # (config/model.py) filters --override-generation-config through a fixed
+        # allowlist — repetition_penalty, temperature, top_k, top_p, min_p,
+        # max_new_tokens — with no penalties in it, and ChatCompletionRequest
+        # declares `presence_penalty: float | None = 0.0`, a hard default that is
+        # always present in the request and therefore always wins. So the instruct
+        # row's presence_penalty=1.5 resolves to 0.0 server-side. SGLang has the
+        # identical gap (same allowlist, same hard default): presence_penalty is a
+        # CLIENT-SIDE parameter on BOTH engines. That is what the model card's own
+        # non-thinking example does, and what its "support for sampling parameters
+        # varies according to inference frameworks" note is warning about.
+        # Everything else in the row DOES land — verified 2026-09-11 by resolving a
+        # bare request through to_sampling_params() inside the pinned image.
         if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
@@ -205,7 +220,7 @@ services:
           : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
           echo "[sampler] instruct row (default): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         fi
-        SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY}}")
+        SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY},\"repetition_penalty\":$${REPEAT_PENALTY:-1.0}}")
         exec vllm serve $$AR "$$@" "$${SPEC_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
       - --
     command:

--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/dflash2.yml
@@ -143,6 +143,7 @@ services:
       - TOP_K=${TOP_K:-}
       - MIN_P=${MIN_P:-}
       - PRESENCE_PENALTY=${PRESENCE_PENALTY:-}
+      - REPEAT_PENALTY=${REPEAT_PENALTY:-}
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
       - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
@@ -233,6 +234,20 @@ services:
         # from .env or shell STILL WINS in both branches. top_k / min_p are
         # identical across the rows and stay mode-independent.
         _temp="$${TEMP:-}"
+        # ⚠️ presence_penalty IS SILENTLY DROPPED — it is in the JSON below for
+        # intent, but vLLM never applies it. get_diff_sampling_param()
+        # (config/model.py) filters --override-generation-config through a fixed
+        # allowlist — repetition_penalty, temperature, top_k, top_p, min_p,
+        # max_new_tokens — with no penalties in it, and ChatCompletionRequest
+        # declares `presence_penalty: float | None = 0.0`, a hard default that is
+        # always present in the request and therefore always wins. So the instruct
+        # row's presence_penalty=1.5 resolves to 0.0 server-side. SGLang has the
+        # identical gap (same allowlist, same hard default): presence_penalty is a
+        # CLIENT-SIDE parameter on BOTH engines. That is what the model card's own
+        # non-thinking example does, and what its "support for sampling parameters
+        # varies according to inference frameworks" note is warning about.
+        # Everything else in the row DOES land — verified 2026-09-11 by resolving a
+        # bare request through to_sampling_params() inside the pinned image.
         if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
@@ -240,7 +255,7 @@ services:
           : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
           echo "[sampler] instruct row (default): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         fi
-        SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY}}")
+        SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY},\"repetition_penalty\":$${REPEAT_PENALTY:-1.0}}")
         exec vllm serve $$AR "$$@" "$${SPEC_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
       - --
     command:

--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
@@ -227,6 +227,7 @@ services:
       - TOP_K=${TOP_K:-}
       - MIN_P=${MIN_P:-}
       - PRESENCE_PENALTY=${PRESENCE_PENALTY:-}
+      - REPEAT_PENALTY=${REPEAT_PENALTY:-}
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
       - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
@@ -316,6 +317,20 @@ services:
         # from .env or shell STILL WINS in both branches. top_k / min_p are
         # identical across the rows and stay mode-independent.
         _temp="$${TEMP:-}"
+        # ⚠️ presence_penalty IS SILENTLY DROPPED — it is in the JSON below for
+        # intent, but vLLM never applies it. get_diff_sampling_param()
+        # (config/model.py) filters --override-generation-config through a fixed
+        # allowlist — repetition_penalty, temperature, top_k, top_p, min_p,
+        # max_new_tokens — with no penalties in it, and ChatCompletionRequest
+        # declares `presence_penalty: float | None = 0.0`, a hard default that is
+        # always present in the request and therefore always wins. So the instruct
+        # row's presence_penalty=1.5 resolves to 0.0 server-side. SGLang has the
+        # identical gap (same allowlist, same hard default): presence_penalty is a
+        # CLIENT-SIDE parameter on BOTH engines. That is what the model card's own
+        # non-thinking example does, and what its "support for sampling parameters
+        # varies according to inference frameworks" note is warning about.
+        # Everything else in the row DOES land — verified 2026-09-11 by resolving a
+        # bare request through to_sampling_params() inside the pinned image.
         if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
@@ -323,7 +338,7 @@ services:
           : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
           echo "[sampler] instruct row (default): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         fi
-        SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY}}")
+        SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY},\"repetition_penalty\":$${REPEAT_PENALTY:-1.0}}")
         exec vllm serve $$AR "$$@" "$${SPEC_ARGS[@]}" "$${ASYNC_ARGS[@]}" "$${MAMBA_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
       - --
     command:

--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/dflash2-fp8.yml
@@ -207,6 +207,20 @@ services:
         # branches. top_k / min_p / repetition_penalty are identical across the
         # rows and stay mode-independent.
         _temp="$${TEMP:-$${TEMPERATURE:-}}"
+        # ⚠️ presence_penalty IS SILENTLY DROPPED — it is in the JSON below for
+        # intent, but vLLM never applies it. get_diff_sampling_param()
+        # (config/model.py) filters --override-generation-config through a fixed
+        # allowlist — repetition_penalty, temperature, top_k, top_p, min_p,
+        # max_new_tokens — with no penalties in it, and ChatCompletionRequest
+        # declares `presence_penalty: float | None = 0.0`, a hard default that is
+        # always present in the request and therefore always wins. So the instruct
+        # row's presence_penalty=1.5 resolves to 0.0 server-side. SGLang has the
+        # identical gap (same allowlist, same hard default): presence_penalty is a
+        # CLIENT-SIDE parameter on BOTH engines. That is what the model card's own
+        # non-thinking example does, and what its "support for sampling parameters
+        # varies according to inference frameworks" note is warning about.
+        # Everything else in the row DOES land — verified 2026-09-11 by resolving a
+        # bare request through to_sampling_params() inside the pinned image.
         if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2

--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/dflash2.yml
@@ -207,6 +207,20 @@ services:
         # branches. top_k / min_p / repetition_penalty are identical across the
         # rows and stay mode-independent.
         _temp="$${TEMP:-$${TEMPERATURE:-}}"
+        # ⚠️ presence_penalty IS SILENTLY DROPPED — it is in the JSON below for
+        # intent, but vLLM never applies it. get_diff_sampling_param()
+        # (config/model.py) filters --override-generation-config through a fixed
+        # allowlist — repetition_penalty, temperature, top_k, top_p, min_p,
+        # max_new_tokens — with no penalties in it, and ChatCompletionRequest
+        # declares `presence_penalty: float | None = 0.0`, a hard default that is
+        # always present in the request and therefore always wins. So the instruct
+        # row's presence_penalty=1.5 resolves to 0.0 server-side. SGLang has the
+        # identical gap (same allowlist, same hard default): presence_penalty is a
+        # CLIENT-SIDE parameter on BOTH engines. That is what the model card's own
+        # non-thinking example does, and what its "support for sampling parameters
+        # varies according to inference frameworks" note is warning about.
+        # Everything else in the row DOES land — verified 2026-09-11 by resolving a
+        # bare request through to_sampling_params() inside the pinned image.
         if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2

--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
@@ -513,6 +513,20 @@ services:
         # branches. top_k / min_p / repetition_penalty are identical across the
         # rows and stay mode-independent.
         _temp="$${TEMP:-$${TEMPERATURE:-}}"
+        # ⚠️ presence_penalty IS SILENTLY DROPPED — it is in the JSON below for
+        # intent, but vLLM never applies it. get_diff_sampling_param()
+        # (config/model.py) filters --override-generation-config through a fixed
+        # allowlist — repetition_penalty, temperature, top_k, top_p, min_p,
+        # max_new_tokens — with no penalties in it, and ChatCompletionRequest
+        # declares `presence_penalty: float | None = 0.0`, a hard default that is
+        # always present in the request and therefore always wins. So the instruct
+        # row's presence_penalty=1.5 resolves to 0.0 server-side. SGLang has the
+        # identical gap (same allowlist, same hard default): presence_penalty is a
+        # CLIENT-SIDE parameter on BOTH engines. That is what the model card's own
+        # non-thinking example does, and what its "support for sampling parameters
+        # varies according to inference frameworks" note is warning about.
+        # Everything else in the row DOES land — verified 2026-09-11 by resolving a
+        # bare request through to_sampling_params() inside the pinned image.
         if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2

--- a/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
@@ -151,6 +151,7 @@ services:
       - TOP_K=${TOP_K:-}
       - MIN_P=${MIN_P:-}
       - PRESENCE_PENALTY=${PRESENCE_PENALTY:-}
+      - REPEAT_PENALTY=${REPEAT_PENALTY:-}
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
       - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
@@ -214,6 +215,20 @@ services:
         # from .env or shell STILL WINS in both branches. top_k / min_p are
         # identical across the rows and stay mode-independent.
         _temp="$${TEMP:-}"
+        # ⚠️ presence_penalty IS SILENTLY DROPPED — it is in the JSON below for
+        # intent, but vLLM never applies it. get_diff_sampling_param()
+        # (config/model.py) filters --override-generation-config through a fixed
+        # allowlist — repetition_penalty, temperature, top_k, top_p, min_p,
+        # max_new_tokens — with no penalties in it, and ChatCompletionRequest
+        # declares `presence_penalty: float | None = 0.0`, a hard default that is
+        # always present in the request and therefore always wins. So the instruct
+        # row's presence_penalty=1.5 resolves to 0.0 server-side. SGLang has the
+        # identical gap (same allowlist, same hard default): presence_penalty is a
+        # CLIENT-SIDE parameter on BOTH engines. That is what the model card's own
+        # non-thinking example does, and what its "support for sampling parameters
+        # varies according to inference frameworks" note is warning about.
+        # Everything else in the row DOES land — verified 2026-09-11 by resolving a
+        # bare request through to_sampling_params() inside the pinned image.
         if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
@@ -221,7 +236,7 @@ services:
           : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
           echo "[sampler] instruct row (default): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         fi
-        SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY}}")
+        SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY},\"repetition_penalty\":$${REPEAT_PENALTY:-1.0}}")
         # -- Mamba/GDN cache knobs (hybrid-model KV headroom) --
         #   MAMBA_BLOCK_SIZE=<tokens>  checkpoint SSM state every N tokens (align mode; multiple of 8)
         #   MAMBA_CACHE_DTYPE=bfloat16 store conv+ssm state in bf16 instead of fp32

--- a/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/dflash2-fp8.yml
@@ -110,6 +110,7 @@ services:
       - TOP_K=${TOP_K:-}
       - MIN_P=${MIN_P:-}
       - PRESENCE_PENALTY=${PRESENCE_PENALTY:-}
+      - REPEAT_PENALTY=${REPEAT_PENALTY:-}
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
       - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
@@ -189,6 +190,20 @@ services:
         # from .env or shell STILL WINS in both branches. top_k / min_p are
         # identical across the rows and stay mode-independent.
         _temp="$${TEMP:-}"
+        # ⚠️ presence_penalty IS SILENTLY DROPPED — it is in the JSON below for
+        # intent, but vLLM never applies it. get_diff_sampling_param()
+        # (config/model.py) filters --override-generation-config through a fixed
+        # allowlist — repetition_penalty, temperature, top_k, top_p, min_p,
+        # max_new_tokens — with no penalties in it, and ChatCompletionRequest
+        # declares `presence_penalty: float | None = 0.0`, a hard default that is
+        # always present in the request and therefore always wins. So the instruct
+        # row's presence_penalty=1.5 resolves to 0.0 server-side. SGLang has the
+        # identical gap (same allowlist, same hard default): presence_penalty is a
+        # CLIENT-SIDE parameter on BOTH engines. That is what the model card's own
+        # non-thinking example does, and what its "support for sampling parameters
+        # varies according to inference frameworks" note is warning about.
+        # Everything else in the row DOES land — verified 2026-09-11 by resolving a
+        # bare request through to_sampling_params() inside the pinned image.
         if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
@@ -196,7 +211,7 @@ services:
           : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
           echo "[sampler] instruct row (default): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         fi
-        SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY}}")
+        SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY},\"repetition_penalty\":$${REPEAT_PENALTY:-1.0}}")
         exec vllm serve $$AR "$$@" "$${SPEC_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
       - --
     command:

--- a/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/dflash2.yml
@@ -121,6 +121,7 @@ services:
       - TOP_K=${TOP_K:-}
       - MIN_P=${MIN_P:-}
       - PRESENCE_PENALTY=${PRESENCE_PENALTY:-}
+      - REPEAT_PENALTY=${REPEAT_PENALTY:-}
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
       - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
@@ -200,6 +201,20 @@ services:
         # from .env or shell STILL WINS in both branches. top_k / min_p are
         # identical across the rows and stay mode-independent.
         _temp="$${TEMP:-}"
+        # ⚠️ presence_penalty IS SILENTLY DROPPED — it is in the JSON below for
+        # intent, but vLLM never applies it. get_diff_sampling_param()
+        # (config/model.py) filters --override-generation-config through a fixed
+        # allowlist — repetition_penalty, temperature, top_k, top_p, min_p,
+        # max_new_tokens — with no penalties in it, and ChatCompletionRequest
+        # declares `presence_penalty: float | None = 0.0`, a hard default that is
+        # always present in the request and therefore always wins. So the instruct
+        # row's presence_penalty=1.5 resolves to 0.0 server-side. SGLang has the
+        # identical gap (same allowlist, same hard default): presence_penalty is a
+        # CLIENT-SIDE parameter on BOTH engines. That is what the model card's own
+        # non-thinking example does, and what its "support for sampling parameters
+        # varies according to inference frameworks" note is warning about.
+        # Everything else in the row DOES land — verified 2026-09-11 by resolving a
+        # bare request through to_sampling_params() inside the pinned image.
         if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
@@ -207,7 +222,7 @@ services:
           : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
           echo "[sampler] instruct row (default): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         fi
-        SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY}}")
+        SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY},\"repetition_penalty\":$${REPEAT_PENALTY:-1.0}}")
         exec vllm serve $$AR "$$@" "$${SPEC_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
       - --
     command:

--- a/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
@@ -201,6 +201,7 @@ services:
       - TOP_K=${TOP_K:-}
       - MIN_P=${MIN_P:-}
       - PRESENCE_PENALTY=${PRESENCE_PENALTY:-}
+      - REPEAT_PENALTY=${REPEAT_PENALTY:-}
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
       - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
@@ -277,6 +278,20 @@ services:
         # from .env or shell STILL WINS in both branches. top_k / min_p are
         # identical across the rows and stay mode-independent.
         _temp="$${TEMP:-}"
+        # ⚠️ presence_penalty IS SILENTLY DROPPED — it is in the JSON below for
+        # intent, but vLLM never applies it. get_diff_sampling_param()
+        # (config/model.py) filters --override-generation-config through a fixed
+        # allowlist — repetition_penalty, temperature, top_k, top_p, min_p,
+        # max_new_tokens — with no penalties in it, and ChatCompletionRequest
+        # declares `presence_penalty: float | None = 0.0`, a hard default that is
+        # always present in the request and therefore always wins. So the instruct
+        # row's presence_penalty=1.5 resolves to 0.0 server-side. SGLang has the
+        # identical gap (same allowlist, same hard default): presence_penalty is a
+        # CLIENT-SIDE parameter on BOTH engines. That is what the model card's own
+        # non-thinking example does, and what its "support for sampling parameters
+        # varies according to inference frameworks" note is warning about.
+        # Everything else in the row DOES land — verified 2026-09-11 by resolving a
+        # bare request through to_sampling_params() inside the pinned image.
         if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
@@ -284,7 +299,7 @@ services:
           : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
           echo "[sampler] instruct row (default): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         fi
-        SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY}}")
+        SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY},\"repetition_penalty\":$${REPEAT_PENALTY:-1.0}}")
         # -- Mamba/GDN cache knobs (hybrid-model KV headroom) --
         #   MAMBA_BLOCK_SIZE=<tokens>  checkpoint SSM state every N tokens (align mode; multiple of 8)
         #   MAMBA_CACHE_DTYPE=bfloat16 store conv+ssm state in bf16 instead of fp32

--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/dflash2-fp8.yml
@@ -207,6 +207,20 @@ services:
         # branches. top_k / min_p / repetition_penalty are identical across the
         # rows and stay mode-independent.
         _temp="$${TEMP:-$${TEMPERATURE:-}}"
+        # ⚠️ presence_penalty IS SILENTLY DROPPED — it is in the JSON below for
+        # intent, but vLLM never applies it. get_diff_sampling_param()
+        # (config/model.py) filters --override-generation-config through a fixed
+        # allowlist — repetition_penalty, temperature, top_k, top_p, min_p,
+        # max_new_tokens — with no penalties in it, and ChatCompletionRequest
+        # declares `presence_penalty: float | None = 0.0`, a hard default that is
+        # always present in the request and therefore always wins. So the instruct
+        # row's presence_penalty=1.5 resolves to 0.0 server-side. SGLang has the
+        # identical gap (same allowlist, same hard default): presence_penalty is a
+        # CLIENT-SIDE parameter on BOTH engines. That is what the model card's own
+        # non-thinking example does, and what its "support for sampling parameters
+        # varies according to inference frameworks" note is warning about.
+        # Everything else in the row DOES land — verified 2026-09-11 by resolving a
+        # bare request through to_sampling_params() inside the pinned image.
         if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2

--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/dflash2.yml
@@ -206,6 +206,20 @@ services:
         # branches. top_k / min_p / repetition_penalty are identical across the
         # rows and stay mode-independent.
         _temp="$${TEMP:-$${TEMPERATURE:-}}"
+        # ⚠️ presence_penalty IS SILENTLY DROPPED — it is in the JSON below for
+        # intent, but vLLM never applies it. get_diff_sampling_param()
+        # (config/model.py) filters --override-generation-config through a fixed
+        # allowlist — repetition_penalty, temperature, top_k, top_p, min_p,
+        # max_new_tokens — with no penalties in it, and ChatCompletionRequest
+        # declares `presence_penalty: float | None = 0.0`, a hard default that is
+        # always present in the request and therefore always wins. So the instruct
+        # row's presence_penalty=1.5 resolves to 0.0 server-side. SGLang has the
+        # identical gap (same allowlist, same hard default): presence_penalty is a
+        # CLIENT-SIDE parameter on BOTH engines. That is what the model card's own
+        # non-thinking example does, and what its "support for sampling parameters
+        # varies according to inference frameworks" note is warning about.
+        # Everything else in the row DOES land — verified 2026-09-11 by resolving a
+        # bare request through to_sampling_params() inside the pinned image.
         if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2

--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
@@ -388,6 +388,20 @@ services:
         # branches. top_k / min_p / repetition_penalty are identical across the
         # rows and stay mode-independent.
         _temp="$${TEMP:-$${TEMPERATURE:-}}"
+        # ⚠️ presence_penalty IS SILENTLY DROPPED — it is in the JSON below for
+        # intent, but vLLM never applies it. get_diff_sampling_param()
+        # (config/model.py) filters --override-generation-config through a fixed
+        # allowlist — repetition_penalty, temperature, top_k, top_p, min_p,
+        # max_new_tokens — with no penalties in it, and ChatCompletionRequest
+        # declares `presence_penalty: float | None = 0.0`, a hard default that is
+        # always present in the request and therefore always wins. So the instruct
+        # row's presence_penalty=1.5 resolves to 0.0 server-side. SGLang has the
+        # identical gap (same allowlist, same hard default): presence_penalty is a
+        # CLIENT-SIDE parameter on BOTH engines. That is what the model card's own
+        # non-thinking example does, and what its "support for sampling parameters
+        # varies according to inference frameworks" note is warning about.
+        # Everything else in the row DOES land — verified 2026-09-11 by resolving a
+        # bare request through to_sampling_params() inside the pinned image.
         if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2

--- a/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/dflash2-fp8.yml
@@ -110,6 +110,7 @@ services:
       - TOP_K=${TOP_K:-}
       - MIN_P=${MIN_P:-}
       - PRESENCE_PENALTY=${PRESENCE_PENALTY:-}
+      - REPEAT_PENALTY=${REPEAT_PENALTY:-}
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
       - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
@@ -189,6 +190,20 @@ services:
         # from .env or shell STILL WINS in both branches. top_k / min_p are
         # identical across the rows and stay mode-independent.
         _temp="$${TEMP:-}"
+        # ⚠️ presence_penalty IS SILENTLY DROPPED — it is in the JSON below for
+        # intent, but vLLM never applies it. get_diff_sampling_param()
+        # (config/model.py) filters --override-generation-config through a fixed
+        # allowlist — repetition_penalty, temperature, top_k, top_p, min_p,
+        # max_new_tokens — with no penalties in it, and ChatCompletionRequest
+        # declares `presence_penalty: float | None = 0.0`, a hard default that is
+        # always present in the request and therefore always wins. So the instruct
+        # row's presence_penalty=1.5 resolves to 0.0 server-side. SGLang has the
+        # identical gap (same allowlist, same hard default): presence_penalty is a
+        # CLIENT-SIDE parameter on BOTH engines. That is what the model card's own
+        # non-thinking example does, and what its "support for sampling parameters
+        # varies according to inference frameworks" note is warning about.
+        # Everything else in the row DOES land — verified 2026-09-11 by resolving a
+        # bare request through to_sampling_params() inside the pinned image.
         if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
@@ -196,7 +211,7 @@ services:
           : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
           echo "[sampler] instruct row (default): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         fi
-        SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY}}")
+        SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY},\"repetition_penalty\":$${REPEAT_PENALTY:-1.0}}")
         exec vllm serve $$AR "$$@" "$${SPEC_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
       - --
     command:

--- a/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/dflash2.yml
@@ -122,6 +122,7 @@ services:
       - TOP_K=${TOP_K:-}
       - MIN_P=${MIN_P:-}
       - PRESENCE_PENALTY=${PRESENCE_PENALTY:-}
+      - REPEAT_PENALTY=${REPEAT_PENALTY:-}
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
       - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
@@ -201,6 +202,20 @@ services:
         # from .env or shell STILL WINS in both branches. top_k / min_p are
         # identical across the rows and stay mode-independent.
         _temp="$${TEMP:-}"
+        # ⚠️ presence_penalty IS SILENTLY DROPPED — it is in the JSON below for
+        # intent, but vLLM never applies it. get_diff_sampling_param()
+        # (config/model.py) filters --override-generation-config through a fixed
+        # allowlist — repetition_penalty, temperature, top_k, top_p, min_p,
+        # max_new_tokens — with no penalties in it, and ChatCompletionRequest
+        # declares `presence_penalty: float | None = 0.0`, a hard default that is
+        # always present in the request and therefore always wins. So the instruct
+        # row's presence_penalty=1.5 resolves to 0.0 server-side. SGLang has the
+        # identical gap (same allowlist, same hard default): presence_penalty is a
+        # CLIENT-SIDE parameter on BOTH engines. That is what the model card's own
+        # non-thinking example does, and what its "support for sampling parameters
+        # varies according to inference frameworks" note is warning about.
+        # Everything else in the row DOES land — verified 2026-09-11 by resolving a
+        # bare request through to_sampling_params() inside the pinned image.
         if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
@@ -208,7 +223,7 @@ services:
           : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
           echo "[sampler] instruct row (default): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         fi
-        SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY}}")
+        SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY},\"repetition_penalty\":$${REPEAT_PENALTY:-1.0}}")
         exec vllm serve $$AR "$$@" "$${SPEC_ARGS[@]}" "$${SAMPLER_ARGS[@]}"
       - --
     command:

--- a/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
@@ -201,6 +201,7 @@ services:
       - TOP_K=${TOP_K:-}
       - MIN_P=${MIN_P:-}
       - PRESENCE_PENALTY=${PRESENCE_PENALTY:-}
+      - REPEAT_PENALTY=${REPEAT_PENALTY:-}
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
       - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
@@ -277,6 +278,20 @@ services:
         # from .env or shell STILL WINS in both branches. top_k / min_p are
         # identical across the rows and stay mode-independent.
         _temp="$${TEMP:-}"
+        # ⚠️ presence_penalty IS SILENTLY DROPPED — it is in the JSON below for
+        # intent, but vLLM never applies it. get_diff_sampling_param()
+        # (config/model.py) filters --override-generation-config through a fixed
+        # allowlist — repetition_penalty, temperature, top_k, top_p, min_p,
+        # max_new_tokens — with no penalties in it, and ChatCompletionRequest
+        # declares `presence_penalty: float | None = 0.0`, a hard default that is
+        # always present in the request and therefore always wins. So the instruct
+        # row's presence_penalty=1.5 resolves to 0.0 server-side. SGLang has the
+        # identical gap (same allowlist, same hard default): presence_penalty is a
+        # CLIENT-SIDE parameter on BOTH engines. That is what the model card's own
+        # non-thinking example does, and what its "support for sampling parameters
+        # varies according to inference frameworks" note is warning about.
+        # Everything else in the row DOES land — verified 2026-09-11 by resolving a
+        # bare request through to_sampling_params() inside the pinned image.
         if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
@@ -284,7 +299,7 @@ services:
           : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
           echo "[sampler] instruct row (default): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         fi
-        SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY}}")
+        SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY},\"repetition_penalty\":$${REPEAT_PENALTY:-1.0}}")
         # -- Mamba/GDN cache knobs (hybrid-model KV headroom) --
         #   MAMBA_BLOCK_SIZE=<tokens>  checkpoint SSM state every N tokens (align mode; multiple of 8)
         #   MAMBA_CACHE_DTYPE=bfloat16 store conv+ssm state in bf16 instead of fp32

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/dflash2-fp8.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/dflash2-fp8.yml
@@ -207,6 +207,20 @@ services:
         # branches. top_k / min_p / repetition_penalty are identical across the
         # rows and stay mode-independent.
         _temp="$${TEMP:-$${TEMPERATURE:-}}"
+        # ⚠️ presence_penalty IS SILENTLY DROPPED — it is in the JSON below for
+        # intent, but vLLM never applies it. get_diff_sampling_param()
+        # (config/model.py) filters --override-generation-config through a fixed
+        # allowlist — repetition_penalty, temperature, top_k, top_p, min_p,
+        # max_new_tokens — with no penalties in it, and ChatCompletionRequest
+        # declares `presence_penalty: float | None = 0.0`, a hard default that is
+        # always present in the request and therefore always wins. So the instruct
+        # row's presence_penalty=1.5 resolves to 0.0 server-side. SGLang has the
+        # identical gap (same allowlist, same hard default): presence_penalty is a
+        # CLIENT-SIDE parameter on BOTH engines. That is what the model card's own
+        # non-thinking example does, and what its "support for sampling parameters
+        # varies according to inference frameworks" note is warning about.
+        # Everything else in the row DOES land — verified 2026-09-11 by resolving a
+        # bare request through to_sampling_params() inside the pinned image.
         if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/dflash2.yml
@@ -206,6 +206,20 @@ services:
         # branches. top_k / min_p / repetition_penalty are identical across the
         # rows and stay mode-independent.
         _temp="$${TEMP:-$${TEMPERATURE:-}}"
+        # ⚠️ presence_penalty IS SILENTLY DROPPED — it is in the JSON below for
+        # intent, but vLLM never applies it. get_diff_sampling_param()
+        # (config/model.py) filters --override-generation-config through a fixed
+        # allowlist — repetition_penalty, temperature, top_k, top_p, min_p,
+        # max_new_tokens — with no penalties in it, and ChatCompletionRequest
+        # declares `presence_penalty: float | None = 0.0`, a hard default that is
+        # always present in the request and therefore always wins. So the instruct
+        # row's presence_penalty=1.5 resolves to 0.0 server-side. SGLang has the
+        # identical gap (same allowlist, same hard default): presence_penalty is a
+        # CLIENT-SIDE parameter on BOTH engines. That is what the model card's own
+        # non-thinking example does, and what its "support for sampling parameters
+        # varies according to inference frameworks" note is warning about.
+        # Everything else in the row DOES land — verified 2026-09-11 by resolving a
+        # bare request through to_sampling_params() inside the pinned image.
         if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
@@ -392,6 +392,20 @@ services:
         # branches. top_k / min_p / repetition_penalty are identical across the
         # rows and stay mode-independent.
         _temp="$${TEMP:-$${TEMPERATURE:-}}"
+        # ⚠️ presence_penalty IS SILENTLY DROPPED — it is in the JSON below for
+        # intent, but vLLM never applies it. get_diff_sampling_param()
+        # (config/model.py) filters --override-generation-config through a fixed
+        # allowlist — repetition_penalty, temperature, top_k, top_p, min_p,
+        # max_new_tokens — with no penalties in it, and ChatCompletionRequest
+        # declares `presence_penalty: float | None = 0.0`, a hard default that is
+        # always present in the request and therefore always wins. So the instruct
+        # row's presence_penalty=1.5 resolves to 0.0 server-side. SGLang has the
+        # identical gap (same allowlist, same hard default): presence_penalty is a
+        # CLIENT-SIDE parameter on BOTH engines. That is what the model card's own
+        # non-thinking example does, and what its "support for sampling parameters
+        # varies according to inference frameworks" note is warning about.
+        # Everything else in the row DOES land — verified 2026-09-11 by resolving a
+        # bare request through to_sampling_params() inside the pinned image.
         if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2

--- a/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
@@ -174,6 +174,7 @@ services:
       - TOP_K=${TOP_K:-}
       - MIN_P=${MIN_P:-}
       - PRESENCE_PENALTY=${PRESENCE_PENALTY:-}
+      - REPEAT_PENALTY=${REPEAT_PENALTY:-}
       - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
       - CUDA_VISIBLE_DEVICES
       - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
@@ -237,6 +238,20 @@ services:
         # from .env or shell STILL WINS in both branches. top_k / min_p are
         # identical across the rows and stay mode-independent.
         _temp="$${TEMP:-}"
+        # ⚠️ presence_penalty IS SILENTLY DROPPED — it is in the JSON below for
+        # intent, but vLLM never applies it. get_diff_sampling_param()
+        # (config/model.py) filters --override-generation-config through a fixed
+        # allowlist — repetition_penalty, temperature, top_k, top_p, min_p,
+        # max_new_tokens — with no penalties in it, and ChatCompletionRequest
+        # declares `presence_penalty: float | None = 0.0`, a hard default that is
+        # always present in the request and therefore always wins. So the instruct
+        # row's presence_penalty=1.5 resolves to 0.0 server-side. SGLang has the
+        # identical gap (same allowlist, same hard default): presence_penalty is a
+        # CLIENT-SIDE parameter on BOTH engines. That is what the model card's own
+        # non-thinking example does, and what its "support for sampling parameters
+        # varies according to inference frameworks" note is warning about.
+        # Everything else in the row DOES land — verified 2026-09-11 by resolving a
+        # bare request through to_sampling_params() inside the pinned image.
         if [ "$${ENABLE_THINKING:-true}" = "true" ]; then
           : "$${_temp:=1.0}" "$${TOP_P:=0.95}" "$${PRESENCE_PENALTY:=0.0}"
           echo "[sampler] thinking row (ENABLE_THINKING=true): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
@@ -244,7 +259,7 @@ services:
           : "$${_temp:=0.7}" "$${TOP_P:=0.80}" "$${PRESENCE_PENALTY:=1.5}"
           echo "[sampler] instruct row (default): temp=$$_temp top_p=$${TOP_P} presence=$${PRESENCE_PENALTY}" >&2
         fi
-        SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY}}")
+        SAMPLER_ARGS=(--override-generation-config "{\"temperature\":$$_temp,\"top_p\":$${TOP_P},\"top_k\":$${TOP_K:-20},\"min_p\":$${MIN_P:-0.0},\"presence_penalty\":$${PRESENCE_PENALTY},\"repetition_penalty\":$${REPEAT_PENALTY:-1.0}}")
         # -- Mamba/GDN cache knobs (hybrid-model KV headroom) --
         #   MAMBA_BLOCK_SIZE=<tokens>  checkpoint SSM state every N tokens (align mode; multiple of 8)
         #   MAMBA_CACHE_DTYPE=bfloat16 store conv+ssm state in bf16 instead of fp32


### PR DESCRIPTION
Three things, all for `qwen3.8-27b`: two feature additions to the SGLang tier, and a
sampler-accuracy sweep that corrects a claim we shipped.

## 1. SGLang tier: metrics + concurrency headroom (13 composes)

* `--enable-metrics` — `/metrics` now serves the 516-series Prometheus surface, including
  `sglang:spec_accept_length` / `sglang:spec_accept_rate`. Those are the acceptance numbers
  we have been scraping out of container logs.
* `MAX_RUNNING_REQUESTS`, defaulting to **2** on the `multi4`/`multi8` tiers where the VRAM
  envelope has the headroom, 1 elsewhere.
* The model-card sampler row selected by `ENABLE_THINKING`, mirroring the vLLM tiers (#1014),
  with `reasoning_effort` pinned to `low` so both engines serve the same reasoning depth.

## 2. The sampler claim we had wrong

The **values** were re-verified against `Qwen/Qwen3.8-27B`'s card and against every provider
backing a shipped compose. The official FP8 and unsloth GGUF cards restate both rows verbatim;
Frozenlock, RadixArk, syvai and z-lab add no sampling guidance, so the base card governs there
too. All six parameters in both rows match what we encode. What did not match was our
description of **how they are delivered**:

**`--preferred-sampling-params` is inert on `/v1/chat/completions` — but not for the reason we
said.** The composes claimed it is "ADVERTISEMENT ONLY … NOTHING applies it to a request",
which came from the upstream help string and `http_server.py:764`. In fact
`tokenizer_manager.py:1353` merges it as `{**preferred, **request}` on every generate request.
It loses anyway: the chat adapter's `to_sampling_params` resolves every key eagerly through
`get_param()` (user → `generation_config.json` → OpenAI default), so the request dict is always
fully populated and always wins. The merged dict is byte-identical to the unmerged one. Right
conclusion, wrong mechanism — and the mechanism is what tells you the flag *is* live on the
native `/generate` endpoint.

**What actually serves the thinking row is `--sampling-defaults model`**, reading the
checkpoint's `generation_config.json` — `temperature 1.0 / top_k 20 / top_p 0.95`, exactly the
card's thinking row, byte-identical across our int4 and fp8 checkpoints. That was an upstream
default we were inheriting silently; it is now pinned explicitly, because the behaviour of the
whole block hangs off it.

**Consequence, now stated in the file:** `ENABLE_THINKING=false` genuinely turns thinking off,
but the sampler stays on the thinking row. There is no instruct row anywhere in the checkpoint
and no flag that installs one.

**`presence_penalty` cannot be pinned server-side on either engine.** vLLM's
`get_diff_sampling_param()` and SGLang's `get_default_sampling_params()` share the same
allowlist — `repetition_penalty, temperature, top_k, top_p, min_p` — and both chat adapters
declare `presence_penalty` with a hard `0.0` default, so it is always present in the request
and always wins. The instruct row's `1.5` has never reached a request on either engine, with no
warning. Documented across all 33 composes rather than left looking like it works. The card
anticipates this and passes the value client-side in its own non-thinking example.

**llama.cpp is the exception** and its two composes now say so: `params_from_json_cmpl()` seeds
each request from the CLI params, so `presence_penalty` does land there. That commit is
comment-only — the default render is byte-identical.

## 3. `repetition_penalty` was in 9 of 20 vLLM composes

So `REPEAT_PENALTY` was live on those and a silent no-op on the other 11. Now uniform, with
`REPEAT_PENALTY` declared in each `environment:` block (bare passthrough on SGLang; each vLLM
file keeps its local spelling).

## How this was verified

By resolving a bare chat request through each engine's own `to_sampling_params()` **inside the
pinned images** — not by reading documentation. The upstream help for
`--preferred-sampling-params` still says "returned in `/get_model_info`", which is exactly what
the original wrong claim was based on.

```
vLLM   instruct row -> temperature=0.7  top_p=0.8   presence_penalty=0.0
SGLang merged dict  == unmerged dict (preferred params change nothing)
```

## Gates

`compose-status-drift`, `compose-mounts-resolve`, `sglang-image-pin-parity`,
`patch-attribution`, `compose-registry-disk`, `locale-utf8` green. All 33 composes render.
The new SGLang flag set parses under v0.5.19.

## Follow-ups (not in this PR)

* Upstream: filed as **[sglang#39096](https://github.com/sgl-project/sglang/issues/39096)** and
  tracked in `docs/UPSTREAM.md`. It re-reports #21816 (stale-bot closed, both fix PRs closed
  unmerged) and corrects it: the five `get_param()` keys that issue believed were working are
  affected too, and with an empty generation config `top_k` resolves to `-1`, silently disabling
  top-k. SGLang's own Responses-API path already omits unset keys for exactly this reason
  (`protocol.py:1793`); the chat path needs the same.
* The `INSTRUCT=1` flip on the llama.cpp composes rides on a spelling b10236 marks
  `DEPRECATED`. Correct today (last-wins is confirmed), but it should move into the entrypoint
  shell — that needs a boot to land safely.
* z-lab benched DFlash2 at `xhigh` reasoning effort; we ship `low`, so their acceptance figure
  and our 3.71 are not comparable. An A/B is unrun.
