### PR TITLE
fix(glm): vendor a minja-compatible chat template — tool calling works, and the #1254 mechanism was wrong

### DIFF
--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q2k/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q2k/moecache.yml
@@ -89,26 +89,34 @@
 #   Status:    🧪 Experimental
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
-#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
-#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
-#       this template. Automatic parser generation failed: While executing
-#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
-#       statically walking the chat template; column 57 of line 163 is the `(` of
-#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
-#       template-COMPILE time, so it is deterministic on every tools request, and the
-#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
-#       empty. Reported club-3090#1250 (@paulp83).
+#     • ✅ TOOL CALLING WORKS — via the vendored template override wired below.
+#       ⚠️ It does NOT work on the GGUF's own embedded template: every request carrying
+#       `tools` returns HTTP 400 "Unable to generate parser for this template …
+#       CallExpression at line 163, column 57", and /props reports supports_tools:false.
+#       Reported club-3090#1250 (@paulp83) and upstream ggml-org/llama.cpp#27754.
+#       ⛔⛔ THE LINE IN THAT ERROR IS THE CRASH SITE, NOT THE CAUSE. Two earlier readings
+#       of this bug were WRONG and are recorded so nobody re-derives them:
+#         ❌ "minja cannot evaluate .items()" — GLM-4.7-Flash.jinja has the identical
+#            construct, is exercised by llama.cpp's own autoparser tests, and passes.
+#         ❌ "the caps probe under-detects supports_object_arguments because the template
+#            iterates instead of indexing" — adding a named access changes nothing; the
+#            probe never gets that far.
+#       ⭐ ACTUAL CAUSE: minja does not implement NUMERIC DOTTED ATTRIBUTE ACCESS (`x.0`).
+#       Jinja2 defines `x.0` as `x[0]`; minja parses it as a non-computed member whose
+#       property is a number literal and throws. The GGUF template uses it in 4 places, so
+#       the caps probe throws, infers NOTHING, and leaves every capability false —
+#       including supports_object_arguments, which gates the JSON-string -> object
+#       conversion of tool arguments (chat.cpp). Arguments therefore stay a string, and
+#       the autoparser then dies on `.items()` at line 163. That is why supports_string_content
+#       is false too, which no tools-only explanation accounts for.
+#       ⇒ The override is the vendor template with `.0.` -> `[0].` in 4 places plus a
+#       null-tool guard. Wire format UNCHANGED. Verified with llama.cpp's own
+#       llama-template-analysis: all four capabilities flip false -> true.
 #       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
 #       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
 #       Same subsystem, opposite end. Do not merge the two.
-#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
-#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
-#       at line 163, byte-identical. It DOES fix other things (null-safe content,
-#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
-#       just not as a fix for this.
-#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
-#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
-#       the rest of the run without the tool checks dominating it.
+#       ⚠️ NOT live-booted: verified by static analysis + the engine's own autoparser, not
+#       by serving 140 GiB end-to-end. Detail: patches/glm53-minja-numeric-index/README.md
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.
@@ -239,6 +247,9 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8130}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+      # minja-compatible chat template — WITHOUT this every tools request 400s and
+      # /props reports supports_tools:false. See patches/glm53-minja-numeric-index/README.md
+      - ../../../patches/glm53-minja-numeric-index/chat_template.jinja:/etc/glm53-chat-template.jinja:ro
     environment:
       # Drafter toggle - docker forwards only what is declared here.
       - SPEC_N=${SPEC_N:-}
@@ -627,6 +638,14 @@ services:
       - '--reasoning-effort'
       - '${REASONING_EFFORT:-max}'
       # Route thoughts to message.reasoning_content (never inline in content).
+      # ⭐ minja cannot parse `x.0` (numeric dotted attribute access); the GGUF's own
+      # template uses it in 4 places, which makes the jinja caps probe throw and report
+      # EVERY capability false — so tool arguments are never converted from JSON string
+      # to object and the autoparser dies. This override is the vendor template with
+      # `.0.` -> `[0].` (semantics-identical in Jinja2) + a null-tool guard. Wire format
+      # unchanged. club-3090#1250.
+      - '--chat-template-file'
+      - '/etc/glm53-chat-template.jinja'
       - '--reasoning-format'
       - '${REASONING_FORMAT:-deepseek}'
       # ✅ What DOES work is not paying for it twice. This GGUF's template sets

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q2k/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q2k/offload.yml
@@ -270,26 +270,34 @@
 #   Best for:  ⭐ CONSTRAINED-HOST-RAM boxes — ~78 GB here vs the moecache
 #              sibling's ~112 GB. Same weights, same engine, no expert pool.
 #   Caveats:
-#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
-#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
-#       this template. Automatic parser generation failed: While executing
-#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
-#       statically walking the chat template; column 57 of line 163 is the `(` of
-#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
-#       template-COMPILE time, so it is deterministic on every tools request, and the
-#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
-#       empty. Reported club-3090#1250 (@paulp83).
+#     • ✅ TOOL CALLING WORKS — via the vendored template override wired below.
+#       ⚠️ It does NOT work on the GGUF's own embedded template: every request carrying
+#       `tools` returns HTTP 400 "Unable to generate parser for this template …
+#       CallExpression at line 163, column 57", and /props reports supports_tools:false.
+#       Reported club-3090#1250 (@paulp83) and upstream ggml-org/llama.cpp#27754.
+#       ⛔⛔ THE LINE IN THAT ERROR IS THE CRASH SITE, NOT THE CAUSE. Two earlier readings
+#       of this bug were WRONG and are recorded so nobody re-derives them:
+#         ❌ "minja cannot evaluate .items()" — GLM-4.7-Flash.jinja has the identical
+#            construct, is exercised by llama.cpp's own autoparser tests, and passes.
+#         ❌ "the caps probe under-detects supports_object_arguments because the template
+#            iterates instead of indexing" — adding a named access changes nothing; the
+#            probe never gets that far.
+#       ⭐ ACTUAL CAUSE: minja does not implement NUMERIC DOTTED ATTRIBUTE ACCESS (`x.0`).
+#       Jinja2 defines `x.0` as `x[0]`; minja parses it as a non-computed member whose
+#       property is a number literal and throws. The GGUF template uses it in 4 places, so
+#       the caps probe throws, infers NOTHING, and leaves every capability false —
+#       including supports_object_arguments, which gates the JSON-string -> object
+#       conversion of tool arguments (chat.cpp). Arguments therefore stay a string, and
+#       the autoparser then dies on `.items()` at line 163. That is why supports_string_content
+#       is false too, which no tools-only explanation accounts for.
+#       ⇒ The override is the vendor template with `.0.` -> `[0].` in 4 places plus a
+#       null-tool guard. Wire format UNCHANGED. Verified with llama.cpp's own
+#       llama-template-analysis: all four capabilities flip false -> true.
 #       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
 #       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
 #       Same subsystem, opposite end. Do not merge the two.
-#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
-#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
-#       at line 163, byte-identical. It DOES fix other things (null-safe content,
-#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
-#       just not as a fix for this.
-#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
-#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
-#       the rest of the run without the tool checks dominating it.
+#       ⚠️ NOT live-booted: verified by static analysis + the engine's own autoparser, not
+#       by serving 140 GiB end-to-end. Detail: patches/glm53-minja-numeric-index/README.md
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.
@@ -420,6 +428,9 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8136}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+      # minja-compatible chat template — WITHOUT this every tools request 400s and
+      # /props reports supports_tools:false. See patches/glm53-minja-numeric-index/README.md
+      - ../../../patches/glm53-minja-numeric-index/chat_template.jinja:/etc/glm53-chat-template.jinja:ro
     environment:
       # Drafter toggle - docker forwards only what is declared here.
       - SPEC_N=${SPEC_N:-}
@@ -808,6 +819,14 @@ services:
       - '--reasoning-effort'
       - '${REASONING_EFFORT:-max}'
       # Route thoughts to message.reasoning_content (never inline in content).
+      # ⭐ minja cannot parse `x.0` (numeric dotted attribute access); the GGUF's own
+      # template uses it in 4 places, which makes the jinja caps probe throw and report
+      # EVERY capability false — so tool arguments are never converted from JSON string
+      # to object and the autoparser dies. This override is the vendor template with
+      # `.0.` -> `[0].` (semantics-identical in Jinja2) + a null-tool guard. Wire format
+      # unchanged. club-3090#1250.
+      - '--chat-template-file'
+      - '/etc/glm53-chat-template.jinja'
       - '--reasoning-format'
       - '${REASONING_FORMAT:-deepseek}'
       # ✅ What DOES work is not paying for it twice. This GGUF's template sets

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q3km/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q3km/moecache.yml
@@ -87,26 +87,34 @@
 #   Status:    🧪 Experimental
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
-#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
-#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
-#       this template. Automatic parser generation failed: While executing
-#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
-#       statically walking the chat template; column 57 of line 163 is the `(` of
-#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
-#       template-COMPILE time, so it is deterministic on every tools request, and the
-#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
-#       empty. Reported club-3090#1250 (@paulp83).
+#     • ✅ TOOL CALLING WORKS — via the vendored template override wired below.
+#       ⚠️ It does NOT work on the GGUF's own embedded template: every request carrying
+#       `tools` returns HTTP 400 "Unable to generate parser for this template …
+#       CallExpression at line 163, column 57", and /props reports supports_tools:false.
+#       Reported club-3090#1250 (@paulp83) and upstream ggml-org/llama.cpp#27754.
+#       ⛔⛔ THE LINE IN THAT ERROR IS THE CRASH SITE, NOT THE CAUSE. Two earlier readings
+#       of this bug were WRONG and are recorded so nobody re-derives them:
+#         ❌ "minja cannot evaluate .items()" — GLM-4.7-Flash.jinja has the identical
+#            construct, is exercised by llama.cpp's own autoparser tests, and passes.
+#         ❌ "the caps probe under-detects supports_object_arguments because the template
+#            iterates instead of indexing" — adding a named access changes nothing; the
+#            probe never gets that far.
+#       ⭐ ACTUAL CAUSE: minja does not implement NUMERIC DOTTED ATTRIBUTE ACCESS (`x.0`).
+#       Jinja2 defines `x.0` as `x[0]`; minja parses it as a non-computed member whose
+#       property is a number literal and throws. The GGUF template uses it in 4 places, so
+#       the caps probe throws, infers NOTHING, and leaves every capability false —
+#       including supports_object_arguments, which gates the JSON-string -> object
+#       conversion of tool arguments (chat.cpp). Arguments therefore stay a string, and
+#       the autoparser then dies on `.items()` at line 163. That is why supports_string_content
+#       is false too, which no tools-only explanation accounts for.
+#       ⇒ The override is the vendor template with `.0.` -> `[0].` in 4 places plus a
+#       null-tool guard. Wire format UNCHANGED. Verified with llama.cpp's own
+#       llama-template-analysis: all four capabilities flip false -> true.
 #       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
 #       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
 #       Same subsystem, opposite end. Do not merge the two.
-#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
-#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
-#       at line 163, byte-identical. It DOES fix other things (null-safe content,
-#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
-#       just not as a fix for this.
-#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
-#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
-#       the rest of the run without the tool checks dominating it.
+#       ⚠️ NOT live-booted: verified by static analysis + the engine's own autoparser, not
+#       by serving 140 GiB end-to-end. Detail: patches/glm53-minja-numeric-index/README.md
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.
@@ -237,6 +245,9 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8133}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+      # minja-compatible chat template — WITHOUT this every tools request 400s and
+      # /props reports supports_tools:false. See patches/glm53-minja-numeric-index/README.md
+      - ../../../patches/glm53-minja-numeric-index/chat_template.jinja:/etc/glm53-chat-template.jinja:ro
     environment:
       # Drafter toggle - docker forwards only what is declared here.
       - SPEC_N=${SPEC_N:-}
@@ -625,6 +636,14 @@ services:
       - '--reasoning-effort'
       - '${REASONING_EFFORT:-max}'
       # Route thoughts to message.reasoning_content (never inline in content).
+      # ⭐ minja cannot parse `x.0` (numeric dotted attribute access); the GGUF's own
+      # template uses it in 4 places, which makes the jinja caps probe throw and report
+      # EVERY capability false — so tool arguments are never converted from JSON string
+      # to object and the autoparser dies. This override is the vendor template with
+      # `.0.` -> `[0].` (semantics-identical in Jinja2) + a null-tool guard. Wire format
+      # unchanged. club-3090#1250.
+      - '--chat-template-file'
+      - '/etc/glm53-chat-template.jinja'
       - '--reasoning-format'
       - '${REASONING_FORMAT:-deepseek}'
       # ✅ What DOES work is not paying for it twice. This GGUF's template sets

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q3km/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q3km/offload.yml
@@ -270,26 +270,34 @@
 #   Best for:  ⭐ CONSTRAINED-HOST-RAM boxes — ~111 GB here vs the moecache
 #              sibling's ~148 GB. Same weights, same engine, no expert pool.
 #   Caveats:
-#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
-#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
-#       this template. Automatic parser generation failed: While executing
-#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
-#       statically walking the chat template; column 57 of line 163 is the `(` of
-#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
-#       template-COMPILE time, so it is deterministic on every tools request, and the
-#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
-#       empty. Reported club-3090#1250 (@paulp83).
+#     • ✅ TOOL CALLING WORKS — via the vendored template override wired below.
+#       ⚠️ It does NOT work on the GGUF's own embedded template: every request carrying
+#       `tools` returns HTTP 400 "Unable to generate parser for this template …
+#       CallExpression at line 163, column 57", and /props reports supports_tools:false.
+#       Reported club-3090#1250 (@paulp83) and upstream ggml-org/llama.cpp#27754.
+#       ⛔⛔ THE LINE IN THAT ERROR IS THE CRASH SITE, NOT THE CAUSE. Two earlier readings
+#       of this bug were WRONG and are recorded so nobody re-derives them:
+#         ❌ "minja cannot evaluate .items()" — GLM-4.7-Flash.jinja has the identical
+#            construct, is exercised by llama.cpp's own autoparser tests, and passes.
+#         ❌ "the caps probe under-detects supports_object_arguments because the template
+#            iterates instead of indexing" — adding a named access changes nothing; the
+#            probe never gets that far.
+#       ⭐ ACTUAL CAUSE: minja does not implement NUMERIC DOTTED ATTRIBUTE ACCESS (`x.0`).
+#       Jinja2 defines `x.0` as `x[0]`; minja parses it as a non-computed member whose
+#       property is a number literal and throws. The GGUF template uses it in 4 places, so
+#       the caps probe throws, infers NOTHING, and leaves every capability false —
+#       including supports_object_arguments, which gates the JSON-string -> object
+#       conversion of tool arguments (chat.cpp). Arguments therefore stay a string, and
+#       the autoparser then dies on `.items()` at line 163. That is why supports_string_content
+#       is false too, which no tools-only explanation accounts for.
+#       ⇒ The override is the vendor template with `.0.` -> `[0].` in 4 places plus a
+#       null-tool guard. Wire format UNCHANGED. Verified with llama.cpp's own
+#       llama-template-analysis: all four capabilities flip false -> true.
 #       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
 #       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
 #       Same subsystem, opposite end. Do not merge the two.
-#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
-#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
-#       at line 163, byte-identical. It DOES fix other things (null-safe content,
-#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
-#       just not as a fix for this.
-#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
-#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
-#       the rest of the run without the tool checks dominating it.
+#       ⚠️ NOT live-booted: verified by static analysis + the engine's own autoparser, not
+#       by serving 140 GiB end-to-end. Detail: patches/glm53-minja-numeric-index/README.md
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.
@@ -420,6 +428,9 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8139}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+      # minja-compatible chat template — WITHOUT this every tools request 400s and
+      # /props reports supports_tools:false. See patches/glm53-minja-numeric-index/README.md
+      - ../../../patches/glm53-minja-numeric-index/chat_template.jinja:/etc/glm53-chat-template.jinja:ro
     environment:
       # Drafter toggle - docker forwards only what is declared here.
       - SPEC_N=${SPEC_N:-}
@@ -808,6 +819,14 @@ services:
       - '--reasoning-effort'
       - '${REASONING_EFFORT:-max}'
       # Route thoughts to message.reasoning_content (never inline in content).
+      # ⭐ minja cannot parse `x.0` (numeric dotted attribute access); the GGUF's own
+      # template uses it in 4 places, which makes the jinja caps probe throw and report
+      # EVERY capability false — so tool arguments are never converted from JSON string
+      # to object and the autoparser dies. This override is the vendor template with
+      # `.0.` -> `[0].` (semantics-identical in Jinja2) + a null-tool guard. Wire format
+      # unchanged. club-3090#1250.
+      - '--chat-template-file'
+      - '/etc/glm53-chat-template.jinja'
       - '--reasoning-format'
       - '${REASONING_FORMAT:-deepseek}'
       # ✅ What DOES work is not paying for it twice. This GGUF's template sets

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq3xxs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq3xxs/moecache.yml
@@ -83,26 +83,34 @@
 #   Status:    🧪 Experimental
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
-#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
-#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
-#       this template. Automatic parser generation failed: While executing
-#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
-#       statically walking the chat template; column 57 of line 163 is the `(` of
-#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
-#       template-COMPILE time, so it is deterministic on every tools request, and the
-#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
-#       empty. Reported club-3090#1250 (@paulp83).
+#     • ✅ TOOL CALLING WORKS — via the vendored template override wired below.
+#       ⚠️ It does NOT work on the GGUF's own embedded template: every request carrying
+#       `tools` returns HTTP 400 "Unable to generate parser for this template …
+#       CallExpression at line 163, column 57", and /props reports supports_tools:false.
+#       Reported club-3090#1250 (@paulp83) and upstream ggml-org/llama.cpp#27754.
+#       ⛔⛔ THE LINE IN THAT ERROR IS THE CRASH SITE, NOT THE CAUSE. Two earlier readings
+#       of this bug were WRONG and are recorded so nobody re-derives them:
+#         ❌ "minja cannot evaluate .items()" — GLM-4.7-Flash.jinja has the identical
+#            construct, is exercised by llama.cpp's own autoparser tests, and passes.
+#         ❌ "the caps probe under-detects supports_object_arguments because the template
+#            iterates instead of indexing" — adding a named access changes nothing; the
+#            probe never gets that far.
+#       ⭐ ACTUAL CAUSE: minja does not implement NUMERIC DOTTED ATTRIBUTE ACCESS (`x.0`).
+#       Jinja2 defines `x.0` as `x[0]`; minja parses it as a non-computed member whose
+#       property is a number literal and throws. The GGUF template uses it in 4 places, so
+#       the caps probe throws, infers NOTHING, and leaves every capability false —
+#       including supports_object_arguments, which gates the JSON-string -> object
+#       conversion of tool arguments (chat.cpp). Arguments therefore stay a string, and
+#       the autoparser then dies on `.items()` at line 163. That is why supports_string_content
+#       is false too, which no tools-only explanation accounts for.
+#       ⇒ The override is the vendor template with `.0.` -> `[0].` in 4 places plus a
+#       null-tool guard. Wire format UNCHANGED. Verified with llama.cpp's own
+#       llama-template-analysis: all four capabilities flip false -> true.
 #       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
 #       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
 #       Same subsystem, opposite end. Do not merge the two.
-#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
-#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
-#       at line 163, byte-identical. It DOES fix other things (null-safe content,
-#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
-#       just not as a fix for this.
-#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
-#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
-#       the rest of the run without the tool checks dominating it.
+#       ⚠️ NOT live-booted: verified by static analysis + the engine's own autoparser, not
+#       by serving 140 GiB end-to-end. Detail: patches/glm53-minja-numeric-index/README.md
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.
@@ -233,6 +241,9 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8125}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+      # minja-compatible chat template — WITHOUT this every tools request 400s and
+      # /props reports supports_tools:false. See patches/glm53-minja-numeric-index/README.md
+      - ../../../patches/glm53-minja-numeric-index/chat_template.jinja:/etc/glm53-chat-template.jinja:ro
     environment:
       # Drafter toggle - docker forwards only what is declared here.
       - SPEC_N=${SPEC_N:-}
@@ -621,6 +632,14 @@ services:
       - '--reasoning-effort'
       - '${REASONING_EFFORT:-max}'
       # Route thoughts to message.reasoning_content (never inline in content).
+      # ⭐ minja cannot parse `x.0` (numeric dotted attribute access); the GGUF's own
+      # template uses it in 4 places, which makes the jinja caps probe throw and report
+      # EVERY capability false — so tool arguments are never converted from JSON string
+      # to object and the autoparser dies. This override is the vendor template with
+      # `.0.` -> `[0].` (semantics-identical in Jinja2) + a null-tool guard. Wire format
+      # unchanged. club-3090#1250.
+      - '--chat-template-file'
+      - '/etc/glm53-chat-template.jinja'
       - '--reasoning-format'
       - '${REASONING_FORMAT:-deepseek}'
       # ✅ What DOES work is not paying for it twice. This GGUF's template sets

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/moecache.yml
@@ -43,26 +43,34 @@
 #   Status:    🧪 Experimental
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
-#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
-#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
-#       this template. Automatic parser generation failed: While executing
-#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
-#       statically walking the chat template; column 57 of line 163 is the `(` of
-#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
-#       template-COMPILE time, so it is deterministic on every tools request, and the
-#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
-#       empty. Reported club-3090#1250 (@paulp83).
+#     • ✅ TOOL CALLING WORKS — via the vendored template override wired below.
+#       ⚠️ It does NOT work on the GGUF's own embedded template: every request carrying
+#       `tools` returns HTTP 400 "Unable to generate parser for this template …
+#       CallExpression at line 163, column 57", and /props reports supports_tools:false.
+#       Reported club-3090#1250 (@paulp83) and upstream ggml-org/llama.cpp#27754.
+#       ⛔⛔ THE LINE IN THAT ERROR IS THE CRASH SITE, NOT THE CAUSE. Two earlier readings
+#       of this bug were WRONG and are recorded so nobody re-derives them:
+#         ❌ "minja cannot evaluate .items()" — GLM-4.7-Flash.jinja has the identical
+#            construct, is exercised by llama.cpp's own autoparser tests, and passes.
+#         ❌ "the caps probe under-detects supports_object_arguments because the template
+#            iterates instead of indexing" — adding a named access changes nothing; the
+#            probe never gets that far.
+#       ⭐ ACTUAL CAUSE: minja does not implement NUMERIC DOTTED ATTRIBUTE ACCESS (`x.0`).
+#       Jinja2 defines `x.0` as `x[0]`; minja parses it as a non-computed member whose
+#       property is a number literal and throws. The GGUF template uses it in 4 places, so
+#       the caps probe throws, infers NOTHING, and leaves every capability false —
+#       including supports_object_arguments, which gates the JSON-string -> object
+#       conversion of tool arguments (chat.cpp). Arguments therefore stay a string, and
+#       the autoparser then dies on `.items()` at line 163. That is why supports_string_content
+#       is false too, which no tools-only explanation accounts for.
+#       ⇒ The override is the vendor template with `.0.` -> `[0].` in 4 places plus a
+#       null-tool guard. Wire format UNCHANGED. Verified with llama.cpp's own
+#       llama-template-analysis: all four capabilities flip false -> true.
 #       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
 #       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
 #       Same subsystem, opposite end. Do not merge the two.
-#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
-#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
-#       at line 163, byte-identical. It DOES fix other things (null-safe content,
-#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
-#       just not as a fix for this.
-#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
-#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
-#       the rest of the run without the tool checks dominating it.
+#       ⚠️ NOT live-booted: verified by static analysis + the engine's own autoparser, not
+#       by serving 140 GiB end-to-end. Detail: patches/glm53-minja-numeric-index/README.md
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.
@@ -194,6 +202,9 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8119}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+      # minja-compatible chat template — WITHOUT this every tools request 400s and
+      # /props reports supports_tools:false. See patches/glm53-minja-numeric-index/README.md
+      - ../../../patches/glm53-minja-numeric-index/chat_template.jinja:/etc/glm53-chat-template.jinja:ro
     environment:
       # Drafter toggle - docker forwards only what is declared here.
       - SPEC_N=${SPEC_N:-}
@@ -551,6 +562,14 @@ services:
       - '--reasoning-effort'
       - '${REASONING_EFFORT:-max}'
       # Route thoughts to message.reasoning_content (never inline in content).
+      # ⭐ minja cannot parse `x.0` (numeric dotted attribute access); the GGUF's own
+      # template uses it in 4 places, which makes the jinja caps probe throw and report
+      # EVERY capability false — so tool arguments are never converted from JSON string
+      # to object and the autoparser dies. This override is the vendor template with
+      # `.0.` -> `[0].` (semantics-identical in Jinja2) + a null-tool guard. Wire format
+      # unchanged. club-3090#1250.
+      - '--chat-template-file'
+      - '/etc/glm53-chat-template.jinja'
       - '--reasoning-format'
       - '${REASONING_FORMAT:-deepseek}'
       # ✅ What DOES work is not paying for it twice. This GGUF's template sets

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q2k/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q2k/moecache.yml
@@ -157,26 +157,34 @@
 #                been run on GLM-5.3-Flash. Stays 🧪.
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
-#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
-#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
-#       this template. Automatic parser generation failed: While executing
-#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
-#       statically walking the chat template; column 57 of line 163 is the `(` of
-#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
-#       template-COMPILE time, so it is deterministic on every tools request, and the
-#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
-#       empty. Reported club-3090#1250 (@paulp83).
+#     • ✅ TOOL CALLING WORKS — via the vendored template override wired below.
+#       ⚠️ It does NOT work on the GGUF's own embedded template: every request carrying
+#       `tools` returns HTTP 400 "Unable to generate parser for this template …
+#       CallExpression at line 163, column 57", and /props reports supports_tools:false.
+#       Reported club-3090#1250 (@paulp83) and upstream ggml-org/llama.cpp#27754.
+#       ⛔⛔ THE LINE IN THAT ERROR IS THE CRASH SITE, NOT THE CAUSE. Two earlier readings
+#       of this bug were WRONG and are recorded so nobody re-derives them:
+#         ❌ "minja cannot evaluate .items()" — GLM-4.7-Flash.jinja has the identical
+#            construct, is exercised by llama.cpp's own autoparser tests, and passes.
+#         ❌ "the caps probe under-detects supports_object_arguments because the template
+#            iterates instead of indexing" — adding a named access changes nothing; the
+#            probe never gets that far.
+#       ⭐ ACTUAL CAUSE: minja does not implement NUMERIC DOTTED ATTRIBUTE ACCESS (`x.0`).
+#       Jinja2 defines `x.0` as `x[0]`; minja parses it as a non-computed member whose
+#       property is a number literal and throws. The GGUF template uses it in 4 places, so
+#       the caps probe throws, infers NOTHING, and leaves every capability false —
+#       including supports_object_arguments, which gates the JSON-string -> object
+#       conversion of tool arguments (chat.cpp). Arguments therefore stay a string, and
+#       the autoparser then dies on `.items()` at line 163. That is why supports_string_content
+#       is false too, which no tools-only explanation accounts for.
+#       ⇒ The override is the vendor template with `.0.` -> `[0].` in 4 places plus a
+#       null-tool guard. Wire format UNCHANGED. Verified with llama.cpp's own
+#       llama-template-analysis: all four capabilities flip false -> true.
 #       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
 #       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
 #       Same subsystem, opposite end. Do not merge the two.
-#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
-#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
-#       at line 163, byte-identical. It DOES fix other things (null-safe content,
-#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
-#       just not as a fix for this.
-#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
-#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
-#       the rest of the run without the tool checks dominating it.
+#       ⚠️ NOT live-booted: verified by static analysis + the engine's own autoparser, not
+#       by serving 140 GiB end-to-end. Detail: patches/glm53-minja-numeric-index/README.md
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.
@@ -301,6 +309,9 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8131}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+      # minja-compatible chat template — WITHOUT this every tools request 400s and
+      # /props reports supports_tools:false. See patches/glm53-minja-numeric-index/README.md
+      - ../../../patches/glm53-minja-numeric-index/chat_template.jinja:/etc/glm53-chat-template.jinja:ro
     environment:
       # Drafter toggle - docker forwards only what is declared here.
       - SPEC_N=${SPEC_N:-}
@@ -619,6 +630,14 @@ services:
       - '--reasoning-effort'
       - '${REASONING_EFFORT:-max}'
       # Route thoughts to message.reasoning_content (never inline in content).
+      # ⭐ minja cannot parse `x.0` (numeric dotted attribute access); the GGUF's own
+      # template uses it in 4 places, which makes the jinja caps probe throw and report
+      # EVERY capability false — so tool arguments are never converted from JSON string
+      # to object and the autoparser dies. This override is the vendor template with
+      # `.0.` -> `[0].` (semantics-identical in Jinja2) + a null-tool guard. Wire format
+      # unchanged. club-3090#1250.
+      - '--chat-template-file'
+      - '/etc/glm53-chat-template.jinja'
       - '--reasoning-format'
       - '${REASONING_FORMAT:-deepseek}'
       # ✅ What DOES work is not paying for it twice. This GGUF's template sets

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q2k/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q2k/offload.yml
@@ -340,26 +340,34 @@
 #   Best for:  ⭐ CONSTRAINED-HOST-RAM boxes — ~42 GB here vs the moecache
 #              sibling's ~112 GB. Same weights, same engine, no expert pool.
 #   Caveats:
-#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
-#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
-#       this template. Automatic parser generation failed: While executing
-#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
-#       statically walking the chat template; column 57 of line 163 is the `(` of
-#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
-#       template-COMPILE time, so it is deterministic on every tools request, and the
-#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
-#       empty. Reported club-3090#1250 (@paulp83).
+#     • ✅ TOOL CALLING WORKS — via the vendored template override wired below.
+#       ⚠️ It does NOT work on the GGUF's own embedded template: every request carrying
+#       `tools` returns HTTP 400 "Unable to generate parser for this template …
+#       CallExpression at line 163, column 57", and /props reports supports_tools:false.
+#       Reported club-3090#1250 (@paulp83) and upstream ggml-org/llama.cpp#27754.
+#       ⛔⛔ THE LINE IN THAT ERROR IS THE CRASH SITE, NOT THE CAUSE. Two earlier readings
+#       of this bug were WRONG and are recorded so nobody re-derives them:
+#         ❌ "minja cannot evaluate .items()" — GLM-4.7-Flash.jinja has the identical
+#            construct, is exercised by llama.cpp's own autoparser tests, and passes.
+#         ❌ "the caps probe under-detects supports_object_arguments because the template
+#            iterates instead of indexing" — adding a named access changes nothing; the
+#            probe never gets that far.
+#       ⭐ ACTUAL CAUSE: minja does not implement NUMERIC DOTTED ATTRIBUTE ACCESS (`x.0`).
+#       Jinja2 defines `x.0` as `x[0]`; minja parses it as a non-computed member whose
+#       property is a number literal and throws. The GGUF template uses it in 4 places, so
+#       the caps probe throws, infers NOTHING, and leaves every capability false —
+#       including supports_object_arguments, which gates the JSON-string -> object
+#       conversion of tool arguments (chat.cpp). Arguments therefore stay a string, and
+#       the autoparser then dies on `.items()` at line 163. That is why supports_string_content
+#       is false too, which no tools-only explanation accounts for.
+#       ⇒ The override is the vendor template with `.0.` -> `[0].` in 4 places plus a
+#       null-tool guard. Wire format UNCHANGED. Verified with llama.cpp's own
+#       llama-template-analysis: all four capabilities flip false -> true.
 #       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
 #       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
 #       Same subsystem, opposite end. Do not merge the two.
-#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
-#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
-#       at line 163, byte-identical. It DOES fix other things (null-safe content,
-#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
-#       just not as a fix for this.
-#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
-#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
-#       the rest of the run without the tool checks dominating it.
+#       ⚠️ NOT live-booted: verified by static analysis + the engine's own autoparser, not
+#       by serving 140 GiB end-to-end. Detail: patches/glm53-minja-numeric-index/README.md
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.
@@ -484,6 +492,9 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8137}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+      # minja-compatible chat template — WITHOUT this every tools request 400s and
+      # /props reports supports_tools:false. See patches/glm53-minja-numeric-index/README.md
+      - ../../../patches/glm53-minja-numeric-index/chat_template.jinja:/etc/glm53-chat-template.jinja:ro
     environment:
       # Drafter toggle - docker forwards only what is declared here.
       - SPEC_N=${SPEC_N:-}
@@ -802,6 +813,14 @@ services:
       - '--reasoning-effort'
       - '${REASONING_EFFORT:-max}'
       # Route thoughts to message.reasoning_content (never inline in content).
+      # ⭐ minja cannot parse `x.0` (numeric dotted attribute access); the GGUF's own
+      # template uses it in 4 places, which makes the jinja caps probe throw and report
+      # EVERY capability false — so tool arguments are never converted from JSON string
+      # to object and the autoparser dies. This override is the vendor template with
+      # `.0.` -> `[0].` (semantics-identical in Jinja2) + a null-tool guard. Wire format
+      # unchanged. club-3090#1250.
+      - '--chat-template-file'
+      - '/etc/glm53-chat-template.jinja'
       - '--reasoning-format'
       - '${REASONING_FORMAT:-deepseek}'
       # ✅ What DOES work is not paying for it twice. This GGUF's template sets

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q3km/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q3km/moecache.yml
@@ -155,26 +155,34 @@
 #                been run on GLM-5.3-Flash. Stays 🧪.
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
-#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
-#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
-#       this template. Automatic parser generation failed: While executing
-#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
-#       statically walking the chat template; column 57 of line 163 is the `(` of
-#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
-#       template-COMPILE time, so it is deterministic on every tools request, and the
-#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
-#       empty. Reported club-3090#1250 (@paulp83).
+#     • ✅ TOOL CALLING WORKS — via the vendored template override wired below.
+#       ⚠️ It does NOT work on the GGUF's own embedded template: every request carrying
+#       `tools` returns HTTP 400 "Unable to generate parser for this template …
+#       CallExpression at line 163, column 57", and /props reports supports_tools:false.
+#       Reported club-3090#1250 (@paulp83) and upstream ggml-org/llama.cpp#27754.
+#       ⛔⛔ THE LINE IN THAT ERROR IS THE CRASH SITE, NOT THE CAUSE. Two earlier readings
+#       of this bug were WRONG and are recorded so nobody re-derives them:
+#         ❌ "minja cannot evaluate .items()" — GLM-4.7-Flash.jinja has the identical
+#            construct, is exercised by llama.cpp's own autoparser tests, and passes.
+#         ❌ "the caps probe under-detects supports_object_arguments because the template
+#            iterates instead of indexing" — adding a named access changes nothing; the
+#            probe never gets that far.
+#       ⭐ ACTUAL CAUSE: minja does not implement NUMERIC DOTTED ATTRIBUTE ACCESS (`x.0`).
+#       Jinja2 defines `x.0` as `x[0]`; minja parses it as a non-computed member whose
+#       property is a number literal and throws. The GGUF template uses it in 4 places, so
+#       the caps probe throws, infers NOTHING, and leaves every capability false —
+#       including supports_object_arguments, which gates the JSON-string -> object
+#       conversion of tool arguments (chat.cpp). Arguments therefore stay a string, and
+#       the autoparser then dies on `.items()` at line 163. That is why supports_string_content
+#       is false too, which no tools-only explanation accounts for.
+#       ⇒ The override is the vendor template with `.0.` -> `[0].` in 4 places plus a
+#       null-tool guard. Wire format UNCHANGED. Verified with llama.cpp's own
+#       llama-template-analysis: all four capabilities flip false -> true.
 #       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
 #       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
 #       Same subsystem, opposite end. Do not merge the two.
-#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
-#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
-#       at line 163, byte-identical. It DOES fix other things (null-safe content,
-#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
-#       just not as a fix for this.
-#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
-#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
-#       the rest of the run without the tool checks dominating it.
+#       ⚠️ NOT live-booted: verified by static analysis + the engine's own autoparser, not
+#       by serving 140 GiB end-to-end. Detail: patches/glm53-minja-numeric-index/README.md
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.
@@ -299,6 +307,9 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8134}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+      # minja-compatible chat template — WITHOUT this every tools request 400s and
+      # /props reports supports_tools:false. See patches/glm53-minja-numeric-index/README.md
+      - ../../../patches/glm53-minja-numeric-index/chat_template.jinja:/etc/glm53-chat-template.jinja:ro
     environment:
       # Drafter toggle - docker forwards only what is declared here.
       - SPEC_N=${SPEC_N:-}
@@ -617,6 +628,14 @@ services:
       - '--reasoning-effort'
       - '${REASONING_EFFORT:-max}'
       # Route thoughts to message.reasoning_content (never inline in content).
+      # ⭐ minja cannot parse `x.0` (numeric dotted attribute access); the GGUF's own
+      # template uses it in 4 places, which makes the jinja caps probe throw and report
+      # EVERY capability false — so tool arguments are never converted from JSON string
+      # to object and the autoparser dies. This override is the vendor template with
+      # `.0.` -> `[0].` (semantics-identical in Jinja2) + a null-tool guard. Wire format
+      # unchanged. club-3090#1250.
+      - '--chat-template-file'
+      - '/etc/glm53-chat-template.jinja'
       - '--reasoning-format'
       - '${REASONING_FORMAT:-deepseek}'
       # ✅ What DOES work is not paying for it twice. This GGUF's template sets

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q3km/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q3km/offload.yml
@@ -338,26 +338,34 @@
 #   Best for:  ⭐ CONSTRAINED-HOST-RAM boxes — ~75 GB here vs the moecache
 #              sibling's ~148 GB. Same weights, same engine, no expert pool.
 #   Caveats:
-#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
-#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
-#       this template. Automatic parser generation failed: While executing
-#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
-#       statically walking the chat template; column 57 of line 163 is the `(` of
-#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
-#       template-COMPILE time, so it is deterministic on every tools request, and the
-#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
-#       empty. Reported club-3090#1250 (@paulp83).
+#     • ✅ TOOL CALLING WORKS — via the vendored template override wired below.
+#       ⚠️ It does NOT work on the GGUF's own embedded template: every request carrying
+#       `tools` returns HTTP 400 "Unable to generate parser for this template …
+#       CallExpression at line 163, column 57", and /props reports supports_tools:false.
+#       Reported club-3090#1250 (@paulp83) and upstream ggml-org/llama.cpp#27754.
+#       ⛔⛔ THE LINE IN THAT ERROR IS THE CRASH SITE, NOT THE CAUSE. Two earlier readings
+#       of this bug were WRONG and are recorded so nobody re-derives them:
+#         ❌ "minja cannot evaluate .items()" — GLM-4.7-Flash.jinja has the identical
+#            construct, is exercised by llama.cpp's own autoparser tests, and passes.
+#         ❌ "the caps probe under-detects supports_object_arguments because the template
+#            iterates instead of indexing" — adding a named access changes nothing; the
+#            probe never gets that far.
+#       ⭐ ACTUAL CAUSE: minja does not implement NUMERIC DOTTED ATTRIBUTE ACCESS (`x.0`).
+#       Jinja2 defines `x.0` as `x[0]`; minja parses it as a non-computed member whose
+#       property is a number literal and throws. The GGUF template uses it in 4 places, so
+#       the caps probe throws, infers NOTHING, and leaves every capability false —
+#       including supports_object_arguments, which gates the JSON-string -> object
+#       conversion of tool arguments (chat.cpp). Arguments therefore stay a string, and
+#       the autoparser then dies on `.items()` at line 163. That is why supports_string_content
+#       is false too, which no tools-only explanation accounts for.
+#       ⇒ The override is the vendor template with `.0.` -> `[0].` in 4 places plus a
+#       null-tool guard. Wire format UNCHANGED. Verified with llama.cpp's own
+#       llama-template-analysis: all four capabilities flip false -> true.
 #       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
 #       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
 #       Same subsystem, opposite end. Do not merge the two.
-#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
-#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
-#       at line 163, byte-identical. It DOES fix other things (null-safe content,
-#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
-#       just not as a fix for this.
-#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
-#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
-#       the rest of the run without the tool checks dominating it.
+#       ⚠️ NOT live-booted: verified by static analysis + the engine's own autoparser, not
+#       by serving 140 GiB end-to-end. Detail: patches/glm53-minja-numeric-index/README.md
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.
@@ -482,6 +490,9 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8140}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+      # minja-compatible chat template — WITHOUT this every tools request 400s and
+      # /props reports supports_tools:false. See patches/glm53-minja-numeric-index/README.md
+      - ../../../patches/glm53-minja-numeric-index/chat_template.jinja:/etc/glm53-chat-template.jinja:ro
     environment:
       # Drafter toggle - docker forwards only what is declared here.
       - SPEC_N=${SPEC_N:-}
@@ -800,6 +811,14 @@ services:
       - '--reasoning-effort'
       - '${REASONING_EFFORT:-max}'
       # Route thoughts to message.reasoning_content (never inline in content).
+      # ⭐ minja cannot parse `x.0` (numeric dotted attribute access); the GGUF's own
+      # template uses it in 4 places, which makes the jinja caps probe throw and report
+      # EVERY capability false — so tool arguments are never converted from JSON string
+      # to object and the autoparser dies. This override is the vendor template with
+      # `.0.` -> `[0].` (semantics-identical in Jinja2) + a null-tool guard. Wire format
+      # unchanged. club-3090#1250.
+      - '--chat-template-file'
+      - '/etc/glm53-chat-template.jinja'
       - '--reasoning-format'
       - '${REASONING_FORMAT:-deepseek}'
       # ✅ What DOES work is not paying for it twice. This GGUF's template sets

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/unsloth-ud-iq3xxs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/unsloth-ud-iq3xxs/moecache.yml
@@ -151,26 +151,34 @@
 #                been run on GLM-5.3-Flash. Stays 🧪.
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
-#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
-#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
-#       this template. Automatic parser generation failed: While executing
-#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
-#       statically walking the chat template; column 57 of line 163 is the `(` of
-#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
-#       template-COMPILE time, so it is deterministic on every tools request, and the
-#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
-#       empty. Reported club-3090#1250 (@paulp83).
+#     • ✅ TOOL CALLING WORKS — via the vendored template override wired below.
+#       ⚠️ It does NOT work on the GGUF's own embedded template: every request carrying
+#       `tools` returns HTTP 400 "Unable to generate parser for this template …
+#       CallExpression at line 163, column 57", and /props reports supports_tools:false.
+#       Reported club-3090#1250 (@paulp83) and upstream ggml-org/llama.cpp#27754.
+#       ⛔⛔ THE LINE IN THAT ERROR IS THE CRASH SITE, NOT THE CAUSE. Two earlier readings
+#       of this bug were WRONG and are recorded so nobody re-derives them:
+#         ❌ "minja cannot evaluate .items()" — GLM-4.7-Flash.jinja has the identical
+#            construct, is exercised by llama.cpp's own autoparser tests, and passes.
+#         ❌ "the caps probe under-detects supports_object_arguments because the template
+#            iterates instead of indexing" — adding a named access changes nothing; the
+#            probe never gets that far.
+#       ⭐ ACTUAL CAUSE: minja does not implement NUMERIC DOTTED ATTRIBUTE ACCESS (`x.0`).
+#       Jinja2 defines `x.0` as `x[0]`; minja parses it as a non-computed member whose
+#       property is a number literal and throws. The GGUF template uses it in 4 places, so
+#       the caps probe throws, infers NOTHING, and leaves every capability false —
+#       including supports_object_arguments, which gates the JSON-string -> object
+#       conversion of tool arguments (chat.cpp). Arguments therefore stay a string, and
+#       the autoparser then dies on `.items()` at line 163. That is why supports_string_content
+#       is false too, which no tools-only explanation accounts for.
+#       ⇒ The override is the vendor template with `.0.` -> `[0].` in 4 places plus a
+#       null-tool guard. Wire format UNCHANGED. Verified with llama.cpp's own
+#       llama-template-analysis: all four capabilities flip false -> true.
 #       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
 #       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
 #       Same subsystem, opposite end. Do not merge the two.
-#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
-#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
-#       at line 163, byte-identical. It DOES fix other things (null-safe content,
-#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
-#       just not as a fix for this.
-#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
-#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
-#       the rest of the run without the tool checks dominating it.
+#       ⚠️ NOT live-booted: verified by static analysis + the engine's own autoparser, not
+#       by serving 140 GiB end-to-end. Detail: patches/glm53-minja-numeric-index/README.md
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.
@@ -295,6 +303,9 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8126}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+      # minja-compatible chat template — WITHOUT this every tools request 400s and
+      # /props reports supports_tools:false. See patches/glm53-minja-numeric-index/README.md
+      - ../../../patches/glm53-minja-numeric-index/chat_template.jinja:/etc/glm53-chat-template.jinja:ro
     environment:
       # Drafter toggle - docker forwards only what is declared here.
       - SPEC_N=${SPEC_N:-}
@@ -613,6 +624,14 @@ services:
       - '--reasoning-effort'
       - '${REASONING_EFFORT:-max}'
       # Route thoughts to message.reasoning_content (never inline in content).
+      # ⭐ minja cannot parse `x.0` (numeric dotted attribute access); the GGUF's own
+      # template uses it in 4 places, which makes the jinja caps probe throw and report
+      # EVERY capability false — so tool arguments are never converted from JSON string
+      # to object and the autoparser dies. This override is the vendor template with
+      # `.0.` -> `[0].` (semantics-identical in Jinja2) + a null-tool guard. Wire format
+      # unchanged. club-3090#1250.
+      - '--chat-template-file'
+      - '/etc/glm53-chat-template.jinja'
       - '--reasoning-format'
       - '${REASONING_FORMAT:-deepseek}'
       # ✅ What DOES work is not paying for it twice. This GGUF's template sets

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/unsloth-ud-iq4xs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/unsloth-ud-iq4xs/moecache.yml
@@ -115,26 +115,34 @@
 #                been run on GLM-5.3-Flash. Stays 🧪.
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
-#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
-#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
-#       this template. Automatic parser generation failed: While executing
-#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
-#       statically walking the chat template; column 57 of line 163 is the `(` of
-#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
-#       template-COMPILE time, so it is deterministic on every tools request, and the
-#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
-#       empty. Reported club-3090#1250 (@paulp83).
+#     • ✅ TOOL CALLING WORKS — via the vendored template override wired below.
+#       ⚠️ It does NOT work on the GGUF's own embedded template: every request carrying
+#       `tools` returns HTTP 400 "Unable to generate parser for this template …
+#       CallExpression at line 163, column 57", and /props reports supports_tools:false.
+#       Reported club-3090#1250 (@paulp83) and upstream ggml-org/llama.cpp#27754.
+#       ⛔⛔ THE LINE IN THAT ERROR IS THE CRASH SITE, NOT THE CAUSE. Two earlier readings
+#       of this bug were WRONG and are recorded so nobody re-derives them:
+#         ❌ "minja cannot evaluate .items()" — GLM-4.7-Flash.jinja has the identical
+#            construct, is exercised by llama.cpp's own autoparser tests, and passes.
+#         ❌ "the caps probe under-detects supports_object_arguments because the template
+#            iterates instead of indexing" — adding a named access changes nothing; the
+#            probe never gets that far.
+#       ⭐ ACTUAL CAUSE: minja does not implement NUMERIC DOTTED ATTRIBUTE ACCESS (`x.0`).
+#       Jinja2 defines `x.0` as `x[0]`; minja parses it as a non-computed member whose
+#       property is a number literal and throws. The GGUF template uses it in 4 places, so
+#       the caps probe throws, infers NOTHING, and leaves every capability false —
+#       including supports_object_arguments, which gates the JSON-string -> object
+#       conversion of tool arguments (chat.cpp). Arguments therefore stay a string, and
+#       the autoparser then dies on `.items()` at line 163. That is why supports_string_content
+#       is false too, which no tools-only explanation accounts for.
+#       ⇒ The override is the vendor template with `.0.` -> `[0].` in 4 places plus a
+#       null-tool guard. Wire format UNCHANGED. Verified with llama.cpp's own
+#       llama-template-analysis: all four capabilities flip false -> true.
 #       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
 #       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
 #       Same subsystem, opposite end. Do not merge the two.
-#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
-#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
-#       at line 163, byte-identical. It DOES fix other things (null-safe content,
-#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
-#       just not as a fix for this.
-#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
-#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
-#       the rest of the run without the tool checks dominating it.
+#       ⚠️ NOT live-booted: verified by static analysis + the engine's own autoparser, not
+#       by serving 140 GiB end-to-end. Detail: patches/glm53-minja-numeric-index/README.md
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.
@@ -259,6 +267,9 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8120}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+      # minja-compatible chat template — WITHOUT this every tools request 400s and
+      # /props reports supports_tools:false. See patches/glm53-minja-numeric-index/README.md
+      - ../../../patches/glm53-minja-numeric-index/chat_template.jinja:/etc/glm53-chat-template.jinja:ro
     environment:
       # Drafter toggle - docker forwards only what is declared here.
       - SPEC_N=${SPEC_N:-}
@@ -577,6 +588,14 @@ services:
       - '--reasoning-effort'
       - '${REASONING_EFFORT:-max}'
       # Route thoughts to message.reasoning_content (never inline in content).
+      # ⭐ minja cannot parse `x.0` (numeric dotted attribute access); the GGUF's own
+      # template uses it in 4 places, which makes the jinja caps probe throw and report
+      # EVERY capability false — so tool arguments are never converted from JSON string
+      # to object and the autoparser dies. This override is the vendor template with
+      # `.0.` -> `[0].` (semantics-identical in Jinja2) + a null-tool guard. Wire format
+      # unchanged. club-3090#1250.
+      - '--chat-template-file'
+      - '/etc/glm53-chat-template.jinja'
       - '--reasoning-format'
       - '${REASONING_FORMAT:-deepseek}'
       # ✅ What DOES work is not paying for it twice. This GGUF's template sets

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q2k/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q2k/moecache.yml
@@ -157,26 +157,34 @@
 #                been run on GLM-5.3-Flash. Stays 🧪.
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
-#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
-#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
-#       this template. Automatic parser generation failed: While executing
-#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
-#       statically walking the chat template; column 57 of line 163 is the `(` of
-#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
-#       template-COMPILE time, so it is deterministic on every tools request, and the
-#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
-#       empty. Reported club-3090#1250 (@paulp83).
+#     • ✅ TOOL CALLING WORKS — via the vendored template override wired below.
+#       ⚠️ It does NOT work on the GGUF's own embedded template: every request carrying
+#       `tools` returns HTTP 400 "Unable to generate parser for this template …
+#       CallExpression at line 163, column 57", and /props reports supports_tools:false.
+#       Reported club-3090#1250 (@paulp83) and upstream ggml-org/llama.cpp#27754.
+#       ⛔⛔ THE LINE IN THAT ERROR IS THE CRASH SITE, NOT THE CAUSE. Two earlier readings
+#       of this bug were WRONG and are recorded so nobody re-derives them:
+#         ❌ "minja cannot evaluate .items()" — GLM-4.7-Flash.jinja has the identical
+#            construct, is exercised by llama.cpp's own autoparser tests, and passes.
+#         ❌ "the caps probe under-detects supports_object_arguments because the template
+#            iterates instead of indexing" — adding a named access changes nothing; the
+#            probe never gets that far.
+#       ⭐ ACTUAL CAUSE: minja does not implement NUMERIC DOTTED ATTRIBUTE ACCESS (`x.0`).
+#       Jinja2 defines `x.0` as `x[0]`; minja parses it as a non-computed member whose
+#       property is a number literal and throws. The GGUF template uses it in 4 places, so
+#       the caps probe throws, infers NOTHING, and leaves every capability false —
+#       including supports_object_arguments, which gates the JSON-string -> object
+#       conversion of tool arguments (chat.cpp). Arguments therefore stay a string, and
+#       the autoparser then dies on `.items()` at line 163. That is why supports_string_content
+#       is false too, which no tools-only explanation accounts for.
+#       ⇒ The override is the vendor template with `.0.` -> `[0].` in 4 places plus a
+#       null-tool guard. Wire format UNCHANGED. Verified with llama.cpp's own
+#       llama-template-analysis: all four capabilities flip false -> true.
 #       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
 #       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
 #       Same subsystem, opposite end. Do not merge the two.
-#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
-#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
-#       at line 163, byte-identical. It DOES fix other things (null-safe content,
-#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
-#       just not as a fix for this.
-#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
-#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
-#       the rest of the run without the tool checks dominating it.
+#       ⚠️ NOT live-booted: verified by static analysis + the engine's own autoparser, not
+#       by serving 140 GiB end-to-end. Detail: patches/glm53-minja-numeric-index/README.md
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.
@@ -301,6 +309,9 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8132}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+      # minja-compatible chat template — WITHOUT this every tools request 400s and
+      # /props reports supports_tools:false. See patches/glm53-minja-numeric-index/README.md
+      - ../../../patches/glm53-minja-numeric-index/chat_template.jinja:/etc/glm53-chat-template.jinja:ro
     environment:
       # Drafter toggle - docker forwards only what is declared here.
       - SPEC_N=${SPEC_N:-}
@@ -619,6 +630,14 @@ services:
       - '--reasoning-effort'
       - '${REASONING_EFFORT:-max}'
       # Route thoughts to message.reasoning_content (never inline in content).
+      # ⭐ minja cannot parse `x.0` (numeric dotted attribute access); the GGUF's own
+      # template uses it in 4 places, which makes the jinja caps probe throw and report
+      # EVERY capability false — so tool arguments are never converted from JSON string
+      # to object and the autoparser dies. This override is the vendor template with
+      # `.0.` -> `[0].` (semantics-identical in Jinja2) + a null-tool guard. Wire format
+      # unchanged. club-3090#1250.
+      - '--chat-template-file'
+      - '/etc/glm53-chat-template.jinja'
       - '--reasoning-format'
       - '${REASONING_FORMAT:-deepseek}'
       # ✅ What DOES work is not paying for it twice. This GGUF's template sets

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q2k/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q2k/offload.yml
@@ -340,26 +340,34 @@
 #   Best for:  ⭐ CONSTRAINED-HOST-RAM boxes — ~16 GB here vs the moecache
 #              sibling's ~112 GB. Same weights, same engine, no expert pool.
 #   Caveats:
-#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
-#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
-#       this template. Automatic parser generation failed: While executing
-#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
-#       statically walking the chat template; column 57 of line 163 is the `(` of
-#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
-#       template-COMPILE time, so it is deterministic on every tools request, and the
-#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
-#       empty. Reported club-3090#1250 (@paulp83).
+#     • ✅ TOOL CALLING WORKS — via the vendored template override wired below.
+#       ⚠️ It does NOT work on the GGUF's own embedded template: every request carrying
+#       `tools` returns HTTP 400 "Unable to generate parser for this template …
+#       CallExpression at line 163, column 57", and /props reports supports_tools:false.
+#       Reported club-3090#1250 (@paulp83) and upstream ggml-org/llama.cpp#27754.
+#       ⛔⛔ THE LINE IN THAT ERROR IS THE CRASH SITE, NOT THE CAUSE. Two earlier readings
+#       of this bug were WRONG and are recorded so nobody re-derives them:
+#         ❌ "minja cannot evaluate .items()" — GLM-4.7-Flash.jinja has the identical
+#            construct, is exercised by llama.cpp's own autoparser tests, and passes.
+#         ❌ "the caps probe under-detects supports_object_arguments because the template
+#            iterates instead of indexing" — adding a named access changes nothing; the
+#            probe never gets that far.
+#       ⭐ ACTUAL CAUSE: minja does not implement NUMERIC DOTTED ATTRIBUTE ACCESS (`x.0`).
+#       Jinja2 defines `x.0` as `x[0]`; minja parses it as a non-computed member whose
+#       property is a number literal and throws. The GGUF template uses it in 4 places, so
+#       the caps probe throws, infers NOTHING, and leaves every capability false —
+#       including supports_object_arguments, which gates the JSON-string -> object
+#       conversion of tool arguments (chat.cpp). Arguments therefore stay a string, and
+#       the autoparser then dies on `.items()` at line 163. That is why supports_string_content
+#       is false too, which no tools-only explanation accounts for.
+#       ⇒ The override is the vendor template with `.0.` -> `[0].` in 4 places plus a
+#       null-tool guard. Wire format UNCHANGED. Verified with llama.cpp's own
+#       llama-template-analysis: all four capabilities flip false -> true.
 #       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
 #       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
 #       Same subsystem, opposite end. Do not merge the two.
-#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
-#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
-#       at line 163, byte-identical. It DOES fix other things (null-safe content,
-#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
-#       just not as a fix for this.
-#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
-#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
-#       the rest of the run without the tool checks dominating it.
+#       ⚠️ NOT live-booted: verified by static analysis + the engine's own autoparser, not
+#       by serving 140 GiB end-to-end. Detail: patches/glm53-minja-numeric-index/README.md
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.
@@ -484,6 +492,9 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8138}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+      # minja-compatible chat template — WITHOUT this every tools request 400s and
+      # /props reports supports_tools:false. See patches/glm53-minja-numeric-index/README.md
+      - ../../../patches/glm53-minja-numeric-index/chat_template.jinja:/etc/glm53-chat-template.jinja:ro
     environment:
       # Drafter toggle - docker forwards only what is declared here.
       - SPEC_N=${SPEC_N:-}
@@ -802,6 +813,14 @@ services:
       - '--reasoning-effort'
       - '${REASONING_EFFORT:-max}'
       # Route thoughts to message.reasoning_content (never inline in content).
+      # ⭐ minja cannot parse `x.0` (numeric dotted attribute access); the GGUF's own
+      # template uses it in 4 places, which makes the jinja caps probe throw and report
+      # EVERY capability false — so tool arguments are never converted from JSON string
+      # to object and the autoparser dies. This override is the vendor template with
+      # `.0.` -> `[0].` (semantics-identical in Jinja2) + a null-tool guard. Wire format
+      # unchanged. club-3090#1250.
+      - '--chat-template-file'
+      - '/etc/glm53-chat-template.jinja'
       - '--reasoning-format'
       - '${REASONING_FORMAT:-deepseek}'
       # ✅ What DOES work is not paying for it twice. This GGUF's template sets

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q3km/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q3km/moecache.yml
@@ -155,26 +155,34 @@
 #                been run on GLM-5.3-Flash. Stays 🧪.
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
-#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
-#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
-#       this template. Automatic parser generation failed: While executing
-#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
-#       statically walking the chat template; column 57 of line 163 is the `(` of
-#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
-#       template-COMPILE time, so it is deterministic on every tools request, and the
-#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
-#       empty. Reported club-3090#1250 (@paulp83).
+#     • ✅ TOOL CALLING WORKS — via the vendored template override wired below.
+#       ⚠️ It does NOT work on the GGUF's own embedded template: every request carrying
+#       `tools` returns HTTP 400 "Unable to generate parser for this template …
+#       CallExpression at line 163, column 57", and /props reports supports_tools:false.
+#       Reported club-3090#1250 (@paulp83) and upstream ggml-org/llama.cpp#27754.
+#       ⛔⛔ THE LINE IN THAT ERROR IS THE CRASH SITE, NOT THE CAUSE. Two earlier readings
+#       of this bug were WRONG and are recorded so nobody re-derives them:
+#         ❌ "minja cannot evaluate .items()" — GLM-4.7-Flash.jinja has the identical
+#            construct, is exercised by llama.cpp's own autoparser tests, and passes.
+#         ❌ "the caps probe under-detects supports_object_arguments because the template
+#            iterates instead of indexing" — adding a named access changes nothing; the
+#            probe never gets that far.
+#       ⭐ ACTUAL CAUSE: minja does not implement NUMERIC DOTTED ATTRIBUTE ACCESS (`x.0`).
+#       Jinja2 defines `x.0` as `x[0]`; minja parses it as a non-computed member whose
+#       property is a number literal and throws. The GGUF template uses it in 4 places, so
+#       the caps probe throws, infers NOTHING, and leaves every capability false —
+#       including supports_object_arguments, which gates the JSON-string -> object
+#       conversion of tool arguments (chat.cpp). Arguments therefore stay a string, and
+#       the autoparser then dies on `.items()` at line 163. That is why supports_string_content
+#       is false too, which no tools-only explanation accounts for.
+#       ⇒ The override is the vendor template with `.0.` -> `[0].` in 4 places plus a
+#       null-tool guard. Wire format UNCHANGED. Verified with llama.cpp's own
+#       llama-template-analysis: all four capabilities flip false -> true.
 #       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
 #       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
 #       Same subsystem, opposite end. Do not merge the two.
-#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
-#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
-#       at line 163, byte-identical. It DOES fix other things (null-safe content,
-#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
-#       just not as a fix for this.
-#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
-#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
-#       the rest of the run without the tool checks dominating it.
+#       ⚠️ NOT live-booted: verified by static analysis + the engine's own autoparser, not
+#       by serving 140 GiB end-to-end. Detail: patches/glm53-minja-numeric-index/README.md
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.
@@ -299,6 +307,9 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8135}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+      # minja-compatible chat template — WITHOUT this every tools request 400s and
+      # /props reports supports_tools:false. See patches/glm53-minja-numeric-index/README.md
+      - ../../../patches/glm53-minja-numeric-index/chat_template.jinja:/etc/glm53-chat-template.jinja:ro
     environment:
       # Drafter toggle - docker forwards only what is declared here.
       - SPEC_N=${SPEC_N:-}
@@ -617,6 +628,14 @@ services:
       - '--reasoning-effort'
       - '${REASONING_EFFORT:-max}'
       # Route thoughts to message.reasoning_content (never inline in content).
+      # ⭐ minja cannot parse `x.0` (numeric dotted attribute access); the GGUF's own
+      # template uses it in 4 places, which makes the jinja caps probe throw and report
+      # EVERY capability false — so tool arguments are never converted from JSON string
+      # to object and the autoparser dies. This override is the vendor template with
+      # `.0.` -> `[0].` (semantics-identical in Jinja2) + a null-tool guard. Wire format
+      # unchanged. club-3090#1250.
+      - '--chat-template-file'
+      - '/etc/glm53-chat-template.jinja'
       - '--reasoning-format'
       - '${REASONING_FORMAT:-deepseek}'
       # ✅ What DOES work is not paying for it twice. This GGUF's template sets

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q3km/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q3km/offload.yml
@@ -338,26 +338,34 @@
 #   Best for:  ⭐ CONSTRAINED-HOST-RAM boxes — ~16 GB here vs the moecache
 #              sibling's ~148 GB. Same weights, same engine, no expert pool.
 #   Caveats:
-#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
-#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
-#       this template. Automatic parser generation failed: While executing
-#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
-#       statically walking the chat template; column 57 of line 163 is the `(` of
-#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
-#       template-COMPILE time, so it is deterministic on every tools request, and the
-#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
-#       empty. Reported club-3090#1250 (@paulp83).
+#     • ✅ TOOL CALLING WORKS — via the vendored template override wired below.
+#       ⚠️ It does NOT work on the GGUF's own embedded template: every request carrying
+#       `tools` returns HTTP 400 "Unable to generate parser for this template …
+#       CallExpression at line 163, column 57", and /props reports supports_tools:false.
+#       Reported club-3090#1250 (@paulp83) and upstream ggml-org/llama.cpp#27754.
+#       ⛔⛔ THE LINE IN THAT ERROR IS THE CRASH SITE, NOT THE CAUSE. Two earlier readings
+#       of this bug were WRONG and are recorded so nobody re-derives them:
+#         ❌ "minja cannot evaluate .items()" — GLM-4.7-Flash.jinja has the identical
+#            construct, is exercised by llama.cpp's own autoparser tests, and passes.
+#         ❌ "the caps probe under-detects supports_object_arguments because the template
+#            iterates instead of indexing" — adding a named access changes nothing; the
+#            probe never gets that far.
+#       ⭐ ACTUAL CAUSE: minja does not implement NUMERIC DOTTED ATTRIBUTE ACCESS (`x.0`).
+#       Jinja2 defines `x.0` as `x[0]`; minja parses it as a non-computed member whose
+#       property is a number literal and throws. The GGUF template uses it in 4 places, so
+#       the caps probe throws, infers NOTHING, and leaves every capability false —
+#       including supports_object_arguments, which gates the JSON-string -> object
+#       conversion of tool arguments (chat.cpp). Arguments therefore stay a string, and
+#       the autoparser then dies on `.items()` at line 163. That is why supports_string_content
+#       is false too, which no tools-only explanation accounts for.
+#       ⇒ The override is the vendor template with `.0.` -> `[0].` in 4 places plus a
+#       null-tool guard. Wire format UNCHANGED. Verified with llama.cpp's own
+#       llama-template-analysis: all four capabilities flip false -> true.
 #       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
 #       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
 #       Same subsystem, opposite end. Do not merge the two.
-#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
-#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
-#       at line 163, byte-identical. It DOES fix other things (null-safe content,
-#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
-#       just not as a fix for this.
-#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
-#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
-#       the rest of the run without the tool checks dominating it.
+#       ⚠️ NOT live-booted: verified by static analysis + the engine's own autoparser, not
+#       by serving 140 GiB end-to-end. Detail: patches/glm53-minja-numeric-index/README.md
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.
@@ -482,6 +490,9 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8141}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+      # minja-compatible chat template — WITHOUT this every tools request 400s and
+      # /props reports supports_tools:false. See patches/glm53-minja-numeric-index/README.md
+      - ../../../patches/glm53-minja-numeric-index/chat_template.jinja:/etc/glm53-chat-template.jinja:ro
     environment:
       # Drafter toggle - docker forwards only what is declared here.
       - SPEC_N=${SPEC_N:-}
@@ -800,6 +811,14 @@ services:
       - '--reasoning-effort'
       - '${REASONING_EFFORT:-max}'
       # Route thoughts to message.reasoning_content (never inline in content).
+      # ⭐ minja cannot parse `x.0` (numeric dotted attribute access); the GGUF's own
+      # template uses it in 4 places, which makes the jinja caps probe throw and report
+      # EVERY capability false — so tool arguments are never converted from JSON string
+      # to object and the autoparser dies. This override is the vendor template with
+      # `.0.` -> `[0].` (semantics-identical in Jinja2) + a null-tool guard. Wire format
+      # unchanged. club-3090#1250.
+      - '--chat-template-file'
+      - '/etc/glm53-chat-template.jinja'
       - '--reasoning-format'
       - '${REASONING_FORMAT:-deepseek}'
       # ✅ What DOES work is not paying for it twice. This GGUF's template sets

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/unsloth-ud-iq3xxs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/unsloth-ud-iq3xxs/moecache.yml
@@ -151,26 +151,34 @@
 #                been run on GLM-5.3-Flash. Stays 🧪.
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
-#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
-#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
-#       this template. Automatic parser generation failed: While executing
-#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
-#       statically walking the chat template; column 57 of line 163 is the `(` of
-#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
-#       template-COMPILE time, so it is deterministic on every tools request, and the
-#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
-#       empty. Reported club-3090#1250 (@paulp83).
+#     • ✅ TOOL CALLING WORKS — via the vendored template override wired below.
+#       ⚠️ It does NOT work on the GGUF's own embedded template: every request carrying
+#       `tools` returns HTTP 400 "Unable to generate parser for this template …
+#       CallExpression at line 163, column 57", and /props reports supports_tools:false.
+#       Reported club-3090#1250 (@paulp83) and upstream ggml-org/llama.cpp#27754.
+#       ⛔⛔ THE LINE IN THAT ERROR IS THE CRASH SITE, NOT THE CAUSE. Two earlier readings
+#       of this bug were WRONG and are recorded so nobody re-derives them:
+#         ❌ "minja cannot evaluate .items()" — GLM-4.7-Flash.jinja has the identical
+#            construct, is exercised by llama.cpp's own autoparser tests, and passes.
+#         ❌ "the caps probe under-detects supports_object_arguments because the template
+#            iterates instead of indexing" — adding a named access changes nothing; the
+#            probe never gets that far.
+#       ⭐ ACTUAL CAUSE: minja does not implement NUMERIC DOTTED ATTRIBUTE ACCESS (`x.0`).
+#       Jinja2 defines `x.0` as `x[0]`; minja parses it as a non-computed member whose
+#       property is a number literal and throws. The GGUF template uses it in 4 places, so
+#       the caps probe throws, infers NOTHING, and leaves every capability false —
+#       including supports_object_arguments, which gates the JSON-string -> object
+#       conversion of tool arguments (chat.cpp). Arguments therefore stay a string, and
+#       the autoparser then dies on `.items()` at line 163. That is why supports_string_content
+#       is false too, which no tools-only explanation accounts for.
+#       ⇒ The override is the vendor template with `.0.` -> `[0].` in 4 places plus a
+#       null-tool guard. Wire format UNCHANGED. Verified with llama.cpp's own
+#       llama-template-analysis: all four capabilities flip false -> true.
 #       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
 #       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
 #       Same subsystem, opposite end. Do not merge the two.
-#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
-#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
-#       at line 163, byte-identical. It DOES fix other things (null-safe content,
-#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
-#       just not as a fix for this.
-#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
-#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
-#       the rest of the run without the tool checks dominating it.
+#       ⚠️ NOT live-booted: verified by static analysis + the engine's own autoparser, not
+#       by serving 140 GiB end-to-end. Detail: patches/glm53-minja-numeric-index/README.md
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.
@@ -295,6 +303,9 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8127}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+      # minja-compatible chat template — WITHOUT this every tools request 400s and
+      # /props reports supports_tools:false. See patches/glm53-minja-numeric-index/README.md
+      - ../../../patches/glm53-minja-numeric-index/chat_template.jinja:/etc/glm53-chat-template.jinja:ro
     environment:
       # Drafter toggle - docker forwards only what is declared here.
       - SPEC_N=${SPEC_N:-}
@@ -613,6 +624,14 @@ services:
       - '--reasoning-effort'
       - '${REASONING_EFFORT:-max}'
       # Route thoughts to message.reasoning_content (never inline in content).
+      # ⭐ minja cannot parse `x.0` (numeric dotted attribute access); the GGUF's own
+      # template uses it in 4 places, which makes the jinja caps probe throw and report
+      # EVERY capability false — so tool arguments are never converted from JSON string
+      # to object and the autoparser dies. This override is the vendor template with
+      # `.0.` -> `[0].` (semantics-identical in Jinja2) + a null-tool guard. Wire format
+      # unchanged. club-3090#1250.
+      - '--chat-template-file'
+      - '/etc/glm53-chat-template.jinja'
       - '--reasoning-format'
       - '${REASONING_FORMAT:-deepseek}'
       # ✅ What DOES work is not paying for it twice. This GGUF's template sets

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/unsloth-ud-iq4xs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/unsloth-ud-iq4xs/moecache.yml
@@ -115,26 +115,34 @@
 #                been run on GLM-5.3-Flash. Stays 🧪.
 #   Best for:  long-context MoE serving experiments on the moe-cache engine
 #   Caveats:
-#     • ⛔ TOOL CALLING IS BROKEN ON THIS ENGINE — template/minja, not the quant.
-#       Any request carrying `tools` returns HTTP 400 "Unable to generate parser for
-#       this template. Automatic parser generation failed: While executing
-#       CallExpression at line 163, column 57". llama.cpp builds a tool parser by
-#       statically walking the chat template; column 57 of line 163 is the `(` of
-#       `_args.items()`, which minja cannot evaluate during that pass. It fails at
-#       template-COMPILE time, so it is deterministic on every tools request, and the
-#       downstream symptom is `<tool_call>` left inline in content with `tool_calls[]`
-#       empty. Reported club-3090#1250 (@paulp83).
+#     • ✅ TOOL CALLING WORKS — via the vendored template override wired below.
+#       ⚠️ It does NOT work on the GGUF's own embedded template: every request carrying
+#       `tools` returns HTTP 400 "Unable to generate parser for this template …
+#       CallExpression at line 163, column 57", and /props reports supports_tools:false.
+#       Reported club-3090#1250 (@paulp83) and upstream ggml-org/llama.cpp#27754.
+#       ⛔⛔ THE LINE IN THAT ERROR IS THE CRASH SITE, NOT THE CAUSE. Two earlier readings
+#       of this bug were WRONG and are recorded so nobody re-derives them:
+#         ❌ "minja cannot evaluate .items()" — GLM-4.7-Flash.jinja has the identical
+#            construct, is exercised by llama.cpp's own autoparser tests, and passes.
+#         ❌ "the caps probe under-detects supports_object_arguments because the template
+#            iterates instead of indexing" — adding a named access changes nothing; the
+#            probe never gets that far.
+#       ⭐ ACTUAL CAUSE: minja does not implement NUMERIC DOTTED ATTRIBUTE ACCESS (`x.0`).
+#       Jinja2 defines `x.0` as `x[0]`; minja parses it as a non-computed member whose
+#       property is a number literal and throws. The GGUF template uses it in 4 places, so
+#       the caps probe throws, infers NOTHING, and leaves every capability false —
+#       including supports_object_arguments, which gates the JSON-string -> object
+#       conversion of tool arguments (chat.cpp). Arguments therefore stay a string, and
+#       the autoparser then dies on `.items()` at line 163. That is why supports_string_content
+#       is false too, which no tools-only explanation accounts for.
+#       ⇒ The override is the vendor template with `.0.` -> `[0].` in 4 places plus a
+#       null-tool guard. Wire format UNCHANGED. Verified with llama.cpp's own
+#       llama-template-analysis: all four capabilities flip false -> true.
 #       ⚠️ NOT club-3090#1195 — that is an INTERMITTENT 500 parsing the model's OUTPUT
 #       ("Failed to parse tool call arguments as JSON", 2/25 turns, payload-dependent).
 #       Same subsystem, opposite end. Do not merge the two.
-#       ⚠️ The vendor's CURRENT template does NOT fix it: zai-org/GLM-5.3-Flash
-#       chat_template.jinja (last modified 2026-09-07) still carries `_args.items()`
-#       at line 163, byte-identical. It DOES fix other things (null-safe content,
-#       `~` concat, break guards in the sort loops), so vendoring it is worth doing —
-#       just not as a fix for this.
-#       ⇒ Everything NOT passing `tools` is unaffected (completion, streaming,
-#       reasoning, long-context all pass). Use SKIP_TOOLS=1 with verify-full to get
-#       the rest of the run without the tool checks dominating it.
+#       ⚠️ NOT live-booted: verified by static analysis + the engine's own autoparser, not
+#       by serving 140 GiB end-to-end. Detail: patches/glm53-minja-numeric-index/README.md
 #     • ⚠️ ATTRIBUTION: the MoE expert cache is **leloch's** work
 #       (github.com/leloch/llama.cpp, RFC ggml-org#24528). This slug packages
 #       it; it does not originate it.
@@ -259,6 +267,9 @@ services:
       - "${BIND_HOST:-0.0.0.0}:${ESTATE_PORT:-${PORT:-8121}}:8080"
     volumes:
       - "${MODEL_DIR:-../../../../../../models-cache}:/models:ro"
+      # minja-compatible chat template — WITHOUT this every tools request 400s and
+      # /props reports supports_tools:false. See patches/glm53-minja-numeric-index/README.md
+      - ../../../patches/glm53-minja-numeric-index/chat_template.jinja:/etc/glm53-chat-template.jinja:ro
     environment:
       # Drafter toggle - docker forwards only what is declared here.
       - SPEC_N=${SPEC_N:-}
@@ -577,6 +588,14 @@ services:
       - '--reasoning-effort'
       - '${REASONING_EFFORT:-max}'
       # Route thoughts to message.reasoning_content (never inline in content).
+      # ⭐ minja cannot parse `x.0` (numeric dotted attribute access); the GGUF's own
+      # template uses it in 4 places, which makes the jinja caps probe throw and report
+      # EVERY capability false — so tool arguments are never converted from JSON string
+      # to object and the autoparser dies. This override is the vendor template with
+      # `.0.` -> `[0].` (semantics-identical in Jinja2) + a null-tool guard. Wire format
+      # unchanged. club-3090#1250.
+      - '--chat-template-file'
+      - '/etc/glm53-chat-template.jinja'
       - '--reasoning-format'
       - '${REASONING_FORMAT:-deepseek}'
       # ✅ What DOES work is not paying for it twice. This GGUF's template sets

--- a/models/glm-5.3-flash/llamacpp-club3090/patches/glm53-minja-numeric-index/README.md
+++ b/models/glm-5.3-flash/llamacpp-club3090/patches/glm53-minja-numeric-index/README.md
@@ -1,0 +1,102 @@
+# glm53-minja-numeric-index — GLM-5.3-Flash chat template, minja-compatible
+
+**What it fixes:** every request carrying `tools` returned HTTP 400 on llama.cpp, and
+`/props` reported `supports_tools: false`, `supports_tool_calls: false`.
+
+```
+Unable to generate parser for this template. Automatic parser generation failed:
+While executing CallExpression at line 163, column 57 in source
+```
+
+Reported by @paulp83 on [club-3090#1250](https://github.com/noonghunna/club-3090/issues/1250)
+(DevQuasar Q3_K_M, 2× 3090), and independently upstream on
+[ggml-org/llama.cpp#27754](https://github.com/ggml-org/llama.cpp/pull/27754) (2026-09-07,
+`/props` showing both tool caps false) — where it received no reply.
+
+## Root cause: minja does not implement numeric dotted attribute access (`x.0`)
+
+⚠️ **The line in the error message is the crash site, NOT the cause.** Two earlier readings of
+this bug were wrong and are recorded here so nobody re-derives them:
+
+1. ❌ *"minja cannot evaluate `.items()`"* — false. `models/templates/GLM-4.7-Flash.jinja`
+   contains the identical `_args.items()` construct, is exercised by llama.cpp's own autoparser
+   tests, and passes.
+2. ❌ *"the caps probe under-detects `supports_object_arguments` because the template iterates
+   rather than indexing"* — false. Adding a named `tool.function.name` access changes nothing;
+   the probe never gets that far.
+
+The actual chain:
+
+| step | where | what happens |
+|---|---|---|
+| 1 | `common/jinja/parser.cpp` | on `.`, `parse_member_expression` calls `parse_primary_expression`, so `content.0` becomes a **non-computed** member whose property is the number literal `0` |
+| 2 | `common/jinja/runtime.cpp` | a non-computed member requires an **identifier** → throws. Jinja2 instead treats `x.0` as `x[0]` |
+| 3 | `common/jinja/caps.cpp` | the object-arguments probe throws → `return; // Nothing can be inferred` → `supports_object_arguments` stays false |
+| 4 | `common/jinja/caps.cpp` | the string-arguments probe then runs and throws at `.items()` → sets `supports_tool_calls=false` **and** `supports_tools=false` |
+| 5 | `common/chat.cpp` | `func_args_not_string()` is gated on `supports_object_arguments`, so it never runs → `arguments` stays a JSON **string** |
+| 6 | `common/chat.cpp` | the autoparser render then hits `.items()` on that string → throws → wrapped as the 400 above |
+
+GLM-4.7-Flash has **zero** `x.0` accesses, so its probe succeeds and it is unaffected. No
+template in llama.cpp's `models/templates/` uses `ident.0.`, so this path is untested upstream.
+
+## The patch — 5 lines
+
+Four are `.0.` → `[0].`, which is **semantics-preserving** (Jinja2 defines `x.0` as `x[0]`).
+The fifth guards the tools loop, because the caps probe passes `tools = [null]` and
+`'function' in tool` trips on it.
+
+```diff
+-{% for tool in tools %}
++{% for tool in tools if tool %}
+-...m.content.0.type == "tool_reference"...        +...m.content[0].type...
+-...tr.output.0.type == "tool_reference"...        +...tr.output[0].type...
+-...m.content.0.output is defined...               +...m.content[0].output...
+-...entry.output.0.type == "tool_reference"...     +...entry.output[0].type...
+```
+
+Lines 39, 81, 85, 103, 230. `fix.diff` in this directory is the exact patch.
+
+**The wire format is untouched** — tool calls still render
+`<tool_call>NAME<arg_key>K</arg_key><arg_value>V</arg_value>…</tool_call>`. That matters: change
+it and the generated parser stops matching what the model actually emits.
+
+## Verification (no model load required)
+
+```bash
+# build once, CPU-only
+cmake -B build -DGGML_CUDA=OFF -DLLAMA_BUILD_SERVER=OFF -DLLAMA_CURL=OFF
+cmake --build build --target llama-template-analysis -j
+./build/bin/llama-template-analysis --template-file chat_template.jinja
+```
+
+| capability | GGUF-embedded | **this override** |
+|---|:--:|:--:|
+| `supports_tools` | false | **true** |
+| `supports_tool_calls` | false | **true** |
+| `supports_parallel_tool_calls` | false | **true** |
+| `supports_string_content` | false | **true** |
+
+Also confirmed via `llama-debug-template-parser` (the real autoparser path): the patched template
+yields `tool_mode: TAG_WITH_TAGGED`, `per_call_start '<tool_call>'`, and a full PEG parser + GBNF
+with the `<arg_key>`/`<arg_value>` rules. And under reference Jinja2 3.1.2 (trim_blocks,
+lstrip_blocks, loopcontrols), original ≡ patched byte-identical across 8 cases including the
+two-call sort path, reasoning_content, typed content and list-of-outputs tool content.
+
+## ⚠️ Not verified
+
+- **No live boot.** GLM-5.3-Flash is ~140 GiB; this has not been served end-to-end with
+  `--chat-template-file`. Everything above is static analysis plus the engine's own autoparser.
+- The production pin is `server-cuda-b10236`; the analysis build is from a local checkout whose
+  minja may differ. The error text and byte offset match exactly, so the mechanism holds, but the
+  builds are not proven identical.
+
+## Upstream
+
+Not fixed upstream as of 2026-09-11. The right fix is in minja — either implement `x.0` as
+`x[0]` per Jinja2, or have the caps probe degrade gracefully instead of inferring nothing when a
+probe throws. Closest prior art is
+[#28509](https://github.com/ggml-org/llama.cpp/issues/28509) (Gemma 4 misclassified
+`supports_typed_content`), same subsystem, closed as completed.
+
+⚠️ ggml-org's `AGENTS.md` bars autonomous agent contributions — this is reported upstream by the
+maintainer, not from here.

--- a/models/glm-5.3-flash/llamacpp-club3090/patches/glm53-minja-numeric-index/chat_template.jinja
+++ b/models/glm-5.3-flash/llamacpp-club3090/patches/glm53-minja-numeric-index/chat_template.jinja
@@ -1,0 +1,257 @@
+[gMASK]<sop>
+{%- set effective_reasoning_effort = reasoning_effort if reasoning_effort is defined and reasoning_effort in ['low', 'high'] else 'max' -%}
+{%- if effective_reasoning_effort is not none -%}<|system|>Reasoning Effort: {{ effective_reasoning_effort | capitalize }}{%- endif -%}
+{%- set clear_thinking = clear_thinking if clear_thinking is defined else false -%}
+{%- if tools -%}
+{%- macro tool_to_json(tool) -%}
+    {%- set ns_tool = namespace(first=true) -%}
+    {{ '{' -}}
+    {%- for k, v in tool.items() -%}
+        {%- if k != 'defer_loading' and k != 'strict' -%}
+            {%- if not ns_tool.first -%}{{- ', ' -}}{%- endif -%}
+            {%- set ns_tool.first = false -%}
+            "{{ k }}": {{ v | tojson(ensure_ascii=False) }}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- '}' -}}
+{%- endmacro -%}
+{%- macro tool_references_to_response(refs) -%}
+    {{- '<tool_response><tools>\n' -}}
+    {%- for tr in refs -%}
+        {%- for tool in tools -%}
+            {%- if 'function' in tool -%}
+                {%- set tool = tool['function'] -%}
+            {%- endif -%}
+            {%- if tool.name == tr.name -%}
+                {{- tool_to_json(tool) + '\n' -}}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endfor -%}
+    {{- '</tools></tool_response>' -}}
+{%- endmacro -%}
+<|system|>
+# Tools
+
+You may call one or more functions to assist with the user query.
+
+You are provided with function signatures within <tools></tools> XML tags:
+<tools>
+{% for tool in tools if tool %}
+{%- if 'function' in tool -%}
+    {%- set tool = tool['function'] -%}
+{%- endif -%}
+{% if tool.defer_loading is not defined or not tool.defer_loading %}
+{{ tool_to_json(tool) }}
+{% endif %}
+{% endfor %}
+</tools>
+
+For each function call, output the function name and arguments within the following XML format:
+<tool_call>{function-name}<arg_key>{arg-key-1}</arg_key><arg_value>{arg-value-1}</arg_value><arg_key>{arg-key-2}</arg_key><arg_value>{arg-value-2}</arg_value>...</tool_call>{%- endif -%}
+{%- macro emit_image() -%}<|begin_of_image|><|image|><|end_of_image|>{%- endmacro -%}
+{%- macro emit_video() -%}<|begin_of_video|><|video|><|end_of_video|>{%- endmacro -%}
+{%- macro emit_audio() -%}<|begin_of_audio|><|end_of_audio|>{%- endmacro -%}
+{%- macro visible_text(content) -%}
+    {%- if content is string -%}
+        {{- content -}}
+    {%- elif content is iterable and content is not mapping -%}
+        {%- for item in content -%}
+            {%- if item is mapping and item.type == 'text' -%}
+                {{- item.text -}}
+            {%- elif item is string -%}
+                {{- item -}}
+            {%- elif item is mapping and item.type in ['image', 'image_url'] -%}
+                {{- emit_image() -}}
+            {%- elif item is mapping and item.type in ['video', 'video_url'] -%}
+                {{- emit_video() -}}
+            {%- elif item is mapping and item.type in ['audio', 'audio_url', 'input_audio'] -%}
+                {{- emit_audio() -}}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- else -%}
+        {{- content }}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro tool_response(text) -%}
+{{- '<tool_response>' + text + '</tool_response>' -}}
+{%- endmacro -%}
+{%- macro render_tool_response(m) -%}
+{%- if m.content is string -%}
+    {{- tool_response(m.content) -}}
+{%- elif m.content and m.content is not mapping and m.content[0].type == "tool_reference" -%}
+    {{- tool_references_to_response(m.content) -}}
+{%- elif is_list_of_outputs(m) -%}
+    {%- for tr in m.content -%}
+        {%- if tr.output is iterable and tr.output is not string and tr.output is not mapping and tr.output and tr.output[0].type == "tool_reference" -%}
+            {{- tool_references_to_response(tr.output) -}}
+        {%- else -%}
+            {{- tool_response(visible_text(tr.output)) -}}
+        {%- endif -%}
+    {%- endfor -%}
+{%- else -%}
+    {{- tool_response(visible_text(m.content)) -}}
+{%- endif -%}
+{%- endmacro -%}
+{%- macro id_of(obj) -%}
+    {%- if obj.tool_call_id -%}
+        {{- obj.tool_call_id -}}
+    {%- elif obj.id -%}
+        {{- obj.id -}}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro is_list_of_outputs(m) -%}
+    {%- if m.content and m.content[0].output is defined -%}1{%- endif -%}
+{%- endmacro -%}
+{%- macro has_dup_tool_result_id(lo, hi, target) -%}
+    {%- set ns_cnt = namespace(n=0) -%}
+    {%- for k in range(lo, hi + 1) -%}
+        {%- set m = messages[k] -%}
+        {%- if is_list_of_outputs(m) -%}
+            {%- for entry in m.content -%}
+                {%- if id_of(entry) == target -%}
+                    {%- set ns_cnt.n = ns_cnt.n + 1 -%}
+                {%- endif -%}
+            {%- endfor -%}
+        {%- elif id_of(m) == target -%}
+            {%- set ns_cnt.n = ns_cnt.n + 1 -%}
+        {%- endif -%}
+        {%- if ns_cnt.n > 1 -%}{%- break -%}{%- endif -%}
+    {%- endfor -%}
+    {%- if ns_cnt.n > 1 -%}1{%- endif -%}
+{%- endmacro -%}
+{%- macro tc_id_exists(tcs, target) -%}
+    {%- set ns_f = namespace(found=false) -%}
+    {%- for tc in tcs -%}
+        {%- if id_of(tc) == target -%}
+            {%- set ns_f.found = true -%}
+            {%- break -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {%- if ns_f.found -%}1{%- endif -%}
+{%- endmacro -%}
+{%- set ns = namespace(last_user_index=-1) -%}
+{%- for m in messages %}
+    {%- if m.role == 'user' %}
+        {%- set ns.last_user_index = loop.index0 -%}
+    {%- endif %}
+{%- endfor %}
+{%- for m in messages -%}
+{%- if m.role == 'user' -%}<|user|>{{ visible_text(m.content) }}
+{%- elif m.role == 'assistant' -%}
+<|assistant|>
+{%- set content = visible_text(m.content) %}
+{%- if m.reasoning_content is string %}
+    {%- set reasoning_content = m.reasoning_content %}
+{%- elif '</think>' in content %}
+    {%- set reasoning_content = content.split('</think>')[0].split('<think>')[-1] %}
+    {%- set content = content.split('</think>')[-1] %}
+{%- endif %}
+{%- if (not clear_thinking or loop.index0 > ns.last_user_index) and reasoning_content is defined -%}
+{{ '<think>' + reasoning_content +  '</think>'}}
+{%- else -%}
+{{ '<think></think>' }}
+{%- endif -%}
+{%- if content.strip() -%}
+{{ content.strip() }}
+{%- endif -%}
+{% if m.tool_calls %}
+{% for tc in m.tool_calls %}
+{%- if tc.function %}
+    {%- set tc = tc.function %}
+{%- endif %}
+{{- '<tool_call>' + tc.name -}}
+{% set _args = tc.arguments %}{% for k, v in _args.items() %}<arg_key>{{ k }}</arg_key><arg_value>{{ v | tojson(ensure_ascii=False) if v is not string else v }}</arg_value>{% endfor %}</tool_call>{% endfor %}
+{% endif %}
+{%- elif m.role == 'tool' -%}
+{%- if loop.first or (messages[loop.index0 - 1].role != "tool") %}
+    {{- '<|observation|>' -}}
+    {%- set block_start = loop.index0 -%}
+    {%- set ns_blk = namespace(end=block_start) -%}
+    {%- for j in range(block_start, messages|length) -%}
+        {%- if messages[j].role == 'tool' -%}
+            {%- set ns_blk.end = j -%}
+        {%- else -%}
+            {%- break -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {%- set ns_a = namespace(tool_calls=none) -%}
+    {%- if block_start > 0 and messages[block_start - 1].role == 'assistant' and messages[block_start - 1].tool_calls -%}
+        {%- set ns_a.tool_calls = messages[block_start - 1].tool_calls -%}
+    {%- endif -%}
+    {%- set ns_chk = namespace(can_sort=true) -%}
+    {%- if not ns_a.tool_calls -%}
+        {%- set ns_chk.can_sort = false -%}
+    {%- else -%}
+        {%- for k in range(block_start, ns_blk.end + 1) -%}
+            {%- set m = messages[k] -%}
+            {%- if is_list_of_outputs(m) -%}
+                {%- for entry in m.content -%}
+                    {%- set eid = id_of(entry) -%}
+                    {%- if not eid -%}
+                        {%- set ns_chk.can_sort = false -%}
+                    {%- elif has_dup_tool_result_id(block_start, ns_blk.end, eid) -%}
+                        {%- set ns_chk.can_sort = false -%}
+                    {%- elif not tc_id_exists(ns_a.tool_calls, eid) -%}
+                        {%- set ns_chk.can_sort = false -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- else -%}
+                {%- set tk_id = id_of(m) -%}
+                {%- if not tk_id -%}
+                    {%- set ns_chk.can_sort = false -%}
+                {%- elif has_dup_tool_result_id(block_start, ns_blk.end, tk_id) -%}
+                    {%- set ns_chk.can_sort = false -%}
+                {%- elif not tc_id_exists(ns_a.tool_calls, tk_id) -%}
+                    {%- set ns_chk.can_sort = false -%}
+                {%- endif -%}
+            {%- endif -%}
+        {%- endfor -%}
+        {%- for i in range(ns_a.tool_calls | length) -%}
+            {%- set tc_id = id_of(ns_a.tool_calls[i]) -%}
+            {%- if not tc_id -%}
+                {%- set ns_chk.can_sort = false -%}
+            {%- endif -%}
+            {%- for j in range(i + 1, ns_a.tool_calls | length) -%}
+                {%- if id_of(ns_a.tool_calls[j]) == tc_id -%}
+                    {%- set ns_chk.can_sort = false -%}
+                {%- endif -%}
+            {%- endfor -%}
+    {%- endfor -%}
+    {%- endif -%}
+    {%- if ns_chk.can_sort -%}
+        {%- for tc in ns_a.tool_calls -%}
+            {%- set tc_id = id_of(tc) -%}
+            {%- for k in range(block_start, ns_blk.end + 1) -%}
+                {%- set m = messages[k] -%}
+                {%- if is_list_of_outputs(m) -%}
+                    {%- for entry in m.content -%}
+                        {%- set eid = id_of(entry) -%}
+                        {%- if eid == tc_id -%}
+                            {%- if entry.output is iterable and entry.output is not string and entry.output is not mapping and entry.output and entry.output[0].type == "tool_reference" -%}
+                                {{- tool_references_to_response(entry.output) -}}
+                            {%- else -%}
+                                {{- tool_response(visible_text(entry.output)) -}}
+                            {%- endif -%}
+                        {%- endif -%}
+    {%- endfor -%}
+{%- else -%}
+                    {%- set tk_id = id_of(m) -%}
+                    {%- if tk_id == tc_id -%}
+                        {{- render_tool_response(m) -}}
+                    {%- endif -%}
+                {%- endif -%}
+            {%- endfor -%}
+        {%- endfor -%}
+    {%- else -%}
+        {%- for k in range(block_start, ns_blk.end + 1) -%}
+            {{- render_tool_response(messages[k]) -}}
+        {%- endfor -%}
+    {%- endif -%}
+{% endif -%}
+{%- elif m.role == 'system' -%}
+<|system|>{{ visible_text(m.content) }}
+{%- endif -%}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+    <|assistant|>{{- '<think>' -}}
+{%- endif -%}

--- a/models/glm-5.3-flash/llamacpp-club3090/patches/glm53-minja-numeric-index/fix.diff
+++ b/models/glm-5.3-flash/llamacpp-club3090/patches/glm53-minja-numeric-index/fix.diff
@@ -1,0 +1,20 @@
+39c39
+< {% for tool in tools %}
+---
+> {% for tool in tools if tool %}
+81c81
+< {%- elif m.content and m.content is not mapping and m.content.0.type == "tool_reference" -%}
+---
+> {%- elif m.content and m.content is not mapping and m.content[0].type == "tool_reference" -%}
+85c85
+<         {%- if tr.output is iterable and tr.output is not string and tr.output is not mapping and tr.output and tr.output.0.type == "tool_reference" -%}
+---
+>         {%- if tr.output is iterable and tr.output is not string and tr.output is not mapping and tr.output and tr.output[0].type == "tool_reference" -%}
+103c103
+<     {%- if m.content and m.content.0.output is defined -%}1{%- endif -%}
+---
+>     {%- if m.content and m.content[0].output is defined -%}1{%- endif -%}
+230c230
+<                             {%- if entry.output is iterable and entry.output is not string and entry.output is not mapping and entry.output and entry.output.0.type == "tool_reference" -%}
+---
+>                             {%- if entry.output is iterable and entry.output is not string and entry.output is not mapping and entry.output and entry.output[0].type == "tool_reference" -%}

--- a/scripts/lib/profiles/patches.yml
+++ b/scripts/lib/profiles/patches.yml
@@ -1084,6 +1084,73 @@ patches:
   - <<: *genesis_env_patch
     id: genesis-pn59-streaming-gdn
     genesis_env: GENESIS_ENABLE_PN59_STREAMING_GDN
+  - id: glm53-minja-numeric-index
+    model: [glm-5.3-flash]
+    status: unverified
+    files:
+      - models/glm-5.3-flash/llamacpp-club3090/patches/glm53-minja-numeric-index
+    load_bearing_when:
+      - composes: null
+        reason: >-
+          Without it EVERY request carrying `tools` returns HTTP 400 ("Unable to generate
+          parser for this template") and /props reports supports_tools:false — so the tool
+          path is dead on all 18 GLM composes, which is why this is load-bearing for tool
+          traffic on every one of them rather than an optimisation. minja does not implement
+          numeric dotted attribute access (`x.0`); Jinja2 defines it as `x[0]`. The GGUF's
+          embedded template uses it in 4 places, so the jinja caps probe throws, infers
+          NOTHING, and leaves every capability false — including supports_object_arguments,
+          which gates the JSON-string -> object conversion of tool arguments in chat.cpp.
+          Arguments then stay a string and the autoparser dies on `.items()`. The `.items()`
+          line named in the error is the CRASH SITE, not the cause — GLM-4.7-Flash.jinja
+          carries the identical construct and passes upstream. Override = vendor template
+          with `.0.` -> `[0].` in 4 places + a null-tool guard; wire format unchanged.
+        evidence: >-
+          models/glm-5.3-flash/llamacpp-club3090/patches/glm53-minja-numeric-index/README.md;
+          club-3090#1250 (@paulp83); ggml-org/llama.cpp#27754 (same symptom reported upstream
+          2026-09-07, unanswered); verified with llama.cpp's own llama-template-analysis —
+          all four capabilities flip false -> true
+    delivery:
+      dockerfile_bake: false
+      entrypoint_invoke: false
+      genesis: false
+    delivery_gaps: []
+    delivery_mechanism: chat_template
+    delivery_spec:
+      jinja: models/glm-5.3-flash/llamacpp-club3090/patches/glm53-minja-numeric-index/chat_template.jinja
+      mounted_at: /etc/glm53-chat-template.jinja
+      mount_mode: ro
+      invoke: --chat-template-file /etc/glm53-chat-template.jinja
+      wired_at: [volumes, command]
+      note: >-
+        The vendor template (zai-org/GLM-5.3-Flash, as embedded in the GGUFs) with `.0.` ->
+        `[0].` in 4 places plus a null-tool guard on the tools loop. Semantics-identical under
+        Jinja2, which defines `x.0` as `x[0]`; the WIRE FORMAT is untouched. Mounted read-only
+        and selected with --chat-template-file; `use_jinja` defaults to true in this engine
+        build so no --jinja flag is required.
+    drift_guard:
+      kind: behavioral
+      check: >-
+        The override must contain NO `.0.` numeric dotted access — re-vendoring a fresh vendor
+        template without re-applying the fix silently returns every jinja capability to false
+        and makes tool calls 400, while boot and /health stay green. Assert positively rather
+        than by absence: llama-template-analysis --template-file <this> must report
+        supports_tools / supports_tool_calls / supports_parallel_tool_calls /
+        supports_string_content ALL true, and GET /props on a booted server must agree. Then a
+        tool-call smoke (auto tool choice, one get_weather-class call) must return
+        finish_reason=tool_calls with valid JSON arguments, and a 3-turn tool loop must replay
+        without 400s. Any behavioral/TPS comparison the guard performs MUST use the
+        SELF-CONTAINED symmetric restart+settle protocol: identical docker restart on BOTH
+        arms -> healthy -> fixed 60s settle -> >=3 bench.sh runs/arm -> compare the grand mean,
+        never a single run (boot-to-boot noise on this rig is ~2.8%, run-to-run ~0.2%).
+      on_fail: tool-calls-silently-dead
+    capability: glm53-tool-calling
+    upstream:
+      ref: ggml-org/llama.cpp (minja numeric dotted attribute access)
+      status: ours
+      drop_when: >-
+        minja implements `x.0` as `x[0]`, or the caps probe degrades gracefully instead of
+        inferring nothing when a probe throws. Closest prior art: ggml-org/llama.cpp#28509
+        (Gemma 4 misclassified supports_typed_content), same subsystem, closed completed.
   - id: qwen38-sglang-autoround-w4a8-v0519
     model: [qwen3.8-27b]
     status: unverified


### PR DESCRIPTION
Fixes the tool path on all 18 GLM composes, and **corrects a mechanism I got wrong in
[#1254](https://github.com/noonghunna/club-3090/pull/1254)**.

From [#1250](https://github.com/noonghunna/club-3090/issues/1250) (@paulp83), and reported
independently upstream on [ggml-org/llama.cpp#27754](https://github.com/ggml-org/llama.cpp/pull/27754)
on 2026-09-07 where it got no reply.

## The line in the error is the crash site, not the cause

Two earlier readings were wrong. Both are recorded in the patch README so nobody re-derives them:

- ❌ *"minja cannot evaluate `.items()`"* — `GLM-4.7-Flash.jinja` carries the **identical**
  construct, is exercised by llama.cpp's own autoparser tests, and passes.
- ❌ *"the caps probe under-detects `supports_object_arguments` because the template iterates
  rather than indexing"* — adding a named access changes nothing; the probe never gets that far.

**Actual cause: minja does not implement numeric dotted attribute access (`x.0`).** Jinja2 defines
`x.0` as `x[0]`; minja parses it as a non-computed member whose property is a number literal, and
throws. The embedded template uses it in 4 places, so the caps probe throws, **infers nothing**, and
leaves every capability false — including `supports_object_arguments`, which gates the JSON-string →
object conversion of tool arguments in `chat.cpp`. Arguments stay a string, and *then* the
autoparser dies on `.items()` at line 163.

The tell that the earlier readings were wrong: **`supports_string_content` is also false**, which no
tools-only explanation accounts for.

## The patch — 5 lines, wire format untouched

```diff
-{% for tool in tools %}
+{% for tool in tools if tool %}          # caps probe passes tools=[null]; 'function' in tool trips
-...m.content.0.type...        +...m.content[0].type...
-...tr.output.0.type...        +...tr.output[0].type...
-...m.content.0.output...      +...m.content[0].output...
-...entry.output.0.type...     +...entry.output[0].type...
```

Tool calls still render `<tool_call>NAME<arg_key>K</arg_key><arg_value>V</arg_value>…`. That is
load-bearing: change the format and the generated parser stops matching what the model emits.

## Verified without loading 140 GiB, with llama.cpp's own tooling

`llama-template-analysis --template-file <t>`:

| capability | GGUF-embedded | **override** |
|---|:--:|:--:|
| `supports_tools` | false | **true** |
| `supports_tool_calls` | false | **true** |
| `supports_parallel_tool_calls` | false | **true** |
| `supports_string_content` | false | **true** |

`llama-debug-template-parser` (the real autoparser path) on the override yields
`tool_mode: TAG_WITH_TAGGED`, `per_call_start '<tool_call>'`, and a full PEG parser + GBNF carrying
the `<arg_key>`/`<arg_value>` rules.

Reference Jinja2 3.1.2: original ≡ override **byte-identical across 8 cases**, including the
two-call sort path, `reasoning_content`, typed content, list-of-outputs tool content, and a
`<think>`-split message.

## ⚠️ Not verified

**No live boot.** GLM-5.3-Flash is ~140 GiB and this has not been served end-to-end. Everything
above is static analysis plus the engine's own autoparser.

The production pin is `server-cuda-b10236`; the analysis build came from a local checkout whose
minja may differ. The error text and byte offset match exactly, so the mechanism holds, but the two
builds are not proven identical.

## Drift guard asserts positively

A re-vendored vendor template without the fix fails **silently** — boot green, `/health` green, tool
calls 400. So the guard requires the caps to read **true** rather than merely checking the `.0.`
string is absent, and pairs that with a tool-call smoke and a 3-turn loop.

## Upstream

Not fixed upstream as of 2026-09-11. Right fix is in minja: implement `x.0` as `x[0]`, or have the
caps probe degrade gracefully rather than inferring nothing when a probe throws. Closest prior art
is [#28509](https://github.com/ggml-org/llama.cpp/issues/28509) (Gemma 4 misclassified
`supports_typed_content`), same subsystem, closed completed. An issue is drafted for the maintainer
to post — ggml-org bars autonomous agent contributions.
