### PR TITLE
fix(cockpit): deleted nested-glob weights variants stop reporting "partial download on disk"

### DIFF
--- a/tools/serve-cockpit/club3090_cockpit/services.py
+++ b/tools/serve-cockpit/club3090_cockpit/services.py
@@ -34,7 +34,7 @@ import subprocess
 import time
 import uuid
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Awaitable, Callable, Optional, Protocol
 
 from club3090_tui_core.detect import (
@@ -737,6 +737,19 @@ class CockpitData:
         root = Path(model_dir or self.weights_model_dir())
         base = root / meta.subdir
         try:
+            # ABSENT must be probed at the directory the verify_glob ACTUALLY lives in,
+            # not at `subdir`. 9 of 87 weights entries carry a nested glob whose first
+            # segment is the variant dir under a SHARED parent -- e.g.
+            # subdir=glm-5.3-flash-gguf + verify_glob=UD-IQ4_XS/*.gguf, with sibling
+            # variants (devquasar-q2k, dflash2, mmproj) in that same parent. Probing
+            # `subdir` there left `base.is_dir()` true for as long as ANY sibling was on
+            # disk, so ABSENT was UNREACHABLE and a cleanly deleted variant reported
+            # PARTIAL forever -- offering "Download resumes it" for a 100-250 GB fresh
+            # pull with nothing to resume. For a flat glob PurePosixPath("*.gguf").parent
+            # is "." so probe == base and the other 78 entries are unaffected.
+            probe = base / PurePosixPath(meta.verify_glob or "").parent
+            if not probe.is_dir():
+                return WEIGHTS_ABSENT, meta
             if not base.is_dir():
                 return WEIGHTS_ABSENT, meta
             if not any(base.glob(meta.verify_glob)):

--- a/tools/serve-cockpit/tests/test_services.py
+++ b/tools/serve-cockpit/tests/test_services.py
@@ -952,6 +952,62 @@ class TestLoadCatalog:
         await cd.enrich_weights([e], model_dir=str(tmp_path))
         assert e.weights_state == WEIGHTS_PRESENT
 
+    @pytest.mark.asyncio
+    async def test_weights_state_absent_when_nested_glob_variant_dir_removed(self, tmp_path):
+        """A variant whose verify_glob carries its own directory component (e.g.
+        subdir=glm-5.3-flash-gguf, verify_glob=UD-IQ4_XS/*.gguf) must read ABSENT once
+        that variant dir is deleted -- even while SIBLING variants keep the shared
+        parent on disk.
+
+        Regression: `base` was the shared PARENT, so `base.is_dir()` stayed true for as
+        long as any sibling existed and ABSENT was UNREACHABLE -- a cleanly deleted
+        variant reported PARTIAL forever, and the UI offered "Download resumes it" for
+        a 100-250 GB fresh pull with nothing to resume. Hit on glm-5.3-flash iq4xs /
+        iq3xxs; 9 of 87 weights entries carry a nested glob like this.
+        """
+        from club3090_cockpit.data import (
+            CatalogEntry, WEIGHTS_PRESENT, WEIGHTS_ABSENT,
+        )
+
+        listing = json.dumps([
+            {"model": "glm-5.3-flash", "variant": "unsloth-ud-iq4xs",
+             "subdir": "glm-5.3-flash-gguf", "hf_repo": "unsloth/x",
+             "size_gb": 100.0, "verify_glob": "UD-IQ4_XS/*.gguf",
+             "status": "experimental"},
+        ])
+        cd = CockpitData(ROOT, runner=full_runner(**{"weights.py list --json": ok(listing)}))
+        hf = tmp_path
+        parent = hf / "glm-5.3-flash-gguf"
+        variant = parent / "UD-IQ4_XS"
+        sibling = parent / "dflash2"          # a DIFFERENT variant sharing the parent
+        variant.mkdir(parents=True)
+        sibling.mkdir(parents=True)
+        (variant / "w.gguf").write_text("x")
+        (sibling / "d.gguf").write_text("x")
+
+        e = CatalogEntry(row=_variant_row_from_dict({
+            "slug": "llamacpp-club3090/glm53-flash-dual-iq4xs-moecache", "port": 8099,
+            "model": "glm-5.3-flash", "switch_engine": "llamacpp-club3090",
+            "launch_engine": "llamacpp-club3090", "engine": "llamacpp-club3090-v1.6",
+            "compose_dir": "models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs",
+            "file": "moecache.yml",
+            "compose_path": "models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/moecache.yml",
+            "kvcalc_key": "SKIP", "container": "c", "status": "experimental",
+            "ctx_label": "", "status_note": "",
+        }))
+        await cd.enrich_weights([e], model_dir=str(tmp_path))
+        assert e.weights_state == WEIGHTS_PRESENT
+
+        # Delete ONLY this variant. The shared parent survives via the sibling.
+        (variant / "w.gguf").unlink()
+        variant.rmdir()
+        assert parent.is_dir() and sibling.is_dir()          # parent still populated
+        await cd.enrich_weights([e], model_dir=str(tmp_path))
+        assert e.weights_state == WEIGHTS_ABSENT, (
+            f"cleanly-deleted nested-glob variant read {e.weights_state!r}; "
+            "ABSENT must be reachable even when siblings keep the parent alive"
+        )
+
     def test_download_progress_aggregates_core_and_companion(self, tmp_path):
         """Live-progress regression: progress must aggregate bytes across the WHOLE
         set (core + companions) / total size — so a core-already-present slug shows


### PR DESCRIPTION
Reported on the rig: **glm-5.3-flash iq4xs / iq3xxs kept showing
`⚠ partial download on disk — Download resumes it` after their weights were cleanly deleted.**
Nothing was left on disk to clean up — the detection was wrong.

## Cause

`_weights_state()` probed ABSENT at `subdir`, but **9 of 87** weights entries carry a *nested*
`verify_glob` whose first segment is the variant dir under a **shared parent**:

```
subdir      = glm-5.3-flash-gguf      ← shared
verify_glob = UD-IQ4_XS/*.gguf        ← the variant lives in here
```

Sibling variants (`devquasar-q2k`, `devquasar-q3km`, `dflash2`, `mmproj` — 248 GiB) keep that parent
alive, so `base.is_dir()` stayed true and **ABSENT was unreachable**. A cleanly deleted variant could
only ever report PARTIAL, forever — and the UI then offered *"Download resumes it"* for what is
really a **100–250 GB fresh pull with nothing to resume**.

All nine affected entries:

| subdir (shared) | variants |
|---|---|
| `glm-5.3-flash-gguf` | `unsloth-ud-iq4xs`, `unsloth-ud-iq3xxs` ← reported |
| `deepseek-v4-flash-0731-gguf` | `unsloth-q8-kxl`, `unsloth-iq2-xxs` |
| `glm-5.3-flash-gguf/devquasar-q2k` · `…/devquasar-q3km` | 1 each |
| `deepseek-v4-flash-vision-exp-gguf/unsloth-ud-q8kxl` | 1 |
| `inkling-small-gguf` | `unsloth-ud-iq4xs` |
| `qwen3.8-flash-next-gguf` | `unsloth-ud-q4kxl` |

## Fix

```python
probe = base / PurePosixPath(meta.verify_glob or "").parent
if not probe.is_dir():
    return WEIGHTS_ABSENT, meta
```

For a flat glob `PurePosixPath("*.gguf").parent` is `"."`, so `probe == base` — the other **78**
entries are behaviourally byte-identical.

**Verified against the real rig state**, not just the fixture: glm53 `iq4xs` and `iq3xxs` both move
`PARTIAL → ABSENT`, with the populated shared parent untouched.

## Controls

Negative control **first** — and the first attempt at it was itself a false clean worth recording:
under the system python `pytest.mark.asyncio` is an unknown mark, so **every async test in this suite
skips**, and a skip reads as "not failing". Re-run in the project's own `.venv` (pytest-asyncio
1.4.0) the new test fails properly:

```
AssertionError: cleanly-deleted nested-glob variant read 'partial';
                ABSENT must be reachable even when siblings keep the parent alive
assert 'partial' == 'absent'
```

…and passes after the fix. The three pre-existing weights-state / download-progress tests still
pass. The regression test plants a shared parent **with a sibling**, deletes only the target variant,
and asserts ABSENT — the exact shape that was unreachable.

## ⚠️ One pre-existing failure, not from this change

Full cockpit suite: **1140 passed, 1 skipped, 1 failed.**

The failure is `test_app_headless.py::TestProfileTemplateDerivation::test_real_registry_reps_are_status_aware`
— *"expected 10 curated reps, got 13"*. It fails **identically on clean master with this change
stashed** — verified, not assumed. Its rep list includes the `sgl/*` slugs, so it most likely dates
from the SGLang tier landing in #1237 and wants its own fix rather than being folded in here.
