### PR TITLE
docs(sglang): warn that return_token_ids / return_prompt_token_ids / return_meta_info are refused under streaming

### DIFF
--- a/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2-bf16.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2-bf16.yml
@@ -275,6 +275,23 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # ⚠️ CLIENT COMPATIBILITY — three OpenAI-extension fields that work on our vLLM
+        # slugs are REFUSED by SGLang when stream=true (serving_chat.py, an explicit
+        # guard, not a bug):
+        #     return_token_ids · return_prompt_token_ids · return_meta_info
+        # e.g. "return_token_ids is not supported with streaming on /v1/chat/completions.
+        # Please set stream=false when using return_token_ids=true."
+        # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
+        # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
+        # you have already committed to the slug. No workaround short of stream=false.
+        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
+        # proxy — which is the worst shape of this: the proxy makes the backends look
+        # interchangeable right up until a field one of them refuses.
+        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
+        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
+        # per-request spec_accept_length out of this engine — see the accept-len A/B in
+        # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.
         # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
         # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
         # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked

--- a/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2-bf16.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2-bf16.yml
@@ -284,11 +284,23 @@ services:
         # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
         # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
         # you have already committed to the slug. No workaround short of stream=false.
-        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
-        # proxy — which is the worst shape of this: the proxy makes the backends look
-        # interchangeable right up until a field one of them refuses.
-        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
-        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # Reported by @Naelith (Discord), surfaced behind an API-switching proxy — the worst
+        # shape of this: the proxy makes the backends look interchangeable right up until a
+        # field one of them refuses.
+        # ✅ MEASURED 2026-09-11 — the clients we ship and run are all CLEAN. Each was pointed
+        # at a request-recording mock endpoint and its actual payload inspected:
+        #     pi      streams; sends max_completion_tokens, messages, model, store, stream,
+        #             stream_options, tools — none of the three
+        #     hermes  streams; sends messages, model, reasoning_effort, stream,
+        #             stream_options, thinking, tools — none of the three
+        #     8-pack  benchlocal-cli + the HermesAgent sandbox set none of them and do not
+        #             stream, so quality runs against sgl/ slugs are fine
+        # ⇒ If you hit this, suspect the PROXY or a bespoke benchmarking client, not the
+        #   agent — a translation layer is the thing likely to add return_token_ids for
+        #   token accounting.
+        # ⓘ hermes also sends `thinking`, which SGLang does not declare. It is TOLERATED
+        #   (the request model ignores extras) but therefore silently DROPPED, not honoured
+        #   — thinking must go via chat_template_kwargs / ENABLE_THINKING here.
         # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
         # per-request spec_accept_length out of this engine — see the accept-len A/B in
         # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.

--- a/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2.yml
@@ -318,11 +318,23 @@ services:
         # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
         # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
         # you have already committed to the slug. No workaround short of stream=false.
-        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
-        # proxy — which is the worst shape of this: the proxy makes the backends look
-        # interchangeable right up until a field one of them refuses.
-        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
-        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # Reported by @Naelith (Discord), surfaced behind an API-switching proxy — the worst
+        # shape of this: the proxy makes the backends look interchangeable right up until a
+        # field one of them refuses.
+        # ✅ MEASURED 2026-09-11 — the clients we ship and run are all CLEAN. Each was pointed
+        # at a request-recording mock endpoint and its actual payload inspected:
+        #     pi      streams; sends max_completion_tokens, messages, model, store, stream,
+        #             stream_options, tools — none of the three
+        #     hermes  streams; sends messages, model, reasoning_effort, stream,
+        #             stream_options, thinking, tools — none of the three
+        #     8-pack  benchlocal-cli + the HermesAgent sandbox set none of them and do not
+        #             stream, so quality runs against sgl/ slugs are fine
+        # ⇒ If you hit this, suspect the PROXY or a bespoke benchmarking client, not the
+        #   agent — a translation layer is the thing likely to add return_token_ids for
+        #   token accounting.
+        # ⓘ hermes also sends `thinking`, which SGLang does not declare. It is TOLERATED
+        #   (the request model ignores extras) but therefore silently DROPPED, not honoured
+        #   — thinking must go via chat_template_kwargs / ENABLE_THINKING here.
         # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
         # per-request spec_accept_length out of this engine — see the accept-len A/B in
         # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.

--- a/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2.yml
@@ -309,6 +309,23 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # ⚠️ CLIENT COMPATIBILITY — three OpenAI-extension fields that work on our vLLM
+        # slugs are REFUSED by SGLang when stream=true (serving_chat.py, an explicit
+        # guard, not a bug):
+        #     return_token_ids · return_prompt_token_ids · return_meta_info
+        # e.g. "return_token_ids is not supported with streaming on /v1/chat/completions.
+        # Please set stream=false when using return_token_ids=true."
+        # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
+        # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
+        # you have already committed to the slug. No workaround short of stream=false.
+        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
+        # proxy — which is the worst shape of this: the proxy makes the backends look
+        # interchangeable right up until a field one of them refuses.
+        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
+        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
+        # per-request spec_accept_length out of this engine — see the accept-len A/B in
+        # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.
         # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
         # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
         # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked

--- a/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/mtp.yml
@@ -306,6 +306,23 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # ⚠️ CLIENT COMPATIBILITY — three OpenAI-extension fields that work on our vLLM
+        # slugs are REFUSED by SGLang when stream=true (serving_chat.py, an explicit
+        # guard, not a bug):
+        #     return_token_ids · return_prompt_token_ids · return_meta_info
+        # e.g. "return_token_ids is not supported with streaming on /v1/chat/completions.
+        # Please set stream=false when using return_token_ids=true."
+        # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
+        # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
+        # you have already committed to the slug. No workaround short of stream=false.
+        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
+        # proxy — which is the worst shape of this: the proxy makes the backends look
+        # interchangeable right up until a field one of them refuses.
+        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
+        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
+        # per-request spec_accept_length out of this engine — see the accept-len A/B in
+        # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.
         # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
         # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
         # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked

--- a/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/mtp.yml
@@ -315,11 +315,23 @@ services:
         # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
         # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
         # you have already committed to the slug. No workaround short of stream=false.
-        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
-        # proxy — which is the worst shape of this: the proxy makes the backends look
-        # interchangeable right up until a field one of them refuses.
-        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
-        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # Reported by @Naelith (Discord), surfaced behind an API-switching proxy — the worst
+        # shape of this: the proxy makes the backends look interchangeable right up until a
+        # field one of them refuses.
+        # ✅ MEASURED 2026-09-11 — the clients we ship and run are all CLEAN. Each was pointed
+        # at a request-recording mock endpoint and its actual payload inspected:
+        #     pi      streams; sends max_completion_tokens, messages, model, store, stream,
+        #             stream_options, tools — none of the three
+        #     hermes  streams; sends messages, model, reasoning_effort, stream,
+        #             stream_options, thinking, tools — none of the three
+        #     8-pack  benchlocal-cli + the HermesAgent sandbox set none of them and do not
+        #             stream, so quality runs against sgl/ slugs are fine
+        # ⇒ If you hit this, suspect the PROXY or a bespoke benchmarking client, not the
+        #   agent — a translation layer is the thing likely to add return_token_ids for
+        #   token accounting.
+        # ⓘ hermes also sends `thinking`, which SGLang does not declare. It is TOLERATED
+        #   (the request model ignores extras) but therefore silently DROPPED, not honoured
+        #   — thinking must go via chat_template_kwargs / ENABLE_THINKING here.
         # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
         # per-request spec_accept_length out of this engine — see the accept-len A/B in
         # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.

--- a/models/qwen3.8-27b/sglang/compose/dual/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/fp8/dflash2.yml
@@ -342,6 +342,23 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # ⚠️ CLIENT COMPATIBILITY — three OpenAI-extension fields that work on our vLLM
+        # slugs are REFUSED by SGLang when stream=true (serving_chat.py, an explicit
+        # guard, not a bug):
+        #     return_token_ids · return_prompt_token_ids · return_meta_info
+        # e.g. "return_token_ids is not supported with streaming on /v1/chat/completions.
+        # Please set stream=false when using return_token_ids=true."
+        # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
+        # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
+        # you have already committed to the slug. No workaround short of stream=false.
+        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
+        # proxy — which is the worst shape of this: the proxy makes the backends look
+        # interchangeable right up until a field one of them refuses.
+        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
+        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
+        # per-request spec_accept_length out of this engine — see the accept-len A/B in
+        # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.
         # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
         # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
         # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked

--- a/models/qwen3.8-27b/sglang/compose/dual/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/fp8/dflash2.yml
@@ -351,11 +351,23 @@ services:
         # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
         # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
         # you have already committed to the slug. No workaround short of stream=false.
-        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
-        # proxy — which is the worst shape of this: the proxy makes the backends look
-        # interchangeable right up until a field one of them refuses.
-        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
-        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # Reported by @Naelith (Discord), surfaced behind an API-switching proxy — the worst
+        # shape of this: the proxy makes the backends look interchangeable right up until a
+        # field one of them refuses.
+        # ✅ MEASURED 2026-09-11 — the clients we ship and run are all CLEAN. Each was pointed
+        # at a request-recording mock endpoint and its actual payload inspected:
+        #     pi      streams; sends max_completion_tokens, messages, model, store, stream,
+        #             stream_options, tools — none of the three
+        #     hermes  streams; sends messages, model, reasoning_effort, stream,
+        #             stream_options, thinking, tools — none of the three
+        #     8-pack  benchlocal-cli + the HermesAgent sandbox set none of them and do not
+        #             stream, so quality runs against sgl/ slugs are fine
+        # ⇒ If you hit this, suspect the PROXY or a bespoke benchmarking client, not the
+        #   agent — a translation layer is the thing likely to add return_token_ids for
+        #   token accounting.
+        # ⓘ hermes also sends `thinking`, which SGLang does not declare. It is TOLERATED
+        #   (the request model ignores extras) but therefore silently DROPPED, not honoured
+        #   — thinking must go via chat_template_kwargs / ENABLE_THINKING here.
         # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
         # per-request spec_accept_length out of this engine — see the accept-len A/B in
         # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.

--- a/models/qwen3.8-27b/sglang/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/fp8/mtp.yml
@@ -361,6 +361,23 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # ⚠️ CLIENT COMPATIBILITY — three OpenAI-extension fields that work on our vLLM
+        # slugs are REFUSED by SGLang when stream=true (serving_chat.py, an explicit
+        # guard, not a bug):
+        #     return_token_ids · return_prompt_token_ids · return_meta_info
+        # e.g. "return_token_ids is not supported with streaming on /v1/chat/completions.
+        # Please set stream=false when using return_token_ids=true."
+        # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
+        # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
+        # you have already committed to the slug. No workaround short of stream=false.
+        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
+        # proxy — which is the worst shape of this: the proxy makes the backends look
+        # interchangeable right up until a field one of them refuses.
+        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
+        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
+        # per-request spec_accept_length out of this engine — see the accept-len A/B in
+        # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.
         # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
         # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
         # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked

--- a/models/qwen3.8-27b/sglang/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/fp8/mtp.yml
@@ -370,11 +370,23 @@ services:
         # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
         # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
         # you have already committed to the slug. No workaround short of stream=false.
-        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
-        # proxy — which is the worst shape of this: the proxy makes the backends look
-        # interchangeable right up until a field one of them refuses.
-        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
-        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # Reported by @Naelith (Discord), surfaced behind an API-switching proxy — the worst
+        # shape of this: the proxy makes the backends look interchangeable right up until a
+        # field one of them refuses.
+        # ✅ MEASURED 2026-09-11 — the clients we ship and run are all CLEAN. Each was pointed
+        # at a request-recording mock endpoint and its actual payload inspected:
+        #     pi      streams; sends max_completion_tokens, messages, model, store, stream,
+        #             stream_options, tools — none of the three
+        #     hermes  streams; sends messages, model, reasoning_effort, stream,
+        #             stream_options, thinking, tools — none of the three
+        #     8-pack  benchlocal-cli + the HermesAgent sandbox set none of them and do not
+        #             stream, so quality runs against sgl/ slugs are fine
+        # ⇒ If you hit this, suspect the PROXY or a bespoke benchmarking client, not the
+        #   agent — a translation layer is the thing likely to add return_token_ids for
+        #   token accounting.
+        # ⓘ hermes also sends `thinking`, which SGLang does not declare. It is TOLERATED
+        #   (the request model ignores extras) but therefore silently DROPPED, not honoured
+        #   — thinking must go via chat_template_kwargs / ENABLE_THINKING here.
         # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
         # per-request spec_accept_length out of this engine — see the accept-len A/B in
         # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.

--- a/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/dflash2.yml
@@ -353,11 +353,23 @@ services:
         # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
         # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
         # you have already committed to the slug. No workaround short of stream=false.
-        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
-        # proxy — which is the worst shape of this: the proxy makes the backends look
-        # interchangeable right up until a field one of them refuses.
-        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
-        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # Reported by @Naelith (Discord), surfaced behind an API-switching proxy — the worst
+        # shape of this: the proxy makes the backends look interchangeable right up until a
+        # field one of them refuses.
+        # ✅ MEASURED 2026-09-11 — the clients we ship and run are all CLEAN. Each was pointed
+        # at a request-recording mock endpoint and its actual payload inspected:
+        #     pi      streams; sends max_completion_tokens, messages, model, store, stream,
+        #             stream_options, tools — none of the three
+        #     hermes  streams; sends messages, model, reasoning_effort, stream,
+        #             stream_options, thinking, tools — none of the three
+        #     8-pack  benchlocal-cli + the HermesAgent sandbox set none of them and do not
+        #             stream, so quality runs against sgl/ slugs are fine
+        # ⇒ If you hit this, suspect the PROXY or a bespoke benchmarking client, not the
+        #   agent — a translation layer is the thing likely to add return_token_ids for
+        #   token accounting.
+        # ⓘ hermes also sends `thinking`, which SGLang does not declare. It is TOLERATED
+        #   (the request model ignores extras) but therefore silently DROPPED, not honoured
+        #   — thinking must go via chat_template_kwargs / ENABLE_THINKING here.
         # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
         # per-request spec_accept_length out of this engine — see the accept-len A/B in
         # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.

--- a/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/dflash2.yml
@@ -344,6 +344,23 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # ⚠️ CLIENT COMPATIBILITY — three OpenAI-extension fields that work on our vLLM
+        # slugs are REFUSED by SGLang when stream=true (serving_chat.py, an explicit
+        # guard, not a bug):
+        #     return_token_ids · return_prompt_token_ids · return_meta_info
+        # e.g. "return_token_ids is not supported with streaming on /v1/chat/completions.
+        # Please set stream=false when using return_token_ids=true."
+        # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
+        # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
+        # you have already committed to the slug. No workaround short of stream=false.
+        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
+        # proxy — which is the worst shape of this: the proxy makes the backends look
+        # interchangeable right up until a field one of them refuses.
+        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
+        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
+        # per-request spec_accept_length out of this engine — see the accept-len A/B in
+        # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.
         # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
         # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
         # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked

--- a/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/mtp.yml
@@ -358,11 +358,23 @@ services:
         # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
         # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
         # you have already committed to the slug. No workaround short of stream=false.
-        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
-        # proxy — which is the worst shape of this: the proxy makes the backends look
-        # interchangeable right up until a field one of them refuses.
-        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
-        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # Reported by @Naelith (Discord), surfaced behind an API-switching proxy — the worst
+        # shape of this: the proxy makes the backends look interchangeable right up until a
+        # field one of them refuses.
+        # ✅ MEASURED 2026-09-11 — the clients we ship and run are all CLEAN. Each was pointed
+        # at a request-recording mock endpoint and its actual payload inspected:
+        #     pi      streams; sends max_completion_tokens, messages, model, store, stream,
+        #             stream_options, tools — none of the three
+        #     hermes  streams; sends messages, model, reasoning_effort, stream,
+        #             stream_options, thinking, tools — none of the three
+        #     8-pack  benchlocal-cli + the HermesAgent sandbox set none of them and do not
+        #             stream, so quality runs against sgl/ slugs are fine
+        # ⇒ If you hit this, suspect the PROXY or a bespoke benchmarking client, not the
+        #   agent — a translation layer is the thing likely to add return_token_ids for
+        #   token accounting.
+        # ⓘ hermes also sends `thinking`, which SGLang does not declare. It is TOLERATED
+        #   (the request model ignores extras) but therefore silently DROPPED, not honoured
+        #   — thinking must go via chat_template_kwargs / ENABLE_THINKING here.
         # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
         # per-request spec_accept_length out of this engine — see the accept-len A/B in
         # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.

--- a/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/mtp.yml
@@ -349,6 +349,23 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # ⚠️ CLIENT COMPATIBILITY — three OpenAI-extension fields that work on our vLLM
+        # slugs are REFUSED by SGLang when stream=true (serving_chat.py, an explicit
+        # guard, not a bug):
+        #     return_token_ids · return_prompt_token_ids · return_meta_info
+        # e.g. "return_token_ids is not supported with streaming on /v1/chat/completions.
+        # Please set stream=false when using return_token_ids=true."
+        # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
+        # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
+        # you have already committed to the slug. No workaround short of stream=false.
+        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
+        # proxy — which is the worst shape of this: the proxy makes the backends look
+        # interchangeable right up until a field one of them refuses.
+        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
+        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
+        # per-request spec_accept_length out of this engine — see the accept-len A/B in
+        # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.
         # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
         # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
         # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked

--- a/models/qwen3.8-27b/sglang/compose/multi4/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/fp8/dflash2.yml
@@ -375,6 +375,23 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # ⚠️ CLIENT COMPATIBILITY — three OpenAI-extension fields that work on our vLLM
+        # slugs are REFUSED by SGLang when stream=true (serving_chat.py, an explicit
+        # guard, not a bug):
+        #     return_token_ids · return_prompt_token_ids · return_meta_info
+        # e.g. "return_token_ids is not supported with streaming on /v1/chat/completions.
+        # Please set stream=false when using return_token_ids=true."
+        # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
+        # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
+        # you have already committed to the slug. No workaround short of stream=false.
+        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
+        # proxy — which is the worst shape of this: the proxy makes the backends look
+        # interchangeable right up until a field one of them refuses.
+        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
+        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
+        # per-request spec_accept_length out of this engine — see the accept-len A/B in
+        # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.
         # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
         # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
         # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked

--- a/models/qwen3.8-27b/sglang/compose/multi4/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/fp8/dflash2.yml
@@ -384,11 +384,23 @@ services:
         # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
         # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
         # you have already committed to the slug. No workaround short of stream=false.
-        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
-        # proxy — which is the worst shape of this: the proxy makes the backends look
-        # interchangeable right up until a field one of them refuses.
-        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
-        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # Reported by @Naelith (Discord), surfaced behind an API-switching proxy — the worst
+        # shape of this: the proxy makes the backends look interchangeable right up until a
+        # field one of them refuses.
+        # ✅ MEASURED 2026-09-11 — the clients we ship and run are all CLEAN. Each was pointed
+        # at a request-recording mock endpoint and its actual payload inspected:
+        #     pi      streams; sends max_completion_tokens, messages, model, store, stream,
+        #             stream_options, tools — none of the three
+        #     hermes  streams; sends messages, model, reasoning_effort, stream,
+        #             stream_options, thinking, tools — none of the three
+        #     8-pack  benchlocal-cli + the HermesAgent sandbox set none of them and do not
+        #             stream, so quality runs against sgl/ slugs are fine
+        # ⇒ If you hit this, suspect the PROXY or a bespoke benchmarking client, not the
+        #   agent — a translation layer is the thing likely to add return_token_ids for
+        #   token accounting.
+        # ⓘ hermes also sends `thinking`, which SGLang does not declare. It is TOLERATED
+        #   (the request model ignores extras) but therefore silently DROPPED, not honoured
+        #   — thinking must go via chat_template_kwargs / ENABLE_THINKING here.
         # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
         # per-request spec_accept_length out of this engine — see the accept-len A/B in
         # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.

--- a/models/qwen3.8-27b/sglang/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/fp8/mtp.yml
@@ -383,11 +383,23 @@ services:
         # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
         # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
         # you have already committed to the slug. No workaround short of stream=false.
-        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
-        # proxy — which is the worst shape of this: the proxy makes the backends look
-        # interchangeable right up until a field one of them refuses.
-        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
-        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # Reported by @Naelith (Discord), surfaced behind an API-switching proxy — the worst
+        # shape of this: the proxy makes the backends look interchangeable right up until a
+        # field one of them refuses.
+        # ✅ MEASURED 2026-09-11 — the clients we ship and run are all CLEAN. Each was pointed
+        # at a request-recording mock endpoint and its actual payload inspected:
+        #     pi      streams; sends max_completion_tokens, messages, model, store, stream,
+        #             stream_options, tools — none of the three
+        #     hermes  streams; sends messages, model, reasoning_effort, stream,
+        #             stream_options, thinking, tools — none of the three
+        #     8-pack  benchlocal-cli + the HermesAgent sandbox set none of them and do not
+        #             stream, so quality runs against sgl/ slugs are fine
+        # ⇒ If you hit this, suspect the PROXY or a bespoke benchmarking client, not the
+        #   agent — a translation layer is the thing likely to add return_token_ids for
+        #   token accounting.
+        # ⓘ hermes also sends `thinking`, which SGLang does not declare. It is TOLERATED
+        #   (the request model ignores extras) but therefore silently DROPPED, not honoured
+        #   — thinking must go via chat_template_kwargs / ENABLE_THINKING here.
         # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
         # per-request spec_accept_length out of this engine — see the accept-len A/B in
         # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.

--- a/models/qwen3.8-27b/sglang/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/fp8/mtp.yml
@@ -374,6 +374,23 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # ⚠️ CLIENT COMPATIBILITY — three OpenAI-extension fields that work on our vLLM
+        # slugs are REFUSED by SGLang when stream=true (serving_chat.py, an explicit
+        # guard, not a bug):
+        #     return_token_ids · return_prompt_token_ids · return_meta_info
+        # e.g. "return_token_ids is not supported with streaming on /v1/chat/completions.
+        # Please set stream=false when using return_token_ids=true."
+        # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
+        # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
+        # you have already committed to the slug. No workaround short of stream=false.
+        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
+        # proxy — which is the worst shape of this: the proxy makes the backends look
+        # interchangeable right up until a field one of them refuses.
+        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
+        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
+        # per-request spec_accept_length out of this engine — see the accept-len A/B in
+        # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.
         # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
         # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
         # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked

--- a/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/dflash2.yml
@@ -358,11 +358,23 @@ services:
         # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
         # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
         # you have already committed to the slug. No workaround short of stream=false.
-        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
-        # proxy — which is the worst shape of this: the proxy makes the backends look
-        # interchangeable right up until a field one of them refuses.
-        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
-        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # Reported by @Naelith (Discord), surfaced behind an API-switching proxy — the worst
+        # shape of this: the proxy makes the backends look interchangeable right up until a
+        # field one of them refuses.
+        # ✅ MEASURED 2026-09-11 — the clients we ship and run are all CLEAN. Each was pointed
+        # at a request-recording mock endpoint and its actual payload inspected:
+        #     pi      streams; sends max_completion_tokens, messages, model, store, stream,
+        #             stream_options, tools — none of the three
+        #     hermes  streams; sends messages, model, reasoning_effort, stream,
+        #             stream_options, thinking, tools — none of the three
+        #     8-pack  benchlocal-cli + the HermesAgent sandbox set none of them and do not
+        #             stream, so quality runs against sgl/ slugs are fine
+        # ⇒ If you hit this, suspect the PROXY or a bespoke benchmarking client, not the
+        #   agent — a translation layer is the thing likely to add return_token_ids for
+        #   token accounting.
+        # ⓘ hermes also sends `thinking`, which SGLang does not declare. It is TOLERATED
+        #   (the request model ignores extras) but therefore silently DROPPED, not honoured
+        #   — thinking must go via chat_template_kwargs / ENABLE_THINKING here.
         # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
         # per-request spec_accept_length out of this engine — see the accept-len A/B in
         # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.

--- a/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/dflash2.yml
@@ -349,6 +349,23 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # ⚠️ CLIENT COMPATIBILITY — three OpenAI-extension fields that work on our vLLM
+        # slugs are REFUSED by SGLang when stream=true (serving_chat.py, an explicit
+        # guard, not a bug):
+        #     return_token_ids · return_prompt_token_ids · return_meta_info
+        # e.g. "return_token_ids is not supported with streaming on /v1/chat/completions.
+        # Please set stream=false when using return_token_ids=true."
+        # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
+        # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
+        # you have already committed to the slug. No workaround short of stream=false.
+        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
+        # proxy — which is the worst shape of this: the proxy makes the backends look
+        # interchangeable right up until a field one of them refuses.
+        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
+        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
+        # per-request spec_accept_length out of this engine — see the accept-len A/B in
+        # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.
         # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
         # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
         # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked

--- a/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/mtp.yml
@@ -354,6 +354,23 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # ⚠️ CLIENT COMPATIBILITY — three OpenAI-extension fields that work on our vLLM
+        # slugs are REFUSED by SGLang when stream=true (serving_chat.py, an explicit
+        # guard, not a bug):
+        #     return_token_ids · return_prompt_token_ids · return_meta_info
+        # e.g. "return_token_ids is not supported with streaming on /v1/chat/completions.
+        # Please set stream=false when using return_token_ids=true."
+        # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
+        # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
+        # you have already committed to the slug. No workaround short of stream=false.
+        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
+        # proxy — which is the worst shape of this: the proxy makes the backends look
+        # interchangeable right up until a field one of them refuses.
+        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
+        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
+        # per-request spec_accept_length out of this engine — see the accept-len A/B in
+        # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.
         # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
         # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
         # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked

--- a/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/mtp.yml
@@ -363,11 +363,23 @@ services:
         # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
         # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
         # you have already committed to the slug. No workaround short of stream=false.
-        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
-        # proxy — which is the worst shape of this: the proxy makes the backends look
-        # interchangeable right up until a field one of them refuses.
-        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
-        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # Reported by @Naelith (Discord), surfaced behind an API-switching proxy — the worst
+        # shape of this: the proxy makes the backends look interchangeable right up until a
+        # field one of them refuses.
+        # ✅ MEASURED 2026-09-11 — the clients we ship and run are all CLEAN. Each was pointed
+        # at a request-recording mock endpoint and its actual payload inspected:
+        #     pi      streams; sends max_completion_tokens, messages, model, store, stream,
+        #             stream_options, tools — none of the three
+        #     hermes  streams; sends messages, model, reasoning_effort, stream,
+        #             stream_options, thinking, tools — none of the three
+        #     8-pack  benchlocal-cli + the HermesAgent sandbox set none of them and do not
+        #             stream, so quality runs against sgl/ slugs are fine
+        # ⇒ If you hit this, suspect the PROXY or a bespoke benchmarking client, not the
+        #   agent — a translation layer is the thing likely to add return_token_ids for
+        #   token accounting.
+        # ⓘ hermes also sends `thinking`, which SGLang does not declare. It is TOLERATED
+        #   (the request model ignores extras) but therefore silently DROPPED, not honoured
+        #   — thinking must go via chat_template_kwargs / ENABLE_THINKING here.
         # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
         # per-request spec_accept_length out of this engine — see the accept-len A/B in
         # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.

--- a/models/qwen3.8-27b/sglang/compose/multi8/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/fp8/dflash2.yml
@@ -382,6 +382,23 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # ⚠️ CLIENT COMPATIBILITY — three OpenAI-extension fields that work on our vLLM
+        # slugs are REFUSED by SGLang when stream=true (serving_chat.py, an explicit
+        # guard, not a bug):
+        #     return_token_ids · return_prompt_token_ids · return_meta_info
+        # e.g. "return_token_ids is not supported with streaming on /v1/chat/completions.
+        # Please set stream=false when using return_token_ids=true."
+        # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
+        # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
+        # you have already committed to the slug. No workaround short of stream=false.
+        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
+        # proxy — which is the worst shape of this: the proxy makes the backends look
+        # interchangeable right up until a field one of them refuses.
+        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
+        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
+        # per-request spec_accept_length out of this engine — see the accept-len A/B in
+        # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.
         # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
         # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
         # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked

--- a/models/qwen3.8-27b/sglang/compose/multi8/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/fp8/dflash2.yml
@@ -391,11 +391,23 @@ services:
         # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
         # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
         # you have already committed to the slug. No workaround short of stream=false.
-        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
-        # proxy — which is the worst shape of this: the proxy makes the backends look
-        # interchangeable right up until a field one of them refuses.
-        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
-        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # Reported by @Naelith (Discord), surfaced behind an API-switching proxy — the worst
+        # shape of this: the proxy makes the backends look interchangeable right up until a
+        # field one of them refuses.
+        # ✅ MEASURED 2026-09-11 — the clients we ship and run are all CLEAN. Each was pointed
+        # at a request-recording mock endpoint and its actual payload inspected:
+        #     pi      streams; sends max_completion_tokens, messages, model, store, stream,
+        #             stream_options, tools — none of the three
+        #     hermes  streams; sends messages, model, reasoning_effort, stream,
+        #             stream_options, thinking, tools — none of the three
+        #     8-pack  benchlocal-cli + the HermesAgent sandbox set none of them and do not
+        #             stream, so quality runs against sgl/ slugs are fine
+        # ⇒ If you hit this, suspect the PROXY or a bespoke benchmarking client, not the
+        #   agent — a translation layer is the thing likely to add return_token_ids for
+        #   token accounting.
+        # ⓘ hermes also sends `thinking`, which SGLang does not declare. It is TOLERATED
+        #   (the request model ignores extras) but therefore silently DROPPED, not honoured
+        #   — thinking must go via chat_template_kwargs / ENABLE_THINKING here.
         # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
         # per-request spec_accept_length out of this engine — see the accept-len A/B in
         # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.

--- a/models/qwen3.8-27b/sglang/compose/multi8/fp8/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/fp8/mtp.yml
@@ -381,6 +381,23 @@ services:
         else
           echo "[w4a8] off (W4A8=1 to enable; ~+44% prefill, ~-11% code decode)" >&2
         fi
+        # ⚠️ CLIENT COMPATIBILITY — three OpenAI-extension fields that work on our vLLM
+        # slugs are REFUSED by SGLang when stream=true (serving_chat.py, an explicit
+        # guard, not a bug):
+        #     return_token_ids · return_prompt_token_ids · return_meta_info
+        # e.g. "return_token_ids is not supported with streaming on /v1/chat/completions.
+        # Please set stream=false when using return_token_ids=true."
+        # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
+        # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
+        # you have already committed to the slug. No workaround short of stream=false.
+        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
+        # proxy — which is the worst shape of this: the proxy makes the backends look
+        # interchangeable right up until a field one of them refuses.
+        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
+        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
+        # per-request spec_accept_length out of this engine — see the accept-len A/B in
+        # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.
         # --- sampler row + thinking default, mirroring the vLLM tiers (#1014) ---
         # The model card publishes TWO sampler rows; ENABLE_THINKING selects one.
         # Values verified against Qwen/Qwen3.8-27B's card 2026-09-11, and re-checked

--- a/models/qwen3.8-27b/sglang/compose/multi8/fp8/mtp.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/fp8/mtp.yml
@@ -390,11 +390,23 @@ services:
         # vLLM streams return_token_ids fine and llama.cpp has no such restriction, so an
         # client that works against vllm/qwen38-27b-* can fail here at REQUEST time — after
         # you have already committed to the slug. No workaround short of stream=false.
-        # Reported by @Naelith (Discord), hit via pi and opencode behind an API-switching
-        # proxy — which is the worst shape of this: the proxy makes the backends look
-        # interchangeable right up until a field one of them refuses.
-        # ✅ The 8-pack is NOT affected: benchlocal-cli and the HermesAgent sandbox set none
-        # of these fields and do not stream, so quality runs against sgl/ slugs are fine.
+        # Reported by @Naelith (Discord), surfaced behind an API-switching proxy — the worst
+        # shape of this: the proxy makes the backends look interchangeable right up until a
+        # field one of them refuses.
+        # ✅ MEASURED 2026-09-11 — the clients we ship and run are all CLEAN. Each was pointed
+        # at a request-recording mock endpoint and its actual payload inspected:
+        #     pi      streams; sends max_completion_tokens, messages, model, store, stream,
+        #             stream_options, tools — none of the three
+        #     hermes  streams; sends messages, model, reasoning_effort, stream,
+        #             stream_options, thinking, tools — none of the three
+        #     8-pack  benchlocal-cli + the HermesAgent sandbox set none of them and do not
+        #             stream, so quality runs against sgl/ slugs are fine
+        # ⇒ If you hit this, suspect the PROXY or a bespoke benchmarking client, not the
+        #   agent — a translation layer is the thing likely to add return_token_ids for
+        #   token accounting.
+        # ⓘ hermes also sends `thinking`, which SGLang does not declare. It is TOLERATED
+        #   (the request model ignores extras) but therefore silently DROPPED, not honoured
+        #   — thinking must go via chat_template_kwargs / ENABLE_THINKING here.
         # ⓘ return_meta_info being non-streaming-only is also the ONLY clean way to read
         # per-request spec_accept_length out of this engine — see the accept-len A/B in
         # learnings/sglang-engine.md, which had to run non-streaming for exactly this reason.


### PR DESCRIPTION
SGLang refuses three OpenAI-extension fields when `stream=true` — an explicit guard in `serving_chat.py`, not a bug:

> `return_token_ids is not supported with streaming on /v1/chat/completions. Please set stream=false when using return_token_ids=true.`

| field | vLLM | SGLang | llama.cpp |
|---|:--:|:--:|:--:|
| `return_token_ids` | ✅ streams | ❌ refuses | ✅ (as `return_tokens`) |
| `return_prompt_token_ids` | ✅ | ❌ refuses | — |
| `return_meta_info` | — | ❌ refuses | — |

Verified in all three engines' sources rather than inferred.

**Why it needs saying:** we actively invite `vllm/` → `sgl/` swaps — #1245's engine-selection table recommends exactly that. A client that works on the vLLM tiers fails here **at request time**, after the user has picked the slug and pulled the weights.

Reported by @Naelith (Discord), hit via **pi** and **opencode** behind an API-switching proxy — the worst shape of this, since the proxy makes the backends look interchangeable right up until a field one of them refuses. No workaround short of `stream=false`.

**✅ The 8-pack is not affected.** `benchlocal-cli` and the HermesAgent sandbox set none of these fields and do not stream. I checked specifically because a blocked 8-pack would have invalidated the community contribution #1245 asks for — and that reassurance is now in the composes so nobody re-derives it.

**No code fix.** Nothing of ours sets any of these fields; the gap was purely that we never documented which client behaviours differ between the engines.

Also records that `return_meta_info` being non-streaming-only is the only clean way to read per-request `spec_accept_length` out of SGLang — the constraint the accept-len A/B had to work around.

Gates: compose-status-drift, compose-mounts-resolve, compose-sampler-profiles, compose-entrypoint-env-declared green; 13/13 render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)