### PR TITLE
fix(rig-state): resolve the power cap from its unit, and stop p2p_gpu_count emitting two lines (#1279, #1281)

### DIFF
--- a/scripts/gpu-mode.sh
+++ b/scripts/gpu-mode.sh
@@ -888,22 +888,79 @@ stop_estate() {
 }
 
 # --- GPU power-cap controls -------------------------------------------------
-# The rig normally runs both 3090s capped at 250W (quieter / cooler — see the
-# systemd unit below). The cap suppresses benchmark TPS, so maintainers need a
-# quick way to uncap to the hardware default for a true-TPS bench, then re-cap.
+# The rig normally runs both 3090s capped below stock (quieter / cooler — see
+# the systemd unit below). The cap suppresses benchmark TPS, so maintainers need
+# a quick way to uncap to the hardware default for a true-TPS bench, then re-cap.
 #
-# `nvidia-power-cap.service` is the single source of truth for the 250W value
-# AND re-applies it on every boot (Type=oneshot, RemainAfterExit=yes, enabled).
-# So `power-cap on` *restarts* that unit — `restart` (not `start`) is required:
-# the unit is already `active` from boot, and `systemctl start` on an
+# ⚠️ THIS SCRIPT HOLDS NO WATTAGE OF ITS OWN. `nvidia-power-cap.service` is the
+# single source of truth for the capped value, and we *read* it from the unit
+# (`systemctl cat` → its `-pl <watts>` ExecStart lines) instead of restating it.
+# It used to be restated: the comment block said 250W and the fallback below
+# executed `nvidia-smi -pl 250`, while the installed unit on this rig caps at
+# 230W — so the two halves of `power-cap on` disagreed about what "on" means,
+# and both reported success (#1281). A cap applied at the wrong wattage is worse
+# than no cap at all, because the benchmark it distorts still looks valid: a
+# cap on this class of rig already produced a −40% reading that was very nearly
+# filed upstream as a speculative-decoding regression. So when the unit is
+# missing or unparseable we REFUSE and say so — we never substitute a guess.
+#
+# The unit re-applies the cap on every boot (Type=oneshot, RemainAfterExit=yes,
+# enabled). So `power-cap on` *restarts* it — `restart` (not `start`) is
+# required: the unit is already `active` from boot, and `systemctl start` on an
 # already-active RemainAfterExit oneshot is a no-op (it won't re-run ExecStart,
 # so the cap wouldn't actually re-apply after a `power-cap off`). `restart`
-# stops it (clearing RemainAfterExit) then re-runs both `-pl 250` ExecStart
-# lines. `power-cap off` reads each card's Default Power Limit from nvidia-smi
+# stops it (clearing RemainAfterExit) then re-runs its ExecStart lines; the
+# fallback below replays exactly those parsed lines when systemd won't.
+# `power-cap off` reads each card's Default Power Limit from nvidia-smi
 # (370W on GPU 0, 420W on GPU 1 here — they differ, so we never hardcode) and
 # applies it. `off` is session-scoped: a reboot OR a driver reload re-applies
-# 250W via the service. We never disable the service.
+# the unit's cap. We never disable the service.
 POWER_CAP_SERVICE="nvidia-power-cap.service"
+
+# powercap_service_plan — the cap the service actually defines, as one
+# "<gpu-index|all> <watts>" row per power-limit ExecStart directive in the unit.
+# Exits 1 printing NOTHING when the unit is absent, unreadable, or carries no
+# parseable wattage — the caller must refuse rather than invent one (#1281).
+powercap_service_plan() {
+    local unit
+    unit="$(systemctl cat "$POWER_CAP_SERVICE" 2>/dev/null)" || return 1
+    [ -n "$unit" ] || return 1
+    printf '%s\n' "$unit" | awk '
+        /^[[:space:]]*ExecStart[[:space:]]*=/ {
+            idx = ""; watts = ""
+            for (i = 1; i <= NF; i++) {
+                if (($i == "-i" || $i == "--id") && i < NF)                 idx   = $(i+1)
+                else if ($i ~ /^--id=/)                                     { split($i, a, "="); idx   = a[2] }
+                else if (($i == "-pl" || $i == "--power-limit") && i < NF)  watts = $(i+1)
+                else if ($i ~ /^--power-limit=/)                            { split($i, a, "="); watts = a[2] }
+            }
+            if (watts ~ /^[0-9]+(\.[0-9]+)?$/) {
+                if (idx !~ /^[0-9]+$/) idx = "all"
+                print idx, watts
+                found++
+            }
+        }
+        END { exit (found > 0 ? 0 : 1) }'
+}
+
+# Display label for a plan: "230W", or "230W/250W" when the unit caps cards
+# differently. Display only — the applied values always come from the plan.
+powercap_plan_watts_label() {
+    printf '%s\n' "$1" | awk '
+        $2 != "" && !($2 in seen) { seen[$2] = 1; out = (out == "" ? $2 "W" : out "/" $2 "W") }
+        END { print out }'
+}
+
+# Same label for informational messages, degrading to a number-free phrase when
+# the unit cannot be read — a message must not invent a wattage either.
+powercap_service_watts_label() {
+    local plan
+    if plan="$(powercap_service_plan)"; then
+        powercap_plan_watts_label "$plan"
+    else
+        printf '%s\n' "its configured cap"
+    fi
+}
 
 # Print per-GPU enforced / default / min / max power limits (one row per card).
 powercap_show() {
@@ -937,7 +994,7 @@ mode_powercap() {
     # A numeric action = an explicit CUSTOM wattage applied to both cards (the
     # serve-cockpit power-cap menu's "custom" option).  Validated against each
     # card's [min,max] range; session-scoped like `off` (the boot service still
-    # re-applies 250W on reboot/reload).
+    # re-applies its own cap on reboot/reload).
     if [[ "$action" =~ ^[0-9]+$ ]]; then
         echo -e "${CYAN}═══ Setting custom GPU power cap (${action}W) ═══${NC}"
         local cidx cmin cmax crc=0 capplied=0
@@ -963,24 +1020,48 @@ mode_powercap() {
             exit 1
         fi
         echo -e "${GREEN}Custom cap ${action}W applied.${NC} ${YELLOW}Session-scoped — a reboot or driver"
-        echo -e "reload re-applies 250W via ${POWER_CAP_SERVICE}.${NC}"
+        echo -e "reload re-applies $(powercap_service_watts_label) via ${POWER_CAP_SERVICE}.${NC}"
         powercap_echo_enforced
         [ "$crc" -eq 0 ] || exit 1
         return
     fi
     case "$action" in
         on)
-            echo -e "${CYAN}═══ Re-applying GPU power cap (250W) ═══${NC}"
-            echo "Restarting ${POWER_CAP_SERVICE} (the boot-time 250W enforcer)."
+            # Resolve the wattage from the unit BEFORE touching anything. No
+            # literal here, and no guess: an unverified cap distorts every
+            # benchmark taken after it while still looking valid (#1281).
+            local plan label pidx pwatts prc=0
+            if ! plan="$(powercap_service_plan)"; then
+                echo -e "${RED}✗ Refusing to re-apply a power cap: cannot resolve one from ${POWER_CAP_SERVICE}.${NC}" >&2
+                echo "  The unit is missing, unreadable, or has no parseable '-pl <watts>' ExecStart line," >&2
+                echo "  and this script deliberately keeps no wattage of its own. Applying a guessed cap is" >&2
+                echo "  worse than applying none — the benchmark it silently suppresses still looks valid." >&2
+                echo "  Inspect the unit:   systemctl cat ${POWER_CAP_SERVICE}" >&2
+                echo "  Or cap explicitly:  gpu-mode power-cap <WATTS>" >&2
+                exit 1
+            fi
+            label="$(powercap_plan_watts_label "$plan")"
+            echo -e "${CYAN}═══ Re-applying GPU power cap (${label}, per ${POWER_CAP_SERVICE}) ═══${NC}"
+            echo "Restarting ${POWER_CAP_SERVICE} (the boot-time ${label} enforcer)."
             # restart, not start — the unit is already active from boot, so
             # `start` is a no-op on a RemainAfterExit oneshot (won't re-run -pl).
             if sudo systemctl restart "$POWER_CAP_SERVICE" 2>/dev/null; then
                 echo -e "${GREEN}Power cap re-applied via systemd.${NC}"
             else
-                # Fallback: service missing/disabled — apply 250W directly.
-                echo -e "${YELLOW}systemctl restart failed; falling back to direct nvidia-smi -pl 250.${NC}" >&2
-                if ! { sudo nvidia-smi -i 0 -pl 250 && sudo nvidia-smi -i 1 -pl 250; }; then
-                    echo -e "${RED}✗ Failed to set 250W cap.${NC} Check sudo + driver state with: nvidia-smi -q -d POWER" >&2
+                # Fallback: the unit exists (we just parsed it) but systemd
+                # would not run it — masked, disabled, failed dependency. Replay
+                # exactly the caps the unit itself defines, never a literal.
+                echo -e "${YELLOW}systemctl restart failed; replaying the unit's own ExecStart caps directly (${label}).${NC}" >&2
+                while read -r pidx pwatts; do
+                    [ -z "$pidx" ] && continue
+                    if [ "$pidx" = "all" ]; then
+                        sudo nvidia-smi -pl "$pwatts" >/dev/null 2>&1 || prc=1
+                    else
+                        sudo nvidia-smi -i "$pidx" -pl "$pwatts" >/dev/null 2>&1 || prc=1
+                    fi
+                done <<< "$plan"
+                if [ "$prc" -ne 0 ]; then
+                    echo -e "${RED}✗ Failed to apply the ${label} cap.${NC} Check sudo + driver state with: nvidia-smi -q -d POWER" >&2
                     exit 1
                 fi
             fi
@@ -1009,7 +1090,7 @@ mode_powercap() {
                 exit 1
             fi
             echo -e "${GREEN}Uncapped to default.${NC} ${YELLOW}Session-scoped — a reboot or driver"
-            echo -e "reload re-applies 250W via ${POWER_CAP_SERVICE}. Run 'gpu-mode power-cap on' to re-cap now.${NC}"
+            echo -e "reload re-applies $(powercap_service_watts_label) via ${POWER_CAP_SERVICE}. Run 'gpu-mode power-cap on' to re-cap now.${NC}"
             powercap_echo_enforced
             [ "$rc" -eq 0 ] || exit 1
             ;;
@@ -1086,7 +1167,7 @@ gemma12b	models	Gemma 4 12B AutoRound INT8 + bf16 KV + MTP n=2 (gemma4_unified a
 deckard	models	Qwen3.6-40B-Deckard Q6_K + MTP n=2 + q8_0 KV + 128K (llama.cpp, dual)	llama-cpp-deckard-40b,litellm,qdrant,openwebui,searxng,spark-dashboard	8199,8080,4000,3010	both
 ai-studio	studio	image · video · audio · voice — ComfyUI both GPUs + qwen director + sidecars + Open WebUI (pick the lane in OWUI)	comfyui,studio-director,studio-gallery,studio-orchestrator,studio-image-shim,studio-tts,studio-step-voice,openwebui,litellm,qdrant,searxng,spark-dashboard	8188,8090,8189,8190,8191,8192,8193,8080,4000,6333,3010	both
 off	ops	Stop all services	all-stopped		none
-power-cap	ops	GPU power-cap controls (on/off/status; both 3090s, 250W default cap)			both
+power-cap	ops	GPU power-cap controls (on/off/status; both 3090s, cap value read from nvidia-power-cap.service)			both
 prune	ops	docker image prune -a (safe — only unreferenced images)			none
 prune-all	ops	+ build cache (keep 5 GB) + dangling networks (volumes safe)			none
 TSV
@@ -1167,10 +1248,11 @@ usage() {
     echo "  off                Stop all services"
     echo "  status             Show running services, GPU, RAM, disk, Docker disk"
     echo ""
-    echo "  GPU power cap (both 3090s; normally capped at 250W for quiet/cool operation):"
-    echo "  power-cap on       Re-apply the 250W cap (via nvidia-power-cap.service)"
+    echo "  GPU power cap (both 3090s; normally capped below stock for quiet/cool operation):"
+    echo "  power-cap on       Re-apply the cap nvidia-power-cap.service defines (read from the"
+    echo "                     unit, never hardcoded; refuses if the unit is missing/unparseable)"
     echo "  power-cap off      Uncap to hardware default for a true-TPS bench"
-    echo "                     (session-scoped — a reboot / driver reload re-caps at 250W)"
+    echo "                     (session-scoped — a reboot / driver reload re-caps via the unit)"
     echo "  power-cap <WATTS>  Apply a custom cap to both cards (e.g. 'power-cap 280';"
     echo "                     validated against each card's [min,max]; session-scoped)"
     echo "  power-cap status   Show per-GPU enforced / default / min / max power limits"

--- a/scripts/lib/p2p-state.sh
+++ b/scripts/lib/p2p-state.sh
@@ -18,9 +18,25 @@
 #   pcie_p2p forced, grant UNVERIFIED  -> WARN (looked engaged, wasn't — #688;
 #                                        driver didn't confirm peer access)
 
-# GPU count (host).
+# GPU count (host). Prints EXACTLY one line: a non-negative integer.
+#
+# The `|| echo 0` this used to carry was not a fallback, it was the bug (#1279):
+# `grep -c` PRINTS `0` *and* exits 1 when it matches nothing, so on any rig where
+# `nvidia-smi -L` fails or lists no GPUs, BOTH sides fired and the function
+# returned the two-line string "0\n0". Every consumer does arithmetic on it
+# (`[[ "$(p2p_gpu_count)" -ge 2 ]]`), which then dies with
+# `[[: 0 0: syntax error in expression` — pasted straight into the diagnostic
+# report a user is about to send us. A caller-side `|| echo 0` cannot rescue it
+# either: the function already exited 0, its last command having been the echo.
+#
+# So: capture the count, keep grep's no-match exit off `set -e`/pipefail, and
+# print one integer whatever happened. `command grep` because the interactive
+# shell shims grep to ugrep.
 p2p_gpu_count() {
-  nvidia-smi -L 2>/dev/null | grep -c '^GPU ' || echo 0
+  local n
+  n="$(nvidia-smi -L 2>/dev/null | command grep -c '^GPU ')" || true
+  [[ "$n" =~ ^[0-9]+$ ]] || n=0
+  printf '%s\n' "$n"
 }
 
 # Host capability: "nvlink" | "pcie_p2p" | "none".

--- a/scripts/tests/test-gpu-mode-power-cap.sh
+++ b/scripts/tests/test-gpu-mode-power-cap.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# test-gpu-mode-power-cap — `gpu-mode power-cap on` must apply the wattage the
+# systemd unit defines, or refuse. It must never apply one of its own.
+#
+# Why this test exists. The script documented the cap as 250 W and called
+# nvidia-power-cap.service "the single source of truth for the 250W value" — but
+# never read the unit. The value was restated in comments and then applied
+# LITERALLY in a path that runs: when `systemctl restart` failed, the fallback
+# executed `nvidia-smi -i 0 -pl 250 && nvidia-smi -i 1 -pl 250`. On the reference
+# rig that unit's ExecStart lines say `-pl 230`, so the fallback capped 20 W away
+# from the service it was standing in for — and reported success either way.
+#
+# That class of error is expensive here: a cap on this rig produced a −40%
+# reading that looked exactly like an upstream speculative-decoding regression
+# and was nearly filed as an engine bug. An unverified cap is worse than no cap,
+# because the benchmark it suppresses still looks valid. Hence: resolve from the
+# unit, or refuse loudly.
+#
+# Contract asserted here:
+#   - unit missing / unparseable        -> REFUSE, non-zero exit, NOTHING applied;
+#   - unit present + systemd restart OK -> systemd does it, no direct -pl at all;
+#   - unit present + restart FAILS      -> replay EXACTLY the unit's own values;
+#   - the `-i`/`-pl` pairs and the wattage in every message come from the unit;
+#   - no power-limit wattage literal survives anywhere in executed code.
+#
+# No GPU is touched: nvidia-smi, sudo and systemctl are all recording stubs, and
+# the harness refuses to run unless it has verified it shadowed the real ones.
+set -uo pipefail
+
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+GPU_MODE="$ROOT_DIR/scripts/gpu-mode.sh"
+
+PASS=0; FAIL=0
+ok() { PASS=$((PASS+1)); }
+no() { echo "FAIL: $1" >&2; FAIL=$((FAIL+1)); }
+eq()     { if [[ "$2" == "$3" ]];  then ok; else no "$1: expected '$3', got '$2'"; fi; }
+has()    { if [[ "$2" == *"$3"* ]]; then ok; else no "$1: missing '$3' — output: $CURRENT_DUMP"; fi; }
+hasnt()  { if [[ "$2" != *"$3"* ]]; then ok; else no "$1: must NOT contain '$3' — output: $CURRENT_DUMP"; fi; }
+
+TMP="$(mktemp -d)"
+BIN="$TMP/bin"; mkdir -p "$BIN"
+DUMPS="$TMP/dumps"; mkdir -p "$DUMPS"
+DUMP_IDX=0
+CURRENT_DUMP="(none)"
+trap 'rm -rf "$TMP"' EXIT
+
+# ── recording stubs ──────────────────────────────────────────────────────────
+# nvidia-smi: answers the query forms the script uses and RECORDS every
+# invocation. `-pl` is recorded and NEVER applied — this rig's cap is
+# deliberately cleared and a test must not change it.
+cat > "$BIN/nvidia-smi" <<'EOS'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$NVSMI_REC"
+case "$*" in
+  *"index,power.limit,power.default_limit,power.min_limit,power.max_limit"*)
+      printf '%s\n' "${MOCK_FULL_ROWS:-}" ;;
+  *"index,power.min_limit,power.max_limit"*)
+      printf '%s\n' "${MOCK_RANGE_ROWS:-}" ;;
+  *"index,power.default_limit"*)
+      printf '%s\n' "${MOCK_DEFAULT_ROWS:-}" ;;
+  *"index,power.limit"*)
+      printf '%s\n' "${MOCK_LIMIT_ROWS:-}" ;;
+  *-pl*)
+      exit "${MOCK_PL_RC:-0}" ;;
+esac
+exit 0
+EOS
+
+# systemctl: `cat` serves the unit fixture named by MOCK_UNIT_FILE (absent file
+# = the unit does not exist, exit 1, like the real thing); `restart` returns
+# MOCK_RESTART_RC so the fallback can be driven deterministically.
+cat > "$BIN/systemctl" <<'EOS'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$SYSTEMCTL_REC"
+case "${1:-}" in
+  cat)
+      if [[ -n "${MOCK_UNIT_FILE:-}" && -f "${MOCK_UNIT_FILE}" ]]; then
+        cat "$MOCK_UNIT_FILE"; exit 0
+      fi
+      echo "No files found for ${2:-}." >&2; exit 1 ;;
+  restart) exit "${MOCK_RESTART_RC:-0}" ;;
+esac
+exit 0
+EOS
+
+# sudo: transparent, so `sudo nvidia-smi …` lands on the stub above.
+printf '#!/usr/bin/env bash\nexec "$@"\n' > "$BIN/sudo"
+chmod +x "$BIN/nvidia-smi" "$BIN/systemctl" "$BIN/sudo"
+
+export PATH="$BIN:$PATH"
+export NVSMI_REC="$TMP/nvidia-smi.calls"
+export SYSTEMCTL_REC="$TMP/systemctl.calls"
+export MOCK_FULL_ROWS MOCK_RANGE_ROWS MOCK_DEFAULT_ROWS MOCK_LIMIT_ROWS
+export MOCK_PL_RC MOCK_UNIT_FILE MOCK_RESTART_RC
+MOCK_LIMIT_ROWS="$(printf '0, 230.00\n1, 230.00')"
+MOCK_DEFAULT_ROWS="$(printf '0, 370.00\n1, 420.00')"
+MOCK_RANGE_ROWS="$(printf '0, 100.00, 390.00\n1, 100.00, 440.00')"
+MOCK_FULL_ROWS="0, 230.00, 370.00, 100.00, 390.00"
+MOCK_PL_RC=0
+
+# ── harness integrity gate ───────────────────────────────────────────────────
+# If PATH shadowing silently failed, every assertion below would still "pass"
+# while the REAL sudo/nvidia-smi changed this rig's power limits. Refuse to run.
+for tool in nvidia-smi systemctl sudo; do
+  resolved="$(command -v "$tool" || true)"
+  if [[ "$resolved" != "$BIN/$tool" ]]; then
+    echo "FAIL: harness did not shadow $tool (resolved: ${resolved:-<none>}) — refusing to run" >&2
+    exit 1
+  fi
+done
+
+# ── unit fixtures ────────────────────────────────────────────────────────────
+# What `systemctl cat` prints for the reference rig's unit: 230 W, not 250 W.
+cat > "$TMP/unit-230.service" <<'EOS'
+# /etc/systemd/system/nvidia-power-cap.service
+[Unit]
+Description=Cap both 3090s for quiet/cool operation
+After=nvidia-persistenced.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/nvidia-smi -i 0 -pl 230
+ExecStart=/usr/bin/nvidia-smi -i 1 -pl 230
+
+[Install]
+WantedBy=multi-user.target
+EOS
+
+# Long-form flag, no per-card index — must still resolve.
+cat > "$TMP/unit-longform.service" <<'EOS'
+# /etc/systemd/system/nvidia-power-cap.service
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/nvidia-smi --power-limit=280
+EOS
+
+# A unit that exists but caps nothing — unparseable, must be refused, not guessed.
+cat > "$TMP/unit-nopl.service" <<'EOS'
+# /etc/systemd/system/nvidia-power-cap.service
+[Service]
+Type=oneshot
+ExecStart=/bin/true
+EOS
+
+# run_powercap <label> <arg...> — full output captured to a file (never piped
+# through head/tail at run time: that would swallow the diagnostic AND the exit
+# status). Sets OUT / RC / CURRENT_DUMP, and truncates the call recorders first.
+run_powercap() {
+  local label="$1"; shift
+  DUMP_IDX=$((DUMP_IDX+1))
+  CURRENT_DUMP="$DUMPS/$(printf '%02d' "$DUMP_IDX")-${label}.log"
+  : > "$NVSMI_REC"; : > "$SYSTEMCTL_REC"
+  bash "$GPU_MODE" power-cap "$@" > "$CURRENT_DUMP" 2>&1
+  RC=$?
+  OUT="$(cat "$CURRENT_DUMP")"
+  PL_CALLS="$(command grep -- '-pl' "$NVSMI_REC" || true)"
+}
+
+# ===========================================================================
+# 1. Unit MISSING -> refuse. Nothing applied, non-zero exit.
+#    Pre-fix this silently applied 250 W and exited 0.
+# ===========================================================================
+MOCK_UNIT_FILE="$TMP/does-not-exist.service"
+MOCK_RESTART_RC=1
+run_powercap "unit-missing" on
+if [[ "$RC" -ne 0 ]]; then ok; else no "unit missing: expected non-zero exit, got $RC — output: $CURRENT_DUMP"; fi
+has  "unit missing: says it is refusing"   "$OUT" "Refusing to re-apply a power cap"
+has  "unit missing: names the unit"        "$OUT" "systemctl cat nvidia-power-cap.service"
+has  "unit missing: offers the explicit escape hatch" "$OUT" "gpu-mode power-cap <WATTS>"
+eq   "unit missing: NOTHING applied"       "$PL_CALLS" ""
+hasnt "unit missing: no invented wattage"  "$OUT" "250"
+
+# Same refusal when the unit exists but defines no power limit.
+MOCK_UNIT_FILE="$TMP/unit-nopl.service"
+run_powercap "unit-unparseable" on
+if [[ "$RC" -ne 0 ]]; then ok; else no "unit unparseable: expected non-zero exit, got $RC — output: $CURRENT_DUMP"; fi
+has "unit unparseable: refuses"            "$OUT" "Refusing to re-apply a power cap"
+eq  "unit unparseable: NOTHING applied"    "$PL_CALLS" ""
+
+# ===========================================================================
+# 2. Unit present, systemd restart FAILS -> replay the unit's OWN values.
+#    Pre-fix this applied 250 W against a unit that says 230 W.
+# ===========================================================================
+MOCK_UNIT_FILE="$TMP/unit-230.service"
+MOCK_RESTART_RC=1
+run_powercap "fallback-replays-unit" on
+eq "fallback: exit 0"                      "$RC" "0"
+eq "fallback: replays exactly the unit's ExecStart caps" \
+   "$PL_CALLS" "$(printf -- '-i 0 -pl 230\n-i 1 -pl 230')"
+has   "fallback: says what it is applying" "$OUT" "230W"
+hasnt "fallback: no 250 W anywhere"        "$OUT" "250"
+
+# Long-form `--power-limit=`, no `-i` -> applies to all cards at the unit's value.
+MOCK_UNIT_FILE="$TMP/unit-longform.service"
+run_powercap "fallback-longform" on
+eq "fallback longform: applies the unit's value to all cards" "$PL_CALLS" "-pl 280"
+has "fallback longform: label from the unit" "$OUT" "280W"
+
+# ===========================================================================
+# 3. Unit present, restart SUCCEEDS -> systemd applies it; no direct -pl.
+#    The banner must quote the unit's value, not a hardcoded one.
+# ===========================================================================
+MOCK_UNIT_FILE="$TMP/unit-230.service"
+MOCK_RESTART_RC=0
+run_powercap "restart-ok" on
+eq    "restart ok: exit 0"                 "$RC" "0"
+eq    "restart ok: no direct -pl (systemd did it)" "$PL_CALLS" ""
+has   "restart ok: restarted the unit"     "$(cat "$SYSTEMCTL_REC")" "restart nvidia-power-cap.service"
+has   "restart ok: banner quotes the unit's value" "$OUT" "230W"
+hasnt "restart ok: no 250 W anywhere"      "$OUT" "250"
+
+# ===========================================================================
+# 4. `off` and a custom wattage still work, and neither invents a cap value.
+#    `off` reads each card's own default (they differ) — unchanged behaviour.
+# ===========================================================================
+run_powercap "off" off
+eq    "off: exit 0"                        "$RC" "0"
+eq    "off: applies each card's own default" \
+      "$PL_CALLS" "$(printf -- '-i 0 -pl 370.00\n-i 1 -pl 420.00')"
+has   "off: session-scope note names the unit's value" "$OUT" "230W"
+hasnt "off: no 250 W anywhere"             "$OUT" "250"
+
+run_powercap "custom" 300
+eq    "custom: exit 0"                     "$RC" "0"
+eq    "custom: applies the requested value" \
+      "$PL_CALLS" "$(printf -- '-i 0 -pl 300\n-i 1 -pl 300')"
+hasnt "custom: no 250 W anywhere"          "$OUT" "250"
+
+# `off` with the unit absent must NOT refuse — uncapping needs no unit, and the
+# message must degrade to a number-free phrase rather than invent one.
+MOCK_UNIT_FILE="$TMP/does-not-exist.service"
+run_powercap "off-no-unit" off
+eq  "off without the unit: exit 0"         "$RC" "0"
+has "off without the unit: number-free session note" "$OUT" "its configured cap"
+
+# ===========================================================================
+# 5. Static guard — no power-limit wattage literal survives in executed code.
+#    Comment lines are stripped first: the comments deliberately record the old
+#    250 W literal as history, and that history must not be what the gate reads.
+# ===========================================================================
+CURRENT_DUMP="(static scan of scripts/gpu-mode.sh)"
+CODE="$(command grep -v '^[[:space:]]*#' "$GPU_MODE")"
+lits="$(printf '%s\n' "$CODE" | command grep -nE '(-pl|--power-limit)[= ]+[0-9]' || true)"
+eq "no -pl literal in executed code" "$lits" ""
+wlits="$(printf '%s\n' "$CODE" | command grep -nE '\(?[0-9]{3}[[:space:]]*W\b' || true)"
+eq "no wattage literal in executed strings" "$wlits" ""
+
+# ===========================================================================
+echo "test-gpu-mode-power-cap: ${PASS} passed, ${FAIL} failed"
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/scripts/tests/test-p2p-state.sh
+++ b/scripts/tests/test-p2p-state.sh
@@ -264,4 +264,49 @@ mk_smi 'GPU 0: RTX 3090\n' "$TOPO_PHB" "$P2P_CNS" "$MEM_SMALL"
 assert_empty "$(hint)"                                  # single card
 echo "  ✓ opportunity hint: split/firmware/driver tiers, BAR1 outranks CNS, silent when moot"
 
+# ── 10. p2p_gpu_count is EXACTLY one integer line, driver up or down (#1279) ─
+# `grep -c` prints 0 AND exits 1 on no match, so the old `|| echo 0` tail fired
+# too and the function returned "0\n0". Every consumer does arithmetic on the
+# result, so report.sh emitted `[[: 0 0: syntax error in expression` into the
+# diagnostic a user was about to send us. "Contains 0" would have passed against
+# the broken version — these assert the LINE COUNT and the arithmetic.
+count_under() {  # count_under <nvidia-smi stub body>
+  printf '#!/usr/bin/env bash\n%s\n' "$1" > "$TMP/nvidia-smi"
+  chmod +x "$TMP/nvidia-smi"
+  PATH="$TMP:$PATH" bash -c 'source scripts/lib/p2p-state.sh; p2p_gpu_count'
+}
+
+# (a) driver query FAILS outright (no GPU / driver not loaded) -> exactly "0"
+out="$(count_under 'exit 1')"
+[[ "$(printf '%s' "$out" | wc -l)" -eq 0 ]] \
+  || fail "failing nvidia-smi: expected ONE line, got $(printf '%s\n' "$out" | wc -l): $(printf '%q' "$out")"
+[[ "$out" =~ ^[0-9]+$ ]] || fail "failing nvidia-smi: not an integer: $(printf '%q' "$out")"
+[[ "$out" == "0" ]]      || fail "failing nvidia-smi: expected 0, got $(printf '%q' "$out")"
+
+# (b) nvidia-smi present but prints nothing matching (empty output) -> "0"
+out="$(count_under 'exit 0')"
+[[ "$out" == "0" ]] || fail "empty nvidia-smi -L: expected 0, got $(printf '%q' "$out")"
+
+# (c) the happy path still counts
+out="$(count_under "printf 'GPU 0: RTX 3090\\nGPU 1: RTX 3090\\n'")"
+[[ "$out" == "2" ]] || fail "two GPUs: expected 2, got $(printf '%q' "$out")"
+
+# (d) the DOWNSTREAM shape that broke: arithmetic on the result, driver down.
+# report.sh:566 runs `[[ "$(p2p_gpu_count)" -ge 2 ]]`; with "0\n0" bash aborts
+# the test with a syntax error ON STDERR and a non-zero status. Assert stderr
+# is clean and the comparison evaluates.
+printf '#!/usr/bin/env bash\nexit 1\n' > "$TMP/nvidia-smi"; chmod +x "$TMP/nvidia-smi"
+err="$(PATH="$TMP:$PATH" bash -c 'source scripts/lib/p2p-state.sh
+if [[ "$(p2p_gpu_count)" -ge 2 ]]; then echo many; else echo few; fi' 2>&1 >/dev/null)"
+[[ -z "$err" ]] || fail "arithmetic on p2p_gpu_count emitted to stderr: $err"
+r="$(PATH="$TMP:$PATH" bash -c 'source scripts/lib/p2p-state.sh
+if [[ "$(p2p_gpu_count)" -ge 2 ]]; then echo many; else echo few; fi' 2>/dev/null)"
+[[ "$r" == "few" ]] || fail "driver-down arithmetic should take the <2 branch (got $r)"
+
+# (e) and it must not trip a pipefail caller (bench.sh runs with -o pipefail)
+r="$(PATH="$TMP:$PATH" bash -c 'set -euo pipefail; source scripts/lib/p2p-state.sh; p2p_gpu_count')" \
+  || fail "p2p_gpu_count returned non-zero under set -euo pipefail"
+[[ "$r" == "0" ]] || fail "pipefail caller: expected 0, got $(printf '%q' "$r")"
+echo "  ✓ p2p_gpu_count: exactly one integer line, driver up or down; arithmetic-safe"
+
 echo "test-p2p-state: ok"


### PR DESCRIPTION
Closes #1279
Closes #1281

Two rig-state correctness defects. Both are silent, and both end up inside an artifact someone then trusts — one in a diagnostic report we ask users to paste, the other in the power envelope a benchmark was taken under.

---

## #1279 — `p2p_gpu_count()` returns the two-line string `"0\n0"`

**Mechanism.** `grep -c` **prints `0` and exits 1** when it matches nothing, so the trailing `|| echo 0` was not a fallback — both sides fired:

```bash
p2p_gpu_count() {
  nvidia-smi -L 2>/dev/null | grep -c '^GPU ' || echo 0    # -> "0\n0"
}
```

Five call sites do arithmetic on the result. `report.sh`'s `[[ "$(p2p_gpu_count)" -ge 2 ]]` therefore printed a **shell syntax error into the report body** on any rig where the driver query fails. The caller-side `|| echo 0` in `bench.sh` cannot rescue it: the function already exited 0, its last command having been the `echo`.

**Change** (`scripts/lib/p2p-state.sh` only — `report.sh` untouched): capture the count, keep the no-match exit off `set -e`/`pipefail`, print exactly one integer line. `command grep`, per the repo convention.

## #1281 — `power-cap on` applies a wattage the script invented

**Mechanism.** The script called `nvidia-power-cap.service` "the single source of truth for the 250W value" but never read the unit. The number lived in comments and in an **executed** fallback that fires whenever `systemctl restart` fails:

```bash
# Fallback: service missing/disabled — apply 250W directly.
if ! { sudo nvidia-smi -i 0 -pl 250 && sudo nvidia-smi -i 1 -pl 250; }; then
```

The installed unit's ExecStart lines say `-pl 230`. So the two halves of one command disagreed about what "on" means, and both reported success. That is the condition behind the −40% reading on this class of rig that looked exactly like an upstream speculative-decoding regression (identical TPS at spec_n=1 and n=2, healthy draft acceptance) and was nearly filed as an engine bug. It was the cap.

**Change** (`scripts/gpu-mode.sh`):

- `powercap_service_plan()` parses `systemctl cat nvidia-power-cap.service` into `<gpu-index|all> <watts>` rows (handles `-i N … -pl W`, `--id=`, `--power-limit=`).
- `power-cap on` resolves that **before touching anything**. Missing / unreadable / no parseable `-pl` ⇒ **refuse**, non-zero exit, nothing applied — an unverified cap is worse than none, because the benchmark it suppresses still looks valid. The refusal names `systemctl cat …` and the explicit `power-cap <WATTS>` escape hatch.
- The fallback now **replays exactly the pairs the unit defines**, so it can no longer disagree with the service it stands in for.
- **No power-limit wattage literal survives in any executed path**, messages included; the ones that cannot resolve the unit (`off` / custom-wattage session-scope notes) degrade to a number-free phrase rather than inventing one. Comment block reconciled. The `off` path is unchanged — it already read each card's own default.

---

## Negative controls

Both tests were written to fail against the pre-fix tree first. No power limit was changed on any rig: `nvidia-smi`, `sudo` and `systemctl` are recording stubs, and the power-cap harness **refuses to run unless it has verified it shadowed the real binaries** (otherwise a broken `PATH` stub would let the assertions "pass" while the real `nvidia-smi -pl` ran).

**#1279 — `scripts/tests/test-p2p-state.sh` §10.** Asserts the function emits *exactly one line* that is a valid integer under a failing `nvidia-smi`, that `[[ "$(p2p_gpu_count)" -ge 2 ]]` leaves stderr clean, and that it survives a `pipefail` caller. "Contains 0" would have passed against the broken version, so the assertion is on the line count.

```
# pre-fix (p2p-state.sh restored from master)
$ bash scripts/tests/test-p2p-state.sh        ; echo "EXIT=$?"
FAIL: failing nvidia-smi: expected ONE line, got 2: $'0\n0'
EXIT=1

# post-fix
$ bash scripts/tests/test-p2p-state.sh        ; echo "EXIT=$?"
  ✓ p2p_gpu_count: exactly one integer line, driver up or down; arithmetic-safe
test-p2p-state: ok
EXIT=0
```

End-to-end, through the repo's own report harness (whose default `nvidia-smi` stub exits 1 — the "driver query fails" rig), running the **real** `report.sh`:

```
# pre-fix — inside the generated report body, right after a </details>
syntax-error lines in the generated report: 1
  57  scripts/report.sh: line 665: [[: 0
  58  0: syntax error in expression (error token is "0")

# post-fix
syntax-error lines in the generated report: 0
```

**#1281 — `scripts/tests/test-gpu-mode-power-cap.sh`** (new, 31 assertions). Drives the real script: unit-missing, unit-present-with-no-`-pl`, restart-OK, restart-FAILS, long-form `--power-limit=`, `off`, custom wattage, plus a comment-stripped static scan for wattage literals in executed code.

```
# pre-fix (gpu-mode.sh restored from master)
$ bash scripts/tests/test-gpu-mode-power-cap.sh ; echo "EXIT=$?"
FAIL: unit missing: expected non-zero exit, got 0
FAIL: unit missing: says it is refusing: missing 'Refusing to re-apply a power cap'
FAIL: unit missing: NOTHING applied: expected '', got '-i 0 -pl 250
-i 1 -pl 250'
FAIL: fallback: replays exactly the unit's ExecStart caps: expected '-i 0 -pl 230
-i 1 -pl 230', got '-i 0 -pl 250
-i 1 -pl 250'
FAIL: restart ok: banner quotes the unit's value: missing '230W'
FAIL: no -pl literal in executed code: expected '', got '776: … nvidia-smi -pl 250 …
777:                if ! { sudo nvidia-smi -i 0 -pl 250 && sudo nvidia-smi -i 1 -pl 250; }; then'
… (22 of 31 failed)
test-gpu-mode-power-cap: 9 passed, 22 failed
EXIT=1

# post-fix
$ bash scripts/tests/test-gpu-mode-power-cap.sh ; echo "EXIT=$?"
test-gpu-mode-power-cap: 31 passed, 0 failed
EXIT=0
```

Behaviour under the stubs, post-fix (unit = `-pl 230`):

```
### on (systemd restart OK)
═══ Re-applying GPU power cap (230W, per nvidia-power-cap.service) ═══
Power cap re-applied via systemd.                       # no direct -pl at all

### on (restart FAILS -> fallback)
systemctl restart failed; replaying the unit's own ExecStart caps directly (230W).
                                                        # applies -i 0 -pl 230, -i 1 -pl 230

### on (unit absent -> refuse, exit 1, nothing applied)
✗ Refusing to re-apply a power cap: cannot resolve one from nvidia-power-cap.service.
  The unit is missing, unreadable, or has no parseable '-pl <watts>' ExecStart line,
  and this script deliberately keeps no wattage of its own. …
  Inspect the unit:   systemctl cat nvidia-power-cap.service
  Or cap explicitly:  gpu-mode power-cap <WATTS>
```

## Gates run

Scoped to what changed (p2p / gpu-mode / power-cap / report / hygiene), all green:

| Gate | Result |
|---|---|
| `test-p2p-state` | ok (incl. new §10) |
| `test-gpu-mode-power-cap` | 31 passed, 0 failed (new) |
| `test-gpu-mode-list` | ok |
| `test-p2p-validate` | PASS |
| `test-detect-nvlink-autop2p` | PASS |
| `test-power-cap-sweep-multigpu` | 28 pass / 0 fail |
| `test-report-power-state` | 42 pass / 0 fail |
| `test-report-exit-code` | PASS |
| `test-script-permissions` | PASS |
| `test-locale-utf8` | ok |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
