### PR TITLE
fix(soak): read the engine's decode counter, and stop rendering unmeasurable turns as 0.0

### DIFF
--- a/scripts/soak-helper.py
+++ b/scripts/soak-helper.py
@@ -3,7 +3,10 @@ import csv
 import json
 import os
 import pathlib
+import re
+import shutil
 import statistics
+import subprocess
 import sys
 import time
 import urllib.error
@@ -535,6 +538,200 @@ def cmd_ingest(state_path, metrics_path, turn):
     pathlib.Path(state_path).write_text(json.dumps(state, indent=2) + "\n")
 
 
+# --- engine-side decode counters (#1268) -------------------------------------
+# A decode rate inferred from SSE arrival times is only honest when the decode
+# window (wall - ttft) is wide enough to time. Below DECODE_FLOOR_MS the window
+# is dominated by scheduling and transport noise, so the harness refuses to
+# quote a rate. That floor is right for the inference and wrong as a
+# measurement policy: on fast hardware a legitimate turn finishes decoding
+# INSIDE it (#849 measured 82-83 ms windows on dual 5090s; #1261 measured
+# 49 / 65 / 97 ms on 3 of 5 turns), so a healthy run can end up with no decode
+# figure on most of its turns. Soak's per-turn decode series is how a Cliff-2b
+# decay would show up, and a series full of holes can hide one.
+#
+# So ask the ENGINE for its own decode rate first: it is computed over real
+# decode steps and does not care how narrow the wall-clock window is. Client
+# timing stays as the FALLBACK, and the floor stays with it, where it is doing
+# its job. Sources, in the order they are tried:
+#
+#   prom-tpot     <engine>:time_per_output_token_seconds on <endpoint>/metrics
+#                 (vLLM always; SGLang with --enable-metrics). The DELTA of
+#                 (_sum, _count) across one turn is that turn's mean seconds per
+#                 output token, i.e. decode steps only — prefill is excluded by
+#                 construction. Attributing the delta to one turn is valid
+#                 because soak is single-stream by design.
+#   sglang-log    "gen throughput (token/s): N" on SGLang's decode-batch lines.
+#   llamacpp-log  llama.cpp's per-request "eval time = ... (N tokens per
+#                 second)" summary. NOT "prompt eval time", which is the prefill
+#                 rate — the lookbehind below is all that keeps them apart.
+#
+# Every turn records WHICH source produced its number (decode_source), because a
+# figure whose provenance a reader has to guess is the defect #1267 is about.
+# SOAK_ENGINE_COUNTER=off restores pure client-side timing for the whole run.
+#
+# NOTE (club-3090#1282): none of this classifies the engine — it probes for a
+# counter and matches signatures. When the canonical engine resolver lands
+# (scripts/lib/engine-kind.sh) the probe can key off it instead of trying each
+# signature in turn. A private engine classifier here would be its own defect,
+# so there deliberately is not one.
+DECODE_FLOOR_MS = 100.0
+
+# Prometheus histogram lines: `<name>_sum{labels} <value>` / `<name>_count ...`.
+# A `_bucket` line cannot match: the suffix group accepts only sum|count.
+_TPOT_RE = re.compile(
+    r"^(?P<name>[A-Za-z_][A-Za-z0-9_:]*?time_per_output_token_seconds)"
+    r"_(?P<field>sum|count)(?:\{[^}]*\})?\s+(?P<value>\S+)\s*$"
+)
+_SGLANG_LOG_RE = re.compile(r"gen throughput \(token/s\):\s*([0-9]+(?:\.[0-9]+)?)")
+_LLAMACPP_LOG_RE = re.compile(
+    r"(?<!prompt )eval time\s*=[^\n]*?([0-9]+(?:\.[0-9]+)?)\s*tokens per second"
+)
+# A counter reading this far out is a parse error, not a measurement.
+ENGINE_TPS_SANE_MAX = 100000.0
+ENGINE_SOURCE_LABELS = {
+    "prom-tpot": "engine-reported: /metrics time_per_output_token_seconds",
+    "sglang-log": "engine-reported: SGLang 'gen throughput (token/s)' log line",
+    "llamacpp-log": "engine-reported: llama.cpp 'eval time' log line",
+}
+
+
+def _metrics_url(endpoint):
+    return endpoint.rstrip("/") + "/metrics"
+
+
+def _read_metrics_text(url, timeout=3.0):
+    """GET a Prometheus page. Any failure means 'no counter', never a run failure."""
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            if getattr(resp, "status", 200) != 200:
+                return ""
+            return resp.read(4 * 1024 * 1024).decode("utf-8", errors="replace")
+    except Exception:
+        return ""
+
+
+def _tpot_series(text):
+    """{metric_name: [sum_seconds, count]}, summed across every label series."""
+    out = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = _TPOT_RE.match(line)
+        if not m:
+            continue
+        try:
+            value = float(m.group("value"))
+        except ValueError:
+            continue
+        if value != value or value in (float("inf"), float("-inf")):
+            continue  # NaN / Inf: the engine has no sample yet
+        slot = out.setdefault(m.group("name"), [0.0, 0.0])
+        slot[0 if m.group("field") == "sum" else 1] += value
+    return out
+
+
+def engine_rate_from_metrics(before_text, after_text, metric):
+    """Decode tok/s for the turn that ran between the two /metrics snapshots."""
+    before = _tpot_series(before_text).get(metric)
+    after = _tpot_series(after_text).get(metric)
+    if not before or not after:
+        return None
+    d_sum = after[0] - before[0]
+    d_count = after[1] - before[1]
+    if d_sum <= 0 or d_count <= 0:
+        return None
+    rate = d_count / d_sum
+    if not 0 < rate < ENGINE_TPS_SANE_MAX:
+        return None
+    return round(rate, 3)
+
+
+def _rfc3339_nano(ts):
+    """`docker logs --since` wants RFC3339. Nanoseconds keep a fast PREVIOUS
+    turn's decode line from falling inside this turn's window."""
+    return "%s.%09dZ" % (time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(ts)), int((ts % 1) * 1e9))
+
+
+def _docker_logs_since(container, since_ts, timeout=15.0):
+    """Engine log tail for one turn. stderr is MERGED into stdout, not
+    discarded: every engine in this repo logs to stderr, so a `2>/dev/null`
+    here would read as 'the counter never fired'."""
+    try:
+        proc = subprocess.run(
+            ["docker", "logs", "--since", _rfc3339_nano(since_ts), "--tail", "2000", container],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=timeout,
+            encoding="utf-8",
+            errors="replace",
+        )
+    except Exception:
+        return ""
+    return proc.stdout or ""
+
+
+def engine_rate_from_logs(text):
+    """(tok/s, source) from the LAST engine decode-rate line in `text`."""
+    for regex, source in ((_SGLANG_LOG_RE, "sglang-log"), (_LLAMACPP_LOG_RE, "llamacpp-log")):
+        hits = regex.findall(text)
+        if not hits:
+            continue
+        try:
+            value = float(hits[-1])
+        except ValueError:
+            continue
+        if 0 < value < ENGINE_TPS_SANE_MAX:
+            return round(value, 3), source
+    return None, ""
+
+
+def decode_label(basis, source, window_ms):
+    """Provenance for one turn's decode figure (#1267).
+
+    The contract: an UNMEASURABLE turn and a genuine SILENT-EMPTY turn must
+    never render the same way. Pre-#1267 both printed a bare `decode_tps=0.0`,
+    so a harmless turn and the failure soak exists to catch were byte-identical
+    in the log and the reader had to redo `wall - ttft` by hand to tell them
+    apart.
+    """
+    if basis == "engine":
+        return ENGINE_SOURCE_LABELS.get(source, "engine-reported: %s" % (source or "engine counter"))
+    if basis == "decode":
+        return "client-timed: %d ms decode window" % window_ms
+    if basis == "wall":
+        return "wall-derived, canvas"
+    if basis == "empty":
+        return "SILENT-EMPTY: 0 completion tokens"
+    if basis == "unmeasurable":
+        return ("no decode figure: %d ms decode window is under the %d ms client-timing "
+                "floor and no engine counter was available" % (window_ms, int(DECODE_FLOOR_MS)))
+    return basis
+
+
+def cmd_engine_counter_probe(endpoint, container=""):
+    """Resolve ONCE per run where decode rates come from; print '<kind> <detail>'.
+
+    prom <metric>    — scrape /metrics before + after each turn
+    log <container>  — scrape `docker logs` for a decode-rate signature per turn
+    none <reason>    — client-side SSE timing, with the DECODE_FLOOR_MS floor
+    """
+    mode = (os.environ.get("SOAK_ENGINE_COUNTER") or "auto").strip().lower()
+    if mode == "off":
+        print("none SOAK_ENGINE_COUNTER=off")
+        return
+    names = sorted(_tpot_series(_read_metrics_text(_metrics_url(endpoint))))
+    if names:
+        print("prom " + names[0])
+        return
+    if container and container != "none" and shutil.which("docker"):
+        # Matched per turn by signature: a container whose logs carry no
+        # decode-rate line just falls back to client timing, labelled as such.
+        print("log " + container)
+        return
+    print("none no decode counter on %s and no container log to read" % _metrics_url(endpoint))
+
+
 def cmd_run(endpoint, req_path, timeout_s, metrics_path):
     body = pathlib.Path(req_path).read_bytes()
     req = urllib.request.Request(
@@ -543,6 +740,16 @@ def cmd_run(endpoint, req_path, timeout_s, metrics_path):
         headers={"Content-Type": "application/json"},
         method="POST",
     )
+    # Engine-side decode counter (#1268). The source is resolved ONCE per run by
+    # cmd_engine_counter_probe and handed down in the environment; the /metrics
+    # snapshot has to be taken BEFORE the request so its delta belongs to this
+    # turn and this turn only (valid because soak is single-stream).
+    counter_kind = (os.environ.get("SOAK_ENGINE_COUNTER_KIND") or "none").strip().lower()
+    if (os.environ.get("SOAK_ENGINE_COUNTER") or "auto").strip().lower() == "off":
+        counter_kind = "none"
+    counter_metric = (os.environ.get("SOAK_ENGINE_COUNTER_METRIC") or "").strip()
+    counter_container = (os.environ.get("SOAK_ENGINE_LOG_CONTAINER") or "").strip()
+    metrics_before = _read_metrics_text(_metrics_url(endpoint)) if counter_kind == "prom" else ""
     t0 = time.time()
     ttft = None
     completion_tokens = 0
@@ -611,6 +818,18 @@ def cmd_run(endpoint, req_path, timeout_s, metrics_path):
         error = f"{type(e).__name__}: {e}"
 
     wall = time.time() - t0
+    # Ask the engine for its own decode rate (#1268). A miss is not a failure:
+    # the client-side window below is the labelled fallback. Only asked when the
+    # turn produced tokens — a zero-token turn is silent-empty, full stop.
+    engine_tps = None
+    engine_source = ""
+    if completion_tokens > 0 and counter_kind == "prom" and metrics_before and counter_metric:
+        engine_tps = engine_rate_from_metrics(
+            metrics_before, _read_metrics_text(_metrics_url(endpoint)), counter_metric)
+        if engine_tps is not None:
+            engine_source = "prom-tpot"
+    elif completion_tokens > 0 and counter_kind == "log" and counter_container:
+        engine_tps, engine_source = engine_rate_from_logs(_docker_logs_since(counter_container, t0))
     # --- decode-rate basis (#809) --------------------------------------------
     # decode TPS = completion_tokens / (wall - ttft) assumes token-by-token
     # autoregressive streaming. Canvas-granularity (block-diffusion) models do
@@ -624,6 +843,11 @@ def cmd_run(endpoint, req_path, timeout_s, metrics_path):
     # tokens, derive from wall time and label the basis, rather than zeroing.
     #
     # decode_basis, carried into the metrics JSON and turn-log.csv:
+    #   engine        the ENGINE's own decode counter answered (#1268). Beats
+    #                 client-side timing whenever it is available, because it is
+    #                 computed over real decode steps and is therefore immune to
+    #                 a decode window too narrow to time. decode_source says
+    #                 which counter.
     #   decode        real decode window observed; decode_tps IS a decode rate
     #   wall          window unmeasurable, derived as completion_tokens / wall.
     #                 Equals wall TPS by construction: it INCLUDES prefill and
@@ -631,8 +855,11 @@ def cmd_run(endpoint, req_path, timeout_s, metrics_path):
     #   empty         completion_tokens == 0 — genuine silent-empty. Keeps the
     #                 0.0 that the silent-empty discriminator depends on; this
     #                 case must not regress (club-3090 #43, #47).
-    #   unmeasurable  window unmeasurable on a run NOT classified as canvas —
-    #                 the pre-#809 autoregressive behaviour, decode_tps = 0.0.
+    #   unmeasurable  window unmeasurable on a run NOT classified as canvas and
+    #                 no engine counter available. decode_tps stays 0.0 in the
+    #                 CSV for column compatibility, but it is NOT a measurement
+    #                 and must never be RENDERED as one (#1267) — see
+    #                 decode_label(), which is what soak-test.sh prints.
     #
     # The canvas SIGNATURE is ttft ≈ wall, i.e. a zero-width window — NOT merely
     # "narrow". That distinction is load-bearing: a fast autoregressive rig
@@ -658,20 +885,39 @@ def cmd_run(endpoint, req_path, timeout_s, metrics_path):
     canvas_signature = completion_tokens > 0 and (
         single_chunk or decode_s * 1000.0 <= canvas_window_ms
     )
+    # Branch order is load-bearing and unchanged from #809 for the client-side
+    # cases: a measurable window still beats the canvas branch (a multi-canvas
+    # turn IS a real decode measurement), and the canvas branch still claims a
+    # zero-width window before "unmeasurable" does. #1268 adds exactly one
+    # thing: where the client would have timed the stream, the engine's own
+    # counter is preferred. Canvas turns are deliberately NOT handed to the
+    # engine counter — an engine's per-output-token accounting is not meaningful
+    # for a model that denoises a whole canvas per step.
+    canvas_turn = granularity == "canvas" or (granularity == "auto" and canvas_signature)
+    measurable_window = decode_s >= DECODE_FLOOR_MS / 1000.0
     if completion_tokens <= 0:
         decode_tps = 0.0
         decode_basis = "empty"
-    elif decode_s >= 0.1:
-        decode_tps = round(completion_tokens / decode_s, 3)
-        decode_basis = "decode"
-    elif granularity == "canvas" or (granularity == "auto" and canvas_signature):
+        decode_source = "none"
+    elif measurable_window or not canvas_turn:
+        if engine_tps is not None:
+            decode_tps = engine_tps
+            decode_basis = "engine"
+            decode_source = engine_source
+        elif measurable_window:
+            decode_tps = round(completion_tokens / decode_s, 3)
+            decode_basis = "decode"
+            decode_source = "stream"
+        else:
+            # Window under the floor, no engine counter: streaming closed before
+            # decode steps were observable separately from prefill. NOT a zero.
+            decode_tps = 0.0
+            decode_basis = "unmeasurable"
+            decode_source = "none"
+    else:
         decode_tps = round(completion_tokens / wall, 3) if wall > 0 else 0.0
         decode_basis = "wall"
-    else:
-        # decode_s < 100 ms: streaming closed before decode steps were
-        # observable separately from prefill, on a run that is not canvas.
-        decode_tps = 0.0
-        decode_basis = "unmeasurable"
+        decode_source = "wall"
     # Reassemble the captured response for continuous-mode ingestion.
     # `tool_calls_response` is in OpenAI tool_calls format, ready to drop
     # into the next turn's assistant message.
@@ -692,6 +938,8 @@ def cmd_run(endpoint, req_path, timeout_s, metrics_path):
         "ttft_ms": round(ttft * 1000),
         "decode_tps": decode_tps,
         "decode_basis": decode_basis,
+        "decode_source": decode_source,
+        "decode_label": decode_label(decode_basis, decode_source, round(decode_s * 1000)),
         "decode_window_ms": round(decode_s * 1000),
         "completion_tokens": completion_tokens,
         # Continuous-mode capture (ignored in fresh mode):
@@ -716,9 +964,10 @@ def cmd_append_log(log_path, session, turn, vram, metrics_path):
                 metrics.get("completion_tokens", 0),
                 metrics.get("status", 0),
                 metrics.get("error", ""),
-                # decode_basis last, so a consumer reading the pre-#809 column
-                # order positionally still lines up.
+                # decode_basis, then decode_source, appended last so a consumer
+                # reading the pre-#809 column order positionally still lines up.
                 metrics.get("decode_basis", "decode"),
+                metrics.get("decode_source", ""),
             ]
         )
 
@@ -732,8 +981,16 @@ def cmd_metric(metrics_path):
     err_flag = 1 if (int(m.get("status", 0)) != 200 or m.get("error")) else 0
     # Field 6 (decode_basis) lets soak-test.sh label a wall-derived figure on the
     # per-turn line and make the canvas classification sticky for the run (#809).
+    # Fields 7-9 carry the provenance the per-turn line must show (#1267/#1268):
+    # the decode window in ms, which source produced the figure, and the label
+    # itself. The label is LAST and contains spaces — soak-test.sh reads it with
+    # a trailing `read` variable, so the wording lives here, in one place.
+    basis = m.get("decode_basis", "decode")
+    source = m.get("decode_source", "") or "none"
+    window_ms = int(m.get("decode_window_ms", 0) or 0)
+    label = m.get("decode_label") or decode_label(basis, source, window_ms)
     print(m.get("status", 0), m.get("t_ms", 0), m.get("ttft_ms", 0), m.get("decode_tps", 0),
-          err_flag, m.get("decode_basis", "decode"))
+          err_flag, basis, window_ms, source, label)
 
 
 def percentile(xs, p):
@@ -773,6 +1030,8 @@ def cmd_summary(turn_log, summary_path, boot_vram, growth_limit, timed_out,
         # which case every row is treated as a real decode measurement — exactly
         # the pre-#809 reading of that data.
         has_decode_basis = "decode_basis" in (reader.fieldnames or [])
+        # decode_source column added 2026-09-13 (#1268). Absent on older CSVs.
+        has_decode_source = "decode_source" in (reader.fieldnames or [])
         for row in reader:
             for key in ("session_id", "turn_id", "t_ms", "vram_mib", "ttft_ms", "status"):
                 row[key] = int(float(row[key] or 0))
@@ -780,6 +1039,7 @@ def cmd_summary(turn_log, summary_path, boot_vram, growth_limit, timed_out,
             # completion_tokens is new (added 2026-05-04) — back-compat for old CSVs
             row["completion_tokens"] = int(float(row.get("completion_tokens", 0) or 0))
             row["decode_basis"] = (row.get("decode_basis") or "decode") if has_decode_basis else "decode"
+            row["decode_source"] = (row.get("decode_source") or "") if has_decode_source else ""
             rows.append(row)
 
     sessions = sorted({r["session_id"] for r in rows})
@@ -799,6 +1059,16 @@ def cmd_summary(turn_log, summary_path, boot_vram, growth_limit, timed_out,
     # every pool here is identical to the pre-#809 pools.
     derived = [r for r in rows if r["decode_basis"] == "wall"]
     measured_rows = [r for r in rows if r["decode_basis"] != "wall"]
+    # Basis pools for the denominator the summary owes the reader (#1267). An
+    # `engine` row IS a decode rate, so it belongs in the decode series with the
+    # client-timed ones; an `unmeasurable` row carries no rate at all and is
+    # dropped by realistic() below — which is numerically right and was, until
+    # now, invisible: p50 described an unstated subset with no denominator shown.
+    engine_rows = [r for r in rows if r["decode_basis"] == "engine"]
+    stream_rows = [r for r in rows if r["decode_basis"] == "decode"]
+    unmeasurable_rows = [r for r in rows if r["decode_basis"] == "unmeasurable"]
+    empty_rows = [r for r in rows if r["decode_basis"] == "empty"]
+    engine_sources = sorted({r["decode_source"] for r in engine_rows if r["decode_source"]})
     tps = [r["decode_tps"] for r in measured_rows if realistic(r["decode_tps"])]
     ttft = [r["ttft_ms"] for r in rows if r["ttft_ms"] > 0]
     first_tps = [r["decode_tps"] for r in measured_rows if r["session_id"] in first and realistic(r["decode_tps"])]
@@ -939,17 +1209,44 @@ def cmd_summary(turn_log, summary_path, boot_vram, growth_limit, timed_out,
                 f"(sessions 1-{baseline_session - 1} had errored turns; their rows are "
                 f"excluded from growth + oscillation)"
             )
-    # Canvas-granularity block — emitted ONLY when a wall-derived turn exists, so
-    # an autoregressive run's summary is unchanged (#809).
+    # Decode-window basis block. Pre-#1267 this was gated on `derived`, i.e. it
+    # appeared ONLY when a canvas turn existed — so an autoregressive run with
+    # unmeasurable turns reported its p50 over an unstated subset and said
+    # nothing about the turns it had dropped. It now fires whenever the run is
+    # not uniformly client-timed decode turns, which keeps a plain healthy run's
+    # summary byte-identical while giving every other run its denominator.
+    basis_seg = []
+    if engine_rows:
+        basis_seg.append(
+            f"{len(engine_rows)} engine-reported"
+            f" ({', '.join(engine_sources) if engine_sources else 'engine counter'})")
+    if stream_rows:
+        basis_seg.append(f"{len(stream_rows)} client-timed")
+    if unmeasurable_rows:
+        basis_seg.append(
+            f"{len(unmeasurable_rows)} unmeasurable (decode window under the "
+            f"{int(DECODE_FLOOR_MS)} ms client-timing floor, no engine counter)")
+    if derived:
+        basis_seg.append(f"{len(derived)} wall-derived (canvas)")
+    if empty_rows:
+        basis_seg.append(f"{len(empty_rows)} silent-empty")
     basis_lines = []
     basis_rows = []
+    if derived or engine_rows or unmeasurable_rows:
+        basis_text = (
+            f"- Decode-window basis: {' / '.join(basis_seg)} of {len(rows)} turn(s). "
+            f"The decode percentiles and retention below are computed over the {len(tps)} "
+            f"turn(s) carrying a decode figure — that is the denominator; turns without one "
+            f"are excluded rather than counted as zero."
+        )
+        if derived:
+            basis_text += (
+                " A wall-derived turn arrived in a single chunk (canvas granularity), so its "
+                "decode window is zero-width and the figure is completion_tokens / wall — it "
+                "INCLUDES prefill and is not a decode rate."
+            )
+        basis_lines = [basis_text]
     if derived:
-        basis_lines = [
-            f"- Decode-window basis: {len(rows) - len(derived)} measured / {len(derived)} "
-            f"wall-derived of {len(rows)} turn(s). A wall-derived turn arrived in a single "
-            f"chunk (canvas granularity), so its decode window is zero-width and the figure "
-            f"is completion_tokens / wall — it INCLUDES prefill and is not a decode rate.",
-        ]
         basis_rows = [
             f"| p50 wall-derived TPS (canvas) | {percentile(dtps, 0.50):.2f} |",
             f"| p95 wall-derived TPS (canvas) | {percentile(dtps, 0.95):.2f} |",
@@ -1018,8 +1315,9 @@ def cmd_summary(turn_log, summary_path, boot_vram, growth_limit, timed_out,
     print(f"[soak]   errors               {len(errors)}")
     print(f"[soak]   silent_empty         {len(silent_empty)} / {len(rows)} ({silent_empty_pct:.1f}%)")
     print(f"[soak]   p50_decode_tps       {percentile(tps, 0.50):.2f}")
+    if basis_lines:
+        print(f"[soak]   decode_basis         {' / '.join(basis_seg)} of {len(rows)}")
     if derived:
-        print(f"[soak]   decode_basis         {len(rows) - len(derived)} measured / {len(derived)} wall-derived (canvas)")
         print(f"[soak]   p50_wall_tps_canvas  {percentile(dtps, 0.50):.2f}  (includes prefill — NOT a decode rate)")
     print(f"[soak]   p95_ttft_ms          {percentile(ttft, 0.95):.0f}")
     print(f"[soak]   tps_retention        {tps_retention * 100:.1f}%")
@@ -1051,6 +1349,7 @@ def main():
         "run": cmd_run,
         "append-log": cmd_append_log,
         "metric": cmd_metric,
+        "engine-counter-probe": cmd_engine_counter_probe,
         "summary": cmd_summary,
     }[cmd](*args)
 

--- a/scripts/soak-test.sh
+++ b/scripts/soak-test.sh
@@ -33,6 +33,14 @@
 #   the overlay bind-mounts stripped (or on a baseline image) and compare
 #   metrics. See https://github.com/noonghunna/club-3090/issues/140.
 #
+# Reading a per-turn decode figure (#1267):
+#   Every turn states where its number came from, because "decode_tps=0.0" used
+#   to mean two opposite things. `n/a` is NOT a measurement of zero.
+#     decode_tps=83.1 ... (engine-reported: ...)      the engine's own counter
+#     decode_tps=83.1 ... (client-timed: 940 ms ...)  inferred from SSE arrivals
+#     decode_tps=n/a  ... (no decode figure: ...)     window too narrow to time
+#     decode_tps=0.0  ... (SILENT-EMPTY: 0 ...)       the failure soak looks for
+#
 # Time budget:
 #   Default SOAK_SESSIONS=20 x SOAK_TURNS=5, capped by SOAK_TIMEOUT_S=1800.
 #   Expect 10-30 minutes depending on config.
@@ -75,6 +83,19 @@
 #                          LABELS it, instead of printing decode_tps=0.0 (#809).
 #                          "auto" detects the signature and latches; "canvas"
 #                          forces it; "autoregressive" restores the old zeroing.
+#   SOAK_ENGINE_COUNTER    auto (default) | off. "auto" reads the ENGINE's own
+#                          decode counter when one is reachable — vLLM/SGLang
+#                          `<engine>:time_per_output_token_seconds` on
+#                          <endpoint>/metrics, SGLang's "gen throughput
+#                          (token/s)" decode-batch line, or llama.cpp's per-
+#                          request "eval time" line — and falls back to timing
+#                          the SSE stream when none is. An engine counter is
+#                          computed over real decode steps, so it is immune to a
+#                          decode window too narrow to time (#1268: #849 saw
+#                          82-83 ms windows, #1261 saw 49/65/97 ms on 3 of 5
+#                          turns, all reported as 0.0). "off" forces client-side
+#                          timing for the whole run. Every per-turn line names
+#                          the source it used; no figure is unattributed.
 #   SOAK_CANVAS_WINDOW_MS  Zero-width bound for the canvas signature, in ms.
 #                          Default: 5. Deliberately far below the 100 ms
 #                          measurability floor — a fast autoregressive rig
@@ -217,6 +238,15 @@ case "$SOAK_DECODE_GRANULARITY" in
   *) echo "ERROR: SOAK_DECODE_GRANULARITY='${SOAK_DECODE_GRANULARITY}' — must be 'auto', 'canvas' or 'autoregressive'." >&2; exit 2 ;;
 esac
 export SOAK_DECODE_GRANULARITY
+# Engine-side decode counter (#1268). "auto" prefers the engine's own counter
+# and falls back to client-side SSE timing; "off" is the one-word reversal of
+# that decision — it pins every turn to client-side timing plus the floor.
+SOAK_ENGINE_COUNTER="${SOAK_ENGINE_COUNTER:-auto}"
+case "$SOAK_ENGINE_COUNTER" in
+  auto|off) ;;
+  *) echo "ERROR: SOAK_ENGINE_COUNTER='${SOAK_ENGINE_COUNTER}' — must be 'auto' or 'off'." >&2; exit 2 ;;
+esac
+export SOAK_ENGINE_COUNTER
 SOAK_TIMEOUT_S="${SOAK_TIMEOUT_S:-1800}"
 SOAK_REQ_TIMEOUT_S="${SOAK_REQ_TIMEOUT_S:-600}"
 SOAK_OUTPUT="${SOAK_OUTPUT:-results/soak-$(date +%Y%m%d-%H%M%S)}"
@@ -378,12 +408,40 @@ RESPONSE_DIR="${SOAK_OUTPUT}/responses"
 STATE_DIR="${SOAK_OUTPUT}/states"
 mkdir -p "$REQUEST_DIR" "$RESPONSE_DIR" "$STATE_DIR"
 
-printf 'session_id,turn_id,t_ms,vram_mib,ttft_ms,decode_tps,completion_tokens,status,error,decode_basis\n' > "$TURN_LOG"
+printf 'session_id,turn_id,t_ms,vram_mib,ttft_ms,decode_tps,completion_tokens,status,error,decode_basis,decode_source\n' > "$TURN_LOG"
 printf 'session_id,turn_id,gpu_index,memory_used_mib,utilization_gpu_pct\n' > "$GPU_LOG"
 
 capture_state "baseline"
 python3 "$HELPER" baseline "$SOAK_OUTPUT" "$CONTAINER" "$ENDPOINT" "$MODEL" \
   "$SOAK_SESSIONS" "$SOAK_TURNS" "$SOAK_MAX_GROWTH_MIB"
+
+# --- decode-rate source (#1268) ---------------------------------------------
+# Resolved once, before the first turn, and announced: a reader must never have
+# to guess whether a decode figure is engine-reported or client-inferred. The
+# probe asks the endpoint/container what it can answer — it does NOT classify
+# the engine (the canonical resolver is club-3090#1282; a private classifier
+# here would be its own defect).
+ENGINE_COUNTER_PROBE="$(python3 "$HELPER" engine-counter-probe "$ENDPOINT" "$CONTAINER" || true)"
+[[ -n "$ENGINE_COUNTER_PROBE" ]] || ENGINE_COUNTER_PROBE="none probe failed"
+SOAK_ENGINE_COUNTER_KIND="${ENGINE_COUNTER_PROBE%% *}"
+ENGINE_COUNTER_DETAIL="${ENGINE_COUNTER_PROBE#* }"
+SOAK_ENGINE_COUNTER_METRIC=""
+SOAK_ENGINE_LOG_CONTAINER=""
+case "$SOAK_ENGINE_COUNTER_KIND" in
+  prom)
+    SOAK_ENGINE_COUNTER_METRIC="$ENGINE_COUNTER_DETAIL"
+    log "decode-rate source: ENGINE counter — ${ENDPOINT}/metrics ${SOAK_ENGINE_COUNTER_METRIC} (computed over the engine's own decode steps; client-side SSE timing is the fallback)"
+    ;;
+  log)
+    SOAK_ENGINE_LOG_CONTAINER="$ENGINE_COUNTER_DETAIL"
+    log "decode-rate source: ENGINE counter — decode-rate lines in 'docker logs ${SOAK_ENGINE_LOG_CONTAINER}' (client-side SSE timing is the fallback on turns that log none)"
+    ;;
+  *)
+    SOAK_ENGINE_COUNTER_KIND="none"
+    log "decode-rate source: CLIENT-side SSE timing — ${ENGINE_COUNTER_DETAIL}. A turn whose decode window is under the measurability floor reports n/a with its window width, never 0.0 (#1267)."
+    ;;
+esac
+export SOAK_ENGINE_COUNTER_KIND SOAK_ENGINE_COUNTER_METRIC SOAK_ENGINE_LOG_CONTAINER
 
 log "running soak test against ${ENDPOINT} (model=${MODEL}, container=${CONTAINER})"
 log "mode=${SOAK_MODE} sessions=${SOAK_SESSIONS} turns=${SOAK_TURNS} max_growth=${SOAK_MAX_GROWTH_MIB}MiB timeout=${SOAK_TIMEOUT_S}s"
@@ -428,7 +486,12 @@ for session in $(seq 1 "$SOAK_SESSIONS"); do
     append_gpu_snapshot "$session" "$turn"
     python3 "$HELPER" append-log "$TURN_LOG" "$session" "$turn" "$vram" "$metrics_file"
 
-    read -r status t_ms ttft_ms decode_tps err_flag decode_basis < <(python3 "$HELPER" metric "$metrics_file")
+    # decode_note is LAST and free-text: `read` slurps the remainder of the line
+    # into it, so the wording of every per-turn provenance label lives in
+    # soak-helper.py::decode_label() and nowhere else. decode_window_ms and
+    # decode_source are read for position — the label already states both.
+    read -r status t_ms ttft_ms decode_tps err_flag decode_basis decode_window_ms decode_source decode_note \
+      < <(python3 "$HELPER" metric "$metrics_file")
     TURNS_RUN=$((TURNS_RUN + 1))
     [[ "${err_flag:-0}" == "1" ]] && session_errors=$((session_errors + 1))
     if [[ "${decode_basis:-decode}" == "wall" ]]; then
@@ -444,10 +507,15 @@ for session in $(seq 1 "$SOAK_SESSIONS"); do
         log "  canvas-granularity generation detected (single-chunk response, zero-width decode window)"
         log "  per-turn figures are wall-derived from here on — wall TPS, includes prefill. See issue #809."
       fi
-      log "  turn ${turn}/${SOAK_TURNS}: status=${status} wall=${t_ms}ms ttft=${ttft_ms}ms decode_tps=${decode_tps} (wall-derived, canvas) vram=${vram}MiB"
-    else
-      log "  turn ${turn}/${SOAK_TURNS}: status=${status} wall=${t_ms}ms ttft=${ttft_ms}ms decode_tps=${decode_tps} vram=${vram}MiB"
     fi
+    # An UNMEASURABLE turn must not render as a numeric 0.0 (#1267): that is
+    # byte-identical to a genuine silent-empty turn, so the failure soak exists
+    # to catch reads exactly like a harmless fast turn. `n/a` + the window width
+    # + the label make the two impossible to confuse. The summary's silent-empty
+    # discriminator is unchanged — it keys on completion_tokens, not on this.
+    decode_show="$decode_tps"
+    [[ "${decode_basis:-decode}" == "unmeasurable" ]] && decode_show="n/a"
+    log "  turn ${turn}/${SOAK_TURNS}: status=${status} wall=${t_ms}ms ttft=${ttft_ms}ms decode_tps=${decode_show} vram=${vram}MiB (${decode_note})"
   done
 
   # Capture warm baseline at END of the first CLEAN session — after all 5 turn

--- a/scripts/tests/fixtures/soak-harness/soak-env.sh
+++ b/scripts/tests/fixtures/soak-harness/soak-env.sh
@@ -7,8 +7,12 @@
 #
 # Source this from a test, then call:
 #   soak_env_init                 — create the sandbox (sets SOAK_ENV_DIR)
-#   soak_stub_start <plan-file>   — boot the stub (sets SOAK_STUB_URL / _PID)
+#   soak_stub_start <plan> [E=V]  — boot the stub (sets SOAK_STUB_URL / _PID);
+#                                   extra KEY=VAL go to the stub process, e.g.
+#                                   STUB_TPOT_TPS=123.456 to serve /metrics
 #   soak_stub_stop                — stop it (by PID; never pkill -f, see below)
+#   soak_stub_docker <log-file>   — put a fake `docker` on PATH whose `logs`
+#                                   prints <log-file> on STDERR (#1268)
 #   soak_run <out-dir> [env...]   — run soak-test.sh, capture stdout+rc
 #
 # `pkill -f` / `pgrep -f` are deliberately NOT used anywhere here: the pattern
@@ -52,10 +56,10 @@ soak_env_cleanup() {
 }
 
 soak_stub_start() {
-  local plan="$1"
+  local plan="$1"; shift
   local port_file="${SOAK_ENV_DIR}/port.txt"
   rm -f "$port_file"
-  python3 "${SOAK_ENV_FIXTURES}/stub-endpoint.py" "$port_file" "$plan" "$SOAK_VRAM_FILE" \
+  env "$@" python3 "${SOAK_ENV_FIXTURES}/stub-endpoint.py" "$port_file" "$plan" "$SOAK_VRAM_FILE" \
     >"${SOAK_ENV_DIR}/stub.log" 2>&1 &
   SOAK_STUB_PID=$!
   local waited=0
@@ -77,6 +81,36 @@ soak_stub_stop() {
     wait "$SOAK_STUB_PID" 2>/dev/null || true
   fi
   SOAK_STUB_PID=""
+}
+
+# soak_stub_docker <log-file> — fake `docker` for the engine-log counter path.
+#
+# Two things it exists to prove, both of which have burned this repo before:
+#   1. `docker logs` output must be read from STDERR as well as stdout — every
+#      engine here logs to stderr, so a helper reading only stdout scores a live
+#      counter as "never fired". This stub prints ONLY on stderr.
+#   2. the harness must bound the scrape to the turn it is measuring. Every
+#      invocation's argv is appended to ${SOAK_ENV_DIR}/docker-argv.log so a
+#      test can assert the --since window was actually passed.
+soak_stub_docker() {
+  local log_file="$1"
+  : > "${SOAK_ENV_DIR}/docker-argv.log"
+  cat > "${SOAK_ENV_BIN}/docker" <<DOCKER
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "${SOAK_ENV_DIR}/docker-argv.log"
+case "\$1" in
+  logs) cat "${log_file}" >&2 ;;
+  inspect)
+    for a in "\$@"; do
+      [[ "\$a" == "{{.State.Running}}" ]] && { echo true; exit 0; }
+    done
+    exit 0 ;;
+  stats) echo '{}' ;;
+  *) : ;;
+esac
+exit 0
+DOCKER
+  chmod +x "${SOAK_ENV_BIN}/docker"
 }
 
 # soak_run <script-root> <out-dir> [KEY=VAL ...]

--- a/scripts/tests/fixtures/soak-harness/stub-endpoint.py
+++ b/scripts/tests/fixtures/soak-harness/stub-endpoint.py
@@ -21,8 +21,12 @@ Plan directive syntax (one per line, '#' comments and blanks ignored):
                    comfortably measurable.
   narrow[:VRAM]    autoregressive fast burst — first content delta, ~80 ms
                    gap, then the rest + usage. Window is under the harness's
-                   100 ms measurability floor but nowhere near zero. This is
-                   the #849 shape that must KEEP printing decode_tps=0.0.
+                   100 ms client-timing floor but nowhere near zero. The #849
+                   shape: must NOT be reclassified as canvas, and since #1267
+                   must render as `decode_tps=n/a` + the window width rather
+                   than a 0.0 indistinguishable from a silent-empty turn. With
+                   STUB_TPOT_TPS set it is also the #1268 shape — a turn the
+                   engine counter can measure and the SSE window cannot.
   canvas[:VRAM]    canvas granularity — the entire response arrives in ONE
                    chunk carrying content + usage, so the decode window is
                    zero-width. The #809 shape.
@@ -34,6 +38,17 @@ Plan directive syntax (one per line, '#' comments and blanks ignored):
 The optional trailing VRAM value is written to <vram-file> BEFORE the response
 is produced, so the fake nvidia-smi the harness calls after each turn reports
 it. That is how a test reproduces "the baseline was taken on a corpse".
+
+Env:
+  STUB_TPOT_TPS   When set to a float, the stub also serves a Prometheus
+                  /metrics page carrying a `vllm:time_per_output_token_seconds`
+                  histogram (plus a decoy histogram and a `_bucket` line that
+                  must NOT be mistaken for `_sum`/`_count`). Its totals advance
+                  by one request's worth on every chat completion, arranged so
+                  the (_count, _sum) DELTA across a turn is exactly this many
+                  tokens per second. That is the engine-counter path of #1268.
+                  Unset (the default) makes /metrics 404, which is the
+                  client-timed fallback path.
 """
 
 import json
@@ -50,6 +65,8 @@ PLAN_IDX = [0]
 PLAN_LOCK = threading.Lock()
 VRAM_FILE = [""]
 ALIVE_FILE = [""]
+# (count, sum_seconds) for the fake time_per_output_token_seconds histogram.
+TPOT = [0.0, 0.0]
 
 
 def next_directive():
@@ -64,6 +81,35 @@ def next_directive():
 def set_vram(value):
     if value is not None and VRAM_FILE[0]:
         pathlib.Path(VRAM_FILE[0]).write_text(str(value) + "\n", encoding="utf-8")
+
+
+def advance_tpot(completion_tokens):
+    """Book `completion_tokens` decode steps at exactly STUB_TPOT_TPS tok/s."""
+    tps = float(os.environ.get("STUB_TPOT_TPS") or 0)
+    if tps <= 0 or completion_tokens <= 0:
+        return
+    with PLAN_LOCK:
+        TPOT[0] += completion_tokens
+        TPOT[1] += completion_tokens / tps
+
+
+def metrics_page():
+    """A Prometheus page shaped like vLLM's, including traps for the parser:
+    a `_bucket` line (must not be read as sum/count) and a decoy histogram
+    (must not be read as the TPOT one)."""
+    with PLAN_LOCK:
+        count, total = TPOT[0], TPOT[1]
+    return (
+        "# HELP vllm:e2e_request_latency_seconds End to end request latency.\n"
+        "# TYPE vllm:e2e_request_latency_seconds histogram\n"
+        'vllm:e2e_request_latency_seconds_sum{model_name="stub-model"} 9999.0\n'
+        'vllm:e2e_request_latency_seconds_count{model_name="stub-model"} 1.0\n'
+        "# HELP vllm:time_per_output_token_seconds Inter-token latency.\n"
+        "# TYPE vllm:time_per_output_token_seconds histogram\n"
+        'vllm:time_per_output_token_seconds_bucket{le="0.01",model_name="stub-model"} 777\n'
+        'vllm:time_per_output_token_seconds_sum{model_name="stub-model"} %r\n'
+        'vllm:time_per_output_token_seconds_count{model_name="stub-model"} %r\n'
+    ) % (total, count)
 
 
 def sse(payload):
@@ -93,6 +139,17 @@ class Handler(BaseHTTPRequestHandler):
         pass  # keep the test output clean
 
     def do_GET(self):
+        if self.path.rstrip("/").endswith("/metrics"):
+            if not (os.environ.get("STUB_TPOT_TPS") or "").strip():
+                self.send_error(404)
+                return
+            payload = metrics_page().encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; version=0.0.4")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
         if self.path.rstrip("/").endswith("/v1/models"):
             if ALIVE_FILE[0] and not pathlib.Path(ALIVE_FILE[0]).exists():
                 # The "engine" has crashed: still listening, no longer serving.
@@ -154,6 +211,8 @@ class Handler(BaseHTTPRequestHandler):
                 self.wfile.write(b"data: [DONE]\n\n")
                 self.wfile.flush()
                 return
+
+            advance_tpot(usage["completion_tokens"])
 
             if kind == "canvas":
                 # ONE chunk carrying the whole canvas + usage: the decode window

--- a/scripts/tests/test-soak-decode-basis.sh
+++ b/scripts/tests/test-soak-decode-basis.sh
@@ -16,9 +16,20 @@
 #   3. genuine silent-empty (completion_tokens == 0) still reports 0.0 and still
 #      counts toward the silent-empty verdict — the discriminator must not regress
 #   4. a fast AUTOREGRESSIVE rig with a narrow-but-real window (#849: 82 ms on
-#      dual NVFP4 5090s) is NOT reclassified, and its output is byte-identical
-#      to origin/master — both the per-turn stream and the summary
+#      dual NVFP4 5090s) is NOT reclassified as canvas
 #   5. SOAK_DECODE_GRANULARITY=autoregressive restores the pre-fix behaviour
+#
+# ⚠️ Two expectations here were SUPERSEDED by #1267 / #1268, deliberately:
+#   - a narrow-but-real window no longer prints `decode_tps=0.0`. That zero was
+#     byte-identical to a genuine silent-empty turn, so it now renders as
+#     `decode_tps=n/a` plus the window width. The byte-identity-with-master leg
+#     therefore covers the `ok` shape only; `narrow` asserts the new contract.
+#   - a run with unmeasurable turns now DOES emit a "Decode-window basis:" line.
+#     It used to appear only when a canvas turn existed, which left an
+#     autoregressive run's p50 describing an unstated subset of its turns.
+# What has NOT changed, and is still asserted below: canvas turns stay
+# wall-derived and labelled, the two series stay apart, and the silent-empty
+# discriminator still keys on completion_tokens.
 set -euo pipefail
 
 # Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
@@ -75,13 +86,25 @@ assert_contains "$(tail -1 "${SOAK_ENV_DIR}/run-canvas/turn-log.csv")" ",wall"
 # A canvas run with no errors is still a PASS.
 [[ "$SOAK_RC" -eq 0 ]] || fail "clean canvas run should exit 0, got $SOAK_RC"
 
-# ── 2. escape hatch: forcing autoregressive restores the pre-fix zeroing ─────
+# ── 2. escape hatch: forcing autoregressive disables the canvas derivation ───
+# Pre-#1267 this asserted a bare `decode_tps=0.0`. The canvas apparatus is still
+# off — that is what this leg exists to prove — but the turns it produces are
+# `unmeasurable`, and an unmeasurable turn must no longer wear a silent-empty
+# turn's rendering.
 soak_stub_start "${PLAN_DIR}/canvas"
 soak_run "$ROOT_DIR" "${SOAK_ENV_DIR}/run-canvas-forced" SOAK_DECODE_GRANULARITY=autoregressive
 soak_stub_stop
-assert_contains "$SOAK_OUT" "decode_tps=0.0 "
+forced_summary="$(cat "${SOAK_ENV_DIR}/run-canvas-forced/summary.md")"
+assert_contains "$SOAK_OUT" "decode_tps=n/a"
+assert_contains "$SOAK_OUT" "no decode figure"
+assert_not_contains "$SOAK_OUT" "decode_tps=0.0"
 assert_not_contains "$SOAK_OUT" "(wall-derived, canvas)"
-assert_not_contains "$(cat "${SOAK_ENV_DIR}/run-canvas-forced/summary.md")" "Decode-window basis:"
+assert_contains "$(tr -d '\r' < "${SOAK_ENV_DIR}/run-canvas-forced/turn-log.csv" | tail -1)" ",unmeasurable"
+# The basis line is now emitted for an unmeasurable run too (#1267) — but it
+# must describe them as unmeasurable, never as canvas.
+assert_contains "$forced_summary" "Decode-window basis:"
+assert_contains "$forced_summary" "unmeasurable"
+assert_not_contains "$forced_summary" "wall-derived"
 
 # ── 3. silent-empty must not regress ────────────────────────────────────────
 # HTTP 200, >=1s, completion_tokens == 0. Not canvas — nothing was produced —
@@ -133,7 +156,13 @@ for f in soak-test.sh soak-helper.py; do
 done
 
 normalise() {
+  # The per-turn provenance label and the decode-rate-source banner are new in
+  # #1267/#1268 and have no counterpart on master. They are dropped here so this
+  # leg keeps asserting what it was written to assert: that no FIGURE drifted.
+  # Their presence is asserted in test-soak-decode-source.sh.
   sed -E \
+    -e '/decode-rate source:/d' \
+    -e 's/ \((client-timed|engine-reported)[^)]*\)$//' \
     -e 's#run-ar-(new|base)-[a-z]+#<RUNDIR>#g' \
     -e 's#http://127\.0\.0\.1:[0-9]+#<ENDPOINT>#g' \
     -e 's/[0-9]+\.[0-9]+/<NUM>/g' \
@@ -179,16 +208,20 @@ if [[ "$have_base" == "1" ]]; then
     if [[ "$shape" == "narrow" ]]; then
       # Prove this leg is actually exercising the #849 fast-burst path rather
       # than quietly landing in the measurable branch: the window is under the
-      # 100 ms floor, so it must still print a bare 0.0 and record the
-      # 'unmeasurable' basis — NOT be reclassified as canvas.
-      assert_contains "$new_out" "decode_tps=0.0 "
+      # 100 ms floor, so it must record the 'unmeasurable' basis — NOT be
+      # reclassified as canvas. Its RENDERING is #1267's, not master's, so the
+      # byte-identity comparison below deliberately does not cover this shape.
+      assert_contains "$new_out" "decode_tps=n/a"
+      assert_not_contains "$new_out" "decode_tps=0.0"
       assert_contains "$(tr -d '\r' < "${SOAK_ENV_DIR}/run-ar-new-${shape}/turn-log.csv" | tail -1)" ",unmeasurable"
+      # NB: no base-vs-new comparison here on purpose, in either direction. An
+      # assertion that master still PRINTS the defect would pass today and fail
+      # the moment this lands on master — a test that dies of its own success.
     else
       assert_contains "$(tr -d '\r' < "${SOAK_ENV_DIR}/run-ar-new-${shape}/turn-log.csv" | tail -1)" ",decode"
+      assert_same "${shape} summary" "$base_summary" "$new_summary"
+      assert_same "${shape} stdout"  "$base_out"     "$new_out"
     fi
-
-    assert_same "${shape} summary" "$base_summary" "$new_summary"
-    assert_same "${shape} stdout"  "$base_out"     "$new_out"
   done
 fi
 

--- a/scripts/tests/test-soak-decode-source.sh
+++ b/scripts/tests/test-soak-decode-source.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# test-soak-decode-source — decode-figure provenance + engine counters.
+#
+# Covers the pair #1267 (an unmeasurable turn and a genuine silent-empty turn
+# rendered IDENTICALLY) and #1268 (the 100 ms client-timing floor discards real
+# decode on fast hardware). Both are failures you cannot see in the output,
+# which is what these assertions are shaped around: they check that two
+# different states RENDER differently, not merely that a run completes.
+#
+# Pre-fix, both states printed a bare `decode_tps=0.0` and the reader had to
+# redo `wall - ttft` by hand to tell "fine, decoded in 49 ms" from "HTTP 200
+# with zero tokens — the failure soak exists to catch". Three real turns from a
+# PASSING 25-turn run on the reference rig:
+#     wall=656ms    ttft=557ms    -> decode window  99 ms
+#     wall=650ms    ttft=550ms    -> decode window 100 ms
+#     wall=10606ms  ttft=10531ms  -> decode window  75 ms
+#
+# Contract asserted here:
+#   1. unmeasurable renders as `decode_tps=n/a` + its window width, and is
+#      textually DISTINGUISHABLE from a silent-empty turn's `decode_tps=0.0`
+#   2. the run summary states the basis split, so p50's denominator is explicit,
+#      and the silent-empty discriminator is unchanged (it keys on
+#      completion_tokens, never on decode_tps)
+#   3. an engine counter, when reachable, produces the figure INSTEAD of the
+#      SSE-timed window — on a turn whose window is under the floor, which
+#      pre-fix reported as 0.0. Three sources: /metrics TPOT histogram,
+#      SGLang's "gen throughput (token/s)" log line, llama.cpp's "eval time"
+#   4. llama.cpp's PROMPT eval line (prefill) is never read as the decode rate
+#   5. the scrape is bounded to the turn (`--since`) and reads STDERR
+#   6. SOAK_ENGINE_COUNTER=off restores pure client-side timing + the floor —
+#      the one-word reversal of the #1268 design decision
+#
+# Negative control (how this test was proven to bite): run it against the
+# pre-fix tree — `git stash` / `git checkout <base> -- scripts/soak-*` — and
+# leg 1 fails on the first assertion, because there `decode_tps=0.0` is all
+# there is. Every engine leg fails there too: no counter is ever read.
+set -euo pipefail
+
+# Force Python's UTF-8 mode (PEP 540) for every python3 this script runs.
+# Repo sources are full of unicode (— × → ⚠), and without this a rig on a real
+# non-UTF-8 locale (de_DE.iso88591 and friends) decodes reads, stdout AND argv
+# with the locale codec, which crashes the launcher/emit paths (#779). Python
+# already auto-enables UTF-8 mode for the C/POSIX locale, so this covers the
+# case it does NOT: a genuine non-UTF-8, non-C locale. Exported, so child
+# processes and nested scripts inherit it. Guarded by test-locale-utf8.sh.
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+# shellcheck source=fixtures/soak-harness/soak-env.sh
+source "${ROOT_DIR}/scripts/tests/fixtures/soak-harness/soak-env.sh"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+assert_contains() { [[ "$1" == *"$2"* ]] || { echo "FAIL: missing '$2' in:" >&2; echo "$1" >&2; exit 1; }; }
+assert_not_contains() { [[ "$1" != *"$2"* ]] || { echo "FAIL: must NOT contain '$2':" >&2; echo "$1" >&2; exit 1; }; }
+
+# turn_line <output> <turn-number> — the per-turn log line for that turn.
+turn_line() { printf '%s\n' "$1" | command grep -F "turn ${2}/" | head -1; }
+# decode_render <line> — just the decode figure + its label, with the volatile
+# VRAM reading normalised away. This is the string a reader uses to tell one
+# kind of turn from another, so it is the string the test compares.
+decode_render() {
+  printf '%s\n' "$1" | sed -E 's/^.*decode_tps=/decode_tps=/; s/vram=[0-9]+MiB/vram=<V>MiB/'
+}
+
+soak_env_init
+trap soak_env_cleanup EXIT
+
+PLAN_DIR="${SOAK_ENV_DIR}/plans"
+LOG_DIR="${SOAK_ENV_DIR}/engine-logs"
+mkdir -p "$PLAN_DIR" "$LOG_DIR"
+
+# ── 1. #1267: unmeasurable vs silent-empty must not render the same ──────────
+# Turns 1-3 decode in ~80 ms (under the floor, real output). Turn 4 is HTTP 200
+# with zero completion tokens after >1 s of "thinking" — the genuine failure.
+cat > "${PLAN_DIR}/narrow-then-empty" <<'PLAN'
+narrow:31900
+narrow:31900
+narrow:31900
+empty:31900
+PLAN
+
+export SOAK_SESSIONS=1
+export SOAK_TURNS=4
+soak_stub_start "${PLAN_DIR}/narrow-then-empty"
+soak_run "$ROOT_DIR" "${SOAK_ENV_DIR}/run-1267"
+soak_stub_stop
+out_1267="$SOAK_OUT"
+summary_1267="$(cat "${SOAK_ENV_DIR}/run-1267/summary.md")"
+
+narrow_line="$(turn_line "$out_1267" 3)"
+empty_line="$(turn_line "$out_1267" 4)"
+[[ -n "$narrow_line" && -n "$empty_line" ]] || fail "could not find both turn lines in:
+$out_1267"
+
+# THE assertion this pair of issues is about.
+if [[ "$(decode_render "$narrow_line")" == "$(decode_render "$empty_line")" ]]; then
+  fail "unmeasurable and silent-empty turns render identically — the #1267 defect:
+  unmeasurable: $narrow_line
+  silent-empty: $empty_line"
+fi
+
+assert_contains "$narrow_line" "decode_tps=n/a"
+assert_contains "$narrow_line" "no decode figure"
+assert_contains "$narrow_line" "ms decode window is under the 100 ms client-timing floor"
+assert_contains "$empty_line" "decode_tps=0.0"
+assert_contains "$empty_line" "SILENT-EMPTY: 0 completion tokens"
+# An unmeasurable turn must not present a number that can be read as a rate.
+assert_not_contains "$narrow_line" "decode_tps=0.0"
+
+# The summary must now state the denominator its p50 was computed over (#1267),
+# and must still classify the silent-empty turn exactly as before.
+assert_contains "$summary_1267" "Decode-window basis:"
+assert_contains "$summary_1267" "3 unmeasurable (decode window under the 100 ms client-timing floor, no engine counter)"
+assert_contains "$summary_1267" "1 silent-empty"
+assert_contains "$summary_1267" "computed over the 0 turn(s) carrying a decode figure"
+assert_contains "$summary_1267" "Silent-empty turns (HTTP 200 + 0 completion tokens): 1 / 4"
+assert_contains "$out_1267" "silent_empty         1 / 4"
+# ...and the CSV must carry both states distinctly.
+csv_1267="$(tr -d '\r' < "${SOAK_ENV_DIR}/run-1267/turn-log.csv" | cut -d, -f10 | tail -n +2 | paste -sd, -)"
+[[ "$csv_1267" == "unmeasurable,unmeasurable,unmeasurable,empty" ]] \
+  || fail "expected the CSV basis column to separate the two states, got: '$csv_1267'"
+
+# ── 2. #1268: /metrics TPOT histogram beats the client-side floor ────────────
+# Same narrow (sub-floor) turns as leg 1, but now the engine answers. Pre-fix
+# these turns are exactly the ones that report 0.0.
+cat > "${PLAN_DIR}/narrow" <<'PLAN'
+narrow:31900
+PLAN
+
+export SOAK_TURNS=3
+soak_stub_start "${PLAN_DIR}/narrow" STUB_TPOT_TPS=123.456
+soak_run "$ROOT_DIR" "${SOAK_ENV_DIR}/run-prom"
+soak_stub_stop
+out_prom="$SOAK_OUT"
+summary_prom="$(cat "${SOAK_ENV_DIR}/run-prom/summary.md")"
+
+assert_contains "$out_prom" "decode-rate source: ENGINE counter"
+assert_contains "$out_prom" "vllm:time_per_output_token_seconds"
+assert_contains "$out_prom" "decode_tps=123.456"
+assert_contains "$out_prom" "(engine-reported: /metrics time_per_output_token_seconds)"
+assert_not_contains "$out_prom" "decode_tps=n/a"
+assert_not_contains "$out_prom" "decode_tps=0.0"
+# The decoy histogram on the same page must not be what got read.
+assert_not_contains "$out_prom" "e2e_request_latency"
+assert_contains "$summary_prom" "3 engine-reported (prom-tpot)"
+assert_contains "$summary_prom" "| p50 decode TPS | 123.46 |"
+csv_prom="$(tr -d '\r' < "${SOAK_ENV_DIR}/run-prom/turn-log.csv" | tail -1)"
+assert_contains "$csv_prom" ",engine,prom-tpot"
+
+# ── 3. #1268: SGLang's decode-batch log line ────────────────────────────────
+# No /metrics here, so the run falls through to the container log — which the
+# fake docker prints on STDERR only, the way every engine in this repo logs.
+cat > "${LOG_DIR}/sglang.log" <<'LOG'
+[2026-09-13 09:00:00 TP0] Prefill batch. #new-seq: 1, #new-token: 1024, #cached-token: 0, token usage: 0.01, #running-req: 0, #queue-req: 0
+[2026-09-13 09:00:01 TP0] Decode batch. #running-req: 1, #token: 1040, token usage: 0.02, gen throughput (token/s): 88.75, #queue-req: 0
+LOG
+
+soak_stub_docker "${LOG_DIR}/sglang.log"
+export SOAK_TURNS=2
+soak_stub_start "${PLAN_DIR}/narrow"
+soak_run "$ROOT_DIR" "${SOAK_ENV_DIR}/run-sglang" CONTAINER=sglang-stub
+soak_stub_stop
+out_sglang="$SOAK_OUT"
+
+assert_contains "$out_sglang" "decode-rate source: ENGINE counter — decode-rate lines in 'docker logs sglang-stub'"
+assert_contains "$out_sglang" "decode_tps=88.75"
+assert_contains "$out_sglang" "(engine-reported: SGLang 'gen throughput (token/s)' log line)"
+assert_not_contains "$out_sglang" "decode_tps=n/a"
+csv_sglang="$(tr -d '\r' < "${SOAK_ENV_DIR}/run-sglang/turn-log.csv" | tail -1)"
+assert_contains "$csv_sglang" ",engine,sglang-log"
+# The scrape must be bounded to the turn being measured, or a stale line from an
+# earlier turn can be reported as this turn's rate.
+docker_argv="$(cat "${SOAK_ENV_DIR}/docker-argv.log")"
+assert_contains "$docker_argv" "logs --since "
+assert_contains "$docker_argv" "--tail"
+
+# ── 4. #1268: llama.cpp eval time — and NOT prompt eval time ────────────────
+# Both lines carry "tokens per second"; the prefill one is ~6.6x faster here, so
+# reading the wrong line would produce a plausible, wrong, unfalsifiable number.
+cat > "${LOG_DIR}/llamacpp.log" <<'LOG'
+slot release: id  0 | task 12 | stop processing: n_past = 1234, truncated = 0
+prompt eval time =    1804.51 ms /  1024 tokens (    1.76 ms per token,   567.34 tokens per second)
+       eval time =    2334.63 ms /   199 runs   (   11.73 ms per token,    85.24 tokens per second)
+      total time =    4139.14 ms /  1223 tokens
+LOG
+
+soak_stub_docker "${LOG_DIR}/llamacpp.log"
+soak_stub_start "${PLAN_DIR}/narrow"
+soak_run "$ROOT_DIR" "${SOAK_ENV_DIR}/run-llamacpp" CONTAINER=llama-cpp-stub
+soak_stub_stop
+out_llamacpp="$SOAK_OUT"
+
+assert_contains "$out_llamacpp" "decode_tps=85.24"
+assert_contains "$out_llamacpp" "(engine-reported: llama.cpp 'eval time' log line)"
+assert_not_contains "$out_llamacpp" "567.34"
+
+# ── 5. the reversal switch: SOAK_ENGINE_COUNTER=off ─────────────────────────
+# The engine counter is reachable (the stub serves /metrics) and must be
+# ignored: client-side timing and the floor, exactly as before #1268 — still
+# labelled, because #1267's contract is independent of where the figure came
+# from. `ok` decodes over ~150 ms (measurable), `narrow` over ~80 ms (not).
+cat > "${PLAN_DIR}/ok-then-narrow" <<'PLAN'
+ok:31900
+narrow:31900
+PLAN
+
+rm -f "${SOAK_ENV_BIN}/docker"   # back to host mode for this leg
+export SOAK_TURNS=2
+soak_stub_start "${PLAN_DIR}/ok-then-narrow" STUB_TPOT_TPS=123.456
+soak_run "$ROOT_DIR" "${SOAK_ENV_DIR}/run-off" SOAK_ENGINE_COUNTER=off
+soak_stub_stop
+out_off="$SOAK_OUT"
+summary_off="$(cat "${SOAK_ENV_DIR}/run-off/summary.md")"
+
+assert_contains "$out_off" "decode-rate source: CLIENT-side SSE timing — SOAK_ENGINE_COUNTER=off"
+assert_not_contains "$out_off" "123.456"
+assert_not_contains "$out_off" "engine-reported"
+assert_contains "$(turn_line "$out_off" 1)" "(client-timed:"
+assert_contains "$(turn_line "$out_off" 1)" "ms decode window)"
+assert_contains "$(turn_line "$out_off" 2)" "decode_tps=n/a"
+assert_contains "$summary_off" "1 client-timed / 1 unmeasurable"
+assert_contains "$summary_off" "computed over the 1 turn(s) carrying a decode figure"
+
+# An invalid value must be refused, not silently coerced into a mode.
+set +e
+bad_out="$(SOAK_ENGINE_COUNTER=maybe bash "${ROOT_DIR}/scripts/soak-test.sh" --quick 2>&1)"
+bad_rc=$?
+set -e
+[[ "$bad_rc" -eq 2 ]] || fail "SOAK_ENGINE_COUNTER=maybe should exit 2, got ${bad_rc}: $bad_out"
+assert_contains "$bad_out" "must be 'auto' or 'off'"
+
+echo "PASS: test-soak-decode-source"


### PR DESCRIPTION
Closes #1267
Closes #1268

Both issues sit on the same measurement path in `soak-test.sh` / `soak-helper.py`, so they are fixed together.

## #1267 — an unmeasurable turn and a silent-empty turn rendered identically

`decode_tps=0.0` meant two opposite things: "fine, this turn decoded in 49 ms" and "HTTP 200 with zero tokens, the failure soak exists to catch". The per-turn lines were byte-identical; separating them meant redoing `wall - ttft` by hand.

Now every turn states its provenance, and an unmeasurable turn is not rendered as a number at all:

```
turn 1/3: ... decode_tps=266.131 vram=31900MiB (client-timed: 150 ms decode window)
turn 2/3: ... decode_tps=n/a     vram=31900MiB (no decode figure: 80 ms decode window is under the 100 ms client-timing floor and no engine counter was available)
turn 3/3: ... decode_tps=0.0     vram=31900MiB (SILENT-EMPTY: 0 completion tokens)
```

This is the convention `bench.sh` and `bench-agentic.sh` already use — `n/a` plus the reason, exclusions stated (`docs/BENCH_CARD.md`) — rather than a fourth format.

The `Decode-window basis:` summary line is no longer gated on a canvas turn existing, so a run with unmeasurable turns finally reports its own counts and p50 gets a stated denominator:

```
- Decode-window basis: 2 engine-reported (prom-tpot) / 1 silent-empty of 3 turn(s). The decode
  percentiles and retention below are computed over the 2 turn(s) carrying a decode figure — that
  is the denominator; turns without one are excluded rather than counted as zero.
```

The silent-empty discriminator is untouched — it keys on `completion_tokens`, never on `decode_tps` — and the label appears **after** `vram=`, so the existing downstream turn-line parser still matches every numeric turn (and now matches canvas turns too, which it did not before).

## #1268 — design decision, and it is overrulable

**Implemented the issue's first-ranked option: read the engine's own counter; keep client-side SSE timing and the 100 ms floor as the fallback.** Sources, tried in order:

| Source | Where |
|---|---|
| `prom-tpot` | `<engine>:time_per_output_token_seconds` histogram on `<endpoint>/metrics` (vLLM always; SGLang with `--enable-metrics`). The `(_sum, _count)` **delta** across one turn is that turn's mean seconds per output token — decode steps only, prefill excluded by construction. Single-turn attribution is valid because soak is single-stream. |
| `sglang-log` | `gen throughput (token/s): N` on SGLang's decode-batch lines |
| `llamacpp-log` | llama.cpp's per-request `eval time = … (N tokens per second)` — never `prompt eval time`, which is prefill |

An engine counter is computed over real decode steps, so it does not care how narrow the wall-clock window is. The floor stays exactly where it is useful: on the inference path, where it is genuinely suppressing noise.

Motivating evidence — three turns from a **passing** 25-turn run on the reference rig, all reported as `0.0`:

```
wall=656ms    ttft=557ms    -> decode window  99 ms
wall=650ms    ttft=550ms    -> decode window 100 ms
wall=10606ms  ttft=10531ms  -> decode window  75 ms
```

Plus the two sightings in the issue: #849 at 82-83 ms and #1261 at 49 / 65 / 97 ms on 3 of 5 turns.

**This is overrulable cheaply.** `SOAK_ENGINE_COUNTER=off` pins a whole run to client-side timing plus the floor — pre-change behaviour, one env var, no code edit. Reverting the preference entirely is a one-line change to the branch order in `cmd_run`. If the counters turn out to disagree with the SSE window in a way we do not like, the switch is the A/B.

Two notes on what this deliberately does **not** do:

- It does not become a fourth incomparable TPS number by accident. The source is named on every line and in the summary, so an engine-reported figure is never silently diffed against a client-timed one.
- It does not classify the engine. It probes what the endpoint and container can answer and matches signatures, so it does not pre-empt the canonical resolver landing in #1282; when that lands the probe can key off it instead.

Canvas-granularity turns are deliberately excluded from the engine-counter path — per-output-token accounting is not meaningful for a model that denoises a whole canvas per step — so #809's behaviour is unchanged.

## Tests

`scripts/tests/test-soak-decode-source.sh` (new) asserts distinguishability itself, not merely that a run completes: it compares the rendered decode figure of an unmeasurable turn against a silent-empty turn and fails if they match. It also covers all three counter sources, the `prompt eval time` vs `eval time` negative control (reading the wrong line yields a plausible, wrong, unfalsifiable number), the `--since` bound on the log scrape, that engine logs are read from **stderr**, and the off switch.

Negative control, run before trusting the green: against the pre-fix tree **34 assertions fail across all five legs**, starting with

```
FAIL: unmeasurable and silent-empty turns render identically — the #1267 defect:
  unmeasurable: [soak]   turn 3/4: status=200 wall=99ms   ttft=19ms   decode_tps=0.0 vram=31900MiB
  silent-empty: [soak]   turn 4/4: status=200 wall=1219ms ttft=1219ms decode_tps=0.0 vram=31900MiB
```

`test-soak-decode-basis.sh` keeps its byte-identity-with-master leg for the measurable-window shape; the narrow shape now asserts the new rendering, and the header records which two of its expectations were superseded and why. No base-vs-new difference is asserted anywhere — an assertion that master still prints the defect would pass today and fail the moment this lands.

Gates run (soak-relevant only, suite not swept): `test-soak-decode-source` PASS · `test-soak-decode-basis` PASS · `test-soak-vram-baseline` PASS · `test-locale-utf8` PASS · `test-script-permissions` PASS · `test-measurement-record` PASS. No GPU, no engine boot — the harness stub serves `/metrics` and a fake `docker logs` supplies the engine log fixtures.

Adjacent, **not** fixed here: `cmd_summary`'s `realistic()` filter still drops any rate above 500 tok/s silently. Engine-reported rates on fast hardware with spec-decode can legitimately exceed that, so it is more reachable now than it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
