### PR TITLE
fix(quality): refuse a bare TOTAL when a pack scores 0/N (cause-agnostic structural-zero guard)

### DIFF
--- a/docs/QUALITY_TEST.md
+++ b/docs/QUALITY_TEST.md
@@ -115,19 +115,22 @@ wrapper invocation, wire it or route it through `--`.
 
 ## ⭐ The canonical two-leg run
 
-> ⚠️ **`--no-thinking` × `hermesagent-20` (#1269).** Four packs default thinking
-> ON (`instructfollow-15`, `reasonmath-15`, `bugfind-15`, `hermesagent-20`).
-> Three degrade gracefully with thinking forced off; `hermesagent-20` can
-> **collapse** — its scenarios are multi-step agent tasks that need room to
-> plan, and a model with no room can return uniformly in ~2s and score 0/20 (not
-> failing the scenarios, not attempting them). The wrapper prints a specific
-> notice up front whenever `--no-thinking` meets a pack set containing that
-> pack, and the structural-zero guard above drops the pack out of the reported
-> TOTAL if it does collapse (`--full`: 150 → 130). It is **not** pre-excluded:
-> saved thinking-off runs on the reference rig score `hermesagent-20` in the
-> 6-15/20 range, so a blanket exclusion would discard valid measurements. To
-> avoid the risk entirely, run the thinking-off leg over the deterministic packs
-> (`--no-sandboxed`).
+> **All four thinking-on packs degrade gracefully with `--no-thinking`** —
+> including `hermesagent-20`, contrary to the original #1269 premise (retracted).
+> Across 150 full 20-scenario `hermesagent-20` entries in the saved results
+> (filtered on per-pack `thinking_enabled`, run-level as fallback):
+>
+> | | n | median | mean | range | runs at 0/20 |
+> |---|--:|--:|--:|--:|--:|
+> | thinking OFF | 74 | 11/20 | 10.3 | 0-15 | 4 |
+> | thinking ON | 76 | 12/20 | 11.1 | 0-16 | 6 |
+>
+> Structural zeros occur on **both** arms and slightly more often with thinking
+> ON, and paired per model the off arm costs ~1-2 scenarios of 20. So a `0/20`
+> on an off-leg is **not** evidence about thinking — treat it as a structural
+> failure and find the real cause (the one investigated incident was a
+> sandboxed-agent constructor mismatch reported as 20 × `verifier_fail`). The
+> structural-zero guard above is deliberately cause-agnostic for that reason.
 
 This is the recipe every announcement quotes and the one to copy if you're producing a number
 anyone else will read. Substitute your slug.
@@ -451,9 +454,17 @@ caused it, and refuses to leave the bare TOTAL standing:
   reports rather than fails. What it does refuse is *publication*: the per-rig
   quality record (whose 8pk field is a bare TOTAL) is not written for that run.
 - Causes seen so far: endpoint not reachable from the sandbox container (#960,
-  also caught by a preflight), thinking forced off on a thinking-default pack
-  (#1269), Docker dying mid-run, sandbox image build failure, sandbox OOM, pack
-  version mismatch.
+  also caught by a preflight); a sandboxed pack whose agent harness failed to
+  initialise — returns in ~1.5s and reports every scenario as `verifier_fail`,
+  with `agent_exit_code=1` / `tool_events=0` in the trace; Docker dying mid-run;
+  sandbox image build or pull failure; sandbox OOM; pack version mismatch.
+- The guard lists candidates and does **not** guess. In particular it is not
+  thinking-aware: forced thinking-off was proposed as a cause in #1269 and the
+  saved results refute it (zeros appear on both thinking arms — see the two-leg
+  section), so pointing triage at thinking would send it the wrong way.
+- A whole pack of `verifier_fail` rows is the one case where that failure mode
+  is **not** a model verdict — a sandboxed agent that dies in its constructor
+  reports exactly that shape.
 
 ## Per-scenario timeouts
 

--- a/docs/QUALITY_TEST.md
+++ b/docs/QUALITY_TEST.md
@@ -115,6 +115,20 @@ wrapper invocation, wire it or route it through `--`.
 
 ## ⭐ The canonical two-leg run
 
+> ⚠️ **`--no-thinking` × `hermesagent-20` (#1269).** Four packs default thinking
+> ON (`instructfollow-15`, `reasonmath-15`, `bugfind-15`, `hermesagent-20`).
+> Three degrade gracefully with thinking forced off; `hermesagent-20` can
+> **collapse** — its scenarios are multi-step agent tasks that need room to
+> plan, and a model with no room can return uniformly in ~2s and score 0/20 (not
+> failing the scenarios, not attempting them). The wrapper prints a specific
+> notice up front whenever `--no-thinking` meets a pack set containing that
+> pack, and the structural-zero guard above drops the pack out of the reported
+> TOTAL if it does collapse (`--full`: 150 → 130). It is **not** pre-excluded:
+> saved thinking-off runs on the reference rig score `hermesagent-20` in the
+> 6-15/20 range, so a blanket exclusion would discard valid measurements. To
+> avoid the risk entirely, run the thinking-off leg over the deterministic packs
+> (`--no-sandboxed`).
+
 This is the recipe every announcement quotes and the one to copy if you're producing a number
 anyone else will read. Substitute your slug.
 
@@ -405,6 +419,41 @@ Failure reasons are surfaced in three places, cheapest first:
 `failure_mode` is one of: `verifier_fail` (answer wrong / below threshold) · `timeout` · `agent_runner_timeout` / `agent_runner_crashed` (sandboxed agentic packs) · `server_error` / `http_error` / `model_endpoint_unreachable` (serving problem, not a quality signal) · `result_json_malformed` · `wrong_answer` · `verifier_not_implemented` (stub, excluded from scoring).
 
 The breakdown is **terminal-only** — `quality-test.sh` does not tee it to a log file, but the same data persists in the saved JSON.
+
+### A whole pack at `0 / N` — the structural-zero guard (#1270)
+
+A pack that scores `0 / N` is almost never a model score: it is the harness, the
+config or the endpoint. But the TOTAL counts those N as model failures, and the
+result is plausible enough to publish — @paulp83's #1253 leg A read **102/150
+(68%)** where the valid subset was **102/130 (78%)**, ten points of apparent
+instruct deficit from one zeroed pack.
+
+`quality-test.sh` therefore checks the **outcome** after every run, whatever
+caused it, and refuses to leave the bare TOTAL standing:
+
+```
+⚠️  STRUCTURAL-ZERO GUARD (#1270) — a pack scored 0/N, so the bare TOTAL
+    printed above is NOT citable.
+  hermesagent-20 scored 0/20 (p50 2.40s, status=ok) — excluded from the TOTAL …
+  TOTAL (valid subset)  102 / 130 (78%)
+  TOTAL (all packs)     102 / 150 (68%)   <- do not cite
+```
+
+- **The `0/N` is the trigger.** Latency is printed as corroboration only: a p50
+  far below that pack's own healthy figure means it failed *fast* (returned
+  without attempting) rather than *hard*. It never gates the warning.
+- **Not the same as `verifier_fail`.** An individual `verifier_fail` row is the
+  MODEL being wrong, not the grader — those keep counting toward both figures.
+  Only a whole pack scoring zero trips the guard.
+- A pack with `total == 0` (sandbox unavailable, stubbed metadata gate) never
+  ran. That is a skip, not a zero, and does not trip the guard.
+- The run's **exit code is unchanged** — a genuine 0/N is possible, so the guard
+  reports rather than fails. What it does refuse is *publication*: the per-rig
+  quality record (whose 8pk field is a bare TOTAL) is not written for that run.
+- Causes seen so far: endpoint not reachable from the sandbox container (#960,
+  also caught by a preflight), thinking forced off on a thinking-default pack
+  (#1269), Docker dying mid-run, sandbox image build failure, sandbox OOM, pack
+  version mismatch.
 
 ## Per-scenario timeouts
 

--- a/scripts/quality-test.sh
+++ b/scripts/quality-test.sh
@@ -127,12 +127,12 @@ OPTIONS (extra)
                    --reasoning suite). Mutually exclusive with --enable-thinking.
                    Use for a clean all-off arm of a reasoning A/B. Also
                    settable via NO_THINKING=1 env.
-                   ⚠ hermesagent-20 is the outlier of those four: its multi-step
-                   agent scenarios can COLLAPSE to 0/20 with thinking forced off
-                   (#1269) while the other three degrade gracefully. The wrapper
-                   warns up front when the pack set contains it, and the
-                   structural-zero guard drops a 0/N pack out of the reported
-                   TOTAL (#1270). Avoid it entirely with --no-sandboxed.
+                   All four degrade gracefully: across 150 saved hermesagent-20
+                   entries the off arm medians 11/20 vs 12/20 on, i.e. ~1-2
+                   scenarios of 20 (#1269). A pack that comes back 0/N is a
+                   structural failure, not a thinking-off score — the
+                   structural-zero guard drops it out of the reported TOTAL
+                   whatever the cause (#1270).
   --thinking-max-tokens N
                    Forward to benchlocal-cli --thinking-max-tokens N. The
                    budget applies only to packs whose thinking gate resolves on
@@ -226,9 +226,10 @@ OUTPUT
   - JSON blob to results/quality/quality-<timestamp>.json (full detail)
   - STRUCTURAL-ZERO GUARD block when ANY pack scored 0/N (#1270): both TOTALs
     (valid subset + all packs, the latter marked "do not cite") plus the zeroed
-    pack's p50 as corroboration. Cause-agnostic and post-hoc; the per-rig
-    quality record is not published for such a run. verifier_fail rows are the
-    MODEL being wrong and keep counting — only a WHOLE pack at 0/N trips it.
+    pack's p50 as corroboration. Cause-agnostic and post-hoc — it reports the
+    outcome and lists candidate causes, it does not guess one; the per-rig
+    quality record is not published for such a run. A verifier_fail row is the
+    MODEL being wrong and keeps counting — only a WHOLE pack at 0/N trips it.
   - Compact one-liner for the compose `Quality:` profile field, stamped with
     per-pack versions and run provenance (#981/#983E)
 
@@ -768,10 +769,6 @@ fi
 # Does a scenario selection touch the Docker-sandboxed packs? (drives the
 # same image preflight that --full gets — cli-40 probes are the primary use)
 SELECTION_HAS_SANDBOX=0
-# Set to 1 below when the sandbox-image preflight decides the sandbox packs
-# cannot run — a pack that will not run cannot collapse, so the #1269 notice
-# must not fire for it.
-SANDBOX_PACKS_SKIPPED=0
 if [[ ${#SCENARIOS[@]} -gt 0 || -n "$SCENARIOS_FILE" ]]; then
   _sel_lines="$(printf '%s\n' ${SCENARIOS[@]+"${SCENARIOS[@]}"})"
   if [[ -n "$SCENARIOS_FILE" ]]; then
@@ -781,26 +778,6 @@ if [[ ${#SCENARIOS[@]} -gt 0 || -n "$SCENARIOS_FILE" ]]; then
     SELECTION_HAS_SANDBOX=1
   fi
 fi
-
-# Will the resolved pack set include hermesagent-20? Mirrors how benchlocal-cli
-# resolves it (--pack > --sandboxed-only > selection > mode flag), so the #1269
-# notice below fires only for a run that genuinely contains the pack.
-# (if-forms, not `[[ ]] &&` — a false condition as the last command would trip set -e)
-_pack_set_includes_hermes() {
-  if [[ -n "$RESUME" ]]; then return 1; fi          # pack set restored from the journal; unknown out here
-  if [[ -n "$PACK" ]]; then
-    if [[ "$PACK" == "hermesagent-20" ]]; then return 0; fi
-    return 1
-  fi
-  if [[ "$NO_SANDBOX" == "1" || "$SANDBOX_PACKS_SKIPPED" == "1" ]]; then return 1; fi
-  if [[ ${#SCENARIOS[@]} -gt 0 || -n "$SCENARIOS_FILE" ]]; then
-    if command grep -qE '^hermesagent-20/' <<<"${_sel_lines:-}"; then return 0; fi
-    return 1
-  fi
-  if [[ "$SANDBOXED_ONLY" == "1" ]]; then return 0; fi
-  if [[ "$MODE" == "--full" ]]; then return 0; fi
-  return 1
-}
 
 if { [[ -z "$PACK" ]] && { [[ "$MODE" == "--full" && "$NO_SANDBOX" != "1" ]] || [[ "$SANDBOXED_ONLY" == "1" ]]; }; } || [[ "$SELECTION_HAS_SANDBOX" == "1" && "$NO_SANDBOX" != "1" ]]; then
   _sb_missing=()
@@ -865,7 +842,6 @@ except Exception:
       echo "  then re-run. For a no-Docker run instead:  bash scripts/quality-test.sh --medium" >&2
       exit 1
     fi
-    SANDBOX_PACKS_SKIPPED=1
     echo "[quality-test] ⚠  sandbox packs (BugFind / CLI / Hermes) will be SKIPPED — not available: ${_sb_missing[*]}" >&2
     echo "               They need pre-built Docker images that aren't auto-pulled. Build them once from a" >&2
     echo "               benchlocal-cli CHECKOUT (the build tooling isn't in the pip package):" >&2
@@ -1052,42 +1028,6 @@ fi
 if [[ "$NO_THINKING" == "1" ]]; then
   CLI_ARGS+=(--no-thinking)
   echo "[quality-test] thinking: disabled for every pack, ignoring per-pack defaults (non-canonical)"
-  # #1269: four packs default thinking ON (instructfollow-15, reasonmath-15,
-  # bugfind-15, hermesagent-20). Three degrade gracefully with thinking forced
-  # off; hermesagent-20 can COLLAPSE — @paulp83's instruct arm returned 0/20 at
-  # p50 2.40s where his thinking arm scored 14/20 at 10.36s on the same rig. A
-  # pack that takes ~10s when it works and returns uniformly in 2.4s is not
-  # failing the scenarios, it is not attempting them.
-  #
-  # Why the pack is NOT pre-dropped here:
-  #   1. The collapse is NOT a property of the combination. 46 saved runs in
-  #      results/quality/ carry hermesagent-20 with thinking resolved OFF; 44 of
-  #      them score 6-15/20 at healthy p50 (including the b9967 pin-bump off-leg
-  #      and a qwen3.8-27b off-leg at 14/20). Treating the pair as structurally
-  #      incompatible would discard measurements this repo cites.
-  #   2. benchlocal-cli has no pack-exclusion flag, and faking one by enumerating
-  #      the other packs' scenarios sets `selection` in the result JSON, i.e.
-  #      turns a canonical 8-pack run into a PARTIAL one (refused by history
-  #      ingestion / rescore without --allow-partial).
-  # So: warn loudly up front, and let the post-run structural-zero guard (#1270)
-  # drop it out of the TOTAL by OUTCOME if it does collapse.
-  if _pack_set_includes_hermes; then
-    echo "[quality-test] ⚠  --no-thinking + hermesagent-20 is a KNOWN-RISKY combination (#1269)." >&2
-    echo "               hermesagent-20 defaults thinking ON — its 20 scenarios are multi-step agent" >&2
-    echo "               tasks that need room to plan. With thinking forced off a model can return" >&2
-    echo "               uniformly in ~2s and score 0/20: not failing the scenarios, NOT ATTEMPTING" >&2
-    echo "               them. The other thinking-on packs (instructfollow-15 / reasonmath-15 /" >&2
-    echo "               bugfind-15) degrade gracefully instead — this one is the outlier." >&2
-    echo "               If it collapses this run it is EXCLUDED from the reported TOTAL and the" >&2
-    echo "               denominator drops by its 20 scenarios (--full: 150 → 130); see the" >&2
-    echo "               STRUCTURAL-ZERO GUARD block printed after the scoreboard." >&2
-    echo "               It is NOT pre-excluded: saved thinking-off runs on the reference rig do" >&2
-    echo "               score this pack 6-15/20, so a blanket drop would discard valid results." >&2
-    echo "               Avoid the risk entirely: drop --no-thinking (pack defaults keep hermes" >&2
-    echo "               thinking-on), or run the thinking-off arm over the deterministic packs" >&2
-    echo "               only (--no-sandboxed, or --medium)." >&2
-    echo >&2
-  fi
 fi
 # ---- reasoning switch: resolved by benchlocal-cli itself (its #131) ---------
 # WHICH request field turns reasoning off is model-specific, and an unrecognised
@@ -1163,21 +1103,39 @@ RC="${RC:-0}"
 # apparent instruct deficit that was one structurally-zeroed pack.
 #
 # Any cause produces the same misleading arithmetic: unreachable endpoint
-# (guarded above), thinking forced off on a thinking-default pack (#1269),
+# (guarded above), a sandboxed pack whose agent harness failed to initialise,
 # Docker dying mid-run, an image pull failure, a sandbox OOM, a pack version
 # mismatch. So this check is cause-AGNOSTIC — it fires on the OUTCOME, after the
 # results are in, whatever produced it. The 0/N is the trigger; latency is
 # printed as corroboration only and never gates the warning.
 #
-# ⚠️ NOT the same thing as verifier_fail. A verifier_fail row is the MODEL being
-# wrong, not the grader, and those keep counting toward both figures. Only a
-# WHOLE PACK scoring zero trips this.
+# ⚠️ Deliberately NOT thinking-aware, and #1269 is why. That issue proposed
+# treating hermesagent-20 as incompatible with --no-thinking; the saved results
+# refute it. Across 150 full 20-scenario hermesagent-20 entries (per-pack
+# thinking_enabled, run-level as fallback): thinking OFF n=74, median 11/20,
+# range 0-15, 4 runs at 0/20; thinking ON n=76, median 12/20, range 0-16, 6 runs
+# at 0/20. Structural zeros occur on BOTH arms and slightly MORE often with
+# thinking ON, and paired per model the off arm costs ~1-2 scenarios of 20 — the
+# same graceful degradation the other three thinking-default-on packs show. So
+# forced thinking-off is NOT a candidate cause, and a guard that pointed at it
+# would send triage the wrong way. It is also why no blanket pre-run drop of the
+# pack exists: it would discard valid measurements, and benchlocal-cli has no
+# pack-exclusion flag anyway (the only wrapper-side spelling is a scenario
+# enumeration, which tags the run PARTIAL).
+#
+# Three of those four thinking-off zeros are ONE incident: three consecutive
+# runs, every scenario ~1.5s, reported as 20 x verifier_fail, trace carrying
+# agent_exit_code=1 / tool_events=0 / an AIAgent.__init__() keyword mismatch. A
+# harness constructor fault wearing the model's label — which is exactly the
+# shape this guard exists to catch, and which qualifies the verifier_fail
+# caveat below: per row a verifier_fail is the model being wrong, but a WHOLE
+# PACK of them can be the harness.
 #
 # Exit contract of the probe below: 0 = nothing to report, 3 = a pack scored
 # 0/N (block printed), anything else = the probe itself broke and said so.
 ZERO_GUARD_RC=0
 if [[ -f "$JSON_OUT" ]]; then
-  python3 - "$JSON_OUT" "$NO_THINKING" <<'PYZERO' || ZERO_GUARD_RC=$?
+  python3 - "$JSON_OUT" <<'PYZERO' || ZERO_GUARD_RC=$?
 import json
 import sys
 
@@ -1187,18 +1145,6 @@ except Exception:
     pass
 
 path = sys.argv[1]
-wrapper_forced_off = len(sys.argv) > 2 and sys.argv[2] == "1"
-
-# Packs whose benchlocal-cli metadata sets `default_thinking: on`. Forcing
-# thinking off on one of these is #1269's mechanism, so the guard can name the
-# likely cause instead of shrugging. benchlocal-cli's per-pack metadata is the
-# source of truth; this mirrors the --no-thinking help text above.
-THINKING_DEFAULT_ON = {
-    "instructfollow-15",
-    "reasonmath-15",
-    "bugfind-15",
-    "hermesagent-20",
-}
 
 try:
     with open(path, encoding="utf-8") as fh:
@@ -1222,9 +1168,6 @@ scored = [p for p in (data.get("packs") or []) if int(p.get("total") or 0) > 0]
 zeroed = [p for p in scored if int(p.get("passed") or 0) == 0]
 if not zeroed:
     sys.exit(0)
-
-forced_off = data.get("thinking_mode") == "force-off" or wrapper_forced_off
-
 
 def fraction(passed, total):
     if not total:
@@ -1254,15 +1197,12 @@ for pack in zeroed:
         % (pid, total, p50_txt, pack.get("status") or "?")
     )
     print("    suspected structural failure, not as a model score.")
-    if forced_off and pid in THINKING_DEFAULT_ON:
-        print("    * check FIRST: thinking was forced OFF for this run and %s" % pid)
-        print("      defaults thinking ON (#1269). Its scenarios need room to plan; forced")
-        print("      thinking-off has been observed to make the pack return without attempting")
-        print("      them. Re-run it without --no-thinking to see whether the zero is real.")
-    else:
-        print("    * cause not determined here. Check: endpoint reachable from a container")
-        print("      (#960), Docker/sandbox health, sandbox image build, sandbox OOM, pack")
-        print("      version mismatch.")
+    print("    * cause not determined here — candidates, cheapest first: endpoint not")
+    print("      reachable from a container (#960); a sandboxed agent whose harness failed")
+    print("      to initialise (returns fast, reports every scenario as verifier_fail);")
+    print("      Docker/sandbox health; sandbox image build or pull; sandbox OOM; pack")
+    print("      version mismatch. Read the trace before reading the score:")
+    print("      benchlocal-cli inspect <json> --pack %s --full" % pid)
     print("    * %s is CORROBORATION only, never the trigger. A p50 far below this" % p50_txt)
     print("      pack's own healthy figure means it failed FAST — returning without")
     print("      attempting — rather than failing hard. Compare against a run that passed.")
@@ -1277,6 +1217,8 @@ print()
 print("  A whole pack at 0/N is a harness/config outcome until proven otherwise.")
 print("  Individual verifier_fail rows are the MODEL being wrong and DO keep counting")
 print("  toward both figures — this guard fires only on a whole pack scoring zero.")
+print("  But a whole pack OF verifier_fail rows can itself be a harness fault: a")
+print("  sandboxed agent that dies in its constructor reports exactly that shape.")
 print(bar)
 sys.exit(3)
 PYZERO

--- a/scripts/quality-test.sh
+++ b/scripts/quality-test.sh
@@ -127,6 +127,12 @@ OPTIONS (extra)
                    --reasoning suite). Mutually exclusive with --enable-thinking.
                    Use for a clean all-off arm of a reasoning A/B. Also
                    settable via NO_THINKING=1 env.
+                   ⚠ hermesagent-20 is the outlier of those four: its multi-step
+                   agent scenarios can COLLAPSE to 0/20 with thinking forced off
+                   (#1269) while the other three degrade gracefully. The wrapper
+                   warns up front when the pack set contains it, and the
+                   structural-zero guard drops a 0/N pack out of the reported
+                   TOTAL (#1270). Avoid it entirely with --no-sandboxed.
   --thinking-max-tokens N
                    Forward to benchlocal-cli --thinking-max-tokens N. The
                    budget applies only to packs whose thinking gate resolves on
@@ -218,6 +224,11 @@ INSTALL benchlocal-cli (one-time)
 OUTPUT
   - Markdown table to stdout (paste-ready for BENCHMARKS quality rows)
   - JSON blob to results/quality/quality-<timestamp>.json (full detail)
+  - STRUCTURAL-ZERO GUARD block when ANY pack scored 0/N (#1270): both TOTALs
+    (valid subset + all packs, the latter marked "do not cite") plus the zeroed
+    pack's p50 as corroboration. Cause-agnostic and post-hoc; the per-rig
+    quality record is not published for such a run. verifier_fail rows are the
+    MODEL being wrong and keep counting — only a WHOLE pack at 0/N trips it.
   - Compact one-liner for the compose `Quality:` profile field, stamped with
     per-pack versions and run provenance (#981/#983E)
 
@@ -757,6 +768,10 @@ fi
 # Does a scenario selection touch the Docker-sandboxed packs? (drives the
 # same image preflight that --full gets — cli-40 probes are the primary use)
 SELECTION_HAS_SANDBOX=0
+# Set to 1 below when the sandbox-image preflight decides the sandbox packs
+# cannot run — a pack that will not run cannot collapse, so the #1269 notice
+# must not fire for it.
+SANDBOX_PACKS_SKIPPED=0
 if [[ ${#SCENARIOS[@]} -gt 0 || -n "$SCENARIOS_FILE" ]]; then
   _sel_lines="$(printf '%s\n' ${SCENARIOS[@]+"${SCENARIOS[@]}"})"
   if [[ -n "$SCENARIOS_FILE" ]]; then
@@ -766,6 +781,26 @@ if [[ ${#SCENARIOS[@]} -gt 0 || -n "$SCENARIOS_FILE" ]]; then
     SELECTION_HAS_SANDBOX=1
   fi
 fi
+
+# Will the resolved pack set include hermesagent-20? Mirrors how benchlocal-cli
+# resolves it (--pack > --sandboxed-only > selection > mode flag), so the #1269
+# notice below fires only for a run that genuinely contains the pack.
+# (if-forms, not `[[ ]] &&` — a false condition as the last command would trip set -e)
+_pack_set_includes_hermes() {
+  if [[ -n "$RESUME" ]]; then return 1; fi          # pack set restored from the journal; unknown out here
+  if [[ -n "$PACK" ]]; then
+    if [[ "$PACK" == "hermesagent-20" ]]; then return 0; fi
+    return 1
+  fi
+  if [[ "$NO_SANDBOX" == "1" || "$SANDBOX_PACKS_SKIPPED" == "1" ]]; then return 1; fi
+  if [[ ${#SCENARIOS[@]} -gt 0 || -n "$SCENARIOS_FILE" ]]; then
+    if command grep -qE '^hermesagent-20/' <<<"${_sel_lines:-}"; then return 0; fi
+    return 1
+  fi
+  if [[ "$SANDBOXED_ONLY" == "1" ]]; then return 0; fi
+  if [[ "$MODE" == "--full" ]]; then return 0; fi
+  return 1
+}
 
 if { [[ -z "$PACK" ]] && { [[ "$MODE" == "--full" && "$NO_SANDBOX" != "1" ]] || [[ "$SANDBOXED_ONLY" == "1" ]]; }; } || [[ "$SELECTION_HAS_SANDBOX" == "1" && "$NO_SANDBOX" != "1" ]]; then
   _sb_missing=()
@@ -830,6 +865,7 @@ except Exception:
       echo "  then re-run. For a no-Docker run instead:  bash scripts/quality-test.sh --medium" >&2
       exit 1
     fi
+    SANDBOX_PACKS_SKIPPED=1
     echo "[quality-test] ⚠  sandbox packs (BugFind / CLI / Hermes) will be SKIPPED — not available: ${_sb_missing[*]}" >&2
     echo "               They need pre-built Docker images that aren't auto-pulled. Build them once from a" >&2
     echo "               benchlocal-cli CHECKOUT (the build tooling isn't in the pip package):" >&2
@@ -1016,6 +1052,42 @@ fi
 if [[ "$NO_THINKING" == "1" ]]; then
   CLI_ARGS+=(--no-thinking)
   echo "[quality-test] thinking: disabled for every pack, ignoring per-pack defaults (non-canonical)"
+  # #1269: four packs default thinking ON (instructfollow-15, reasonmath-15,
+  # bugfind-15, hermesagent-20). Three degrade gracefully with thinking forced
+  # off; hermesagent-20 can COLLAPSE — @paulp83's instruct arm returned 0/20 at
+  # p50 2.40s where his thinking arm scored 14/20 at 10.36s on the same rig. A
+  # pack that takes ~10s when it works and returns uniformly in 2.4s is not
+  # failing the scenarios, it is not attempting them.
+  #
+  # Why the pack is NOT pre-dropped here:
+  #   1. The collapse is NOT a property of the combination. 46 saved runs in
+  #      results/quality/ carry hermesagent-20 with thinking resolved OFF; 44 of
+  #      them score 6-15/20 at healthy p50 (including the b9967 pin-bump off-leg
+  #      and a qwen3.8-27b off-leg at 14/20). Treating the pair as structurally
+  #      incompatible would discard measurements this repo cites.
+  #   2. benchlocal-cli has no pack-exclusion flag, and faking one by enumerating
+  #      the other packs' scenarios sets `selection` in the result JSON, i.e.
+  #      turns a canonical 8-pack run into a PARTIAL one (refused by history
+  #      ingestion / rescore without --allow-partial).
+  # So: warn loudly up front, and let the post-run structural-zero guard (#1270)
+  # drop it out of the TOTAL by OUTCOME if it does collapse.
+  if _pack_set_includes_hermes; then
+    echo "[quality-test] ⚠  --no-thinking + hermesagent-20 is a KNOWN-RISKY combination (#1269)." >&2
+    echo "               hermesagent-20 defaults thinking ON — its 20 scenarios are multi-step agent" >&2
+    echo "               tasks that need room to plan. With thinking forced off a model can return" >&2
+    echo "               uniformly in ~2s and score 0/20: not failing the scenarios, NOT ATTEMPTING" >&2
+    echo "               them. The other thinking-on packs (instructfollow-15 / reasonmath-15 /" >&2
+    echo "               bugfind-15) degrade gracefully instead — this one is the outlier." >&2
+    echo "               If it collapses this run it is EXCLUDED from the reported TOTAL and the" >&2
+    echo "               denominator drops by its 20 scenarios (--full: 150 → 130); see the" >&2
+    echo "               STRUCTURAL-ZERO GUARD block printed after the scoreboard." >&2
+    echo "               It is NOT pre-excluded: saved thinking-off runs on the reference rig do" >&2
+    echo "               score this pack 6-15/20, so a blanket drop would discard valid results." >&2
+    echo "               Avoid the risk entirely: drop --no-thinking (pack defaults keep hermes" >&2
+    echo "               thinking-on), or run the thinking-off arm over the deterministic packs" >&2
+    echo "               only (--no-sandboxed, or --medium)." >&2
+    echo >&2
+  fi
 fi
 # ---- reasoning switch: resolved by benchlocal-cli itself (its #131) ---------
 # WHICH request field turns reasoning off is model-specific, and an unrecognised
@@ -1082,6 +1154,142 @@ fi
 # Run; capture exit code so we can also try to emit the compact one-liner
 benchlocal-cli "${CLI_ARGS[@]}" || RC=$?
 RC="${RC:-0}"
+
+# ---- #1270: structural-zero guard — refuse a bare TOTAL when a pack scored 0/N
+# The #960 preflight above guards ONE cause of a zeroed pack (endpoint not
+# reachable from the sandbox container). @paulp83's #1253 endpoint WAS reachable,
+# so that preflight passed correctly and the damage happened anyway: his leg A
+# read 102/150 (68%) where the valid subset was 102/130 (78%) — ten points of
+# apparent instruct deficit that was one structurally-zeroed pack.
+#
+# Any cause produces the same misleading arithmetic: unreachable endpoint
+# (guarded above), thinking forced off on a thinking-default pack (#1269),
+# Docker dying mid-run, an image pull failure, a sandbox OOM, a pack version
+# mismatch. So this check is cause-AGNOSTIC — it fires on the OUTCOME, after the
+# results are in, whatever produced it. The 0/N is the trigger; latency is
+# printed as corroboration only and never gates the warning.
+#
+# ⚠️ NOT the same thing as verifier_fail. A verifier_fail row is the MODEL being
+# wrong, not the grader, and those keep counting toward both figures. Only a
+# WHOLE PACK scoring zero trips this.
+#
+# Exit contract of the probe below: 0 = nothing to report, 3 = a pack scored
+# 0/N (block printed), anything else = the probe itself broke and said so.
+ZERO_GUARD_RC=0
+if [[ -f "$JSON_OUT" ]]; then
+  python3 - "$JSON_OUT" "$NO_THINKING" <<'PYZERO' || ZERO_GUARD_RC=$?
+import json
+import sys
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8")
+except Exception:
+    pass
+
+path = sys.argv[1]
+wrapper_forced_off = len(sys.argv) > 2 and sys.argv[2] == "1"
+
+# Packs whose benchlocal-cli metadata sets `default_thinking: on`. Forcing
+# thinking off on one of these is #1269's mechanism, so the guard can name the
+# likely cause instead of shrugging. benchlocal-cli's per-pack metadata is the
+# source of truth; this mirrors the --no-thinking help text above.
+THINKING_DEFAULT_ON = {
+    "instructfollow-15",
+    "reasonmath-15",
+    "bugfind-15",
+    "hermesagent-20",
+}
+
+try:
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+except Exception as exc:
+    # Unreadable/truncated results must be LOUD. A silent skip here would make
+    # "guard found nothing" indistinguishable from "guard never ran".
+    print(
+        "[quality-test] WARN: structural-zero guard could not read %s (%s)" % (path, exc),
+        file=sys.stderr,
+    )
+    print(
+        "[quality-test]   the TOTAL above has NOT been checked for 0/N packs (#1270).",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+
+# Only SCORED packs count. total == 0 means the pack never ran (sandbox
+# unavailable, stubbed metadata gate) — a skip, not a zero score.
+scored = [p for p in (data.get("packs") or []) if int(p.get("total") or 0) > 0]
+zeroed = [p for p in scored if int(p.get("passed") or 0) == 0]
+if not zeroed:
+    sys.exit(0)
+
+forced_off = data.get("thinking_mode") == "force-off" or wrapper_forced_off
+
+
+def fraction(passed, total):
+    if not total:
+        return "%d / 0" % passed
+    return "%d / %d (%d%%)" % (passed, total, round(100.0 * passed / total))
+
+
+all_passed = sum(int(p.get("passed") or 0) for p in scored)
+all_total = sum(int(p.get("total") or 0) for p in scored)
+valid = [p for p in scored if int(p.get("passed") or 0) > 0]
+valid_passed = sum(int(p.get("passed") or 0) for p in valid)
+valid_total = sum(int(p.get("total") or 0) for p in valid)
+
+bar = "=" * 74
+print()
+print(bar)
+print("⚠️  STRUCTURAL-ZERO GUARD (#1270) — a pack scored 0/N, so the bare TOTAL")
+print("    printed above is NOT citable.")
+print(bar)
+for pack in zeroed:
+    pid = pack.get("pack_id") or "?"
+    total = int(pack.get("total") or 0)
+    p50 = (pack.get("latency") or {}).get("p50")
+    p50_txt = "p50 %.2fs" % p50 if isinstance(p50, (int, float)) else "p50 n/a"
+    print(
+        "  %s scored 0/%d (%s, status=%s) — excluded from the TOTAL as a"
+        % (pid, total, p50_txt, pack.get("status") or "?")
+    )
+    print("    suspected structural failure, not as a model score.")
+    if forced_off and pid in THINKING_DEFAULT_ON:
+        print("    * check FIRST: thinking was forced OFF for this run and %s" % pid)
+        print("      defaults thinking ON (#1269). Its scenarios need room to plan; forced")
+        print("      thinking-off has been observed to make the pack return without attempting")
+        print("      them. Re-run it without --no-thinking to see whether the zero is real.")
+    else:
+        print("    * cause not determined here. Check: endpoint reachable from a container")
+        print("      (#960), Docker/sandbox health, sandbox image build, sandbox OOM, pack")
+        print("      version mismatch.")
+    print("    * %s is CORROBORATION only, never the trigger. A p50 far below this" % p50_txt)
+    print("      pack's own healthy figure means it failed FAST — returning without")
+    print("      attempting — rather than failing hard. Compare against a run that passed.")
+print()
+if valid_total:
+    print("  TOTAL (valid subset)  %s" % fraction(valid_passed, valid_total))
+else:
+    print("  TOTAL (valid subset)  none — every scored pack returned 0/N; the whole run")
+    print("                        is suspect, not just one pack.")
+print("  TOTAL (all packs)     %s   <- do not cite" % fraction(all_passed, all_total))
+print()
+print("  A whole pack at 0/N is a harness/config outcome until proven otherwise.")
+print("  Individual verifier_fail rows are the MODEL being wrong and DO keep counting")
+print("  toward both figures — this guard fires only on a whole pack scoring zero.")
+print(bar)
+sys.exit(3)
+PYZERO
+fi
+STRUCTURAL_ZERO=0
+case "$ZERO_GUARD_RC" in
+  0) ;;
+  3) STRUCTURAL_ZERO=1 ;;
+  *)
+    echo "[quality-test] WARN: the structural-zero guard (#1270) exited ${ZERO_GUARD_RC} — the" >&2
+    echo "               TOTAL above has NOT been checked for 0/N packs." >&2
+    ;;
+esac
 
 # ---- emit compact one-liner suitable for compose Quality: schema field -------
 
@@ -1180,7 +1388,14 @@ fi
 # quality run's score supersedes in c3 (append-only history kept). resolve-serving
 # maps the served container -> slug; unmatched/bare-metal runs skip cleanly. This
 # writes a quality-ONLY record (no TPS) that MERGES with the bench TPS record.
-if [[ "${QUALITY_RECORD:-1}" == "1" && -f "${JSON_OUT:-}" ]] && command -v python3 >/dev/null 2>&1; then
+# Same defect, a different consumer: the record's 8pk field IS a bare TOTAL
+# (c3 renders it verbatim), so a run that tripped the structural-zero guard has
+# no citable figure to publish. Skip it and say so — the skip and this notice
+# are the same branch.
+if [[ "$STRUCTURAL_ZERO" == "1" && "${QUALITY_RECORD:-1}" == "1" && -f "${JSON_OUT:-}" ]]; then
+  echo "[quality-test] per-rig quality record NOT written: a pack scored 0/N, so this run has no citable TOTAL (#1270)."
+fi
+if [[ "$STRUCTURAL_ZERO" != "1" && "${QUALITY_RECORD:-1}" == "1" && -f "${JSON_OUT:-}" ]] && command -v python3 >/dev/null 2>&1; then
   _qt_score="$(python3 - "$JSON_OUT" <<'PYQ' 2>/dev/null
 import json, sys
 try:

--- a/scripts/tests/test-quality-zero-pack.sh
+++ b/scripts/tests/test-quality-zero-pack.sh
@@ -11,18 +11,25 @@ export PYTHONUTF8="${PYTHONUTF8:-1}"
 #   2. It must NOT fire on a pack that merely FAILED scenarios (verifier_fail
 #      rows are the MODEL being wrong and keep counting), nor on a pack with
 #      total == 0 (sandbox-unavailable / stubbed = never ran, not a zero score).
-#   3. #1269: --no-thinking over a pack set containing hermesagent-20 prints a
-#      loud, specific up-front notice naming the mechanism AND the reduced
-#      denominator — and does NOT print it for a pack set without that pack.
+#   3. The guard is deliberately NOT thinking-aware (#1269 retracted). Its
+#      premise — that --no-thinking makes hermesagent-20 return a structural
+#      zero — is refuted by the saved results: across 150 full 20-scenario
+#      hermesagent-20 entries the thinking-OFF arm is n=74, median 11/20, 4 runs
+#      at 0/20, and the thinking-ON arm is n=76, median 12/20, 6 runs at 0/20 —
+#      zeros on BOTH arms, slightly more often with thinking ON. So the guard
+#      must NOT name forced thinking-off as a cause (that is where triage went
+#      wrong), and the wrapper must NOT warn about the combination. Cases F/J/E2
+#      below pin that removal so it cannot silently come back.
 #
-# NEGATIVE CONTROLS (each of these FAILS against pre-#1269/#1270 quality-test.sh):
+# NEGATIVE CONTROLS (each of these FAILS against pre-#1270 quality-test.sh):
 #   - case A: the guard block + both TOTAL figures + the record refusal
 #   - case D: the every-pack-zeroed wording
-#   - case E: cause attribution that does NOT blame thinking when thinking was
-#             not forced off
-#   - case F/J: the #1269 up-front notice
-# And the false-positive controls (B, C, G, H, I) assert the guard/notice stay
-# silent, so a guard that fires unconditionally cannot pass either.
+#   - case E: the cause-agnostic candidate list
+#   - case K: a loud failure on an unreadable results JSON
+# The false-positive controls (B, C) assert the guard stays silent when no pack
+# zeroed, so a guard that fires unconditionally cannot pass either. Cases F, J
+# and E2 are the REGRESSION controls for the retraction: they fail if any
+# thinking-specific claim or attribution comes back.
 #
 set -euo pipefail
 
@@ -204,9 +211,6 @@ assert_contains A "$OUT" "p50 2.40s"
 assert_contains A "$OUT" "TOTAL (valid subset)  102 / 130 (78%)"
 assert_contains A "$OUT" "TOTAL (all packs)     102 / 150 (68%)   <- do not cite"
 assert_contains A "$OUT" "verifier_fail rows are the MODEL being wrong and DO keep counting"
-# thinking_mode: force-off + a thinking-default-on pack -> name #1269 as the first suspect
-assert_contains A "$OUT" "check FIRST: thinking was forced OFF"
-assert_contains A "$OUT" "(#1269)"
 # the per-rig record is a bare TOTAL too: it must not be published
 assert_contains A "$OUT" "per-rig quality record NOT written"
 assert_not_contains A "$(cat "$record_log")" "MEASUREMENT_RECORD"
@@ -230,43 +234,72 @@ assert_contains D "$OUT" "STRUCTURAL-ZERO GUARD (#1270)"
 assert_contains D "$OUT" "TOTAL (valid subset)  none — every scored pack returned 0/N"
 assert_contains D "$OUT" "TOTAL (all packs)     0 / 30 (0%)   <- do not cite"
 
-echo "--- case E: thinking NOT forced off -> do not blame thinking ---"
+echo "--- case E: cause-agnostic candidate list, no guessed cause ---"
 run_wrapper "${tmp_work}/pack-defaults.json" -- --quick
 assert_contains E "$OUT" "STRUCTURAL-ZERO GUARD (#1270)"
-assert_not_contains E "$OUT" "check FIRST: thinking was forced OFF"
 assert_contains E "$OUT" "cause not determined here"
-assert_contains E "$OUT" "endpoint reachable from a container"
+assert_contains E "$OUT" "reachable from a container"
+# the real observed cause of the one investigated incident belongs on the list
+assert_contains E "$OUT" "harness failed"
+assert_contains E "$OUT" "every scenario as verifier_fail"
+# ...and a whole pack of verifier_fail rows must be called out as possibly the harness
+assert_contains E "$OUT" "whole pack OF verifier_fail rows can itself be a harness fault"
+# no thinking attribution, on either arm
+assert_not_contains E "$OUT" "thinking was forced OFF"
+assert_not_contains E "$OUT" "defaults thinking ON"
 
-echo "--- case E2: JSON without thinking_mode falls back to the wrapper's NO_THINKING ---"
+echo "--- case E2 (regression control): thinking_mode=force-off must NOT be blamed ---"
+# The retracted #1269 shape: a 0/20 hermesagent-20 in a thinking_mode=force-off
+# run. The guard must report it identically to any other cause — zeros occur on
+# both arms, so naming thinking here would send triage the wrong way.
+run_wrapper "${tmp_work}/paul-off.json" -- --quick
+assert_contains E2 "$OUT" "STRUCTURAL-ZERO GUARD (#1270)"
+assert_contains E2 "$OUT" "cause not determined here"
+assert_not_contains E2 "$OUT" "thinking was forced OFF"
+assert_not_contains E2 "$OUT" "#1269"
+# same with the wrapper's own --no-thinking in play
 run_wrapper "${tmp_work}/no-tmode.json" NO_THINKING=1 -- --quick
-assert_contains E2 "$OUT" "check FIRST: thinking was forced OFF"
+assert_contains E2 "$OUT" "cause not determined here"
+assert_not_contains E2 "$OUT" "thinking was forced OFF"
 
-echo "--- case F: #1269 up-front notice on --full --no-thinking ---"
+echo "--- case F (regression control): --full --no-thinking must NOT warn about the combination ---"
+# #1269's premise is retracted: thinking-OFF hermesagent-20 medians 11/20 over 74
+# saved runs. A warning that fires on every off-leg and misattributes the cause is
+# worse than silence, so the wrapper must stay quiet about the pairing.
 run_wrapper "${tmp_work}/paul-off.json" -- --full --no-thinking
-assert_contains F "$OUT" "--no-thinking + hermesagent-20 is a KNOWN-RISKY combination (#1269)"
-assert_contains F "$OUT" "NOT ATTEMPTING"
-assert_contains F "$OUT" "denominator drops by its 20 scenarios (--full: 150 → 130)"
-assert_contains F "$OUT" "instructfollow-15 / reasonmath-15 /"
-assert_contains F "$OUT" "--no-sandboxed, or --medium"
+assert_contains F "$OUT" "thinking: disabled for every pack"
+assert_not_contains F "$OUT" "KNOWN-RISKY"
+assert_not_contains F "$OUT" "hermesagent-20 is the outlier"
+assert_not_contains F "$OUT" "NOT ATTEMPTING"
+assert_not_contains F "$OUT" "150 → 130"
+assert_not_contains F "$OUT" "thinking was forced OFF"
+# the outcome guard still fires on the same run — the removal is of the CAUSE claim only
+assert_contains F "$OUT" "STRUCTURAL-ZERO GUARD (#1270)"
+assert_contains F "$OUT" "TOTAL (valid subset)  102 / 130 (78%)"
 assert_not_contains F "$OUT" "sandbox packs (BugFind / CLI / Hermes) will be SKIPPED"
 
-echo "--- case G: --medium --no-thinking has no hermesagent-20 -> no notice ---"
+echo "--- case G: a healthy off-leg stays quiet end to end ---"
 run_wrapper "${tmp_work}/paul-healthy.json" -- --medium --no-thinking
 assert_contains G "$OUT" "thinking: disabled for every pack"
-assert_not_contains G "$OUT" "KNOWN-RISKY combination (#1269)"
+assert_not_contains G "$OUT" "KNOWN-RISKY"
+assert_not_contains G "$OUT" "STRUCTURAL-ZERO GUARD"
 
-echo "--- case H: --full WITHOUT --no-thinking -> no notice ---"
+echo "--- case H: --full WITHOUT --no-thinking, healthy -> quiet ---"
 run_wrapper "${tmp_work}/paul-healthy.json" -- --full
-assert_not_contains H "$OUT" "KNOWN-RISKY combination (#1269)"
+assert_not_contains H "$OUT" "KNOWN-RISKY"
+assert_not_contains H "$OUT" "STRUCTURAL-ZERO GUARD"
 
-echo "--- case I: --full --no-thinking --no-sandboxed drops hermes -> no notice ---"
+echo "--- case I: --full --no-thinking --no-sandboxed -> quiet ---"
 run_wrapper "${tmp_work}/paul-healthy.json" -- --full --no-thinking --no-sandboxed
 assert_contains I "$OUT" "thinking: disabled for every pack"
-assert_not_contains I "$OUT" "KNOWN-RISKY combination (#1269)"
+assert_not_contains I "$OUT" "KNOWN-RISKY"
 
-echo "--- case J: --pack hermesagent-20 --no-thinking -> notice ---"
+echo "--- case J (regression control): --pack hermesagent-20 --no-thinking must NOT warn ---"
 run_wrapper "${tmp_work}/paul-off.json" -- --pack hermesagent-20 --no-thinking
-assert_contains J "$OUT" "KNOWN-RISKY combination (#1269)"
+assert_contains J "$OUT" "thinking: disabled for every pack"
+assert_not_contains J "$OUT" "KNOWN-RISKY"
+assert_not_contains J "$OUT" "hermesagent-20 is the outlier"
+assert_not_contains J "$OUT" "thinking was forced OFF"
 
 echo "--- case K: an unreadable results JSON must say so, not pass silently ---"
 : > "${tmp_work}/truncated.json"
@@ -279,4 +312,4 @@ if [[ "$FAILED" != "0" ]]; then
   echo "FAIL: test-quality-zero-pack" >&2
   exit 1
 fi
-echo "PASS: test-quality-zero-pack (#1269 notice + #1270 structural-zero guard)"
+echo "PASS: test-quality-zero-pack (#1270 structural-zero guard, cause-agnostic by design)"

--- a/scripts/tests/test-quality-zero-pack.sh
+++ b/scripts/tests/test-quality-zero-pack.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+#
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+# test-quality-zero-pack — guards the #1269 / #1270 contract:
+#
+#   1. #1270 STRUCTURAL-ZERO GUARD (cause-agnostic, post-hoc): when ANY pack
+#      comes back 0/N, quality-test.sh must NOT leave the bare TOTAL standing.
+#      It prints both figures (valid subset + all packs), marks the all-packs
+#      one "do not cite", and refuses to publish the per-rig quality record.
+#      Trigger is the 0/N; latency is printed as corroboration only.
+#   2. It must NOT fire on a pack that merely FAILED scenarios (verifier_fail
+#      rows are the MODEL being wrong and keep counting), nor on a pack with
+#      total == 0 (sandbox-unavailable / stubbed = never ran, not a zero score).
+#   3. #1269: --no-thinking over a pack set containing hermesagent-20 prints a
+#      loud, specific up-front notice naming the mechanism AND the reduced
+#      denominator — and does NOT print it for a pack set without that pack.
+#
+# NEGATIVE CONTROLS (each of these FAILS against pre-#1269/#1270 quality-test.sh):
+#   - case A: the guard block + both TOTAL figures + the record refusal
+#   - case D: the every-pack-zeroed wording
+#   - case E: cause attribution that does NOT blame thinking when thinking was
+#             not forced off
+#   - case F/J: the #1269 up-front notice
+# And the false-positive controls (B, C, G, H, I) assert the guard/notice stay
+# silent, so a guard that fires unconditionally cannot pass either.
+#
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+FAILED=0
+
+assert_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "ASSERTION FAILED [$label]: expected output to contain:" >&2
+    echo "  $needle" >&2
+    echo "--- output ---" >&2
+    echo "$haystack" >&2
+    FAILED=1
+  fi
+}
+
+assert_not_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "ASSERTION FAILED [$label]: expected output NOT to contain:" >&2
+    echo "  $needle" >&2
+    echo "--- output ---" >&2
+    echo "$haystack" >&2
+    FAILED=1
+  fi
+}
+
+tmp_bin="$(mktemp -d)"
+tmp_work="$(mktemp -d)"
+record_log="${tmp_work}/record-calls.log"
+run_out="${tmp_work}/run.out"
+before_list="$(mktemp)"
+after_list="$(mktemp)"
+find results/quality -maxdepth 1 -name 'quality-*.json' -print 2>/dev/null | sort > "$before_list" || true
+cleanup() {
+  find results/quality -maxdepth 1 -name 'quality-*.json' -print 2>/dev/null | sort > "$after_list" || true
+  comm -13 "$before_list" "$after_list" | xargs -r rm -f
+  rm -rf "$tmp_bin" "$tmp_work"
+  rm -f "$before_list" "$after_list"
+}
+trap cleanup EXIT
+
+REAL_PYTHON3="$(command -v python3)"
+
+cat > "${tmp_bin}/curl" <<'MOCK_CURL'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  case "$arg" in
+    */v1/models) printf '{"data":[{"id":"mock-model"}]}'; exit 0 ;;
+    */props|*/get_model_info) exit 1 ;;
+  esac
+done
+exit 0
+MOCK_CURL
+chmod +x "${tmp_bin}/curl"
+
+# benchlocal-cli mock: copies the fixture named by MOCK_RESULT_JSON to whatever
+# --save-json path the wrapper chose. That is the real delivery path — the
+# wrapper reads the same file a live run would.
+cat > "${tmp_bin}/benchlocal-cli" <<'MOCK_BENCHLOCAL'
+#!/usr/bin/env bash
+json_out=""
+argv=("$@")
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --save-json) json_out="${2:-}"; shift 2 ;;
+    list) echo 'toolcall-15'; exit 0 ;;
+    --help) echo '--reasoning-effort'; exit 0 ;;
+    *) shift ;;
+  esac
+done
+printf '%s\n' "${argv[*]}" >> "${BENCHLOCAL_MOCK_LOG}"
+if [[ -n "$json_out" && -n "${MOCK_RESULT_JSON:-}" ]]; then
+  mkdir -p "$(dirname "$json_out")"
+  cp "$MOCK_RESULT_JSON" "$json_out"
+fi
+echo "TOTAL (mock benchlocal scoreboard)"
+exit 0
+MOCK_BENCHLOCAL
+chmod +x "${tmp_bin}/benchlocal-cli"
+
+# python3 shim: records measurement_record.py invocations (the per-rig quality
+# record IS a bare TOTAL, so the guard must stop it reaching the corpus) and
+# forwards every other python3 call to the real interpreter untouched.
+cat > "${tmp_bin}/python3" <<EOF
+#!/usr/bin/env bash
+if [[ "\${1:-}" == *measurement_record.py ]]; then
+  printf '%s\n' "MEASUREMENT_RECORD \$*" >> "\${RECORD_MOCK_LOG}"
+  exit 0
+fi
+exec "${REAL_PYTHON3}" "\$@"
+EOF
+chmod +x "${tmp_bin}/python3"
+
+# docker mock: only the sandbox-image preflight calls docker in these runs
+# (the hermes container-reachability probe needs a loopback URL, and URL=http://mock
+# is not one). Report the three sandbox images present and freshly built so
+# --full does not degrade to "sandbox packs will be SKIPPED".
+cat > "${tmp_bin}/docker" <<'MOCK_DOCKER'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "image" && "${2:-}" == "inspect" ]]; then
+  case "${3:-}" in
+    benchlocal-sandbox-*:latest)
+      if [[ "${4:-}" == "--format" ]]; then
+        date -u -d '+1 day' '+%Y-%m-%dT%H:%M:%S.000000000Z'
+      fi
+      exit 0
+      ;;
+  esac
+  exit 1
+fi
+exit 1
+MOCK_DOCKER
+chmod +x "${tmp_bin}/docker"
+
+# ---- fixtures ----------------------------------------------------------------
+# @paulp83's #1253 shape: hermesagent-20 structurally zeroed at a p50 an order of
+# magnitude below its healthy figure; the other 7 packs sum to 102/130.
+pack_row() { # pack_row <id> <passed> <total> <p50> [status] [extra-json]
+  printf '{"pack_id":"%s","passed":%s,"total":%s,"scenario_count":%s,"score":%s,"skipped":false,"status":"%s","latency":{"mean":%s,"p50":%s,"p95":%s}%s}' \
+    "$1" "$2" "$3" "$3" "$(awk -v p="$2" -v t="$3" 'BEGIN{printf (t?p/t:0)}')" "${5:-ok}" "$4" "$4" "$4" "${6:-}"
+}
+
+write_result() { # write_result <path> <thinking_mode|-> <packs-json>
+  local path="$1" tmode="$2" packs="$3" tm_field=""
+  [[ "$tmode" != "-" ]] && tm_field=",\"thinking_mode\":\"${tmode}\""
+  cat > "$path" <<JSON
+{"schema_version":1,"runner_version":"0.9.9","endpoint":"http://mock","model":"mock-model",
+ "mode":"full","started_at":"2026-09-12T00:00:00Z","finished_at":"2026-09-12T00:30:00Z",
+ "thinking_enabled":false${tm_field},"warnings":[],"packs":[${packs}]}
+JSON
+}
+
+SEVEN_VALID="$(pack_row toolcall-15 15 15 0.79),$(pack_row instructfollow-15 13 15 1.33),$(pack_row structoutput-15 15 15 2.07),$(pack_row dataextract-15 12 15 3.09),$(pack_row reasonmath-15 12 15 6.29),$(pack_row bugfind-15 11 15 5.66),$(pack_row cli-40 24 40 2.38)"
+
+write_result "${tmp_work}/paul-off.json" force-off \
+  "${SEVEN_VALID},$(pack_row hermesagent-20 0 20 2.40)"
+write_result "${tmp_work}/paul-healthy.json" force-off \
+  "${SEVEN_VALID},$(pack_row hermesagent-20 3 20 10.36)"
+write_result "${tmp_work}/skipped-sandbox.json" force-off \
+  "$(pack_row toolcall-15 15 15 0.79),{\"pack_id\":\"hermesagent-20\",\"passed\":0,\"total\":0,\"scenario_count\":20,\"score\":0.0,\"skipped\":true,\"status\":\"sandbox-unavailable\",\"latency\":null}"
+write_result "${tmp_work}/all-zero.json" force-off \
+  "$(pack_row toolcall-15 0 15 0.02),$(pack_row instructfollow-15 0 15 0.02)"
+write_result "${tmp_work}/pack-defaults.json" pack-defaults \
+  "${SEVEN_VALID},$(pack_row hermesagent-20 0 20 0.04)"
+write_result "${tmp_work}/no-tmode.json" - \
+  "${SEVEN_VALID},$(pack_row hermesagent-20 0 20 2.40)"
+
+# run_wrapper <fixture> [KEY=VAL ...] -- [wrapper args ...]
+run_wrapper() {
+  local fixture="$1"; shift
+  local extra_env=()
+  while [[ $# -gt 0 && "$1" != "--" ]]; do extra_env+=("$1"); shift; done
+  [[ "${1:-}" == "--" ]] && shift
+  : > "$record_log"
+  : > "${tmp_work}/benchlocal-args.log"
+  set +e
+  env PATH="${tmp_bin}:$PATH" \
+      BENCHLOCAL_MOCK_LOG="${tmp_work}/benchlocal-args.log" \
+      RECORD_MOCK_LOG="$record_log" \
+      MOCK_RESULT_JSON="$fixture" \
+      PREFLIGHT_NO_AUTODETECT=1 URL=http://mock MODEL=mock-model \
+      ${extra_env[@]+"${extra_env[@]}"} \
+      bash scripts/quality-test.sh "$@" > "$run_out" 2>&1
+  local rc=$?
+  set -e
+  RUN_RC=$rc
+  OUT="$(cat "$run_out")"
+}
+
+echo "--- case A: #1270 fires on a 0/N pack and refuses the bare TOTAL ---"
+run_wrapper "${tmp_work}/paul-off.json" -- --quick
+assert_contains A "$OUT" "STRUCTURAL-ZERO GUARD (#1270)"
+assert_contains A "$OUT" "hermesagent-20 scored 0/20"
+assert_contains A "$OUT" "p50 2.40s"
+assert_contains A "$OUT" "TOTAL (valid subset)  102 / 130 (78%)"
+assert_contains A "$OUT" "TOTAL (all packs)     102 / 150 (68%)   <- do not cite"
+assert_contains A "$OUT" "verifier_fail rows are the MODEL being wrong and DO keep counting"
+# thinking_mode: force-off + a thinking-default-on pack -> name #1269 as the first suspect
+assert_contains A "$OUT" "check FIRST: thinking was forced OFF"
+assert_contains A "$OUT" "(#1269)"
+# the per-rig record is a bare TOTAL too: it must not be published
+assert_contains A "$OUT" "per-rig quality record NOT written"
+assert_not_contains A "$(cat "$record_log")" "MEASUREMENT_RECORD"
+
+echo "--- case B: no 0/N pack -> guard silent, record published (false-positive control) ---"
+run_wrapper "${tmp_work}/paul-healthy.json" -- --quick
+assert_not_contains B "$OUT" "STRUCTURAL-ZERO GUARD"
+assert_not_contains B "$OUT" "do not cite"
+assert_not_contains B "$OUT" "per-rig quality record NOT written"
+assert_contains B "$(cat "$record_log")" "MEASUREMENT_RECORD"
+assert_contains B "$(cat "$record_log")" "--quality-8pk 105/150"
+
+echo "--- case C: total==0 (sandbox-unavailable) is a SKIP, not a zero score ---"
+run_wrapper "${tmp_work}/skipped-sandbox.json" -- --quick
+assert_not_contains C "$OUT" "STRUCTURAL-ZERO GUARD"
+assert_contains C "$(cat "$record_log")" "MEASUREMENT_RECORD"
+
+echo "--- case D: every scored pack zeroed -> no valid subset to cite ---"
+run_wrapper "${tmp_work}/all-zero.json" -- --quick
+assert_contains D "$OUT" "STRUCTURAL-ZERO GUARD (#1270)"
+assert_contains D "$OUT" "TOTAL (valid subset)  none — every scored pack returned 0/N"
+assert_contains D "$OUT" "TOTAL (all packs)     0 / 30 (0%)   <- do not cite"
+
+echo "--- case E: thinking NOT forced off -> do not blame thinking ---"
+run_wrapper "${tmp_work}/pack-defaults.json" -- --quick
+assert_contains E "$OUT" "STRUCTURAL-ZERO GUARD (#1270)"
+assert_not_contains E "$OUT" "check FIRST: thinking was forced OFF"
+assert_contains E "$OUT" "cause not determined here"
+assert_contains E "$OUT" "endpoint reachable from a container"
+
+echo "--- case E2: JSON without thinking_mode falls back to the wrapper's NO_THINKING ---"
+run_wrapper "${tmp_work}/no-tmode.json" NO_THINKING=1 -- --quick
+assert_contains E2 "$OUT" "check FIRST: thinking was forced OFF"
+
+echo "--- case F: #1269 up-front notice on --full --no-thinking ---"
+run_wrapper "${tmp_work}/paul-off.json" -- --full --no-thinking
+assert_contains F "$OUT" "--no-thinking + hermesagent-20 is a KNOWN-RISKY combination (#1269)"
+assert_contains F "$OUT" "NOT ATTEMPTING"
+assert_contains F "$OUT" "denominator drops by its 20 scenarios (--full: 150 → 130)"
+assert_contains F "$OUT" "instructfollow-15 / reasonmath-15 /"
+assert_contains F "$OUT" "--no-sandboxed, or --medium"
+assert_not_contains F "$OUT" "sandbox packs (BugFind / CLI / Hermes) will be SKIPPED"
+
+echo "--- case G: --medium --no-thinking has no hermesagent-20 -> no notice ---"
+run_wrapper "${tmp_work}/paul-healthy.json" -- --medium --no-thinking
+assert_contains G "$OUT" "thinking: disabled for every pack"
+assert_not_contains G "$OUT" "KNOWN-RISKY combination (#1269)"
+
+echo "--- case H: --full WITHOUT --no-thinking -> no notice ---"
+run_wrapper "${tmp_work}/paul-healthy.json" -- --full
+assert_not_contains H "$OUT" "KNOWN-RISKY combination (#1269)"
+
+echo "--- case I: --full --no-thinking --no-sandboxed drops hermes -> no notice ---"
+run_wrapper "${tmp_work}/paul-healthy.json" -- --full --no-thinking --no-sandboxed
+assert_contains I "$OUT" "thinking: disabled for every pack"
+assert_not_contains I "$OUT" "KNOWN-RISKY combination (#1269)"
+
+echo "--- case J: --pack hermesagent-20 --no-thinking -> notice ---"
+run_wrapper "${tmp_work}/paul-off.json" -- --pack hermesagent-20 --no-thinking
+assert_contains J "$OUT" "KNOWN-RISKY combination (#1269)"
+
+echo "--- case K: an unreadable results JSON must say so, not pass silently ---"
+: > "${tmp_work}/truncated.json"
+printf '{"packs":[{"pack_id":"toolcall-15",' > "${tmp_work}/truncated.json"
+run_wrapper "${tmp_work}/truncated.json" -- --quick
+assert_contains K "$OUT" "structural-zero guard could not read"
+assert_contains K "$OUT" "has NOT been checked for 0/N packs"
+
+if [[ "$FAILED" != "0" ]]; then
+  echo "FAIL: test-quality-zero-pack" >&2
+  exit 1
+fi
+echo "PASS: test-quality-zero-pack (#1269 notice + #1270 structural-zero guard)"


### PR DESCRIPTION
Ships the **#1270** structural-zero guard. **#1269's premise was retracted during review** and every
claim built on it has been removed from this branch — see *What #1269 turned out to be* below.
`Closes #1270`; `Refs #1269`, which stays **open** as the unresolved-cause investigation.

## The defect

A pack that comes back `0 / N` is almost never a model score — it is the harness, the config or
the endpoint. But the TOTAL counted those N scenarios as model failures, and the result was
plausible enough to publish: #1253's leg A read **102/150 (68%)** where the valid subset was
**102/130 (78%)**. Ten points of apparent instruct deficit from one structurally-zeroed pack.

## The mechanism the existing guard missed

`scripts/quality-test.sh` already guarded this exact arithmetic — its comment describes the
damage almost verbatim — but for **one cause**: it probes whether the endpoint is reachable from a
container (#960). That endpoint *was* reachable, so the preflight passed correctly and the damage
happened anyway. We reasoned about the failure class, shipped a cause-specific preflight, and left
the **outcome** undetected. Any other cause produces the same misleading TOTAL: a sandboxed agent
whose harness fails to initialise, Docker dying mid-run, an image pull failure, a sandbox OOM, a
pack version mismatch.

## What ships (#1270)

Implemented on our side, not in `benchlocal-cli`. Confirmed first: the wrapper already drives the
CLI with `--save-json` on every run, and the saved JSON carries per-pack `passed` / `total` /
`score` / `status` / `skipped` / `latency.p50` plus a `totals` rollup — verified against real saved
runs, not assumed. No parse was invented and `benchlocal-cli` was not touched.

When any pack has `total > 0` and `passed == 0`:

```
==========================================================================
⚠️  STRUCTURAL-ZERO GUARD (#1270) — a pack scored 0/N, so the bare TOTAL
    printed above is NOT citable.
==========================================================================
  hermesagent-20 scored 0/20 (p50 1.51s, status=ok) — excluded from the TOTAL as a
    suspected structural failure, not as a model score.
    * cause not determined here — candidates, cheapest first: endpoint not
      reachable from a container (#960); a sandboxed agent whose harness failed
      to initialise (returns fast, reports every scenario as verifier_fail);
      Docker/sandbox health; sandbox image build or pull; sandbox OOM; pack
      version mismatch. Read the trace before reading the score:
      benchlocal-cli inspect <json> --pack hermesagent-20 --full
    * p50 1.51s is CORROBORATION only, never the trigger. …

  TOTAL (valid subset)  102 / 130 (78%)
  TOTAL (all packs)     102 / 150 (68%)   <- do not cite

  A whole pack at 0/N is a harness/config outcome until proven otherwise.
  Individual verifier_fail rows are the MODEL being wrong and DO keep counting
  toward both figures — this guard fires only on a whole pack scoring zero.
  But a whole pack OF verifier_fail rows can itself be a harness fault: a
  sandboxed agent that dies in its constructor reports exactly that shape.
==========================================================================
```

- **The `0/N` is the trigger.** Latency is printed alongside and never gates the warning.
- **It lists candidate causes and does not guess one.** Deliberately not thinking-aware — see below.
- **`verifier_fail` is not conflated**, with the one qualification the investigation earned: per
  *row* it is the model being wrong and keeps counting; a whole *pack* of them can be the harness.
- **`total == 0` is a skip, not a zero** (sandbox-unavailable, stubbed gate) — no trigger, and it
  enters neither denominator.
- **Every pack zeroed** prints "no valid subset — the whole run is suspect" rather than `0 / 0`.
- **The per-rig quality record is not published** for such a run. Its `8pk` field *is* a bare TOTAL
  (rendered verbatim downstream). The skip and its printed reason are the same branch, so the
  notice cannot appear without the skip happening.
- **Exit code deliberately unchanged.** A genuine `0/N` is possible, so the guard refuses
  *publication*, not the run; a non-zero exit would red legitimate historical shapes.
- **If the probe itself breaks** (unreadable / truncated JSON) it says so on stderr rather than
  returning "found nothing" — success is not allowed to look like failure.

## What #1269 turned out to be — premise retracted

The first revision of this PR added a `--no-thinking` × `hermesagent-20` warning and a
"check FIRST: thinking was forced OFF" attribution in the guard. **The saved results refute the
premise**, so both are gone. Across 150 full 20-scenario `hermesagent-20` entries (filtered on
per-pack `thinking_enabled`, run-level as fallback):

| | n | median | mean | range | runs at 0/20 |
|---|--:|--:|--:|--:|--:|
| thinking OFF | 74 | 11/20 | 10.3 | 0–15 | **4** |
| thinking ON | 76 | 12/20 | 11.1 | 0–16 | **6** |

Structural zeros occur on **both** arms and slightly **more** often with thinking ON. Paired per
model the off arm costs ~1–2 scenarios of 20 — the same graceful degradation the other three
thinking-default-on packs show. A `qwen3.8-27b` leg at `thinking_mode=force-off` scored 14/20 at
p50 22.3 s. So `--no-thinking` × `hermesagent-20` is **not** a risky combination and that pack is
**not** "the outlier".

And three of the four thinking-off zeros are **one incident**: three consecutive runs, every
scenario ~1.5 s, reported as 20 × `verifier_fail`, with `agent_exit_code=1`, `tool_events=0` and
`AIAgent.__init__() got an unexpected keyword argument 'persist_session'` in the trace. A hermes-agent
constructor mismatch wearing the model's label — exactly the shape the #1270 guard exists to catch,
and the reason its `verifier_fail` caveat is now qualified.

Removed on that basis:

1. the up-front "KNOWN-RISKY combination" notice and its `_pack_set_includes_hermes` resolver — a
   warning that fires on every off-leg and misattributes the cause is worse than silence, because
   it steers future triage straight at thinking, which is where triage went wrong;
2. the help-text claim that `hermesagent-20` "can COLLAPSE to 0/20 with thinking forced off … while
   the other three degrade gracefully", replaced by the measured off-vs-on medians (all four
   degrade gracefully);
3. the guard's `forced_off and pid in THINKING_DEFAULT_ON` branch, the `THINKING_DEFAULT_ON` set and
   the `NO_THINKING` argv it needed — every zeroed pack now gets the same cause-agnostic list,
   which gained the real observed cause and a pointer at the trace;
4. the `--no-thinking` × `hermesagent-20` callout in `docs/QUALITY_TEST.md`, replaced by the table
   above and "treat a 0/20 as a structural failure, not as evidence about thinking".

`SANDBOX_PACKS_SKIPPED` went with (1): it was scaffolding for that notice and became write-only
once the notice was removed — the sandbox preflight never read it. That region is now byte-identical
to `master`.

Kept, unchanged in behaviour: the #1270 guard. The evidence only supports it.

## Negative controls

`scripts/tests/test-quality-zero-pack.sh` — 12 cases, driven end-to-end through the real wrapper
with mocked `curl` / `benchlocal-cli` / `docker`, plus a `python3` shim that records
`measurement_record.py` invocations so the record refusal is asserted **at the call**, not only via
a log line. No GPU, no engine, no live endpoint.

**#1270 controls — against `master`'s wrapper** (`git show master:scripts/quality-test.sh`, same test file):

```
PRE-FIX EXIT=1
  FAIL x8  case A   guard block, both TOTAL figures, the "do not cite" marker, the record
                    refusal — and the record log contained
                    "MEASUREMENT_RECORD … --quality-8pk 102/150", i.e. the pre-fix wrapper
                    published the misleading figure
  FAIL x3  case D   every-pack-zeroed wording
  FAIL x6  case E   cause-agnostic candidate list + the qualified verifier_fail caveat
  FAIL x3  case E2  the force-off 0/20 shape is not reported at all
  FAIL x2  case F   guard does not fire on the --full --no-thinking run
  FAIL x2  case K   an unreadable results JSON passes silently
  pass     cases B, C, G, H, I — they assert ABSENCE, so a guard that fired unconditionally
                    would fail them
```

**Retraction controls — against the previous commit on this branch** (`bfae6ae9`, which carried the notice):

```
EXIT=1
  FAIL x3  case E   still named thinking as the cause
  FAIL x5  case E2  "thinking was forced OFF" / "#1269" attribution on a force-off 0/20
  FAIL x4  case F   "KNOWN-RISKY", "NOT ATTEMPTING", "150 → 130"
  FAIL x2  case J   notice on --pack hermesagent-20 --no-thinking
  pass     every #1270 case — the guard's behaviour is unchanged by the retraction
```

Post-fix: `EXIT=0`, `PASS: test-quality-zero-pack (#1270 structural-zero guard, cause-agnostic by
design)`, all 12 cases.

## Gates run

Only those relevant to this change (other work is in flight on the shared checkout; the full sweep
is for the maintainer to run serially on `master`). All **PASS**:

```
test-quality-zero-pack (new)   test-quality-thinking       test-quality-card
test-quality-passthrough       test-quality-baseline       test-thinking-control
test-thinking-pin              test-thinking-probe-optin   test-rerun-failed-packs
test-report-exit-code          test-measurement-record     test-locale-utf8
test-script-permissions        test-docs-slugs-resolve
```

`test-quality-passthrough` includes the docs flag-drift guard, which covers the `docs/QUALITY_TEST.md`
edits. Also smoke-checked `--both-modes` (guard fires per leg, exit codes unchanged) and `--resume`
(guard reads the restored JSON) through the mock.

## Files changed

- `scripts/quality-test.sh` — structural-zero guard, record refusal, help text. Two regions differ
  from `master`; no new CLI flags.
- `scripts/tests/test-quality-zero-pack.sh` — new.
- `docs/QUALITY_TEST.md` — a "whole pack at 0/N" subsection under *Diagnosing failures*, and the
  measured off-vs-on table on the canonical two-leg run.

`benchlocal-cli` untouched; no other scripts touched.

Closes #1270
Refs #1269

🤖 Generated with [Claude Code](https://claude.com/claude-code)
