### PR TITLE
docs(qwen3.8/vllm): correct the --prefix-match-unit comment — pmu is also inert under MTP

### DIFF
--- a/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/autoround-int4/mtp.yml
@@ -381,7 +381,22 @@ services:
       # 15-38% on agent traffic (bench-agentic), flatter TTFT-vs-ctx growth
       # (6.8x vs 9.7x); decode-neutral, soak PASS (0 leak). ⚠️ align mode is
       # upstream-EXPERIMENTAL + adds ~100ms cold-start TTFT (precopy JIT). Disable
-      # with MAMBA_CACHE_MODE=none. pmu is inert unless align is active.
+      # with MAMBA_CACHE_MODE=none.
+      # ⚠️ CORRECTED 2026-09-11 (club-3090#1246): pmu is inert unless align is
+      # active — AND inert whenever the MTP drafter is on, which is the default
+      # on this compose. Measured on vllm/qwen38-27b-dual-max (v0.27.1; 7 prompt
+      # sizes, 2 arms separated by a reboot, every prompt UUID-prefixed so none
+      # is a prefix of another): with MTP n=3 reuse snaps to the attention-block
+      # boundary and loses one block, an exact 7/7 fit for
+      #     cached_tokens = max(0, (floor(N/B) - 1) * B)
+      # where B is that slug's block size (1,600 on the one measured). With
+      # SPEC_N=0 the same prompts reuse ~99.7% at exact 16-token granularity —
+      # pmu does what it advertises only with the drafter OFF. Consequence:
+      # prefix reuse is EXACTLY ZERO below 2*B (~3.2K tokens), and ~21% of
+      # reusable tokens are lost at 10-14K. ⚠️ B is per-slug and only dual/fp8
+      # was measured — don't quote 1,600 for this compose without checking.
+      # NOT a reason to drop MTP: it buys decode throughput, and which side wins
+      # end-to-end is UNBENCHED.
       # ⚠️ align mode checkpoints the GDN/SSM state at EVERY attention block
       # (1,616 tok here) and those pages come out of the KV pool but are NOT in
       # vLLM's "GPU KV cache size" figure — measured 2026-09-04: the pool filled

--- a/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/fp8/mtp.yml
@@ -645,7 +645,22 @@ services:
       # 15-38% on agent traffic (bench-agentic), flatter TTFT-vs-ctx growth
       # (6.8x vs 9.7x); decode-neutral, soak PASS (0 leak). ⚠️ align mode is
       # upstream-EXPERIMENTAL + adds ~100ms cold-start TTFT (precopy JIT). Disable
-      # with MAMBA_CACHE_MODE=none. pmu is inert unless align is active.
+      # with MAMBA_CACHE_MODE=none.
+      # ⚠️ CORRECTED 2026-09-11 (club-3090#1246): pmu is inert unless align is
+      # active — AND inert whenever the MTP drafter is on, which is the default
+      # on this compose. Measured on vllm/qwen38-27b-dual-max (v0.27.1; 7 prompt
+      # sizes, 2 arms separated by a reboot, every prompt UUID-prefixed so none
+      # is a prefix of another): with MTP n=3 reuse snaps to the attention-block
+      # boundary and loses one block, an exact 7/7 fit for
+      #     cached_tokens = max(0, (floor(N/B) - 1) * B)
+      # where B is that slug's block size (1,600 on the one measured). With
+      # SPEC_N=0 the same prompts reuse ~99.7% at exact 16-token granularity —
+      # pmu does what it advertises only with the drafter OFF. Consequence:
+      # prefix reuse is EXACTLY ZERO below 2*B (~3.2K tokens), and ~21% of
+      # reusable tokens are lost at 10-14K. ⚠️ B is per-slug — 1,600 is THIS
+      # compose's measured value; don't carry it to the sibling slugs unread.
+      # NOT a reason to drop MTP: it buys decode throughput, and which side wins
+      # end-to-end is UNBENCHED.
       - --mamba-cache-mode
       - "${MAMBA_CACHE_MODE:-align}"
       - --prefix-match-unit

--- a/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/dual/nvfp4/mtp.yml
@@ -293,7 +293,22 @@ services:
       # 15-38% on agent traffic (bench-agentic), flatter TTFT-vs-ctx growth
       # (6.8x vs 9.7x); decode-neutral, soak PASS (0 leak). ⚠️ align mode is
       # upstream-EXPERIMENTAL + adds ~100ms cold-start TTFT (precopy JIT). Disable
-      # with MAMBA_CACHE_MODE=none. pmu is inert unless align is active.
+      # with MAMBA_CACHE_MODE=none.
+      # ⚠️ CORRECTED 2026-09-11 (club-3090#1246): pmu is inert unless align is
+      # active — AND inert whenever the MTP drafter is on, which is the default
+      # on this compose. Measured on vllm/qwen38-27b-dual-max (v0.27.1; 7 prompt
+      # sizes, 2 arms separated by a reboot, every prompt UUID-prefixed so none
+      # is a prefix of another): with MTP n=3 reuse snaps to the attention-block
+      # boundary and loses one block, an exact 7/7 fit for
+      #     cached_tokens = max(0, (floor(N/B) - 1) * B)
+      # where B is that slug's block size (1,600 on the one measured). With
+      # SPEC_N=0 the same prompts reuse ~99.7% at exact 16-token granularity —
+      # pmu does what it advertises only with the drafter OFF. Consequence:
+      # prefix reuse is EXACTLY ZERO below 2*B (~3.2K tokens), and ~21% of
+      # reusable tokens are lost at 10-14K. ⚠️ B is per-slug and only dual/fp8
+      # was measured — don't quote 1,600 for this compose without checking.
+      # NOT a reason to drop MTP: it buys decode throughput, and which side wins
+      # end-to-end is UNBENCHED.
       - --mamba-cache-mode
       - "${MAMBA_CACHE_MODE:-align}"
       - --prefix-match-unit

--- a/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/autoround-int4/mtp.yml
@@ -354,7 +354,22 @@ services:
       # 15-38% on agent traffic (bench-agentic), flatter TTFT-vs-ctx growth
       # (6.8x vs 9.7x); decode-neutral, soak PASS (0 leak). ⚠️ align mode is
       # upstream-EXPERIMENTAL + adds ~100ms cold-start TTFT (precopy JIT). Disable
-      # with MAMBA_CACHE_MODE=none. pmu is inert unless align is active.
+      # with MAMBA_CACHE_MODE=none.
+      # ⚠️ CORRECTED 2026-09-11 (club-3090#1246): pmu is inert unless align is
+      # active — AND inert whenever the MTP drafter is on, which is the default
+      # on this compose. Measured on vllm/qwen38-27b-dual-max (v0.27.1; 7 prompt
+      # sizes, 2 arms separated by a reboot, every prompt UUID-prefixed so none
+      # is a prefix of another): with MTP n=3 reuse snaps to the attention-block
+      # boundary and loses one block, an exact 7/7 fit for
+      #     cached_tokens = max(0, (floor(N/B) - 1) * B)
+      # where B is that slug's block size (1,600 on the one measured). With
+      # SPEC_N=0 the same prompts reuse ~99.7% at exact 16-token granularity —
+      # pmu does what it advertises only with the drafter OFF. Consequence:
+      # prefix reuse is EXACTLY ZERO below 2*B (~3.2K tokens), and ~21% of
+      # reusable tokens are lost at 10-14K. ⚠️ B is per-slug and only dual/fp8
+      # was measured — don't quote 1,600 for this compose without checking.
+      # NOT a reason to drop MTP: it buys decode throughput, and which side wins
+      # end-to-end is UNBENCHED.
       - --mamba-cache-mode
       - "${MAMBA_CACHE_MODE:-align}"
       - --prefix-match-unit

--- a/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi4/fp8/mtp.yml
@@ -520,7 +520,22 @@ services:
       # 15-38% on agent traffic (bench-agentic), flatter TTFT-vs-ctx growth
       # (6.8x vs 9.7x); decode-neutral, soak PASS (0 leak). ⚠️ align mode is
       # upstream-EXPERIMENTAL + adds ~100ms cold-start TTFT (precopy JIT). Disable
-      # with MAMBA_CACHE_MODE=none. pmu is inert unless align is active.
+      # with MAMBA_CACHE_MODE=none.
+      # ⚠️ CORRECTED 2026-09-11 (club-3090#1246): pmu is inert unless align is
+      # active — AND inert whenever the MTP drafter is on, which is the default
+      # on this compose. Measured on vllm/qwen38-27b-dual-max (v0.27.1; 7 prompt
+      # sizes, 2 arms separated by a reboot, every prompt UUID-prefixed so none
+      # is a prefix of another): with MTP n=3 reuse snaps to the attention-block
+      # boundary and loses one block, an exact 7/7 fit for
+      #     cached_tokens = max(0, (floor(N/B) - 1) * B)
+      # where B is that slug's block size (1,600 on the one measured). With
+      # SPEC_N=0 the same prompts reuse ~99.7% at exact 16-token granularity —
+      # pmu does what it advertises only with the drafter OFF. Consequence:
+      # prefix reuse is EXACTLY ZERO below 2*B (~3.2K tokens), and ~21% of
+      # reusable tokens are lost at 10-14K. ⚠️ B is per-slug and only dual/fp8
+      # was measured — don't quote 1,600 for this compose without checking.
+      # NOT a reason to drop MTP: it buys decode throughput, and which side wins
+      # end-to-end is UNBENCHED.
       - --mamba-cache-mode
       - "${MAMBA_CACHE_MODE:-align}"
       - --prefix-match-unit

--- a/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/autoround-int4/mtp.yml
@@ -354,7 +354,22 @@ services:
       # 15-38% on agent traffic (bench-agentic), flatter TTFT-vs-ctx growth
       # (6.8x vs 9.7x); decode-neutral, soak PASS (0 leak). ⚠️ align mode is
       # upstream-EXPERIMENTAL + adds ~100ms cold-start TTFT (precopy JIT). Disable
-      # with MAMBA_CACHE_MODE=none. pmu is inert unless align is active.
+      # with MAMBA_CACHE_MODE=none.
+      # ⚠️ CORRECTED 2026-09-11 (club-3090#1246): pmu is inert unless align is
+      # active — AND inert whenever the MTP drafter is on, which is the default
+      # on this compose. Measured on vllm/qwen38-27b-dual-max (v0.27.1; 7 prompt
+      # sizes, 2 arms separated by a reboot, every prompt UUID-prefixed so none
+      # is a prefix of another): with MTP n=3 reuse snaps to the attention-block
+      # boundary and loses one block, an exact 7/7 fit for
+      #     cached_tokens = max(0, (floor(N/B) - 1) * B)
+      # where B is that slug's block size (1,600 on the one measured). With
+      # SPEC_N=0 the same prompts reuse ~99.7% at exact 16-token granularity —
+      # pmu does what it advertises only with the drafter OFF. Consequence:
+      # prefix reuse is EXACTLY ZERO below 2*B (~3.2K tokens), and ~21% of
+      # reusable tokens are lost at 10-14K. ⚠️ B is per-slug and only dual/fp8
+      # was measured — don't quote 1,600 for this compose without checking.
+      # NOT a reason to drop MTP: it buys decode throughput, and which side wins
+      # end-to-end is UNBENCHED.
       - --mamba-cache-mode
       - "${MAMBA_CACHE_MODE:-align}"
       - --prefix-match-unit

--- a/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/multi8/fp8/mtp.yml
@@ -538,7 +538,22 @@ services:
       # 15-38% on agent traffic (bench-agentic), flatter TTFT-vs-ctx growth
       # (6.8x vs 9.7x); decode-neutral, soak PASS (0 leak). ⚠️ align mode is
       # upstream-EXPERIMENTAL + adds ~100ms cold-start TTFT (precopy JIT). Disable
-      # with MAMBA_CACHE_MODE=none. pmu is inert unless align is active.
+      # with MAMBA_CACHE_MODE=none.
+      # ⚠️ CORRECTED 2026-09-11 (club-3090#1246): pmu is inert unless align is
+      # active — AND inert whenever the MTP drafter is on, which is the default
+      # on this compose. Measured on vllm/qwen38-27b-dual-max (v0.27.1; 7 prompt
+      # sizes, 2 arms separated by a reboot, every prompt UUID-prefixed so none
+      # is a prefix of another): with MTP n=3 reuse snaps to the attention-block
+      # boundary and loses one block, an exact 7/7 fit for
+      #     cached_tokens = max(0, (floor(N/B) - 1) * B)
+      # where B is that slug's block size (1,600 on the one measured). With
+      # SPEC_N=0 the same prompts reuse ~99.7% at exact 16-token granularity —
+      # pmu does what it advertises only with the drafter OFF. Consequence:
+      # prefix reuse is EXACTLY ZERO below 2*B (~3.2K tokens), and ~21% of
+      # reusable tokens are lost at 10-14K. ⚠️ B is per-slug and only dual/fp8
+      # was measured — don't quote 1,600 for this compose without checking.
+      # NOT a reason to drop MTP: it buys decode throughput, and which side wins
+      # end-to-end is UNBENCHED.
       - --mamba-cache-mode
       - "${MAMBA_CACHE_MODE:-align}"
       - --prefix-match-unit

--- a/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
+++ b/models/qwen3.8-27b/vllm/compose/single/nvfp4/mtp.yml
@@ -316,7 +316,22 @@ services:
       # 15-38% on agent traffic (bench-agentic), flatter TTFT-vs-ctx growth
       # (6.8x vs 9.7x); decode-neutral, soak PASS (0 leak). ⚠️ align mode is
       # upstream-EXPERIMENTAL + adds ~100ms cold-start TTFT (precopy JIT). Disable
-      # with MAMBA_CACHE_MODE=none. pmu is inert unless align is active.
+      # with MAMBA_CACHE_MODE=none.
+      # ⚠️ CORRECTED 2026-09-11 (club-3090#1246): pmu is inert unless align is
+      # active — AND inert whenever the MTP drafter is on, which is the default
+      # on this compose. Measured on vllm/qwen38-27b-dual-max (v0.27.1; 7 prompt
+      # sizes, 2 arms separated by a reboot, every prompt UUID-prefixed so none
+      # is a prefix of another): with MTP n=3 reuse snaps to the attention-block
+      # boundary and loses one block, an exact 7/7 fit for
+      #     cached_tokens = max(0, (floor(N/B) - 1) * B)
+      # where B is that slug's block size (1,600 on the one measured). With
+      # SPEC_N=0 the same prompts reuse ~99.7% at exact 16-token granularity —
+      # pmu does what it advertises only with the drafter OFF. Consequence:
+      # prefix reuse is EXACTLY ZERO below 2*B (~3.2K tokens), and ~21% of
+      # reusable tokens are lost at 10-14K. ⚠️ B is per-slug and only dual/fp8
+      # was measured — don't quote 1,600 for this compose without checking.
+      # NOT a reason to drop MTP: it buys decode throughput, and which side wins
+      # end-to-end is UNBENCHED.
       - --mamba-cache-mode
       - "${MAMBA_CACHE_MODE:-align}"
       - --prefix-match-unit


### PR DESCRIPTION
Follow-up to #1260 / #1246. Comment-only.

## The problem

All 8 qwen3.8 MTP composes carried:

```
# Disable with MAMBA_CACHE_MODE=none. pmu is inert unless align is active.
```

That names one condition and misses the bigger one. `--prefix-match-unit` is
**also inert whenever the MTP drafter is on** — which is the default on every
one of these composes. As written it told users the knob was live in exactly
the configuration where it does nothing.

## What replaces it

The corrected comment states the mechanism, the measurement behind it, and its
limits. Measured on `vllm/qwen38-27b-dual-max` (pinned v0.27.1, shipped
defaults): 7 prompt sizes, two arms separated by a full reboot, every prompt
UUID-prefixed so no prompt is a prefix of another.

| prompt tokens | MTP n=3 | SPEC_N=0 |
|---:|---:|---:|
| 2,344 | **0** | 2,336 — 99.7% |
| 3,644 | 1,600 | 3,632 — 99.7% |
| 7,132 | 4,800 | 7,120 — 99.8% |
| 14,144 | 11,200 | 14,112 — 99.8% |

The MTP arm is an exact 7/7 fit for `cached_tokens = max(0, (⌊N/B⌋ − 1) × B)`
with `B` = 1,600, the attention block size — block-quantized, minus one block
(`drop_eagle_block`). The `SPEC_N=0` arm is every row an exact multiple of 16,
i.e. `--prefix-match-unit 16` doing precisely what it says.

So prefix reuse is **exactly zero below 2×B (~3,200 tokens)** and ~21% of
reusable tokens are lost at 10–14K.

## What the comment deliberately does not claim

- `B` is per-slug — this same family already reports 1,616 in the
  `dual/autoround-int4` align note. Only `dual/fp8` was measured, and the
  comment says so on each file rather than implying 1,600 is universal.
- MTP-on vs MTP-off has **not** been benched end-to-end. MTP buys decode
  throughput; this costs warm-prefill work. The comment closes by saying which
  side wins is unbenched, so nobody reads it as "turn the drafter off".

## Scope

Exactly the 8 files that carried the stale sentence. The qwen3.6 and tess MTP
composes do **not** set `--prefix-match-unit`, so there is no stale comment
there to correct — and asserting the coarsening on those slugs would mean
claiming a measurement I haven't taken.

## Verification

- Every qwen3.8 compose parsed before and after and compared as loaded YAML —
  **semantically identical to HEAD**, confirming comment-only.
- Compose/docs gate subset: 22 passed, 0 failed.
- Full gate sweep green, run quiescent.
