### PR TITLE
feat(report): surface the GPU power cap up front as a % of each card's default

### DIFF
--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -144,6 +144,29 @@ details() {
 
 have() { command -v "$1" >/dev/null 2>&1; }
 
+# gpu_power_caps — one "idx|limit_w|default_w|percent" row per GPU whose power
+# limit is BELOW its factory default. Empty output when nothing is capped.
+#
+# ⚠️ Empty is NOT proof of "at stock power": it is also what an absent
+# nvidia-smi, an unreadable query (driver/library mismatch, no permission) or a
+# non-numeric [N/A] field produce. The GPU hardware section states that case
+# explicitly; do not re-interpret emptiness here as a clean bill of health.
+gpu_power_caps() {
+  have nvidia-smi || return 0
+  nvidia-smi --query-gpu=index,power.limit,power.default_limit \
+    --format=csv,noheader,nounits 2>/dev/null \
+    | while IFS=, read -r _cap_idx _cap_lim _cap_def; do
+        _cap_idx="${_cap_idx// /}"; _cap_lim="${_cap_lim// /}"; _cap_def="${_cap_def// /}"
+        # nounits still yields "230.00"; drop the fraction before integer tests.
+        _cap_lim="${_cap_lim%.*}"; _cap_def="${_cap_def%.*}"
+        [[ "$_cap_idx" =~ ^[0-9]+$ ]] || continue
+        [[ "$_cap_lim" =~ ^[0-9]+$ && "$_cap_def" =~ ^[0-9]+$ ]] || continue
+        [[ "$_cap_def" -gt 0 && "$_cap_lim" -lt "$_cap_def" ]] || continue
+        printf '%s|%s|%s|%s\n' "$_cap_idx" "$_cap_lim" "$_cap_def" \
+          "$(( _cap_lim * 100 / _cap_def ))"
+      done
+}
+
 # ---------------------------------------------------------------------------
 # Header
 # ---------------------------------------------------------------------------
@@ -179,6 +202,33 @@ if [[ $EUID -ne 0 ]] && ! sudo -n true 2>/dev/null; then
     printf '>\n> For a complete report re-run with sudo:\n>\n> ```bash\n> sudo bash scripts/report.sh %s\n> ```\n' "${REPORT_ARGS:-}"
     printf '>\n> Worth doing before filing a CPU-offload issue: memory channels and speed are the\n> variables that set throughput on those configs, and they cannot be read without root.\n'
   fi
+fi
+
+# GPU power cap — warn UP FRONT, for the same reason the root-gated block above
+# does: reports get truncated from the bottom, and a reader scanning a paste
+# will not go hunting for a nested bullet in the GPU section.
+#
+# This exists because a run on this stack measured ~40% below its own recorded
+# baseline, with a signature that read as an upstream speculative-decoding
+# regression (spec_n=1 and spec_n=2 producing identical throughput while draft
+# acceptance stayed healthy). An upstream bug report was nearly filed. The cause
+# was a persistent 230 W cap against 370/420 W factory defaults, applied at boot
+# by a systemd unit and found only by manually reading power.limit.
+#
+# The generalisation is what matters for a *shared* report: a cap applied at
+# boot is nobody's per-run decision, so the reporter does not know to mention
+# it, and every throughput number in the report is silently power-dependent.
+# The percentage is deliberate — a triager reading someone else's rig has no
+# idea what that card's stock TDP is, so a bare "limit=230 W" reads as normal.
+_pwr_caps="$(gpu_power_caps)"
+if [[ -n "$_pwr_caps" ]]; then
+  printf '\n> ⚠️ **GPU power cap active — the throughput numbers in this report are NOT at stock power.**\n'
+  while IFS='|' read -r _pc_idx _pc_lim _pc_def _pc_pct; do
+    [[ -n "$_pc_idx" ]] || continue
+    printf '> - GPU %s capped to %s W of %s W default (%s%%)\n' \
+      "$_pc_idx" "$_pc_lim" "$_pc_def" "$_pc_pct"
+  done <<< "$_pwr_caps"
+  printf '>\n> Treat every benchmark below as power-limited: it is not comparable to a baseline\n> taken at stock power, and a deep cap can look like an engine or speculative-decoding\n> regression rather than a power one. Caps commonly survive reboots (a systemd unit or\n> startup script running `nvidia-smi -pl`), so a rig can boot capped without anyone\n> choosing it for this run. Check and clear before comparing against any baseline:\n>\n> ```bash\n> nvidia-smi --query-gpu=index,power.limit,power.default_limit,enforced.power.limit --format=csv\n> ```\n'
 fi
 
 # ---------------------------------------------------------------------------
@@ -479,9 +529,36 @@ if ! have nvidia-smi; then
   echo "_nvidia-smi not available — no NVIDIA GPU detected or driver not installed_"
 else
   {
-    nvidia-smi --query-gpu=index,name,memory.total,driver_version,vbios_version,persistence_mode,power.limit,power.default_limit,power.max_limit,power.draw,pci.bus_id,pcie.link.gen.current,pcie.link.gen.max,pcie.link.width.current,pcie.link.width.max \
-      --format=csv,noheader 2>/dev/null \
-      | while IFS=, read -r idx name memtotal driver vbios persistence pwr_limit pwr_default pwr_max pwr_draw bus_id pcie_gen_cur pcie_gen_max pcie_width_cur pcie_width_max; do
+    # Captured into a variable rather than piped straight into `while read`:
+    # nvidia-smi can be installed and STILL fail this query (driver/library
+    # version mismatch, a container started without --gpus, permission denial).
+    # A failed query piped into the loop yields zero iterations, so this whole
+    # section used to render as a heading with nothing whatsoever under it — and
+    # a reader cannot distinguish "no power cap" from "power was never read".
+    # The power limit is precisely the field that failure mode hides, so the
+    # empty case now says so out loud instead of looking complete.
+    _gpu_fields='index,name,memory.total,driver_version,vbios_version,persistence_mode,power.limit,power.default_limit,power.max_limit,power.draw,pci.bus_id,pcie.link.gen.current,pcie.link.gen.max,pcie.link.width.current,pcie.link.width.max'
+
+    # enforced.power.limit is APPENDED and then fallen back from, never assumed.
+    # An nvidia-smi that does not recognise a field prints
+    #   Field "enforced.power.limit" is not a valid field to query.
+    # to STDOUT and exits non-zero — so a non-empty test would score that error
+    # text as a GPU row and parse it as one card. Gate on the EXIT CODE, and on
+    # failure retry the field set every driver has, so a report from an older
+    # driver loses one optional column instead of the whole GPU section.
+    _gpu_rows="$(nvidia-smi --query-gpu="${_gpu_fields},enforced.power.limit" --format=csv,noheader 2>/dev/null)"
+    _gpu_rows_rc=$?
+    if [[ "$_gpu_rows_rc" -ne 0 ]]; then
+      _gpu_rows="$(nvidia-smi --query-gpu="${_gpu_fields}" --format=csv,noheader 2>/dev/null)"
+      _gpu_rows_rc=$?
+    fi
+    if [[ "$_gpu_rows_rc" -ne 0 || -z "${_gpu_rows//[[:space:]]/}" ]]; then
+      echo "- ⚠️ **GPU fields unreadable** — \`nvidia-smi\` is installed but \`--query-gpu\` returned no rows (exit ${_gpu_rows_rc})."
+      echo "  - **Power limit: NOT READ.** The absence of a power-cap warning in this report does *not* mean these cards are at their default power limit."
+      echo "  - Usual causes: driver/library version mismatch, a container without \`--gpus\`, or insufficient permission. Confirm by hand with \`nvidia-smi --query-gpu=index,power.limit,power.default_limit --format=csv\`."
+    else
+    printf '%s\n' "$_gpu_rows" \
+      | while IFS=, read -r idx name memtotal driver vbios persistence pwr_limit pwr_default pwr_max pwr_draw bus_id pcie_gen_cur pcie_gen_max pcie_width_cur pcie_width_max pwr_enforced; do
           # trim leading spaces from CSV fields
           idx="${idx# }"; name="${name# }"; memtotal="${memtotal# }"
           driver="${driver# }"; vbios="${vbios# }"; persistence="${persistence# }"
@@ -489,17 +566,38 @@ else
           pwr_max="${pwr_max# }"; pwr_draw="${pwr_draw# }"
           bus_id="${bus_id# }"; pcie_gen_cur="${pcie_gen_cur# }"; pcie_gen_max="${pcie_gen_max# }"
           pcie_width_cur="${pcie_width_cur# }"; pcie_width_max="${pcie_width_max# }"
+          pwr_enforced="${pwr_enforced# }"
 
-          # Flag if user has capped below default
+          # Flag if user has capped below default.
+          #
+          # State the cap as a PERCENTAGE of the card's own default, not just as
+          # a wattage: whoever triages this report has no idea what that card's
+          # stock TDP is, so "limit=230.00 W" reads as an ordinary number while
+          # "62% of 370.00 W default" does not. The uncapped rendering is left
+          # byte-for-byte as it was, so a healthy report gains nothing.
           power_note=""
+          power_envelope=""
           pwr_limit_w="${pwr_limit% W}"; pwr_limit_w="${pwr_limit_w%.*}"
           pwr_default_w="${pwr_default% W}"; pwr_default_w="${pwr_default_w%.*}"
           if [[ "$pwr_limit_w" =~ ^[0-9]+$ ]] && [[ "$pwr_default_w" =~ ^[0-9]+$ ]]; then
-            if [[ "$pwr_limit_w" -lt "$pwr_default_w" ]]; then
-              power_note=" ⚠ user-capped below default"
+            if [[ "$pwr_limit_w" -lt "$pwr_default_w" ]] && [[ "$pwr_default_w" -gt 0 ]]; then
+              power_envelope=" ($(( pwr_limit_w * 100 / pwr_default_w ))% of ${pwr_default} default, max=${pwr_max})"
+              power_note=" ⚠ **CAPPED BELOW DEFAULT** — throughput on this card is power-limited, not comparable to a stock-power baseline"
             elif [[ "$pwr_limit_w" -gt "$pwr_default_w" ]]; then
               power_note=" (overclocked above default)"
             fi
+          fi
+          [[ -n "$power_envelope" ]] || power_envelope=" (default=${pwr_default}, max=${pwr_max})"
+
+          # enforced.power.limit is what the driver is ACTUALLY clamping to; it
+          # diverges from power.limit under thermal or hardware slowdown, and
+          # nothing else in this report would reveal it. Emitted only when the
+          # two differ, so the common case costs zero bytes.
+          pwr_enforced_note=""
+          pwr_enforced_w="${pwr_enforced% W}"; pwr_enforced_w="${pwr_enforced_w%.*}"
+          if [[ "$pwr_enforced_w" =~ ^[0-9]+$ ]] && [[ "$pwr_limit_w" =~ ^[0-9]+$ ]] \
+             && [[ "$pwr_enforced_w" -ne "$pwr_limit_w" ]]; then
+            pwr_enforced_note=" | enforced=${pwr_enforced} ⚠ driver is clamping below the set limit (thermal / HW slowdown)"
           fi
 
           # Flag if PCIe lane width is below max — that's hardware-level (slot
@@ -514,9 +612,10 @@ else
           fi
 
           echo "- **GPU $idx:** $name | $memtotal | driver $driver | VBIOS $vbios | persistence=$persistence"
-          echo "  - **Power:** limit=${pwr_limit} (default=${pwr_default}, max=${pwr_max}) | current_draw=${pwr_draw}${power_note}"
+          echo "  - **Power:** limit=${pwr_limit}${power_envelope} | current_draw=${pwr_draw}${pwr_enforced_note}${power_note}"
           echo "  - **PCIe:** x${pcie_width_cur} lanes negotiated (GPU max x${pcie_width_max}, Gen up to ${pcie_gen_max}) | bus ${bus_id}${pcie_note}"
         done
+    fi
 
     cuda_ver=$(nvidia-smi 2>/dev/null | grep -oE 'CUDA Version: [0-9.]+' | head -1 | awk '{print $3}')
     [[ -n "$cuda_ver" ]] && echo "- **CUDA Runtime (per driver):** $cuda_ver"

--- a/scripts/tests/fixtures/report-harness/report-env.sh
+++ b/scripts/tests/fixtures/report-harness/report-env.sh
@@ -39,6 +39,14 @@ report_env_init() {
   : > "$REPORT_TRACE"
 }
 
+# report_nvsmi_stub — replace the hard-fail nvidia-smi stub with a scripted one.
+# The script body is read from stdin. Additive: the default stub stays `exit 1`
+# for every existing caller, so this only affects tests that opt in.
+report_nvsmi_stub() {
+  cat > "${REPORT_FAKE_BIN}/nvidia-smi"
+  chmod +x "${REPORT_FAKE_BIN}/nvidia-smi"
+}
+
 report_env_cleanup() {
   report_stub_stop
   [[ -n "${REPORT_ENV_DIR:-}" ]] && rm -rf "$REPORT_ENV_DIR"

--- a/scripts/tests/test-report-power-state.sh
+++ b/scripts/tests/test-report-power-state.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# test-report-power-state — a shared report must say what power envelope it was
+# taken under, and must never let "power was not read" look like "power is fine".
+#
+# Why this test exists. A run on this stack measured ~40% below its own recorded
+# baseline with a signature that read as an upstream speculative-decoding
+# regression: spec_n=1 and spec_n=2 produced identical throughput while draft
+# acceptance stayed healthy. An upstream bug report was nearly filed. The cause
+# was a persistent 230 W cap against 370/420 W factory defaults, applied at boot
+# by a systemd unit, and found only by manually reading `power.limit`.
+#
+# report.sh has emitted a per-GPU wattage since its first commit, so "is the
+# number present" was never the gap. The gap was interpretability:
+#   1. a cap was a soft parenthetical nested two levels into a mid-report
+#      section, in a paste that gets truncated from the bottom;
+#   2. it was stated in absolute watts, and whoever triages someone else's rig
+#      does not know that card's stock TDP, so "limit=230.00 W" reads as normal;
+#   3. when nvidia-smi was installed but its query FAILED, the GPU section
+#      rendered as a heading with nothing under it — so the absence of a cap
+#      warning was indistinguishable from a cap nobody ever looked for.
+#
+# Contract asserted here:
+#   - a cap below default surfaces UP FRONT, per GPU, as watts-of-watts AND a
+#     percentage of that card's own default;
+#   - an uncapped rig emits no cap warning anywhere (the negative control — a
+#     banner that always fired would assert nothing);
+#   - enforced.power.limit is surfaced when, and only when, it undercuts the
+#     set limit;
+#   - a present-but-unreadable query says "NOT READ" explicitly;
+#   - a machine with no nvidia-smi at all still produces a report.
+set -uo pipefail
+
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+PASS=0; FAIL=0
+DUMP_DIR="$(mktemp -d)"
+DUMP_IDX=0
+CURRENT_DUMP="(none)"
+
+ok() { PASS=$((PASS+1)); }
+no() { echo "FAIL: $1" >&2; FAIL=$((FAIL+1)); }
+eq() { if [[ "$2" == "$3" ]]; then ok; else no "$1: expected '$3', got '$2'"; fi; }
+# Full report output is CAPTURED to a file and only its path is printed: nine
+# failing assertions each dumping 80 lines of report is unreadable, and the
+# diagnostic still has to survive.
+has()   { if [[ "$2" == *"$3"* ]]; then ok; else no "$1: missing '$3' — report: $CURRENT_DUMP"; fi; }
+hasnt() { if [[ "$2" != *"$3"* ]]; then ok; else no "$1: must NOT contain '$3' — report: $CURRENT_DUMP"; fi; }
+
+# ===========================================================================
+# Layer 1 — gpu_power_caps() as a unit. Extracted with sed (the repo pattern)
+# so report.sh's main body does not run.
+# ===========================================================================
+HELPERS="$(mktemp --suffix=.sh)"
+tmp="$(mktemp -d)"
+cleanup_unit() { rm -rf "$tmp" "$HELPERS"; }
+trap cleanup_unit EXIT
+
+sed -n '/^gpu_power_caps()/,/^}/p' scripts/report.sh > "$HELPERS"
+if [[ ! -s "$HELPERS" ]]; then
+  # Recorded as a failure rather than exiting, so a run against a report.sh
+  # WITHOUT the capture still exercises the end-to-end assertions below and
+  # reports every gap rather than only the first.
+  no "gpu_power_caps() not found in scripts/report.sh — the power-state capture is absent"
+  printf 'gpu_power_caps() { return 0; }\n' > "$HELPERS"
+fi
+printf 'have() { command -v "$1" >/dev/null 2>&1; }\n' >> "$HELPERS"
+
+# shellcheck source=/dev/null
+source "$HELPERS"
+
+# A scripted nvidia-smi whose rows come from the environment, so one stub serves
+# every arm below.
+cat > "$tmp/nvidia-smi" <<'EOS'
+#!/usr/bin/env bash
+if [[ "$*" == *"index,power.limit,power.default_limit"* ]]; then
+  printf '%s\n' "${MOCK_ROWS:-}"
+fi
+exit 0
+EOS
+chmod +x "$tmp/nvidia-smi"
+export PATH="$tmp:$PATH"
+
+# 1a. both cards capped — the incident's exact numbers
+export MOCK_ROWS="$(printf '0, 230.00, 370.00\n1, 230.00, 420.00')"
+eq "capped: both cards reported with percentages" "$(gpu_power_caps)" "$(printf '0|230|370|62\n1|230|420|54')"
+
+# 1b. NEGATIVE CONTROL — nothing capped means no rows at all
+export MOCK_ROWS="$(printf '0, 370.00, 370.00\n1, 420.00, 420.00')"
+eq "uncapped: no rows" "$(gpu_power_caps)" ""
+
+# 1c. one capped, one not — only the capped card is listed
+export MOCK_ROWS="$(printf '0, 230.00, 370.00\n1, 420.00, 420.00')"
+eq "mixed: only the capped card" "$(gpu_power_caps)" "0|230|370|62"
+
+# 1d. an overclocked card is not a cap
+export MOCK_ROWS="0, 390.00, 370.00"
+eq "above default is not a cap" "$(gpu_power_caps)" ""
+
+# 1e. [N/A] / [Not Supported] must not be scored as a cap (would be a false alarm)
+export MOCK_ROWS="$(printf '0, [N/A], [N/A]\n1, [Not Supported], 420.00')"
+eq "non-numeric fields yield no rows" "$(gpu_power_caps)" ""
+
+# 1f. a machine with no nvidia-smi must not error. gpu_power_caps uses only
+# builtins plus nvidia-smi, so an empty PATH is a faithful "no GPU" rig.
+out="$(PATH="$tmp/definitely-absent" gpu_power_caps 2>&1)"; rc=$?
+eq "no nvidia-smi: empty output" "$out" ""
+eq "no nvidia-smi: exit 0" "$rc" "0"
+unset MOCK_ROWS
+
+# ===========================================================================
+# Layer 2 — the REAL report.sh end to end, under a scripted nvidia-smi.
+# No GPU, no engine, no container.
+# ===========================================================================
+trap - EXIT
+cleanup_unit
+
+# shellcheck source=fixtures/report-harness/report-env.sh
+source "${ROOT_DIR}/scripts/tests/fixtures/report-harness/report-env.sh"
+report_env_init "$ROOT_DIR"
+cleanup_all() { report_env_cleanup; }
+trap cleanup_all EXIT
+
+# report_run re-enables `set -e` on exit; this test counts failures instead of
+# dying on the first one, so -e is turned back off and each report is saved.
+run_report() {
+  report_run "$@"
+  set +e
+  DUMP_IDX=$((DUMP_IDX+1))
+  CURRENT_DUMP="${DUMP_DIR}/report-${DUMP_IDX}.md"
+  printf '%s\n' "$REPORT_OUT" > "$CURRENT_DUMP"
+}
+
+# Answers every nvidia-smi call the GPU section makes. Limits come from the
+# environment so the capped and uncapped arms share one stub. Dispatch order
+# matters: the big identity query also contains the substring "power.limit".
+install_nvsmi() {
+  report_nvsmi_stub <<'EOS'
+#!/usr/bin/env bash
+args="$*"
+L0="${MOCK_LIM0:-370.00}"; L1="${MOCK_LIM1:-420.00}"
+D0="${MOCK_DEF0:-370.00}"; D1="${MOCK_DEF1:-420.00}"
+E0="${MOCK_ENF0:-$L0}";    E1="${MOCK_ENF1:-$L1}"
+case "$args" in
+  *enforced.power.limit*)
+    # big per-GPU identity + envelope query (csv,noheader — units included)
+    [[ "${MOCK_QUERY_FAILS:-0}" == "1" ]] && exit 1
+    if [[ "${MOCK_NO_ENFORCED_FIELD:-0}" == "1" ]]; then
+      # Verbatim shape of a real nvidia-smi meeting an unknown field: the error
+      # goes to STDOUT and the exit code is non-zero.
+      echo 'Field "enforced.power.limit" is not a valid field to query.'
+      exit 2
+    fi
+    echo "0, MockForce RTX 3090, 24576 MiB, 610.57.04, 94.02.42.80.88, Enabled, ${L0} W, ${D0} W, 390.00 W, 41.00 W, 00000000:01:00.0, 1, 4, 16, 16, ${E0} W"
+    echo "1, MockForce RTX 3090, 24576 MiB, 610.57.04, 94.02.42.C0.05, Enabled, ${L1} W, ${D1} W, 450.00 W, 28.00 W, 00000000:02:00.0, 1, 4, 8, 16, ${E1} W"
+    exit 0 ;;
+  *index,power.limit,power.default_limit*)
+    # gpu_power_caps (csv,noheader,nounits)
+    [[ "${MOCK_QUERY_FAILS:-0}" == "1" ]] && exit 1
+    echo "0, ${L0}, ${D0}"
+    echo "1, ${L1}, ${D1}"
+    exit 0 ;;
+  *pcie.link.width.max*)
+    # the fallback field set, without enforced.power.limit (older driver)
+    [[ "${MOCK_QUERY_FAILS:-0}" == "1" ]] && exit 1
+    echo "0, MockForce RTX 3090, 24576 MiB, 470.00, 94.02.42.80.88, Enabled, ${L0} W, ${D0} W, 390.00 W, 41.00 W, 00000000:01:00.0, 1, 4, 16, 16"
+    echo "1, MockForce RTX 3090, 24576 MiB, 470.00, 94.02.42.C0.05, Enabled, ${L1} W, ${D1} W, 450.00 W, 28.00 W, 00000000:02:00.0, 1, 4, 8, 16"
+    exit 0 ;;
+  -L) echo "GPU 0: MockForce RTX 3090 (UUID: GPU-0)"
+      echo "GPU 1: MockForce RTX 3090 (UUID: GPU-1)"; exit 0 ;;
+  *ecc.mode.current*)  echo "[N/A]"; exit 0 ;;
+  *index,memory.used*) echo "0, 0"; echo "1, 0"; exit 0 ;;
+  *nvlink*)            exit 1 ;;
+  *topo*-p2p*)         exit 1 ;;
+  *topo*)              echo "     GPU0 GPU1"; echo "GPU0  X   SYS"; echo "GPU1 SYS   X"; exit 0 ;;
+  "")                  echo "CUDA Version: 13.2"; exit 0 ;;
+  *)                   exit 0 ;;
+esac
+EOS
+}
+install_nvsmi
+
+# --- 2a. CAPPED: the incident state — 230 W on cards defaulting to 370/420 ---
+export MOCK_LIM0=230.00 MOCK_LIM1=230.00
+run_report --no-redact
+CAPPED_OUT="$REPORT_OUT"; CAPPED_DUMP="$CURRENT_DUMP"
+eq "capped report still exits 0" "$REPORT_RC" "0"
+
+has "capped: up-front banner"         "$CAPPED_OUT" "GPU power cap active"
+has "capped: banner warns on numbers" "$CAPPED_OUT" "NOT at stock power"
+has "capped: GPU0 watts-of-watts + %" "$CAPPED_OUT" "GPU 0 capped to 230 W of 370 W default (62%)"
+has "capped: GPU1 watts-of-watts + %" "$CAPPED_OUT" "GPU 1 capped to 230 W of 420 W default (54%)"
+has "capped: per-GPU line states % of that card's own default" \
+    "$CAPPED_OUT" "limit=230.00 W (62% of 370.00 W default, max=390.00 W)"
+has "capped: per-GPU anomaly marker"  "$CAPPED_OUT" "CAPPED BELOW DEFAULT"
+has "capped: names the reproducing command" "$CAPPED_OUT" \
+    "nvidia-smi --query-gpu=index,power.limit,power.default_limit,enforced.power.limit --format=csv"
+
+# The banner must PRECEDE the GPU section: a paste truncated from the bottom has
+# to still carry the warning. `|| true` — grep exiting 1 under pipefail would
+# otherwise abort the run instead of failing this assertion.
+banner_line="$(command grep -n 'GPU power cap active' "$CAPPED_DUMP" 2>/dev/null | head -1 | cut -d: -f1 || true)"
+gpusec_line="$(command grep -n '^## GPU hardware' "$CAPPED_DUMP" 2>/dev/null | head -1 | cut -d: -f1 || true)"
+if [[ -n "$banner_line" && -n "$gpusec_line" && "$banner_line" -lt "$gpusec_line" ]]; then ok
+else no "banner must appear before '## GPU hardware' (banner=${banner_line:-absent} gpu=${gpusec_line:-absent}) — report: $CAPPED_DUMP"; fi
+unset MOCK_LIM0 MOCK_LIM1
+
+# --- 2b. NEGATIVE CONTROL: an uncapped rig warns about nothing ---------------
+run_report --no-redact
+eq "uncapped report exits 0" "$REPORT_RC" "0"
+hasnt "uncapped: no banner"        "$REPORT_OUT" "GPU power cap active"
+hasnt "uncapped: no cap marker"    "$REPORT_OUT" "CAPPED BELOW DEFAULT"
+hasnt "uncapped: no bogus percent" "$REPORT_OUT" "% of 370.00 W default"
+# ...but the envelope is still stated, so a reader can see it WAS read.
+has "uncapped: envelope still stated" "$REPORT_OUT" "limit=370.00 W (default=370.00 W, max=390.00 W)"
+
+# --- 2c. enforced.power.limit undercutting the set limit is surfaced ---------
+export MOCK_ENF0=200.00
+run_report --no-redact
+has "enforced below set limit is flagged"  "$REPORT_OUT" "enforced=200.00 W"
+has "enforced flag explains the mechanism" "$REPORT_OUT" "thermal / HW slowdown"
+unset MOCK_ENF0
+# ...and stays silent when enforced == limit, so the common case costs nothing.
+run_report --no-redact
+hasnt "enforced == limit prints nothing" "$REPORT_OUT" "enforced="
+
+# --- 2d. THE FALSE-CLEAN: nvidia-smi installed, query fails ------------------
+# Pre-fix this rendered '## GPU hardware' followed by NOTHING, so "no cap
+# warning" was indistinguishable from "power was never read".
+export MOCK_QUERY_FAILS=1
+run_report --no-redact
+eq "unreadable query still exits 0" "$REPORT_RC" "0"
+has "unreadable: says the fields could not be read"   "$REPORT_OUT" "GPU fields unreadable"
+has "unreadable: says POWER specifically was not read" "$REPORT_OUT" "Power limit: NOT READ"
+has "unreadable: denies the clean reading" "$REPORT_OUT" \
+    "does *not* mean these cards are at their default power limit"
+hasnt "unreadable: must not claim a cap" "$REPORT_OUT" "GPU power cap active"
+# ...and the section must not be an empty block.
+gpu_body="$(sed -n '/^## GPU hardware/,/^### /p' "$CURRENT_DUMP" | sed '1d;$d' | tr -d '[:space:]' || true)"
+if [[ -n "$gpu_body" ]]; then ok
+else no "GPU hardware section is an EMPTY block when the query fails — report: $CURRENT_DUMP"; fi
+unset MOCK_QUERY_FAILS
+
+# --- 2d-bis. a driver that does not know enforced.power.limit ----------------
+# nvidia-smi prints "Field ... is not a valid field to query." to STDOUT and
+# exits non-zero, so an emptiness check would have parsed that error text as a
+# GPU row. The section must fall back to the universal field set and still
+# report the cap — losing one optional column, not the whole section.
+export MOCK_NO_ENFORCED_FIELD=1 MOCK_LIM0=230.00 MOCK_LIM1=230.00
+run_report --no-redact
+eq "old driver still exits 0" "$REPORT_RC" "0"
+has   "old driver: GPU rows survive the fallback" "$REPORT_OUT" "**GPU 0:**"
+# The discriminator: the fallback field set reports driver 470.00, the primary
+# one 610.57.04. Without this, every other assertion in this arm would also
+# pass if the fallback had never been taken.
+has   "old driver: the FALLBACK query is what answered" "$REPORT_OUT" "driver 470.00"
+has   "old driver: cap still reported"            "$REPORT_OUT" "62% of 370.00 W default"
+has   "old driver: banner still fires"            "$REPORT_OUT" "GPU power cap active"
+hasnt "old driver: error text never parsed as a GPU row" "$REPORT_OUT" "is not a valid field to query"
+hasnt "old driver: no bogus enforced value" "$REPORT_OUT" "enforced="
+unset MOCK_NO_ENFORCED_FIELD MOCK_LIM0 MOCK_LIM1
+
+# --- 2e. no nvidia-smi at all: a GPU-less machine still reports --------------
+printf '#!/usr/bin/env bash\nexit 1\n' > "${REPORT_FAKE_BIN}/nvidia-smi"
+run_report --no-redact
+eq "no-GPU machine exits 0" "$REPORT_RC" "0"
+has   "no-GPU machine still emits the GPU section" "$REPORT_OUT" "## GPU hardware"
+hasnt "no-GPU machine claims no cap"               "$REPORT_OUT" "GPU power cap active"
+
+# --- 2f. the warning survives redaction (it carries no host/user/path) ------
+install_nvsmi
+export MOCK_LIM0=230.00 MOCK_LIM1=230.00
+run_report
+has "redacted run still warns about the cap" "$REPORT_OUT" "GPU power cap active"
+has "redacted run keeps the percentage"      "$REPORT_OUT" "of 370 W default (62%)"
+unset MOCK_LIM0 MOCK_LIM1
+
+echo "----------------------------------------"
+echo "PASS: $PASS  FAIL: $FAIL"
+if [[ "$FAIL" -ne 0 ]]; then
+  echo "Saved reports: $DUMP_DIR" >&2
+  exit 1
+fi
+rm -rf "$DUMP_DIR"
+echo "OK: report.sh power-state capture"


### PR DESCRIPTION
## The incident this prevents

A benchmark on a club rig read **~40% below its own recorded baseline**. The evidence looked like an
upstream speculative-decoding regression: `spec_n=1` and `spec_n=2` produced *identical* throughput
while draft acceptance stayed healthy — dead throughput with healthy acceptance. An upstream bug
report was nearly filed.

The cause was a **230 W power cap** against factory defaults of **370 W / 420 W**, applied at boot by
a systemd unit (`nvidia-power-cap.service`) and found only by reading `power.limit` by hand.

The generalisation is the part that matters for a *shared* report: a cap applied at boot is nobody's
per-run decision, so the reporter does not know to mention it — and every throughput number in the
report is silently power-dependent.

## What was already there, and what was actually missing

`report.sh` has emitted a per-GPU wattage since its first commit, so the datum was never absent.
Three things made it uninterpretable:

1. A cap was a soft parenthetical (`⚠ user-capped below default`) nested two levels into a
   mid-report section — in a paste that gets truncated from the bottom.
2. It was stated only in absolute watts. Whoever triages someone else's rig does not know that
   card's stock TDP, so `limit=230.00 W` reads as an ordinary number.
3. When `nvidia-smi` was installed but its query **failed** (driver/library mismatch, a container
   without `--gpus`, permission denial), the GPU section rendered as a heading with *nothing under
   it*. The absence of a cap warning was indistinguishable from a cap nobody looked for.

## What changed

`scripts/report.sh`

- **`gpu_power_caps()`** — per-GPU cap detection; one row per card whose limit is below its own
  factory default.
- **An up-front warning block**, placed and styled like the existing root-gated one, for the reason
  that block already states in its own comment (reports get truncated from the bottom):

  ```
  > ⚠️ **GPU power cap active — the throughput numbers in this report are NOT at stock power.**
  > - GPU 0 capped to 230 W of 370 W default (62%)
  > - GPU 1 capped to 230 W of 420 W default (54%)
  >
  > Treat every benchmark below as power-limited: it is not comparable to a baseline
  > taken at stock power, and a deep cap can look like an engine or speculative-decoding
  > regression rather than a power one. Caps commonly survive reboots (a systemd unit or
  > startup script running `nvidia-smi -pl`), so a rig can boot capped without anyone
  > choosing it for this run. Check and clear before comparing against any baseline:
  >
  > ```bash
  > nvidia-smi --query-gpu=index,power.limit,power.default_limit,enforced.power.limit --format=csv
  > ```
  ```

- **The per-GPU line states the cap as a percentage of that card's own default:**

  ```
  - **GPU 0:** NVIDIA GeForce RTX 3090 | 24576 MiB | driver 610.57.04 | VBIOS 94.02.42.80.88 | persistence=Enabled
    - **Power:** limit=230.00 W (62% of 370.00 W default, max=390.00 W) | current_draw=228.41 W ⚠ **CAPPED BELOW DEFAULT** — throughput on this card is power-limited, not comparable to a stock-power baseline
  ```

  The **uncapped rendering is byte-for-byte unchanged**, so a healthy report gains nothing. Verified
  by diffing a real before/after run on a 2× 3090 rig: only timestamp, uptime, RAM, STREAM and
  power-draw jitter differed.

- **`enforced.power.limit`** is reported when, and only when, it undercuts the set limit (thermal /
  hardware slowdown). Nothing else in the report reveals it; it costs zero bytes in the common case.

- **The GPU query is gated on its exit code, not on emptiness.** `nvidia-smi` prints
  `Field "enforced.power.limit" is not a valid field to query.` to **stdout** and exits non-zero, so
  an emptiness check would have parsed that error text as a GPU row. On failure it retries the field
  set every driver has — an older driver loses one optional column instead of the whole section — and
  if both attempts fail the section says the power limit was **NOT READ** instead of rendering empty.

Size: unchanged on an uncapped rig; ~900 bytes when capped. Nothing was refactored.

`scripts/tests/fixtures/report-harness/report-env.sh`

- Adds `report_nvsmi_stub` so a test can script `nvidia-smi` instead of the harness's hard-fail stub.
  Additive — the default stays `exit 1` for every existing caller.

## The negative control

`scripts/tests/test-report-power-state.sh` — 42 assertions in two layers: `gpu_power_caps()` as a
unit (sed-extracted, the repo pattern), then the **real `report.sh` end to end** under a scripted
`nvidia-smi`. No GPU, no engine, no container.

Run with only `scripts/report.sh` reverted to its pre-fix state (test scaffolding unchanged):

```
FAIL: gpu_power_caps() not found in scripts/report.sh — the power-state capture is absent
FAIL: capped: up-front banner: missing 'GPU power cap active'
FAIL: capped: GPU0 watts-of-watts + %: missing 'GPU 0 capped to 230 W of 370 W default (62%)'
FAIL: capped: GPU1 watts-of-watts + %: missing 'GPU 1 capped to 230 W of 420 W default (54%)'
FAIL: capped: per-GPU line states % of that card's own default: missing 'limit=230.00 W (62% of 370.00 W default, max=390.00 W)'
FAIL: capped: per-GPU anomaly marker: missing 'CAPPED BELOW DEFAULT'
FAIL: banner must appear before '## GPU hardware' (banner=absent gpu=37)
FAIL: unreadable: says the fields could not be read: missing 'GPU fields unreadable'
FAIL: unreadable: says POWER specifically was not read: missing 'Power limit: NOT READ'
...
PASS: 23  FAIL: 20
```

Post-fix: `PASS: 42  FAIL: 0`.

Both directions are asserted, so the test cannot pass by being unconditional:

- an **uncapped** rig must emit no banner, no cap marker and no percentage — while still stating the
  envelope, so a reader can see it *was* read;
- `enforced=` must be **absent** when it equals the set limit;
- the **old-driver fallback** arm asserts on the driver version only the fallback query returns, so
  it cannot pass without the fallback actually being taken (removing the retry turns that arm red).

Also asserted: `[N/A]` / `[Not Supported]` must not be scored as a cap, an overclocked card is not a
cap, and a machine with **no** `nvidia-smi` still produces a report.

## Tests run

| Test | Result |
|---|---|
| `test-report-power-state` (new) | PASS 42 / FAIL 0 |
| `test-report-exit-code` | PASS |
| `test-report-engine-liveness` | PASS |
| `test-report-calib` | PASS |
| `test-script-permissions` | PASS |
| `test-locale-utf8` | PASS |
| `test-power-cap-sweep-multigpu` | PASS 28 / FAIL 0 |

Scoped to the report/harness/permissions gates rather than the full sweep, since other work was in
flight concurrently; a serial full sweep on `master` after merge is worth doing.

## Scope

**Partial fix for #1265.** This is only the power-state line that was split out of it. The two main
halves of that issue remain open and unstarted here:

- capturing the engine's **resolved configuration** (`docker inspect` Cmd / Entrypoint / Env behind a
  secret **allowlist**), and
- the **diff against the shipped recipe** resolved through the registry.

Refs #1265

Deliberately left out: `power.min_limit` (adds nothing a reader can act on — `max` is already
reported), and any annotation of the benchmark sections themselves; the up-front block covers the
"which envelope was this taken under" question for the whole report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
