### PR TITLE
fix(harness): make acceptance + endpoint detection engine-aware — a dead drafter was passing verify-full on SGLang

### DIFF
--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -1604,7 +1604,19 @@ if (( CAP_ENABLED )); then
         }'
       fi
     else
-      echo "  no drafter output in the log (spec-dec off, or the engine does not log acceptance)"
+      # ⚠ THREE DIFFERENT STATES USED TO PRINT THIS ONE LINE. Until 2026-09-11 the
+      # parser knew only vLLM's "draft acceptance rate =" wording, so every SGLang
+      # run landed here — including a DEAD DFlash2 drafter (accept len ~1.0,
+      # sglang#39087), which is slow but never wrong and passes every functional
+      # test. "Nothing to report" and "I cannot read this engine" must not look the
+      # same. Recognised wordings: vLLM `draft acceptance rate = X`; SGLang
+      # `accept len: X, accept rate: Y`.
+      echo "  no acceptance data in the measured window. Either spec-dec is OFF for this"
+      echo "  run, or this engine words its acceptance line differently and the parser"
+      echo "  (scripts/lib/capture.sh, mode=acceptance) has not been taught it."
+      echo "  ⚠ Do NOT read this as 'the drafter is fine' — verify it fired:"
+      echo "      docker logs <container> 2>&1 | grep -oE 'accept len: [0-9.]+' | tail"
+      echo "      healthy is 2-5; ~1.0 means the drafter is drafting garbage"
     fi
   fi
 

--- a/scripts/concurrency-probe.sh
+++ b/scripts/concurrency-probe.sh
@@ -202,14 +202,24 @@ _container_cmd() { docker inspect "$CONTAINER" --format '{{join .Config.Cmd " "}
 _served_seqs()   { _container_cmd | command grep -oE 'max-num-seqs [0-9]+'  | command grep -oE '[0-9]+' | head -1; }
 _served_np()     { _container_cmd | command grep -oE '\-np +[0-9]+'         | command grep -oE '[0-9]+' | head -1; }
 _served_ctx()    { _container_cmd | command grep -oE 'max-model-len [0-9]+' | command grep -oE '[0-9]+' | head -1; }
+# SGLang names the same knob --max-running-requests. Without this the detector fell
+# through vLLM's --max-num-seqs, llama.cpp's -np and /props (none of which SGLang has)
+# and hit the #818 FATAL — so concurrency-probe could not run against ANY sgl/ slug.
+_served_max_running() { _container_cmd | command grep -oE 'max-running-requests [0-9]+' | command grep -oE '[0-9]+' | head -1; }
 # llama.cpp-family servers report the slot count as total_slots on /props.
 _props_slots()   { curl -s -m 3 "${URL}/props" 2>/dev/null \
   | python3 -c 'import json,sys; v=json.load(sys.stdin).get("total_slots",""); print(v if isinstance(v,int) else "")' 2>/dev/null; }
+# SGLang exposes it on /get_server_info (flat, top-level). Used when the compose set
+# it via env rather than a literal flag in the container cmd.
+_sgl_max_running() { curl -s -m 3 "${URL}/get_server_info" 2>/dev/null \
+  | python3 -c 'import json,sys; v=json.load(sys.stdin).get("max_running_requests",""); print(v if isinstance(v,int) else "")' 2>/dev/null; }
 
 _detect_slots() {
   local n
   n="$(_served_seqs || true)"; [[ -n "$n" ]] && { echo "$n"; return; }
   n="$(_served_np || true)";   [[ -n "$n" ]] && { echo "$n"; return; }
+  n="$(_served_max_running || true)"; [[ -n "$n" ]] && { echo "$n"; return; }
+  n="$(_sgl_max_running || true)";    [[ -n "$n" ]] && { echo "$n"; return; }
   n="$(_props_slots || true)"; [[ -n "$n" ]] && { echo "$n"; return; }
   echo ""
 }
@@ -305,7 +315,9 @@ if [[ -n "$SWEEP" || "$MATRIX" == "1" ]]; then
 elif [[ -z "${CONCURRENCY:-}" ]]; then
   _conc_src="container max-num-seqs"; CONCURRENCY="$(_served_seqs || true)"
   if [[ -z "$CONCURRENCY" ]]; then _conc_src="container -np";          CONCURRENCY="$(_served_np || true)"; fi
+  if [[ -z "$CONCURRENCY" ]]; then _conc_src="container max-running-requests"; CONCURRENCY="$(_served_max_running || true)"; fi
   if [[ -z "$CONCURRENCY" ]]; then _conc_src="server /props total_slots"; CONCURRENCY="$(_props_slots || true)"; fi
+  if [[ -z "$CONCURRENCY" ]]; then _conc_src="server /get_server_info max_running_requests"; CONCURRENCY="$(_sgl_max_running || true)"; fi
   if [[ -z "$CONCURRENCY" ]]; then
     echo "[concurrency-probe] FATAL: cannot detect the served slot count" \
          "(container cmd and ${URL}/props both failed) — pass CONCURRENCY=N explicitly" >&2

--- a/scripts/lib/capture.sh
+++ b/scripts/lib/capture.sh
@@ -496,23 +496,53 @@ elif mode == "acceptance":
     # Acceptance WITHOUT a fire rate is a deception: measured 2026-08-01, a drafter
     # reported 0.992 acceptance while firing on 5 of ~20 requests (zero on novel
     # content). Report how OFTEN it fired alongside how WELL it did when it fired.
-    acc, drafted, accepted = [], 0, 0
+    # TWO ENGINES, TWO WORDINGS, AND THEY DO NOT LOG THE SAME QUANTITY.
+    #   vLLM    : "draft acceptance rate = 0.85"        -> a RATE in [0,1]
+    #   SGLang  : "accept len: 5.66, accept rate: 0.67" -> a LENGTH (tok/step) AND a rate
+    # Until 2026-09-11 only the vLLM wording was matched, so on SGLang this parser
+    # failed outright and bench printed "no drafter output in the log (spec-dec off,
+    # or the engine does not log acceptance)" -- collapsing THREE different states
+    # (drafter off / drafter DEAD / wording not recognised) into one benign-looking
+    # line. A dead DFlash2 drafter (accept len ~1.0, sglang#39087) read identically
+    # to a healthy SGLang run. Keep the two quantities in SEPARATE lists: averaging a
+    # length into a rate silently produces a number that is neither.
+    acc, alen, drafted, accepted = [], [], 0, 0
     for ln in lines:
         m = re.search(r"draft acceptance(?: rate)?\s*=\s*([0-9.]+)", ln)
         if m:
             acc.append(float(m.group(1)))
+        m_sgl_rate = re.search(r"accept rate:\s*([0-9.]+)", ln)
+        if m_sgl_rate:
+            acc.append(float(m_sgl_rate.group(1)))
+        m_sgl_len = re.search(r"accept len:\s*([0-9.]+)", ln)
+        if m_sgl_len:
+            alen.append(float(m_sgl_len.group(1)))
         m2 = re.search(r"\(\s*(\d+)\s*accepted\s*/\s*(\d+)\s*(?:generated|drafted)", ln)
         if m2:
             accepted += int(m2.group(1))
             drafted += int(m2.group(2))
-    if not acc:
+    if not acc and not alen:
         sys.exit(1)
+    # SGLang emits a length but the caller's summary line is rate-shaped; surface the
+    # length explicitly rather than letting it vanish. accept len ~1.0 means the
+    # drafter is drafting garbage and being rejected -- slow, never wrong, and
+    # invisible to every functional test (sglang#39087).
+    if alen:
+        _al = f" accept_len_mean={sum(alen)/len(alen):.3f} accept_len_last={alen[-1]:.3f}"
+        _al += f" accept_len_min={min(alen):.3f} accept_len_max={max(alen):.3f}"
+        if sum(alen)/len(alen) < 1.5:
+            _al += " ⚠DRAFTER-LOOKS-DEAD(accept_len<1.5)"
+    else:
+        _al = ""
+    if not acc:
+        print(f"fired={len(alen)}{_al}")
+        sys.exit(0)
     # `last` is the final acceptance the log carries. It exists because the sweep's
     # TSV `accept` column has always meant exactly that — a per-arm boot ends with
     # its own last value — and swapping in the mean would silently redefine every
     # historical row. bench.sh quotes the mean; the sweep quotes last. Same scrape.
     print(f"fired={len(acc)} last={acc[-1]:.3f} mean={sum(acc)/len(acc):.3f} "
-          f"min={min(acc):.3f} max={max(acc):.3f} accepted={accepted} drafted={drafted}")
+          f"min={min(acc):.3f} max={max(acc):.3f} accepted={accepted} drafted={drafted}{_al}")
 
 elif mode == "timings":
     # llama.cpp per-request print_timing. `prompt eval time` is PREFILL; the bare

--- a/scripts/lib/profiles/drafters/zlab-qwen38-dflash2.yml
+++ b/scripts/lib/profiles/drafters/zlab-qwen38-dflash2.yml
@@ -26,6 +26,17 @@ status: experimental
 # ⛔⛔ ON SGLANG THE QUANTIZED ONE SILENTLY DRAFTS GARBAGE:
 #     syvai (compressed-tensors)  accept len 1.03, accept rate 0.004  (n=422)
 #     z-lab (bf16, this profile)  accept len 3.71 @262K / 5.27 @32K   (n=100)
+# ⚠️ THOSE TWO FIGURES HAVE NO RECORDED reasoning_effort, AND EFFORT IS WORTH ~28%.
+# Measured 2026-09-11 (A,B,A,B over 4 boots, per-request meta_info.spec_accept_length,
+# n=12/arm, ~2.6K ctx, thinking ON): REASONING_EFFORT=low 5.362 (CV 2.9%) vs xhigh
+# 3.872 (CV 4.7%) = -27.8%, against ~2.8% boot-to-boot noise. The run above predates
+# #1244, when the composes did not pin reasoning_effort and the template default
+# ('xhigh') applied — so 3.71/5.27 are almost certainly xhigh numbers, while the
+# SHIPPED config is now low. Context depth ALSO moves this by a similar amount, and
+# nothing separates the two: xhigh@32K read 5.27 there but xhigh@2.6K reads 3.87 here,
+# which depth alone cannot explain. ⇒ Do not treat 3.71 as the shipped baseline, and
+# do not "correct" it to 5.36 — different context, different regime. A 262K ×
+# {low,xhigh} run is what would make any of these comparable.
 # Decode on the shipped recipe: ~38 tok/s vs ~171-175. Nothing errors, nothing warns,
 # and verify-full returns "All checks passed" for BOTH (bad drafts are REJECTED, so a
 # dead drafter is slow, never wrong — and verify-full's acceptance check SKIPS on SGLang

--- a/scripts/quality-test.sh
+++ b/scripts/quality-test.sh
@@ -723,6 +723,23 @@ sys.exit(0 if walk(obj) else 1)
      && docker inspect "$CONTAINER" >/dev/null 2>&1; then
     docker inspect "$CONTAINER" 2>/dev/null \
       | grep -Eq -- '(--reasoning[= ]+on|"--reasoning"[[:space:]]*,[[:space:]]*"on")' && return 0
+    # SGLang spells it --reasoning-parser <name>; vLLM spells it --reasoning-parser too.
+    docker inspect "$CONTAINER" 2>/dev/null \
+      | grep -Eq -- '--reasoning-parser' && return 0
+  fi
+  # SGLang has no /props, so the probe above cannot see it. /get_model_info carries
+  # reasoning_parser; a non-null value means the server splits <think> into
+  # reasoning_content, i.e. reasoning parsing IS on. Without this the mismatch warning
+  # never fired on SGLang — and an unforced leg silently inherits the pack defaults,
+  # which is the "no-thinking leg is really a second thinking leg" trap.
+  if curl -sf -m 3 "${URL}/get_model_info" 2>/dev/null | python3 -c '
+import json, sys
+try: d = json.load(sys.stdin)
+except Exception: sys.exit(1)
+rp = d.get("reasoning_parser")
+sys.exit(0 if rp else 1)
+' >/dev/null 2>&1; then
+    return 0
   fi
   return 1
 }

--- a/scripts/spec-sweep.sh
+++ b/scripts/spec-sweep.sh
@@ -201,7 +201,25 @@ _measure_vllm_arm() {
   if [[ "$n" != "0" ]]; then
     local cn
     cn="$(docker ps --format '{{.Names}}' | grep -m1 -E 'vllm' || true)"
-    [[ -n "$cn" ]] && acc="$(docker logs "$cn" 2>&1 | grep 'SpecDecoding metrics' | tail -1 | grep -oE 'acceptance rate: [0-9.]+%' | tail -1 | grep -oE '[0-9.]+' || echo '—')"
+    # Two engines word this differently. vLLM: "SpecDecoding metrics: ... acceptance
+    # rate: 85.0%". SGLang: "accept len: 5.66, accept rate: 0.67" (a RATE in [0,1],
+    # so scale to % to keep the column comparable). Until 2026-09-11 only the vLLM
+    # wording was read and SGLang rows printed '—' — an honest blank, but it meant the
+    # sweep could not find an acceptance knee on the engine at all.
+    if [[ -n "$cn" ]]; then
+      acc="$(docker logs "$cn" 2>&1 | grep 'SpecDecoding metrics' | tail -1 | grep -oE 'acceptance rate: [0-9.]+%' | tail -1 | grep -oE '[0-9.]+' || true)"
+      if [[ -z "$acc" ]]; then
+        acc="$(docker logs "$cn" 2>&1 | grep -oE 'accept rate: [0-9.]+' | tail -1 | grep -oE '[0-9.]+' \
+               | awk '{printf "%.1f", $1*100}' || true)"
+      fi
+      # ⚠ NOT carried here: SGLang also reports accept LENGTH (tok/step), which is the
+      # more diagnostic quantity for a block drafter — a dead one reads ~1.0
+      # (sglang#39087) while its RATE can still look unremarkable. This sweep's
+      # RESULTS record is a fixed 3 fields ("$n|$med|$acc") that downstream does
+      # arithmetic on, so adding a fourth here would change its shape. The length is
+      # asserted in verify-full.sh and reported by bench.sh instead.
+      [[ -z "$acc" ]] && acc='—'
+    fi
     [[ "$acc" != "—" && -n "$acc" ]] && acc="$(awk -v p="$acc" 'BEGIN{printf "%.2f", p/100}')"
   fi
   RESULTS+=("$n|$med|$acc")

--- a/scripts/verify-full.sh
+++ b/scripts/verify-full.sh
@@ -633,7 +633,45 @@ check_mtp_acceptance() {
   # generalized harness).
   case "$ENGINE_KIND" in
     llamacpp) skip "llama.cpp engine — MTP acceptance check is vLLM-log-format-specific (run engine-side verification separately)"; return 0 ;;
-    sglang)   skip "SGLang engine — MTP acceptance check is vLLM-log-format-specific";   return 0 ;;
+    sglang)
+      # ⚠ THIS USED TO `skip`, AND THAT IS HOW A DEAD DRAFTER PASSED verify-full.
+      # sglang#39087: a compressed-tensors DFlash2 drafter drafts garbage — accept
+      # len 1.03 vs 3.71 for identical BF16 weights, decode ~38 vs ~171 tok/s — with
+      # no error and no warning, because speculative decoding REJECTS bad drafts:
+      # the output stays correct, it is just slow. This check was the only gate that
+      # could have caught it, and it was skipping on the one engine where it happened.
+      # SGLang's wording is `accept len: N.NN, accept rate: N.NN` (scheduler
+      # metrics_reporter.py) — parseable, just not vLLM's.
+      if ! container_is_real; then
+        skip "container '${CONTAINER}' not found (CONTAINER=none for host endpoints)"
+        return 0
+      fi
+      curl -sf -m 60 "${URL}/v1/chat/completions" \
+        -H "Content-Type: application/json" \
+        -d "{
+          \"model\": \"${MODEL}\",
+          \"messages\": [{\"role\": \"user\", \"content\": \"Count from 1 to 80, one number per line.\"}],
+          \"max_tokens\": 500,
+          \"temperature\": 0.0,
+          ${THINK_OFF_STD}\"chat_template_kwargs\": ${THINK_OFF_KW}
+        }" >/dev/null 2>&1 || { fail "metrics-trigger request failed" "Check docker logs"; return 1; }
+      sleep 3
+      local sgl_al
+      sgl_al="$(docker logs --tail 400 "${CONTAINER}" 2>&1 \
+                | grep -oE 'accept len: [0-9]+\.[0-9]+' | tail -5 \
+                | grep -oE '[0-9]+\.[0-9]+' \
+                | awk '{s+=$1; n++} END{if(n) printf "%.3f", s/n}')"
+      if [[ -z "$sgl_al" ]]; then
+        skip "no 'accept len' in the last 400 log lines (spec-dec off for this compose?)"
+        return 0
+      fi
+      if awk -v a="$sgl_al" -v m="${MTP_ACCEPT_MIN:-2.0}" 'BEGIN{exit !(a+0 >= m+0)}'; then
+        pass "acceptance length ${sgl_al} >= ${MTP_ACCEPT_MIN:-2.0} (SGLang)"
+      else
+        fail "acceptance length ${sgl_al} < ${MTP_ACCEPT_MIN:-2.0} (SGLang)" \
+             "A drafter near 1.0 is drafting garbage and being rejected — output stays correct but decode collapses (sglang#39087). Check the drafter checkpoint is UNQUANTIZED and that --speculative-draft-model-quantization is 'unquant'."
+      fi
+      return 0 ;;
   esac
   if ! command -v docker >/dev/null 2>&1; then
     skip "docker not in PATH (host engine build? — see #87 for generalized harness work)"


### PR DESCRIPTION
The harness was written vLLM-first with llama.cpp bolted on. SGLang is a third engine that falls
through nearly every detector, and it does so in four different ways — one of which let a **dead
drafter pass `verify-full`**.

Found while chasing why our published DFlash2 accept-len (3.71) disagreed with a fresh measurement
by 46%.

## How SGLang was failing, by severity

| behaviour | where | why it matters |
|---|---|---|
| **passed vacuously** | `verify-full` `skip`ped the acceptance check | a drafter at accept-len 1.03 returned "All checks passed" |
| **hard FATAL** | `concurrency-probe` exit 2 | could not run against **any** `sgl/` slug |
| **silently never fired** | `quality-test` reasoning-mismatch warning | the "no-thinking leg is really a second thinking leg" trap |
| **honest blank** | `spec-sweep` printed `—` | benign, but no acceptance knee on the engine |
| *(already worked)* | `verify-stress` n_ctx | **no change** — SGLang exposes `max_model_len` on `/v1/models` |

That last row is worth stating: I was about to patch it, checked first, and it already worked.

## 1. Acceptance parsing — `capture.sh`, `bench.sh`, `spec-sweep.sh`

The two engines do not log the same **quantity**:

```
vLLM   : draft acceptance rate = 0.85          -> a RATE in [0,1]
SGLang : accept len: 5.66, accept rate: 0.67   -> a LENGTH (tok/step) AND a rate
```

Only the vLLM wording was matched, so every SGLang run failed the parse. The two are kept in
**separate lists** — averaging a tok/step figure into a rate produces a number that is neither.
`accept_len < 1.5` now raises `⚠DRAFTER-LOOKS-DEAD`, which is the sglang#39087 signature.

`bench.sh` previously printed one line for three different states:

> `no drafter output in the log (spec-dec off, or the engine does not log acceptance)`

"Spec-dec is off", "the drafter is dead" and "I cannot read this engine's log" are different
diagnoses and only the first is harmless. Now split, with the manual `accept len` check spelled out.

Validated against four fixtures — SGLang, vLLM, dead-drafter, no-spec:

```
sgl      -> fired=3 mean=0.643 ... accept_len_mean=5.480
vllm     -> fired=2 mean=0.830                              (unchanged, no spurious length)
dead     -> accept_len_mean=1.020 ⚠DRAFTER-LOOKS-DEAD
no-spec  -> exit 1 (genuinely no data)
```

## 2. `verify-full` — the gate that skipped

```bash
sglang)   skip "SGLang engine — MTP acceptance check is vLLM-log-format-specific";   return 0 ;;
```

This is why sglang#39087 passed validation. Now implemented against SGLang's own wording, honouring
`MTP_ACCEPT_MIN`, with a failure message pointing at the actual cause (quantized drafter /
`--speculative-draft-model-quantization`). Extraction validated on the same three states: healthy
**PASS 5.480**, dead **FAIL 1.020**, none **SKIP**.

## 3. Endpoint detection without `/props` — `concurrency-probe`, `quality-test`

SGLang has no `/props`. Shapes confirmed against a live server, not docs:

| need | endpoint | key |
|---|---|---|
| slot count | `/get_server_info` | `max_running_requests` |
| reasoning-on | `/get_model_info` | `reasoning_parser` |

`concurrency-probe` gains both a container-cmd path (`--max-running-requests`) and the endpoint
fallback. The live test is instructive — the container-cmd path returns **empty** because our
composes set it via shell expansion in the entrypoint rather than a literal flag, so the endpoint
fallback is the one that actually fires.

⚠️ Deliberately **not** wired: `/get_model_info` also exposes `preferred_sampling_params`, which
looks like the readback `--sampling-from-server` wants. It is inert on the chat path (#1244), so
recording it as "what we sampled with" would be worse than recording nothing.

## 4. Drafter profile — the 3.71 provenance

Annotates that `3.71 @262K / 5.27 @32K` has **no recorded `reasoning_effort`**, and that effort is
worth −27.8% (`low` 5.362 vs `xhigh` 3.872, n=12/arm, A,B,A,B over 4 boots). Since the run predates
#1244 — when the composes did not pin the rung and the template default `xhigh` applied — those are
almost certainly xhigh numbers while the shipped config is now `low`.

It explicitly says **do not "correct" 3.71 to 5.36**: different context depth (262K vs ~2.6K),
different regime. Depth and effort are both worth ~25-30% and nothing separates them — the two do
not even reconcile (xhigh@32K read 5.27 there, xhigh@2.6K reads 3.87 here). A 262K × {low, xhigh}
run is what would make any of these comparable, and it is filed as a re-test trigger.

## What this does not do

No shared engine-capability layer. Each detector still carries its own ordered fallback chain,
duplicated across scripts — so a fourth engine repeats this exercise. These are additive fallbacks
that don't preclude that refactor; doing it properly touches every gate script and wants its own PR.
