### PR TITLE
feat(qwen3.8): vendor @A1RM4X's SGLang W4A8 patch and wire it to every sgl/ slug (from #1226)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -361,6 +361,19 @@ Dense 27B, Qwen3-Next hybrid (16 full-attention + 48 linear-attention layers, 24
 
 ⚠️ **Do not diff these against the Qwen3.6-27B rows.** Different checkpoint, different sampler defaults (this tier follows the 3.8 model card's Instruct row), and cross-session TPS comparison is invalid on this rig — single boots swing ~5 TPS on the code leg, which is wider than most tier gaps. Same-session A/B only.
 
+
+### Quad-card (4× RTX 3090, TP=4) — SGLang
+
+Community submission. **Not a shipped compose** — @A1RM4X ran his own TP=4 W4A8 compose from
+[#1226](https://github.com/noonghunna/club-3090/pull/1226); the equivalent on the shipped catalog is
+`sgl/qwen38-27b-multi4-superfast` with `W4A8=1`, which mounts the same vendored patch. His numbers
+are banked here because they are the only W4A8 measurements on this engine from a rig that can
+actually run TP=4.
+
+| Config | Rig | KV | Max ctx | Narr / Code TPS | PP tok/s | Peak VRAM | Date | Notes |
+| --- | --- | --- | ---: | ---: | ---: | ---: | --- | --- |
+| TP=4 · DFlash2 n=8 · **W4A8** (@A1RM4X's own compose, [#1226](https://github.com/noonghunna/club-3090/pull/1226)) | @A1RM4X (4× 3090 Turbo 24 GB, **NVLink** (0,2)/(1,3), 220 W cap) | fp8 e4m3 | 262144 | **144.6 / 244.8** (c=1, CV 1.5% / ~1%) | 1810 @16K (flat 1K–16K) | **22,055–22,365 MiB/card** (0 MiB leak) | 2026-09-09 | 🧪 Experimental. **SGLang v0.5.19.** The *engine A/B* of his own vLLM DFlash2 run — same model/quant/DFlash2/FP8 KV/TP4/262K/220 W; only engine + drafter depth (7→8) differ, so the decode delta is an engine comparison. **SGLang wins c=1 decode +43%** (144.6/244.8 vs vLLM 100.8/185.0); ITL p50 21.9 ms vs ~31 ms. **The win narrows as concurrency rises:** +43% at c=1 → +4%/+6% by c=8 (vLLM's batching scales harder; crossover between c=4 and c=8) → +11%/+10% at c=16. No knee at c=16 on either engine (combined decode still climbs c=8→c=16: narr 315→535, code 620→974). **Prefill:** raw TPS slightly lower (1683–1875 vs vLLM 1758–1910) **but TTFT is *lower* at 4K+** — 1.5 s vs 2.1 s @4K, 2.7 s vs 4.3 s @8K, **5.0 s vs 8.6 s @16K** — speculative prefill overlap cutting user-visible latency at long context. **SpecDecode (Prometheus, `--enable-metrics`):** `spec_accept_length` **5.65 tok/step**, `spec_accept_rate` **66.0%** (54 accepted / 56 drafts, 6 requests, 6.5 s window). ⚠️ c=1 code decode is short-completion (646–800 tok actual vs 800 target — the quicksort prompt self-terminates); c=8 codeln TTFT 1069 ms and c=16 codeln TTFT 2356 ms are single-outlier rounds (medians fine). **Read against his vLLM DFlash2 row, not the Qwen3.6-27B tier.** ⚠️ **This is a 4-card NVLink rig** — the reference rig has 2 PCIe-only 3090s, so these do not transfer to the `dual` tiers. Raw: [`results/sglang-q38-ar-w4a8-dflash2-tp4-20260909/`](results/sglang-q38-ar-w4a8-dflash2-tp4-20260909/). Patch: [`models/qwen3.8-27b/sglang/patches/sglang-autoround-w4a8-v0.5.19/`](models/qwen3.8-27b/sglang/patches/sglang-autoround-w4a8-v0.5.19/). |
+
 ---
 
 ## Qwen3.6-40B-Deckard

--- a/models/qwen3.8-27b/CHANGELOG.md
+++ b/models/qwen3.8-27b/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 Dated history for Qwen3.8-27B configs in this repo. Append-only — add a new entry, don't rewrite past ones.
 
+## 2026-09-11 — SGLang W4A8: vendor @A1RM4X's re-cut patch, wire it to every `sgl/` slug
+
+Takes the **patch half** of [#1226](https://github.com/noonghunna/club-3090/pull/1226) — the
+installer, the v0.5.19 re-cut and the `patches.yml` entry, cherry-picked with @A1RM4X's authorship
+intact — and leaves his TP=4 compose out, because the eleven `sgl/` slugs shipped in
+[#1237](https://github.com/noonghunna/club-3090/pull/1237) already cover that shape with a
+`W4A8=1` toggle. His bench numbers are banked in BENCHMARKS.md as a community 4-card row.
+
+`W4A8=1` now works on all 13 SGLang composes with no extra steps: the patch dir is vendored at
+`models/qwen3.8-27b/sglang/patches/sglang-autoround-w4a8-v0.5.19/` and each compose already mounted
+that path at `/etc/club3090/w4a8`. Until this commit the mount resolved to nothing and the toggle
+hard-failed by design rather than silently serving W4A16; that guard stays, but its message no
+longer tells you to go land #1226.
+
+**Why a patch at all.** SGLang has no env-gated W4A8 path the way vLLM does
+(`VLLM_MARLIN_INPUT_DTYPE=int8`) — here, applying the patch *is* the activation. The patch is a
+**re-cut of @jb-seo's `0004-autoround-w4a8.patch` (cut against v0.5.18) onto v0.5.19**, which is the
+first release carrying DFlash2 upstream, so a single engine build can serve W4A8 + DFlash2 together.
+
+**The re-cut's real contribution is the shape guard.** jb-seo's eligibility gate omitted the
+per-shard `K%128==0 / N%64==0` constraint that `prepare_w4a8` hard-asserts. On Qwen3.8-27B's merged
+GDN `in_proj_ba` tensor (N=96 → 48/rank at TP=4, not 64-divisible) a naive W4A8 pass crashes in
+`gptq_marlin_repack` with `size_n=48 is not divisible by 64`. The guard pre-checks each shard and
+routes non-conformant layers to standard Marlin W4A16 instead of crashing. @A1RM4X proved it
+necessary by isolation: stock v0.5.19 without the guard crashes identically, which exonerates the
+rest of the patch.
+
+**⚠️ Checkpoint data fix — separate from the patch, do not skip.** Stock SGLang crashes on the Avuja
+AutoRound checkpoint at weight-load *even without* W4A8: its GDN `in_proj_a`/`in_proj_b` layers are
+BF16 in the checkpoint, but SGLang builds a merged `in_proj_ba` and routes it through GPTQ-Marlin.
+The fix is data-side, in the target's `config.json`
+(`".*in_proj_ba.*": {"bits":16,"data_type":"fp"}`). The patch does **not** fix this — it is a
+checkpoint property. Full story in the patch README.
+
+**Measured on @A1RM4X's 4× 3090 Turbo (NVLink, 220 W, fp8 KV, TP=4, DFlash2 n=8), 2026-09-09:**
+SGLang wins c=1 decode **+43%** (144.6 narr / 244.8 code vs vLLM 100.8 / 185.0); the win narrows to
++4%/+6% by c=8 as vLLM's batching scales harder (crossover c=4→8), then +11%/+10% at c=16. Prefill
+raw TPS −2%…−17%, but **TTFT is lower at 4K+** (5.0 s vs 8.6 s @16K). `spec_accept_length` 5.65
+tok/step, accept rate 66%. Raw in `results/sglang-q38-ar-w4a8-dflash2-tp4-20260909/`.
+⚠️ That is a 4-card NVLink rig; it does not transfer to the PCIe-only dual tiers.
+
+On our own 2× 3090, the same toggle measured **+44.5% prefill@10K / +33.9%@90K for −11.1% code
+decode** on `sgl/qwen38-27b-dual-fast`, and took `dual-superfast` prefill to 1779 tok/s against
+vLLM's 1778 — parity, while still ahead on decode. It is a trade, not a free win.
+
+**Status: 🧪 Experimental**, unchanged. No verify-stress, soak or 8-pack has been run on any `sgl/`
+slug with `W4A8=1`.
+
+
 ## 2026-09-04 — dual-fast: `MAMBA_BLOCK_SIZE` knob — the "2.17×/2.49× concurrency" pool figures were ~20% optimistic; 8192-token SSM checkpoints recover it (2×242K concurrent, 0 preemptions)
 
 **Finding.** vLLM's "GPU KV cache size: N tokens" counts attention KV only. In `--mamba-cache-mode align` (the shipped default) the GDN/SSM state is checkpointed at **every attention block** — 1,616 tokens on this slug, since align pads the attention block up to the mamba page — and those state pages are carved out of the *same* pool at runtime without appearing in N. Measured on the ref 2×3090 (v0.27.1, W4A8, MTP n=4, util 0.92, 4 seqs): pool reported **530,081 tokens (2.02×)**, but two ~200K prompts filled it (`kv_cache_usage_perc` → 0.98) at ~400K live tokens, preempted twice and serialized (TTFT 292 s / 481 s). Effective capacity ≈ **80% of nominal**, so the header's 652,346 → 2.49× and 567,737 → 2.17× read as ~2.0× / ~1.75× in practice. `max_num_seqs` (4→2: +0.8%), util 0.90→0.92 (+3%), `MAX_NUM_BATCHED_TOKENS` 8192→4096 (0 — the 1.96 GiB "peak activation" reserve is fixed) and `MAMBA_CACHE_MODE=none` (a no-op while prefix caching is on) do not move it.

--- a/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2-bf16.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2-bf16.yml
@@ -246,14 +246,17 @@ services:
         if [ "$$_w4a8" = "1" ]; then
           _p=/etc/club3090/w4a8
           if [ ! -f "$$_p/install.sh" ]; then
-            echo "[w4a8] W4A8=1 but the patch is not mounted at $$_p." >&2
-            echo "[w4a8] This compose does NOT vendor it. Land club-3090#1226 (or mount its" >&2
-            echo "[w4a8] patch dir there yourself), then retry. Refusing to serve W4A16 silently." >&2
+            echo "[w4a8] W4A8=1 but no installer at $$_p." >&2
+            echo "[w4a8] The patch IS vendored (models/qwen3.8-27b/sglang/patches/" >&2
+            echo "[w4a8] sglang-autoround-w4a8-v0.5.19) and mounted there by default, so this" >&2
+            echo "[w4a8] means the mount did not resolve - a W4A8_PATCH_DIR override pointing" >&2
+            echo "[w4a8] somewhere else, or docker created an empty dir because the path was" >&2
+            echo "[w4a8] missing. Refusing to serve W4A16 silently." >&2
             exit 1
           fi
           bash "$$_p/install.sh" || { echo "[w4a8] install FAILED" >&2; exit 1; }
           bash "$$_p/install.sh" --verify || { echo "[w4a8] post-install verify FAILED" >&2; exit 1; }
-          echo "[w4a8] ON - int8 activations via club-3090#1226" >&2
+          echo "[w4a8] ON - int8 activations (patch by @A1RM4X, club-3090#1226; re-cut of @jb-seo's)" >&2
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi

--- a/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2.yml
@@ -280,14 +280,17 @@ services:
         if [ "$$_w4a8" = "1" ]; then
           _p=/etc/club3090/w4a8
           if [ ! -f "$$_p/install.sh" ]; then
-            echo "[w4a8] W4A8=1 but the patch is not mounted at $$_p." >&2
-            echo "[w4a8] This compose does NOT vendor it. Land club-3090#1226 (or mount its" >&2
-            echo "[w4a8] patch dir there yourself), then retry. Refusing to serve W4A16 silently." >&2
+            echo "[w4a8] W4A8=1 but no installer at $$_p." >&2
+            echo "[w4a8] The patch IS vendored (models/qwen3.8-27b/sglang/patches/" >&2
+            echo "[w4a8] sglang-autoround-w4a8-v0.5.19) and mounted there by default, so this" >&2
+            echo "[w4a8] means the mount did not resolve - a W4A8_PATCH_DIR override pointing" >&2
+            echo "[w4a8] somewhere else, or docker created an empty dir because the path was" >&2
+            echo "[w4a8] missing. Refusing to serve W4A16 silently." >&2
             exit 1
           fi
           bash "$$_p/install.sh" || { echo "[w4a8] install FAILED" >&2; exit 1; }
           bash "$$_p/install.sh" --verify || { echo "[w4a8] post-install verify FAILED" >&2; exit 1; }
-          echo "[w4a8] ON - int8 activations via club-3090#1226" >&2
+          echo "[w4a8] ON - int8 activations (patch by @A1RM4X, club-3090#1226; re-cut of @jb-seo's)" >&2
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi

--- a/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/mtp.yml
@@ -292,14 +292,17 @@ services:
         if [ "$$_w4a8" = "1" ]; then
           _p=/etc/club3090/w4a8
           if [ ! -f "$$_p/install.sh" ]; then
-            echo "[w4a8] W4A8=1 but the patch is not mounted at $$_p." >&2
-            echo "[w4a8] This compose does NOT vendor it. Land club-3090#1226 (or mount its" >&2
-            echo "[w4a8] patch dir there yourself), then retry. Refusing to serve W4A16 silently." >&2
+            echo "[w4a8] W4A8=1 but no installer at $$_p." >&2
+            echo "[w4a8] The patch IS vendored (models/qwen3.8-27b/sglang/patches/" >&2
+            echo "[w4a8] sglang-autoround-w4a8-v0.5.19) and mounted there by default, so this" >&2
+            echo "[w4a8] means the mount did not resolve - a W4A8_PATCH_DIR override pointing" >&2
+            echo "[w4a8] somewhere else, or docker created an empty dir because the path was" >&2
+            echo "[w4a8] missing. Refusing to serve W4A16 silently." >&2
             exit 1
           fi
           bash "$$_p/install.sh" || { echo "[w4a8] install FAILED" >&2; exit 1; }
           bash "$$_p/install.sh" --verify || { echo "[w4a8] post-install verify FAILED" >&2; exit 1; }
-          echo "[w4a8] ON - int8 activations via club-3090#1226" >&2
+          echo "[w4a8] ON - int8 activations (patch by @A1RM4X, club-3090#1226; re-cut of @jb-seo's)" >&2
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi

--- a/models/qwen3.8-27b/sglang/compose/dual/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/fp8/dflash2.yml
@@ -313,14 +313,17 @@ services:
         if [ "$$_w4a8" = "1" ]; then
           _p=/etc/club3090/w4a8
           if [ ! -f "$$_p/install.sh" ]; then
-            echo "[w4a8] W4A8=1 but the patch is not mounted at $$_p." >&2
-            echo "[w4a8] This compose does NOT vendor it. Land club-3090#1226 (or mount its" >&2
-            echo "[w4a8] patch dir there yourself), then retry. Refusing to serve W4A16 silently." >&2
+            echo "[w4a8] W4A8=1 but no installer at $$_p." >&2
+            echo "[w4a8] The patch IS vendored (models/qwen3.8-27b/sglang/patches/" >&2
+            echo "[w4a8] sglang-autoround-w4a8-v0.5.19) and mounted there by default, so this" >&2
+            echo "[w4a8] means the mount did not resolve - a W4A8_PATCH_DIR override pointing" >&2
+            echo "[w4a8] somewhere else, or docker created an empty dir because the path was" >&2
+            echo "[w4a8] missing. Refusing to serve W4A16 silently." >&2
             exit 1
           fi
           bash "$$_p/install.sh" || { echo "[w4a8] install FAILED" >&2; exit 1; }
           bash "$$_p/install.sh" --verify || { echo "[w4a8] post-install verify FAILED" >&2; exit 1; }
-          echo "[w4a8] ON - int8 activations via club-3090#1226" >&2
+          echo "[w4a8] ON - int8 activations (patch by @A1RM4X, club-3090#1226; re-cut of @jb-seo's)" >&2
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi

--- a/models/qwen3.8-27b/sglang/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/fp8/mtp.yml
@@ -347,14 +347,17 @@ services:
         if [ "$$_w4a8" = "1" ]; then
           _p=/etc/club3090/w4a8
           if [ ! -f "$$_p/install.sh" ]; then
-            echo "[w4a8] W4A8=1 but the patch is not mounted at $$_p." >&2
-            echo "[w4a8] This compose does NOT vendor it. Land club-3090#1226 (or mount its" >&2
-            echo "[w4a8] patch dir there yourself), then retry. Refusing to serve W4A16 silently." >&2
+            echo "[w4a8] W4A8=1 but no installer at $$_p." >&2
+            echo "[w4a8] The patch IS vendored (models/qwen3.8-27b/sglang/patches/" >&2
+            echo "[w4a8] sglang-autoround-w4a8-v0.5.19) and mounted there by default, so this" >&2
+            echo "[w4a8] means the mount did not resolve - a W4A8_PATCH_DIR override pointing" >&2
+            echo "[w4a8] somewhere else, or docker created an empty dir because the path was" >&2
+            echo "[w4a8] missing. Refusing to serve W4A16 silently." >&2
             exit 1
           fi
           bash "$$_p/install.sh" || { echo "[w4a8] install FAILED" >&2; exit 1; }
           bash "$$_p/install.sh" --verify || { echo "[w4a8] post-install verify FAILED" >&2; exit 1; }
-          echo "[w4a8] ON - int8 activations via club-3090#1226" >&2
+          echo "[w4a8] ON - int8 activations (patch by @A1RM4X, club-3090#1226; re-cut of @jb-seo's)" >&2
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi

--- a/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/dflash2.yml
@@ -315,14 +315,17 @@ services:
         if [ "$$_w4a8" = "1" ]; then
           _p=/etc/club3090/w4a8
           if [ ! -f "$$_p/install.sh" ]; then
-            echo "[w4a8] W4A8=1 but the patch is not mounted at $$_p." >&2
-            echo "[w4a8] This compose does NOT vendor it. Land club-3090#1226 (or mount its" >&2
-            echo "[w4a8] patch dir there yourself), then retry. Refusing to serve W4A16 silently." >&2
+            echo "[w4a8] W4A8=1 but no installer at $$_p." >&2
+            echo "[w4a8] The patch IS vendored (models/qwen3.8-27b/sglang/patches/" >&2
+            echo "[w4a8] sglang-autoround-w4a8-v0.5.19) and mounted there by default, so this" >&2
+            echo "[w4a8] means the mount did not resolve - a W4A8_PATCH_DIR override pointing" >&2
+            echo "[w4a8] somewhere else, or docker created an empty dir because the path was" >&2
+            echo "[w4a8] missing. Refusing to serve W4A16 silently." >&2
             exit 1
           fi
           bash "$$_p/install.sh" || { echo "[w4a8] install FAILED" >&2; exit 1; }
           bash "$$_p/install.sh" --verify || { echo "[w4a8] post-install verify FAILED" >&2; exit 1; }
-          echo "[w4a8] ON - int8 activations via club-3090#1226" >&2
+          echo "[w4a8] ON - int8 activations (patch by @A1RM4X, club-3090#1226; re-cut of @jb-seo's)" >&2
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi

--- a/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/mtp.yml
@@ -335,14 +335,17 @@ services:
         if [ "$$_w4a8" = "1" ]; then
           _p=/etc/club3090/w4a8
           if [ ! -f "$$_p/install.sh" ]; then
-            echo "[w4a8] W4A8=1 but the patch is not mounted at $$_p." >&2
-            echo "[w4a8] This compose does NOT vendor it. Land club-3090#1226 (or mount its" >&2
-            echo "[w4a8] patch dir there yourself), then retry. Refusing to serve W4A16 silently." >&2
+            echo "[w4a8] W4A8=1 but no installer at $$_p." >&2
+            echo "[w4a8] The patch IS vendored (models/qwen3.8-27b/sglang/patches/" >&2
+            echo "[w4a8] sglang-autoround-w4a8-v0.5.19) and mounted there by default, so this" >&2
+            echo "[w4a8] means the mount did not resolve - a W4A8_PATCH_DIR override pointing" >&2
+            echo "[w4a8] somewhere else, or docker created an empty dir because the path was" >&2
+            echo "[w4a8] missing. Refusing to serve W4A16 silently." >&2
             exit 1
           fi
           bash "$$_p/install.sh" || { echo "[w4a8] install FAILED" >&2; exit 1; }
           bash "$$_p/install.sh" --verify || { echo "[w4a8] post-install verify FAILED" >&2; exit 1; }
-          echo "[w4a8] ON - int8 activations via club-3090#1226" >&2
+          echo "[w4a8] ON - int8 activations (patch by @A1RM4X, club-3090#1226; re-cut of @jb-seo's)" >&2
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi

--- a/models/qwen3.8-27b/sglang/compose/multi4/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/fp8/dflash2.yml
@@ -346,14 +346,17 @@ services:
         if [ "$$_w4a8" = "1" ]; then
           _p=/etc/club3090/w4a8
           if [ ! -f "$$_p/install.sh" ]; then
-            echo "[w4a8] W4A8=1 but the patch is not mounted at $$_p." >&2
-            echo "[w4a8] This compose does NOT vendor it. Land club-3090#1226 (or mount its" >&2
-            echo "[w4a8] patch dir there yourself), then retry. Refusing to serve W4A16 silently." >&2
+            echo "[w4a8] W4A8=1 but no installer at $$_p." >&2
+            echo "[w4a8] The patch IS vendored (models/qwen3.8-27b/sglang/patches/" >&2
+            echo "[w4a8] sglang-autoround-w4a8-v0.5.19) and mounted there by default, so this" >&2
+            echo "[w4a8] means the mount did not resolve - a W4A8_PATCH_DIR override pointing" >&2
+            echo "[w4a8] somewhere else, or docker created an empty dir because the path was" >&2
+            echo "[w4a8] missing. Refusing to serve W4A16 silently." >&2
             exit 1
           fi
           bash "$$_p/install.sh" || { echo "[w4a8] install FAILED" >&2; exit 1; }
           bash "$$_p/install.sh" --verify || { echo "[w4a8] post-install verify FAILED" >&2; exit 1; }
-          echo "[w4a8] ON - int8 activations via club-3090#1226" >&2
+          echo "[w4a8] ON - int8 activations (patch by @A1RM4X, club-3090#1226; re-cut of @jb-seo's)" >&2
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi

--- a/models/qwen3.8-27b/sglang/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/fp8/mtp.yml
@@ -360,14 +360,17 @@ services:
         if [ "$$_w4a8" = "1" ]; then
           _p=/etc/club3090/w4a8
           if [ ! -f "$$_p/install.sh" ]; then
-            echo "[w4a8] W4A8=1 but the patch is not mounted at $$_p." >&2
-            echo "[w4a8] This compose does NOT vendor it. Land club-3090#1226 (or mount its" >&2
-            echo "[w4a8] patch dir there yourself), then retry. Refusing to serve W4A16 silently." >&2
+            echo "[w4a8] W4A8=1 but no installer at $$_p." >&2
+            echo "[w4a8] The patch IS vendored (models/qwen3.8-27b/sglang/patches/" >&2
+            echo "[w4a8] sglang-autoround-w4a8-v0.5.19) and mounted there by default, so this" >&2
+            echo "[w4a8] means the mount did not resolve - a W4A8_PATCH_DIR override pointing" >&2
+            echo "[w4a8] somewhere else, or docker created an empty dir because the path was" >&2
+            echo "[w4a8] missing. Refusing to serve W4A16 silently." >&2
             exit 1
           fi
           bash "$$_p/install.sh" || { echo "[w4a8] install FAILED" >&2; exit 1; }
           bash "$$_p/install.sh" --verify || { echo "[w4a8] post-install verify FAILED" >&2; exit 1; }
-          echo "[w4a8] ON - int8 activations via club-3090#1226" >&2
+          echo "[w4a8] ON - int8 activations (patch by @A1RM4X, club-3090#1226; re-cut of @jb-seo's)" >&2
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi

--- a/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/dflash2.yml
@@ -320,14 +320,17 @@ services:
         if [ "$$_w4a8" = "1" ]; then
           _p=/etc/club3090/w4a8
           if [ ! -f "$$_p/install.sh" ]; then
-            echo "[w4a8] W4A8=1 but the patch is not mounted at $$_p." >&2
-            echo "[w4a8] This compose does NOT vendor it. Land club-3090#1226 (or mount its" >&2
-            echo "[w4a8] patch dir there yourself), then retry. Refusing to serve W4A16 silently." >&2
+            echo "[w4a8] W4A8=1 but no installer at $$_p." >&2
+            echo "[w4a8] The patch IS vendored (models/qwen3.8-27b/sglang/patches/" >&2
+            echo "[w4a8] sglang-autoround-w4a8-v0.5.19) and mounted there by default, so this" >&2
+            echo "[w4a8] means the mount did not resolve - a W4A8_PATCH_DIR override pointing" >&2
+            echo "[w4a8] somewhere else, or docker created an empty dir because the path was" >&2
+            echo "[w4a8] missing. Refusing to serve W4A16 silently." >&2
             exit 1
           fi
           bash "$$_p/install.sh" || { echo "[w4a8] install FAILED" >&2; exit 1; }
           bash "$$_p/install.sh" --verify || { echo "[w4a8] post-install verify FAILED" >&2; exit 1; }
-          echo "[w4a8] ON - int8 activations via club-3090#1226" >&2
+          echo "[w4a8] ON - int8 activations (patch by @A1RM4X, club-3090#1226; re-cut of @jb-seo's)" >&2
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi

--- a/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/mtp.yml
@@ -340,14 +340,17 @@ services:
         if [ "$$_w4a8" = "1" ]; then
           _p=/etc/club3090/w4a8
           if [ ! -f "$$_p/install.sh" ]; then
-            echo "[w4a8] W4A8=1 but the patch is not mounted at $$_p." >&2
-            echo "[w4a8] This compose does NOT vendor it. Land club-3090#1226 (or mount its" >&2
-            echo "[w4a8] patch dir there yourself), then retry. Refusing to serve W4A16 silently." >&2
+            echo "[w4a8] W4A8=1 but no installer at $$_p." >&2
+            echo "[w4a8] The patch IS vendored (models/qwen3.8-27b/sglang/patches/" >&2
+            echo "[w4a8] sglang-autoround-w4a8-v0.5.19) and mounted there by default, so this" >&2
+            echo "[w4a8] means the mount did not resolve - a W4A8_PATCH_DIR override pointing" >&2
+            echo "[w4a8] somewhere else, or docker created an empty dir because the path was" >&2
+            echo "[w4a8] missing. Refusing to serve W4A16 silently." >&2
             exit 1
           fi
           bash "$$_p/install.sh" || { echo "[w4a8] install FAILED" >&2; exit 1; }
           bash "$$_p/install.sh" --verify || { echo "[w4a8] post-install verify FAILED" >&2; exit 1; }
-          echo "[w4a8] ON - int8 activations via club-3090#1226" >&2
+          echo "[w4a8] ON - int8 activations (patch by @A1RM4X, club-3090#1226; re-cut of @jb-seo's)" >&2
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi

--- a/models/qwen3.8-27b/sglang/compose/multi8/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/fp8/dflash2.yml
@@ -353,14 +353,17 @@ services:
         if [ "$$_w4a8" = "1" ]; then
           _p=/etc/club3090/w4a8
           if [ ! -f "$$_p/install.sh" ]; then
-            echo "[w4a8] W4A8=1 but the patch is not mounted at $$_p." >&2
-            echo "[w4a8] This compose does NOT vendor it. Land club-3090#1226 (or mount its" >&2
-            echo "[w4a8] patch dir there yourself), then retry. Refusing to serve W4A16 silently." >&2
+            echo "[w4a8] W4A8=1 but no installer at $$_p." >&2
+            echo "[w4a8] The patch IS vendored (models/qwen3.8-27b/sglang/patches/" >&2
+            echo "[w4a8] sglang-autoround-w4a8-v0.5.19) and mounted there by default, so this" >&2
+            echo "[w4a8] means the mount did not resolve - a W4A8_PATCH_DIR override pointing" >&2
+            echo "[w4a8] somewhere else, or docker created an empty dir because the path was" >&2
+            echo "[w4a8] missing. Refusing to serve W4A16 silently." >&2
             exit 1
           fi
           bash "$$_p/install.sh" || { echo "[w4a8] install FAILED" >&2; exit 1; }
           bash "$$_p/install.sh" --verify || { echo "[w4a8] post-install verify FAILED" >&2; exit 1; }
-          echo "[w4a8] ON - int8 activations via club-3090#1226" >&2
+          echo "[w4a8] ON - int8 activations (patch by @A1RM4X, club-3090#1226; re-cut of @jb-seo's)" >&2
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi

--- a/models/qwen3.8-27b/sglang/compose/multi8/fp8/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/fp8/mtp.yml
@@ -367,14 +367,17 @@ services:
         if [ "$$_w4a8" = "1" ]; then
           _p=/etc/club3090/w4a8
           if [ ! -f "$$_p/install.sh" ]; then
-            echo "[w4a8] W4A8=1 but the patch is not mounted at $$_p." >&2
-            echo "[w4a8] This compose does NOT vendor it. Land club-3090#1226 (or mount its" >&2
-            echo "[w4a8] patch dir there yourself), then retry. Refusing to serve W4A16 silently." >&2
+            echo "[w4a8] W4A8=1 but no installer at $$_p." >&2
+            echo "[w4a8] The patch IS vendored (models/qwen3.8-27b/sglang/patches/" >&2
+            echo "[w4a8] sglang-autoround-w4a8-v0.5.19) and mounted there by default, so this" >&2
+            echo "[w4a8] means the mount did not resolve - a W4A8_PATCH_DIR override pointing" >&2
+            echo "[w4a8] somewhere else, or docker created an empty dir because the path was" >&2
+            echo "[w4a8] missing. Refusing to serve W4A16 silently." >&2
             exit 1
           fi
           bash "$$_p/install.sh" || { echo "[w4a8] install FAILED" >&2; exit 1; }
           bash "$$_p/install.sh" --verify || { echo "[w4a8] post-install verify FAILED" >&2; exit 1; }
-          echo "[w4a8] ON - int8 activations via club-3090#1226" >&2
+          echo "[w4a8] ON - int8 activations (patch by @A1RM4X, club-3090#1226; re-cut of @jb-seo's)" >&2
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi

--- a/models/qwen3.8-27b/sglang/patches/sglang-autoround-w4a8-v0.5.19/0004-autoround-w4a8.v0519.patch
+++ b/models/qwen3.8-27b/sglang/patches/sglang-autoround-w4a8-v0.5.19/0004-autoround-w4a8.v0519.patch
@@ -1,0 +1,3828 @@
+diff --git a/python/sglang/kernels/jit/csrc/gemm/marlin_w4a8/dequant.h b/python/sglang/kernels/jit/csrc/gemm/marlin_w4a8/dequant.h
+new file mode 100644
+index 0000000..4f17adc
+--- /dev/null
++++ b/python/sglang/kernels/jit/csrc/gemm/marlin_w4a8/dequant.h
+@@ -0,0 +1,557 @@
++// SPDX-License-Identifier: Apache-2.0
++// Adapted from vLLM v0.27.1 (6e448d0ea9bf3d88d898b65449ca6dc2aec170ac).
++// Copyright contributors to the vLLM project; Marlin: Elias Frantar.
++// SGLang standalone W4A8 experiment: no vLLM build or runtime dependency.
++/*
++Fast Dequantization (Converting INT4/INT8/FP4/FP8 to FP16/BF16)
++
++The process of fast dequantization can be summarized as a combination
++of bitwise operations and floating-point computations:
++
++weight =>(bit_op / bitwise operations)=>
++f16_value =>(flop / floating-point computation)=>
++dequantized_weight
++
++Since the dequantized weights typically require subtracting the zero point and
++applying a scale factor, the floating-point computation step can be fused with
++the zero-point subtraction and scaling operations.
++
++The following are the parts that need to be modified for the fused operation
++of zero-point subtraction and scaling.
++
++## INT4 => FP16/BF16 or INT8 => FP16
++
++The floating-point computation is `__hsub2`
++
++If has zero points:
++
++    flop(bit_op(weight)) - flop(bit_op(zp))
++  = sub(bit_op(weight), bias) - sub(bit_op(zp), bias)
++  = bit_op(weight) - bit_op(zp)
++
++so we don't need additional modification.
++
++If has float zero points:
++
++    flop(bit_op(weight)) - fzp
++  = sub(bit_op(weight), bias) - fzp
++  = bit_op(weight) - (fzp + bias)
++
++where the `fzp + bias` can be computed at weight loading. But this
++may have accuracy issue, so we should not use this in most cases.
++
++If has not zero points:
++
++    scale(flop(bit_op(weight)))
++  = scale(sub(bit_op(weight), bias))
++  = scale(bit_op(weight)) - scale(bias)
++  = fma(bit_op(weight), scale_factor, scale(bias))
++
++where the `scale(bias)` can be cached. But this may have accuracy issue,
++so we should not use this in most cases.
++
++
++## INT8 => BF16
++
++INT8 => BF16 is a special case, it use byte_perm instead of flop.
++We cannot fused byte_perm with scaling.
++
++
++## FP4/FP8 => FP16/BF16
++
++    scale(flop(bit_op(weight)))
++  = scale(mul(bit_op(weight), multiplier))
++  = mul(bit_op(weight), scale_factor * multiplier)
++
++where `scale_factor * multiplier` can be computed at weight loading.
++
++*/
++
++#include "marlin_dtypes.cuh"
++
++namespace MARLIN_NAMESPACE_NAME {
++
++#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 750
++// Lookup-table based 3-input logical operation; explicitly used for
++// dequantization as the compiler does not seem to automatically recognize it in
++// all cases.
++template <int lut>
++__device__ inline int lop3(int a, int b, int c) {
++  int res;
++  asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n" : "=r"(res) : "r"(a), "r"(b), "r"(c), "n"(lut));
++  return res;
++}
++
++// Constructs destination register by taking bytes from 2 sources (based on
++// mask)
++template <int start_byte, int mask>
++__device__ inline uint32_t prmt(uint32_t a) {
++  uint32_t res;
++  asm volatile("prmt.b32 %0, %1, %2, %3;\n" : "=r"(res) : "r"(a), "n"(start_byte), "n"(mask));
++  return res;
++}
++
++template <typename scalar_t2, sglang::host::ScalarTypeId w_type_id, bool skip_flop = false>
++__device__ inline void dequant(int q, scalar_t2* frag_b);
++
++//
++// Efficiently dequantize 4bit values packed in an int32 value into a full
++// B-fragment of 4 fp16 values. We mostly follow the strategy in the link below,
++// with some small changes:
++// - FP16:
++// https://github.com/NVIDIA/FasterTransformer/blob/release/v5.3_tag/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h#L215-L287
++// - BF16:
++// https://github.com/NVIDIA/FasterTransformer/blob/release/v5.3_tag/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h#L327-L385
++//
++template <>
++__device__ inline void dequant<half2, sglang::host::kU4B8.id(), true>(int q, half2* frag_b) {
++  const int MASK = 0x000f000f;
++  const int EX = 0x64006400;
++  // Guarantee that the `(a & b) | c` operations are LOP3s.
++  int lo = lop3<(0xf0 & 0xcc) | 0xaa>(q, MASK, EX);
++  q >>= 4;
++  int hi = lop3<(0xf0 & 0xcc) | 0xaa>(q, MASK, EX);
++
++  frag_b[0] = *reinterpret_cast<half2*>(&lo);
++  frag_b[1] = *reinterpret_cast<half2*>(&hi);
++}
++
++template <>
++__device__ inline void dequant<half2, sglang::host::kU4B8.id(), false>(int q, half2* frag_b) {
++  const int LO = 0x000f000f;
++  const int HI = 0x00f000f0;
++  const int EX = 0x64006400;
++  // Guarantee that the `(a & b) | c` operations are LOP3s.
++  // clang-format off
++  int lo = lop3<(0xf0 & 0xcc) | 0xaa>(q, LO, EX);
++  int hi = lop3<(0xf0 & 0xcc) | 0xaa>(q, HI, EX);
++  // clang-format on
++  // We want signed int4 outputs, hence we fuse the `-8` symmetric zero point
++  // directly into `SUB` and `ADD`.
++  const int SUB = 0x64086408;
++  const int MUL = 0x2c002c00;
++  const int ADD = 0xd480d480;
++  frag_b[0] = __hsub2(*reinterpret_cast<half2*>(&lo), *reinterpret_cast<const half2*>(&SUB));
++  frag_b[1] = __hfma2(
++      *reinterpret_cast<half2*>(&hi), *reinterpret_cast<const half2*>(&MUL), *reinterpret_cast<const half2*>(&ADD));
++}
++
++template <>
++__device__ inline void dequant<half2, sglang::host::kU4.id(), true>(int q, half2* frag_b) {
++  dequant<half2, sglang::host::kU4B8.id(), true>(q, frag_b);
++}
++
++template <>
++__device__ inline void dequant<half2, sglang::host::kU4.id(), false>(int q, half2* frag_b) {
++  const int LO = 0x000f000f;
++  const int HI = 0x00f000f0;
++  const int EX = 0x64006400;
++  // Guarantee that the `(a & b) | c` operations are LOP3s.
++  // clang-format off
++  int lo = lop3<(0xf0 & 0xcc) | 0xaa>(q, LO, EX);
++  int hi = lop3<(0xf0 & 0xcc) | 0xaa>(q, HI, EX);
++  // clang-format on
++  // We want signed int4 outputs, hence we fuse the `-8` symmetric zero point
++  // directly into `SUB` and `ADD`.
++  const int SUB = 0x64006400;
++  const int MUL = 0x2c002c00;
++  const int ADD = 0xd400d400;
++  frag_b[0] = __hsub2(*reinterpret_cast<half2*>(&lo), *reinterpret_cast<const half2*>(&SUB));
++  frag_b[1] = __hfma2(
++      *reinterpret_cast<half2*>(&hi), *reinterpret_cast<const half2*>(&MUL), *reinterpret_cast<const half2*>(&ADD));
++}
++
++template <>
++__device__ inline void dequant<nv_bfloat162, sglang::host::kU4B8.id(), true>(int q, nv_bfloat162* frag_b) {
++  static constexpr uint32_t MASK = 0x000f000f;
++  static constexpr uint32_t EX = 0x43004300;
++
++  // Guarantee that the `(a & b) | c` operations are LOP3s.
++  // clang-format off
++  int lo = lop3<(0xf0 & 0xcc) | 0xaa>(q, MASK, EX);
++  q >>= 4;
++  int hi = lop3<(0xf0 & 0xcc) | 0xaa>(q, MASK, EX);
++  // clang-format on
++
++  frag_b[0] = *reinterpret_cast<nv_bfloat162*>(&lo);
++  frag_b[1] = *reinterpret_cast<nv_bfloat162*>(&hi);
++}
++
++template <>
++__device__ inline void dequant<nv_bfloat162, sglang::host::kU4B8.id(), false>(int q, nv_bfloat162* frag_b) {
++  dequant<nv_bfloat162, sglang::host::kU4B8.id(), true>(q, frag_b);
++
++  static constexpr uint32_t SUB = 0x43084308;
++
++  frag_b[0] = __hsub2(frag_b[0], *reinterpret_cast<const nv_bfloat162*>(&SUB));
++  frag_b[1] = __hsub2(frag_b[1], *reinterpret_cast<const nv_bfloat162*>(&SUB));
++}
++
++template <>
++__device__ inline void dequant<nv_bfloat162, sglang::host::kU4.id(), true>(int q, nv_bfloat162* frag_b) {
++  dequant<nv_bfloat162, sglang::host::kU4B8.id(), true>(q, frag_b);
++}
++
++template <>
++__device__ inline void dequant<nv_bfloat162, sglang::host::kU4.id(), false>(int q, nv_bfloat162* frag_b) {
++  dequant<nv_bfloat162, sglang::host::kU4.id(), true>(q, frag_b);
++
++  static constexpr uint32_t SUB = 0x43004300;
++
++  frag_b[0] = __hsub2(frag_b[0], *reinterpret_cast<const nv_bfloat162*>(&SUB));
++  frag_b[1] = __hsub2(frag_b[1], *reinterpret_cast<const nv_bfloat162*>(&SUB));
++}
++
++//
++// Fast Int8ToFp16/Int8ToBf16: Efficiently dequantize 8bit int values to fp16 or
++// bf16 Reference:
++// - FP16:
++// https://github.com/NVIDIA/FasterTransformer/blob/release/v5.3_tag/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h#L53-L85
++// - BF16:
++// https://github.com/NVIDIA/FasterTransformer/blob/release/v5.3_tag/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h#L125-L175
++//
++template <>
++__device__ inline void dequant<half2, sglang::host::kU8B128.id(), true>(int q, half2* frag_b) {
++  static constexpr uint32_t mask_for_elt_01 = 0x5250;
++  static constexpr uint32_t mask_for_elt_23 = 0x5351;
++  static constexpr uint32_t start_byte_for_fp16 = 0x64646464;
++
++  uint32_t lo = prmt<start_byte_for_fp16, mask_for_elt_01>(q);
++  uint32_t hi = prmt<start_byte_for_fp16, mask_for_elt_23>(q);
++
++  frag_b[0] = *reinterpret_cast<half2*>(&lo);
++  frag_b[1] = *reinterpret_cast<half2*>(&hi);
++}
++
++template <>
++__device__ inline void dequant<half2, sglang::host::kU8B128.id(), false>(int q, half2* frag_b) {
++  dequant<half2, sglang::host::kU8B128.id(), true>(q, frag_b);
++
++  static constexpr uint32_t I8s_TO_F16s_MAGIC_NUM = 0x64806480;
++  frag_b[0] = __hsub2(frag_b[0], *reinterpret_cast<const half2*>(&I8s_TO_F16s_MAGIC_NUM));
++  frag_b[1] = __hsub2(frag_b[1], *reinterpret_cast<const half2*>(&I8s_TO_F16s_MAGIC_NUM));
++}
++
++template <>
++__device__ inline void dequant<half2, sglang::host::kU8.id(), true>(int q, half2* frag_b) {
++  dequant<half2, sglang::host::kU8B128.id(), true>(q, frag_b);
++}
++
++template <>
++__device__ inline void dequant<half2, sglang::host::kU8.id(), false>(int q, half2* frag_b) {
++  dequant<half2, sglang::host::kU8.id(), true>(q, frag_b);
++
++  static constexpr uint32_t I8s_TO_F16s_MAGIC_NUM = 0x64006400;
++  frag_b[0] = __hsub2(frag_b[0], *reinterpret_cast<const half2*>(&I8s_TO_F16s_MAGIC_NUM));
++  frag_b[1] = __hsub2(frag_b[1], *reinterpret_cast<const half2*>(&I8s_TO_F16s_MAGIC_NUM));
++}
++
++template <>
++__device__ inline void dequant<nv_bfloat162, sglang::host::kU8B128.id(), false>(int q, nv_bfloat162* frag_b) {
++  float fp32_intermediates[4];
++  uint32_t* fp32_intermediates_casted = reinterpret_cast<uint32_t*>(fp32_intermediates);
++
++  static constexpr uint32_t fp32_base = 0x4B000000;
++  fp32_intermediates_casted[0] = __byte_perm(q, fp32_base, 0x7650);
++  fp32_intermediates_casted[1] = __byte_perm(q, fp32_base, 0x7652);
++  fp32_intermediates_casted[2] = __byte_perm(q, fp32_base, 0x7651);
++  fp32_intermediates_casted[3] = __byte_perm(q, fp32_base, 0x7653);
++
++  fp32_intermediates[0] -= 8388736.f;
++  fp32_intermediates[1] -= 8388736.f;
++  fp32_intermediates[2] -= 8388736.f;
++  fp32_intermediates[3] -= 8388736.f;
++
++  uint32_t* bf16_result_ptr = reinterpret_cast<uint32_t*>(frag_b);
++  bf16_result_ptr[0] = __byte_perm(fp32_intermediates_casted[0], fp32_intermediates_casted[1], 0x7632);
++  bf16_result_ptr[1] = __byte_perm(fp32_intermediates_casted[2], fp32_intermediates_casted[3], 0x7632);
++}
++
++template <>
++__device__ inline void dequant<nv_bfloat162, sglang::host::kU8.id(), false>(int q, nv_bfloat162* frag_b) {
++  float fp32_intermediates[4];
++  uint32_t* fp32_intermediates_casted = reinterpret_cast<uint32_t*>(fp32_intermediates);
++
++  static constexpr uint32_t fp32_base = 0x4B000000;
++  fp32_intermediates_casted[0] = __byte_perm(q, fp32_base, 0x7650);
++  fp32_intermediates_casted[1] = __byte_perm(q, fp32_base, 0x7652);
++  fp32_intermediates_casted[2] = __byte_perm(q, fp32_base, 0x7651);
++  fp32_intermediates_casted[3] = __byte_perm(q, fp32_base, 0x7653);
++
++  fp32_intermediates[0] -= 8388608.f;
++  fp32_intermediates[1] -= 8388608.f;
++  fp32_intermediates[2] -= 8388608.f;
++  fp32_intermediates[3] -= 8388608.f;
++
++  uint32_t* bf16_result_ptr = reinterpret_cast<uint32_t*>(frag_b);
++  bf16_result_ptr[0] = __byte_perm(fp32_intermediates_casted[0], fp32_intermediates_casted[1], 0x7632);
++  bf16_result_ptr[1] = __byte_perm(fp32_intermediates_casted[2], fp32_intermediates_casted[3], 0x7632);
++}
++
++template <>
++__device__ inline void dequant<half2, sglang::host::kFE4M3fn.id(), true>(int q, half2* frag_b) {
++  // Constants for FP8 (E4M3) and FP16 formats
++  constexpr int FP8_EXPONENT = 4, FP16_EXPONENT = 5;
++  constexpr int RIGHT_SHIFT = FP16_EXPONENT - FP8_EXPONENT;
++  constexpr int MASK = 0x7F007F00;
++
++  // Extract and shift FP8 values to FP16 format
++  int Out1 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
++  q <<= 8;
++  int Out2 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
++
++  // Note: reverse indexing is intentional because weights are permuted
++  frag_b[1] = *reinterpret_cast<const half2*>(&Out1);
++  frag_b[0] = *reinterpret_cast<const half2*>(&Out2);
++}
++
++template <>
++__device__ inline void dequant<half2, sglang::host::kFE4M3fn.id(), false>(int q, half2* frag_b) {
++  dequant<half2, sglang::host::kFE4M3fn.id(), true>(q, frag_b);
++
++  // Constants for FP8 (E4M3) and FP16 formats
++  constexpr int FP8_EXPONENT = 4, FP16_EXPONENT = 5;
++
++  // Construct and apply exponent bias
++  constexpr int BIAS_OFFSET = (1 << (FP16_EXPONENT - 1)) - (1 << (FP8_EXPONENT - 1));
++  const half2 bias_reg = __float2half2_rn(float(1 << BIAS_OFFSET));
++
++  // Convert to half2 and apply bias
++  frag_b[1] = __hmul2(frag_b[1], bias_reg);
++  frag_b[0] = __hmul2(frag_b[0], bias_reg);
++}
++
++template <>
++__device__ inline void dequant<nv_bfloat162, sglang::host::kFE4M3fn.id(), true>(int q, nv_bfloat162* frag_b) {
++  // Constants for FP8 (E4M3) and BF16 formats
++  constexpr int FP8_EXPONENT = 4, BF16_EXPONENT = 8;
++  constexpr int RIGHT_SHIFT = BF16_EXPONENT - FP8_EXPONENT;
++
++  constexpr int MASK = 0x7F007F00;
++
++  // Extract and shift FP8 values to BF16 format
++  int Out1 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
++  q <<= 8;
++  int Out2 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
++
++  // Note: reverse indexing is intentional because weights are permuted
++  frag_b[1] = *reinterpret_cast<const nv_bfloat162*>(&Out1);
++  frag_b[0] = *reinterpret_cast<const nv_bfloat162*>(&Out2);
++}
++
++template <>
++__device__ inline void dequant<nv_bfloat162, sglang::host::kFE4M3fn.id(), false>(int q, nv_bfloat162* frag_b) {
++  dequant<nv_bfloat162, sglang::host::kFE4M3fn.id(), true>(q, frag_b);
++
++  // Constants for FP8 (E4M3) and BF16 formats
++  constexpr int FP8_EXPONENT = 4, BF16_EXPONENT = 8;
++
++  // Construct and apply exponent bias
++  constexpr int BIAS_OFFSET = (1 << (BF16_EXPONENT - 1)) - (1 << (FP8_EXPONENT - 1));
++  // Add 127 (float exponent bias) to BIAS_OFFSET and shift to float exponent
++  // position
++  constexpr uint32_t BIAS = (BIAS_OFFSET + 127) << 23;
++  const nv_bfloat162 bias_reg = __float2bfloat162_rn(*reinterpret_cast<const float*>(&BIAS));
++
++  // Convert to bfloat162 and apply bias
++  frag_b[1] = __hmul2(frag_b[1], bias_reg);
++  frag_b[0] = __hmul2(frag_b[0], bias_reg);
++}
++
++template <>
++__device__ inline void dequant<half2, sglang::host::kFE2M1f.id(), true>(int q, half2* frag_b) {
++  // Constants for FP4 (E2M1) and FP16 formats
++  constexpr int FP4_EXPONENT = 2, FP16_EXPONENT = 5;
++  constexpr int RIGHT_SHIFT = FP16_EXPONENT - FP4_EXPONENT;
++  constexpr int MASK = 0x70007000;
++
++  // Extract and shift FP4 values to FP16 format
++  int Out1 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
++  q <<= 4;
++  int Out2 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
++
++  // Note: reverse indexing is intentional because weights are permuted
++  frag_b[1] = *reinterpret_cast<const half2*>(&Out1);
++  frag_b[0] = *reinterpret_cast<const half2*>(&Out2);
++}
++
++template <>
++__device__ inline void dequant<half2, sglang::host::kFE2M1f.id(), false>(int q, half2* frag_b) {
++  dequant<half2, sglang::host::kFE2M1f.id(), true>(q, frag_b);
++
++  // Constants for FP4 (E2M1) and FP16 formats
++  constexpr int FP4_EXPONENT = 2, FP16_EXPONENT = 5;
++
++  // Construct and apply exponent bias
++  constexpr int BIAS_OFFSET = (1 << (FP16_EXPONENT - 1)) - (1 << (FP4_EXPONENT - 1));
++  const half2 bias_reg = __float2half2_rn(float(1 << BIAS_OFFSET));
++
++  // Convert to half2 and apply bias
++  frag_b[1] = __hmul2(frag_b[1], bias_reg);
++  frag_b[0] = __hmul2(frag_b[0], bias_reg);
++}
++
++template <>
++__device__ inline void dequant<nv_bfloat162, sglang::host::kFE2M1f.id(), true>(int q, nv_bfloat162* frag_b) {
++  // Constants for FP4 (E2M1) and FP16 formats
++  constexpr int FP4_EXPONENT = 2, BF16_EXPONENT = 8;
++  constexpr int RIGHT_SHIFT = BF16_EXPONENT - FP4_EXPONENT;
++  constexpr int MASK = 0x70007000;
++
++  // Extract and shift FP4 values to FP16 format
++  int Out1 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
++  q <<= 4;
++  int Out2 = (q & 0x80008000) | ((q & MASK) >> RIGHT_SHIFT);
++
++  // Note: reverse indexing is intentional because weights are permuted
++  frag_b[1] = *reinterpret_cast<const nv_bfloat162*>(&Out1);
++  frag_b[0] = *reinterpret_cast<const nv_bfloat162*>(&Out2);
++}
++
++template <>
++__device__ inline void dequant<nv_bfloat162, sglang::host::kFE2M1f.id(), false>(int q, nv_bfloat162* frag_b) {
++  dequant<nv_bfloat162, sglang::host::kFE2M1f.id(), true>(q, frag_b);
++
++  // Constants for FP4 (E2M1) and BF16 formats
++  constexpr int FP4_EXPONENT = 2, BF16_EXPONENT = 8;
++
++  // Construct and apply exponent bias
++  constexpr int BIAS_OFFSET = (1 << (BF16_EXPONENT - 1)) - (1 << (FP4_EXPONENT - 1));
++  // Add 127 (float exponent bias) to BIAS_OFFSET and shift to float exponent
++  // position
++  constexpr uint32_t BIAS = (BIAS_OFFSET + 127) << 23;
++  const nv_bfloat162 bias_reg = __float2bfloat162_rn(*reinterpret_cast<const float*>(&BIAS));
++
++  // Convert to half2 and apply bias
++  frag_b[1] = __hmul2(frag_b[1], bias_reg);
++  frag_b[0] = __hmul2(frag_b[0], bias_reg);
++}
++
++template <>
++__device__ inline void dequant<__nv_fp8x4_e4m3, sglang::host::kFE2M1f.id(), true>(int q, __nv_fp8x4_e4m3* frag_b) {
++  // Constants for FP4 (E2M1) and FP16 formats
++  constexpr int FP4_EXPONENT = 2, FP8_EXPONENT = 4;
++  constexpr int RIGHT_SHIFT = FP8_EXPONENT - FP4_EXPONENT;
++  constexpr int MASK = 0x70707070;
++
++  // Extract and shift FP4 values to FP16 format
++  int Out1 = (q & 0x80808080) | ((q & MASK) >> RIGHT_SHIFT);
++  q <<= 4;
++  int Out2 = (q & 0x80808080) | ((q & MASK) >> RIGHT_SHIFT);
++
++  // Note1: reverse indexing is intentional because weights are permuted
++  // Note2: when dequant to 8bit type, we write to `frag_b[2]` instead of
++  //        `frag_b[1]` to fit the layout of tensorcore
++  frag_b[1] = *reinterpret_cast<const __nv_fp8x4_e4m3*>(&Out1);
++  frag_b[0] = *reinterpret_cast<const __nv_fp8x4_e4m3*>(&Out2);
++}
++
++template <>
++__device__ inline void dequant<int32_t, sglang::host::kU4B8.id(), true>(int q, int32_t* frag_b) {
++  constexpr int repeated_zp = 0x08080808;
++  constexpr int MASK = 0x80808080;
++
++  frag_b[0] = ((q & 0x0F0F0F0F | MASK) - repeated_zp) ^ MASK;
++  q >>= 4;
++  frag_b[1] = ((q & 0x0F0F0F0F | MASK) - repeated_zp) ^ MASK;
++}
++
++template <>
++__device__ inline void dequant<__nv_fp8x4_e4m3, sglang::host::kU4B8.id(), true>(int q, __nv_fp8x4_e4m3* frag_b) {
++  int s = q & 0x08080808;
++  int Out1 = ((q & 0x07070707) | (s << 4)) + (s >> 3);
++  q >>= 4;
++  s = q & 0x08080808;
++  int Out2 = ((q & 0x07070707) | (s << 4)) + (s >> 3);
++
++  frag_b[0] = *reinterpret_cast<const __nv_fp8x4_e4m3*>(&Out1);
++  frag_b[1] = *reinterpret_cast<const __nv_fp8x4_e4m3*>(&Out2);
++}
++
++template <typename scalar_t2, sglang::host::ScalarTypeId s_type_id>
++__device__ inline void dequant_fp8_scales(int q, scalar_t2* frag_b);
++
++template <>
++__device__ inline void dequant_fp8_scales<half2, sglang::host::kFE4M3fn.id()>(int q, half2* frag_b) {
++  int Out1 = (q & 0xFF00FF00) >> 1;
++  ;
++  q <<= 8;
++  int Out2 = (q & 0xFF00FF00) >> 1;
++
++  // Note: reverse indexing is intentional because weights are permuted
++  frag_b[1] = *reinterpret_cast<const half2*>(&Out1);
++  frag_b[0] = *reinterpret_cast<const half2*>(&Out2);
++};
++
++template <>
++__device__ inline void dequant_fp8_scales<nv_bfloat162, sglang::host::kFE4M3fn.id()>(int q, nv_bfloat162* frag_b) {
++  constexpr int FP8_EXPONENT = 4, BF16_EXPONENT = 8;
++  constexpr int RIGHT_SHIFT = BF16_EXPONENT - FP8_EXPONENT;
++  constexpr int MASK = 0x7F007F00;
++
++  // Extract and shift FP8 values to BF16 format
++  int Out1 = ((q & 0x80008000) >> 1) | ((q & MASK) >> RIGHT_SHIFT);
++  q <<= 8;
++  int Out2 = ((q & 0x80008000) >> 1) | ((q & MASK) >> RIGHT_SHIFT);
++
++  // Note: reverse indexing is intentional because weights are permuted
++  frag_b[1] = *reinterpret_cast<const nv_bfloat162*>(&Out1);
++  frag_b[0] = *reinterpret_cast<const nv_bfloat162*>(&Out2);
++}
++
++template <>
++__device__ inline void dequant_fp8_scales<nv_bfloat162, sglang::host::kFE8M0fnu.id()>(int q, nv_bfloat162* frag_b) {
++  // In this conversion, 2 ** -127 in FP8E8M0 would become 0 in BF16,
++  // but we assume that such a extreme value would not occur in real models.
++  int Out1 = (q & 0xFF00FF00) >> 1;
++  q <<= 7;
++  int Out2 = q & 0x7F807F80;
++
++  // Note: reverse indexing is intentional because weights are permuted
++  frag_b[1] = *reinterpret_cast<const nv_bfloat162*>(&Out1);
++  frag_b[0] = *reinterpret_cast<const nv_bfloat162*>(&Out2);
++};
++
++// subtract zero point in quanted format and then dequant
++template <typename scalar_t2, sglang::host::ScalarTypeId w_type_id, bool skip_flop = false>
++__device__ inline void sub_zp_and_dequant(int q, scalar_t2* frag_b, int zp);
++
++template <>
++__device__ inline void sub_zp_and_dequant<int32_t, sglang::host::kU4.id(), true>(int q, int32_t* frag_b, int zp) {
++  // INT4 with zp -> INT8
++  // see https://github.com/vllm-project/vllm/pull/24722
++  int repeated_zp = 0x01010101 * zp;
++  int MASK = 0x80808080;
++
++  frag_b[0] = ((q & 0x0F0F0F0F | MASK) - repeated_zp) ^ MASK;
++  q >>= 4;
++  frag_b[1] = ((q & 0x0F0F0F0F | MASK) - repeated_zp) ^ MASK;
++}
++
++template <>
++__device__ inline void
++sub_zp_and_dequant<__nv_fp8x4_e4m3, sglang::host::kU4.id(), true>(int q, __nv_fp8x4_e4m3* frag_b, int zp) {
++  // INT4 with zp -> FP8
++  // see https://github.com/vllm-project/vllm/pull/24722
++  uint32_t u_q = *reinterpret_cast<uint32_t*>(&q);
++  uint32_t u_zp = *reinterpret_cast<uint32_t*>(&zp);
++  uint32_t u_zp1 = u_zp + 1;
++  uint32_t repeated_zp = 0x01010101 * u_zp;
++
++  uint32_t q0, s;
++  q0 = (u_q & 0x0F0F0F0F) | 0x70707070;
++  s = (q0 + repeated_zp) & 0x80808080;
++  uint32_t Out1 = (q0 + (s >> 7) * u_zp1) & 0x0F0F0F0F | s;
++
++  u_q >>= 4;
++  q0 = (u_q & 0x0F0F0F0F) | 0x70707070;
++  s = (q0 + repeated_zp) & 0x80808080;
++  uint32_t Out2 = (q0 + (s >> 7) * u_zp1) & 0x0F0F0F0F | s;
++
++  frag_b[0] = *reinterpret_cast<const __nv_fp8x4_e4m3*>(&Out1);
++  frag_b[1] = *reinterpret_cast<const __nv_fp8x4_e4m3*>(&Out2);
++}
++
++#endif
++
++}  // namespace MARLIN_NAMESPACE_NAME
+diff --git a/python/sglang/kernels/jit/csrc/gemm/marlin_w4a8/entry.cuh b/python/sglang/kernels/jit/csrc/gemm/marlin_w4a8/entry.cuh
+new file mode 100644
+index 0000000..1e563bb
+--- /dev/null
++++ b/python/sglang/kernels/jit/csrc/gemm/marlin_w4a8/entry.cuh
+@@ -0,0 +1,191 @@
++// SPDX-License-Identifier: Apache-2.0
++#pragma once
++
++#include <sgl_kernel/tensor.h>
++
++#include <sgl_kernel/utils.cuh>
++
++#include "marlin_template.h"
++#include "repack.cuh"
++
++namespace sglang {
++
++using host::RuntimeDeviceCheck;
++
++// Deliberately narrow standalone experiment: symmetric INT4, no act-order,
++// FP16/BF16 signed group scales, INT8 input, FP32 reduction, no fused bias.
++template <typename output_t, int group_size, int m_blocks, int n_blocks, int k_blocks, int threads>
++void launch_marlin_w4a8(
++    const int8_t* a,
++    const int32_t* b,
++    const output_t* s,
++    const float* a_s,
++    output_t* c,
++    float* c_tmp,
++    int32_t* locks,
++    int m,
++    int n,
++    int k,
++    int sms,
++    int shared,
++    cudaStream_t stream) {
++  constexpr auto output_id = std::is_same_v<output_t, bf16_t> ? host::kBFloat16.id() : host::kFloat16.id();
++  auto kernel = device::marlin_w4a8::Marlin<
++      host::kS8.id(),
++      host::kU4B8.id(),
++      output_id,
++      output_id,
++      threads,
++      m_blocks,
++      n_blocks,
++      k_blocks,
++      false,
++      4,
++      group_size / 16,
++      false>;
++  RuntimeDeviceCheck(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, shared));
++  kernel<<<sms, threads, shared, stream>>>(
++      reinterpret_cast<const int4*>(a),
++      reinterpret_cast<const int4*>(b),
++      reinterpret_cast<int4*>(c),
++      reinterpret_cast<int4*>(c_tmp),
++      nullptr,
++      a_s,
++      reinterpret_cast<const int4*>(s),
++      nullptr,
++      nullptr,
++      nullptr,
++      k / group_size,
++      m,
++      n,
++      k,
++      k,
++      locks,
++      false,
++      false,
++      true,
++      shared);
++  RuntimeDeviceCheck(cudaGetLastError());
++}
++
++template <typename output_t, int group_size, int m_blocks>
++void dispatch_marlin_w4a8(
++    const int8_t* a,
++    const int32_t* b,
++    const output_t* s,
++    const float* a_s,
++    output_t* c,
++    float* c_tmp,
++    int32_t* locks,
++    int m,
++    int n,
++    int k,
++    int sms,
++    int shared,
++    cudaStream_t stream) {
++  if (n % 256 == 0 && m_blocks > 1) {
++    launch_marlin_w4a8<output_t, group_size, m_blocks, 16, 4, 256>(
++        a, b, s, a_s, c, c_tmp, locks, m, n, k, sms, shared, stream);
++  } else if (n % 128 == 0) {
++    launch_marlin_w4a8<output_t, group_size, m_blocks, 8, 4, 128>(
++        a, b, s, a_s, c, c_tmp, locks, m, n, k, sms, shared, stream);
++  } else {
++    launch_marlin_w4a8<output_t, group_size, m_blocks, 4, 8, 128>(
++        a, b, s, a_s, c, c_tmp, locks, m, n, k, sms, shared, stream);
++  }
++}
++
++template <typename output_t, int group_size>
++void gptq_marlin_w4a8(
++    tvm::ffi::TensorView a,
++    tvm::ffi::TensorView b,
++    tvm::ffi::TensorView scales,
++    tvm::ffi::TensorView a_scales,
++    tvm::ffi::TensorView c,
++    tvm::ffi::TensorView c_tmp,
++    tvm::ffi::TensorView workspace) {
++  using namespace host;
++  static_assert(group_size == 32 || group_size == 64 || group_size == 128);
++  static_assert(std::is_same_v<output_t, bf16_t> || std::is_same_v<output_t, fp16_t>);
++  auto M = SymbolicSize{"M"}, K = SymbolicSize{"K"}, N = SymbolicSize{"N"};
++  auto device = SymbolicDevice{};
++  device.set_options<kDLCUDA>();
++  TensorMatcher({M, K}).with_dtype<int8_t>().with_device(device).verify(a);
++  TensorMatcher({M, N}).with_dtype<output_t>().with_device(device).verify(c);
++  const int m = M.unwrap(), n = N.unwrap(), k = K.unwrap();
++  RuntimeCheck(
++      k % 128 == 0 && n % 64 == 0 && k % group_size == 0,
++      "W4A8 requires K divisible by 128/group_size and N divisible by 64");
++  TensorMatcher({k / 16, n * 2}).with_dtype<int32_t>().with_device(device).verify(b);
++  TensorMatcher({k / group_size, n}).with_dtype<output_t>().with_device(device).verify(scales);
++  TensorMatcher({m, 1}).with_dtype<float>().with_device(device).verify(a_scales);
++  DLDevice dev = device.unwrap();
++  auto stream = LaunchKernel::resolve_device(dev);
++  int sms, shared, major;
++  RuntimeDeviceCheck(cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, dev.device_id));
++  RuntimeDeviceCheck(cudaDeviceGetAttribute(&shared, cudaDevAttrMaxSharedMemoryPerBlockOptin, dev.device_id));
++  RuntimeDeviceCheck(cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, dev.device_id));
++  RuntimeCheck(major == 8 && shared >= 65536, "W4A8 experiment requires SM8x and >=64 KiB shared memory");
++  TensorMatcher({sms}).with_dtype<int32_t>().with_device(device).verify(workspace);
++  TensorMatcher({sms * 64 * 256}).with_dtype<float>().with_device(device).verify(c_tmp);
++  auto* ap = static_cast<const int8_t*>(a.data_ptr());
++  auto* cp = static_cast<output_t*>(c.data_ptr());
++  auto* asp = static_cast<const float*>(a_scales.data_ptr());
++  int rest = m;
++  while (rest > 0) {
++    // Same M splitting as Marlin's host dispatcher; workspaces are reused on
++    // this stream after each launch. At most 128 independent 64-row problems.
++    int part = rest >= 64 ? std::min(rest / 64, 128) * 64 : rest;
++    int mb = std::min((part + 15) / 16, 4);
++#define SGL_W4A8_DISPATCH(MB)                            \
++  case MB:                                               \
++    dispatch_marlin_w4a8<output_t, group_size, MB>(      \
++        ap,                                              \
++        static_cast<const int32_t*>(b.data_ptr()),       \
++        static_cast<const output_t*>(scales.data_ptr()), \
++        asp,                                             \
++        cp,                                              \
++        static_cast<float*>(c_tmp.data_ptr()),           \
++        static_cast<int32_t*>(workspace.data_ptr()),     \
++        part,                                            \
++        n,                                               \
++        k,                                               \
++        sms,                                             \
++        shared,                                          \
++        stream);                                         \
++    break
++    switch (mb) {
++      SGL_W4A8_DISPATCH(1);
++      SGL_W4A8_DISPATCH(2);
++      SGL_W4A8_DISPATCH(3);
++      SGL_W4A8_DISPATCH(4);
++    }
++#undef SGL_W4A8_DISPATCH
++    ap += static_cast<int64_t>(part) * k;
++    cp += static_cast<int64_t>(part) * n;
++    asp += part;
++    rest -= part;
++  }
++}
++
++void gptq_marlin_w4a8_repack(tvm::ffi::TensorView qweight, tvm::ffi::TensorView out) {
++  using namespace host;
++  auto Rows = SymbolicSize{"Rows"}, N = SymbolicSize{"N"};
++  auto device = SymbolicDevice{};
++  device.set_options<kDLCUDA>();
++  TensorMatcher({Rows, N}).with_dtype<int32_t>().with_device(device).verify(qweight);
++  int k = Rows.unwrap() * 8, n = N.unwrap();
++  RuntimeCheck(k % 128 == 0 && n % 64 == 0, "Unsupported W4A8 repack shape");
++  TensorMatcher({k / 16, n * 2}).with_dtype<int32_t>().with_device(device).verify(out);
++  DLDevice dev = device.unwrap();
++  auto stream = LaunchKernel::resolve_device(dev);
++  int sms;
++  RuntimeDeviceCheck(cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, dev.device_id));
++  auto kernel = device::marlin_w4a8::gptq_marlin_repack_kernel<256, 4, false, true>;
++  // 8 stages of 32x32 INT4 tiles = 4096 bytes (plus unused permutation area).
++  kernel<<<sms, 256, 8192, stream>>>(
++      static_cast<const uint32_t*>(qweight.data_ptr()), nullptr, static_cast<uint32_t*>(out.data_ptr()), k, n);
++  RuntimeDeviceCheck(cudaGetLastError());
++}
++
++}  // namespace sglang
+diff --git a/python/sglang/kernels/jit/csrc/gemm/marlin_w4a8/marlin.cuh b/python/sglang/kernels/jit/csrc/gemm/marlin_w4a8/marlin.cuh
+new file mode 100644
+index 0000000..0680d98
+--- /dev/null
++++ b/python/sglang/kernels/jit/csrc/gemm/marlin_w4a8/marlin.cuh
+@@ -0,0 +1,176 @@
++// SPDX-License-Identifier: Apache-2.0
++// Adapted from vLLM v0.27.1 (6e448d0ea9bf3d88d898b65449ca6dc2aec170ac).
++// Copyright contributors to the vLLM project; Marlin: Elias Frantar.
++// SGLang standalone W4A8 experiment: no vLLM build or runtime dependency.
++#pragma once
++
++#ifndef _sglang_marlin_w4a8_cuh
++#define _sglang_marlin_w4a8_cuh
++#include <cuda.h>
++#include <cuda_fp16.h>
++#include <cuda_runtime.h>
++#include <iostream>
++
++#ifndef MARLIN_NAMESPACE_NAME
++#define MARLIN_NAMESPACE_NAME sglang::device::marlin_w4a8
++#endif
++
++namespace MARLIN_NAMESPACE_NAME {
++
++// Marlin params
++
++// 8 warps are a good choice since every SM has 4 schedulers and having more
++// than 1 warp per schedule allows some more latency hiding. At the same time,
++// we want relatively few warps to have many registers per warp and small tiles.
++static constexpr int default_threads = 256;
++
++static constexpr int pipe_stages = 4;  // 4 pipeline stages fit into shared memory
++
++static constexpr int min_thread_n = 64;
++static constexpr int min_thread_k = 64;
++static constexpr int max_thread_n = 256;
++
++static constexpr int tile_size = 16;
++static constexpr int max_par = 16;
++
++// Repack params
++static constexpr int repack_stages = 8;
++
++static constexpr int repack_threads = 256;
++
++static constexpr int tile_k_size = tile_size;
++static constexpr int tile_n_size = tile_k_size * 4;
++
++// Helpers
++template <typename T, int n>
++struct Vec {
++  T elems[n];
++  __device__ T& operator[](int i) {
++    return elems[i];
++  }
++};
++
++using I4 = Vec<int, 4>;
++
++constexpr int div_ceil(int a, int b) {
++  return (a + b - 1) / b;
++}
++
++#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
++
++__device__ inline void cp_async1_ca_pred(void* smem_ptr, const void* glob_ptr, bool pred = true) {
++  if (pred) {
++    reinterpret_cast<int32_t*>(smem_ptr)[0] = reinterpret_cast<const int32_t*>(glob_ptr)[0];
++  }
++}
++
++__device__ inline void cp_async2_ca_pred(void* smem_ptr, const void* glob_ptr, bool pred = true) {
++  if (pred) {
++    reinterpret_cast<int64_t*>(smem_ptr)[0] = reinterpret_cast<const int64_t*>(glob_ptr)[0];
++  }
++}
++
++__device__ inline void cp_async4_ca_pred(void* smem_ptr, const void* glob_ptr, bool pred = true) {
++  if (pred) {
++    reinterpret_cast<int4*>(smem_ptr)[0] = reinterpret_cast<const int4*>(glob_ptr)[0];
++  }
++}
++
++__device__ inline void cp_async4_pred(void* smem_ptr, const void* glob_ptr, bool pred = true) {
++  if (pred) {
++    reinterpret_cast<int4*>(smem_ptr)[0] = reinterpret_cast<const int4*>(glob_ptr)[0];
++  }
++}
++
++__device__ inline void cp_async4(void* smem_ptr, const void* glob_ptr) {
++  reinterpret_cast<int4*>(smem_ptr)[0] = reinterpret_cast<const int4*>(glob_ptr)[0];
++}
++
++__device__ inline void cp_async_fence() {}
++
++template <int n>
++__device__ inline void cp_async_wait() {}
++
++#else
++
++__device__ inline void cp_async1_ca_pred(void* smem_ptr, const void* glob_ptr, bool pred = true) {
++  const int BYTES = 4;
++  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
++  asm volatile(
++      "{\n"
++      "   .reg .pred p;\n"
++      "   setp.ne.b32 p, %0, 0;\n"
++      "   @p cp.async.ca.shared.global [%1], [%2], %3;\n"
++      "}\n" ::"r"((int)pred),
++      "r"(smem),
++      "l"(glob_ptr),
++      "n"(BYTES));
++}
++
++__device__ inline void cp_async2_ca_pred(void* smem_ptr, const void* glob_ptr, bool pred = true) {
++  const int BYTES = 8;
++  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
++  asm volatile(
++      "{\n"
++      "   .reg .pred p;\n"
++      "   setp.ne.b32 p, %0, 0;\n"
++      "   @p cp.async.ca.shared.global [%1], [%2], %3;\n"
++      "}\n" ::"r"((int)pred),
++      "r"(smem),
++      "l"(glob_ptr),
++      "n"(BYTES));
++}
++
++__device__ inline void cp_async4_ca_pred(void* smem_ptr, const void* glob_ptr, bool pred = true) {
++  const int BYTES = 16;
++  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
++  asm volatile(
++      "{\n"
++      "   .reg .pred p;\n"
++      "   setp.ne.b32 p, %0, 0;\n"
++      "   @p cp.async.ca.shared.global [%1], [%2], %3;\n"
++      "}\n" ::"r"((int)pred),
++      "r"(smem),
++      "l"(glob_ptr),
++      "n"(BYTES));
++}
++
++__device__ inline void cp_async4_pred(void* smem_ptr, const void* glob_ptr, bool pred = true) {
++  const int BYTES = 16;
++  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
++  asm volatile(
++      "{\n"
++      "   .reg .pred p;\n"
++      "   setp.ne.b32 p, %0, 0;\n"
++      "   @p cp.async.cg.shared.global [%1], [%2], %3;\n"
++      "}\n" ::"r"((int)pred),
++      "r"(smem),
++      "l"(glob_ptr),
++      "n"(BYTES));
++}
++
++__device__ inline void cp_async4(void* smem_ptr, const void* glob_ptr) {
++  const int BYTES = 16;
++  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
++  asm volatile(
++      "{\n"
++      "   cp.async.cg.shared.global [%0], [%1], %2;\n"
++      "}\n" ::"r"(smem),
++      "l"(glob_ptr),
++      "n"(BYTES));
++}
++
++__device__ inline void cp_async_fence() {
++  asm volatile("cp.async.commit_group;\n" ::);
++}
++
++template <int n>
++__device__ inline void cp_async_wait() {
++  asm volatile("cp.async.wait_group %0;\n" ::"n"(n));
++}
++
++#endif
++
++}  // namespace MARLIN_NAMESPACE_NAME
++
++#endif
+\ No newline at end of file
+diff --git a/python/sglang/kernels/jit/csrc/gemm/marlin_w4a8/marlin_dtypes.cuh b/python/sglang/kernels/jit/csrc/gemm/marlin_w4a8/marlin_dtypes.cuh
+new file mode 100644
+index 0000000..0545445
+--- /dev/null
++++ b/python/sglang/kernels/jit/csrc/gemm/marlin_w4a8/marlin_dtypes.cuh
+@@ -0,0 +1,150 @@
++// SPDX-License-Identifier: Apache-2.0
++// Adapted from vLLM v0.27.1 (6e448d0ea9bf3d88d898b65449ca6dc2aec170ac).
++// Copyright contributors to the vLLM project; Marlin: Elias Frantar.
++// SGLang standalone W4A8 experiment: no vLLM build or runtime dependency.
++
++#ifndef _sglang_marlin_w4a8_data_types_cuh
++#define _sglang_marlin_w4a8_data_types_cuh
++#include <sgl_kernel/scalar_type.hpp>
++
++#include "marlin.cuh"
++#include <cuda_bf16.h>
++#include <cuda_fp16.h>
++#include <cuda_fp8.h>
++
++#ifndef MARLIN_NAMESPACE_NAME
++#define MARLIN_NAMESPACE_NAME sglang::device::marlin_w4a8
++#endif
++
++namespace MARLIN_NAMESPACE_NAME {
++
++template <long scalar_type_id>
++class MarlinScalarType {};
++
++template <>
++class MarlinScalarType<sglang::host::kFloat16.id()> {
++ public:
++  using scalar_t = half;
++  using scalar_t2 = half2;
++  using scalar_t4 = half2;
++  using scalar_32bit_t = half2;
++
++  // Matrix fragments for tensor core instructions; their precise layout is
++  // documented here:
++  // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#matrix-fragments-for-mma-m16n8k16-with-floating-point-type
++  using FragA = Vec<half2, 4>;
++  using FragB = Vec<half2, 2>;
++  using FragC = Vec<float, 4>;
++  using FragS = Vec<half2, 1>;
++  using FragS0 = Vec<__nv_fp8x2_e4m3, 1>;
++  using FragZP = Vec<half2, 4>;
++
++  static __device__ float inline num2float(const half x) {
++    return __half2float(x);
++  }
++
++  static __device__ half2 inline num2num2(const half x) {
++    return __half2half2(x);
++  }
++
++  static __device__ half2 inline nums2num2(const half x1, const half x2) {
++    return __halves2half2(x1, x2);
++  }
++
++  static __host__ __device__ half inline float2num(const float x) {
++    return __float2half(x);
++  }
++
++  static __host__ __device__ float2 inline num22float2(const half2 x) {
++    return __half22float2(x);
++  }
++};
++
++template <>
++class MarlinScalarType<sglang::host::kBFloat16.id()> {
++ public:
++  using scalar_t = nv_bfloat16;
++  using scalar_t2 = nv_bfloat162;
++  using scalar_t4 = nv_bfloat162;
++  using scalar_32bit_t = nv_bfloat162;
++
++  using FragA = Vec<nv_bfloat162, 4>;
++  using FragB = Vec<nv_bfloat162, 2>;
++  using FragC = Vec<float, 4>;
++  using FragS = Vec<nv_bfloat162, 1>;
++  using FragS0 = Vec<__nv_fp8x2_e4m3, 1>;
++  using FragZP = Vec<nv_bfloat162, 4>;
++
++#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 800
++  static __device__ float inline num2float(const nv_bfloat16 x) {
++    return __bfloat162float(x);
++  }
++
++  static __device__ nv_bfloat162 inline num2num2(const nv_bfloat16 x) {
++    return __bfloat162bfloat162(x);
++  }
++
++  static __device__ nv_bfloat162 inline nums2num2(const nv_bfloat16 x1, const nv_bfloat16 x2) {
++    return __halves2bfloat162(x1, x2);
++  }
++
++  static __host__ __device__ nv_bfloat16 inline float2num(const float x) {
++    return __float2bfloat16(x);
++  }
++
++  static __host__ __device__ float2 inline num22float2(const nv_bfloat162 x) {
++    return __bfloat1622float2(x);
++  }
++#endif
++};
++
++template <>
++class MarlinScalarType<sglang::host::kFE4M3fn.id()> {
++ public:
++  using scalar_t = __nv_fp8_e4m3;
++  using scalar_t2 = __nv_fp8x2_e4m3;
++  using scalar_t4 = __nv_fp8x4_e4m3;
++  using scalar_32bit_t = __nv_fp8x4_e4m3;
++
++  using FragA = Vec<__nv_fp8x4_e4m3, 4>;
++  using FragB = Vec<__nv_fp8x4_e4m3, 2>;
++  using FragC = Vec<float, 4>;
++  using FragZP = Vec<__nv_fp8x2_e4m3, 4>;
++
++  static __host__ __device__ float2 inline num22float2(const __nv_fp8x2_e4m3 x) {
++    return (float2)x;
++  }
++};
++
++template <>
++class MarlinScalarType<sglang::host::kS8.id()> {
++ public:
++  using scalar_t = int8_t;
++  using scalar_t2 = int16_t;
++  using scalar_t4 = int32_t;
++  using scalar_32bit_t = int32_t;
++
++  using FragA = Vec<int32_t, 4>;
++  using FragB = Vec<int32_t, 2>;
++  using FragC = Vec<float, 4>;
++  using FragZP = Vec<int16_t, 4>;
++};
++
++template <typename scalar_t>
++class MarlinScalarType2 {};
++
++template <>
++class MarlinScalarType2<half> : public MarlinScalarType<sglang::host::kFloat16.id()> {};
++
++template <>
++class MarlinScalarType2<nv_bfloat16> : public MarlinScalarType<sglang::host::kBFloat16.id()> {};
++
++template <>
++class MarlinScalarType2<__nv_fp8_e4m3> : public MarlinScalarType<sglang::host::kFE4M3fn.id()> {};
++
++template <>
++class MarlinScalarType2<int8_t> : public MarlinScalarType<sglang::host::kS8.id()> {};
++
++}  // namespace MARLIN_NAMESPACE_NAME
++
++#endif
+diff --git a/python/sglang/kernels/jit/csrc/gemm/marlin_w4a8/marlin_mma.h b/python/sglang/kernels/jit/csrc/gemm/marlin_w4a8/marlin_mma.h
+new file mode 100644
+index 0000000..c669629
+--- /dev/null
++++ b/python/sglang/kernels/jit/csrc/gemm/marlin_w4a8/marlin_mma.h
+@@ -0,0 +1,326 @@
++// SPDX-License-Identifier: Apache-2.0
++// Adapted from vLLM v0.27.1 (6e448d0ea9bf3d88d898b65449ca6dc2aec170ac).
++// Copyright contributors to the vLLM project; Marlin: Elias Frantar.
++// SGLang standalone W4A8 experiment: no vLLM build or runtime dependency.
++
++#include "marlin_dtypes.cuh"
++
++namespace MARLIN_NAMESPACE_NAME {
++
++// m16n8k16 tensor core mma instruction with fp16 inputs and fp32
++// output/accumulation.
++template <sglang::host::ScalarTypeId type_id, bool use_fp16_accum, int k_size = 16>
++__device__ inline void
++mma(const typename MarlinScalarType<type_id>::FragA& a_frag,
++    const typename MarlinScalarType<type_id>::FragB& frag_b,
++    typename MarlinScalarType<type_id>::FragC& frag_c,
++    int idx = 0) {
++  const uint32_t* a = reinterpret_cast<const uint32_t*>(&a_frag);
++  const uint32_t* b = reinterpret_cast<const uint32_t*>(&frag_b);
++  using scalar_t = typename MarlinScalarType<type_id>::scalar_t;
++  if constexpr (!std::is_same<scalar_t, half>::value || k_size != 16) {
++    static_assert(!use_fp16_accum);
++  }
++
++  if constexpr (k_size == 16) {
++    if constexpr (std::is_same<scalar_t, half>::value && !use_fp16_accum) {
++#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 750
++      float* c = reinterpret_cast<float*>(&frag_c);
++      asm volatile(
++          "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
++          "{%0,%1,%2,%3}, {%4,%5}, {%6}, {%7,%8,%9,%10};\n"
++          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
++          : "r"(a[0]), "r"(a[1]), "r"(b[0]), "f"(c[0]), "f"(c[1]), "f"(c[2]), "f"(c[3]));
++      asm volatile(
++          "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
++          "{%0,%1,%2,%3}, {%4,%5}, {%6}, {%7,%8,%9,%10};\n"
++          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
++          : "r"(a[2]), "r"(a[3]), "r"(b[1]), "f"(c[0]), "f"(c[1]), "f"(c[2]), "f"(c[3]));
++#else
++      float* c = reinterpret_cast<float*>(&frag_c);
++      asm volatile(
++          "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
++          "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
++          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
++          : "r"(a[0]),
++            "r"(a[1]),
++            "r"(a[2]),
++            "r"(a[3]),
++            "r"(b[0]),
++            "r"(b[1]),
++            "f"(c[0]),
++            "f"(c[1]),
++            "f"(c[2]),
++            "f"(c[3]));
++#endif
++    } else if constexpr (std::is_same<scalar_t, half>::value && use_fp16_accum) {
++#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 750
++      uint32_t* c = reinterpret_cast<uint32_t*>(&frag_c);
++      asm volatile(
++          "mma.sync.aligned.m16n8k8.row.col.f16.f16.f16.f16 "
++          "{%0,%1}, {%2,%3}, {%4}, {%5,%6};\n"
++          : "=r"(c[0]), "=r"(c[1])
++          : "r"(a[0]), "r"(a[1]), "r"(b[0]), "r"(c[0]), "r"(c[1]));
++      asm volatile(
++          "mma.sync.aligned.m16n8k8.row.col.f16.f16.f16.f16 "
++          "{%0,%1}, {%2,%3}, {%4}, {%5,%6};\n"
++          : "=r"(c[0]), "=r"(c[1])
++          : "r"(a[2]), "r"(a[3]), "r"(b[1]), "r"(c[0]), "r"(c[1]));
++#else
++      uint32_t* c = reinterpret_cast<uint32_t*>(&frag_c);
++      asm volatile(
++          "mma.sync.aligned.m16n8k16.row.col.f16.f16.f16.f16 "
++          "{%0,%1}, {%2,%3,%4,%5}, {%6,%7}, {%8,%9};\n"
++          : "=r"(c[0]), "=r"(c[1])
++          : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]), "r"(b[1]), "r"(c[0]), "r"(c[1]));
++#endif
++    } else if constexpr (std::is_same<scalar_t, nv_bfloat16>::value) {
++      float* c = reinterpret_cast<float*>(&frag_c);
++      asm volatile(
++          "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 "
++          "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
++          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
++          : "r"(a[0]),
++            "r"(a[1]),
++            "r"(a[2]),
++            "r"(a[3]),
++            "r"(b[0]),
++            "r"(b[1]),
++            "f"(c[0]),
++            "f"(c[1]),
++            "f"(c[2]),
++            "f"(c[3]));
++    } else if constexpr (std::is_same<scalar_t, __nv_fp8_e4m3>::value) {
++      float* c = reinterpret_cast<float*>(&frag_c);
++      asm volatile(
++          "mma.sync.aligned.m16n8k16.row.col.f32.e4m3.e4m3.f32 "
++          "{%0,%1,%2,%3}, {%4,%5}, {%6}, {%7,%8,%9,%10};\n"
++          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
++          : "r"(a[idx * 2]), "r"(a[idx * 2 + 1]), "r"(b[idx]), "f"(c[0]), "f"(c[1]), "f"(c[2]), "f"(c[3]));
++    } else if constexpr (std::is_same<scalar_t, int8_t>::value) {
++      int32_t* c = reinterpret_cast<int32_t*>(&frag_c);
++      asm volatile(
++          "mma.sync.aligned.m16n8k16.row.col.s32.s8.s8.s32.satfinite "
++          "{%0,%1,%2,%3}, {%4,%5}, {%6}, {%7,%8,%9,%10};\n"
++          : "=r"(c[0]), "=r"(c[1]), "=r"(c[2]), "=r"(c[3])
++          : "r"(a[idx * 2]), "r"(a[idx * 2 + 1]), "r"(b[idx]), "r"(c[0]), "r"(c[1]), "r"(c[2]), "r"(c[3]));
++    }
++  } else if (k_size == 32) {
++    if constexpr (std::is_same<scalar_t, __nv_fp8_e4m3>::value) {
++      float* c = reinterpret_cast<float*>(&frag_c);
++      asm volatile(
++          "mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 "
++          "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
++          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
++          : "r"(a[0]),
++            "r"(a[1]),
++            "r"(a[2]),
++            "r"(a[3]),
++            "r"(b[0]),
++            "r"(b[1]),
++            "f"(c[0]),
++            "f"(c[1]),
++            "f"(c[2]),
++            "f"(c[3]));
++    } else if constexpr (std::is_same<scalar_t, int8_t>::value) {
++      int32_t* c = reinterpret_cast<int32_t*>(&frag_c);
++#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 750
++      asm volatile(
++          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32.satfinite "
++          "{%0,%1}, {%2}, {%3}, {%4,%5};\n"
++          : "=r"(c[0]), "=r"(c[1])
++          : "r"(a[0]), "r"(b[0]), "r"(c[0]), "r"(c[1]));
++      asm volatile(
++          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32.satfinite "
++          "{%0,%1}, {%2}, {%3}, {%4,%5};\n"
++          : "=r"(c[2]), "=r"(c[3])
++          : "r"(a[1]), "r"(b[0]), "r"(c[2]), "r"(c[3]));
++      asm volatile(
++          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32.satfinite "
++          "{%0,%1}, {%2}, {%3}, {%4,%5};\n"
++          : "=r"(c[0]), "=r"(c[1])
++          : "r"(a[2]), "r"(b[1]), "r"(c[0]), "r"(c[1]));
++      asm volatile(
++          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32.satfinite "
++          "{%0,%1}, {%2}, {%3}, {%4,%5};\n"
++          : "=r"(c[2]), "=r"(c[3])
++          : "r"(a[3]), "r"(b[1]), "r"(c[2]), "r"(c[3]));
++#else
++      asm volatile(
++          "mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32.satfinite "
++          "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
++          : "=r"(c[0]), "=r"(c[1]), "=r"(c[2]), "=r"(c[3])
++          : "r"(a[0]),
++            "r"(a[1]),
++            "r"(a[2]),
++            "r"(a[3]),
++            "r"(b[0]),
++            "r"(b[1]),
++            "r"(c[0]),
++            "r"(c[1]),
++            "r"(c[2]),
++            "r"(c[3]));
++#endif
++    }
++  }
++}
++
++template <sglang::host::ScalarTypeId type_id, bool use_fp16_accum, int k_size = 16>
++__device__ inline void mma_trans(
++    const typename MarlinScalarType<type_id>::FragA& a_frag,
++    const typename MarlinScalarType<type_id>::FragB& frag_b,
++    const typename MarlinScalarType<type_id>::FragB& frag_b2,
++    typename MarlinScalarType<type_id>::FragC& frag_c) {
++  const uint32_t* a = reinterpret_cast<const uint32_t*>(&a_frag);
++  const uint32_t* b = reinterpret_cast<const uint32_t*>(&frag_b);
++  const uint32_t* b2 = reinterpret_cast<const uint32_t*>(&frag_b2);
++  float* c = reinterpret_cast<float*>(&frag_c);
++  using scalar_t = typename MarlinScalarType<type_id>::scalar_t;
++  if constexpr (!std::is_same<scalar_t, half>::value || k_size != 16) {
++    static_assert(!use_fp16_accum);
++  }
++
++  if constexpr (k_size == 16) {
++    if constexpr (std::is_same<scalar_t, half>::value && !use_fp16_accum) {
++#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 750
++      float* c = reinterpret_cast<float*>(&frag_c);
++      asm volatile(
++          "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
++          "{%0,%1,%2,%3}, {%4,%5}, {%6}, {%7,%8,%9,%10};\n"
++          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
++          : "r"(b[0]), "r"(b2[0]), "r"(a[0]), "f"(c[0]), "f"(c[1]), "f"(c[2]), "f"(c[3]));
++      asm volatile(
++          "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32 "
++          "{%0,%1,%2,%3}, {%4,%5}, {%6}, {%7,%8,%9,%10};\n"
++          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
++          : "r"(b[1]), "r"(b2[1]), "r"(a[1]), "f"(c[0]), "f"(c[1]), "f"(c[2]), "f"(c[3]));
++#else
++      float* c = reinterpret_cast<float*>(&frag_c);
++      asm volatile(
++          "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
++          "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
++          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
++          : "r"(b[0]),
++            "r"(b2[0]),
++            "r"(b[1]),
++            "r"(b2[1]),
++            "r"(a[0]),
++            "r"(a[1]),
++            "f"(c[0]),
++            "f"(c[1]),
++            "f"(c[2]),
++            "f"(c[3]));
++#endif
++    } else if constexpr (std::is_same<scalar_t, half>::value && use_fp16_accum) {
++#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 750
++      uint32_t* c = reinterpret_cast<uint32_t*>(&frag_c);
++      asm volatile(
++          "mma.sync.aligned.m16n8k8.row.col.f16.f16.f16.f16 "
++          "{%0,%1}, {%2,%3}, {%4}, {%5,%6};\n"
++          : "=r"(c[0]), "=r"(c[1])
++          : "r"(b[0]), "r"(b2[0]), "r"(a[0]), "r"(c[0]), "r"(c[1]));
++      asm volatile(
++          "mma.sync.aligned.m16n8k8.row.col.f16.f16.f16.f16 "
++          "{%0,%1}, {%2,%3}, {%4}, {%5,%6};\n"
++          : "=r"(c[0]), "=r"(c[1])
++          : "r"(b[1]), "r"(b2[1]), "r"(a[1]), "r"(c[0]), "r"(c[1]));
++#else
++      uint32_t* c = reinterpret_cast<uint32_t*>(&frag_c);
++      asm volatile(
++          "mma.sync.aligned.m16n8k16.row.col.f16.f16.f16.f16 "
++          "{%0,%1}, {%2,%3,%4,%5}, {%6,%7}, {%8,%9};\n"
++          : "=r"(c[0]), "=r"(c[1])
++          : "r"(b[0]), "r"(b2[0]), "r"(b[1]), "r"(b2[1]), "r"(a[0]), "r"(a[1]), "r"(c[0]), "r"(c[1]));
++#endif
++    } else if constexpr (std::is_same<scalar_t, nv_bfloat16>::value) {
++      float* c = reinterpret_cast<float*>(&frag_c);
++      asm volatile(
++          "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 "
++          "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
++          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
++          : "r"(b[0]),
++            "r"(b2[0]),
++            "r"(b[1]),
++            "r"(b2[1]),
++            "r"(a[0]),
++            "r"(a[1]),
++            "f"(c[0]),
++            "f"(c[1]),
++            "f"(c[2]),
++            "f"(c[3]));
++    } else if constexpr (std::is_same<scalar_t, __nv_fp8_e4m3>::value) {
++      float* c = reinterpret_cast<float*>(&frag_c);
++      asm volatile(
++          "mma.sync.aligned.m16n8k16.row.col.f32.e4m3.e4m3.f32 "
++          "{%0,%1,%2,%3}, {%4,%5}, {%6}, {%7,%8,%9,%10};\n"
++          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
++          : "r"(b[0]), "r"(b2[0]), "r"(a[0]), "f"(c[0]), "f"(c[1]), "f"(c[2]), "f"(c[3]));
++    } else if constexpr (std::is_same<scalar_t, int8_t>::value) {
++      int32_t* c = reinterpret_cast<int32_t*>(&frag_c);
++      asm volatile(
++          "mma.sync.aligned.m16n8k16.row.col.s32.s8.s8.s32.satfinite "
++          "{%0,%1,%2,%3}, {%4,%5}, {%6}, {%7,%8,%9,%10};\n"
++          : "=r"(c[0]), "=r"(c[1]), "=r"(c[2]), "=r"(c[3])
++          : "r"(b[0]), "r"(b2[0]), "r"(a[0]), "r"(c[0]), "r"(c[1]), "r"(c[2]), "r"(c[3]));
++    }
++  } else {
++    if constexpr (std::is_same<scalar_t, __nv_fp8_e4m3>::value) {
++      float* c = reinterpret_cast<float*>(&frag_c);
++      asm volatile(
++          "mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 "
++          "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
++          : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
++          : "r"(b[0]),
++            "r"(b2[0]),
++            "r"(b[1]),
++            "r"(b2[1]),
++            "r"(a[0]),
++            "r"(a[1]),
++            "f"(c[0]),
++            "f"(c[1]),
++            "f"(c[2]),
++            "f"(c[3]));
++    } else if constexpr (std::is_same<scalar_t, int8_t>::value) {
++      int32_t* c = reinterpret_cast<int32_t*>(&frag_c);
++#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 750
++      asm volatile(
++          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32.satfinite "
++          "{%0,%1}, {%2}, {%3}, {%4,%5};\n"
++          : "=r"(c[0]), "=r"(c[1])
++          : "r"(b[0]), "r"(a[0]), "r"(c[0]), "r"(c[1]));
++      asm volatile(
++          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32.satfinite "
++          "{%0,%1}, {%2}, {%3}, {%4,%5};\n"
++          : "=r"(c[2]), "=r"(c[3])
++          : "r"(b2[1]), "r"(a[0]), "r"(c[2]), "r"(c[3]));
++      asm volatile(
++          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32.satfinite "
++          "{%0,%1}, {%2}, {%3}, {%4,%5};\n"
++          : "=r"(c[0]), "=r"(c[1])
++          : "r"(b[0]), "r"(a[1]), "r"(c[0]), "r"(c[1]));
++      asm volatile(
++          "mma.sync.aligned.m8n8k16.row.col.s32.s8.s8.s32.satfinite "
++          "{%0,%1}, {%2}, {%3}, {%4,%5};\n"
++          : "=r"(c[2]), "=r"(c[3])
++          : "r"(b2[1]), "r"(a[1]), "r"(c[2]), "r"(c[3]));
++#else
++      asm volatile(
++          "mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32.satfinite "
++          "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
++          : "=r"(c[0]), "=r"(c[1]), "=r"(c[2]), "=r"(c[3])
++          : "r"(b[0]),
++            "r"(b2[0]),
++            "r"(b[1]),
++            "r"(b2[1]),
++            "r"(a[0]),
++            "r"(a[1]),
++            "r"(c[0]),
++            "r"(c[1]),
++            "r"(c[2]),
++            "r"(c[3]));
++#endif
++    }
++  }
++}
++
++}  // namespace MARLIN_NAMESPACE_NAME
+\ No newline at end of file
+diff --git a/python/sglang/kernels/jit/csrc/gemm/marlin_w4a8/marlin_template.h b/python/sglang/kernels/jit/csrc/gemm/marlin_w4a8/marlin_template.h
+new file mode 100644
+index 0000000..b861c60
+--- /dev/null
++++ b/python/sglang/kernels/jit/csrc/gemm/marlin_w4a8/marlin_template.h
+@@ -0,0 +1,1939 @@
++// SPDX-License-Identifier: Apache-2.0
++// Adapted from vLLM v0.27.1 (6e448d0ea9bf3d88d898b65449ca6dc2aec170ac).
++// Copyright contributors to the vLLM project; Marlin: Elias Frantar.
++// SGLang standalone W4A8 experiment: no vLLM build or runtime dependency.
++/*
++ * Modified by Neural Magic
++ * Copyright (C) Marlin.2024 Elias Frantar
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *         http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++/*
++ * Adapted from https://github.com/IST-DASLab/marlin
++ */
++
++#ifndef MARLIN_NAMESPACE_NAME
++#define MARLIN_NAMESPACE_NAME sglang::device::marlin_w4a8
++#endif
++
++#include <sgl_kernel/scalar_type.hpp>
++
++#include "dequant.h"
++#include "marlin.cuh"
++#include "marlin_dtypes.cuh"
++#include "marlin_mma.h"
++
++#define STATIC_ASSERT_SCALAR_TYPE_VALID(scalar_t)                                        \
++  static_assert(                                                                         \
++      std::is_same<scalar_t, half>::value || std::is_same<scalar_t, nv_bfloat16>::value, \
++      "only float16 and bfloat16 is supported");
++
++namespace MARLIN_NAMESPACE_NAME {
++
++#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 750
++
++template <
++    typename scalar_t,                           // compute dtype, half or nv_float16
++    const sglang::host::ScalarTypeId b_type_id,  // weight MarlinScalarType id
++    const sglang::host::ScalarTypeId s_type_id,  // weight scale ScalarType id
++    const int threads,                           // number of threads in a threadblock
++    const int thread_m_blocks,                   // number of 16x16 blocks in the m
++                                                 // dimension (batchsize) of the
++                                                 // threadblock
++    const int thread_n_blocks,                   // same for n dimension (output)
++    const int thread_k_blocks,                   // same for k dimension (reduction)
++    const bool m_block_size_8,                   // whether m_block_size == 8
++                                                 // only works when thread_m_blocks == 1
++    const int stages,                            // number of stages for the async global->shared
++                                                 // fetch pipeline
++    const bool has_act_order,                    // whether act_order is enabled
++    const int group_blocks,                      // number of consecutive 16x16 blocks
++                                                 // with a separate quantization scale
++    const bool is_zp_float                       // is zero point of float16 type?
++    >
++__global__ void Marlin(
++    const int4* __restrict__ A,           // fp16 input matrix of shape mxk
++    const int4* __restrict__ B,           // 4bit quantized weight matrix of shape kxn
++    int4* __restrict__ C,                 // fp16 output buffer of shape mxn
++    int4* __restrict__ C_tmp,             // fp32 tmp output buffer (for reduce)
++    const int4* __restrict__ scales_ptr,  // fp16 quantization scales of shape
++                                          // (k/groupsize)xn
++    const int* __restrict__ g_idx,        // int32 group indices of shape k
++    int num_groups,                       // number of scale groups per output channel
++    int prob_m,                           // batch dimension m
++    int prob_n,                           // output dimension n
++    int prob_k,                           // reduction dimension k
++    int* locks,                           // extra global storage for barrier synchronization
++    bool use_fp32_reduce                  // whether to use fp32 global reduce
++) {}
++
++}  // namespace marlin
++
++#else
++
++// Instruction for loading a full 16x16 matrix fragment of operand A from shared
++// memory, directly in tensor core layout.
++template <int count, sglang::host::ScalarTypeId type_id>
++__device__ inline void ldsm(typename MarlinScalarType<type_id>::FragA& frag_a, const void* smem_ptr) {
++  uint32_t* a = reinterpret_cast<uint32_t*>(&frag_a);
++  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
++  if constexpr (count == 4) {
++    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0,%1,%2,%3}, [%4];\n"
++                 : "=r"(a[0]), "=r"(a[1]), "=r"(a[2]), "=r"(a[3])
++                 : "r"(smem));
++  } else if constexpr (count == 2) {
++    asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0,%1}, [%2];\n" : "=r"(a[0]), "=r"(a[1]) : "r"(smem));
++  } else if constexpr (count == 1) {
++    asm volatile("ldmatrix.sync.aligned.m8n8.x1.shared.b16 {%0}, [%1];\n" : "=r"(a[0]) : "r"(smem));
++  } else {
++    static_assert(count == 1 || count == 2 || count == 4, "invalid count");
++  }
++}
++
++// Multiply dequantized values by the corresponding quantization scale; used
++// only for grouped quantization.
++template <sglang::host::ScalarTypeId type_id>
++__device__ inline void
++scale(typename MarlinScalarType<type_id>::FragB& frag_b, typename MarlinScalarType<type_id>::FragS& frag_s, int i) {
++  using scalar_t = typename MarlinScalarType<type_id>::scalar_t;
++  using scalar_t2 = typename MarlinScalarType<type_id>::scalar_t2;
++  scalar_t2 s = MarlinScalarType<type_id>::num2num2(reinterpret_cast<scalar_t*>(&frag_s)[i]);
++  frag_b[0] = __hmul2(frag_b[0], s);
++  frag_b[1] = __hmul2(frag_b[1], s);
++}
++
++template <sglang::host::ScalarTypeId type_id>
++__device__ inline void scale_and_sub(
++    typename MarlinScalarType<type_id>::FragB& frag_b,
++    typename MarlinScalarType<type_id>::scalar_t s,
++    typename MarlinScalarType<type_id>::scalar_t zp) {
++  using scalar_t = typename MarlinScalarType<type_id>::scalar_t;
++  using scalar_t2 = typename MarlinScalarType<type_id>::scalar_t2;
++  scalar_t2 s2 = MarlinScalarType<type_id>::num2num2(s);
++  scalar_t2 zp2 = MarlinScalarType<type_id>::num2num2(zp);
++  frag_b[0] = __hfma2(frag_b[0], s2, __hneg2(zp2));
++  frag_b[1] = __hfma2(frag_b[1], s2, __hneg2(zp2));
++}
++
++template <sglang::host::ScalarTypeId type_id>
++__device__ inline void sub_zp(
++    typename MarlinScalarType<type_id>::FragB& frag_b, typename MarlinScalarType<type_id>::scalar_t2& frag_zp, int i) {
++  using scalar_t = typename MarlinScalarType<type_id>::scalar_t;
++  using scalar_t2 = typename MarlinScalarType<type_id>::scalar_t2;
++  scalar_t2 zp = MarlinScalarType<type_id>::num2num2(reinterpret_cast<scalar_t*>(&frag_zp)[i]);
++  frag_b[0] = __hsub2(frag_b[0], zp);
++  frag_b[1] = __hsub2(frag_b[1], zp);
++}
++
++// Same as above, but for act_order (each K is multiplied individually)
++template <sglang::host::ScalarTypeId type_id>
++__device__ inline void scale4(
++    typename MarlinScalarType<type_id>::FragB& frag_b,
++    typename MarlinScalarType<type_id>::FragS& frag_s_1,
++    typename MarlinScalarType<type_id>::FragS& frag_s_2,
++    typename MarlinScalarType<type_id>::FragS& frag_s_3,
++    typename MarlinScalarType<type_id>::FragS& frag_s_4,
++    int i) {
++  using scalar_t = typename MarlinScalarType<type_id>::scalar_t;
++  using scalar_t2 = typename MarlinScalarType<type_id>::scalar_t2;
++
++  scalar_t2 s_val_1_2;
++  s_val_1_2.x = reinterpret_cast<scalar_t*>(&frag_s_1)[i];
++  s_val_1_2.y = reinterpret_cast<scalar_t*>(&frag_s_2)[i];
++
++  scalar_t2 s_val_3_4;
++  s_val_3_4.x = reinterpret_cast<scalar_t*>(&frag_s_3)[i];
++  s_val_3_4.y = reinterpret_cast<scalar_t*>(&frag_s_4)[i];
++
++  frag_b[0] = __hmul2(frag_b[0], s_val_1_2);
++  frag_b[1] = __hmul2(frag_b[1], s_val_3_4);
++}
++
++// Given 2 floats multiply by 2 scales (halves)
++template <sglang::host::ScalarTypeId type_id>
++__device__ inline void scale_float(float* c, typename MarlinScalarType<type_id>::FragS& s) {
++  using scalar_t = typename MarlinScalarType<type_id>::scalar_t;
++  scalar_t* s_ptr = reinterpret_cast<scalar_t*>(&s);
++  c[0] = __fmul_rn(c[0], MarlinScalarType<type_id>::num2float(s_ptr[0]));
++  c[1] = __fmul_rn(c[1], MarlinScalarType<type_id>::num2float(s_ptr[1]));
++}
++
++// Wait until barrier reaches `count`, then lock for current threadblock.
++__device__ inline void barrier_acquire(int* lock, int count) {
++  if (threadIdx.x == 0) {
++    int state = -1;
++    do
++      // Guarantee that subsequent writes by this threadblock will be visible
++      // globally.
++      asm volatile("ld.global.acquire.gpu.b32 %0, [%1];\n" : "=r"(state) : "l"(lock));
++    while (state != count);
++  }
++  __syncthreads();
++}
++
++// Release barrier and increment visitation count.
++__device__ inline void barrier_release(int* lock, bool reset = false) {
++  __syncthreads();
++  if (threadIdx.x == 0) {
++    if (reset) {
++      lock[0] = 0;
++      return;
++    }
++    int val = 1;
++    // Make sure that all writes since acquiring this barrier are visible
++    // globally, while releasing the barrier.
++    asm volatile("fence.acq_rel.gpu;\n");
++    asm volatile("red.relaxed.gpu.global.add.s32 [%0], %1;\n" : : "l"(lock), "r"(val));
++  }
++}
++
++// Wait until value of lock to be negative, and then add 1
++__device__ inline void wait_negative_and_add(int* lock) {
++  if (threadIdx.x == 0) {
++    int state = 0;
++    do
++      // Guarantee that subsequent writes by this threadblock will be visible
++      // globally.
++      asm volatile("ld.global.acquire.gpu.b32 %0, [%1];\n" : "=r"(state) : "l"(lock));
++    while (state >= 0);
++    atomicAdd(lock, 1);
++  }
++  __syncthreads();
++}
++
++template <
++    const sglang::host::ScalarTypeId a_type_id,  // A ScalarType id
++    const sglang::host::ScalarTypeId b_type_id,  // B ScalarType id
++    const sglang::host::ScalarTypeId c_type_id,  // C ScalarType id
++    const sglang::host::ScalarTypeId s_type_id,  // B_SCALE ScalarType id
++    const int threads,                           // number of threads in a threadblock
++    const int thread_m_blocks,                   // number of 16x16 blocks in the m
++                                                 // dimension (batchsize) of the
++                                                 // threadblock
++    const int thread_n_blocks,                   // same for n dimension (output)
++    const int thread_k_blocks,                   // same for k dimension (reduction)
++    const bool m_block_size_8,                   // whether m_block_size == 8
++                                                 // only works when thread_m_blocks == 1
++    const int stages,                            // number of stages for the async global->shared
++                                                 // fetch pipeline
++    const int group_blocks,                      // number of consecutive 16x16 blocks
++                                                 // with a separate quantization scale
++    const bool is_zp_float                       // is zero point of float16 type?
++    >
++__global__ void Marlin(
++    const int4* __restrict__ A0,  // fp16 input matrix of shape mxk
++    const int4* __restrict__ B,   // 4bit quantized weight matrix of shape kxn
++    int4* __restrict__ C0,        // fp16 output buffer of shape mxn
++    int4* __restrict__ C_tmp,     // fp32 tmp output buffer (for reduce)
++    const int4* __restrict__ b_bias_ptr,
++    // float scales of input matrix, only used when is_a_8bit == true.
++    // shape (m,)
++    const float* __restrict__ a_scales_ptr,
++    // fp16 quantization scales. shape (k/groupsize, n)
++    const int4* __restrict__ scales_ptr,
++    // float global scale (for nvfp4// only)
++    const float* __restrict__ global_scale_ptr,
++    // 4bit packed zero-points of shape
++    // (k/groupsize, n/pack_factor)
++    const int4* __restrict__ zp_ptr,
++    // int32 group indices of shape k
++    const int* __restrict__ g_idx,
++    int num_groups,  // number of scale groups per output channel
++    int prob_m,      // batch dimension m
++    int prob_n,      // output dimension n
++    int prob_k,      // reduction dimension k
++    int lda,         // A.stride(0), equal to prob_k is A is contiguous
++    int* locks,      // extra global storage for barrier synchronization
++    bool has_bias,
++    bool use_atomic_add,   // whether to use atomic add to reduce
++    bool use_fp32_reduce,  // whether to use fp32 global reduce
++    int max_shared_mem) {
++  // Each threadblock processes one "stripe" of the B matrix with (roughly) the
++  // same size, which might involve multiple column "slices" (of width 16 *
++  // `thread_n_blocks`). Stripes are defined as shown in the 3x3 matrix 5 SM
++  // example:
++  //   0 1 3
++  //   0 2 3
++  //   1 2 4
++  // While this kind of partitioning makes things somewhat more complicated, it
++  // ensures good utilization of all SMs for many kinds of shape and GPU
++  // configurations, while requiring as few slow global cross-threadblock
++  // reductions as possible.
++
++#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 890
++  // FP8 computation is only supported for Ada Lovelace or newer architectures.
++  if constexpr (a_type_id == sglang::host::kFE4M3fn.id()) return;
++#endif
++
++#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 750
++  // Turing TensorCore only supports fp16 and int8
++  if constexpr (a_type_id != sglang::host::kFloat16.id() && a_type_id != sglang::host::kS8.id()) return;
++#endif
++
++#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 750
++  constexpr auto num_bits = sglang::host::ScalarType::from_id(b_type_id).size_bits();
++  // Disable use_fp16_accum for NVFP4 and cases when group_size == -1 &&
++  // num_bits == 4
++  constexpr bool use_fp16_accum =
++      a_type_id == sglang::host::kFloat16.id() &&
++      (!(b_type_id == sglang::host::kFE2M1f.id() && s_type_id == sglang::host::kFE4M3fn.id()) &&
++       !(group_blocks == -1 && num_bits == 4));
++#else
++  constexpr bool use_fp16_accum = false;
++#endif
++  using Adtype = MarlinScalarType<a_type_id>;
++  using Cdtype = MarlinScalarType<c_type_id>;
++  const int4* A = A0;
++  int4* C = C0;
++
++  using scalar_t = typename MarlinScalarType<a_type_id>::scalar_t;
++  using scalar_t2 = typename MarlinScalarType<a_type_id>::scalar_t2;
++  using scalar_32bit_t = typename MarlinScalarType<a_type_id>::scalar_32bit_t;
++
++  using c_scalar_t = typename MarlinScalarType<c_type_id>::scalar_t;
++  using c_scalar_t2 = typename MarlinScalarType<c_type_id>::scalar_t2;
++
++  using FragA = typename MarlinScalarType<a_type_id>::FragA;
++  using FragB = typename MarlinScalarType<a_type_id>::FragB;
++  using FragC = typename MarlinScalarType<a_type_id>::FragC;
++  using FragS = typename MarlinScalarType<c_type_id>::FragS;
++  using FragZP = typename MarlinScalarType<c_type_id>::FragZP;
++
++  static constexpr auto a_type = sglang::host::ScalarType::from_id(a_type_id);
++  static constexpr auto b_type = sglang::host::ScalarType::from_id(b_type_id);
++  static constexpr auto c_type = sglang::host::ScalarType::from_id(c_type_id);
++  static constexpr auto s_type = sglang::host::ScalarType::from_id(s_type_id);
++  if constexpr (b_type == sglang::host::kFE2M1f) {
++    static_assert(
++        s_type == sglang::host::kFE4M3fn && group_blocks == 1 ||
++        s_type == sglang::host::kFE8M0fnu && group_blocks == 2);
++  } else if constexpr (s_type == sglang::host::kFE8M0fnu) {
++    // MXFP8: FP8 weights with e8m0 microscaling block scales
++    static_assert(b_type == sglang::host::kFE4M3fn && group_blocks == 2);
++  } else if constexpr (std::is_same<scalar_t, nv_bfloat16>::value) {
++    static_assert(s_type == sglang::host::kBFloat16);
++  } else if constexpr (std::is_same<scalar_t, half>::value) {
++    static_assert(s_type == sglang::host::kFloat16);
++  }
++
++  constexpr bool is_a_8bit = a_type.size_bits() == 8;
++  constexpr bool is_8bit_scale = s_type.size_bits() == 8;
++  if constexpr (!is_a_8bit) {
++    static_assert(std::is_same<scalar_t, c_scalar_t>::value);
++  }
++  constexpr bool has_zp = b_type == sglang::host::kU4 || b_type == sglang::host::kU8;
++  constexpr bool is_int_type = b_type == sglang::host::kU4 || b_type == sglang::host::kU8 ||
++                               b_type == sglang::host::kS4 || b_type == sglang::host::kS8 ||
++                               b_type == sglang::host::kU4B8 || b_type == sglang::host::kU8B128;
++  // see comments of dequant.h for more details
++  constexpr bool dequant_skip_flop = is_a_8bit ||
++                                     (b_type == sglang::host::kFE4M3fn && !(s_type == sglang::host::kFE8M0fnu)) ||
++                                     b_type == sglang::host::kFE2M1f && s_type == sglang::host::kFE4M3fn ||
++                                     has_zp && !is_zp_float && !std::is_same<scalar_t, nv_bfloat16>::value ||
++                                     has_zp && !is_zp_float && !(b_type == sglang::host::kU8);
++
++  float global_scale_f32 = 1.0f;
++
++  if constexpr (b_type == sglang::host::kFE2M1f && s_type == sglang::host::kFE4M3fn) {
++    global_scale_f32 = global_scale_ptr[0];
++  }
++
++  constexpr bool has_act_order = group_blocks == 0;
++  constexpr int m_block_size = m_block_size_8 ? 8 : (16 * thread_m_blocks);
++
++  extern __shared__ int4 sh[];
++  float* sh_a_s = reinterpret_cast<float*>(sh);
++  int4* sh_new = sh + (is_a_8bit ? (4 * thread_m_blocks) : 0);
++  constexpr int pack_factor = 32 / b_type.size_bits();
++  static_assert(thread_m_blocks == 1 || !m_block_size_8);
++
++  // For larger GEMMs we run multiple batchsize 64 versions in parallel for a
++  // better partitioning with less reductions
++  int parallel = 1;
++  if (prob_m > m_block_size) {
++    parallel = prob_m / m_block_size;
++    prob_m = m_block_size;
++  }
++
++  int k_tiles = prob_k / 16 / thread_k_blocks;
++  int n_tiles = prob_n / 16 / thread_n_blocks;
++
++  int global_mn_tiles = parallel * n_tiles;
++  int part2_mn_tiles = global_mn_tiles;
++  int part1_mn_iters = 0;
++  bool in_part2 = false;
++
++  if (global_mn_tiles > gridDim.x) {
++    part2_mn_tiles = global_mn_tiles % gridDim.x;
++    if (part2_mn_tiles * 3 <= gridDim.x) part2_mn_tiles += gridDim.x;
++    part1_mn_iters = (global_mn_tiles - part2_mn_tiles) / gridDim.x;
++  }
++
++  int iters = div_ceil(k_tiles * part2_mn_tiles, gridDim.x);
++
++  if constexpr (!has_act_order && group_blocks != -1) {
++    if (group_blocks >= thread_k_blocks) {
++      // Ensure that the number of tiles in each stripe is a multiple of the
++      // groupsize; this avoids an annoying special case where a stripe starts
++      // in the middle of group.
++      iters = (group_blocks / thread_k_blocks) * div_ceil(iters, (group_blocks / thread_k_blocks));
++    }
++  }
++
++  int slice_row = 0;
++  int slice_col_par = blockIdx.x;
++  int slice_col;
++  int slice_iters = k_tiles;  // number of threadblock tiles in the current slice
++  // total number of active threadblocks in the current slice
++  int slice_count = 1;
++  // index of threadblock in current slice; numbered bottom to top
++  int slice_idx = 0;
++
++  int par_id = 0;
++  int locks_off = 0;
++
++  if (part2_mn_tiles >= gridDim.x) {
++    // when part2_mn_tiles >= sms
++    // then there are at most $sms$ conflict tile blocks
++    locks_off = blockIdx.x;
++  } else {
++    locks_off = (iters * blockIdx.x) / k_tiles - 1;
++  }
++
++  // Compute all information about the current slice which is required for
++  // synchronization.
++  bool first_init = true;
++  auto init_part2_slice = [&]() {
++    slice_iters = iters * (blockIdx.x + 1) - (k_tiles * slice_col_par + slice_row);
++    if (slice_iters < 0 || slice_col_par >= part2_mn_tiles) slice_iters = 0;
++    if (slice_iters == 0) return;
++    if (slice_row + slice_iters > k_tiles) slice_iters = k_tiles - slice_row;
++    slice_count = 1;
++    slice_idx = 0;
++    int col_first = iters * div_ceil(k_tiles * slice_col_par, iters);
++    if (col_first <= k_tiles * (slice_col_par + 1)) {
++      int col_off = col_first - k_tiles * slice_col_par;
++      slice_count = div_ceil(k_tiles - col_off, iters);
++      if (col_off > 0) slice_count++;
++      int delta_first = iters * blockIdx.x - col_first;
++      if (delta_first < 0 || (col_off == 0 && delta_first == 0))
++        slice_idx = slice_count - 1;
++      else {
++        slice_idx = slice_count - 1 - delta_first / iters;
++        if (col_off > 0) slice_idx--;
++      }
++    }
++    if (part2_mn_tiles >= gridDim.x) {
++      if (slice_count > 1 && slice_idx == slice_count - 1) {
++        locks_off++;
++      }
++    } else {
++      locks_off++;
++    }
++
++    if (first_init && use_atomic_add && slice_count > 1 && slice_idx == 0) {
++      constexpr int threads_per_m = 16 * thread_n_blocks / 8;
++      int m_per_thread = div_ceil(thread_m_blocks * 16, threads / threads_per_m);
++      if (m_block_size_8) m_per_thread = div_ceil(8, threads / threads_per_m);
++      for (int i = 0; i < m_per_thread; i++) {
++        int row = threads / threads_per_m * i + threadIdx.x / threads_per_m;
++        if (row < prob_m) {
++          int col = slice_col * 16 * thread_n_blocks / 8 + threadIdx.x % threads_per_m;
++          C[row * prob_n / 8 + col] = {0, 0, 0, 0};
++        }
++      }
++      // After write zero to output, write a negative value to lock.
++      // Every SM that processes the same slice would wait for
++      // the negative value, and then atomicAdd 1 to it.
++      // After all SMs are processed, the lock value would back to 0 again.
++      __syncthreads();
++      if (threadIdx.x == 0) locks[locks_off] = 1 - slice_count;
++    }
++
++    if (slice_col == n_tiles) {
++      A += 16 * thread_m_blocks * lda / (is_a_8bit ? 16 : 8);
++      C += 16 * thread_m_blocks * prob_n / 8;
++      slice_col = 0;
++      par_id++;
++    }
++    if (is_a_8bit && (first_init || slice_col == 0)) {
++      __syncthreads();
++      int a_s_gl_rd = par_id * 16 * thread_m_blocks + threadIdx.x;
++      cp_async1_ca_pred(&sh_a_s[threadIdx.x], &a_scales_ptr[a_s_gl_rd], threadIdx.x < prob_m);
++    }
++  };
++
++  auto init_part1_slice = [&]() {
++    if (part1_mn_iters) {
++      part1_mn_iters--;
++      par_id = slice_col_par / n_tiles;
++      slice_col = slice_col_par % n_tiles;
++      slice_iters = k_tiles;
++      A = A0 + 16 * thread_m_blocks / (is_a_8bit ? 16 : 8) * par_id * lda;
++      C = C0 + 16 * thread_m_blocks / 8 * par_id * prob_n;
++      if (is_a_8bit) {
++        __syncthreads();
++        int a_s_gl_rd = par_id * 16 * thread_m_blocks + threadIdx.x;
++        cp_async1_ca_pred(&sh_a_s[threadIdx.x], &a_scales_ptr[a_s_gl_rd], threadIdx.x < prob_m);
++      }
++    }
++  };
++
++  auto init_slice = [&]() {
++    if (!in_part2 && !part1_mn_iters) {
++      in_part2 = true;
++      slice_col_par = (iters * blockIdx.x) / k_tiles;
++      slice_row = (iters * blockIdx.x) % k_tiles;
++      slice_col = (slice_col_par + global_mn_tiles - part2_mn_tiles) % n_tiles;
++      par_id = (slice_col_par + global_mn_tiles - part2_mn_tiles) / n_tiles;
++      A = A0 + 16 * thread_m_blocks / (is_a_8bit ? 16 : 8) * par_id * lda;
++      C = C0 + 16 * thread_m_blocks / 8 * par_id * prob_n;
++    }
++    if (!in_part2) {
++      init_part1_slice();
++    } else {
++      init_part2_slice();
++      first_init = false;
++    }
++  };
++
++  init_slice();
++
++  // A sizes/strides
++
++  // stride of the A matrix in global memory
++  int a_gl_stride = lda / (is_a_8bit ? 16 : 8);
++  // stride of an A matrix tile in shared memory
++  constexpr int a_sh_stride = 16 * thread_k_blocks / (is_a_8bit ? 16 : 8);
++  // delta between subsequent A tiles in global memory
++  constexpr int a_gl_rd_delta_o = 16 * thread_k_blocks / (is_a_8bit ? 16 : 8);
++  // between subsequent accesses within a tile
++  int a_gl_rd_delta_i = a_gl_stride * (threads / a_gl_rd_delta_o);
++  // between shared memory writes
++  constexpr int a_sh_wr_delta = a_sh_stride * (threads / a_gl_rd_delta_o);
++  // within a shared memory tile
++  constexpr int a_sh_rd_delta_i = a_sh_stride * 16;
++  // overall size of a tile
++  constexpr int a_sh_stage = a_sh_stride * m_block_size;
++  // number of shared write iterations for a tile
++  constexpr int a_sh_wr_iters = div_ceil(a_sh_stage, a_sh_wr_delta);
++
++  // B sizes/strides
++  int b_gl_stride = 16 * prob_n / (pack_factor * (is_a_8bit ? 2 : 4));
++  constexpr int b_sh_stride = ((thread_n_blocks * 16) * 16 / pack_factor) / (is_a_8bit ? 2 : 4);
++  constexpr int b_thread_vecs = b_type.size_bits() == 4 ? 1 : 2;
++  constexpr int b_sh_stride_threads = b_sh_stride / b_thread_vecs;
++
++  int b_gl_rd_delta_o = b_gl_stride * thread_k_blocks / (is_a_8bit ? 2 : 1);
++  constexpr int b_sh_wr_delta = threads * b_thread_vecs;
++  constexpr int b_sh_stage = b_sh_stride * thread_k_blocks / (is_a_8bit ? 2 : 1);
++  constexpr int b_sh_wr_iters = b_sh_stage / b_sh_wr_delta;
++
++  // Scale sizes/strides without act_order
++  int s_gl_stride = prob_n / (is_8bit_scale ? 16 : 8);
++  constexpr int s_sh_stride = 16 * thread_n_blocks / (is_8bit_scale ? 16 : 8);
++  constexpr int s_tb_groups =
++      !has_act_order && group_blocks != -1 && group_blocks < thread_k_blocks ? thread_k_blocks / group_blocks : 1;
++  constexpr int s_sh_stage = s_tb_groups * s_sh_stride;
++  int s_gl_rd_delta = s_gl_stride;
++
++  // Scale size/strides with act_order
++  constexpr int tb_k = 16 * thread_k_blocks;
++  constexpr int g_idx_stage = has_act_order ? (tb_k * sizeof(int)) / 16 : 0;
++  // constexpr int act_s_row_stride      = 1;
++  // int           act_s_col_stride      = act_s_row_stride * num_groups;
++  constexpr int act_s_max_num_groups = 32;
++  int act_s_col_stride = 1;
++  int act_s_col_warp_stride = act_s_col_stride * 8;
++
++  constexpr int tb_n_warps = thread_n_blocks / (is_a_8bit ? 2 : 4);
++  int act_s_col_tb_stride = act_s_col_warp_stride * tb_n_warps;
++
++  // Zero-points sizes/strides
++  int zp_gl_stride = is_zp_float ? prob_n / 8 : (prob_n / pack_factor) / 4;
++  constexpr int zp_sh_stride = is_zp_float ? 16 * thread_n_blocks / 8 : ((16 * thread_n_blocks) / pack_factor) / 4;
++  constexpr int zp_tb_groups = s_tb_groups;
++  constexpr int zp_sh_stage = has_zp ? zp_tb_groups * zp_sh_stride : 0;
++  int zp_gl_rd_delta = zp_gl_stride;
++
++  // Global A read index of current thread.
++  int a_gl_rd = a_gl_stride * (threadIdx.x / a_gl_rd_delta_o) + (threadIdx.x % a_gl_rd_delta_o);
++  a_gl_rd += a_gl_rd_delta_o * slice_row;
++  // Shared write index of current thread.
++  int a_sh_wr = a_sh_stride * (threadIdx.x / a_gl_rd_delta_o) + (threadIdx.x % a_gl_rd_delta_o);
++  // Shared read index.
++  int a_sh_rd = a_sh_stride * ((threadIdx.x % 32) % (16 / (m_block_size_8 ? 2 : 1))) +
++                (threadIdx.x % 32) / (16 / (m_block_size_8 ? 2 : 1));
++  a_sh_rd += 2 * ((threadIdx.x / 32) / tb_n_warps) * b_sh_wr_iters;
++
++  int b_gl_rd;
++  if (threads <= b_sh_stride) {
++    b_gl_rd = threadIdx.x;
++  } else {
++    b_gl_rd = b_gl_stride * (threadIdx.x / b_sh_stride) + (threadIdx.x % b_sh_stride);
++  }
++
++  b_gl_rd += b_sh_stride * slice_col;
++  b_gl_rd += b_gl_rd_delta_o * slice_row;
++  auto b_sh_rd = threadIdx.x * b_thread_vecs;
++  b_sh_rd += b_sh_rd / b_sh_stride * (b_sh_stride * (b_sh_wr_iters - 1));
++
++  // For act_order
++  int slice_k_start = tb_k * slice_row;
++  int slice_k_finish = slice_k_start + tb_k * slice_iters;
++  int slice_k_start_shared_fetch = slice_k_start;
++  int slice_n_offset = act_s_col_tb_stride * slice_col;
++
++  // No act_order
++  int s_gl_rd;
++  if constexpr (!has_act_order) {
++    if constexpr (group_blocks == -1) {
++      s_gl_rd = s_sh_stride * slice_col + threadIdx.x;
++    } else if constexpr (group_blocks >= thread_k_blocks) {
++      s_gl_rd = s_gl_stride * ((thread_k_blocks * slice_row) / group_blocks) + s_sh_stride * slice_col + threadIdx.x;
++    } else {
++      s_gl_rd = s_gl_stride * ((thread_k_blocks * slice_row) / group_blocks + threadIdx.x / s_sh_stride) +
++                s_sh_stride * slice_col + threadIdx.x % s_sh_stride;
++    }
++  }
++  auto s_sh_wr = threadIdx.x;
++  bool s_sh_wr_pred = threadIdx.x < s_sh_stage;
++
++  // Zero-points
++  int zp_gl_rd;
++  if constexpr (has_zp) {
++    if constexpr (group_blocks == -1) {
++      zp_gl_rd = zp_sh_stride * slice_col + threadIdx.x;
++    } else if constexpr (group_blocks >= thread_k_blocks) {
++      zp_gl_rd = zp_gl_stride * ((thread_k_blocks * slice_row) / group_blocks) + zp_sh_stride * slice_col + threadIdx.x;
++    } else {
++      zp_gl_rd = zp_gl_stride * ((thread_k_blocks * slice_row) / group_blocks + threadIdx.x / zp_sh_stride) +
++                 zp_sh_stride * slice_col + threadIdx.x % zp_sh_stride;
++    }
++  }
++  auto zp_sh_wr = threadIdx.x;
++  bool zp_sh_wr_pred = zp_sh_stage > 0 && threadIdx.x < zp_sh_stage;
++
++  // We use a different scale layout for grouped and column-wise quantization as
++  // we scale a `half2` tile in column-major layout in the former and in
++  // row-major in the latter case.
++  int s_sh_rd;
++  if constexpr (is_a_8bit) {
++    s_sh_rd = 4 * ((threadIdx.x / 32) % tb_n_warps) + (threadIdx.x % 4);
++  } else if constexpr (group_blocks != -1)
++    s_sh_rd = 8 * ((threadIdx.x / 32) % tb_n_warps) + (threadIdx.x % 32) / 4;
++  else if constexpr (group_blocks == -1 && (m_block_size_8 || (has_zp && !dequant_skip_flop)))
++    s_sh_rd = 8 * ((threadIdx.x / 32) % tb_n_warps) + (threadIdx.x % 32) / 8;
++  else
++    s_sh_rd = 8 * ((threadIdx.x / 32) % tb_n_warps) + (threadIdx.x % 32) % 4;
++
++  int bias_sh_rd;
++  if constexpr (m_block_size_8) {
++    bias_sh_rd = 8 * ((threadIdx.x / 32) % tb_n_warps) + (threadIdx.x % 32) / 8;
++  } else {
++    bias_sh_rd = (is_a_8bit ? 4 : 8) * ((threadIdx.x / 32) % tb_n_warps) + (threadIdx.x % 32) % 4;
++  }
++
++  int bias_sh_wr = threadIdx.x;
++  int bias_gl_rd = (thread_n_blocks * 16 / 8) * slice_col + threadIdx.x;
++
++  // Zero-points have the same read layout as the scales
++  // (without column-wise case)
++  constexpr int num_col_threads = 8;
++  constexpr int num_row_threads = 4;
++  constexpr int num_ints_per_thread = 8 / pack_factor;
++  int zp_sh_rd;
++  if constexpr (has_zp) {
++    if constexpr (is_zp_float) {
++      if constexpr (group_blocks != -1) {
++        zp_sh_rd = 8 * ((threadIdx.x / 32) % tb_n_warps) + (threadIdx.x % 32) / 4;
++      }
++    } else if (is_a_8bit) {
++      zp_sh_rd = num_ints_per_thread * num_col_threads * ((threadIdx.x / 32) % tb_n_warps / 2) +
++                 num_ints_per_thread * ((threadIdx.x % 32) / num_row_threads);
++    } else {
++      zp_sh_rd = num_ints_per_thread * num_col_threads * ((threadIdx.x / 32) % tb_n_warps) +
++                 num_ints_per_thread * ((threadIdx.x % 32) / num_row_threads);
++    }
++  }
++
++  // Precompute which thread should not read memory in which iterations; this is
++  // needed if there are more threads than required for a certain tilesize or
++  // when the batchsize is not a multiple of 16.
++  bool a_sh_wr_pred[a_sh_wr_iters];
++#pragma unroll
++  for (int i = 0; i < a_sh_wr_iters; i++)
++    a_sh_wr_pred[i] = a_sh_wr_delta * i + a_sh_wr < a_sh_stride * prob_m;
++
++  // To ensure that writing and reading A tiles to/from shared memory, the
++  // latter in fragment format, is fully bank conflict free, we need to use a
++  // rather fancy XOR-based layout. The key here is that neither reads nor
++  // writes of the 16-byte `int4` blocks of 8 consecutive threads involve the
++  // same shared memory banks. Further, it seems (based on NSight-Compute) that
++  // each warp must also write a consecutive memory segment?
++  auto transform_a = [&](int i) {
++    int row = i / a_gl_rd_delta_o;
++    return a_gl_rd_delta_o * row + (i % a_gl_rd_delta_o) ^ (row % 8);
++  };
++  // Since the computation of this remapping is non-trivial and, due to our main
++  // loop unrolls, all shared memory accesses are static, we simply precompute
++  // both transformed reads and writes.
++  int a_sh_wr_trans[a_sh_wr_iters];
++#pragma unroll
++  for (int i = 0; i < a_sh_wr_iters; i++)
++    a_sh_wr_trans[i] = transform_a(a_sh_wr_delta * i + a_sh_wr);
++  int a_sh_rd_trans[b_sh_wr_iters][thread_m_blocks];
++#pragma unroll
++  for (int i = 0; i < b_sh_wr_iters; i++) {
++#pragma unroll
++    for (int j = 0; j < thread_m_blocks; j++)
++      a_sh_rd_trans[i][j] = transform_a(2 * i + a_sh_rd_delta_i * j + a_sh_rd);
++  }
++
++  // Since B-accesses have non-constant stride they have to be computed at
++  // runtime; we break dependencies between subsequent accesses with a tile by
++  // maintining multiple pointers (we have enough registers), a tiny
++  // optimization.
++
++  // Shared memory storage for global fetch pipelines.
++  constexpr int sh_red_size = (2 * thread_n_blocks + 1) * 16 * thread_m_blocks;
++  constexpr int sh_b_size = stages * b_sh_stage;
++  int4* sh_b = sh_new;
++  int4* sh_red = sh_new;
++  constexpr int sh_size_b_red_min = (sh_red_size < sh_b_size ? sh_red_size : sh_b_size);
++  constexpr int sh_size_b_red_max = (sh_red_size > sh_b_size ? sh_red_size : sh_b_size);
++  constexpr int sh_bias_size = (thread_n_blocks * 16 / 8);
++  constexpr int sh_b_red_bias_size =
++      sh_size_b_red_max > (sh_size_b_red_min + sh_bias_size) ? sh_size_b_red_max : (sh_size_b_red_min + sh_bias_size);
++
++  int4* sh_bias = sh_new + sh_size_b_red_min;
++  int4* sh_g_idx = sh_new + sh_b_red_bias_size;
++  int4* sh_zp = sh_g_idx + (stages * g_idx_stage);
++  constexpr int sh_s_size = has_act_order ? (act_s_max_num_groups * s_sh_stride) : (stages * s_sh_stage);
++  int4* sh_s = sh_zp + (stages * zp_sh_stage);
++  int4* sh_a = sh_s + sh_s_size;
++
++  // Register storage for double buffer of shared memory reads.
++  FragA frag_a[2][thread_m_blocks];
++  I4 frag_b_quant[2][b_thread_vecs];
++  FragC frag_c[thread_m_blocks][is_a_8bit ? 2 : 4][2];
++  FragC frag_c_tmp[thread_m_blocks][is_a_8bit ? 2 : 4][2];
++  FragS frag_s[2][4];  // No act-order
++  FragS frag_bias[2][4];
++  FragS act_frag_s[2][4][4];             // For act-order
++  int frag_qzp[2][num_ints_per_thread];  // Zero-points
++  FragZP frag_zp;                        // Zero-points in fp16
++  FragZP frag_zpf[2];                    // Zero-points in fp16 in HQQ
++
++  if constexpr (is_a_8bit) {
++#pragma unroll
++    for (int j = 0; j < 2; j++) {
++#pragma unroll
++      for (int i = 0; i < thread_m_blocks; i++) {
++#pragma unroll
++        for (int g = 0; g < 4; g++) {
++          frag_c_tmp[i][j][0][g] = 0.0f;
++        }
++
++#pragma unroll
++        for (int g = 0; g < 4; g++) {
++          frag_c_tmp[i][j][1][g] = 0.0f;
++        }
++      }
++    }
++  }
++
++  // Zero accumulators.
++  auto zero_accums = [&]() {
++#pragma unroll
++    for (int i = 0; i < thread_m_blocks * 4 * 2 * 4; i++)
++      reinterpret_cast<float*>(frag_c)[i] = 0;
++  };
++
++  int sh_first_group_id = -1;
++  int sh_num_groups = -1;
++
++  auto fetch_act_order_scales_to_shared = [&](bool is_async, int first_group_id, int last_group_id) {
++    sh_first_group_id = first_group_id;
++    sh_num_groups = last_group_id - first_group_id + 1;
++
++    if (sh_num_groups > act_s_max_num_groups) {
++      sh_num_groups = act_s_max_num_groups;
++    }
++
++    if (sh_first_group_id + sh_num_groups > num_groups) {
++      sh_num_groups = num_groups - sh_first_group_id;
++    }
++
++    int row_offset = first_group_id * s_gl_stride;
++
++    if (is_async) {
++      for (int i = 0; i < sh_num_groups; i++) {
++        if (threadIdx.x < s_sh_stride) {
++          cp_async4_pred(
++              &sh_s[(i * s_sh_stride) + threadIdx.x],
++              &scales_ptr[row_offset + (i * s_gl_stride) + slice_n_offset + threadIdx.x]);
++        }
++      }
++    } else {
++      for (int i = 0; i < sh_num_groups; i++) {
++        if (threadIdx.x < s_sh_stride) {
++          sh_s[(i * s_sh_stride) + threadIdx.x] =
++              scales_ptr[row_offset + (i * s_gl_stride) + slice_n_offset + threadIdx.x];
++        }
++      }
++    }
++  };
++  // Asynchronously fetch the next A, B and s tile from global to the next
++  // shared memory pipeline location.
++  auto fetch_to_shared = [&](int pipe, int a_off, bool pred = true) {
++    if (pred) {
++      int4* sh_a_stage = sh_a + a_sh_stage * pipe;
++#pragma unroll
++      for (int i = 0; i < a_sh_wr_iters; i++) {
++        cp_async4_pred(
++            &sh_a_stage[a_sh_wr_trans[i]],
++            &A[a_gl_rd_delta_i * i + a_gl_rd + a_gl_rd_delta_o * a_off],
++            a_sh_wr_pred[i]);
++      }
++      int4* sh_b_stage = sh_b + b_sh_stage * pipe;
++#pragma unroll
++      for (int i = 0; i < (b_sh_wr_iters * b_thread_vecs); i++) {
++        constexpr int count = div_ceil(b_sh_stride, threads);
++        int b_gl_idx = b_gl_rd + (i % count) * threads + b_gl_stride * (i / count) * div_ceil(threads, b_sh_stride);
++
++        cp_async4(&sh_b_stage[threads * i + threadIdx.x], &B[b_gl_idx]);
++      }
++
++      b_gl_rd += b_gl_rd_delta_o;
++
++      if constexpr (has_act_order) {
++        // Fetch g_idx thread-block portion
++        int full_pipe = a_off;
++        int cur_k = slice_k_start_shared_fetch + tb_k * full_pipe;
++        if (cur_k < prob_k && cur_k < slice_k_finish) {
++          int4* sh_g_idx_stage = sh_g_idx + g_idx_stage * pipe;
++
++          int4 const* cur_g_idx_stage_ptr = reinterpret_cast<int4 const*>(&g_idx[cur_k]);
++
++          if (threadIdx.x < g_idx_stage) {
++            cp_async4_pred(&sh_g_idx_stage[threadIdx.x], &cur_g_idx_stage_ptr[threadIdx.x]);
++          }
++        }
++      } else {
++        if constexpr (group_blocks != -1) {
++          int4* sh_s_stage = sh_s + s_sh_stage * pipe;
++
++          // Only fetch scales if this tile starts a new group
++          if (pipe % div_ceil(group_blocks, thread_k_blocks) == 0) {
++            if (s_sh_wr_pred) {
++              cp_async4(&sh_s_stage[s_sh_wr], &scales_ptr[s_gl_rd]);
++            }
++            s_gl_rd += s_gl_rd_delta * s_tb_groups;
++          }
++        }
++
++        if constexpr (has_zp && group_blocks != -1) {
++          int4* sh_zp_stage = sh_zp + zp_sh_stage * pipe;
++
++          // Only fetch zero points if this tile starts a new group
++          if (pipe % div_ceil(group_blocks, thread_k_blocks) == 0) {
++            if (zp_sh_wr_pred) {
++              cp_async4(&sh_zp_stage[zp_sh_wr], &zp_ptr[zp_gl_rd]);
++            }
++            zp_gl_rd += zp_gl_rd_delta * zp_tb_groups;
++          }
++        }
++      }
++    }
++    // Insert a fence even when we are winding down the pipeline to ensure that
++    // waiting is also correct at this point.
++    cp_async_fence();
++  };
++
++  auto fetch_col_zp_to_shared = [&]() {
++    if (zp_sh_wr_pred) {
++      cp_async4(&sh_zp[zp_sh_wr], &zp_ptr[zp_gl_rd]);
++    }
++  };
++
++  auto fetch_col_scale_to_shared = [&]() {
++    if (s_sh_wr_pred) {
++      cp_async4(&sh_s[s_sh_wr], &scales_ptr[s_gl_rd]);
++    }
++  };
++
++  // Wait until the next thread tile has been loaded to shared memory.
++  auto wait_for_stage = [&]() {
++    // We only have `stages - 2` active fetches since we are double buffering
++    // and can only issue the next fetch when it is guaranteed that the previous
++    // shared memory load is fully complete (as it may otherwise be
++    // overwritten).
++    cp_async_wait<stages - 2>();
++    __syncthreads();
++  };
++
++  // Load the next sub-tile from the current location in the shared memory pipe
++  // into the current register buffer.
++  auto fetch_to_registers = [&](int k, int pipe) {
++    int4* sh_a_stage = sh_a + a_sh_stage * pipe;
++#pragma unroll
++    for (int i = 0; i < thread_m_blocks; i++)
++      ldsm<m_block_size_8 ? 2 : 4, a_type_id>(frag_a[k % 2][i], &sh_a_stage[a_sh_rd_trans[k % b_sh_wr_iters][i]]);
++    int4* sh_b_stage = sh_b + b_sh_stage * pipe;
++
++#pragma unroll
++    for (int i = 0; i < b_thread_vecs; i++) {
++      frag_b_quant[k % 2][i] = *reinterpret_cast<I4*>(&sh_b_stage[b_sh_stride * (k % b_sh_wr_iters) + b_sh_rd + i]);
++    }
++  };
++
++  bool is_same_group[stages];
++  int same_group_id[stages];
++
++  auto init_same_group = [&](int pipe) {
++    if constexpr (!has_act_order) {
++      return;
++    }
++
++    int4* sh_g_idx_stage = sh_g_idx + g_idx_stage * pipe;
++    int* sh_g_idx_int_ptr = reinterpret_cast<int*>(sh_g_idx_stage);
++
++    int group_id_1 = sh_g_idx_int_ptr[0];
++    int group_id_2 = sh_g_idx_int_ptr[tb_k - 1];
++
++    is_same_group[pipe] = group_id_1 == group_id_2;
++    same_group_id[pipe] = group_id_1;
++  };
++
++  auto fetch_scales_to_registers = [&](int k, int full_pipe) {
++    int pipe = full_pipe % stages;
++    using IT1 = typename std::conditional_t<is_a_8bit, int2, int4>;
++    using IT0 = typename std::conditional_t<is_a_8bit, int, int2>;
++    constexpr int group_blocks2 = div_ceil(group_blocks, is_a_8bit ? 2 : 1);
++
++    if constexpr (!has_act_order) {
++      // No act-order case
++      if constexpr (group_blocks == -1) {
++        // load only when starting a new slice
++        if (k == 0 && full_pipe == 0 && dequant_skip_flop) {
++          reinterpret_cast<int4*>(&frag_s)[0] = sh_s[s_sh_rd];
++          reinterpret_cast<int4*>(&frag_s)[1] = sh_s[s_sh_rd + 4];
++        }
++      } else if constexpr (group_blocks != -1) {
++        if constexpr (group_blocks >= thread_k_blocks) {
++          constexpr int g = group_blocks / thread_k_blocks;
++          if (pipe % g == 0) {
++            if (k % b_sh_wr_iters == 0) {
++              int4* sh_s_stage = sh_s + s_sh_stage * (g * (pipe / g));
++              reinterpret_cast<int4*>(&frag_s[k % 2])[0] = sh_s_stage[s_sh_rd];
++            } else {
++              reinterpret_cast<int4*>(&frag_s[1])[0] = reinterpret_cast<int4*>(&frag_s[0])[0];
++            }
++          }
++        } else if (group_blocks2 < b_sh_wr_iters || k % b_sh_wr_iters == 0) {
++          auto warp_id = threadIdx.x / 32;
++          int warp_row = warp_id / tb_n_warps;
++
++          int k_blocks = b_sh_wr_iters * warp_row + k % b_sh_wr_iters;
++          int cur_group_id = k_blocks / group_blocks2;
++
++          int4* sh_s_stage = sh_s + s_sh_stage * pipe;
++
++          if constexpr (!is_8bit_scale) {
++            reinterpret_cast<int4*>(&frag_s[k % 2])[0] = sh_s_stage[s_sh_rd + cur_group_id * s_sh_stride];
++          } else {
++            reinterpret_cast<int2*>(&frag_s[k % 2])[0] =
++                reinterpret_cast<int2*>(sh_s_stage)[s_sh_rd + cur_group_id * (2 * s_sh_stride)];
++          }
++        } else if (group_blocks >= b_sh_wr_iters) {
++          if constexpr (!is_8bit_scale) {
++            reinterpret_cast<int4*>(&frag_s[1])[0] = reinterpret_cast<int4*>(&frag_s[0])[0];
++          } else {
++            reinterpret_cast<int2*>(&frag_s[1])[0] = reinterpret_cast<int2*>(&frag_s[0])[0];
++          }
++        }
++      }
++
++      return;
++    }
++
++    // Act-order case
++
++    // Determine K of the "current" thread-block
++    int cur_k = slice_k_start + tb_k * full_pipe;
++    if (cur_k >= prob_k || cur_k >= slice_k_finish) {
++      return;
++    }
++
++    // Reset (to current thread-block) since we read g_idx portion from the
++    // shared memory
++    cur_k = 0;
++
++    // Progress to current iteration
++    cur_k += k % b_sh_wr_iters;
++
++    // Determine "position" inside the thread-block (based on warp and
++    // thread-id)
++    auto warp_id = threadIdx.x / 32;
++    int warp_row = warp_id / tb_n_warps;
++    int warp_col = warp_id % tb_n_warps;
++
++    cur_k += warp_row * 16 * b_sh_wr_iters;
++
++    auto th_id = threadIdx.x % 32;
++    cur_k += (th_id % 4) * 2;  // Due to tensor-core layout for fp16 B matrix
++
++    int s_col_shift =
++        /*slice_n_offset +*/ (act_s_col_warp_stride * warp_col) + (th_id / 4) * act_s_col_stride;
++
++    if (is_same_group[pipe]) {
++      if (k % 2 == 0) {
++        *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][0][0]))) =
++            sh_s[(same_group_id[pipe] - sh_first_group_id) * s_sh_stride + s_col_shift];
++      } else {
++        *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][0][0]))) =
++            *(reinterpret_cast<int4*>(&(act_frag_s[(k - 1) % 2][0][0])));
++      }
++
++      for (int i = 1; i < 4; i++) {
++        *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][i][0]))) = *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][0][0])));
++      }
++      return;
++    }
++
++    int4* sh_g_idx_stage = sh_g_idx + g_idx_stage * pipe;
++    int* sh_g_idx_int_ptr = reinterpret_cast<int*>(sh_g_idx_stage);
++
++    constexpr int k_frag_offsets[4] = {0, 1, 8, 9};  // Tensor core offsets per thread
++
++#pragma unroll
++    for (int i = 0; i < 4; i++) {
++      int actual_k = cur_k + k_frag_offsets[i];
++
++      int group_id = sh_g_idx_int_ptr[actual_k];
++      int rel_group_id = group_id - sh_first_group_id;
++
++      *(reinterpret_cast<int4*>(&(act_frag_s[k % 2][i][0]))) = sh_s[rel_group_id * s_sh_stride + s_col_shift];
++    }
++  };
++
++  auto fetch_zp_to_registers = [&](int k, int full_pipe) {
++    // This code does not handle group_blocks == 0,
++    // which signifies act_order.
++    // has_zp implies AWQ, which doesn't have act_order,
++    static_assert(!has_zp || group_blocks != 0);
++
++    if constexpr (has_zp && !is_zp_float) {
++      int pipe = full_pipe % stages;
++
++      if constexpr (group_blocks == -1) {
++        // load only when starting a new slice
++        if (k == 0 && full_pipe == 0 || is_a_8bit) {
++#pragma unroll
++          for (int i = 0; i < num_ints_per_thread; i++) {
++            frag_qzp[k % 2][i] = (reinterpret_cast<int*>(sh_zp))[zp_sh_rd + i];
++          }
++        }
++      } else if constexpr (group_blocks >= thread_k_blocks) {
++        constexpr int g = group_blocks / thread_k_blocks;
++        if (pipe % g == 0 && k % b_sh_wr_iters == 0 || is_a_8bit) {
++          int4* sh_zp_stage = sh_zp + zp_sh_stage * (g * (pipe / g));
++#pragma unroll
++          for (int i = 0; i < num_ints_per_thread; i++) {
++            frag_qzp[k % 2][i] = (reinterpret_cast<int*>(sh_zp_stage))[zp_sh_rd + i];
++          }
++        }
++      } else {
++        auto warp_id = threadIdx.x / 32;
++
++        int warp_row = warp_id / tb_n_warps;
++
++        int k_blocks = b_sh_wr_iters * warp_row + k % b_sh_wr_iters;
++        int cur_group_id = k_blocks / div_ceil(group_blocks, is_a_8bit ? 2 : 1);
++
++        int4* sh_zp_stage = sh_zp + zp_sh_stage * pipe;
++
++        sh_zp_stage += cur_group_id * zp_sh_stride;
++
++#pragma unroll
++        for (int i = 0; i < num_ints_per_thread; i++) {
++          frag_qzp[k % 2][i] = (reinterpret_cast<int*>(sh_zp_stage))[zp_sh_rd + i];
++        }
++      }
++    }
++
++    else if constexpr (has_zp && is_zp_float) {
++      int pipe = full_pipe % stages;
++
++      if constexpr (group_blocks != -1) {
++        if constexpr (group_blocks >= thread_k_blocks) {
++          constexpr int g = group_blocks / thread_k_blocks;
++          if (pipe % g == 0 && k % b_sh_wr_iters == 0) {
++            int4* sh_zp_stage = sh_zp + zp_sh_stage * (g * (pipe / g));
++            reinterpret_cast<int4*>(&frag_zpf[k % 2])[0] = sh_zp_stage[zp_sh_rd];
++          }
++        } else if (group_blocks < b_sh_wr_iters || k % b_sh_wr_iters == 0) {
++          auto warp_id = threadIdx.x / 32;
++
++          int warp_row = warp_id / tb_n_warps;
++          int k_blocks = b_sh_wr_iters * warp_row + k % b_sh_wr_iters;
++          int cur_group_id = k_blocks / group_blocks;
++
++          int4* sh_zp_stage = sh_zp + zp_sh_stage * pipe;
++
++          reinterpret_cast<int4*>(&frag_zpf[k % 2])[0] = sh_zp_stage[zp_sh_rd + cur_group_id * zp_sh_stride];
++        }
++      }
++    }
++  };
++
++  auto dequant_data = [&](int q, scalar_32bit_t* frag_b_ptr, int zp = 0) {
++    if constexpr (a_type.size_bits() != b_type.size_bits()) {
++      if constexpr (is_a_8bit && has_zp) {
++        sub_zp_and_dequant<scalar_32bit_t, b_type_id, dequant_skip_flop>(q, frag_b_ptr, zp);
++      } else {
++        dequant<scalar_32bit_t, b_type_id, dequant_skip_flop>(q, frag_b_ptr);
++      }
++    }
++  };
++
++  // Execute the actual tensor core matmul of a sub-tile.
++  bool is_first_matmul_in_slice = true;
++  auto matmul = [&](int k, int pipe) {
++    if (is_a_8bit) return;
++    int k2 = k % 2;
++    constexpr int g = group_blocks > 0 ? div_ceil(group_blocks, thread_k_blocks) : 1;
++    const bool is_new_zp = (group_blocks == 0) ||
++                           ((group_blocks > 0) && (group_blocks < b_sh_wr_iters || k == 0)) && (pipe % g == 0) ||
++                           (group_blocks == -1 && is_first_matmul_in_slice);
++    if constexpr (has_zp && !is_zp_float) {
++      if (is_new_zp) {
++        if constexpr (group_blocks == -1) is_first_matmul_in_slice = false;
++        int zp_quant_0, zp_quant_1;
++
++        if constexpr (b_type.size_bits() == 4) {
++          zp_quant_0 = frag_qzp[k2][0];
++          zp_quant_1 = zp_quant_0 >> 8;
++        } else {
++          static_assert(b_type.size_bits() == 8);
++          zp_quant_0 = frag_qzp[k2][0];
++          zp_quant_1 = frag_qzp[k2][1];
++        }
++
++        dequant_data(zp_quant_0, reinterpret_cast<scalar_32bit_t*>(&frag_zp));
++        dequant_data(zp_quant_1, reinterpret_cast<scalar_32bit_t*>(&frag_zp) + 2);
++      }
++    }
++    if constexpr (!dequant_skip_flop && has_zp && is_zp_float) {
++      if (is_new_zp) {
++        reinterpret_cast<int4*>(&frag_zp)[0] = reinterpret_cast<int4*>(&frag_zpf[k2])[0];
++      }
++    }
++
++    if constexpr (s_type == sglang::host::kFE4M3fn || s_type == sglang::host::kFE8M0fnu) {
++      int s_quant_0 = reinterpret_cast<int*>(frag_s[k2])[0];
++      int s_quant_1 = reinterpret_cast<int*>(frag_s[k2])[1];
++
++      dequant_fp8_scales<c_scalar_t2, s_type_id>(s_quant_0, reinterpret_cast<c_scalar_t2*>(&frag_s[k2]));
++      dequant_fp8_scales<c_scalar_t2, s_type_id>(s_quant_1, reinterpret_cast<c_scalar_t2*>(&frag_s[k2]) + 2);
++    }
++
++// We have the m dimension as the inner loop in order to encourage overlapping
++// dequantization and matmul operations.
++#pragma unroll
++    for (int j = 0; j < 4; j++) {
++      FragB frag_b0;
++      FragB frag_b1;
++      int b_quant_0, b_quant_1;
++
++      if constexpr (b_type_id == sglang::host::kFE2M1f.id()) {
++        b_quant_1 = frag_b_quant[k2][0][j];
++        b_quant_0 = b_quant_1 << 8;
++      } else if constexpr (b_type.size_bits() == 4) {
++        b_quant_0 = frag_b_quant[k2][0][j];
++        b_quant_1 = b_quant_0 >> 8;
++      } else {
++        static_assert(b_type.size_bits() == 8);
++        int* frag_b_quant_ptr = reinterpret_cast<int*>(frag_b_quant[k2]);
++        b_quant_0 = frag_b_quant_ptr[j * 2 + 0];
++        b_quant_1 = frag_b_quant_ptr[j * 2 + 1];
++      }
++
++      dequant_data(b_quant_0, reinterpret_cast<scalar_32bit_t*>(&frag_b0));
++      dequant_data(b_quant_1, reinterpret_cast<scalar_32bit_t*>(&frag_b1));
++
++      if constexpr (dequant_skip_flop && has_zp && !is_zp_float && !is_a_8bit) {
++        sub_zp<a_type_id>(frag_b0, frag_zp[j], 0);
++        sub_zp<a_type_id>(frag_b1, frag_zp[j], 1);
++      }
++
++      // Apply scale to frag_b0
++      if constexpr (has_act_order && !is_a_8bit) {
++        static_assert(group_blocks != -1);
++        scale4<a_type_id>(
++            frag_b0, act_frag_s[k2][0][j], act_frag_s[k2][1][j], act_frag_s[k2][2][j], act_frag_s[k2][3][j], 0);
++        scale4<a_type_id>(
++            frag_b1, act_frag_s[k2][0][j], act_frag_s[k2][1][j], act_frag_s[k2][2][j], act_frag_s[k2][3][j], 1);
++      } else if constexpr (!dequant_skip_flop && has_zp && !is_zp_float && group_blocks == -1 && !is_a_8bit) {
++        int idx = (threadIdx.x / 4) % 2;
++        scalar_t2 s2 = Adtype::nums2num2(
++            reinterpret_cast<scalar_t*>(&frag_s[j / 2][j % 2 * 2 + 0])[idx],
++            reinterpret_cast<scalar_t*>(&frag_s[j / 2][j % 2 * 2 + 1])[idx]);
++        if (is_new_zp) frag_zp[j] = __hmul2(frag_zp[j], s2);
++        scale_and_sub<a_type_id>(frag_b0, s2.x, frag_zp[j].x);
++        scale_and_sub<a_type_id>(frag_b1, s2.y, frag_zp[j].y);
++      } else if constexpr (!dequant_skip_flop && has_zp && group_blocks != -1 && !is_a_8bit) {
++        if (is_new_zp) frag_zp[j] = __hmul2(frag_zp[j], *reinterpret_cast<scalar_t2*>(&frag_s[k2][j]));
++        scale_and_sub<a_type_id>(frag_b0, frag_s[k2][j][0].x, frag_zp[j].x);
++        scale_and_sub<a_type_id>(frag_b1, frag_s[k2][j][0].y, frag_zp[j].y);
++      } else if constexpr (group_blocks != -1 && !is_a_8bit) {
++        scale<a_type_id>(frag_b0, frag_s[k2][j], 0);
++        scale<a_type_id>(frag_b1, frag_s[k2][j], 1);
++      }
++
++#pragma unroll
++      for (int i = 0; i < thread_m_blocks; i++) {
++        if constexpr (m_block_size_8) {
++          mma_trans<a_type_id, use_fp16_accum>(frag_a[k2][i], frag_b0, frag_b1, frag_c[i][j][0]);
++        } else {
++          mma<a_type_id, use_fp16_accum>(frag_a[k2][i], frag_b0, frag_c[i][j][0]);
++          mma<a_type_id, use_fp16_accum>(frag_a[k2][i], frag_b1, frag_c[i][j][1]);
++        }
++      }
++    }
++  };
++
++  auto matmul_a8 = [&](int k) {
++    int k2 = k % 2;
++#pragma unroll
++    for (int j = 0; j < 2; j++) {
++      FragB frag_b[2];
++
++      if (is_a_8bit && b_type.size_bits() == 4 && !has_zp) {
++        dequant_data(frag_b_quant[k2][0][j * 2], reinterpret_cast<scalar_32bit_t*>(&frag_b));
++        dequant_data(frag_b_quant[k2][0][j * 2 + 1], reinterpret_cast<scalar_32bit_t*>(&frag_b) + 2);
++      } else if (is_a_8bit && b_type.size_bits() == 4 && has_zp) {
++        int off = (threadIdx.x / 32) % 2 * 2 + j;
++        int zp = (frag_qzp[k2][0] >> (off * 8)) & 0xF;
++        dequant_data(frag_b_quant[k2][0][j * 2], reinterpret_cast<scalar_32bit_t*>(&frag_b), zp);
++        zp = (frag_qzp[k2][0] >> (off * 8 + 4)) & 0xF;
++        dequant_data(frag_b_quant[k2][0][j * 2 + 1], reinterpret_cast<scalar_32bit_t*>(&frag_b) + 2, zp);
++      } else {
++        reinterpret_cast<int2*>(&frag_b)[0] = reinterpret_cast<int2*>(&frag_b_quant[k2][j])[0];
++        reinterpret_cast<int2*>(&frag_b)[1] = reinterpret_cast<int2*>(&frag_b_quant[k2][j])[1];
++      }
++
++#pragma unroll
++      for (int i = 0; i < thread_m_blocks; i++) {
++        mma<a_type_id, false, 32>(frag_a[k2][i], frag_b[0], (group_blocks == -1 ? frag_c : frag_c_tmp)[i][j][0]);
++        mma<a_type_id, false, 32>(frag_a[k2][i], frag_b[1], (group_blocks == -1 ? frag_c : frag_c_tmp)[i][j][1]);
++      }
++
++      if constexpr (group_blocks != -1) {
++        if (group_blocks == 2 || k == 1) {
++          if constexpr (a_type == sglang::host::kS8) {
++            // Keep checkpoint scales signed and floating point. Integer MMA
++            // accumulates one group; FP32 accumulates scaled groups. This avoids
++            // unsigned-scale corruption, INT4 sign-fold clipping, and overflow
++            // from multiplying and summing quantized scales in int32.
++            float2 s_vals[2] = {
++                Cdtype::num22float2(frag_s[k2][j * 2][0]), Cdtype::num22float2(frag_s[k2][j * 2 + 1][0])};
++#pragma unroll
++            for (int i = 0; i < thread_m_blocks; i++) {
++#pragma unroll
++              for (int side = 0; side < 2; side++) {
++#pragma unroll
++                for (int g = 0; g < 4; g++) {
++                  float scale = reinterpret_cast<float*>(&s_vals[side])[g % 2];
++                  int32_t partial = *reinterpret_cast<int32_t*>(&frag_c_tmp[i][j][side][g]);
++                  frag_c[i][j][side][g] += __int2float_rn(partial) * scale;
++                  frag_c_tmp[i][j][side][g] = 0.0f;
++                }
++              }
++            }
++          } else {
++            float2 s_vals[2];
++            if constexpr (s_type_id != sglang::host::kFE8M0fnu.id()) {
++              static_assert(a_type.size_bits() == 16 || s_type.size_bits() == 16);
++              s_vals[0] = Cdtype::num22float2(frag_s[k2][j * 2][0]);
++              s_vals[1] = Cdtype::num22float2(frag_s[k2][j * 2 + 1][0]);
++            } else {
++              int32_t* s_vals_int = reinterpret_cast<int32_t*>(&s_vals[0]);
++              int32_t s_vals_e8m0 = *reinterpret_cast<int32_t*>(&frag_s[k2][j][0]);
++
++              s_vals_int[0] = (s_vals_e8m0 & 0xFF) << 23;
++              s_vals_int[1] = (s_vals_e8m0 & 0xFF00) << 15;
++              s_vals_int[2] = (s_vals_e8m0 & 0xFF0000) << 7;
++              s_vals_int[3] = (s_vals_e8m0 & 0xFF000000) >> 1;
++            }
++
++#pragma unroll
++            for (int i = 0; i < thread_m_blocks; i++) {
++#pragma unroll
++              for (int g = 0; g < 4; g++) {
++                float scale = reinterpret_cast<float*>(&s_vals[0])[g % 2];
++                frag_c[i][j][0][g] += frag_c_tmp[i][j][0][g] * scale;
++                frag_c_tmp[i][j][0][g] = 0.0f;
++              }
++
++#pragma unroll
++              for (int g = 0; g < 4; g++) {
++                float scale = reinterpret_cast<float*>(&s_vals[1])[g % 2];
++                frag_c[i][j][1][g] += frag_c_tmp[i][j][1][g] * scale;
++                frag_c_tmp[i][j][1][g] = 0.0f;
++              }
++            }
++          }
++        }
++      }
++    }
++  };
++
++  // Since we slice across the k dimension of a tile in order to increase the
++  // number of warps while keeping the n dimension of a tile reasonable, we have
++  // multiple warps that accumulate their partial sums of the same output
++  // location; which we have to reduce over in the end. We do in shared memory.
++  auto thread_block_reduce = [&]() {
++    constexpr int red_off = threads / b_sh_stride_threads / 2;
++    if (red_off >= 1) {
++      auto red_idx = threadIdx.x / b_sh_stride_threads;
++      constexpr int red_sh_stride = b_sh_stride_threads * (is_a_8bit ? 2 : 4) * 2;
++      constexpr int red_sh_delta = b_sh_stride_threads;
++      int red_sh_rd = red_sh_stride * (threadIdx.x / b_sh_stride_threads) + (threadIdx.x % b_sh_stride_threads);
++
++      // Parallel logarithmic shared memory reduction. We make sure to avoid any
++      // unnecessary read or write iterations, e.g., for two warps we write only
++      // once by warp 1 and read only once by warp 0.
++
++#pragma unroll
++      for (int m_block = 0; m_block < thread_m_blocks; m_block++) {
++#pragma unroll
++        for (int i = red_off; i > 0; i /= 2) {
++          if (i <= red_idx && red_idx < 2 * i) {
++#pragma unroll
++            for (int j = 0; j < (is_a_8bit ? 2 : 4) * 2; j += (m_block_size_8 ? 2 : 1)) {
++              int red_sh_wr = red_sh_delta * j + (red_sh_rd - red_sh_stride * i);
++              if (i < red_off) {
++                float* c_rd = reinterpret_cast<float*>(&sh_red[red_sh_delta * j + red_sh_rd]);
++                float* c_wr = reinterpret_cast<float*>(&sh_red[red_sh_wr]);
++#pragma unroll
++                for (int k = 0; k < 4; k++)
++                  reinterpret_cast<FragC*>(frag_c)[(is_a_8bit ? 2 : 4) * 2 * m_block + j][k] += c_rd[k] + c_wr[k];
++              }
++              sh_red[red_sh_wr] = reinterpret_cast<int4*>(&frag_c)[(is_a_8bit ? 2 : 4) * 2 * m_block + j];
++            }
++          }
++          __syncthreads();
++        }
++        if (red_idx == 0) {
++#pragma unroll
++          for (int i = 0; i < (is_a_8bit ? 2 : 4) * 2; i += (m_block_size_8 ? 2 : 1)) {
++            float* c_rd = reinterpret_cast<float*>(&sh_red[red_sh_delta * i + red_sh_rd]);
++#pragma unroll
++            for (int j = 0; j < 4; j++)
++              reinterpret_cast<FragC*>(frag_c)[(is_a_8bit ? 2 : 4) * 2 * m_block + i][j] += c_rd[j];
++          }
++        }
++        __syncthreads();
++      }
++    }
++  };
++
++  // Since multiple threadblocks may process parts of the same column slice, we
++  // finally have to globally reduce over the results. As the striped
++  // partitioning minimizes the number of such reductions and our outputs are
++  // usually rather small, we perform this reduction serially in L2 cache.
++  auto global_reduce_fp16 = [&](bool first = false, bool last = false) {
++    // We are very careful here to reduce directly in the output buffer to
++    // maximize L2 cache utilization in this step. To do this, we write out
++    // results in FP16 (but still reduce with FP32 compute).
++    constexpr int active_threads = 32 * tb_n_warps;
++    if (threadIdx.x < active_threads) {
++      int c_gl_stride = prob_n / 8;
++      int c_gl_wr_delta_o = 8 * c_gl_stride * (is_a_8bit ? 2 : 1);
++      int c_gl_wr_delta_i = 4 * (active_threads / 32);
++      int c_gl_wr;
++      if constexpr (m_block_size_8) {
++        c_gl_wr = c_gl_stride * ((threadIdx.x % 4) * 2) + 4 * (threadIdx.x / 32) + (threadIdx.x % 32) / 8;
++        c_gl_wr += (2 * thread_n_blocks) * slice_col;
++      } else {
++        c_gl_wr =
++            c_gl_stride * ((threadIdx.x % 32) / 4) * (is_a_8bit ? 2 : 1) + 4 * (threadIdx.x / 32) + threadIdx.x % 4;
++        c_gl_wr += (2 * thread_n_blocks) * slice_col * (is_a_8bit ? 2 : 1);
++      }
++      constexpr int c_sh_wr_delta = active_threads;
++      auto c_sh_wr = threadIdx.x;
++
++      int row = (threadIdx.x % 32) / 4;
++
++      if (!first) {
++// Interestingly, doing direct global accesses here really seems to mess up
++// the compiler and lead to slowdowns, hence we also use async-copies even
++// though these fetches are not actually asynchronous.
++#pragma unroll
++        for (int i = 0; i < (m_block_size_8 ? 2 : thread_m_blocks * 4); i++) {
++          if constexpr (m_block_size_8) {
++            cp_async4_pred(
++                &sh_red[c_sh_wr + c_sh_wr_delta * i],
++                &C[c_gl_wr + i * c_gl_stride + (threadIdx.x % 8) / 4 * c_gl_wr_delta_i],
++                (threadIdx.x % 4) * 2 + i < prob_m);
++          } else if constexpr (is_a_8bit) {
++            int2* sh_red_int2 = reinterpret_cast<int2*>(sh_red);
++            int2* c_int2 = reinterpret_cast<int2*>(C);
++            cp_async2_ca_pred(
++                &sh_red_int2[c_sh_wr + c_sh_wr_delta * i],
++                &c_int2[c_gl_wr + c_gl_wr_delta_o * (i / 2) + c_gl_wr_delta_i * (i % 2)],
++                i < (thread_m_blocks - 1) * 4 || 8 * (i / 2) + row < prob_m);
++          } else {
++            cp_async4_pred(
++                &sh_red[c_sh_wr + c_sh_wr_delta * i],
++                &C[c_gl_wr + c_gl_wr_delta_o * (i / 2) + c_gl_wr_delta_i * (i % 2)],
++                i < (thread_m_blocks - 1) * 4 || 8 * (i / 2) + row < prob_m);
++          }
++        }
++        cp_async_fence();
++        cp_async_wait<0>();
++      }
++
++#pragma unroll
++      for (int i = 0; i < (m_block_size_8 ? 2 : thread_m_blocks * 4); i++) {
++        bool mask = (!m_block_size_8) && (i < (thread_m_blocks - 1) * 4 || 8 * (i / 2) + row < prob_m) ||
++                    (m_block_size_8) && ((threadIdx.x % 4) * 2 + i < prob_m);
++        if (mask) {
++          if (!first) {
++            c_scalar_t* c_red_f16;
++            if constexpr (is_a_8bit) {
++              int2 tmp = reinterpret_cast<int2*>(sh_red)[c_sh_wr + i * c_sh_wr_delta];
++              c_red_f16 = reinterpret_cast<c_scalar_t*>(&tmp);
++            } else {
++              int4 tmp = sh_red[c_sh_wr + i * c_sh_wr_delta];
++              c_red_f16 = reinterpret_cast<c_scalar_t*>(&tmp);
++            }
++#pragma unroll
++            for (int j = 0; j < 2 * (is_a_8bit ? 2 : 4); j++) {
++              int delta = 0;
++              if constexpr (m_block_size_8) {
++                delta = j % 2 == 1 ? -2 : 0;
++              }
++              reinterpret_cast<float*>(&frag_c)[(is_a_8bit ? 2 : 4) * 2 * 4 * (i / 4) + 4 * j + (i % 4) + delta] +=
++                  Cdtype::num2float(c_red_f16[j]);
++            }
++          }
++          if (!last) {
++            c_scalar_t c_f16[is_a_8bit ? 4 : 8];
++#pragma unroll
++            for (int j = 0; j < 2 * (is_a_8bit ? 2 : 4); j++) {
++              int delta = 0;
++              if constexpr (m_block_size_8) {
++                delta = j % 2 == 1 ? -2 : 0;
++              }
++              c_f16[j] = Cdtype::float2num(
++                  reinterpret_cast<float*>(&frag_c)[(is_a_8bit ? 2 : 4) * 2 * 4 * (i / 4) + 4 * j + (i % 4) + delta]);
++            }
++            if constexpr (m_block_size_8) {
++              C[c_gl_wr + i * c_gl_stride + (threadIdx.x % 8) / 4 * c_gl_wr_delta_i] = *reinterpret_cast<int4*>(c_f16);
++            } else if constexpr (is_a_8bit) {
++              int2* c_int2 = reinterpret_cast<int2*>(C);
++              c_int2[c_gl_wr + c_gl_wr_delta_o * (i / 2) + c_gl_wr_delta_i * (i % 2)] = *reinterpret_cast<int2*>(c_f16);
++            } else {
++              C[c_gl_wr + c_gl_wr_delta_o * (i / 2) + c_gl_wr_delta_i * (i % 2)] = *reinterpret_cast<int4*>(c_f16);
++            }
++          }
++        }
++      }
++    }
++  };
++
++  // Globally reduce over threadblocks that compute the same column block.
++  // We use a tmp C buffer to reduce in full fp32 precision.
++  auto global_reduce_fp32 = [&](bool first = false, bool last = false) {
++    constexpr int tb_m = thread_m_blocks * 16;
++    constexpr int tb_n = thread_n_blocks * 16;
++
++    constexpr int c_size = tb_m * tb_n * sizeof(float) / 16;
++
++    constexpr int active_threads = 32 * tb_n_warps;
++    bool is_th_active = threadIdx.x < active_threads;
++
++    constexpr int num_floats = thread_m_blocks * (is_a_8bit ? 2 : 4) * 2 * 4;
++    constexpr int th_size = num_floats * sizeof(float) / 16;
++
++    int c_cur_offset = locks_off * c_size;
++
++    if (!is_th_active) {
++      return;
++    }
++
++    if (!first) {
++      float* frag_c_ptr = reinterpret_cast<float*>(&frag_c);
++#pragma unroll
++      for (int k = 0; k < th_size; k += (m_block_size_8 ? 2 : 1)) {
++        sh_red[threadIdx.x] = C_tmp[c_cur_offset + active_threads * k + threadIdx.x];
++
++        float* sh_c_ptr = reinterpret_cast<float*>(&sh_red[threadIdx.x]);
++#pragma unroll
++        for (int f = 0; f < 4; f++) {
++          frag_c_ptr[k * 4 + f] += sh_c_ptr[f];
++        }
++      }
++    }
++
++    if (!last) {
++      int4* frag_c_ptr = reinterpret_cast<int4*>(&frag_c);
++#pragma unroll
++      for (int k = 0; k < th_size; k += (m_block_size_8 ? 2 : 1)) {
++        C_tmp[c_cur_offset + active_threads * k + threadIdx.x] = frag_c_ptr[k];
++      }
++    }
++  };
++
++  // Write out the reduce final result in the correct layout. We only actually
++  // reshuffle matrix fragments in this step, the reduction above is performed
++  // in fragment layout.
++  auto write_result = [&](bool last) {
++    int c_gl_stride = prob_n / 8;
++    constexpr int c_sh_stride = 2 * thread_n_blocks + 1;
++    int c_gl_wr_delta = c_gl_stride * (threads / (2 * thread_n_blocks));
++    constexpr int c_sh_rd_delta = c_sh_stride * (threads / (2 * thread_n_blocks));
++
++    int c_gl_wr = c_gl_stride * (threadIdx.x / (2 * thread_n_blocks)) + (threadIdx.x % (2 * thread_n_blocks));
++    c_gl_wr += (2 * thread_n_blocks) * slice_col;
++    int c_sh_wr;
++    if constexpr (m_block_size_8) {
++      c_sh_wr = (8 * c_sh_stride) * ((threadIdx.x % 32) % 4 * 2) + (threadIdx.x % 32) / 4;
++      c_sh_wr += 64 * (threadIdx.x / 32);
++    } else {
++      c_sh_wr = (4 * c_sh_stride) * ((threadIdx.x % 32) / 4) + (threadIdx.x % 32) % 4;
++      c_sh_wr += (is_a_8bit ? 16 : 32) * (threadIdx.x / 32);
++    }
++
++    int c_sh_rd = c_sh_stride * (threadIdx.x / (2 * thread_n_blocks)) + (threadIdx.x % (2 * thread_n_blocks));
++
++    int c_gl_wr_end = c_gl_stride * prob_m;
++    // We first reorder in shared memory to guarantee the most efficient final
++    // global write patterns
++    auto write = [&](int idx, float c0, float c1, FragS& s, FragS& b_bias) {
++      if constexpr (b_type == sglang::host::kFE2M1f && s_type == sglang::host::kFE4M3fn) {
++        c0 *= global_scale_f32;
++        c1 *= global_scale_f32;
++      }
++      c_scalar_t2 res = Cdtype::nums2num2(Cdtype::float2num(c0), Cdtype::float2num(c1));
++
++      // For per-column quantization we finally apply the scale here (only for
++      // 4-bit)
++      if constexpr (
++          !has_act_order && group_blocks == -1 && !is_a_8bit && b_type.size_bits() == 4 &&
++          (has_zp && dequant_skip_flop || !has_zp)) {
++        c_scalar_t2 tmp_scale = s[0];
++        if constexpr (m_block_size_8) {
++          tmp_scale = Cdtype::num2num2(reinterpret_cast<scalar_t*>(&s[0])[(threadIdx.x % 8) / 4]);
++        }
++        res = __hmul2(res, tmp_scale);
++      }
++      if (has_bias && last) {
++        c_scalar_t2 tmp_bias = b_bias[0];
++        if constexpr (m_block_size_8) {
++          tmp_bias = Cdtype::num2num2(reinterpret_cast<scalar_t*>(&b_bias[0])[(threadIdx.x % 8) / 4]);
++        }
++        res = __hadd2(res, tmp_bias);
++      }
++
++      if constexpr (m_block_size_8) {
++        ((c_scalar_t*)sh_red)[idx] = res.x;
++        ((c_scalar_t*)sh_red)[idx + 8 * c_sh_stride] = res.y;
++      } else {
++        ((c_scalar_t2*)sh_red)[idx] = res;
++      }
++    };
++
++    if (threadIdx.x / 32 < tb_n_warps) {
++#pragma unroll
++      for (int i = 0; i < thread_m_blocks; i++) {
++#pragma unroll
++        for (int j = 0; j < (is_a_8bit ? 2 : 4); j++) {
++          if constexpr (m_block_size_8) {
++            int wr = c_sh_wr + 16 * j;
++            write(
++                wr,
++                frag_c[i][j][0][0],
++                frag_c[i][j][0][1],
++                frag_s[j / 2][2 * (j % 2) + 0],
++                frag_bias[j / 2][2 * (j % 2) + 0]);
++            write(
++                wr + 8,
++                frag_c[i][j][0][2],
++                frag_c[i][j][0][3],
++                frag_s[j / 2][2 * (j % 2) + 1],
++                frag_bias[j / 2][2 * (j % 2) + 1]);
++          } else {
++            int wr = c_sh_wr + 8 * j;
++            write(
++                wr + (4 * c_sh_stride) * 0 + 0,
++                frag_c[i][j][0][0],
++                frag_c[i][j][0][1],
++                frag_s[j / 2][2 * (j % 2) + 0],
++                frag_bias[j / 2][2 * (j % 2) + 0]);
++            write(
++                wr + (4 * c_sh_stride) * 8 + 0,
++                frag_c[i][j][0][2],
++                frag_c[i][j][0][3],
++                frag_s[j / 2][2 * (j % 2) + 0],
++                frag_bias[j / 2][2 * (j % 2) + 0]);
++            write(
++                wr + (4 * c_sh_stride) * 0 + 4,
++                frag_c[i][j][1][0],
++                frag_c[i][j][1][1],
++                frag_s[j / 2][2 * (j % 2) + 1],
++                frag_bias[j / 2][2 * (j % 2) + 1]);
++            write(
++                wr + (4 * c_sh_stride) * 8 + 4,
++                frag_c[i][j][1][2],
++                frag_c[i][j][1][3],
++                frag_s[j / 2][2 * (j % 2) + 1],
++                frag_bias[j / 2][2 * (j % 2) + 1]);
++          }
++        }
++        c_sh_wr += 16 * (4 * c_sh_stride);
++      }
++    }
++    __syncthreads();
++
++#pragma unroll
++    for (int i = 0; i < div_ceil(16 * thread_m_blocks, threads / (2 * thread_n_blocks)); i++) {
++      if (c_gl_wr < c_gl_wr_end) {
++        if (use_atomic_add && slice_count > 1) {
++          c_scalar_t2* C_half2 = reinterpret_cast<c_scalar_t2*>(&C[c_gl_wr]);
++          c_scalar_t2* sh_red_half2 = reinterpret_cast<c_scalar_t2*>(&sh_red[c_sh_rd]);
++#pragma unroll
++          for (int a = 0; a < 4; a++) {
++            atomicAdd(&C_half2[a], sh_red_half2[a]);
++          }
++        } else {
++          C[c_gl_wr] = sh_red[c_sh_rd];
++        }
++        c_gl_wr += c_gl_wr_delta;
++        c_sh_rd += c_sh_rd_delta;
++      }
++    }
++    __syncthreads();
++  };
++
++  // Start global fetch and register load pipelines.
++  auto start_pipes = [&]() {
++
++#pragma unroll
++    for (int i = 0; i < stages - 1; i++) {
++      if (has_act_order && i == 0) {
++        int last_g_idx = slice_k_start + stages * tb_k * 2;
++        if (last_g_idx >= prob_k) {
++          last_g_idx = prob_k - 1;
++        }
++        fetch_act_order_scales_to_shared(true, g_idx[slice_k_start], g_idx[last_g_idx]);
++      }
++
++      if constexpr (has_zp && !is_zp_float && group_blocks == -1) {
++        if (i == 0) {
++          fetch_col_zp_to_shared();
++          if constexpr (!dequant_skip_flop) {
++            fetch_col_scale_to_shared();
++          }
++        }
++      }
++      fetch_to_shared(i, i, i < slice_iters);
++    }
++
++    zero_accums();
++    wait_for_stage();
++    init_same_group(0);
++    fetch_to_registers(0, 0);
++    fetch_scales_to_registers(0, 0);
++    fetch_zp_to_registers(0, 0);
++    a_gl_rd += a_gl_rd_delta_o * (stages - 1);
++    if constexpr (has_act_order) {
++      slice_k_start_shared_fetch += tb_k * (stages - 1);
++    }
++  };
++  if (slice_iters) {
++    start_pipes();
++  }
++
++  // Main loop.
++  while (slice_iters) {
++    // We unroll over both the global fetch and the register load pipeline to
++    // ensure all shared memory accesses are static. Note that both pipelines
++    // have even length meaning that the next iteration will always start at
++    // index 0.
++
++#pragma unroll
++    for (int pipe = 0; pipe < stages;) {
++#pragma unroll
++      for (int k = 0; k < b_sh_wr_iters; k++) {
++        fetch_to_registers(k + 1, pipe % stages);
++        fetch_scales_to_registers(k + 1, pipe);
++        fetch_zp_to_registers(k + 1, pipe);
++        if (k == b_sh_wr_iters - 2) {
++          fetch_to_shared((pipe + stages - 1) % stages, pipe, slice_iters >= stages);
++          pipe++;
++          wait_for_stage();
++          init_same_group(pipe % stages);
++        }
++
++        if constexpr (!is_a_8bit) {
++          matmul(k, pipe - (k >= b_sh_wr_iters - 2 ? 1 : 0));
++        } else {
++          static_assert(group_blocks != 0 && group_blocks != 1);
++          matmul_a8(k);
++        }
++      }
++      slice_iters--;
++      if (slice_iters == 0) {
++        break;
++      }
++    }
++
++    a_gl_rd += a_gl_rd_delta_o * stages;
++
++    if constexpr (has_act_order) {
++      slice_k_start += tb_k * stages;
++
++      if (slice_k_start < prob_k) {
++        slice_k_start_shared_fetch += tb_k * stages;
++        int first_group_id = g_idx[slice_k_start];
++        int last_g_idx = slice_k_start + stages * tb_k * 2;
++        if (last_g_idx >= prob_k) {
++          last_g_idx = prob_k - 1;
++        }
++        int last_group_id = g_idx[last_g_idx];
++        if (last_group_id >= sh_first_group_id + sh_num_groups) {
++          fetch_act_order_scales_to_shared(false, first_group_id, last_group_id);
++          __syncthreads();
++        }
++      }
++    }
++
++    // Process results and, if necessary, proceed to the next column slice.
++    // While this pattern may not be the most readable, other ways of writing
++    // the loop seemed to noticeably worse performance after compilation.
++    if (slice_iters == 0) {
++      // convert fp16 accum to fp32 for reduction
++      if constexpr (use_fp16_accum) {
++#pragma unroll
++        for (int i = 0; i < (thread_m_blocks * (is_a_8bit ? 2 : 4) * 2); i++) {
++          float* frag_c_part_float = reinterpret_cast<float*>(frag_c) + i * 4;
++          scalar_t* frag_c_part_half = reinterpret_cast<scalar_t*>(frag_c_part_float);
++
++#pragma unroll
++          for (int i = 3; i >= 0; i--) {
++            frag_c_part_float[i] = Cdtype::num2float(frag_c_part_half[i]);
++          }
++        }
++      }
++
++      if constexpr (is_a_8bit) {
++        float frag_a_s[2 * thread_m_blocks];
++
++        for (int i = 0; i < 2 * thread_m_blocks; i++)
++          frag_a_s[i] = sh_a_s[i * 8 + (threadIdx.x % 32) / 4];
++
++#pragma unroll
++        for (int j = 0; j < 2; j++) {
++#pragma unroll
++          for (int i = 0; i < thread_m_blocks; i++) {
++#pragma unroll
++            for (int g = 0; g < 4; g++) {
++              float c_val = frag_c[i][j][0][g];
++
++              if constexpr (a_type == sglang::host::kS8 && group_blocks == -1) {
++                c_val = __int2float_rn(*reinterpret_cast<int32_t*>(&c_val));
++              }
++              float s_val = frag_a_s[i * 2 + g / 2];
++              frag_c[i][j][0][g] = c_val * s_val;
++            }
++#pragma unroll
++            for (int g = 0; g < 4; g++) {
++              float c_val = frag_c[i][j][1][g];
++
++              if constexpr (a_type == sglang::host::kS8 && group_blocks == -1) {
++                c_val = __int2float_rn(*reinterpret_cast<int32_t*>(&c_val));
++              }
++              float s_val = frag_a_s[i * 2 + g / 2];
++              frag_c[i][j][1][g] = c_val * s_val;
++            }
++          }
++        }
++      }
++
++      cp_async_wait<0>();
++      bool last = slice_idx == slice_count - 1;
++      // For per-column scales, we only fetch them here in the final step before
++      // write-out
++      if constexpr (!has_act_order && group_blocks == -1 && (has_zp && dequant_skip_flop || !has_zp)) {
++        if (b_type.size_bits() == 8 || (last || use_atomic_add) || is_a_8bit) {
++          if (s_sh_wr_pred) {
++            cp_async4(&sh_s[s_sh_wr], &scales_ptr[s_gl_rd]);
++          }
++          cp_async_fence();
++        }
++      }
++
++      thread_block_reduce();
++
++      if (has_bias && last) {
++        __syncthreads();
++        cp_async4_pred(&sh_bias[bias_sh_wr], &b_bias_ptr[bias_gl_rd], threadIdx.x < 16 * thread_n_blocks / 8);
++        cp_async_fence();
++      }
++
++      if constexpr (!has_act_order && group_blocks == -1 && (has_zp && dequant_skip_flop || !has_zp || is_a_8bit)) {
++        if constexpr (is_a_8bit) {
++          cp_async_wait<0>();
++          __syncthreads();
++          if (threadIdx.x / 32 < tb_n_warps) {
++            reinterpret_cast<int4*>(&frag_s)[0] = sh_s[s_sh_rd + 0];
++          }
++        } else if (b_type.size_bits() == 8 || (last || use_atomic_add)) {
++          cp_async_wait<0>();
++          __syncthreads();
++          if (threadIdx.x / 32 < tb_n_warps) {
++            reinterpret_cast<int4*>(&frag_s)[0] = sh_s[s_sh_rd + 0];
++            reinterpret_cast<int4*>(&frag_s)[1] = sh_s[s_sh_rd + 4];
++            if constexpr (m_block_size_8) {
++              int idx = (threadIdx.x / 4) % 2;
++              c_scalar_t2* frag_s_half2 = reinterpret_cast<c_scalar_t2*>(frag_s);
++#pragma unroll
++              for (int i = 0; i < 8; i++) {
++                frag_s_half2[i] = Cdtype::num2num2(reinterpret_cast<c_scalar_t*>(&frag_s_half2[i])[idx]);
++              }
++            }
++          }
++        }
++      }
++
++      // For 8-bit channelwise, we apply the scale before the global reduction
++      // that converts the fp32 results to fp16 (so that we avoid possible
++      // overflow in fp16)
++      if constexpr (!has_act_order && group_blocks == -1 && is_a_8bit) {
++#pragma unroll
++        for (int j = 0; j < 2; j++) {
++          float2 aa[2];
++          aa[0] = Cdtype::num22float2(frag_s[0][j * 2][0]);
++          aa[1] = Cdtype::num22float2(frag_s[0][j * 2 + 1][0]);
++
++#pragma unroll
++          for (int i = 0; i < thread_m_blocks; i++) {
++#pragma unroll
++            for (int g = 0; g < 4; g++) {
++              float scale = reinterpret_cast<float*>(&aa[0])[g % 2];
++              frag_c[i][j][0][g] *= scale;
++            }
++
++#pragma unroll
++            for (int g = 0; g < 4; g++) {
++              float scale = reinterpret_cast<float*>(&aa[1])[g % 2];
++              frag_c[i][j][1][g] *= scale;
++            }
++          }
++        }
++      } else if (
++          !has_act_order && group_blocks == -1 && b_type.size_bits() == 8 && (has_zp && dequant_skip_flop || !has_zp)) {
++        if (threadIdx.x / 32 < tb_n_warps) {
++#pragma unroll
++          for (int i = 0; i < thread_m_blocks; i++) {
++#pragma unroll
++            for (int j = 0; j < 4; j++) {
++              scale_float<c_type_id>(reinterpret_cast<float*>(&frag_c[i][j][0][0]), frag_s[j / 2][2 * (j % 2) + 0]);
++              scale_float<c_type_id>(
++                  reinterpret_cast<float*>(&frag_c[i][j][0][2]), frag_s[j / 2][2 * (j % 2) + (m_block_size_8 ? 1 : 0)]);
++
++              if constexpr (!m_block_size_8) {
++                scale_float<c_type_id>(reinterpret_cast<float*>(&frag_c[i][j][1][0]), frag_s[j / 2][2 * (j % 2) + 1]);
++                scale_float<c_type_id>(reinterpret_cast<float*>(&frag_c[i][j][1][2]), frag_s[j / 2][2 * (j % 2) + 1]);
++              }
++            }
++          }
++        }
++      }
++
++      if (slice_count > 1 && !use_atomic_add) {
++        // only globally reduce if there is more than one block in a slice
++        barrier_acquire(&locks[locks_off], slice_idx);
++        if (use_fp32_reduce) {
++          global_reduce_fp32(slice_idx == 0, last);
++        } else {
++          global_reduce_fp16(slice_idx == 0, last);
++        }
++        barrier_release(&locks[locks_off], last);
++      }
++
++      if (has_bias && last) {
++        cp_async_wait<0>();
++        __syncthreads();
++        reinterpret_cast<int4*>(&frag_bias)[0] = sh_bias[bias_sh_rd];
++        if constexpr (!is_a_8bit) reinterpret_cast<int4*>(&frag_bias)[1] = sh_bias[bias_sh_rd + 4];
++        __syncthreads();
++      }
++
++      if (use_atomic_add && slice_count > 1 && slice_idx != 0) wait_negative_and_add(&locks[locks_off]);
++      if (last || use_atomic_add)
++        // only the last block in a slice actually writes the result
++        write_result(last);
++      slice_row = 0;
++      if (!in_part2) {
++        slice_col_par += gridDim.x;
++      } else {
++        slice_col_par++;
++        slice_col++;
++      }
++      is_first_matmul_in_slice = true;
++      init_slice();
++
++      if (slice_iters) {
++        a_gl_rd = a_gl_stride * (threadIdx.x / a_gl_rd_delta_o) + (threadIdx.x % a_gl_rd_delta_o);
++        a_gl_rd += a_gl_rd_delta_o * slice_row;
++        b_gl_rd = b_gl_stride * (threadIdx.x / b_sh_stride) + (threadIdx.x % b_sh_stride);
++        b_gl_rd += b_sh_stride * slice_col + b_gl_rd_delta_o * slice_row;
++
++        bias_gl_rd = (thread_n_blocks * 16 / 8) * slice_col + threadIdx.x;
++        // Update slice k/n for scales loading
++        if constexpr (has_act_order) {
++          slice_k_start = tb_k * slice_row;
++          slice_k_finish = slice_k_start + tb_k * slice_iters;
++          slice_k_start_shared_fetch = slice_k_start;
++          slice_n_offset = act_s_col_tb_stride * slice_col;
++        } else {
++          if constexpr (group_blocks == -1) {
++            s_gl_rd = s_sh_stride * slice_col + threadIdx.x;
++            zp_gl_rd = zp_sh_stride * slice_col + threadIdx.x;
++          } else if constexpr (group_blocks >= thread_k_blocks) {
++            s_gl_rd =
++                s_gl_stride * ((thread_k_blocks * slice_row) / group_blocks) + s_sh_stride * slice_col + threadIdx.x;
++            zp_gl_rd =
++                zp_gl_stride * ((thread_k_blocks * slice_row) / group_blocks) + zp_sh_stride * slice_col + threadIdx.x;
++          } else {
++            s_gl_rd = s_gl_stride * ((thread_k_blocks * slice_row) / group_blocks + threadIdx.x / s_sh_stride) +
++                      s_sh_stride * slice_col + threadIdx.x % s_sh_stride;
++            zp_gl_rd = zp_gl_stride * ((thread_k_blocks * slice_row) / group_blocks + threadIdx.x / zp_sh_stride) +
++                       zp_sh_stride * slice_col + threadIdx.x % zp_sh_stride;
++          }
++        }
++        start_pipes();
++      }
++    }
++  }
++}
++
++}  // namespace MARLIN_NAMESPACE_NAME
++
++#endif
+diff --git a/python/sglang/kernels/jit/csrc/gemm/marlin_w4a8/repack.cuh b/python/sglang/kernels/jit/csrc/gemm/marlin_w4a8/repack.cuh
+new file mode 100644
+index 0000000..54ca614
+--- /dev/null
++++ b/python/sglang/kernels/jit/csrc/gemm/marlin_w4a8/repack.cuh
+@@ -0,0 +1,258 @@
++// SPDX-License-Identifier: Apache-2.0
++// Adapted from vLLM v0.27.1 (6e448d0ea9bf3d88d898b65449ca6dc2aec170ac).
++// Copyright contributors to the vLLM project; Marlin: Elias Frantar.
++// SGLang standalone W4A8 experiment: no vLLM build or runtime dependency.
++#pragma once
++#include "marlin.cuh"
++namespace sglang::device::marlin_w4a8 {
++template <int const num_threads, int const num_bits, bool const has_perm, bool is_a_8bit>
++__global__ void gptq_marlin_repack_kernel(
++    uint32_t const* __restrict__ b_q_weight_ptr,
++    uint32_t const* __restrict__ perm_ptr,
++    uint32_t* __restrict__ out_ptr,
++    int size_k,
++    int size_n) {
++  constexpr int pack_factor = 32 / num_bits;
++
++  constexpr int target_tile_n_size = tile_n_size / (is_a_8bit ? 2 : 1);
++  constexpr int target_tile_k_size = tile_k_size * (is_a_8bit ? 2 : 1);
++  int k_tiles = size_k / target_tile_k_size;
++  int n_tiles = size_n / target_tile_n_size;
++  int block_k_tiles = div_ceil(k_tiles, gridDim.x);
++
++  auto start_k_tile = blockIdx.x * block_k_tiles;
++  if (start_k_tile >= k_tiles) {
++    return;
++  }
++
++  int finish_k_tile = min(start_k_tile + block_k_tiles, k_tiles);
++
++  // Wait until the next thread tile has been loaded to shared memory.
++  auto wait_for_stage = [&]() {
++    // We only have `stages - 2` active fetches since we are double buffering
++    // and can only issue the next fetch when it is guaranteed that the previous
++    // shared memory load is fully complete (as it may otherwise be
++    // overwritten).
++    cp_async_wait<repack_stages - 2>();
++    __syncthreads();
++  };
++
++  extern __shared__ int4 sh[];
++
++  constexpr int perm_size = target_tile_k_size / 4;
++
++  int4* sh_perm_ptr = sh;
++  int4* sh_pipe_ptr = sh_perm_ptr;
++  if constexpr (has_perm) {
++    sh_pipe_ptr += perm_size;
++  }
++
++  constexpr int tile_ints = target_tile_k_size / pack_factor;
++
++  constexpr int stage_n_threads = target_tile_n_size / 4;
++  constexpr int stage_k_threads = has_perm ? target_tile_k_size : tile_ints;
++  constexpr int stage_size = stage_k_threads * stage_n_threads;
++
++  auto load_perm_to_shared = [&](int k_tile_id) {
++    int first_k_int4 = (k_tile_id * target_tile_k_size) / 4;
++
++    int4 const* perm_int4_ptr = reinterpret_cast<int4 const*>(perm_ptr);
++
++    if (threadIdx.x < perm_size) {
++      sh_perm_ptr[threadIdx.x] = perm_int4_ptr[first_k_int4 + threadIdx.x];
++    }
++    __syncthreads();
++  };
++
++  auto fetch_to_shared = [&](int pipe, int k_tile_id, int n_tile_id) {
++    if (n_tile_id >= n_tiles) {
++      cp_async_fence();
++      return;
++    }
++
++    int first_n = n_tile_id * target_tile_n_size;
++
++    int4* sh_ptr = sh_pipe_ptr + stage_size * pipe;
++
++    if constexpr (has_perm) {
++      if (threadIdx.x < stage_size) {
++        auto k_id = threadIdx.x / stage_n_threads;
++        auto n_id = threadIdx.x % stage_n_threads;
++
++        uint32_t const* sh_perm_int_ptr = reinterpret_cast<uint32_t const*>(sh_perm_ptr);
++
++        int src_k = sh_perm_int_ptr[k_id];
++        int src_k_packed = src_k / pack_factor;
++
++        cp_async4(
++            &sh_ptr[k_id * stage_n_threads + n_id],
++            reinterpret_cast<int4 const*>(&(b_q_weight_ptr[src_k_packed * size_n + first_n + (n_id * 4)])));
++      }
++
++    } else {
++      if (threadIdx.x < stage_size) {
++        auto k_id = threadIdx.x / stage_n_threads;
++        auto n_id = threadIdx.x % stage_n_threads;
++
++        int first_k = k_tile_id * target_tile_k_size;
++        int first_k_packed = first_k / pack_factor;
++
++        cp_async4(
++            &sh_ptr[k_id * stage_n_threads + n_id],
++            reinterpret_cast<int4 const*>(&(b_q_weight_ptr[(first_k_packed + k_id) * size_n + first_n + (n_id * 4)])));
++      }
++    }
++
++    cp_async_fence();
++  };
++
++  auto repack_tile = [&](int pipe, int k_tile_id, int n_tile_id) {
++    if (n_tile_id >= n_tiles) {
++      return;
++    }
++
++    auto warp_id = threadIdx.x / 32;
++    auto th_id = threadIdx.x % 32;
++
++    if (warp_id >= 4) {
++      return;
++    }
++
++    int tc_col = th_id / 4;
++    int tc_row = (th_id % 4) * (is_a_8bit ? 4 : 2);
++
++    constexpr int tc_offsets[4] = {0, 1, 8, 9};
++
++    int cur_n = (warp_id / (is_a_8bit ? 2 : 1)) * 16 + tc_col;
++
++    constexpr int sh_stride = target_tile_n_size;
++    constexpr uint32_t mask = (1 << num_bits) - 1;
++
++    int4* sh_stage_ptr = sh_pipe_ptr + stage_size * pipe;
++    uint32_t* sh_stage_int_ptr = reinterpret_cast<uint32_t*>(sh_stage_ptr);
++
++    uint32_t* sh_perm_int_ptr = reinterpret_cast<uint32_t*>(sh_perm_ptr);
++
++    uint32_t vals[8];
++
++    if constexpr (has_perm) {
++      static_assert(!is_a_8bit);
++      for (int i = 0; i < 4; i++) {
++        int k_idx = tc_row + tc_offsets[i];
++
++        uint32_t src_k = sh_perm_int_ptr[k_idx];
++        uint32_t src_k_pos = src_k % pack_factor;
++
++        uint32_t b1_val = sh_stage_int_ptr[k_idx * sh_stride + cur_n];
++        uint32_t b1_cur_val = (b1_val >> (src_k_pos * num_bits)) & mask;
++
++        uint32_t b2_val = sh_stage_int_ptr[k_idx * sh_stride + cur_n + 8];
++        uint32_t b2_cur_val = (b2_val >> (src_k_pos * num_bits)) & mask;
++
++        vals[i] = b1_cur_val;
++        vals[4 + i] = b2_cur_val;
++      }
++
++    } else {
++      uint32_t b1_vals[tile_ints];
++      uint32_t b2_vals[tile_ints];
++
++#pragma unroll
++      for (int i = 0; i < tile_ints; i++) {
++        if constexpr (is_a_8bit) {
++          b1_vals[i] = sh_stage_int_ptr[cur_n + sh_stride * i + (warp_id % 2) * 8];
++        } else {
++          b1_vals[i] = sh_stage_int_ptr[cur_n + sh_stride * i];
++          b2_vals[i] = sh_stage_int_ptr[cur_n + 8 + sh_stride * i];
++        }
++      }
++
++#pragma unroll
++      for (int i = 0; i < 4; i++) {
++        int cur_elem = tc_row + (is_a_8bit ? i : tc_offsets[i]);
++        int cur_int = cur_elem / pack_factor;
++        int cur_pos = cur_elem % pack_factor;
++
++        vals[i] = (b1_vals[cur_int] >> (cur_pos * num_bits)) & mask;
++        if constexpr (is_a_8bit)
++          vals[4 + i] = (b1_vals[cur_int + tile_ints / 2] >> (cur_pos * num_bits)) & mask;
++        else
++          vals[4 + i] = (b2_vals[cur_int] >> (cur_pos * num_bits)) & mask;
++      }
++    }
++
++    constexpr int tile_size = target_tile_k_size * target_tile_n_size / pack_factor;
++    int out_offset = (k_tile_id * n_tiles + n_tile_id) * tile_size;
++
++    // Result of:
++    // https://github.com/NVIDIA/FasterTransformer/blob/main/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h
++    if constexpr (!is_a_8bit && num_bits == 4) {
++      int pack_idx[8] = {0, 2, 4, 6, 1, 3, 5, 7};
++
++      uint32_t res = 0;
++#pragma unroll
++      for (int i = 0; i < 8; i++) {
++        res |= vals[pack_idx[i]] << (i * 4);
++      }
++
++      out_ptr[out_offset + th_id * 4 + warp_id] = res;
++
++    } else if constexpr (is_a_8bit && num_bits == 4) {
++      int pack_idx[8] = {0, 4, 1, 5, 2, 6, 3, 7};
++
++      uint32_t res = 0;
++#pragma unroll
++      for (int i = 0; i < 8; i++) {
++        res |= vals[pack_idx[i]] << (i * 4);
++      }
++
++      out_ptr[out_offset + th_id * 4 + warp_id] = res;
++
++    } else {
++      constexpr int pack_idx[4] = {0, 2, 1, 3};
++
++      uint32_t res1 = 0;
++      uint32_t res2 = 0;
++#pragma unroll
++      for (int i = 0; i < 4; i++) {
++        const int ii = is_a_8bit ? i : pack_idx[i];
++        res1 |= vals[ii] << (i * 8);
++        res2 |= vals[4 + ii] << (i * 8);
++      }
++
++      out_ptr[out_offset + th_id * 8 + (warp_id * 2) + 0] = res1;
++      out_ptr[out_offset + th_id * 8 + (warp_id * 2) + 1] = res2;
++    }
++  };
++
++  auto start_pipes = [&](int k_tile_id, int n_tile_id) {
++#pragma unroll
++    for (int pipe = 0; pipe < repack_stages - 1; pipe++) {
++      fetch_to_shared(pipe, k_tile_id, n_tile_id + pipe);
++    }
++
++    wait_for_stage();
++  };
++#pragma unroll
++  for (int k_tile_id = start_k_tile; k_tile_id < finish_k_tile; k_tile_id++) {
++    int n_tile_id = 0;
++
++    if constexpr (has_perm) {
++      load_perm_to_shared(k_tile_id);
++    }
++
++    start_pipes(k_tile_id, n_tile_id);
++
++    while (n_tile_id < n_tiles) {
++#pragma unroll
++      for (int pipe = 0; pipe < repack_stages; pipe++) {
++        fetch_to_shared((pipe + repack_stages - 1) % repack_stages, k_tile_id, n_tile_id + pipe + repack_stages - 1);
++        repack_tile(pipe, k_tile_id, n_tile_id + pipe);
++        wait_for_stage();
++      }
++      n_tile_id += repack_stages;
++    }
++  }
++}
++
++}  // namespace sglang::device::marlin_w4a8
+diff --git a/python/sglang/kernels/ops/quantization/gptq_marlin_w4a8.py b/python/sglang/kernels/ops/quantization/gptq_marlin_w4a8.py
+new file mode 100644
+index 0000000..aead518
+--- /dev/null
++++ b/python/sglang/kernels/ops/quantization/gptq_marlin_w4a8.py
+@@ -0,0 +1,93 @@
++# SPDX-License-Identifier: Apache-2.0
++"""Standalone SM8x AutoRound W4A8 experiment; no vLLM runtime dependency.
++
++The model-facing dtype stays FP16/BF16. Only the linear's internal activation
++is INT8. Signed checkpoint scales stay floating point, including negative
++AutoRound scales; neither INT4 codes nor scales are requantized.
++"""
++
++import logging
++
++import torch
++
++from sglang.kernels.jit.utils import cache_once, load_jit, make_cpp_args
++from sglang.kernels.ops.quantization.int8_kernel import per_token_quant_int8
++
++logger = logging.getLogger(__name__)
++
++# Temporary source-level A/B switch, deliberately no new server/quant config.
++ENABLED = True
++
++
++@cache_once
++def _jit_module(dtype: torch.dtype, group_size: int):
++    args = make_cpp_args(dtype, group_size)
++    return load_jit(
++        "gptq_marlin_int8",
++        *args,
++        cuda_files=["gemm/marlin_w4a8/entry.cuh"],
++        cuda_wrappers=[
++            ("gemm", f"gptq_marlin_w4a8<{args}>"),
++            ("repack", "gptq_marlin_w4a8_repack"),
++        ],
++    )
++
++
++def prepare_w4a8(qweight: torch.Tensor, scales: torch.Tensor, group_size: int):
++    """Convert GPTQ [K/8,N] packing to W4A8; preserve (q-8)*scale exactly."""
++    assert qweight.dtype == torch.int32 and qweight.ndim == 2
++    assert scales.dtype in (torch.float16, torch.bfloat16)
++    k, n = qweight.shape[0] * 8, qweight.shape[1]
++    assert group_size in (32, 64, 128) and k % 128 == 0 and n % 64 == 0
++    assert scales.shape == (k // group_size, n)
++    assert qweight.device == scales.device and qweight.is_cuda
++    assert torch.cuda.get_device_capability(qweight.device)[0] == 8
++    if not torch.isfinite(scales).all().item():
++        raise ValueError("Non-finite AutoRound scales in W4A8 layer")
++    module = _jit_module(scales.dtype, group_size)
++    packed = torch.empty((k // 16, n * 2), dtype=torch.int32, device=qweight.device)
++    module.repack(qweight.contiguous(), packed)
++    # W4A8 uses Marlin's single-scale permutation even for grouped weights.
++    perm = [2 * i + j for i in range(4) for j in (0, 1, 8, 9, 16, 17, 24, 25)]
++    scales = scales.reshape(-1, 32)[:, perm].reshape(k // group_size, n).contiguous()
++    logger.info(
++        "[Marlin] W4A8 prepared: weight_bits=4 activation_dtype=int8 "
++        "output_dtype=%s scale_encoding=signed_float arch=sm%d%d K=%d N=%d group_size=%d",
++        scales.dtype,
++        *torch.cuda.get_device_capability(qweight.device),
++        k,
++        n,
++        group_size,
++    )
++    return packed, scales
++
++
++def w4a8_gemm(a, a_scales, weight, scales, workspace, group_size):
++    """INT8 Tensor Core GEMM with floating group scales and FP32 reduction."""
++    assert a.dtype == torch.int8 and a.ndim == 2 and a.is_contiguous()
++    assert a_scales.dtype == torch.float32 and a_scales.shape == (a.shape[0], 1)
++    m, k = a.shape
++    n = scales.shape[1]
++    assert weight.shape == (k // 16, n * 2)
++    out = torch.empty((m, n), dtype=scales.dtype, device=a.device)
++    if m == 0:
++        return out
++    sms = workspace.numel()
++    tmp = torch.empty(sms * 64 * 256, dtype=torch.float32, device=a.device)
++    _jit_module(scales.dtype, group_size).gemm(
++        a, weight, scales, a_scales, out, tmp, workspace
++    )
++    return out
++
++
++def apply_w4a8(x, weight, scales, workspace, group_size, bias=None):
++    assert x.dtype == scales.dtype
++    shape = x.shape[:-1] + (scales.shape[1],)
++    flat = x.reshape(-1, x.shape[-1]).contiguous()
++    if flat.shape[0] == 0:
++        return torch.empty(shape, dtype=x.dtype, device=x.device)
++    a, a_scales = per_token_quant_int8(flat)
++    out = w4a8_gemm(a, a_scales, weight, scales, workspace, group_size)
++    if bias is not None:
++        out.add_(bias)
++    return out.reshape(shape)
+diff --git a/python/sglang/srt/hardware_backend/gpu/quantization/gptq_kernels.py b/python/sglang/srt/hardware_backend/gpu/quantization/gptq_kernels.py
+index e3a0c8c..030c6b0 100644
+--- a/python/sglang/srt/hardware_backend/gpu/quantization/gptq_kernels.py
++++ b/python/sglang/srt/hardware_backend/gpu/quantization/gptq_kernels.py
+@@ -131,6 +131,7 @@ class GPTQLinearKernel:
+ class GPTQMarlinLinearKernel:
+     def __init__(self, quant_config: Optional[QuantizationConfig] = None):
+         self.quant_config = quant_config
++        self.use_w4a8 = False
+ 
+     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+         device = getattr(layer, "qweight").device
+@@ -149,6 +150,47 @@ class GPTQMarlinLinearKernel:
+         # Allocate marlin workspace.
+         self.workspace = marlin_make_workspace(device)
+ 
++        if getattr(self.quant_config, "experimental_w4a8", False):
++            from sglang.kernels.ops.quantization import gptq_marlin_w4a8 as w4a8
++
++            self.use_w4a8 = (
++                w4a8.ENABLED
++                and c.weight_type.size_bits == 4
++                and not c.zero_points
++                and not c.has_g_idx
++                and c.group_size in (32, 64, 128)
++                and c.act_type in (torch.float16, torch.bfloat16)
++                and torch.cuda.get_device_capability(device)[0] == 8
++            )
++            if self.use_w4a8:
++                # Shape guard (club-3090 fix 2026-09-08): prepare_w4a8
++                # hard-asserts K % 128 == 0 and N % 64 == 0 on the per-TP-shard
++                # dims. Layers that fail it (GDN linear-attn projections / fused
++                # qkv whose packed shard dims don't line up) MUST fall back to
++                # the standard Marlin W4A16 path instead of crashing the engine.
++                # partition_weight_shape is [in_features, out_features] = [K, N].
++                _k_shard, _n_shard = c.partition_weight_shape[0], c.partition_weight_shape[1]
++                if _k_shard % 128 != 0 or _n_shard % 64 != 0:
++                    import logging as _w4a8_logging
++
++                    _w4a8_logging.getLogger(__name__).info(
++                        "[Marlin] W4A8 skipped (shard %dx%d incompatible with "
++                        "K%%128==0 / N%%64==0): using standard Marlin W4A16 path",
++                        _k_shard,
++                        _n_shard,
++                    )
++                    self.use_w4a8 = False
++            if self.use_w4a8:
++                weight, scales = w4a8.prepare_w4a8(
++                    layer.qweight, layer.scales, c.group_size
++                )
++                replace_parameter(layer, "qweight", weight)
++                replace_parameter(layer, "scales", scales)
++                layer.g_idx_sort_indices = marlin_make_empty_g_idx(device)
++                replace_parameter(layer, "g_idx", marlin_make_empty_g_idx(device))
++                replace_parameter(layer, "qzeros", marlin_make_empty_g_idx(device))
++                return
++
+         # Default names since marlin requires empty parameters for these,
+         # TODO: remove this requirement from marlin (allow optional tensors)
+         self.w_q_name = "qweight"
+@@ -234,6 +276,13 @@ class GPTQMarlinLinearKernel:
+     ) -> torch.Tensor:
+         c = self.kernel_config
+ 
++        if self.use_w4a8:
++            from sglang.kernels.ops.quantization.gptq_marlin_w4a8 import apply_w4a8
++
++            return apply_w4a8(
++                x, layer.qweight, layer.scales, self.workspace, c.group_size, bias
++            )
++
+         def _get_weight_params(
+             layer: torch.nn.Module,
+         ) -> tuple[
+diff --git a/python/sglang/srt/layers/quantization/auto_round.py b/python/sglang/srt/layers/quantization/auto_round.py
+index 53caa88..b516f43 100644
+--- a/python/sglang/srt/layers/quantization/auto_round.py
++++ b/python/sglang/srt/layers/quantization/auto_round.py
+@@ -562,6 +562,9 @@ class AutoRoundConfig(QuantizationConfig):
+ 
+         if is_linear:
+             if use_marlin:
++                # Local W4A8 experiment: preserve the existing AutoRound/GPTQ
++                # frontend and model dtype; only replace the dense GPU kernel.
++                quant_args_marlin.experimental_w4a8 = True
+                 return GPTQMarlinLinearMethod(quant_args_marlin)
+             else:
+                 return GPTQLinearMethod(quant_args)

--- a/models/qwen3.8-27b/sglang/patches/sglang-autoround-w4a8-v0.5.19/README.md
+++ b/models/qwen3.8-27b/sglang/patches/sglang-autoround-w4a8-v0.5.19/README.md
@@ -1,0 +1,113 @@
+# SGLang AutoRound W4A8 (v0.5.19 re-cut)
+
+**What it does:** adds INT8-activation (W4A8) GEMM to SGLang's AutoRound INT4
+path. Weights stay the AutoRound INT4 (group 128, symmetric) — activations run
+as INT8 on the tensor cores via the Marlin kernel family, on top of SGLang's
+existing `gptq_kernels.py` AutoRound dispatch. On Ampere (sm_86) this is the
+dense-GEMM route to W4A8; no FP8 compute needed (which sm_86 lacks).
+
+**Activation is unconditional-with-patch.** Unlike the vLLM sibling (which is
+gated behind `VLLM_MARLIN_INPUT_DTYPE=int8`), the SGLang patch flips
+`quant_args_marlin.experimental_w4a8 = True` on every Marlin AutoRound layer,
+with no env var. So *applying the patch* is what turns W4A8 on — a container
+with the patch applied but the shape-guard/`in_proj_ba` data fix absent will
+serve a *mix* of W4A8 and W4A16 layers (the non-conformant GDN shards fall back),
+never a silent all-BF16 path. The installer hard-fails on a partial patch, so
+the "half-wired" state is caught at boot, not in the field.
+
+**Provenance:** re-cut of jb-seo's `0004-autoround-w4a8.patch` from the
+club-3090 contribution (cut against SGLang **v0.5.18**) onto **v0.5.19** —
+the first release with DFlash2 upstream, so one engine carries W4A8 + DFlash2.
+Adaptations vs the v0.5.18 cut:
+
+| File | Change |
+| --- | --- |
+| `gptq_kernels.py` | byte-identical v0.5.18→v0.5.19 — applies verbatim |
+| `auto_round.py` | 1-line context fix: `if isinstance(layer, (LinearBase, ParallelLMHead)):` → `if is_linear:` (v0.5.19 refactored the gate) |
+| 8 new files (`gptq_marlin_w4a8.py` + 7 CUDA sources) | new files, no context dependency |
+
+## The shape guard — this PR's real fix (NOT in jb-seo's cut)
+
+AutoRound's W4A8 eligibility gate omitted the per-shard `K%128==0` /
+`N%64==0` constraint that `prepare_w4a8` hard-asserts. On the Qwen3.8-27B
+GDN (hybrid linear-attention) layers the merged `in_proj_ba` tensor is
+**N=96 → 48/rank at TP4**, which is *not* 64-divisible. Without the guard a
+naive W4A8 pass crashes in `gptq_marlin_repack` with
+`size_n=48 is not divisible by 64` at weight load.
+
+The guard pre-checks each shard's K/N **before** routing it to the W4A8
+path; non-conformant shards log
+
+```
+[Marlin] W4A8 skipped (shard ... not 128/64 divisible) — using standard Marlin W4A16
+```
+
+and fall back to standard Marlin W4A16 for that layer. Consequence on
+Qwen3.8-27B at TP4: the GDN merged-projection layers run W4A16 (their N is
+the problem), everything else (the bulk of the dense FFN/attention weight)
+runs W4A8. That is the measured configuration the benches in
+`results/sglang-q38-ar-w4a8-dflash2-tp4-20260908/` were taken with.
+
+**Necessity was proven by isolation:** stock v0.5.19 *without* the guard,
+run on the same checkpoint, crashes identically at `gptq_marlin_repack.cuh:
+311: size_n=48`. The rest of the patch is exonerated — the guard is the fix.
+
+## Checkpoint data fix (separate from the patch — DO NOT SKIP)
+
+Stock SGLang crashes on the Avuja Qwen3.8-27B AutoRound checkpoint at
+weight-load **even without W4A8**: the GDN `in_proj_a`/`in_proj_b` layers are
+BF16 in the checkpoint (`extra_config` bits:16) but SGLang builds a merged
+`in_proj_ba` module and routes it through GPTQ-Marlin, which asserts
+`size_n % 64 == 0`. The fix is **data-side**, in the target's
+`config.json`:
+
+```json
+"extra_config": {
+  ".*in_proj_ba.*": {"bits": 16, "data_type": "fp"}
+}
+```
+
+Avuja's published checkpoint already carries this (backup of the pristine
+file: `config.json.bak-sglang-test`). If you point the compose at another
+AutoRound Qwen3.8-27B checkpoint (biMEMO, Vishva007, …), apply the same
+one-liner first or the stack will crash-loop at weight load. This is a
+checkpoint property, not a patch property — the patch cannot and does not
+fix it.
+
+## Install
+
+`install.sh` (mounted at `/etc/club3090/w4a8/` by the compose) is idempotent
+and content-marker-based (works whether or not the SGLang tree is a git
+repo):
+
+- 3/3 markers present → "already applied — skipping"
+- 0/3 → applies the patch (`git apply` if the tree is a repo, `patch(1) -p1`
+  otherwise), then re-checks
+- 1–2/3 → hard fail: partial state, recreate the container
+
+It is invoked from the compose entrypoint **before** `sglang serve`.
+A failed apply is fatal by design: a half-wired W4A8 would serve a mix of
+INT8- and BF16-activation layers silently.
+
+## Pinned image
+
+`lmsysorg/sglang:v0.5.19` (2026-09-05 release, the DFlash2 cut). Per the
+repo's engine-pinning policy (AGENTS.md "Engine image pinning"), this compose
+pins the exact release the patch was cut against — a rolling tag would break
+the `auto_round.py` anchor the moment upstream touches that gate again.
+
+## Validation status
+
+- **v0.5.19 isolation run (no W4A8, no DFlash2):** reproduced the
+  `size_n=48` Marlin crash on stock — the guard's target.
+- **Full boot (TP4, DFlash2 n=8, fp8 KV, bf16 SSM, 262K ctx):** all quantized
+  linears prepared W4A8 with 0 skip-errors, DFlash2 accept length ~4.4–4.5,
+  KV pool 731,047 tokens (fp8), mamba pool 84 slots (bf16), `max_running
+  requests = 16` not capped. Coherent output verified (math exact, prose
+  coherent) — W4A8 numerics are clean on this checkpoint.
+- **Bench:** `results/sglang-q38-ar-w4a8-dflash2-tp4-20260908/` — full
+  bench-ultimate run (prefill ladder 512→16K, decode saturation c=1..16,
+  narrative + code) head-to-head vs the vLLM 0.27.1 baseline on the same
+  model/quant/drafter. SGLang wins c=1 decode by ~45%; vLLM closes the gap
+  by c=8; prefill within 2–17%. See the BENCHMARKS.md row for the headline
+  numbers.

--- a/models/qwen3.8-27b/sglang/patches/sglang-autoround-w4a8-v0.5.19/install.sh
+++ b/models/qwen3.8-27b/sglang/patches/sglang-autoround-w4a8-v0.5.19/install.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Apply the v0.5.19-adapted W4A8 patch to SGLang inside the container.
+#
+# Re-cut of jb-seo's club-3090 0004-autoround-w4a8.patch (cut against v0.5.18)
+# onto SGLang v0.5.19. The only adaptation: auto_round.py context line
+#   `if isinstance(layer, (LinearBase, ParallelLMHead)):`
+#   -> `if is_linear:`
+# (v0.5.19 refactored that). gptq_kernels.py is byte-identical between the two
+# versions, so its hunks apply verbatim. The 8 new files (w4a8.py + 7 CUDA
+# sources) are new files with no context dependency.
+#
+# Run from the compose command BEFORE `sglang serve`. Idempotent: a restart
+# re-runs it and detects the already-applied state instead of failing.
+# Usage:  install.sh          (apply if not applied)
+#         install.sh --verify (report state only, change nothing)
+
+set -uo pipefail
+
+SGLANG_DIR="${SGLANG_DIR:-/sgl-workspace/sglang}"
+PATCH_DIR="${SGLANG_PATCH_DIR:-/etc/club3090/w4a8}"
+PATCH="$PATCH_DIR/0004-autoround-w4a8.v0519.patch"
+
+GPTQ="$SGLANG_DIR/python/sglang/srt/hardware_backend/gpu/quantization/gptq_kernels.py"
+AR="$SGLANG_DIR/python/sglang/srt/layers/quantization/auto_round.py"
+W4A8PY="$SGLANG_DIR/python/sglang/kernels/ops/quantization/gptq_marlin_w4a8.py"
+CUDA="$SGLANG_DIR/python/sglang/kernels/jit/csrc/gemm/marlin_w4a8"
+
+die() { echo "[w4a8] ERROR: $*" >&2; exit 1; }
+
+[ -d "$SGLANG_DIR" ] || die "SGLang source not at $SGLANG_DIR (override with SGLANG_DIR=...)"
+[ -f "$GPTQ" ] || die "gptq_kernels.py not found under $SGLANG_DIR — wrong SGLANG_DIR?"
+
+# Per-component markers (content-based, so they work whether or not the tree
+# is a git repo).
+m_gptq() { grep -q 'self.use_w4a8 = False' "$GPTQ"; }
+m_ar()   { grep -q 'quant_args_marlin.experimental_w4a8 = True' "$AR"; }
+m_new()  { [ -f "$W4A8PY" ] && [ -f "$CUDA/entry.cuh" ] \
+          && [ -f "$CUDA/marlin_template.h" ] && [ -f "$CUDA/repack.cuh" ]; }
+
+if [ "${1:-}" = "--verify" ]; then
+  if m_gptq; then echo "  gptq_kernels.py : applied";  else echo "  gptq_kernels.py : NOT applied";  exit 1; fi
+  if m_ar;   then echo "  auto_round.py   : applied";  else echo "  auto_round.py   : NOT applied";  exit 1; fi
+  if m_new;  then echo "  W4A8 new files  : present";  else echo "  W4A8 new files  : MISSING";      exit 1; fi
+  echo "[w4a8] all checks passed"
+  exit 0
+fi
+
+a=0
+m_gptq && a=$((a+1))
+m_ar   && a=$((a+1))
+m_new  && a=$((a+1))
+
+case "$a" in
+  3) echo "[w4a8] already applied — skipping"; exit 0 ;;
+  0) : ;;
+  *) die "partial application detected ($a/3 markers present) — recreate the container and retry" ;;
+esac
+
+[ -f "$PATCH" ] || die "patch not found at $PATCH"
+
+echo "[w4a8] applying v0.5.19-adapted W4A8 patch..."
+if git -C "$SGLANG_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "[w4a8]   tree is a git repo — using git apply"
+  git -C "$SGLANG_DIR" apply --check "$PATCH" 2>&1 | sed 's/^/    /' || die "git apply --check failed (context drift?)"
+  git -C "$SGLANG_DIR" apply "$PATCH" || die "git apply failed"
+else
+  echo "[w4a8]   not a git repo — using patch(1)"
+  patch -p1 -d "$SGLANG_DIR" < "$PATCH" >/dev/null || die "patch apply failed"
+fi
+
+echo "[w4a8] verifying..."
+bash "$0" --verify || die "post-apply verification failed"
+echo "[w4a8] applied + verified OK"

--- a/results/sglang-q38-ar-w4a8-dflash2-tp4-20260909/sglang-q38-ar-w4a8-dflash2-tp4-20260909.txt
+++ b/results/sglang-q38-ar-w4a8-dflash2-tp4-20260909/sglang-q38-ar-w4a8-dflash2-tp4-20260909.txt
@@ -1,0 +1,805 @@
+# Engine: SGLang v0.5.19 (image lmsysorg/sglang:v0.5.19), container sglang-qwen38b27-int4-tp4-dflash2-w4a8
+# Date: 2026-09-09 (09:15 ET), host Ur4nus
+# Config: TP4, W4A8 (AutoRound INT4, jb-seo v0.5.19 re-cut + shape guard), DFlash2 drafter,
+#         fp8_e4m3 KV, bf16 SSM, mamba-84/max-running-16, mem_fraction_static 0.77, ctx 262144
+#         + --enable-metrics, --reasoning-parser qwen3, --tool-call-parser qwen3_coder,
+#         --chat-template froggeric v22.5, --default-chat-template-kwargs enable_thinking:true,
+#         --preferred-sampling-params temp=0.7/top_p=0.8/top_k=20/min_p=0/presence_pen=1.5
+# GPUs: 4x RTX 3090 Turbo 24GB, 220W cap, driver 610.57.04, NVLink (0,2)/(1,3)
+# This run has /metrics enabled (server metrics + SGLang log sections present).
+#
+=== Ultimate OpenAI-Backend Bench ===
+  URL: http://localhost:8000
+  Model: vLLM
+  Mode: full
+  Containers: sglang-qwen38b27-int4-tp4-dflash2-w4a8
+  Concurrency levels (decode): 1,2,4,8,16
+  Prefill sizes (target tokens): 512,1024,2048,4096,8192,16384
+  Runs: decode=3 (warmups 2), prefill=2 (warmups 1)
+  GPU poll interval: 0.5s   JSON out: off
+
+  NVIDIA driver: 610.57.04
+  GPUs (idle snapshot):
+    0, NVIDIA GeForce RTX 3090, 24576, 42, 27.90, 220.00, 210
+    1, NVIDIA GeForce RTX 3090, 24576, 42, 24.50, 220.00, 210
+    2, NVIDIA GeForce RTX 3090, 24576, 42, 27.91, 220.00, 210
+    3, NVIDIA GeForce RTX 3090, 24576, 38, 26.84, 220.00, 210
+
+  vLLM /version: n/a
+
+  Served model id: vLLM  max_model_len: 262144
+  sglang /metrics: available (http://localhost:8000/metrics) — engine auto-detected: sglang — will report deltas
+
+========================================================================
+  PREFILL BENCH (concurrency=1, gen=16 tok, unique=True)
+========================================================================
+
+--- Prefill target ~512 tokens ---
+  warm-1: actual_prompt=   551  ttft=    357ms  prefill_TPS=  1543.0
+  run-1: actual_prompt=   553  ttft=    327ms  prefill_TPS=  1689.9  gen_TPS=153.76  wall=  0.43s
+  run-2: actual_prompt=   551  ttft=    329ms  prefill_TPS=  1677.2  gen_TPS=123.37  wall=  0.46s
+  GPU during prefill ~512t (0.9s, 8 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    97.5   30.0    22365    22365   85.5  104.9   55.0   57.0     1732
+       1    98.0   12.5    22057    22057  122.8  209.9   49.0   51.0     1815
+       2    95.0   34.0    22055    22055  132.2  187.0   55.0   56.0     1838
+       3    97.5   15.0    22055    22055  149.2  214.2   54.5   57.0     1912
+    total power avg=489.8 W   phase throughput=1276.7 tok/s   efficiency: 2.6064 tok/W  (2606.37 tok/kJ)
+
+  === prefill summary [~512 tok] (n=2) ===
+  TTFT (ms)            mean=  327.88ms   std=   0.90   CV= 0.3%   min=327.24   max=328.52
+  prefill tok/s        mean= 1683.53   std=   8.96   CV= 0.5%   min=1677.20   max=1689.87
+  gen tok/s (c1)       mean=  138.57   std=  21.49   CV=15.5%   min=123.37   max=153.76
+  actual prompt tokens: mean=552 (target 512)
+
+--- Prefill target ~1024 tokens ---
+  warm-1: actual_prompt=  1053  ttft=    682ms  prefill_TPS=  1544.2
+  run-1: actual_prompt=  1054  ttft=    682ms  prefill_TPS=  1544.7  gen_TPS=188.79  wall=  0.77s
+  run-2: actual_prompt=  1052  ttft=    682ms  prefill_TPS=  1543.0  gen_TPS=150.01  wall=  0.79s
+  GPU during prefill ~1024t (1.6s, 12 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    99.0   18.0    22365    22365  219.6  220.4   61.0   62.0     1800
+       1    98.7   20.7    22057    22057  218.6  219.8   52.3   53.0     1895
+       2    98.0   19.0    22055    22055  217.4  218.5   59.0   60.0     1880
+       3    99.3   17.3    22055    22055  219.4  220.4   62.3   64.0     1735
+    total power avg=875.0 W   phase throughput=1374.2 tok/s   efficiency: 1.5704 tok/W  (1570.44 tok/kJ)
+
+  === prefill summary [~1024 tok] (n=2) ===
+  TTFT (ms)            mean=  682.06ms   std=   0.37   CV= 0.1%   min=681.79   max=682.32
+  prefill tok/s        mean= 1543.86   std=   1.23   CV= 0.1%   min=1542.99   max=1544.73
+  gen tok/s (c1)       mean=  169.40   std=  27.42   CV=16.2%   min=150.01   max=188.79
+  actual prompt tokens: mean=1053 (target 1024)
+
+--- Prefill target ~2048 tokens ---
+  warm-1: actual_prompt=  2061  ttft=   1135ms  prefill_TPS=  1815.4
+  run-1: actual_prompt=  2061  ttft=   1131ms  prefill_TPS=  1822.1  gen_TPS=150.77  wall=  1.24s
+  run-2: actual_prompt=  2061  ttft=   1126ms  prefill_TPS=  1830.6  gen_TPS=106.11  wall=  1.28s
+  GPU during prefill ~2048t (2.5s, 16 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    98.0   15.5    22365    22365  217.3  217.9   63.2   64.0     1808
+       1    98.0   15.8    22057    22057  216.4  217.3   53.8   54.0     1905
+       2    99.0   19.5    22055    22055  217.2  217.5   61.8   62.0     1845
+       3    98.2   14.0    22055    22055  217.7  218.2   67.0   68.0     1860
+    total power avg=868.7 W   phase throughput=1652.2 tok/s   efficiency: 1.9020 tok/W  (1902.01 tok/kJ)
+
+  === prefill summary [~2048 tok] (n=2) ===
+  TTFT (ms)            mean= 1128.49ms   std=   3.68   CV= 0.3%   min=1125.89   max=1131.09
+  prefill tok/s        mean= 1826.35   std=   5.95   CV= 0.3%   min=1822.14   max=1830.55
+  gen tok/s (c1)       mean=  128.44   std=  31.58   CV=24.6%   min=106.11   max=150.77
+  actual prompt tokens: mean=2061 (target 2048)
+
+--- Prefill target ~4096 tokens ---
+  warm-1: actual_prompt=  4072  ttft=   2166ms  prefill_TPS=  1880.3
+  run-1: actual_prompt=  4074  ttft=   2170ms  prefill_TPS=  1877.6  gen_TPS= 93.44  wall=  2.34s
+  run-2: actual_prompt=  4073  ttft=   2174ms  prefill_TPS=  1873.1  gen_TPS=249.70  wall=  2.24s
+  GPU during prefill ~4096t (4.6s, 28 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0   100.0   12.6    22365    22365  217.3  218.6   65.4   66.0     1774
+       1    98.7   14.4    22057    22057  216.3  217.1   56.1   57.0     1905
+       2    99.4   16.3    22055    22055  217.5  218.6   64.1   65.0     1839
+       3   100.0   12.4    22055    22055  217.8  218.3   69.6   70.0     1845
+    total power avg=869.0 W   phase throughput=1785.9 tok/s   efficiency: 2.0551 tok/W  (2055.15 tok/kJ)
+
+  === prefill summary [~4096 tok] (n=2) ===
+  TTFT (ms)            mean= 2172.10ms   std=   3.29   CV= 0.2%   min=2169.77   max=2174.42
+  prefill tok/s        mean= 1875.38   std=   3.17   CV= 0.2%   min=1873.14   max=1877.62
+  gen tok/s (c1)       mean=  171.57   std= 110.49   CV=64.4%   min=93.44   max=249.70
+  actual prompt tokens: mean=4074 (target 4096)
+
+--- Prefill target ~8192 tokens ---
+  warm-1: actual_prompt=  8104  ttft=   4374ms  prefill_TPS=  1852.7
+  run-1: actual_prompt=  8104  ttft=   4371ms  prefill_TPS=  1854.0  gen_TPS=186.15  wall=  4.46s
+  run-2: actual_prompt=  8104  ttft=   4374ms  prefill_TPS=  1852.9  gen_TPS= 92.70  wall=  4.55s
+  GPU during prefill ~8192t (9.0s, 60 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    99.7   12.1    22365    22365  218.3  219.2   67.7   68.0     1813
+       1    99.9   12.4    22057    22057  217.0  218.1   59.1   60.0     1892
+       2    99.8   12.5    22055    22055  217.6  219.5   67.1   68.0     1834
+       3    99.8   12.3    22055    22055  217.8  219.1   71.5   72.0     1792
+    total power avg=870.7 W   phase throughput=1803.7 tok/s   efficiency: 2.0716 tok/W  (2071.56 tok/kJ)
+
+  === prefill summary [~8192 tok] (n=2) ===
+  TTFT (ms)            mean= 4372.43ms   std=   1.75   CV= 0.0%   min=4371.19   max=4373.67
+  prefill tok/s        mean= 1853.43   std=   0.74   CV= 0.0%   min=1852.91   max=1853.96
+  gen tok/s (c1)       mean=  139.43   std=  66.08   CV=47.4%   min=92.70   max=186.15
+  actual prompt tokens: mean=8104 (target 8192)
+
+--- Prefill target ~16384 tokens ---
+  warm-1: actual_prompt= 16160  ttft=   8919ms  prefill_TPS=  1811.8
+  run-1: actual_prompt= 16162  ttft=   8927ms  prefill_TPS=  1810.4  gen_TPS=244.22  wall=  8.99s
+  run-2: actual_prompt= 16159  ttft=   8925ms  prefill_TPS=  1810.6  gen_TPS= 90.28  wall=  9.10s
+  GPU during prefill ~16384t (18.1s, 120 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    98.4   11.9    22365    22365  218.3  219.4   70.4   71.0     1780
+       1    99.6   11.9    22057    22057  216.6  217.8   63.1   64.0     1870
+       2    99.6   12.2    22055    22055  218.2  219.0   71.1   72.0     1804
+       3    99.7   12.0    22055    22055  218.4  219.3   73.2   74.0     1786
+    total power avg=871.6 W   phase throughput=1787.9 tok/s   efficiency: 2.0514 tok/W  (2051.37 tok/kJ)
+
+  === prefill summary [~16384 tok] (n=2) ===
+  TTFT (ms)            mean= 8926.03ms   std=   1.62   CV= 0.0%   min=8924.88   max=8927.18
+  prefill tok/s        mean= 1810.49   std=   0.09   CV= 0.0%   min=1810.43   max=1810.56
+  gen tok/s (c1)       mean=  167.25   std= 108.86   CV=65.1%   min=90.28   max=244.22
+  actual prompt tokens: mean=16160 (target 16384)
+
+========================================================================
+  DECODE SATURATION — NARRATIVE (prompt=65 chars, max_tokens=1000)
+========================================================================
+
+--- Concurrency=1 (simultaneous requests) ---
+  warmups (2):
+    w1-r0      wall=   6.44s  ttft=    69ms  toks= 1000  wall_TPS= 155.24  decode_TPS= 156.91  itl_p50= 21.8ms  itl_p95= 22.5ms
+    w2-r0      wall=   7.09s  ttft=    65ms  toks= 1000  wall_TPS= 140.99  decode_TPS= 142.29  itl_p50= 21.8ms  itl_p95= 22.5ms
+  GPU during warmup narrative c=1 (13.5s, 96 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    96.0   39.3    22365    22365  219.6  219.8   70.0   71.0     1631
+       1    96.5   38.4    22057    22057  219.5  219.9   64.1   65.0     1735
+       2    96.0   39.0    22055    22055  219.6  219.8   71.1   72.0     1644
+       3    96.3   38.3    22055    22055  219.6  220.3   72.1   74.0     1657
+    r0         wall=   6.90s  ttft=    63ms  toks=  987  wall_TPS= 142.99  decode_TPS= 144.31  itl_p50= 21.8ms  itl_p95= 22.5ms
+  combined   wall_TPS= 142.99  decode_TPS= 144.31  avg_ttft=    63ms  itl_p50= 21.8ms  itl_p95= 22.5ms
+    r0         wall=   7.33s  ttft=    68ms  toks= 1000  wall_TPS= 136.47  decode_TPS= 137.75  itl_p50= 21.8ms  itl_p95= 22.4ms
+  combined   wall_TPS= 136.47  decode_TPS= 137.75  avg_ttft=    68ms  itl_p50= 21.8ms  itl_p95= 22.4ms
+    r0         wall=   6.58s  ttft=    64ms  toks=  989  wall_TPS= 150.37  decode_TPS= 151.84  itl_p50= 21.8ms  itl_p95= 22.5ms
+  combined   wall_TPS= 150.37  decode_TPS= 151.84  avg_ttft=    64ms  itl_p50= 21.8ms  itl_p95= 22.5ms
+  GPU during measured narrative c=1 (20.8s, 148 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    96.2   39.4    22365    22365  219.6  219.8   70.8   71.0     1630
+       1    96.2   39.7    22057    22057  219.6  220.1   65.3   66.0     1721
+       2    96.0   39.1    22055    22055  219.6  219.9   71.9   73.0     1639
+       3    96.2   39.3    22055    22055  219.6  220.0   72.8   73.0     1647
+    total power avg=878.5 W   phase throughput=143.0 tok/s   efficiency: 0.1628 tok/W  (162.79 tok/kJ)
+
+  === summary [narrative c=1] (n=3) ===
+  combined wall_TPS    mean=  143.28   std=   6.95   CV= 4.9%   min=136.47   max=150.37
+  combined decode_TPS  mean=  144.63   std=   7.05   CV= 4.9%   min=137.75   max=151.84
+  per-req decode_TPS   mean=  144.63   std=   7.05   CV= 4.9%   min=137.75   max=151.84
+  avg TTFT (ms)        mean=   65.04ms   std=   2.80   CV= 4.3%   min=62.98   max=68.23
+  ITL p50 (ms)         mean=   21.80ms   std=   0.03   CV= 0.1%   min=21.77   max=21.83
+  ITL p95 (ms)         mean=   22.48ms   std=   0.04   CV= 0.2%   min=22.43   max=22.51
+
+--- Concurrency=2 (simultaneous requests) ---
+  warmups (2):
+    w1-r0      wall=   8.72s  ttft=    98ms  toks=  952  wall_TPS= 109.23  decode_TPS= 110.48  itl_p50= 28.5ms  itl_p95= 29.2ms
+    w1-r1      wall=   8.69s  ttft=    98ms  toks= 1000  wall_TPS= 115.12  decode_TPS= 116.43  itl_p50= 28.5ms  itl_p95= 29.2ms
+    w2-r0      wall=   8.76s  ttft=    97ms  toks= 1000  wall_TPS= 114.17  decode_TPS= 115.45  itl_p50= 28.4ms  itl_p95= 29.1ms
+    w2-r1      wall=   8.83s  ttft=    97ms  toks=  983  wall_TPS= 111.32  decode_TPS= 112.56  itl_p50= 28.4ms  itl_p95= 29.1ms
+  GPU during warmup narrative c=2 (17.5s, 120 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    97.1   32.0    22365    22365  219.4  219.8   72.0   72.0     1684
+       1    97.3   32.2    22057    22057  219.4  219.9   66.3   67.0     1775
+       2    97.2   32.5    22055    22055  219.5  220.2   73.0   73.0     1688
+       3    97.1   32.0    22055    22055  219.4  219.8   73.7   74.0     1708
+    r0         wall=   8.90s  ttft=    97ms  toks= 1000  wall_TPS= 112.41  decode_TPS= 113.65  itl_p50= 28.5ms  itl_p95= 29.4ms
+    r1         wall=   9.38s  ttft=    96ms  toks= 1000  wall_TPS= 106.57  decode_TPS= 107.68  itl_p50= 28.5ms  itl_p95= 29.4ms
+  combined   wall_TPS= 213.15  decode_TPS= 221.33  avg_ttft=    97ms  itl_p50= 28.5ms  itl_p95= 29.4ms
+    r0         wall=   9.01s  ttft=    98ms  toks=  961  wall_TPS= 106.68  decode_TPS= 107.85  itl_p50= 28.5ms  itl_p95= 29.2ms
+    r1         wall=   8.98s  ttft=    98ms  toks= 1000  wall_TPS= 111.36  decode_TPS= 112.59  itl_p50= 28.5ms  itl_p95= 29.2ms
+  combined   wall_TPS= 217.69  decode_TPS= 220.45  avg_ttft=    98ms  itl_p50= 28.5ms  itl_p95= 29.2ms
+    r0         wall=   9.00s  ttft=    97ms  toks=  945  wall_TPS= 105.00  decode_TPS= 106.14  itl_p50= 28.4ms  itl_p95= 29.3ms
+    r1         wall=   7.83s  ttft=    97ms  toks= 1000  wall_TPS= 127.72  decode_TPS= 129.32  itl_p50= 28.5ms  itl_p95= 29.4ms
+  combined   wall_TPS= 216.10  decode_TPS= 235.46  avg_ttft=    97ms  itl_p50= 28.4ms  itl_p95= 29.4ms
+  GPU during measured narrative c=2 (27.4s, 192 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    97.0   32.8    22365    22365  219.5  219.9   72.8   73.0     1677
+       1    97.3   32.9    22057    22057  219.4  219.8   67.0   67.0     1767
+       2    97.0   32.9    22055    22055  219.5  220.0   72.2   73.0     1675
+       3    97.1   32.9    22055    22055  219.4  219.9   74.0   74.0     1698
+    total power avg=877.9 W   phase throughput=215.6 tok/s   efficiency: 0.2456 tok/W  (245.58 tok/kJ)
+
+  === summary [narrative c=2] (n=3) ===
+  combined wall_TPS    mean=  215.65   std=   2.30   CV= 1.1%   min=213.15   max=217.69
+  combined decode_TPS  mean=  225.75   std=   8.43   CV= 3.7%   min=220.45   max=235.46
+  per-req decode_TPS   mean=  112.87   std=   4.21   CV= 3.7%   min=110.22   max=117.73
+  avg TTFT (ms)        mean=   97.22ms   std=   0.77   CV= 0.8%   min=96.52   max=98.05
+  ITL p50 (ms)         mean=   28.46ms   std=   0.02   CV= 0.1%   min=28.45   max=28.48
+  ITL p95 (ms)         mean=   29.34ms   std=   0.08   CV= 0.3%   min=29.25   max=29.39
+
+--- Concurrency=4 (simultaneous requests) ---
+  warmups (2):
+    w1-r0      wall=  14.26s  ttft=   186ms  toks= 1000  wall_TPS=  70.14  decode_TPS=  71.07  itl_p50= 44.7ms  itl_p95= 45.6ms
+    w1-r1      wall=  13.90s  ttft=   186ms  toks= 1000  wall_TPS=  71.93  decode_TPS=  72.90  itl_p50= 44.7ms  itl_p95= 45.6ms
+    w1-r2      wall=  13.82s  ttft=   186ms  toks= 1000  wall_TPS=  72.36  decode_TPS=  73.34  itl_p50= 44.7ms  itl_p95= 45.6ms
+    w1-r3      wall=  14.55s  ttft=   186ms  toks=  980  wall_TPS=  67.36  decode_TPS=  68.23  itl_p50= 44.7ms  itl_p95= 45.6ms
+    w2-r0      wall=  13.56s  ttft=   102ms  toks=  989  wall_TPS=  72.93  decode_TPS=  73.48  itl_p50= 44.8ms  itl_p95= 45.8ms
+    w2-r1      wall=  13.75s  ttft=   101ms  toks= 1000  wall_TPS=  72.71  decode_TPS=  73.25  itl_p50= 44.8ms  itl_p95= 45.7ms
+    w2-r2      wall=  13.88s  ttft=   101ms  toks=  992  wall_TPS=  71.49  decode_TPS=  72.01  itl_p50= 44.8ms  itl_p95= 45.7ms
+    w2-r3      wall=  13.90s  ttft=   101ms  toks= 1000  wall_TPS=  71.92  decode_TPS=  72.45  itl_p50= 44.8ms  itl_p95= 45.7ms
+  GPU during warmup narrative c=4 (28.5s, 192 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    97.9   23.8    22365    22365  219.1  220.2   73.4   74.0     1729
+       1    98.0   24.1    22057    22057  219.2  219.7   68.0   68.0     1817
+       2    97.8   23.7    22055    22055  219.2  220.2   72.3   73.0     1738
+       3    97.9   24.0    22055    22055  219.2  219.8   75.0   75.0     1753
+    r0         wall=  13.77s  ttft=   101ms  toks=  980  wall_TPS=  71.17  decode_TPS=  71.70  itl_p50= 44.6ms  itl_p95= 45.4ms
+    r1         wall=  13.53s  ttft=   100ms  toks= 1000  wall_TPS=  73.90  decode_TPS=  74.45  itl_p50= 44.6ms  itl_p95= 45.4ms
+    r2         wall=  14.09s  ttft=   100ms  toks= 1000  wall_TPS=  71.00  decode_TPS=  71.51  itl_p50= 44.6ms  itl_p95= 45.3ms
+    r3         wall=  12.93s  ttft=   100ms  toks=  870  wall_TPS=  67.28  decode_TPS=  67.80  itl_p50= 44.7ms  itl_p95= 45.4ms
+  combined   wall_TPS= 273.34  decode_TPS= 285.45  avg_ttft=   100ms  itl_p50= 44.6ms  itl_p95= 45.4ms
+    r0         wall=  14.28s  ttft=   102ms  toks=  999  wall_TPS=  69.96  decode_TPS=  70.46  itl_p50= 44.7ms  itl_p95= 45.7ms
+    r1         wall=  13.17s  ttft=   101ms  toks=  930  wall_TPS=  70.60  decode_TPS=  71.15  itl_p50= 44.7ms  itl_p95= 45.7ms
+    r2         wall=  14.44s  ttft=   102ms  toks= 1000  wall_TPS=  69.25  decode_TPS=  69.74  itl_p50= 44.6ms  itl_p95= 45.6ms
+    r3         wall=  14.07s  ttft=   101ms  toks=  973  wall_TPS=  69.15  decode_TPS=  69.65  itl_p50= 44.7ms  itl_p95= 45.7ms
+  combined   wall_TPS= 270.22  decode_TPS= 281.00  avg_ttft=   102ms  itl_p50= 44.7ms  itl_p95= 45.7ms
+    r0         wall=  13.56s  ttft=   100ms  toks=  991  wall_TPS=  73.06  decode_TPS=  73.61  itl_p50= 44.8ms  itl_p95= 46.2ms
+    r1         wall=  13.30s  ttft=   100ms  toks=  962  wall_TPS=  72.35  decode_TPS=  72.90  itl_p50= 44.8ms  itl_p95= 46.2ms
+    r2         wall=  13.93s  ttft=   100ms  toks= 1000  wall_TPS=  71.78  decode_TPS=  72.30  itl_p50= 44.8ms  itl_p95= 46.1ms
+    r3         wall=  13.86s  ttft=   100ms  toks= 1000  wall_TPS=  72.16  decode_TPS=  72.68  itl_p50= 44.8ms  itl_p95= 46.2ms
+  combined   wall_TPS= 283.75  decode_TPS= 291.49  avg_ttft=   100ms  itl_p50= 44.8ms  itl_p95= 46.2ms
+  GPU during measured narrative c=4 (42.5s, 296 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    97.9   24.1    22365    22365  219.2  219.6   73.8   74.0     1729
+       1    97.9   24.4    22057    22057  219.2  219.9   68.0   68.0     1812
+       2    97.8   24.1    22055    22055  219.2  219.9   71.9   72.0     1731
+       3    98.0   24.0    22055    22055  219.2  219.6   75.0   75.0     1750
+    total power avg=876.8 W   phase throughput=275.7 tok/s   efficiency: 0.3144 tok/W  (314.38 tok/kJ)
+
+  === summary [narrative c=4] (n=3) ===
+  combined wall_TPS    mean=  275.77   std=   7.09   CV= 2.6%   min=270.22   max=283.75
+  combined decode_TPS  mean=  285.98   std=   5.26   CV= 1.8%   min=281.00   max=291.49
+  per-req decode_TPS   mean=   71.50   std=   1.32   CV= 1.8%   min=70.25   max=72.87
+  avg TTFT (ms)        mean=  100.70ms   std=   0.72   CV= 0.7%   min=100.26   max=101.53
+  ITL p50 (ms)         mean=   44.70ms   std=   0.07   CV= 0.2%   min=44.65   max=44.77
+  ITL p95 (ms)         mean=   45.76ms   std=   0.42   CV= 0.9%   min=45.36   max=46.20
+
+--- Concurrency=8 (simultaneous requests) ---
+  warmups (2):
+    w1-r0      wall=  24.72s  ttft=   279ms  toks=  975  wall_TPS=  39.44  decode_TPS=  39.89  itl_p50= 82.6ms  itl_p95= 84.2ms
+    w1-r1      wall=  24.62s  ttft=   280ms  toks= 1000  wall_TPS=  40.61  decode_TPS=  41.08  itl_p50= 82.6ms  itl_p95= 84.2ms
+    w1-r2      wall=  23.51s  ttft=   280ms  toks=  896  wall_TPS=  38.11  decode_TPS=  38.57  itl_p50= 82.6ms  itl_p95= 84.3ms
+    w1-r3      wall=  24.80s  ttft=   280ms  toks= 1000  wall_TPS=  40.31  decode_TPS=  40.77  itl_p50= 82.5ms  itl_p95= 84.3ms
+    w1-r4      wall=  23.21s  ttft=   279ms  toks=  887  wall_TPS=  38.22  decode_TPS=  38.69  itl_p50= 82.6ms  itl_p95= 84.3ms
+    w1-r5      wall=  25.35s  ttft=   278ms  toks= 1000  wall_TPS=  39.45  decode_TPS=  39.89  itl_p50= 82.5ms  itl_p95= 84.2ms
+    w1-r6      wall=  24.28s  ttft=   278ms  toks= 1000  wall_TPS=  41.18  decode_TPS=  41.66  itl_p50= 82.6ms  itl_p95= 84.3ms
+    w1-r7      wall=  25.10s  ttft=   277ms  toks=  983  wall_TPS=  39.16  decode_TPS=  39.60  itl_p50= 82.6ms  itl_p95= 84.2ms
+    w2-r0      wall=  23.57s  ttft=   147ms  toks= 1000  wall_TPS=  42.43  decode_TPS=  42.70  itl_p50= 82.9ms  itl_p95= 84.7ms
+    w2-r1      wall=  25.55s  ttft=   146ms  toks= 1000  wall_TPS=  39.14  decode_TPS=  39.36  itl_p50= 82.8ms  itl_p95= 84.7ms
+    w2-r2      wall=  25.40s  ttft=   147ms  toks= 1000  wall_TPS=  39.38  decode_TPS=  39.60  itl_p50= 82.8ms  itl_p95= 84.6ms
+    w2-r3      wall=  25.90s  ttft=   147ms  toks= 1000  wall_TPS=  38.60  decode_TPS=  38.82  itl_p50= 82.8ms  itl_p95= 84.6ms
+    w2-r4      wall=  26.00s  ttft=   145ms  toks=  978  wall_TPS=  37.62  decode_TPS=  37.83  itl_p50= 82.8ms  itl_p95= 84.7ms
+    w2-r5      wall=  24.69s  ttft=   145ms  toks=  948  wall_TPS=  38.40  decode_TPS=  38.63  itl_p50= 82.9ms  itl_p95= 84.7ms
+    w2-r6      wall=  25.07s  ttft=   145ms  toks= 1000  wall_TPS=  39.89  decode_TPS=  40.12  itl_p50= 82.9ms  itl_p95= 84.5ms
+    w2-r7      wall=  24.95s  ttft=   144ms  toks= 1000  wall_TPS=  40.08  decode_TPS=  40.31  itl_p50= 82.9ms  itl_p95= 84.6ms
+  GPU during warmup narrative c=8 (51.4s, 352 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    98.8   17.4    22488    22489  219.1  219.8   74.0   74.0     1778
+       1    98.8   17.3    22180    22181  219.0  219.7   68.0   68.0     1855
+       2    98.7   17.3    22178    22179  219.0  219.6   71.8   72.0     1785
+       3    98.8   17.2    22178    22179  218.9  219.5   74.9   75.0     1797
+    r0         wall=  23.75s  ttft=   146ms  toks=  951  wall_TPS=  40.04  decode_TPS=  40.29  itl_p50= 83.0ms  itl_p95= 84.4ms
+    r1         wall=  24.57s  ttft=   145ms  toks= 1000  wall_TPS=  40.70  decode_TPS=  40.94  itl_p50= 83.0ms  itl_p95= 84.4ms
+    r2         wall=  25.34s  ttft=   145ms  toks=  992  wall_TPS=  39.14  decode_TPS=  39.37  itl_p50= 83.0ms  itl_p95= 84.4ms
+    r3         wall=  25.22s  ttft=   145ms  toks=  957  wall_TPS=  37.94  decode_TPS=  38.16  itl_p50= 82.9ms  itl_p95= 84.4ms
+    r4         wall=  24.77s  ttft=   145ms  toks= 1000  wall_TPS=  40.37  decode_TPS=  40.61  itl_p50= 83.0ms  itl_p95= 84.4ms
+    r5         wall=  25.17s  ttft=   144ms  toks=  944  wall_TPS=  37.51  decode_TPS=  37.73  itl_p50= 82.9ms  itl_p95= 84.4ms
+    r6         wall=  25.55s  ttft=   143ms  toks=  987  wall_TPS=  38.63  decode_TPS=  38.85  itl_p50= 82.9ms  itl_p95= 84.4ms
+    r7         wall=  25.71s  ttft=   143ms  toks= 1000  wall_TPS=  38.90  decode_TPS=  39.11  itl_p50= 82.9ms  itl_p95= 84.4ms
+  combined   wall_TPS= 304.59  decode_TPS= 315.06  avg_ttft=   144ms  itl_p50= 83.0ms  itl_p95= 84.4ms
+    r0         wall=  24.22s  ttft=   146ms  toks=  933  wall_TPS=  38.53  decode_TPS=  38.76  itl_p50= 82.6ms  itl_p95= 84.1ms
+    r1         wall=  24.72s  ttft=   145ms  toks= 1000  wall_TPS=  40.45  decode_TPS=  40.69  itl_p50= 82.6ms  itl_p95= 84.1ms
+    r2         wall=  25.27s  ttft=   146ms  toks= 1000  wall_TPS=  39.58  decode_TPS=  39.81  itl_p50= 82.6ms  itl_p95= 84.2ms
+    r3         wall=  25.10s  ttft=   145ms  toks= 1000  wall_TPS=  39.85  decode_TPS=  40.08  itl_p50= 82.6ms  itl_p95= 84.2ms
+    r4         wall=  24.52s  ttft=   145ms  toks=  895  wall_TPS=  36.50  decode_TPS=  36.72  itl_p50= 82.6ms  itl_p95= 84.2ms
+    r5         wall=  24.95s  ttft=   144ms  toks=  968  wall_TPS=  38.80  decode_TPS=  39.02  itl_p50= 82.6ms  itl_p95= 84.2ms
+    r6         wall=  25.05s  ttft=   143ms  toks= 1000  wall_TPS=  39.92  decode_TPS=  40.15  itl_p50= 82.6ms  itl_p95= 84.2ms
+    r7         wall=  25.09s  ttft=   143ms  toks= 1000  wall_TPS=  38.76  decode_TPS=  39.02  itl_p50= 82.6ms  itl_p95= 84.2ms
+  combined   wall_TPS= 305.43  decode_TPS= 312.14  avg_ttft=   144ms  itl_p50= 82.6ms  itl_p95= 84.2ms
+    r0         wall=  26.28s  ttft=   144ms  toks=  978  wall_TPS=  37.22  decode_TPS=  37.42  itl_p50= 82.8ms  itl_p95= 84.4ms
+    r1         wall=  24.27s  ttft=   145ms  toks=  980  wall_TPS=  40.38  decode_TPS=  40.62  itl_p50= 82.9ms  itl_p95= 84.4ms
+    r2         wall=  25.48s  ttft=   144ms  toks= 1000  wall_TPS=  39.25  decode_TPS=  39.47  itl_p50= 82.9ms  itl_p95= 84.4ms
+    r3         wall=  26.19s  ttft=   145ms  toks= 1000  wall_TPS=  38.19  decode_TPS=  38.40  itl_p50= 82.8ms  itl_p95= 84.4ms
+    r4         wall=  23.15s  ttft=   144ms  toks= 1000  wall_TPS=  43.19  decode_TPS=  43.46  itl_p50= 83.0ms  itl_p95= 84.4ms
+    r5         wall=  25.80s  ttft=   144ms  toks= 1000  wall_TPS=  38.76  decode_TPS=  38.97  itl_p50= 82.9ms  itl_p95= 84.4ms
+    r6         wall=  25.30s  ttft=   144ms  toks= 1000  wall_TPS=  39.52  decode_TPS=  39.75  itl_p50= 82.9ms  itl_p95= 84.4ms
+    r7         wall=  26.03s  ttft=   142ms  toks=  993  wall_TPS=  38.15  decode_TPS=  38.36  itl_p50= 82.9ms  itl_p95= 84.4ms
+  combined   wall_TPS= 302.56  decode_TPS= 316.46  avg_ttft=   144ms  itl_p50= 82.9ms  itl_p95= 84.4ms
+  GPU during measured narrative c=8 (77.3s, 528 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    98.8   17.1    22489    22489  219.1  220.0   74.0   74.0     1775
+       1    98.9   17.2    22181    22181  219.0  219.7   68.0   68.0     1852
+       2    98.6   17.2    22179    22179  219.0  219.7   71.1   72.0     1793
+       3    98.9   16.7    22179    22179  218.9  219.7   74.0   75.0     1797
+    total power avg=876.1 W   phase throughput=304.1 tok/s   efficiency: 0.3471 tok/W  (347.14 tok/kJ)
+
+  === summary [narrative c=8] (n=3) ===
+  combined wall_TPS    mean=  304.19   std=   1.48   CV= 0.5%   min=302.56   max=305.43
+  combined decode_TPS  mean=  314.55   std=   2.20   CV= 0.7%   min=312.14   max=316.46
+  per-req decode_TPS   mean=   39.32   std=   0.28   CV= 0.7%   min=39.02   max=39.56
+  avg TTFT (ms)        mean=  144.29ms   std=   0.29   CV= 0.2%   min=143.96   max=144.50
+  ITL p50 (ms)         mean=   82.82ms   std=   0.18   CV= 0.2%   min=82.61   max=82.96
+  ITL p95 (ms)         mean=   84.33ms   std=   0.13   CV= 0.2%   min=84.18   max=84.41
+
+--- Concurrency=16 (simultaneous requests) ---
+  warmups (2):
+    w1-r0      wall=  28.83s  ttft=   258ms  toks=  957  wall_TPS=  33.19  decode_TPS=  33.49  itl_p50= 95.3ms  itl_p95= 96.8ms
+    w1-r1      wall=  31.07s  ttft=   257ms  toks= 1000  wall_TPS=  32.18  decode_TPS=  32.45  itl_p50= 95.2ms  itl_p95= 96.9ms
+    w1-r2      wall=  30.19s  ttft=   256ms  toks= 1000  wall_TPS=  33.13  decode_TPS=  33.41  itl_p50= 95.2ms  itl_p95= 96.7ms
+    w1-r3      wall=  29.99s  ttft=   257ms  toks=  940  wall_TPS=  31.34  decode_TPS=  31.61  itl_p50= 95.3ms  itl_p95= 96.8ms
+    w1-r4      wall=  31.14s  ttft=   256ms  toks=  993  wall_TPS=  31.89  decode_TPS=  32.16  itl_p50= 95.2ms  itl_p95= 96.7ms
+    w1-r5      wall=  26.89s  ttft=   256ms  toks=  916  wall_TPS=  34.06  decode_TPS=  34.39  itl_p50= 95.3ms  itl_p95= 96.8ms
+    w1-r6      wall=  30.92s  ttft=   256ms  toks= 1000  wall_TPS=  32.35  decode_TPS=  32.62  itl_p50= 95.2ms  itl_p95= 96.8ms
+    w1-r7      wall=  30.18s  ttft=   255ms  toks= 1000  wall_TPS=  33.13  decode_TPS=  33.41  itl_p50= 95.2ms  itl_p95= 96.7ms
+    w1-r8      wall=  31.19s  ttft=   471ms  toks= 1000  wall_TPS=  32.07  decode_TPS=  32.56  itl_p50= 95.2ms  itl_p95= 96.8ms
+    w1-r9      wall=  30.98s  ttft=   470ms  toks= 1000  wall_TPS=  32.28  decode_TPS=  32.78  itl_p50= 95.2ms  itl_p95= 96.8ms
+    w1-r10     wall=  30.98s  ttft=   470ms  toks= 1000  wall_TPS=  32.28  decode_TPS=  32.78  itl_p50= 95.2ms  itl_p95= 96.7ms
+    w1-r11     wall=  30.08s  ttft=   469ms  toks= 1000  wall_TPS=  33.25  decode_TPS=  33.77  itl_p50= 95.2ms  itl_p95= 96.7ms
+    w1-r12     wall=  29.30s  ttft=   470ms  toks= 1000  wall_TPS=  34.13  decode_TPS=  34.69  itl_p50= 95.3ms  itl_p95= 96.6ms
+    w1-r13     wall=  29.30s  ttft=   468ms  toks= 1000  wall_TPS=  34.13  decode_TPS=  34.69  itl_p50= 95.3ms  itl_p95= 96.7ms
+    w1-r14     wall=  30.58s  ttft=   468ms  toks= 1000  wall_TPS=  32.70  decode_TPS=  33.21  itl_p50= 95.2ms  itl_p95= 96.7ms
+    w1-r15     wall=  29.21s  ttft=   468ms  toks= 1000  wall_TPS=  34.24  decode_TPS=  34.80  itl_p50= 95.2ms  itl_p95= 96.7ms
+    w2-r0      wall=  27.16s  ttft=   274ms  toks=  914  wall_TPS=  33.65  decode_TPS=  33.99  itl_p50= 95.3ms  itl_p95= 96.7ms
+    w2-r1      wall=  28.66s  ttft=   273ms  toks=  988  wall_TPS=  34.47  decode_TPS=  34.80  itl_p50= 95.3ms  itl_p95= 96.7ms
+    w2-r2      wall=  28.75s  ttft=   272ms  toks= 1000  wall_TPS=  34.79  decode_TPS=  35.12  itl_p50= 95.3ms  itl_p95= 96.7ms
+    w2-r3      wall=  28.30s  ttft=   274ms  toks=  986  wall_TPS=  34.84  decode_TPS=  35.18  itl_p50= 95.3ms  itl_p95= 97.0ms
+    w2-r4      wall=  30.53s  ttft=   273ms  toks= 1000  wall_TPS=  32.76  decode_TPS=  33.05  itl_p50= 95.3ms  itl_p95= 97.3ms
+    w2-r5      wall=  30.85s  ttft=   271ms  toks= 1000  wall_TPS=  32.42  decode_TPS=  32.70  itl_p50= 95.2ms  itl_p95= 97.1ms
+    w2-r6      wall=  29.26s  ttft=   271ms  toks= 1000  wall_TPS=  34.17  decode_TPS=  34.49  itl_p50= 95.3ms  itl_p95= 97.1ms
+    w2-r7      wall=  30.58s  ttft=   271ms  toks=  983  wall_TPS=  32.15  decode_TPS=  32.43  itl_p50= 95.3ms  itl_p95= 97.2ms
+    w2-r8      wall=  30.14s  ttft=   272ms  toks=  967  wall_TPS=  32.09  decode_TPS=  32.38  itl_p50= 95.3ms  itl_p95= 97.1ms
+    w2-r9      wall=  29.91s  ttft=   272ms  toks= 1000  wall_TPS=  33.44  decode_TPS=  33.74  itl_p50= 95.3ms  itl_p95= 97.5ms
+    w2-r10     wall=  30.40s  ttft=   271ms  toks= 1000  wall_TPS=  32.89  decode_TPS=  33.19  itl_p50= 95.3ms  itl_p95= 97.2ms
+    w2-r11     wall=  28.40s  ttft=   271ms  toks=  975  wall_TPS=  34.34  decode_TPS=  34.67  itl_p50= 95.3ms  itl_p95= 96.8ms
+    w2-r12     wall=  30.52s  ttft=   272ms  toks= 1000  wall_TPS=  32.76  decode_TPS=  33.06  itl_p50= 95.3ms  itl_p95= 97.0ms
+    w2-r13     wall=  29.80s  ttft=   271ms  toks= 1000  wall_TPS=  33.56  decode_TPS=  33.87  itl_p50= 95.3ms  itl_p95= 97.1ms
+    w2-r14     wall=  31.03s  ttft=   271ms  toks= 1000  wall_TPS=  32.23  decode_TPS=  32.51  itl_p50= 95.2ms  itl_p95= 97.1ms
+    w2-r15     wall=  28.30s  ttft=   271ms  toks= 1000  wall_TPS=  35.34  decode_TPS=  35.68  itl_p50= 95.3ms  itl_p95= 96.6ms
+  GPU during warmup narrative c=16 (62.2s, 428 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    98.9   20.0    22841    22841  219.2  219.7   73.6   74.0     1699
+       1    98.9   20.3    22533    22533  219.2  219.8   67.2   68.0     1782
+       2    98.9   20.3    22531    22531  219.2  219.8   71.2   72.0     1708
+       3    98.9   20.2    22531    22531  219.2  219.8   74.0   74.0     1712
+    r0         wall=  30.88s  ttft=   259ms  toks=  963  wall_TPS=  31.19  decode_TPS=  31.45  itl_p50= 95.3ms  itl_p95= 97.1ms
+    r1         wall=  29.23s  ttft=   259ms  toks= 1000  wall_TPS=  34.21  decode_TPS=  34.52  itl_p50= 95.3ms  itl_p95= 96.8ms
+    r2         wall=  29.98s  ttft=   259ms  toks=  888  wall_TPS=  29.62  decode_TPS=  29.88  itl_p50= 95.3ms  itl_p95= 97.1ms
+    r3         wall=  29.14s  ttft=   258ms  toks= 1000  wall_TPS=  34.32  decode_TPS=  34.63  itl_p50= 95.3ms  itl_p95= 96.8ms
+    r4         wall=  29.14s  ttft=   259ms  toks= 1000  wall_TPS=  34.32  decode_TPS=  34.63  itl_p50= 95.2ms  itl_p95= 96.9ms
+    r5         wall=  29.14s  ttft=   258ms  toks= 1000  wall_TPS=  34.32  decode_TPS=  34.63  itl_p50= 95.3ms  itl_p95= 96.9ms
+    r6         wall=  27.82s  ttft=   258ms  toks= 1000  wall_TPS=  35.95  decode_TPS=  36.28  itl_p50= 95.3ms  itl_p95= 96.8ms
+    r7         wall=  30.83s  ttft=   256ms  toks=  982  wall_TPS=  31.85  decode_TPS=  32.12  itl_p50= 95.3ms  itl_p95= 97.3ms
+    r8         wall=  30.69s  ttft=   263ms  toks=  959  wall_TPS=  31.25  decode_TPS=  31.52  itl_p50= 95.3ms  itl_p95= 97.0ms
+    r9         wall=  30.62s  ttft=   262ms  toks=  985  wall_TPS=  32.16  decode_TPS=  32.44  itl_p50= 95.3ms  itl_p95= 97.0ms
+    r10        wall=  30.55s  ttft=   262ms  toks=  959  wall_TPS=  31.39  decode_TPS=  31.66  itl_p50= 95.3ms  itl_p95= 97.0ms
+    r11        wall=  31.37s  ttft=   262ms  toks=  981  wall_TPS=  31.27  decode_TPS=  31.53  itl_p50= 95.2ms  itl_p95= 97.0ms
+    r12        wall=  31.05s  ttft=   261ms  toks=  960  wall_TPS=  30.91  decode_TPS=  31.18  itl_p50= 95.3ms  itl_p95= 96.9ms
+    r13        wall=  28.67s  ttft=   262ms  toks= 1000  wall_TPS=  34.88  decode_TPS=  35.20  itl_p50= 95.3ms  itl_p95= 96.7ms
+    r14        wall=  30.17s  ttft=   260ms  toks= 1000  wall_TPS=  33.15  decode_TPS=  33.43  itl_p50= 95.3ms  itl_p95= 97.1ms
+    r15        wall=  28.48s  ttft=   260ms  toks=  931  wall_TPS=  32.69  decode_TPS=  32.99  itl_p50= 95.3ms  itl_p95= 96.6ms
+  combined   wall_TPS= 497.54  decode_TPS= 528.09  avg_ttft=   260ms  itl_p50= 95.3ms  itl_p95= 96.9ms
+    r0         wall=  26.21s  ttft=   271ms  toks= 1000  wall_TPS=  38.15  decode_TPS=  38.55  itl_p50= 95.3ms  itl_p95= 96.7ms
+    r1         wall=  29.84s  ttft=   270ms  toks=  988  wall_TPS=  33.10  decode_TPS=  33.41  itl_p50= 95.2ms  itl_p95= 96.9ms
+    r2         wall=  27.91s  ttft=   270ms  toks= 1000  wall_TPS=  35.83  decode_TPS=  36.18  itl_p50= 95.3ms  itl_p95= 96.9ms
+    r3         wall=  29.69s  ttft=   269ms  toks=  986  wall_TPS=  33.21  decode_TPS=  33.52  itl_p50= 95.2ms  itl_p95= 97.0ms
+    r4         wall=  31.11s  ttft=   269ms  toks= 1000  wall_TPS=  32.15  decode_TPS=  32.43  itl_p50= 95.2ms  itl_p95= 96.8ms
+    r5         wall=  28.61s  ttft=   268ms  toks= 1000  wall_TPS=  34.95  decode_TPS=  35.28  itl_p50= 95.3ms  itl_p95= 96.7ms
+    r6         wall=  27.26s  ttft=   269ms  toks= 1000  wall_TPS=  36.69  decode_TPS=  37.05  itl_p50= 95.3ms  itl_p95= 96.7ms
+    r7         wall=  29.77s  ttft=   269ms  toks=  936  wall_TPS=  31.44  decode_TPS=  31.73  itl_p50= 95.3ms  itl_p95= 96.8ms
+    r8         wall=  28.09s  ttft=   269ms  toks=  923  wall_TPS=  32.85  decode_TPS=  33.17  itl_p50= 95.3ms  itl_p95= 96.7ms
+    r9         wall=  29.15s  ttft=   267ms  toks=  955  wall_TPS=  32.76  decode_TPS=  33.07  itl_p50= 95.2ms  itl_p95= 96.7ms
+    r10        wall=  28.96s  ttft=   267ms  toks=  949  wall_TPS=  32.77  decode_TPS=  33.08  itl_p50= 95.2ms  itl_p95= 96.7ms
+    r11        wall=  29.58s  ttft=   270ms  toks=  995  wall_TPS=  33.64  decode_TPS=  33.95  itl_p50= 95.3ms  itl_p95= 96.7ms
+    r12        wall=  30.95s  ttft=   269ms  toks= 1000  wall_TPS=  32.31  decode_TPS=  32.60  itl_p50= 95.2ms  itl_p95= 96.8ms
+    r13        wall=  30.62s  ttft=   270ms  toks= 1000  wall_TPS=  32.66  decode_TPS=  32.95  itl_p50= 95.2ms  itl_p95= 96.8ms
+    r14        wall=  30.99s  ttft=   269ms  toks= 1000  wall_TPS=  32.27  decode_TPS=  32.56  itl_p50= 95.2ms  itl_p95= 96.9ms
+    r15        wall=  30.72s  ttft=   269ms  toks=  995  wall_TPS=  32.39  decode_TPS=  32.68  itl_p50= 95.2ms  itl_p95= 97.0ms
+  combined   wall_TPS= 505.60  decode_TPS= 542.19  avg_ttft=   269ms  itl_p50= 95.2ms  itl_p95= 96.8ms
+    r0         wall=  30.44s  ttft=   259ms  toks=  985  wall_TPS=  32.36  decode_TPS=  32.64  itl_p50= 95.2ms  itl_p95= 96.9ms
+    r1         wall=  30.44s  ttft=   258ms  toks= 1000  wall_TPS=  32.86  decode_TPS=  33.14  itl_p50= 95.2ms  itl_p95= 96.7ms
+    r2         wall=  30.25s  ttft=   258ms  toks= 1000  wall_TPS=  33.05  decode_TPS=  33.34  itl_p50= 95.2ms  itl_p95= 96.9ms
+    r3         wall=  27.34s  ttft=   257ms  toks=  971  wall_TPS=  35.51  decode_TPS=  35.85  itl_p50= 95.3ms  itl_p95= 96.7ms
+    r4         wall=  29.61s  ttft=   256ms  toks= 1000  wall_TPS=  33.77  decode_TPS=  34.07  itl_p50= 95.3ms  itl_p95= 96.6ms
+    r5         wall=  30.74s  ttft=   256ms  toks=  996  wall_TPS=  32.40  decode_TPS=  32.68  itl_p50= 95.3ms  itl_p95= 96.9ms
+    r6         wall=  30.62s  ttft=   256ms  toks= 1000  wall_TPS=  32.66  decode_TPS=  32.94  itl_p50= 95.2ms  itl_p95= 96.8ms
+    r7         wall=  30.25s  ttft=   255ms  toks= 1000  wall_TPS=  33.06  decode_TPS=  33.34  itl_p50= 95.3ms  itl_p95= 96.8ms
+    r8         wall=  30.25s  ttft=   262ms  toks= 1000  wall_TPS=  33.06  decode_TPS=  33.35  itl_p50= 95.3ms  itl_p95= 96.7ms
+    r9         wall=  30.92s  ttft=   262ms  toks= 1000  wall_TPS=  32.34  decode_TPS=  32.62  itl_p50= 95.2ms  itl_p95= 96.6ms
+    r10        wall=  30.62s  ttft=   261ms  toks= 1000  wall_TPS=  32.66  decode_TPS=  32.94  itl_p50= 95.2ms  itl_p95= 96.7ms
+    r11        wall=  30.67s  ttft=   261ms  toks= 1000  wall_TPS=  32.61  decode_TPS=  32.89  itl_p50= 95.2ms  itl_p95= 96.7ms
+    r12        wall=  29.51s  ttft=   260ms  toks=  955  wall_TPS=  32.36  decode_TPS=  32.65  itl_p50= 95.3ms  itl_p95= 96.8ms
+    r13        wall=  29.95s  ttft=   261ms  toks=  996  wall_TPS=  33.26  decode_TPS=  33.55  itl_p50= 95.3ms  itl_p95= 96.7ms
+    r14        wall=  29.14s  ttft=   259ms  toks= 1000  wall_TPS=  34.31  decode_TPS=  34.62  itl_p50= 95.3ms  itl_p95= 96.6ms
+    r15        wall=  28.86s  ttft=   259ms  toks= 1000  wall_TPS=  34.65  decode_TPS=  34.96  itl_p50= 95.3ms  itl_p95= 96.7ms
+  combined   wall_TPS= 514.36  decode_TPS= 535.56  avg_ttft=   259ms  itl_p50= 95.3ms  itl_p95= 96.7ms
+  GPU during measured narrative c=16 (93.4s, 640 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    98.9   20.5    22841    22841  219.2  220.0   73.2   74.0     1696
+       1    98.9   20.3    22533    22533  219.3  219.9   67.0   68.0     1785
+       2    98.8   20.3    22531    22531  219.2  219.7   71.8   72.0     1699
+       3    98.9   20.3    22531    22531  219.3  219.8   74.0   74.0     1715
+    total power avg=877.0 W   phase throughput=505.7 tok/s   efficiency: 0.5766 tok/W  (576.61 tok/kJ)
+
+  === summary [narrative c=16] (n=3) ===
+  combined wall_TPS    mean=  505.83   std=   8.41   CV= 1.7%   min=497.54   max=514.36
+  combined decode_TPS  mean=  535.28   std=   7.05   CV= 1.3%   min=528.09   max=542.19
+  per-req decode_TPS   mean=   33.46   std=   0.44   CV= 1.3%   min=33.01   max=33.89
+  avg TTFT (ms)        mean=  262.62ms   std=   5.69   CV= 2.2%   min=258.80   max=269.16
+  ITL p50 (ms)         mean=   95.26ms   std=   0.01   CV= 0.0%   min=95.24   max=95.27
+  ITL p95 (ms)         mean=   96.82ms   std=   0.09   CV= 0.1%   min=96.73   max=96.92
+
+  === SGLang log metrics (last 15 entries, narrative) ===
+  decode tok/s         mean=  504.02tok/s   std=  76.94   CV=15.3%   min=329.68   max=591.36
+  prefill tok/s        mean= 6168.68tok/s   std=10910.72   CV=176.9%   min=6.43   max=29540.79
+  accept len           mean=    3.16   std=   0.21   CV= 6.7%   min=2.82   max=3.52
+  accept rate          mean=    0.31   std=   0.03   CV= 9.9%   min=0.26   max=0.36
+  queue reqs           mean=    0.00   std=   0.00   CV= 0.0%   min=0.00   max=0.00
+  KV usage             mean=    0.01   std=   0.01   CV=84.5%   min=0.00   max=0.02
+
+========================================================================
+  DECODE SATURATION — CODE (prompt=78 chars, max_tokens=800)
+========================================================================
+
+--- Concurrency=1 (simultaneous requests) ---
+  warmups (2):
+    w1-r0      wall=   0.96s  ttft=    52ms  toks=  286  wall_TPS= 299.39  decode_TPS= 316.79  itl_p50= 21.7ms  itl_p95= 23.6ms
+    w2-r0      wall=   2.59s  ttft=    68ms  toks=  658  wall_TPS= 253.83  decode_TPS= 260.67  itl_p50= 21.9ms  itl_p95= 22.8ms
+  GPU during warmup code c=1 (3.5s, 24 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    88.2   35.7    22841    22841  217.6  220.1   72.2   73.0     1568
+       1    95.8   38.7    22533    22533  217.4  221.5   67.0   67.0     1725
+       2    80.0   32.5    22531    22531  216.8  220.1   70.3   71.0     1670
+       3    91.7   35.5    22531    22531  218.1  221.5   72.7   73.0     1648
+    r0         wall=   3.12s  ttft=    64ms  toks=  800  wall_TPS= 256.40  decode_TPS= 261.79  itl_p50= 22.0ms  itl_p95= 22.8ms
+  combined   wall_TPS= 256.40  decode_TPS= 261.79  avg_ttft=    64ms  itl_p50= 22.0ms  itl_p95= 22.8ms
+    r0         wall=   2.74s  ttft=    65ms  toks=  646  wall_TPS= 235.46  decode_TPS= 241.17  itl_p50= 21.9ms  itl_p95= 22.7ms
+  combined   wall_TPS= 235.46  decode_TPS= 241.17  avg_ttft=    65ms  itl_p50= 21.9ms  itl_p95= 22.7ms
+    r0         wall=   1.73s  ttft=    67ms  toks=  386  wall_TPS= 222.62  decode_TPS= 231.57  itl_p50= 21.9ms  itl_p95= 22.6ms
+  combined   wall_TPS= 222.62  decode_TPS= 231.57  avg_ttft=    67ms  itl_p50= 21.9ms  itl_p95= 22.6ms
+  GPU during measured code c=1 (7.6s, 52 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    96.2   39.1    22841    22841  219.7  220.3   72.0   72.0     1597
+       1    95.7   38.5    22533    22533  219.5  219.9   66.9   67.0     1708
+       2    95.8   38.5    22531    22531  219.5  220.0   70.1   71.0     1620
+       3    95.2   38.8    22531    22531  219.6  220.4   72.3   73.0     1629
+    total power avg=878.3 W   phase throughput=241.1 tok/s   efficiency: 0.2745 tok/W  (274.48 tok/kJ)
+
+  === summary [code c=1] (n=3) ===
+  combined wall_TPS    mean=  238.16   std=  17.05   CV= 7.2%   min=222.62   max=256.40
+  combined decode_TPS  mean=  244.84   std=  15.44   CV= 6.3%   min=231.57   max=261.79
+  per-req decode_TPS   mean=  244.84   std=  15.44   CV= 6.3%   min=231.57   max=261.79
+  avg TTFT (ms)        mean=   65.41ms   std=   1.45   CV= 2.2%   min=64.24   max=67.03
+  ITL p50 (ms)         mean=   21.91ms   std=   0.04   CV= 0.2%   min=21.87   max=21.96
+  ITL p95 (ms)         mean=   22.70ms   std=   0.12   CV= 0.5%   min=22.60   max=22.83
+
+--- Concurrency=2 (simultaneous requests) ---
+  warmups (2):
+    w1-r0      wall=   2.79s  ttft=    97ms  toks=  518  wall_TPS= 185.58  decode_TPS= 192.24  itl_p50= 28.4ms  itl_p95= 29.3ms
+    w1-r1      wall=   2.32s  ttft=    97ms  toks=  457  wall_TPS= 196.63  decode_TPS= 205.16  itl_p50= 28.5ms  itl_p95= 29.3ms
+    w2-r0      wall=   1.75s  ttft=    98ms  toks=  349  wall_TPS= 199.38  decode_TPS= 211.26  itl_p50= 28.4ms  itl_p95= 29.5ms
+    w2-r1      wall=   2.22s  ttft=    98ms  toks=  408  wall_TPS= 183.87  decode_TPS= 192.36  itl_p50= 28.3ms  itl_p95= 29.3ms
+  GPU during warmup code c=2 (5.0s, 36 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    96.6   34.7    22841    22841  219.5  219.8   72.6   73.0     1652
+       1    96.6   33.8    22533    22533  219.5  220.4   67.0   67.0     1758
+       2    96.1   34.3    22531    22531  219.4  219.9   70.7   71.0     1680
+       3    96.6   32.8    22531    22531  219.4  219.8   72.9   73.0     1682
+    r0         wall=   2.07s  ttft=    98ms  toks=  397  wall_TPS= 191.78  decode_TPS= 201.27  itl_p50= 28.5ms  itl_p95= 29.6ms
+    r1         wall=   2.14s  ttft=    97ms  toks=  413  wall_TPS= 192.68  decode_TPS= 201.84  itl_p50= 28.5ms  itl_p95= 29.6ms
+  combined   wall_TPS= 377.90  decode_TPS= 403.11  avg_ttft=    97ms  itl_p50= 28.5ms  itl_p95= 29.7ms
+    r0         wall=   1.81s  ttft=    97ms  toks=  377  wall_TPS= 208.86  decode_TPS= 220.73  itl_p50= 28.4ms  itl_p95= 29.3ms
+    r1         wall=   3.30s  ttft=    97ms  toks=  726  wall_TPS= 219.68  decode_TPS= 226.30  itl_p50= 23.0ms  itl_p95= 28.9ms
+  combined   wall_TPS= 333.75  decode_TPS= 447.03  avg_ttft=    97ms  itl_p50= 28.2ms  itl_p95= 29.2ms
+    r0         wall=   3.05s  ttft=    97ms  toks=  708  wall_TPS= 231.98  decode_TPS= 239.61  itl_p50= 28.1ms  itl_p95= 29.1ms
+    r1         wall=   1.95s  ttft=    97ms  toks=  403  wall_TPS= 206.79  decode_TPS= 217.60  itl_p50= 28.4ms  itl_p95= 29.3ms
+  combined   wall_TPS= 364.02  decode_TPS= 457.21  avg_ttft=    97ms  itl_p50= 28.3ms  itl_p95= 29.2ms
+  GPU during measured code c=2 (8.5s, 56 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    96.3   33.7    22841    22841  219.4  220.3   72.5   73.0     1666
+       1    96.6   34.1    22533    22533  219.4  219.8   67.0   67.0     1754
+       2    96.6   33.8    22531    22531  219.5  220.0   71.0   71.0     1662
+       3    96.6   34.1    22531    22531  219.5  220.0   73.0   73.0     1671
+    total power avg=877.8 W   phase throughput=355.6 tok/s   efficiency: 0.4051 tok/W  (405.13 tok/kJ)
+
+  === summary [code c=2] (n=3) ===
+  combined wall_TPS    mean=  358.56   std=  22.57   CV= 6.3%   min=333.75   max=377.90
+  combined decode_TPS  mean=  435.78   std=  28.75   CV= 6.6%   min=403.11   max=457.21
+  per-req decode_TPS   mean=  217.89   std=  14.38   CV= 6.6%   min=201.55   max=228.60
+  avg TTFT (ms)        mean=   97.11ms   std=   0.27   CV= 0.3%   min=96.90   max=97.42
+  ITL p50 (ms)         mean=   28.35ms   std=   0.17   CV= 0.6%   min=28.20   max=28.53
+  ITL p95 (ms)         mean=   29.36ms   std=   0.29   CV= 1.0%   min=29.19   max=29.70
+
+--- Concurrency=4 (simultaneous requests) ---
+  warmups (2):
+    w1-r0      wall=   4.05s  ttft=   100ms  toks=  539  wall_TPS= 133.04  decode_TPS= 136.40  itl_p50= 44.4ms  itl_p95= 45.8ms
+    w1-r1      wall=   4.43s  ttft=   100ms  toks=  604  wall_TPS= 136.30  decode_TPS= 139.45  itl_p50= 44.0ms  itl_p95= 45.8ms
+    w1-r2      wall=   4.57s  ttft=   100ms  toks=  688  wall_TPS= 150.60  decode_TPS= 153.95  itl_p50= 43.8ms  itl_p95= 45.8ms
+    w1-r3      wall=   2.78s  ttft=   100ms  toks=  361  wall_TPS= 129.72  decode_TPS= 134.54  itl_p50= 44.6ms  itl_p95= 46.0ms
+    w2-r0      wall=   5.65s  ttft=   103ms  toks=  800  wall_TPS= 141.70  decode_TPS= 144.34  itl_p50= 44.4ms  itl_p95= 45.5ms
+    w2-r1      wall=   4.65s  ttft=   103ms  toks=  531  wall_TPS= 114.28  decode_TPS= 116.86  itl_p50= 44.6ms  itl_p95= 45.5ms
+    w2-r2      wall=   5.11s  ttft=   102ms  toks=  761  wall_TPS= 148.87  decode_TPS= 151.90  itl_p50= 44.5ms  itl_p95= 45.5ms
+    w2-r3      wall=   4.31s  ttft=   102ms  toks=  507  wall_TPS= 117.75  decode_TPS= 120.59  itl_p50= 44.7ms  itl_p95= 45.6ms
+  GPU during warmup code c=4 (10.2s, 72 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    97.6   25.8    22841    22841  219.2  219.6   72.9   73.0     1709
+       1    97.7   25.7    22533    22533  219.2  219.7   67.0   67.0     1802
+       2    97.6   26.7    22531    22531  219.3  219.9   71.6   72.0     1714
+       3    97.7   25.7    22531    22531  219.3  219.9   73.7   74.0     1728
+    r0         wall=   3.19s  ttft=   101ms  toks=  367  wall_TPS= 115.01  decode_TPS= 118.78  itl_p50= 44.7ms  itl_p95= 46.1ms
+    r1         wall=   3.98s  ttft=   101ms  toks=  488  wall_TPS= 122.75  decode_TPS= 125.96  itl_p50= 44.6ms  itl_p95= 45.8ms
+    r2         wall=   5.75s  ttft=   100ms  toks=  800  wall_TPS= 139.04  decode_TPS= 141.51  itl_p50= 37.0ms  itl_p95= 45.4ms
+    r3         wall=   5.78s  ttft=   100ms  toks=  800  wall_TPS= 138.38  decode_TPS= 140.82  itl_p50= 37.0ms  itl_p95= 45.4ms
+  combined   wall_TPS= 424.65  decode_TPS= 527.07  avg_ttft=   101ms  itl_p50= 44.3ms  itl_p95= 45.6ms
+    r0         wall=   3.12s  ttft=   106ms  toks=  389  wall_TPS= 124.67  decode_TPS= 129.03  itl_p50= 44.5ms  itl_p95= 46.1ms
+    r1         wall=   3.42s  ttft=   105ms  toks=  400  wall_TPS= 117.13  decode_TPS= 120.85  itl_p50= 44.5ms  itl_p95= 46.1ms
+    r2         wall=   2.96s  ttft=   104ms  toks=  371  wall_TPS= 125.18  decode_TPS= 129.75  itl_p50= 44.5ms  itl_p95= 46.1ms
+    r3         wall=   3.80s  ttft=   104ms  toks=  576  wall_TPS= 151.72  decode_TPS= 156.00  itl_p50= 44.3ms  itl_p95= 45.9ms
+  combined   wall_TPS= 457.27  decode_TPS= 535.63  avg_ttft=   105ms  itl_p50= 44.5ms  itl_p95= 46.1ms
+    r0         wall=   5.92s  ttft=   103ms  toks=  800  wall_TPS= 135.08  decode_TPS= 137.47  itl_p50= 37.4ms  itl_p95= 45.1ms
+    r1         wall=   4.91s  ttft=   103ms  toks=  704  wall_TPS= 143.28  decode_TPS= 146.35  itl_p50= 44.2ms  itl_p95= 45.2ms
+    r2         wall=   6.06s  ttft=   103ms  toks=  800  wall_TPS= 132.00  decode_TPS= 134.27  itl_p50= 37.3ms  itl_p95= 45.1ms
+    r3         wall=   3.05s  ttft=   102ms  toks=  379  wall_TPS= 124.22  decode_TPS= 128.52  itl_p50= 44.7ms  itl_p95= 45.4ms
+  combined   wall_TPS= 442.68  decode_TPS= 546.62  avg_ttft=   103ms  itl_p50= 44.2ms  itl_p95= 45.2ms
+  GPU during measured code c=4 (15.6s, 108 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    97.5   26.5    22841    22841  219.2  219.8   73.0   73.0     1704
+       1    97.6   26.1    22533    22533  219.3  219.8   67.0   67.0     1799
+       2    97.4   26.2    22531    22531  219.3  219.8   71.9   72.0     1719
+       3    97.4   26.2    22531    22531  219.3  219.7   73.8   74.0     1733
+    total power avg=877.1 W   phase throughput=439.4 tok/s   efficiency: 0.5009 tok/W  (500.94 tok/kJ)
+
+  === summary [code c=4] (n=3) ===
+  combined wall_TPS    mean=  441.53   std=  16.34   CV= 3.7%   min=424.65   max=457.27
+  combined decode_TPS  mean=  536.44   std=   9.80   CV= 1.8%   min=527.07   max=546.62
+  per-req decode_TPS   mean=  134.11   std=   2.45   CV= 1.8%   min=131.77   max=136.65
+  avg TTFT (ms)        mean=  102.79ms   std=   2.03   CV= 2.0%   min=100.75   max=104.82
+  ITL p50 (ms)         mean=   44.33ms   std=   0.14   CV= 0.3%   min=44.18   max=44.47
+  ITL p95 (ms)         mean=   45.64ms   std=   0.49   CV= 1.1%   min=45.17   max=46.14
+
+--- Concurrency=8 (simultaneous requests) ---
+  warmups (2):
+    w1-r0      wall=   5.75s  ttft=   144ms  toks=  373  wall_TPS=  64.91  decode_TPS=  66.59  itl_p50= 82.4ms  itl_p95= 83.7ms
+    w1-r1      wall=   6.18s  ttft=   145ms  toks=  401  wall_TPS=  64.87  decode_TPS=  66.43  itl_p50= 82.3ms  itl_p95= 83.7ms
+    w1-r2      wall=   5.75s  ttft=   145ms  toks=  381  wall_TPS=  66.31  decode_TPS=  68.03  itl_p50= 82.5ms  itl_p95= 84.0ms
+    w1-r3      wall=   6.90s  ttft=   144ms  toks=  550  wall_TPS=  79.67  decode_TPS=  81.37  itl_p50= 81.8ms  itl_p95= 83.7ms
+    w1-r4      wall=   6.81s  ttft=   144ms  toks=  530  wall_TPS=  77.83  decode_TPS=  79.51  itl_p50= 82.1ms  itl_p95= 83.6ms
+    w1-r5      wall=   6.03s  ttft=   144ms  toks=  418  wall_TPS=  69.27  decode_TPS=  70.96  itl_p50= 82.5ms  itl_p95= 83.6ms
+    w1-r6      wall=   6.37s  ttft=   144ms  toks=  479  wall_TPS=  75.18  decode_TPS=  76.92  itl_p50= 82.4ms  itl_p95= 83.8ms
+    w1-r7      wall=   4.77s  ttft=   142ms  toks=  329  wall_TPS=  68.95  decode_TPS=  71.07  itl_p50= 82.6ms  itl_p95= 83.9ms
+    w2-r0      wall=   9.59s  ttft=   146ms  toks=  800  wall_TPS=  83.44  decode_TPS=  84.73  itl_p50= 81.6ms  itl_p95= 84.0ms
+    w2-r1      wall=   7.05s  ttft=   146ms  toks=  472  wall_TPS=  66.97  decode_TPS=  68.39  itl_p50= 82.6ms  itl_p95= 84.4ms
+    w2-r2      wall=   9.43s  ttft=   146ms  toks=  800  wall_TPS=  84.82  decode_TPS=  86.16  itl_p50= 81.8ms  itl_p95= 84.1ms
+    w2-r3      wall=   7.50s  ttft=   145ms  toks=  490  wall_TPS=  65.36  decode_TPS=  66.65  itl_p50= 82.5ms  itl_p95= 84.2ms
+    w2-r4      wall=   9.55s  ttft=   145ms  toks=  756  wall_TPS=  79.17  decode_TPS=  80.39  itl_p50= 81.4ms  itl_p95= 83.8ms
+    w2-r5      wall=   6.78s  ttft=   144ms  toks=  456  wall_TPS=  67.26  decode_TPS=  68.72  itl_p50= 82.7ms  itl_p95= 84.2ms
+    w2-r6      wall=   9.64s  ttft=   144ms  toks=  800  wall_TPS=  83.02  decode_TPS=  84.28  itl_p50= 81.4ms  itl_p95= 84.0ms
+    w2-r7      wall=   6.11s  ttft=   144ms  toks=  418  wall_TPS=  68.46  decode_TPS=  70.11  itl_p50= 82.7ms  itl_p95= 84.1ms
+  GPU during warmup code c=8 (16.5s, 112 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    98.6   18.6    22841    22841  219.0  219.8   73.3   74.0     1745
+       1    98.5   18.4    22533    22533  218.8  219.7   67.2   68.0     1843
+       2    98.6   19.1    22531    22531  219.0  219.9   71.9   72.0     1752
+       3    98.3   19.5    22531    22531  219.0  219.7   74.0   74.0     1793
+    r0         wall=   9.76s  ttft=   146ms  toks=  800  wall_TPS=  81.98  decode_TPS=  83.23  itl_p50= 81.5ms  itl_p95= 83.9ms
+    r1         wall=   9.19s  ttft=   145ms  toks=  690  wall_TPS=  75.09  decode_TPS=  76.30  itl_p50= 82.1ms  itl_p95= 83.8ms
+    r2         wall=   9.44s  ttft=   146ms  toks=  698  wall_TPS=  73.98  decode_TPS=  75.14  itl_p50= 82.0ms  itl_p95= 83.6ms
+    r3         wall=   9.19s  ttft=   145ms  toks=  691  wall_TPS=  75.20  decode_TPS=  76.40  itl_p50= 82.1ms  itl_p95= 84.0ms
+    r4         wall=   5.77s  ttft=   144ms  toks=  333  wall_TPS=  57.71  decode_TPS=  59.19  itl_p50= 82.5ms  itl_p95= 84.3ms
+    r5         wall=  10.11s  ttft=   144ms  toks=  769  wall_TPS=  76.03  decode_TPS=  77.13  itl_p50= 74.3ms  itl_p95= 83.6ms
+    r6         wall=   8.22s  ttft=   144ms  toks=  574  wall_TPS=  69.87  decode_TPS=  71.11  itl_p50= 82.2ms  itl_p95= 84.1ms
+    r7         wall=   9.19s  ttft=   143ms  toks=  607  wall_TPS=  66.07  decode_TPS=  67.12  itl_p50= 82.1ms  itl_p95= 84.1ms
+  combined   wall_TPS= 510.35  decode_TPS= 585.61  avg_ttft=   145ms  itl_p50= 82.1ms  itl_p95= 84.1ms
+    r0         wall=   5.03s  ttft=   147ms  toks=  358  wall_TPS=  71.22  decode_TPS=  73.37  itl_p50= 82.6ms  itl_p95= 84.0ms
+    r1         wall=   6.30s  ttft=   147ms  toks=  457  wall_TPS=  72.51  decode_TPS=  74.25  itl_p50= 82.3ms  itl_p95= 84.0ms
+    r2         wall=   5.33s  ttft=   147ms  toks=  382  wall_TPS=  71.64  decode_TPS=  73.67  itl_p50= 82.6ms  itl_p95= 83.9ms
+    r3         wall=   5.92s  ttft=   147ms  toks=  404  wall_TPS=  68.29  decode_TPS=  70.03  itl_p50= 82.4ms  itl_p95= 83.9ms
+    r4         wall=   5.98s  ttft=   146ms  toks=  417  wall_TPS=  69.73  decode_TPS=  71.47  itl_p50= 82.5ms  itl_p95= 83.8ms
+    r5         wall=   8.39s  ttft=   146ms  toks=  783  wall_TPS=  93.30  decode_TPS=  94.95  itl_p50= 63.3ms  itl_p95= 83.5ms
+    r6         wall=   7.49s  ttft=   146ms  toks=  623  wall_TPS=  83.13  decode_TPS=  84.78  itl_p50= 81.6ms  itl_p95= 83.8ms
+    r7         wall=   8.28s  ttft=   145ms  toks=  800  wall_TPS=  96.67  decode_TPS=  98.39  itl_p50= 63.8ms  itl_p95= 83.5ms
+  combined   wall_TPS= 503.31  decode_TPS= 640.91  avg_ttft=   146ms  itl_p50= 82.2ms  itl_p95= 83.9ms
+    r0         wall=   6.96s  ttft=   147ms  toks=  520  wall_TPS=  74.70  decode_TPS=  76.30  itl_p50= 82.3ms  itl_p95= 83.7ms
+    r1         wall=   8.29s  ttft=   146ms  toks=  755  wall_TPS=  91.02  decode_TPS=  92.65  itl_p50= 81.5ms  itl_p95= 83.6ms
+    r2         wall=   5.60s  ttft=   146ms  toks=  384  wall_TPS=  68.55  decode_TPS=  70.38  itl_p50= 82.6ms  itl_p95= 83.8ms
+    r3         wall=   5.94s  ttft=   145ms  toks=  392  wall_TPS=  66.01  decode_TPS=  67.66  itl_p50= 82.6ms  itl_p95= 83.7ms
+    r4         wall=   8.65s  ttft=   145ms  toks=  800  wall_TPS=  92.46  decode_TPS=  94.03  itl_p50= 59.9ms  itl_p95= 83.7ms
+    r5         wall=   5.60s  ttft=   145ms  toks=  377  wall_TPS=  67.31  decode_TPS=  69.10  itl_p50= 82.7ms  itl_p95= 84.1ms
+    r6         wall=   6.50s  ttft=   144ms  toks=  414  wall_TPS=  63.69  decode_TPS=  65.13  itl_p50= 82.4ms  itl_p95= 83.8ms
+    r7         wall=   8.08s  ttft=   144ms  toks=  774  wall_TPS=  95.74  decode_TPS=  97.47  itl_p50= 81.9ms  itl_p95= 83.6ms
+  combined   wall_TPS= 510.36  decode_TPS= 632.73  avg_ttft=   145ms  itl_p50= 82.3ms  itl_p95= 83.7ms
+  GPU during measured code c=8 (27.2s, 188 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    98.6   19.1    22841    22841  219.0  219.5   73.4   74.0     1762
+       1    98.4   19.9    22533    22533  218.9  219.9   67.3   68.0     1833
+       2    98.4   19.9    22531    22531  219.1  219.8   71.9   72.0     1771
+       3    98.2   20.0    22531    22531  219.1  219.7   73.9   74.0     1767
+    total power avg=876.1 W   phase throughput=508.0 tok/s   efficiency: 0.5798 tok/W  (579.85 tok/kJ)
+
+  === summary [code c=8] (n=3) ===
+  combined wall_TPS    mean=  508.01   std=   4.07   CV= 0.8%   min=503.31   max=510.36
+  combined decode_TPS  mean=  619.75   std=  29.85   CV= 4.8%   min=585.61   max=640.91
+  per-req decode_TPS   mean=   77.47   std=   3.73   CV= 4.8%   min=73.20   max=80.11
+  avg TTFT (ms)        mean=  145.32ms   std=   0.90   CV= 0.6%   min=144.59   max=146.32
+  ITL p50 (ms)         mean=   82.18ms   std=   0.08   CV= 0.1%   min=82.10   max=82.25
+  ITL p95 (ms)         mean=   83.89ms   std=   0.18   CV= 0.2%   min=83.72   max=84.08
+
+--- Concurrency=16 (simultaneous requests) ---
+  warmups (2):
+    w1-r0      wall=  12.28s  ttft=   273ms  toks=  707  wall_TPS=  57.55  decode_TPS=  58.86  itl_p50= 94.9ms  itl_p95=108.3ms
+    w1-r1      wall=  11.94s  ttft=   272ms  toks=  703  wall_TPS=  58.89  decode_TPS=  60.26  itl_p50= 94.8ms  itl_p95=108.4ms
+    w1-r2      wall=  13.13s  ttft=   273ms  toks=  800  wall_TPS=  60.92  decode_TPS=  62.21  itl_p50= 94.8ms  itl_p95=108.0ms
+    w1-r3      wall=  13.09s  ttft=   272ms  toks=  800  wall_TPS=  61.09  decode_TPS=  62.39  itl_p50= 94.8ms  itl_p95=108.0ms
+    w1-r4      wall=   5.98s  ttft=   272ms  toks=  371  wall_TPS=  61.99  decode_TPS=  64.94  itl_p50= 95.1ms  itl_p95= 96.8ms
+    w1-r5      wall=   7.69s  ttft=   272ms  toks=  458  wall_TPS=  59.56  decode_TPS=  61.75  itl_p50= 95.1ms  itl_p95= 96.8ms
+    w1-r6      wall=   8.25s  ttft=   272ms  toks=  410  wall_TPS=  49.71  decode_TPS=  51.41  itl_p50= 94.9ms  itl_p95= 96.7ms
+    w1-r7      wall=  12.90s  ttft=   272ms  toks=  800  wall_TPS=  62.01  decode_TPS=  63.35  itl_p50= 94.8ms  itl_p95=107.9ms
+    w1-r8      wall=   9.53s  ttft=   271ms  toks=  564  wall_TPS=  59.20  decode_TPS=  60.93  itl_p50= 94.7ms  itl_p95= 96.6ms
+    w1-r9      wall=  12.12s  ttft=   276ms  toks=  714  wall_TPS=  58.89  decode_TPS=  60.26  itl_p50= 94.9ms  itl_p95=108.3ms
+    w1-r10     wall=  12.74s  ttft=   275ms  toks=  800  wall_TPS=  62.82  decode_TPS=  64.20  itl_p50= 94.8ms  itl_p95=108.2ms
+    w1-r11     wall=  12.80s  ttft=   275ms  toks=  800  wall_TPS=  62.50  decode_TPS=  63.87  itl_p50= 94.8ms  itl_p95=108.0ms
+    w1-r12     wall=  10.97s  ttft=   274ms  toks=  694  wall_TPS=  63.27  decode_TPS=  64.89  itl_p50= 94.8ms  itl_p95=107.8ms
+    w1-r13     wall=   9.70s  ttft=   275ms  toks=  511  wall_TPS=  52.70  decode_TPS=  54.24  itl_p50= 94.6ms  itl_p95= 96.6ms
+    w1-r14     wall=  13.16s  ttft=   275ms  toks=  800  wall_TPS=  60.81  decode_TPS=  62.10  itl_p50= 94.7ms  itl_p95=107.8ms
+    w1-r15     wall=   8.25s  ttft=   273ms  toks=  446  wall_TPS=  54.09  decode_TPS=  55.95  itl_p50= 94.9ms  itl_p95= 96.4ms
+    w2-r0      wall=   4.64s  ttft=   260ms  toks=  287  wall_TPS=  61.89  decode_TPS=  65.57  itl_p50= 95.2ms  itl_p95= 96.7ms
+    w2-r1      wall=  10.35s  ttft=   260ms  toks=  679  wall_TPS=  65.62  decode_TPS=  67.31  itl_p50= 93.6ms  itl_p95=107.6ms
+    w2-r2      wall=   8.87s  ttft=   259ms  toks=  523  wall_TPS=  58.97  decode_TPS=  60.75  itl_p50= 94.3ms  itl_p95=107.5ms
+    w2-r3      wall=  10.90s  ttft=   259ms  toks=  696  wall_TPS=  63.82  decode_TPS=  65.37  itl_p50= 92.8ms  itl_p95=107.5ms
+    w2-r4      wall=   7.33s  ttft=   259ms  toks=  417  wall_TPS=  56.92  decode_TPS=  59.00  itl_p50= 94.3ms  itl_p95= 96.4ms
+    w2-r5      wall=   9.25s  ttft=   258ms  toks=  549  wall_TPS=  59.37  decode_TPS=  61.07  itl_p50= 94.3ms  itl_p95=107.6ms
+    w2-r6      wall=   6.21s  ttft=   258ms  toks=  348  wall_TPS=  56.07  decode_TPS=  58.50  itl_p50= 94.7ms  itl_p95= 96.7ms
+    w2-r7      wall=  11.54s  ttft=   258ms  toks=  800  wall_TPS=  69.33  decode_TPS=  70.92  itl_p50= 92.2ms  itl_p95=107.4ms
+    w2-r8      wall=  10.14s  ttft=   256ms  toks=  602  wall_TPS=  59.34  decode_TPS=  60.88  itl_p50= 93.9ms  itl_p95=107.5ms
+    w2-r9      wall=   6.30s  ttft=   257ms  toks=  373  wall_TPS=  59.22  decode_TPS=  61.74  itl_p50= 94.7ms  itl_p95= 96.7ms
+    w2-r10     wall=  11.57s  ttft=   256ms  toks=  800  wall_TPS=  69.17  decode_TPS=  70.74  itl_p50= 92.1ms  itl_p95=107.4ms
+    w2-r11     wall=  11.50s  ttft=   260ms  toks=  800  wall_TPS=  69.56  decode_TPS=  71.18  itl_p50= 92.2ms  itl_p95=107.4ms
+    w2-r12     wall=   7.92s  ttft=   260ms  toks=  430  wall_TPS=  54.31  decode_TPS=  56.16  itl_p50= 94.2ms  itl_p95= 96.5ms
+    w2-r13     wall=  11.27s  ttft=   260ms  toks=  800  wall_TPS=  70.98  decode_TPS=  72.66  itl_p50= 92.3ms  itl_p95=107.4ms
+    w2-r14     wall=   3.87s  ttft=   259ms  toks=  242  wall_TPS=  62.48  decode_TPS=  66.95  itl_p50= 94.9ms  itl_p95= 96.8ms
+    w2-r15     wall=   8.97s  ttft=   259ms  toks=  506  wall_TPS=  56.39  decode_TPS=  58.07  itl_p50= 94.3ms  itl_p95=107.8ms
+  GPU during warmup code c=16 (24.7s, 172 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    98.8   20.9    22841    22841  219.2  219.6   73.2   74.0     1708
+       1    98.8   20.8    22533    22533  219.3  219.8   67.0   68.0     1793
+       2    98.5   21.1    22531    22531  219.2  219.8   71.9   72.0     1720
+       3    98.8   21.0    22531    22531  219.3  219.9   74.0   74.0     1729
+    r0         wall=   6.81s  ttft=   258ms  toks=  395  wall_TPS=  58.00  decode_TPS=  60.28  itl_p50= 94.9ms  itl_p95= 96.8ms
+    r1         wall=   9.17s  ttft=   257ms  toks=  516  wall_TPS=  56.25  decode_TPS=  57.87  itl_p50= 94.5ms  itl_p95= 96.7ms
+    r2         wall=  13.34s  ttft=   257ms  toks=  800  wall_TPS=  59.97  decode_TPS=  61.15  itl_p50= 94.0ms  itl_p95=107.1ms
+    r3         wall=   7.63s  ttft=   258ms  toks=  441  wall_TPS=  57.77  decode_TPS=  59.79  itl_p50= 94.8ms  itl_p95= 96.6ms
+    r4         wall=  13.94s  ttft=   257ms  toks=  800  wall_TPS=  57.38  decode_TPS=  58.45  itl_p50= 93.4ms  itl_p95=107.2ms
+    r5         wall=  13.26s  ttft=   256ms  toks=  800  wall_TPS=  60.35  decode_TPS=  61.54  itl_p50= 94.1ms  itl_p95=107.2ms
+    r6         wall=  13.34s  ttft=   257ms  toks=  800  wall_TPS=  59.97  decode_TPS=  61.15  itl_p50= 94.1ms  itl_p95=107.2ms
+    r7         wall=  12.17s  ttft=   256ms  toks=  800  wall_TPS=  65.72  decode_TPS=  67.13  itl_p50= 94.0ms  itl_p95= 97.2ms
+    r8         wall=  13.41s  ttft=   256ms  toks=  800  wall_TPS=  59.65  decode_TPS=  60.81  itl_p50= 94.1ms  itl_p95=107.2ms
+    r9         wall=  13.87s  ttft=   255ms  toks=  800  wall_TPS=  57.66  decode_TPS=  58.74  itl_p50= 93.7ms  itl_p95=107.1ms
+    r10        wall=   6.43s  ttft=   255ms  toks=  391  wall_TPS=  60.77  decode_TPS=  63.27  itl_p50= 94.9ms  itl_p95= 96.9ms
+    r11        wall=  13.94s  ttft=   259ms  toks=  800  wall_TPS=  57.39  decode_TPS=  58.47  itl_p50= 93.5ms  itl_p95=107.1ms
+    r12        wall=  11.55s  ttft=   258ms  toks=  699  wall_TPS=  60.53  decode_TPS=  61.92  itl_p50= 94.1ms  itl_p95= 96.2ms
+    r13        wall=   4.92s  ttft=   258ms  toks=  324  wall_TPS=  65.89  decode_TPS=  69.53  itl_p50= 95.0ms  itl_p95= 96.7ms
+    r14        wall=  12.81s  ttft=   258ms  toks=  800  wall_TPS=  62.43  decode_TPS=  63.71  itl_p50= 94.1ms  itl_p95=107.1ms
+    r15        wall=  13.64s  ttft=   258ms  toks=  800  wall_TPS=  58.64  decode_TPS=  59.77  itl_p50= 93.9ms  itl_p95=107.1ms
+  combined   wall_TPS= 772.13  decode_TPS= 983.58  avg_ttft=   257ms  itl_p50= 94.2ms  itl_p95=106.7ms
+    r0         wall=  10.89s  ttft=   267ms  toks=  600  wall_TPS=  55.08  decode_TPS=  56.46  itl_p50= 94.8ms  itl_p95=108.0ms
+    r1         wall=   7.68s  ttft=   266ms  toks=  385  wall_TPS=  50.15  decode_TPS=  51.95  itl_p50= 95.0ms  itl_p95= 96.6ms
+    r2         wall=   8.14s  ttft=   265ms  toks=  441  wall_TPS=  54.16  decode_TPS=  55.98  itl_p50= 95.0ms  itl_p95= 96.5ms
+    r3         wall=  12.81s  ttft=   264ms  toks=  800  wall_TPS=  62.44  decode_TPS=  63.75  itl_p50= 94.4ms  itl_p95=107.6ms
+    r4         wall=   9.12s  ttft=   265ms  toks=  456  wall_TPS=  49.97  decode_TPS=  51.47  itl_p50= 94.8ms  itl_p95= 96.6ms
+    r5         wall=   9.04s  ttft=   265ms  toks=  505  wall_TPS=  55.87  decode_TPS=  57.55  itl_p50= 94.8ms  itl_p95= 96.5ms
+    r6         wall=   9.75s  ttft=   264ms  toks=  553  wall_TPS=  56.72  decode_TPS=  58.30  itl_p50= 94.8ms  itl_p95= 98.1ms
+    r7         wall=   6.35s  ttft=   264ms  toks=  360  wall_TPS=  56.72  decode_TPS=  59.18  itl_p50= 95.1ms  itl_p95= 96.4ms
+    r8         wall=  10.29s  ttft=   263ms  toks=  612  wall_TPS=  59.49  decode_TPS=  61.05  itl_p50= 94.9ms  itl_p95=107.6ms
+    r9         wall=   8.69s  ttft=   262ms  toks=  453  wall_TPS=  52.13  decode_TPS=  53.75  itl_p50= 94.8ms  itl_p95= 96.2ms
+    r10        wall=  12.03s  ttft=   261ms  toks=  775  wall_TPS=  64.43  decode_TPS=  65.86  itl_p50= 94.7ms  itl_p95=107.8ms
+    r11        wall=  12.53s  ttft=   262ms  toks=  800  wall_TPS=  63.84  decode_TPS=  65.20  itl_p50= 94.5ms  itl_p95=107.6ms
+    r12        wall=  12.81s  ttft=   261ms  toks=  800  wall_TPS=  62.45  decode_TPS=  63.75  itl_p50= 94.5ms  itl_p95=107.4ms
+    r13        wall=  11.64s  ttft=   262ms  toks=  681  wall_TPS=  58.52  decode_TPS=  59.87  itl_p50= 94.7ms  itl_p95=107.8ms
+    r14        wall=  12.94s  ttft=   270ms  toks=  800  wall_TPS=  61.84  decode_TPS=  63.12  itl_p50= 94.5ms  itl_p95=107.5ms
+    r15        wall=  12.91s  ttft=   270ms  toks=  800  wall_TPS=  61.97  decode_TPS=  63.25  itl_p50= 94.5ms  itl_p95=107.5ms
+  combined   wall_TPS= 759.13  decode_TPS= 950.49  avg_ttft=   263ms  itl_p50= 94.7ms  itl_p95=106.4ms
+    r0         wall=  10.56s  ttft=   270ms  toks=  586  wall_TPS=  55.49  decode_TPS=  56.94  itl_p50= 94.8ms  itl_p95=108.1ms
+    r1         wall=  10.78s  ttft=   270ms  toks=  571  wall_TPS=  52.99  decode_TPS=  54.35  itl_p50= 94.9ms  itl_p95=108.1ms
+    r2         wall=   6.08s  ttft=   270ms  toks=  377  wall_TPS=  61.99  decode_TPS=  64.86  itl_p50= 95.1ms  itl_p95= 96.7ms
+    r3         wall=   9.29s  ttft=   270ms  toks=  498  wall_TPS=  53.61  decode_TPS=  55.22  itl_p50= 94.7ms  itl_p95= 96.6ms
+    r4         wall=  13.00s  ttft=   270ms  toks=  800  wall_TPS=  61.55  decode_TPS=  62.86  itl_p50= 94.2ms  itl_p95=107.9ms
+    r5         wall=  11.21s  ttft=   269ms  toks=  669  wall_TPS=  59.66  decode_TPS=  61.13  itl_p50= 94.8ms  itl_p95=108.1ms
+    r6         wall=   8.27s  ttft=   269ms  toks=  452  wall_TPS=  54.66  decode_TPS=  56.49  itl_p50= 94.9ms  itl_p95= 96.5ms
+    r7         wall=   6.65s  ttft=   268ms  toks=  376  wall_TPS=  56.57  decode_TPS=  58.94  itl_p50= 95.1ms  itl_p95= 96.6ms
+    r8         wall=   6.46s  ttft=   269ms  toks=  385  wall_TPS=  59.60  decode_TPS=  62.19  itl_p50= 95.0ms  itl_p95= 96.9ms
+    r9         wall=  12.91s  ttft=   268ms  toks=  800  wall_TPS=  61.98  decode_TPS=  63.29  itl_p50= 94.2ms  itl_p95=107.9ms
+    r10        wall=  11.29s  ttft=   272ms  toks=  721  wall_TPS=  63.84  decode_TPS=  65.41  itl_p50= 94.8ms  itl_p95=108.1ms
+    r11        wall=   6.55s  ttft=   272ms  toks=  408  wall_TPS=  62.25  decode_TPS=  64.95  itl_p50= 95.1ms  itl_p95= 96.8ms
+    r12        wall=  11.95s  ttft=   271ms  toks=  800  wall_TPS=  66.97  decode_TPS=  68.52  itl_p50= 94.7ms  itl_p95=108.1ms
+    r13        wall=  12.94s  ttft=   271ms  toks=  800  wall_TPS=  61.81  decode_TPS=  63.13  itl_p50= 94.3ms  itl_p95=107.9ms
+    r14        wall=  12.28s  ttft=   271ms  toks=  800  wall_TPS=  65.13  decode_TPS=  66.60  itl_p50= 94.6ms  itl_p95=108.0ms
+    r15        wall=  12.79s  ttft=   270ms  toks=  800  wall_TPS=  62.57  decode_TPS=  63.92  itl_p50= 94.4ms  itl_p95=108.0ms
+  combined   wall_TPS= 757.31  decode_TPS= 988.80  avg_ttft=   270ms  itl_p50= 94.8ms  itl_p95=107.6ms
+  GPU during measured code c=16 (39.9s, 272 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    98.8   20.9    22841    22841  219.2  219.7   73.1   74.0     1702
+       1    98.8   20.4    22533    22533  219.2  219.6   67.1   68.0     1801
+       2    98.8   20.6    22531    22531  219.2  219.8   71.8   72.0     1716
+       3    98.8   20.7    22531    22531  219.3  219.7   74.0   74.0     1728
+    total power avg=876.9 W   phase throughput=762.8 tok/s   efficiency: 0.8699 tok/W  (869.89 tok/kJ)
+
+  === summary [code c=16] (n=3) ===
+  combined wall_TPS    mean=  762.86   std=   8.08   CV= 1.1%   min=757.31   max=772.13
+  combined decode_TPS  mean=  974.29   std=  20.78   CV= 2.1%   min=950.49   max=988.80
+  per-req decode_TPS   mean=   60.89   std=   1.30   CV= 2.1%   min=59.41   max=61.80
+  avg TTFT (ms)        mean=  263.45ms   std=   6.45   CV= 2.4%   min=257.05   max=269.95
+  ITL p50 (ms)         mean=   94.59ms   std=   0.30   CV= 0.3%   min=94.25   max=94.78
+  ITL p95 (ms)         mean=  106.89ms   std=   0.61   CV= 0.6%   min=106.39   max=107.56
+
+  === SGLang log metrics (last 15 entries, code) ===
+  decode tok/s         mean=  756.69tok/s   std= 128.81   CV=17.0%   min=519.86   max=910.03
+  prefill tok/s        mean= 5504.30tok/s   std=9545.93   CV=173.4%   min=19.30   max=25428.02
+  accept len           mean=    5.65   std=   0.27   CV= 4.8%   min=5.05   max=6.16
+  accept rate          mean=    0.66   std=   0.04   CV= 5.8%   min=0.58   max=0.74
+  queue reqs           mean=    0.00   std=   0.00   CV= 0.0%   min=0.00   max=0.00
+  KV usage             mean=    0.01   std=   0.01   CV=96.8%   min=0.00   max=0.01
+
+  === SGLang server metrics (deltas, full bench) ===
+    prompt tokens processed:   103759
+    generation tokens emitted: 243906
+    server-side avg TTFT:           346 ms
+    server-side avg ITL:          20.35 ms
+    server-side avg E2E:          15462 ms
+    spec-decode (engine-reported): accept_len=5.65  accept_rate=66.2%  (log)
+    kv_cache_usage: 0.000
+    num_requests_running: 0.000
+    num_requests_waiting: 0.000
+
+========================================================================
+  FINAL SUMMARY
+========================================================================
+  Prefill (c=1, gen=16):
+      target   actual   ttft_ms  prefill_t/s
+         512      552       328       1683.5
+        1024     1053       682       1543.9
+        2048     2061      1128       1826.3
+        4096     4074      2172       1875.4
+        8192     8104      4372       1853.4
+       16384    16160      8926       1810.5
+
+  Decode saturation — narrative:
+       c  comb_dtps  req_dtps  ttft_ms  itl50_ms  itl95_ms   tok/W
+       1     144.63    144.63       65      21.8      22.5  0.1628
+       2     225.75    112.87       97      28.5      29.3  0.2456
+       4     285.98     71.50      101      44.7      45.8  0.3144
+       8     314.55     39.32      144      82.8      84.3  0.3471
+      16     535.28     33.45      263      95.3      96.8  0.5766
+
+  Decode saturation — code:
+       c  comb_dtps  req_dtps  ttft_ms  itl50_ms  itl95_ms   tok/W
+       1     244.84    244.84       65      21.9      22.7  0.2745
+       2     435.78    217.89       97      28.3      29.4  0.4051
+       4     536.44    134.11      103      44.3      45.6  0.5009
+       8     619.75     77.47      145      82.2      83.9  0.5798
+      16     974.29     60.89      263      94.6     106.9  0.8699
+
+=== Peak GPU temperature (whole run, 4444 samples) ===
+    GPU 0: peak 74.0 C
+    GPU 1: peak 68.0 C
+    GPU 2: peak 73.0 C
+    GPU 3: peak 75.0 C
+
+=== GPU state (post-test) ===
+0, 52, 21, 22841, 24576, 216.64, 220.00, 73, 1785
+1, 0, 0, 22533, 24576, 202.08, 220.00, 65, 1935
+2, 0, 0, 22531, 24576, 212.18, 220.00, 70, 1905
+3, 0, 0, 22531, 24576, 207.05, 220.00, 71, 1920
+
+=== Last 5 SGLang accept-len lines (per container) ===
+  --- sglang-qwen38b27-int4-tp4-dflash2-w4a8 ---
+    (none)
+
+=== Results saved ===
+  (none — TEXT_OUT/JSON_OUT disabled)

--- a/results/sglang-q38-ar-w4a8-dflash2-tp4-20260909/vllm-q38-ar-w4a8-dflash2-tp4-20260819.txt
+++ b/results/sglang-q38-ar-w4a8-dflash2-tp4-20260909/vllm-q38-ar-w4a8-dflash2-tp4-20260819.txt
@@ -1,0 +1,800 @@
+# bench-ultimate.sh — vllm-q38-ar-w4a8-dflash2-tp4
+# Date: 2026-08-19
+# Host: Ur4nus, 4x RTX 3090 (24GB), NVIDIA driver 610.57.04, vLLM v0.27.1
+# Model: Qwen3.8-27B (AutoRound W4A8, dflash2 speculative decoding, TP=4)
+# Stack: vllm-q38-ar-w4a8-dflash2-tp4 (TP4, max_model_len=262144)
+# Concurrency: 1,2,4,8,16 | Runs: 3 | Warmups: 2 | Prefill sizes: 512..16384 (gen=16, unique markers)
+# GPU power limit: 220W per GPU (all phases ~875W total at load)
+
+=== Ultimate OpenAI-Backend Bench ===
+  URL: http://localhost:8000
+  Model: vLLM
+  Mode: full
+  Containers: vllm-q38-ar-w4a8-dflash2-tp4
+  Concurrency levels (decode): 1,2,4,8,16
+  Prefill sizes (target tokens): 512,1024,2048,4096,8192,16384
+  Runs: decode=3 (warmups 2), prefill=2 (warmups 1)
+  GPU poll interval: 0.5s   JSON out: off
+
+  NVIDIA driver: 610.57.04
+  GPUs (idle snapshot):
+    0, NVIDIA GeForce RTX 3090, 24576, 60, 129.57, 220.00, 1695
+    1, NVIDIA GeForce RTX 3090, 24576, 55, 116.47, 220.00, 1695
+    2, NVIDIA GeForce RTX 3090, 24576, 59, 123.65, 220.00, 1695
+    3, NVIDIA GeForce RTX 3090, 24576, 56, 122.30, 220.00, 1695
+
+  vLLM /version: {"version":"0.27.1"}
+
+  Served model id: vLLM  max_model_len: 262144
+  vLLM /metrics: available (http://localhost:8000/metrics) — will report deltas
+
+========================================================================
+  PREFILL BENCH (concurrency=1, gen=16 tok, unique=True)
+========================================================================
+
+--- Prefill target ~512 tokens ---
+  warm-1: actual_prompt=   553  ttft=    308ms  prefill_TPS=  1793.5
+  run-1: actual_prompt=   551  ttft=    302ms  prefill_TPS=  1821.8  gen_TPS= 75.38  wall=  0.51s
+  run-2: actual_prompt=   553  ttft=    326ms  prefill_TPS=  1694.2  gen_TPS= 57.16  wall=  0.61s
+  GPU during prefill ~512t (1.1s, 8 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    91.0   19.0    22850    22850  164.8  184.8   65.0   66.0     1838
+       1    77.5   23.0    22850    22850  156.2  177.8   58.5   59.0     1912
+       2   100.0   16.0    22850    22850  157.0  179.0   64.5   65.0     1845
+       3    76.5   25.0    22850    22850  163.7  184.4   64.0   65.0     1852
+    total power avg=641.7 W   phase throughput=1013.0 tok/s   efficiency: 1.5786 tok/W  (1578.60 tok/kJ)
+
+  === prefill summary [~512 tok] (n=2) ===
+  TTFT (ms)            mean=  314.43ms   std=  16.94   CV= 5.4%   min=302.45   max=326.41
+  prefill tok/s        mean= 1758.01   std=   90.23   CV= 5.1%   min=1694.21   max=1821.81
+  gen tok/s (c1)       mean=   66.27   std=   12.88   CV=19.4%   min=57.16   max=75.38
+  actual prompt tokens: mean=552 (target 512)
+
+--- Prefill target ~1024 tokens ---
+  warm-1: actual_prompt=  1052  ttft=    561ms  prefill_TPS=  1876.1
+  run-1: actual_prompt=  1053  ttft=    553ms  prefill_TPS=  1903.0  gen_TPS= 72.96  wall=  0.77s
+  run-2: actual_prompt=  1054  ttft=    578ms  prefill_TPS=  1823.4  gen_TPS= 67.07  wall=  0.82s
+  GPU during prefill ~1024t (1.6s, 12 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    92.7   17.3    22850    22850  219.0  220.3   67.0   67.0     1820
+       1    90.7   18.7    22850    22850  217.9  218.1   59.3   60.0     1895
+       2    92.0   18.0    22850    22850  218.6  218.9   67.0   67.0     1800
+       3   100.0   14.0    22850    22850  218.3  219.3   68.0   69.0     1850
+    total power avg=873.7 W   phase throughput=1345.6 tok/s   efficiency: 1.5401 tok/W  (1540.09 tok/kJ)
+
+  === prefill summary [~1024 tok] (n=2) ===
+  TTFT (ms)            mean=  565.68ms   std=  17.47   CV= 3.1%   min=553.33   max=578.04
+  prefill tok/s        mean= 1863.22   std=   56.29   CV= 3.0%   min=1823.41   max=1903.02
+  gen tok/s (c1)       mean=   70.01   std=    4.17   CV= 6.0%   min=67.07   max=72.96
+  actual prompt tokens: mean=1054 (target 1024)
+
+--- Prefill target ~2048 tokens ---
+  warm-1: actual_prompt=  2060  ttft=   1066ms  prefill_TPS=  1932.6
+  run-1: actual_prompt=  2060  ttft=   1070ms  prefill_TPS=  1925.5  gen_TPS= 81.66  wall=  1.27s
+  run-2: actual_prompt=  2061  ttft=   1089ms  prefill_TPS=  1893.3  gen_TPS= 78.28  wall=  1.29s
+  GPU during prefill ~2048t (2.6s, 16 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    91.0   15.8    22850    22850  218.4  218.6   68.0   69.0     1826
+       1    91.8   13.8    22850    22850  216.6  217.1   60.0   60.0     1852
+       2    94.2   17.5    22850    22850  218.8  219.0   68.2   69.0     1811
+       3    94.5   15.2    22850    22850  217.7  219.2   69.8   70.0     1826
+    total power avg=871.5 W   phase throughput=1622.8 tok/s   efficiency: 1.8619 tok/W  (1861.95 tok/kJ)
+
+  === prefill summary [~2048 tok] (n=2) ===
+  TTFT (ms)            mean= 1079.21ms   std=   13.24   CV= 1.2%   min=1069.85   max=1088.58
+  prefill tok/s        mean= 1909.40   std=   22.77   CV= 1.2%   min=1893.30   max=1925.50
+  gen tok/s (c1)       mean=   79.97   std=    2.39   CV= 3.0%   min=78.28   max=81.66
+  actual prompt tokens: mean=2060 (target 2048)
+
+--- Prefill target ~4096 tokens ---
+  warm-1: actual_prompt=  4075  ttft=   2128ms  prefill_TPS=  1915.3
+  run-1: actual_prompt=  4074  ttft=   2124ms  prefill_TPS=  1918.0  gen_TPS=101.69  wall=  2.28s
+  run-2: actual_prompt=  4073  ttft=   2140ms  prefill_TPS=  1903.0  gen_TPS=165.04  wall=  2.24s
+  GPU during prefill ~4096t (4.5s, 28 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    98.3   13.6    22850    22850  219.3  220.2   69.6   70.0     1764
+       1    96.0   15.3    22850    22850  218.4  219.2   61.4   62.0     1875
+       2    95.4   14.6    22850    22850  218.2  219.0   69.7   70.0     1824
+       3    95.0   15.7    22850    22850  219.0  219.4   71.1   72.0     1824
+    total power avg=874.9 W   phase throughput=1809.8 tok/s   efficiency: 2.0685 tok/W  (2068.55 tok/kJ)
+
+  === prefill summary [~4096 tok] (n=2) ===
+  TTFT (ms)            mean= 2132.20ms   std=   11.45   CV= 0.5%   min=2124.11   max=2140.29
+  prefill tok/s        mean= 1910.50   std=   10.59   CV= 0.6%   min=1903.01   max=1917.98
+  gen tok/s (c1)       mean=  133.36   std=   44.80   CV=33.6%   min=101.69   max=165.04
+  actual prompt tokens: mean=4074 (target 4096)
+
+--- Prefill target ~8192 tokens ---
+  warm-1: actual_prompt=  8102  ttft=   4262ms  prefill_TPS=  1901.1
+  run-1: actual_prompt=  8103  ttft=   4263ms  prefill_TPS=  1901.0  gen_TPS=169.34  wall=  4.36s
+  run-2: actual_prompt=  8101  ttft=   4262ms  prefill_TPS=  1900.9  gen_TPS=166.23  wall=  4.36s
+  GPU during prefill ~8192t (8.7s, 56 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0   100.0   12.6    23130    23130  218.3  219.4   70.9   71.0     1775
+       1    98.6   13.5    23130    23130  216.2  218.2   63.1   64.0     1871
+       2    99.6   12.6    23130    23130  217.4  218.4   71.5   72.0     1798
+       3    97.8   14.0    23130    23130  218.0  218.7   72.2   73.0     1806
+    total power avg=869.9 W   phase throughput=1862.8 tok/s   efficiency: 2.1415 tok/W  (2141.53 tok/kJ)
+
+  === prefill summary [~8192 tok] (n=2) ===
+  TTFT (ms)            mean= 4262.14ms   std=    0.53   CV= 0.0%   min=4261.77   max=4262.52
+  prefill tok/s        mean= 1900.92   std=    0.10   CV= 0.0%   min=1900.85   max=1900.99
+  gen tok/s (c1)       mean=  167.79   std=    2.20   CV= 1.3%   min=166.23   max=169.34
+  actual prompt tokens: mean=8102 (target 8192)
+
+--- Prefill target ~16384 tokens ---
+  warm-1: actual_prompt= 16159  ttft=   8635ms  prefill_TPS=  1871.2
+  run-1: actual_prompt= 16160  ttft=   8626ms  prefill_TPS=  1873.4  gen_TPS= 73.68  wall=  8.84s
+  run-2: actual_prompt= 16161  ttft=   8632ms  prefill_TPS=  1872.2  gen_TPS= 82.25  wall=  8.83s
+  GPU during prefill ~16384t (17.7s, 112 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    99.0   12.7    23430    23430  214.9  219.5   71.6   72.0     1729
+       1    99.0   12.6    23430    23430  211.1  217.4   64.9   66.0     1834
+       2    99.4   12.8    23430    23430  215.1  219.1   73.1   74.0     1765
+       3    98.7   12.9    23430    23430  214.5  218.6   72.9   73.0     1774
+    total power avg=855.6 W   phase throughput=1830.9 tok/s   efficiency: 2.1399 tok/W  (2139.94 tok/kJ)
+
+  === prefill summary [~16384 tok] (n=2) ===
+  TTFT (ms)            mean= 8629.05ms   std=    4.39   CV= 0.1%   min=8625.94   max=8632.15
+  prefill tok/s        mean= 1872.80   std=    0.87   CV= 0.0%   min=1872.19   max=1873.42
+  gen tok/s (c1)       mean=   77.96   std=    6.06   CV= 7.8%   min=73.68   max=82.25
+  actual prompt tokens: mean=16160 (target 16384)
+
+========================================================================
+  DECODE SATURATION — NARRATIVE (prompt=65 chars, max_tokens=1000)
+========================================================================
+
+--- Concurrency=1 (simultaneous requests) ---
+  warmups (2):
+    w1-r0      wall=   9.73s  ttft=   198ms  toks=  987  wall_TPS= 101.46  decode_TPS= 103.57  itl_p50= 31.0ms  itl_p95= 35.6ms
+    w2-r0      wall=  10.16s  ttft=    83ms  toks=  992  wall_TPS=  97.59  decode_TPS=  98.39  itl_p50= 31.1ms  itl_p95= 36.0ms
+  GPU during warmup narrative c=1 (19.9s, 136 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    72.3   27.5    23430    23430  218.4  219.3   71.8   72.0     1764
+       1    73.8   27.2    23430    23430  217.5  219.0   65.6   66.0     1853
+       2    75.5   27.7    23430    23430  218.2  218.9   73.6   74.0     1779
+       3    75.6   27.5    23430    23430  218.3  219.2   72.8   73.0     1793
+    r0         wall=   9.54s  ttft=    84ms  toks=  961  wall_TPS= 100.77  decode_TPS= 101.67  itl_p50= 31.2ms  itl_p95= 35.0ms
+  combined   wall_TPS= 100.77  decode_TPS= 101.67  avg_ttft=    84ms  itl_p50= 31.2ms  itl_p95= 35.0ms
+    r0         wall=   9.46s  ttft=    85ms  toks=  978  wall_TPS= 103.34  decode_TPS= 104.28  itl_p50= 31.2ms  itl_p95= 34.9ms
+  combined   wall_TPS= 103.34  decode_TPS= 104.28  avg_ttft=    85ms  itl_p50= 31.2ms  itl_p95= 34.9ms
+    r0         wall=   9.51s  ttft=    84ms  toks=  909  wall_TPS=  95.61  decode_TPS=  96.46  itl_p50= 31.2ms  itl_p95= 35.7ms
+  combined   wall_TPS=  95.61  decode_TPS=  96.46  avg_ttft=    84ms  itl_p50= 31.2ms  itl_p95= 35.7ms
+  GPU during measured narrative c=1 (28.5s, 200 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    73.2   27.5    23430    23430  218.7  219.2   72.2   73.0     1770
+       1    77.3   27.4    23430    23430  218.1  219.1   66.3   67.0     1843
+       2    76.2   27.3    23430    23430  218.6  219.2   74.1   75.0     1755
+       3    71.1   27.3    23430    23430  218.4  219.0   73.0   74.0     1796
+    total power avg=873.8 W   phase throughput=99.9 tok/s   efficiency: 0.1143 tok/W  (114.32 tok/kJ)
+
+  === summary [narrative c=1] (n=3) ===
+  combined wall_TPS    mean=   99.91   std=   3.94   CV= 3.9%   min=95.61   max=103.34
+  combined decode_TPS  mean=  100.80   std=   3.98   CV= 3.9%   min=96.46   max=104.28
+  per-req decode_TPS   mean=  100.80   std=   3.98   CV= 3.9%   min=96.46   max=104.28
+  avg TTFT (ms)        mean=   84.43ms   std=   0.30   CV= 0.4%   min=84.15   max=84.76
+  ITL p50 (ms)         mean=   31.21ms   std=   0.03   CV= 0.1%   min=31.19   max=31.25
+  ITL p95 (ms)         mean=   35.20ms   std=   0.47   CV= 1.3%   min=34.87   max=35.73
+
+--- Concurrency=2 (simultaneous requests) ---
+  warmups (2):
+    w1-r0      wall=  12.51s  ttft=   106ms  toks=  987  wall_TPS=  78.91  decode_TPS=  79.58  itl_p50= 37.6ms  itl_p95= 40.2ms
+    w1-r1      wall=  11.99s  ttft=   106ms  toks=  943  wall_TPS=  78.62  decode_TPS=  79.32  itl_p50= 37.6ms  itl_p95= 40.2ms
+    w2-r0      wall=  11.10s  ttft=   108ms  toks=  911  wall_TPS=  82.05  decode_TPS=  82.86  itl_p50= 37.4ms  itl_p95= 39.9ms
+    w2-r1      wall=  11.40s  ttft=   108ms  toks=  991  wall_TPS=  86.94  decode_TPS=  87.78  itl_p50= 37.3ms  itl_p95= 39.8ms
+  GPU during warmup narrative c=2 (23.9s, 164 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    75.8   24.7    23430    23430  218.5  219.7   72.9   73.0     1763
+       1    78.9   25.0    23430    23430  218.1  219.6   67.0   67.0     1844
+       2    80.2   25.0    23430    23430  218.6  219.6   74.3   75.0     1771
+       3    78.0   25.1    23430    23430  218.5  219.3   73.6   74.0     1801
+    r0         wall=  11.48s  ttft=   108ms  toks= 1000  wall_TPS=  87.10  decode_TPS=  87.92  itl_p50= 37.6ms  itl_p95= 40.4ms
+    r1         wall=  11.45s  ttft=   107ms  toks= 1000  wall_TPS=  87.35  decode_TPS=  88.18  itl_p50= 37.6ms  itl_p95= 40.4ms
+  combined   wall_TPS= 174.19  decode_TPS= 176.10  avg_ttft=   108ms  itl_p50= 37.6ms  itl_p95= 40.4ms
+    r0         wall=  10.68s  ttft=   111ms  toks=  893  wall_TPS=  83.58  decode_TPS=  84.46  itl_p50= 37.4ms  itl_p95= 40.2ms
+    r1         wall=  11.45s  ttft=   111ms  toks=  948  wall_TPS=  82.83  decode_TPS=  83.64  itl_p50= 37.3ms  itl_p95= 40.2ms
+  combined   wall_TPS= 160.85  decode_TPS= 168.10  avg_ttft=   111ms  itl_p50= 37.3ms  itl_p95= 40.2ms
+    r0         wall=  10.56s  ttft=   109ms  toks=  865  wall_TPS=  81.93  decode_TPS=  82.78  itl_p50= 37.3ms  itl_p95= 40.1ms
+    r1         wall=  11.13s  ttft=   109ms  toks= 1000  wall_TPS=  89.87  decode_TPS=  90.76  itl_p50= 37.2ms  itl_p95= 40.1ms
+  combined   wall_TPS= 167.61  decode_TPS= 173.54  avg_ttft=   109ms  itl_p50= 37.3ms  itl_p95= 40.1ms
+  GPU during measured narrative c=2 (34.1s, 236 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    78.4   25.2    23430    23430  218.8  219.6   73.0   73.0     1756
+       1    80.9   25.4    23430    23430  218.7  219.4   67.1   68.0     1842
+       2    80.0   25.3    23430    23430  218.8  219.6   73.5   74.0     1762
+       3    78.3   25.3    23430    23430  218.8  219.6   74.0   74.0     1795
+    total power avg=875.1 W   phase throughput=167.5 tok/s   efficiency: 0.1915 tok/W  (191.46 tok/kJ)
+
+  === summary [narrative c=2] (n=3) ===
+  combined wall_TPS    mean=  167.55   std=   6.67   CV= 4.0%   min=160.85   max=174.19
+  combined decode_TPS  mean=  172.58   std=   4.08   CV= 2.4%   min=168.10   max=176.10
+  per-req decode_TPS   mean=   86.29   std=   2.04   CV= 2.4%   min=84.05   max=88.05
+  avg TTFT (ms)        mean=  109.13ms   std=   1.68   CV= 1.5%   min=107.57   max=110.92
+  ITL p50 (ms)         mean=   37.39ms   std=   0.21   CV= 0.6%   min=37.26   max=37.63
+  ITL p95 (ms)         mean=   40.21ms   std=   0.14   CV= 0.3%   min=40.09   max=40.37
+
+--- Concurrency=4 (simultaneous requests) ---
+  warmups (2):
+    w1-r0      wall=  15.52s  ttft=   124ms  toks=  943  wall_TPS=  60.74  decode_TPS=  61.23  itl_p50= 52.1ms  itl_p95= 54.6ms
+    w1-r1      wall=  15.34s  ttft=   123ms  toks= 1000  wall_TPS=  65.20  decode_TPS=  65.73  itl_p50= 52.1ms  itl_p95= 54.6ms
+    w1-r2      wall=  15.93s  ttft=   123ms  toks=  997  wall_TPS=  62.57  decode_TPS=  63.05  itl_p50= 52.0ms  itl_p95= 54.6ms
+    w1-r3      wall=  15.68s  ttft=   123ms  toks= 1000  wall_TPS=  63.78  decode_TPS=  64.29  itl_p50= 52.1ms  itl_p95= 54.6ms
+    w2-r0      wall=  15.10s  ttft=   111ms  toks=  878  wall_TPS=  58.16  decode_TPS=  58.59  itl_p50= 52.3ms  itl_p95= 54.8ms
+    w2-r1      wall=  16.01s  ttft=   111ms  toks= 1000  wall_TPS=  62.48  decode_TPS=  62.91  itl_p50= 52.2ms  itl_p95= 54.7ms
+    w2-r2      wall=  16.09s  ttft=   110ms  toks=  996  wall_TPS=  61.91  decode_TPS=  62.34  itl_p50= 52.2ms  itl_p95= 54.7ms
+    w2-r3      wall=  16.47s  ttft=   110ms  toks=  982  wall_TPS=  59.62  decode_TPS=  60.02  itl_p50= 52.1ms  itl_p95= 54.7ms
+  GPU during warmup narrative c=4 (32.4s, 220 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    85.8   21.6    23430    23430  219.2  219.6   73.5   74.0     1766
+       1    87.0   21.6    23430    23430  219.2  219.6   67.8   68.0     1847
+       2    88.5   21.5    23430    23430  219.3  219.8   73.1   74.0     1782
+       3    87.2   21.5    23430    23430  219.3  219.7   74.0   75.0     1805
+    r0         wall=  16.40s  ttft=   111ms  toks=  947  wall_TPS=  57.73  decode_TPS=  58.13  itl_p50= 52.5ms  itl_p95= 55.4ms
+    r1         wall=  16.54s  ttft=   111ms  toks= 1000  wall_TPS=  60.45  decode_TPS=  60.86  itl_p50= 52.5ms  itl_p95= 55.4ms
+    r2         wall=  16.45s  ttft=   111ms  toks= 1000  wall_TPS=  60.80  decode_TPS=  61.21  itl_p50= 52.5ms  itl_p95= 55.4ms
+    r3         wall=  16.13s  ttft=   110ms  toks= 1000  wall_TPS=  62.01  decode_TPS=  62.44  itl_p50= 52.6ms  itl_p95= 55.4ms
+  combined   wall_TPS= 238.59  decode_TPS= 242.64  avg_ttft=   111ms  itl_p50= 52.5ms  itl_p95= 55.4ms
+    r0         wall=  15.81s  ttft=   110ms  toks= 1000  wall_TPS=  63.27  decode_TPS=  63.71  itl_p50= 51.8ms  itl_p95= 54.4ms
+    r1         wall=  15.73s  ttft=   110ms  toks= 1000  wall_TPS=  63.57  decode_TPS=  64.02  itl_p50= 51.8ms  itl_p95= 54.5ms
+    r2         wall=  14.49s  ttft=   110ms  toks=  889  wall_TPS=  61.35  decode_TPS=  61.82  itl_p50= 52.0ms  itl_p95= 54.6ms
+    r3         wall=  15.84s  ttft=   110ms  toks=  966  wall_TPS=  60.98  decode_TPS=  61.40  itl_p50= 51.8ms  itl_p95= 54.5ms
+  combined   wall_TPS= 243.34  decode_TPS= 250.95  avg_ttft=   110ms  itl_p50= 51.9ms  itl_p95= 54.5ms
+    r0         wall=  15.29s  ttft=   112ms  toks=  902  wall_TPS=  58.98  decode_TPS=  59.41  itl_p50= 52.3ms  itl_p95= 54.6ms
+    r1         wall=  15.21s  ttft=   112ms  toks=  910  wall_TPS=  59.82  decode_TPS=  60.26  itl_p50= 52.3ms  itl_p95= 54.6ms
+    r2         wall=  14.57s  ttft=   112ms  toks=  828  wall_TPS=  56.83  decode_TPS=  57.27  itl_p50= 52.3ms  itl_p95= 54.6ms
+    r3         wall=  15.59s  ttft=   111ms  toks=  979  wall_TPS=  62.81  decode_TPS=  63.26  itl_p50= 52.2ms  itl_p95= 54.6ms
+  combined   wall_TPS= 232.18  decode_TPS= 240.20  avg_ttft=   112ms  itl_p50= 52.3ms  itl_p95= 54.6ms
+  GPU during measured narrative c=4 (48.0s, 328 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    86.7   21.8    23430    23430  219.3  219.6   73.4   74.0     1772
+       1    87.9   21.7    23430    23430  219.2  219.8   67.9   68.0     1852
+       2    88.6   21.4    23430    23430  219.3  219.7   73.0   73.0     1776
+       3    86.6   21.5    23430    23430  219.2  219.6   74.0   75.0     1801
+    total power avg=876.9 W   phase throughput=238.0 tok/s   efficiency: 0.2715 tok/W  (271.46 tok/kJ)
+
+  === summary [narrative c=4] (n=3) ===
+  combined wall_TPS    mean=  238.04   std=   5.60   CV= 2.4%   min=232.18   max=243.34
+  combined decode_TPS  mean=  244.60   std=   5.64   CV= 2.3%   min=240.20   max=250.95
+  per-req decode_TPS   mean=   61.15   std=   1.41   CV= 2.3%   min=60.05   max=62.74
+  avg TTFT (ms)        mean=  110.94ms   std=   0.72   CV= 0.7%   min=110.20   max=111.65
+  ITL p50 (ms)         mean=   52.23ms   std=   0.34   CV= 0.7%   min=51.86   max=52.54
+  ITL p95 (ms)         mean=   54.85ms   std=   0.51   CV= 0.9%   min=54.52   max=55.44
+
+--- Concurrency=8 (simultaneous requests) ---
+  warmups (2):
+    w1-r0      wall=  26.50s  ttft=   177ms  toks=  940  wall_TPS=  35.47  decode_TPS=  35.70  itl_p50= 86.7ms  itl_p95= 89.6ms
+    w1-r1      wall=  24.15s  ttft=   177ms  toks=  876  wall_TPS=  36.28  decode_TPS=  36.54  itl_p50= 87.0ms  itl_p95= 89.7ms
+    w1-r2      wall=  25.73s  ttft=   177ms  toks=  955  wall_TPS=  37.11  decode_TPS=  37.37  itl_p50= 86.8ms  itl_p95= 89.6ms
+    w1-r3      wall=  26.36s  ttft=   176ms  toks=  943  wall_TPS=  35.77  decode_TPS=  36.01  itl_p50= 86.7ms  itl_p95= 89.6ms
+    w1-r4      wall=  26.62s  ttft=   176ms  toks=  998  wall_TPS=  37.49  decode_TPS=  37.74  itl_p50= 86.7ms  itl_p95= 89.5ms
+    w1-r5      wall=  26.69s  ttft=   176ms  toks= 1000  wall_TPS=  37.46  decode_TPS=  37.71  itl_p50= 86.7ms  itl_p95= 89.5ms
+    w1-r6      wall=  26.09s  ttft=   176ms  toks=  906  wall_TPS=  34.73  decode_TPS=  34.96  itl_p50= 86.7ms  itl_p95= 89.6ms
+    w1-r7      wall=  25.95s  ttft=   175ms  toks=  948  wall_TPS=  36.53  decode_TPS=  36.78  itl_p50= 86.7ms  itl_p95= 89.6ms
+    w2-r0      wall=  27.86s  ttft=   242ms  toks= 1000  wall_TPS=  35.90  decode_TPS=  36.21  itl_p50= 86.6ms  itl_p95= 89.2ms
+    w2-r1      wall=  26.61s  ttft=    63ms  toks=  972  wall_TPS=  36.53  decode_TPS=  36.62  itl_p50= 86.7ms  itl_p95= 89.4ms
+    w2-r2      wall=  27.29s  ttft=   242ms  toks= 1000  wall_TPS=  36.65  decode_TPS=  36.98  itl_p50= 86.7ms  itl_p95= 89.3ms
+    w2-r3      wall=  27.76s  ttft=   242ms  toks= 1000  wall_TPS=  36.02  decode_TPS=  36.34  itl_p50= 86.7ms  itl_p95= 89.1ms
+    w2-r4      wall=  27.38s  ttft=   241ms  toks=  989  wall_TPS=  36.12  decode_TPS=  36.44  itl_p50= 86.7ms  itl_p95= 89.3ms
+    w2-r5      wall=  27.22s  ttft=   241ms  toks= 1000  wall_TPS=  36.73  decode_TPS=  37.06  itl_p50= 86.7ms  itl_p95= 89.4ms
+    w2-r6      wall=  26.97s  ttft=   241ms  toks=  952  wall_TPS=  35.30  decode_TPS=  35.61  itl_p50= 86.7ms  itl_p95= 89.3ms
+    w2-r7      wall=  26.44s  ttft=   240ms  toks=  944  wall_TPS=  35.70  decode_TPS=  36.03  itl_p50= 86.8ms  itl_p95= 89.2ms
+  GPU during warmup narrative c=8 (54.6s, 372 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    94.0   17.4    23430    23430  219.4  219.9   74.0   74.0     1784
+       1    94.7   17.3    23430    23430  219.2  219.7   68.0   68.0     1868
+       2    94.3   17.4    23430    23430  219.3  219.7   73.0   73.0     1803
+       3    94.3   17.3    23430    23430  219.2  219.7   74.3   75.0     1820
+    r0         wall=  25.54s  ttft=    70ms  toks=  928  wall_TPS=  36.33  decode_TPS=  36.43  itl_p50= 86.7ms  itl_p95= 89.4ms
+    r1         wall=  27.30s  ttft=   234ms  toks=  973  wall_TPS=  35.64  decode_TPS=  35.94  itl_p50= 86.5ms  itl_p95= 89.5ms
+    r2         wall=  26.84s  ttft=   234ms  toks= 1000  wall_TPS=  37.26  decode_TPS=  37.59  itl_p50= 86.7ms  itl_p95= 89.4ms
+    r3         wall=  26.35s  ttft=   233ms  toks=  983  wall_TPS=  37.31  decode_TPS=  37.64  itl_p50= 86.7ms  itl_p95= 89.5ms
+    r4         wall=  26.75s  ttft=   233ms  toks=  988  wall_TPS=  36.93  decode_TPS=  37.25  itl_p50= 86.7ms  itl_p95= 89.4ms
+    r5         wall=  25.04s  ttft=   233ms  toks=  858  wall_TPS=  34.26  decode_TPS=  34.59  itl_p50= 86.8ms  itl_p95= 89.5ms
+    r6         wall=  24.95s  ttft=   232ms  toks=  912  wall_TPS=  36.55  decode_TPS=  36.89  itl_p50= 86.8ms  itl_p95= 89.5ms
+    r7         wall=  26.57s  ttft=   232ms  toks= 1000  wall_TPS=  37.63  decode_TPS=  37.96  itl_p50= 86.7ms  itl_p95= 89.3ms
+  combined   wall_TPS= 279.89  decode_TPS= 294.30  avg_ttft=   213ms  itl_p50= 86.7ms  itl_p95= 89.4ms
+    r0         wall=  24.59s  ttft=   160ms  toks=  903  wall_TPS=  36.73  decode_TPS=  36.97  itl_p50= 87.0ms  itl_p95= 89.5ms
+    r1         wall=  24.91s  ttft=   160ms  toks=  905  wall_TPS=  36.33  decode_TPS=  36.56  itl_p50= 87.0ms  itl_p95= 89.4ms
+    r2         wall=  26.26s  ttft=   160ms  toks=  992  wall_TPS=  37.78  decode_TPS=  38.01  itl_p50= 86.8ms  itl_p95= 89.5ms
+    r3         wall=  26.57s  ttft=   160ms  toks=  980  wall_TPS=  36.89  decode_TPS=  37.11  itl_p50= 86.9ms  itl_p95= 89.6ms
+    r4         wall=  25.63s  ttft=   159ms  toks=  923  wall_TPS=  36.01  decode_TPS=  36.23  itl_p50= 87.0ms  itl_p95= 89.4ms
+    r5         wall=  26.42s  ttft=   159ms  toks=  939  wall_TPS=  35.54  decode_TPS=  35.76  itl_p50= 86.9ms  itl_p95= 89.5ms
+    r6         wall=  26.47s  ttft=   159ms  toks=  976  wall_TPS=  36.88  decode_TPS=  37.10  itl_p50= 86.9ms  itl_p95= 89.5ms
+    r7         wall=  26.37s  ttft=   158ms  toks= 1000  wall_TPS=  37.92  decode_TPS=  38.15  itl_p50= 86.9ms  itl_p95= 89.4ms
+  combined   wall_TPS= 286.74  decode_TPS= 295.90  avg_ttft=   159ms  itl_p50= 86.9ms  itl_p95= 89.5ms
+    r0         wall=  26.38s  ttft=   164ms  toks=  967  wall_TPS=  36.66  decode_TPS=  36.89  itl_p50= 86.6ms  itl_p95= 89.4ms
+    r1         wall=  25.14s  ttft=   164ms  toks=  956  wall_TPS=  38.03  decode_TPS=  38.28  itl_p50= 86.8ms  itl_p95= 89.6ms
+    r2         wall=  25.57s  ttft=   164ms  toks=  997  wall_TPS=  38.99  decode_TPS=  39.24  itl_p50= 86.8ms  itl_p95= 89.3ms
+    r3         wall=  26.90s  ttft=   164ms  toks=  994  wall_TPS=  36.95  decode_TPS=  37.18  itl_p50= 86.6ms  itl_p95= 89.2ms
+    r4         wall=  26.38s  ttft=   163ms  toks=  977  wall_TPS=  37.04  decode_TPS=  37.27  itl_p50= 86.6ms  itl_p95= 89.4ms
+    r5         wall=  26.00s  ttft=   163ms  toks=  948  wall_TPS=  36.46  decode_TPS=  36.69  itl_p50= 86.7ms  itl_p95= 89.3ms
+    r6         wall=  26.50s  ttft=   163ms  toks= 1000  wall_TPS=  37.73  decode_TPS=  37.96  itl_p50= 86.7ms  itl_p95= 89.5ms
+    r7         wall=  24.89s  ttft=   163ms  toks=  921  wall_TPS=  37.00  decode_TPS=  37.24  itl_p50= 86.8ms  itl_p95= 89.6ms
+  combined   wall_TPS= 288.48  decode_TPS= 300.74  avg_ttft=   163ms  itl_p50= 86.7ms  itl_p95= 89.4ms
+  GPU during measured narrative c=8 (80.8s, 548 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    93.8   17.5    23430    23430  219.4  219.8   73.6   74.0     1784
+       1    94.6   17.5    23430    23430  219.3  219.8   67.7   68.0     1863
+       2    94.4   17.4    23430    23430  219.3  220.1   72.9   73.0     1802
+       3    94.2   17.5    23430    23430  219.3  219.8   74.0   75.0     1819
+    total power avg=877.3 W   phase throughput=285.0 tok/s   efficiency: 0.3248 tok/W  (324.83 tok/kJ)
+
+  === summary [narrative c=8] (n=3) ===
+  combined wall_TPS    mean=  285.04   std=   4.54   CV= 1.6%   min=279.89   max=288.48
+  combined decode_TPS  mean=  296.98   std=   3.36   CV= 1.1%   min=294.30   max=300.74
+  per-req decode_TPS   mean=   37.12   std=   0.42   CV= 1.1%   min=36.79   max=37.59
+  avg TTFT (ms)        mean=  178.38ms   std=  29.64   CV=16.6%   min=159.21   max=212.52
+  ITL p50 (ms)         mean=   86.76ms   std=   0.12   CV= 0.1%   min=86.69   max=86.90
+  ITL p95 (ms)         mean=   89.45ms   std=   0.03   CV= 0.0%   min=89.43   max=89.49
+
+--- Concurrency=16 (simultaneous requests) ---
+  warmups (2):
+    w1-r0      wall=  31.67s  ttft=   186ms  toks= 1000  wall_TPS=  31.58  decode_TPS=  31.76  itl_p50=102.2ms  itl_p95=104.5ms
+    w1-r1      wall=  30.81s  ttft=   186ms  toks=  949  wall_TPS=  30.80  decode_TPS=  30.99  itl_p50=102.3ms  itl_p95=104.5ms
+    w1-r2      wall=  30.90s  ttft=   185ms  toks=  951  wall_TPS=  30.78  decode_TPS=  30.96  itl_p50=102.2ms  itl_p95=104.5ms
+    w1-r3      wall=  31.23s  ttft=   185ms  toks=  956  wall_TPS=  30.61  decode_TPS=  30.79  itl_p50=102.3ms  itl_p95=104.8ms
+    w1-r4      wall=  31.13s  ttft=   185ms  toks=  920  wall_TPS=  29.56  decode_TPS=  29.73  itl_p50=102.1ms  itl_p95=104.8ms
+    w1-r5      wall=  30.15s  ttft=   184ms  toks=  892  wall_TPS=  29.58  decode_TPS=  29.76  itl_p50=102.3ms  itl_p95=104.5ms
+    w1-r6      wall=  32.14s  ttft=   184ms  toks=  971  wall_TPS=  30.21  decode_TPS=  30.39  itl_p50=102.1ms  itl_p95=104.6ms
+    w1-r7      wall=  32.05s  ttft=   184ms  toks=  982  wall_TPS=  30.64  decode_TPS=  30.81  itl_p50=102.1ms  itl_p95=104.6ms
+    w1-r8      wall=  32.00s  ttft=   183ms  toks= 1000  wall_TPS=  31.25  decode_TPS=  31.43  itl_p50=102.1ms  itl_p95=104.8ms
+    w1-r9      wall=  31.23s  ttft=   468ms  toks= 1000  wall_TPS=  32.02  decode_TPS=  32.51  itl_p50=102.2ms  itl_p95=104.7ms
+    w1-r10     wall=  32.24s  ttft=   469ms  toks= 1000  wall_TPS=  31.01  decode_TPS=  31.47  itl_p50=102.1ms  itl_p95=104.5ms
+    w1-r11     wall=  31.01s  ttft=   468ms  toks= 1000  wall_TPS=  32.24  decode_TPS=  32.74  itl_p50=102.1ms  itl_p95=104.5ms
+    w1-r12     wall=  29.94s  ttft=   468ms  toks= 1000  wall_TPS=  33.40  decode_TPS=  33.93  itl_p50=102.2ms  itl_p95=104.3ms
+    w1-r13     wall=  31.66s  ttft=   467ms  toks=  920  wall_TPS=  29.05  decode_TPS=  29.49  itl_p50=102.2ms  itl_p95=104.5ms
+    w1-r14     wall=  30.43s  ttft=   468ms  toks=  946  wall_TPS=  31.08  decode_TPS=  31.57  itl_p50=102.2ms  itl_p95=104.4ms
+    w1-r15     wall=  29.13s  ttft=   467ms  toks=  894  wall_TPS=  30.69  decode_TPS=  31.19  itl_p50=102.2ms  itl_p95=104.4ms
+    w2-r0      wall=  28.95s  ttft=    74ms  toks=  942  wall_TPS=  32.54  decode_TPS=  32.63  itl_p50=102.3ms  itl_p95=104.4ms
+    w2-r1      wall=  32.02s  ttft=   362ms  toks= 1000  wall_TPS=  31.23  decode_TPS=  31.59  itl_p50=102.2ms  itl_p95=104.4ms
+    w2-r2      wall=  32.02s  ttft=   361ms  toks=  961  wall_TPS=  30.02  decode_TPS=  30.36  itl_p50=102.2ms  itl_p95=104.5ms
+    w2-r3      wall=  30.06s  ttft=   361ms  toks=  924  wall_TPS=  30.74  decode_TPS=  31.12  itl_p50=102.3ms  itl_p95=104.3ms
+    w2-r4      wall=  31.22s  ttft=   361ms  toks=  980  wall_TPS=  31.39  decode_TPS=  31.76  itl_p50=102.3ms  itl_p95=104.4ms
+    w2-r5      wall=  31.12s  ttft=   360ms  toks=  965  wall_TPS=  31.01  decode_TPS=  31.37  itl_p50=102.2ms  itl_p95=104.4ms
+    w2-r6      wall=  32.21s  ttft=   360ms  toks=  950  wall_TPS=  29.49  decode_TPS=  29.83  itl_p50=102.2ms  itl_p95=104.5ms
+    w2-r7      wall=  31.22s  ttft=   360ms  toks=  947  wall_TPS=  30.33  decode_TPS=  30.69  itl_p50=102.2ms  itl_p95=104.3ms
+    w2-r8      wall=  32.74s  ttft=   359ms  toks=  949  wall_TPS=  28.99  decode_TPS=  29.31  itl_p50=102.2ms  itl_p95=104.4ms
+    w2-r9      wall=  31.62s  ttft=   359ms  toks=  973  wall_TPS=  30.77  decode_TPS=  31.13  itl_p50=102.3ms  itl_p95=104.6ms
+    w2-r10     wall=  31.51s  ttft=   359ms  toks=  893  wall_TPS=  28.34  decode_TPS=  28.66  itl_p50=102.2ms  itl_p95=104.4ms
+    w2-r11     wall=  31.22s  ttft=   358ms  toks= 1000  wall_TPS=  32.03  decode_TPS=  32.40  itl_p50=102.2ms  itl_p95=104.5ms
+    w2-r12     wall=  31.12s  ttft=   358ms  toks=  895  wall_TPS=  28.76  decode_TPS=  29.09  itl_p50=102.2ms  itl_p95=104.3ms
+    w2-r13     wall=  32.37s  ttft=   357ms  toks=  997  wall_TPS=  30.80  decode_TPS=  31.14  itl_p50=102.2ms  itl_p95=104.4ms
+    w2-r14     wall=  31.86s  ttft=   357ms  toks=  990  wall_TPS=  31.07  decode_TPS=  31.42  itl_p50=102.2ms  itl_p95=104.4ms
+    w2-r15     wall=  31.94s  ttft=   357ms  toks= 1000  wall_TPS=  31.31  decode_TPS=  31.66  itl_p50=102.2ms  itl_p95=104.3ms
+  GPU during warmup narrative c=16 (65.0s, 444 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    94.6   22.1    23430    23430  219.5  220.1   73.0   73.0     1696
+       1    95.2   22.0    23430    23430  219.3  220.1   67.0   67.0     1791
+       2    95.1   22.0    23430    23430  219.4  220.0   72.9   73.0     1710
+       3    95.0   22.1    23430    23430  219.4  220.0   74.0   74.0     1728
+    r0         wall=  32.47s  ttft=   162ms  toks= 1000  wall_TPS=  30.79  decode_TPS=  30.95  itl_p50=102.0ms  itl_p95=104.8ms
+    r1         wall=  32.58s  ttft=   162ms  toks=  984  wall_TPS=  30.21  decode_TPS=  30.36  itl_p50=102.0ms  itl_p95=104.7ms
+    r2         wall=  32.21s  ttft=   162ms  toks=  985  wall_TPS=  30.58  decode_TPS=  30.74  itl_p50=102.1ms  itl_p95=104.7ms
+    r3         wall=  28.58s  ttft=   162ms  toks=  913  wall_TPS=  31.95  decode_TPS=  32.13  itl_p50=102.0ms  itl_p95=104.5ms
+    r4         wall=  30.91s  ttft=   161ms  toks=  930  wall_TPS=  30.09  decode_TPS=  30.25  itl_p50=102.1ms  itl_p95=104.6ms
+    r5         wall=  28.37s  ttft=   161ms  toks=  868  wall_TPS=  30.60  decode_TPS=  30.77  itl_p50=102.2ms  itl_p95=104.4ms
+    r6         wall=  32.12s  ttft=   160ms  toks=  974  wall_TPS=  30.32  decode_TPS=  30.47  itl_p50=102.1ms  itl_p95=104.6ms
+    r7         wall=  30.24s  ttft=   161ms  toks=  959  wall_TPS=  31.72  decode_TPS=  31.89  itl_p50=102.0ms  itl_p95=104.6ms
+    r8         wall=  32.52s  ttft=   253ms  toks=  990  wall_TPS=  30.44  decode_TPS=  30.68  itl_p50=102.0ms  itl_p95=104.8ms
+    r9         wall=  32.72s  ttft=   424ms  toks= 1000  wall_TPS=  30.56  decode_TPS=  30.96  itl_p50=102.0ms  itl_p95=104.7ms
+    r10        wall=  30.14s  ttft=   423ms  toks=  948  wall_TPS=  31.45  decode_TPS=  31.90  itl_p50=102.0ms  itl_p95=104.5ms
+    r11        wall=  31.36s  ttft=   422ms  toks=  925  wall_TPS=  29.49  decode_TPS=  29.90  itl_p50=102.0ms  itl_p95=104.6ms
+    r12        wall=  32.21s  ttft=   422ms  toks=  987  wall_TPS=  30.65  decode_TPS=  31.05  itl_p50=102.0ms  itl_p95=104.7ms
+    r13        wall=  32.62s  ttft=   422ms  toks= 1000  wall_TPS=  30.66  decode_TPS=  31.06  itl_p50=102.1ms  itl_p95=104.6ms
+    r14        wall=  30.69s  ttft=   422ms  toks=  960  wall_TPS=  31.28  decode_TPS=  31.71  itl_p50=102.1ms  itl_p95=104.4ms
+    r15        wall=  31.58s  ttft=   421ms  toks=  981  wall_TPS=  31.07  decode_TPS=  31.49  itl_p50=102.0ms  itl_p95=104.8ms
+  combined   wall_TPS= 470.73  decode_TPS= 496.30  avg_ttft=   281ms  itl_p50=102.0ms  itl_p95=104.6ms
+    r0         wall=  31.77s  ttft=    78ms  toks=  972  wall_TPS=  30.59  decode_TPS=  30.67  itl_p50=102.2ms  itl_p95=105.3ms
+    r1         wall=  32.25s  ttft=   344ms  toks=  973  wall_TPS=  30.17  decode_TPS=  30.50  itl_p50=102.2ms  itl_p95=105.0ms
+    r2         wall=  30.56s  ttft=   344ms  toks=  936  wall_TPS=  30.63  decode_TPS=  30.98  itl_p50=102.2ms  itl_p95=105.0ms
+    r3         wall=  32.05s  ttft=   343ms  toks=  894  wall_TPS=  27.89  decode_TPS=  28.19  itl_p50=102.2ms  itl_p95=105.4ms
+    r4         wall=  32.05s  ttft=   344ms  toks=  989  wall_TPS=  30.86  decode_TPS=  31.19  itl_p50=102.2ms  itl_p95=104.8ms
+    r5         wall=  31.92s  ttft=   343ms  toks=  992  wall_TPS=  31.08  decode_TPS=  31.41  itl_p50=102.2ms  itl_p95=104.9ms
+    r6         wall=  31.06s  ttft=   343ms  toks=  936  wall_TPS=  30.14  decode_TPS=  30.47  itl_p50=102.3ms  itl_p95=105.1ms
+    r7         wall=  30.36s  ttft=   342ms  toks= 1000  wall_TPS=  32.93  decode_TPS=  33.31  itl_p50=102.2ms  itl_p95=105.0ms
+    r8         wall=  31.45s  ttft=   342ms  toks=  959  wall_TPS=  30.49  decode_TPS=  30.83  itl_p50=102.2ms  itl_p95=105.1ms
+    r9         wall=  32.47s  ttft=   342ms  toks=  959  wall_TPS=  29.54  decode_TPS=  29.85  itl_p50=102.1ms  itl_p95=104.9ms
+    r10        wall=  30.56s  ttft=   341ms  toks=  942  wall_TPS=  30.83  decode_TPS=  31.17  itl_p50=102.2ms  itl_p95=105.0ms
+    r11        wall=  30.74s  ttft=   341ms  toks=  923  wall_TPS=  30.02  decode_TPS=  30.36  itl_p50=102.3ms  itl_p95=104.7ms
+    r12        wall=  31.17s  ttft=   341ms  toks=  955  wall_TPS=  30.64  decode_TPS=  30.98  itl_p50=102.2ms  itl_p95=105.1ms
+    r13        wall=  29.35s  ttft=   341ms  toks=  921  wall_TPS=  31.38  decode_TPS=  31.75  itl_p50=102.3ms  itl_p95=104.9ms
+    r14        wall=  32.36s  ttft=   341ms  toks=  979  wall_TPS=  30.25  decode_TPS=  30.57  itl_p50=102.3ms  itl_p95=105.1ms
+    r15        wall=  30.74s  ttft=   340ms  toks= 1000  wall_TPS=  32.53  decode_TPS=  32.89  itl_p50=102.2ms  itl_p95=105.0ms
+  combined   wall_TPS= 472.19  decode_TPS= 495.13  avg_ttft=   325ms  itl_p50=102.2ms  itl_p95=105.1ms
+    r0         wall=  30.38s  ttft=   160ms  toks=  956  wall_TPS=  31.47  decode_TPS=  31.63  itl_p50=102.3ms  itl_p95=104.8ms
+    r1         wall=  32.10s  ttft=   160ms  toks= 1000  wall_TPS=  31.15  decode_TPS=  31.31  itl_p50=102.2ms  itl_p95=104.5ms
+    r2         wall=  31.89s  ttft=   160ms  toks=  939  wall_TPS=  29.44  decode_TPS=  29.59  itl_p50=102.2ms  itl_p95=104.6ms
+    r3         wall=  31.89s  ttft=   160ms  toks= 1000  wall_TPS=  31.35  decode_TPS=  31.51  itl_p50=102.2ms  itl_p95=104.6ms
+    r4         wall=  32.18s  ttft=   160ms  toks=  972  wall_TPS=  30.21  decode_TPS=  30.36  itl_p50=102.2ms  itl_p95=104.7ms
+    r5         wall=  31.89s  ttft=   159ms  toks= 1000  wall_TPS=  31.35  decode_TPS=  31.51  itl_p50=102.2ms  itl_p95=104.6ms
+    r6         wall=  31.52s  ttft=   159ms  toks=  965  wall_TPS=  30.62  decode_TPS=  30.77  itl_p50=102.2ms  itl_p95=104.8ms
+    r7         wall=  30.76s  ttft=   283ms  toks=  943  wall_TPS=  30.66  decode_TPS=  30.94  itl_p50=102.2ms  itl_p95=104.4ms
+    r8         wall=  29.98s  ttft=   481ms  toks=  929  wall_TPS=  30.98  decode_TPS=  31.49  itl_p50=102.3ms  itl_p95=104.6ms
+    r9         wall=  29.48s  ttft=   480ms  toks=  934  wall_TPS=  31.69  decode_TPS=  32.21  itl_p50=102.3ms  itl_p95=104.5ms
+    r10        wall=  31.52s  ttft=   480ms  toks=  959  wall_TPS=  30.43  decode_TPS=  30.90  itl_p50=102.2ms  itl_p95=104.6ms
+    r11        wall=  31.03s  ttft=   479ms  toks=  881  wall_TPS=  28.39  decode_TPS=  28.84  itl_p50=102.2ms  itl_p95=104.4ms
+    r12        wall=  31.03s  ttft=   480ms  toks=  918  wall_TPS=  29.58  decode_TPS=  30.05  itl_p50=102.2ms  itl_p95=104.4ms
+    r13        wall=  31.03s  ttft=   479ms  toks=  948  wall_TPS=  30.55  decode_TPS=  31.03  itl_p50=102.3ms  itl_p95=104.6ms
+    r14        wall=  32.53s  ttft=   480ms  toks= 1000  wall_TPS=  30.74  decode_TPS=  31.20  itl_p50=102.1ms  itl_p95=104.5ms
+    r15        wall=  31.32s  ttft=   479ms  toks=  929  wall_TPS=  29.66  decode_TPS=  30.12  itl_p50=102.2ms  itl_p95=104.5ms
+  combined   wall_TPS= 469.51  decode_TPS= 493.46  avg_ttft=   328ms  itl_p50=102.2ms  itl_p95=104.6ms
+  GPU during measured narrative c=16 (97.7s, 668 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    94.6   22.0    23430    23430  219.5  220.2   73.1   74.0     1695
+       1    95.2   22.0    23430    23430  219.3  220.0   67.0   67.0     1789
+       2    95.2   21.9    23430    23430  219.5  220.0   73.0   73.0     1710
+       3    95.1   22.0    23430    23430  219.4  220.0   74.0   74.0     1725
+    total power avg=877.7 W   phase throughput=470.7 tok/s   efficiency: 0.5363 tok/W  (536.27 tok/kJ)
+
+  === summary [narrative c=16] (n=3) ===
+  combined wall_TPS    mean=  470.81   std=   1.34   CV= 0.3%   min=469.51   max=472.19
+  combined decode_TPS  mean=  494.96   std=   1.43   CV= 0.3%   min=493.46   max=496.30
+  per-req decode_TPS   mean=   30.93   std=   0.09   CV= 0.3%   min=30.84   max=31.02
+  avg TTFT (ms)        mean=  311.42ms   std=  26.14   CV= 8.4%   min=281.26   max=327.53
+  ITL p50 (ms)         mean=  102.16ms   std=   0.10   CV= 0.1%   min=102.05   max=102.22
+  ITL p95 (ms)         mean=  104.76ms   std=   0.27   CV= 0.3%   min=104.58   max=105.06
+
+  === vLLM log metrics (last 15 entries, narrative) ===
+  PP tok/s             mean=   10.67tok/s   std=  18.31   CV=171.7%   min=0.00   max=40.00
+  GP tok/s             mean=  474.65tok/s   std=  39.84   CV= 8.4%   min=399.70   max=519.80
+  E2E ms               n/a (log scrape unavailable)
+  queue ms             n/a (log scrape unavailable)
+  inference ms         n/a (log scrape unavailable)
+
+========================================================================
+  DECODE SATURATION — CODE (prompt=78 chars, max_tokens=800)
+========================================================================
+
+--- Concurrency=1 (simultaneous requests) ---
+  warmups (2):
+    w1-r0      wall=   3.89s  ttft=    60ms  toks=  712  wall_TPS= 182.97  decode_TPS= 185.82  itl_p50= 31.2ms  itl_p95= 35.3ms
+    w2-r0      wall=   4.53s  ttft=    81ms  toks=  800  wall_TPS= 176.69  decode_TPS= 179.91  itl_p50= 31.2ms  itl_p95= 34.2ms
+  GPU during warmup code c=1 (8.4s, 60 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    72.3   27.7    23430    23430  218.5  219.1   73.0   73.0     1742
+       1    77.5   27.9    23430    23430  218.3  218.9   67.0   67.0     1820
+       2    76.4   28.1    23430    23430  218.4  219.4   73.0   73.0     1745
+       3    74.9   27.8    23430    23430  218.5  219.2   73.1   74.0     1785
+    r0         wall=   3.07s  ttft=    59ms  toks=  614  wall_TPS= 199.70  decode_TPS= 203.60  itl_p50= 31.6ms  itl_p95= 36.1ms
+  combined   wall_TPS= 199.70  decode_TPS= 203.60  avg_ttft=    59ms  itl_p50= 31.6ms  itl_p95= 36.1ms
+    r0         wall=   4.46s  ttft=    86ms  toks=  800  wall_TPS= 179.23  decode_TPS= 182.76  itl_p50= 31.0ms  itl_p95= 34.3ms
+  combined   wall_TPS= 179.23  decode_TPS= 182.76  avg_ttft=    86ms  itl_p50= 31.0ms  itl_p95= 34.3ms
+    r0         wall=   4.83s  ttft=    88ms  toks=  800  wall_TPS= 165.59  decode_TPS= 168.67  itl_p50= 31.3ms  itl_p95= 34.9ms
+  combined   wall_TPS= 165.59  decode_TPS= 168.67  avg_ttft=    88ms  itl_p50= 31.3ms  itl_p95= 34.9ms
+  GPU during measured code c=1 (12.4s, 84 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    73.9   27.5    23430    23430  218.7  219.5   73.0   73.0     1744
+       1    77.0   28.0    23430    23430  218.5  219.1   67.0   67.0     1823
+       2    77.1   27.8    23430    23430  218.8  219.4   72.9   73.0     1756
+       3    72.3   27.8    23430    23430  218.6  219.2   73.0   73.0     1792
+    total power avg=874.6 W   phase throughput=179.0 tok/s   efficiency: 0.2046 tok/W  (204.62 tok/kJ)
+
+  === summary [code c=1] (n=3) ===
+  combined wall_TPS    mean=  181.50   std=  17.17   CV= 9.5%   min=165.59   max=199.70
+  combined decode_TPS  mean=  185.01   std=  17.57   CV= 9.5%   min=168.67   max=203.60
+  per-req decode_TPS   mean=  185.01   std=  17.57   CV= 9.5%   min=168.67   max=203.60
+  avg TTFT (ms)        mean=   77.78ms   std=  16.38   CV=21.1%   min=58.90   max=88.17
+  ITL p50 (ms)         mean=   31.30ms   std=   0.32   CV= 1.0%   min=30.97   max=31.61
+  ITL p95 (ms)         mean=   35.09ms   std=   0.91   CV= 2.6%   min=34.31   max=36.09
+
+--- Concurrency=2 (simultaneous requests) ---
+  warmups (2):
+    w1-r0      wall=   4.48s  ttft=   105ms  toks=  630  wall_TPS= 140.54  decode_TPS= 143.90  itl_p50= 37.0ms  itl_p95= 39.3ms
+    w1-r1      wall=   5.22s  ttft=   105ms  toks=  800  wall_TPS= 153.25  decode_TPS= 156.38  itl_p50= 36.9ms  itl_p95= 39.3ms
+    w2-r0      wall=   5.22s  ttft=    59ms  toks=  800  wall_TPS= 153.14  decode_TPS= 154.89  itl_p50= 37.1ms  itl_p95= 40.1ms
+    w2-r1      wall=   5.60s  ttft=   160ms  toks=  800  wall_TPS= 142.93  decode_TPS= 147.14  itl_p50= 37.0ms  itl_p95= 39.7ms
+  GPU during warmup code c=2 (10.8s, 76 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    78.0   25.7    23430    23430  219.0  219.5   73.0   73.0     1762
+       1    78.8   25.6    23430    23430  218.5  219.4   67.0   67.0     1847
+       2    80.1   25.4    23430    23430  218.9  219.3   73.0   73.0     1763
+       3    78.3   25.8    23430    23430  218.8  219.4   73.4   74.0     1797
+    r0         wall=   5.46s  ttft=   107ms  toks=  800  wall_TPS= 146.61  decode_TPS= 149.54  itl_p50= 36.9ms  itl_p95= 40.0ms
+    r1         wall=   4.40s  ttft=   107ms  toks=  633  wall_TPS= 143.74  decode_TPS= 147.30  itl_p50= 37.3ms  itl_p95= 40.1ms
+  combined   wall_TPS= 262.62  decode_TPS= 296.84  avg_ttft=   107ms  itl_p50= 37.1ms  itl_p95= 40.0ms
+    r0         wall=   4.64s  ttft=   105ms  toks=  706  wall_TPS= 152.14  decode_TPS= 155.65  itl_p50= 37.3ms  itl_p95= 40.7ms
+    r1         wall=   5.59s  ttft=   104ms  toks=  800  wall_TPS= 142.99  decode_TPS= 145.71  itl_p50= 37.0ms  itl_p95= 40.4ms
+  combined   wall_TPS= 269.18  decode_TPS= 301.36  avg_ttft=   105ms  itl_p50= 37.2ms  itl_p95= 40.7ms
+    r0         wall=   4.50s  ttft=   110ms  toks=  700  wall_TPS= 155.47  decode_TPS= 159.35  itl_p50= 37.6ms  itl_p95= 40.2ms
+    r1         wall=   4.72s  ttft=   109ms  toks=  701  wall_TPS= 148.52  decode_TPS= 152.04  itl_p50= 37.5ms  itl_p95= 40.2ms
+  combined   wall_TPS= 296.83  decode_TPS= 311.39  avg_ttft=   109ms  itl_p50= 37.5ms  itl_p95= 40.2ms
+  GPU during measured code c=2 (15.8s, 108 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    77.0   25.2    23430    23430  218.9  219.7   73.0   73.0     1756
+       1    80.0   25.1    23430    23430  218.6  219.5   67.0   67.0     1838
+       2    80.1   25.4    23430    23430  218.9  219.4   73.0   73.0     1768
+       3    79.8   25.7    23430    23430  218.9  219.6   73.5   74.0     1781
+    total power avg=875.3 W   phase throughput=275.1 tok/s   efficiency: 0.3143 tok/W  (314.32 tok/kJ)
+
+  === summary [code c=2] (n=3) ===
+  combined wall_TPS    mean=  276.21   std=  18.16   CV= 6.6%   min=262.62   max=296.83
+  combined decode_TPS  mean=  303.19   std=   7.45   CV= 2.5%   min=296.84   max=311.39
+  per-req decode_TPS   mean=  151.60   std=   3.72   CV= 2.5%   min=148.42   max=155.69
+  avg TTFT (ms)        mean=  106.87ms   std=   2.40   CV= 2.2%   min=104.60   max=109.39
+  ITL p50 (ms)         mean=   37.26ms   std=   0.24   CV= 0.6%   min=37.09   max=37.54
+  ITL p95 (ms)         mean=   40.28ms   std=   0.33   CV= 0.8%   min=40.02   max=40.66
+
+--- Concurrency=4 (simultaneous requests) ---
+  warmups (2):
+    w1-r0      wall=   3.63s  ttft=   115ms  toks=  446  wall_TPS= 122.88  decode_TPS= 126.91  itl_p50= 52.2ms  itl_p95= 54.7ms
+    w1-r1      wall=   6.26s  ttft=   115ms  toks=  800  wall_TPS= 127.71  decode_TPS= 130.10  itl_p50= 46.1ms  itl_p95= 54.1ms
+    w1-r2      wall=   4.50s  ttft=   115ms  toks=  436  wall_TPS=  96.98  decode_TPS=  99.52  itl_p50= 51.7ms  itl_p95= 54.5ms
+    w1-r3      wall=   4.58s  ttft=   115ms  toks=  443  wall_TPS=  96.75  decode_TPS=  99.23  itl_p50= 51.6ms  itl_p95= 54.6ms
+    w2-r0      wall=   7.40s  ttft=    63ms  toks=  800  wall_TPS= 108.15  decode_TPS= 109.09  itl_p50= 52.0ms  itl_p95= 54.5ms
+    w2-r1      wall=   7.13s  ttft=   221ms  toks=  800  wall_TPS= 112.21  decode_TPS= 115.80  itl_p50= 52.1ms  itl_p95= 54.5ms
+    w2-r2      wall=   7.94s  ttft=   221ms  toks=  800  wall_TPS= 100.80  decode_TPS= 103.69  itl_p50= 51.8ms  itl_p95= 54.3ms
+    w2-r3      wall=   6.26s  ttft=   221ms  toks=  637  wall_TPS= 101.74  decode_TPS= 105.46  itl_p50= 52.3ms  itl_p95= 54.5ms
+  GPU during warmup code c=4 (14.2s, 100 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    82.8   22.3    23430    23430  219.0  219.5   73.0   73.0     1776
+       1    85.9   22.7    23430    23430  219.0  219.8   67.0   67.0     1853
+       2    86.2   22.9    23430    23430  219.1  219.7   73.0   73.0     1775
+       3    83.4   23.1    23430    23430  219.1  219.5   73.8   74.0     1804
+    r0         wall=   4.09s  ttft=   112ms  toks=  402  wall_TPS=  98.24  decode_TPS= 101.02  itl_p50= 51.8ms  itl_p95= 54.3ms
+    r1         wall=   6.36s  ttft=   112ms  toks=  800  wall_TPS= 125.75  decode_TPS= 128.00  itl_p50= 45.1ms  itl_p95= 53.6ms
+    r2         wall=   4.74s  ttft=   112ms  toks=  468  wall_TPS=  98.83  decode_TPS= 101.22  itl_p50= 51.5ms  itl_p95= 54.0ms
+    r3         wall=   3.21s  ttft=   112ms  toks=  336  wall_TPS= 104.81  decode_TPS= 108.60  itl_p50= 52.1ms  itl_p95= 55.1ms
+  combined   wall_TPS= 315.32  decode_TPS= 438.83  avg_ttft=   112ms  itl_p50= 51.5ms  itl_p95= 54.1ms
+    r0         wall=   3.37s  ttft=   117ms  toks=  344  wall_TPS= 102.06  decode_TPS= 105.74  itl_p50= 52.3ms  itl_p95= 54.1ms
+    r1         wall=   5.33s  ttft=   117ms  toks=  619  wall_TPS= 116.05  decode_TPS= 118.66  itl_p50= 51.5ms  itl_p95= 53.9ms
+    r2         wall=   6.46s  ttft=   117ms  toks=  800  wall_TPS= 123.88  decode_TPS= 126.17  itl_p50= 47.1ms  itl_p95= 53.7ms
+    r3         wall=   6.71s  ttft=   117ms  toks=  800  wall_TPS= 119.28  decode_TPS= 121.40  itl_p50= 46.4ms  itl_p95= 53.7ms
+  combined   wall_TPS= 382.14  decode_TPS= 471.97  avg_ttft=   117ms  itl_p50= 51.4ms  itl_p95= 53.9ms
+    r0         wall=   3.36s  ttft=   111ms  toks=  364  wall_TPS= 108.43  decode_TPS= 112.13  itl_p50= 52.0ms  itl_p95= 54.7ms
+    r1         wall=   6.46s  ttft=   111ms  toks=  759  wall_TPS= 117.42  decode_TPS= 119.46  itl_p50= 48.7ms  itl_p95= 54.5ms
+    r2         wall=   7.00s  ttft=   110ms  toks=  800  wall_TPS= 114.31  decode_TPS= 116.14  itl_p50= 46.9ms  itl_p95= 54.2ms
+    r3         wall=   7.07s  ttft=   110ms  toks=  800  wall_TPS= 113.19  decode_TPS= 114.99  itl_p50= 46.8ms  itl_p95= 54.2ms
+  combined   wall_TPS= 385.27  decode_TPS= 462.72  avg_ttft=   111ms  itl_p50= 50.9ms  itl_p95= 54.6ms
+  GPU during measured code c=4 (20.1s, 136 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    83.2   22.8    23430    23430  219.1  219.7   73.0   73.0     1764
+       1    85.9   22.7    23430    23430  219.0  219.7   67.0   68.0     1851
+       2    85.5   23.4    23430    23430  219.2  219.6   73.1   74.0     1765
+       3    84.4   22.6    23430    23430  219.1  219.9   73.9   74.0     1796
+    total power avg=876.4 W   phase throughput=362.1 tok/s   efficiency: 0.4131 tok/W  (413.11 tok/kJ)
+
+  === summary [code c=4] (n=3) ===
+  combined wall_TPS    mean=  360.91   std=  39.52   CV=10.9%   min=315.32   max=385.27
+  combined decode_TPS  mean=  457.84   std=  17.10   CV= 3.7%   min=438.83   max=471.97
+  per-req decode_TPS   mean=  114.46   std=   4.27   CV= 3.7%   min=109.71   max=117.99
+  avg TTFT (ms)        mean=  113.24ms   std=   3.50   CV= 3.1%   min=110.54   max=117.20
+  ITL p50 (ms)         mean=   51.27ms   std=   0.34   CV= 0.7%   min=50.87   max=51.49
+  ITL p95 (ms)         mean=   54.21ms   std=   0.34   CV= 0.6%   min=53.94   max=54.59
+
+--- Concurrency=8 (simultaneous requests) ---
+  warmups (2):
+    w1-r0      wall=  10.25s  ttft=   163ms  toks=  800  wall_TPS=  78.02  decode_TPS=  79.28  itl_p50= 72.1ms  itl_p95= 87.4ms
+    w1-r1      wall=   3.54s  ttft=   163ms  toks=  248  wall_TPS=  69.96  decode_TPS=  73.33  itl_p50= 86.5ms  itl_p95= 88.5ms
+    w1-r2      wall=   8.84s  ttft=   162ms  toks=  631  wall_TPS=  71.37  decode_TPS=  72.71  itl_p50= 78.9ms  itl_p95= 87.5ms
+    w1-r3      wall=   5.69s  ttft=   162ms  toks=  383  wall_TPS=  67.27  decode_TPS=  69.24  itl_p50= 86.0ms  itl_p95= 88.0ms
+    w1-r4      wall=   8.22s  ttft=   162ms  toks=  580  wall_TPS=  70.60  decode_TPS=  72.01  itl_p50= 79.5ms  itl_p95= 87.8ms
+    w1-r5      wall=  10.52s  ttft=   161ms  toks=  800  wall_TPS=  76.04  decode_TPS=  77.22  itl_p50= 70.9ms  itl_p95= 87.5ms
+    w1-r6      wall=   9.38s  ttft=   161ms  toks=  673  wall_TPS=  71.77  decode_TPS=  73.02  itl_p50= 78.4ms  itl_p95= 87.7ms
+    w1-r7      wall=  10.68s  ttft=   161ms  toks=  800  wall_TPS=  74.90  decode_TPS=  76.05  itl_p50= 70.4ms  itl_p95= 87.4ms
+    w2-r0      wall=   7.59s  ttft=   165ms  toks=  476  wall_TPS=  62.71  decode_TPS=  64.10  itl_p50= 86.6ms  itl_p95= 88.7ms
+    w2-r1      wall=   8.77s  ttft=   165ms  toks=  634  wall_TPS=  72.29  decode_TPS=  73.68  itl_p50= 86.2ms  itl_p95= 88.3ms
+    w2-r2      wall=   9.04s  ttft=   164ms  toks=  659  wall_TPS=  72.88  decode_TPS=  74.23  itl_p50= 86.0ms  itl_p95= 88.2ms
+    w2-r3      wall=   9.95s  ttft=   164ms  toks=  741  wall_TPS=  74.50  decode_TPS=  75.75  itl_p50= 85.3ms  itl_p95= 88.3ms
+    w2-r4      wall=   6.95s  ttft=   164ms  toks=  451  wall_TPS=  64.85  decode_TPS=  66.41  itl_p50= 86.7ms  itl_p95= 88.6ms
+    w2-r5      wall=  10.33s  ttft=   164ms  toks=  800  wall_TPS=  77.42  decode_TPS=  78.66  itl_p50= 80.5ms  itl_p95= 88.0ms
+    w2-r6      wall=  10.33s  ttft=   163ms  toks=  800  wall_TPS=  77.42  decode_TPS=  78.66  itl_p50= 80.7ms  itl_p95= 88.2ms
+    w2-r7      wall=   5.91s  ttft=   163ms  toks=  375  wall_TPS=  63.50  decode_TPS=  65.30  itl_p50= 87.0ms  itl_p95= 88.6ms
+  GPU during warmup code c=8 (21.0s, 144 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    91.3   18.7    23430    23430  219.2  219.8   73.2   74.0     1780
+       1    91.3   18.8    23430    23430  219.2  219.9   67.1   68.0     1860
+       2    92.8   18.9    23430    23430  219.3  219.9   73.2   74.0     1794
+       3    92.6   18.6    23430    23430  219.3  219.8   74.0   74.0     1805
+    r0         wall=   9.86s  ttft=   167ms  toks=  718  wall_TPS=  72.86  decode_TPS=  74.11  itl_p50= 79.7ms  itl_p95= 87.8ms
+    r1         wall=   4.08s  ttft=   167ms  toks=  279  wall_TPS=  68.42  decode_TPS=  71.34  itl_p50= 86.8ms  itl_p95= 88.5ms
+    r2         wall=  10.39s  ttft=   166ms  toks=  728  wall_TPS=  70.08  decode_TPS=  71.23  itl_p50= 79.6ms  itl_p95= 87.8ms
+    r3         wall=   8.67s  ttft=   166ms  toks=  616  wall_TPS=  71.07  decode_TPS=  72.46  itl_p50= 80.7ms  itl_p95= 88.1ms
+    r4         wall=  10.44s  ttft=   166ms  toks=  795  wall_TPS=  76.14  decode_TPS=  77.38  itl_p50= 79.5ms  itl_p95= 87.7ms
+    r5         wall=  10.98s  ttft=   166ms  toks=  800  wall_TPS=  72.86  decode_TPS=  73.97  itl_p50= 79.0ms  itl_p95= 87.7ms
+    r6         wall=  10.17s  ttft=   165ms  toks=  681  wall_TPS=  66.98  decode_TPS=  68.09  itl_p50= 79.7ms  itl_p95= 87.8ms
+    r7         wall=  10.63s  ttft=   166ms  toks=  800  wall_TPS=  75.24  decode_TPS=  76.43  itl_p50= 79.5ms  itl_p95= 87.7ms
+  combined   wall_TPS= 493.32  decode_TPS= 585.01  avg_ttft=   166ms  itl_p50= 79.7ms  itl_p95= 87.9ms
+    r0         wall=  10.27s  ttft=   166ms  toks=  717  wall_TPS=  69.79  decode_TPS=  70.93  itl_p50= 85.7ms  itl_p95= 88.5ms
+    r1         wall=   6.43s  ttft=   165ms  toks=  422  wall_TPS=  65.66  decode_TPS=  67.39  itl_p50= 87.0ms  itl_p95= 88.9ms
+    r2         wall=  11.26s  ttft=   165ms  toks=  789  wall_TPS=  70.10  decode_TPS=  71.14  itl_p50= 84.7ms  itl_p95= 88.4ms
+    r3         wall=  11.09s  ttft=   165ms  toks=  800  wall_TPS=  72.15  decode_TPS=  73.24  itl_p50= 85.1ms  itl_p95= 88.5ms
+    r4         wall=  11.49s  ttft=   165ms  toks=  800  wall_TPS=  69.62  decode_TPS=  70.63  itl_p50= 72.9ms  itl_p95= 88.1ms
+    r5         wall=   6.34s  ttft=   164ms  toks=  363  wall_TPS=  57.26  decode_TPS=  58.78  itl_p50= 86.8ms  itl_p95= 89.3ms
+    r6         wall=  11.49s  ttft=   163ms  toks=  800  wall_TPS=  69.62  decode_TPS=  70.63  itl_p50= 73.0ms  itl_p95= 88.3ms
+    r7         wall=  11.53s  ttft=   163ms  toks=  800  wall_TPS=  69.36  decode_TPS=  70.36  itl_p50= 71.8ms  itl_p95= 88.2ms
+  combined   wall_TPS= 476.08  decode_TPS= 553.10  avg_ttft=   164ms  itl_p50= 85.8ms  itl_p95= 88.4ms
+    r0         wall=  11.04s  ttft=   164ms  toks=  800  wall_TPS=  72.46  decode_TPS=  73.55  itl_p50= 82.8ms  itl_p95= 88.5ms
+    r1         wall=  10.10s  ttft=   164ms  toks=  739  wall_TPS=  73.13  decode_TPS=  74.34  itl_p50= 85.9ms  itl_p95= 89.1ms
+    r2         wall=  10.47s  ttft=   164ms  toks=  800  wall_TPS=  76.39  decode_TPS=  77.60  itl_p50= 85.6ms  itl_p95= 88.9ms
+    r3         wall=   6.85s  ttft=   163ms  toks=  416  wall_TPS=  60.72  decode_TPS=  62.21  itl_p50= 86.9ms  itl_p95= 89.6ms
+    r4         wall=  10.38s  ttft=   163ms  toks=  800  wall_TPS=  77.10  decode_TPS=  78.33  itl_p50= 85.7ms  itl_p95= 88.9ms
+    r5         wall=   9.17s  ttft=   162ms  toks=  603  wall_TPS=  65.78  decode_TPS=  66.96  itl_p50= 86.2ms  itl_p95= 89.3ms
+    r6         wall=  11.20s  ttft=   162ms  toks=  800  wall_TPS=  71.44  decode_TPS=  72.49  itl_p50= 79.1ms  itl_p95= 88.7ms
+    r7         wall=   6.44s  ttft=   162ms  toks=  420  wall_TPS=  65.18  decode_TPS=  66.86  itl_p50= 87.2ms  itl_p95= 89.7ms
+  combined   wall_TPS= 480.24  decode_TPS= 572.34  avg_ttft=   163ms  itl_p50= 86.0ms  itl_p95= 89.3ms
+  GPU during measured code c=8 (33.7s, 228 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    91.8   18.2    23430    23430  219.4  219.9   73.3   74.0     1777
+       1    93.3   18.5    23430    23430  219.3  219.7   67.1   68.0     1856
+       2    93.3   18.1    23430    23430  219.4  219.8   73.0   74.0     1793
+       3    93.1   18.3    23430    23430  219.4  219.7   74.0   75.0     1810
+    total power avg=877.4 W   phase throughput=482.9 tok/s   efficiency: 0.5504 tok/W  (550.41 tok/kJ)
+
+  === summary [code c=8] (n=3) ===
+  combined wall_TPS    mean=  483.21   std=   9.00   CV= 1.9%   min=476.08   max=493.32
+  combined decode_TPS  mean=  570.15   std=  16.07   CV= 2.8%   min=553.10   max=585.01
+  per-req decode_TPS   mean=   71.27   std=   2.01   CV= 2.8%   min=69.14   max=73.13
+  avg TTFT (ms)        mean=  164.53ms   std=   1.53   CV= 0.9%   min=163.08   max=166.13
+  ITL p50 (ms)         mean=   83.86ms   std=   3.59   CV= 4.3%   min=79.71   max=86.03
+  ITL p95 (ms)         mean=   88.53ms   std=   0.72   CV= 0.8%   min=87.89   max=89.31
+
+--- Concurrency=16 (simultaneous requests) ---
+  warmups (2):
+    w1-r0      wall=   4.63s  ttft=   150ms  toks=  273  wall_TPS=  58.91  decode_TPS=  60.88  itl_p50=101.7ms  itl_p95=104.6ms
+    w1-r1      wall=  10.26s  ttft=   150ms  toks=  534  wall_TPS=  52.05  decode_TPS=  52.82  itl_p50=101.7ms  itl_p95=116.3ms
+    w1-r2      wall=  12.33s  ttft=   150ms  toks=  727  wall_TPS=  58.97  decode_TPS=  59.70  itl_p50=101.2ms  itl_p95=114.1ms
+    w1-r3      wall=  12.55s  ttft=   150ms  toks=  800  wall_TPS=  63.74  decode_TPS=  64.51  itl_p50=101.1ms  itl_p95=113.9ms
+    w1-r4      wall=  12.99s  ttft=   150ms  toks=  800  wall_TPS=  61.59  decode_TPS=  62.31  itl_p50=101.0ms  itl_p95=112.9ms
+    w1-r5      wall=   9.01s  ttft=   149ms  toks=  465  wall_TPS=  51.62  decode_TPS=  52.49  itl_p50=101.8ms  itl_p95=118.3ms
+    w1-r6      wall=   5.04s  ttft=   265ms  toks=  279  wall_TPS=  55.40  decode_TPS=  58.47  itl_p50=101.7ms  itl_p95=103.8ms
+    w1-r7      wall=   5.51s  ttft=   453ms  toks=  305  wall_TPS=  55.39  decode_TPS=  60.36  itl_p50=101.8ms  itl_p95=103.3ms
+    w1-r8      wall=  13.95s  ttft=   454ms  toks=  800  wall_TPS=  57.35  decode_TPS=  59.28  itl_p50= 92.1ms  itl_p95=111.9ms
+    w1-r9      wall=  13.88s  ttft=   453ms  toks=  800  wall_TPS=  57.64  decode_TPS=  59.59  itl_p50= 92.4ms  itl_p95=112.1ms
+    w1-r10     wall=  13.57s  ttft=   454ms  toks=  800  wall_TPS=  58.94  decode_TPS=  60.98  itl_p50= 96.4ms  itl_p95=112.0ms
+    w1-r11     wall=  13.71s  ttft=   453ms  toks=  800  wall_TPS=  58.33  decode_TPS=  60.32  itl_p50= 93.5ms  itl_p95=112.0ms
+    w1-r12     wall=   9.63s  ttft=   453ms  toks=  542  wall_TPS=  56.26  decode_TPS=  59.04  itl_p50=101.8ms  itl_p95=113.4ms
+    w1-r13     wall=   5.03s  ttft=   452ms  toks=  273  wall_TPS=  54.22  decode_TPS=  59.57  itl_p50=101.7ms  itl_p95=103.6ms
+    w1-r14     wall=   6.76s  ttft=   452ms  toks=  367  wall_TPS=  54.26  decode_TPS=  58.14  itl_p50=101.4ms  itl_p95=103.2ms
+    w1-r15     wall=   7.21s  ttft=   452ms  toks=  364  wall_TPS=  50.45  decode_TPS=  53.82  itl_p50=101.4ms  itl_p95=104.3ms
+    w2-r0      wall=   8.92s  ttft=   206ms  toks=  463  wall_TPS=  51.93  decode_TPS=  53.16  itl_p50=101.8ms  itl_p95=105.2ms
+    w2-r1      wall=  13.97s  ttft=   206ms  toks=  800  wall_TPS=  57.26  decode_TPS=  58.11  itl_p50=101.2ms  itl_p95=110.0ms
+    w2-r2      wall=   5.88s  ttft=   206ms  toks=  314  wall_TPS=  53.36  decode_TPS=  55.29  itl_p50=102.3ms  itl_p95=105.5ms
+    w2-r3      wall=  13.49s  ttft=   206ms  toks=  711  wall_TPS=  52.72  decode_TPS=  53.54  itl_p50=101.2ms  itl_p95=110.1ms
+    w2-r4      wall=  12.60s  ttft=   205ms  toks=  764  wall_TPS=  60.63  decode_TPS=  61.64  itl_p50=101.5ms  itl_p95=110.5ms
+    w2-r5      wall=  14.13s  ttft=   205ms  toks=  800  wall_TPS=  56.62  decode_TPS=  57.46  itl_p50=100.9ms  itl_p95=110.2ms
+    w2-r6      wall=  13.49s  ttft=   205ms  toks=  749  wall_TPS=  55.54  decode_TPS=  56.39  itl_p50=101.5ms  itl_p95=110.3ms
+    w2-r7      wall=  14.17s  ttft=   205ms  toks=  800  wall_TPS=  56.47  decode_TPS=  57.30  itl_p50=101.0ms  itl_p95=109.6ms
+    w2-r8      wall=  10.98s  ttft=   204ms  toks=  594  wall_TPS=  54.08  decode_TPS=  55.11  itl_p50=101.8ms  itl_p95=110.3ms
+    w2-r9      wall=   9.01s  ttft=   204ms  toks=  483  wall_TPS=  53.61  decode_TPS=  54.85  itl_p50=101.8ms  itl_p95=104.8ms
+    w2-r10     wall=  13.41s  ttft=   203ms  toks=  800  wall_TPS=  59.68  decode_TPS=  60.60  itl_p50=101.4ms  itl_p95=110.2ms
+    w2-r11     wall=  13.87s  ttft=   309ms  toks=  800  wall_TPS=  57.66  decode_TPS=  58.98  itl_p50=101.3ms  itl_p95=110.4ms
+    w2-r12     wall=  11.19s  ttft=   462ms  toks=  592  wall_TPS=  52.88  decode_TPS=  55.16  itl_p50=101.7ms  itl_p95=110.4ms
+    w2-r13     wall=  10.00s  ttft=   461ms  toks=  535  wall_TPS=  53.48  decode_TPS=  56.06  itl_p50=101.6ms  itl_p95=104.0ms
+    w2-r14     wall=  10.00s  ttft=   461ms  toks=  547  wall_TPS=  54.68  decode_TPS=  57.31  itl_p50=101.7ms  itl_p95=104.7ms
+    w2-r15     wall=   8.81s  ttft=   461ms  toks=  438  wall_TPS=  49.72  decode_TPS=  52.46  itl_p50=101.8ms  itl_p95=104.8ms
+  GPU during warmup code c=16 (28.1s, 192 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    93.5   21.4    23430    23430  219.4  219.9   73.0   74.0     1718
+       1    94.1   21.4    23430    23430  219.3  220.0   67.0   68.0     1814
+       2    94.4   21.5    23430    23430  219.4  219.8   73.0   73.0     1730
+       3    94.4   21.4    23430    23430  219.4  219.8   74.0   74.0     1753
+    r0         wall=  14.65s  ttft=   163ms  toks=  800  wall_TPS=  54.60  decode_TPS=  55.22  itl_p50=101.7ms  itl_p95=121.1ms
+    r1         wall=  14.59s  ttft=   163ms  toks=  800  wall_TPS=  54.83  decode_TPS=  55.45  itl_p50=101.5ms  itl_p95=121.2ms
+    r2         wall=  13.27s  ttft=   163ms  toks=  666  wall_TPS=  50.20  decode_TPS=  50.83  itl_p50=102.0ms  itl_p95=121.1ms
+    r3         wall=   9.75s  ttft=   163ms  toks=  573  wall_TPS=  58.78  decode_TPS=  59.78  itl_p50=101.3ms  itl_p95=103.8ms
+    r4         wall=  14.21s  ttft=   162ms  toks=  800  wall_TPS=  56.29  decode_TPS=  56.94  itl_p50=101.8ms  itl_p95=121.1ms
+    r5         wall=  15.08s  ttft=   162ms  toks=  800  wall_TPS=  53.05  decode_TPS=  53.62  itl_p50=101.4ms  itl_p95=120.9ms
+    r6         wall=  10.81s  ttft=   162ms  toks=  639  wall_TPS=  59.12  decode_TPS=  60.02  itl_p50=101.4ms  itl_p95=121.7ms
+    r7         wall=  15.31s  ttft=   161ms  toks=  800  wall_TPS=  52.26  decode_TPS=  52.82  itl_p50=101.2ms  itl_p95=121.0ms
+    r8         wall=  14.89s  ttft=   256ms  toks=  800  wall_TPS=  53.74  decode_TPS=  54.68  itl_p50=101.7ms  itl_p95=120.9ms
+    r9         wall=  13.96s  ttft=   425ms  toks=  800  wall_TPS=  57.29  decode_TPS=  59.09  itl_p50=101.9ms  itl_p95=120.7ms
+    r10        wall=   6.75s  ttft=   425ms  toks=  350  wall_TPS=  51.88  decode_TPS=  55.37  itl_p50=101.8ms  itl_p95=103.9ms
+    r11        wall=  13.69s  ttft=   425ms  toks=  722  wall_TPS=  52.75  decode_TPS=  54.44  itl_p50=102.0ms  itl_p95=120.9ms
+    r12        wall=   5.84s  ttft=   425ms  toks=  308  wall_TPS=  52.76  decode_TPS=  56.90  itl_p50=102.2ms  itl_p95=103.9ms
+    r13        wall=   8.39s  ttft=   424ms  toks=  451  wall_TPS=  53.74  decode_TPS=  56.61  itl_p50=101.5ms  itl_p95=103.6ms
+    r14        wall=  14.13s  ttft=   424ms  toks=  789  wall_TPS=  55.84  decode_TPS=  57.57  itl_p50=101.8ms  itl_p95=120.9ms
+    r15        wall=   8.49s  ttft=   424ms  toks=  391  wall_TPS=  46.06  decode_TPS=  48.48  itl_p50=101.6ms  itl_p95=103.3ms
+  combined   wall_TPS= 685.22  decode_TPS= 887.81  avg_ttft=   283ms  itl_p50=101.7ms  itl_p95=120.5ms
+    r0         wall=  14.48s  ttft=   119ms  toks=  800  wall_TPS=  55.26  decode_TPS=  55.72  itl_p50=101.6ms  itl_p95=121.7ms
+    r1         wall=  12.82s  ttft=   119ms  toks=  663  wall_TPS=  51.72  decode_TPS=  52.20  itl_p50=102.0ms  itl_p95=121.9ms
+    r2         wall=  14.59s  ttft=   118ms  toks=  800  wall_TPS=  54.84  decode_TPS=  55.29  itl_p50=101.7ms  itl_p95=121.6ms
+    r3         wall=  12.70s  ttft=   118ms  toks=  681  wall_TPS=  53.62  decode_TPS=  54.13  itl_p50=102.1ms  itl_p95=121.9ms
+    r4         wall=  12.70s  ttft=   118ms  toks=  724  wall_TPS=  57.01  decode_TPS=  57.55  itl_p50=102.0ms  itl_p95=122.1ms
+    r5         wall=   9.88s  ttft=   226ms  toks=  473  wall_TPS=  47.87  decode_TPS=  48.99  itl_p50=101.8ms  itl_p95=104.3ms
+    r6         wall=  14.38s  ttft=   439ms  toks=  800  wall_TPS=  55.64  decode_TPS=  57.40  itl_p50=101.7ms  itl_p95=121.5ms
+    r7         wall=  14.88s  ttft=   438ms  toks=  800  wall_TPS=  53.76  decode_TPS=  55.40  itl_p50=101.5ms  itl_p95=121.5ms
+    r8         wall=   9.78s  ttft=   438ms  toks=  538  wall_TPS=  54.98  decode_TPS=  57.56  itl_p50=101.8ms  itl_p95=104.0ms
+    r9         wall=  14.27s  ttft=   438ms  toks=  800  wall_TPS=  56.07  decode_TPS=  57.85  itl_p50=101.7ms  itl_p95=121.4ms
+    r10        wall=   8.62s  ttft=   437ms  toks=  433  wall_TPS=  50.26  decode_TPS=  52.95  itl_p50=102.0ms  itl_p95=104.4ms
+    r11        wall=  10.42s  ttft=   437ms  toks=  550  wall_TPS=  52.77  decode_TPS=  55.08  itl_p50=101.7ms  itl_p95=104.7ms
+    r12        wall=  13.36s  ttft=   437ms  toks=  699  wall_TPS=  52.32  decode_TPS=  54.09  itl_p50=102.0ms  itl_p95=121.9ms
+    r13        wall=  13.58s  ttft=   436ms  toks=  791  wall_TPS=  58.23  decode_TPS=  60.16  itl_p50=101.8ms  itl_p95=121.5ms
+    r14        wall=   8.51s  ttft=   435ms  toks=  437  wall_TPS=  51.35  decode_TPS=  54.12  itl_p50=101.9ms  itl_p95=104.4ms
+    r15        wall=  13.36s  ttft=   435ms  toks=  690  wall_TPS=  51.65  decode_TPS=  53.39  itl_p50=102.0ms  itl_p95=121.6ms
+  combined   wall_TPS= 717.69  decode_TPS= 881.87  avg_ttft=   324ms  itl_p50=101.8ms  itl_p95=121.5ms
+    r0         wall=   7.50s  ttft=   350ms  toks=  374  wall_TPS=  49.89  decode_TPS=  52.33  itl_p50=101.9ms  itl_p95=105.1ms
+    r1         wall=  13.88s  ttft=    81ms  toks=  800  wall_TPS=  57.62  decode_TPS=  57.96  itl_p50=101.6ms  itl_p95=118.0ms
+    r2         wall=   7.20s  ttft=   350ms  toks=  406  wall_TPS=  56.42  decode_TPS=  59.31  itl_p50=102.0ms  itl_p95=104.4ms
+    r3         wall=  13.38s  ttft=   349ms  toks=  800  wall_TPS=  59.77  decode_TPS=  61.37  itl_p50=101.9ms  itl_p95=115.8ms
+    r4         wall=  13.95s  ttft=   349ms  toks=  754  wall_TPS=  54.04  decode_TPS=  55.43  itl_p50=101.6ms  itl_p95=112.3ms
+    r5         wall=   9.85s  ttft=   348ms  toks=  531  wall_TPS=  53.93  decode_TPS=  55.91  itl_p50=101.7ms  itl_p95=120.5ms
+    r6         wall=   9.03s  ttft=   349ms  toks=  435  wall_TPS=  48.18  decode_TPS=  50.12  itl_p50=101.7ms  itl_p95=104.1ms
+    r7         wall=   8.76s  ttft=   348ms  toks=  449  wall_TPS=  51.27  decode_TPS=  53.40  itl_p50=101.6ms  itl_p95=104.1ms
+    r8         wall=  10.08s  ttft=   348ms  toks=  483  wall_TPS=  47.92  decode_TPS=  49.64  itl_p50=101.7ms  itl_p95=120.9ms
+    r9         wall=  13.54s  ttft=   347ms  toks=  709  wall_TPS=  52.38  decode_TPS=  53.76  itl_p50=101.7ms  itl_p95=115.1ms
+    r10        wall=  13.38s  ttft=   347ms  toks=  660  wall_TPS=  49.32  decode_TPS=  50.63  itl_p50=101.7ms  itl_p95=116.4ms
+    r11        wall=  12.15s  ttft=   347ms  toks=  675  wall_TPS=  55.56  decode_TPS=  57.19  itl_p50=102.0ms  itl_p95=119.8ms
+    r12        wall=  13.32s  ttft=   347ms  toks=  800  wall_TPS=  60.06  decode_TPS=  61.67  itl_p50=101.8ms  itl_p95=116.5ms
+    r13        wall=  12.68s  ttft=   347ms  toks=  649  wall_TPS=  51.18  decode_TPS=  52.62  itl_p50=102.1ms  itl_p95=119.8ms
+    r14        wall=  12.51s  ttft=   346ms  toks=  602  wall_TPS=  48.11  decode_TPS=  49.48  itl_p50=101.9ms  itl_p95=119.7ms
+    r15        wall=   8.66s  ttft=   346ms  toks=  427  wall_TPS=  49.32  decode_TPS=  51.37  itl_p50=101.6ms  itl_p95=104.2ms
+  combined   wall_TPS= 684.75  decode_TPS= 872.18  avg_ttft=   331ms  itl_p50=101.8ms  itl_p95=110.8ms
+  GPU during measured code c=16 (44.2s, 300 samples):
+     GPU   util%  VRAM%  MiB avg  MiB max  W avg  W max  C avg  C max  MHz avg
+       0    94.4   21.7    23430    23430  219.4  220.2   73.1   74.0     1717
+       1    94.8   21.8    23430    23430  219.4  220.0   67.0   68.0     1808
+       2    94.7   21.8    23430    23430  219.4  219.8   73.0   73.0     1726
+       3    94.5   21.7    23430    23430  219.4  219.9   74.0   74.0     1745
+    total power avg=877.6 W   phase throughput=695.8 tok/s   efficiency: 0.7928 tok/W  (792.84 tok/kJ)
+
+  === summary [code c=16] (n=3) ===
+  combined wall_TPS    mean=  695.89   std=  18.88   CV= 2.7%   min=684.75   max=717.69
+  combined decode_TPS  mean=  880.62   std=   7.89   CV= 0.9%   min=872.18   max=887.81
+  per-req decode_TPS   mean=   55.04   std=   0.49   CV= 0.9%   min=54.51   max=55.49
+  avg TTFT (ms)        mean=  312.85ms   std=  26.06   CV= 8.3%   min=283.03   max=331.23
+  ITL p50 (ms)         mean=  101.76ms   std=   0.08   CV= 0.1%   min=101.67   max=101.83
+  ITL p95 (ms)         mean=  117.62ms   std=   5.90   CV= 5.0%   min=110.83   max=121.49
+
+  === vLLM log metrics (last 15 entries, code) ===
+  PP tok/s             mean=   22.00tok/s   std=  12.72   CV=57.8%   min=0.00   max=40.00
+  GP tok/s             mean=  560.00tok/s   std= 143.50   CV=25.6%   min=338.20   max=813.60
+  E2E ms               n/a (log scrape unavailable)
+  queue ms             n/a (log scrape unavailable)
+  inference ms         n/a (log scrape unavailable)
+
+  === vLLM server metrics (deltas, full bench) ===
+    prompt tokens processed:   103755
+    generation tokens emitted: 248595
+    server-side avg TTFT:           367 ms
+    server-side avg E2E:          16900 ms
+    spec-decode: draft=453859  accepted=183867  acceptance=40.5%  mean_accept_len=5.56 (log)
+    vllm:num_requests_running: 0.000
+    vllm:num_requests_waiting: 0.000
+
+========================================================================
+  FINAL SUMMARY
+========================================================================
+  Prefill (c=1, gen=16):
+      target   actual   ttft_ms  prefill_t/s
+         512      552       314       1758.0
+        1024     1054       566       1863.2
+        2048     2060      1079       1909.4
+        4096     4074      2132       1910.5
+        8192     8102      4262       1900.9
+       16384    16160      8629       1872.8
+
+  Decode saturation — narrative:
+       c  comb_dtps  req_dtps  ttft_ms  itl50_ms  itl95_ms   tok/W
+       1     100.80    100.80       84      31.2      35.2  0.1143
+       2     172.58     86.29      109      37.4      40.2  0.1915
+       4     244.60     61.15      111      52.2      54.9  0.2715
+       8     296.98     37.12      178      86.8      89.5  0.3248
+      16     494.96     30.93      311     102.2     104.8  0.5363
+
+  Decode saturation — code:
+       c  comb_dtps  req_dtps  ttft_ms  itl50_ms  itl95_ms   tok/W
+       1     185.01    185.01       78      31.3      35.1  0.2046
+       2     303.19    151.60      107      37.3      40.3  0.3143
+       4     457.84    114.46      113      51.3      54.2  0.4131
+       8     570.15     71.27      165      83.9      88.5  0.5504
+      16     880.62     55.04      313     101.8     117.6  0.7928
+
+=== Peak GPU temperature (whole run, 5092 samples) ===
+    GPU 0: peak 74.0 C
+    GPU 1: peak 68.0 C
+    GPU 2: peak 75.0 C
+    GPU 3: peak 75.0 C
+
+=== GPU state (post-test) ===
+0, 73, 27, 23430, 24576, 219.12, 220.00, 73, 1800
+1, 32, 13, 23430, 24576, 215.54, 220.00, 67, 1920
+2, 84, 28, 23430, 24576, 219.02, 220.00, 73, 1785
+3, 83, 23, 23430, 24576, 219.54, 220.00, 74, 1785
+
+=== Last 5 SpecDecoding metrics (per container) ===
+  --- vllm-q38-ar-w4a8-dflash2-tp4 ---
+(APIServer pid=1) INFO 08-19 12:29:36 [metrics.py:120] SpecDecoding metrics: Mean acceptance length: 5.65, Accepted throughput: 548.59 tokens/s, Drafted throughput: 826.68 tokens/s, Accepted: 5486 tokens, Drafted: 8267 tokens, Per-position acceptance rate: 0.917, 0.800, 0.717, 0.640, 0.585, 0.520, 0.466, Avg Draft acceptance rate: 66.4%
+(APIServer pid=1) INFO 08-19 12:29:46 [metrics.py:120] SpecDecoding metrics: Mean acceptance length: 5.55, Accepted throughput: 666.79 tokens/s, Drafted throughput: 1026.03 tokens/s, Accepted: 6669 tokens, Drafted: 10262 tokens, Per-position acceptance rate: 0.916, 0.813, 0.717, 0.634, 0.560, 0.484, 0.426, Avg Draft acceptance rate: 65.0%
+(APIServer pid=1) INFO 08-19 12:29:56 [metrics.py:120] SpecDecoding metrics: Mean acceptance length: 5.46, Accepted throughput: 508.49 tokens/s, Drafted throughput: 798.53 tokens/s, Accepted: 5086 tokens, Drafted: 7987 tokens, Per-position acceptance rate: 0.906, 0.798, 0.693, 0.613, 0.554, 0.479, 0.413, Avg Draft acceptance rate: 63.7%
+(APIServer pid=1) INFO 08-19 12:30:06 [metrics.py:120] SpecDecoding metrics: Mean acceptance length: 5.74, Accepted throughput: 559.45 tokens/s, Drafted throughput: 826.63 tokens/s, Accepted: 5595 tokens, Drafted: 8267 tokens, Per-position acceptance rate: 0.925, 0.834, 0.741, 0.664, 0.588, 0.517, 0.467, Avg Draft acceptance rate: 67.7%
+(APIServer pid=1) INFO 08-19 12:30:16 [metrics.py:120] SpecDecoding metrics: Mean acceptance length: 5.38, Accepted throughput: 627.05 tokens/s, Drafted throughput: 1002.32 tokens/s, Accepted: 6271 tokens, Drafted: 10024 tokens, Per-position acceptance rate: 0.896, 0.784, 0.690, 0.607, 0.541, 0.457, 0.404, Avg Draft acceptance rate: 62.6%

--- a/scripts/lib/profiles/patches.yml
+++ b/scripts/lib/profiles/patches.yml
@@ -1084,3 +1084,30 @@ patches:
   - <<: *genesis_env_patch
     id: genesis-pn59-streaming-gdn
     genesis_env: GENESIS_ENABLE_PN59_STREAMING_GDN
+  - id: qwen38-sglang-autoround-w4a8-v0519
+    model: [qwen3.8-27b]
+    status: unverified
+    files:
+      - models/qwen3.8-27b/sglang/patches/sglang-autoround-w4a8-v0.5.19
+    load_bearing_when: []   # the sglang compose is disk-only (not registry-wired) — same as the qwen3.6 sglang archives
+    delivery:
+      dockerfile_bake: false
+      entrypoint_invoke: true
+      genesis: false
+    delivery_gaps: []
+    delivery_mechanism: install_script
+    delivery_spec:
+      script: models/qwen3.8-27b/sglang/patches/sglang-autoround-w4a8-v0.5.19/install.sh
+      mounted_at: /etc/club3090/w4a8
+      invoke: "bash /etc/club3090/w4a8/install.sh"
+      invoked_before: sglang-launch
+      wired_at: [volumes, entrypoint]
+    drift_guard:
+      kind: marker
+      check: "install.sh hard-fails (exit 1) if any of the 3 content markers is missing after apply, or if a partial 1-2/3 state is detected — a re-pinned image that drops a W4A8 hook serves nothing, not a half-wired mix"
+      on_fail: refuse-to-boot
+    capability: sglang-w4a8-dense-gemm
+    upstream:
+      ref: jb-seo/club-3090 (0004-autoround-w4a8.patch, cut against SGLang v0.5.18)
+      status: ours
+      drop_when: "SGLang lands AutoRound W4A8 with the K%128/N%64 shape guard natively in the AutoRoundConfig eligibility gate — then this re-cut + guard is retired (keep the compose, drop the mount)."

--- a/scripts/lib/profiles/patches.yml
+++ b/scripts/lib/profiles/patches.yml
@@ -1089,7 +1089,41 @@ patches:
     status: unverified
     files:
       - models/qwen3.8-27b/sglang/patches/sglang-autoround-w4a8-v0.5.19
-    load_bearing_when: []   # the sglang compose is disk-only (not registry-wired) — same as the qwen3.6 sglang archives
+    load_bearing_when:
+      - composes:
+          - sgl/qwen38-27b-dual-fast
+          - sgl/qwen38-27b-dual-superfast
+          - sgl/qwen38-27b-dual-max
+          - sgl/qwen38-27b-multi4-fast
+          - sgl/qwen38-27b-multi4-superfast
+          - sgl/qwen38-27b-multi4-max
+          - sgl/qwen38-27b-multi4-supermax
+          - sgl/qwen38-27b-multi8-fast
+          - sgl/qwen38-27b-multi8-superfast
+          - sgl/qwen38-27b-multi8-max
+          - sgl/qwen38-27b-multi8-supermax
+        reason: >-
+          Enables the serve-time W4A8 toggle (W4A8=1 -> int8 activations on the int4 weights) on every
+          registry-wired sgl/ slug. Unlike vLLM, SGLang has NO env-gated W4A8 path, so here APPLYING THE
+          PATCH IS THE ACTIVATION: each compose mounts this dir at /etc/club3090/w4a8 and the entrypoint
+          runs install.sh + install.sh --verify before launch. The patch is a re-cut of @jb-seo's
+          0004-autoround-w4a8.patch (cut against v0.5.19's predecessor v0.5.18) onto v0.5.19 by @A1RM4X
+          (club-3090#1226); its substantive addition is the per-shard K%128==0 / N%64==0 shape guard that
+          jb-seo's eligibility gate omitted -- without it Qwen3.8-27B's merged GDN in_proj_ba (N=96 ->
+          48/rank at TP=4) crashes in gptq_marlin_repack with 'size_n=48 is not divisible by 64'; the
+          guard routes non-conformant shards to standard Marlin W4A16 instead. DORMANT AT THE DEFAULT:
+          W4A8=0 ships, the installer is never invoked, and the composes serve stock W4A16 -- so this is
+          load-bearing only for the W4A8=1 path, and the toggle hard-fails rather than silently serving
+          W4A16 if the mount does not resolve. Measured on the reference 2x3090 PCIe rig: dual-fast
+          prefill@10K 1183 -> 1710 (+44.5%, n=3 CV 0.8%) and @90K 953 -> 1276 (+33.9%) for -11.1% code
+          decode; dual-superfast prefill@10K 1234 -> 1779 (+44.1%, n=3 CV 0.4%) and @90K 973 -> 1345
+          (+38.3%), decode ~flat, MTP accept unchanged 3.71 -> 3.72. A trade, not a free win. NOT load-
+          bearing for the two unregistered composes (dual/autoround-int4/dflash2-bf16.yml,
+          dual/fp8/dflash2.yml), which carry the same toggle but have no slug.
+        evidence: >-
+          models/qwen3.8-27b/sglang/patches/sglang-autoround-w4a8-v0.5.19/README.md; club-3090#1226
+          (@A1RM4X's re-cut + shape guard, cherry-picked with authorship preserved); BENCHMARKS.md 'Quad-
+          card (4x RTX 3090, TP=4) - SGLang' row (@A1RM4X's own 4-card numbers)
     delivery:
       dockerfile_bake: false
       entrypoint_invoke: true


### PR DESCRIPTION
Takes the **patch half** of [#1226](https://github.com/noonghunna/club-3090/pull/1226) and leaves
the compose half, because the eleven `sgl/` slugs that landed in
[#1237](https://github.com/noonghunna/club-3090/pull/1237) already cover that shape.

## Authorship

The first two commits are **cherry-picked from #1226 with @A1RM4X as author** — not rewritten, not
squashed into ours:

| commit | author | content |
|---|---|---|
| `71e8ae92` | **@A1RM4X** | the v0.5.19 patch, installer, patch README, `patches.yml` entry |
| `1ed9cec5` | **@A1RM4X** | his 2026-09-09 bench results (the `--enable-metrics` run + its vLLM A/B pair) |
| `<ours>` | maintainer | wiring, BENCHMARKS row, CHANGELOG |

Upstream of both: **@jb-seo**, whose `0004-autoround-w4a8.patch` (cut against v0.5.18) this re-cuts.

## What this unlocks

`W4A8=1` now works on all 13 SGLang composes with no extra steps. The composes already mounted
`${W4A8_PATCH_DIR:-../../../patches/sglang-autoround-w4a8-v0.5.19}` at `/etc/club3090/w4a8` and
already called `install.sh` / `install.sh --verify` — the interface was written against his
installer. Until now that path resolved to nothing and the toggle hard-failed **by design**, rather
than silently serving W4A16. That guard stays; only its message changes, because "Land club-3090#1226"
stops being useful advice once the patch is in the tree.

```bash
W4A8=1 bash scripts/switch.sh --force sgl/qwen38-27b-multi4-superfast
```

## The shape guard is the substance

@jb-seo's eligibility gate omitted the per-shard `K%128==0 / N%64==0` constraint that
`prepare_w4a8` hard-asserts. On Qwen3.8-27B's merged GDN `in_proj_ba` tensor (N=96 → 48/rank at
TP=4, not 64-divisible) a naive W4A8 pass crashes in `gptq_marlin_repack` with
`size_n=48 is not divisible by 64`. The guard pre-checks each shard and routes non-conformant layers
to standard Marlin W4A16 instead. @A1RM4X established it was necessary by isolation — stock v0.5.19
*without* the guard crashes identically — which exonerates the rest of the patch.

⚠️ **Separate from the patch, and easy to miss:** stock SGLang crashes on the Avuja AutoRound
checkpoint at weight-load *even without* W4A8, because its GDN `in_proj_a`/`in_proj_b` are BF16 while
SGLang builds a merged `in_proj_ba` and routes it through GPTQ-Marlin. That fix is data-side, in the
target's `config.json`. The patch does not address it — it is a checkpoint property. The patch README
carries the full story.

## Numbers

His, 4× 3090 Turbo + NVLink, TP=4, DFlash2 n=8, 2026-09-09 — banked as a community row under a new
**Quad-card (4× RTX 3090, TP=4) — SGLang** section, flagged as a 4-card NVLink rig so nobody reads it
as transferable to the PCIe-only duals:

- c=1 decode **144.6 narr / 244.8 code**, **+43%** over his own vLLM DFlash2 run
- the lead narrows to +4%/+6% by c=8 (vLLM's batching scales harder), +11%/+10% at c=16
- prefill raw TPS −2%…−17%, but **TTFT lower at 4K+** — 5.0 s vs 8.6 s @16K
- `spec_accept_length` 5.65 tok/step, accept rate 66%

Ours, 2× 3090 PCIe, for the same toggle: **+44.5% prefill@10K / +33.9%@90K for −11.1% code decode**
on `dual-fast`, and `dual-superfast` prefill to **1779 tok/s vs vLLM's 1778** — parity while still
ahead on decode. A trade, not a free win.

## What is deliberately not here

- **His `multi4/autoround-int4/dflash2-w4a8.yml`** — superseded by `sgl/qwen38-27b-multi4-superfast`
  + `W4A8=1`. Shipping both would be two files doing one job.
- **`models/qwen3.8-27b/sglang/README.md`** and the `test-compose-registry-disk` count bump — both
  compose-scoped, and there is no compose.

## `patches.yml`: `load_bearing_when` was wrong, not just under-documented

His entry carried `load_bearing_when: []`, justified as *"the sglang compose is disk-only (not
registry-wired)"*. That was true of **his** TP=4 compose and false for ours — eleven `sgl/` slugs are
registry-wired. Now populated with all eleven, matching how `qwen-w4a8-int8-act` documents the vLLM
side of the same toggle: dormant at the default, load-bearing only for the `W4A8=1` path.

Worth naming because an empty `load_bearing_when` made `test-patch-attribution` **vacuous** for this
patch — that gate cross-checks the listed slugs against the actual compose mounts, and had nothing to
check. It passes against the populated value.

The two *unregistered* composes (`dual/autoround-int4/dflash2-bf16.yml`, `dual/fp8/dflash2.yml`)
carry the same toggle but have no slug, so they are deliberately excluded from the list.

## Status

🧪 Experimental, unchanged. **No verify-stress, soak or 8-pack has been run on any `sgl/` slug with
`W4A8=1`** — on either rig.

## Note for anyone who set W4A8=1 early

Because the composes mounted a host path that didn't exist yet, docker created it as an empty
**root-owned** directory in the checkout. If you hit a permission error on `git pull` under
`models/qwen3.8-27b/sglang/patches/`, that's what it is — `sudo rmdir` the empty dirs and pull again.
