### PR TITLE
docs(sglang): the DFlash2 headers named a drafter that stopped being the default in #1237

### DIFF
--- a/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2-bf16.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2-bf16.yml
@@ -4,8 +4,12 @@
 #              Frozenlock AutoRound INT4 W4A16 g128 — the collapse-free checkpoint.
 #   Engine:    SGLang STOCK v0.5.19 (`lmsysorg/sglang:v0.5.19`) — NO PATCHES.
 #   Topology:  Dual 3090 PCIe (TP=2, no NVLink)
-#   Drafter:   DFlash2 EXTERNAL block-drafter (syv-ai W4A16, compressed-tensors,
-#              5 layers, `DFlash2DraftModel`) — NOT the in-checkpoint MTP head.
+#   Drafter:   DFlash2 EXTERNAL block-drafter, 5 layers, `DFlash2DraftModel`
+#              — NOT the in-checkpoint MTP head. DEFAULT is the z-lab BF16
+#              drafter (`DRAFTER_DIR=…/qwen3.8-27b-dflash2-zlab-bf16`,
+#              `DRAFT_QUANT=unquant`). The syv-ai W4A16 compressed-tensors
+#              drafter is HISTORY, not the default — it drafted garbage
+#              (sglang#39087); see Provenance.
 #   KV:        bf16 (`--kv-cache-dtype auto` over the bf16 model dtype).
 #              ⚠️ See THE vLLM TIER NAMES block — bf16 is inherited here as a
 #              hypothesis, NOT as a proven SGLang requirement.

--- a/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/autoround-int4/dflash2.yml
@@ -4,8 +4,12 @@
 #              Frozenlock AutoRound INT4 W4A16 g128 — the collapse-free checkpoint.
 #   Engine:    SGLang STOCK v0.5.19 (`lmsysorg/sglang:v0.5.19`) — NO PATCHES.
 #   Topology:  Dual 3090 PCIe (TP=2, no NVLink)
-#   Drafter:   DFlash2 EXTERNAL block-drafter (syv-ai W4A16, compressed-tensors,
-#              5 layers, `DFlash2DraftModel`) — NOT the in-checkpoint MTP head.
+#   Drafter:   DFlash2 EXTERNAL block-drafter, 5 layers, `DFlash2DraftModel`
+#              — NOT the in-checkpoint MTP head. DEFAULT is the z-lab BF16
+#              drafter (`DRAFTER_DIR=…/qwen3.8-27b-dflash2-zlab-bf16`,
+#              `DRAFT_QUANT=unquant`). The syv-ai W4A16 compressed-tensors
+#              drafter is HISTORY, not the default — it drafted garbage
+#              (sglang#39087); see Provenance.
 #   KV:        fp8_e4m3 — same as the MTP sibling; full 262K fits because fp8 KV
 #              is half the bytes of bf16.
 #   Vision:    ✅ tower present. The MTP sibling scored verify-full 4/4 on vision

--- a/models/qwen3.8-27b/sglang/compose/dual/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/dual/fp8/dflash2.yml
@@ -4,8 +4,12 @@
 #              OFFICIAL Qwen/Qwen3.8-27B-FP8 — block-quantised e4m3, ~29 GB.
 #   Engine:    SGLang STOCK v0.5.19 (`lmsysorg/sglang:v0.5.19`) — NO PATCHES.
 #   Topology:  Dual 3090 PCIe (TP=2, no NVLink)
-#   Drafter:   DFlash2 EXTERNAL block-drafter (syv-ai W4A16, compressed-tensors,
-#              5 layers, `DFlash2DraftModel`) — NOT the in-checkpoint MTP head.
+#   Drafter:   DFlash2 EXTERNAL block-drafter, 5 layers, `DFlash2DraftModel`
+#              — NOT the in-checkpoint MTP head. DEFAULT is the z-lab BF16
+#              drafter (`DRAFTER_DIR=…/qwen3.8-27b-dflash2-zlab-bf16`,
+#              `DRAFT_QUANT=unquant`). The syv-ai W4A16 compressed-tensors
+#              drafter is HISTORY, not the default — it drafted garbage
+#              (sglang#39087); see Provenance.
 #   KV:        fp8_e4m3 — same as the MTP sibling; full 262K fits because fp8 KV
 #              is half the bytes of bf16.
 #   Vision:    ✅ tower present. The MTP sibling scored verify-full 4/4 on vision
@@ -13,13 +17,26 @@
 #   Max ctx:   262144 (full arch max, as the fp8 MTP sibling which MEASURED a
 #              409,552-token pool at this setting).
 #   Genesis:   N/A — Genesis is a vLLM construct.
-#   Status:    👁️ Preview — ⛔⛔ THE DRAFTER IS DEAD ON THIS PIN. Booted, served,
-#              verify-full ALL PASS 2026-09-10 — and still ~0% acceptance
-#              (accept len 1.03, accept rate 0.004 over n=422). Decode is
-#              38.6/38.9 vs the MTP sibling's 89.2/112.5: -57% / -65%. It pays
-#              full verify cost for zero accepted tokens. DO NOT SHIP.
-#   Caveats:   Drafter contributes nothing; this tier is strictly slower than
-#              sglang/…/mtp.yml. Root cause NOT diagnosed — see the header note.
+#   Status:    👁️ Preview — ⚠️ UNMEASURED ON ITS CURRENT DRAFTER (see below).
+#              The "drafter is dead" verdict this header used to carry was
+#              measured 2026-09-10 against the SYV-AI compressed-tensors
+#              drafter: accept len 1.03, accept rate 0.004 over n=422, decode
+#              38.6/38.9 vs the MTP sibling's 89.2/112.5 (−57%/−65%). That is
+#              sglang#39087 and it is NO LONGER THE SHIPPED CONFIG — since
+#              #1237 this compose defaults to the z-lab BF16 drafter
+#              (DRAFTER_DIR=…-dflash2-zlab-bf16, DRAFT_QUANT=unquant), the
+#              same repoint that restored acceptance to 3.71 on
+#              dual/autoround-int4/dflash2.yml. Those siblings were re-measured
+#              and re-labelled "drafter FIXED 2026-09-10"; THIS ONE WAS NOT
+#              re-measured, so its real acceptance is unknown — do not read the
+#              old numbers as current, and do not assume the fix carried over
+#              either. Re-measure before promoting: club-3090#1264.
+#   Caveats:   Acceptance UNVERIFIED on this compose. Until someone boots it and
+#              reads `accept len` from the scheduler metrics, treat the drafter
+#              as unproven rather than dead. ⚠️ On SGLang a garbage drafter is
+#              silent — drafts get rejected, so output stays correct and only
+#              decode collapses; verify-full step 9 is the only signal, and it
+#              only started working on SGLang in #1263.
 #   Best for:  the SUPERFAST rung of the SGLang tier ladder — mirrors
 #              vllm/qwen38-27b-dual-superfast on the drafter+KV axis only.
 #

--- a/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/autoround-int4/dflash2.yml
@@ -4,8 +4,12 @@
 #              Frozenlock AutoRound INT4 W4A16 g128 — the collapse-free checkpoint.
 #   Engine:    SGLang STOCK v0.5.19 (`lmsysorg/sglang:v0.5.19`) — NO PATCHES.
 #   Topology:  4x GPU (TP=4) — NOT the reference rig
-#   Drafter:   DFlash2 EXTERNAL block-drafter (syv-ai W4A16, compressed-tensors,
-#              5 layers, `DFlash2DraftModel`) — NOT the in-checkpoint MTP head.
+#   Drafter:   DFlash2 EXTERNAL block-drafter, 5 layers, `DFlash2DraftModel`
+#              — NOT the in-checkpoint MTP head. DEFAULT is the z-lab BF16
+#              drafter (`DRAFTER_DIR=…/qwen3.8-27b-dflash2-zlab-bf16`,
+#              `DRAFT_QUANT=unquant`). The syv-ai W4A16 compressed-tensors
+#              drafter is HISTORY, not the default — it drafted garbage
+#              (sglang#39087); see Provenance.
 #   KV:        fp8_e4m3 — same as the MTP sibling; full 262K fits because fp8 KV
 #              is half the bytes of bf16.
 #   Vision:    ✅ tower present. The MTP sibling scored verify-full 4/4 on vision

--- a/models/qwen3.8-27b/sglang/compose/multi4/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi4/fp8/dflash2.yml
@@ -4,8 +4,12 @@
 #              OFFICIAL Qwen/Qwen3.8-27B-FP8 — block-quantised e4m3, ~29 GB.
 #   Engine:    SGLang STOCK v0.5.19 (`lmsysorg/sglang:v0.5.19`) — NO PATCHES.
 #   Topology:  4x GPU (TP=4) — NOT the reference rig
-#   Drafter:   DFlash2 EXTERNAL block-drafter (syv-ai W4A16, compressed-tensors,
-#              5 layers, `DFlash2DraftModel`) — NOT the in-checkpoint MTP head.
+#   Drafter:   DFlash2 EXTERNAL block-drafter, 5 layers, `DFlash2DraftModel`
+#              — NOT the in-checkpoint MTP head. DEFAULT is the z-lab BF16
+#              drafter (`DRAFTER_DIR=…/qwen3.8-27b-dflash2-zlab-bf16`,
+#              `DRAFT_QUANT=unquant`). The syv-ai W4A16 compressed-tensors
+#              drafter is HISTORY, not the default — it drafted garbage
+#              (sglang#39087); see Provenance.
 #   KV:        fp8_e4m3 — same as the MTP sibling; full 262K fits because fp8 KV
 #              is half the bytes of bf16.
 #   Vision:    ✅ tower present. The MTP sibling scored verify-full 4/4 on vision

--- a/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/autoround-int4/dflash2.yml
@@ -4,8 +4,12 @@
 #              Frozenlock AutoRound INT4 W4A16 g128 — the collapse-free checkpoint.
 #   Engine:    SGLang STOCK v0.5.19 (`lmsysorg/sglang:v0.5.19`) — NO PATCHES.
 #   Topology:  8x GPU (TP=8) — NOT the reference rig
-#   Drafter:   DFlash2 EXTERNAL block-drafter (syv-ai W4A16, compressed-tensors,
-#              5 layers, `DFlash2DraftModel`) — NOT the in-checkpoint MTP head.
+#   Drafter:   DFlash2 EXTERNAL block-drafter, 5 layers, `DFlash2DraftModel`
+#              — NOT the in-checkpoint MTP head. DEFAULT is the z-lab BF16
+#              drafter (`DRAFTER_DIR=…/qwen3.8-27b-dflash2-zlab-bf16`,
+#              `DRAFT_QUANT=unquant`). The syv-ai W4A16 compressed-tensors
+#              drafter is HISTORY, not the default — it drafted garbage
+#              (sglang#39087); see Provenance.
 #   KV:        fp8_e4m3 — same as the MTP sibling; full 262K fits because fp8 KV
 #              is half the bytes of bf16.
 #   Vision:    ✅ tower present. The MTP sibling scored verify-full 4/4 on vision

--- a/models/qwen3.8-27b/sglang/compose/multi8/fp8/dflash2.yml
+++ b/models/qwen3.8-27b/sglang/compose/multi8/fp8/dflash2.yml
@@ -4,8 +4,12 @@
 #              OFFICIAL Qwen/Qwen3.8-27B-FP8 — block-quantised e4m3, ~29 GB.
 #   Engine:    SGLang STOCK v0.5.19 (`lmsysorg/sglang:v0.5.19`) — NO PATCHES.
 #   Topology:  8x GPU (TP=8) — NOT the reference rig
-#   Drafter:   DFlash2 EXTERNAL block-drafter (syv-ai W4A16, compressed-tensors,
-#              5 layers, `DFlash2DraftModel`) — NOT the in-checkpoint MTP head.
+#   Drafter:   DFlash2 EXTERNAL block-drafter, 5 layers, `DFlash2DraftModel`
+#              — NOT the in-checkpoint MTP head. DEFAULT is the z-lab BF16
+#              drafter (`DRAFTER_DIR=…/qwen3.8-27b-dflash2-zlab-bf16`,
+#              `DRAFT_QUANT=unquant`). The syv-ai W4A16 compressed-tensors
+#              drafter is HISTORY, not the default — it drafted garbage
+#              (sglang#39087); see Provenance.
 #   KV:        fp8_e4m3 — same as the MTP sibling; full 262K fits because fp8 KV
 #              is half the bytes of bf16.
 #   Vision:    ✅ tower present. The MTP sibling scored verify-full 4/4 on vision


### PR DESCRIPTION
Two documentation defects found while scoping #1264. **Comment-only** — every SGLang compose parses
to YAML identical to HEAD.

## 1. `dual/fp8/dflash2.yml` told users not to use it, based on a drafter it no longer runs

Its header carried a current-tense verdict:

> ⛔⛔ THE DRAFTER IS DEAD ON THIS PIN … accept len 1.03, accept rate 0.004 over n=422 … DO NOT SHIP

Measured **2026-09-10 against the syv-ai compressed-tensors drafter** — sglang#39087. But since
#1237 the compose defaults to `DRAFTER_DIR=…-dflash2-zlab-bf16` with `DRAFT_QUANT=unquant`, the
same repoint that restored acceptance to **3.71** on `dual/autoround-int4/dflash2.yml`.

All three siblings carrying that drafter were re-measured and re-labelled *"drafter FIXED
2026-09-10"*:

| compose | status | drafter default |
|---|---|---|
| `dual/autoround-int4/dflash2.yml` | 🧪 drafter FIXED | zlab-bf16 |
| `multi4/fp8/dflash2.yml` | 🧪 drafter FIXED | zlab-bf16 |
| `multi8/fp8/dflash2.yml` | 🧪 drafter FIXED | zlab-bf16 |
| **`dual/fp8/dflash2.yml`** | **👁️ "DRAFTER IS DEAD"** | **zlab-bf16** ← missed |

It's unregistered — no slug resolves to it — so impact is documentation-only. But it's the file
someone reads when looking for an fp8 DFlash2 dual, and it told them not to on the strength of a
measurement that predates its own drafter.

**Re-worded, not re-measured — and it says so.** The old numbers are now explicitly attributed to
the syv-ai drafter, and acceptance on the current drafter is marked **UNKNOWN**. I deliberately did
*not* assume it inherited the sibling's 3.71: that would be replacing one unverified claim with
another. Re-measurement is tracked in #1264.

## 2. The `Drafter:` line named syv-ai in all 7 DFlash2 composes

Every one of them defaults to the z-lab BF16 drafter. The header now states the actual default and
marks syv-ai as history with its failure mode. The syv-ai mentions in the **Provenance** blocks are
left untouched — there they're correct, and that trail is worth keeping.

## Verification

- All 13 SGLang composes parsed before and after and compared as loaded YAML — **semantically
  identical to HEAD**.
- Full gate sweep **152 passed, 0 failed**.

⚠️ One note on that sweep: my first attempt reported `0 passed, 152 failed`, which was my own bug —
a typo'd log path made every redirect fail, so every test was scored as failed. Worth recording
because it failed *closed* rather than open; the inverse would have been the dangerous direction.
