### PR TITLE
fix(qwen3.8): sgl super* slugs cannot fetch their drafter; SpecDecoding tail blank on 2 of 3 engines (#1251)

### DIFF
--- a/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2-bf16.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2-bf16.yml
@@ -226,7 +226,22 @@ services:
         if [ "$$_n" = "0" ]; then
           echo "[spec] drafter OFF (SPEC_N=0)" >&2
         else
-          [ -d "$$D" ] || { echo "[spec] drafter not found at $$D" >&2; exit 1; }
+          if [ ! -d "$$D" ]; then
+            echo "[spec] drafter not found at $$D" >&2
+            echo "[spec]" >&2
+            echo "[spec] Fetch it with:" >&2
+            echo "[spec]   WEIGHT_KEY=qwen3.8-27b:dflash2-zlab bash scripts/setup.sh qwen3.8-27b" >&2
+            echo "[spec]" >&2
+            echo "[spec] ⚠️ WITH_DFLASH_DRAFT=1 fetches the WRONG drafter for this engine." >&2
+            echo "[spec] It resolves to syvai/Qwen3.8-27B-DFlash2-W4A16 (compressed-tensors)," >&2
+            echo "[spec] which the vLLM tiers use. On SGLang that checkpoint SILENTLY drafts" >&2
+            echo "[spec] garbage - accept len ~1.03 vs ~5.3, decode ~38 vs ~171 tok/s, with no" >&2
+            echo "[spec] error and a fully passing test suite (sglang#39087). These slugs need" >&2
+            echo "[spec] the UNQUANTIZED z-lab release, ~3.6 GiB." >&2
+            echo "[spec]" >&2
+            echo "[spec] Or run without the drafter: SPEC_N=0" >&2
+            exit 1
+          fi
           # ⚠️⚠️ --speculative-draft-model-quantization IS LOAD-BEARING: without
           # it SGLang inherits the TARGET's `auto-round` for a compressed-tensors
           # drafter (serving_hook.py:629).

--- a/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2.yml
@@ -260,7 +260,22 @@ services:
         if [ "$$_n" = "0" ]; then
           echo "[spec] drafter OFF (SPEC_N=0)" >&2
         else
-          [ -d "$$D" ] || { echo "[spec] drafter not found at $$D" >&2; exit 1; }
+          if [ ! -d "$$D" ]; then
+            echo "[spec] drafter not found at $$D" >&2
+            echo "[spec]" >&2
+            echo "[spec] Fetch it with:" >&2
+            echo "[spec]   WEIGHT_KEY=qwen3.8-27b:dflash2-zlab bash scripts/setup.sh qwen3.8-27b" >&2
+            echo "[spec]" >&2
+            echo "[spec] ⚠️ WITH_DFLASH_DRAFT=1 fetches the WRONG drafter for this engine." >&2
+            echo "[spec] It resolves to syvai/Qwen3.8-27B-DFlash2-W4A16 (compressed-tensors)," >&2
+            echo "[spec] which the vLLM tiers use. On SGLang that checkpoint SILENTLY drafts" >&2
+            echo "[spec] garbage - accept len ~1.03 vs ~5.3, decode ~38 vs ~171 tok/s, with no" >&2
+            echo "[spec] error and a fully passing test suite (sglang#39087). These slugs need" >&2
+            echo "[spec] the UNQUANTIZED z-lab release, ~3.6 GiB." >&2
+            echo "[spec]" >&2
+            echo "[spec] Or run without the drafter: SPEC_N=0" >&2
+            exit 1
+          fi
           # ⚠️⚠️ --speculative-draft-model-quantization IS LOAD-BEARING: without
           # it SGLang inherits the TARGET's `auto-round` for a compressed-tensors
           # drafter (serving_hook.py:629).

--- a/models/qwen3.8-27b/sglang/compose/dual/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/fp8/dflash2.yml
@@ -293,7 +293,22 @@ services:
         if [ "$$_n" = "0" ]; then
           echo "[spec] drafter OFF (SPEC_N=0)" >&2
         else
-          [ -d "$$D" ] || { echo "[spec] drafter not found at $$D" >&2; exit 1; }
+          if [ ! -d "$$D" ]; then
+            echo "[spec] drafter not found at $$D" >&2
+            echo "[spec]" >&2
+            echo "[spec] Fetch it with:" >&2
+            echo "[spec]   WEIGHT_KEY=qwen3.8-27b:dflash2-zlab bash scripts/setup.sh qwen3.8-27b" >&2
+            echo "[spec]" >&2
+            echo "[spec] ⚠️ WITH_DFLASH_DRAFT=1 fetches the WRONG drafter for this engine." >&2
+            echo "[spec] It resolves to syvai/Qwen3.8-27B-DFlash2-W4A16 (compressed-tensors)," >&2
+            echo "[spec] which the vLLM tiers use. On SGLang that checkpoint SILENTLY drafts" >&2
+            echo "[spec] garbage - accept len ~1.03 vs ~5.3, decode ~38 vs ~171 tok/s, with no" >&2
+            echo "[spec] error and a fully passing test suite (sglang#39087). These slugs need" >&2
+            echo "[spec] the UNQUANTIZED z-lab release, ~3.6 GiB." >&2
+            echo "[spec]" >&2
+            echo "[spec] Or run without the drafter: SPEC_N=0" >&2
+            exit 1
+          fi
           # ⚠️⚠️ --speculative-draft-model-quantization IS LOAD-BEARING: without
           # it SGLang inherits the TARGET's `auto-round` for a compressed-tensors
           # drafter (serving_hook.py:629).

--- a/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/dflash2.yml
@@ -295,7 +295,22 @@ services:
         if [ "$$_n" = "0" ]; then
           echo "[spec] drafter OFF (SPEC_N=0)" >&2
         else
-          [ -d "$$D" ] || { echo "[spec] drafter not found at $$D" >&2; exit 1; }
+          if [ ! -d "$$D" ]; then
+            echo "[spec] drafter not found at $$D" >&2
+            echo "[spec]" >&2
+            echo "[spec] Fetch it with:" >&2
+            echo "[spec]   WEIGHT_KEY=qwen3.8-27b:dflash2-zlab bash scripts/setup.sh qwen3.8-27b" >&2
+            echo "[spec]" >&2
+            echo "[spec] ⚠️ WITH_DFLASH_DRAFT=1 fetches the WRONG drafter for this engine." >&2
+            echo "[spec] It resolves to syvai/Qwen3.8-27B-DFlash2-W4A16 (compressed-tensors)," >&2
+            echo "[spec] which the vLLM tiers use. On SGLang that checkpoint SILENTLY drafts" >&2
+            echo "[spec] garbage - accept len ~1.03 vs ~5.3, decode ~38 vs ~171 tok/s, with no" >&2
+            echo "[spec] error and a fully passing test suite (sglang#39087). These slugs need" >&2
+            echo "[spec] the UNQUANTIZED z-lab release, ~3.6 GiB." >&2
+            echo "[spec]" >&2
+            echo "[spec] Or run without the drafter: SPEC_N=0" >&2
+            exit 1
+          fi
           # ⚠️⚠️ --speculative-draft-model-quantization IS LOAD-BEARING: without
           # it SGLang inherits the TARGET's `auto-round` for a compressed-tensors
           # drafter (serving_hook.py:629).

--- a/models/qwen3.8-27b/sglang/compose/multi4/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/fp8/dflash2.yml
@@ -326,7 +326,22 @@ services:
         if [ "$$_n" = "0" ]; then
           echo "[spec] drafter OFF (SPEC_N=0)" >&2
         else
-          [ -d "$$D" ] || { echo "[spec] drafter not found at $$D" >&2; exit 1; }
+          if [ ! -d "$$D" ]; then
+            echo "[spec] drafter not found at $$D" >&2
+            echo "[spec]" >&2
+            echo "[spec] Fetch it with:" >&2
+            echo "[spec]   WEIGHT_KEY=qwen3.8-27b:dflash2-zlab bash scripts/setup.sh qwen3.8-27b" >&2
+            echo "[spec]" >&2
+            echo "[spec] ⚠️ WITH_DFLASH_DRAFT=1 fetches the WRONG drafter for this engine." >&2
+            echo "[spec] It resolves to syvai/Qwen3.8-27B-DFlash2-W4A16 (compressed-tensors)," >&2
+            echo "[spec] which the vLLM tiers use. On SGLang that checkpoint SILENTLY drafts" >&2
+            echo "[spec] garbage - accept len ~1.03 vs ~5.3, decode ~38 vs ~171 tok/s, with no" >&2
+            echo "[spec] error and a fully passing test suite (sglang#39087). These slugs need" >&2
+            echo "[spec] the UNQUANTIZED z-lab release, ~3.6 GiB." >&2
+            echo "[spec]" >&2
+            echo "[spec] Or run without the drafter: SPEC_N=0" >&2
+            exit 1
+          fi
           # ⚠️⚠️ --speculative-draft-model-quantization IS LOAD-BEARING: without
           # it SGLang inherits the TARGET's `auto-round` for a compressed-tensors
           # drafter (serving_hook.py:629).

--- a/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/dflash2.yml
@@ -300,7 +300,22 @@ services:
         if [ "$$_n" = "0" ]; then
           echo "[spec] drafter OFF (SPEC_N=0)" >&2
         else
-          [ -d "$$D" ] || { echo "[spec] drafter not found at $$D" >&2; exit 1; }
+          if [ ! -d "$$D" ]; then
+            echo "[spec] drafter not found at $$D" >&2
+            echo "[spec]" >&2
+            echo "[spec] Fetch it with:" >&2
+            echo "[spec]   WEIGHT_KEY=qwen3.8-27b:dflash2-zlab bash scripts/setup.sh qwen3.8-27b" >&2
+            echo "[spec]" >&2
+            echo "[spec] ⚠️ WITH_DFLASH_DRAFT=1 fetches the WRONG drafter for this engine." >&2
+            echo "[spec] It resolves to syvai/Qwen3.8-27B-DFlash2-W4A16 (compressed-tensors)," >&2
+            echo "[spec] which the vLLM tiers use. On SGLang that checkpoint SILENTLY drafts" >&2
+            echo "[spec] garbage - accept len ~1.03 vs ~5.3, decode ~38 vs ~171 tok/s, with no" >&2
+            echo "[spec] error and a fully passing test suite (sglang#39087). These slugs need" >&2
+            echo "[spec] the UNQUANTIZED z-lab release, ~3.6 GiB." >&2
+            echo "[spec]" >&2
+            echo "[spec] Or run without the drafter: SPEC_N=0" >&2
+            exit 1
+          fi
           # ⚠️⚠️ --speculative-draft-model-quantization IS LOAD-BEARING: without
           # it SGLang inherits the TARGET's `auto-round` for a compressed-tensors
           # drafter (serving_hook.py:629).

--- a/models/qwen3.8-27b/sglang/compose/multi8/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/fp8/dflash2.yml
@@ -333,7 +333,22 @@ services:
         if [ "$$_n" = "0" ]; then
           echo "[spec] drafter OFF (SPEC_N=0)" >&2
         else
-          [ -d "$$D" ] || { echo "[spec] drafter not found at $$D" >&2; exit 1; }
+          if [ ! -d "$$D" ]; then
+            echo "[spec] drafter not found at $$D" >&2
+            echo "[spec]" >&2
+            echo "[spec] Fetch it with:" >&2
+            echo "[spec]   WEIGHT_KEY=qwen3.8-27b:dflash2-zlab bash scripts/setup.sh qwen3.8-27b" >&2
+            echo "[spec]" >&2
+            echo "[spec] ⚠️ WITH_DFLASH_DRAFT=1 fetches the WRONG drafter for this engine." >&2
+            echo "[spec] It resolves to syvai/Qwen3.8-27B-DFlash2-W4A16 (compressed-tensors)," >&2
+            echo "[spec] which the vLLM tiers use. On SGLang that checkpoint SILENTLY drafts" >&2
+            echo "[spec] garbage - accept len ~1.03 vs ~5.3, decode ~38 vs ~171 tok/s, with no" >&2
+            echo "[spec] error and a fully passing test suite (sglang#39087). These slugs need" >&2
+            echo "[spec] the UNQUANTIZED z-lab release, ~3.6 GiB." >&2
+            echo "[spec]" >&2
+            echo "[spec] Or run without the drafter: SPEC_N=0" >&2
+            exit 1
+          fi
           # ⚠️⚠️ --speculative-draft-model-quantization IS LOAD-BEARING: without
           # it SGLang inherits the TARGET's `auto-round` for a compressed-tensors
           # drafter (serving_hook.py:629).

--- a/scripts/bench-agentic.sh
+++ b/scripts/bench-agentic.sh
@@ -759,7 +759,14 @@ fi
 if command -v docker >/dev/null 2>&1 && docker inspect "${CONTAINER}" >/dev/null 2>&1; then
   echo ""
   echo "=== Last 3 SpecDecoding metrics ==="
-  docker logs "${CONTAINER}" 2>&1 | grep "SpecDecoding metrics" | tail -3 || true
+  # vLLM tags these "SpecDecoding metrics"; SGLang writes "accept len: N, accept rate: N"
+  # on its decode-batch line and llama.cpp writes "draft acceptance = N". Grepping only
+  # the vLLM string printed an EMPTY block on the other two — which reads as "spec-dec
+  # produced nothing" rather than "I only know one engine's wording". Seen in the wild on
+  # club-3090#1251 (2x 5090, sgl/qwen38-27b-dual-fast): the section came back blank while
+  # the drafter was running fine.
+  docker logs "${CONTAINER}" 2>&1 \
+    | grep -E "SpecDecoding metrics|accept len:|draft acceptance" | tail -3 || true
 fi
 
 # --- per-rig #249 record: the agentic TTFT/decode-by-turn curve (no canonical

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -2187,7 +2187,14 @@ if [[ "${CONTAINER:-}" != "none" ]] && command -v docker >/dev/null 2>&1 \
    && docker inspect "${CONTAINER}" >/dev/null 2>&1; then
   echo ""
   echo "=== Last 3 SpecDecoding metrics ==="
-  docker logs "${CONTAINER}" 2>&1 | grep "SpecDecoding metrics" | tail -3 || true
+  # vLLM tags these "SpecDecoding metrics"; SGLang writes "accept len: N, accept rate: N"
+  # on its decode-batch line and llama.cpp writes "draft acceptance = N". Grepping only
+  # the vLLM string printed an EMPTY block on the other two — which reads as "spec-dec
+  # produced nothing" rather than "I only know one engine's wording". Seen in the wild on
+  # club-3090#1251 (2x 5090, sgl/qwen38-27b-dual-fast): the section came back blank while
+  # the drafter was running fine.
+  docker logs "${CONTAINER}" 2>&1 \
+    | grep -E "SpecDecoding metrics|accept len:|draft acceptance" | tail -3 || true
 fi
 
 # Repeated at the END on purpose (#832): a reader who tails the log, or who

--- a/scripts/lib/profiles/models/qwen3.8-27b.yml
+++ b/scripts/lib/profiles/models/qwen3.8-27b.yml
@@ -167,6 +167,14 @@ weights:
     format: bf16
     local_subdir: qwen3.8-27b-dflash2-zlab-bf16
     hf_repo: z-lab/Qwen3.8-27B-DFlash2
+    # MEASURED on disk 2026-09-11: 3,849,114,690 bytes = 3.85 GB decimal (3.58 GiB).
+    # The setup.sh disk gate wants the DECIMAL figure. This was ABSENT, so setup.sh
+    # could not size the download — and this is the drafter EVERY sgl/ super* slug
+    # needs. Its sibling `dflash2` (syvai W4A16, 1.2 GB) is what setup.dflash points
+    # at, i.e. what WITH_DFLASH_DRAFT=1 fetches: correct for the vLLM tiers, and on
+    # SGLang it silently drafts garbage (sglang#39087). Fetch this one explicitly:
+    #   WEIGHT_KEY=qwen3.8-27b:dflash2-zlab bash scripts/setup.sh qwen3.8-27b
+    size_gb: 3.85
   # F16 multimodal projector — the mmproj companion of the VISION slug
   # (llamacpp/qwen38-27b-single-iq4xs-vision). Quant-INDEPENDENT: one F16 tower
   # for every llama.cpp GGUF quant of this model, so it lands at the SHARED gguf

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -961,6 +961,23 @@ if [[ "${WITH_DFLASH_DRAFT:-0}" == "1" ]] && [[ "${SKIP_MODEL:-0}" != "1" ]]; th
   fi
   echo "[dflash]  WITH_DFLASH_DRAFT=1 — downloading ${DFLASH_KEY} ..."
   download_weight_key "${DFLASH_KEY}"
+  # setup.dflash is ONE key, but the engines need DIFFERENT drafters. For
+  # qwen3.8-27b it resolves to `dflash2` (syvai W4A16) — correct for the vLLM
+  # super*/ultra* tiers. The SGLang sgl/…-super* slugs need the UNQUANTIZED z-lab
+  # release, and pointing them at the quantized one does NOT fail loudly: it drafts
+  # garbage at accept len ~1.03 vs ~5.3 (decode ~38 vs ~171 tok/s) with no error and
+  # a passing test suite (sglang#39087). Surfaced by a user hitting the
+  # missing-drafter path on 2x 5090 (club-3090#1251).
+  case "${DFLASH_KEY}" in
+    qwen3.8-27b:dflash2)
+      echo ""
+      echo "[dflash]  NOTE: that is the vLLM drafter. To serve an SGLang"
+      echo "[dflash]        sgl/qwen38-27b-*-super* slug, ALSO fetch the z-lab BF16 one:"
+      echo "[dflash]          WEIGHT_KEY=qwen3.8-27b:dflash2-zlab bash scripts/setup.sh qwen3.8-27b"
+      echo "[dflash]        (~3.85 GB. The quantized drafter silently collapses"
+      echo "[dflash]         acceptance on SGLang - sglang#39087.)"
+      ;;
+  esac
   echo ""
 else
   echo "[dflash]  Skipping DFlash draft model. Set WITH_DFLASH_DRAFT=1 to fetch it when a matching compose requires it."


### PR DESCRIPTION
Two defects, both surfaced by [#1251](https://github.com/noonghunna/club-3090/issues/1251) —
@paulp83's 2× 5090 submission, the first community SGLang report.

## 1. The `sgl/…-super*` slugs cannot fetch their drafter

```
drafter not found at /models/qwen3.8-27b-dflash2-zlab-bf16
```

The slug is unbootable out of the box, and following our own docs doesn't fix it.
`setup.dflash` is a **single key per model**, but the two engines need different drafters:

| slug family | key | repo | size |
|---|---|---|--:|
| vLLM `super*`/`ultra*` | `dflash2` | `syvai/…-DFlash2-W4A16` | 1.2 GB |
| **SGLang `sgl/…-super*`** | `dflash2-zlab` | `z-lab/…-DFlash2` (BF16) | 3.85 GB |

`setup.dflash` resolves to `dflash2`, so `WITH_DFLASH_DRAFT=1` fetches the vLLM drafter and the
SGLang composes then look for a directory that was never downloaded.

⚠️ **The loud failure is the good outcome.** Pointing an `sgl/` slug at the quantized drafter
instead does not error — it drafts garbage at accept len ~1.03 vs ~5.3, decode ~38 vs ~171 tok/s,
with a fully passing test suite ([sglang#39087](https://github.com/sgl-project/sglang/issues/39087)).
A user who "fixes" the path by symlinking whatever setup fetched gets a 4× decode loss and no signal
at all. So the recovery message matters as much as the fetch does.

Three changes:

- **The 7 `dflash2` composes** now tell you how to recover rather than just stating the path: the
  exact `WEIGHT_KEY` command, a warning that `WITH_DFLASH_DRAFT=1` gets the wrong one *and why that
  is dangerous rather than merely unhelpful*, and `SPEC_N=0` to boot with no drafter.
- **`setup.sh`** notes the engine split immediately after fetching the vLLM drafter, so the command
  is in front of anyone who ran `WITH_DFLASH_DRAFT=1`.
- **`dflash2-zlab` had no `size_gb`**, so the disk gate could not size the download — for the
  drafter every `sgl/ super*` slug needs. Measured on disk: 3,849,114,690 B = **3.85 GB** decimal
  (3.58 GiB).

**Deliberately not changed:** `setup.dflash` stays single-valued. Making `WITH_DFLASH_DRAFT` fetch
both pushes 3.85 GB onto vLLM-only users, and a per-engine key needs setup to know which engine you
will serve, which it doesn't. `WEIGHT_KEY` is already the documented "exact catalog entry" flow.

## 2. The SpecDecoding tail was blank on 2 of 3 engines

`bench.sh` and `bench-agentic.sh` both close with a hardcoded

```bash
docker logs "$CONTAINER" | grep "SpecDecoding metrics" | tail -3
```

That's vLLM's string. SGLang writes `accept len: N, accept rate: N`; llama.cpp writes
`draft acceptance = N`. On either, the section came back **empty** — which reads as "spec-dec
produced nothing", not "this only knows one engine's wording".

Both SpecDecoding blocks in #1251 are blank while the MTP drafter was running normally. The only
acceptance lines anywhere in that report come from an unrelated llama.cpp container captured under
*Recent failed boot attempts*.

Same class as [#1249](https://github.com/noonghunna/club-3090/pull/1249), **separate site** — these
are hardcoded greps rather than the shared `capture.sh` parser, so that PR didn't reach them.
Fixture-checked against a log carrying all three wordings plus a spec-free line: old grep matched
1 of 3, new one matches 3 of 3 and still ignores the spec-free line.

## Gates

`model-weights-registry`, `profiles-compat`, `setup-picker`, `setup-verify-count`,
`compose-status-drift`, `compose-mounts-resolve`, `bench-capture`, `script-permissions` — 8/8. All 7
composes render. Exec bits verified per-commit (the `os.replace` trap from #1249).

## Follow-up

@paulp83's numbers still aren't bankable: his acceptance was never captured, so his `dual-fast` run
has TPS without the drafter-health figure that says whether those TPS mean anything. Worth asking
him to re-run on this branch.
