### PR TITLE
fix(harness): resolve sglang-* containers to ENGINE_KIND=sglang (5 sites)

### DIFF
--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -431,6 +431,10 @@ if [[ "$ENGINE_KIND" == "unknown" && "${CONTAINER:-}" != "none" ]] && command -v
     ENGINE_KIND="llamacpp"
   elif [[ "${container_image} ${container_name}" == *"vllm"* ]]; then
     ENGINE_KIND="vllm"
+  elif [[ "${container_image} ${container_name}" == *"sglang"* || "${container_image} ${container_name}" == *"lmsysorg"* ]]; then
+    # club-3090#1261: without this an SGLang container read as "unknown", which
+    # silently changed which spec-decode metrics bench.sh went looking for.
+    ENGINE_KIND="sglang"
   fi
 fi
 

--- a/scripts/lib/report_calib.sh
+++ b/scripts/lib/report_calib.sh
@@ -18,6 +18,7 @@ calib_engine_for_container() {
   case "$1" in
     vllm-*)                 echo "vllm" ;;
     llama-cpp-*|ik-llama-*) echo "llamacpp" ;;
+    sglang-*|sgl-*)         echo "sglang" ;;   # club-3090#1261
     *)                      echo "unknown" ;;
   esac
 }

--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -928,11 +928,12 @@ fi
 # Engine class — drives which probes run inside the container body. Inferred
 # from container name; user can override with ENGINE_KIND=vllm|llamacpp env var.
 case "${ENGINE_KIND:-}" in
-  vllm|llamacpp|unknown) ;;  # respect user override
+  vllm|llamacpp|sglang|unknown) ;;  # respect user override (sglang: club-3090#1261)
   *)
     case "$CONTAINER" in
-      vllm-*)      ENGINE_KIND="vllm" ;;
-      llama-cpp-*) ENGINE_KIND="llamacpp" ;;
+      vllm-*)         ENGINE_KIND="vllm" ;;
+      llama-cpp-*)    ENGINE_KIND="llamacpp" ;;
+      sglang-*|sgl-*) ENGINE_KIND="sglang" ;;   # club-3090#1261
       club3090-*)
         container_image=$(docker ps --filter "name=$CONTAINER" --format '{{.Image}}' 2>/dev/null | head -1)
         case "$container_image" in

--- a/scripts/tests/test-engine-detection-sglang.sh
+++ b/scripts/tests/test-engine-detection-sglang.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# Guard: an `sglang-*` container must resolve to ENGINE_KIND=sglang everywhere.
+#
+# Why this exists (club-3090#1261, @paulp83): a hand-rolled SGLang NVFP4 run
+# printed `engine=unknown`, so verify-full's acceptance check fell through the
+# `case "$ENGINE_KIND"` dispatch into the vLLM branch, found no "SpecDecoding
+# metrics" line, and SKIPPED. The DFlash2 drafter was never verified alive —
+# which is exactly the sglang#39087 false-clean (a garbage-drafting drafter
+# leaves output correct and only collapses decode, silently).
+#
+# The cause was NOT the acceptance check added in #1249. It was detection:
+# every container-name fallback listed `vllm-*` and `llama-cpp-*` and simply
+# had no `sglang-*` arm, even though rebench-full.sh and club3090-env.sh both
+# already use that prefix. So the #1249 SGLang branch was unreachable by
+# auto-detection and had likely never fired.
+#
+# ⚠️ This test must FAIL against the pre-fix tree. If it passes before the fix,
+# it is asserting the wrong thing.
+set -uo pipefail
+
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+FAIL=0
+
+ok()  { printf "  \033[32m✓\033[0m %s\n" "$1"; }
+bad() { printf "  \033[31m✗\033[0m %s\n" "$1"; printf "    expected=%s got=%s\n" "$2" "$3"; FAIL=1; }
+check() { [[ "$2" == "$3" ]] && ok "$1" || bad "$1" "$2" "$3"; }
+
+# --- 1 & 2: detect_engine() in verify-full.sh and verify-stress.sh -----------
+# Extract just the function and drive it with a dead URL so hints 1 and 2 fail
+# immediately (connection refused, not a timeout) and the container-name
+# fallback — the arm that was missing — is what actually decides.
+DEAD_URL="http://127.0.0.1:1"
+
+for script in verify-full.sh verify-stress.sh; do
+  awk '/^detect_engine\(\) \{/,/^\}/' "${ROOT}/scripts/${script}" > "${TMP}/fn.sh"
+  if [[ ! -s "${TMP}/fn.sh" ]]; then
+    bad "${script}: detect_engine() not extractable" "a function body" "empty"
+    continue
+  fi
+  # shellcheck disable=SC1090
+  got="$(URL="$DEAD_URL" MODEL=x CONTAINER=sglang-qwen38-27b-nvfp4-dflash2-dual \
+         bash -c "source '${TMP}/fn.sh'; detect_engine" 2>/dev/null)"
+  check "${script}: sglang-* container → sglang" "sglang" "$got"
+
+  # Negative control: the arms that already worked must keep working, and an
+  # unrecognised name must still be honestly 'unknown' rather than defaulting.
+  got="$(URL="$DEAD_URL" MODEL=x CONTAINER=vllm-qwen38-27b \
+         bash -c "source '${TMP}/fn.sh'; detect_engine" 2>/dev/null)"
+  check "${script}: vllm-* still → vllm" "vllm" "$got"
+  got="$(URL="$DEAD_URL" MODEL=x CONTAINER=totally-unrecognised \
+         bash -c "source '${TMP}/fn.sh'; detect_engine" 2>/dev/null)"
+  check "${script}: unknown name still → unknown" "unknown" "$got"
+done
+
+# --- 3: calib_engine_for_container() in lib/report_calib.sh -----------------
+# shellcheck source=../lib/report_calib.sh
+source "${ROOT}/scripts/lib/report_calib.sh"
+check "report_calib: sglang-* → sglang" "sglang" "$(calib_engine_for_container sglang-qwen38-27b-dual-fast)"
+check "report_calib: vllm-* → vllm"     "vllm"   "$(calib_engine_for_container vllm-qwen38-27b)"
+check "report_calib: junk → unknown"    "unknown" "$(calib_engine_for_container some-other-container)"
+
+# --- 4: report.sh must RESPECT an explicit ENGINE_KIND=sglang override ------
+# Its override guard reads `case "${ENGINE_KIND:-}" in vllm|llamacpp|unknown)`,
+# so `sglang` fell through to the re-derive branch and was silently discarded.
+if command grep -qE '^\s*vllm\|llamacpp\|sglang\|unknown\)' "${ROOT}/scripts/report.sh"; then
+  ok "report.sh: honours ENGINE_KIND=sglang override"
+else
+  bad "report.sh: honours ENGINE_KIND=sglang override" "sglang in the override guard" "absent"
+fi
+
+# --- 5: bench.sh container-name detection must know sglang ------------------
+if awk '/^ENGINE_KIND="\$\{ENGINE_KIND:-unknown\}"/,/^fi$/' "${ROOT}/scripts/bench.sh" \
+     | command grep -q 'sglang'; then
+  ok "bench.sh: container-name detection knows sglang"
+else
+  bad "bench.sh: container-name detection knows sglang" "an sglang branch" "absent"
+fi
+
+echo
+if [[ "$FAIL" == "0" ]]; then
+  printf "\033[32mtest-engine-detection-sglang: PASS\033[0m\n"
+else
+  printf "\033[31mtest-engine-detection-sglang: FAIL\033[0m\n"
+fi
+exit "$FAIL"

--- a/scripts/verify-full.sh
+++ b/scripts/verify-full.sh
@@ -139,10 +139,18 @@ detect_engine() {
     sglang-*)  echo "sglang"; return 0 ;;
     b[0-9]*)   echo "llamacpp"; return 0 ;;   # llama-server build str: b10454[-hash]
   esac
-  # Hint 3: container name pattern as a fallback (cheap, no extra HTTP)
+  # Hint 3: container name pattern as a fallback (cheap, no extra HTTP).
+  # ⚠️ sglang-* was MISSING here until club-3090#1261. SGLang does not set a
+  # `sglang-`-prefixed system_fingerprint, so hint 2 never matches it and every
+  # SGLang run fell through to "unknown" — which meant the `case "$ENGINE_KIND"`
+  # dispatch below skipped straight past the SGLang branch into the vLLM one and
+  # SKIPPED the acceptance check. A dead DFlash2 drafter (sglang#39087) leaves
+  # output correct and only collapses decode, so that skip is silent. The prefix
+  # is the same one rebench-full.sh and club3090-env.sh already use.
   case "$CONTAINER" in
     vllm-*)      echo "vllm"; return 0 ;;
-    llama-cpp-*) echo "llamacpp"; return 0 ;;
+    llama-cpp-*|ik-llama-*) echo "llamacpp"; return 0 ;;
+    sglang-*|sgl-*) echo "sglang"; return 0 ;;
   esac
   echo "unknown"
 }

--- a/scripts/verify-stress.sh
+++ b/scripts/verify-stress.sh
@@ -473,9 +473,11 @@ detect_engine() {
     vllm-*)   echo "vllm"; return 0 ;;
     sglang-*) echo "sglang"; return 0 ;;
   esac
+  # sglang-*/sgl-* added club-3090#1261 — see the long note in verify-full.sh.
   case "$CONTAINER" in
     vllm-*)      echo "vllm"; return 0 ;;
-    llama-cpp-*) echo "llamacpp"; return 0 ;;
+    llama-cpp-*|ik-llama-*) echo "llamacpp"; return 0 ;;
+    sglang-*|sgl-*) echo "sglang"; return 0 ;;
   esac
   echo "unknown"
 }


### PR DESCRIPTION
Found via #1261 (@paulp83). Fixes a silent gate skip, not a cosmetic label.

## The failure

His SGLang NVFP4 run printed:

```
model=qwen3.8-27b  container=sglang-qwen38-27b-nvfp4-dflash2-dual  engine=unknown
[9/10] MTP acceptance length threshold ...
  ⊘ no SpecDecoding metrics in logs (compose may not have spec-decode enabled) (skipped)
```

`engine=unknown` → the `case "$ENGINE_KIND"` dispatch never reached the SGLang
branch → fell into the vLLM one → grepped for vLLM's wording → skipped.

**That skip is the dangerous kind.** sglang#39087 is a drafter that drafts
garbage: the drafts are rejected, so output stays *correct* and only decode
collapses — accept len 1.03 vs 3.71, ~38 vs ~171 tok/s, with nothing in the log
saying so. The acceptance check is the only gate that catches it, and it is the
gate that skipped.

## The cause was detection, not the check

The SGLang assertion added in #1249 is fine. It was simply unreachable: every
container-name fallback listed `vllm-*` and `llama-cpp-*` and had **no
`sglang-*` arm** — despite `rebench-full.sh:317` and `club3090-env.sh:33`
already using that prefix. SGLang doesn't set an `sglang-`-prefixed
`system_fingerprint` either, so the HTTP hint missed too.

So #1249's SGLang branch had almost certainly **never fired on any run**,
including @paulp83's earlier #1251 and #1253.

## Five sites

| file | what was wrong |
|---|---|
| `scripts/verify-full.sh` | `detect_engine()` hint 3 |
| `scripts/verify-stress.sh` | `detect_engine()` hint 3 |
| `scripts/lib/report_calib.sh` | `calib_engine_for_container()` |
| `scripts/report.sh` | container case **and** its override guard — it read `vllm\|llamacpp\|unknown)`, so an explicit `ENGINE_KIND=sglang` was silently discarded and re-derived |
| `scripts/bench.sh` | inline image/name detection |

Also folded `ik-llama-*` into the two verify scripts' llamacpp arm, matching
what `report_calib.sh` already did.

## Downstream branching was checked, not assumed

Every `ENGINE_KIND` consumer, comparing old `unknown` vs new `sglang`:

- **Improves:** Genesis probe now skips cleanly instead of running a vLLM-only
  check; `verify-stress` gets the right `docker logs` hint instead of a generic
  one; `bench.sh` footer prints the engine instead of `unknown`.
- **The point of the fix:** `verify-full` step 9 now reaches the real SGLang
  acceptance assertion.
- **Unchanged:** `report.sh` probe set and `bench.sh` PP mode branch on
  `llamacpp`, so `sglang` and `unknown` both take the same else. No regression.

## Negative control

`scripts/tests/test-engine-detection-sglang.sh` was written **before** the fix
and fails on the pre-fix tree at exactly the five points, while its three
controls pass:

```
✗ verify-full.sh: sglang-* container → sglang     expected=sglang got=unknown
✗ verify-stress.sh: sglang-* container → sglang   expected=sglang got=unknown
✗ report_calib: sglang-* → sglang                 expected=sglang got=unknown
✗ report.sh: honours ENGINE_KIND=sglang override
✗ bench.sh: container-name detection knows sglang
✓ verify-full.sh: vllm-* still → vllm
✓ verify-full.sh: unknown name still → unknown
✓ report_calib: junk → unknown
```

It drives the real `detect_engine()` bodies (extracted and sourced) against a
dead URL so hints 1–2 fail fast and the container-name fallback is what
actually decides — rather than asserting on source text.
