### PR TITLE
fix(glm): point the drafter-missing remediation at scripts/setup.sh, not an out-of-repo wrapper

### DIFF
--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q2k/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q2k/moecache.yml
@@ -401,8 +401,8 @@ services:
             echo "[spec]   $$_draft" >&2
             echo "[spec] This slug REQUIRES it (block-45 MTP is unwired => no other spec path)." >&2
             echo "[spec] Fix one of:" >&2
-            echo "[spec]   - download it: /opt/ai/hf-download.sh Anbeeld/GLM-5.3-Flash-DFlash2-GGUF \\" >&2
-            echo "[spec]       <MODEL_DIR>/glm-5.3-flash-gguf/dflash2 GLM-5.3-Flash-DFlash2-Q4_K_M.gguf" >&2
+            echo "[spec]   - fetch it with setup (knows this drafter is required):" >&2
+            echo "[spec]       WEIGHTS=q2k bash scripts/setup.sh glm-5.3-flash" >&2
             echo "[spec]   - or run drafter-off knowingly: SPEC_N=0" >&2
             exit 1
           fi

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q2k/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q2k/offload.yml
@@ -582,8 +582,8 @@ services:
             echo "[spec]   $$_draft" >&2
             echo "[spec] This slug REQUIRES it (block-45 MTP is unwired => no other spec path)." >&2
             echo "[spec] Fix one of:" >&2
-            echo "[spec]   - download it: /opt/ai/hf-download.sh Anbeeld/GLM-5.3-Flash-DFlash2-GGUF \\" >&2
-            echo "[spec]       <MODEL_DIR>/glm-5.3-flash-gguf/dflash2 GLM-5.3-Flash-DFlash2-Q4_K_M.gguf" >&2
+            echo "[spec]   - fetch it with setup (knows this drafter is required):" >&2
+            echo "[spec]       WEIGHTS=q2k bash scripts/setup.sh glm-5.3-flash" >&2
             echo "[spec]   - or run drafter-off knowingly: SPEC_N=0" >&2
             exit 1
           fi

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q3km/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q3km/moecache.yml
@@ -399,8 +399,8 @@ services:
             echo "[spec]   $$_draft" >&2
             echo "[spec] This slug REQUIRES it (block-45 MTP is unwired => no other spec path)." >&2
             echo "[spec] Fix one of:" >&2
-            echo "[spec]   - download it: /opt/ai/hf-download.sh Anbeeld/GLM-5.3-Flash-DFlash2-GGUF \\" >&2
-            echo "[spec]       <MODEL_DIR>/glm-5.3-flash-gguf/dflash2 GLM-5.3-Flash-DFlash2-Q4_K_M.gguf" >&2
+            echo "[spec]   - fetch it with setup (knows this drafter is required):" >&2
+            echo "[spec]       WEIGHTS=q3km bash scripts/setup.sh glm-5.3-flash" >&2
             echo "[spec]   - or run drafter-off knowingly: SPEC_N=0" >&2
             exit 1
           fi

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q3km/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/devquasar-q3km/offload.yml
@@ -582,8 +582,8 @@ services:
             echo "[spec]   $$_draft" >&2
             echo "[spec] This slug REQUIRES it (block-45 MTP is unwired => no other spec path)." >&2
             echo "[spec] Fix one of:" >&2
-            echo "[spec]   - download it: /opt/ai/hf-download.sh Anbeeld/GLM-5.3-Flash-DFlash2-GGUF \\" >&2
-            echo "[spec]       <MODEL_DIR>/glm-5.3-flash-gguf/dflash2 GLM-5.3-Flash-DFlash2-Q4_K_M.gguf" >&2
+            echo "[spec]   - fetch it with setup (knows this drafter is required):" >&2
+            echo "[spec]       WEIGHTS=q3km bash scripts/setup.sh glm-5.3-flash" >&2
             echo "[spec]   - or run drafter-off knowingly: SPEC_N=0" >&2
             exit 1
           fi

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq3xxs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq3xxs/moecache.yml
@@ -395,8 +395,8 @@ services:
             echo "[spec]   $$_draft" >&2
             echo "[spec] This slug REQUIRES it (block-45 MTP is unwired => no other spec path)." >&2
             echo "[spec] Fix one of:" >&2
-            echo "[spec]   - download it: /opt/ai/hf-download.sh Anbeeld/GLM-5.3-Flash-DFlash2-GGUF \\" >&2
-            echo "[spec]       <MODEL_DIR>/glm-5.3-flash-gguf/dflash2 GLM-5.3-Flash-DFlash2-Q4_K_M.gguf" >&2
+            echo "[spec]   - fetch it with setup (knows this drafter is required):" >&2
+            echo "[spec]       WEIGHTS=iq3xxs bash scripts/setup.sh glm-5.3-flash" >&2
             echo "[spec]   - or run drafter-off knowingly: SPEC_N=0" >&2
             exit 1
           fi

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/dual/unsloth-ud-iq4xs/moecache.yml
@@ -340,8 +340,8 @@ services:
             echo "[spec]   $$_draft" >&2
             echo "[spec] This slug REQUIRES it (block-45 MTP is unwired => no other spec path)." >&2
             echo "[spec] Fix one of:" >&2
-            echo "[spec]   - download it: /opt/ai/hf-download.sh Anbeeld/GLM-5.3-Flash-DFlash2-GGUF \\" >&2
-            echo "[spec]       <MODEL_DIR>/glm-5.3-flash-gguf/dflash2 GLM-5.3-Flash-DFlash2-Q4_K_M.gguf" >&2
+            echo "[spec]   - fetch it with setup (knows this drafter is required):" >&2
+            echo "[spec]       WEIGHTS=iq4xs bash scripts/setup.sh glm-5.3-flash" >&2
             echo "[spec]   - or run drafter-off knowingly: SPEC_N=0" >&2
             exit 1
           fi

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q2k/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q2k/moecache.yml
@@ -440,8 +440,8 @@ services:
             echo "[spec]   $$_draft" >&2
             echo "[spec] This slug REQUIRES it (block-45 MTP is unwired => no other spec path)." >&2
             echo "[spec] Fix one of:" >&2
-            echo "[spec]   - download it: /opt/ai/hf-download.sh Anbeeld/GLM-5.3-Flash-DFlash2-GGUF \\" >&2
-            echo "[spec]       <MODEL_DIR>/glm-5.3-flash-gguf/dflash2 GLM-5.3-Flash-DFlash2-Q4_K_M.gguf" >&2
+            echo "[spec]   - fetch it with setup (knows this drafter is required):" >&2
+            echo "[spec]       WEIGHTS=q2k bash scripts/setup.sh glm-5.3-flash" >&2
             echo "[spec]   - or run drafter-off knowingly: SPEC_N=0" >&2
             exit 1
           fi

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q2k/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q2k/offload.yml
@@ -623,8 +623,8 @@ services:
             echo "[spec]   $$_draft" >&2
             echo "[spec] This slug REQUIRES it (block-45 MTP is unwired => no other spec path)." >&2
             echo "[spec] Fix one of:" >&2
-            echo "[spec]   - download it: /opt/ai/hf-download.sh Anbeeld/GLM-5.3-Flash-DFlash2-GGUF \\" >&2
-            echo "[spec]       <MODEL_DIR>/glm-5.3-flash-gguf/dflash2 GLM-5.3-Flash-DFlash2-Q4_K_M.gguf" >&2
+            echo "[spec]   - fetch it with setup (knows this drafter is required):" >&2
+            echo "[spec]       WEIGHTS=q2k bash scripts/setup.sh glm-5.3-flash" >&2
             echo "[spec]   - or run drafter-off knowingly: SPEC_N=0" >&2
             exit 1
           fi

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q3km/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q3km/moecache.yml
@@ -438,8 +438,8 @@ services:
             echo "[spec]   $$_draft" >&2
             echo "[spec] This slug REQUIRES it (block-45 MTP is unwired => no other spec path)." >&2
             echo "[spec] Fix one of:" >&2
-            echo "[spec]   - download it: /opt/ai/hf-download.sh Anbeeld/GLM-5.3-Flash-DFlash2-GGUF \\" >&2
-            echo "[spec]       <MODEL_DIR>/glm-5.3-flash-gguf/dflash2 GLM-5.3-Flash-DFlash2-Q4_K_M.gguf" >&2
+            echo "[spec]   - fetch it with setup (knows this drafter is required):" >&2
+            echo "[spec]       WEIGHTS=q3km bash scripts/setup.sh glm-5.3-flash" >&2
             echo "[spec]   - or run drafter-off knowingly: SPEC_N=0" >&2
             exit 1
           fi

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q3km/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/devquasar-q3km/offload.yml
@@ -621,8 +621,8 @@ services:
             echo "[spec]   $$_draft" >&2
             echo "[spec] This slug REQUIRES it (block-45 MTP is unwired => no other spec path)." >&2
             echo "[spec] Fix one of:" >&2
-            echo "[spec]   - download it: /opt/ai/hf-download.sh Anbeeld/GLM-5.3-Flash-DFlash2-GGUF \\" >&2
-            echo "[spec]       <MODEL_DIR>/glm-5.3-flash-gguf/dflash2 GLM-5.3-Flash-DFlash2-Q4_K_M.gguf" >&2
+            echo "[spec]   - fetch it with setup (knows this drafter is required):" >&2
+            echo "[spec]       WEIGHTS=q3km bash scripts/setup.sh glm-5.3-flash" >&2
             echo "[spec]   - or run drafter-off knowingly: SPEC_N=0" >&2
             exit 1
           fi

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/unsloth-ud-iq3xxs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/unsloth-ud-iq3xxs/moecache.yml
@@ -434,8 +434,8 @@ services:
             echo "[spec]   $$_draft" >&2
             echo "[spec] This slug REQUIRES it (block-45 MTP is unwired => no other spec path)." >&2
             echo "[spec] Fix one of:" >&2
-            echo "[spec]   - download it: /opt/ai/hf-download.sh Anbeeld/GLM-5.3-Flash-DFlash2-GGUF \\" >&2
-            echo "[spec]       <MODEL_DIR>/glm-5.3-flash-gguf/dflash2 GLM-5.3-Flash-DFlash2-Q4_K_M.gguf" >&2
+            echo "[spec]   - fetch it with setup (knows this drafter is required):" >&2
+            echo "[spec]       WEIGHTS=iq3xxs bash scripts/setup.sh glm-5.3-flash" >&2
             echo "[spec]   - or run drafter-off knowingly: SPEC_N=0" >&2
             exit 1
           fi

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/unsloth-ud-iq4xs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi4/unsloth-ud-iq4xs/moecache.yml
@@ -398,8 +398,8 @@ services:
             echo "[spec]   $$_draft" >&2
             echo "[spec] This slug REQUIRES it (block-45 MTP is unwired => no other spec path)." >&2
             echo "[spec] Fix one of:" >&2
-            echo "[spec]   - download it: /opt/ai/hf-download.sh Anbeeld/GLM-5.3-Flash-DFlash2-GGUF \\" >&2
-            echo "[spec]       <MODEL_DIR>/glm-5.3-flash-gguf/dflash2 GLM-5.3-Flash-DFlash2-Q4_K_M.gguf" >&2
+            echo "[spec]   - fetch it with setup (knows this drafter is required):" >&2
+            echo "[spec]       WEIGHTS=iq4xs bash scripts/setup.sh glm-5.3-flash" >&2
             echo "[spec]   - or run drafter-off knowingly: SPEC_N=0" >&2
             exit 1
           fi

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q2k/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q2k/moecache.yml
@@ -440,8 +440,8 @@ services:
             echo "[spec]   $$_draft" >&2
             echo "[spec] This slug REQUIRES it (block-45 MTP is unwired => no other spec path)." >&2
             echo "[spec] Fix one of:" >&2
-            echo "[spec]   - download it: /opt/ai/hf-download.sh Anbeeld/GLM-5.3-Flash-DFlash2-GGUF \\" >&2
-            echo "[spec]       <MODEL_DIR>/glm-5.3-flash-gguf/dflash2 GLM-5.3-Flash-DFlash2-Q4_K_M.gguf" >&2
+            echo "[spec]   - fetch it with setup (knows this drafter is required):" >&2
+            echo "[spec]       WEIGHTS=q2k bash scripts/setup.sh glm-5.3-flash" >&2
             echo "[spec]   - or run drafter-off knowingly: SPEC_N=0" >&2
             exit 1
           fi

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q2k/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q2k/offload.yml
@@ -623,8 +623,8 @@ services:
             echo "[spec]   $$_draft" >&2
             echo "[spec] This slug REQUIRES it (block-45 MTP is unwired => no other spec path)." >&2
             echo "[spec] Fix one of:" >&2
-            echo "[spec]   - download it: /opt/ai/hf-download.sh Anbeeld/GLM-5.3-Flash-DFlash2-GGUF \\" >&2
-            echo "[spec]       <MODEL_DIR>/glm-5.3-flash-gguf/dflash2 GLM-5.3-Flash-DFlash2-Q4_K_M.gguf" >&2
+            echo "[spec]   - fetch it with setup (knows this drafter is required):" >&2
+            echo "[spec]       WEIGHTS=q2k bash scripts/setup.sh glm-5.3-flash" >&2
             echo "[spec]   - or run drafter-off knowingly: SPEC_N=0" >&2
             exit 1
           fi

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q3km/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q3km/moecache.yml
@@ -438,8 +438,8 @@ services:
             echo "[spec]   $$_draft" >&2
             echo "[spec] This slug REQUIRES it (block-45 MTP is unwired => no other spec path)." >&2
             echo "[spec] Fix one of:" >&2
-            echo "[spec]   - download it: /opt/ai/hf-download.sh Anbeeld/GLM-5.3-Flash-DFlash2-GGUF \\" >&2
-            echo "[spec]       <MODEL_DIR>/glm-5.3-flash-gguf/dflash2 GLM-5.3-Flash-DFlash2-Q4_K_M.gguf" >&2
+            echo "[spec]   - fetch it with setup (knows this drafter is required):" >&2
+            echo "[spec]       WEIGHTS=q3km bash scripts/setup.sh glm-5.3-flash" >&2
             echo "[spec]   - or run drafter-off knowingly: SPEC_N=0" >&2
             exit 1
           fi

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q3km/offload.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/devquasar-q3km/offload.yml
@@ -621,8 +621,8 @@ services:
             echo "[spec]   $$_draft" >&2
             echo "[spec] This slug REQUIRES it (block-45 MTP is unwired => no other spec path)." >&2
             echo "[spec] Fix one of:" >&2
-            echo "[spec]   - download it: /opt/ai/hf-download.sh Anbeeld/GLM-5.3-Flash-DFlash2-GGUF \\" >&2
-            echo "[spec]       <MODEL_DIR>/glm-5.3-flash-gguf/dflash2 GLM-5.3-Flash-DFlash2-Q4_K_M.gguf" >&2
+            echo "[spec]   - fetch it with setup (knows this drafter is required):" >&2
+            echo "[spec]       WEIGHTS=q3km bash scripts/setup.sh glm-5.3-flash" >&2
             echo "[spec]   - or run drafter-off knowingly: SPEC_N=0" >&2
             exit 1
           fi

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/unsloth-ud-iq3xxs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/unsloth-ud-iq3xxs/moecache.yml
@@ -434,8 +434,8 @@ services:
             echo "[spec]   $$_draft" >&2
             echo "[spec] This slug REQUIRES it (block-45 MTP is unwired => no other spec path)." >&2
             echo "[spec] Fix one of:" >&2
-            echo "[spec]   - download it: /opt/ai/hf-download.sh Anbeeld/GLM-5.3-Flash-DFlash2-GGUF \\" >&2
-            echo "[spec]       <MODEL_DIR>/glm-5.3-flash-gguf/dflash2 GLM-5.3-Flash-DFlash2-Q4_K_M.gguf" >&2
+            echo "[spec]   - fetch it with setup (knows this drafter is required):" >&2
+            echo "[spec]       WEIGHTS=iq3xxs bash scripts/setup.sh glm-5.3-flash" >&2
             echo "[spec]   - or run drafter-off knowingly: SPEC_N=0" >&2
             exit 1
           fi

--- a/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/unsloth-ud-iq4xs/moecache.yml
+++ b/models/glm-5.3-flash/llamacpp-club3090/compose/multi8/unsloth-ud-iq4xs/moecache.yml
@@ -398,8 +398,8 @@ services:
             echo "[spec]   $$_draft" >&2
             echo "[spec] This slug REQUIRES it (block-45 MTP is unwired => no other spec path)." >&2
             echo "[spec] Fix one of:" >&2
-            echo "[spec]   - download it: /opt/ai/hf-download.sh Anbeeld/GLM-5.3-Flash-DFlash2-GGUF \\" >&2
-            echo "[spec]       <MODEL_DIR>/glm-5.3-flash-gguf/dflash2 GLM-5.3-Flash-DFlash2-Q4_K_M.gguf" >&2
+            echo "[spec]   - fetch it with setup (knows this drafter is required):" >&2
+            echo "[spec]       WEIGHTS=iq4xs bash scripts/setup.sh glm-5.3-flash" >&2
             echo "[spec]   - or run drafter-off knowingly: SPEC_N=0" >&2
             exit 1
           fi

--- a/scripts/tests/test-compose-no-rig-paths.sh
+++ b/scripts/tests/test-compose-no-rig-paths.sh
@@ -11,13 +11,39 @@
 # only live in reviewers' heads decay; this is the same reasoning as
 # test-compose-bind-host.sh.
 #
-# What is CHECKED: `${VAR:-<rig-path>}` defaults and bare rig paths on the host side
-# of a volume/command. What is NOT checked: comments and prose. Documenting the
-# reference rig ("measured on /mnt/models/...") is legitimate and stays legal — the
-# failure mode this guards is a value the compose would actually USE.
+# What is CHECKED — three surfaces:
+#   (a) `${VAR:-<rig-path>}` environment defaults.
+#   (b) bare rig paths on the host side of a volume/command list entry.
+#   (c) rig paths ANYWHERE a container actually runs or PRINTS — i.e. inside an
+#       `entrypoint:` or `command:` block, comments excluded.
+#
+# Surface (c) was added 2026-09-12 for #1271. 18 GLM composes printed
+#     echo "[spec]   - download it: /opt/ai/hf-download.sh …"
+# as the remediation for a missing DFlash2 drafter — a hardened wrapper that lives
+# only on the maintainer's rig and is NOT in this repo. Every user but one was
+# handed a script they cannot run, in the one place they are guaranteed to be
+# reading: having just been refused a boot. The gate was GREEN throughout, because
+# a rig path inside an entrypoint `echo` is neither an env default (a) nor a bare
+# host-side list entry (b). The blind spot was the checked surface, not the intent
+# — the header above already claimed this class. So: remediation text a user is
+# told to TYPE is a value the compose USES, and is checked.
+#
+# What is NOT checked: comments and prose. Documenting the reference rig
+# ("measured on /mnt/models/...", "Ledger: /opt/ai/moecache-releases.md") is
+# legitimate and stays legal, inside an entrypoint block as well as outside it —
+# the failure mode this guards is a value the compose would actually USE or SHOW.
+#
+# CONTAINER-side absolutes are legal and must never trip this: `/models/...`,
+# `/etc/club3090/...`, `/app/llama-server`, `/dev/shm` are all correct inside the
+# container. That allowance is structural, not a deny-list exception — RIG_PREFIXES
+# only matches absolutes a stranger cannot have, and none of those match it. The
+# prefix set is deliberately NOT widened: an over-wide docs gate once produced
+# ~200 false positives, so breadth here is bought only with evidence.
 #
 # If a compose genuinely needs an operator-supplied absolute path, give it a knob
 # with a portable default (repo-relative, or another variable), never a rig path.
+# If it needs to tell a user how to fetch something, point at an IN-REPO command
+# (`bash scripts/setup.sh <model>`), never at a script on the maintainer's rig.
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
@@ -27,29 +53,131 @@ cd "$ROOT"
 # (/dev, /tmp, /usr and friends are fine and common).
 RIG_PREFIXES='/opt/ai|/mnt/models|/home/[a-z][a-z0-9_-]*'
 
+# scan_env_and_host <file> — surfaces (a) and (b). Comments stripped first so
+# prose about the reference rig stays legal.
+scan_env_and_host() {
+  sed 's/#.*$//' "$1" \
+    | grep -nE "\\\$\{[A-Za-z_][A-Za-z0-9_]*:-(${RIG_PREFIXES})|^[[:space:]]*-[[:space:]]*\"?(${RIG_PREFIXES})/" \
+    || true
+}
+
+# scan_run_blocks <file> — surface (c). Walks `entrypoint:`/`command:` blocks by
+# indentation (a block ends at the next line indented no deeper than its key, with
+# blank lines belonging to the block, since these are YAML block scalars holding a
+# shell script). Full-line comments inside the block are prose and skipped.
+# Emits `<lineno>:<text>` so the caller can report like grep -n.
+scan_run_blocks() {
+  awk -v rig="(${RIG_PREFIXES})" '
+    function key_line() { return $0 ~ /^[[:space:]]*(entrypoint|command)[[:space:]]*:/ }
+    key_line() {
+      match($0, /^[[:space:]]*/); keyindent = RLENGTH; inblock = 1
+      # A value on the key line itself (`command: /opt/ai/x`) is still a value.
+      rest = $0; sub(/^[[:space:]]*(entrypoint|command)[[:space:]]*:/, "", rest)
+      if (rest ~ /[^[:space:]]/ && rest ~ rig) printf "%d:%s\n", FNR, $0
+      next
+    }
+    !inblock { next }
+    /^[[:space:]]*$/ { next }                 # blank lines stay inside the block
+    { match($0, /^[[:space:]]*/); if (RLENGTH <= keyindent) { inblock = 0; next } }
+    /^[[:space:]]*#/ { next }                 # prose about the reference rig: legal
+    $0 ~ rig { printf "%d:%s\n", FNR, $0 }
+  ' "$1"
+}
+
+# ---------------------------------------------------------------------------
+# SELF-TEST. A scanner that matches nothing is indistinguishable from a clean
+# tree, which is exactly how surface (c) stayed green over 18 broken composes.
+# So prove both directions on synthetic fixtures before trusting the real run:
+# the must-fail fixture must be caught, and the must-pass fixture (container
+# absolutes + rig paths in comments) must not be. If either flips, this gate
+# fails LOUDLY rather than reporting a clean tree.
+# ---------------------------------------------------------------------------
+selftest_dir="$(mktemp -d)"
+trap 'rm -rf "$selftest_dir"' EXIT
+
+cat > "${selftest_dir}/must-fail.yml" <<'FIXTURE'
+services:
+  llm:
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # A rig path in a comment here is legal — /opt/ai/moecache-releases.md.
+        if [ ! -f "$$_draft" ]; then
+          echo "[spec] download it: /opt/ai/hf-download.sh some/repo" >&2
+          exit 1
+        fi
+        exec /app/llama-server "$$@"
+FIXTURE
+
+cat > "${selftest_dir}/must-pass.yml" <<'FIXTURE'
+services:
+  llm:
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        # Ledger: /opt/ai/moecache-releases.md — prose, stays legal.
+        _mmproj="$${MMPROJ:-/models/glm-5.3-flash-gguf/mmproj/mmproj-F16.gguf}"
+        [ -f /etc/club3090/engine.env ] && . /etc/club3090/engine.env
+        echo "[spec] fetch it: bash scripts/setup.sh glm-5.3-flash" >&2
+        exec /app/llama-server "$$@"
+    command:
+      - '-m'
+      - '/models/glm-5.3-flash-gguf/Q2_K/model-00001-of-00009.gguf'
+FIXTURE
+
+st_fail_hits="$(scan_run_blocks "${selftest_dir}/must-fail.yml" | wc -l | tr -d ' ')"
+st_pass_hits="$(scan_run_blocks "${selftest_dir}/must-pass.yml" | wc -l | tr -d ' ')"
+
+if [ "$st_fail_hits" -eq 0 ]; then
+  echo "FAIL: self-test — the entrypoint scanner did not catch a rig path in an" >&2
+  echo "      entrypoint echo. The scanner is broken or inert; a clean result from" >&2
+  echo "      this gate would be meaningless. Fix scan_run_blocks." >&2
+  exit 1
+fi
+if [ "$st_pass_hits" -ne 0 ]; then
+  echo "FAIL: self-test — the entrypoint scanner flagged legitimate container-side" >&2
+  echo "      paths or commented prose (${st_pass_hits} false positive(s)):" >&2
+  scan_run_blocks "${selftest_dir}/must-pass.yml" | sed 's/^/        /' >&2
+  echo "      Container absolutes (/models, /etc/club3090, /app) must stay legal." >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Real run.
+# ---------------------------------------------------------------------------
 fails=0
 checked=0
 
 while IFS= read -r f; do
   checked=$((checked+1))
-  # Strip comments so prose about the reference rig stays legal, then look for
-  # (a) a rig path used as an env default, or (b) a bare rig path on the host side
-  # of a volume entry.
+
+  # (a) + (b): a rig path used as an env default, or bare on the host side of a
+  # volume entry.
   while IFS= read -r line; do
     [ -n "$line" ] || continue
     echo "FAIL: $f uses a maintainer-rig path as a value:" >&2
     echo "        $(printf '%s' "$line" | sed 's/^[[:space:]]*//')" >&2
     echo "        Use a portable default (repo-relative, or another variable)." >&2
     fails=$((fails+1))
-  done < <(
-    sed 's/#.*$//' "$f" \
-      | grep -nE "\\\$\{[A-Za-z_][A-Za-z0-9_]*:-(${RIG_PREFIXES})|^[[:space:]]*-[[:space:]]*\"?(${RIG_PREFIXES})/" \
-      || true
-  )
+  done < <(scan_env_and_host "$f")
+
+  # (c): a rig path inside what the container runs or prints.
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    echo "FAIL: $f names a maintainer-rig path in its entrypoint/command:" >&2
+    echo "        $(printf '%s' "$line" | sed 's/^[0-9]*:[[:space:]]*//')" >&2
+    echo "        Nothing under /opt/ai, /mnt/models or a home dir exists for a user" >&2
+    echo "        who cloned this repo. Point at an in-repo command (e.g." >&2
+    echo "        'bash scripts/setup.sh <model>') or a container-side path." >&2
+    fails=$((fails+1))
+  done < <(scan_run_blocks "$f")
 done < <(find models -name '*.yml' -path '*/compose/*' | sort)
 
 if [ "$fails" -gt 0 ]; then
   echo "$fails rig-path check(s) failed across $checked composes" >&2
   exit 1
 fi
-echo "test-compose-no-rig-paths: ok ($checked composes, no rig paths used as values)"
+echo "test-compose-no-rig-paths: ok ($checked composes, no rig paths used as values;"
+echo "                            env defaults, host-side entries and entrypoint/command text)"


### PR DESCRIPTION
## The defect

When the DFlash2 drafter GGUF is missing, 18 GLM-5.3-Flash composes refuse to boot. **The refusal is correct** and is untouched here — this export has no wired MTP head, so the external drafter is the only speculative path, and a missing file otherwise crash-loops on a cryptic `gguf_init_from_file` error.

What was wrong is the remediation it printed:

```
[spec] Fix one of:
[spec]   - download it: <maintainer-rig path>/hf-download.sh Anbeeld/GLM-5.3-Flash-DFlash2-GGUF \
[spec]       <MODEL_DIR>/glm-5.3-flash-gguf/dflash2 GLM-5.3-Flash-DFlash2-Q4_K_M.gguf
```

`hf-download.sh` **is not in this repo.** It is a hardened download wrapper that exists only on the maintainer's own machine. So for every user but one, that line named a script they cannot run at a path that does not exist — in the one place they are guaranteed to be reading, having just been refused a boot. Surfaced by @paulp83 in #1247, who hit the guard and had to work the fix out himself.

**18 composes carried it** — verified by a fresh grep, matching the list in #1271 exactly, and `hf-download.sh` now appears nowhere under `models/`:

```
glm-5.3-flash/llamacpp-club3090/compose/{dual,multi4,multi8}/devquasar-q2k/{moecache,offload}.yml
glm-5.3-flash/llamacpp-club3090/compose/{dual,multi4,multi8}/devquasar-q3km/{moecache,offload}.yml
glm-5.3-flash/llamacpp-club3090/compose/{dual,multi4,multi8}/unsloth-ud-iq3xxs/moecache.yml
glm-5.3-flash/llamacpp-club3090/compose/{dual,multi4,multi8}/unsloth-ud-iq4xs/moecache.yml
```

## The replacement, and how it was verified

```
[spec] Fix one of:
[spec]   - fetch it with setup (knows this drafter is required):
[spec]       WEIGHTS=<alias> bash scripts/setup.sh glm-5.3-flash
[spec]   - or run drafter-off knowingly: SPEC_N=0
```

**The shape suggested in the issue does not work, and shipping it into 18 files would have replaced one unusable command with another.** `WEIGHTS` is an *environment* variable, not a positional. `setup.sh` takes a single positional and rejects a second with exit 64 (the guard added for #250):

```
$ bash scripts/setup.sh glm-5.3-flash WEIGHTS=q2k
ERROR: setup.sh takes a single model name; got extra argument(s): WEIGHTS=q2k
exit=64
```

The env form was then verified for all four aliases with `SETUP_DUMP_KEYS=1`, which resolves the dispatch and exits before any download:

| `WEIGHTS=` | resolved primary | `always_draft` | exit |
|---|---|---|---|
| `q2k` | `glm-5.3-flash:devquasar-q2k` | `glm-5.3-flash:dflash2-q4km` | 0 |
| `q3km` | `glm-5.3-flash:devquasar-q3km` | `glm-5.3-flash:dflash2-q4km` | 0 |
| `iq3xxs` | `glm-5.3-flash:unsloth-ud-iq3xxs` | `glm-5.3-flash:dflash2-q4km` | 0 |
| `iq4xs` | `glm-5.3-flash:unsloth-ud-iq4xs` | `glm-5.3-flash:dflash2-q4km` | 0 |

`always_draft` resolving unconditionally is the part that makes the command actually fix the failure — `setup.sh` fetches the drafter as a required companion, which is precisely what the user is missing.

**The alias is per-file, not a shared placeholder.** Each compose gets the alias for its own quant directory, derived from `weights_aliases` in the model profile — a mismatched value would send the user off to download a different 107-157 GB quant. Unregistered aliases hard-error (`WEIGHTS=bogus` → exit 1, "supported: autoround iq3xxs iq4xs q2k q3km"), so there is no silent-wrong-variant path.

The shape also matches the `WITH_VISION=1 bash scripts/setup.sh glm-5.3-flash` line already sitting a few lines above it in the same entrypoint.

Finally, the guard's failure path was executed directly (extracted entrypoint, `$$`→`$`, fake `-md` pointing at a nonexistent file) to read what a refused user now actually sees:

```
[spec] FATAL: external DFlash2 drafter not found:
[spec]   /nonexistent/GLM-5.3-Flash-DFlash2-Q4_K_M.gguf
[spec] This slug REQUIRES it (block-45 MTP is unwired => no other spec path).
[spec] Fix one of:
[spec]   - fetch it with setup (knows this drafter is required):
[spec]       WEIGHTS=q2k bash scripts/setup.sh glm-5.3-flash
[spec]   - or run drafter-off knowingly: SPEC_N=0
exit=1
```

Still exits 1. The refusal logic, its exit status and every engine flag are unchanged.

## Why the existing gate was green

`test-compose-no-rig-paths.sh` exists for exactly this class — its header already claimed *"no compose may use a maintainer-rig absolute path"*. But it checked only two surfaces:

- **(a)** `${VAR:-<rig path>}` environment defaults
- **(b)** bare rig paths on the **host side** of a volume/command list entry

A rig path inside an entrypoint `echo` string is neither. The gate therefore passed 158 composes clean while 18 of them handed users an unusable instruction. **The blind spot was the checked surface, not the intent.**

This PR adds surface **(c)**: rig paths anywhere the container actually *runs or prints* — inside an `entrypoint:` or `command:` block, walked by indentation (blank lines belong to the block, since these are YAML block scalars holding a shell script), with full-line comments skipped so reference-rig prose stays legal.

`RIG_PREFIXES` is **unchanged**. Container-side absolutes (`/models/...`, `/etc/club3090/...`, `/app/llama-server`) do not match it, so the allowance is structural rather than a deny-list exception — and not widening the set is deliberate, since an over-wide docs gate previously produced ~200 false positives.

## Negative control

The rule here is that a gate which only ever passes is worth nothing, so both directions were demonstrated on the real tree before the composes were touched.

**Extended gate, unfixed composes** — exits 1, 18 failures, naming exactly the 18 files, no false positives across the other 140:

```
FAIL: models/glm-5.3-flash/.../dual/devquasar-q2k/moecache.yml names a maintainer-rig path in its entrypoint/command:
        echo "[spec]   - download it: <rig>/hf-download.sh Anbeeld/GLM-5.3-Flash-DFlash2-GGUF \\" >&2
        Nothing under the maintainer-rig prefixes exists for a user
        who cloned this repo. Point at an in-repo command (e.g.
        'bash scripts/setup.sh <model>') or a container-side path.
...
18 rig-path check(s) failed across 158 composes
EXIT=1
```

**Pre-change gate, that identical unfixed tree** — green:

```
test-compose-no-rig-paths: ok (158 composes, no rig paths used as values)
OLD_GATE_EXIT=0
```

**Extended gate, after the fix** — green, exit 0, all 158 composes.

To keep that property from decaying, the scanner now carries its own **self-test** on two synthetic fixtures, run before it ever touches the tree: a must-fail fixture (rig path in an entrypoint `echo`) that it must catch, and a must-pass fixture (`/models/...`, `/etc/club3090/...`, plus rig paths in comments) that it must not flag. If either flips, the gate fails loudly instead of reporting a clean tree — because a scanner that matches nothing is indistinguishable from a clean tree, which is exactly how this defect survived.

## Tests

21 compose-related gates, all pass: every `test-compose-*.sh` (17, including the extended `no-rig-paths`), plus `test-studio-derig`, `test-setup-registry-derived`, `test-spec-depth-default-drift`, `test-docs-slugs-resolve`. The full 152-test sweep was deliberately not run here — other agents were active in the tree and the guard suite flakes when suites overlap; it should be run serially on `master`.

Additionally: all 18 composes still parse, and their entrypoint scripts still pass `bash -n` after the edit.

**Nothing was booted, no weights downloaded, no GPU workload run.**

## Out of scope

- **#1247** — the underlying reason a user reaches this message at all (`c3 pull` not fetching the `always_draft` companion; only `setup.sh` does). Fixing that reduces how often anyone sees this text, but the text should be correct either way.
- Trackers and per-model learnings are updated centrally by the maintainer, so they are untouched here.

Closes #1271

🤖 Generated with [Claude Code](https://claude.com/claude-code)
