### PR TITLE
fix(harness): resolve engine family in ONE place; SGLang no longer mis-routes to the llama.cpp path

### DIFF
--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -288,6 +288,11 @@ fi
 # Auto-detect running container + port (URL/CONTAINER env vars still win).
 # See scripts/preflight.sh::preflight_autodetect_endpoint.
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+# Canonical engine classification (club-3090#1282). Sourced UNCONDITIONALLY —
+# it was briefly nested under the registry-lookup guard, which would have left
+# engine_kind_* undefined at the call site if that sibling were absent.
+# shellcheck source=lib/engine-kind.sh
+source "${ROOT_DIR}/scripts/lib/engine-kind.sh"
 if [[ -f "${ROOT_DIR}/scripts/preflight.sh" ]]; then
   # shellcheck source=preflight.sh
   source "${ROOT_DIR}/scripts/preflight.sh"
@@ -427,15 +432,12 @@ ENGINE_KIND="${ENGINE_KIND:-unknown}"
 if [[ "$ENGINE_KIND" == "unknown" && "${CONTAINER:-}" != "none" ]] && command -v docker >/dev/null 2>&1 && docker inspect "${CONTAINER}" >/dev/null 2>&1; then
   container_image="$(docker inspect --format '{{.Config.Image}}' "${CONTAINER}" 2>/dev/null || true)"
   container_name="$(docker inspect --format '{{.Name}}' "${CONTAINER}" 2>/dev/null || true)"
-  if [[ "${container_image} ${container_name}" == *"llama.cpp"* || "${container_image} ${container_name}" == *"llama-cpp"* ]]; then
-    ENGINE_KIND="llamacpp"
-  elif [[ "${container_image} ${container_name}" == *"vllm"* ]]; then
-    ENGINE_KIND="vllm"
-  elif [[ "${container_image} ${container_name}" == *"sglang"* || "${container_image} ${container_name}" == *"lmsysorg"* ]]; then
-    # club-3090#1261: without this an SGLang container read as "unknown", which
-    # silently changed which spec-decode metrics bench.sh went looking for.
-    ENGINE_KIND="sglang"
-  fi
+  # club-3090#1261 gave SGLang its arm here; club-3090#1282 moved the rules to
+  # scripts/lib/engine-kind.sh so a new engine is added in ONE place. Image
+  # first, then the container name — both are just evidence for the same rules.
+  ENGINE_KIND="$(engine_kind_from_image "${container_image}")"
+  [[ "$ENGINE_KIND" == "unknown" ]] && ENGINE_KIND="$(engine_kind_from_image "${container_name}")"
+  [[ "$ENGINE_KIND" == "unknown" ]] && ENGINE_KIND="$(engine_kind_from_container "${container_name#/}")"
 fi
 
 PP_MODE="log"

--- a/scripts/lib/engine-kind.sh
+++ b/scripts/lib/engine-kind.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# engine-kind.sh — THE single source of truth for "which engine family is this?"
+#
+# Sourceable, stdlib-only (no python3, no registry emit) except for the one
+# slug-based entry point, which delegates to registry-lookup.sh.
+#
+# WHY THIS FILE EXISTS (club-3090#1282, @paulp83)
+# ----------------------------------------------
+# Engine classification used to be re-implemented in every script that needed
+# it. `spec-sweep.sh` carried a private TWO-valued version —
+#     print("vllm" if eng.startswith("vllm") else "llamacpp")
+# — so `sglang-stable` fell through to `llamacpp` and the sweep hunted for a
+# llama.cpp server that was never there. That was the SIXTH site of a defect
+# closed at five the same morning (#1263), and the five-site fix was itself five
+# more private arms. The rules now live here once; scripts keep their own
+# evidence-gathering (they genuinely have different evidence available) and
+# delegate only the DECISION.
+#
+# CONTRACT
+# --------
+# Every function prints exactly one of: vllm | llamacpp | sglang | unknown
+# and returns 0. "unknown" is a value, not an error — callers must handle it
+# rather than treating silence as a kind. Nothing here touches the network.
+#
+#   engine_kind_from_engine_id   <registry `engine:` value>   e.g. sglang-stable
+#   engine_kind_from_container   <container name>             e.g. sglang-qwen38
+#   engine_kind_from_image       <docker image ref>           e.g. lmsysorg/sglang:v0.5.19
+#   engine_kind_from_fingerprint <system_fingerprint>         e.g. b10920-4df29be4f
+#   engine_kind_from_slug        <catalog slug>               e.g. sgl/qwen38-27b-dual-max
+#
+# python3 here must not be locale-coerced (#779): a UTF-8 slug or engine id
+# would otherwise raise UnicodeEncodeError under LC_ALL=C and the caller
+# would silently read "unknown".
+export PYTHONUTF8="${PYTHONUTF8:-1}"
+
+# ⚠️ ADDING AN ENGINE: add its arms HERE and nowhere else. The inventory of
+# everything else an engine touches is in the maintainer tracker; the guard
+# `scripts/tests/test-engine-kind-resolver.sh` fails if a private classifier
+# reappears in scripts/.
+
+# Registry `engine:` id → family. Ids are prefixed by family everywhere in the
+# catalog (vllm-stable, sglang-stable, llamacpp-club3090-v1.6), with two
+# historical exceptions that are llama.cpp builds under their own names:
+# `llama-cpp-local` (the mainline profile's id — note the FILE is
+# llama-cpp-mainline.yml; it is the only profile whose basename != its id) and
+# `beellama-local`.
+engine_kind_from_engine_id() {
+  case "${1:-}" in
+    vllm*)                                   echo "vllm" ;;
+    sglang*|sgl-*)                           echo "sglang" ;;
+    llama-cpp*|llamacpp*|ik-llama*|beellama*) echo "llamacpp" ;;
+    *)                                       echo "unknown" ;;
+  esac
+  return 0
+}
+
+# Container-name convention. This is a SECOND taxonomy that parallels the
+# engine ids — club3090-env.sh, rebench-full.sh and the launchers all name
+# containers by family prefix. `sgl-*` is accepted alongside `sglang-*` because
+# hand-rolled community runs use it (#1261).
+engine_kind_from_container() {
+  case "${1:-}" in
+    vllm-*)                                        echo "vllm" ;;
+    sglang-*|sgl-*)                                echo "sglang" ;;
+    llama-cpp-*|llamacpp-*|ik-llama-*|beellama-*)  echo "llamacpp" ;;
+    *)                                             echo "unknown" ;;
+  esac
+  return 0
+}
+
+# Docker image reference. ⚠️ Order matters: llama.cpp and SGLang are tested
+# before vLLM because a vendor image can carry the vllm string in another
+# family's ref (lmcache/vllm-openai is vLLM, but the general shape is why the
+# narrower matches go first).
+engine_kind_from_image() {
+  local ref="${1:-}"
+  case "$ref" in
+    *llama.cpp*|*llama-cpp*|*llamacpp*) echo "llamacpp" ;;
+    *sglang*|*lmsysorg*)                echo "sglang" ;;
+    *vllm*)                             echo "vllm" ;;
+    *)                                  echo "unknown" ;;
+  esac
+  return 0
+}
+
+# OpenAI `system_fingerprint`. vLLM emits "vllm-0.29.0-tp2-…"; llama-server
+# emits its build string "b10920[-hash]". ⚠️ SGLang does NOT emit an
+# sglang-prefixed fingerprint in every version — the arm is kept for the
+# versions that do, but callers must fall back to container/image evidence
+# rather than concluding "not sglang" from a miss (#1261).
+engine_kind_from_fingerprint() {
+  case "${1:-}" in
+    vllm-*)   echo "vllm" ;;
+    sglang-*) echo "sglang" ;;
+    b[0-9]*)  echo "llamacpp" ;;
+    *)        echo "unknown" ;;
+  esac
+  return 0
+}
+
+# Catalog slug → registry `engine:` → family. The only entry point that needs
+# the registry; prints "unknown" when the slug is absent or the registry cannot
+# be consulted, so callers keep one code path.
+engine_kind_from_slug() {
+  local slug="${1:-}" root eng
+  [[ -n "$slug" ]] || { echo "unknown"; return 0; }
+  root="${ENGINE_KIND_ROOT:-$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)}"
+  eng="$(python3 - "$slug" "$root" <<'PY' 2>/dev/null || true
+import sys, os
+sys.path.insert(0, os.path.join(sys.argv[2], "scripts/lib/profiles"))
+try:
+    from compose_registry import COMPOSE_REGISTRY
+except Exception:
+    raise SystemExit
+e = COMPOSE_REGISTRY.get(sys.argv[1])
+if e:
+    print(e.get("engine") or "")
+PY
+)"
+  [[ -n "$eng" ]] || { echo "unknown"; return 0; }
+  engine_kind_from_engine_id "$eng"
+  return 0
+}

--- a/scripts/lib/report_calib.sh
+++ b/scripts/lib/report_calib.sh
@@ -14,13 +14,14 @@
 # Echoes: vllm | llamacpp | unknown
 # "llamacpp" intentionally covers BOTH mainline llama.cpp and ik_llama — both
 # use the ggml allocator, so kv-calc's vLLM memory model applies to neither.
+# Delegates to the canonical resolver (club-3090#1282) — do NOT re-inline the
+# prefix arms here; scripts/lib/engine-kind.sh is the single source of truth.
 calib_engine_for_container() {
-  case "$1" in
-    vllm-*)                 echo "vllm" ;;
-    llama-cpp-*|ik-llama-*) echo "llamacpp" ;;
-    sglang-*|sgl-*)         echo "sglang" ;;   # club-3090#1261
-    *)                      echo "unknown" ;;
-  esac
+  if ! declare -F engine_kind_from_container >/dev/null 2>&1; then
+    # shellcheck source=engine-kind.sh
+    source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/engine-kind.sh"
+  fi
+  engine_kind_from_container "$1"
 }
 
 # Map a running container name to its kv-calc model id (a MODEL_SPECS key in

--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -95,6 +95,9 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
 # KV-calc calibration helpers (engine/model detection + per-model filter, #168).
+# Canonical engine classification (club-3090#1282) — single source of truth.
+# shellcheck source=lib/engine-kind.sh
+source "$REPO_ROOT/scripts/lib/engine-kind.sh"
 source "$REPO_ROOT/scripts/lib/report_calib.sh"
 # shellcheck source=lib/p2p-state.sh
 source "$REPO_ROOT/scripts/lib/p2p-state.sh"
@@ -1029,19 +1032,13 @@ fi
 case "${ENGINE_KIND:-}" in
   vllm|llamacpp|sglang|unknown) ;;  # respect user override (sglang: club-3090#1261)
   *)
-    case "$CONTAINER" in
-      vllm-*)         ENGINE_KIND="vllm" ;;
-      llama-cpp-*)    ENGINE_KIND="llamacpp" ;;
-      sglang-*|sgl-*) ENGINE_KIND="sglang" ;;   # club-3090#1261
-      club3090-*)
-        container_image=$(docker ps --filter "name=$CONTAINER" --format '{{.Image}}' 2>/dev/null | head -1)
-        case "$container_image" in
-          *llama.cpp*|*llama-cpp*) ENGINE_KIND="llamacpp" ;;
-          *vllm*)                  ENGINE_KIND="vllm" ;;
-          *)                       ENGINE_KIND="unknown" ;;
-        esac ;;
-      *)           ENGINE_KIND="unknown" ;;
-    esac ;;
+    # Prefix arms live in scripts/lib/engine-kind.sh (club-3090#1282).
+    ENGINE_KIND="$(engine_kind_from_container "$CONTAINER")"
+    if [[ "$ENGINE_KIND" == "unknown" ]]; then
+      # club3090-* and any other non-conventional name: fall back to the image.
+      container_image=$(docker ps --filter "name=$CONTAINER" --format '{{.Image}}' 2>/dev/null | head -1)
+      ENGINE_KIND="$(engine_kind_from_image "$container_image")"
+    fi ;;
 esac
 
 if [[ "$CONTAINER" == "none" ]]; then

--- a/scripts/spec-sweep.sh
+++ b/scripts/spec-sweep.sh
@@ -69,20 +69,20 @@ PROMPT='Write a detailed 800-word essay on the history and impact of the printin
 [[ -n "$SWEEP_N" ]] || { echo "SWEEP_N is required (e.g. SWEEP_N=\"0 1 2 4\") — 0 = spec-OFF baseline arm." >&2; exit 2; }
 
 # --- engine resolution (registry when SLUG given; else llama.cpp fast path) --
+# ⚠️ This used to be a PRIVATE two-valued classifier
+# (`"vllm" if eng.startswith("vllm") else "llamacpp"`), which silently routed
+# every SGLang slug into the llama.cpp fast path — club-3090#1282. The rules now
+# live in scripts/lib/engine-kind.sh and NOTHING here re-implements them; a
+# guard test fails if a private classifier reappears anywhere under scripts/.
+# shellcheck source=lib/engine-kind.sh
+source "${ROOT_DIR}/scripts/lib/engine-kind.sh"
 ENGINE_FAMILY="llamacpp"
 if [[ -n "$SLUG" ]]; then
-  ENGINE_FAMILY="$(python3 - "$SLUG" <<'PY'
-import sys
-sys.path.insert(0, "scripts/lib/profiles")
-from compose_registry import COMPOSE_REGISTRY
-e = COMPOSE_REGISTRY.get(sys.argv[1])
-if e is None:
-    print("unknown"); raise SystemExit
-eng = e["engine"]
-print("vllm" if eng.startswith("vllm") else "llamacpp")
-PY
-)"
-  [[ "$ENGINE_FAMILY" != "unknown" ]] || { echo "unknown SLUG '$SLUG' (not in compose_registry)" >&2; exit 2; }
+  ENGINE_FAMILY="$(ENGINE_KIND_ROOT="$ROOT_DIR" engine_kind_from_slug "$SLUG")"
+  # "unknown" now also covers a slug whose engine id we do not recognise. The
+  # old code silently called that llamacpp and swept the wrong path; refusing
+  # is the point of the fix.
+  [[ "$ENGINE_FAMILY" != "unknown" ]] || { echo "unknown SLUG '$SLUG' (not in compose_registry, or its engine id is unrecognised — add it to scripts/lib/engine-kind.sh)" >&2; exit 2; }
   if [[ -z "$URL" ]]; then
     PORT="$(python3 - "$SLUG" <<'PY'
 import sys
@@ -96,13 +96,15 @@ PY
 elif [[ -z "$URL" ]]; then
   URL="http://localhost:8020"
 fi
-[[ "$ENGINE_FAMILY" == "vllm" && -z "$SLUG" ]] && { echo "vLLM sweeps need SLUG (reboot per arm)." >&2; exit 2; }
+# Everything that is not llama.cpp reboots per arm, so it needs a SLUG. Written
+# as != llamacpp (not == vllm) so a newly added engine inherits the safe path.
+[[ "$ENGINE_FAMILY" != "llamacpp" && -z "$SLUG" ]] && { echo "$ENGINE_FAMILY sweeps need SLUG (reboot per arm)." >&2; exit 2; }
 
 echo "[spec-sweep] engine=$ENGINE_FAMILY url=$URL n in { $SWEEP_N } gens=$GENS x ${GEN_TOKENS}tok temp=$TEMP"
 
 if [[ "$SWEEP_DRY" == "1" ]]; then
   for n in $SWEEP_N; do
-    if [[ "$ENGINE_FAMILY" == "vllm" ]]; then
+    if [[ "$ENGINE_FAMILY" != "llamacpp" ]]; then
       echo "[sweep:dry] would: SPEC_N=$n switch.sh $SLUG -> measure n=$n"
     else
       echo "[sweep:dry] would: per-request speculative.n_max=$n against $URL (no reboot)"
@@ -282,7 +284,9 @@ if [[ "$ENGINE_FAMILY" == "llamacpp" ]]; then
     exit 3
   fi
 else
-  # --- vLLM: reboot per arm ----------------------------------------------------
+  # --- vLLM / SGLang: reboot per arm -------------------------------------------
+  # SGLang lands here (not the llama.cpp fast path) as of club-3090#1282;
+  # _measure_vllm_arm reads its `accept rate:` / `accept len:` lines (#1249/#1252).
   # --force + restore-on-exit trap (same rationale as the llama.cpp reboot path
   # above): a status-gated slug (experimental/incubating) would otherwise be
   # REFUSED by switch.sh AFTER the old container is torn down, and set -e would

--- a/scripts/tests/test-engine-detection-sglang.sh
+++ b/scripts/tests/test-engine-detection-sglang.sh
@@ -34,7 +34,12 @@ check() { [[ "$2" == "$3" ]] && ok "$1" || bad "$1" "$2" "$3"; }
 DEAD_URL="http://127.0.0.1:1"
 
 for script in verify-full.sh verify-stress.sh; do
-  awk '/^detect_engine\(\) \{/,/^\}/' "${ROOT}/scripts/${script}" > "${TMP}/fn.sh"
+  # club-3090#1282: detect_engine now DELEGATES the prefix arms to the canonical
+  # resolver, so the extracted body needs the lib in scope. Sourcing it here is
+  # not a weakening of the control — the arms under test are the lib's, and this
+  # test still drives the real extracted function against a dead URL.
+  { echo "source '${ROOT}/scripts/lib/engine-kind.sh'"; \
+    awk '/^detect_engine\(\) \{/,/^\}/' "${ROOT}/scripts/${script}"; } > "${TMP}/fn.sh"
   if [[ ! -s "${TMP}/fn.sh" ]]; then
     bad "${script}: detect_engine() not extractable" "a function body" "empty"
     continue
@@ -70,13 +75,22 @@ else
   bad "report.sh: honours ENGINE_KIND=sglang override" "sglang in the override guard" "absent"
 fi
 
-# --- 5: bench.sh container-name detection must know sglang ------------------
-if awk '/^ENGINE_KIND="\$\{ENGINE_KIND:-unknown\}"/,/^fi$/' "${ROOT}/scripts/bench.sh" \
-     | command grep -q 'sglang'; then
-  ok "bench.sh: container-name detection knows sglang"
+# --- 5: bench.sh detection must RESOLVE sglang ------------------------------
+# ⚠️ This used to grep bench.sh for a literal 'sglang' arm. club-3090#1282 moved
+# the arms into scripts/lib/engine-kind.sh, so a text assertion would now fail
+# on a correct tree — it was asserting the IMPLEMENTATION SHAPE, not the
+# behaviour. Assert the outcome instead: bench.sh must source the canonical
+# resolver, and that resolver must answer sglang for both evidence forms
+# bench.sh actually has (image ref and container name).
+if command grep -q 'lib/engine-kind.sh' "${ROOT}/scripts/bench.sh"; then
+  ok "bench.sh: sources the canonical engine resolver"
 else
-  bad "bench.sh: container-name detection knows sglang" "an sglang branch" "absent"
+  bad "bench.sh: sources the canonical engine resolver" "a source of lib/engine-kind.sh" "absent"
 fi
+got="$(bash -c "source '${ROOT}/scripts/lib/engine-kind.sh'; engine_kind_from_image lmsysorg/sglang:v0.5.19" 2>/dev/null)"
+check "bench.sh path: sglang image → sglang" "sglang" "$got"
+got="$(bash -c "source '${ROOT}/scripts/lib/engine-kind.sh'; engine_kind_from_container sglang-qwen38" 2>/dev/null)"
+check "bench.sh path: sglang-* container → sglang" "sglang" "$got"
 
 echo
 if [[ "$FAIL" == "0" ]]; then

--- a/scripts/tests/test-engine-kind-resolver.sh
+++ b/scripts/tests/test-engine-kind-resolver.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Guard: engine classification is resolved in ONE place, and every consumer
+# agrees with it.
+#
+# Why this exists (club-3090#1282, @paulp83): `spec-sweep.sh` carried its own
+# private two-valued classifier —
+#     print("vllm" if eng.startswith("vllm") else "llamacpp")
+# — so `sglang-stable` fell through to `llamacpp` and the sweep went hunting for
+# a llama.cpp server. That was the SIXTH site of a defect we had closed at five
+# the same morning (#1263). The fix for five sites was five more private arms;
+# this test exists so the seventh site cannot happen quietly.
+#
+# ⚠️ Arms 1-2 must FAIL against the pre-fix tree. If they pass before the fix
+# they are asserting the wrong thing.
+set -uo pipefail
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+NAME="test-engine-kind-resolver"
+FAIL=0
+bad() { echo "FAIL: $1 — expected '$2', got '$3'" >&2; FAIL=1; }
+ok()  { echo "  ✓ $1"; }
+
+LIB="${ROOT}/scripts/lib/engine-kind.sh"
+
+# --- 1: the canonical resolver exists and is the single source of truth ------
+if [[ ! -f "$LIB" ]]; then
+  bad "canonical resolver" "scripts/lib/engine-kind.sh to exist" "missing"
+else
+  # shellcheck source=lib/engine-kind.sh
+  source "$LIB"
+  for probe in \
+    "engine_kind_from_engine_id sglang-stable:sglang" \
+    "engine_kind_from_engine_id vllm-stable:vllm" \
+    "engine_kind_from_engine_id llama-cpp-local:llamacpp" \
+    "engine_kind_from_engine_id llamacpp-club3090-v1.6:llamacpp" \
+    "engine_kind_from_engine_id beellama-local:llamacpp" \
+    "engine_kind_from_engine_id totally-new-engine:unknown" \
+    "engine_kind_from_container sglang-qwen38:sglang" \
+    "engine_kind_from_container sgl-qwen38:sglang" \
+    "engine_kind_from_container vllm-qwen36-27b:vllm" \
+    "engine_kind_from_container llama-cpp-glm53:llamacpp" \
+    "engine_kind_from_container ik-llama-qwen:llamacpp" \
+    "engine_kind_from_container nothing-like-an-engine:unknown" \
+    "engine_kind_from_image lmsysorg/sglang:v0.5.19:sglang" \
+    "engine_kind_from_image vllm/vllm-openai:v0.29.0:vllm" \
+    "engine_kind_from_image ghcr.io/ggml-org/llama.cpp:llamacpp" \
+    "engine_kind_from_fingerprint sglang-0.5.19:sglang" \
+    "engine_kind_from_fingerprint vllm-0.29.0-tp2:vllm" \
+    "engine_kind_from_fingerprint b10920-4df29be4f:llamacpp" \
+  ; do
+    want="${probe##*:}"; call="${probe%:*}"
+    got="$($call 2>/dev/null || true)"
+    [[ "$got" == "$want" ]] || bad "resolver: $call" "$want" "$got"
+  done
+  [[ $FAIL -eq 0 ]] && ok "canonical resolver maps every known engine id, container, image and fingerprint"
+fi
+
+# --- 2: spec-sweep.sh must classify an SGLang slug as sglang (#1282) ---------
+# Drive the real script against a dead URL so it prints its classification and
+# exits before touching a server. The banner line is the observable.
+out="$(cd "$ROOT" && SWEEP_N="0 1" SLUG=sgl/qwen38-27b-dual-max \
+        URL=http://127.0.0.1:9 timeout 120 bash scripts/spec-sweep.sh 2>&1 | head -40 || true)"
+line="$(command grep -oE '\[spec-sweep\] engine=[a-z]+' <<<"$out" | head -1)"
+case "$line" in
+  *engine=sglang) ok "spec-sweep resolves an sglang slug to engine=sglang (#1282)" ;;
+  "")             bad "spec-sweep classification" "a '[spec-sweep] engine=' banner" "no banner (script died earlier)" ;;
+  *)              bad "spec-sweep classification" "engine=sglang" "${line##*engine=}" ;;
+esac
+
+# --- 3: controls — the other two kinds must NOT regress ---------------------
+for pair in "vllm/minimal:vllm" "llamacpp/default:llamacpp"; do
+  slug="${pair%:*}"; want="${pair##*:}"
+  out="$(cd "$ROOT" && SWEEP_N="0 1" SLUG="$slug" URL=http://127.0.0.1:9 \
+          timeout 120 bash scripts/spec-sweep.sh 2>&1 | head -40 || true)"
+  got="$(command grep -oE '\[spec-sweep\] engine=[a-z]+' <<<"$out" | head -1)"; got="${got##*engine=}"
+  [[ "$got" == "$want" ]] || bad "spec-sweep control $slug" "$want" "${got:-<no banner>}"
+done
+[[ $FAIL -eq 0 ]] && ok "vllm and llamacpp slugs still classify correctly"
+
+# --- 4: no script may re-implement the mapping privately --------------------
+# This is the arm that stops a seventh site. A new private classifier is any
+# vllm/llamacpp/sglang literal decision outside the lib and its own test.
+# Scope: executable lines only (comments explaining the OLD code are fine), and
+# only the non-test, non-lib scripts — scripts/tests/ legitimately asserts on
+# engine strings, and engine-kind.sh IS the implementation.
+priv="$(command grep -rnE 'startswith\("vllm"\)|"vllm" if ' \
+          "${ROOT}/scripts" --include='*.sh' 2>/dev/null \
+          | command grep -v '/scripts/tests/' \
+          | command grep -v '/scripts/lib/engine-kind.sh' \
+          | command grep -vE ':[0-9]+:[[:space:]]*#' || true)"
+if [[ -n "$priv" ]]; then
+  bad "private classifier re-implementation" "none outside scripts/lib/engine-kind.sh" "$priv"
+else
+  ok "no script re-implements the engine mapping privately"
+fi
+
+if [[ $FAIL -ne 0 ]]; then echo "FAIL: $NAME" >&2; exit 1; fi
+echo "PASS: $NAME (centralised engine-kind resolver, #1282)"

--- a/scripts/tests/test-spec-sweep.sh
+++ b/scripts/tests/test-spec-sweep.sh
@@ -86,10 +86,15 @@ fi
 echo "  ✓ vLLM SWEEP_DRY plans reboot-per-arm (one knob, SPEC_N=0 baseline)"
 echo "  ✓ SWEEP_DRY booted nothing at the docker layer (both slugs)"
 
-# 6. vLLM without SLUG refused (exit 2) — can't reboot without a target.
-#    (Engine defaults to llamacpp without a slug, so force via a vllm slug
-#    minus SLUG isn't expressible — assert the guard directly instead.)
-grep -q 'vLLM sweeps need SLUG' "$SWEEP" || fail "vLLM-needs-SLUG guard missing from script"
-echo "  ✓ vLLM-needs-SLUG guard present"
+# 6. A reboot-per-arm engine without SLUG refused (exit 2) — can't reboot
+#    without a target. (Engine defaults to llamacpp without a slug, so forcing
+#    it via a vllm slug minus SLUG isn't expressible — assert the guard itself.)
+#    ⚠️ club-3090#1282 widened this from `== "vllm"` to `!= "llamacpp"` so a
+#    NEWLY ADDED engine inherits the safe reboot path instead of silently taking
+#    llama.cpp's per-request fast path. Assert the condition, not the old
+#    vLLM-specific wording.
+command grep -q 'ENGINE_FAMILY" != "llamacpp" && -z "$SLUG"' "$SWEEP" \
+  || fail "reboot-per-arm-needs-SLUG guard missing (or narrowed back to == vllm)"
+echo "  ✓ reboot-per-arm-needs-SLUG guard present, and engine-agnostic"
 
 echo "test-spec-sweep: ok"

--- a/scripts/verify-full.sh
+++ b/scripts/verify-full.sh
@@ -77,6 +77,10 @@ done
 # Auto-detect running container + port (URL/CONTAINER env vars still win).
 # See scripts/preflight.sh::preflight_autodetect_endpoint.
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+# Canonical engine classification (club-3090#1282). Sourced unconditionally:
+# the rules live in ONE place and every consumer delegates to them.
+# shellcheck source=lib/engine-kind.sh
+source "${ROOT_DIR}/scripts/lib/engine-kind.sh"
 if [[ -f "${ROOT_DIR}/scripts/preflight.sh" ]]; then
   # shellcheck source=preflight.sh
   source "${ROOT_DIR}/scripts/preflight.sh"
@@ -134,11 +138,9 @@ detect_engine() {
     -H 'Content-Type: application/json' \
     -d "{\"model\":\"${MODEL}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":1}" 2>/dev/null \
     | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('system_fingerprint','') or '')" 2>/dev/null)"
-  case "$fp" in
-    vllm-*)    echo "vllm"; return 0 ;;
-    sglang-*)  echo "sglang"; return 0 ;;
-    b[0-9]*)   echo "llamacpp"; return 0 ;;   # llama-server build str: b10454[-hash]
-  esac
+  local k
+  k="$(engine_kind_from_fingerprint "$fp")"
+  [[ "$k" != "unknown" ]] && { echo "$k"; return 0; }
   # Hint 3: container name pattern as a fallback (cheap, no extra HTTP).
   # ⚠️ sglang-* was MISSING here until club-3090#1261. SGLang does not set a
   # `sglang-`-prefixed system_fingerprint, so hint 2 never matches it and every
@@ -147,12 +149,10 @@ detect_engine() {
   # SKIPPED the acceptance check. A dead DFlash2 drafter (sglang#39087) leaves
   # output correct and only collapses decode, so that skip is silent. The prefix
   # is the same one rebench-full.sh and club3090-env.sh already use.
-  case "$CONTAINER" in
-    vllm-*)      echo "vllm"; return 0 ;;
-    llama-cpp-*|ik-llama-*) echo "llamacpp"; return 0 ;;
-    sglang-*|sgl-*) echo "sglang"; return 0 ;;
-  esac
-  echo "unknown"
+  # The prefix arms themselves now live in scripts/lib/engine-kind.sh
+  # (club-3090#1282) so adding an engine is a ONE-place change.
+  engine_kind_from_container "$CONTAINER"
+  return 0
 }
 
 # True only when $CONTAINER names a real Docker container. `--type container`

--- a/scripts/verify-stress.sh
+++ b/scripts/verify-stress.sh
@@ -329,6 +329,10 @@ trap finalize_save_json EXIT
 # Auto-detect running container + port (URL/CONTAINER env vars still win).
 # See scripts/preflight.sh::preflight_autodetect_endpoint.
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+# Canonical engine classification (club-3090#1282). Sourced unconditionally:
+# the rules live in ONE place and every consumer delegates to them.
+# shellcheck source=lib/engine-kind.sh
+source "${ROOT_DIR}/scripts/lib/engine-kind.sh"
 
 # --- per-rig #249 record: self-tee stdout so the ceiling-ladder line (the ctx
 # ceiling this stress run validates) can be parsed at the end for the corpus
@@ -469,17 +473,14 @@ detect_engine() {
     -H 'Content-Type: application/json' \
     -d "{\"model\":\"${MODEL}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":1}" 2>/dev/null \
     | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('system_fingerprint','') or '')" 2>/dev/null)"
-  case "$fp" in
-    vllm-*)   echo "vllm"; return 0 ;;
-    sglang-*) echo "sglang"; return 0 ;;
-  esac
-  # sglang-*/sgl-* added club-3090#1261 — see the long note in verify-full.sh.
-  case "$CONTAINER" in
-    vllm-*)      echo "vllm"; return 0 ;;
-    llama-cpp-*|ik-llama-*) echo "llamacpp"; return 0 ;;
-    sglang-*|sgl-*) echo "sglang"; return 0 ;;
-  esac
-  echo "unknown"
+  local k
+  k="$(engine_kind_from_fingerprint "$fp")"
+  [[ "$k" != "unknown" ]] && { echo "$k"; return 0; }
+  # Container-name fallback. sglang-*/sgl-* added club-3090#1261; the arms
+  # themselves now live in scripts/lib/engine-kind.sh (club-3090#1282) so a new
+  # engine is added in ONE place — see the long note in verify-full.sh.
+  engine_kind_from_container "$CONTAINER"
+  return 0
 }
 ENGINE_KIND="$(detect_engine)"
 


### PR DESCRIPTION
Fixes #1282, and does it the way the issue actually asks — one resolver, not a sixth arm.

## The defect

`scripts/spec-sweep.sh` carried a private two-valued classifier:

```python
print("vllm" if eng.startswith("vllm") else "llamacpp")
```

so every SGLang slug fell through to `llamacpp`. Without a SLUG that's the hard exit @paulp83 hit in #1251. **With** a SLUG it was worse than a crash: it took llama.cpp's per-request `speculative.n_max` fast path against an SGLang endpoint, the capability probe failed, and it fell back to reboot-per-arm *by accident via the wrong branch* — never reading SGLang's own acceptance lines.

This was the **sixth** site of a defect closed at five the same morning (#1263) — and that five-site fix was itself five more private arms. @paulp83's deeper point is the right one, and it lands on our own patch.

## The fix

`scripts/lib/engine-kind.sh` is now the single source of truth, with five entry points — one per **evidence form**, because scripts genuinely differ in what evidence they have:

| entry point | evidence | used by |
|---|---|---|
| `engine_kind_from_engine_id` | registry `engine:` value | slug path |
| `engine_kind_from_container` | container name | verify-full, verify-stress, report, bench, report_calib |
| `engine_kind_from_image` | docker image ref | report, bench |
| `engine_kind_from_fingerprint` | OpenAI `system_fingerprint` | verify-full, verify-stress |
| `engine_kind_from_slug` | catalog slug → registry | spec-sweep |

What is centralised is the **rules**; each script keeps its own evidence-gathering. All six previous classifier sites now delegate.

**Routing is written as `!= "llamacpp"` rather than `== "vllm"`,** so a newly added engine inherits the safe reboot-per-arm path instead of silently taking llama.cpp's per-request one. SGLang consequently lands in the branch where `_measure_vllm_arm` reads its `accept rate:` / `accept len:` lines (#1249/#1252).

## Behaviour change, deliberate

A slug whose engine id is **unrecognised** now refuses, instead of being silently called `llamacpp` and swept down the wrong path. That is the point of the fix, but it is a behaviour change rather than a pure refactor.

## Negative control

```
pre-fix   exit 1 — 3 real failures:
            resolver missing
            spec-sweep classification: expected engine=sglang, got llamacpp
            private classifier re-implementation present
post-fix  exit 0
```

The guard also has an arm that **fails if a private classifier reappears** anywhere under `scripts/` — that is the part meant to stop a seventh site.

## Two tests changed, and why

Both asserted **implementation shape** that centralisation legitimately invalidates, so both were converted to assert behaviour:

- `test-engine-detection-sglang` grepped `bench.sh` for a literal `sglang` arm — it now asserts bench sources the resolver and that the resolver answers `sglang` for both evidence forms bench actually has.
- `test-spec-sweep` grepped for the old vLLM-specific guard wording — it now asserts the widened condition, and fails if it is ever narrowed back to `== vllm`.

## A real bug the gates caught

`test-locale-utf8` failed on the first sweep: the new lib's `python3` call was missing `PYTHONUTF8`, so a UTF-8 slug under `LC_ALL=C` would have raised and the caller would have silently read `"unknown"` (#779). Fixed — and it is exactly the failure mode this resolver exists to prevent.

## Verification

Full sweep on this branch, plus targeted re-runs of both initially-red gates after fixing them: `test-spec-sweep`, `test-locale-utf8`, `test-engine-kind-resolver`, `test-engine-detection-sglang` all pass. ⚠️ The sweep ran while other work was in flight on this machine and this suite is known to flake under contention, so a clean quiescent sweep is worth one more run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
