### PR TITLE
fix(glm): tool calling is dead on llama.cpp (minja vs `_args.items()`) — document it, and stop printing a Qwen hint for it (#1250)

### DIFF
--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q2k/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q2k/moecache.yml
@@ -89,6 +89,26 @@
 #   Status:    🧪 Experimental
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
+#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
+#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
+#       this template. Automatic parser generation failed: While executing
+#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
+#       statically walking the chat template; column 57 of line 163 is the `(` of
+#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
+#       template-COMPILE time, so it is deterministic on every tools request, and the
+#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
+#       empty. Reported club-3090#1250 (@paulp83).
+#       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
+#       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
+#       Same subsystem, opposite end. Do not merge the two.
+#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
+#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
+#       at line 163, byte-identical. It DOES fix other things (null-safe content,
+#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
+#       just not as a fix for this.
+#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
+#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
+#       the rest of the run without the tool checks dominating it.
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q2k/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q2k/offload.yml
@@ -270,6 +270,26 @@
 #   Best for:  ⭐ CONSTRAINED-HOST-RAM boxes — ~78 GB here vs the moecache
 #              sibling's ~112 GB. Same weights, same engine, no expert pool.
 #   Caveats:
+#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
+#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
+#       this template. Automatic parser generation failed: While executing
+#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
+#       statically walking the chat template; column 57 of line 163 is the `(` of
+#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
+#       template-COMPILE time, so it is deterministic on every tools request, and the
+#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
+#       empty. Reported club-3090#1250 (@paulp83).
+#       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
+#       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
+#       Same subsystem, opposite end. Do not merge the two.
+#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
+#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
+#       at line 163, byte-identical. It DOES fix other things (null-safe content,
+#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
+#       just not as a fix for this.
+#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
+#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
+#       the rest of the run without the tool checks dominating it.
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q3km/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q3km/moecache.yml
@@ -87,6 +87,26 @@
 #   Status:    🧪 Experimental
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
+#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
+#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
+#       this template. Automatic parser generation failed: While executing
+#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
+#       statically walking the chat template; column 57 of line 163 is the `(` of
+#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
+#       template-COMPILE time, so it is deterministic on every tools request, and the
+#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
+#       empty. Reported club-3090#1250 (@paulp83).
+#       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
+#       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
+#       Same subsystem, opposite end. Do not merge the two.
+#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
+#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
+#       at line 163, byte-identical. It DOES fix other things (null-safe content,
+#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
+#       just not as a fix for this.
+#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
+#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
+#       the rest of the run without the tool checks dominating it.
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q3km/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q3km/offload.yml
@@ -270,6 +270,26 @@
 #   Best for:  ⭐ CONSTRAINED-HOST-RAM boxes — ~111 GB here vs the moecache
 #              sibling's ~148 GB. Same weights, same engine, no expert pool.
 #   Caveats:
+#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
+#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
+#       this template. Automatic parser generation failed: While executing
+#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
+#       statically walking the chat template; column 57 of line 163 is the `(` of
+#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
+#       template-COMPILE time, so it is deterministic on every tools request, and the
+#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
+#       empty. Reported club-3090#1250 (@paulp83).
+#       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
+#       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
+#       Same subsystem, opposite end. Do not merge the two.
+#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
+#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
+#       at line 163, byte-identical. It DOES fix other things (null-safe content,
+#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
+#       just not as a fix for this.
+#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
+#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
+#       the rest of the run without the tool checks dominating it.
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq3xxs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq3xxs/moecache.yml
@@ -83,6 +83,26 @@
 #   Status:    🧪 Experimental
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
+#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
+#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
+#       this template. Automatic parser generation failed: While executing
+#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
+#       statically walking the chat template; column 57 of line 163 is the `(` of
+#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
+#       template-COMPILE time, so it is deterministic on every tools request, and the
+#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
+#       empty. Reported club-3090#1250 (@paulp83).
+#       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
+#       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
+#       Same subsystem, opposite end. Do not merge the two.
+#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
+#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
+#       at line 163, byte-identical. It DOES fix other things (null-safe content,
+#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
+#       just not as a fix for this.
+#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
+#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
+#       the rest of the run without the tool checks dominating it.
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/moecache.yml
@@ -43,6 +43,26 @@
 #   Status:    🧪 Experimental
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
+#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
+#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
+#       this template. Automatic parser generation failed: While executing
+#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
+#       statically walking the chat template; column 57 of line 163 is the `(` of
+#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
+#       template-COMPILE time, so it is deterministic on every tools request, and the
+#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
+#       empty. Reported club-3090#1250 (@paulp83).
+#       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
+#       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
+#       Same subsystem, opposite end. Do not merge the two.
+#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
+#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
+#       at line 163, byte-identical. It DOES fix other things (null-safe content,
+#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
+#       just not as a fix for this.
+#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
+#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
+#       the rest of the run without the tool checks dominating it.
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q2k/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q2k/moecache.yml
@@ -157,6 +157,26 @@
 #                been run on GLM-5.3-Flash. Stays 🧪.
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
+#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
+#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
+#       this template. Automatic parser generation failed: While executing
+#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
+#       statically walking the chat template; column 57 of line 163 is the `(` of
+#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
+#       template-COMPILE time, so it is deterministic on every tools request, and the
+#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
+#       empty. Reported club-3090#1250 (@paulp83).
+#       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
+#       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
+#       Same subsystem, opposite end. Do not merge the two.
+#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
+#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
+#       at line 163, byte-identical. It DOES fix other things (null-safe content,
+#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
+#       just not as a fix for this.
+#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
+#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
+#       the rest of the run without the tool checks dominating it.
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q2k/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q2k/offload.yml
@@ -340,6 +340,26 @@
 #   Best for:  ⭐ CONSTRAINED-HOST-RAM boxes — ~42 GB here vs the moecache
 #              sibling's ~112 GB. Same weights, same engine, no expert pool.
 #   Caveats:
+#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
+#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
+#       this template. Automatic parser generation failed: While executing
+#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
+#       statically walking the chat template; column 57 of line 163 is the `(` of
+#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
+#       template-COMPILE time, so it is deterministic on every tools request, and the
+#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
+#       empty. Reported club-3090#1250 (@paulp83).
+#       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
+#       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
+#       Same subsystem, opposite end. Do not merge the two.
+#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
+#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
+#       at line 163, byte-identical. It DOES fix other things (null-safe content,
+#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
+#       just not as a fix for this.
+#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
+#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
+#       the rest of the run without the tool checks dominating it.
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q3km/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q3km/moecache.yml
@@ -155,6 +155,26 @@
 #                been run on GLM-5.3-Flash. Stays 🧪.
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
+#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
+#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
+#       this template. Automatic parser generation failed: While executing
+#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
+#       statically walking the chat template; column 57 of line 163 is the `(` of
+#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
+#       template-COMPILE time, so it is deterministic on every tools request, and the
+#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
+#       empty. Reported club-3090#1250 (@paulp83).
+#       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
+#       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
+#       Same subsystem, opposite end. Do not merge the two.
+#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
+#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
+#       at line 163, byte-identical. It DOES fix other things (null-safe content,
+#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
+#       just not as a fix for this.
+#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
+#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
+#       the rest of the run without the tool checks dominating it.
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q3km/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q3km/offload.yml
@@ -338,6 +338,26 @@
 #   Best for:  ⭐ CONSTRAINED-HOST-RAM boxes — ~75 GB here vs the moecache
 #              sibling's ~148 GB. Same weights, same engine, no expert pool.
 #   Caveats:
+#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
+#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
+#       this template. Automatic parser generation failed: While executing
+#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
+#       statically walking the chat template; column 57 of line 163 is the `(` of
+#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
+#       template-COMPILE time, so it is deterministic on every tools request, and the
+#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
+#       empty. Reported club-3090#1250 (@paulp83).
+#       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
+#       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
+#       Same subsystem, opposite end. Do not merge the two.
+#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
+#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
+#       at line 163, byte-identical. It DOES fix other things (null-safe content,
+#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
+#       just not as a fix for this.
+#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
+#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
+#       the rest of the run without the tool checks dominating it.
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/unsloth-ud-iq3xxs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/unsloth-ud-iq3xxs/moecache.yml
@@ -151,6 +151,26 @@
 #                been run on GLM-5.3-Flash. Stays 🧪.
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
+#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
+#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
+#       this template. Automatic parser generation failed: While executing
+#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
+#       statically walking the chat template; column 57 of line 163 is the `(` of
+#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
+#       template-COMPILE time, so it is deterministic on every tools request, and the
+#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
+#       empty. Reported club-3090#1250 (@paulp83).
+#       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
+#       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
+#       Same subsystem, opposite end. Do not merge the two.
+#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
+#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
+#       at line 163, byte-identical. It DOES fix other things (null-safe content,
+#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
+#       just not as a fix for this.
+#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
+#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
+#       the rest of the run without the tool checks dominating it.
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/unsloth-ud-iq4xs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/unsloth-ud-iq4xs/moecache.yml
@@ -115,6 +115,26 @@
 #                been run on GLM-5.3-Flash. Stays 🧪.
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
+#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
+#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
+#       this template. Automatic parser generation failed: While executing
+#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
+#       statically walking the chat template; column 57 of line 163 is the `(` of
+#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
+#       template-COMPILE time, so it is deterministic on every tools request, and the
+#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
+#       empty. Reported club-3090#1250 (@paulp83).
+#       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
+#       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
+#       Same subsystem, opposite end. Do not merge the two.
+#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
+#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
+#       at line 163, byte-identical. It DOES fix other things (null-safe content,
+#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
+#       just not as a fix for this.
+#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
+#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
+#       the rest of the run without the tool checks dominating it.
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q2k/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q2k/moecache.yml
@@ -157,6 +157,26 @@
 #                been run on GLM-5.3-Flash. Stays 🧪.
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
+#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
+#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
+#       this template. Automatic parser generation failed: While executing
+#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
+#       statically walking the chat template; column 57 of line 163 is the `(` of
+#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
+#       template-COMPILE time, so it is deterministic on every tools request, and the
+#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
+#       empty. Reported club-3090#1250 (@paulp83).
+#       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
+#       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
+#       Same subsystem, opposite end. Do not merge the two.
+#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
+#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
+#       at line 163, byte-identical. It DOES fix other things (null-safe content,
+#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
+#       just not as a fix for this.
+#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
+#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
+#       the rest of the run without the tool checks dominating it.
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q2k/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q2k/offload.yml
@@ -340,6 +340,26 @@
 #   Best for:  ⭐ CONSTRAINED-HOST-RAM boxes — ~16 GB here vs the moecache
 #              sibling's ~112 GB. Same weights, same engine, no expert pool.
 #   Caveats:
+#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
+#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
+#       this template. Automatic parser generation failed: While executing
+#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
+#       statically walking the chat template; column 57 of line 163 is the `(` of
+#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
+#       template-COMPILE time, so it is deterministic on every tools request, and the
+#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
+#       empty. Reported club-3090#1250 (@paulp83).
+#       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
+#       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
+#       Same subsystem, opposite end. Do not merge the two.
+#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
+#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
+#       at line 163, byte-identical. It DOES fix other things (null-safe content,
+#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
+#       just not as a fix for this.
+#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
+#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
+#       the rest of the run without the tool checks dominating it.
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q3km/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q3km/moecache.yml
@@ -155,6 +155,26 @@
 #                been run on GLM-5.3-Flash. Stays 🧪.
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
+#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
+#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
+#       this template. Automatic parser generation failed: While executing
+#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
+#       statically walking the chat template; column 57 of line 163 is the `(` of
+#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
+#       template-COMPILE time, so it is deterministic on every tools request, and the
+#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
+#       empty. Reported club-3090#1250 (@paulp83).
+#       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
+#       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
+#       Same subsystem, opposite end. Do not merge the two.
+#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
+#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
+#       at line 163, byte-identical. It DOES fix other things (null-safe content,
+#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
+#       just not as a fix for this.
+#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
+#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
+#       the rest of the run without the tool checks dominating it.
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q3km/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q3km/offload.yml
@@ -338,6 +338,26 @@
 #   Best for:  ⭐ CONSTRAINED-HOST-RAM boxes — ~16 GB here vs the moecache
 #              sibling's ~148 GB. Same weights, same engine, no expert pool.
 #   Caveats:
+#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
+#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
+#       this template. Automatic parser generation failed: While executing
+#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
+#       statically walking the chat template; column 57 of line 163 is the `(` of
+#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
+#       template-COMPILE time, so it is deterministic on every tools request, and the
+#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
+#       empty. Reported club-3090#1250 (@paulp83).
+#       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
+#       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
+#       Same subsystem, opposite end. Do not merge the two.
+#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
+#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
+#       at line 163, byte-identical. It DOES fix other things (null-safe content,
+#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
+#       just not as a fix for this.
+#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
+#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
+#       the rest of the run without the tool checks dominating it.
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/unsloth-ud-iq3xxs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/unsloth-ud-iq3xxs/moecache.yml
@@ -151,6 +151,26 @@
 #                been run on GLM-5.3-Flash. Stays 🧪.
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
+#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
+#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
+#       this template. Automatic parser generation failed: While executing
+#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
+#       statically walking the chat template; column 57 of line 163 is the `(` of
+#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
+#       template-COMPILE time, so it is deterministic on every tools request, and the
+#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
+#       empty. Reported club-3090#1250 (@paulp83).
+#       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
+#       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
+#       Same subsystem, opposite end. Do not merge the two.
+#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
+#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
+#       at line 163, byte-identical. It DOES fix other things (null-safe content,
+#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
+#       just not as a fix for this.
+#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
+#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
+#       the rest of the run without the tool checks dominating it.
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/unsloth-ud-iq4xs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/unsloth-ud-iq4xs/moecache.yml
@@ -115,6 +115,26 @@
 #                been run on GLM-5.3-Flash. Stays 🧪.
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
+#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
+#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
+#       this template. Automatic parser generation failed: While executing
+#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
+#       statically walking the chat template; column 57 of line 163 is the `(` of
+#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
+#       template-COMPILE time, so it is deterministic on every tools request, and the
+#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
+#       empty. Reported club-3090#1250 (@paulp83).
+#       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
+#       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
+#       Same subsystem, opposite end. Do not merge the two.
+#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
+#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
+#       at line 163, byte-identical. It DOES fix other things (null-safe content,
+#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
+#       just not as a fix for this.
+#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
+#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
+#       the rest of the run without the tool checks dominating it.
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.

--- a/scripts/verify-full.sh
+++ b/scripts/verify-full.sh
@@ -357,8 +357,23 @@ except Exception as e:
     print(f'__PARSE_ERROR__: {e}')
 " 2>&1)"
   if echo "$tool_calls" | grep -q "__INLINED__"; then
-    fail "model emitted <tool_call> as inline text (tool_calls[] empty)" \
-         "Known issue: MTP × TurboQuant incompat. Use docker-compose.tools.yml or .tools-text.yml. See README Known issues."
+    # This hint was hardcoded to the Qwen3.6/vLLM cause and printed on EVERY engine.
+    # A GLM-on-llama.cpp reporter was told "MTP x TurboQuant incompat, use
+    # docker-compose.tools.yml" — a file that does not exist for that model, naming a
+    # mechanism absent from their stack (club-3090#1250). A hint that confidently names
+    # the WRONG cause is worse than no hint: it sends the reporter to fix something that
+    # was never broken, and they cannot tell it is wrong without knowing the codebase.
+    case "$ENGINE_KIND" in
+      llamacpp)
+        fail "model emitted <tool_call> as inline text (tool_calls[] empty)" \
+             "llama.cpp builds its tool parser by statically walking the chat template. If the template uses constructs minja cannot evaluate, parser generation FAILS and the tags stay in content. Re-send a request WITH tools and look for HTTP 400 'Unable to generate parser for this template' — if present this is template/minja, not the model or the quant (GLM-5.3-Flash hits it at _args.items(): club-3090#1250). Otherwise check --jinja and --chat-template-file." ;;
+      sglang)
+        fail "model emitted <tool_call> as inline text (tool_calls[] empty)" \
+             "Check --tool-call-parser matches the model family (qwen3_coder on the Qwen3.x composes) and that the chat template emits the format that parser expects." ;;
+      *)
+        fail "model emitted <tool_call> as inline text (tool_calls[] empty)" \
+             "On the Qwen3.6 vLLM tiers this is the MTP x TurboQuant incompat - use docker-compose.tools.yml or .tools-text.yml (README Known issues). On other stacks check --tool-call-parser and the chat template first." ;;
+    esac
   elif echo "$tool_calls" | grep -qi "get_weather"; then
     pass "tool_calls[] populated with get_weather"
   else


### PR DESCRIPTION
Both from [#1250](https://github.com/noonghunna/club-3090/issues/1250) — @paulp83 running
`llama-cpp-glm53-flash-q3km-moecache`, where every tools request returned HTTP 400.

## Root cause (upstream, not ours)

```
Unable to generate parser for this template. Automatic parser generation failed:
While executing CallExpression at line 163, column 57
```

llama.cpp builds a tool-call parser by statically walking the chat template. Line 163 col 57 of the
template embedded in that GGUF is the `(` of `_args.items()`:

```jinja
{%- set _args = tc.arguments %}{% for k, v in _args.items() %}<arg_key>{{ k }}</arg_key>...
```

minja cannot evaluate that during the parser-generation pass. It fails at **template-compile time**,
so it is deterministic on every request carrying `tools` — not intermittent, not payload-dependent,
not the quant. The `<tool_call>` leaking into `content` with `tool_calls[]` empty is the same bug
downstream: no parser was generated, so nothing extracts the tags.

**⚠️ Not [#1195](https://github.com/noonghunna/club-3090/issues/1195).** That is an *intermittent
500* parsing the model's **output** (`Failed to parse tool call arguments as JSON`, 2/25 soak turns).
This is a *deterministic 400* building the parser from the **template**. Same subsystem, opposite
end — called out explicitly in the caveat so the two don't get merged and one buried behind the
other.

**⚠️ The vendor's updated template does not fix it.** `zai-org/GLM-5.3-Flash/chat_template.jinja`
(last modified 2026-09-07) still carries `_args.items()` at line 163, byte-identical to the embedded
one. It *does* fix other things — null-safe `content`, `~` rather than `+` for concat, `break` guards
in the sort loops — so vendoring it is worth doing on its own merits. Checked against the live
upstream file before writing the caveat rather than assumed.

## 1. `verify-full` was handing out a Qwen remediation on every engine

```
Known issue: MTP × TurboQuant incompat. Use docker-compose.tools.yml or .tools-text.yml.
```

Hardcoded, no engine branch. There is no `docker-compose.tools.yml` for GLM, TurboQuant isn't in
that stack, and MTP isn't the mechanism — so the reporter was sent to fix something that was never
broken, with no way to tell the hint was wrong without knowing this codebase.

**A hint that confidently names the wrong cause is worse than no hint.** Now branches on
`ENGINE_KIND`: the llama.cpp arm names the real mechanism *and* how to confirm it (re-send with
tools, look for the 400); the SGLang arm points at `--tool-call-parser`; the Qwen text stays as the
default.

## 2. 18 GLM composes never mentioned that tools are dead

Those files carry a ~200-line Caveats block covering drafter placement, the context cliff, host RAM
and cold-start — and nothing about tool calling, while the tool path returns 400 every time. Now
documented, with the mechanism, the #1195 distinction, the upstream-template finding, and the
`SKIP_TOOLS=1` workaround for getting the rest of a verify-full run.

Everything not passing `tools` is unaffected — his report shows IDE-agent one-shot, LCB-coding,
reasoning-heavy (8192 tokens), completion, streaming and output-quality all passing.

## Gates

`compose-status-drift`, `compose-mounts-resolve`, `script-permissions`, `verify-vision` green;
18/18 composes render; exec bit verified.

## Not done

No template override is shipped. A minja-compatible rewrite of that one construct is the real fix
and wants its own change — ideally alongside vendoring the 2026-09-07 upstream template for the
other fixes it carries. Worth checking whether the unsloth GGUFs embed the same construct before
assuming it's universal across publishers.
